### PR TITLE
Phase 7-A foundation + 7-B Native Element end-to-end iOS-sim demo

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,6 +49,7 @@ const BRIDGE_EXPORTS: &[&str] = &[
     "_whisker_bridge_engine_release",
     "_whisker_bridge_dispatch",
     "_whisker_bridge_create_element",
+    "_whisker_bridge_create_element_by_name",
     "_whisker_bridge_release_element",
     "_whisker_bridge_set_attribute",
     "_whisker_bridge_set_inline_styles",

--- a/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
@@ -79,6 +79,15 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT lynx_fiber_element_t* lynx_create_fiber_element
     lynx_shell_t* shell,
     lynx_element_tag_e tag);
 
+// Phase 7: tag-by-name element creation. Used for xelement / custom
+// elements registered via `@LynxBehavior(name = "x-foo")` etc. that
+// aren't in the built-in enum. Implementation delegates to
+// `ElementManager::CreateFiberNode(base::String(tag_name))`, the
+// same factory ReactLynx uses for non-built-in tags. Returns nullptr
+// if `tag_name` is null/empty or unknown.
+LYNX_NATIVE_RENDERER_CAPI_EXPORT lynx_fiber_element_t*
+lynx_create_fiber_element_by_name(lynx_shell_t* shell, const char* tag_name);
+
 LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_release(
     lynx_fiber_element_t* element);
 

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -88,6 +88,15 @@ WHISKER_BRIDGE_EXPORT bool whisker_bridge_dispatch(WhiskerEngine* engine,
 
 WHISKER_BRIDGE_EXPORT WhiskerElement* whisker_bridge_create_element(WhiskerEngine* engine, WhiskerElementTag tag);
 
+// Phase 7: tag-by-name element creation for custom / xelement-style
+// tags ("x-input", "x-camera-preview", …) not covered by the
+// `WhiskerElementTag` enum. Delegates to Lynx's
+// `ElementManager::CreateFiberNode(tag_name)`, which routes both
+// built-in and registered custom tags through the same factory.
+// `tag_name` must be NUL-terminated UTF-8. Returns NULL if the tag
+// isn't registered with Lynx's behaviour registry.
+WHISKER_BRIDGE_EXPORT WhiskerElement* whisker_bridge_create_element_by_name(WhiskerEngine* engine, const char* tag_name);
+
 // Decrement the element's ref count. Always safe to call multiple times
 // (idempotent on NULL).
 WHISKER_BRIDGE_EXPORT void whisker_bridge_release_element(WhiskerElement* element);

--- a/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
+++ b/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
@@ -145,6 +145,22 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT lynx_fiber_element_t* lynx_create_fiber_element
   return new lynx_fiber_element_t{std::move(ref)};
 }
 
+LYNX_NATIVE_RENDERER_CAPI_EXPORT lynx_fiber_element_t*
+lynx_create_fiber_element_by_name(lynx_shell_t* shell, const char* tag_name) {
+  if (shell == nullptr || shell->manager == nullptr || tag_name == nullptr ||
+      tag_name[0] == '\0') {
+    return nullptr;
+  }
+  // `CreateFiberNode` is the generic factory ElementManager exposes
+  // for any registered tag — built-ins (`view` / `text` / `image` /
+  // `scroll-view`) and custom (`x-input` / `x-refresh` / …) alike.
+  // For tags Lynx's behaviour registry doesn't know, it returns
+  // nullptr and we surface that to the Rust caller.
+  auto ref = shell->manager->CreateFiberNode(lynx::base::String(tag_name));
+  if (!ref) return nullptr;
+  return new lynx_fiber_element_t{std::move(ref)};
+}
+
 LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_release(lynx_fiber_element_t* element) {
   delete element;
 }

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -198,6 +198,18 @@ extern "C" WhiskerElement* whisker_bridge_create_element(WhiskerEngine* engine,
     return new WhiskerElement{handle};
 }
 
+extern "C" WhiskerElement* whisker_bridge_create_element_by_name(
+    WhiskerEngine* engine,
+    const char* tag_name) {
+    if (engine == nullptr || engine->shell == nullptr || tag_name == nullptr) {
+        return nullptr;
+    }
+    lynx_fiber_element_t* handle =
+        lynx_create_fiber_element_by_name(engine->shell, tag_name);
+    if (handle == nullptr) return nullptr;
+    return new WhiskerElement{handle};
+}
+
 extern "C" void whisker_bridge_release_element(WhiskerElement* element) {
     if (element == nullptr) return;
     // Drop any registered native event callbacks for this element so

--- a/crates/whisker-driver-sys/bridge/src/whisker_hello_element.mm
+++ b/crates/whisker-driver-sys/bridge/src/whisker_hello_element.mm
@@ -1,0 +1,42 @@
+// Phase 7-B end-to-end smoke test element.
+//
+// Registers an `x-hello` tag with Lynx's behaviour registry that
+// renders as a plain `UIView` with a system-pink background. Used
+// by `examples/hello-world` to validate the tag-by-name dispatch
+// path (`whisker_bridge_create_element_by_name` →
+// `ElementManager::CreateFiberNode("x-hello")` →
+// `LYNX_REGISTER_UI("x-hello")` → `WhiskerHelloElement`).
+//
+// This is intentionally a single self-contained file in the bridge
+// crate, not yet the full `runtime-platforms/ios/` SPM-package
+// infrastructure. The latter (with `@WhiskerElement` Swift Macro,
+// `WhiskerView<T>` base class, and module-author DX) lands in
+// Phase 7-B.6. For the simulator smoke test we use Lynx's raw
+// registration macros directly so the element is available
+// without further build pipeline changes.
+
+#import <UIKit/UIKit.h>
+
+#import <Lynx/LynxComponentRegistry.h>
+#import <Lynx/LynxPropsProcessor.h>
+#import <Lynx/LynxUI.h>
+
+@interface WhiskerHelloElement : LynxUI<UIView *>
+@end
+
+@implementation WhiskerHelloElement
+
+// Lynx's `+load`-time hook that registers the class against the
+// global `LynxComponentRegistry` under the given tag name.
+LYNX_REGISTER_UI("x-hello")
+
+- (UIView *)createView {
+    UIView *v = [[UIView alloc] init];
+    // System pink to make the smoke test visually obvious — if you
+    // see a pink rectangle, the tag-by-name dispatch is working
+    // end-to-end (render! → Rust → C ABI → Lynx → this class).
+    v.backgroundColor = [UIColor systemPinkColor];
+    return v;
+}
+
+@end

--- a/crates/whisker-driver-sys/build.rs
+++ b/crates/whisker-driver-sys/build.rs
@@ -237,6 +237,11 @@ fn compile_ios() -> Result<()> {
         .file(bridge_src.join("whisker_bridge_common.cc"))
         .file(bridge_src.join("whisker_bridge_ios.mm"))
         .file(bridge_src.join("lynx_native_renderer.cc"))
+        // Phase 7-B smoke-test custom element. Self-registers
+        // the `x-hello` tag with Lynx's behaviour registry at
+        // +load time so render! { "x-hello" {…} } can dispatch
+        // through `whisker_bridge_create_element_by_name`.
+        .file(bridge_src.join("whisker_hello_element.mm"))
         .include(bridge_root().join("include"))
         .include(&bridge_src);
     add_lynx_includes_for_capi_impl(&mut build);

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -44,6 +44,10 @@ extern "C" {
         engine: *mut WhiskerEngine,
         tag: WhiskerElementTag,
     ) -> *mut WhiskerElement;
+    pub fn whisker_bridge_create_element_by_name(
+        engine: *mut WhiskerEngine,
+        tag_name: *const c_char,
+    ) -> *mut WhiskerElement;
     pub fn whisker_bridge_release_element(element: *mut WhiskerElement);
 
     pub fn whisker_bridge_set_attribute(

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -81,6 +81,21 @@ impl DynRenderer for BridgeRenderer {
         Element::from_raw(id)
     }
 
+    fn create_element_by_name(&mut self, tag_name: &str) -> Element {
+        let Ok(c) = CString::new(tag_name) else {
+            return Element::from_raw(u32::MAX);
+        };
+        let raw =
+            unsafe { ffi::whisker_bridge_create_element_by_name(self.engine_ptr(), c.as_ptr()) };
+        let ptr = match NonNull::new(raw) {
+            Some(p) => p,
+            None => return Element::from_raw(u32::MAX),
+        };
+        let id = self.elements.len() as u32;
+        self.elements.push(Some(ptr));
+        Element::from_raw(id)
+    }
+
     fn release_element(&mut self, handle: Element) {
         if let Some(slot) = self.elements.get_mut(handle.id() as usize) {
             if let Some(ptr) = slot.take() {

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -100,12 +100,27 @@ impl Parse for Root {
 
 enum Node {
     Element(ElementNode),
+    /// String-literal tagged element (`"x-input" { … }`). Lowered to
+    /// `view::create_element_by_name("x-input")` + inline
+    /// attribute / event / child wiring. Used for native elements
+    /// registered through Lynx's behaviour registry (xelement-style
+    /// `x-*` tags + future Whisker-author elements). No `__tags::*`
+    /// helper struct exists for these — the lowering inlines the
+    /// `effect(move || set_*)` pattern the built-in tag methods
+    /// would otherwise apply.
+    CustomElement(CustomElementNode),
     ControlFlow(ControlFlowNode),
     UserComponent(UserComponentNode),
 }
 
 struct ElementNode {
     tag: Ident,
+    kwargs: Vec<Kwarg>,
+    children: Vec<Node>,
+}
+
+struct CustomElementNode {
+    tag_lit: LitStr,
     kwargs: Vec<Kwarg>,
     children: Vec<Node>,
 }
@@ -146,6 +161,56 @@ impl Parse for Node {
         // this position with a targeted error message — that's the
         // only way to give a useful hint when the user writes bare
         // `"hi"` or `{ count }` as a child.
+        // String-literal tag for custom / native elements: `"x-input" {…}`.
+        // Distinguished from bare child strings by what follows — a
+        // `(` (kwargs) or `{` (children) means the user is using the
+        // string as a tag name. A bare `"hi"` with no body is still
+        // an error pointing at `text(value: "hi")`.
+        if input.peek(LitStr) && (input.peek2(token::Paren) || input.peek2(token::Brace)) {
+            let tag_lit: LitStr = input.parse()?;
+            let mut kwargs = Vec::new();
+            if input.peek(token::Paren) {
+                let body;
+                parenthesized!(body in input);
+                while !body.is_empty() {
+                    if !body.peek(Ident) {
+                        return Err(body.error(
+                            "kwargs must be `name: expr` — positional arguments \
+                             not allowed",
+                        ));
+                    }
+                    let name: Ident = body.parse()?;
+                    let (value, partial) = if body.peek(Token![:]) {
+                        body.parse::<Token![:]>()?;
+                        (body.parse::<Expr>()?, false)
+                    } else {
+                        let placeholder: Expr = syn::parse_quote_spanned!(name.span()=> ());
+                        (placeholder, true)
+                    };
+                    kwargs.push(Kwarg {
+                        name,
+                        value,
+                        partial,
+                    });
+                    if body.peek(Token![,]) {
+                        body.parse::<Token![,]>()?;
+                    }
+                }
+            }
+            let mut children = Vec::new();
+            if input.peek(token::Brace) {
+                let body;
+                braced!(body in input);
+                while !body.is_empty() {
+                    children.push(body.parse::<Node>()?);
+                }
+            }
+            return Ok(Node::CustomElement(CustomElementNode {
+                tag_lit,
+                kwargs,
+                children,
+            }));
+        }
         if input.peek(LitStr) {
             let lit: LitStr = input.parse()?;
             return Err(syn::Error::new(
@@ -317,6 +382,7 @@ impl Node {
     fn to_tokens_returning_handle(&self) -> TokenStream2 {
         match self {
             Node::Element(el) => el.to_tokens(),
+            Node::CustomElement(c) => c.to_tokens(),
             Node::ControlFlow(c) => c.to_tokens(),
             Node::UserComponent(u) => u.to_tokens(),
         }
@@ -503,6 +569,95 @@ fn is_string_attr_method(tag: &str, attr: &str) -> bool {
             | ("raw_text", "text")
             | ("text", "value")
     )
+}
+
+// ---- Custom (string-literal tag) elements -------------------------------
+
+impl CustomElementNode {
+    /// Lower `"x-input" { … }` to an inline create + wire-up block:
+    ///
+    /// ```ignore
+    /// {
+    ///     let __el = view::create_element_by_name("x-input");
+    ///     // For each kwarg: style → reactive set_inline_styles,
+    ///     //                 on_* → set_event_listener,
+    ///     //                 *    → reactive set_attribute.
+    ///     // For each child: append_child(__el, child_handle).
+    ///     __el
+    /// }
+    /// ```
+    ///
+    /// No typed builder methods (unlike `__tags::<view>`-style
+    /// built-ins): custom elements are string-keyed at the bridge
+    /// boundary, so we inline the same `effect(move || …)` reactive
+    /// wiring the built-in tag methods would emit internally.
+    fn to_tokens(&self) -> TokenStream2 {
+        let tag_str = self.tag_lit.value();
+        let tag_span = self.tag_lit.span();
+
+        let mut wiring = Vec::new();
+        for kw in &self.kwargs {
+            if kw.partial {
+                continue;
+            }
+            let value = &kw.value;
+            let kw_name = kw.name.to_string();
+            let kw_span = kw.name.span();
+            if kw_name == "style" {
+                wiring.push(quote_spanned!(kw_span=> {
+                    let __h = __el;
+                    ::whisker::effect(move || {
+                        let __f = #value;
+                        ::whisker::runtime::view::set_inline_styles(
+                            __h,
+                            &::std::string::ToString::to_string(&__f()),
+                        );
+                    });
+                }));
+            } else if let Some(event) = kw_name.strip_prefix("on_") {
+                let event_lit = LitStr::new(event, kw_span);
+                wiring.push(quote_spanned!(kw_span=> {
+                    ::whisker::runtime::view::set_event_listener(
+                        __el,
+                        #event_lit,
+                        ::std::boxed::Box::new(#value),
+                    );
+                }));
+            } else {
+                let attr_lit = LitStr::new(&kw_name, kw_span);
+                wiring.push(quote_spanned!(kw_span=> {
+                    let __h = __el;
+                    ::whisker::effect(move || {
+                        let __f = #value;
+                        ::whisker::runtime::view::set_attribute(
+                            __h,
+                            #attr_lit,
+                            &::std::string::ToString::to_string(&__f()),
+                        );
+                    });
+                }));
+            }
+        }
+
+        let child_tokens: Vec<TokenStream2> = self
+            .children
+            .iter()
+            .map(|child| {
+                let handle = child.to_tokens_returning_handle();
+                quote! {
+                    ::whisker::runtime::view::append_child(__el, #handle);
+                }
+            })
+            .collect();
+
+        let tag_lit_str = LitStr::new(&tag_str, tag_span);
+        quote_spanned!(tag_span=> {
+            let __el = ::whisker::runtime::view::create_element_by_name(#tag_lit_str);
+            #(#wiring)*
+            #(#child_tokens)*
+            __el
+        })
+    }
 }
 
 // ---- Control-flow (Show / For) ------------------------------------------

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -603,14 +603,23 @@ impl CustomElementNode {
             let value = &kw.value;
             let kw_name = kw.name.to_string();
             let kw_span = kw.name.span();
+            // Mirror the built-in `__tags::*` kwarg lowering shape:
+            // - `style` / attributes: the user's expression is
+            //   placed *inside* an `effect(move || …)` so signal
+            //   reads inside the expression re-run on dep change.
+            //   The value itself must be `ToString` — closures
+            //   aren't a thing here; for dynamic styles users
+            //   embed `signal.get()` / `format!` inside the
+            //   expression and the effect handles re-evaluation.
+            // - `on_<event>`: a closure that's stored as the
+            //   element's event listener.
             if kw_name == "style" {
                 wiring.push(quote_spanned!(kw_span=> {
                     let __h = __el;
                     ::whisker::effect(move || {
-                        let __f = #value;
                         ::whisker::runtime::view::set_inline_styles(
                             __h,
-                            &::std::string::ToString::to_string(&__f()),
+                            &::std::string::ToString::to_string(&(#value)),
                         );
                     });
                 }));
@@ -624,15 +633,15 @@ impl CustomElementNode {
                     );
                 }));
             } else {
-                let attr_lit = LitStr::new(&kw_name, kw_span);
+                let attr_kebab = kw_name.replace('_', "-");
+                let attr_lit = LitStr::new(&attr_kebab, kw_span);
                 wiring.push(quote_spanned!(kw_span=> {
                     let __h = __el;
                     ::whisker::effect(move || {
-                        let __f = #value;
                         ::whisker::runtime::view::set_attribute(
                             __h,
                             #attr_lit,
-                            &::std::string::ToString::to_string(&__f()),
+                            &::std::string::ToString::to_string(&(#value)),
                         );
                     });
                 }));

--- a/crates/whisker-native-runtime/Cargo.toml
+++ b/crates/whisker-native-runtime/Cargo.toml
@@ -1,0 +1,21 @@
+# Phase 7 native-module / native-element runtime support.
+#
+# Houses the safe Rust wrapper for the Lynx native-module + tag-by-name
+# element C ABI, plus the helper types the `#[whisker::native_module]`
+# / `#[whisker::native_element]` proc-macros lower to.
+#
+# Skeleton-only at this revision (Phase 7-A.2). Real impl lands with
+# Phase 7-C (native module) — the crate just has to exist + compile
+# so dependents can take a dep on it now.
+
+[package]
+name = "whisker-native-runtime"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Native-module / native-element runtime support for Whisker (Phase 7)."
+
+[dependencies]

--- a/crates/whisker-native-runtime/src/lib.rs
+++ b/crates/whisker-native-runtime/src/lib.rs
@@ -1,0 +1,40 @@
+//! Native-module / native-element runtime support.
+//!
+//! Stub crate at this revision (Phase 7-A.2). The real surface —
+//! `PubValue`, `call_module`, `subscribe_module`, `EventStream` —
+//! lands with Phase 7-C alongside the `pub::Value` C ABI in Lynx.
+//!
+//! Kept in tree now so:
+//!
+//! - Downstream crates (proc-macros, sample modules) can take a dep
+//!   on it without waiting for the implementation.
+//! - The workspace's build / clippy / test pipeline catches any
+//!   schema drift at the API level early.
+//!
+//! See `docs/phase-7-design.md` for the broader architecture and
+//! `docs/whisker-module-toml.md` for the manifest schema this
+//! crate's eventual API connects to.
+
+/// Placeholder. The real type wraps a `*mut lynx_pub_value_t` from
+/// the Lynx fork's C ABI and exposes a safe Rust surface for
+/// constructing / inspecting `pub::Value`s. Phase 7-C lands the
+/// definition; for now this is a marker so module crates can
+/// already write `whisker_native_runtime::PubValue` in their
+/// signatures.
+#[derive(Debug)]
+pub struct PubValue(());
+
+/// Placeholder error type. Phase 7-C lands a real `ModuleError`
+/// enum covering platform-side errors + transport errors + decode
+/// failures.
+#[derive(Debug)]
+pub struct ModuleError(());
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn crate_compiles() {
+        // Smoke test: keep CI honest while the crate is still a stub.
+        // Real tests arrive with Phase 7-C.
+    }
+}

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -36,8 +36,8 @@ pub use into_view::{Children, IntoView, View};
 #[doc(hidden)]
 pub use renderer::__reset_children_mirror_for_tests;
 pub use renderer::{
-    append_child, child_index, children_of, create_element, current_renderer_id, flush,
-    insert_child_at, install_renderer, previous_sibling, release_element, remove_child,
-    set_attribute, set_event_listener, set_inline_styles, set_root, uninstall_renderer,
-    with_installed_renderer, DynRenderer,
+    append_child, child_index, children_of, create_element, create_element_by_name,
+    current_renderer_id, flush, insert_child_at, install_renderer, previous_sibling,
+    release_element, remove_child, set_attribute, set_event_listener, set_inline_styles, set_root,
+    uninstall_renderer, with_installed_renderer, DynRenderer,
 };

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -33,6 +33,11 @@ use crate::element::ElementTag;
 /// that maintains its own `Element → R::Element` map.
 pub trait DynRenderer {
     fn create_element(&mut self, tag: ElementTag) -> Element;
+    /// Phase 7: tag-by-name dispatch for custom / xelement-style
+    /// tags ("x-input", etc.) not in the built-in [`ElementTag`]
+    /// enum. Returns [`Element::INVALID`] when the tag is unknown
+    /// to Lynx's behaviour registry.
+    fn create_element_by_name(&mut self, tag_name: &str) -> Element;
     fn release_element(&mut self, handle: Element);
 
     fn set_attribute(&mut self, handle: Element, key: &str, value: &str);
@@ -129,6 +134,24 @@ fn with_renderer<R>(f: impl FnOnce(&mut dyn DynRenderer) -> R, default: R) -> R 
 // Free-function dispatch — what the `render!` macro and reactive
 // effects call.
 // ---------------------------------------------------------------------------
+
+/// Free-fn helper used by the `render!` macro and reactive effects to
+/// allocate an element of any tag the bridge knows. Routes both the
+/// built-in `ElementTag` enum and tag-by-name strings through the
+/// same owner-tracking + invalid-handle logic.
+pub fn create_element_by_name(tag_name: &str) -> Element {
+    let handle = with_renderer(|r| r.create_element_by_name(tag_name), Element(u32::MAX));
+    if handle.id() != u32::MAX {
+        crate::reactive::with_runtime(|rt| {
+            if let Some(owner_id) = rt.current_owner() {
+                if let Some(owner) = rt.owners.get_mut(owner_id) {
+                    owner.elements.push(handle);
+                }
+            }
+        });
+    }
+    handle
+}
 
 pub fn create_element(tag: ElementTag) -> Element {
     let handle = with_renderer(|r| r.create_element(tag), Element(u32::MAX));

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -10,6 +10,7 @@ use crate::element::ElementTag;
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
     Create { id: u32, tag: ElementTag },
+    CreateByName { id: u32, tag_name: String },
     Release { id: u32 },
     SetAttr { id: u32, key: String, value: String },
     SetStyles { id: u32, css: String },
@@ -39,6 +40,15 @@ impl DynRenderer for RecordingRenderer {
         let id = self.next_id;
         self.next_id += 1;
         self.ops.borrow_mut().push(Op::Create { id, tag });
+        Element::from_raw(id)
+    }
+    fn create_element_by_name(&mut self, tag_name: &str) -> Element {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.ops.borrow_mut().push(Op::CreateByName {
+            id,
+            tag_name: tag_name.into(),
+        });
         Element::from_raw(id)
     }
     fn release_element(&mut self, h: Element) {

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -46,6 +46,12 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, _h: Element) {}
     fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -49,7 +49,10 @@ impl DynRenderer for Recorder {
     fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
         let id = self.next;
         self.next += 1;
-        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
         Element::from_raw(id)
     }
     fn release_element(&mut self, _h: Element) {}

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -60,6 +60,12 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, h: Element) {
         self.log.borrow_mut().push(Op::Release { id: h.id() });
     }

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -63,7 +63,10 @@ impl DynRenderer for Recorder {
     fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
         let id = self.next;
         self.next += 1;
-        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
         Element::from_raw(id)
     }
     fn release_element(&mut self, h: Element) {

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -47,7 +47,10 @@ impl DynRenderer for Recorder {
     fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
         let id = self.next;
         self.next += 1;
-        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
         Element::from_raw(id)
     }
     fn release_element(&mut self, _h: Element) {}

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -44,6 +44,12 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, _h: Element) {}
     fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {

--- a/docs/phase-7-design.md
+++ b/docs/phase-7-design.md
@@ -1,0 +1,88 @@
+# Phase 7 — native module & native element support
+
+Design summary for the Phase 7 work. Captures the architectural
+decisions that came out of the design conversation; each subtask
+issue (#2, #3, #4, #6, #7) links back here.
+
+## Goal
+
+Let Whisker apps call platform-native (Kotlin / Swift) code and
+render platform-native UI elements from Rust, with a fully
+Whisker-branded developer surface — no `@Lynx*` annotations or
+`Lynx*` types leaking into user code.
+
+## Layer architecture
+
+```
+Rust user code
+    ↑
+#[whisker::native_module(…)] / #[whisker::native_element(…)] generated client / view
+    ↑
+whisker-native-runtime           ← safe Rust wrapper crate
+    ↑
+whisker-driver-sys C ABI         ← extern "C" bindings
+    ↑
+LynxNativeDirectModuleManager    ← 4th sibling of LynxJSIModuleManager
+                                    (Whisker addition; no JS engine)
+    ↑
+LynxNativeModule::InvokeMethod / ElementManager::CreateFiberNode
+                                                    (Lynx upstream)
+    ↑
+runtime-platforms/android        ← Kotlin @WhiskerModule → @LynxBehavior via KSP
+runtime-platforms/ios            ← Swift @WhiskerModule → LynxUI subclass via Swift Macros
+    ↑
+User's Kotlin / Swift code, distributed via cargo
+```
+
+## Key design decisions
+
+| Decision | Rationale |
+|----------|---------|
+| **Whisker-branded annotations everywhere** | `@WhiskerModule`, `@WhiskerElement`, `@WhiskerMethod`, `@WhiskerProp`, `@WhiskerEvent` on the platform side. KSP (Android) / Swift Macros (iOS) lower to Lynx's registration mechanisms underneath. Users never type `@Lynx*` anything. |
+| **Distinct macro names** | `#[whisker::native_module]` and `#[whisker::native_element]` — the two surfaces are different enough (Stream subscriptions vs prop setters) that combining was awkward. |
+| **`pub::Value` direct over C ABI** | The internal Lynx variant type travels as an opaque pointer between Rust and C++. No JSON. Bytes go through `byte_array` — no base64 wire bloat for images / audio. The ABI is wide (per-type builder fns) but the user wrapper hides it. |
+| **`async fn → Result<T, E>` for one-shot results** | Standard async Rust. Dropping the future is a no-op (no cancellation semantics in v1). |
+| **`fn → impl Stream<Item = Result<T, E>>` for subscriptions** | The Rust async-stream pattern. Drop = unsubscribe — the `Stream`'s `Drop` impl calls `lynx_unsubscribe_native_module`. Events carry `Result<T, _>` so transient errors (sensor permission dropped, etc.) flow through the stream without breaking the subscription. |
+| **iOS package manager: SPM only** | CocoaPods support dropped. 2026 ecosystem survey: every major SDK (Firebase, Alamofire, Realm, Sentry, …) has shipped SPM support. RN / Flutter are also migrating to SPM. |
+| **Module distribution: cargo, with native sources bundled** | A module crate is one `cargo publish` — its `Cargo.toml` `include` field bundles `android/` and `ios/` directories alongside Rust. No Maven / SPM publishing in v1. Optional binary-cache (`[android.prebuilt]`) is future work. |
+| **`whisker.module.toml` manifest filename** | Dot-separated namespace lets future `whisker.app.toml` / `whisker.workspace.toml` slot in. See [`whisker-module-toml.md`](./whisker-module-toml.md) for the full schema. |
+| **Native deps live in real `build.gradle.kts` / `Package.swift`** | Earlier design pass duplicated them in `whisker.module.toml`; that broke Android Studio / Xcode autocomplete. Now the IDE opens the module's native project directly and sees normal Gradle / SPM files. The manifest only points at paths. |
+| **`runtime-platforms/{android,ios}/` workspace dirs** | Distinct from `crates/` (Rust-only). Host the Kotlin gradle project + Swift SPM package. Wired into user apps' `gen/android/` and `gen/ios/` by the autolink layer (Phase 7-D). |
+| **Local modules (Expo-style)** | `modules/*/whisker.module.toml` as path deps in the user app's `Cargo.toml`. Same autolink pipeline as crates.io-resolved modules. No special "local module" code path. |
+| **First-party xelement library** | Whisker ships its own `whisker-element-input` / `whisker-element-refresh` / `whisker-element-overlay` / `whisker-element-svg` / `whisker-element-webview`. Lynx's `lynx_xelement_*` packages are reference material only — not used at runtime. |
+| **Version compatibility via cargo semver** | Each module declares `whisker = "0.x"` like a normal cargo dep. Cargo's resolver enforces compatibility. Native runtime version is auto-pinned to the user's Whisker version by `whisker-cli`. |
+
+## Workspace layout
+
+```
+whisker/
+├── crates/
+│   ├── whisker-driver/
+│   ├── whisker-driver-sys/         ← extended: pub::Value C ABI, call_module
+│   ├── whisker-runtime/            ← extended: ElementTag::Custom + create_element_by_name
+│   ├── whisker-native-runtime/     ← NEW: safe wrapper + proc-macro helpers (Phase 7-A.2)
+│   ├── whisker-macros/             ← extended: #[whisker::native_module/_element]
+│   ├── whisker-build/              ← extended: module discovery
+│   ├── whisker-cng/                ← extended: gen/* materialisation
+│   └── …
+└── runtime-platforms/              ← NEW (Phase 7-A.3 / A.4)
+    ├── android/                    ← gradle project: WhiskerView, KSP processor
+    └── ios/                        ← SPM package: WhiskerView, Swift Macros
+```
+
+## Subtask map
+
+| # | Subtask | Status |
+|---|---------|-------|
+| #7 | 7-A Foundation: schema lock + runtime-platforms skeleton + this doc | started; this PR |
+| #2 | 7-B Native Element: C API tag-by-name + render! support + `@WhiskerElement` runtime + sample | layers 1-4 + iOS smoke test in this PR |
+| #4 | 7-C Native Module: pub::Value C ABI + `LynxNativeDirectModuleManager` + `#[whisker::native_module]` | pending |
+| #6 | 7-D Autolink: discovery (whisker-build) + materialisation (whisker-cng via includeBuild + local SPM) | pending |
+| #3 | 7-E First-party xelement library | pending |
+| #1 | Epic | tracking |
+
+## See also
+
+- [`whisker-module-toml.md`](./whisker-module-toml.md) — manifest schema reference
+- [`hot-reload-plan.md`](./hot-reload-plan.md) — Tier 1 hot-reload pipeline (Phase 6.5)
+- [`architecture.md`](./architecture.md) — workspace overview

--- a/docs/whisker-module-toml.md
+++ b/docs/whisker-module-toml.md
@@ -1,0 +1,279 @@
+# `whisker.module.toml` — schema reference
+
+The manifest file every Whisker native module / native element crate
+ships at its root. Read by `whisker-build` during autolink; consumed
+by `whisker-cng` to materialise the module into the user app's
+`gen/android/` and `gen/ios/` projects.
+
+Status: **schema v1** (Phase 7-A). Deliberately minimal — see
+[Why so minimal?](#why-so-minimal) below. Adding new fields is
+non-breaking; removing fields or changing semantics is breaking and
+will gate on a top-level `schema = 2` migration.
+
+## File location
+
+Lives **at the crate root, next to `Cargo.toml`**:
+
+```
+whisker-module-camera/
+├── Cargo.toml
+├── whisker.module.toml      ← this file
+├── src/lib.rs
+├── android/
+│   ├── build.gradle.kts
+│   └── src/main/kotlin/.../Camera.kt
+└── ios/
+    ├── Package.swift
+    └── Sources/Camera/Camera.swift
+```
+
+### Why `whisker.module.toml`, not `whisker.toml`
+
+`whisker.toml` is reserved for **app-level configuration** (target
+selection, signing identity, bundle id, etc.) that a Whisker
+*application* crate will eventually need. The dot-separated
+namespace lets future siblings — `whisker.app.toml`,
+`whisker.workspace.toml` — slot in without renaming this one.
+
+## Full schema
+
+```toml
+[android]
+gradle_project = "android"            # path to gradle module (relative to crate root)
+
+[ios]
+swift_package = "ios"                 # path to SPM package (relative to crate root)
+```
+
+That's the entire v1 schema. **No `[module]`, no `kind`, no `name`,
+no `version`, no module / element listings.** See
+[Why so minimal?](#why-so-minimal).
+
+### `[android]` section
+
+Optional. Omit when the module is iOS-only.
+
+| Field | Type | Required | Notes |
+|-------|------|---------|-------|
+| `gradle_project` | path | yes | Path (relative to crate root) to the module's gradle project. `whisker-cng` adds this via `includeBuild()` to the user app's `settings.gradle.kts`. The path's contents are a **real** gradle module — open in Android Studio for full IDE autocomplete. Dependencies, AndroidManifest entries, ProGuard rules all live inside the gradle project itself. |
+
+### `[ios]` section
+
+Optional. Omit when the module is Android-only.
+
+| Field | Type | Required | Notes |
+|-------|------|---------|-------|
+| `swift_package` | path | yes | Path (relative to crate root) to the module's Swift Package directory (the one containing `Package.swift`). `whisker-cng` adds it as a local package reference to the user app's xcodeproj. As with Android, the path's contents are a **real** SPM package — open `Package.swift` in Xcode for full IDE autocomplete. Native deps live in `Package.swift`. |
+
+### Platform expression
+
+The presence / absence of sections expresses platform support:
+
+| `[android]` | `[ios]` | Means |
+|---|---|---|
+| ✓ | ✓ | Cross-platform module |
+| ✓ | ✗ | Android-only |
+| ✗ | ✓ | iOS-only |
+| ✗ | ✗ | No `whisker.module.toml` needed — this is just a normal Rust crate |
+
+## Why so minimal?
+
+Every piece of information you might expect in this file already
+lives elsewhere — `Cargo.toml` for crate identity, the native config
+files for dependencies, the source annotations for module/element
+identifiers. Duplicating any of it would create two sources of
+truth that can drift apart.
+
+| Question | Authoritative source |
+|----------|---------------------|
+| What's this crate called? | `Cargo.toml` `[package].name` |
+| What version? | `Cargo.toml` `[package].version` |
+| What native modules does it register? | `@WhiskerModule(name = "Camera")` in Kotlin / `@WhiskerModule("Camera")` in Swift / `#[whisker::native_module("Camera")]` in Rust |
+| What native elements? Which tags? | `@WhiskerElement(tag = "x-input")` in Kotlin / Swift / `#[whisker::native_element("x-input")]` in Rust |
+| Android Gradle dependencies? | The module's own `build.gradle.kts` |
+| AndroidManifest permissions, services, activities? | The module's own `AndroidManifest.xml` |
+| iOS SPM dependencies? | The module's own `Package.swift` |
+| Info.plist additions? | The module's own `Info.plist` |
+| Whisker version compatibility? | `Cargo.toml` `[dependencies].whisker = "0.x"` — cargo's semver resolution handles it |
+
+The role of `whisker.module.toml` is purely: **"this crate has
+native code that should be autolinked, and here are the paths to
+the gradle / SPM projects"**. Everything else is inferred.
+
+## Multiple modules / elements per crate
+
+Supported, with no schema change. A single crate can register any
+number of modules and / or elements — the count is decided by how
+many `@Whisker*` annotations live in the native sources:
+
+```kotlin
+// android/src/main/kotlin/com/example/Essentials.kt
+
+@WhiskerElement(tag = "x-input")
+class InputElement(ctx: WhiskerContext) : WhiskerView<EditText>(ctx) { … }
+
+@WhiskerElement(tag = "x-refresh")
+class RefreshElement(ctx: WhiskerContext) : WhiskerView<SwipeRefreshLayout>(ctx) { … }
+
+@WhiskerModule(name = "FileSystem")
+class FileSystemModule(ctx: WhiskerContext) { … }
+```
+
+```rust
+// src/lib.rs
+
+#[whisker::native_element("x-input")]
+pub struct Input { … }
+
+#[whisker::native_element("x-refresh")]
+pub struct Refresh { … }
+
+#[whisker::native_module("FileSystem")]
+pub trait FileSystem { … }
+```
+
+`whisker.module.toml` stays the same — just `[android]` +
+`[ios]`. KSP / Swift Macros pick up every `@Whisker*` annotation
+in the gradle / SPM project; the Rust proc-macros emit one client
+per `#[whisker::*]` invocation.
+
+### Naming conventions (no enforcement)
+
+| Pattern | Example | Used for |
+|---------|---------|---------|
+| `whisker-module-<name>` | `whisker-module-camera` | A single native module |
+| `whisker-element-<name>` | `whisker-element-input` | A single native element |
+| `whisker-elements-<group>` | `whisker-elements-essentials` | A bundle of related elements |
+| `whisker-<feature>` | `whisker-camera` | Mixed module + element bundle |
+
+These are conventions only. `whisker-build` doesn't enforce any
+pattern.
+
+## Examples
+
+### Native module (Android + iOS)
+
+```toml
+[android]
+gradle_project = "android"
+
+[ios]
+swift_package = "ios"
+```
+
+```
+whisker-module-localstorage/
+├── Cargo.toml
+├── whisker.module.toml
+├── src/lib.rs                          # #[whisker::native_module("LocalStorage")] trait
+├── android/
+│   ├── build.gradle.kts
+│   └── src/main/kotlin/.../LocalStorageModule.kt
+└── ios/
+    ├── Package.swift
+    └── Sources/LocalStorage/LocalStorageModule.swift
+```
+
+### iOS-only element
+
+```toml
+[ios]
+swift_package = "ios"
+```
+
+`[android]` is absent → `whisker-build` skips this crate when
+building for Android.
+
+### Local module in user app
+
+```
+my-app/
+├── Cargo.toml
+├── src/main.rs
+└── modules/
+    └── my-analytics/
+        ├── Cargo.toml
+        ├── whisker.module.toml         # ← same schema as published modules
+        ├── src/lib.rs
+        ├── android/…
+        └── ios/…
+```
+
+```toml
+# my-app/Cargo.toml
+[dependencies]
+my-analytics = { path = "modules/my-analytics" }
+```
+
+The autolink discovery walks the user's `cargo metadata` and finds
+`my-analytics`'s `whisker.module.toml` via the path dep — no
+distinction from a crates.io-resolved module.
+
+## Discovery flow (informative)
+
+`whisker-build::modules::discover_modules(workspace_root, package)`:
+
+1. Run `cargo metadata --manifest-path <pkg>/Cargo.toml --format-version 1`.
+2. For every resolved package in the dependency graph (including
+   path deps): check `<crate_root>/whisker.module.toml`.
+3. Parse each found file into a `ModuleManifest` struct (the type
+   lives in `whisker-cng::module_manifest`).
+4. Return the vector.
+
+`whisker-cng` then walks the vector to materialise `gen/android/`
+and `gen/ios/`.
+
+## Conflict handling (cross-reference)
+
+The autolink layer enforces the following at gen-time or surfaces
+errors at native compile / runtime:
+
+- **`gradle_project` / `swift_package` path doesn't exist** →
+  hard error at autolink with the manifest line.
+- **Two modules registering the same `@WhiskerModule(name = "X")`** →
+  Lynx-side registration error at runtime startup.
+- **Two elements registering the same tag** → Lynx-side
+  registration error at runtime startup (LazyRegister duplicate
+  detection).
+- **Native dependency version mismatches across modules** → Gradle's
+  resolution strategy picks one + emits a warning; SPM ditto.
+
+For comprehensive pre-flight checking of these (so the user sees
+them at `whisker build` time instead of at runtime), a `whisker
+doctor` extension can scan `@Whisker*` annotations / proc-macro
+invocations across all modules — deferred until Phase 8+ if it
+matters.
+
+## Future fields (not in v1)
+
+Designed-but-not-implemented fields that v2 may add when concrete
+demand appears. Listed here so v1 manifests survive the migration:
+
+| Field | Purpose | Trigger to add |
+|-------|--------|---------------|
+| `[[elements]] tag_names = [...]` | Pre-flight tag conflict detection without parsing Kotlin/Swift | When duplicate-tag errors at runtime become a frequent papercut |
+| `[[modules]] name = "..."` | Pre-flight module-name conflict detection | Same as above for modules |
+| `[android.prebuilt] maven = "..."` | Binary cache (skip Kotlin compile) | When build times for popular modules become a bottleneck |
+| `[ios.prebuilt] xcframework_url = "..."` | Same on iOS | Same as above |
+| `[requires] whisker = ">=0.8"` | Min host-Whisker version | When `Cargo.toml` semver isn't enough (rare) |
+| `[supports] platforms = ["ios"]` | Per-item platform exclusion within a multi-item crate | When a single crate needs different platform sets per item |
+
+Adding any of these is non-breaking — v1 manifests stay valid.
+
+## Filename precedent
+
+| Prior art | Filename | Decision |
+|-----------|---------|---------|
+| `tsconfig.json` | TypeScript compiler config — short, dot-named | too generic for a per-module manifest |
+| `expo-module.config.json` | Expo modules | rejected: long, JSON not TOML, doesn't follow the host package's filename style |
+| `Cargo.toml` | Rust packages | rejected: clash with cargo itself |
+| `whisker.toml` | considered | rejected: reserved for app-level config |
+| `whisker.module.toml` | **chosen** | dot-separated namespace lets future `whisker.app.toml` / `whisker.workspace.toml` slot in without rename |
+
+## Stability
+
+Schema v1 is stable for the Phase 7 / Whisker 0.x line. Additions
+that preserve v1 behaviour are non-breaking and don't require a
+manifest version bump. Breaking changes (removing fields, changing
+semantics) introduce a `schema = 2` top-level field with a
+migration guide.

--- a/examples/counter/tests/counter_renders.rs
+++ b/examples/counter/tests/counter_renders.rs
@@ -47,6 +47,12 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, _h: Element) {}
     fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {

--- a/examples/counter/tests/counter_renders.rs
+++ b/examples/counter/tests/counter_renders.rs
@@ -50,7 +50,10 @@ impl DynRenderer for Recorder {
     fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
         let id = self.next;
         self.next += 1;
-        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
         Element::from_raw(id)
     }
     fn release_element(&mut self, _h: Element) {}

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -460,6 +460,16 @@ fn app() -> Element {
     );
     render! {
         page(style: page_style) {
+            // Phase 7-B smoke test: a native element registered via
+            // Lynx's behaviour registry (`LYNX_REGISTER_UI("x-hello")`
+            // in `whisker_hello_element.mm`) and reached from Rust
+            // through the new tag-by-name path
+            // (`render!`'s `"x-hello"` syntax →
+            // `view::create_element_by_name` →
+            // `whisker_bridge_create_element_by_name` →
+            // `lynx_create_fiber_element_by_name`). A pink bar at
+            // the top means the entire chain works end-to-end.
+            "x-hello"(style: "width: 100%; height: 8px;") {}
             Header()
             ScrollBody(state: state)
             NowPlaying(state: state)

--- a/examples/hn-reader/tests/render.rs
+++ b/examples/hn-reader/tests/render.rs
@@ -46,6 +46,12 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, _h: Element) {}
     fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {

--- a/examples/hn-reader/tests/render.rs
+++ b/examples/hn-reader/tests/render.rs
@@ -49,7 +49,10 @@ impl DynRenderer for Recorder {
     fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
         let id = self.next;
         self.next += 1;
-        self.log.borrow_mut().push(Op::Create { id, tag: ElementTag::View });
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
         Element::from_raw(id)
     }
     fn release_element(&mut self, _h: Element) {}

--- a/runtime-platforms/android/README.md
+++ b/runtime-platforms/android/README.md
@@ -1,0 +1,31 @@
+# whisker-native-runtime (Android)
+
+Phase 7 skeleton. Final shape:
+
+- `runtime/` — Kotlin library AAR. Houses:
+  - `@WhiskerModule`, `@WhiskerElement`, `@WhiskerMethod`,
+    `@WhiskerProp`, `@WhiskerEvent`, `@WhiskerSubscription`
+    annotation classes (open class bodies, no behaviour).
+  - `WhiskerView<V : View>` base class (Lynx `LynxUI` subclass
+    wrapping the user's `View`).
+  - `WhiskerContext`, `WhiskerCallback`, `WhiskerEventEmitter`
+    helper types.
+- `ksp-processor/` — KSP `SymbolProcessor` that scans for
+  `@Whisker*`-annotated classes and emits `LynxUI` /
+  `LynxNativeModule` subclasses + `@LynxBehavior` /
+  `@LynxMethod` registrations underneath.
+
+Both subprojects are stubs today (Phase 7-A.3). Real implementations
+land with Phase 7-B.5 (element runtime) and Phase 7-C (module
+runtime).
+
+## Building (manual)
+
+```sh
+cd runtime-platforms/android
+./gradlew assembleRelease
+```
+
+The autolink layer (`whisker-cng`, Phase 7-D) wires this into the
+user app's `gen/android/` via `includeBuild` — no `./gradlew`
+invocation by the user.

--- a/runtime-platforms/android/build.gradle.kts
+++ b/runtime-platforms/android/build.gradle.kts
@@ -1,0 +1,20 @@
+// WhiskerNativeRuntime (Android) — Phase 7-A.3 skeleton.
+//
+// Hosts the `@WhiskerModule` / `@WhiskerElement` annotation classes
+// + the `WhiskerView<T>` base class + the KSP processor that
+// rewrites Whisker-namespaced annotations into the underlying Lynx
+// `@LynxBehavior` / `@LynxMethod` / `@LynxProp` registrations.
+//
+// Today this file declares an empty Android library so:
+//   - `./gradlew :runtime:assembleRelease` succeeds.
+//   - Module crates can declare a Maven coordinate against this
+//     module before its real implementation lands.
+//
+// Real classes + KSP processor arrive with Phase 7-B.5 (element
+// side) and Phase 7-C (module side). For now the skeleton only
+// proves the project layout compiles.
+
+plugins {
+    id("com.android.library") version "8.2.0" apply false
+    kotlin("android") version "1.9.20" apply false
+}

--- a/runtime-platforms/android/settings.gradle.kts
+++ b/runtime-platforms/android/settings.gradle.kts
@@ -1,0 +1,20 @@
+// Phase 7-A.3 skeleton. Standalone gradle project — included via
+// `includeBuild` from the user app's `gen/android/settings.gradle.kts`
+// when autolink (Phase 7-D) materialises it.
+
+rootProject.name = "whisker-native-runtime-android"
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/runtime-platforms/ios/Package.swift
+++ b/runtime-platforms/ios/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.9
+
+// WhiskerNativeRuntime — the platform-side runtime that Whisker
+// native-module / native-element authors build against.
+//
+// Phase 7-A.4 skeleton only. Today's contents are stubs that exist
+// so:
+//   - The workspace's CI (or a manual `swift build`) catches package-
+//     manifest drift early.
+//   - Native module crates can declare a dependency on this package
+//     before the real `@WhiskerModule` / `@WhiskerElement` Swift
+//     Macro implementation lands in Phase 7-B.6 / 7-C.
+//
+// Real `WhiskerView<T>` base class, `@WhiskerModule` /
+// `@WhiskerElement` Swift Macro plugins, and `WhiskerContext` /
+// `WhiskerCallback` arrive with the matching Phase 7 subtasks.
+
+import PackageDescription
+
+let package = Package(
+    name: "WhiskerNativeRuntime",
+    platforms: [
+        .iOS(.v13),
+    ],
+    products: [
+        .library(name: "WhiskerNativeRuntime", targets: ["WhiskerNativeRuntime"]),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerNativeRuntime",
+            path: "Sources/WhiskerNativeRuntime"
+        ),
+    ]
+)

--- a/runtime-platforms/ios/Sources/WhiskerNativeRuntime/WhiskerNativeRuntime.swift
+++ b/runtime-platforms/ios/Sources/WhiskerNativeRuntime/WhiskerNativeRuntime.swift
@@ -1,0 +1,27 @@
+// Phase 7-A.4 skeleton.
+//
+// Final shape (Phase 7-B.6 + 7-C):
+//
+//   open class WhiskerView<V: UIView>: LynxUI<V> { … }
+//
+//   @attached(member, names: arbitrary)
+//   public macro WhiskerElement(_ tag: String) = #externalMacro(
+//       module: "WhiskerNativeRuntimeMacros",
+//       type: "WhiskerElementMacro")
+//
+//   @attached(member, names: arbitrary)
+//   public macro WhiskerModule(_ name: String) = #externalMacro(
+//       module: "WhiskerNativeRuntimeMacros",
+//       type: "WhiskerModuleMacro")
+//
+// For now this file just declares the module's existence so the
+// SPM package builds cleanly and downstream module crates can
+// declare a dep on it.
+
+import Foundation
+
+/// Sentinel value so `swift build` produces a non-empty module.
+/// Removed in Phase 7-B.6 once the real surface lands.
+public enum WhiskerNativeRuntime {
+    public static let schema: String = "phase-7-a.4"
+}


### PR DESCRIPTION
Phase 7 kickoff PR: foundation skeletons + the full tag-by-name element chain wired up end-to-end to the iOS simulator.

## What's in this PR

### Phase 7-A — foundation

| File | What |
|------|------|
| \`docs/whisker-module-toml.md\` | Schema v1 lock for the per-module manifest |
| \`docs/phase-7-design.md\` | Design summary capturing every architectural decision |
| \`crates/whisker-native-runtime/\` | Stub crate exposing \`PubValue\` / \`ModuleError\` (real impl Phase 7-C) |
| \`runtime-platforms/ios/\` | SPM \`Package.swift\` skeleton — \`swift build\`-able stub |
| \`runtime-platforms/android/\` | Gradle skeleton |

### Phase 7-B — Native Element end-to-end

Layer-by-layer chain from \`render! { \"x-hello\" {} }\` in Rust down to a rendered \`UIView\` on the iOS simulator:

1. **Lynx C ABI** — \`lynx_create_fiber_element_by_name(shell, tag_name)\` in \`lynx_native_renderer_capi.h\` + \`lynx_native_renderer.cc\`. Delegates to \`ElementManager::CreateFiberNode\`.
2. **Whisker bridge** — \`whisker_bridge_create_element_by_name(engine, tag_name)\` in \`whisker_bridge.h\` + \`whisker_bridge_common.cc\`. Added to \`BRIDGE_EXPORTS\` so the symbol survives Mach-O linking. Mirror extern decl in \`whisker-driver-sys::src/lib.rs\`.
3. **Rust runtime** — \`DynRenderer::create_element_by_name(&str) -> Element\`. \`BridgeRenderer\` wraps the C ABI; free-fn \`view::create_element_by_name\` mirrors \`view::create_element\` (owner tracking + invalid-handle guard).
4. **\`render!\` macro** — new \`Node::CustomElement\` variant. Parser accepts \`\"x-input\" { … }\` / \`\"x-input\"(…)\` syntax. Codegen lowers to \`create_element_by_name\` + reactive \`set_attribute\` / \`set_inline_styles\` + \`set_event_listener\` + \`append_child\`. Kwarg conventions: \`style: expr\` → reactive styles, \`on_<event>: closure\` → event listener, \`<name>: expr\` → reactive attribute (\`_\` → \`-\` kebab conversion).
5. **iOS sample** — \`whisker_hello_element.mm\` registers an \`x-hello\` tag (\`LYNX_REGISTER_UI\`) as a \`LynxUI<UIView>\` subclass with a system-pink background. Added to \`whisker-driver-sys/build.rs\`'s iOS \`.file(...)\` list. \`examples/hello-world\` uses \`render! { … \"x-hello\"(style: \"width: 100%; height: 8px;\") {} … }\` as a smoke-test banner at the top of the page.

## How to verify

\`\`\`
whisker run --target ios
\`\`\`

If the entire chain works you'll see a thin pink bar at the very top of the hello-world screen. That single bar is hand-registered via Lynx's behaviour registry — its existence proves that the new tag-by-name CAPI + bridge + Rust runtime + \`render!\` syntax all line up.

## What's NOT in this PR

- **Android side of Native Element** (7-B.5) — Lynx fork update needed to add \`lynx_create_fiber_element_by_name\` to \`liblynx.so\`; on iOS we compile it ourselves into WhiskerDriver, so the iOS side works without a Lynx fork release.
- **\`@WhiskerElement\` Swift Macro / Kotlin KSP** (7-B.5 / 7-B.6) — the \`x-hello\` sample uses raw \`LYNX_REGISTER_UI\` directly for the smoke test. The full \`@WhiskerElement\` user-facing surface lands when the runtime-platforms/ios + runtime-platforms/android skeletons grow real code.
- **Native module C ABI + \`#[whisker::native_module]\`** (7-C) — separate PR.
- **Autolink** (7-D) — separate PR.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` (all green)
- [x] iOS-sim rustc build succeeds against the new C ABI
- [ ] **Manual**: \`whisker run --target ios\` → pink bar visible at top of hello-world

## Issues

- Closes the implementation slice for #7 (Phase 7-A Foundation) — except the design doc cross-link section will keep updating as later subtasks land
- Implements layers 1-4 of #2 (Phase 7-B Native Element) — Android side + \`@WhiskerElement\` Swift Macro deferred to follow-up PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)