### PR TITLE
refactor(driver): move whisker_aslr_anchor out of #[whisker::main] macro (P6α-5)

### DIFF
--- a/crates/whisker-dev-server/src/hotpatch/cache.rs
+++ b/crates/whisker-dev-server/src/hotpatch/cache.rs
@@ -8,7 +8,7 @@
 //! original — closer to the sub-second budget.
 //!
 //! Apart from the symbols, we also capture the static virtual
-//! address of `whisker_aslr_anchor` (emitted by `#[whisker::main]`)
+//! address of `whisker_aslr_anchor` (exported by `whisker-driver`)
 //! in the host binary. That becomes `JumpTable::aslr_reference`,
 //! and our vendored subsecond's `apply_patch` uses it as
 //!

--- a/crates/whisker-driver/src/lib.rs
+++ b/crates/whisker-driver/src/lib.rs
@@ -11,3 +11,41 @@ pub mod lynx;
 
 pub use lynx::bootstrap;
 pub use lynx::renderer::BridgeRenderer;
+
+/// ASLR anchor symbol used by Whisker's vendored subsecond fork to
+/// compute the slide between this dylib's cached static layout
+/// (recorded by the dev-server at link time) and its runtime load
+/// address.
+///
+/// `dlsym(RTLD_DEFAULT, "whisker_aslr_anchor")` resolves to this
+/// fn's runtime address; pairing that with the static address the
+/// dev-server captured produces a precise per-dylib base offset.
+/// The fn body never executes — only the symbol's address matters.
+///
+/// ## Why a unique name (not `main`)
+///
+/// Upstream subsecond anchors on `main`. That works for binaries
+/// where `main` is the PIE entry and unique in the linker
+/// namespace. Whisker ships the user crate as a `dylib` loaded via
+/// Android `System.loadLibrary`, where the namespace can contain
+/// several `main` symbols (`app_process64`'s + stale patch memfds')
+/// and `dlsym(RTLD_DEFAULT, "main")` picks the wrong one. A
+/// Whisker-specific symbol exists only in user dylibs + patches,
+/// so the lookup is collision-free regardless of namespace order.
+///
+/// ## Why it lives here (not in `#[whisker::main]`)
+///
+/// Every Whisker dylib statically links `whisker-driver`, so the
+/// symbol auto-exports from any `whisker` user crate without the
+/// `#[whisker::main]` macro needing to inject it. Patch dylibs
+/// produced by the hot-reload pipeline also pick up this symbol
+/// via `--require-defined whisker_aslr_anchor` (see
+/// `whisker-dev-server::hotpatch::patcher`).
+///
+/// Same `extern "C"` + `#[no_mangle]` shape every Whisker dylib
+/// needs; centralising it here means the macro stays focused on
+/// turning a user `fn app()` into a `whisker_app_main` FFI entry.
+#[no_mangle]
+pub extern "C" fn whisker_aslr_anchor() -> std::ffi::c_int {
+    0
+}

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -99,28 +99,12 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
             ::whisker::__main_runtime::tick(engine)
         }
 
-        // Anchor symbol used by Whisker's vendored subsecond fork to
-        // compute the ASLR slide between this dylib's static layout
-        // (cached server-side) and its runtime load address. Both the
-        // host dylib and every patch dylib must export this so
-        // `dlsym(RTLD_DEFAULT, "whisker_aslr_anchor")` resolves
-        // unambiguously inside the user's `.so`.
-        //
-        // Why a unique name instead of `main` (upstream subsecond's
-        // sentinel): on Android, Whisker is loaded via
-        // `System.loadLibrary` into a process whose linker namespace
-        // already contains several `main` symbols
-        // (`app_process64`'s, plus any prior memfd patches), so a
-        // dlsym for `main` returns the wrong one and the slide math
-        // computes garbage. A unique name only exists in the user's
-        // `.so`, so the lookup is collision-free regardless of
-        // namespace order.
-        //
-        // The stub never runs — Whisker is JNI-loaded, never executed
-        // as a process entry point. It only needs to exist in the
-        // export list at a known static address.
-        #[no_mangle]
-        pub extern "C" fn whisker_aslr_anchor() -> ::std::ffi::c_int { 0 }
+        // Note: the ASLR anchor symbol (`whisker_aslr_anchor`) used
+        // to be injected here. It now lives in `whisker-driver` as a
+        // plain `#[no_mangle]` fn — every Whisker user dylib links
+        // that crate, so the symbol auto-exports without needing
+        // macro plumbing. Patch dylibs explicitly retain it via
+        // `--require-defined` in the dev-server linker plan.
     };
 
     expanded.into()

--- a/crates/whisker-subsecond/src/lib.rs
+++ b/crates/whisker-subsecond/src/lib.rs
@@ -530,9 +530,10 @@ pub unsafe fn apply_patch(mut table: JumpTable) -> Result<Vec<*const ()>, PatchE
         // memfds', etc.) — `dlsym(RTLD_DEFAULT, "main")` then returns the
         // wrong one and the computed ASLR slide is garbage.
         //
-        // `whisker_aslr_anchor` is synthesised by `#[whisker::main]` and
-        // is unique to the user's `.so`, so the dlsym lookup is
-        // unambiguous regardless of namespace order.
+        // `whisker_aslr_anchor` is exported by `whisker-driver`
+        // (statically linked into every Whisker dylib) and is unique
+        // to the user's `.so`, so the dlsym lookup is unambiguous
+        // regardless of namespace order.
         let old_offset = aslr_reference() - table.aslr_reference as usize;
 
         let new_offset = unsafe {


### PR DESCRIPTION
Closes task **P6α-5** (Phase 6α: Lynx fork series finale).

## What

Moves the `whisker_aslr_anchor` symbol from the `#[whisker::main]` macro into `whisker-driver` as a plain top-level fn. Every Whisker dylib already statically links `whisker-driver`, so the symbol auto-exports without macro plumbing.

## Why

The macro previously emitted three `#[no_mangle] pub extern "C"` symbols: `whisker_app_main`, `whisker_tick`, and `whisker_aslr_anchor`. Only the first two need a user-fn pointer (so they belong in the macro). The third is a constant zero-returning stub — its job is "exist at a known address so subsecond's `dlsym(RTLD_DEFAULT, ...)` can compute the dylib's load base". That's a runtime ABI detail, not a macro concern.

Centralising it in `whisker-driver` means:

- The macro stays focused on user-facing concerns.
- Any binary that statically links `whisker-driver` automatically exports the anchor (test fixtures, future desktop preview targets, etc.) — no implicit "no `#[whisker::main]` → patch crashes" gotcha.
- Patch dylibs still keep the symbol via the existing `--require-defined whisker_aslr_anchor` flag in `whisker-dev-server::hotpatch::patcher` — no pipeline change.

## Verification

Symbol is present in the compiled `whisker-driver` rlib:

\`\`\`
$ nm target/release/deps/libwhisker_driver-*.rlib | grep whisker_aslr
0000000000000c5c T _whisker_aslr_anchor
\`\`\`

Full workspace tests + clippy + fmt all green.

## Out of scope

- The hot-reload pipeline's "anchor on `whisker_aslr_anchor` instead of `main`" decision stays as-is (this is just refactoring where the symbol *originates*, not changing what subsecond looks up).
- No examples / docs changes outside comment updates in `whisker-subsecond` and `whisker-dev-server::hotpatch::cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)