### PR TITLE
refactor: rename ElementHandle → Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Whisker lets you build native iOS and Android apps in Rust with a Leptos-style *
 
 ```rust
 use whisker::prelude::*;
-use whisker::runtime::view::ElementHandle;
+use whisker::runtime::view::Element;
 
 #[whisker::main]
-fn app() -> ElementHandle {
+fn app() -> Element {
     let count = RwSignal::new(0);
     render! {
         page {

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -6,7 +6,7 @@
 //! use whisker::prelude::*;
 //!
 //! #[whisker::main]
-//! fn app() -> ElementHandle {
+//! fn app() -> Element {
 //!     render! { page { text { "Hello" } } }
 //! }
 //! ```
@@ -20,7 +20,7 @@
 //!    `DynRenderer` so `view::create_element` / `set_attribute` / …
 //!    inside the user's `render!` macro route through the bridge.
 //! 3. We invoke `app()`. The user's body runs `render!`, which
-//!    populates the Lynx element tree and returns an `ElementHandle`
+//!    populates the Lynx element tree and returns an `Element`
 //!    for the root.
 //! 4. We call `view::set_root(root)` and `view::flush()` to commit
 //!    the initial frame.
@@ -51,7 +51,7 @@ use whisker_runtime::reactive::{
     flush as reactive_flush, flush_mounts as reactive_flush_mounts, remount_components_for,
 };
 use whisker_runtime::view::{
-    flush as renderer_flush, install_renderer, set_root, DynRenderer, ElementHandle,
+    flush as renderer_flush, install_renderer, set_root, DynRenderer, Element,
 };
 
 thread_local! {
@@ -77,7 +77,7 @@ pub fn run<F>(
     request_frame_data: *mut c_void,
     app_fn: F,
 ) where
-    F: FnOnce() -> ElementHandle + 'static,
+    F: FnOnce() -> Element + 'static,
 {
     if engine_raw.is_null() {
         return;
@@ -85,7 +85,7 @@ pub fn run<F>(
     // Boxed init context, handed across the C ABI via raw pointer.
     let ctx = Box::new(InitCtx {
         engine: engine_raw as *mut WhiskerEngine,
-        app_fn: Some(Box::new(app_fn) as Box<dyn FnOnce() -> ElementHandle + 'static>),
+        app_fn: Some(Box::new(app_fn) as Box<dyn FnOnce() -> Element + 'static>),
         request_frame,
         request_frame_data,
     });
@@ -99,7 +99,7 @@ struct InitCtx {
     /// to call it. `FnOnce` because the user fn is invoked once at
     /// mount; subsequent re-renders happen incrementally through the
     /// reactive runtime, not by re-calling this fn.
-    app_fn: Option<Box<dyn FnOnce() -> ElementHandle + 'static>>,
+    app_fn: Option<Box<dyn FnOnce() -> Element + 'static>>,
     request_frame: Option<extern "C" fn(*mut c_void)>,
     request_frame_data: *mut c_void,
 }

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -6,7 +6,7 @@
 //! invoking the user's `render!`-bearing fn, so the macro's
 //! `create_element` / `set_attribute` / etc. calls land here.
 //!
-//! Translation layer: the public `ElementHandle` is a `u32` index
+//! Translation layer: the public `Element` is a `u32` index
 //! assigned by [`BridgeRenderer::create_element`]. Internally a
 //! `Vec<Option<NonNull<WhiskerElement>>>` maps each index back to the
 //! raw C pointer the bridge gave us. Released slots become `None`;
@@ -18,13 +18,13 @@ use std::ptr::NonNull;
 
 use whisker_driver_sys::{self as ffi, WhiskerElement, WhiskerElementTag, WhiskerEngine};
 use whisker_runtime::element::ElementTag;
-use whisker_runtime::view::{DynRenderer, ElementHandle};
+use whisker_runtime::view::{DynRenderer, Element};
 
 pub struct BridgeRenderer {
     engine: NonNull<WhiskerEngine>,
     /// Index → raw C element pointer. `None` means the slot has been
     /// released. Index assigned at `create_element` time, returned in
-    /// the public `ElementHandle`.
+    /// the public `Element`.
     elements: Vec<Option<NonNull<WhiskerElement>>>,
     /// Owned per-event listener closures. See the type-shape comment
     /// on the old `Renderer` impl for the double-box rationale —
@@ -51,7 +51,7 @@ impl BridgeRenderer {
         self.engine.as_ptr()
     }
 
-    fn lookup(&self, handle: ElementHandle) -> Option<NonNull<WhiskerElement>> {
+    fn lookup(&self, handle: Element) -> Option<NonNull<WhiskerElement>> {
         self.elements
             .get(handle.id() as usize)
             .and_then(|slot| *slot)
@@ -70,18 +70,18 @@ fn map_tag(tag: ElementTag) -> WhiskerElementTag {
 }
 
 impl DynRenderer for BridgeRenderer {
-    fn create_element(&mut self, tag: ElementTag) -> ElementHandle {
+    fn create_element(&mut self, tag: ElementTag) -> Element {
         let raw = unsafe { ffi::whisker_bridge_create_element(self.engine_ptr(), map_tag(tag)) };
         let ptr = match NonNull::new(raw) {
             Some(p) => p,
-            None => return ElementHandle::from_raw(u32::MAX),
+            None => return Element::from_raw(u32::MAX),
         };
         let id = self.elements.len() as u32;
         self.elements.push(Some(ptr));
-        ElementHandle::from_raw(id)
+        Element::from_raw(id)
     }
 
-    fn release_element(&mut self, handle: ElementHandle) {
+    fn release_element(&mut self, handle: Element) {
         if let Some(slot) = self.elements.get_mut(handle.id() as usize) {
             if let Some(ptr) = slot.take() {
                 unsafe { ffi::whisker_bridge_release_element(ptr.as_ptr()) };
@@ -89,7 +89,7 @@ impl DynRenderer for BridgeRenderer {
         }
     }
 
-    fn set_attribute(&mut self, handle: ElementHandle, key: &str, value: &str) {
+    fn set_attribute(&mut self, handle: Element, key: &str, value: &str) {
         let Some(ptr) = self.lookup(handle) else {
             return;
         };
@@ -102,7 +102,7 @@ impl DynRenderer for BridgeRenderer {
         };
     }
 
-    fn set_inline_styles(&mut self, handle: ElementHandle, css: &str) {
+    fn set_inline_styles(&mut self, handle: Element, css: &str) {
         let Some(ptr) = self.lookup(handle) else {
             return;
         };
@@ -110,13 +110,13 @@ impl DynRenderer for BridgeRenderer {
         unsafe { ffi::whisker_bridge_set_inline_styles(ptr.as_ptr(), css_c.as_ptr()) };
     }
 
-    fn append_child(&mut self, parent: ElementHandle, child: ElementHandle) {
+    fn append_child(&mut self, parent: Element, child: Element) {
         let Some(p) = self.lookup(parent) else { return };
         let Some(c) = self.lookup(child) else { return };
         unsafe { ffi::whisker_bridge_append_child(p.as_ptr(), c.as_ptr()) };
     }
 
-    fn remove_child(&mut self, parent: ElementHandle, child: ElementHandle) {
+    fn remove_child(&mut self, parent: Element, child: Element) {
         let Some(p) = self.lookup(parent) else { return };
         let Some(c) = self.lookup(child) else { return };
         unsafe { ffi::whisker_bridge_remove_child(p.as_ptr(), c.as_ptr()) };
@@ -124,7 +124,7 @@ impl DynRenderer for BridgeRenderer {
 
     fn set_event_listener(
         &mut self,
-        handle: ElementHandle,
+        handle: Element,
         event_name: &str,
         callback: Box<dyn Fn() + 'static>,
     ) {
@@ -147,7 +147,7 @@ impl DynRenderer for BridgeRenderer {
         };
     }
 
-    fn set_root(&mut self, page: ElementHandle) {
+    fn set_root(&mut self, page: Element) {
         let Some(ptr) = self.lookup(page) else { return };
         unsafe { ffi::whisker_bridge_set_root(self.engine_ptr(), ptr.as_ptr()) };
     }

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -9,7 +9,7 @@
 //!    type (string-ish primitives + `Option<T>` get `into` /
 //!    `strip_option`, `Children` gets a default) and any `#[prop(...)]`
 //!    attributes the user wrote.
-//! 2. A rewritten `fn xxx(__props: XxxProps) -> ElementHandle { … }`
+//! 2. A rewritten `fn xxx(__props: XxxProps) -> Element { … }`
 //!    that destructures the props back into local variables and runs
 //!    the user's original body inside the existing
 //!    `mount_component_remountable` hot-reload machinery.
@@ -194,7 +194,7 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
             // inner, which has to live at the user crate's source
             // position for hot reload to find it).
             let __body: ::std::boxed::Box<
-                dyn ::std::ops::Fn() -> ::whisker::runtime::view::ElementHandle + 'static,
+                dyn ::std::ops::Fn() -> ::whisker::runtime::view::Element + 'static,
             > = ::std::boxed::Box::new(move || {
                 #(#restores)*
                 ::whisker::__hot::call(move || {
@@ -530,7 +530,7 @@ mod tests {
     #[test]
     fn expand_emits_props_struct_and_rewritten_fn() {
         let input: TokenStream2 = quote! {
-            fn card(title: String) -> ElementHandle {
+            fn card(title: String) -> Element {
                 render! { view { text { {title.clone()} } } }
             }
         };
@@ -544,7 +544,7 @@ mod tests {
     #[test]
     fn expand_handles_no_param_component() {
         let input: TokenStream2 = quote! {
-            fn header() -> ElementHandle {
+            fn header() -> Element {
                 render! { view { text { "Hi" } } }
             }
         };
@@ -561,7 +561,7 @@ mod tests {
     #[test]
     fn expand_handles_option_param() {
         let input: TokenStream2 = quote! {
-            fn x(label: Option<String>) -> ElementHandle {
+            fn x(label: Option<String>) -> Element {
                 render! { view {} }
             }
         };
@@ -576,7 +576,7 @@ mod tests {
     #[test]
     fn expand_handles_generic_component() {
         let input: TokenStream2 = quote! {
-            fn typed<T: Clone + 'static>(value: T) -> ElementHandle {
+            fn typed<T: Clone + 'static>(value: T) -> Element {
                 render! { view {} }
             }
         };
@@ -595,7 +595,7 @@ mod tests {
         // `setter(into)`, otherwise `Into<T>` with unconstrained `T`
         // breaks call-site inference. Concrete fields keep `into`.
         let input: TokenStream2 = quote! {
-            fn typed<T: Clone + 'static>(value: T, label: String) -> ElementHandle {
+            fn typed<T: Clone + 'static>(value: T, label: String) -> Element {
                 render! { view {} }
             }
         };
@@ -623,7 +623,7 @@ mod tests {
         // `Option<T>` where T is generic: still need strip_option,
         // but `into` would need a known target type → must be skipped.
         let input: TokenStream2 = quote! {
-            fn typed<T: Clone + 'static>(value: Option<T>) -> ElementHandle {
+            fn typed<T: Clone + 'static>(value: Option<T>) -> Element {
                 render! { view {} }
             }
         };

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! - [`main`] — designates the user's app entry. Generates the
 //!   `whisker_app_main` and `whisker_tick` FFI exports the native
-//!   host calls into; the user writes `fn app() -> ElementHandle`.
+//!   host calls into; the user writes `fn app() -> Element`.
 //! - [`render!`] — fine-grained renderer macro. Emits imperative
 //!   `view::*` dispatch + `effect`s for dynamic parts. See
 //!   `crates/whisker-macros/src/render.rs` for the grammar.
@@ -74,7 +74,7 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         // on) or just invokes `#fn_name()` directly (release) is
         // decided by `whisker`'s own `hot-reload` feature flag — the
         // user crate doesn't need a matching feature of its own.
-        fn __whisker_app_dispatch() -> ::whisker::runtime::view::ElementHandle {
+        fn __whisker_app_dispatch() -> ::whisker::runtime::view::Element {
             ::whisker::__main_runtime::call_user_app(#fn_name)
         }
 
@@ -129,7 +129,7 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Phase 6.5a fine-grained renderer macro. Emits imperative
 /// element-creation code that calls into
 /// [`whisker::runtime::view`] through the thread-local installed
-/// renderer, and returns an [`ElementHandle`].
+/// renderer, and returns an [`Element`].
 ///
 /// ```ignore
 /// use whisker::prelude::*;
@@ -154,7 +154,7 @@ pub fn render(input: TokenStream) -> TokenStream {
 
 /// Mark a function as a Whisker reactive component.
 ///
-/// The macro takes the user's `fn xxx(a: A, b: B) -> ElementHandle`
+/// The macro takes the user's `fn xxx(a: A, b: B) -> Element`
 /// and emits both:
 ///
 /// 1. A `XxxProps` struct (Pascal-cased function name + `Props`)
@@ -168,7 +168,7 @@ pub fn render(input: TokenStream) -> TokenStream {
 ///    `#[prop(default = expr)]` attribute on a parameter is forwarded
 ///    to typed-builder as the field's default.
 ///
-/// 2. A rewritten `fn xxx(__props: XxxProps) -> ElementHandle` whose
+/// 2. A rewritten `fn xxx(__props: XxxProps) -> Element` whose
 ///    body destructures the props back into local variables and runs
 ///    the user's original `#block` inside the existing
 ///    `mount_component_remountable` machinery (per-component
@@ -185,7 +185,7 @@ pub fn render(input: TokenStream) -> TokenStream {
 /// use whisker::prelude::*;
 ///
 /// #[component]
-/// fn counter(initial: i32) -> ElementHandle {
+/// fn counter(initial: i32) -> Element {
 ///     let (count, set_count) = signal(initial);
 ///     render! { /* ... */ }
 /// }

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -59,7 +59,7 @@ pub fn expand(input: TokenStream) -> TokenStream {
         Ok(root) => root.to_tokens().into(),
         Err(err) => {
             // Pair the compile_error with a same-typed placeholder
-            // so the surrounding code (`let h: ElementHandle = render!
+            // so the surrounding code (`let h: Element = render!
             // { … };`) keeps type-checking and diagnostics stay
             // confined to the actual syntax error. Same approach
             // leptos uses for its `view!` macro.

--- a/crates/whisker-macros/tests/ra_completion.rs
+++ b/crates/whisker-macros/tests/ra_completion.rs
@@ -64,9 +64,9 @@ const RA_VERSION: &str = "2026-05-18";
 fn partial_kwarg_in_render_completes_builder_methods() {
     let source = r#"
 use whisker::prelude::*;
-use whisker::runtime::view::ElementHandle;
+use whisker::runtime::view::Element;
 
-fn probe() -> ElementHandle {
+fn probe() -> Element {
     render! {
         view(sty|)
     }
@@ -89,10 +89,10 @@ fn partial_kwarg_inside_component_body_completes_builder_methods() {
     // body, which the proc-macro rewrites into nested closures.
     let source = r#"
 use whisker::prelude::*;
-use whisker::runtime::view::ElementHandle;
+use whisker::runtime::view::Element;
 
 #[component]
-fn probe() -> ElementHandle {
+fn probe() -> Element {
     render! {
         view(sty|)
     }
@@ -111,9 +111,9 @@ fn partial_tag_name_at_root_completes_to_builtin_view() {
     // root of a render! should surface `view` (built-in tag).
     let source = r#"
 use whisker::prelude::*;
-use whisker::runtime::view::ElementHandle;
+use whisker::runtime::view::Element;
 
-fn probe() -> ElementHandle {
+fn probe() -> Element {
     render! {
         vie|
     }
@@ -130,9 +130,9 @@ fn probe() -> ElementHandle {
 fn partial_tag_name_in_children_block_completes_to_builtin_view() {
     let source = r#"
 use whisker::prelude::*;
-use whisker::runtime::view::ElementHandle;
+use whisker::runtime::view::Element;
 
-fn probe() -> ElementHandle {
+fn probe() -> Element {
     render! {
         view() {
             vie|

--- a/crates/whisker-runtime/src/main_thread.rs
+++ b/crates/whisker-runtime/src/main_thread.rs
@@ -12,7 +12,7 @@
 //! use whisker::runtime::main_thread::run_on_main_thread;
 //!
 //! #[component]
-//! fn list_view() -> ElementHandle {
+//! fn list_view() -> Element {
 //!     let data = RwSignal::new(None);
 //!
 //!     on_mount(move || {

--- a/crates/whisker-runtime/src/reactive/component.rs
+++ b/crates/whisker-runtime/src/reactive/component.rs
@@ -27,7 +27,7 @@ use std::rc::Rc;
 use super::owner::{create_owner, dispose_owner, with_owner};
 use super::runtime::OwnerId;
 use super::with_runtime;
-use crate::view::ElementHandle;
+use crate::view::Element;
 
 /// Mount a component: create a fresh child owner, register `fn_ptr`
 /// against it for hot reload, run `body` inside that owner, and
@@ -163,7 +163,7 @@ thread_local! {
     /// nested component mounts handle themselves because the body's
     /// inner `view::append_child` calls drain the inner pending
     /// mounts before this function's own value is stashed.
-    static PENDING_MOUNT: Cell<Option<(MountId, ElementHandle)>> = const { Cell::new(None) };
+    static PENDING_MOUNT: Cell<Option<(MountId, Element)>> = const { Cell::new(None) };
 }
 
 /// Stable identifier for a remountable mount site. Generationless on
@@ -181,23 +181,23 @@ pub(crate) struct MountSite {
     /// handle out of the runtime borrow before invoking it (the body
     /// re-enters the runtime via `view::*` / `signal()` / etc., so
     /// holding the runtime borrow across the call would deadlock).
-    pub body: Rc<dyn Fn() -> ElementHandle + 'static>,
+    pub body: Rc<dyn Fn() -> Element + 'static>,
     /// Current owner — `Some` between mounts, `None` during the
     /// dispose-then-remount window.
     pub owner: Option<OwnerId>,
     /// Element handle the body returned for its outermost element.
     /// Detached from the parent at the start of each remount, then
     /// replaced by the new body's root inserted at the same slot.
-    pub body_root: Option<ElementHandle>,
+    pub body_root: Option<Element>,
     /// Parent element this component is attached to. `None` until
     /// `view::append_child` fires for the body_root for the first
     /// time. `Some(_)` thereafter, kept up to date across remounts.
-    pub parent: Option<ElementHandle>,
+    pub parent: Option<Element>,
     /// Element handle that was the body_root's immediate predecessor
     /// in `parent`'s child list at attach time. `None` if the body
     /// was the first child of parent. Stable across remounts unless
     /// the anchor itself is removed by some other code path.
-    pub anchor: Option<ElementHandle>,
+    pub anchor: Option<Element>,
 }
 
 /// Called by `view::append_child` after every successful attach.
@@ -208,7 +208,7 @@ pub(crate) struct MountSite {
 /// No-op if no mount is pending or the pending body_root doesn't
 /// match — in that case the pending entry is restored so a later
 /// matching attach can still claim it.
-pub fn on_component_root_attached(parent: ElementHandle, child: ElementHandle) {
+pub fn on_component_root_attached(parent: Element, child: Element) {
     let pending = PENDING_MOUNT.with(|cell| cell.take());
     let Some((mount_id, root)) = pending else {
         return;
@@ -256,11 +256,11 @@ pub fn __reset_pending_mount_for_tests() {
 /// re-invokes `body` in a new owner, removes the old body_root
 /// from its parent, and inserts the new body_root at the same slot
 /// (using the recorded anchor).
-pub fn mount_component_remountable<F>(fn_ptr: *const (), body: F) -> ElementHandle
+pub fn mount_component_remountable<F>(fn_ptr: *const (), body: F) -> Element
 where
-    F: Fn() -> ElementHandle + 'static,
+    F: Fn() -> Element + 'static,
 {
-    let body: Rc<dyn Fn() -> ElementHandle + 'static> = Rc::new(body);
+    let body: Rc<dyn Fn() -> Element + 'static> = Rc::new(body);
 
     // Initial mount: fresh owner, run body, capture root.
     let body_for_first = body.clone();
@@ -401,9 +401,9 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
 
     struct RemountInfo {
         mount_id: MountId,
-        parent: ElementHandle,
-        old_body_root: ElementHandle,
-        body: Rc<dyn Fn() -> ElementHandle + 'static>,
+        parent: Element,
+        old_body_root: Element,
+        body: Rc<dyn Fn() -> Element + 'static>,
         fn_ptr: *const (),
     }
 
@@ -427,7 +427,7 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
     }
 
     // 1. Snapshot each unique parent's child list.
-    let mut parent_snapshot: std::collections::HashMap<ElementHandle, Vec<ElementHandle>> =
+    let mut parent_snapshot: std::collections::HashMap<Element, Vec<Element>> =
         std::collections::HashMap::new();
     for info in &infos {
         parent_snapshot
@@ -442,10 +442,8 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
     //    no-op against Lynx — visible as "stale subtree still on
     //    screen" after hot reload. Doing the remove first keeps the
     //    handle live.
-    let mut by_parent: std::collections::HashMap<
-        ElementHandle,
-        Vec<(ElementHandle, Option<ElementHandle>)>,
-    > = std::collections::HashMap::new();
+    let mut by_parent: std::collections::HashMap<Element, Vec<(Element, Option<Element>)>> =
+        std::collections::HashMap::new();
     for info in &infos {
         crate::view::remove_child(info.parent, info.old_body_root);
         by_parent
@@ -456,13 +454,8 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
 
     // 3. Dispose old owners + run new bodies, collecting (mount_id,
     //    parent, old_root, new_root, new_owner).
-    let mut results: Vec<(
-        MountId,
-        ElementHandle,
-        ElementHandle,
-        ElementHandle,
-        OwnerId,
-    )> = Vec::with_capacity(infos.len());
+    let mut results: Vec<(MountId, Element, Element, Element, OwnerId)> =
+        Vec::with_capacity(infos.len());
     for info in infos {
         let old_owner = with_runtime(|rt| {
             let site = rt.mount_sites.get_mut(&info.mount_id)?;
@@ -515,14 +508,14 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
     //    step 2 — the live-handle requirement.)
     for (parent, pairs) in &by_parent {
         let snapshot = parent_snapshot.get(parent).cloned().unwrap_or_default();
-        let old_to_new: std::collections::HashMap<ElementHandle, ElementHandle> = pairs
+        let old_to_new: std::collections::HashMap<Element, Element> = pairs
             .iter()
             .filter_map(|(o, n)| n.map(|new_root| (*o, new_root)))
             .collect();
 
         // Desired final list = snapshot with each old replaced by its
         // matching new (leaving non-replaced siblings untouched).
-        let desired: Vec<ElementHandle> = snapshot
+        let desired: Vec<Element> = snapshot
             .iter()
             .map(|c| old_to_new.get(c).copied().unwrap_or(*c))
             .collect();
@@ -531,7 +524,7 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
         // order. Non-replaced siblings remain in place; inserting at
         // index `i` only shifts elements from `i` onwards by one slot,
         // which is exactly the semantics we want.
-        let new_set: std::collections::HashSet<ElementHandle> =
+        let new_set: std::collections::HashSet<Element> =
             pairs.iter().filter_map(|(_, n)| *n).collect();
         for (idx, child) in desired.iter().enumerate() {
             if new_set.contains(child) {

--- a/crates/whisker-runtime/src/reactive/runtime.rs
+++ b/crates/whisker-runtime/src/reactive/runtime.rs
@@ -139,7 +139,7 @@ pub struct Owner {
     /// `BridgeRenderer::elements` map from accumulating dangling
     /// `WhiskerElement*` pointers across `<Show>` flips, `<For>`
     /// item removals, and per-component remounts.
-    pub elements: Vec<crate::view::ElementHandle>,
+    pub elements: Vec<crate::view::Element>,
 }
 
 impl Owner {

--- a/crates/whisker-runtime/src/view/control_flow.rs
+++ b/crates/whisker-runtime/src/view/control_flow.rs
@@ -20,7 +20,7 @@ use std::rc::Rc;
 use crate::element::ElementTag;
 use crate::reactive::{create_owner, dispose_owner, effect, with_owner};
 
-use super::handle::ElementHandle;
+use super::handle::Element;
 use super::into_view::{IntoView, View};
 use super::renderer::create_element;
 
@@ -33,13 +33,13 @@ use super::renderer::create_element;
 /// instantiated, so state from the previous branch is not
 /// accidentally retained.
 ///
-/// Returns the wrapper [`ElementHandle`] — the parent attaches this
+/// Returns the wrapper [`Element`] — the parent attaches this
 /// once and the inner content swaps in place.
 pub fn show(
     when: impl Fn() -> bool + 'static,
     children: impl Fn() -> View + 'static,
     fallback: Option<Box<dyn Fn() -> View + 'static>>,
-) -> ElementHandle {
+) -> Element {
     let wrapper = create_element(ElementTag::View);
     // Track the currently-mounted owner so we can dispose it on the
     // next flip. `Rc<RefCell>` because the effect closure runs many
@@ -89,7 +89,7 @@ pub fn for_each<T, K, V, EachFn, KeyFn, ChildFn>(
     each: EachFn,
     key: KeyFn,
     children: ChildFn,
-) -> ElementHandle
+) -> Element
 where
     T: 'static,
     K: Eq + Hash + Clone + 'static,
@@ -108,7 +108,7 @@ where
     // re-attach in the new order during a reorder.
     struct Entry {
         owner: crate::reactive::OwnerId,
-        handles: Vec<ElementHandle>,
+        handles: Vec<Element>,
     }
     let entries: Rc<RefCell<HashMap<K, Entry>>> = Rc::new(RefCell::new(HashMap::new()));
 

--- a/crates/whisker-runtime/src/view/handle.rs
+++ b/crates/whisker-runtime/src/view/handle.rs
@@ -1,4 +1,4 @@
-//! [`ElementHandle`] — opaque, `Copy`, backend-agnostic identifier.
+//! [`Element`] — opaque, `Copy`, backend-agnostic identifier.
 //!
 //! IDs are allocated by the renderer's [`create_element`] call and
 //! are valid until [`release_element`] (or the renderer being
@@ -12,9 +12,9 @@
 /// Backend-agnostic element handle. `Copy` so it threads through
 /// reactive closures without lifetime gymnastics.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ElementHandle(pub(crate) u32);
+pub struct Element(pub(crate) u32);
 
-impl ElementHandle {
+impl Element {
     /// The numeric id this handle wraps. Mostly useful for renderers
     /// that store per-element state in side maps.
     pub fn id(self) -> u32 {

--- a/crates/whisker-runtime/src/view/into_view.rs
+++ b/crates/whisker-runtime/src/view/into_view.rs
@@ -1,7 +1,7 @@
 //! [`IntoView`] — uniform return type for components.
 //!
 //! A component fn returns `impl IntoView`. The renderer or parent
-//! component calls `.into_view()` to get either an [`ElementHandle`]
+//! component calls `.into_view()` to get either an [`Element`]
 //! (for "this is one element") or a `View` (for fragments, tuples,
 //! components nested inside `render!`).
 //!
@@ -10,7 +10,7 @@
 //! children, or a "marker" view (used by `Show`/`For` to mark
 //! reactive boundaries — Phase 6.5a A3 Step 4).
 
-use super::handle::ElementHandle;
+use super::handle::Element;
 
 /// A renderable. Components return `impl IntoView`; the renderer
 /// (called by the macro at mount time, or by the parent's
@@ -40,7 +40,7 @@ pub type Children = ::std::rc::Rc<dyn ::std::ops::Fn() -> View + 'static>;
 #[derive(Debug, Clone)]
 pub enum View {
     /// A single element handle the caller has already created.
-    Element(ElementHandle),
+    Element(Element),
     /// A text snippet — `materialize` creates a `raw_text` element
     /// with `text=<value>`. The `IntoView` impls for `&str` /
     /// `String` / primitive numeric types route through here so
@@ -64,13 +64,13 @@ impl View {
     /// returned list is what the `{expr}` macro path stashes so the
     /// next effect re-run can detach the previous children before
     /// attaching the new ones.
-    pub fn attach_to(self, parent: ElementHandle) -> Vec<ElementHandle> {
+    pub fn attach_to(self, parent: Element) -> Vec<Element> {
         let mut out = Vec::new();
         self.materialise_into(parent, &mut out);
         out
     }
 
-    fn materialise_into(self, parent: ElementHandle, out: &mut Vec<ElementHandle>) {
+    fn materialise_into(self, parent: Element, out: &mut Vec<Element>) {
         match self {
             View::Element(h) => {
                 super::append_child(parent, h);
@@ -95,13 +95,13 @@ impl View {
     /// contributes, in child-order. **Only `Element` and `Fragment`
     /// contribute.** `Text` returns nothing here because its element
     /// only exists once `attach_to` has run.
-    pub fn elements(&self) -> Vec<ElementHandle> {
+    pub fn elements(&self) -> Vec<Element> {
         let mut out = Vec::new();
         self.collect_into(&mut out);
         out
     }
 
-    fn collect_into(&self, out: &mut Vec<ElementHandle>) {
+    fn collect_into(&self, out: &mut Vec<Element>) {
         match self {
             View::Element(h) => out.push(*h),
             View::Fragment(children) => {
@@ -124,7 +124,7 @@ impl IntoView for View {
     }
 }
 
-impl IntoView for ElementHandle {
+impl IntoView for Element {
     fn into_view(self) -> View {
         View::Element(self)
     }

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -5,7 +5,7 @@
 //! but with two key differences:
 //!
 //! 1. **Type-erased handle**. The new system uses a single
-//!    [`ElementHandle`] (a `Copy` newtype around a `u32` ID) regardless
+//!    [`Element`] (a `Copy` newtype around a `u32` ID) regardless
 //!    of which backend is mounted. The renderer maps these IDs to
 //!    whatever concrete types it needs internally — `MockRenderer`
 //!    keeps a `HashMap<u32, MockOp>`, the production bridge maps each
@@ -31,7 +31,7 @@ pub mod renderer;
 mod tests;
 
 pub use control_flow::{for_each, show};
-pub use handle::ElementHandle;
+pub use handle::Element;
 pub use into_view::{Children, IntoView, View};
 #[doc(hidden)]
 pub use renderer::__reset_children_mirror_for_tests;

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -21,34 +21,34 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use super::handle::ElementHandle;
+use super::handle::Element;
 use crate::element::ElementTag;
 
 /// Object-safe renderer trait. The renderer owns whatever per-element
-/// state it needs and answers in `ElementHandle` IDs.
+/// state it needs and answers in `Element` IDs.
 ///
 /// Mirrors the shape of [`crate::renderer::Renderer`] but is
-/// type-erased — the handle type is always [`ElementHandle`]. Existing
+/// type-erased — the handle type is always [`Element`]. Existing
 /// `R: Renderer` implementations bridge into here via a small adapter
-/// that maintains its own `ElementHandle → R::ElementHandle` map.
+/// that maintains its own `Element → R::Element` map.
 pub trait DynRenderer {
-    fn create_element(&mut self, tag: ElementTag) -> ElementHandle;
-    fn release_element(&mut self, handle: ElementHandle);
+    fn create_element(&mut self, tag: ElementTag) -> Element;
+    fn release_element(&mut self, handle: Element);
 
-    fn set_attribute(&mut self, handle: ElementHandle, key: &str, value: &str);
-    fn set_inline_styles(&mut self, handle: ElementHandle, css: &str);
+    fn set_attribute(&mut self, handle: Element, key: &str, value: &str);
+    fn set_inline_styles(&mut self, handle: Element, css: &str);
 
-    fn append_child(&mut self, parent: ElementHandle, child: ElementHandle);
-    fn remove_child(&mut self, parent: ElementHandle, child: ElementHandle);
+    fn append_child(&mut self, parent: Element, child: Element);
+    fn remove_child(&mut self, parent: Element, child: Element);
 
     fn set_event_listener(
         &mut self,
-        handle: ElementHandle,
+        handle: Element,
         event_name: &str,
         callback: Box<dyn Fn() + 'static>,
     );
 
-    fn set_root(&mut self, page: ElementHandle);
+    fn set_root(&mut self, page: Element);
     fn flush(&mut self);
 }
 
@@ -72,7 +72,7 @@ thread_local! {
     /// effect: the mirror also enables `previous_sibling` /
     /// `next_sibling` queries for any future need (e.g. insert_after
     /// shimming when we ship the wrapper-less remount path).
-    static CHILDREN_OF: RefCell<HashMap<ElementHandle, Vec<ElementHandle>>> =
+    static CHILDREN_OF: RefCell<HashMap<Element, Vec<Element>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -130,8 +130,8 @@ fn with_renderer<R>(f: impl FnOnce(&mut dyn DynRenderer) -> R, default: R) -> R 
 // effects call.
 // ---------------------------------------------------------------------------
 
-pub fn create_element(tag: ElementTag) -> ElementHandle {
-    let handle = with_renderer(|r| r.create_element(tag), ElementHandle(u32::MAX));
+pub fn create_element(tag: ElementTag) -> Element {
+    let handle = with_renderer(|r| r.create_element(tag), Element(u32::MAX));
     // Track the freshly-created element in whichever reactive owner
     // is currently active. `dispose_owner` later releases everything
     // in this list via `release_element`. This is what stops
@@ -151,19 +151,19 @@ pub fn create_element(tag: ElementTag) -> ElementHandle {
     handle
 }
 
-pub fn release_element(handle: ElementHandle) {
+pub fn release_element(handle: Element) {
     with_renderer(|r| r.release_element(handle), ())
 }
 
-pub fn set_attribute(handle: ElementHandle, key: &str, value: &str) {
+pub fn set_attribute(handle: Element, key: &str, value: &str) {
     with_renderer(|r| r.set_attribute(handle, key, value), ())
 }
 
-pub fn set_inline_styles(handle: ElementHandle, css: &str) {
+pub fn set_inline_styles(handle: Element, css: &str) {
     with_renderer(|r| r.set_inline_styles(handle, css), ())
 }
 
-pub fn append_child(parent: ElementHandle, child: ElementHandle) {
+pub fn append_child(parent: Element, child: Element) {
     with_renderer(|r| r.append_child(parent, child), ());
     CHILDREN_OF.with_borrow_mut(|map| {
         map.entry(parent).or_default().push(child);
@@ -174,7 +174,7 @@ pub fn append_child(parent: ElementHandle, child: ElementHandle) {
     crate::reactive::on_component_root_attached(parent, child);
 }
 
-pub fn remove_child(parent: ElementHandle, child: ElementHandle) {
+pub fn remove_child(parent: Element, child: Element) {
     with_renderer(|r| r.remove_child(parent, child), ());
     CHILDREN_OF.with_borrow_mut(|map| {
         if let Some(children) = map.get_mut(&parent) {
@@ -193,8 +193,8 @@ pub fn remove_child(parent: ElementHandle, child: ElementHandle) {
 /// O(N) cost is fine for `<For>` reorders and #[component] remounts
 /// where N is the parent's current child count. Replace with a
 /// direct Lynx API once the bridge gains one.
-pub fn insert_child_at(parent: ElementHandle, child: ElementHandle, index: usize) {
-    let to_re_append: Vec<ElementHandle> = CHILDREN_OF.with_borrow(|map| {
+pub fn insert_child_at(parent: Element, child: Element, index: usize) {
+    let to_re_append: Vec<Element> = CHILDREN_OF.with_borrow(|map| {
         map.get(&parent)
             .map(|children| {
                 if index >= children.len() {
@@ -217,7 +217,7 @@ pub fn insert_child_at(parent: ElementHandle, child: ElementHandle, index: usize
 /// Return the element handle that appears immediately before `child`
 /// in `parent`'s child list, or `None` if `child` is the first child
 /// or `parent` has no recorded children.
-pub fn previous_sibling(parent: ElementHandle, child: ElementHandle) -> Option<ElementHandle> {
+pub fn previous_sibling(parent: Element, child: Element) -> Option<Element> {
     CHILDREN_OF.with_borrow(|map| {
         let children = map.get(&parent)?;
         let idx = children.iter().position(|c| *c == child)?;
@@ -232,7 +232,7 @@ pub fn previous_sibling(parent: ElementHandle, child: ElementHandle) -> Option<E
 /// Index of `child` in `parent`'s ordered child list, or `None` if
 /// not tracked. Used by the wrapper-less remount path to re-insert
 /// the new body root at the same position as the old one.
-pub fn child_index(parent: ElementHandle, child: ElementHandle) -> Option<usize> {
+pub fn child_index(parent: Element, child: Element) -> Option<usize> {
     CHILDREN_OF.with_borrow(|map| {
         let children = map.get(&parent)?;
         children.iter().position(|c| *c == child)
@@ -243,7 +243,7 @@ pub fn child_index(parent: ElementHandle, child: ElementHandle) -> Option<usize>
 /// the parent has no tracked children. Used by the batched
 /// `remount_components_for` so it can compute the final desired
 /// child order before any mutation churns the indices.
-pub fn children_of(parent: ElementHandle) -> Vec<ElementHandle> {
+pub fn children_of(parent: Element) -> Vec<Element> {
     CHILDREN_OF.with_borrow(|map| map.get(&parent).cloned().unwrap_or_default())
 }
 
@@ -255,15 +255,11 @@ pub fn __reset_children_mirror_for_tests() {
     CHILDREN_OF.with_borrow_mut(|map| map.clear());
 }
 
-pub fn set_event_listener(
-    handle: ElementHandle,
-    event_name: &str,
-    callback: Box<dyn Fn() + 'static>,
-) {
+pub fn set_event_listener(handle: Element, event_name: &str, callback: Box<dyn Fn() + 'static>) {
     with_renderer(|r| r.set_event_listener(handle, event_name, callback), ())
 }
 
-pub fn set_root(page: ElementHandle) {
+pub fn set_root(page: Element) {
     with_renderer(|r| r.set_root(page), ())
 }
 

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -35,52 +35,47 @@ impl RecordingRenderer {
 }
 
 impl DynRenderer for RecordingRenderer {
-    fn create_element(&mut self, tag: ElementTag) -> ElementHandle {
+    fn create_element(&mut self, tag: ElementTag) -> Element {
         let id = self.next_id;
         self.next_id += 1;
         self.ops.borrow_mut().push(Op::Create { id, tag });
-        ElementHandle::from_raw(id)
+        Element::from_raw(id)
     }
-    fn release_element(&mut self, h: ElementHandle) {
+    fn release_element(&mut self, h: Element) {
         self.ops.borrow_mut().push(Op::Release { id: h.id() });
     }
-    fn set_attribute(&mut self, h: ElementHandle, key: &str, value: &str) {
+    fn set_attribute(&mut self, h: Element, key: &str, value: &str) {
         self.ops.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: key.into(),
             value: value.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: ElementHandle, css: &str) {
+    fn set_inline_styles(&mut self, h: Element, css: &str) {
         self.ops.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, parent: ElementHandle, child: ElementHandle) {
+    fn append_child(&mut self, parent: Element, child: Element) {
         self.ops.borrow_mut().push(Op::Append {
             parent: parent.id(),
             child: child.id(),
         });
     }
-    fn remove_child(&mut self, parent: ElementHandle, child: ElementHandle) {
+    fn remove_child(&mut self, parent: Element, child: Element) {
         self.ops.borrow_mut().push(Op::Remove {
             parent: parent.id(),
             child: child.id(),
         });
     }
-    fn set_event_listener(
-        &mut self,
-        h: ElementHandle,
-        name: &str,
-        _callback: Box<dyn Fn() + 'static>,
-    ) {
+    fn set_event_listener(&mut self, h: Element, name: &str, _callback: Box<dyn Fn() + 'static>) {
         self.ops.borrow_mut().push(Op::Event {
             id: h.id(),
             name: name.into(),
         });
     }
-    fn set_root(&mut self, page: ElementHandle) {
+    fn set_root(&mut self, page: Element) {
         self.ops.borrow_mut().push(Op::SetRoot { id: page.id() });
     }
     fn flush(&mut self) {
@@ -146,7 +141,7 @@ fn install_returns_previous_renderer() {
 
 #[test]
 fn element_handle_into_view() {
-    let h = ElementHandle::from_raw(7);
+    let h = Element::from_raw(7);
     let v = h.into_view();
     match v {
         View::Element(e) => assert_eq!(e.id(), 7),
@@ -163,29 +158,26 @@ fn unit_into_empty() {
 
 #[test]
 fn option_some_and_none() {
-    let some_h = Some(ElementHandle::from_raw(3));
-    let none_h: Option<ElementHandle> = None;
-    assert_eq!(
-        some_h.into_view().elements(),
-        vec![ElementHandle::from_raw(3)]
-    );
-    assert_eq!(none_h.into_view().elements(), Vec::<ElementHandle>::new());
+    let some_h = Some(Element::from_raw(3));
+    let none_h: Option<Element> = None;
+    assert_eq!(some_h.into_view().elements(), vec![Element::from_raw(3)]);
+    assert_eq!(none_h.into_view().elements(), Vec::<Element>::new());
 }
 
 #[test]
 fn tuple_into_fragment_preserves_order() {
     let v = (
-        ElementHandle::from_raw(10),
-        ElementHandle::from_raw(20),
-        ElementHandle::from_raw(30),
+        Element::from_raw(10),
+        Element::from_raw(20),
+        Element::from_raw(30),
     )
         .into_view();
     assert_eq!(
         v.elements(),
         vec![
-            ElementHandle::from_raw(10),
-            ElementHandle::from_raw(20),
-            ElementHandle::from_raw(30),
+            Element::from_raw(10),
+            Element::from_raw(20),
+            Element::from_raw(30),
         ]
     );
 }
@@ -193,18 +185,18 @@ fn tuple_into_fragment_preserves_order() {
 #[test]
 fn nested_tuples_flatten_in_order() {
     let v = (
-        ElementHandle::from_raw(1),
-        (ElementHandle::from_raw(2), ElementHandle::from_raw(3)),
-        ElementHandle::from_raw(4),
+        Element::from_raw(1),
+        (Element::from_raw(2), Element::from_raw(3)),
+        Element::from_raw(4),
     )
         .into_view();
     assert_eq!(
         v.elements(),
         vec![
-            ElementHandle::from_raw(1),
-            ElementHandle::from_raw(2),
-            ElementHandle::from_raw(3),
-            ElementHandle::from_raw(4),
+            Element::from_raw(1),
+            Element::from_raw(2),
+            Element::from_raw(3),
+            Element::from_raw(4),
         ]
     );
 }
@@ -215,10 +207,10 @@ fn view_attach_appends_each_leaf() {
     with_installed_renderer(Box::new(renderer), || {
         let parent = create_element(ElementTag::View);
         let frag = View::Fragment(vec![
-            View::Element(ElementHandle::from_raw(100)),
-            View::Element(ElementHandle::from_raw(200)),
+            View::Element(Element::from_raw(100)),
+            View::Element(Element::from_raw(200)),
             View::Empty,
-            View::Element(ElementHandle::from_raw(300)),
+            View::Element(Element::from_raw(300)),
         ]);
         frag.attach_to(parent);
     });

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -80,8 +80,7 @@ pub mod __tags {
     use crate::ElementTag;
     use whisker_runtime::reactive::effect;
     use whisker_runtime::view::{
-        append_child, create_element, set_attribute, set_event_listener, set_inline_styles,
-        ElementHandle,
+        append_child, create_element, set_attribute, set_event_listener, set_inline_styles, Element,
     };
 
     // Each built-in tag is a struct + a hand-written inherent
@@ -101,7 +100,7 @@ pub mod __tags {
     /// direction) and a single content subtree.
     #[allow(non_camel_case_types)]
     pub struct page {
-        handle: ElementHandle,
+        handle: Element,
     }
     #[allow(non_snake_case)]
     pub fn __page_ctor() -> page {
@@ -152,13 +151,13 @@ pub mod __tags {
             self
         }
         /// Append a child handle.
-        pub fn child(self, child: ElementHandle) -> Self {
+        pub fn child(self, child: Element) -> Self {
             append_child(self.handle, child);
             self
         }
         /// Finish building and return the underlying handle.
         #[allow(non_snake_case)]
-        pub fn __h(self) -> ElementHandle {
+        pub fn __h(self) -> Element {
             self.handle
         }
     }
@@ -169,7 +168,7 @@ pub mod __tags {
     /// React Native or `<div>` in the web.
     #[allow(non_camel_case_types)]
     pub struct view {
-        handle: ElementHandle,
+        handle: Element,
     }
     #[allow(non_snake_case)]
     pub fn __view_ctor() -> view {
@@ -220,13 +219,13 @@ pub mod __tags {
             self
         }
         /// Append a child handle.
-        pub fn child(self, child: ElementHandle) -> Self {
+        pub fn child(self, child: Element) -> Self {
             append_child(self.handle, child);
             self
         }
         /// Finish building and return the underlying handle.
         #[allow(non_snake_case)]
-        pub fn __h(self) -> ElementHandle {
+        pub fn __h(self) -> Element {
             self.handle
         }
     }
@@ -236,7 +235,7 @@ pub mod __tags {
     /// string-literal children.
     #[allow(non_camel_case_types)]
     pub struct text {
-        handle: ElementHandle,
+        handle: Element,
     }
     #[allow(non_snake_case)]
     pub fn __text_ctor() -> text {
@@ -280,7 +279,7 @@ pub mod __tags {
             effect(move || set_attribute(h, name, &f().to_string()));
             self
         }
-        pub fn child(self, child: ElementHandle) -> Self {
+        pub fn child(self, child: Element) -> Self {
             append_child(self.handle, child);
             self
         }
@@ -303,7 +302,7 @@ pub mod __tags {
             self
         }
         #[allow(non_snake_case)]
-        pub fn __h(self) -> ElementHandle {
+        pub fn __h(self) -> Element {
             self.handle
         }
     }
@@ -313,7 +312,7 @@ pub mod __tags {
     /// string-literal children of `text` / `view`.
     #[allow(non_camel_case_types)]
     pub struct raw_text {
-        handle: ElementHandle,
+        handle: Element,
     }
     #[allow(non_snake_case)]
     pub fn __raw_text_ctor() -> raw_text {
@@ -357,12 +356,12 @@ pub mod __tags {
             effect(move || set_attribute(h, name, &f().to_string()));
             self
         }
-        pub fn child(self, child: ElementHandle) -> Self {
+        pub fn child(self, child: Element) -> Self {
             append_child(self.handle, child);
             self
         }
         #[allow(non_snake_case)]
-        pub fn __h(self) -> ElementHandle {
+        pub fn __h(self) -> Element {
             self.handle
         }
 
@@ -382,7 +381,7 @@ pub mod __tags {
     /// optionally `style=` for sizing.
     #[allow(non_camel_case_types)]
     pub struct image {
-        handle: ElementHandle,
+        handle: Element,
     }
     #[allow(non_snake_case)]
     pub fn __image_ctor() -> image {
@@ -426,12 +425,12 @@ pub mod __tags {
             effect(move || set_attribute(h, name, &f().to_string()));
             self
         }
-        pub fn child(self, child: ElementHandle) -> Self {
+        pub fn child(self, child: Element) -> Self {
             append_child(self.handle, child);
             self
         }
         #[allow(non_snake_case)]
-        pub fn __h(self) -> ElementHandle {
+        pub fn __h(self) -> Element {
             self.handle
         }
 
@@ -451,7 +450,7 @@ pub mod __tags {
     /// `scroll_orientation=` to `"vertical"` or `"horizontal"`.
     #[allow(non_camel_case_types)]
     pub struct scroll_view {
-        handle: ElementHandle,
+        handle: Element,
     }
     #[allow(non_snake_case)]
     pub fn __scroll_view_ctor() -> scroll_view {
@@ -495,12 +494,12 @@ pub mod __tags {
             effect(move || set_attribute(h, name, &f().to_string()));
             self
         }
-        pub fn child(self, child: ElementHandle) -> Self {
+        pub fn child(self, child: Element) -> Self {
             append_child(self.handle, child);
             self
         }
         #[allow(non_snake_case)]
-        pub fn __h(self) -> ElementHandle {
+        pub fn __h(self) -> Element {
             self.handle
         }
 
@@ -553,11 +552,11 @@ pub mod __main_runtime {
     ///   screen keeps showing pre-edit content.
     /// - **off** (release): body collapses to `f()`, `subsecond` is
     ///   not pulled in at all.
-    use whisker_runtime::view::ElementHandle;
+    use whisker_runtime::view::Element;
 
     #[cfg(feature = "hot-reload")]
     #[inline(always)]
-    pub fn call_user_app(f: fn() -> ElementHandle) -> ElementHandle {
+    pub fn call_user_app(f: fn() -> Element) -> Element {
         // `move` is load-bearing: without it, `|| f()` captures `f` by
         // *reference* (the body only reads `f`, and `f`'s `Copy`-ness is
         // not enough to flip Rust to by-value capture). Subsecond's
@@ -572,7 +571,7 @@ pub mod __main_runtime {
 
     #[cfg(not(feature = "hot-reload"))]
     #[inline(always)]
-    pub fn call_user_app(f: fn() -> ElementHandle) -> ElementHandle {
+    pub fn call_user_app(f: fn() -> Element) -> Element {
         f()
     }
 }

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -20,9 +20,7 @@ use whisker::prelude::*;
 use whisker::runtime::reactive::{
     __reset_for_tests, __reset_pending_mount_for_tests, create_owner,
 };
-use whisker::runtime::view::{
-    install_renderer, uninstall_renderer, DynRenderer, ElementHandle, View,
-};
+use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element, View};
 use whisker::with_owner;
 
 // ----- Recording renderer ----------------------------------------------------
@@ -42,36 +40,35 @@ struct Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> ElementHandle {
+    fn create_element(&mut self, tag: ElementTag) -> Element {
         let id = self.next;
         self.next += 1;
         self.log.borrow_mut().push(Op::Create { id, tag });
-        ElementHandle::from_raw(id)
+        Element::from_raw(id)
     }
-    fn release_element(&mut self, _h: ElementHandle) {}
-    fn set_attribute(&mut self, h: ElementHandle, k: &str, v: &str) {
+    fn release_element(&mut self, _h: Element) {}
+    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: ElementHandle, css: &str) {
+    fn set_inline_styles(&mut self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: ElementHandle, c: ElementHandle) {
+    fn append_child(&mut self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, _p: ElementHandle, _c: ElementHandle) {}
-    fn set_event_listener(&mut self, _h: ElementHandle, _name: &str, _cb: Box<dyn Fn() + 'static>) {
-    }
-    fn set_root(&mut self, _p: ElementHandle) {}
+    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn set_event_listener(&mut self, _h: Element, _name: &str, _cb: Box<dyn Fn() + 'static>) {}
+    fn set_root(&mut self, _p: Element) {}
     fn flush(&mut self) {}
 }
 
@@ -110,25 +107,25 @@ fn push_capture(s: impl Into<String>) {
 // ----- Test components -------------------------------------------------------
 
 #[component]
-fn no_props_component() -> ElementHandle {
+fn no_props_component() -> Element {
     push_capture("no_props_component:invoked");
     render! { view() }
 }
 
 #[component]
-fn one_string_prop(label: String) -> ElementHandle {
+fn one_string_prop(label: String) -> Element {
     push_capture(format!("one_string_prop:label={label}"));
     render! { view() }
 }
 
 #[component]
-fn two_props(title: String, count: i32) -> ElementHandle {
+fn two_props(title: String, count: i32) -> Element {
     push_capture(format!("two_props:title={title},count={count}"));
     render! { view() }
 }
 
 #[component]
-fn option_prop(alt: Option<String>) -> ElementHandle {
+fn option_prop(alt: Option<String>) -> Element {
     // `.as_deref()` borrows the inner str so the FnMut closure
     // surrounding this body can be invoked more than once (per-
     // component remount). Calling `.unwrap_or_else(...)` directly
@@ -142,13 +139,13 @@ fn option_prop(alt: Option<String>) -> ElementHandle {
 }
 
 #[component]
-fn with_default_prop(#[prop(default = 5)] count: i32) -> ElementHandle {
+fn with_default_prop(#[prop(default = 5)] count: i32) -> Element {
     push_capture(format!("with_default_prop:count={count}"));
     render! { view() }
 }
 
 #[component]
-fn with_children(label: String, children: Children) -> ElementHandle {
+fn with_children(label: String, children: Children) -> Element {
     push_capture(format!("with_children:label={label}"));
     // Materialise the children imperatively. We can't write the
     // ergonomic `view { {children()} }` here because `render!`'s
@@ -166,7 +163,7 @@ fn with_children(label: String, children: Children) -> ElementHandle {
 }
 
 #[component]
-fn generic_label<T: std::fmt::Display + Clone + 'static>(value: T) -> ElementHandle {
+fn generic_label<T: std::fmt::Display + Clone + 'static>(value: T) -> Element {
     push_capture(format!("generic_label:value={value}"));
     render! { view() }
 }

--- a/crates/whisker/tests/component_macro.rs
+++ b/crates/whisker/tests/component_macro.rs
@@ -2,7 +2,7 @@
 //!
 //! Originally tested `#[component]` decorated functions with various
 //! return types. After the True per-component remount change
-//! (`#[component]` now always returns `ElementHandle` via the
+//! (`#[component]` now always returns `Element` via the
 //! remountable mount path), this file exercises the underlying
 //! `mount_component` API directly to verify owner cascade /
 //! cleanup semantics that the proc-macro is built on. The macro's
@@ -17,7 +17,7 @@ use whisker::runtime::reactive::{
 };
 
 // Stable fn pointers for the tests. Using these instead of
-// component fns since the macro now forces an `ElementHandle`
+// component fns since the macro now forces an `Element`
 // return type and the owner-mechanic tests don't render anything.
 fn dummy_outer() {}
 fn dummy_inner() {}

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -24,7 +24,7 @@ use whisker::runtime::reactive::{
 };
 use whisker::runtime::view::{
     __reset_children_mirror_for_tests, append_child, create_element, install_renderer,
-    uninstall_renderer, DynRenderer, ElementHandle,
+    uninstall_renderer, DynRenderer, Element,
 };
 use whisker::{flush, ElementTag};
 
@@ -54,47 +54,47 @@ impl Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> ElementHandle {
+    fn create_element(&mut self, tag: ElementTag) -> Element {
         let id = self.next;
         self.next += 1;
         self.log.borrow_mut().push(Op::Create { id, tag });
-        ElementHandle::from_raw(id)
+        Element::from_raw(id)
     }
-    fn release_element(&mut self, h: ElementHandle) {
+    fn release_element(&mut self, h: Element) {
         self.log.borrow_mut().push(Op::Release { id: h.id() });
     }
-    fn set_attribute(&mut self, h: ElementHandle, k: &str, v: &str) {
+    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: ElementHandle, css: &str) {
+    fn set_inline_styles(&mut self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: ElementHandle, c: ElementHandle) {
+    fn append_child(&mut self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, p: ElementHandle, c: ElementHandle) {
+    fn remove_child(&mut self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Remove {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn set_event_listener(&mut self, h: ElementHandle, name: &str, _cb: Box<dyn Fn() + 'static>) {
+    fn set_event_listener(&mut self, h: Element, name: &str, _cb: Box<dyn Fn() + 'static>) {
         self.log.borrow_mut().push(Op::Event {
             id: h.id(),
             name: name.into(),
         });
     }
-    fn set_root(&mut self, _p: ElementHandle) {}
+    fn set_root(&mut self, _p: Element) {}
     fn flush(&mut self) {}
 }
 
@@ -123,7 +123,7 @@ fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
 // ----------------------------------------------------------------------------
 
 #[component]
-fn leaf(label: &'static str) -> ElementHandle {
+fn leaf(label: &'static str) -> Element {
     render! {
         view {
             text(value: label)
@@ -136,7 +136,7 @@ fn leaf(label: &'static str) -> ElementHandle {
 /// `render!` would have appended the component to in real code; the
 /// MountSite's `parent` / `anchor` get bound the moment we
 /// `append_child` here.
-fn mount_under_test_parent(make: impl FnOnce() -> ElementHandle) -> (ElementHandle, ElementHandle) {
+fn mount_under_test_parent(make: impl FnOnce() -> Element) -> (Element, Element) {
     let parent = create_element(ElementTag::View);
     let root = make();
     append_child(parent, root);
@@ -327,7 +327,7 @@ fn nested_component_mount_sites_cleared_on_parent_remount() {
     use whisker::runtime::reactive::owners_for_fn;
 
     #[component]
-    fn inner() -> ElementHandle {
+    fn inner() -> Element {
         render! {
             view {
                 text(value: "x")
@@ -336,7 +336,7 @@ fn nested_component_mount_sites_cleared_on_parent_remount() {
     }
 
     #[component]
-    fn outer() -> ElementHandle {
+    fn outer() -> Element {
         render! {
             view {
                 inner()
@@ -386,7 +386,7 @@ fn batch_with_parent_and_child_skips_descendant() {
     use whisker::runtime::reactive::owners_for_fn;
 
     #[component]
-    fn child() -> ElementHandle {
+    fn child() -> Element {
         render! {
             view {
                 text(value: "c")
@@ -395,7 +395,7 @@ fn batch_with_parent_and_child_skips_descendant() {
     }
 
     #[component]
-    fn parent_of_child() -> ElementHandle {
+    fn parent_of_child() -> Element {
         render! {
             view {
                 child()
@@ -456,7 +456,7 @@ fn remount_preserves_signal_held_above_in_context() {
     }
 
     #[component]
-    fn inner_screen() -> ElementHandle {
+    fn inner_screen() -> Element {
         let state = use_context::<AppState>().unwrap();
         let local = signal(99_i32);
         render! {

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, create_owner, dispose_owner};
-use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, ElementHandle};
+use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
 use whisker::{flush, with_owner};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,40 +38,40 @@ impl Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> ElementHandle {
+    fn create_element(&mut self, tag: ElementTag) -> Element {
         let id = self.next;
         self.next += 1;
         self.log.borrow_mut().push(Op::Create { id, tag });
-        ElementHandle::from_raw(id)
+        Element::from_raw(id)
     }
-    fn release_element(&mut self, _h: ElementHandle) {}
-    fn set_attribute(&mut self, h: ElementHandle, k: &str, v: &str) {
+    fn release_element(&mut self, _h: Element) {}
+    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: ElementHandle, css: &str) {
+    fn set_inline_styles(&mut self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: ElementHandle, c: ElementHandle) {
+    fn append_child(&mut self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, _p: ElementHandle, _c: ElementHandle) {}
-    fn set_event_listener(&mut self, h: ElementHandle, name: &str, _cb: Box<dyn Fn() + 'static>) {
+    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn set_event_listener(&mut self, h: Element, name: &str, _cb: Box<dyn Fn() + 'static>) {
         self.log.borrow_mut().push(Op::Event {
             id: h.id(),
             name: name.into(),
         });
     }
-    fn set_root(&mut self, _p: ElementHandle) {}
+    fn set_root(&mut self, _p: Element) {}
     fn flush(&mut self) {}
 }
 

--- a/docs/reactivity-design.md
+++ b/docs/reactivity-design.md
@@ -335,12 +335,12 @@ scoped to one list and keyed (= efficient).
 
 ```rust
 pub trait IntoView {
-    fn into_element(self) -> ElementHandle;
+    fn into_element(self) -> Element;
 }
 ```
 
 Implementations:
-- `ElementHandle` — identity
+- `Element` — identity
 - `()` — empty fragment
 - `(A, B, C, …)` tuples — fragment of children
 - `Option<T: IntoView>` — empty when `None`
@@ -399,20 +399,20 @@ order are preserved.
 
 ### Macro-emitted body shape
 
-`#[component]` wraps the user body in a `Box<dyn Fn() -> ElementHandle>`,
+`#[component]` wraps the user body in a `Box<dyn Fn() -> Element>`,
 capturing props by move into a factory scope and re-cloning them on
 each body invocation:
 
 ```rust
 // User writes:
 #[component]
-fn screen(name: String, count: ReadSignal<i32>) -> ElementHandle { … }
+fn screen(name: String, count: ReadSignal<i32>) -> Element { … }
 
 // Macro emits (roughly):
-fn screen(name: String, count: ReadSignal<i32>) -> ElementHandle {
+fn screen(name: String, count: ReadSignal<i32>) -> Element {
     let __whisker_prop_name = name;
     let __whisker_prop_count = count;
-    let __body: Box<dyn Fn() -> ElementHandle + 'static> = Box::new(move || {
+    let __body: Box<dyn Fn() -> Element + 'static> = Box::new(move || {
         let name  = Clone::clone(&__whisker_prop_name);
         let count = Clone::clone(&__whisker_prop_count);
         // user body
@@ -463,7 +463,7 @@ because the blast radius is scoped to one component subtree.
 - `crates/whisker-runtime/src/render.rs` — **rewrite** as the renderer
   that walks `IntoView` and wires effects to FiberElement handles.
 - `crates/whisker-runtime/src/element.rs` — `Element` value-tree type
-  becomes internal-only; `ElementHandle` (the FiberElement-wrapping
+  becomes internal-only; `Element` (the FiberElement-wrapping
   Copy handle) is the new public type returned from `into_element`.
 - `crates/whisker-macros/src/rsx.rs` — **rewrite** as `render.rs` (new
   macro name).

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -181,7 +181,7 @@ closures**. When you want to pass a derived value, build it with
 
 ```rust
 #[component]
-fn display(value: ReadSignal<i32>) -> ElementHandle {
+fn display(value: ReadSignal<i32>) -> Element {
     render! { text { {format!("{}", value.get())} } }
 }
 
@@ -210,10 +210,10 @@ C).
 
 ```rust
 use whisker::prelude::*;
-use whisker::runtime::view::ElementHandle;
+use whisker::runtime::view::Element;
 
 #[component]
-fn counter(initial: i32) -> ElementHandle {
+fn counter(initial: i32) -> Element {
     let count = RwSignal::new(initial);
 
     effect(move || log::info!("count is {}", count.get()));
@@ -243,7 +243,7 @@ calls.
 
 ```rust
 #[component]
-fn greeting(name: String, count: ReadSignal<i32>) -> ElementHandle {
+fn greeting(name: String, count: ReadSignal<i32>) -> Element {
     render! {
         text { "Hello, " {name.clone()} " ×" {count.get()} }
     }
@@ -276,7 +276,7 @@ fn badge(
     label: String,
     color: Option<String>,                  // omittable, or pass &str
     #[prop(default = 12)] padding: i32,     // omittable; default 12
-) -> ElementHandle { /* … */ }
+) -> Element { /* … */ }
 
 render! { badge(label: "new") }                          // both defaults
 render! { badge(label: "new", color: "red", padding: 8) }
@@ -290,7 +290,7 @@ call's `{…}` block:
 
 ```rust
 #[component]
-fn card(title: String, children: Children) -> ElementHandle {
+fn card(title: String, children: Children) -> Element {
     render! {
         view {
             text { {title.clone()} }
@@ -314,7 +314,7 @@ must implement `Clone` (or `Copy`, which implies it).
 
 ```rust
 #[component]
-fn user_card(user: User, badges: Vec<Badge>) -> ElementHandle { /* ... */ }
+fn user_card(user: User, badges: Vec<Badge>) -> Element { /* ... */ }
 
 #[derive(Clone)]                    // ← required
 struct User { name: String, id: u64 }
@@ -353,7 +353,7 @@ want to put in a prop is already `Clone`:
 ```rust
 // `Box<dyn Fn() + 'static>` is not Clone, but Rc<dyn Fn() + 'static> is.
 #[component]
-fn button(label: &'static str, on_click: Rc<dyn Fn() + 'static>) -> ElementHandle {
+fn button(label: &'static str, on_click: Rc<dyn Fn() + 'static>) -> Element {
     render! {
         view(on_tap: move || on_click()) {
             text { {label} }
@@ -397,13 +397,13 @@ Pass values down through the owner tree without prop-drilling:
 
 ```rust
 #[component]
-fn app() -> ElementHandle {
+fn app() -> Element {
     provide_context(Theme::Dark);
     render! { my_inner_component() }
 }
 
 #[component]
-fn my_inner_component() -> ElementHandle {
+fn my_inner_component() -> Element {
     let theme = use_context::<Theme>().unwrap_or(Theme::Light);
     /* ... */
 }
@@ -489,7 +489,7 @@ is cheap:
 
 ```rust
 #[component]
-fn parent() -> ElementHandle {
+fn parent() -> Element {
     let count = RwSignal::new(0);
     render! {
         view {
@@ -500,12 +500,12 @@ fn parent() -> ElementHandle {
 }
 
 #[component]
-fn display(count: RwSignal<i32>) -> ElementHandle {
+fn display(count: RwSignal<i32>) -> Element {
     render! { text { {count.get()} } }
 }
 
 #[component]
-fn controls(count: RwSignal<i32>) -> ElementHandle {
+fn controls(count: RwSignal<i32>) -> Element {
     render! {
         view(on_tap: move || count.update(|n| *n += 1)) {
             text { "+1" }
@@ -527,7 +527,7 @@ struct AppState {
 }
 
 #[component]
-fn app() -> ElementHandle {
+fn app() -> Element {
     provide_context(AppState {
         count: RwSignal::new(0),
         theme: RwSignal::new(Theme::Dark),
@@ -536,7 +536,7 @@ fn app() -> ElementHandle {
 }
 
 #[component]
-fn some_deep_descendant() -> ElementHandle {
+fn some_deep_descendant() -> Element {
     let state = use_context::<AppState>().unwrap();
     render! { text { {state.count.get()} } }
 }

--- a/docs/render-macro.md
+++ b/docs/render-macro.md
@@ -21,7 +21,7 @@ render! {
 }
 ```
 
-The macro returns an `ElementHandle` — the root of the produced
+The macro returns an `Element` — the root of the produced
 tree. For component invocations and `{expr}` it returns whatever
 the inner code returns.
 
@@ -133,7 +133,7 @@ text {
 
 ```rust
 view {
-    {header()}         // ElementHandle: insert as child
+    {header()}         // Element: insert as child
     {count.get()}      // i32: render as text
     {name.clone()}     // String: render as text
     {tuple_of_three}   // (A, B, C): each child inserted in order
@@ -147,7 +147,7 @@ it lives inside `{…}` (never inside `(…)` which is for kwargs).
 The expression is dispatched through `IntoView`. Built-in impls
 cover:
 
-- `ElementHandle` — attached as a child.
+- `Element` — attached as a child.
 - `View` — attached as-is (Element / Fragment / Text / Empty).
 - `&str`, `String`, `&String` — rendered as a `raw_text` element.
 - All numeric primitives + `bool` / `char` — same, via `Display`.

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -9,7 +9,7 @@ description = "Minimal Whisker counter — canonical Phase 6.5a render! / signal
 # and the macro expansion behaves as documented. Mobile deployment
 # (the `whisker_app_main` FFI path) wires up only once Step 5b
 # rebuilds the production bootstrap against the new `render!` /
-# `ElementHandle` return type — see #11.
+# `Element` return type — see #11.
 [lib]
 crate-type = ["rlib"]
 

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -47,7 +47,7 @@ pub struct AppState {
 /// - `Show` toggles a celebratory message in/out depending on a
 ///   memo that derives from the same signal.
 #[component]
-pub fn counter(state: AppState) -> whisker::runtime::view::ElementHandle {
+pub fn counter(state: AppState) -> whisker::runtime::view::Element {
     let big_enough = memo(move || state.count.get() > 10);
 
     render! {
@@ -91,7 +91,7 @@ pub fn counter(state: AppState) -> whisker::runtime::view::ElementHandle {
 /// Mount the root component. Creates the shared state and invokes
 /// the counter component. The returned handle is what a host would
 /// hand to `set_root(...)` once deployed.
-pub fn render_app() -> whisker::runtime::view::ElementHandle {
+pub fn render_app() -> whisker::runtime::view::Element {
     let state = AppState {
         count: RwSignal::new(0),
     };

--- a/examples/counter/tests/counter_renders.rs
+++ b/examples/counter/tests/counter_renders.rs
@@ -4,7 +4,7 @@
 //!
 //! This is the closest thing to "the example actually runs" until
 //! Step 5b of #11 wires the production bootstrap onto the new
-//! `render!` / `ElementHandle` surface. Until then this test is the
+//! `render!` / `Element` surface. Until then this test is the
 //! end-to-end validation that the new reactive layer composes
 //! correctly for a user-style codebase.
 
@@ -15,7 +15,7 @@ use counter::{counter, AppState, CounterProps};
 use whisker::flush;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, create_owner, with_owner};
-use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, ElementHandle};
+use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
@@ -41,40 +41,40 @@ impl Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> ElementHandle {
+    fn create_element(&mut self, tag: ElementTag) -> Element {
         let id = self.next;
         self.next += 1;
         self.log.borrow_mut().push(Op::Create { id, tag });
-        ElementHandle::from_raw(id)
+        Element::from_raw(id)
     }
-    fn release_element(&mut self, _h: ElementHandle) {}
-    fn set_attribute(&mut self, h: ElementHandle, k: &str, v: &str) {
+    fn release_element(&mut self, _h: Element) {}
+    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: ElementHandle, css: &str) {
+    fn set_inline_styles(&mut self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: ElementHandle, c: ElementHandle) {
+    fn append_child(&mut self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, _p: ElementHandle, _c: ElementHandle) {}
-    fn set_event_listener(&mut self, h: ElementHandle, name: &str, _cb: Box<dyn Fn() + 'static>) {
+    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn set_event_listener(&mut self, h: Element, name: &str, _cb: Box<dyn Fn() + 'static>) {
         self.log.borrow_mut().push(Op::Event {
             id: h.id(),
             name: name.into(),
         });
     }
-    fn set_root(&mut self, _p: ElementHandle) {}
+    fn set_root(&mut self, _p: Element) {}
     fn flush(&mut self) {}
 }
 

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! Exercises a wide slice of the Whisker surface:
 //!
-//! - `#[whisker::main]` returning `ElementHandle`.
+//! - `#[whisker::main]` returning `Element`.
 //! - `RwSignal<T>` shared by passing a `Copy` `AppState` through
 //!   the component tree.
 //! - `render!` with `text(value: …)` kwargs, `style:` and other
@@ -29,7 +29,7 @@
 //!   shadows, `position: absolute`.
 
 use whisker::prelude::*;
-use whisker::runtime::view::ElementHandle;
+use whisker::runtime::view::Element;
 
 // ---- App state --------------------------------------------------------------
 
@@ -71,12 +71,7 @@ const ACCENT_2: &str = "#ff5e9b";
 // ---- Building blocks --------------------------------------------------------
 
 #[component]
-fn art_tile(
-    c1: &'static str,
-    c2: &'static str,
-    w: &'static str,
-    radius: &'static str,
-) -> ElementHandle {
+fn art_tile(c1: &'static str, c2: &'static str, w: &'static str, radius: &'static str) -> Element {
     let style = format!(
         "width: {w}; aspect-ratio: 1; border-radius: {radius}; \
          background-image: linear-gradient(135deg, {c1} 0%, {c2} 100%);"
@@ -87,7 +82,7 @@ fn art_tile(
 }
 
 #[component]
-fn chip(label: &'static str, accented: bool) -> ElementHandle {
+fn chip(label: &'static str, accented: bool) -> Element {
     let (bg, fg) = if accented {
         (ACCENT, TEXT_PRIMARY)
     } else {
@@ -104,7 +99,7 @@ fn chip(label: &'static str, accented: bool) -> ElementHandle {
 }
 
 #[component]
-fn section_header(title: &'static str) -> ElementHandle {
+fn section_header(title: &'static str) -> Element {
     render! {
         view {
             text(
@@ -125,7 +120,7 @@ fn recent_card(
     sub: &'static str,
     c1: &'static str,
     c2: &'static str,
-) -> ElementHandle {
+) -> Element {
     let title_style =
         format!("font-size: 14px; font-weight: 600; color: {TEXT_PRIMARY}; margin-top: 8px;");
     let sub_style = format!("font-size: 12px; color: {TEXT_SECONDARY}; margin-top: 2px;");
@@ -145,7 +140,7 @@ fn grid_tile(
     c1: &'static str,
     c2: &'static str,
     state: AppState,
-) -> ElementHandle {
+) -> Element {
     let bitmask = state.liked_mixes;
     let liked_bit = 1u8 << index;
     let on_heart = move || bitmask.update(|b| *b ^= liked_bit);
@@ -197,7 +192,7 @@ fn activity_row(
     title: &'static str,
     sub: &'static str,
     when: &'static str,
-) -> ElementHandle {
+) -> Element {
     let avatar_style = format!(
         "width: 44px; height: 44px; border-radius: 22px; \
          background-image: linear-gradient(135deg, {c1} 0%, {c2} 100%); \
@@ -227,12 +222,7 @@ fn activity_row(
 }
 
 #[component]
-fn tab_item(
-    index: usize,
-    label: &'static str,
-    glyph: &'static str,
-    state: AppState,
-) -> ElementHandle {
+fn tab_item(index: usize, label: &'static str, glyph: &'static str, state: AppState) -> Element {
     let tab = state.selected_tab;
     let on_pick = move || tab.set(index);
     let glyph_style = move || {
@@ -262,7 +252,7 @@ fn tab_item(
 }
 
 #[component]
-fn tab_bar(state: AppState) -> ElementHandle {
+fn tab_bar(state: AppState) -> Element {
     let style = format!(
         "position: absolute; left: 0; right: 0; bottom: 0; \
          display: flex; flex-direction: row; justify-content: space-around; \
@@ -281,7 +271,7 @@ fn tab_bar(state: AppState) -> ElementHandle {
 }
 
 #[component]
-fn now_playing(state: AppState) -> ElementHandle {
+fn now_playing(state: AppState) -> Element {
     let playing = state.is_playing;
     let toggle = move || playing.update(|p| *p = !*p);
     let glyph = move || if playing.get() { "▌▌" } else { "▶" };
@@ -318,7 +308,7 @@ fn now_playing(state: AppState) -> ElementHandle {
 }
 
 #[component]
-fn header() -> ElementHandle {
+fn header() -> Element {
     let bg_style = format!(
         "width: 100%; padding: 60px 20px 18px; \
          background-image: linear-gradient(180deg, #2c1860 0%, {BG} 100%); \
@@ -356,7 +346,7 @@ fn header() -> ElementHandle {
 }
 
 #[component]
-fn chips() -> ElementHandle {
+fn chips() -> Element {
     render! {
         view(style: "display: flex; flex-direction: row; padding: 0 20px 8px; flex-wrap: nowrap;") {
             chip(label: "All",        accented: true)
@@ -368,7 +358,7 @@ fn chips() -> ElementHandle {
 }
 
 #[component]
-fn recents() -> ElementHandle {
+fn recents() -> Element {
     render! {
         scroll_view(
             scroll_orientation: "horizontal",
@@ -384,7 +374,7 @@ fn recents() -> ElementHandle {
 }
 
 #[component]
-fn featured() -> ElementHandle {
+fn featured() -> Element {
     let cap = format!(
         "font-size: 12px; color: {TEXT_SECONDARY}; \
          text-transform: uppercase; letter-spacing: 1.5px;"
@@ -406,7 +396,7 @@ fn featured() -> ElementHandle {
 }
 
 #[component]
-fn grid(state: AppState) -> ElementHandle {
+fn grid(state: AppState) -> Element {
     render! {
         view(style: "padding: 4px 20px 0; display: flex; flex-direction: row; \
                      flex-wrap: wrap; justify-content: space-between;") {
@@ -421,7 +411,7 @@ fn grid(state: AppState) -> ElementHandle {
 }
 
 #[component]
-fn activity_feed() -> ElementHandle {
+fn activity_feed() -> Element {
     render! {
         view(style: "display: flex; flex-direction: column; padding: 0 0 8px;") {
             activity_row(initial: "A", c1: "#ff7e5f", c2: "#feb47b", title: "Alice", sub: "Started following you",            when: "2m")
@@ -434,7 +424,7 @@ fn activity_feed() -> ElementHandle {
 }
 
 #[component]
-fn scroll_body(state: AppState) -> ElementHandle {
+fn scroll_body(state: AppState) -> Element {
     let style = format!(
         "flex-grow: 1; flex-shrink: 1; width: 100%; background-color: {BG}; \
          display: flex; flex-direction: column;"
@@ -458,7 +448,7 @@ fn scroll_body(state: AppState) -> ElementHandle {
 // ---- Main app ---------------------------------------------------------------
 
 #[whisker::main]
-fn app() -> ElementHandle {
+fn app() -> Element {
     // Allocate every app-wide signal in the bootstrap owner. `AppState`
     // is `Copy`, so threading it through `#[component]` props below
     // doesn't introduce any `move ||` boilerplate.

--- a/examples/hn-reader/src/lib.rs
+++ b/examples/hn-reader/src/lib.rs
@@ -31,7 +31,7 @@
 
 use serde::Deserialize;
 use whisker::prelude::*;
-use whisker::runtime::view::ElementHandle;
+use whisker::runtime::view::Element;
 
 // ---- Data model -------------------------------------------------------------
 
@@ -105,7 +105,7 @@ fn fetch_blocking() -> Result<Vec<Story>, String> {
 /// via per-component remount on hot reload (issue #17 made
 /// `#[component]` layout-transparent).
 #[component]
-fn story_row(story: Story) -> ElementHandle {
+fn story_row(story: Story) -> Element {
     let title = story
         .title
         .clone()
@@ -148,7 +148,7 @@ fn story_row(story: Story) -> ElementHandle {
 
 /// HN-style orange header bar.
 #[component]
-fn header() -> ElementHandle {
+fn header() -> Element {
     let bar_style = format!(
         "width: 100%; padding: 16px; \
          display: flex; flex-direction: row; \
@@ -166,7 +166,7 @@ fn header() -> ElementHandle {
 /// we can read the signal reactively without owned-String capture
 /// issues. Empty string when there's nothing to say (loaded state).
 #[component]
-fn status_banner(state: RwSignal<LoadState>) -> ElementHandle {
+fn status_banner(state: RwSignal<LoadState>) -> Element {
     let status_text = move || match state.get() {
         LoadState::Loading => "Loading top stories…",
         LoadState::Loaded(_) => "",
@@ -189,7 +189,7 @@ fn status_banner(state: RwSignal<LoadState>) -> ElementHandle {
 /// Root of the app. Owns the load-state signal and kicks off the
 /// background fetch on mount.
 #[component]
-pub fn hn_reader() -> ElementHandle {
+pub fn hn_reader() -> Element {
     let state = RwSignal::new(LoadState::Loading);
 
     on_mount(move || {
@@ -240,7 +240,7 @@ pub fn hn_reader() -> ElementHandle {
 // ---- Main app ---------------------------------------------------------------
 
 #[whisker::main]
-fn app() -> ElementHandle {
+fn app() -> Element {
     // The `page` element needs explicit dimensions + background +
     // flex direction. Without `width: 100vw; height: 100vh;` it
     // collapses to 0 px on iOS and the whole screen renders as the

--- a/examples/hn-reader/tests/render.rs
+++ b/examples/hn-reader/tests/render.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use hn_reader::{hn_reader, HnReaderProps};
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, create_owner, with_owner};
-use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, ElementHandle};
+use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
@@ -40,40 +40,40 @@ impl Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> ElementHandle {
+    fn create_element(&mut self, tag: ElementTag) -> Element {
         let id = self.next;
         self.next += 1;
         self.log.borrow_mut().push(Op::Create { id, tag });
-        ElementHandle::from_raw(id)
+        Element::from_raw(id)
     }
-    fn release_element(&mut self, _h: ElementHandle) {}
-    fn set_attribute(&mut self, h: ElementHandle, k: &str, v: &str) {
+    fn release_element(&mut self, _h: Element) {}
+    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: ElementHandle, css: &str) {
+    fn set_inline_styles(&mut self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: ElementHandle, c: ElementHandle) {
+    fn append_child(&mut self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, _p: ElementHandle, _c: ElementHandle) {}
-    fn set_event_listener(&mut self, h: ElementHandle, name: &str, _cb: Box<dyn Fn() + 'static>) {
+    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn set_event_listener(&mut self, h: Element, name: &str, _cb: Box<dyn Fn() + 'static>) {
         self.log.borrow_mut().push(Op::Event {
             id: h.id(),
             name: name.into(),
         });
     }
-    fn set_root(&mut self, _p: ElementHandle) {}
+    fn set_root(&mut self, _p: Element) {}
     fn flush(&mut self) {}
 }
 


### PR DESCRIPTION
## Summary

- Rename `ElementHandle` → `Element` across the workspace.

## Why

- 7 chars vs 13 — about half the keystrokes in component signatures (`fn foo() -> Element` reads better than `fn foo() -> ElementHandle`).
- Matches the prevailing convention in the ecosystem: React's `JSX.Element`, Leptos's `Element`, …
- Reads naturally alongside the existing `ElementTag` enum — an `Element` is an instance, an `ElementTag` names its kind.

## Mechanics

Bulk `s/\bElementHandle\b/Element/g` across all `.rs`, `.md`, and `.toml` files. No behavioural change — the struct definition, methods, and call sites are identical apart from the name.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all --check` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `cargo test --workspace` — same pass counts as before the rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)