### PR TITLE
chore(cli): curated whisker run output + silence Lynx-header warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "flate2",
+ "indicatif",
  "sha2",
  "tar",
  "ureq",

--- a/crates/whisker-build/Cargo.toml
+++ b/crates/whisker-build/Cargo.toml
@@ -32,3 +32,9 @@ flate2 = "1"
 # SHA-256 verification of downloaded tarballs against the constants
 # hard-coded in src/lynx.rs.
 sha2 = "0.10"
+# Curated terminal output for `whisker run` / `whisker build`. Used by
+# the `ui` module to replace ad-hoc `eprintln!` calls scattered across
+# whisker-build / whisker-dev-server / whisker-cli with structured
+# step + status events. Stays a single shared crate so the three
+# orchestration layers all hit the same look + feel.
+indicatif = "0.17"

--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -233,14 +233,11 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
         }
     }
 
-    eprintln!(
-        "[whisker-build] cargo rustc --crate-type dylib --target {triple} -p {pkg} ({profile:?})",
-        pkg = b.package,
-        profile = b.profile,
-    );
+    let cargo_step = crate::ui::step("compile", format!("{} ({triple})", b.package));
     let status = cmd
         .status()
         .with_context(|| format!("spawn cargo for {triple}"))?;
+    cargo_step.done("");
     if !status.success() {
         return Err(anyhow!("cargo build failed ({status}) for {triple}"));
     }
@@ -286,10 +283,10 @@ pub fn stage_jni_libs(
     std::fs::copy(&libcxx, &dst_libcxx)
         .with_context(|| format!("copy {} → {}", libcxx.display(), dst_libcxx.display()))?;
 
-    eprintln!(
-        "[whisker-build] staged jniLibs: {} + libc++_shared.so",
+    crate::ui::info(format!(
+        "stage jniLibs ({} + libc++_shared.so)",
         so_name.to_string_lossy(),
-    );
+    ));
     Ok(())
 }
 
@@ -328,7 +325,7 @@ pub fn run_gradle_assemble(gen_android: &Path, profile: Profile) -> Result<PathB
         Profile::Release => ":app:assembleRelease",
         Profile::Debug => ":app:assembleDebug",
     };
-    eprintln!("[whisker-build] gradle {task}");
+    let _gradle_step = crate::ui::step("gradle", task.to_string());
     let java_home = resolve_java_home()?;
     let gradlew = gen_android.join("gradlew");
     if !gradlew.is_file() {

--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -192,11 +192,7 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
     let triple_upper = triple_env.to_uppercase();
 
     let mut cmd = Command::new("cargo");
-    // `--quiet` suppresses cargo's `Compiling X` / `Finished` lines
-    // so they don't fight with the compile-step spinner. Same
-    // rationale as the iOS side.
     cmd.arg("rustc")
-        .arg("--quiet")
         .args(["--target", triple])
         .args(["-p", b.package])
         .args(["--crate-type", "dylib"]);
@@ -238,8 +234,8 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
     }
 
     let cargo_step = crate::ui::step("compile", format!("{} ({triple})", b.package));
-    let status = cmd
-        .status()
+    let status = cargo_step
+        .pipe(&mut cmd)
         .with_context(|| format!("spawn cargo for {triple}"))?;
     cargo_step.done("");
     if !status.success() {

--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -192,7 +192,11 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
     let triple_upper = triple_env.to_uppercase();
 
     let mut cmd = Command::new("cargo");
+    // `--quiet` suppresses cargo's `Compiling X` / `Finished` lines
+    // so they don't fight with the compile-step spinner. Same
+    // rationale as the iOS side.
     cmd.arg("rustc")
+        .arg("--quiet")
         .args(["--target", triple])
         .args(["-p", b.package])
         .args(["--crate-type", "dylib"]);

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -74,10 +74,11 @@ const BRIDGE_EXPORTS: &[&str] = &[
 /// passes `None` (prod has no Tier 1).
 /// Which iOS slice(s) to put in the resulting xcframework.
 ///
-/// `whisker run --target ios-sim` only ever loads the simulator
-/// slice; building the device + x86 slices wastes 60+ seconds of
-/// dev-loop time. Production `whisker build` keeps the universal
-/// shape so the resulting artifact runs on real hardware too.
+/// `whisker run --target ios-sim` only ever loads the host-arch
+/// simulator slice; building the device + cross-arch slices wastes
+/// 60+ seconds of dev-loop time. Production `whisker build` keeps
+/// the universal shape so the resulting artifact runs on real
+/// hardware too.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum IosSlices {
     /// arm64 device + arm64 sim + x86_64 sim. Required for shipping;
@@ -85,9 +86,35 @@ pub enum IosSlices {
     /// / linker caches keyed on the simulator triple, which lands
     /// last in the build order).
     Universal,
-    /// arm64 sim only. Right choice for `whisker run --target ios-sim`
-    /// on an Apple Silicon Mac.
-    SimulatorArm64,
+    /// One simulator slice matching the host architecture
+    /// (`aarch64-apple-ios-sim` on Apple Silicon Macs, `x86_64-apple-ios`
+    /// on Intel). Right choice for `whisker run --target ios-sim` —
+    /// xcodebuild's `-arch <host>` pin in the dev-server's app link
+    /// keeps the link line single-arch so this lone slice resolves
+    /// every reference.
+    SimulatorHost,
+}
+
+/// The single iOS-sim triple matching the current host. Used by the
+/// dev-server's `SimulatorHost` xcframework build + by the matching
+/// `-arch <host>` constraint the dev-server adds to xcodebuild.
+pub fn host_simulator_triple() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "aarch64-apple-ios-sim"
+    } else {
+        "x86_64-apple-ios"
+    }
+}
+
+/// The Mach-O arch name for the current host (`arm64` / `x86_64`).
+/// xcodebuild's `-arch` flag wants this form, not the rustc triple
+/// form.
+pub fn host_simulator_arch() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        "x86_64"
+    }
 }
 
 pub fn build_xcframework(
@@ -149,13 +176,15 @@ pub fn build_xcframework_with(
     // typical Apple-Silicon dev machine runs the arm64 simulator).
     // For `SimulatorArm64` there's nothing to order — it's the
     // only triple compiled.
+    let host_sim = host_simulator_triple();
+    let host_only: [&str; 1] = [host_sim];
     let triples: &[&str] = match slices {
         IosSlices::Universal => &[
             "aarch64-apple-ios",
             "x86_64-apple-ios",
             "aarch64-apple-ios-sim",
         ],
-        IosSlices::SimulatorArm64 => &["aarch64-apple-ios-sim"],
+        IosSlices::SimulatorHost => &host_only,
     };
     for triple in triples {
         let s = crate::ui::step("compile", format!("{package} ({triple})"));
@@ -164,6 +193,9 @@ pub fn build_xcframework_with(
     }
 
     let target_dir = workspace_root.join("target");
+    // For `SimulatorHost`, this is the lone slice we just built. For
+    // `Universal`, this is the arm64 simulator slice that gets
+    // lipo'd together with the x86 one further down.
     let sim_arm64_dylib = target_dir
         .join("aarch64-apple-ios-sim/release")
         .join(&cargo_dylib_name);
@@ -225,20 +257,25 @@ pub fn build_xcframework_with(
         )?;
         staged_fws.push(sim_fw);
     } else {
-        if !sim_arm64_dylib.is_file() {
+        // SimulatorHost: one slice matching the host architecture.
+        // The dev-server's app xcodebuild line pins `-arch <host>`,
+        // so a single-slice xcframework is sufficient — the linker
+        // won't reach for the other arch.
+        let host_sim_dylib = target_dir
+            .join(host_sim)
+            .join("release")
+            .join(&cargo_dylib_name);
+        if !host_sim_dylib.is_file() {
             return Err(anyhow!(
                 "expected dylib not built: {}",
-                sim_arm64_dylib.display()
+                host_sim_dylib.display(),
             ));
         }
-        // Single-slice xcframework — the arm64-sim dylib is the only
-        // input and lands at `target/whisker-driver/sim/<dylib>`.
         let sim_parent = out.join("sim");
         std::fs::create_dir_all(&sim_parent)?;
         let staged = sim_parent.join(&cargo_dylib_name);
-        std::fs::copy(&sim_arm64_dylib, &staged).with_context(|| {
-            format!("copy {} → {}", sim_arm64_dylib.display(), staged.display())
-        })?;
+        std::fs::copy(&host_sim_dylib, &staged)
+            .with_context(|| format!("copy {} → {}", host_sim_dylib.display(), staged.display()))?;
         let sim_fw =
             build_framework_dir(&sim_parent, &staged, &rust_headers_src, &bridge_headers_src)?;
         staged_fws.push(sim_fw);

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -100,10 +100,11 @@ pub fn build_xcframework(
         ));
     }
 
-    eprintln!("[whisker-build] cleaning {}", out.display());
+    let clean_step = crate::ui::step("clean", out.display().to_string());
     if out.exists() {
         std::fs::remove_dir_all(&out).with_context(|| format!("rm -rf {}", out.display()))?;
     }
+    clean_step.done("");
     std::fs::create_dir_all(&out).with_context(|| format!("mkdir -p {}", out.display()))?;
 
     // Order matters: the last triple's rustc / linker capture wins in
@@ -115,10 +116,10 @@ pub fn build_xcframework(
         "x86_64-apple-ios",
         "aarch64-apple-ios-sim",
     ];
-    eprintln!("[whisker-build] cargo rustc per iOS triple (package: {package})");
     for triple in triples {
-        eprintln!("    -- {triple}");
+        let s = crate::ui::step("compile", format!("{package} ({triple})"));
         cargo_build_ios_dylib(workspace_root, package, triple, features, capture)?;
+        s.done("");
     }
 
     let target_dir = workspace_root.join("target");
@@ -150,10 +151,7 @@ pub fn build_xcframework(
     let sim_fat_parent = out.join("sim");
     std::fs::create_dir_all(&sim_fat_parent)?;
     let sim_fat = sim_fat_parent.join(&cargo_dylib_name);
-    eprintln!(
-        "[whisker-build] lipo simulator slices → {}",
-        sim_fat.display()
-    );
+    crate::ui::info(format!("lipo {}", sim_fat.display()));
     let status = Command::new("lipo")
         .args(["-create"])
         .arg(&sim_arm64_dylib)
@@ -173,7 +171,7 @@ pub fn build_xcframework(
     )?;
 
     let xcf = out.join(format!("{FRAMEWORK_NAME}.xcframework"));
-    eprintln!("[whisker-build] xcodebuild -create-xcframework");
+    let xcf_step = crate::ui::step("xcframework", FRAMEWORK_NAME.to_string());
     let status = Command::new("xcodebuild")
         .arg("-create-xcframework")
         .args(["-framework"])
@@ -187,7 +185,7 @@ pub fn build_xcframework(
     if !status.success() {
         return Err(anyhow!("xcodebuild -create-xcframework failed ({status})"));
     }
-    eprintln!("[whisker-build] xcframework: {}", xcf.display());
+    xcf_step.done("");
     Ok(xcf)
 }
 
@@ -267,7 +265,7 @@ fn build_framework_dir(
     bridge_headers_src: &Path,
 ) -> Result<PathBuf> {
     let fw_dir = parent.join(format!("{FRAMEWORK_NAME}.framework"));
-    eprintln!("[whisker-build] staging {}", fw_dir.display());
+    crate::ui::info(format!("stage {}", fw_dir.display()));
     if fw_dir.exists() {
         std::fs::remove_dir_all(&fw_dir)?;
     }
@@ -403,10 +401,7 @@ pub fn run_xcodebuild_app(args: &XcodebuildArgs<'_>) -> Result<PathBuf> {
         ));
     }
 
-    eprintln!(
-        "[whisker-build] xcodebuild -configuration {} -sdk {}",
-        args.configuration, args.sdk,
-    );
+    let _xc_step = crate::ui::step("xcodebuild", args.xcodeproj_name.to_string());
     let destination = match args.sdk {
         "iphonesimulator" => "generic/platform=iOS Simulator".to_string(),
         "iphoneos" => "generic/platform=iOS".to_string(),

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -74,47 +74,24 @@ const BRIDGE_EXPORTS: &[&str] = &[
 /// passes `None` (prod has no Tier 1).
 /// Which iOS slice(s) to put in the resulting xcframework.
 ///
-/// `whisker run --target ios-sim` only ever loads the host-arch
-/// simulator slice; building the device + cross-arch slices wastes
-/// 60+ seconds of dev-loop time. Production `whisker build` keeps
-/// the universal shape so the resulting artifact runs on real
-/// hardware too.
+/// `whisker run --target ios-sim` doesn't need the device slice —
+/// skipping it cuts the dev-loop's initial build by one cargo
+/// triple (~20–60s warm cache). The simulator pair (arm64 + x86_64)
+/// stays as a fat slice because `xcodebuild
+/// -destination 'generic/platform=iOS Simulator'` insists on
+/// linking against a universal binary; pinning `-arch <host>`
+/// alongside the destination is rejected by xcodebuild.
+///
+/// Production `whisker build` keeps the universal shape so the
+/// resulting artifact runs on real hardware too.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum IosSlices {
-    /// arm64 device + arm64 sim + x86_64 sim. Required for shipping;
-    /// also used by Tier 1 capture (the dev-server populates rustc
-    /// / linker caches keyed on the simulator triple, which lands
-    /// last in the build order).
+    /// arm64 device + arm64 sim + x86_64 sim. Required for shipping.
     Universal,
-    /// One simulator slice matching the host architecture
-    /// (`aarch64-apple-ios-sim` on Apple Silicon Macs, `x86_64-apple-ios`
-    /// on Intel). Right choice for `whisker run --target ios-sim` —
-    /// xcodebuild's `-arch <host>` pin in the dev-server's app link
-    /// keeps the link line single-arch so this lone slice resolves
-    /// every reference.
-    SimulatorHost,
-}
-
-/// The single iOS-sim triple matching the current host. Used by the
-/// dev-server's `SimulatorHost` xcframework build + by the matching
-/// `-arch <host>` constraint the dev-server adds to xcodebuild.
-pub fn host_simulator_triple() -> &'static str {
-    if cfg!(target_arch = "aarch64") {
-        "aarch64-apple-ios-sim"
-    } else {
-        "x86_64-apple-ios"
-    }
-}
-
-/// The Mach-O arch name for the current host (`arm64` / `x86_64`).
-/// xcodebuild's `-arch` flag wants this form, not the rustc triple
-/// form.
-pub fn host_simulator_arch() -> &'static str {
-    if cfg!(target_arch = "aarch64") {
-        "arm64"
-    } else {
-        "x86_64"
-    }
+    /// arm64 sim + x86_64 sim (lipo'd into one fat slice). Right
+    /// choice for `whisker run --target ios-sim` — both sim archs
+    /// are needed at link time, but the device slice isn't.
+    SimulatorFat,
 }
 
 pub fn build_xcframework(
@@ -170,21 +147,17 @@ pub fn build_xcframework_with(
     }
     std::fs::create_dir_all(&out).with_context(|| format!("mkdir -p {}", out.display()))?;
 
-    // Pick the triple set + their order based on `slices`. For
-    // `Universal`, arm64-sim lands last so its rustc + linker
-    // capture wins the dev-server's last-write-wins cache (the
-    // typical Apple-Silicon dev machine runs the arm64 simulator).
-    // For `SimulatorArm64` there's nothing to order — it's the
-    // only triple compiled.
-    let host_sim = host_simulator_triple();
-    let host_only: [&str; 1] = [host_sim];
+    // Triple set + order driven by `slices`. arm64-sim lands last in
+    // both variants so its rustc + linker capture wins the
+    // dev-server's last-write-wins cache (Apple-Silicon dev machines
+    // run the arm64 simulator natively).
     let triples: &[&str] = match slices {
         IosSlices::Universal => &[
             "aarch64-apple-ios",
             "x86_64-apple-ios",
             "aarch64-apple-ios-sim",
         ],
-        IosSlices::SimulatorHost => &host_only,
+        IosSlices::SimulatorFat => &["x86_64-apple-ios", "aarch64-apple-ios-sim"],
     };
     for triple in triples {
         let s = crate::ui::step("compile", format!("{package} ({triple})"));
@@ -210,19 +183,26 @@ pub fn build_xcframework_with(
     // tree before handing the lot to xcodebuild.
     let mut staged_fws: Vec<PathBuf> = Vec::new();
 
+    let sim_x86_dylib = target_dir
+        .join("x86_64-apple-ios/release")
+        .join(&cargo_dylib_name);
+    for p in [&sim_arm64_dylib, &sim_x86_dylib] {
+        if !p.is_file() {
+            return Err(anyhow!("expected dylib not built: {}", p.display()));
+        }
+    }
+
+    // Device slice — only for Universal.
     if matches!(slices, IosSlices::Universal) {
         let device_dylib = target_dir
             .join("aarch64-apple-ios/release")
             .join(&cargo_dylib_name);
-        let sim_x86_dylib = target_dir
-            .join("x86_64-apple-ios/release")
-            .join(&cargo_dylib_name);
-        for p in [&device_dylib, &sim_arm64_dylib, &sim_x86_dylib] {
-            if !p.is_file() {
-                return Err(anyhow!("expected dylib not built: {}", p.display()));
-            }
+        if !device_dylib.is_file() {
+            return Err(anyhow!(
+                "expected dylib not built: {}",
+                device_dylib.display()
+            ));
         }
-        // Device slice framework.
         let device_fw_parent = out.join("device");
         let device_fw = build_framework_dir(
             &device_fw_parent,
@@ -231,55 +211,35 @@ pub fn build_xcframework_with(
             &bridge_headers_src,
         )?;
         staged_fws.push(device_fw);
-
-        // Lipo arm64 + x86 sim dylibs into a fat sim binary.
-        let sim_fat_parent = out.join("sim");
-        std::fs::create_dir_all(&sim_fat_parent)?;
-        let sim_fat = sim_fat_parent.join(&cargo_dylib_name);
-        crate::ui::debug(format!("lipo {}", sim_fat.display()));
-        let status = Command::new("lipo")
-            .args(["-create"])
-            .arg(&sim_arm64_dylib)
-            .arg(&sim_x86_dylib)
-            .args(["-output"])
-            .arg(&sim_fat)
-            .status()
-            .context("spawn lipo")?;
-        if !status.success() {
-            xcf_step.fail(format!("lipo {status}"));
-            return Err(anyhow!("lipo failed ({status})"));
-        }
-        let sim_fw = build_framework_dir(
-            &sim_fat_parent,
-            &sim_fat,
-            &rust_headers_src,
-            &bridge_headers_src,
-        )?;
-        staged_fws.push(sim_fw);
-    } else {
-        // SimulatorHost: one slice matching the host architecture.
-        // The dev-server's app xcodebuild line pins `-arch <host>`,
-        // so a single-slice xcframework is sufficient — the linker
-        // won't reach for the other arch.
-        let host_sim_dylib = target_dir
-            .join(host_sim)
-            .join("release")
-            .join(&cargo_dylib_name);
-        if !host_sim_dylib.is_file() {
-            return Err(anyhow!(
-                "expected dylib not built: {}",
-                host_sim_dylib.display(),
-            ));
-        }
-        let sim_parent = out.join("sim");
-        std::fs::create_dir_all(&sim_parent)?;
-        let staged = sim_parent.join(&cargo_dylib_name);
-        std::fs::copy(&host_sim_dylib, &staged)
-            .with_context(|| format!("copy {} → {}", host_sim_dylib.display(), staged.display()))?;
-        let sim_fw =
-            build_framework_dir(&sim_parent, &staged, &rust_headers_src, &bridge_headers_src)?;
-        staged_fws.push(sim_fw);
     }
+
+    // Lipo arm64 + x86 sim dylibs into a fat sim binary. Both
+    // `Universal` and `SimulatorFat` need this — xcodebuild's
+    // `-destination 'generic/platform=iOS Simulator'` link demands
+    // a universal simulator slice.
+    let sim_fat_parent = out.join("sim");
+    std::fs::create_dir_all(&sim_fat_parent)?;
+    let sim_fat = sim_fat_parent.join(&cargo_dylib_name);
+    crate::ui::debug(format!("lipo {}", sim_fat.display()));
+    let status = Command::new("lipo")
+        .args(["-create"])
+        .arg(&sim_arm64_dylib)
+        .arg(&sim_x86_dylib)
+        .args(["-output"])
+        .arg(&sim_fat)
+        .status()
+        .context("spawn lipo")?;
+    if !status.success() {
+        xcf_step.fail(format!("lipo {status}"));
+        return Err(anyhow!("lipo failed ({status})"));
+    }
+    let sim_fw = build_framework_dir(
+        &sim_fat_parent,
+        &sim_fat,
+        &rust_headers_src,
+        &bridge_headers_src,
+    )?;
+    staged_fws.push(sim_fw);
 
     for fw in &staged_fws {
         xcframework_cmd.args(["-framework"]).arg(fw);
@@ -321,8 +281,15 @@ fn cargo_build_ios_dylib(
     capture: Option<&CaptureShims>,
 ) -> Result<()> {
     let mut cmd = Command::new("cargo");
+    // `--quiet` suppresses cargo's `Compiling X` / `Finished` lines
+    // that otherwise interleave with our compile-step spinner. The
+    // spinner already shows the same info (`compile  hello-world
+    // (triple) …` → `✓ 6.7s`); cargo's prefix-aligned variant just
+    // produces visual stutter as the spinner redraws around it.
+    // Errors still surface via stderr passthrough.
     cmd.args([
         "rustc",
+        "--quiet",
         "--release",
         "-p",
         package,

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -161,7 +161,7 @@ pub fn build_xcframework_with(
     };
     for triple in triples {
         let s = crate::ui::step("compile", format!("{package} ({triple})"));
-        cargo_build_ios_dylib(workspace_root, package, triple, features, capture)?;
+        cargo_build_ios_dylib(workspace_root, package, triple, features, capture, &s)?;
         s.done("");
     }
 
@@ -279,17 +279,11 @@ fn cargo_build_ios_dylib(
     triple: &str,
     features: &[String],
     capture: Option<&CaptureShims>,
+    step: &crate::ui::Step,
 ) -> Result<()> {
     let mut cmd = Command::new("cargo");
-    // `--quiet` suppresses cargo's `Compiling X` / `Finished` lines
-    // that otherwise interleave with our compile-step spinner. The
-    // spinner already shows the same info (`compile  hello-world
-    // (triple) …` → `✓ 6.7s`); cargo's prefix-aligned variant just
-    // produces visual stutter as the spinner redraws around it.
-    // Errors still surface via stderr passthrough.
     cmd.args([
         "rustc",
-        "--quiet",
         "--release",
         "-p",
         package,
@@ -321,10 +315,8 @@ fn cargo_build_ios_dylib(
             cmd.env(k, v);
         }
     }
-    let status = cmd
-        .current_dir(workspace_root)
-        .status()
-        .context("spawn cargo")?;
+    cmd.current_dir(workspace_root);
+    let status = step.pipe(&mut cmd).context("spawn cargo")?;
     if !status.success() {
         return Err(anyhow!("cargo rustc failed for {triple} ({status})"));
     }

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -72,11 +72,45 @@ const BRIDGE_EXPORTS: &[&str] = &[
 /// dev-server's Patcher can construct hot patches. Dev-server's
 /// Tier 2 cold rebuild path passes `Some(&shims)`; `whisker build`
 /// passes `None` (prod has no Tier 1).
+/// Which iOS slice(s) to put in the resulting xcframework.
+///
+/// `whisker run --target ios-sim` only ever loads the simulator
+/// slice; building the device + x86 slices wastes 60+ seconds of
+/// dev-loop time. Production `whisker build` keeps the universal
+/// shape so the resulting artifact runs on real hardware too.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum IosSlices {
+    /// arm64 device + arm64 sim + x86_64 sim. Required for shipping;
+    /// also used by Tier 1 capture (the dev-server populates rustc
+    /// / linker caches keyed on the simulator triple, which lands
+    /// last in the build order).
+    Universal,
+    /// arm64 sim only. Right choice for `whisker run --target ios-sim`
+    /// on an Apple Silicon Mac.
+    SimulatorArm64,
+}
+
 pub fn build_xcframework(
     workspace_root: &Path,
     package: &str,
     features: &[String],
     capture: Option<&CaptureShims>,
+) -> Result<PathBuf> {
+    build_xcframework_with(
+        workspace_root,
+        package,
+        features,
+        capture,
+        IosSlices::Universal,
+    )
+}
+
+pub fn build_xcframework_with(
+    workspace_root: &Path,
+    package: &str,
+    features: &[String],
+    capture: Option<&CaptureShims>,
+    slices: IosSlices,
 ) -> Result<PathBuf> {
     let out = workspace_root.join("target/whisker-driver");
     let lib_stem = package.replace('-', "_");
@@ -100,22 +134,29 @@ pub fn build_xcframework(
         ));
     }
 
-    let clean_step = crate::ui::step("clean", out.display().to_string());
+    // Clean isn't a step the user needs to watch — it's a sub-100ms
+    // rm-rf of our own artifact dir. Just do it silently; the debug
+    // line below records the path for verbose-mode triage.
+    crate::ui::debug(format!("clean {}", out.display()));
     if out.exists() {
         std::fs::remove_dir_all(&out).with_context(|| format!("rm -rf {}", out.display()))?;
     }
-    clean_step.done("");
     std::fs::create_dir_all(&out).with_context(|| format!("mkdir -p {}", out.display()))?;
 
-    // Order matters: the last triple's rustc / linker capture wins in
-    // the dev-server's Tier 1 thin-rebuild cache (timestamp-keyed,
-    // last-write-wins). arm64-sim lands last so the most common dev
-    // machine — an arm64 Mac — sees its slice as the live cache.
-    let triples = [
-        "aarch64-apple-ios",
-        "x86_64-apple-ios",
-        "aarch64-apple-ios-sim",
-    ];
+    // Pick the triple set + their order based on `slices`. For
+    // `Universal`, arm64-sim lands last so its rustc + linker
+    // capture wins the dev-server's last-write-wins cache (the
+    // typical Apple-Silicon dev machine runs the arm64 simulator).
+    // For `SimulatorArm64` there's nothing to order — it's the
+    // only triple compiled.
+    let triples: &[&str] = match slices {
+        IosSlices::Universal => &[
+            "aarch64-apple-ios",
+            "x86_64-apple-ios",
+            "aarch64-apple-ios-sim",
+        ],
+        IosSlices::SimulatorArm64 => &["aarch64-apple-ios-sim"],
+    };
     for triple in triples {
         let s = crate::ui::step("compile", format!("{package} ({triple})"));
         cargo_build_ios_dylib(workspace_root, package, triple, features, capture)?;
@@ -123,66 +164,102 @@ pub fn build_xcframework(
     }
 
     let target_dir = workspace_root.join("target");
-    let device_dylib = target_dir
-        .join("aarch64-apple-ios/release")
-        .join(&cargo_dylib_name);
     let sim_arm64_dylib = target_dir
         .join("aarch64-apple-ios-sim/release")
         .join(&cargo_dylib_name);
-    let sim_x86_dylib = target_dir
-        .join("x86_64-apple-ios/release")
-        .join(&cargo_dylib_name);
-    for p in [&device_dylib, &sim_arm64_dylib, &sim_x86_dylib] {
-        if !p.is_file() {
-            return Err(anyhow!("expected dylib not built: {}", p.display()));
-        }
-    }
-
-    // Device slice framework.
-    let device_fw_parent = out.join("device");
-    let device_fw = build_framework_dir(
-        &device_fw_parent,
-        &device_dylib,
-        &rust_headers_src,
-        &bridge_headers_src,
-    )?;
-
-    // Lipo two sim dylibs into a single fat binary, then frame it.
-    let sim_fat_parent = out.join("sim");
-    std::fs::create_dir_all(&sim_fat_parent)?;
-    let sim_fat = sim_fat_parent.join(&cargo_dylib_name);
-    crate::ui::info(format!("lipo {}", sim_fat.display()));
-    let status = Command::new("lipo")
-        .args(["-create"])
-        .arg(&sim_arm64_dylib)
-        .arg(&sim_x86_dylib)
-        .args(["-output"])
-        .arg(&sim_fat)
-        .status()
-        .context("spawn lipo")?;
-    if !status.success() {
-        return Err(anyhow!("lipo failed ({status})"));
-    }
-    let sim_fw = build_framework_dir(
-        &sim_fat_parent,
-        &sim_fat,
-        &rust_headers_src,
-        &bridge_headers_src,
-    )?;
 
     let xcf = out.join(format!("{FRAMEWORK_NAME}.xcframework"));
     let xcf_step = crate::ui::step("xcframework", FRAMEWORK_NAME.to_string());
-    let status = Command::new("xcodebuild")
-        .arg("-create-xcframework")
-        .args(["-framework"])
-        .arg(&device_fw)
-        .args(["-framework"])
-        .arg(&sim_fw)
-        .args(["-output"])
-        .arg(&xcf)
+
+    let mut xcframework_cmd = std::process::Command::new("xcodebuild");
+    xcframework_cmd.arg("-create-xcframework");
+
+    // Common: every variant wraps each slice in its own .framework
+    // tree before handing the lot to xcodebuild.
+    let mut staged_fws: Vec<PathBuf> = Vec::new();
+
+    if matches!(slices, IosSlices::Universal) {
+        let device_dylib = target_dir
+            .join("aarch64-apple-ios/release")
+            .join(&cargo_dylib_name);
+        let sim_x86_dylib = target_dir
+            .join("x86_64-apple-ios/release")
+            .join(&cargo_dylib_name);
+        for p in [&device_dylib, &sim_arm64_dylib, &sim_x86_dylib] {
+            if !p.is_file() {
+                return Err(anyhow!("expected dylib not built: {}", p.display()));
+            }
+        }
+        // Device slice framework.
+        let device_fw_parent = out.join("device");
+        let device_fw = build_framework_dir(
+            &device_fw_parent,
+            &device_dylib,
+            &rust_headers_src,
+            &bridge_headers_src,
+        )?;
+        staged_fws.push(device_fw);
+
+        // Lipo arm64 + x86 sim dylibs into a fat sim binary.
+        let sim_fat_parent = out.join("sim");
+        std::fs::create_dir_all(&sim_fat_parent)?;
+        let sim_fat = sim_fat_parent.join(&cargo_dylib_name);
+        crate::ui::debug(format!("lipo {}", sim_fat.display()));
+        let status = Command::new("lipo")
+            .args(["-create"])
+            .arg(&sim_arm64_dylib)
+            .arg(&sim_x86_dylib)
+            .args(["-output"])
+            .arg(&sim_fat)
+            .status()
+            .context("spawn lipo")?;
+        if !status.success() {
+            xcf_step.fail(format!("lipo {status}"));
+            return Err(anyhow!("lipo failed ({status})"));
+        }
+        let sim_fw = build_framework_dir(
+            &sim_fat_parent,
+            &sim_fat,
+            &rust_headers_src,
+            &bridge_headers_src,
+        )?;
+        staged_fws.push(sim_fw);
+    } else {
+        if !sim_arm64_dylib.is_file() {
+            return Err(anyhow!(
+                "expected dylib not built: {}",
+                sim_arm64_dylib.display()
+            ));
+        }
+        // Single-slice xcframework — the arm64-sim dylib is the only
+        // input and lands at `target/whisker-driver/sim/<dylib>`.
+        let sim_parent = out.join("sim");
+        std::fs::create_dir_all(&sim_parent)?;
+        let staged = sim_parent.join(&cargo_dylib_name);
+        std::fs::copy(&sim_arm64_dylib, &staged).with_context(|| {
+            format!("copy {} → {}", sim_arm64_dylib.display(), staged.display())
+        })?;
+        let sim_fw =
+            build_framework_dir(&sim_parent, &staged, &rust_headers_src, &bridge_headers_src)?;
+        staged_fws.push(sim_fw);
+    }
+
+    for fw in &staged_fws {
+        xcframework_cmd.args(["-framework"]).arg(fw);
+    }
+    xcframework_cmd.args(["-output"]).arg(&xcf);
+
+    // `xcodebuild -create-xcframework` always prints `xcframework
+    // successfully written out to: <path>` on stdout, which doubles
+    // the visible confirmation that the step itself already gives.
+    // Discard it; failures still surface via the exit status + our
+    // anyhow message.
+    let status = xcframework_cmd
+        .stdout(std::process::Stdio::null())
         .status()
         .context("spawn xcodebuild -create-xcframework")?;
     if !status.success() {
+        xcf_step.fail(format!("{status}"));
         return Err(anyhow!("xcodebuild -create-xcframework failed ({status})"));
     }
     xcf_step.done("");
@@ -265,7 +342,7 @@ fn build_framework_dir(
     bridge_headers_src: &Path,
 ) -> Result<PathBuf> {
     let fw_dir = parent.join(format!("{FRAMEWORK_NAME}.framework"));
-    crate::ui::info(format!("stage {}", fw_dir.display()));
+    crate::ui::debug(format!("stage {}", fw_dir.display()));
     if fw_dir.exists() {
         std::fs::remove_dir_all(&fw_dir)?;
     }

--- a/crates/whisker-build/src/lib.rs
+++ b/crates/whisker-build/src/lib.rs
@@ -28,6 +28,7 @@ pub mod android;
 pub mod capture;
 pub mod ios;
 pub mod lynx;
+pub mod ui;
 
 pub use capture::{
     capture_env_vars, target_linker_env_var, target_rustflags_env_var, CaptureShims,

--- a/crates/whisker-build/src/lynx.rs
+++ b/crates/whisker-build/src/lynx.rs
@@ -178,8 +178,9 @@ fn ensure_lynx(platform: LynxPlatform) -> Result<PathBuf> {
     }
 
     let url = download_url(platform);
-    eprintln!("[whisker-build::lynx] downloading {url}");
+    let dl_step = crate::ui::step("download", url.clone());
     let bytes = http_get(&url).with_context(|| format!("download {url}"))?;
+    dl_step.done(format!("{} KB", bytes.len() / 1024));
     verify_sha256(&bytes, expected_sha).with_context(|| {
         format!(
             "checksum mismatch for {url}; \
@@ -199,7 +200,7 @@ fn ensure_lynx(platform: LynxPlatform) -> Result<PathBuf> {
             cache.display(),
         );
     }
-    eprintln!("[whisker-build::lynx] cached at {}", cache.display(),);
+    crate::ui::info(format!("cached lynx at {}", cache.display()));
     Ok(cache)
 }
 

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -138,6 +138,36 @@ impl Step {
         self.finish(StepKind::Fail, &summary.into());
     }
 
+    /// Spawn `cmd`, stream its stdout + stderr line-by-line, and
+    /// return its [`ExitStatus`]. Cargo-style progress lines
+    /// (`    Compiling X v0.1.0`, `    Finished …`, `    Updating
+    /// crates.io …`) update the spinner's message in place so the
+    /// step stays a single live line; everything else — rustc
+    /// errors, linker output, warnings — is printed above the
+    /// spinner so it persists in scrollback for copy-paste triage.
+    ///
+    /// In non-TTY mode (CI, `tee` to a file, `WHISKER_VERBOSE=1`)
+    /// every line is emitted verbatim — no in-place rewriting,
+    /// because there's no spinner to anchor against.
+    pub fn pipe(
+        &self,
+        cmd: &mut std::process::Command,
+    ) -> std::io::Result<std::process::ExitStatus> {
+        cmd.stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let mut child = cmd.spawn()?;
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        let bar_stdout = self.bar.clone();
+        let bar_stderr = self.bar.clone();
+        let t_out = std::thread::spawn(move || stream_through_bar(stdout, bar_stdout));
+        let t_err = std::thread::spawn(move || stream_through_bar(stderr, bar_stderr));
+        let status = child.wait()?;
+        let _ = t_out.join();
+        let _ = t_err.join();
+        Ok(status)
+    }
+
     fn finish(self, kind: StepKind, summary: &str) {
         let elapsed = format_elapsed(self.started_at.elapsed());
         let summary = if summary.is_empty() {
@@ -153,6 +183,99 @@ impl Step {
             eprintln!("{line}");
         }
     }
+}
+
+/// Read `stream` line-by-line; route cargo-progress lines through
+/// the spinner's `set_message`, everything else through
+/// [`ProgressBar::println`] (or `eprintln!` when there's no bar).
+fn stream_through_bar<R: std::io::Read + Send + 'static>(
+    stream: Option<R>,
+    bar: Option<ProgressBar>,
+) {
+    use std::io::{BufRead, BufReader};
+    let Some(s) = stream else { return };
+    let reader = BufReader::new(s);
+    for line in reader.lines().map_while(Result::ok) {
+        if let Some(progress) = cargo_progress_text(&line) {
+            if let Some(bar) = &bar {
+                bar.set_message(progress.to_string());
+            }
+            // No bar (non-TTY / verbose): emit verbatim. Without
+            // this branch the progress lines would be silently
+            // discarded in CI logs.
+            else if matches!(mode(), Mode::Verbose) {
+                eprintln!("[whisker] {line}");
+            }
+        } else if !line.is_empty() {
+            // Diagnostics / errors / unrecognised tool output:
+            // persist in scrollback. `println` writes a line above
+            // the spinner, the bar redraws below.
+            if let Some(bar) = &bar {
+                bar.println(&line);
+            } else {
+                eprintln!("{line}");
+            }
+        }
+    }
+}
+
+/// Recognise a cargo-style progress line (`    Compiling foo v0.1.0`,
+/// `   Compiling foo v0.1.0`, `    Finished …`) and return the
+/// trimmed text — that's what we surface inside the spinner.
+/// Returns `None` for anything that isn't progress (rustc errors,
+/// linker output, the user's `println!` output, etc.).
+///
+/// Tolerates ANSI escapes — cargo emits color codes to TTYs, and
+/// piping doesn't always strip them when cargo's `--color=always` is
+/// in effect or when the user's `.cargo/config.toml` forces it.
+fn cargo_progress_text(line: &str) -> Option<&str> {
+    let stripped = strip_leading_ansi(line.trim_start());
+    let first_word = stripped.split_whitespace().next()?;
+    // Keep this list aligned with cargo's `Status` shell glyphs. New
+    // verbs (`Generating`, etc.) can be added as cargo introduces them.
+    if matches!(
+        first_word,
+        "Compiling"
+            | "Checking"
+            | "Finished"
+            | "Updating"
+            | "Downloading"
+            | "Downloaded"
+            | "Fresh"
+            | "Locking"
+            | "Building"
+            | "Documenting"
+            | "Generating"
+            | "Installing"
+            | "Removing"
+            | "Compiled"
+    ) {
+        Some(stripped.trim_end())
+    } else {
+        None
+    }
+}
+
+/// Strip a leading sequence of ANSI escape codes — `\x1b[…m` SGR
+/// sequences cargo uses to color the status verb. Defensive: most
+/// pipe scenarios get a no-color stream from cargo, but
+/// `CARGO_TERM_COLOR=always` / `.cargo/config.toml` overrides exist.
+fn strip_leading_ansi(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i + 1 < bytes.len() && bytes[i] == 0x1b && bytes[i + 1] == b'[' {
+        // Find the terminating letter (in range @..~ = 0x40..0x7e).
+        let mut j = i + 2;
+        while j < bytes.len() && !(0x40..=0x7e).contains(&bytes[j]) {
+            j += 1;
+        }
+        if j < bytes.len() {
+            i = j + 1;
+        } else {
+            break;
+        }
+    }
+    &s[i..]
 }
 
 #[derive(Copy, Clone)]

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -61,10 +61,8 @@ fn multi() -> &'static MultiProgress {
     M.get_or_init(MultiProgress::new)
 }
 
-/// The current persistent dev-server status bar, if any. `Some` once
-/// [`ensure_status`] has run; otherwise no status anchor exists and
-/// new step bars just append to the multi-progress in arrival order.
-static STATUS_BAR: Mutex<Option<ProgressBar>> = Mutex::new(None);
+// (Removed: a persistent indicatif bar for dev-server status. See
+// the `set_status` impl below for the simpler printed-line model.)
 
 // ---- Configuration ----------------------------------------------------
 
@@ -197,14 +195,22 @@ pub fn section(name: &str) {
 /// `eprintln!` when nothing's animated.
 fn emit_above_bars(line: &str) {
     // `multi.println` panics with a "no bars in multi" check? Actually
-    // it just no-ops when there are no bars. Either way it's the safe
-    // primitive — fall back to eprintln only when we know we're
-    // non-TTY (in which case no multi anyway).
-    if is_tty() {
-        let _ = multi().println(line);
-    } else {
+    // `multi.suspend` is the indicatif-blessed primitive for
+    // interleaving arbitrary output with bars: it clears the bars,
+    // runs the closure (which writes via eprintln!), and redraws
+    // the bars cleanly. Earlier attempts used `multi.println`,
+    // which left the bar's then-current spinner frame stuck in
+    // scrollback every time it pushed a line above the bars —
+    // that's what produced the "`⠁ compile …` then `✓ compile …`
+    // on two separate lines" duplication users reported.
+    if !is_tty() {
         eprintln!("{line}");
+        return;
     }
+    let line_owned = line.to_string();
+    multi().suspend(|| {
+        eprintln!("{line_owned}");
+    });
 }
 
 // ---- Steps (durable progress lines) ----------------------------------
@@ -310,6 +316,9 @@ fn stream_through_bar<R: std::io::Read + Send + 'static>(
         if let Some(progress) = cargo_progress_text(&line) {
             if let Some(bar) = &bar {
                 bar.set_message(progress.to_string());
+                // No steady_tick anymore (see step() docs) so we
+                // tick manually to repaint the new {msg}.
+                bar.tick();
             }
             // No bar (non-TTY / verbose): emit verbatim. Without
             // this branch the progress lines would be silently
@@ -319,10 +328,15 @@ fn stream_through_bar<R: std::io::Read + Send + 'static>(
             }
         } else if !line.is_empty() {
             // Diagnostics / errors / unrecognised tool output:
-            // persist in scrollback. `println` writes a line above
-            // the spinner, the bar redraws below.
-            if let Some(bar) = &bar {
-                bar.println(&line);
+            // persist in scrollback. Use multi.suspend (not
+            // bar.println) so the bar is properly cleared before
+            // the line lands and redrawn afterwards — same fix as
+            // `emit_above_bars`.
+            if bar.is_some() {
+                let line_owned = line.clone();
+                multi().suspend(|| {
+                    eprintln!("{line_owned}");
+                });
             } else {
                 eprintln!("{line}");
             }
@@ -433,24 +447,24 @@ pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
             // across steps (`compile     hello-world …`,
             // `stage       xcframework …`). 18 chars covers the
             // longest verb we use (`xcodebuild`) plus padding.
+            //
+            // No `enable_steady_tick`: combined with multi.suspend
+            // (which clears/redraws bars around external writes),
+            // an async tick raced with the suspend cycle and could
+            // briefly redraw the bar at a stale position. The
+            // {msg} column updates whenever cargo emits a new
+            // progress line — that's the actual "still working"
+            // signal, animation isn't needed on top.
             bar.set_style(
                 ProgressStyle::with_template("  {spinner:.cyan} {prefix:<12} {msg:<24} …")
                     .expect("template literal is valid"),
             );
             bar.set_prefix(name.clone());
             bar.set_message(detail.clone());
-            bar.enable_steady_tick(Duration::from_millis(80));
-            // Join the shared MultiProgress so step bars and the
-            // dev-server status bar coordinate redraws. When a
-            // status bar exists, new step bars insert *above* it so
-            // status stays anchored at the bottom.
-            let bar = {
-                let guard = STATUS_BAR.lock().expect("status mutex");
-                match guard.as_ref() {
-                    Some(status) => multi().insert_before(status, bar),
-                    None => multi().add(bar),
-                }
-            };
+            let bar = multi().add(bar);
+            // Manual tick so the bar shows up immediately rather
+            // than waiting for the first `set_message` update.
+            bar.tick();
             Step {
                 bar: Some(bar),
                 started_at,

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -106,68 +106,64 @@ fn is_tty() -> bool {
     *TTY.get_or_init(|| std::io::stderr().is_terminal())
 }
 
-// ---- Persistent dev-server status bar --------------------------------
+// ---- Dev-server status (printed-line model) -------------------------
+//
+// An earlier iteration anchored a persistent indicatif `ProgressBar`
+// at the bottom and updated it via `set_message`. In practice
+// `MultiProgress::println` (called every time a section header / step
+// transition fired) preserved the bar's then-current frame in the
+// scrollback above each printed line — the user saw the same
+// `◍ dev-server …` line stacked 3-4 times.
+//
+// The simpler model below skips the persistent bar entirely:
+//
+// - `ensure_status` emits a single info-style line on first call
+//   ("dev-server starting" or similar). Subsequent calls are no-ops.
+// - `set_status` deduplicates: it tracks the most-recently-emitted
+//   status string and only prints when the new value differs. That
+//   way startup events (`starting…` → `ws://… · 0 client(s)`) only
+//   produce a line per *state change*, not per call.
+// - `finish_status` prints a final line on shutdown.
+//
+// Trade-off: no live spinner. Dev-server state changes are rare
+// (bind, client connect, patch sent) so a static line per state is
+// clearer than an animated bottom anchor that has rendering bugs.
 
-/// Initialise the persistent status bar (anchored at the bottom of
-/// the rendered area). Subsequent calls update the same bar — only
-/// the first call decides the bar's label / prefix.
-///
-/// Safe to call before any [`step`] starts; the bar slots into the
-/// shared [`multi`] and every subsequent step bar inserts above it.
-pub fn ensure_status(label: impl Into<String>) {
-    if !matches!(mode(), Mode::Curated) || !is_tty() {
-        // Verbose / non-TTY: no spinner-style bottom bar; status
-        // changes go through `set_status` which falls back to
-        // `info()`-style lines.
-        return;
+/// Last status string we printed. Used to dedupe rapid-fire
+/// `set_status` calls.
+static LAST_STATUS: Mutex<Option<String>> = Mutex::new(None);
+
+/// Mark the dev-server's status surface as "active". Currently a
+/// no-op recorder — kept as part of the public API because callers
+/// in `whisker-dev-server` use it as a sentinel that says "you're
+/// allowed to call `set_status` after this point".
+pub fn ensure_status(_label: impl Into<String>) {
+    if let Ok(mut guard) = LAST_STATUS.lock() {
+        *guard = Some(String::new());
     }
-    let mut guard = STATUS_BAR.lock().expect("status mutex");
-    if guard.is_some() {
-        return;
-    }
-    let bar = ProgressBar::new_spinner();
-    bar.set_style(
-        ProgressStyle::with_template("  \x1b[35m◍\x1b[0m {prefix:<12} {msg}")
-            .expect("status template is valid"),
-    );
-    bar.set_prefix(label.into());
-    bar.set_message("");
-    bar.enable_steady_tick(Duration::from_millis(200));
-    *guard = Some(multi().add(bar));
 }
 
-/// Update the persistent status bar's message in place. No-op when
-/// no bar is active (verbose / non-TTY / before `ensure_status`).
+/// Emit a dev-server status line. Deduplicates against the last
+/// emission so back-to-back `set_status("X")` calls don't double-
+/// print the same content. The line goes through `info()` so it
+/// shares the `· <msg>` visual style with other one-shot lines.
 pub fn set_status(msg: impl Into<String>) {
     let m = msg.into();
-    match mode() {
-        Mode::Verbose => eprintln!("[whisker] status: {m}"),
-        Mode::Curated => {
-            if let Ok(guard) = STATUS_BAR.lock() {
-                if let Some(bar) = guard.as_ref() {
-                    bar.set_message(m);
-                    return;
-                }
-            }
-            // No bar yet (non-TTY or pre-`ensure_status`): fall back
-            // to a regular info line so the message isn't lost.
-            info(m);
+    let m_for_dedupe = m.clone();
+    if let Ok(mut guard) = LAST_STATUS.lock() {
+        if guard.as_ref() == Some(&m_for_dedupe) {
+            return;
         }
+        *guard = Some(m_for_dedupe);
     }
+    info(format!("dev-server · {m}"));
 }
 
-/// Tear down the status bar at the end of a run. Leaves a final
-/// rendered line in scrollback (via `finish_with_message` + the
-/// `{msg}` template swap the steps use).
+/// Emit a final dev-server status line on shutdown. Same code path
+/// as `set_status` minus the dedupe (we want the goodbye visible
+/// even if it matches the previous status).
 pub fn finish_status(final_msg: impl Into<String>) {
-    if let Ok(mut guard) = STATUS_BAR.lock() {
-        if let Some(bar) = guard.take() {
-            bar.set_style(
-                ProgressStyle::with_template("{msg}").expect("template literal is valid"),
-            );
-            bar.finish_with_message(final_msg.into());
-        }
-    }
+    info(format!("dev-server · {}", final_msg.into()));
 }
 
 // ---- Section headers --------------------------------------------------

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -60,15 +60,22 @@ enum Mode {
 fn mode() -> Mode {
     static MODE: OnceLock<Mode> = OnceLock::new();
     *MODE.get_or_init(|| {
-        if std::env::var("WHISKER_VERBOSE")
-            .map(|v| !v.is_empty() && v != "0")
-            .unwrap_or(false)
-        {
+        if is_verbose() {
             Mode::Verbose
         } else {
             Mode::Curated
         }
     })
+}
+
+/// `true` when `WHISKER_VERBOSE=1` is set in the environment. Same
+/// switch the `--verbose` CLI flag toggles. Public so the
+/// dev-server's noise filters (e.g. xcodebuild warning suppression)
+/// can opt out under verbose mode and let everything through.
+pub fn is_verbose() -> bool {
+    std::env::var("WHISKER_VERBOSE")
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
 }
 
 /// `true` when stderr is connected to an interactive terminal and we
@@ -178,7 +185,15 @@ impl Step {
         let glyph = kind.glyph();
         let line = render_step_line(glyph, &self.name, &self.detail, &summary, kind);
         if let Some(bar) = self.bar {
-            bar.finish_with_message(line.clone());
+            // Swap the spinner template for a plain `{msg}` so the
+            // final line is *exactly* the formatted text we built —
+            // without the leftover `{spinner}` glyph + `{prefix}`
+            // duplication + trailing `…` that the live template
+            // would otherwise re-render around it.
+            bar.set_style(
+                ProgressStyle::with_template("{msg}").expect("template literal is valid"),
+            );
+            bar.finish_with_message(line);
         } else {
             eprintln!("{line}");
         }

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -42,10 +42,29 @@
 //! of a signature change.
 
 use std::io::IsTerminal;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+// ---- Shared MultiProgress + status bar -------------------------------
+//
+// Steps and the dev-server status share a single `MultiProgress` so
+// their drawing doesn't fight: the status bar is anchored at the
+// bottom, individual step bars insert above it. Without coordination,
+// indicatif's redraws and `eprintln!`s interleave and we end up with
+// the "client connected" line wedged between two spinner frames the
+// user reported.
+
+fn multi() -> &'static MultiProgress {
+    static M: OnceLock<MultiProgress> = OnceLock::new();
+    M.get_or_init(MultiProgress::new)
+}
+
+/// The current persistent dev-server status bar, if any. `Some` once
+/// [`ensure_status`] has run; otherwise no status anchor exists and
+/// new step bars just append to the multi-progress in arrival order.
+static STATUS_BAR: Mutex<Option<ProgressBar>> = Mutex::new(None);
 
 // ---- Configuration ----------------------------------------------------
 
@@ -87,6 +106,70 @@ fn is_tty() -> bool {
     *TTY.get_or_init(|| std::io::stderr().is_terminal())
 }
 
+// ---- Persistent dev-server status bar --------------------------------
+
+/// Initialise the persistent status bar (anchored at the bottom of
+/// the rendered area). Subsequent calls update the same bar — only
+/// the first call decides the bar's label / prefix.
+///
+/// Safe to call before any [`step`] starts; the bar slots into the
+/// shared [`multi`] and every subsequent step bar inserts above it.
+pub fn ensure_status(label: impl Into<String>) {
+    if !matches!(mode(), Mode::Curated) || !is_tty() {
+        // Verbose / non-TTY: no spinner-style bottom bar; status
+        // changes go through `set_status` which falls back to
+        // `info()`-style lines.
+        return;
+    }
+    let mut guard = STATUS_BAR.lock().expect("status mutex");
+    if guard.is_some() {
+        return;
+    }
+    let bar = ProgressBar::new_spinner();
+    bar.set_style(
+        ProgressStyle::with_template("  \x1b[35m◍\x1b[0m {prefix:<12} {msg}")
+            .expect("status template is valid"),
+    );
+    bar.set_prefix(label.into());
+    bar.set_message("");
+    bar.enable_steady_tick(Duration::from_millis(200));
+    *guard = Some(multi().add(bar));
+}
+
+/// Update the persistent status bar's message in place. No-op when
+/// no bar is active (verbose / non-TTY / before `ensure_status`).
+pub fn set_status(msg: impl Into<String>) {
+    let m = msg.into();
+    match mode() {
+        Mode::Verbose => eprintln!("[whisker] status: {m}"),
+        Mode::Curated => {
+            if let Ok(guard) = STATUS_BAR.lock() {
+                if let Some(bar) = guard.as_ref() {
+                    bar.set_message(m);
+                    return;
+                }
+            }
+            // No bar yet (non-TTY or pre-`ensure_status`): fall back
+            // to a regular info line so the message isn't lost.
+            info(m);
+        }
+    }
+}
+
+/// Tear down the status bar at the end of a run. Leaves a final
+/// rendered line in scrollback (via `finish_with_message` + the
+/// `{msg}` template swap the steps use).
+pub fn finish_status(final_msg: impl Into<String>) {
+    if let Ok(mut guard) = STATUS_BAR.lock() {
+        if let Some(bar) = guard.take() {
+            bar.set_style(
+                ProgressStyle::with_template("{msg}").expect("template literal is valid"),
+            );
+            bar.finish_with_message(final_msg.into());
+        }
+    }
+}
+
 // ---- Section headers --------------------------------------------------
 
 /// Print a section header. Sections group related steps together:
@@ -101,13 +184,30 @@ pub fn section(name: &str) {
             // Line drawing matches what `cargo` itself emits during
             // its "Compiling" / "Finished" phases — a single visual
             // rhythm across the whole pipeline.
-            let bar = "─".repeat(40usize.saturating_sub(name.len()));
-            if is_tty() {
-                eprintln!("\n\x1b[1;36m──── {name} {bar}\x1b[0m");
+            let bar_chars = "─".repeat(40usize.saturating_sub(name.len()));
+            let line = if is_tty() {
+                format!("\n\x1b[1;36m──── {name} {bar_chars}\x1b[0m")
             } else {
-                eprintln!("\n──── {name} {bar}");
-            }
+                format!("\n──── {name} {bar_chars}")
+            };
+            emit_above_bars(&line);
         }
+    }
+}
+
+/// Print a line, routing through the shared MultiProgress when a
+/// status bar / step bar is alive so the line lands ABOVE the bars
+/// instead of overlapping with their redraw. Falls back to plain
+/// `eprintln!` when nothing's animated.
+fn emit_above_bars(line: &str) {
+    // `multi.println` panics with a "no bars in multi" check? Actually
+    // it just no-ops when there are no bars. Either way it's the safe
+    // primitive — fall back to eprintln only when we know we're
+    // non-TTY (in which case no multi anyway).
+    if is_tty() {
+        let _ = multi().println(line);
+    } else {
+        eprintln!("{line}");
     }
 }
 
@@ -344,6 +444,17 @@ pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
             bar.set_prefix(name.clone());
             bar.set_message(detail.clone());
             bar.enable_steady_tick(Duration::from_millis(80));
+            // Join the shared MultiProgress so step bars and the
+            // dev-server status bar coordinate redraws. When a
+            // status bar exists, new step bars insert *above* it so
+            // status stays anchored at the bottom.
+            let bar = {
+                let guard = STATUS_BAR.lock().expect("status mutex");
+                match guard.as_ref() {
+                    Some(status) => multi().insert_before(status, bar),
+                    None => multi().add(bar),
+                }
+            };
             Step {
                 bar: Some(bar),
                 started_at,
@@ -406,7 +517,7 @@ pub fn info(msg: impl AsRef<str>) {
         Mode::Verbose => eprintln!("[whisker] {m}"),
         Mode::Curated => {
             if is_tty() {
-                eprintln!("  \x1b[90m·\x1b[0m {m}");
+                emit_above_bars(&format!("  \x1b[90m·\x1b[0m {m}"));
             } else {
                 eprintln!("  · {m}");
             }
@@ -424,7 +535,7 @@ pub fn warn(msg: impl AsRef<str>) {
         Mode::Verbose => eprintln!("[whisker] warn: {m}"),
         Mode::Curated => {
             if is_tty() {
-                eprintln!("  \x1b[33m⚠\x1b[0m {m}");
+                emit_above_bars(&format!("  \x1b[33m⚠\x1b[0m {m}"));
             } else {
                 eprintln!("  ! {m}");
             }
@@ -457,7 +568,7 @@ pub fn error(msg: impl AsRef<str>) {
         Mode::Verbose => eprintln!("[whisker] error: {m}"),
         Mode::Curated => {
             if is_tty() {
-                eprintln!("  \x1b[31m✗\x1b[0m {m}");
+                emit_above_bars(&format!("  \x1b[31m✗\x1b[0m {m}"));
             } else {
                 eprintln!("  X {m}");
             }

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -294,6 +294,21 @@ pub fn warn(msg: impl AsRef<str>) {
     }
 }
 
+/// Verbose-only diagnostic. Same shape as [`info`] but hidden by
+/// default — only printed when `WHISKER_VERBOSE=1`. Use for internal
+/// state that's useful when debugging the dev-server itself
+/// (ASLR references, intermediate file paths, patcher symbol diffs)
+/// but distracting noise during normal `whisker run`.
+pub fn debug(msg: impl AsRef<str>) {
+    match mode() {
+        Mode::Verbose => {
+            let m = msg.as_ref();
+            eprintln!("[whisker] debug: {m}");
+        }
+        Mode::Curated => {}
+    }
+}
+
 /// Hard failure indicator. Use after a [`Step::fail`] or stand-alone
 /// when the failure isn't tied to a specific step. Doesn't exit the
 /// process — that's the caller's call (typical pattern: `error(...)

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -1,0 +1,359 @@
+//! Curated terminal output for `whisker run` / `whisker build`.
+//!
+//! Replaces ad-hoc `eprintln!("[whisker-build] …")` /
+//! `eprintln!("[whisker-dev-server] …")` lines with a single, uniform
+//! event surface that the user sees as:
+//!
+//! ```text
+//! ──── Build ────────────────────────────────────
+//!   ⏵  compile      hello-world             …
+//!   ✓  compile      hello-world             6.7s
+//!   ⏵  stage        xcframework             …
+//!   ✓  stage        xcframework             0.3s
+//!   ⚠  simctl       target already booted
+//!
+//! ──── Patch ───────────────────────────────────
+//!   ✓  patch        tier 1                  730ms
+//! ```
+//!
+//! ## Behaviour modes
+//!
+//! - **Default**: spinners + curated step list, color when stderr is
+//!   a TTY, ASCII fallback otherwise.
+//! - **`WHISKER_VERBOSE=1`**: every event is emitted as plain
+//!   `[whisker] …` lines without spinners. Same content the
+//!   pre-refactor `eprintln!` calls produced, but uniformly prefixed.
+//!   Underlying tool output (cargo / xcodebuild / gradle) also
+//!   streams through verbatim — the caller is responsible for piping
+//!   those streams; we don't capture them here.
+//!
+//! `WHISKER_VERBOSE` is meant as the `--verbose` CLI flag's
+//! transport: the CLI sets it before invoking the dev-server / build
+//! pipeline so the env-var is the single source of truth across
+//! crate boundaries.
+//!
+//! ## Why a shared module, not a trait
+//!
+//! whisker-build, whisker-dev-server, and whisker-cli all need to
+//! emit status. Threading an `OutputSink` trait through every call
+//! site would be a big refactor with no payoff (there's exactly one
+//! production sink — stderr). A free-fn surface with a thread-local
+//! configuration knob keeps the migration to a per-call edit instead
+//! of a signature change.
+
+use std::io::IsTerminal;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+// ---- Configuration ----------------------------------------------------
+
+#[derive(Copy, Clone, Debug)]
+enum Mode {
+    /// Default — colored output with spinners (when stderr is a TTY).
+    Curated,
+    /// `WHISKER_VERBOSE=1` — plain `[whisker] …` lines, no spinners.
+    Verbose,
+}
+
+fn mode() -> Mode {
+    static MODE: OnceLock<Mode> = OnceLock::new();
+    *MODE.get_or_init(|| {
+        if std::env::var("WHISKER_VERBOSE")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+        {
+            Mode::Verbose
+        } else {
+            Mode::Curated
+        }
+    })
+}
+
+/// `true` when stderr is connected to an interactive terminal and we
+/// should use ANSI color + spinner refresh. Off by default in CI /
+/// piped builds — the [`Mode::Curated`] path still works there but
+/// without animation.
+fn is_tty() -> bool {
+    static TTY: OnceLock<bool> = OnceLock::new();
+    *TTY.get_or_init(|| std::io::stderr().is_terminal())
+}
+
+// ---- Section headers --------------------------------------------------
+
+/// Print a section header. Sections group related steps together:
+/// `"Build"`, `"Patch"`, `"Watch"`, `"Install"`. Keep names short
+/// (one word) so the visual rhythm is regular.
+pub fn section(name: &str) {
+    match mode() {
+        Mode::Verbose => {
+            eprintln!("[whisker] ─── {name} ───");
+        }
+        Mode::Curated => {
+            // Line drawing matches what `cargo` itself emits during
+            // its "Compiling" / "Finished" phases — a single visual
+            // rhythm across the whole pipeline.
+            let bar = "─".repeat(40usize.saturating_sub(name.len()));
+            if is_tty() {
+                eprintln!("\n\x1b[1;36m──── {name} {bar}\x1b[0m");
+            } else {
+                eprintln!("\n──── {name} {bar}");
+            }
+        }
+    }
+}
+
+// ---- Steps (durable progress lines) ----------------------------------
+
+/// A live progress line. Created with [`step`], updated by
+/// [`Step::done`] / [`Step::fail`].
+///
+/// In curated TTY mode this is a spinner that re-renders in place; in
+/// verbose mode each transition prints a separate line. Either way
+/// the same call sites work — callers don't branch on mode.
+pub struct Step {
+    /// `Some` only in curated TTY mode — non-TTY curated still emits
+    /// plain lines, just without animation.
+    bar: Option<ProgressBar>,
+    /// Used by `done()` / `fail()` for the elapsed-time render.
+    started_at: Instant,
+    /// Carried separately from the bar's prefix because verbose-mode
+    /// transitions need it for the final line emission too.
+    name: String,
+    detail: String,
+}
+
+impl Step {
+    /// Resolve the step to a success state with an optional summary
+    /// (`"6.7s"`, `"1.2 MB"`, etc.). Pass an empty string to suppress.
+    pub fn done(self, summary: impl Into<String>) {
+        self.finish(StepKind::Done, &summary.into());
+    }
+
+    /// Resolve the step to a failure. Renders an `✗` marker; the
+    /// caller is expected to follow up with an `ui::error(...)` line
+    /// containing the actionable detail.
+    pub fn fail(self, summary: impl Into<String>) {
+        self.finish(StepKind::Fail, &summary.into());
+    }
+
+    fn finish(self, kind: StepKind, summary: &str) {
+        let elapsed = format_elapsed(self.started_at.elapsed());
+        let summary = if summary.is_empty() {
+            elapsed
+        } else {
+            format!("{summary}  {elapsed}")
+        };
+        let glyph = kind.glyph();
+        let line = render_step_line(glyph, &self.name, &self.detail, &summary, kind);
+        if let Some(bar) = self.bar {
+            bar.finish_with_message(line.clone());
+        } else {
+            eprintln!("{line}");
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+enum StepKind {
+    Done,
+    Fail,
+}
+
+impl StepKind {
+    fn glyph(&self) -> &'static str {
+        match self {
+            StepKind::Done => "✓",
+            StepKind::Fail => "✗",
+        }
+    }
+}
+
+/// Start a step.
+///
+/// `name` is the verb-noun anchor (`"compile"`, `"stage"`,
+/// `"install"`, `"patch"`); `detail` is the variable suffix that
+/// changes per invocation (`"hello-world"`, `"xcframework"`).
+///
+/// The split is purely typographical — keeping `name` to a small
+/// closed set lets readers visually align columns down the run log.
+pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
+    let name = name.into();
+    let detail = detail.into();
+    let started_at = Instant::now();
+
+    match mode() {
+        Mode::Verbose => {
+            eprintln!("[whisker] ⏵ {name}: {detail}");
+            Step {
+                bar: None,
+                started_at,
+                name,
+                detail,
+            }
+        }
+        Mode::Curated if is_tty() => {
+            let bar = ProgressBar::new_spinner();
+            // 12-char fixed-width name column keeps verbs left-aligned
+            // across steps (`compile     hello-world …`,
+            // `stage       xcframework …`). 18 chars covers the
+            // longest verb we use (`xcodebuild`) plus padding.
+            bar.set_style(
+                ProgressStyle::with_template("  {spinner:.cyan} {prefix:<12} {msg:<24} …")
+                    .expect("template literal is valid"),
+            );
+            bar.set_prefix(name.clone());
+            bar.set_message(detail.clone());
+            bar.enable_steady_tick(Duration::from_millis(80));
+            Step {
+                bar: Some(bar),
+                started_at,
+                name,
+                detail,
+            }
+        }
+        Mode::Curated => {
+            // Curated but non-TTY (CI, piped to file). Emit a single
+            // "started" line; `finish()` will emit the final state.
+            eprintln!("  ⏵ {name:<12} {detail}");
+            Step {
+                bar: None,
+                started_at,
+                name,
+                detail,
+            }
+        }
+    }
+}
+
+fn render_step_line(
+    glyph: &str,
+    name: &str,
+    detail: &str,
+    summary: &str,
+    kind: StepKind,
+) -> String {
+    if is_tty() {
+        let color = match kind {
+            StepKind::Done => "\x1b[32m",
+            StepKind::Fail => "\x1b[31m",
+        };
+        format!("  {color}{glyph}\x1b[0m {name:<12} {detail:<24} {summary}")
+    } else {
+        format!("  {glyph} {name:<12} {detail:<24} {summary}")
+    }
+}
+
+fn format_elapsed(d: Duration) -> String {
+    let ms = d.as_millis();
+    if ms < 1000 {
+        format!("{ms}ms")
+    } else if ms < 60_000 {
+        format!("{:.1}s", d.as_secs_f64())
+    } else {
+        let total_secs = d.as_secs();
+        format!("{}m{:02}s", total_secs / 60, total_secs % 60)
+    }
+}
+
+// ---- One-shot lines (info / warn / error) ----------------------------
+
+/// Informational line. Lower visual weight than [`step`]; use for
+/// state changes that don't have a "started → finished" arc (e.g.
+/// "watching examples/", "client connected", "patch sent").
+pub fn info(msg: impl AsRef<str>) {
+    let m = msg.as_ref();
+    match mode() {
+        Mode::Verbose => eprintln!("[whisker] {m}"),
+        Mode::Curated => {
+            if is_tty() {
+                eprintln!("  \x1b[90m·\x1b[0m {m}");
+            } else {
+                eprintln!("  · {m}");
+            }
+        }
+    }
+}
+
+/// Non-fatal warning. Renders distinctly from `info` and `error` so
+/// scanning a log for actionable items works without grep tricks.
+/// Use for "simctl says target already booted" and other benign
+/// rough edges that don't stop the pipeline.
+pub fn warn(msg: impl AsRef<str>) {
+    let m = msg.as_ref();
+    match mode() {
+        Mode::Verbose => eprintln!("[whisker] warn: {m}"),
+        Mode::Curated => {
+            if is_tty() {
+                eprintln!("  \x1b[33m⚠\x1b[0m {m}");
+            } else {
+                eprintln!("  ! {m}");
+            }
+        }
+    }
+}
+
+/// Hard failure indicator. Use after a [`Step::fail`] or stand-alone
+/// when the failure isn't tied to a specific step. Doesn't exit the
+/// process — that's the caller's call (typical pattern: `error(...)
+/// + Err(anyhow!(...))?`).
+pub fn error(msg: impl AsRef<str>) {
+    let m = msg.as_ref();
+    match mode() {
+        Mode::Verbose => eprintln!("[whisker] error: {m}"),
+        Mode::Curated => {
+            if is_tty() {
+                eprintln!("  \x1b[31m✗\x1b[0m {m}");
+            } else {
+                eprintln!("  X {m}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_elapsed_chooses_unit_by_magnitude() {
+        assert_eq!(format_elapsed(Duration::from_millis(42)), "42ms");
+        assert_eq!(format_elapsed(Duration::from_millis(999)), "999ms");
+        assert_eq!(format_elapsed(Duration::from_millis(1_000)), "1.0s");
+        assert_eq!(format_elapsed(Duration::from_millis(6_750)), "6.8s");
+        assert_eq!(format_elapsed(Duration::from_secs(125)), "2m05s");
+    }
+
+    #[test]
+    fn step_kind_glyphs_are_recognisable_ascii() {
+        // Quick sanity — broken assertion would mean someone swapped
+        // the glyphs accidentally (we render these in non-TTY too,
+        // where we want them distinct).
+        assert_eq!(StepKind::Done.glyph(), "✓");
+        assert_eq!(StepKind::Fail.glyph(), "✗");
+    }
+
+    #[test]
+    fn render_step_line_aligns_name_column_at_12_chars() {
+        // Force the non-TTY branch (plain output) so the assertion
+        // doesn't depend on `is_tty()` returning false at test time
+        // — which it does under cargo test, but explicit is better.
+        std::env::set_var("WHISKER_VERBOSE", "");
+        let line = if is_tty() {
+            // Test fixture: derive the non-color version even when
+            // running interactively. We can't easily mock is_tty()
+            // from a unit test without an extra abstraction, so
+            // verify the structure on the plain branch instead.
+            return;
+        } else {
+            render_step_line("✓", "compile", "hello-world", "6.7s", StepKind::Done)
+        };
+        // "  ✓ compile      hello-world              6.7s"
+        //          ^^^^^^^^^^^ 12 chars of name column
+        assert!(line.contains("✓"));
+        assert!(line.contains("compile"));
+        assert!(line.contains("hello-world"));
+        assert!(line.contains("6.7s"));
+    }
+}

--- a/crates/whisker-cli/src/bin/cargo_whisker.rs
+++ b/crates/whisker-cli/src/bin/cargo_whisker.rs
@@ -4,10 +4,21 @@
 //! argv[1]. Strip it so the inner CLI sees the same shape as a direct
 //! `whisker <args>` invocation.
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     let mut args: Vec<String> = std::env::args().collect();
     if args.get(1).map(String::as_str) == Some("whisker") {
         args.remove(1);
     }
-    whisker_cli::run(args)
+    if let Err(e) = whisker_cli::run(args) {
+        let message = if std::env::var("WHISKER_VERBOSE")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+        {
+            format!("{e:#}")
+        } else {
+            e.root_cause().to_string()
+        };
+        whisker_build::ui::error(&message);
+        std::process::exit(1);
+    }
 }

--- a/crates/whisker-cli/src/bin/whisker.rs
+++ b/crates/whisker-cli/src/bin/whisker.rs
@@ -1,5 +1,27 @@
 //! `whisker` binary entry point.
 
-fn main() -> anyhow::Result<()> {
-    whisker_cli::run(std::env::args())
+fn main() {
+    if let Err(e) = whisker_cli::run(std::env::args()) {
+        // anyhow's default formatter prints `Error: <top>\n\nCaused by:\n    <chain>`,
+        // which surfaces our internal call-stack to the user (`resolve user-crate
+        // manifest (Cargo.toml + whisker.rs)`) on every misuse. We re-render through
+        // `whisker_build::ui::error()` so the user sees a single line in the same
+        // visual style as the rest of `whisker run`'s output. Verbose mode prints
+        // the full chain so we don't actually lose debuggability — the chain is
+        // still in `e:#`.
+        let message = if std::env::var("WHISKER_VERBOSE")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+        {
+            format!("{e:#}")
+        } else {
+            // `root_cause()` is the leaf of the anyhow chain — the
+            // actually-actionable detail (e.g. "no `[package]` Cargo.toml at or
+            // above …"). The intermediate frames are only useful for debugging
+            // the CLI itself, which is what `--verbose` is for.
+            e.root_cause().to_string()
+        };
+        whisker_build::ui::error(&message);
+        std::process::exit(1);
+    }
 }

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -44,6 +44,14 @@ pub mod rustc_shim;
     version
 )]
 struct Cli {
+    /// Show every step's full underlying output (raw cargo /
+    /// xcodebuild / simctl streams + the internal debug logs the
+    /// curated UI hides by default). Plumbed into `whisker-build::ui`
+    /// via the `WHISKER_VERBOSE` env var so subprocesses
+    /// (`whisker-dev-server`, the shim binaries, etc.) inherit it.
+    #[arg(long, short = 'v', global = true)]
+    verbose: bool,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -70,6 +78,12 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<()> {
         Ok(c) => c,
         Err(e) => e.exit(),
     };
+    // `--verbose` and `WHISKER_VERBOSE=1` are the same switch. Setting
+    // the env var means any subprocess we spawn (dev-server, shim
+    // binaries) sees the same mode without further plumbing.
+    if cli.verbose {
+        std::env::set_var("WHISKER_VERBOSE", "1");
+    }
     match cli.command {
         Command::Doctor(a) => doctor::run(a),
         Command::Run(a) => run::run(a),

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -141,7 +141,18 @@ impl Builder {
         let capture = self.capture.clone();
 
         tokio::task::spawn_blocking(move || -> Result<()> {
-            whisker_build::ios::build_xcframework(&ws, &pkg, &features, capture.as_ref())?;
+            // Dev loop only ever loads the arm64-sim slice on an
+            // Apple Silicon Mac. Building the device + x86 slices
+            // adds ~60s per initial `whisker run` for no benefit
+            // here; production `whisker build` still goes through
+            // the universal path via `whisker-cli::build`.
+            whisker_build::ios::build_xcframework_with(
+                &ws,
+                &pkg,
+                &features,
+                capture.as_ref(),
+                whisker_build::ios::IosSlices::SimulatorArm64,
+            )?;
             Ok(())
         })
         .await

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -151,7 +151,7 @@ impl Builder {
                 &pkg,
                 &features,
                 capture.as_ref(),
-                whisker_build::ios::IosSlices::SimulatorArm64,
+                whisker_build::ios::IosSlices::SimulatorHost,
             )?;
             Ok(())
         })

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -151,7 +151,7 @@ impl Builder {
                 &pkg,
                 &features,
                 capture.as_ref(),
-                whisker_build::ios::IosSlices::SimulatorHost,
+                whisker_build::ios::IosSlices::SimulatorFat,
             )?;
             Ok(())
         })

--- a/crates/whisker-dev-server/src/hotpatch/shim_paths.rs
+++ b/crates/whisker-dev-server/src/hotpatch/shim_paths.rs
@@ -79,23 +79,30 @@ pub fn resolve_shim_paths(workspace_root: &Path) -> Result<ShimPaths> {
 }
 
 fn build_shims(workspace_root: &Path) -> Result<()> {
-    eprintln!(
-        "[whisker-dev-server] building shim binaries (`cargo build -p whisker-cli --bin whisker-rustc-shim --bin whisker-linker-shim`)…"
-    );
-    let status = std::process::Command::new("cargo")
-        .args([
-            "build",
-            "-p",
-            "whisker-cli",
-            "--bin",
-            "whisker-rustc-shim",
-            "--bin",
-            "whisker-linker-shim",
-        ])
-        .current_dir(workspace_root)
-        .status()
-        .context("spawn cargo")?;
-    anyhow::ensure!(status.success(), "cargo exited {status}");
+    // First-run setup: the rustc / linker capture shims are produced
+    // by `cargo build` against `whisker-cli`. Once built, they live
+    // under `target/debug/` and subsequent `whisker run` invocations
+    // skip this step. Stream the cargo output through a step so it
+    // looks like the rest of the initial-build section rather than
+    // dumping ~200 lines of `Compiling X v…` ahead of any UI chrome.
+    let step = whisker_build::ui::step("setup", "whisker-cli shims");
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args([
+        "build",
+        "-p",
+        "whisker-cli",
+        "--bin",
+        "whisker-rustc-shim",
+        "--bin",
+        "whisker-linker-shim",
+    ])
+    .current_dir(workspace_root);
+    let status = step.pipe(&mut cmd).context("spawn cargo")?;
+    if !status.success() {
+        step.fail(format!("{status}"));
+        anyhow::bail!("cargo exited {status}");
+    }
+    step.done("");
     Ok(())
 }
 

--- a/crates/whisker-dev-server/src/hotpatch/thin_build.rs
+++ b/crates/whisker-dev-server/src/hotpatch/thin_build.rs
@@ -98,6 +98,15 @@ pub fn build_obj_plan(captured: &CapturedRustcInvocation, output_dir: &Path) -> 
     set_out_dir(&mut args, output_dir);
     let object_path = output_dir.join(object_filename(&captured.crate_name));
     set_emit_obj(&mut args, &object_path);
+    // cargo's captured args include `--json=artifacts,…` +
+    // `--error-format=json` so its build pipeline can parse rustc's
+    // structured output. We just spawn rustc and inspect exit status;
+    // leaving the JSON flags in produces a noisy
+    // `{"$message_type":"artifact",…}` line on stdout for every
+    // patch, which clutters the dev terminal. Strip them so rustc
+    // falls back to human-readable output (errors still surface on
+    // stderr in plain text).
+    strip_json_flags(&mut args);
     // Reuse rustc's incremental cache across thin rebuilds. rustc
     // fingerprints source files + query results into this dir; the
     // next invocation skips re-typechecking + re-codegenning anything
@@ -174,6 +183,29 @@ fn set_incremental(args: &mut Vec<String>, incremental_dir: &Path) {
     }
     args.push("-C".into());
     args.push(format!("incremental={}", incremental_dir.display()));
+}
+
+/// Remove `--json=…` and `--error-format=json` from the captured
+/// rustc args so the thin rebuild emits plain human text instead of
+/// the structured JSON channel cargo would have parsed. Both forms
+/// (separated and `=`) are stripped; we don't restore a default
+/// because rustc's default is already human output.
+fn strip_json_flags(args: &mut Vec<String>) {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        // `--json <list>` or `--error-format <fmt>` (separated forms)
+        if (arg == "--json" || arg == "--error-format") && i + 1 < args.len() {
+            args.drain(i..=i + 1);
+            continue;
+        }
+        // `--json=...` or `--error-format=...` (equals forms)
+        if arg.starts_with("--json=") || arg.starts_with("--error-format=") {
+            args.remove(i);
+            continue;
+        }
+        i += 1;
+    }
 }
 
 /// Force `--emit` to exactly one directive: `obj=<path>`. Strips

--- a/crates/whisker-dev-server/src/hotpatch/wrapper.rs
+++ b/crates/whisker-dev-server/src/hotpatch/wrapper.rs
@@ -139,14 +139,14 @@ pub fn load_captured_args(cache_dir: &Path) -> Result<HashMap<String, CapturedRu
         let body = match std::fs::read_to_string(&path) {
             Ok(b) => b,
             Err(e) => {
-                eprintln!("[whisker-dev] skip {}: {e}", path.display());
+                whisker_build::ui::warn(format!("skip {}: {e}", path.display()));
                 continue;
             }
         };
         let inv: CapturedRustcInvocation = match serde_json::from_str(&body) {
             Ok(i) => i,
             Err(e) => {
-                eprintln!("[whisker-dev] skip {}: malformed json: {e}", path.display());
+                whisker_build::ui::warn(format!("skip {}: malformed json: {e}", path.display()));
                 continue;
             }
         };
@@ -200,14 +200,14 @@ pub fn load_captured_linker_args(
         let body = match std::fs::read_to_string(&path) {
             Ok(b) => b,
             Err(e) => {
-                eprintln!("[whisker-dev] skip {}: {e}", path.display());
+                whisker_build::ui::warn(format!("skip {}: {e}", path.display()));
                 continue;
             }
         };
         let inv: CapturedLinkerInvocation = match serde_json::from_str(&body) {
             Ok(i) => i,
             Err(e) => {
-                eprintln!("[whisker-dev] skip {}: malformed json: {e}", path.display());
+                whisker_build::ui::warn(format!("skip {}: malformed json: {e}", path.display()));
                 continue;
             }
         };

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -257,6 +257,13 @@ async fn ios_install_and_launch(
         .join(package);
 
     let xc_step = whisker_build::ui::step("xcodebuild", p.scheme.clone());
+    // Pin the build to the host arch. `generic/platform=iOS Simulator`
+    // would otherwise emit a universal binary needing both arm64 +
+    // x86_64 simulator slices in the xcframework — but the dev-loop
+    // xcframework is single-slice (`IosSlices::SimulatorHost`). With
+    // `-arch <host>` xcodebuild only links the matching slice and
+    // the build stays single-arch end-to-end.
+    let host_arch = whisker_build::ios::host_simulator_arch();
     let mut xc_cmd = Command::new("xcodebuild");
     xc_cmd
         .arg("-project")
@@ -264,6 +271,7 @@ async fn ios_install_and_launch(
         .args(["-scheme", &p.scheme])
         .args(["-configuration", "Debug"])
         .args(["-destination", "generic/platform=iOS Simulator"])
+        .args(["-arch", host_arch])
         .arg("-derivedDataPath")
         .arg(&derived)
         .args(["-quiet", "build"]);

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -62,10 +62,135 @@ impl Installer {
     }
 
     fn host_skip(&self) -> Result<()> {
-        eprintln!(
-            "[whisker-dev-server] host target: install/launch is the user's job (run the binary yourself)"
+        whisker_build::ui::info(
+            "host target: install/launch is the user's job — run the binary manually",
         );
         Ok(())
+    }
+}
+
+/// Run a `tokio::process::Command` to completion, capture its stderr,
+/// and filter known-benign lines (`already booted`, `found nothing to
+/// terminate`, xcodebuild's IDE noise). The actual exit status is
+/// returned verbatim; the caller decides what counts as failure. Used
+/// for `xcrun simctl ...` invocations where the stderr signal is
+/// ~70 % noise.
+async fn run_filtered(mut cmd: Command, kind: SimctlNoise) -> Result<std::process::ExitStatus> {
+    use tokio::io::AsyncReadExt;
+    cmd.stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = cmd.spawn().context("spawn child")?;
+    let mut stdout = child.stdout.take();
+    let mut stderr = child.stderr.take();
+
+    let (out_buf, err_buf) = tokio::join!(
+        async {
+            let mut s = Vec::new();
+            if let Some(mut h) = stdout.take() {
+                let _ = h.read_to_end(&mut s).await;
+            }
+            s
+        },
+        async {
+            let mut s = Vec::new();
+            if let Some(mut h) = stderr.take() {
+                let _ = h.read_to_end(&mut s).await;
+            }
+            s
+        }
+    );
+    let status = child.wait().await.context("wait for child")?;
+
+    let stderr_str = String::from_utf8_lossy(&err_buf);
+    for line in stderr_str.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if kind.is_benign(trimmed) {
+            continue;
+        }
+        // Anything that survived the filter is real output — surface
+        // it as a warning so the user notices but the curated layout
+        // isn't drowned.
+        whisker_build::ui::warn(trimmed);
+    }
+    // Stdout from these tools is usually empty or low-noise (e.g.
+    // `simctl launch` prints `<bundle_id>: <pid>`); echo it through
+    // info() at debug-grade.
+    let stdout_str = String::from_utf8_lossy(&out_buf);
+    for line in stdout_str.lines() {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && !kind.is_benign_stdout(trimmed) {
+            whisker_build::ui::info(trimmed);
+        }
+    }
+    Ok(status)
+}
+
+/// Classifies which sub-command produced the stderr — we tune the
+/// "benign noise" set per tool because the false-positive shape
+/// differs (simctl emits NSPOSIX error preambles, xcodebuild emits
+/// `IDERunDestination` etc.).
+#[derive(Copy, Clone)]
+enum SimctlNoise {
+    /// `xcrun simctl boot` — "Unable to boot device in current state: Booted"
+    /// fires when the sim is already up, which is the normal case
+    /// after the first `whisker run`.
+    Boot,
+    /// `xcrun simctl terminate` — "found nothing to terminate" fires
+    /// on the very first run before the app exists in the sim.
+    Terminate,
+    /// `xcrun simctl install` / `launch` — generally low-noise but
+    /// can emit POSIX prefixes; treat anything matching the known
+    /// boilerplate as suppressed.
+    Other,
+    /// `xcodebuild` — `[MT] IDERunDestination`, the date-time
+    /// preamble lines, and the post-build "xcframework written"
+    /// confirmation all belong here.
+    Xcodebuild,
+}
+
+impl SimctlNoise {
+    fn is_benign(&self, line: &str) -> bool {
+        // Lines common to several Apple tools.
+        if line.contains("An error was encountered processing the command")
+            || line.contains("Underlying error (domain=")
+            || line.starts_with("    The request to terminate")
+        {
+            return true;
+        }
+        match self {
+            SimctlNoise::Boot => {
+                line.contains("Unable to boot device in current state: Booted")
+                    || line.starts_with("(code=405)")
+            }
+            SimctlNoise::Terminate => {
+                line.contains("found nothing to terminate")
+                    || line.contains("(domain=NSPOSIXErrorDomain, code=3)")
+            }
+            SimctlNoise::Other => false,
+            SimctlNoise::Xcodebuild => {
+                // `2026-05-21 18:21:52.770 xcodebuild[54160:34595363]
+                //  [MT] IDERunDestination: …`
+                (line.starts_with("20")
+                    && line.contains("xcodebuild[")
+                    && line.contains("] [MT] "))
+                    // The xcframework command echoes a single
+                    // confirmation we already cover via our own step.
+                    || line.starts_with("xcframework successfully written out to:")
+            }
+        }
+    }
+
+    fn is_benign_stdout(&self, line: &str) -> bool {
+        match self {
+            // `simctl launch` always reports `<bundle_id>: <pid>` on
+            // success; it duplicates info our `step.done(...)`
+            // already covers.
+            SimctlNoise::Other => line.contains(": ") && line.chars().any(|c| c.is_ascii_digit()),
+            _ => false,
+        }
     }
 }
 
@@ -131,8 +256,9 @@ async fn ios_install_and_launch(
         .join("target/.whisker/ios-derived")
         .join(package);
 
-    eprintln!("[whisker-dev-server] xcodebuild building app for Simulator");
-    let xc_status = Command::new("xcodebuild")
+    let xc_step = whisker_build::ui::step("xcodebuild", p.scheme.clone());
+    let mut xc_cmd = Command::new("xcodebuild");
+    xc_cmd
         .arg("-project")
         .arg(&xcode_project)
         .args(["-scheme", &p.scheme])
@@ -140,13 +266,15 @@ async fn ios_install_and_launch(
         .args(["-destination", "generic/platform=iOS Simulator"])
         .arg("-derivedDataPath")
         .arg(&derived)
-        .args(["-quiet", "build"])
-        .status()
+        .args(["-quiet", "build"]);
+    let xc_status = run_filtered(xc_cmd, SimctlNoise::Xcodebuild)
         .await
         .context("spawn xcodebuild")?;
     if !xc_status.success() {
+        xc_step.fail(format!("{xc_status}"));
         anyhow::bail!("xcodebuild build failed ({xc_status})");
     }
+    xc_step.done("");
 
     let app_path = derived
         .join("Build/Products/Debug-iphonesimulator")
@@ -160,46 +288,55 @@ async fn ios_install_and_launch(
     }
 
     // Best-effort boot of either the caller's override or the first
-    // available iPhone simctl knows about.
+    // available iPhone simctl knows about. "Already booted" stderr
+    // is filtered as a benign noise pattern.
     let device = p
         .device_override
         .clone()
         .or_else(pick_available_iphone)
         .unwrap_or_else(|| "iPhone 17 Pro".into());
-    let _ = Command::new("xcrun")
-        .args(["simctl", "boot", &device])
-        .status()
-        .await;
+    let boot_step = whisker_build::ui::step("boot", device.clone());
+    let mut boot_cmd = Command::new("xcrun");
+    boot_cmd.args(["simctl", "boot", &device]);
+    let _ = run_filtered(boot_cmd, SimctlNoise::Boot).await;
+    boot_step.done("");
 
-    eprintln!("[whisker-dev-server] simctl install {}", app_path.display());
-    let install = Command::new("xcrun")
+    let install_step = whisker_build::ui::step("install", format!("{}.app", p.scheme));
+    let mut install_cmd = Command::new("xcrun");
+    install_cmd
         .args(["simctl", "install", "booted"])
-        .arg(&app_path)
-        .status()
+        .arg(&app_path);
+    let install = run_filtered(install_cmd, SimctlNoise::Other)
         .await
         .context("spawn simctl install")?;
     if !install.success() {
+        install_step.fail(format!("{install}"));
         anyhow::bail!("simctl install {} failed ({install})", app_path.display());
     }
+    install_step.done("");
 
     // Force the previous run to die so the relaunch re-bootstraps the
-    // runtime + reconnects the dev WebSocket.
-    let _ = Command::new("xcrun")
-        .args(["simctl", "terminate", "booted", &p.bundle_id])
-        .status()
-        .await;
+    // runtime + reconnects the dev WebSocket. Errors here are benign
+    // (first launch — nothing running yet).
+    let mut term_cmd = Command::new("xcrun");
+    term_cmd.args(["simctl", "terminate", "booted", &p.bundle_id]);
+    let _ = run_filtered(term_cmd, SimctlNoise::Terminate).await;
 
     // `SIMCTL_CHILD_<NAME>` shows up as `<NAME>` inside the launched
     // app's env — that's how the dev-runtime finds us.
-    let launch = Command::new("xcrun")
+    let launch_step = whisker_build::ui::step("launch", p.bundle_id.clone());
+    let mut launch_cmd = Command::new("xcrun");
+    launch_cmd
         .args(["simctl", "launch", "booted", &p.bundle_id])
-        .env("SIMCTL_CHILD_WHISKER_DEV_ADDR", "127.0.0.1:9876")
-        .status()
+        .env("SIMCTL_CHILD_WHISKER_DEV_ADDR", "127.0.0.1:9876");
+    let launch = run_filtered(launch_cmd, SimctlNoise::Other)
         .await
         .context("spawn simctl launch")?;
     if !launch.success() {
+        launch_step.fail(format!("{launch}"));
         anyhow::bail!("simctl launch {} failed ({launch})", p.bundle_id);
     }
+    launch_step.done("");
     Ok(())
 }
 

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -145,6 +145,14 @@ async fn run_filtered(mut cmd: Command, kind: SimctlNoise) -> Result<std::proces
 /// Real errors are preserved: lines containing `error:` /
 /// `fatal error:` / `** BUILD FAILED **` always fall through.
 fn is_benign_xcodebuild_line(raw: &str) -> bool {
+    // Under `--verbose` / `WHISKER_VERBOSE=1`, let every line
+    // through — that's the explicit "I want to see the full
+    // underlying tool output" mode, including the deprecation
+    // chain we'd otherwise suppress.
+    if whisker_build::ui::is_verbose() {
+        return false;
+    }
+
     let line = raw.trim_start_matches(|c: char| c.is_ascii_whitespace() || c == '·');
 
     // Always surface real errors. Check this first so we don't

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -190,16 +190,17 @@ fn is_benign_xcodebuild_line(raw: &str) -> bool {
     }
 
     // Source-line listings rendered alongside the warning chain:
-    //   `217 | #import "LynxBackground..."`
-    //   `    |         ^`
-    // These look like `<digits> |` or `<whitespace> |` (caret line).
-    let trimmed = line.trim_start();
-    if let Some(rest) = trimmed.strip_prefix(|c: char| c.is_ascii_digit() || c == ' ') {
-        if rest.trim_start().starts_with("| ") || rest.trim_start() == "|" {
-            return true;
-        }
-    }
-    if trimmed.starts_with("| ") || trimmed == "|" {
+    //   `217 | #import "LynxBackgroundInfo.h"`
+    //   `    | ^`
+    //   `56 |`        (empty source line for context)
+    // After trimming leading whitespace + all leading digits, the
+    // remainder always starts with `|` (with or without trailing
+    // content). Multi-digit line numbers were the gap that earlier
+    // single-char `strip_prefix` filters missed.
+    let after_digits = line
+        .trim_start()
+        .trim_start_matches(|c: char| c.is_ascii_digit() || c.is_ascii_whitespace());
+    if after_digits.starts_with('|') {
         return true;
     }
 

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -257,13 +257,6 @@ async fn ios_install_and_launch(
         .join(package);
 
     let xc_step = whisker_build::ui::step("xcodebuild", p.scheme.clone());
-    // Pin the build to the host arch. `generic/platform=iOS Simulator`
-    // would otherwise emit a universal binary needing both arm64 +
-    // x86_64 simulator slices in the xcframework — but the dev-loop
-    // xcframework is single-slice (`IosSlices::SimulatorHost`). With
-    // `-arch <host>` xcodebuild only links the matching slice and
-    // the build stays single-arch end-to-end.
-    let host_arch = whisker_build::ios::host_simulator_arch();
     let mut xc_cmd = Command::new("xcodebuild");
     xc_cmd
         .arg("-project")
@@ -271,7 +264,6 @@ async fn ios_install_and_launch(
         .args(["-scheme", &p.scheme])
         .args(["-configuration", "Debug"])
         .args(["-destination", "generic/platform=iOS Simulator"])
-        .args(["-arch", host_arch])
         .arg("-derivedDataPath")
         .arg(&derived)
         .args(["-quiet", "build"]);

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -128,6 +128,76 @@ async fn run_filtered(mut cmd: Command, kind: SimctlNoise) -> Result<std::proces
     Ok(status)
 }
 
+/// `xcodebuild`'s `-quiet` flag silences progress chatter but the
+/// underlying compiler still emits diagnostics — which under Xcode
+/// with iOS 26 SDK + Lynx's pre-iOS-26 framework headers means a
+/// hundreds-of-lines deprecation cascade (`'mainScreen' is
+/// deprecated`, `'screens' is deprecated`, …) on every build. None
+/// of it is actionable by Whisker users (the headers ship from
+/// upstream Lynx), so we filter it as benign here.
+///
+/// Approach: drop anything that looks like a clang / xcodebuild
+/// warning chain — the `warning:` line, the `note:` follow-ups,
+/// the source-line listings (`  217 |`, `      |   ^`), the
+/// "in file included from" / "N warnings generated." summaries,
+/// and the `[MT] IDERunDestination` IDE chatter.
+///
+/// Real errors are preserved: lines containing `error:` /
+/// `fatal error:` / `** BUILD FAILED **` always fall through.
+fn is_benign_xcodebuild_line(raw: &str) -> bool {
+    let line = raw.trim_start_matches(|c: char| c.is_ascii_whitespace() || c == '·');
+
+    // Always surface real errors. Check this first so we don't
+    // accidentally suppress a `warning:`-prefixed error message.
+    if line.starts_with("error:")
+        || line.contains(" error:")
+        || line.starts_with("fatal error:")
+        || line.starts_with("** BUILD FAILED")
+        || line.starts_with("** BUILD INTERRUPTED")
+    {
+        return false;
+    }
+
+    // `2026-05-21 18:21:52.770 xcodebuild[54160:34595363] [MT] IDERunDestination …`
+    if raw.starts_with("20") && raw.contains("xcodebuild[") && raw.contains("] [MT] ") {
+        return true;
+    }
+
+    // The xcframework command's success line.
+    if line.starts_with("xcframework successfully written out to:") {
+        return true;
+    }
+
+    // Diagnostic chain: warnings, notes, source line listings,
+    // `N warnings generated.` summary.
+    if line.starts_with("warning:")
+        || line.contains(" warning:")
+        || line.starts_with("note:")
+        || line.contains(" note:")
+        || line.starts_with("In file included from")
+        || line.ends_with(" warnings generated.")
+        || line.ends_with(" warning generated.")
+    {
+        return true;
+    }
+
+    // Source-line listings rendered alongside the warning chain:
+    //   `217 | #import "LynxBackground..."`
+    //   `    |         ^`
+    // These look like `<digits> |` or `<whitespace> |` (caret line).
+    let trimmed = line.trim_start();
+    if let Some(rest) = trimmed.strip_prefix(|c: char| c.is_ascii_digit() || c == ' ') {
+        if rest.trim_start().starts_with("| ") || rest.trim_start() == "|" {
+            return true;
+        }
+    }
+    if trimmed.starts_with("| ") || trimmed == "|" {
+        return true;
+    }
+
+    false
+}
+
 /// Classifies which sub-command produced the stderr — we tune the
 /// "benign noise" set per tool because the false-positive shape
 /// differs (simctl emits NSPOSIX error preambles, xcodebuild emits
@@ -170,20 +240,18 @@ impl SimctlNoise {
                     || line.contains("(domain=NSPOSIXErrorDomain, code=3)")
             }
             SimctlNoise::Other => false,
-            SimctlNoise::Xcodebuild => {
-                // `2026-05-21 18:21:52.770 xcodebuild[54160:34595363]
-                //  [MT] IDERunDestination: …`
-                (line.starts_with("20")
-                    && line.contains("xcodebuild[")
-                    && line.contains("] [MT] "))
-                    // The xcframework command echoes a single
-                    // confirmation we already cover via our own step.
-                    || line.starts_with("xcframework successfully written out to:")
-            }
+            SimctlNoise::Xcodebuild => is_benign_xcodebuild_line(line),
         }
     }
 
     fn is_benign_stdout(&self, line: &str) -> bool {
+        // For xcodebuild, also fold stdout through the benign filter
+        // — `-quiet` doesn't fully silence it on iOS 26 SDK + Lynx
+        // pre-iOS-26 headers, so `mainScreen` deprecations etc. land
+        // on stdout depending on Xcode version.
+        if matches!(self, SimctlNoise::Xcodebuild) && is_benign_xcodebuild_line(line) {
+            return true;
+        }
         match self {
             // `simctl launch` always reports `<bundle_id>: <pid>` on
             // success; it duplicates info our `step.done(...)`

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -252,8 +252,16 @@ impl DevServer {
         ));
         whisker_build::ui::debug(format!("mode={:?}", self.config.hot_patch_mode));
 
+        // Anchor a persistent dev-server status bar at the bottom
+        // of the rendered area. Client connect / patch sent /
+        // build state updates all flow through `set_status` —
+        // they stay out of the build-step scrollback that way.
+        whisker_build::ui::ensure_status("dev-server");
+        whisker_build::ui::set_status("starting…");
+
         let (sender, bound, _server_handle) =
             server::serve(self.config.bind_addr, self.on_event.clone()).await?;
+        whisker_build::ui::set_status(format!("ws://{bound} · 0 client(s)"));
         whisker_build::ui::debug(format!("ws://{bound}/whisker-dev"));
 
         // Watch the user crate's `src/`. `crate_dir` is whatever the

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -252,12 +252,10 @@ impl DevServer {
         ));
         whisker_build::ui::debug(format!("mode={:?}", self.config.hot_patch_mode));
 
-        // Anchor a persistent dev-server status bar at the bottom
-        // of the rendered area. Client connect / patch sent /
-        // build state updates all flow through `set_status` —
-        // they stay out of the build-step scrollback that way.
+        // Dev-server status flows through `set_status`; deduped so
+        // back-to-back transitions (startup → bound → first
+        // connect) don't stack lines.
         whisker_build::ui::ensure_status("dev-server");
-        whisker_build::ui::set_status("starting…");
 
         let (sender, bound, _server_handle) =
             server::serve(self.config.bind_addr, self.on_event.clone()).await?;

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -247,15 +247,14 @@ impl DevServer {
     pub async fn run(self) -> Result<()> {
         whisker_build::ui::section("whisker run");
         whisker_build::ui::info(format!(
-            "target={:?} · package={} · mode={:?}",
-            self.config.target, self.config.package, self.config.hot_patch_mode,
+            "{} · {:?}",
+            self.config.package, self.config.target,
         ));
+        whisker_build::ui::debug(format!("mode={:?}", self.config.hot_patch_mode));
 
         let (sender, bound, _server_handle) =
             server::serve(self.config.bind_addr, self.on_event.clone()).await?;
-        whisker_build::ui::info(format!(
-            "ws://{bound}/whisker-dev (waiting for clients; Ctrl-C to quit)"
-        ));
+        whisker_build::ui::debug(format!("ws://{bound}/whisker-dev"));
 
         // Watch the user crate's `src/`. `crate_dir` is whatever the
         // cli resolved (`Cargo.toml` parent) — for in-workspace
@@ -268,7 +267,7 @@ impl DevServer {
             std::time::Duration::from_millis(200),
             tx,
         )?;
-        whisker_build::ui::info(format!("watching {}", watch_root.display()));
+        whisker_build::ui::debug(format!("watching {}", watch_root.display()));
         emit(&self.on_event, Event::Started);
 
         // Configure the initial build. For Tier 1 it doubles as the
@@ -325,7 +324,7 @@ impl DevServer {
         let patcher = match tier1_init {
             Some(prep) => match init_patcher_for(&self.config, &prep) {
                 Ok(p) => {
-                    whisker_build::ui::info("Tier 1 patcher ready");
+                    whisker_build::ui::debug("Tier 1 patcher ready");
                     Some(p)
                 }
                 Err(e) => {
@@ -346,7 +345,7 @@ impl DevServer {
         // glitch.
         while let Some(change) = rx.recv().await {
             whisker_build::ui::section("Change");
-            whisker_build::ui::info(format!(
+            whisker_build::ui::debug(format!(
                 "{:?} — {} path(s)",
                 change.kind,
                 change.paths.len(),
@@ -354,18 +353,21 @@ impl DevServer {
             let action = decide_action(change.kind, patcher.is_some());
             match action {
                 LoopAction::Ignore => {
-                    whisker_build::ui::info(format!("ignored ({:?})", change.kind));
+                    whisker_build::ui::debug(format!("ignored ({:?})", change.kind));
                 }
                 LoopAction::Tier1Patch => {
                     let p = patcher.as_ref().expect("decide_action guarantees Some");
+                    // Open the step as soon as we know we're patching;
+                    // the spinner runs across both the build + the
+                    // wire-up so the user sees a single elapsed
+                    // duration for "edit → app updated".
+                    let patch_step = whisker_build::ui::step("patch", "tier 1");
                     let Some(aslr_reference) = sender.latest_aslr_reference() else {
                         // No client has reported its `aslr_reference` yet
                         // (handshake hasn't completed, or never connected).
                         // Without that value we can't build a stub-asm-style
                         // patch — fall back to Tier 2 cold rebuild.
-                        whisker_build::ui::warn(
-                            "tier1 skipped: no client aslr_reference yet; using Tier 2",
-                        );
+                        patch_step.fail("no client aslr_reference yet; using Tier 2");
                         run_build_cycle(
                             &builder,
                             &installer,
@@ -384,8 +386,8 @@ impl DevServer {
                             let dylib_bytes = match read_lib_bytes(&plan.table.lib) {
                                 Ok(b) => Arc::new(b),
                                 Err(e) => {
-                                    whisker_build::ui::warn(format!(
-                                        "tier1 patch built but could not read dylib bytes ({}): {e:#}; using Tier 2",
+                                    patch_step.fail(format!(
+                                        "could not read dylib bytes ({}): {e:#}; using Tier 2",
                                         plan.table.lib.display(),
                                     ));
                                     run_build_cycle(
@@ -404,18 +406,15 @@ impl DevServer {
                                 table: plan.table,
                                 dylib_bytes,
                             });
-                            let patch_step = whisker_build::ui::step("patch", "tier 1");
-                            patch_step.done(format!(
-                                "{n} client(s) · built {built_in:?} · queued {:?} · total {:?}",
-                                send_started.elapsed(),
-                                started.elapsed(),
+                            whisker_build::ui::debug(format!(
+                                "built {built_in:?} · queued {:?}",
+                                send_started.elapsed()
                             ));
+                            patch_step.done(format!("{n} client(s)"));
                             emit(&self.on_event, Event::PatchSent);
                         }
                         Err(e) => {
-                            whisker_build::ui::warn(format!(
-                                "tier1 patch failed ({e:#}); using Tier 2 cold rebuild",
-                            ));
+                            patch_step.fail(format!("{e:#}; using Tier 2 cold rebuild"));
                             run_build_cycle(
                                 &builder,
                                 &installer,
@@ -474,15 +473,19 @@ fn log_patch_diff(report: &hotpatch::DiffReport) {
         return;
     }
     if !report.added.is_empty() {
-        whisker_build::ui::info(format!(
+        whisker_build::ui::debug(format!(
             "patch added {} symbol(s): {:?}",
             report.added.len(),
             report.added.iter().take(5).collect::<Vec<_>>(),
         ));
     }
     if !report.removed.is_empty() {
-        whisker_build::ui::warn(format!(
-            "patch removed {} symbol(s) — host shell may crash on stale callers: {:?}",
+        // Removed-symbol counts are noisy on every patch (typically
+        // thousands of `GCC_except_table*` entries that compiled
+        // away). Surface only in verbose mode; the "host shell may
+        // crash" warning was alarmist for the normal case.
+        whisker_build::ui::debug(format!(
+            "patch removed {} symbol(s): {:?}",
             report.removed.len(),
             report.removed.iter().take(5).collect::<Vec<_>>(),
         ));

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -245,19 +245,17 @@ impl DevServer {
     /// `ChangeKind::RustCode` events. Patcher initialisation or
     /// `build_patch` failure falls back to Tier 2 silently.
     pub async fn run(self) -> Result<()> {
-        eprintln!(
-            "[whisker-dev-server] starting (target={:?}, package={}, addr={}, mode={:?})",
-            self.config.target,
-            self.config.package,
-            self.config.bind_addr,
-            self.config.hot_patch_mode,
-        );
+        whisker_build::ui::section("whisker run");
+        whisker_build::ui::info(format!(
+            "target={:?} · package={} · mode={:?}",
+            self.config.target, self.config.package, self.config.hot_patch_mode,
+        ));
 
         let (sender, bound, _server_handle) =
             server::serve(self.config.bind_addr, self.on_event.clone()).await?;
-        eprintln!(
-            "[whisker-dev-server] ws://{bound}/whisker-dev (waiting for clients; Ctrl-C to quit)"
-        );
+        whisker_build::ui::info(format!(
+            "ws://{bound}/whisker-dev (waiting for clients; Ctrl-C to quit)"
+        ));
 
         // Watch the user crate's `src/`. `crate_dir` is whatever the
         // cli resolved (`Cargo.toml` parent) — for in-workspace
@@ -270,7 +268,7 @@ impl DevServer {
             std::time::Duration::from_millis(200),
             tx,
         )?;
-        eprintln!("[whisker-dev-server] watching {}", watch_root.display());
+        whisker_build::ui::info(format!("watching {}", watch_root.display()));
         emit(&self.on_event, Event::Started);
 
         // Configure the initial build. For Tier 1 it doubles as the
@@ -295,10 +293,9 @@ impl DevServer {
                     Some(prep)
                 }
                 Err(e) => {
-                    eprintln!(
-                        "[whisker-dev-server] Tier 1 capture setup failed: {e:#} — \
-                         falling back to Tier 2 cold rebuilds",
-                    );
+                    whisker_build::ui::warn(format!(
+                        "Tier 1 capture setup failed ({e:#}); falling back to Tier 2 cold rebuilds",
+                    ));
                     None
                 }
             }
@@ -319,7 +316,7 @@ impl DevServer {
         // unfriendly when you've started an emulator and want the app
         // up immediately. A failure here doesn't abort: the loop
         // still enters, so fixing the source and saving recovers.
-        eprintln!("[whisker-dev-server] initial build");
+        whisker_build::ui::section("Initial build");
         run_build_cycle(&builder, &installer, &self.on_event, &sender, "initial").await;
 
         // After the fat build has happened, Patcher::initialize can
@@ -328,14 +325,13 @@ impl DevServer {
         let patcher = match tier1_init {
             Some(prep) => match init_patcher_for(&self.config, &prep) {
                 Ok(p) => {
-                    eprintln!("[whisker-dev-server] Tier 1 patcher ready");
+                    whisker_build::ui::info("Tier 1 patcher ready");
                     Some(p)
                 }
                 Err(e) => {
-                    eprintln!(
-                        "[whisker-dev-server] Tier 1 patcher init failed: {e:#} — \
-                         falling back to Tier 2 cold rebuilds",
-                    );
+                    whisker_build::ui::warn(format!(
+                        "Tier 1 patcher init failed ({e:#}); falling back to Tier 2 cold rebuilds",
+                    ));
                     None
                 }
             },
@@ -349,15 +345,16 @@ impl DevServer {
         // the dev loop from being killed by a transient build
         // glitch.
         while let Some(change) = rx.recv().await {
-            eprintln!(
-                "[whisker-dev-server] change ({:?}) — {} path(s)",
+            whisker_build::ui::section("Change");
+            whisker_build::ui::info(format!(
+                "{:?} — {} path(s)",
                 change.kind,
                 change.paths.len(),
-            );
+            ));
             let action = decide_action(change.kind, patcher.is_some());
             match action {
                 LoopAction::Ignore => {
-                    eprintln!("[whisker-dev-server] ignored ({:?})", change.kind);
+                    whisker_build::ui::info(format!("ignored ({:?})", change.kind));
                 }
                 LoopAction::Tier1Patch => {
                     let p = patcher.as_ref().expect("decide_action guarantees Some");
@@ -366,10 +363,8 @@ impl DevServer {
                         // (handshake hasn't completed, or never connected).
                         // Without that value we can't build a stub-asm-style
                         // patch — fall back to Tier 2 cold rebuild.
-                        eprintln!(
-                            "[whisker-dev-server] tier1 patch skipped: \
-                             no client `aslr_reference` reported yet — \
-                             falling back to Tier 2 cold rebuild",
+                        whisker_build::ui::warn(
+                            "tier1 skipped: no client aslr_reference yet; using Tier 2",
                         );
                         run_build_cycle(
                             &builder,
@@ -389,12 +384,10 @@ impl DevServer {
                             let dylib_bytes = match read_lib_bytes(&plan.table.lib) {
                                 Ok(b) => Arc::new(b),
                                 Err(e) => {
-                                    eprintln!(
-                                        "[whisker-dev-server] tier1 patch built but \
-                                         could not read dylib bytes ({}): {e:#} — \
-                                         falling back to Tier 2",
+                                    whisker_build::ui::warn(format!(
+                                        "tier1 patch built but could not read dylib bytes ({}): {e:#}; using Tier 2",
                                         plan.table.lib.display(),
-                                    );
+                                    ));
                                     run_build_cycle(
                                         &builder,
                                         &installer,
@@ -411,20 +404,18 @@ impl DevServer {
                                 table: plan.table,
                                 dylib_bytes,
                             });
-                            eprintln!(
-                                "[whisker-dev-server] tier1 patch sent to {n} client(s) \
-                                 (built in {built_in:?}, queued for send in {:?}, \
-                                 total edit→send: {:?})",
+                            let patch_step = whisker_build::ui::step("patch", "tier 1");
+                            patch_step.done(format!(
+                                "{n} client(s) · built {built_in:?} · queued {:?} · total {:?}",
                                 send_started.elapsed(),
                                 started.elapsed(),
-                            );
+                            ));
                             emit(&self.on_event, Event::PatchSent);
                         }
                         Err(e) => {
-                            eprintln!(
-                                "[whisker-dev-server] tier1 patch failed: {e:#} — \
-                                 falling back to Tier 2 cold rebuild",
-                            );
+                            whisker_build::ui::warn(format!(
+                                "tier1 patch failed ({e:#}); using Tier 2 cold rebuild",
+                            ));
                             run_build_cycle(
                                 &builder,
                                 &installer,
@@ -483,19 +474,18 @@ fn log_patch_diff(report: &hotpatch::DiffReport) {
         return;
     }
     if !report.added.is_empty() {
-        eprintln!(
-            "[whisker-dev-server] patch added {} symbol(s): {:?}",
+        whisker_build::ui::info(format!(
+            "patch added {} symbol(s): {:?}",
             report.added.len(),
             report.added.iter().take(5).collect::<Vec<_>>(),
-        );
+        ));
     }
     if !report.removed.is_empty() {
-        eprintln!(
-            "[whisker-dev-server] patch removed {} symbol(s) — \
-             host shell may crash on stale callers: {:?}",
+        whisker_build::ui::warn(format!(
+            "patch removed {} symbol(s) — host shell may crash on stale callers: {:?}",
             report.removed.len(),
             report.removed.iter().take(5).collect::<Vec<_>>(),
-        );
+        ));
     }
 }
 
@@ -723,16 +713,16 @@ async fn run_build_cycle(
         Ok(()) => {
             emit(on_event, Event::BuildSucceeded);
             if let Err(e) = installer.install_and_launch().await {
-                eprintln!("[whisker-dev-server] {label} install failed: {e}");
+                whisker_build::ui::error(format!("{label} install failed: {e}"));
             }
-            eprintln!(
-                "[whisker-dev-server] {label} done; {} client(s) connected",
+            whisker_build::ui::info(format!(
+                "{label} done · {} client(s) connected",
                 sender.client_count()
-            );
+            ));
         }
         Err(e) => {
             let msg = format!("{e:#}");
-            eprintln!("[whisker-dev-server] {label} build failed: {msg}");
+            whisker_build::ui::error(format!("{label} build failed: {msg}"));
             emit(on_event, Event::BuildFailed(msg));
         }
     }

--- a/crates/whisker-dev-server/src/server.rs
+++ b/crates/whisker-dev-server/src/server.rs
@@ -189,10 +189,7 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
 
     let (mut tx_ws, mut rx_ws) = socket.split();
     let mut bcast_rx = state.tx.subscribe();
-    whisker_build::ui::info(format!(
-        "client connected (total: {})",
-        state.tx.receiver_count(),
-    ));
+    whisker_build::ui::set_status(format!("{} client(s) connected", state.tx.receiver_count(),));
     // `aslr_reference` is internal handshake plumbing; emit at debug
     // grade so the steady-state UI stays clean.
     if let Some(cb) = &state.on_event {

--- a/crates/whisker-dev-server/src/server.rs
+++ b/crates/whisker-dev-server/src/server.rs
@@ -173,7 +173,7 @@ pub async fn serve(
 
     let handle = tokio::spawn(async move {
         if let Err(e) = axum::serve(listener, app).await {
-            eprintln!("[whisker-dev-server] axum serve error: {e}");
+            whisker_build::ui::error(format!("axum serve error: {e}"));
         }
     });
 
@@ -189,10 +189,10 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
 
     let (mut tx_ws, mut rx_ws) = socket.split();
     let mut bcast_rx = state.tx.subscribe();
-    eprintln!(
-        "[whisker-dev-server] client connected (total: {})",
+    whisker_build::ui::info(format!(
+        "client connected (total: {})",
         state.tx.receiver_count(),
-    );
+    ));
     if let Some(cb) = &state.on_event {
         cb(Event::ClientConnected);
     }
@@ -209,7 +209,7 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                 let frame = match encode_patch_frame(&patch) {
                     Ok(b) => b,
                     Err(e) => {
-                        eprintln!("[whisker-dev-server] encode patch frame: {e}");
+                        whisker_build::ui::warn(format!("encode patch frame: {e}"));
                         continue;
                     }
                 };
@@ -227,9 +227,9 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                     Some(Err(_)) => break,
                     Some(Ok(Message::Text(t))) => {
                         if let Some(aslr) = parse_client_aslr_reference(&t) {
-                            eprintln!(
-                                "[whisker-dev-server] client hello: aslr_reference={aslr:#x}"
-                            );
+                            whisker_build::ui::info(format!(
+                                "client hello · aslr_reference={aslr:#x}"
+                            ));
                             if let Ok(mut g) = state.aslr_reference.lock() {
                                 *g = Some(aslr);
                             }

--- a/crates/whisker-dev-server/src/server.rs
+++ b/crates/whisker-dev-server/src/server.rs
@@ -193,6 +193,8 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
         "client connected (total: {})",
         state.tx.receiver_count(),
     ));
+    // `aslr_reference` is internal handshake plumbing; emit at debug
+    // grade so the steady-state UI stays clean.
     if let Some(cb) = &state.on_event {
         cb(Event::ClientConnected);
     }
@@ -227,7 +229,7 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                     Some(Err(_)) => break,
                     Some(Ok(Message::Text(t))) => {
                         if let Some(aslr) = parse_client_aslr_reference(&t) {
-                            whisker_build::ui::info(format!(
+                            whisker_build::ui::debug(format!(
                                 "client hello · aslr_reference={aslr:#x}"
                             ));
                             if let Ok(mut g) = state.aslr_reference.lock() {

--- a/crates/whisker-driver-sys/build.rs
+++ b/crates/whisker-driver-sys/build.rs
@@ -76,6 +76,29 @@ fn add_lynx_includes_for_capi_impl(build: &mut cc::Build) {
         .include(primjs.join("napi/jsc"));
 }
 
+/// Silence diagnostics that fire on every Lynx public header rather
+/// than our own code. `cargo build` otherwise prints ~300 lines of
+/// `-Wunused-parameter` cargo-warning messages per build of the
+/// bridge, drowning out anything that's actually actionable.
+///
+/// We don't want to mask warnings on OUR sources, but cc-rs has no
+/// per-file warning override — the `Build` instance compiles both
+/// `whisker_bridge_*.cc` (ours) and the Lynx headers transitively.
+/// Lynx's own GN build silences these too (see Lynx's
+/// `BUILD.gn`'s `default_warning_flags`), so suppressing here just
+/// matches the upstream stance.
+///
+/// Kept as a single named call so the future "split this Build into
+/// our-sources + lynx-headers builds" refactor has an obvious anchor
+/// to replace.
+fn silence_upstream_lynx_warnings(build: &mut cc::Build) {
+    // Source of the bulk of the noise: Lynx's many `virtual` interface
+    // methods accept context parameters they ignore in their default
+    // impl. `-Wno-unused-parameter` is the precise switch; broader
+    // `-w` would also hide actionable warnings in our own code.
+    build.flag_if_supported("-Wno-unused-parameter");
+}
+
 // --- Android ---------------------------------------------------------
 
 fn compile_android() -> Result<()> {
@@ -125,6 +148,7 @@ fn compile_android() -> Result<()> {
     // via `.cargo/config.toml` target-feature flags.
     build.flag("-march=armv8.1-a");
     build.flag("-mno-outline-atomics");
+    silence_upstream_lynx_warnings(&mut build);
     build.compile("whisker_bridge_static");
 
     // --- Link-line emission -----------------------------------------
@@ -233,6 +257,7 @@ fn compile_ios() -> Result<()> {
     // cc::Build picks Obj-C++ semantics for `.mm` files automatically
     // (it appends `-x objective-c++`), so no extra flag is needed for
     // `whisker_bridge_ios.mm`.
+    silence_upstream_lynx_warnings(&mut build);
     build.compile("whisker_bridge_static");
 
     // --- Link-line emission for the parent dylib --------------------


### PR DESCRIPTION
Major cleanup of `whisker run` / `whisker build` terminal output. Multi-pass refinement based on user feedback throughout the development.

## Final result

```
──── whisker run ─────────────────────────────
  · hello-world · IosSimulator
  · dev-server · ws://127.0.0.1:9876 · 0 client(s)

──── Initial build ───────────────────────────
  ✓ setup        whisker-cli shims        25.9s
  ⠋ compile      hello-world (...)        Compiling indicatif v0.17.11
  · dev-server · 1 client(s) connected
  ✓ compile      hello-world (...)        24.4s
  ✓ xcframework  WhiskerDriver            0.4s
  ✓ xcodebuild   HelloWorld               4.1s
  ✓ boot         iPhone 17 Pro            0.4s
  ✓ install      HelloWorld.app           0.7s
  ✓ launch       rs.whisker.examples      0.2s

──── Change ───────────────────────────────────
  ✓ patch        tier 1                   1 client(s)  1.4s
```

`--verbose` (or `WHISKER_VERBOSE=1`) restores every demoted line + full anyhow chains + raw tool output for debugging.

## Changes

### Noise suppression
- **289 → 0** cargo-warning lines: `-Wno-unused-parameter` on the cc::Build that compiles against Lynx's deep C++ header tree (`whisker-driver-sys/build.rs`).
- **simctl benign errors filtered** ("already booted" / "found nothing to terminate" on every re-run).
- **xcodebuild deprecation chain** suppressed (Lynx 3.7.0 headers use `[UIScreen mainScreen]`, deprecated in iOS 26 SDK — hundreds of lines per build, not actionable). `warning:` / `note:` / `In file included from …` / source-line listings (`217 | #import …`, `    | ^`) / `N warnings generated.` all filtered.
- **`{"$message_type":"artifact","artifact":"…","emit":"obj"}` lines** from rustc removed — `strip_json_flags` clears cargo's `--json=…` / `--error-format=json` from the captured patch-build args.
- **iOS build time**: dev loop builds two sim slices (arm64 + x86_64) instead of universal three (skips device slice). Production `whisker build` still ships universal.

### Curated UI (`whisker-build::ui`)
- New module replaces 25+ scattered `eprintln!("[whisker-build] …")` / `eprintln!("[whisker-dev-server] …")` / `eprintln!("[whisker-dev] skip …")` call sites.
- **`section`** / **`step`** / **`info`** / **`warn`** / **`error`** / **`debug`** as the unified surface.
- TTY mode: indicatif spinners with fixed-width name column for vertical alignment; non-TTY emits plain lines for the same shape.
- **`Step::pipe(cmd) -> ExitStatus`** streams cargo / xcodebuild output: cargo-progress lines (`Compiling X v0.1.0`, `Finished …`) update the spinner's `{msg}` in place; rustc errors / warnings / panics go through `MultiProgress::suspend` so they persist in scrollback for copy-paste triage without leaking stale spinner frames.
- **`set_status` (dev-server status)**: deduplicated info-style line for ws bind / client connect / patches.
- **Step finish**: template swaps to `{msg}` so the final line is exactly the formatted text (no leftover `{spinner}` glyph + `…`).

### Verbose mode
- New global **`--verbose` / `-v`** flag on the top-level CLI, equivalent to `WHISKER_VERBOSE=1` env var. Sub-process inheritance via env var so dev-server / shim binaries / build crates all see it without per-flag plumbing.
- Verbose mode: bypass xcodebuild benign-noise filter, restore all `debug()` lines, full anyhow chains on error.
- `WHISKER_VERBOSE=1` also kept as standalone — useful for `tee` to file / CI.

### Error formatting
- `whisker run` outside an app crate used to print anyhow's full chain (`Error: resolve user-crate manifest …\nCaused by: no [package] Cargo.toml at or above …`). Now extracts the chain's root cause and emits via `ui::error(…)` — one focused line. Verbose mode keeps `{e:#}` for debugging.

### iOS-side fixes
- `IosSlices::SimulatorFat` (arm64 + x86_64 lipo'd into one fat sim slice; device skipped) for dev runs.
- Reverted an earlier `-arch <host>` pin on xcodebuild — incompatible with `-destination 'generic/platform=iOS Simulator'` (xcodebuild rejects with `destination implies architecture, architecture must not also be specified`).

### Other
- Setup of shim binaries (`whisker-rustc-shim` / `whisker-linker-shim`) on first run now streams through a `setup` step instead of dumping ~200 cargo lines before any UI chrome appeared.

## Out of scope

- Streaming xcodebuild progress through the spinner (currently uses `-quiet` + stderr filter).
- A user-facing config knob for which sim arch to build (dev currently always builds both; cross-arch builds add ~3s on warm cache).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] User manually tested `cargo whisker run --target ios` through multiple refinement rounds; final output verified single-line per step + single-line dev-server status (no scrollback duplication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)