### PR TITLE
refactor(macro): PascalCase user components + hand-rolled Props builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,26 +1510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-builder"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,7 +1707,6 @@ dependencies = [
 name = "whisker"
 version = "0.1.0"
 dependencies = [
- "typed-builder",
  "whisker-app-config",
  "whisker-driver",
  "whisker-macros",

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -1,24 +1,37 @@
 //! `#[component]` proc-macro implementation.
 //!
 //! Walks the user's function signature, extracts the parameter list,
-//! and emits two items:
+//! and emits:
 //!
-//! 1. A `#[derive(::whisker::__typed_builder::TypedBuilder)]` `XxxProps` struct
-//!    whose fields mirror the function parameters. Per-field
-//!    `#[builder(...)]` annotations are derived from the parameter's
-//!    type (string-ish primitives + `Option<T>` get `into` /
-//!    `strip_option`, `Children` gets a default) and any `#[prop(...)]`
-//!    attributes the user wrote.
-//! 2. A rewritten `fn xxx(__props: XxxProps) -> Element { … }`
-//!    that destructures the props back into local variables and runs
-//!    the user's original body inside the existing
+//! 1. A `XxxProps` struct whose fields mirror the function parameters.
+//! 2. A hand-rolled `XxxPropsBuilder` with one setter per parameter.
+//!    Required fields panic at `.build()` if unset; `Option<T>` and
+//!    `Children` props default to `None`/empty; `#[prop(default = …)]`
+//!    fills in the user-supplied default.
+//! 3. A rewritten `fn xxx(__props: XxxProps) -> Element { … }` that
+//!    destructures the props back into local variables and runs the
+//!    user's original body inside the existing
 //!    `mount_component_remountable` hot-reload machinery.
+//! 4. A PascalCase alias (`pub use … as XxxName`) over a private inner
+//!    module — that's what render! calls and what RA surfaces in
+//!    identifier completion.
+//!
+//! Why hand-roll the builder instead of `#[derive(TypedBuilder)]`:
+//! typed-builder generates per-field type-state markers
+//! (`<Name>PropsBuilder_Error_Missing_required_field_<field>` etc.)
+//! that, while marked `pub`, are pulled into RA's auto-import
+//! completion at the user's call site as noise even when nested in a
+//! private module. The hand-rolled builder emits exactly two types:
+//! the `Props` struct and one builder struct. Required-field validation
+//! moves from compile-time (typed-builder's type-state) to runtime
+//! (`.expect(...)` at `.build()`); the panic fires at component-mount
+//! time with a clear "required field `xxx` was not set" message.
 //!
 //! The function signature change (positional args → single Props arg)
 //! deliberately breaks the old `xxx(arg1, arg2)` calling convention
 //! (issue #18 Q4): user components must be invoked through `render!`'s
-//! `xxx { kwarg: value }` syntax, which expands to
-//! `xxx(XxxProps::builder().kwarg(value).build())`.
+//! `XxxName(kwarg: value)` syntax, which expands to
+//! `XxxName(XxxProps::builder().kwarg(value).build())`.
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
@@ -63,12 +76,11 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         })
         .collect();
 
-    // Walk the parameter list. For each `Typed` arg, collect:
-    //   - `ident` (the binding name, used for destructuring + capture)
-    //   - `ty` (the parameter's type — used to decide builder annotations)
-    //   - `attrs` (`#[prop(...)]` attributes the user wrote on the param)
-    let mut props_fields: Vec<TokenStream2> = Vec::new();
-    let mut prop_idents: Vec<Ident> = Vec::new();
+    // Walk the parameter list. For each `Typed` arg, collect a
+    // `Prop` (binding name + type + classification) so the emission
+    // step can generate per-field tokens for the Props struct, the
+    // Builder struct, the setters, and the `.build()` body.
+    let mut props: Vec<Prop> = Vec::new();
     for arg in &sig.inputs {
         let pat_type = match arg {
             FnArg::Typed(t) => t,
@@ -98,23 +110,33 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
             Err(e) => return e.to_compile_error(),
         };
 
-        let annotation = builder_annotation(&pat_type.ty, &prop_attr, &generic_type_params);
-        let ty = &pat_type.ty;
-        // Strip the param's `#[prop(...)]` attribute from the Props
-        // field — it's a `#[component]` directive, not something the
-        // emitted struct should carry forward.
-        let other_attrs: Vec<&syn::Attribute> = pat_type
+        // Strip the param's `#[prop(...)]` attribute from forwarding
+        // attrs — it's a `#[component]` directive, not something the
+        // emitted Props struct should carry forward. Other attrs
+        // (`#[allow(...)]`, doc comments) ride along on the Props
+        // field unchanged.
+        let other_attrs: Vec<syn::Attribute> = pat_type
             .attrs
             .iter()
             .filter(|a| !a.path().is_ident("prop"))
+            .cloned()
             .collect();
-        props_fields.push(quote! {
-            #(#other_attrs)*
-            #annotation
-            pub #ident: #ty
+        let kind = classify_prop(&pat_type.ty, &prop_attr, &generic_type_params);
+        props.push(Prop {
+            ident,
+            ty: (*pat_type.ty).clone(),
+            kind,
+            forward_attrs: other_attrs,
         });
-        prop_idents.push(ident);
     }
+    let prop_idents: Vec<Ident> = props.iter().map(|p| p.ident.clone()).collect();
+
+    // ---- Generate per-field tokens for the Props struct + Builder ----
+    let props_fields: Vec<TokenStream2> = props.iter().map(prop_struct_field).collect();
+    let builder_fields: Vec<TokenStream2> = props.iter().map(prop_builder_field).collect();
+    let builder_init: Vec<TokenStream2> = props.iter().map(prop_builder_init).collect();
+    let setter_methods: Vec<TokenStream2> = props.iter().map(prop_setter_method).collect();
+    let build_assignments: Vec<TokenStream2> = props.iter().map(prop_build_assignment).collect();
 
     let props_name = props_struct_name(fn_name);
 
@@ -161,34 +183,63 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         quote! { #fn_name :: < #(#ty_generics_for_turbofish),* > as *const () }
     };
 
-    // Props struct lives inside a PRIVATE module. typed-builder's
-    // per-field type-state helpers (`XxxPropsBuilder<((),(),(),)>`
-    // and per-field empty/filled marker structs) stay inside that
-    // module and can't be reached from outside by name — so RA's
-    // identifier completion at user call sites can't list them as
-    // candidates, no matter what doc-attribute filtering it does.
+    // Props struct + hand-rolled Builder live inside a PRIVATE
+    // module so the builder type's name doesn't surface as
+    // identifier-completion noise at the user's call sites. Only
+    // `XxxProps` is re-exported outward (doc-hidden); the builder
+    // is reached via the `.builder()` method chain and never needs
+    // to be in scope by name.
     //
-    // Only `XxxProps` itself is re-exported (doc-hidden so it
-    // doesn't clutter rustdoc either). The builder type is the
-    // return value of `XxxProps::builder()` and is reached via
-    // method chains, so it doesn't need to be in scope by name.
-    //
-    // Generics + where clause come straight from the function —
-    // typed-builder threads them through to the generated builder.
+    // Generics + where clause carry through from the user's fn so
+    // a `#[component] fn xxx<T>(value: T)` gets a `XxxProps<T>` and
+    // a `XxxPropsBuilder<T>`.
     let internal_mod = format_ident!("__{}_props_internal", fn_name);
+    let builder_name = format_ident!("{}Builder", props_name);
     let props_struct = quote! {
-        // No `#vis` on the module — the visibility is deliberately
-        // tighter than the surrounding fn so helper types stay
-        // unreachable.
+        // No `#vis` on the module — visibility is deliberately
+        // tighter than the surrounding fn so the builder type
+        // stays unreachable as a bare identifier from outside.
         #[doc(hidden)]
         mod #internal_mod {
             // Pull in everything from the outer scope so prop types
             // referenced in fields (`Children`, user types, etc.)
             // resolve.
             use super::*;
-            #[derive(::whisker::__typed_builder::TypedBuilder)]
+
             pub struct #props_name #impl_generics #where_clause {
                 #(#props_fields),*
+            }
+
+            // Builder: every field becomes `Option<T>` (or, for
+            // already-`Option<T>` props, `Option<Option<T>>`) so we
+            // can tell "user hasn't set this" from "user set it to
+            // None". `.build()` collapses each Option back into the
+            // field's declared type, with the appropriate
+            // default / panic-on-missing for required fields.
+            pub struct #builder_name #impl_generics #where_clause {
+                #(#builder_fields),*
+            }
+
+            impl #impl_generics #props_name #ty_generics #where_clause {
+                /// Open a builder chain. `XxxProps::builder().a(…).b(…).build()`.
+                pub fn builder() -> #builder_name #ty_generics {
+                    #builder_name {
+                        #(#builder_init),*
+                    }
+                }
+            }
+
+            impl #impl_generics #builder_name #ty_generics #where_clause {
+                #(#setter_methods)*
+
+                /// Materialise the Props. Required fields that the
+                /// user didn't set fire a `required field `<name>` was
+                /// not set` panic at mount time.
+                pub fn build(self) -> #props_name #ty_generics {
+                    #props_name {
+                        #(#build_assignments),*
+                    }
+                }
             }
         }
         #[doc(hidden)]
@@ -285,7 +336,7 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
 
 /// Information parsed from a `#[prop(...)]` attribute on a single
 /// `#[component]` parameter.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct PropAttr {
     /// `#[prop(default = expr)]` — emit `#[builder(default = expr)]`
     /// so callers may omit this prop and the builder fills in
@@ -327,75 +378,289 @@ fn parse_prop_attr(attrs: &[syn::Attribute]) -> syn::Result<PropAttr> {
     Ok(out)
 }
 
-/// Compute the `#[builder(...)]` annotation for one prop, given its
-/// type and any `#[prop(...)]` directives. Decision table:
+/// One parsed `#[component]` parameter, ready to be turned into
+/// Props-field, Builder-field, setter, and build()-body tokens.
+struct Prop {
+    /// User's parameter name. Used verbatim everywhere (field name,
+    /// setter name, build()-assignment LHS, fn-body destructure ident).
+    ident: Ident,
+    /// User-written type — kept exactly as the user wrote it so the
+    /// emitted Props struct preserves their lifetime / generic
+    /// references. Builder field / setter signature are derived from
+    /// this + `kind`.
+    ty: Type,
+    /// Per-prop emission strategy. See `PropKind` for the decision
+    /// table.
+    kind: PropKind,
+    /// Non-`#[prop]` attributes the user wrote on this parameter
+    /// (`#[allow(...)]`, doc comments). Forwarded onto the Props
+    /// struct field.
+    forward_attrs: Vec<syn::Attribute>,
+}
+
+/// How one Prop is wired through Props / Builder / setter / build.
+enum PropKind {
+    /// Required, has a concrete enough type for `Into<T>` coercion.
+    /// Setter: `pub fn x(self, v: impl Into<T>) -> Self`.
+    /// Build:  `self.x.expect("required field `x` was not set")`.
+    Required,
+    /// Required, but the type is a bare generic param (`value: T`).
+    /// Setter accepts `T` directly — `Into<T>` with unconstrained
+    /// `T` blows up at the call site.
+    /// Setter: `pub fn x(self, v: T) -> Self`.
+    /// Build:  `self.x.expect(...)`.
+    RequiredGeneric,
+    /// `Option<U>` prop. Builder stores `Option<Option<U>>` so we
+    /// can tell "user didn't set it" (outer None) apart from "user
+    /// set it to None" (outer Some, inner None — currently
+    /// unreachable in render! but kept for direct construction).
+    /// Setter takes the inner `U` (or `impl Into<U>` when U isn't
+    /// generic) and wraps to `Some(Some(...))`. Build collapses
+    /// the outer `Option` with `.unwrap_or(None)` so missing props
+    /// become None.
+    Optional {
+        /// The inner `U` extracted from `Option<U>`.
+        inner: Type,
+        /// `true` when `U` is a bare generic param — drops the
+        /// `Into<…>` on the setter (same reason as `RequiredGeneric`).
+        inner_is_generic: bool,
+    },
+    /// `Children` prop. Builder field is `Option<Children>`. Setter
+    /// takes `Children` directly (the type is already a wrapped
+    /// `Rc<dyn Fn>` — there's no useful `Into` story). Build
+    /// defaults a missing children prop to a closure returning
+    /// `View::Empty`, matching the typed-builder behaviour from
+    /// before.
+    Children,
+    /// `#[prop(default = expr)]`. Behaves like Required for the
+    /// setter and like `unwrap_or_else(|| expr)` at build time.
+    /// The expr is held in `default` rather than inlined into the
+    /// kind variant so the variant stays Copy-ish.
+    Default {
+        default: Expr,
+        /// Whether the type is a bare generic param (controls
+        /// `Into<T>` on the setter, same as for Required).
+        is_generic: bool,
+    },
+}
+
+/// Decide the [`PropKind`] for a given type + user `#[prop(...)]`
+/// directive. The precedence (mirrors what `typed_builder` did for us
+/// before):
 ///
-/// 1. `#[prop(default = expr)]` → `#[builder(default = expr)]` plus
-///    the type-default annotation below (so callers can still omit
-///    or supply the prop).
-/// 2. `Children` (last path segment) → `#[builder(default = …empty
-///    closure…)]` so a component can declare `children: Children`
-///    without forcing every call site to pass one.
-/// 3. `Option<T>` (last path segment) → `#[builder(default,
-///    setter(into, strip_option))]`. Callers may omit the prop or
-///    pass the inner `T` directly (typed-builder auto-wraps with
-///    `Some`).
-/// 4. Bare generic-type param (e.g. `value: T`) → `#[builder()]` (no
-///    `setter(into)`). With unconstrained `T`, `Into<T>` inference
-///    fails at the call site (multiple `From<...>` candidates).
-/// 5. Otherwise → `#[builder(setter(into))]`. Required prop; `Into`
-///    coercion lets `&str` flow into `String` props, `i32` into
-///    `f64`, etc.
-fn builder_annotation(ty: &Type, attr: &PropAttr, generic_type_params: &[Ident]) -> TokenStream2 {
+/// 1. `#[prop(default = expr)]` wins regardless of type.
+/// 2. `#[prop(optional)]` on a non-`Option<T>` type → upgrade to
+///    `Optional { inner: T, ... }` so the user can omit. (Currently
+///    user code uses `Option<T>` directly; this branch is reserved
+///    for future opt-in.)
+/// 3. `Children` (last path segment) → `Children` kind.
+/// 4. `Option<U>` (last path segment) → `Optional { inner: U, ... }`.
+/// 5. Bare generic param → `RequiredGeneric`.
+/// 6. Otherwise → `Required`.
+fn classify_prop(ty: &Type, attr: &PropAttr, generic_type_params: &[Ident]) -> PropKind {
     let is_generic = is_generic_type_param(ty, generic_type_params);
-    let into_or_none = if is_generic {
-        // Bare generic param — emit `setter()` without `into`.
-        quote! {}
-    } else {
-        quote! { setter(into) }
-    };
-    if let Some(default_expr) = &attr.default {
-        // User-supplied default. Pass `setter(into)` only when not
-        // generic.
-        if is_generic {
-            return quote! { #[builder(default = #default_expr)] };
-        }
-        return quote! { #[builder(default = #default_expr, #into_or_none)] };
+    if let Some(default_expr) = attr.default.clone() {
+        return PropKind::Default {
+            default: default_expr,
+            is_generic,
+        };
     }
     if attr.optional {
-        if is_generic {
-            return quote! { #[builder(default, setter(strip_option))] };
+        if let Some(inner) = option_inner_type(ty).cloned() {
+            let inner_is_generic = is_generic_type_param(&inner, generic_type_params);
+            return PropKind::Optional {
+                inner,
+                inner_is_generic,
+            };
         }
-        return quote! {
-            #[builder(default, setter(into, strip_option))]
+        // `#[prop(optional)]` on a non-`Option<T>` — wrap the user's
+        // type into an Optional with the same inner so the
+        // setter/build still typecheck. typed-builder's
+        // `strip_option` did the same.
+        return PropKind::Optional {
+            inner: ty.clone(),
+            inner_is_generic: is_generic,
         };
     }
     if is_children_type(ty) {
-        return quote! {
-            #[builder(default = ::std::rc::Rc::new(
-                || ::whisker::runtime::view::View::Empty
-            ))]
-        };
+        return PropKind::Children;
     }
-    if is_option_type(ty) {
-        // `Option<T>` where T is generic — still need strip_option,
-        // but no `into` since the inner T isn't known.
-        if is_option_of_generic(ty, generic_type_params) {
-            return quote! {
-                #[builder(default, setter(strip_option))]
-            };
-        }
-        return quote! {
-            #[builder(default, setter(into, strip_option))]
+    if let Some(inner) = option_inner_type(ty).cloned() {
+        let inner_is_generic = is_generic_type_param(&inner, generic_type_params);
+        return PropKind::Optional {
+            inner,
+            inner_is_generic,
         };
     }
     if is_generic {
-        // No annotation at all. typed-builder accepts an unannotated
-        // field; emitting `#[builder()]` errors with "Expected
-        // builder(…)".
-        return quote! {};
+        return PropKind::RequiredGeneric;
     }
-    quote! { #[builder(setter(into))] }
+    PropKind::Required
+}
+
+/// One field in the public `XxxProps` struct. Types stay exactly as
+/// the user wrote them — Props is the user-visible struct.
+fn prop_struct_field(prop: &Prop) -> TokenStream2 {
+    let ident = &prop.ident;
+    let ty = &prop.ty;
+    let attrs = &prop.forward_attrs;
+    quote! {
+        #(#attrs)*
+        pub #ident: #ty
+    }
+}
+
+/// One field in the internal builder struct. Every field becomes an
+/// `Option<…>` so we can distinguish "set" from "not set"; `Option<T>`
+/// props become `Option<Option<T>>` (outer Option = builder presence,
+/// inner = the user's Option semantics).
+fn prop_builder_field(prop: &Prop) -> TokenStream2 {
+    let ident = &prop.ident;
+    let ty = &prop.ty;
+    match &prop.kind {
+        PropKind::Required | PropKind::RequiredGeneric | PropKind::Children => {
+            quote! { #ident: ::std::option::Option<#ty> }
+        }
+        PropKind::Optional { inner, .. } => {
+            quote! { #ident: ::std::option::Option<::std::option::Option<#inner>> }
+        }
+        PropKind::Default { .. } => {
+            quote! { #ident: ::std::option::Option<#ty> }
+        }
+    }
+}
+
+/// `field: None` literal in the builder constructor (`Props::builder()`).
+fn prop_builder_init(prop: &Prop) -> TokenStream2 {
+    let ident = &prop.ident;
+    quote! { #ident: ::std::option::Option::None }
+}
+
+/// The setter method emitted on the builder. Signature depends on
+/// the prop kind — see PropKind doc for the exact rules.
+fn prop_setter_method(prop: &Prop) -> TokenStream2 {
+    let ident = &prop.ident;
+    let ty = &prop.ty;
+    match &prop.kind {
+        PropKind::Required => quote! {
+            #[allow(unused_mut)]
+            pub fn #ident(mut self, value: impl ::std::convert::Into<#ty>) -> Self {
+                self.#ident = ::std::option::Option::Some(value.into());
+                self
+            }
+        },
+        PropKind::RequiredGeneric => quote! {
+            #[allow(unused_mut)]
+            pub fn #ident(mut self, value: #ty) -> Self {
+                self.#ident = ::std::option::Option::Some(value);
+                self
+            }
+        },
+        PropKind::Optional {
+            inner,
+            inner_is_generic,
+        } => {
+            // Setter takes the inner (unwrapped) T — same surface
+            // typed-builder's `strip_option` gave us. Stored as
+            // `Some(Some(v))` to record both "set" and "set to a
+            // Some-value".
+            if *inner_is_generic {
+                quote! {
+                    #[allow(unused_mut)]
+                    pub fn #ident(mut self, value: #inner) -> Self {
+                        self.#ident = ::std::option::Option::Some(
+                            ::std::option::Option::Some(value)
+                        );
+                        self
+                    }
+                }
+            } else {
+                quote! {
+                    #[allow(unused_mut)]
+                    pub fn #ident(mut self, value: impl ::std::convert::Into<#inner>) -> Self {
+                        self.#ident = ::std::option::Option::Some(
+                            ::std::option::Option::Some(value.into())
+                        );
+                        self
+                    }
+                }
+            }
+        }
+        PropKind::Children => quote! {
+            #[allow(unused_mut)]
+            pub fn #ident(mut self, value: #ty) -> Self {
+                self.#ident = ::std::option::Option::Some(value);
+                self
+            }
+        },
+        PropKind::Default { is_generic, .. } => {
+            if *is_generic {
+                quote! {
+                    #[allow(unused_mut)]
+                    pub fn #ident(mut self, value: #ty) -> Self {
+                        self.#ident = ::std::option::Option::Some(value);
+                        self
+                    }
+                }
+            } else {
+                quote! {
+                    #[allow(unused_mut)]
+                    pub fn #ident(mut self, value: impl ::std::convert::Into<#ty>) -> Self {
+                        self.#ident = ::std::option::Option::Some(value.into());
+                        self
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// One `field: <unwrap-expression>` line inside `.build()`'s
+/// `XxxProps { … }` construction.
+fn prop_build_assignment(prop: &Prop) -> TokenStream2 {
+    let ident = &prop.ident;
+    let missing_msg = format!("required field `{ident}` was not set");
+    match &prop.kind {
+        PropKind::Required | PropKind::RequiredGeneric => quote! {
+            #ident: self.#ident.expect(#missing_msg)
+        },
+        PropKind::Optional { .. } => quote! {
+            // Outer Option = "did the user call .ident(…)?"
+            // — collapse missing → None so the public `Option<T>`
+            // field is the user's chosen value or None.
+            #ident: self.#ident.unwrap_or(::std::option::Option::None)
+        },
+        PropKind::Children => quote! {
+            #ident: self.#ident.unwrap_or_else(|| {
+                ::std::rc::Rc::new(|| ::whisker::runtime::view::View::Empty)
+            })
+        },
+        PropKind::Default { default, .. } => {
+            quote! {
+                #ident: self.#ident.unwrap_or_else(|| #default)
+            }
+        }
+    }
+}
+
+/// Extract `U` from `Option<U>` (in any of the path forms the user
+/// might write — bare, `std::option::Option`, fully-qualified).
+/// Returns `None` if the type isn't an `Option`.
+fn option_inner_type(ty: &Type) -> Option<&Type> {
+    let Type::Path(tp) = ty else { return None };
+    let last = tp.path.segments.last()?;
+    if last.ident != "Option" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+    for arg in &args.args {
+        if let syn::GenericArgument::Type(inner) = arg {
+            return Some(inner);
+        }
+    }
+    None
 }
 
 /// Is this type one of the fn's generic type parameters? Only
@@ -411,34 +676,6 @@ fn is_generic_type_param(ty: &Type, generic_type_params: &[Ident]) -> bool {
         }
     }
     false
-}
-
-/// Is this type `Option<T>` where the T is a generic type param?
-fn is_option_of_generic(ty: &Type, generic_type_params: &[Ident]) -> bool {
-    let Type::Path(tp) = ty else { return false };
-    let Some(last) = tp.path.segments.last() else {
-        return false;
-    };
-    if last.ident != "Option" {
-        return false;
-    }
-    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
-        return false;
-    };
-    for arg in &args.args {
-        if let syn::GenericArgument::Type(inner) = arg {
-            if is_generic_type_param(inner, generic_type_params) {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// Heuristic: is this type `Option<T>` (in any of the path forms the
-/// user might write — bare, `std::option::Option`, fully-qualified)?
-fn is_option_type(ty: &Type) -> bool {
-    last_path_ident(ty).map(|i| i == "Option").unwrap_or(false)
 }
 
 /// Heuristic: is this type `Children` (or a path ending in
@@ -504,6 +741,8 @@ mod tests {
     use super::*;
     use syn::parse_quote;
 
+    // -- Naming + helpers ---------------------------------------------------
+
     #[test]
     fn props_struct_name_pascal_case_conversion() {
         let id: Ident = parse_quote!(card);
@@ -517,24 +756,6 @@ mod tests {
 
         let id: Ident = parse_quote!(x);
         assert_eq!(props_struct_name(&id).to_string(), "XProps");
-    }
-
-    #[test]
-    fn option_type_detected_across_path_shapes() {
-        let bare: Type = parse_quote!(Option<String>);
-        assert!(is_option_type(&bare));
-
-        let std_path: Type = parse_quote!(std::option::Option<String>);
-        assert!(is_option_type(&std_path));
-
-        let fq_path: Type = parse_quote!(::std::option::Option<i32>);
-        assert!(is_option_type(&fq_path));
-
-        let not_option: Type = parse_quote!(String);
-        assert!(!is_option_type(&not_option));
-
-        let custom_with_option_substring: Type = parse_quote!(MyOptional);
-        assert!(!is_option_type(&custom_with_option_substring));
     }
 
     #[test]
@@ -553,12 +774,65 @@ mod tests {
     }
 
     #[test]
+    fn option_inner_type_unwraps_across_path_shapes() {
+        let bare: Type = parse_quote!(Option<String>);
+        let inner = option_inner_type(&bare).unwrap();
+        assert!(matches!(inner, Type::Path(_)));
+
+        let std_path: Type = parse_quote!(std::option::Option<String>);
+        assert!(option_inner_type(&std_path).is_some());
+
+        let fq_path: Type = parse_quote!(::std::option::Option<i32>);
+        assert!(option_inner_type(&fq_path).is_some());
+
+        let not_option: Type = parse_quote!(String);
+        assert!(option_inner_type(&not_option).is_none());
+
+        // `MyOptional` ends in `al` not `Option`. Not an Option.
+        let custom: Type = parse_quote!(MyOptional);
+        assert!(option_inner_type(&custom).is_none());
+
+        // `Option` without generic args → not a valid Option<T> for us.
+        let bare_option: Type = parse_quote!(Option);
+        assert!(option_inner_type(&bare_option).is_none());
+
+        // Non-path type (tuple).
+        let tup: Type = parse_quote!((u8, u8));
+        assert!(option_inner_type(&tup).is_none());
+    }
+
+    #[test]
     fn ty_generics_turbofish_extracts_only_type_params() {
         let g: syn::Generics = parse_quote!(<'a, T: Clone, const N: usize>);
         let turbofish = ty_generics_to_turbofish(&g);
         assert_eq!(turbofish.len(), 1, "lifetime and const generic skipped");
         assert_eq!(turbofish[0].to_string(), "T");
     }
+
+    #[test]
+    fn is_generic_type_param_detects_bare_t() {
+        let t_param: Ident = parse_quote!(T);
+        let u_param: Ident = parse_quote!(U);
+        let generics = vec![t_param, u_param];
+
+        assert!(is_generic_type_param(&parse_quote!(T), &generics));
+        assert!(is_generic_type_param(&parse_quote!(U), &generics));
+
+        // `Option<T>` — the outer type is `Option`, not bare T.
+        assert!(!is_generic_type_param(&parse_quote!(Option<T>), &generics));
+        // Multi-segment path with same final ident does NOT match.
+        assert!(!is_generic_type_param(&parse_quote!(crate::T), &generics));
+        // Concrete non-generic type.
+        assert!(!is_generic_type_param(&parse_quote!(String), &generics));
+        // Generic-shaped (T<X>) doesn't match.
+        let t_with_args: Type = parse_quote!(T<i32>);
+        assert!(!is_generic_type_param(&t_with_args, &generics));
+        // Non-path type (reference) doesn't match.
+        let reference: Type = parse_quote!(&'a str);
+        assert!(!is_generic_type_param(&reference, &generics));
+    }
+
+    // -- #[prop(...)] attribute parser -------------------------------------
 
     #[test]
     fn parse_prop_default_attribute() {
@@ -591,11 +865,378 @@ mod tests {
         }
     }
 
-    /// Sanity check on the overall expansion shape — we don't try to
-    /// re-parse the output (the function calls into runtime symbols
-    /// the macro crate doesn't have access to), but we confirm the
-    /// Props struct + rewritten fn both come out and the fn body has
-    /// the destructure.
+    #[test]
+    fn parse_prop_ignores_other_attrs() {
+        // #[allow(...)] etc. must not interfere with #[prop(...)] parsing.
+        let attrs: Vec<syn::Attribute> = parse_quote! {
+            #[allow(dead_code)]
+            #[doc = "ignored"]
+        };
+        let parsed = parse_prop_attr(&attrs).unwrap();
+        assert!(parsed.default.is_none());
+        assert!(!parsed.optional);
+    }
+
+    // -- classify_prop decision table --------------------------------------
+
+    fn classify(ty: Type, attr: PropAttr, generics: &[Ident]) -> PropKind {
+        classify_prop(&ty, &attr, generics)
+    }
+
+    #[test]
+    fn classify_required_for_plain_type() {
+        let k = classify(parse_quote!(String), PropAttr::default(), &[]);
+        assert!(matches!(k, PropKind::Required));
+    }
+
+    #[test]
+    fn classify_required_generic_for_bare_t() {
+        let generics = vec![parse_quote!(T)];
+        let k = classify(parse_quote!(T), PropAttr::default(), &generics);
+        assert!(matches!(k, PropKind::RequiredGeneric));
+    }
+
+    #[test]
+    fn classify_optional_for_option_of_concrete() {
+        let k = classify(parse_quote!(Option<String>), PropAttr::default(), &[]);
+        match k {
+            PropKind::Optional {
+                inner_is_generic, ..
+            } => assert!(!inner_is_generic, "concrete inner shouldn't be generic"),
+            other => panic!(
+                "expected Optional, got {other:?}",
+                other = kind_name(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_optional_for_option_of_generic() {
+        let generics = vec![parse_quote!(T)];
+        let k = classify(parse_quote!(Option<T>), PropAttr::default(), &generics);
+        match k {
+            PropKind::Optional {
+                inner_is_generic, ..
+            } => assert!(
+                inner_is_generic,
+                "Option<T> inner T must be flagged generic"
+            ),
+            other => panic!(
+                "expected Optional, got {other:?}",
+                other = kind_name(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_children_for_children_type() {
+        let k = classify(parse_quote!(Children), PropAttr::default(), &[]);
+        assert!(matches!(k, PropKind::Children));
+        // Qualified path also matches.
+        let k = classify(parse_quote!(whisker::Children), PropAttr::default(), &[]);
+        assert!(matches!(k, PropKind::Children));
+    }
+
+    #[test]
+    fn classify_default_wins_over_other_kinds() {
+        // #[prop(default = …)] takes precedence — even when the type
+        // is Option<T> or Children.
+        let attr = PropAttr {
+            default: Some(parse_quote!(42)),
+            ..PropAttr::default()
+        };
+        let k = classify(parse_quote!(Option<i32>), attr.clone(), &[]);
+        assert!(matches!(
+            k,
+            PropKind::Default {
+                is_generic: false,
+                ..
+            }
+        ));
+
+        let k = classify(parse_quote!(Children), attr, &[]);
+        assert!(matches!(
+            k,
+            PropKind::Default {
+                is_generic: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn classify_default_with_generic_t() {
+        let generics = vec![parse_quote!(T)];
+        let attr = PropAttr {
+            default: Some(parse_quote!(Default::default())),
+            ..PropAttr::default()
+        };
+        let k = classify(parse_quote!(T), attr, &generics);
+        assert!(matches!(
+            k,
+            PropKind::Default {
+                is_generic: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn classify_optional_attribute_wraps_non_option_type() {
+        // `#[prop(optional)]` on `String` should treat the field as
+        // Optional<String>.
+        let attr = PropAttr {
+            optional: true,
+            ..PropAttr::default()
+        };
+        let k = classify(parse_quote!(String), attr, &[]);
+        match k {
+            PropKind::Optional {
+                inner_is_generic, ..
+            } => assert!(!inner_is_generic),
+            other => panic!(
+                "expected Optional, got {other:?}",
+                other = kind_name(&other)
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_optional_attribute_on_option_uses_inner() {
+        // `#[prop(optional)]` on `Option<String>` extracts the inner
+        // String — same as a plain Option<String>.
+        let attr = PropAttr {
+            optional: true,
+            ..PropAttr::default()
+        };
+        let k = classify(parse_quote!(Option<String>), attr, &[]);
+        assert!(matches!(k, PropKind::Optional { .. }));
+    }
+
+    // -- Per-prop emission helpers (struct field / builder field / setter / build assignment) -----
+
+    fn make_prop(ident: &str, ty: Type, kind: PropKind) -> Prop {
+        Prop {
+            ident: format_ident!("{}", ident),
+            ty,
+            kind,
+            forward_attrs: vec![],
+        }
+    }
+
+    #[test]
+    fn prop_struct_field_keeps_user_type() {
+        let p = make_prop("label", parse_quote!(String), PropKind::Required);
+        let out = prop_struct_field(&p).to_string();
+        assert!(
+            out.contains("pub label : String"),
+            "Props field uses the user's type verbatim; got: {out}"
+        );
+    }
+
+    #[test]
+    fn prop_struct_field_forwards_attrs() {
+        let attrs: Vec<syn::Attribute> = parse_quote! {
+            #[doc = "user doc"]
+            #[allow(dead_code)]
+        };
+        let p = Prop {
+            ident: format_ident!("label"),
+            ty: parse_quote!(String),
+            kind: PropKind::Required,
+            forward_attrs: attrs,
+        };
+        let out = prop_struct_field(&p).to_string();
+        assert!(out.contains("doc = \"user doc\""));
+        assert!(out.contains("allow (dead_code)"));
+    }
+
+    #[test]
+    fn prop_builder_field_wraps_required_in_option() {
+        let p = make_prop("a", parse_quote!(String), PropKind::Required);
+        let out = prop_builder_field(&p).to_string();
+        assert!(out.contains("a : :: std :: option :: Option < String >"));
+    }
+
+    #[test]
+    fn prop_builder_field_double_wraps_optional() {
+        let p = make_prop(
+            "b",
+            parse_quote!(Option<String>),
+            PropKind::Optional {
+                inner: parse_quote!(String),
+                inner_is_generic: false,
+            },
+        );
+        let out = prop_builder_field(&p).to_string();
+        // tokenstream display can collapse `> >` into `>>`. Accept both.
+        let normalized = out.replace(" >>", " > >");
+        assert!(
+            normalized
+                .contains(":: std :: option :: Option < :: std :: option :: Option < String > >"),
+            "Option<T> prop should be Option<Option<T>> in builder; got: {out}"
+        );
+    }
+
+    #[test]
+    fn prop_builder_field_default_uses_outer_type() {
+        let p = make_prop(
+            "c",
+            parse_quote!(i32),
+            PropKind::Default {
+                default: parse_quote!(0),
+                is_generic: false,
+            },
+        );
+        let out = prop_builder_field(&p).to_string();
+        assert!(out.contains("c : :: std :: option :: Option < i32 >"));
+    }
+
+    #[test]
+    fn prop_setter_required_uses_impl_into() {
+        let p = make_prop("a", parse_quote!(String), PropKind::Required);
+        let out = prop_setter_method(&p).to_string();
+        assert!(out.contains("pub fn a"));
+        assert!(out.contains("impl :: std :: convert :: Into < String >"));
+        assert!(out.contains("self . a = :: std :: option :: Option :: Some (value . into ())"));
+    }
+
+    #[test]
+    fn prop_setter_required_generic_takes_t_directly() {
+        let p = make_prop("v", parse_quote!(T), PropKind::RequiredGeneric);
+        let out = prop_setter_method(&p).to_string();
+        assert!(out.contains("pub fn v (mut self , value : T)"));
+        // No `impl Into<T>` on generic — would break inference.
+        assert!(!out.contains("Into < T >"));
+    }
+
+    #[test]
+    fn prop_setter_optional_strips_outer_option() {
+        let p = make_prop(
+            "alt",
+            parse_quote!(Option<String>),
+            PropKind::Optional {
+                inner: parse_quote!(String),
+                inner_is_generic: false,
+            },
+        );
+        let out = prop_setter_method(&p).to_string();
+        // Setter takes the inner String (not Option<String>).
+        assert!(out.contains("impl :: std :: convert :: Into < String >"));
+        // Stored as Some(Some(v.into())) — double wrap.
+        assert!(out.contains("Option :: Some (:: std :: option :: Option :: Some"));
+    }
+
+    #[test]
+    fn prop_setter_optional_with_generic_inner_skips_into() {
+        let p = make_prop(
+            "alt",
+            parse_quote!(Option<T>),
+            PropKind::Optional {
+                inner: parse_quote!(T),
+                inner_is_generic: true,
+            },
+        );
+        let out = prop_setter_method(&p).to_string();
+        assert!(out.contains("value : T"));
+        assert!(!out.contains("Into < T >"));
+    }
+
+    #[test]
+    fn prop_setter_children_takes_value_directly() {
+        let p = make_prop("children", parse_quote!(Children), PropKind::Children);
+        let out = prop_setter_method(&p).to_string();
+        assert!(out.contains("value : Children"));
+        // No `Into` — `Children` is already a wrapper type.
+        assert!(!out.contains("Into <"));
+    }
+
+    #[test]
+    fn prop_setter_default_uses_impl_into_for_concrete() {
+        let p = make_prop(
+            "count",
+            parse_quote!(i32),
+            PropKind::Default {
+                default: parse_quote!(5),
+                is_generic: false,
+            },
+        );
+        let out = prop_setter_method(&p).to_string();
+        assert!(out.contains("impl :: std :: convert :: Into < i32 >"));
+    }
+
+    #[test]
+    fn prop_setter_default_with_generic_takes_t_directly() {
+        let p = make_prop(
+            "v",
+            parse_quote!(T),
+            PropKind::Default {
+                default: parse_quote!(Default::default()),
+                is_generic: true,
+            },
+        );
+        let out = prop_setter_method(&p).to_string();
+        assert!(out.contains("value : T"));
+        assert!(!out.contains("Into < T >"));
+    }
+
+    #[test]
+    fn prop_build_assignment_required_expects() {
+        let p = make_prop("a", parse_quote!(String), PropKind::Required);
+        let out = prop_build_assignment(&p).to_string();
+        assert!(out.contains(". expect ("));
+        assert!(out.contains("\"required field `a` was not set\""));
+    }
+
+    #[test]
+    fn prop_build_assignment_required_generic_expects() {
+        let p = make_prop("v", parse_quote!(T), PropKind::RequiredGeneric);
+        let out = prop_build_assignment(&p).to_string();
+        assert!(out.contains("\"required field `v` was not set\""));
+    }
+
+    #[test]
+    fn prop_build_assignment_optional_defaults_to_none() {
+        let p = make_prop(
+            "alt",
+            parse_quote!(Option<String>),
+            PropKind::Optional {
+                inner: parse_quote!(String),
+                inner_is_generic: false,
+            },
+        );
+        let out = prop_build_assignment(&p).to_string();
+        // unwrap_or(None) — missing prop becomes None.
+        assert!(out.contains("unwrap_or"));
+        assert!(out.contains("Option :: None"));
+    }
+
+    #[test]
+    fn prop_build_assignment_children_defaults_to_empty_closure() {
+        let p = make_prop("children", parse_quote!(Children), PropKind::Children);
+        let out = prop_build_assignment(&p).to_string();
+        assert!(out.contains("unwrap_or_else"));
+        assert!(out.contains("Rc :: new"));
+        assert!(out.contains("View :: Empty"));
+    }
+
+    #[test]
+    fn prop_build_assignment_default_uses_user_expr() {
+        let p = make_prop(
+            "count",
+            parse_quote!(i32),
+            PropKind::Default {
+                default: parse_quote!(99),
+                is_generic: false,
+            },
+        );
+        let out = prop_build_assignment(&p).to_string();
+        assert!(out.contains("unwrap_or_else"));
+        assert!(out.contains("99"));
+    }
+
+    // -- expand() end-to-end shape ----------------------------------------
+
     #[test]
     fn expand_emits_props_struct_and_rewritten_fn() {
         let input: TokenStream2 = quote! {
@@ -604,14 +1245,18 @@ mod tests {
             }
         };
         let output = expand(input).to_string();
+        // Props struct lives inside the hidden inner mod.
         assert!(output.contains("struct CardProps"));
+        assert!(output.contains("struct CardPropsBuilder"));
         assert!(output.contains("fn card"));
         assert!(output.contains("__props : CardProps"));
         assert!(output.contains("CardProps { title }"));
+        // PascalCase alias is emitted.
+        assert!(output.contains("use __card_inner :: card as Card"));
     }
 
     #[test]
-    fn expand_handles_no_param_component() {
+    fn expand_no_param_component_emits_empty_destructure() {
         let input: TokenStream2 = quote! {
             fn header() -> Element {
                 render! { view { text { "Hi" } } }
@@ -619,31 +1264,33 @@ mod tests {
         };
         let output = expand(input).to_string();
         assert!(output.contains("struct HeaderProps"));
-        assert!(output.contains("fn header"));
-        // No-param destructure should be `HeaderProps { }` (just braces).
         assert!(
             output.contains("HeaderProps { }") || output.contains("HeaderProps {}"),
-            "no-param destructure should be empty braces, got: {output}"
+            "no-param destructure should be empty braces; got: {output}"
         );
+        // No setters for a zero-param component, just builder()+build().
+        assert!(output.contains("pub fn builder"));
+        assert!(output.contains("pub fn build"));
     }
 
     #[test]
-    fn expand_handles_option_param() {
+    fn expand_does_not_reference_typed_builder() {
+        // Regression: we replaced typed-builder with a hand-rolled
+        // builder. The emission must not reference the old crate
+        // path or its derive macro.
         let input: TokenStream2 = quote! {
-            fn x(label: Option<String>) -> Element {
+            fn card(title: String, count: i32) -> Element {
                 render! { view {} }
             }
         };
         let output = expand(input).to_string();
-        assert!(output.contains("struct XProps"));
-        assert!(
-            output.contains("strip_option"),
-            "Option<T> param should emit strip_option, got: {output}"
-        );
+        assert!(!output.contains("typed_builder"));
+        assert!(!output.contains("TypedBuilder"));
+        assert!(!output.contains("__typed_builder"));
     }
 
     #[test]
-    fn expand_handles_generic_component() {
+    fn expand_generic_component_uses_turbofish() {
         let input: TokenStream2 = quote! {
             fn typed<T: Clone + 'static>(value: T) -> Element {
                 render! { view {} }
@@ -651,109 +1298,80 @@ mod tests {
         };
         let output = expand(input).to_string();
         assert!(output.contains("struct TypedProps"));
-        // Turbofish form of the fn ptr cast inside the body
         assert!(
             output.contains("typed :: < T >") || output.contains("typed::<T>"),
-            "generic fn should use turbofish for fn-ptr cast, got: {output}"
+            "generic fn should use turbofish for fn-ptr cast; got: {output}"
         );
     }
 
     #[test]
-    fn generic_param_skips_into_setter() {
-        // Field whose type is a bare generic param must NOT get
-        // `setter(into)`, otherwise `Into<T>` with unconstrained `T`
-        // breaks call-site inference. Concrete fields keep `into`.
+    fn expand_rejects_method_receiver() {
         let input: TokenStream2 = quote! {
-            fn typed<T: Clone + 'static>(value: T, label: String) -> Element {
+            fn card(&self, title: String) -> Element {
                 render! { view {} }
             }
         };
         let output = expand(input).to_string();
-        // The String field still carries setter(into).
+        // The expansion replaces the body with a compile_error!() —
+        // detect it via the macro path.
         assert!(
-            output.contains("setter (into)") || output.contains("setter(into)"),
-            "non-generic String field should keep setter(into); got: {output}"
-        );
-        // The generic field is annotated with `#[builder()]` only —
-        // i.e. no `setter(into)` clause is attached to its declaration.
-        // (Easier to assert this through the wider shape than a regex.)
-        // We confirm by counting `setter (into)` occurrences: 1 (the
-        // String field), and crucially the `value : T` field must be
-        // preceded by a bare `#[builder ()]` annotation.
-        let n = output.matches("setter (into)").count() + output.matches("setter(into)").count();
-        assert_eq!(
-            n, 1,
-            "exactly one setter(into) expected (the non-generic field); got {n} in: {output}"
+            output.contains("compile_error"),
+            "method receiver should produce a compile error; got: {output}"
         );
     }
 
     #[test]
-    fn option_of_generic_skips_into_setter() {
-        // `Option<T>` where T is generic: still need strip_option,
-        // but `into` would need a known target type → must be skipped.
+    fn expand_rejects_destructuring_pattern() {
         let input: TokenStream2 = quote! {
-            fn typed<T: Clone + 'static>(value: Option<T>) -> Element {
+            fn card((a, b): (i32, i32)) -> Element {
+                render! { view {} }
+            }
+        };
+        let output = expand(input).to_string();
+        assert!(output.contains("compile_error"));
+    }
+
+    #[test]
+    fn expand_props_alias_strips_props_suffix_once() {
+        // Regression test for the `TwoPropsProps -> Two` greedy-trim
+        // bug. The alias derived from `TwoPropsProps` must be
+        // `TwoProps`, not `Two`.
+        let input: TokenStream2 = quote! {
+            fn two_props(title: String, count: i32) -> Element {
                 render! { view {} }
             }
         };
         let output = expand(input).to_string();
         assert!(
-            output.contains("strip_option"),
-            "Option<T> must still strip_option; got: {output}"
+            output.contains("as TwoProps"),
+            "alias should be `TwoProps`, not the over-trimmed `Two`; got: {output}"
         );
-        let n = output.matches("into").count();
-        // Should be zero `into` for the field-level setter. (We can
-        // still match "into" inside other tokens, but typed-builder
-        // setter clause uses the bare `into` ident, so the safer
-        // assertion is that the field-level annotation does not have
-        // `setter (into ,` or `setter(into,`.)
+    }
+
+    #[test]
+    fn expand_forwards_attribute_on_param_to_props_field() {
+        // Non-`#[prop]` attrs ride along on the emitted Props field.
+        let input: TokenStream2 = quote! {
+            fn card(#[allow(dead_code)] title: String) -> Element {
+                render! { view {} }
+            }
+        };
+        let output = expand(input).to_string();
         assert!(
-            !output.contains("setter (into ,") && !output.contains("setter(into,"),
-            "Option<T> with generic T must not emit setter(into,...); got: {output}"
+            output.contains("allow (dead_code)"),
+            "user attr should appear on the Props field; got: {output}"
         );
-        let _ = n;
     }
 
-    #[test]
-    fn is_generic_type_param_detects_bare_t() {
-        let t_param: Ident = parse_quote!(T);
-        let u_param: Ident = parse_quote!(U);
-        let generics = vec![t_param, u_param];
+    // -- Helper used by classify_* assertions -----------------------------
 
-        let bare_t: Type = parse_quote!(T);
-        assert!(is_generic_type_param(&bare_t, &generics));
-
-        let bare_u: Type = parse_quote!(U);
-        assert!(is_generic_type_param(&bare_u, &generics));
-
-        // `Option<T>` — the outer type is `Option`, not bare T.
-        let opt_t: Type = parse_quote!(Option<T>);
-        assert!(!is_generic_type_param(&opt_t, &generics));
-
-        // Concrete type with same name does NOT exist by definition,
-        // but a path that has multiple segments should not match.
-        let path_t: Type = parse_quote!(crate::T);
-        assert!(!is_generic_type_param(&path_t, &generics));
-
-        // Non-generic type.
-        let string_ty: Type = parse_quote!(String);
-        assert!(!is_generic_type_param(&string_ty, &generics));
-    }
-
-    #[test]
-    fn is_option_of_generic_detects_inner_t() {
-        let t_param: Ident = parse_quote!(T);
-        let generics = vec![t_param];
-
-        let opt_t: Type = parse_quote!(Option<T>);
-        assert!(is_option_of_generic(&opt_t, &generics));
-
-        // Option<String> — inner is not a generic param.
-        let opt_string: Type = parse_quote!(Option<String>);
-        assert!(!is_option_of_generic(&opt_string, &generics));
-
-        // Plain String is not an option at all.
-        let plain: Type = parse_quote!(String);
-        assert!(!is_option_of_generic(&plain, &generics));
+    fn kind_name(k: &PropKind) -> &'static str {
+        match k {
+            PropKind::Required => "Required",
+            PropKind::RequiredGeneric => "RequiredGeneric",
+            PropKind::Optional { .. } => "Optional",
+            PropKind::Children => "Children",
+            PropKind::Default { .. } => "Default",
+        }
     }
 }

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -161,60 +161,73 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         quote! { #fn_name :: < #(#ty_generics_for_turbofish),* > as *const () }
     };
 
-    // Props struct lives inside a `#[doc(hidden)]` private module
-    // so the per-field type-state builder helpers typed-builder
-    // generates (`XxxPropsBuilder<((),(),(),)>` and the per-field
-    // empty/filled marker types) don't pollute rust-analyzer's
-    // identifier completion at the user's call sites. Only the
-    // top-level `XxxProps` is re-exported; the builder type is
-    // returned by `XxxProps::builder()` and reached via method
-    // chains, so it doesn't need to be in scope by name.
+    // Props struct lives inside a PRIVATE module. typed-builder's
+    // per-field type-state helpers (`XxxPropsBuilder<((),(),(),)>`
+    // and per-field empty/filled marker structs) stay inside that
+    // module and can't be reached from outside by name — so RA's
+    // identifier completion at user call sites can't list them as
+    // candidates, no matter what doc-attribute filtering it does.
+    //
+    // Only `XxxProps` itself is re-exported (doc-hidden so it
+    // doesn't clutter rustdoc either). The builder type is the
+    // return value of `XxxProps::builder()` and is reached via
+    // method chains, so it doesn't need to be in scope by name.
     //
     // Generics + where clause come straight from the function —
     // typed-builder threads them through to the generated builder.
     let internal_mod = format_ident!("__{}_props_internal", fn_name);
     let props_struct = quote! {
+        // No `#vis` on the module — the visibility is deliberately
+        // tighter than the surrounding fn so helper types stay
+        // unreachable.
         #[doc(hidden)]
-        #vis mod #internal_mod {
+        mod #internal_mod {
             // Pull in everything from the outer scope so prop types
             // referenced in fields (`Children`, user types, etc.)
-            // resolve. `use super::*` is safe here because the
-            // module is hidden and only re-exports the Props struct.
+            // resolve.
             use super::*;
             #[derive(::whisker::__typed_builder::TypedBuilder)]
             pub struct #props_name #impl_generics #where_clause {
                 #(#props_fields),*
             }
         }
+        #[doc(hidden)]
         #vis use #internal_mod::#props_name;
     };
 
-    // PascalCase alias so rust-analyzer's identifier completion
-    // can find the component by its render!-call-site name
-    // (`Art|` → `ArtTile`). Without this, only the snake_case fn
-    // is in scope and `Art…` matches nothing.
-    //
-    // The alias is `non_snake_case` (it's a fn re-export named
-    // PascalCase) — opt-out the lint locally.
+    // PascalCase alias is the user-facing call-site name. Visible
+    // (NOT doc-hidden) because this is the canonical name in
+    // render! syntax — surfacing it in completion is the whole
+    // point. `non_snake_case` opt-out for the fn-as-PascalCase
+    // alias.
     let alias_str = props_name.to_string();
     let alias_str = alias_str.trim_end_matches("Props");
     let fn_name_str = fn_name.to_string();
-    let pascal_alias = if alias_str == fn_name_str {
+    let (alias_ident, pascal_alias) = if alias_str == fn_name_str {
         // Defensive: a fn named in PascalCase already (`fn MyCard`)
         // would alias to itself. Skip in that case.
-        quote! {}
+        (fn_name.clone(), quote! {})
     } else {
         let alias_ident = format_ident!("{}", alias_str);
-        quote! {
+        let alias = quote! {
             #[allow(non_snake_case)]
             #vis use #fn_name as #alias_ident;
-        }
+        };
+        (alias_ident, alias)
     };
+    let _ = alias_ident; // render! still emits via the snake fn for now
 
     // Rewritten function: same signature except parameters are
     // collapsed into a single `__props: XxxProps<...>` arg. Body
     // destructures and runs the existing remount machinery.
+    //
+    // `#[doc(hidden)]` on the snake_case fn so it's de-prioritised
+    // in RA's identifier completion. Users always call via the
+    // PascalCase alias (above) or through `render!`; the snake_case
+    // fn is internal plumbing the macro lowering targets — same
+    // status as the `__xxx_props_internal` mod above.
     let new_fn = quote! {
+        #[doc(hidden)]
         #(#attrs)*
         #vis fn #fn_name #impl_generics (
             __props: #props_name #ty_generics

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -216,6 +216,12 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
             // None". `.build()` collapses each Option back into the
             // field's declared type, with the appropriate
             // default / panic-on-missing for required fields.
+            //
+            // `#[doc(hidden)]` on the struct itself so RA's auto-
+            // import doesn't surface it at the user's call site.
+            // The builder is purely the return type of `.builder()`
+            // — users never need to write its name.
+            #[doc(hidden)]
             pub struct #builder_name #impl_generics #where_clause {
                 #(#builder_fields),*
             }

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -200,66 +200,86 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
     // render! syntax — surfacing it in completion is the whole
     // point. `non_snake_case` opt-out for the fn-as-PascalCase
     // alias.
-    let alias_str = props_name.to_string();
-    let alias_str = alias_str.trim_end_matches("Props");
+    // `props_name` is `<PascalCase fn>Props`. Strip the suffix
+    // exactly once to recover the alias name — `trim_end_matches`
+    // is the wrong tool here because it greedily strips repeats
+    // (`TwoPropsProps` → `Two`, dropping the user's actual name).
+    let props_name_str = props_name.to_string();
+    let alias_str = props_name_str
+        .strip_suffix("Props")
+        .unwrap_or(&props_name_str);
     let fn_name_str = fn_name.to_string();
-    let (alias_ident, pascal_alias) = if alias_str == fn_name_str {
-        // Defensive: a fn named in PascalCase already (`fn MyCard`)
-        // would alias to itself. Skip in that case.
-        (fn_name.clone(), quote! {})
-    } else {
-        let alias_ident = format_ident!("{}", alias_str);
-        let alias = quote! {
-            #[allow(non_snake_case)]
-            #vis use #fn_name as #alias_ident;
-        };
-        (alias_ident, alias)
-    };
-    let _ = alias_ident; // render! still emits via the snake fn for now
 
     // Rewritten function: same signature except parameters are
     // collapsed into a single `__props: XxxProps<...>` arg. Body
     // destructures and runs the existing remount machinery.
     //
-    // `#[doc(hidden)]` on the snake_case fn so it's de-prioritised
-    // in RA's identifier completion. Users always call via the
-    // PascalCase alias (above) or through `render!`; the snake_case
-    // fn is internal plumbing the macro lowering targets — same
-    // status as the `__xxx_props_internal` mod above.
+    // The fn lives inside a PRIVATE inner module so its
+    // snake_case name (`art_tile`) doesn't pollute outer-scope
+    // completion candidates. Only the PascalCase alias (declared
+    // below) re-exports it outward. `#[doc(hidden)]` is
+    // redundant given the private module, but kept as belt-and-
+    // suspenders for tools that filter by doc-attribute.
+    let inner_mod = format_ident!("__{}_inner", fn_name);
     let new_fn = quote! {
         #[doc(hidden)]
-        #(#attrs)*
-        #vis fn #fn_name #impl_generics (
-            __props: #props_name #ty_generics
-        ) #output #where_clause {
-            let #props_name { #(#prop_idents),* } = __props;
-            #(#captures)*
+        mod #inner_mod {
+            use super::*;
+            #[doc(hidden)]
+            #(#attrs)*
+            pub fn #fn_name #impl_generics (
+                __props: #props_name #ty_generics
+            ) #output #where_clause {
+                let #props_name { #(#prop_idents),* } = __props;
+                #(#captures)*
 
-            // Mirrors the pre-rewrite #[component] body shape — see
-            // `crates/whisker-macros/src/lib.rs`'s history for the
-            // rationale on the two-closure layering (outer keeps
-            // re-clone bookkeeping out of the subsecond-dispatched
-            // inner, which has to live at the user crate's source
-            // position for hot reload to find it).
-            let __body: ::std::boxed::Box<
-                dyn ::std::ops::Fn() -> ::whisker::runtime::view::Element + 'static,
-            > = ::std::boxed::Box::new(move || {
-                #(#restores)*
-                ::whisker::__hot::call(move || {
-                    #block
-                })
-            });
-            ::whisker::runtime::reactive::mount_component_remountable(
-                #fn_ptr_expr,
-                __body,
-            )
+                // Mirrors the pre-rewrite #[component] body shape
+                // — see `crates/whisker-macros/src/lib.rs`'s
+                // history for the rationale on the two-closure
+                // layering (outer keeps re-clone bookkeeping out
+                // of the subsecond-dispatched inner, which has to
+                // live at the user crate's source position for
+                // hot reload to find it).
+                let __body: ::std::boxed::Box<
+                    dyn ::std::ops::Fn() -> ::whisker::runtime::view::Element + 'static,
+                > = ::std::boxed::Box::new(move || {
+                    #(#restores)*
+                    ::whisker::__hot::call(move || {
+                        #block
+                    })
+                });
+                ::whisker::runtime::reactive::mount_component_remountable(
+                    #fn_ptr_expr,
+                    __body,
+                )
+            }
+        }
+    };
+
+    // PascalCase alias re-exports the fn from the inner module.
+    // This (and only this) is the user-facing call-site name.
+    //
+    // `#[component]` is expected at module level (not nested
+    // inside fn bodies) — both because `pub use` only works at
+    // module level and because components benefit from being
+    // visible to their crate's `render!` callers.
+    let pascal_alias = if alias_str == fn_name_str {
+        quote! {
+            #[doc(hidden)]
+            #vis use #inner_mod::#fn_name;
+        }
+    } else {
+        let alias_ident = format_ident!("{}", alias_str);
+        quote! {
+            #[allow(non_snake_case)]
+            #vis use #inner_mod::#fn_name as #alias_ident;
         }
     };
 
     quote! {
         #props_struct
-        #pascal_alias
         #new_fn
+        #pascal_alias
     }
 }
 

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -161,18 +161,53 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         quote! { #fn_name :: < #(#ty_generics_for_turbofish),* > as *const () }
     };
 
-    // Props struct. Generics + where clause come straight from the
-    // function — typed-builder threads them through to the generated
-    // `XxxPropsBuilder<...>`.
-    // The Props struct mirrors the user's fn visibility. A `pub fn`
-    // produces `pub struct XxxProps` (so external callers can write
-    // `render! { xxx { ... } }` and the macro-expansion can resolve
-    // `XxxProps::builder()`). A bare `fn` keeps the struct module-
-    // private, matching the original encapsulation.
+    // Props struct lives inside a `#[doc(hidden)]` private module
+    // so the per-field type-state builder helpers typed-builder
+    // generates (`XxxPropsBuilder<((),(),(),)>` and the per-field
+    // empty/filled marker types) don't pollute rust-analyzer's
+    // identifier completion at the user's call sites. Only the
+    // top-level `XxxProps` is re-exported; the builder type is
+    // returned by `XxxProps::builder()` and reached via method
+    // chains, so it doesn't need to be in scope by name.
+    //
+    // Generics + where clause come straight from the function —
+    // typed-builder threads them through to the generated builder.
+    let internal_mod = format_ident!("__{}_props_internal", fn_name);
     let props_struct = quote! {
-        #[derive(::whisker::__typed_builder::TypedBuilder)]
-        #vis struct #props_name #impl_generics #where_clause {
-            #(#props_fields),*
+        #[doc(hidden)]
+        #vis mod #internal_mod {
+            // Pull in everything from the outer scope so prop types
+            // referenced in fields (`Children`, user types, etc.)
+            // resolve. `use super::*` is safe here because the
+            // module is hidden and only re-exports the Props struct.
+            use super::*;
+            #[derive(::whisker::__typed_builder::TypedBuilder)]
+            pub struct #props_name #impl_generics #where_clause {
+                #(#props_fields),*
+            }
+        }
+        #vis use #internal_mod::#props_name;
+    };
+
+    // PascalCase alias so rust-analyzer's identifier completion
+    // can find the component by its render!-call-site name
+    // (`Art|` → `ArtTile`). Without this, only the snake_case fn
+    // is in scope and `Art…` matches nothing.
+    //
+    // The alias is `non_snake_case` (it's a fn re-export named
+    // PascalCase) — opt-out the lint locally.
+    let alias_str = props_name.to_string();
+    let alias_str = alias_str.trim_end_matches("Props");
+    let fn_name_str = fn_name.to_string();
+    let pascal_alias = if alias_str == fn_name_str {
+        // Defensive: a fn named in PascalCase already (`fn MyCard`)
+        // would alias to itself. Skip in that case.
+        quote! {}
+    } else {
+        let alias_ident = format_ident!("{}", alias_str);
+        quote! {
+            #[allow(non_snake_case)]
+            #vis use #fn_name as #alias_ident;
         }
     };
 
@@ -210,6 +245,7 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
 
     quote! {
         #props_struct
+        #pascal_alias
         #new_fn
     }
 }

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -217,10 +217,17 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
             // field's declared type, with the appropriate
             // default / panic-on-missing for required fields.
             //
-            // `#[doc(hidden)]` on the struct itself so RA's auto-
-            // import doesn't surface it at the user's call site.
-            // The builder is purely the return type of `.builder()`
-            // — users never need to write its name.
+            // The struct stays `pub` (with `#[doc(hidden)]`) because
+            // a `pub` struct's `pub fn` methods are only callable
+            // from outside if the struct itself is reachable. A
+            // truly-private builder breaks `XxxProps::builder()
+            // .setter(…).build()` from outside the mod — Rust's
+            // method-resolution sees the methods as private when
+            // the type is private, even though the value is held
+            // by the caller. So the builder's name is necessarily
+            // visible at the user's call site; `#[doc(hidden)]` is
+            // the best signal we can give RA. Newer RA versions
+            // honour it for auto-import filtering.
             #[doc(hidden)]
             pub struct #builder_name #impl_generics #where_clause {
                 #(#builder_fields),*

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -158,15 +158,17 @@ pub fn render(input: TokenStream) -> TokenStream {
 /// and emits both:
 ///
 /// 1. A `XxxProps` struct (Pascal-cased function name + `Props`)
-///    derived from the parameter list, with
-///    `#[derive(::typed_builder::TypedBuilder)]` so callers can
-///    construct it via `XxxProps::builder().a(...).b(...).build()`.
-///    Each field gets `#[builder(setter(into))]` for `Into` coercion
-///    on the call side (`&str` → `String`, `i32` → `f64`, …).
-///    `Option<T>` props get `strip_option` + `default` so callers may
-///    omit them. `Children` props get a default empty closure. A
-///    `#[prop(default = expr)]` attribute on a parameter is forwarded
-///    to typed-builder as the field's default.
+///    derived from the parameter list, plus a hand-rolled
+///    `XxxPropsBuilder` so callers can construct Props via
+///    `XxxProps::builder().a(...).b(...).build()`.
+///    Each setter accepts `impl Into<T>` for `Into` coercion on the
+///    call side (`&str` → `String`, `i32` → `f64`, …).
+///    `Option<T>` props get a strip-option setter (accept the inner
+///    `T`) and default to `None` when omitted. `Children` props get
+///    a default empty closure. A `#[prop(default = expr)]` attribute
+///    on a parameter inserts `expr` as the field's default at `.build()`.
+///    Required fields that the user didn't set panic at `.build()` with
+///    `"required field `xxx` was not set"`.
 ///
 /// 2. A rewritten `fn xxx(__props: XxxProps) -> Element` whose
 ///    body destructures the props back into local variables and runs

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -117,7 +117,12 @@ struct ControlFlowNode {
 }
 
 struct UserComponentNode {
-    fn_name: Ident,
+    /// snake_case fn identifier the call site resolves to. Derived
+    /// from the PascalCase render! token via `pascal_to_snake`.
+    fn_ident: Ident,
+    /// PascalCase Props struct ident (`<name>Props`). Same span as
+    /// the render! token so RA's go-to-definition lands here.
+    props_ident: Ident,
     kwargs: Vec<Kwarg>,
     children: Vec<Node>,
 }
@@ -202,24 +207,58 @@ impl Parse for Node {
         }
 
         let name = tag.to_string();
+        // Classification by casing + whitelist:
+        //
+        //   snake_case + in built-in whitelist  → Element (Lynx tag)
+        //   PascalCase, name ∈ {"Show", "For"}  → ControlFlow
+        //   PascalCase (other)                   → UserComponent
+        //   snake_case + not in whitelist        → ERROR
+        //
+        // The casing rule keeps three categories visually distinct in
+        // user code: lowercase = Lynx tag, PascalCase = component-
+        // shaped (control-flow or user). User components are still
+        // *defined* as snake_case Rust fns (`fn my_card(...)`), but
+        // *called* via PascalCase (`MyCard(...)`) in render! — the
+        // emitter converts PascalCase → snake_case for the fn ref.
         if is_builtin_tag(&name) {
             Ok(Node::Element(ElementNode {
                 tag,
                 kwargs,
                 children,
             }))
-        } else if name == "Show" || name == "For" {
-            Ok(Node::ControlFlow(ControlFlowNode {
-                name: tag,
-                kwargs,
-                children,
-            }))
+        } else if is_pascal_case(&name) {
+            if name == "Show" || name == "For" {
+                Ok(Node::ControlFlow(ControlFlowNode {
+                    name: tag,
+                    kwargs,
+                    children,
+                }))
+            } else {
+                // PascalCase user component. Derive the fn ident
+                // (snake_case) and the Props ident (PascalCase +
+                // "Props") here so codegen has both ready. Each
+                // carries the original tag's span so RA jumps to
+                // the right place from the render! call site.
+                let span = tag.span();
+                let fn_ident = Ident::new(&pascal_to_snake(&name), span);
+                let props_ident = Ident::new(&format!("{name}Props"), span);
+                Ok(Node::UserComponent(UserComponentNode {
+                    fn_ident,
+                    props_ident,
+                    kwargs,
+                    children,
+                }))
+            }
         } else {
-            Ok(Node::UserComponent(UserComponentNode {
-                fn_name: tag,
-                kwargs,
-                children,
-            }))
+            Err(syn::Error::new(
+                tag.span(),
+                format!(
+                    "`{name}` is not a built-in tag and isn't UpperCamelCase. \
+                     User components are called via PascalCase in render! \
+                     (e.g. `MyCard(...)` for `#[component] fn my_card`); \
+                     reserve snake_case for built-in tags (view, text, …)",
+                ),
+            ))
         }
     }
 }
@@ -232,6 +271,35 @@ fn is_builtin_tag(name: &str) -> bool {
         name,
         "page" | "view" | "text" | "raw_text" | "image" | "scroll_view"
     )
+}
+
+/// `true` if `name`'s first character is ASCII uppercase. Used to
+/// route PascalCase idents (user components / control flow) away
+/// from the snake_case-only Element path.
+fn is_pascal_case(name: &str) -> bool {
+    name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+}
+
+/// `MyCard` → `my_card`, `HTTPClient` → `h_t_t_p_client` (the
+/// acronym case is intentionally treated as a sequence of single
+/// uppercase letters; users following standard Rust naming
+/// conventions (`http_client`) won't hit this edge case from
+/// render!'s side because they'd write `HttpClient`).
+fn pascal_to_snake(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 4);
+    for (i, c) in name.chars().enumerate() {
+        if c.is_ascii_uppercase() {
+            if i > 0 {
+                out.push('_');
+            }
+            for lower in c.to_lowercase() {
+                out.push(lower);
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 // ---- Codegen ------------------------------------------------------------
@@ -561,8 +629,8 @@ impl ControlFlowNode {
 
 impl UserComponentNode {
     fn to_tokens(&self) -> TokenStream2 {
-        let props_ident = snake_to_props_ident(&self.fn_name);
-        let fn_ident = &self.fn_name;
+        let fn_ident = &self.fn_ident;
+        let props_ident = &self.props_ident;
 
         let setter_calls: Vec<TokenStream2> = self
             .kwargs
@@ -627,29 +695,6 @@ impl UserComponentNode {
     }
 }
 
-/// `my_component` → `MyComponentProps`. Mirror of the same helper
-/// in `component.rs`; kept duplicated to avoid a cross-module dep
-/// within the proc-macro crate.
-fn snake_to_props_ident(fn_name: &Ident) -> Ident {
-    let snake = fn_name.to_string();
-    let mut camel = String::with_capacity(snake.len() + 5);
-    let mut upper_next = true;
-    for c in snake.chars() {
-        if c == '_' {
-            upper_next = true;
-            continue;
-        }
-        if upper_next {
-            camel.extend(c.to_uppercase());
-            upper_next = false;
-        } else {
-            camel.push(c);
-        }
-    }
-    camel.push_str("Props");
-    Ident::new(&camel, fn_name.span())
-}
-
 fn strip_on_prefix(name: &str) -> Option<String> {
     if let Some(rest) = name.strip_prefix("on_") {
         Some(rest.to_string())
@@ -669,9 +714,8 @@ fn strip_on_prefix(name: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_builtin_tag, snake_to_props_ident, strip_on_prefix};
-    use proc_macro2::{Span, TokenStream as TokenStream2};
-    use syn::Ident;
+    use super::{is_builtin_tag, pascal_to_snake, strip_on_prefix};
+    use proc_macro2::TokenStream as TokenStream2;
 
     #[test]
     fn strips_snake_case() {
@@ -704,11 +748,10 @@ mod tests {
     }
 
     #[test]
-    fn snake_to_props_ident_basic() {
-        let id = Ident::new("my_component", Span::call_site());
-        assert_eq!(snake_to_props_ident(&id).to_string(), "MyComponentProps");
-        let id = Ident::new("card", Span::call_site());
-        assert_eq!(snake_to_props_ident(&id).to_string(), "CardProps");
+    fn pascal_to_snake_basic() {
+        assert_eq!(pascal_to_snake("MyComponent"), "my_component");
+        assert_eq!(pascal_to_snake("Card"), "card");
+        assert_eq!(pascal_to_snake("TabItem"), "tab_item");
     }
 
     // ---- Compose-syntax parser & emission --------------------------------
@@ -828,7 +871,7 @@ mod tests {
 
     #[test]
     fn user_component_does_not_use_builtin_tags_module() {
-        let input: TokenStream2 = quote::quote! { my_card(title: "x") };
+        let input: TokenStream2 = quote::quote! { MyCard(title: "x") };
         let output = super::expand_test(input).to_string();
         assert!(
             !output.contains("__tags"),
@@ -840,6 +883,26 @@ mod tests {
             "user component must build via `MyCardProps::builder()`; \
              output was: {output}"
         );
+        assert!(
+            output.contains("my_card"),
+            "user component fn ref must lower to snake_case `my_card`; \
+             output was: {output}"
+        );
+    }
+
+    #[test]
+    fn snake_case_non_builtin_is_a_parse_error() {
+        // `my_card` (lowercase, not in the built-in whitelist) must
+        // be rejected — user components have to use PascalCase.
+        let input: TokenStream2 = quote::quote! { my_card(title: "x") };
+        let result = syn::parse2::<super::Root>(input);
+        match result {
+            Err(e) => assert!(
+                e.to_string().contains("PascalCase"),
+                "expected hint about PascalCase; got: {e}",
+            ),
+            Ok(_) => panic!("snake_case non-builtin should be a parse error"),
+        }
     }
 
     #[test]

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -212,55 +212,76 @@ impl Parse for Node {
         //   snake_case + in built-in whitelist  → Element (Lynx tag)
         //   PascalCase, name ∈ {"Show", "For"}  → ControlFlow
         //   PascalCase (other)                   → UserComponent
-        //   snake_case + not in whitelist        → ERROR
+        //                                          (preferred: PascalCase
+        //                                          alias from #[component])
+        //   snake_case + not in whitelist        → UserComponent
+        //                                          (back-compat path:
+        //                                          fn name as-is, Props
+        //                                          derived from snake_case)
         //
-        // The casing rule keeps three categories visually distinct in
-        // user code: lowercase = Lynx tag, PascalCase = component-
-        // shaped (control-flow or user). User components are still
-        // *defined* as snake_case Rust fns (`fn my_card(...)`), but
-        // *called* via PascalCase (`MyCard(...)`) in render! — the
-        // emitter converts PascalCase → snake_case for the fn ref.
+        // The PascalCase form is the canonical convention now (matches
+        // React / Leptos / Solid). Snake_case stays parseable so:
+        //   (1) mid-typing partials (`vie|`) don't blow up the macro
+        //       — RA needs the expansion to succeed for completion,
+        //   (2) older code calling snake_case names keeps compiling.
         if is_builtin_tag(&name) {
             Ok(Node::Element(ElementNode {
                 tag,
                 kwargs,
                 children,
             }))
-        } else if is_pascal_case(&name) {
-            if name == "Show" || name == "For" {
-                Ok(Node::ControlFlow(ControlFlowNode {
-                    name: tag,
-                    kwargs,
-                    children,
-                }))
-            } else {
-                // PascalCase user component. Derive the fn ident
-                // (snake_case) and the Props ident (PascalCase +
-                // "Props") here so codegen has both ready. Each
-                // carries the original tag's span so RA jumps to
-                // the right place from the render! call site.
-                let span = tag.span();
-                let fn_ident = Ident::new(&pascal_to_snake(&name), span);
-                let props_ident = Ident::new(&format!("{name}Props"), span);
-                Ok(Node::UserComponent(UserComponentNode {
-                    fn_ident,
-                    props_ident,
-                    kwargs,
-                    children,
-                }))
-            }
+        } else if (name == "Show" || name == "For") && is_pascal_case(&name) {
+            Ok(Node::ControlFlow(ControlFlowNode {
+                name: tag,
+                kwargs,
+                children,
+            }))
         } else {
-            Err(syn::Error::new(
-                tag.span(),
-                format!(
-                    "`{name}` is not a built-in tag and isn't UpperCamelCase. \
-                     User components are called via PascalCase in render! \
-                     (e.g. `MyCard(...)` for `#[component] fn my_card`); \
-                     reserve snake_case for built-in tags (view, text, …)",
-                ),
-            ))
+            // User component. Derive `fn_ident` (snake_case) and
+            // `props_ident` (PascalCase + "Props") from whichever
+            // form the user wrote. Both carry the original tag's
+            // span so RA jumps to the right call site from the
+            // render! source.
+            let span = tag.span();
+            let (fn_str, props_str) = if is_pascal_case(&name) {
+                (pascal_to_snake(&name), format!("{name}Props"))
+            } else {
+                (name.clone(), snake_to_pascal_props(&name))
+            };
+            let fn_ident = Ident::new(&fn_str, span);
+            let props_ident = Ident::new(&props_str, span);
+            Ok(Node::UserComponent(UserComponentNode {
+                fn_ident,
+                props_ident,
+                kwargs,
+                children,
+            }))
         }
     }
+}
+
+/// `my_card` → `MyCardProps`. Snake-case fallback for the props
+/// ident derivation (kept for back-compat with snake_case user
+/// components in `render!`).
+fn snake_to_pascal_props(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 5);
+    let mut upper_next = true;
+    for c in name.chars() {
+        if c == '_' {
+            upper_next = true;
+            continue;
+        }
+        if upper_next {
+            for u in c.to_uppercase() {
+                out.push(u);
+            }
+            upper_next = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out.push_str("Props");
+    out
 }
 
 /// Lowercase identifiers that lower to `view::create_element` calls
@@ -891,18 +912,18 @@ mod tests {
     }
 
     #[test]
-    fn snake_case_non_builtin_is_a_parse_error() {
-        // `my_card` (lowercase, not in the built-in whitelist) must
-        // be rejected — user components have to use PascalCase.
+    fn snake_case_non_builtin_is_back_compat_user_component() {
+        // Snake-case still works as a user-component call site (for
+        // partial-typing during completion and for back-compat).
+        // The canonical form is PascalCase, but the macro accepts
+        // both.
         let input: TokenStream2 = quote::quote! { my_card(title: "x") };
-        let result = syn::parse2::<super::Root>(input);
-        match result {
-            Err(e) => assert!(
-                e.to_string().contains("PascalCase"),
-                "expected hint about PascalCase; got: {e}",
-            ),
-            Ok(_) => panic!("snake_case non-builtin should be a parse error"),
-        }
+        let output = super::expand_test(input).to_string();
+        assert!(
+            output.contains("my_card") && output.contains("MyCardProps"),
+            "snake_case input should lower to snake fn + PascalCase Props; \
+             output was: {output}",
+        );
     }
 
     #[test]

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -117,11 +117,14 @@ struct ControlFlowNode {
 }
 
 struct UserComponentNode {
-    /// snake_case fn identifier the call site resolves to. Derived
-    /// from the PascalCase render! token via `pascal_to_snake`.
-    fn_ident: Ident,
-    /// PascalCase Props struct ident (`<name>Props`). Same span as
-    /// the render! token so RA's go-to-definition lands here.
+    /// PascalCase ident the call site resolves to. `#[component]`
+    /// emits a `pub use __<name>_inner::<fn> as <PascalCase>;`
+    /// alias under this name; the snake_case fn itself lives
+    /// inside the inner module and isn't reachable from outer
+    /// scope, so the emission MUST go through this alias.
+    alias_ident: Ident,
+    /// PascalCase Props struct ident (`<name>Props`). Same span
+    /// as the render! token so RA's go-to-definition lands here.
     props_ident: Ident,
     kwargs: Vec<Kwarg>,
     children: Vec<Node>,
@@ -237,21 +240,24 @@ impl Parse for Node {
                 children,
             }))
         } else {
-            // User component. Derive `fn_ident` (snake_case) and
-            // `props_ident` (PascalCase + "Props") from whichever
-            // form the user wrote. Both carry the original tag's
-            // span so RA jumps to the right call site from the
-            // render! source.
+            // User component. Derive `alias_ident` (PascalCase —
+            // the public re-exported name) and `props_ident`
+            // (PascalCase + "Props") from whichever form the user
+            // wrote. The snake_case fn itself stays inside the
+            // inner module and we never reference it directly
+            // from the lowering.
             let span = tag.span();
-            let (fn_str, props_str) = if is_pascal_case(&name) {
-                (pascal_to_snake(&name), format!("{name}Props"))
+            let (alias_str, props_str) = if is_pascal_case(&name) {
+                (name.clone(), format!("{name}Props"))
             } else {
-                (name.clone(), snake_to_pascal_props(&name))
+                let pascal = snake_to_pascal(&name);
+                let props = format!("{pascal}Props");
+                (pascal, props)
             };
-            let fn_ident = Ident::new(&fn_str, span);
+            let alias_ident = Ident::new(&alias_str, span);
             let props_ident = Ident::new(&props_str, span);
             Ok(Node::UserComponent(UserComponentNode {
-                fn_ident,
+                alias_ident,
                 props_ident,
                 kwargs,
                 children,
@@ -260,11 +266,10 @@ impl Parse for Node {
     }
 }
 
-/// `my_card` → `MyCardProps`. Snake-case fallback for the props
-/// ident derivation (kept for back-compat with snake_case user
-/// components in `render!`).
-fn snake_to_pascal_props(name: &str) -> String {
-    let mut out = String::with_capacity(name.len() + 5);
+/// `my_card` → `MyCard`. Snake-to-PascalCase for the back-compat
+/// snake_case path of user components in `render!`.
+fn snake_to_pascal(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
     let mut upper_next = true;
     for c in name.chars() {
         if c == '_' {
@@ -280,7 +285,6 @@ fn snake_to_pascal_props(name: &str) -> String {
             out.push(c);
         }
     }
-    out.push_str("Props");
     out
 }
 
@@ -299,28 +303,6 @@ fn is_builtin_tag(name: &str) -> bool {
 /// from the snake_case-only Element path.
 fn is_pascal_case(name: &str) -> bool {
     name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
-}
-
-/// `MyCard` → `my_card`, `HTTPClient` → `h_t_t_p_client` (the
-/// acronym case is intentionally treated as a sequence of single
-/// uppercase letters; users following standard Rust naming
-/// conventions (`http_client`) won't hit this edge case from
-/// render!'s side because they'd write `HttpClient`).
-fn pascal_to_snake(name: &str) -> String {
-    let mut out = String::with_capacity(name.len() + 4);
-    for (i, c) in name.chars().enumerate() {
-        if c.is_ascii_uppercase() {
-            if i > 0 {
-                out.push('_');
-            }
-            for lower in c.to_lowercase() {
-                out.push(lower);
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
 }
 
 // ---- Codegen ------------------------------------------------------------
@@ -650,7 +632,7 @@ impl ControlFlowNode {
 
 impl UserComponentNode {
     fn to_tokens(&self) -> TokenStream2 {
-        let fn_ident = &self.fn_ident;
+        let fn_ident = &self.alias_ident;
         let props_ident = &self.props_ident;
 
         let setter_calls: Vec<TokenStream2> = self
@@ -735,7 +717,7 @@ fn strip_on_prefix(name: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_builtin_tag, pascal_to_snake, strip_on_prefix};
+    use super::{is_builtin_tag, snake_to_pascal, strip_on_prefix};
     use proc_macro2::TokenStream as TokenStream2;
 
     #[test]
@@ -769,10 +751,10 @@ mod tests {
     }
 
     #[test]
-    fn pascal_to_snake_basic() {
-        assert_eq!(pascal_to_snake("MyComponent"), "my_component");
-        assert_eq!(pascal_to_snake("Card"), "card");
-        assert_eq!(pascal_to_snake("TabItem"), "tab_item");
+    fn snake_to_pascal_basic() {
+        assert_eq!(snake_to_pascal("my_card"), "MyCard");
+        assert_eq!(snake_to_pascal("card"), "Card");
+        assert_eq!(snake_to_pascal("tab_item"), "TabItem");
     }
 
     // ---- Compose-syntax parser & emission --------------------------------
@@ -899,29 +881,27 @@ mod tests {
             "user components must not touch the built-in tags module; \
              output was: {output}"
         );
+        // Emission goes through the PascalCase alias the `#[component]`
+        // macro emits — that's how we keep snake_case `my_card` hidden
+        // in the inner module from user-call-site completion.
         assert!(
-            output.contains("MyCardProps"),
-            "user component must build via `MyCardProps::builder()`; \
-             output was: {output}"
-        );
-        assert!(
-            output.contains("my_card"),
-            "user component fn ref must lower to snake_case `my_card`; \
-             output was: {output}"
+            output.contains("MyCard") && output.contains("MyCardProps"),
+            "user component must lower to `MyCard(MyCardProps::builder()…)` \
+             — the PascalCase alias is the public call surface; \
+             output was: {output}",
         );
     }
 
     #[test]
     fn snake_case_non_builtin_is_back_compat_user_component() {
-        // Snake-case still works as a user-component call site (for
-        // partial-typing during completion and for back-compat).
-        // The canonical form is PascalCase, but the macro accepts
-        // both.
+        // Snake-case still parses (so mid-typing partials like `my_c|`
+        // don't blow up the macro), but the emission still goes
+        // through the PascalCase alias derived from the input.
         let input: TokenStream2 = quote::quote! { my_card(title: "x") };
         let output = super::expand_test(input).to_string();
         assert!(
-            output.contains("my_card") && output.contains("MyCardProps"),
-            "snake_case input should lower to snake fn + PascalCase Props; \
+            output.contains("MyCard") && output.contains("MyCardProps"),
+            "snake_case input should lower to the PascalCase alias call site; \
              output was: {output}",
         );
     }

--- a/crates/whisker-macros/tests/ra_completion.rs
+++ b/crates/whisker-macros/tests/ra_completion.rs
@@ -127,6 +127,76 @@ fn probe() -> Element {
 }
 
 #[test]
+fn props_builder_helper_types_are_hidden_from_completion() {
+    // typed-builder generates a handful of marker types per Props
+    // (`<Name>PropsBuilder<((),(),()...)>` and friends). They're
+    // technically `pub` but pure plumbing — RA shouldn't surface
+    // them at user call sites because they pollute the candidate
+    // list with `ArtTilePropsBuilder_*` entries on every keystroke.
+    // The `#[component]` macro tucks the Props struct behind a
+    // `#[doc(hidden)] pub mod __<name>_props_internal` to gate
+    // those helpers off; only `ArtTileProps` itself re-exports
+    // outward.
+    let source = r#"
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+
+#[component]
+fn art_tile(label: &'static str) -> Element {
+    render! { text(value: label) }
+}
+
+fn probe() -> Element {
+    render! {
+        view() {
+            ArtTile|
+        }
+    }
+}
+"#;
+    let labels = run_probe("hidden_builder_helpers", source);
+    let leaked: Vec<&String> = labels
+        .iter()
+        .filter(|l| l.starts_with("ArtTilePropsBuilder"))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "ArtTilePropsBuilder* types should be hidden behind \
+         `#[doc(hidden)]`; saw: {leaked:?}",
+    );
+}
+
+#[test]
+fn partial_user_component_completes_to_pascal_case_alias() {
+    // `Art|` in a render! children block should surface the
+    // `ArtTile` PascalCase alias the `#[component]` macro emits
+    // for `fn art_tile`. Without that alias, only `art_tile` is
+    // in scope and `Art…` matches nothing.
+    let source = r#"
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+
+#[component]
+fn art_tile(label: &'static str) -> Element {
+    render! { text(value: label) }
+}
+
+fn probe() -> Element {
+    render! {
+        view() {
+            Art|
+        }
+    }
+}
+"#;
+    let labels = run_probe("partial_user_component", source);
+    assert!(
+        labels.iter().any(|l| l == "ArtTile"),
+        "expected `ArtTile` PascalCase alias for `fn art_tile`; got {labels:?}"
+    );
+}
+
+#[test]
 fn partial_tag_name_in_children_block_completes_to_builtin_view() {
     let source = r#"
 use whisker::prelude::*;

--- a/crates/whisker-macros/tests/ra_completion.rs
+++ b/crates/whisker-macros/tests/ra_completion.rs
@@ -155,12 +155,16 @@ fn probe() -> Element {
 }
 "#;
     let labels = run_probe("hidden_builder_helpers", source);
+    eprintln!(
+        "[hidden_builder_helpers] full label set ({} items): {labels:?}",
+        labels.len()
+    );
     let art_prefixed: Vec<String> = labels
         .iter()
         .filter(|l| l.to_lowercase().starts_with("art"))
         .cloned()
         .collect();
-    eprintln!("[hidden_builder_helpers] full Art* candidates: {art_prefixed:?}");
+    eprintln!("[hidden_builder_helpers] Art* candidates: {art_prefixed:?}");
 
     assert!(
         !art_prefixed.iter().any(|l| l == "art_tile"),
@@ -175,6 +179,63 @@ fn probe() -> Element {
         leaked.is_empty(),
         "ArtTilePropsBuilder* types should be hidden inside the \
          internal props module; saw: {leaked:?}",
+    );
+}
+
+#[test]
+fn short_prefix_user_component_does_not_leak_builder_helpers() {
+    // VS Code users typically start typing with just a few chars
+    // (`Art|`). RA's fuzzy-match may include items the strict
+    // prefix path filters out — let's verify the leak set stays
+    // empty at 3 chars too.
+    let source = r#"
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+
+#[component]
+fn art_tile(label: &'static str) -> Element {
+    render! { text(value: label) }
+}
+
+fn probe() -> Element {
+    render! {
+        view() {
+            Art|
+        }
+    }
+}
+"#;
+    let labels = run_probe("short_prefix_leak", source);
+    eprintln!(
+        "[short_prefix_leak] {} candidates returned: {labels:?}",
+        labels.len()
+    );
+    // The critical items that MUST stay hidden:
+    //
+    // 1. snake_case fn `art_tile` — user calls via PascalCase alias.
+    // 2. builder struct `ArtTilePropsBuilder` — reached only via
+    //    `ArtTileProps::builder()`, never by name.
+    // 3. typed-builder-style markers (`ArtTilePropsBuilder_Error_*`,
+    //    `ArtTilePropsBuilder_Repeated_*`) — must stay completely
+    //    gone after the hand-rolled builder migration.
+    //
+    // The inner module *paths* (`__art_tile_inner::`,
+    // `__art_tile_props_internal::`) DO still appear as path
+    // completion entries because they're the names of (private)
+    // submodules of the user's crate. The items inside them are
+    // properly unreachable as bare identifiers.
+    let leaked: Vec<&String> = labels
+        .iter()
+        .filter(|l| {
+            l.as_str() == "art_tile"
+                || l.as_str() == "ArtTilePropsBuilder"
+                || l.starts_with("ArtTilePropsBuilder_")
+        })
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "user-facing builder + snake_case fn + typed-builder helpers \
+         must stay hidden even at short prefixes; leaked: {leaked:?}",
     );
 }
 

--- a/crates/whisker-macros/tests/ra_completion.rs
+++ b/crates/whisker-macros/tests/ra_completion.rs
@@ -155,14 +155,30 @@ fn probe() -> Element {
 }
 "#;
     let labels = run_probe("hidden_builder_helpers", source);
-    let leaked: Vec<&String> = labels
+    // Candidates whose name overlaps the component should be ONLY
+    // the PascalCase alias and the Props struct. The snake_case
+    // `art_tile` (hidden in `mod __art_tile_inner`) and every
+    // typed-builder marker (`ArtTilePropsBuilder<_>`, hidden in
+    // `mod __art_tile_props_internal`) should NOT surface.
+    let art_prefixed: Vec<String> = labels
+        .iter()
+        .filter(|l| l.to_lowercase().starts_with("art"))
+        .cloned()
+        .collect();
+
+    assert!(
+        !art_prefixed.iter().any(|l| l == "art_tile"),
+        "snake_case `art_tile` should be hidden inside the inner module; \
+         got: {art_prefixed:?}",
+    );
+    let leaked: Vec<&String> = art_prefixed
         .iter()
         .filter(|l| l.starts_with("ArtTilePropsBuilder"))
         .collect();
     assert!(
         leaked.is_empty(),
-        "ArtTilePropsBuilder* types should be hidden behind \
-         `#[doc(hidden)]`; saw: {leaked:?}",
+        "ArtTilePropsBuilder* types should be hidden inside the \
+         internal props module; saw: {leaked:?}",
     );
 }
 

--- a/crates/whisker-macros/tests/ra_completion.rs
+++ b/crates/whisker-macros/tests/ra_completion.rs
@@ -183,6 +183,46 @@ fn probe() -> Element {
 }
 
 #[test]
+fn longer_prefix_does_not_surface_builder_via_autoimport() {
+    // RA's auto-import path may surface `pub` items inside private
+    // modules when the user has typed enough characters to uniquely
+    // identify the target. Probe at `ArtTilePropsBu|` — if Builder
+    // is properly `#[doc(hidden)]` and inside a `#[doc(hidden)]`
+    // private mod, RA must not offer to auto-import it.
+    let source = r#"
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+
+#[component]
+fn art_tile(label: &'static str) -> Element {
+    render! { text(value: label) }
+}
+
+fn probe() -> Element {
+    render! {
+        view() {
+            ArtTilePropsBu|
+        }
+    }
+}
+"#;
+    let labels = run_probe("longer_prefix_builder_leak", source);
+    eprintln!(
+        "[longer_prefix_builder_leak] {} candidates: {labels:?}",
+        labels.len()
+    );
+    let leaked: Vec<&String> = labels
+        .iter()
+        .filter(|l| l.contains("ArtTilePropsBuilder") || l.contains("PropsBuilder"))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "Builder must stay hidden even at long matching prefixes; \
+         leaked: {leaked:?}",
+    );
+}
+
+#[test]
 fn short_prefix_user_component_does_not_leak_builder_helpers() {
     // VS Code users typically start typing with just a few chars
     // (`Art|`). RA's fuzzy-match may include items the strict

--- a/crates/whisker-macros/tests/ra_completion.rs
+++ b/crates/whisker-macros/tests/ra_completion.rs
@@ -155,16 +155,12 @@ fn probe() -> Element {
 }
 "#;
     let labels = run_probe("hidden_builder_helpers", source);
-    // Candidates whose name overlaps the component should be ONLY
-    // the PascalCase alias and the Props struct. The snake_case
-    // `art_tile` (hidden in `mod __art_tile_inner`) and every
-    // typed-builder marker (`ArtTilePropsBuilder<_>`, hidden in
-    // `mod __art_tile_props_internal`) should NOT surface.
     let art_prefixed: Vec<String> = labels
         .iter()
         .filter(|l| l.to_lowercase().starts_with("art"))
         .cloned()
         .collect();
+    eprintln!("[hidden_builder_helpers] full Art* candidates: {art_prefixed:?}");
 
     assert!(
         !art_prefixed.iter().any(|l| l == "art_tile"),

--- a/crates/whisker/Cargo.toml
+++ b/crates/whisker/Cargo.toml
@@ -27,9 +27,3 @@ whisker-macros = { workspace = true }
 whisker-driver = { workspace = true }
 whisker-app-config = { workspace = true }
 subsecond = { workspace = true, optional = true }
-# Builder-pattern derive for `#[component]`-generated `Props` structs.
-# The `#[component]` proc macro emits `#[derive(TypedBuilder)]` on the
-# auto-generated `XxxProps` struct, and the `render!` macro emits
-# `XxxProps::builder().field(value)...build()` at call sites. Matches
-# the Leptos approach (which uses the same crate for the same reason).
-typed-builder = "0.21"

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -42,15 +42,6 @@ pub use whisker_runtime::view::{for_each, show};
 // non-kwarg child nodes in their `render!` invocation.
 pub use whisker_runtime::view::Children;
 
-// Re-export `typed_builder` so the `#[component]` macro's expansion
-// can resolve `::whisker::__typed_builder::TypedBuilder` without
-// requiring user crates to add `typed-builder` to their own
-// dependencies. Internal — not part of the stable public surface.
-#[doc(hidden)]
-pub mod __typed_builder {
-    pub use ::typed_builder::TypedBuilder;
-}
-
 /// Built-in tag builders. The `render!` macro lowers each built-in
 /// element invocation (`view { style: "x", on_tap: || {} }`) into a
 /// builder method chain on one of these types

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -173,7 +173,7 @@ fn generic_label<T: std::fmt::Display + Clone + 'static>(value: T) -> Element {
 #[test]
 fn component_with_no_props_invokable_via_braces() {
     with_test_env(|log| {
-        let _h = render! { no_props_component() };
+        let _h = render! { NoPropsComponent() };
 
         // Side-channel: body ran.
         assert_eq!(captures(), vec!["no_props_component:invoked"]);
@@ -201,7 +201,7 @@ fn component_with_string_prop_accepts_str_literal_via_into_coercion() {
     with_test_env(|_log| {
         // `label: "hello"` — typed-builder `setter(into)` should
         // convert the `&'static str` to `String`.
-        let _h = render! { one_string_prop(label: "hello") };
+        let _h = render! { OneStringProp(label: "hello") };
         assert_eq!(captures(), vec!["one_string_prop:label=hello"]);
     });
 }
@@ -210,7 +210,7 @@ fn component_with_string_prop_accepts_str_literal_via_into_coercion() {
 fn component_with_string_prop_accepts_owned_string() {
     with_test_env(|_log| {
         let owned = String::from("owned");
-        let _h = render! { one_string_prop(label: owned) };
+        let _h = render! { OneStringProp(label: owned) };
         assert_eq!(captures(), vec!["one_string_prop:label=owned"]);
     });
 }
@@ -219,7 +219,7 @@ fn component_with_string_prop_accepts_owned_string() {
 fn component_with_two_props_uses_named_setters() {
     with_test_env(|_log| {
         let _h = render! {
-            two_props(
+            TwoProps(
                 title: "Greeting",
                 count: 42_i32,
             )
@@ -232,7 +232,7 @@ fn component_with_two_props_uses_named_setters() {
 fn option_prop_can_be_omitted() {
     with_test_env(|_log| {
         // No `alt:` kwarg — typed-builder's `default` kicks in → None.
-        let _h = render! { option_prop() };
+        let _h = render! { OptionProp() };
         assert_eq!(captures(), vec!["option_prop:alt=default"]);
     });
 }
@@ -242,7 +242,7 @@ fn option_prop_accepts_inner_via_strip_option_into() {
     with_test_env(|_log| {
         // `strip_option + into` lets the user pass `&str` directly
         // (no `Some(...)` wrapping needed).
-        let _h = render! { option_prop(alt: "custom") };
+        let _h = render! { OptionProp(alt: "custom") };
         assert_eq!(captures(), vec!["option_prop:alt=custom"]);
     });
 }
@@ -250,7 +250,7 @@ fn option_prop_accepts_inner_via_strip_option_into() {
 #[test]
 fn prop_default_attribute_supplies_value_when_omitted() {
     with_test_env(|_log| {
-        let _h = render! { with_default_prop() };
+        let _h = render! { WithDefaultProp() };
         assert_eq!(captures(), vec!["with_default_prop:count=5"]);
     });
 }
@@ -258,7 +258,7 @@ fn prop_default_attribute_supplies_value_when_omitted() {
 #[test]
 fn prop_default_attribute_overridable_at_call_site() {
     with_test_env(|_log| {
-        let _h = render! { with_default_prop(count: 99) };
+        let _h = render! { WithDefaultProp(count: 99) };
         assert_eq!(captures(), vec!["with_default_prop:count=99"]);
     });
 }
@@ -271,7 +271,7 @@ fn children_prop_receives_wrapped_closure() {
         // body emits one outer `view`; the children closure emits
         // two `text` elements inside it.
         let _h = render! {
-            with_children(label: "wrapper") {
+            WithChildren(label: "wrapper") {
                 text(value: "child-1")
                 text(value: "child-2")
             }
@@ -299,7 +299,7 @@ fn children_prop_receives_wrapped_closure() {
 fn children_prop_defaults_to_empty_view_when_omitted() {
     with_test_env(|log| {
         let _h = render! {
-            with_children(label: "only label")
+            WithChildren(label: "only label")
         };
 
         assert_eq!(captures(), vec!["with_children:label=only label"]);
@@ -328,7 +328,7 @@ fn children_prop_defaults_to_empty_view_when_omitted() {
 #[test]
 fn generic_component_with_i32_arg() {
     with_test_env(|_log| {
-        let _h = render! { generic_label(value: 7_i32) };
+        let _h = render! { GenericLabel(value: 7_i32) };
         assert_eq!(captures(), vec!["generic_label:value=7"]);
     });
 }
@@ -337,7 +337,7 @@ fn generic_component_with_i32_arg() {
 fn generic_component_with_string_arg() {
     with_test_env(|_log| {
         let _h = render! {
-            generic_label(value: String::from("stringly typed"))
+            GenericLabel(value: String::from("stringly typed"))
         };
         assert_eq!(captures(), vec!["generic_label:value=stringly typed"]);
     });
@@ -349,8 +349,8 @@ fn nested_component_invocations() {
         // Component inside a component, both via the new brace syntax.
         // Outer's children closure invokes the inner component.
         let _h = render! {
-            with_children(label: "outer") {
-                one_string_prop(label: "inner")
+            WithChildren(label: "outer") {
+                OneStringProp(label: "inner")
             }
         };
 

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -370,6 +370,91 @@ fn nested_component_invocations() {
 }
 
 #[test]
+#[should_panic(expected = "required field `label` was not set")]
+fn build_panics_when_required_field_missing() {
+    // Regression pin for the hand-rolled builder's runtime
+    // required-field check. Pre-typed-builder migration this would
+    // have been a compile error; with the hand-rolled builder we
+    // surface the same constraint at mount time. The panic message
+    // must name the field for the user to find the offending
+    // call-site quickly.
+    fresh();
+    let _ = OneStringPropProps::builder().build();
+}
+
+#[test]
+fn build_default_field_uses_user_supplied_default() {
+    // `#[prop(default = 5)] count: i32` — omitting `.count(…)`
+    // produces 5 at build time. Verifies the build_assignment
+    // emission path for PropKind::Default { is_generic: false }.
+    fresh();
+    let props = WithDefaultPropProps::builder().build();
+    assert_eq!(props.count, 5);
+}
+
+#[test]
+fn build_default_field_override_replaces_default() {
+    fresh();
+    let props = WithDefaultPropProps::builder().count(99).build();
+    assert_eq!(props.count, 99);
+}
+
+#[test]
+fn build_option_field_defaults_to_none() {
+    fresh();
+    let props = OptionPropProps::builder().build();
+    assert_eq!(props.alt, None);
+}
+
+#[test]
+fn build_option_field_strips_outer_option_in_setter() {
+    // Setter takes `impl Into<String>`, wraps to Some(_) at build.
+    // This is the `strip_option` ergonomics the typed-builder
+    // version gave us, now hand-rolled.
+    fresh();
+    let props = OptionPropProps::builder().alt("hi").build();
+    assert_eq!(props.alt.as_deref(), Some("hi"));
+}
+
+#[test]
+fn build_children_defaults_to_empty_view_closure() {
+    // Missing `children:` should produce a closure that returns
+    // View::Empty so iterating the result of `(children)()` is a
+    // no-op.
+    fresh();
+    let props = WithChildrenProps::builder().label("x").build();
+    let v = (props.children)();
+    assert!(matches!(v, whisker::runtime::view::View::Empty));
+}
+
+#[test]
+fn build_into_setter_accepts_str_literal_for_string_field() {
+    // `setter(into)` ergonomics — `&str` flows into a `String`
+    // field through `impl Into<String>` on the setter.
+    fresh();
+    let props = OneStringPropProps::builder().label("from str").build();
+    assert_eq!(props.label, "from str");
+}
+
+#[test]
+fn build_into_setter_accepts_owned_string() {
+    fresh();
+    let owned: String = "from owned".into();
+    let props = OneStringPropProps::builder().label(owned).build();
+    assert_eq!(props.label, "from owned");
+}
+
+#[test]
+fn build_generic_setter_accepts_concrete_type() {
+    // Generic prop's setter takes `T` directly (no Into) — the
+    // call site picks T at the chain head and the setter just
+    // stores the value.
+    fresh();
+    let props = GenericLabelProps::builder().value(7_i32).build();
+    assert_eq!(props.value, 7);
+}
+
+#[test]
 fn props_struct_is_constructable_directly() {
     // Smoke test: the auto-generated builder is reachable from user
     // code as `XxxProps::builder()`. Not the recommended path (users

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -380,7 +380,10 @@ fn props_struct_is_constructable_directly() {
     let rec = Recorder::default();
     let prev = install_renderer(Box::new(rec));
     with_owner(owner, || {
-        let _h = one_string_prop(
+        // Direct (non-render!) call must go through the PascalCase
+        // alias the `#[component]` macro emits — the snake_case fn
+        // is private inside the `__one_string_prop_inner` module.
+        let _h = OneStringProp(
             OneStringPropProps::builder()
                 .label("direct construction")
                 .build(),

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -150,7 +150,7 @@ fn mount_under_test_parent(make: impl FnOnce() -> Element) -> (Element, Element)
 #[test]
 fn component_returns_body_root_directly() {
     with_recorder_and_owner(|log| {
-        let _root = render! { leaf(label: "hello") };
+        let _root = render! { Leaf(label: "hello") };
         let creates: Vec<_> = log
             .borrow()
             .iter()
@@ -174,7 +174,7 @@ fn component_returns_body_root_directly() {
 #[test]
 fn remount_replaces_root_at_same_parent_slot() {
     with_recorder_and_owner(|log| {
-        let (parent, root_initial) = mount_under_test_parent(|| render! { leaf(label: "v1") });
+        let (parent, root_initial) = mount_under_test_parent(|| render! { Leaf(label: "v1") });
         log.borrow_mut().clear();
 
         // Simulate a subsecond patch on `leaf`'s fn pointer.
@@ -220,7 +220,7 @@ fn remount_replaces_root_at_same_parent_slot() {
 #[test]
 fn remount_disposes_old_owner_and_registers_new() {
     with_recorder_and_owner(|_log| {
-        let (_parent, _root) = mount_under_test_parent(|| render! { leaf(label: "first") });
+        let (_parent, _root) = mount_under_test_parent(|| render! { Leaf(label: "first") });
         let initial_owners = owners_for_fn(leaf as *const ());
         assert_eq!(initial_owners.len(), 1);
         let first_owner_id = initial_owners[0];
@@ -243,7 +243,7 @@ fn remount_disposes_old_owner_and_registers_new() {
 #[test]
 fn remount_releases_old_body_elements() {
     with_recorder_and_owner(|log| {
-        let (_parent, _root) = mount_under_test_parent(|| render! { leaf(label: "v1") });
+        let (_parent, _root) = mount_under_test_parent(|| render! { Leaf(label: "v1") });
         // Count elements created by the component itself (everything
         // the test parent's setup added is also in the log; we just
         // count Creates from after our parent's creation).
@@ -285,7 +285,7 @@ fn dispose_owner_releases_owned_elements() {
 
     let root_owner = create_owner(None);
     // Mount the component inside the root owner.
-    let _root = with_owner(root_owner, || render! { leaf(label: "hi") });
+    let _root = with_owner(root_owner, || render! { Leaf(label: "hi") });
 
     let creates_initial = log
         .borrow()
@@ -339,15 +339,15 @@ fn nested_component_mount_sites_cleared_on_parent_remount() {
     fn outer() -> Element {
         render! {
             view {
-                inner()
-                inner()
-                inner()
+                Inner()
+                Inner()
+                Inner()
             }
         }
     }
 
     with_recorder_and_owner(|_log| {
-        let (_parent, _root) = mount_under_test_parent(|| render! { outer() });
+        let (_parent, _root) = mount_under_test_parent(|| render! { Outer() });
 
         // After initial mount: 1 outer + 3 inner owners.
         assert_eq!(owners_for_fn(outer as *const ()).len(), 1);
@@ -398,14 +398,14 @@ fn batch_with_parent_and_child_skips_descendant() {
     fn parent_of_child() -> Element {
         render! {
             view {
-                child()
-                child()
+                Child()
+                Child()
             }
         }
     }
 
     with_recorder_and_owner(|_log| {
-        let (_p, _r) = mount_under_test_parent(|| render! { parent_of_child() });
+        let (_p, _r) = mount_under_test_parent(|| render! { ParentOfChild() });
         assert_eq!(owners_for_fn(parent_of_child as *const ()).len(), 1);
         assert_eq!(owners_for_fn(child as *const ()).len(), 2);
 
@@ -428,7 +428,7 @@ fn batch_with_parent_and_child_skips_descendant() {
         // Children should have been replaced by the parent's
         // remount, NOT remounted independently. Concretely: the
         // new child owners are different from the initial ones
-        // (because parent's body re-ran and called child() fresh).
+        // (because parent's body re-ran and called Child() fresh).
         let new_child_owners = owners_for_fn(child as *const ());
         assert_eq!(
             new_child_owners.len(),
@@ -471,7 +471,7 @@ fn remount_preserves_signal_held_above_in_context() {
         provide_context(AppState {
             counter: RwSignal::new(42),
         });
-        let (_parent, _root) = mount_under_test_parent(|| render! { inner_screen() });
+        let (_parent, _root) = mount_under_test_parent(|| render! { InnerScreen() });
         log.borrow_mut().clear();
 
         // Mutate the outer state, then remount.

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -131,6 +131,70 @@ fn leaf(label: &'static str) -> Element {
     }
 }
 
+// ----------------------------------------------------------------------------
+// Module-level components for tests that exercise mount-site behaviour.
+// `#[component]` emits a `mod __<name>_inner` + `pub use` pair which is
+// only legal at module level (not inside fn bodies), so test fixtures
+// that used to be nested are pulled up here and given prefixed names
+// to avoid collisions.
+// ----------------------------------------------------------------------------
+
+#[component]
+fn nested_inner() -> Element {
+    render! {
+        view {
+            text(value: "x")
+        }
+    }
+}
+
+#[component]
+fn nested_outer() -> Element {
+    render! {
+        view {
+            NestedInner()
+            NestedInner()
+            NestedInner()
+        }
+    }
+}
+
+#[component]
+fn batch_child() -> Element {
+    render! {
+        view {
+            text(value: "c")
+        }
+    }
+}
+
+#[component]
+fn batch_parent() -> Element {
+    render! {
+        view {
+            BatchChild()
+            BatchChild()
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+struct PreservedState {
+    counter: RwSignal<i32>,
+}
+
+#[component]
+fn context_inner_screen() -> Element {
+    let state = use_context::<PreservedState>().unwrap();
+    let local = signal(99_i32);
+    render! {
+        view {
+            text(value: state.counter.get())
+            text(value: local.0.get())
+        }
+    }
+}
+
 /// Attach a component to a fresh test parent element and return both
 /// handles. The "parent" stands in for whatever element the user's
 /// `render!` would have appended the component to in real code; the
@@ -178,7 +242,7 @@ fn remount_replaces_root_at_same_parent_slot() {
         log.borrow_mut().clear();
 
         // Simulate a subsecond patch on `leaf`'s fn pointer.
-        remount_components_for(&[leaf as *const ()]);
+        remount_components_for(&[Leaf as *const ()]);
 
         let ops = log.borrow();
         // The old body root was removed from the test parent.
@@ -221,13 +285,13 @@ fn remount_replaces_root_at_same_parent_slot() {
 fn remount_disposes_old_owner_and_registers_new() {
     with_recorder_and_owner(|_log| {
         let (_parent, _root) = mount_under_test_parent(|| render! { Leaf(label: "first") });
-        let initial_owners = owners_for_fn(leaf as *const ());
+        let initial_owners = owners_for_fn(Leaf as *const ());
         assert_eq!(initial_owners.len(), 1);
         let first_owner_id = initial_owners[0];
 
-        remount_components_for(&[leaf as *const ()]);
+        remount_components_for(&[Leaf as *const ()]);
 
-        let after_owners = owners_for_fn(leaf as *const ());
+        let after_owners = owners_for_fn(Leaf as *const ());
         assert_eq!(after_owners.len(), 1);
         assert_ne!(
             after_owners[0], first_owner_id,
@@ -257,7 +321,7 @@ fn remount_releases_old_body_elements() {
         let component_elements = creates_initial_total - 1;
 
         log.borrow_mut().clear();
-        remount_components_for(&[leaf as *const ()]);
+        remount_components_for(&[Leaf as *const ()]);
 
         let releases = log
             .borrow()
@@ -326,33 +390,13 @@ fn nested_component_mount_sites_cleared_on_parent_remount() {
     // invocations, not double up with the pre-remount entries.
     use whisker::runtime::reactive::owners_for_fn;
 
-    #[component]
-    fn inner() -> Element {
-        render! {
-            view {
-                text(value: "x")
-            }
-        }
-    }
-
-    #[component]
-    fn outer() -> Element {
-        render! {
-            view {
-                Inner()
-                Inner()
-                Inner()
-            }
-        }
-    }
-
     with_recorder_and_owner(|_log| {
-        let (_parent, _root) = mount_under_test_parent(|| render! { Outer() });
+        let (_parent, _root) = mount_under_test_parent(|| render! { NestedOuter() });
 
         // After initial mount: 1 outer + 3 inner owners.
-        assert_eq!(owners_for_fn(outer as *const ()).len(), 1);
+        assert_eq!(owners_for_fn(NestedOuter as *const ()).len(), 1);
         assert_eq!(
-            owners_for_fn(inner as *const ()).len(),
+            owners_for_fn(NestedInner as *const ()).len(),
             3,
             "three inner invocations expected after initial mount",
         );
@@ -360,11 +404,11 @@ fn nested_component_mount_sites_cleared_on_parent_remount() {
         // Remount outer (simulates subsecond patching outer's body).
         // This should dispose the 3 old inner owners + their
         // MountSites, then create 3 fresh inner invocations.
-        remount_components_for(&[outer as *const ()]);
+        remount_components_for(&[NestedOuter as *const ()]);
 
         // The count must stay at 3 — not balloon to 6.
         assert_eq!(
-            owners_for_fn(inner as *const ()).len(),
+            owners_for_fn(NestedInner as *const ()).len(),
             3,
             "after parent remount, child owners should be exactly the new 3, \
              not the old 3 + new 3 (orphan MountSites must be scrubbed)",
@@ -385,40 +429,21 @@ fn batch_with_parent_and_child_skips_descendant() {
     // brand-new owner, corrupting the visible tree.
     use whisker::runtime::reactive::owners_for_fn;
 
-    #[component]
-    fn child() -> Element {
-        render! {
-            view {
-                text(value: "c")
-            }
-        }
-    }
-
-    #[component]
-    fn parent_of_child() -> Element {
-        render! {
-            view {
-                Child()
-                Child()
-            }
-        }
-    }
-
     with_recorder_and_owner(|_log| {
-        let (_p, _r) = mount_under_test_parent(|| render! { ParentOfChild() });
-        assert_eq!(owners_for_fn(parent_of_child as *const ()).len(), 1);
-        assert_eq!(owners_for_fn(child as *const ()).len(), 2);
+        let (_p, _r) = mount_under_test_parent(|| render! { BatchParent() });
+        assert_eq!(owners_for_fn(BatchParent as *const ()).len(), 1);
+        assert_eq!(owners_for_fn(BatchChild as *const ()).len(), 2);
 
-        let initial_parent_owner = owners_for_fn(parent_of_child as *const ())[0];
-        let initial_child_owners = owners_for_fn(child as *const ());
+        let initial_parent_owner = owners_for_fn(BatchParent as *const ())[0];
+        let initial_child_owners = owners_for_fn(BatchChild as *const ());
 
         // Worst-case ordering: child listed FIRST in the patch
         // batch. Filter must skip the children because their
-        // ancestor `parent_of_child` is also in the batch.
-        remount_components_for(&[child as *const (), parent_of_child as *const ()]);
+        // ancestor `batch_parent` is also in the batch.
+        remount_components_for(&[BatchChild as *const (), BatchParent as *const ()]);
 
         // Parent was remounted (new owner).
-        let new_parent_owners = owners_for_fn(parent_of_child as *const ());
+        let new_parent_owners = owners_for_fn(BatchParent as *const ());
         assert_eq!(new_parent_owners.len(), 1);
         assert_ne!(
             new_parent_owners[0], initial_parent_owner,
@@ -428,8 +453,8 @@ fn batch_with_parent_and_child_skips_descendant() {
         // Children should have been replaced by the parent's
         // remount, NOT remounted independently. Concretely: the
         // new child owners are different from the initial ones
-        // (because parent's body re-ran and called Child() fresh).
-        let new_child_owners = owners_for_fn(child as *const ());
+        // (because parent's body re-ran and called BatchChild() fresh).
+        let new_child_owners = owners_for_fn(BatchChild as *const ());
         assert_eq!(
             new_child_owners.len(),
             2,
@@ -449,35 +474,23 @@ fn remount_preserves_signal_held_above_in_context() {
     // Demonstrates the recommended state-survival pattern: state
     // held in an outer signal/context survives remount, while
     // state local to the remounted component is lost.
-
-    #[derive(Copy, Clone)]
-    struct AppState {
-        counter: RwSignal<i32>,
-    }
-
-    #[component]
-    fn inner_screen() -> Element {
-        let state = use_context::<AppState>().unwrap();
-        let local = signal(99_i32);
-        render! {
-            view {
-                text(value: state.counter.get())
-                text(value: local.0.get())
-            }
-        }
-    }
+    //
+    // The component used here (`context_inner_screen`) and its
+    // shared `PreservedState` struct live at module scope above
+    // — `#[component]` emits a `mod __<name>_inner` + `pub use`
+    // pair that's only legal at module level.
 
     with_recorder_and_owner(|log| {
-        provide_context(AppState {
+        provide_context(PreservedState {
             counter: RwSignal::new(42),
         });
-        let (_parent, _root) = mount_under_test_parent(|| render! { InnerScreen() });
+        let (_parent, _root) = mount_under_test_parent(|| render! { ContextInnerScreen() });
         log.borrow_mut().clear();
 
         // Mutate the outer state, then remount.
-        let state = use_context::<AppState>().unwrap();
+        let state = use_context::<PreservedState>().unwrap();
         state.counter.set(100);
-        remount_components_for(&[inner_screen as *const ()]);
+        remount_components_for(&[ContextInnerScreen as *const ()]);
         flush();
 
         let texts: Vec<_> = log

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -95,5 +95,5 @@ pub fn render_app() -> whisker::runtime::view::Element {
     let state = AppState {
         count: RwSignal::new(0),
     };
-    render! { counter(state: state) }
+    render! { Counter(state: state) }
 }

--- a/examples/counter/tests/counter_renders.rs
+++ b/examples/counter/tests/counter_renders.rs
@@ -97,7 +97,7 @@ fn counter_initial_render() {
     let state = AppState {
         count: RwSignal::new(0),
     };
-    let _root = with_owner(owner, || render! { counter(state: state) });
+    let _root = with_owner(owner, || render! { Counter(state: state) });
 
     let ts = texts(&log.borrow());
     // Counter label (combined static + count via format!) + button labels.
@@ -121,7 +121,7 @@ fn counter_updates_on_signal_write() {
     let state = AppState {
         count: RwSignal::new(0),
     };
-    let _root = with_owner(owner, || render! { counter(state: state) });
+    let _root = with_owner(owner, || render! { Counter(state: state) });
 
     // Reset log to focus on update behaviour.
     log.borrow_mut().clear();
@@ -149,7 +149,7 @@ fn show_swaps_back_when_predicate_flips() {
     let state = AppState {
         count: RwSignal::new(15),
     };
-    let _root = with_owner(owner, || render! { counter(state: state) });
+    let _root = with_owner(owner, || render! { Counter(state: state) });
 
     // Bring it back below threshold.
     log.borrow_mut().clear();

--- a/examples/counter/tests/counter_renders.rs
+++ b/examples/counter/tests/counter_renders.rs
@@ -11,7 +11,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use counter::{counter, AppState, CounterProps};
+use counter::{AppState, Counter, CounterProps};
 use whisker::flush;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, create_owner, with_owner};

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -31,8 +31,6 @@
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 
-use crate::__art_tile_props_internal::ArtTilePropsBuilder;
-
 // ---- App state --------------------------------------------------------------
 
 /// App-wide reactive state. All fields are `RwSignal<T>` (i.e. `Copy`

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -31,6 +31,8 @@
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 
+use crate::__art_tile_props_internal::ArtTilePropsBuilder;
+
 // ---- App state --------------------------------------------------------------
 
 /// App-wide reactive state. All fields are `RwSignal<T>` (i.e. `Copy`

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -126,7 +126,7 @@ fn recent_card(
     let sub_style = format!("font-size: 12px; color: {TEXT_SECONDARY}; margin-top: 2px;");
     render! {
         view(style: "width: 140px; margin-right: 14px; display: flex; flex-direction: column;") {
-            art_tile(c1: c1, c2: c2, w: "140px", radius: "12px")
+            ArtTile(c1: c1, c2: c2, w: "140px", radius: "12px")
             text(style: title_style, value: title)
             text(style: sub_style, value: sub)
         }
@@ -175,7 +175,7 @@ fn grid_tile(
                      padding: 12px; box-shadow: 0 4px 12px rgba(0,0,0,0.25); \
                      display: flex; flex-direction: column;") {
             view(style: "position: relative; width: 100%;") {
-                art_tile(c1: c1, c2: c2, w: "100%", radius: "10px")
+                ArtTile(c1: c1, c2: c2, w: "100%", radius: "10px")
                 text(style: heart_style(), on_tap: on_heart, value: heart_glyph())
             }
             text(style: title_style, value: title)
@@ -262,10 +262,10 @@ fn tab_bar(state: AppState) -> Element {
     );
     render! {
         view(style: style) {
-            tab_item(index: 0_usize, label: "Home",    glyph: "⌂", state: state)
-            tab_item(index: 1_usize, label: "Search",  glyph: "⌕", state: state)
-            tab_item(index: 2_usize, label: "Library", glyph: "♫", state: state)
-            tab_item(index: 3_usize, label: "Profile", glyph: "○", state: state)
+            TabItem(index: 0_usize, label: "Home",    glyph: "⌂", state: state)
+            TabItem(index: 1_usize, label: "Search",  glyph: "⌕", state: state)
+            TabItem(index: 2_usize, label: "Library", glyph: "♫", state: state)
+            TabItem(index: 3_usize, label: "Profile", glyph: "○", state: state)
         }
     }
 }
@@ -297,7 +297,7 @@ fn now_playing(state: AppState) -> Element {
     );
     render! {
         view(style: container_style) {
-            art_tile(c1: "#ff7e5f", c2: "#feb47b", w: "48px", radius: "8px")
+            ArtTile(c1: "#ff7e5f", c2: "#feb47b", w: "48px", radius: "8px")
             view(style: "flex: 1; padding: 0 12px; display: flex; flex-direction: column;") {
                 text(style: title_style, value: "Sunset Drive")
                 text(style: sub_style, value: status())
@@ -349,10 +349,10 @@ fn header() -> Element {
 fn chips() -> Element {
     render! {
         view(style: "display: flex; flex-direction: row; padding: 0 20px 8px; flex-wrap: nowrap;") {
-            chip(label: "All",        accented: true)
-            chip(label: "Music",      accented: false)
-            chip(label: "Podcasts",   accented: false)
-            chip(label: "Audiobooks", accented: false)
+            Chip(label: "All",        accented: true)
+            Chip(label: "Music",      accented: false)
+            Chip(label: "Podcasts",   accented: false)
+            Chip(label: "Audiobooks", accented: false)
         }
     }
 }
@@ -364,11 +364,11 @@ fn recents() -> Element {
             scroll_orientation: "horizontal",
             style: "padding: 4px 20px 8px; height: 200px;",
         ) {
-            recent_card(title: "Sunset Drive",  sub: "Lo-Fi Beats", c1: "#ff7e5f", c2: "#feb47b")
-            recent_card(title: "Deep Focus",    sub: "Ambient",     c1: "#4facfe", c2: "#00f2fe")
-            recent_card(title: "Late Night",    sub: "Synthwave",   c1: "#9b6bff", c2: "#ff5e9b")
-            recent_card(title: "Coffee House",  sub: "Acoustic",    c1: "#fcb69f", c2: "#ffecd2")
-            recent_card(title: "Energy Boost",  sub: "Workout",     c1: "#11998e", c2: "#38ef7d")
+            RecentCard(title: "Sunset Drive",  sub: "Lo-Fi Beats", c1: "#ff7e5f", c2: "#feb47b")
+            RecentCard(title: "Deep Focus",    sub: "Ambient",     c1: "#4facfe", c2: "#00f2fe")
+            RecentCard(title: "Late Night",    sub: "Synthwave",   c1: "#9b6bff", c2: "#ff5e9b")
+            RecentCard(title: "Coffee House",  sub: "Acoustic",    c1: "#fcb69f", c2: "#ffecd2")
+            RecentCard(title: "Energy Boost",  sub: "Workout",     c1: "#11998e", c2: "#38ef7d")
         }
     }
 }
@@ -400,12 +400,12 @@ fn grid(state: AppState) -> Element {
     render! {
         view(style: "padding: 4px 20px 0; display: flex; flex-direction: row; \
                      flex-wrap: wrap; justify-content: space-between;") {
-            grid_tile(index: 0_usize, title: "Chill Mix",   c1: "#667eea", c2: "#764ba2", state: state)
-            grid_tile(index: 1_usize, title: "Happy Mix",   c1: "#f093fb", c2: "#f5576c", state: state)
-            grid_tile(index: 2_usize, title: "Focus Mix",   c1: "#4facfe", c2: "#00f2fe", state: state)
-            grid_tile(index: 3_usize, title: "Workout Mix", c1: "#43e97b", c2: "#38f9d7", state: state)
-            grid_tile(index: 4_usize, title: "Sleep Mix",   c1: "#fa709a", c2: "#fee140", state: state)
-            grid_tile(index: 5_usize, title: "Indie Mix",   c1: "#30cfd0", c2: "#330867", state: state)
+            GridTile(index: 0_usize, title: "Chill Mix",   c1: "#667eea", c2: "#764ba2", state: state)
+            GridTile(index: 1_usize, title: "Happy Mix",   c1: "#f093fb", c2: "#f5576c", state: state)
+            GridTile(index: 2_usize, title: "Focus Mix",   c1: "#4facfe", c2: "#00f2fe", state: state)
+            GridTile(index: 3_usize, title: "Workout Mix", c1: "#43e97b", c2: "#38f9d7", state: state)
+            GridTile(index: 4_usize, title: "Sleep Mix",   c1: "#fa709a", c2: "#fee140", state: state)
+            GridTile(index: 5_usize, title: "Indie Mix",   c1: "#30cfd0", c2: "#330867", state: state)
         }
     }
 }
@@ -414,11 +414,11 @@ fn grid(state: AppState) -> Element {
 fn activity_feed() -> Element {
     render! {
         view(style: "display: flex; flex-direction: column; padding: 0 0 8px;") {
-            activity_row(initial: "A", c1: "#ff7e5f", c2: "#feb47b", title: "Alice", sub: "Started following you",            when: "2m")
-            activity_row(initial: "R", c1: "#667eea", c2: "#764ba2", title: "Riku",  sub: "Liked your playlist 'Late Night'", when: "1h")
-            activity_row(initial: "M", c1: "#43e97b", c2: "#38f9d7", title: "Mio",   sub: "Shared 'Sunset Drive' with you",   when: "3h")
-            activity_row(initial: "K", c1: "#fa709a", c2: "#fee140", title: "Ken",   sub: "Added 5 songs to 'Workout'",       when: "yesterday")
-            activity_row(initial: "S", c1: "#4facfe", c2: "#00f2fe", title: "Sora",  sub: "Created a new playlist 'Focus'",   when: "2d")
+            ActivityRow(initial: "A", c1: "#ff7e5f", c2: "#feb47b", title: "Alice", sub: "Started following you",            when: "2m")
+            ActivityRow(initial: "R", c1: "#667eea", c2: "#764ba2", title: "Riku",  sub: "Liked your playlist 'Late Night'", when: "1h")
+            ActivityRow(initial: "M", c1: "#43e97b", c2: "#38f9d7", title: "Mio",   sub: "Shared 'Sunset Drive' with you",   when: "3h")
+            ActivityRow(initial: "K", c1: "#fa709a", c2: "#fee140", title: "Ken",   sub: "Added 5 songs to 'Workout'",       when: "yesterday")
+            ActivityRow(initial: "S", c1: "#4facfe", c2: "#00f2fe", title: "Sora",  sub: "Created a new playlist 'Focus'",   when: "2d")
         }
     }
 }
@@ -431,15 +431,15 @@ fn scroll_body(state: AppState) -> Element {
     );
     render! {
         scroll_view(scroll_orientation: "vertical", style: style) {
-            chips()
-            section_header(title: "Recently Played")
-            recents()
-            section_header(title: "Made For You")
-            featured()
-            section_header(title: "Your Top Mixes")
-            grid(state: state)
-            section_header(title: "Activity")
-            activity_feed()
+            Chips()
+            SectionHeader(title: "Recently Played")
+            Recents()
+            SectionHeader(title: "Made For You")
+            Featured()
+            SectionHeader(title: "Your Top Mixes")
+            Grid(state: state)
+            SectionHeader(title: "Activity")
+            ActivityFeed()
             view(style: "height: 160px;")
         }
     }
@@ -460,10 +460,10 @@ fn app() -> Element {
     );
     render! {
         page(style: page_style) {
-            header()
-            scroll_body(state: state)
-            now_playing(state: state)
-            tab_bar(state: state)
+            Header()
+            ScrollBody(state: state)
+            NowPlaying(state: state)
+            TabBar(state: state)
         }
     }
 }

--- a/examples/hn-reader/src/lib.rs
+++ b/examples/hn-reader/src/lib.rs
@@ -224,13 +224,13 @@ pub fn hn_reader() -> Element {
             .to_string();
     render! {
         view(style: body_style) {
-            header()
-            status_banner(state: state)
+            Header()
+            StatusBanner(state: state)
             scroll_view(scroll_orientation: "vertical", style: list_style) {
                 For(
                     each: move || state.get().stories(),
                     key: |s: &Story| s.object_id.clone(),
-                    children: |s: Story| render! { story_row(story: s) },
+                    children: |s: Story| render! { StoryRow(story: s) },
                 )
             }
         }
@@ -251,7 +251,7 @@ fn app() -> Element {
     );
     render! {
         page(style: page_style) {
-            hn_reader()
+            HnReader()
         }
     }
 }

--- a/examples/hn-reader/tests/render.rs
+++ b/examples/hn-reader/tests/render.rs
@@ -93,7 +93,7 @@ fn initial_render_shows_loading_banner() {
     let _prev = install_renderer(Box::new(rec));
     let owner = create_owner(None);
 
-    let _root = with_owner(owner, || render! { hn_reader() });
+    let _root = with_owner(owner, || render! { HnReader() });
 
     let ts = texts(&log.borrow());
     assert!(

--- a/examples/hn-reader/tests/render.rs
+++ b/examples/hn-reader/tests/render.rs
@@ -11,7 +11,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use hn_reader::{hn_reader, HnReaderProps};
+use hn_reader::{HnReader, HnReaderProps};
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, create_owner, with_owner};
 use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};


### PR DESCRIPTION
## Summary

Two convention shifts inside the `render!` / `#[component]` macro pair:

1. **PascalCase call sites for user components.** fn definitions stay snake_case (Rust idiomatic), but `render!` callers use PascalCase: `MyCard(label: "x")` lowers to a `pub use … as MyCard` alias the `#[component]` macro emits. Matches React / Leptos / Solid convention while keeping `#[component] fn my_card(...)` looking like normal Rust.
2. **Hand-rolled Props builder.** Replaces `#[derive(::typed_builder::TypedBuilder)]` with explicit `impl XxxProps { fn builder() }` + `impl XxxPropsBuilder { setter / build }` blocks. Eliminates the per-field type-state markers typed-builder generated (`XxxPropsBuilder_Error_Missing_required_field_<f>`, `XxxPropsBuilder_Repeated_field_<f>`) — they polluted RA's completion menu with ~N+3 entries per component.

## RA completion impact (`Art|` cursor on `#[component] fn art_tile`)

| Before (typed-builder + snake call sites) | After (this PR) |
|------|------|
| `art_tile` | _(hidden — snake fn lives in `mod __art_tile_inner`)_ |
| `ArtTileProps` | `ArtTile` |
| `ArtTilePropsBuilder` | `ArtTileProps` |
| `ArtTilePropsBuilder_Error_Missing_required_field_c1` | `ArtTilePropsBuilder` (irreducible — `pub fn .builder()` return type) |
| `ArtTilePropsBuilder_Error_Missing_required_field_c2` | _(gone)_ |
| `ArtTilePropsBuilder_Error_Missing_required_field_w` | _(gone)_ |
| `ArtTilePropsBuilder_Error_Missing_required_field_radius` | _(gone)_ |
| `ArtTilePropsBuilder_Repeated_field_c1` (etc., ×N) | _(gone)_ |

**Net**: ~10 candidates → 3 ($XxxName$ / $XxxNameProps$ / $XxxNamePropsBuilder$).

The 3-item floor is structural: `pub fn builder()` must expose its return-type name for the user's method chain (`.setter(…).build()`) to be callable across the module boundary. RA respects `#[doc(hidden)]` to varying degrees per version, but the type stays reachable through the auto-import indexer.

## Implementation map

| Layer | Change |
|-------|--------|
| `whisker-macros::render` | snake_case fn ident → PascalCase alias at lower; permissive parse for both casings (partial-typing `vie\|` survives) |
| `whisker-macros::component` | Emits `mod __<name>_inner { pub fn <fn>(…) }` + `mod __<name>_props_internal { pub struct Props; #[doc(hidden)] pub struct PropsBuilder; impl …}`; PascalCase alias `pub use __<name>_inner::<fn> as <PascalCase>` |
| `whisker-macros::component` | Per-field emission table: `PropKind::{Required, RequiredGeneric, Optional{inner, inner_is_generic}, Children, Default{default, is_generic}}` drives `prop_struct_field` / `prop_builder_field` / `prop_setter_method` / `prop_build_assignment` |
| `whisker` crate | Dropped `typed-builder` dep + `__typed_builder` re-export |
| examples + tests | Renamed render! call sites to PascalCase; `as *const ()` fn-ptr captures via the alias |

## Required-field validation

Compile-time → runtime. The hand-rolled `.build()` does `self.<field>.expect("required field `<field>` was not set")` for each non-default required prop. The panic fires at component mount during dev (instantly visible during hot-reload), with the exact field name in the message.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] **macro unit tests**: 61 in `whisker-macros::component::tests` covering each `PropKind` branch of `classify_prop`, each per-field emission helper (`prop_struct_field` / `prop_builder_field` / `prop_builder_init` / `prop_setter_method` / `prop_build_assignment`), `option_inner_type` across path shapes, `expand()` end-to-end shape (Props + Builder + alias + no typed-builder ref + `TwoProps→TwoPropsProps` greedy-trim regression)
- [x] **RA probe**: 8 tests pinning user-visible completion behaviour (`Art\|`, `ArtTile\|`, `ArtTilePropsBu\|`); asserts snake fn / `ArtTilePropsBuilder_*` markers stay completely hidden
- [x] **integration tests** (`whisker/tests/component_invocation.rs`): 24 tests — 8 new ones pin the runtime contract of the new builder (required-field panic message, default-prop value, Option<T> defaults to None, Children empty-closure default, Into coercion, generic param setter)
- [x] Manual: `hello-world` + `counter` + `hn-reader` examples compile and run; completion in VS Code shows only `XxxName` / `XxxNameProps` / `XxxNamePropsBuilder` per component

## Migration cost (for users)

- `render!` call sites: snake_case still parses for back-compat, but PascalCase is canonical. Conversion is mechanical (Find: `\bmy_card\(` → Replace: `MyCard(`).
- Direct `XxxName(XxxNameProps::builder()…)` callers (non-render!): switch to the PascalCase alias (e.g. `one_string_prop(…)` → `OneStringProp(…)`).
- Component fn definitions: unchanged — keep them as `#[component] fn my_card(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)