### PR TITLE
Phase 7-Φ.E: hello-world reactive helpers migrated to computed

### DIFF
--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -146,14 +146,18 @@ fn grid_tile(
     let on_heart = move || bitmask.update(|b| *b ^= liked_bit);
 
     // Heart appearance — driven reactively off the bitmask signal.
-    let heart_glyph = move || {
+    // Φ.B removed the render! macro's `move ||` auto-wrap, so a bare
+    // call like `value: heart_glyph()` becomes a one-shot snapshot.
+    // We route through `computed` so the read sits inside an effect
+    // and re-fires when bitmask changes.
+    let heart_glyph = computed(move || {
         if bitmask.get() & liked_bit != 0 {
-            "♥"
+            "♥".to_string()
         } else {
-            "♡"
+            "♡".to_string()
         }
-    };
-    let heart_style = move || {
+    });
+    let heart_style = computed(move || {
         let color = if bitmask.get() & liked_bit != 0 {
             ACCENT_2
         } else {
@@ -165,7 +169,7 @@ fn grid_tile(
              background-color: rgba(0,0,0,0.45); color: {color}; \
              font-size: 16px; text-align: center; line-height: 28px;"
         )
-    };
+    });
     let title_style =
         format!("font-size: 14px; font-weight: 600; color: {TEXT_PRIMARY}; margin-top: 10px;");
     let sub_style = format!("font-size: 11px; color: {TEXT_SECONDARY}; margin-top: 2px;");
@@ -176,7 +180,7 @@ fn grid_tile(
                      display: flex; flex-direction: column;") {
             view(style: "position: relative; width: 100%;") {
                 ArtTile(c1: c1, c2: c2, w: "100%", radius: "10px")
-                text(style: heart_style(), on_tap: on_heart, value: heart_glyph())
+                text(style: heart_style, on_tap: on_heart, value: heart_glyph)
             }
             text(style: title_style, value: title)
             text(style: sub_style, value: "Daily Mix")
@@ -225,28 +229,28 @@ fn activity_row(
 fn tab_item(index: usize, label: &'static str, glyph: &'static str, state: AppState) -> Element {
     let tab = state.selected_tab;
     let on_pick = move || tab.set(index);
-    let glyph_style = move || {
+    let glyph_style = computed(move || {
         let color = if tab.get() == index {
             ACCENT
         } else {
             TEXT_MUTED
         };
         format!("font-size: 22px; color: {color};")
-    };
-    let label_style = move || {
+    });
+    let label_style = computed(move || {
         let selected = tab.get() == index;
         let color = if selected { ACCENT } else { TEXT_MUTED };
         let weight = if selected { 700 } else { 500 };
         format!("font-size: 11px; color: {color}; font-weight: {weight};")
-    };
+    });
     render! {
         view(
             style: "display: flex; flex-direction: column; align-items: center; \
                     gap: 4px; padding: 4px 12px;",
             on_tap: on_pick,
         ) {
-            text(style: glyph_style(), value: glyph)
-            text(style: label_style(), value: label)
+            text(style: glyph_style, value: glyph)
+            text(style: label_style, value: label)
         }
     }
 }
@@ -274,14 +278,20 @@ fn tab_bar(state: AppState) -> Element {
 fn now_playing(state: AppState) -> Element {
     let playing = state.is_playing;
     let toggle = move || playing.update(|p| *p = !*p);
-    let glyph = move || if playing.get() { "▌▌" } else { "▶" };
-    let status = move || {
+    let glyph = computed(move || {
         if playing.get() {
-            "Lo-Fi Beats · playing"
+            "▌▌".to_string()
         } else {
-            "Lo-Fi Beats · paused"
+            "▶".to_string()
         }
-    };
+    });
+    let status = computed(move || {
+        if playing.get() {
+            "Lo-Fi Beats · playing".to_string()
+        } else {
+            "Lo-Fi Beats · paused".to_string()
+        }
+    });
     let container_style = format!(
         "position: absolute; left: 12px; right: 12px; bottom: 78px; \
          display: flex; flex-direction: row; align-items: center; \
@@ -300,9 +310,9 @@ fn now_playing(state: AppState) -> Element {
             ArtTile(c1: "#ff7e5f", c2: "#feb47b", w: "48px", radius: "8px")
             view(style: "flex: 1; padding: 0 12px; display: flex; flex-direction: column;") {
                 text(style: title_style, value: "Sunset Drive")
-                text(style: sub_style, value: status())
+                text(style: sub_style, value: status)
             }
-            text(style: btn_style, on_tap: toggle, value: glyph())
+            text(style: btn_style, on_tap: toggle, value: glyph)
         }
     }
 }


### PR DESCRIPTION
Visual-reactivity audit after Phase 7-Φ.B's macro auto-wrap removal.

## Problem

Pre-Φ.B, hello-world used the let-closure-then-call pattern for reactive UI bits:

\`\`\`rust
let heart_glyph = move || if bitmask.get() & bit != 0 { \"♥\" } else { \"♡\" };
text(value: heart_glyph())   // ← reactive via macro auto-wrap
\`\`\`

The macro wrapped each kwarg in \`move || …to_string()\`, so the inner signal read happened *inside* the effect closure, making the read tracked.

Φ.B made that wrap explicit: kwargs flow verbatim into the builder method, which dispatches on \`Signal<T>::Static\` (set-once) vs \`Signal<T>::Dynamic\` (effect-wrapped). \`text(value: heart_glyph())\` now produces a static snapshot — the closure is called once at render-emission time, no signal subscription registered.

## Fix

Switch each let-closure to a \`computed(...)\`, and pass the resulting \`ReadSignal<T>\` to the prop:

\`\`\`rust
let heart_glyph = computed(move || if bitmask.get() & bit != 0 { \"♥\".to_string() } else { \"♡\".to_string() });
text(value: heart_glyph)   // → Signal::Dynamic, reactive
\`\`\`

Five helpers updated:

| Component   | Helper                         | Reads          |
|-------------|--------------------------------|----------------|
| grid_tile   | \`heart_glyph\`, \`heart_style\`   | \`bitmask\`      |
| tab_item    | \`glyph_style\`, \`label_style\`   | \`selected_tab\` |
| now_playing | \`glyph\`, \`status\`              | \`is_playing\`   |

## hn-reader

No migration needed — its reactive surfaces are \`Show(when:, fallback:)\` and \`For(each:)\` which route through render!'s ControlFlow emit path, not the kwarg_to_setter that Φ.B touched. \`when\` / \`fallback\` / \`each\` closures pass through verbatim into \`view::show\` / \`view::for_each\` and run inside their own internal effects, same as before.

## Verification

iOS sim end-to-end:

- **hello-world**: launches with all sections (Recently Played, Made For You, Your Top Mixes with heart states, Now Playing with pause glyph + status, tab bar with Home highlighted). All five computed-driven props in the initial render.
- **hn-reader**: launches → 80ms later transitions from Loading to a list of HN front-page stories. The Show + For + resource chain works through the same scheduling path my Φ.B changes added regression tests for.

## Scope

Tiny — just call-site migrations inside one example file. No public API change, no test changes (the example crates' tests run against the in-memory renderer and don't exercise the reactive prop chain).

## Why a separate PR

PR #30 was already merged with the core mechanism; rolling this audit into that PR would have kept it from landing while we explored the hn-reader Loading-stuck bug. Keeping the migration small and isolated lets it merge fast and serves as the worked example for the migration guide work in Phase 7-Φ.F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)