### PR TITLE
refactor: rename memo → computed (drop Memo alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Major decisions made so far:
 - **Hybrid CLI** — `whisker` (primary) and `cargo whisker` (alias).
 - **Hot reload** — Tier 1 (subsecond function-body patch, ~1s) + Tier 2 (dylib swap, 5–30s).
 - **Leptos-style fine-grained reactivity** — components run once,
-  `signal` + `effect` + `memo` form a dependency graph, the
+  `signal` + `effect` + `computed` form a dependency graph, the
   `render!` macro wires up per-property effects so a signal write
   updates only the affected element attribute. No virtual DOM, no
   diff pass.

--- a/crates/whisker-runtime/src/reactive/computed.rs
+++ b/crates/whisker-runtime/src/reactive/computed.rs
@@ -1,6 +1,6 @@
-//! Derived memoised values.
+//! Derived (computed) values.
 //!
-//! [`memo`] is the "effect that caches its return value" primitive.
+//! [`computed`] is the "effect that caches its return value" primitive.
 //! Conceptually it's a compute-driven [`ReadSignal`]: subscribers read
 //! through `r.get()` (and friends) exactly the way they would a signal,
 //! but the value is produced by the compute closure rather than written
@@ -9,13 +9,12 @@
 //! from the cached one (`T: PartialEq`) — the typical "stable identity"
 //! optimisation.
 //!
-//! [`memo`] returns a [`ReadSignal<T>`], not a separate `Memo<T>`
-//! type. This is the canonical "readable reactive value" handle in
-//! Whisker; component props that expect a dynamic value should take a
-//! `ReadSignal<T>` (or `WriteSignal<T>` / `RwSignal<T>` for write
-//! capabilities) regardless of whether the source is a primitive
-//! signal or a memoised computation. See `docs/reactivity-design.md`
-//! for the rationale.
+//! [`computed`] returns a [`ReadSignal<T>`] directly. This is the
+//! canonical "readable reactive value" handle in Whisker; component
+//! props that expect a dynamic value should take a `ReadSignal<T>`
+//! (or `WriteSignal<T>` / `RwSignal<T>` for write capabilities)
+//! regardless of whether the source is a primitive signal or a
+//! computed value. See `docs/reactivity-design.md` for the rationale.
 
 use std::any::Any;
 use std::cell::RefCell;
@@ -27,32 +26,25 @@ use super::scheduler;
 use super::signal::ReadSignal;
 use super::with_runtime;
 
-/// Back-compat alias. `memo()` now returns [`ReadSignal<T>`] directly;
-/// `Memo<T>` is kept as a type alias so existing code (`fn foo(m:
-/// Memo<i32>)`) keeps compiling. New code should write `ReadSignal<T>`.
-#[deprecated(
-    since = "0.2.0",
-    note = "memo() now returns ReadSignal<T>. Use ReadSignal<T> in type signatures instead."
-)]
-pub type Memo<T> = ReadSignal<T>;
-
-/// Create a memoised computation. `f` is run once immediately to seed
-/// the cache, then re-run whenever a tracked source changes.
+/// Create a computed (derived) value. `f` is run once immediately to
+/// seed the cache, then re-run whenever a tracked source changes.
 ///
 /// The returned [`ReadSignal<T>`] reads the cached value via `.get()`
 /// / `.with()` / `.get_untracked()` / `.with_untracked()` — exactly
 /// the same surface as a primitive signal. Subscribers (downstream
-/// effects, memos, `{expr}` interpolations) are only notified when the
-/// recomputed value differs from the previously-cached one
-/// (`T: PartialEq`), so a memo whose result is unchanged costs nothing
-/// downstream.
+/// effects, computed values, `{expr}` interpolations) are only
+/// notified when the recomputed value differs from the previously-
+/// cached one (`T: PartialEq`), so a computed value whose result is
+/// unchanged costs nothing downstream.
 ///
 /// ```ignore
 /// let (count, _set) = signal(0_i32);
-/// let doubled: ReadSignal<i32> = memo(move || count.get() * 2);
+/// let doubled: ReadSignal<i32> = computed(move || count.get() * 2);
 /// assert_eq!(doubled.get(), 0);
 /// ```
-pub fn memo<T: 'static + Clone + PartialEq>(mut f: impl FnMut() -> T + 'static) -> ReadSignal<T> {
+pub fn computed<T: 'static + Clone + PartialEq>(
+    mut f: impl FnMut() -> T + 'static,
+) -> ReadSignal<T> {
     // We need access to the node id inside the compute closure so it
     // can write back to its own value slot. Allocate the node first
     // with a placeholder value of the right type, then replace the
@@ -79,7 +71,7 @@ pub fn memo<T: 'static + Clone + PartialEq>(mut f: impl FnMut() -> T + 'static) 
 
     let needs_warning = with_runtime(|rt| rt.current_owner().is_none());
     if needs_warning {
-        super::warn_no_owner("memo()");
+        super::warn_no_owner("computed()");
     }
     let node_id = with_runtime(|rt| {
         let owner = rt.current_owner().unwrap_or_else(|| {
@@ -89,7 +81,7 @@ pub fn memo<T: 'static + Clone + PartialEq>(mut f: impl FnMut() -> T + 'static) 
         });
         let id = rt.nodes.insert(ReactiveNode {
             owner,
-            data: NodeData::Memo {
+            data: NodeData::Computed {
                 value: value.clone(),
                 compute: trampoline,
             },
@@ -111,7 +103,7 @@ pub fn memo<T: 'static + Clone + PartialEq>(mut f: impl FnMut() -> T + 'static) 
             let borrow = value_clone.borrow();
             let old: &T = borrow
                 .downcast_ref::<T>()
-                .expect("Memo: type mismatch on recompute");
+                .expect("computed: type mismatch on recompute");
             old != &new
         };
         if changed {
@@ -119,7 +111,7 @@ pub fn memo<T: 'static + Clone + PartialEq>(mut f: impl FnMut() -> T + 'static) 
                 let mut borrow = value_clone.borrow_mut();
                 let slot = borrow
                     .downcast_mut::<T>()
-                    .expect("Memo: type mismatch on write-back");
+                    .expect("computed: type mismatch on write-back");
                 *slot = new;
             }
             // Notify subscribers.

--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -11,7 +11,7 @@
 //! - [`signal`] — [`signal`] / [`RwSignal`] / [`ReadSignal`] /
 //!   [`WriteSignal`].
 //! - [`effect`] — [`effect`] + dependency tracking.
-//! - [`memo`] — [`memo`] (returns [`ReadSignal<T>`]).
+//! - [`computed`] — [`computed`] (returns [`ReadSignal<T>`]).
 //! - [`scheduler`] — batching / flush.
 //!
 //! All operations are single-threaded — reactive UI runs on the Lynx
@@ -29,9 +29,9 @@
 //! executes.
 
 pub mod component;
+pub mod computed;
 pub mod context;
 pub mod effect;
-pub mod memo;
 pub mod owner;
 pub mod runtime;
 pub mod scheduler;
@@ -47,11 +47,9 @@ pub use component::{
     flush_mounts, mount_component, mount_component_remountable, on_component_root_attached,
     on_mount, owners_for_fn, remount_components_for, unmount_component, MountId,
 };
+pub use computed::computed;
 pub use context::{provide_context, use_context, with_context};
 pub use effect::effect;
-pub use memo::memo;
-#[allow(deprecated)]
-pub use memo::Memo;
 pub use owner::{create_owner, dispose_owner, on_cleanup, with_owner};
 pub use runtime::{NodeId, OwnerId};
 pub use scheduler::flush;
@@ -80,7 +78,7 @@ thread_local! {
 /// closures.
 ///
 /// Crate-internal; the public surface is the typed `signal` / `effect`
-/// / `memo` / `dispose_owner` etc. functions. Exposing the raw
+/// / `computed` / `dispose_owner` etc. functions. Exposing the raw
 /// runtime would let callers violate borrow-window invariants.
 pub(crate) fn with_runtime<R>(f: impl FnOnce(&mut ReactiveRuntime) -> R) -> R {
     RUNTIME.with_borrow_mut(f)

--- a/crates/whisker-runtime/src/reactive/owner.rs
+++ b/crates/whisker-runtime/src/reactive/owner.rs
@@ -1,7 +1,7 @@
 //! Owner (scope) lifecycle: create, dispose, enter/exit.
 //!
 //! Owners form a tree. Every reactive primitive (signal / effect /
-//! memo) belongs to exactly one owner. Disposing an owner cascades
+//! computed) belongs to exactly one owner. Disposing an owner cascades
 //! into its children, then frees every node it allocated, then runs
 //! its cleanup callbacks in LIFO order.
 //!
@@ -138,7 +138,7 @@ pub fn dispose_owner(owner: OwnerId) {
     }
 
     // Step 4: free every node this owner allocated. For effects /
-    // memos, also detach them from any subscriber list they were on,
+    // computed values, also detach them from any subscriber list they were on,
     // so other live nodes don't try to notify a freed slot later.
     with_runtime(|rt| {
         for node_id in &nodes {

--- a/crates/whisker-runtime/src/reactive/runtime.rs
+++ b/crates/whisker-runtime/src/reactive/runtime.rs
@@ -9,8 +9,8 @@
 //! `RwSignal`) are `Copy` newtypes around a `NodeId`. They look their
 //! value up through the runtime on every operation. Cloning a handle
 //! is just an integer copy; the lifetime of the underlying state is
-//! bounded by its owning `Owner`, not by the handle. `memo()` returns
-//! a `ReadSignal<T>` that happens to be backed by a `NodeData::Memo`
+//! bounded by its owning `Owner`, not by the handle. `computed()` returns
+//! a `ReadSignal<T>` that happens to be backed by a `NodeData::Computed`
 //! node — externally indistinguishable from a primitive signal.
 //!
 //! This module defines the types only. The thread-local instance and
@@ -49,11 +49,11 @@ pub enum NodeKind {
     /// Derived value. Like an effect, but caches its return so
     /// downstream readers can observe it through the same dependency
     /// mechanism as a signal.
-    Memo,
+    Computed,
 }
 
 /// The mutable payload of a [`ReactiveNode`]. Signals carry a value,
-/// effects carry a compute closure, memos carry both.
+/// effects carry a compute closure, computed values carry both.
 ///
 /// The compute closure is wrapped in `Rc<RefCell<…>>` so the
 /// scheduler can grab a clone of the handle before invoking it,
@@ -66,7 +66,7 @@ pub enum NodeData {
     Effect {
         compute: Rc<RefCell<dyn FnMut()>>,
     },
-    Memo {
+    Computed {
         value: Rc<RefCell<dyn Any>>,
         compute: Rc<RefCell<dyn FnMut()>>,
     },
@@ -77,7 +77,7 @@ impl NodeData {
         match self {
             NodeData::Signal { .. } => NodeKind::Signal,
             NodeData::Effect { .. } => NodeKind::Effect,
-            NodeData::Memo { .. } => NodeKind::Memo,
+            NodeData::Computed { .. } => NodeKind::Computed,
         }
     }
 
@@ -86,7 +86,7 @@ impl NodeData {
     pub fn value(&self) -> Option<&Rc<RefCell<dyn Any>>> {
         match self {
             NodeData::Signal { value } => Some(value),
-            NodeData::Memo { value, .. } => Some(value),
+            NodeData::Computed { value, .. } => Some(value),
             NodeData::Effect { .. } => None,
         }
     }
@@ -96,7 +96,7 @@ impl NodeData {
 ///
 /// `sources` records what this node read in its last run (downstream
 /// dependencies); `subscribers` records who reads us. Both sets are
-/// kept in sync by the effect/memo runner — on each re-run, the runner
+/// kept in sync by the effect/computed runner — on each re-run, the runner
 /// re-derives `sources` by tracking signal reads during the closure,
 /// then sets `subscribers` on the new sources symmetrically.
 pub struct ReactiveNode {
@@ -164,7 +164,7 @@ impl Owner {
 ///
 /// 1. Open a short `with_borrow_mut` to read or mutate `owners` /
 ///    `nodes` / `current_*`.
-/// 2. If user code needs to run (effect / memo closure), drop the
+/// 2. If user code needs to run (effect / computed closure), drop the
 ///    borrow first by cloning the necessary handles out, then call
 ///    the closure.
 /// 3. Re-open a short borrow to restore book-keeping.
@@ -176,15 +176,15 @@ pub struct ReactiveRuntime {
     pub owners: SlotMap<OwnerId, Owner>,
     pub nodes: SlotMap<NodeId, ReactiveNode>,
     /// Owner stack: the topmost is the "current" owner — new signals,
-    /// effects, memos, and lifecycle hooks register against it. Push
+    /// effects, computed values, and lifecycle hooks register against it. Push
     /// when entering a `with_owner` (or `#[component]`) scope, pop on
     /// exit.
     pub owner_stack: Vec<OwnerId>,
-    /// The effect/memo currently being computed, if any. Signal reads
+    /// The effect/computed currently being computed, if any. Signal reads
     /// inside this effect register a `sources`/`subscribers` link
     /// against it.
     pub current_tracker: Option<NodeId>,
-    /// Queue of effect/memo nodes scheduled to re-run on the next flush.
+    /// Queue of effect/computed nodes scheduled to re-run on the next flush.
     /// Populated by signal writes; drained by [`flush_pending`].
     pub pending: Vec<NodeId>,
     /// True while [`flush_pending`] is actively draining `pending`.

--- a/crates/whisker-runtime/src/reactive/scheduler.rs
+++ b/crates/whisker-runtime/src/reactive/scheduler.rs
@@ -50,7 +50,7 @@ pub(crate) fn schedule(node: NodeId) {
     }
 }
 
-/// Drain the pending queue, re-running effects and memos in the order
+/// Drain the pending queue, re-running effects and computeds in the order
 /// they were scheduled. Skips entries whose node has been disposed.
 ///
 /// Reentrant: a re-running effect may itself write signals, which
@@ -102,7 +102,7 @@ pub fn flush() {
     with_runtime(|rt| rt.flushing = false);
 }
 
-/// Re-run the compute closure for an effect or memo, if it's still
+/// Re-run the compute closure for an effect or computed, if it's still
 /// alive in the arena. Sets up dependency tracking and owner-stack
 /// scoping around the call.
 ///
@@ -126,7 +126,7 @@ fn run_node_if_alive(node: NodeId) {
         let owner = n.owner;
         let compute = match &n.data {
             NodeData::Effect { compute } => compute.clone(),
-            NodeData::Memo { compute, .. } => compute.clone(),
+            NodeData::Computed { compute, .. } => compute.clone(),
             NodeData::Signal { .. } => return None,
         };
         // Detach from existing sources before re-tracking.

--- a/crates/whisker-runtime/src/reactive/signal.rs
+++ b/crates/whisker-runtime/src/reactive/signal.rs
@@ -98,7 +98,7 @@ impl<T: 'static> Copy for ReadSignal<T> {}
 
 impl<T: 'static + Clone> ReadSignal<T> {
     /// Read the current value, registering this signal as a dependency
-    /// of the currently-running effect / memo (if any).
+    /// of the currently-running effect / computed (if any).
     pub fn get(self) -> T {
         self.with(|v| v.clone())
     }
@@ -289,7 +289,7 @@ impl<T: 'static + Clone> RwSignal<T> {
 fn track_and_fetch(id: NodeId) -> Rc<RefCell<dyn Any>> {
     with_runtime(|rt| {
         if let Some(tracker) = rt.current_tracker {
-            // Avoid self-subscription (a memo reading its own value).
+            // Avoid self-subscription (a computed reading its own value).
             if tracker != id {
                 if let Some(node) = rt.nodes.get_mut(id) {
                     node.subscribers.insert(tracker);

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -342,21 +342,21 @@ fn stored_value_disposed_with_owner() {
     assert!(!leftover);
 }
 
-// ----- Memo -----------------------------------------------------------------
+// ----- Computed -----------------------------------------------------------------
 
 #[test]
-fn memo_caches_initial_value() {
+fn computed_caches_initial_value() {
     fresh();
     let (count, _set) = signal(3_i32);
-    let doubled = memo(move || count.get() * 2);
+    let doubled = computed(move || count.get() * 2);
     assert_eq!(doubled.get(), 6);
 }
 
 #[test]
-fn memo_recomputes_on_source_change() {
+fn computed_recomputes_on_source_change() {
     fresh();
     let (count, set_count) = signal(0_i32);
-    let doubled = memo(move || count.get() * 2);
+    let doubled = computed(move || count.get() * 2);
     assert_eq!(doubled.get(), 0);
     set_count.set(5);
     flush();
@@ -364,10 +364,10 @@ fn memo_recomputes_on_source_change() {
 }
 
 #[test]
-fn memo_notifies_downstream_subscribers() {
+fn computed_notifies_downstream_subscribers() {
     fresh();
     let (count, set_count) = signal(0_i32);
-    let doubled = memo(move || count.get() * 2);
+    let doubled = computed(move || count.get() * 2);
     let observed: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
     let obs_clone = observed.clone();
     effect(move || obs_clone.borrow_mut().push(doubled.get()));
@@ -379,11 +379,11 @@ fn memo_notifies_downstream_subscribers() {
 }
 
 #[test]
-fn memo_does_not_notify_when_value_unchanged() {
+fn computed_does_not_notify_when_value_unchanged() {
     fresh();
     let (count, set_count) = signal(5_i32);
-    // floor-div by 10 — different `count` values yield the same memo value
-    let bucket = memo(move || count.get() / 10);
+    // floor-div by 10 — different `count` values yield the same computed value
+    let bucket = computed(move || count.get() / 10);
     let runs = Rc::new(RefCell::new(0));
     let runs_clone = runs.clone();
     effect(move || {

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -32,15 +32,10 @@ pub use whisker_macros::{component, main, render};
 // directly. The underlying impl lives in `whisker_runtime::reactive`
 // for callers that prefer the long path.
 pub use whisker_runtime::reactive::{
-    create_owner, dispose_owner, effect, flush, flush_mounts, memo, mount_component, on_cleanup,
-    on_mount, provide_context, signal, unmount_component, use_context, with_context, with_owner,
-    ReadSignal, RwSignal, StoredValue, WriteSignal,
+    computed, create_owner, dispose_owner, effect, flush, flush_mounts, mount_component,
+    on_cleanup, on_mount, provide_context, signal, unmount_component, use_context, with_context,
+    with_owner, ReadSignal, RwSignal, StoredValue, WriteSignal,
 };
-// Back-compat type alias. `memo()` now returns `ReadSignal<T>`; this
-// alias keeps `Memo<T>` in old type signatures compiling. New code
-// should write `ReadSignal<T>`.
-#[allow(deprecated)]
-pub use whisker_runtime::reactive::Memo;
 // Control-flow components used by the `render!` macro.
 pub use whisker_runtime::view::{for_each, show};
 // `Children` is the conventional prop type for components that wrap
@@ -607,12 +602,10 @@ pub mod __hot {
 pub mod prelude {
     pub use crate::Children;
     pub use crate::ElementTag;
-    #[allow(deprecated)]
-    pub use crate::Memo;
     pub use crate::{component, main, render};
     pub use crate::{
-        effect, for_each, memo, on_cleanup, on_mount, provide_context, run_on_main_thread, show,
-        signal, use_context, with_context, ReadSignal, RwSignal, StoredValue, WriteSignal,
+        computed, effect, for_each, on_cleanup, on_mount, provide_context, run_on_main_thread,
+        show, signal, use_context, with_context, ReadSignal, RwSignal, StoredValue, WriteSignal,
     };
     // Re-export the `__tags` struct names so RA can complete
     // `vie|` → `view`, `te|` → `text`, etc. when the user is

--- a/docs/reactivity-design.md
+++ b/docs/reactivity-design.md
@@ -43,14 +43,14 @@ let (read, write) = count.split();   // any time
 
 All three types (`ReadSignal<T>`, `WriteSignal<T>`, `RwSignal<T>`)
 are `Copy` arena handles — clone is free, `'static`, moves into
-closures without lifetime annotations. `memo()` also returns
+closures without lifetime annotations. `computed()` also returns
 `ReadSignal<T>` (it's a compute-driven signal); there is no separate
-`Memo<T>` type.
+`Computed<T>` (gone — use `ReadSignal<T>`) type.
 
 API surface:
 
 ```rust
-// ReadSignal<T> (also what memo() returns)
+// ReadSignal<T> (also what computed() returns)
 fn get(&self) -> T where T: Clone;
 fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R;
 fn get_untracked(&self) -> T where T: Clone;        // no dep registration
@@ -89,10 +89,10 @@ effect(|prev: Option<i32>| {
 });
 ```
 
-### Memo — a compute-driven `ReadSignal`
+### Computed — a compute-driven `ReadSignal`
 
 ```rust
-let doubled: ReadSignal<i32> = memo(move || count.get() * 2);
+let doubled: ReadSignal<i32> = computed(move || count.get() * 2);
 log::info!("{}", doubled.get());           // 0
 set_count.set(5);
 log::info!("{}", doubled.get());           // 10
@@ -102,7 +102,7 @@ Like an effect that caches its return value. The returned handle is a
 `ReadSignal<T>` — exactly the same type a primitive signal hands out —
 so component props that take a "readable reactive value" use
 `ReadSignal<T>` regardless of whether the source is `signal()` or
-`memo()`. **Lazy**: re-runs only when dependencies change *and* it has
+`computed()`. **Lazy**: re-runs only when dependencies change *and* it has
 at least one subscriber.
 
 ### Resource (Phase A4)
@@ -165,7 +165,7 @@ struct Owner {
 
 struct ReactiveNode {
     owner:  OwnerId,
-    kind:   NodeKind,                          // Signal | Effect | Memo
+    kind:   NodeKind,                          // Signal | Effect | Computed
     value:  Option<Box<dyn Any>>,
     sources:     HashSet<NodeId>,              // who I depend on
     subscribers: HashSet<NodeId>,              // who depends on me
@@ -429,10 +429,10 @@ types it's a compile error — wrap in `Rc<T>` / `Arc<T>` if needed.
 
 | Edit | Outcome |
 |---|---|
-| Body of an existing `effect` / `memo` / event handler | New code runs next time; state preserved |
+| Body of an existing `effect` / `computed` / event handler | New code runs next time; state preserved |
 | Body of an existing dynamic `{expr}` in `render!` | Updates next time deps change; state preserved |
 | Adding a new static element in `#[component]`'s `render!` | Component remounted; local state lost; parent attachment + sibling order preserved |
-| Adding a new `signal()` / `effect()` / `memo()` inside the component body | Component remounted; local state lost |
+| Adding a new `signal()` / `effect()` / `computed()` inside the component body | Component remounted; local state lost |
 | Editing static styles / attributes | Component remounted; local state lost |
 | Edits to a non-`#[component]` helper invoked via `{helper()}` | Effect re-fires with patched helper body; state preserved |
 | Edits to the top-level `app()` (`#[whisker::main]`) | Not currently re-invoked; needs manual restart |
@@ -467,7 +467,7 @@ because the blast radius is scoped to one component subtree.
   Copy handle) is the new public type returned from `into_element`.
 - `crates/whisker-macros/src/rsx.rs` — **rewrite** as `render.rs` (new
   macro name).
-- `crates/whisker-runtime/src/signal.rs` — extend with effect / memo /
+- `crates/whisker-runtime/src/signal.rs` — extend with effect / computed /
   owner / scheduler. The current `Signal` API survives in spirit but
   the closed `T: Add + From<i32>` constraint on `update` goes away.
 - `crates/whisker/src/prelude.rs` — re-export the new surface.

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -4,7 +4,7 @@ Whisker uses Leptos-style fine-grained reactivity. The mental model
 is simple once you accept its single non-obvious rule:
 
 > **A component function runs exactly once.** The reactive primitives
-> it creates — signals, effects, memos — form a graph that lives on
+> it creates — signals, effects, computed values — form a graph that lives on
 > after the function returns, and that graph is what makes the UI
 > respond to state changes.
 
@@ -20,7 +20,7 @@ For the architecture rationale behind this design, see
 ## Signals
 
 A signal is a reactive value. Reading it inside a tracked context
-(an effect, memo, or `render!` interpolation) registers a
+(an effect, computed, or `render!` interpolation) registers a
 subscription; writing it schedules every subscriber to re-run.
 
 Two equivalent ways to create one:
@@ -67,7 +67,7 @@ let len = names.with(|v| v.len());
 
 ### Untracked reads
 
-By default reads inside an effect / memo / `{expr}` register a
+By default reads inside an effect / computed / `{expr}` register a
 dependency. Sometimes you want to read a signal without subscribing
 — `get_untracked` / `with_untracked` skip the tracking step:
 
@@ -111,7 +111,7 @@ set_count.set(8);   // logs "count is now 8"
 
 Effects are the bridge from reactive state to "the outside world" —
 logging, persistence, animations, opening a connection. They never
-return a value other subscribers can read; for that, use `memo`.
+return a value other subscribers can read; for that, use `computed`.
 
 ### Effects and ownership
 
@@ -141,17 +141,17 @@ This is **microtask batching** in Solid / Leptos terminology.
 
 ## Memos — derived signals
 
-`memo` is a compute-driven [`ReadSignal`]: the value is produced by
+`computed` is a compute-driven [`ReadSignal`]: the value is produced by
 a closure that re-runs when its tracked sources change, but the
 public handle is exactly the same `ReadSignal<T>` you get from
 `signal()`. Component props that take a "dynamic readable value"
 write `ReadSignal<T>` and don't care whether the source is a
-primitive signal or a memo — that's the whole point of the
+primitive signal or a computed value — that's the whole point of the
 unification.
 
 ```rust
 let (count, set_count) = signal(0);
-let doubled: ReadSignal<i32> = memo(move || count.get() * 2);
+let doubled: ReadSignal<i32> = computed(move || count.get() * 2);
 
 doubled.get();                // 0
 set_count.set(7);
@@ -164,7 +164,7 @@ required for this). The downstream fan-out suppression is what
 makes:
 
 ```rust
-let bucket = memo(move || count.get() / 10);
+let bucket = computed(move || count.get() / 10);
 effect(move || log::info!("bucket = {}", bucket.get()));
 ```
 
@@ -172,12 +172,12 @@ effect(move || log::info!("bucket = {}", bucket.get()));
 times — because the bucket value didn't change on the `0 → 5`
 transition.
 
-### `memo` instead of `move ||` in component props
+### `computed` instead of `move ||` in component props
 
 Whisker's convention is: **components accept reactive values only as
 `ReadSignal<T>` / `WriteSignal<T>` / `RwSignal<T>`, never as
 closures**. When you want to pass a derived value, build it with
-`memo` and pass the resulting `ReadSignal`:
+`computed` and pass the resulting `ReadSignal`:
 
 ```rust
 #[component]
@@ -187,7 +187,7 @@ fn display(value: ReadSignal<i32>) -> Element {
 
 let (count, _) = signal(0);
 render! { display(value: count) }                              // primitive signal
-render! { display(value: memo(move || count.get() * 2)) }      // derived signal
+render! { display(value: computed(move || count.get() * 2)) }      // derived signal
 ```
 
 This keeps `move ||` out of component signatures, makes prop types
@@ -195,7 +195,7 @@ self-documenting ("is this reactive?"), and survives hot-reload
 better than `impl Fn() + 'static` closures (whose anonymous type
 changes between rebuilds).
 
-A leftover `Memo<T>` type alias points at `ReadSignal<T>` for
+A leftover `Computed<T>` (gone — use `ReadSignal<T>`) type alias points at `ReadSignal<T>` for
 backward compatibility but is deprecated — use `ReadSignal<T>` in
 new code.
 
@@ -557,7 +557,7 @@ render! { text { {banner_text} } }
 
 ## Rules and gotchas
 
-- **`signal()` / `effect()` / `memo()` must be called inside a
+- **`signal()` / `effect()` / `computed()` must be called inside a
   component or other reactive owner.** Calling them outside emits a
   debug-build warning and falls back to a detached owner that
   doesn't clean up cleanly.

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -26,7 +26,7 @@ use whisker::prelude::*;
 
 /// App-wide state. A single signal is enough for the demo; bigger
 /// apps would group several signals (or derived `ReadSignal`s built
-/// with `memo()`) into a struct like this and pass it by `Copy` into
+/// with `computed()`) into a struct like this and pass it by `Copy` into
 /// child components.
 #[derive(Copy, Clone)]
 pub struct AppState {
@@ -45,10 +45,10 @@ pub struct AppState {
 ///   are batched within each handler so multi-update handlers only
 ///   trigger one re-render.
 /// - `Show` toggles a celebratory message in/out depending on a
-///   memo that derives from the same signal.
+///   computed value that derives from the same signal.
 #[component]
 pub fn counter(state: AppState) -> whisker::runtime::view::Element {
-    let big_enough = memo(move || state.count.get() > 10);
+    let big_enough = computed(move || state.count.get() > 10);
 
     render! {
         view(style: "display: flex; flex-direction: column; gap: 12px; padding: 20px;") {


### PR DESCRIPTION
## Summary

- Rename `memo` → `computed` for the derived-value primitive.
- Drop the `Memo<T>` deprecated type alias (it was already pointing at `ReadSignal<T>`).
- Update all internal symbols, docs, examples, and tests.

## Why

`computed` describes the use case more accurately than `memo`:

- The primitive's job is **building a derived/computed value**. Memoisation is an internal optimisation, not the user-facing concept.
- Vue / MobX / Knockout all call this `computed`.
- Leptos uses `memo`, but in practice Whisker code uses it as a derived-signal builder rather than a memoised function — calling it `computed` matches what the code is actually doing.

## Changes

| Before | After |
|--------|-------|
| `pub fn memo(...) -> ReadSignal<T>` | `pub fn computed(...) -> ReadSignal<T>` |
| `memo.rs` | `computed.rs` |
| `NodeData::Memo` | `NodeData::Computed` |
| `NodeKind::Memo` | `NodeKind::Computed` |
| `pub type Memo<T> = ReadSignal<T>` (deprecated) | — (use `ReadSignal<T>`) |

User-facing rename:

```rust
// before
let doubled: Memo<i32> = memo(move || count.get() * 2);

// after
let doubled: ReadSignal<i32> = computed(move || count.get() * 2);
```

## Migration

For external users who still write `Memo<T>` in type signatures: replace with `ReadSignal<T>` (the alias was already a transparent re-export).

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all --check` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `cargo test --workspace` — all green (incl. `computed_*` renamed test fns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)