### PR TITLE
Phase 7-Φ.D: native_element proc-macro + Lynx C ABI integration

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,6 +49,7 @@ const BRIDGE_EXPORTS: &[&str] = &[
     "_whisker_bridge_engine_release",
     "_whisker_bridge_dispatch",
     "_whisker_bridge_create_element",
+    "_whisker_bridge_create_element_by_name",
     "_whisker_bridge_release_element",
     "_whisker_bridge_set_attribute",
     "_whisker_bridge_set_inline_styles",

--- a/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
@@ -79,6 +79,15 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT lynx_fiber_element_t* lynx_create_fiber_element
     lynx_shell_t* shell,
     lynx_element_tag_e tag);
 
+// Phase 7: tag-by-name element creation. Used for xelement / custom
+// elements registered via `@LynxBehavior(name = "x-foo")` etc. that
+// aren't in the built-in enum. Implementation delegates to
+// `ElementManager::CreateFiberNode(base::String(tag_name))`, the
+// same factory ReactLynx uses for non-built-in tags. Returns nullptr
+// if `tag_name` is null/empty or unknown.
+LYNX_NATIVE_RENDERER_CAPI_EXPORT lynx_fiber_element_t*
+lynx_create_fiber_element_by_name(lynx_shell_t* shell, const char* tag_name);
+
 LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_release(
     lynx_fiber_element_t* element);
 

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -88,6 +88,15 @@ WHISKER_BRIDGE_EXPORT bool whisker_bridge_dispatch(WhiskerEngine* engine,
 
 WHISKER_BRIDGE_EXPORT WhiskerElement* whisker_bridge_create_element(WhiskerEngine* engine, WhiskerElementTag tag);
 
+// Phase 7: tag-by-name element creation for custom / xelement-style
+// tags ("x-input", "x-camera-preview", …) not covered by the
+// `WhiskerElementTag` enum. Delegates to Lynx's
+// `ElementManager::CreateFiberNode(tag_name)`, which routes both
+// built-in and registered custom tags through the same factory.
+// `tag_name` must be NUL-terminated UTF-8. Returns NULL if the tag
+// isn't registered with Lynx's behaviour registry.
+WHISKER_BRIDGE_EXPORT WhiskerElement* whisker_bridge_create_element_by_name(WhiskerEngine* engine, const char* tag_name);
+
 // Decrement the element's ref count. Always safe to call multiple times
 // (idempotent on NULL).
 WHISKER_BRIDGE_EXPORT void whisker_bridge_release_element(WhiskerElement* element);

--- a/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
+++ b/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
@@ -145,6 +145,22 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT lynx_fiber_element_t* lynx_create_fiber_element
   return new lynx_fiber_element_t{std::move(ref)};
 }
 
+LYNX_NATIVE_RENDERER_CAPI_EXPORT lynx_fiber_element_t*
+lynx_create_fiber_element_by_name(lynx_shell_t* shell, const char* tag_name) {
+  if (shell == nullptr || shell->manager == nullptr || tag_name == nullptr ||
+      tag_name[0] == '\0') {
+    return nullptr;
+  }
+  // `CreateFiberNode` is the generic factory ElementManager exposes
+  // for any registered tag — built-ins (`view` / `text` / `image` /
+  // `scroll-view`) and custom (`x-input` / `x-refresh` / …) alike.
+  // For tags Lynx's behaviour registry doesn't know, it returns
+  // nullptr and we surface that to the Rust caller.
+  auto ref = shell->manager->CreateFiberNode(lynx::base::String(tag_name));
+  if (!ref) return nullptr;
+  return new lynx_fiber_element_t{std::move(ref)};
+}
+
 LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_release(lynx_fiber_element_t* element) {
   delete element;
 }

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -198,6 +198,18 @@ extern "C" WhiskerElement* whisker_bridge_create_element(WhiskerEngine* engine,
     return new WhiskerElement{handle};
 }
 
+extern "C" WhiskerElement* whisker_bridge_create_element_by_name(
+    WhiskerEngine* engine,
+    const char* tag_name) {
+    if (engine == nullptr || engine->shell == nullptr || tag_name == nullptr) {
+        return nullptr;
+    }
+    lynx_fiber_element_t* handle =
+        lynx_create_fiber_element_by_name(engine->shell, tag_name);
+    if (handle == nullptr) return nullptr;
+    return new WhiskerElement{handle};
+}
+
 extern "C" void whisker_bridge_release_element(WhiskerElement* element) {
     if (element == nullptr) return;
     // Drop any registered native event callbacks for this element so

--- a/crates/whisker-driver-sys/bridge/src/whisker_hello_element.mm
+++ b/crates/whisker-driver-sys/bridge/src/whisker_hello_element.mm
@@ -1,0 +1,42 @@
+// Phase 7-B end-to-end smoke test element.
+//
+// Registers an `x-hello` tag with Lynx's behaviour registry that
+// renders as a plain `UIView` with a system-pink background. Used
+// by `examples/hello-world` to validate the tag-by-name dispatch
+// path (`whisker_bridge_create_element_by_name` →
+// `ElementManager::CreateFiberNode("x-hello")` →
+// `LYNX_REGISTER_UI("x-hello")` → `WhiskerHelloElement`).
+//
+// This is intentionally a single self-contained file in the bridge
+// crate, not yet the full `runtime-platforms/ios/` SPM-package
+// infrastructure. The latter (with `@WhiskerElement` Swift Macro,
+// `WhiskerView<T>` base class, and module-author DX) lands in
+// Phase 7-B.6. For the simulator smoke test we use Lynx's raw
+// registration macros directly so the element is available
+// without further build pipeline changes.
+
+#import <UIKit/UIKit.h>
+
+#import <Lynx/LynxComponentRegistry.h>
+#import <Lynx/LynxPropsProcessor.h>
+#import <Lynx/LynxUI.h>
+
+@interface WhiskerHelloElement : LynxUI<UIView *>
+@end
+
+@implementation WhiskerHelloElement
+
+// Lynx's `+load`-time hook that registers the class against the
+// global `LynxComponentRegistry` under the given tag name.
+LYNX_REGISTER_UI("x-hello")
+
+- (UIView *)createView {
+    UIView *v = [[UIView alloc] init];
+    // System pink to make the smoke test visually obvious — if you
+    // see a pink rectangle, the tag-by-name dispatch is working
+    // end-to-end (render! → Rust → C ABI → Lynx → this class).
+    v.backgroundColor = [UIColor systemPinkColor];
+    return v;
+}
+
+@end

--- a/crates/whisker-driver-sys/build.rs
+++ b/crates/whisker-driver-sys/build.rs
@@ -236,6 +236,7 @@ fn compile_ios() -> Result<()> {
         .flag("-fobjc-arc")
         .file(bridge_src.join("whisker_bridge_common.cc"))
         .file(bridge_src.join("whisker_bridge_ios.mm"))
+        .file(bridge_src.join("whisker_hello_element.mm"))
         .file(bridge_src.join("lynx_native_renderer.cc"))
         .include(bridge_root().join("include"))
         .include(&bridge_src);

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -44,6 +44,10 @@ extern "C" {
         engine: *mut WhiskerEngine,
         tag: WhiskerElementTag,
     ) -> *mut WhiskerElement;
+    pub fn whisker_bridge_create_element_by_name(
+        engine: *mut WhiskerEngine,
+        tag_name: *const c_char,
+    ) -> *mut WhiskerElement;
     pub fn whisker_bridge_release_element(element: *mut WhiskerElement);
 
     pub fn whisker_bridge_set_attribute(

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -81,6 +81,21 @@ impl DynRenderer for BridgeRenderer {
         Element::from_raw(id)
     }
 
+    fn create_element_by_name(&mut self, tag_name: &str) -> Element {
+        let Ok(c) = CString::new(tag_name) else {
+            return Element::from_raw(u32::MAX);
+        };
+        let raw =
+            unsafe { ffi::whisker_bridge_create_element_by_name(self.engine_ptr(), c.as_ptr()) };
+        let ptr = match NonNull::new(raw) {
+            Some(p) => p,
+            None => return Element::from_raw(u32::MAX),
+        };
+        let id = self.elements.len() as u32;
+        self.elements.push(Some(ptr));
+        Element::from_raw(id)
+    }
+
     fn release_element(&mut self, handle: Element) {
         if let Some(slot) = self.elements.get_mut(handle.id() as usize) {
             if let Some(ptr) = slot.take() {

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -16,6 +16,7 @@ use quote::quote;
 use syn::{parse_macro_input, ItemFn};
 
 mod component;
+mod native_element;
 mod render;
 
 /// Annotates the user's app function (returning `whisker::Element`) and
@@ -198,4 +199,36 @@ pub fn render(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
     component::expand(item.into()).into()
+}
+
+/// Declare a Whisker-side wrapper for a Lynx-registered native element.
+///
+/// ```ignore
+/// #[whisker::native_element("x-hello")]
+/// pub fn x_hello(style: Signal<String>) -> Element;
+/// ```
+///
+/// Generates the same Props + builder + PascalCase-alias surface as
+/// `#[component]`, but the function body is **auto-generated**: it
+/// calls `view::create_element_by_name(tag)` and then applies each
+/// declared prop as either an inline-style (for the `style` prop) or
+/// a SetAttribute (everything else, kebab-cased). Static vs reactive
+/// dispatch goes through the same `apply_styles` / `apply_attr`
+/// helpers built-in tags use, so a `Signal::Dynamic` prop transparently
+/// effect-wraps the attribute write.
+///
+/// Call-site shape mirrors built-in tags + user components:
+///
+/// ```ignore
+/// render! {
+///     XHello(style: "width: 100%; height: 8px;")
+/// }
+/// ```
+///
+/// See `crates/whisker-macros/src/native_element.rs` for the
+/// emission details (children + event-handler props are NOT yet
+/// supported; tracked in Phase 7-Φ follow-ups).
+#[proc_macro_attribute]
+pub fn native_element(attr: TokenStream, item: TokenStream) -> TokenStream {
+    native_element::expand(attr.into(), item.into()).into()
 }

--- a/crates/whisker-macros/src/native_element.rs
+++ b/crates/whisker-macros/src/native_element.rs
@@ -1,0 +1,363 @@
+//! `#[whisker::native_element]` proc-macro.
+//!
+//! Generates a builder-style API for a custom Lynx element identified
+//! by a tag-name string. The macro shape mirrors `#[component]` —
+//! same `<Name>Props` struct, same hand-rolled builder, same
+//! PascalCase alias — but the function body is **auto-generated**
+//! rather than supplied by the user. Each declared parameter
+//! becomes an attribute on the underlying Lynx element.
+//!
+//! ## User syntax
+//!
+//! ```ignore
+//! #[whisker::native_element("x-hello")]
+//! pub fn x_hello(style: Signal<String>) {}
+//! //                                    ^^
+//! //                                    empty body — the macro replaces
+//! //                                    it with the create_element_by_name
+//! //                                    + apply_* sequence and rewrites
+//! //                                    the return type to `Element`.
+//! ```
+//!
+//! Rust's grammar requires a body for top-level `fn` items (no
+//! `extern fn ...;` outside an `extern {}` block), so the
+//! placeholder `{}` is unavoidable. The macro discards whatever
+//! return type and body the user supplies — the auto-generated
+//! body always returns `whisker::runtime::view::Element`.
+//!
+//! ## What the macro emits
+//!
+//! Conceptually:
+//!
+//! ```ignore
+//! pub struct XHelloProps { style: Signal<String> }
+//! impl XHelloProps {
+//!     pub fn builder() -> XHelloPropsBuilder { … }
+//! }
+//! impl XHelloPropsBuilder {
+//!     pub fn style(self, v: impl Into<Signal<String>>) -> Self { … }
+//!     pub fn build(self) -> XHelloProps { … }
+//! }
+//! pub fn XHello(props: XHelloProps) -> Element {
+//!     let h = ::whisker::runtime::view::create_element_by_name("x-hello");
+//!     // For `style` specifically: route through apply_styles
+//!     // (Lynx's SetRawInlineStyles). Every other declared param
+//!     // becomes a `SetAttribute(name_kebab_case, value)`.
+//!     ::whisker::__tags::apply_styles(h, props.style);
+//!     h
+//! }
+//! ```
+//!
+//! The auto-generated body delegates static-vs-reactive dispatch to
+//! the same `apply_styles` / `apply_attr` helpers that built-in tags
+//! use, so a `Signal::Dynamic` prop transparently effect-wraps the
+//! underlying SetAttribute / SetRawInlineStyles call — every native
+//! element gets Whisker's reactive semantics for free.
+//!
+//! ## Call-site shape
+//!
+//! Same as user components and built-in tags. Inside `render!`:
+//!
+//! ```ignore
+//! render! {
+//!     XHello(style: "width: 100%; height: 8px;")
+//! }
+//! ```
+//!
+//! lowers to:
+//!
+//! ```ignore
+//! XHello(XHelloProps::builder().style("width: 100%; height: 8px;").build())
+//! ```
+//!
+//! ## What's NOT supported (yet)
+//!
+//! - **Children**: native elements with sub-elements (e.g. a custom
+//!   `<x-card>{children}</x-card>`). The bridge supports
+//!   `append_child` but the macro doesn't surface it yet.
+//! - **Event handlers**: `on_<event>` props that map to
+//!   `set_event_listener`. Easy to add — same shape as
+//!   `__tags::*::on(...)`, just guarded by an attribute-name prefix
+//!   in the macro.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::spanned::Spanned;
+use syn::{parse2, FnArg, Ident, ItemFn, LitStr, Pat, Type};
+
+pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
+    // Attribute payload: a single string literal — the tag name
+    // `lynx_create_fiber_element_by_name` will register against.
+    let tag_name: LitStr = match parse2(attr.clone()) {
+        Ok(s) => s,
+        Err(_) => {
+            return syn::Error::new(
+                attr.span(),
+                "#[whisker::native_element(\"<tag-name>\")] requires a \
+                 string-literal tag name (e.g. `\"x-hello\"`, `\"x-input\"`)",
+            )
+            .to_compile_error();
+        }
+    };
+    let tag_name_str = tag_name.value();
+
+    let input: ItemFn = match parse2(item) {
+        Ok(f) => f,
+        Err(e) => return e.to_compile_error(),
+    };
+
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+    let sig = &input.sig;
+    let fn_name = &sig.ident;
+
+    if !sig.generics.params.is_empty() {
+        return syn::Error::new(
+            sig.generics.span(),
+            "#[whisker::native_element] does not support generic parameters \
+             — native elements are tag-name driven, not type-parameterised. \
+             Each tag is a distinct registered Lynx UI class.",
+        )
+        .to_compile_error();
+    }
+
+    // Walk the parameter list. Each `Typed` arg becomes a `Prop` —
+    // ident + type. We reject patterns and receivers up front.
+    let mut props: Vec<Prop> = Vec::new();
+    for arg in &sig.inputs {
+        let pat_type = match arg {
+            FnArg::Typed(t) => t,
+            FnArg::Receiver(r) => {
+                return syn::Error::new(
+                    r.span(),
+                    "#[whisker::native_element] does not support method receivers",
+                )
+                .to_compile_error();
+            }
+        };
+        let ident = match &*pat_type.pat {
+            Pat::Ident(pi) => pi.ident.clone(),
+            other => {
+                return syn::Error::new(
+                    other.span(),
+                    "#[whisker::native_element] parameters must be plain identifiers",
+                )
+                .to_compile_error();
+            }
+        };
+        props.push(Prop {
+            ident,
+            ty: (*pat_type.ty).clone(),
+        });
+    }
+
+    // ----- Props struct + builder ----------------------------------
+
+    let props_name = format_ident!("{}", to_pascal_case(&fn_name.to_string()) + "Props");
+    let builder_name = format_ident!("{}Builder", props_name);
+    let internal_mod = format_ident!("__{}_props_internal", fn_name);
+
+    let props_fields: Vec<TokenStream2> = props
+        .iter()
+        .map(|p| {
+            let i = &p.ident;
+            let t = &p.ty;
+            quote! { pub #i: #t }
+        })
+        .collect();
+
+    let builder_fields: Vec<TokenStream2> = props
+        .iter()
+        .map(|p| {
+            let i = &p.ident;
+            let t = &p.ty;
+            quote! { #i: ::std::option::Option<#t> }
+        })
+        .collect();
+
+    let builder_init: Vec<TokenStream2> = props
+        .iter()
+        .map(|p| {
+            let i = &p.ident;
+            quote! { #i: ::std::option::Option::None }
+        })
+        .collect();
+
+    // Each setter takes `impl Into<#ty>`. For Signal<T>-shaped types,
+    // that means String / &str / ReadSignal<T> / RwSignal<T> / Memo<T>
+    // all flow in via the existing From impls.
+    let setters: Vec<TokenStream2> = props
+        .iter()
+        .map(|p| {
+            let i = &p.ident;
+            let t = &p.ty;
+            quote! {
+                #[allow(unused_mut)]
+                pub fn #i(mut self, value: impl ::std::convert::Into<#t>) -> Self {
+                    self.#i = ::std::option::Option::Some(value.into());
+                    self
+                }
+            }
+        })
+        .collect();
+
+    let build_assignments: Vec<TokenStream2> = props
+        .iter()
+        .map(|p| {
+            let i = &p.ident;
+            let name = i.to_string();
+            let err = format!("required prop `{name}` was not set on `{tag_name_str}`");
+            quote! {
+                #i: self.#i.expect(#err)
+            }
+        })
+        .collect();
+
+    // ----- Auto-generated body --------------------------------------
+    //
+    // For each prop, decide whether it's `style` (→ apply_styles, i.e.
+    // SetRawInlineStyles) or a regular attribute (→ apply_attr with the
+    // kebab-cased prop name). Future native-element props will likely
+    // want a `#[prop(attr = "data-foo")]` escape hatch for explicit
+    // attribute-name overrides; not needed for the smoke test.
+    // `apply_styles<V, T>` and `apply_attr<V, T>` are generic over the
+    // Signal's inner T; without a hint the compiler can't pick
+    // between `T = String` (identity Into on a Signal<String>) and
+    // `T = Signal<String>` (wrap-as-Static on the whole Signal). We
+    // hard-code `T = String` via turbofish — for v1, every native
+    // element prop is `Signal<String>` and the resulting attribute /
+    // inline-styles call already serialises through ToString anyway.
+    // Future versions may extract T from a `Signal<U>` prop type
+    // when U != String; until then this rule is documented in the
+    // macro's doc-comment.
+    let apply_calls: Vec<TokenStream2> = props
+        .iter()
+        .map(|p| {
+            let i = &p.ident;
+            let name = i.to_string();
+            if name == "style" {
+                quote! {
+                    ::whisker::__tags::apply_styles::<_, ::std::string::String>(
+                        __handle, props.#i,
+                    );
+                }
+            } else {
+                let attr_name = name.replace('_', "-");
+                quote! {
+                    ::whisker::__tags::apply_attr::<_, ::std::string::String>(
+                        __handle, #attr_name, props.#i,
+                    );
+                }
+            }
+        })
+        .collect();
+
+    let prop_idents: Vec<Ident> = props.iter().map(|p| p.ident.clone()).collect();
+    let drop_unused = if prop_idents.is_empty() {
+        // Quiet `unused_variables` when the user declares no props —
+        // common for placeholder native elements like the `x-hello`
+        // smoke test.
+        quote! { let _ = props; }
+    } else {
+        quote! {}
+    };
+
+    let inner_mod = format_ident!("__{}_inner", fn_name);
+
+    // PascalCase alias — same scheme as `#[component]`.
+    let pascal_alias_ident = format_ident!("{}", to_pascal_case(&fn_name.to_string()));
+    let fn_name_str = fn_name.to_string();
+    let alias_emission = if pascal_alias_ident.to_string() == fn_name_str {
+        // snake_case name already matches PascalCase (rare for native
+        // elements; their convention is `x_input` → `XInput`). Skip
+        // the alias to avoid `pub use … as same_name`.
+        quote! {
+            #[doc(hidden)]
+            #vis use #inner_mod::#fn_name;
+        }
+    } else {
+        quote! {
+            #[allow(non_snake_case)]
+            #vis use #inner_mod::#fn_name as #pascal_alias_ident;
+        }
+    };
+
+    quote! {
+        #[doc(hidden)]
+        mod #internal_mod {
+            use super::*;
+
+            pub struct #props_name {
+                #(#props_fields,)*
+            }
+
+            #[doc(hidden)]
+            pub struct #builder_name {
+                #(#builder_fields,)*
+            }
+
+            impl #props_name {
+                pub fn builder() -> #builder_name {
+                    #builder_name {
+                        #(#builder_init,)*
+                    }
+                }
+            }
+
+            impl #builder_name {
+                #(#setters)*
+
+                pub fn build(self) -> #props_name {
+                    #props_name {
+                        #(#build_assignments,)*
+                    }
+                }
+            }
+        }
+
+        #[doc(hidden)]
+        #vis use #internal_mod::#props_name;
+
+        #[doc(hidden)]
+        mod #inner_mod {
+            use super::*;
+            #[doc(hidden)]
+            #(#attrs)*
+            pub fn #fn_name(props: #props_name) -> ::whisker::runtime::view::Element {
+                #drop_unused
+                let __handle = ::whisker::runtime::view::create_element_by_name(#tag_name);
+                #(#apply_calls)*
+                __handle
+            }
+        }
+
+        #alias_emission
+    }
+}
+
+struct Prop {
+    ident: Ident,
+    ty: Type,
+}
+
+/// `x_hello` / `x_input` → `XHello` / `XInput`. ASCII-only — native
+/// element names should stay simple.
+fn to_pascal_case(snake: &str) -> String {
+    let mut out = String::with_capacity(snake.len());
+    let mut capitalize_next = true;
+    for ch in snake.chars() {
+        if ch == '_' {
+            capitalize_next = true;
+            continue;
+        }
+        if capitalize_next {
+            for upper in ch.to_uppercase() {
+                out.push(upper);
+            }
+            capitalize_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}

--- a/crates/whisker-macros/src/native_element.rs
+++ b/crates/whisker-macros/src/native_element.rs
@@ -267,7 +267,11 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
     // PascalCase alias — same scheme as `#[component]`.
     let pascal_alias_ident = format_ident!("{}", to_pascal_case(&fn_name.to_string()));
     let fn_name_str = fn_name.to_string();
-    let alias_emission = if pascal_alias_ident.to_string() == fn_name_str {
+    // Compare `Ident == str` directly to avoid `Ident::to_string()`'s
+    // allocation (clippy::cmp_owned). `syn::Ident` impls
+    // `PartialEq<str>` / `PartialEq<&str>`; we go through the
+    // already-allocated `fn_name_str.as_str()` for clarity.
+    let alias_emission = if pascal_alias_ident == fn_name_str.as_str() {
         // snake_case name already matches PascalCase (rare for native
         // elements; their convention is `x_input` → `XInput`). Skip
         // the alias to avoid `pub use … as same_name`.

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -36,8 +36,8 @@ pub use into_view::{Children, IntoView, View};
 #[doc(hidden)]
 pub use renderer::__reset_children_mirror_for_tests;
 pub use renderer::{
-    append_child, child_index, children_of, create_element, current_renderer_id, flush,
-    insert_child_at, install_renderer, previous_sibling, release_element, remove_child,
-    set_attribute, set_event_listener, set_inline_styles, set_root, uninstall_renderer,
-    with_installed_renderer, DynRenderer,
+    append_child, child_index, children_of, create_element, create_element_by_name,
+    current_renderer_id, flush, insert_child_at, install_renderer, previous_sibling,
+    release_element, remove_child, set_attribute, set_event_listener, set_inline_styles, set_root,
+    uninstall_renderer, with_installed_renderer, DynRenderer,
 };

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -33,6 +33,11 @@ use crate::element::ElementTag;
 /// that maintains its own `Element → R::Element` map.
 pub trait DynRenderer {
     fn create_element(&mut self, tag: ElementTag) -> Element;
+    /// Phase 7: tag-by-name dispatch for custom / xelement-style
+    /// tags ("x-input", etc.) not in the built-in [`ElementTag`]
+    /// enum. Returns [`Element::INVALID`] when the tag is unknown
+    /// to Lynx's behaviour registry.
+    fn create_element_by_name(&mut self, tag_name: &str) -> Element;
     fn release_element(&mut self, handle: Element);
 
     fn set_attribute(&mut self, handle: Element, key: &str, value: &str);
@@ -129,6 +134,24 @@ fn with_renderer<R>(f: impl FnOnce(&mut dyn DynRenderer) -> R, default: R) -> R 
 // Free-function dispatch — what the `render!` macro and reactive
 // effects call.
 // ---------------------------------------------------------------------------
+
+/// Free-fn helper used by the `render!` macro and reactive effects to
+/// allocate an element of any tag the bridge knows. Routes both the
+/// built-in `ElementTag` enum and tag-by-name strings through the
+/// same owner-tracking + invalid-handle logic.
+pub fn create_element_by_name(tag_name: &str) -> Element {
+    let handle = with_renderer(|r| r.create_element_by_name(tag_name), Element(u32::MAX));
+    if handle.id() != u32::MAX {
+        crate::reactive::with_runtime(|rt| {
+            if let Some(owner_id) = rt.current_owner() {
+                if let Some(owner) = rt.owners.get_mut(owner_id) {
+                    owner.elements.push(handle);
+                }
+            }
+        });
+    }
+    handle
+}
 
 pub fn create_element(tag: ElementTag) -> Element {
     let handle = with_renderer(|r| r.create_element(tag), Element(u32::MAX));

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -41,6 +41,15 @@ impl DynRenderer for RecordingRenderer {
         self.ops.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.ops.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, h: Element) {
         self.ops.borrow_mut().push(Op::Release { id: h.id() });
     }

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -25,7 +25,7 @@ pub use whisker_runtime as runtime;
 // the same enum.
 pub use whisker_runtime::element::ElementTag;
 
-pub use whisker_macros::{component, main, render};
+pub use whisker_macros::{component, main, native_element, render};
 
 // Phase 6.5a reactive surface, lifted to the top-level namespace so
 // user code can `use whisker::*` and reach the typical primitives
@@ -101,7 +101,12 @@ pub mod __tags {
     /// `Dynamic` case wraps the read in an `effect` so the
     /// returned [`ReadSignal<T>::get`] call registers the source
     /// as a dependency.
-    fn apply_styles<V, T>(h: Element, v: V)
+    ///
+    /// `pub` so the `#[whisker::native_element]` proc-macro can
+    /// route through the same helper from outside this module.
+    /// Not part of the stable surface — gated under `__tags` which
+    /// itself is `#[doc(hidden)]`.
+    pub fn apply_styles<V, T>(h: Element, v: V)
     where
         V: ::std::convert::Into<Signal<T>>,
         T: ::std::string::ToString + ::std::clone::Clone + 'static,
@@ -116,7 +121,10 @@ pub mod __tags {
 
     /// Apply a named attribute value to `h`. Same Static / Dynamic
     /// dispatch as [`apply_styles`].
-    fn apply_attr<V, T>(h: Element, name: &'static str, v: V)
+    ///
+    /// `pub` so the `#[whisker::native_element]` proc-macro can
+    /// route through the same helper.
+    pub fn apply_attr<V, T>(h: Element, name: &'static str, v: V)
     where
         V: ::std::convert::Into<Signal<T>>,
         T: ::std::string::ToString + ::std::clone::Clone + 'static,

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -46,6 +46,15 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, _h: Element) {}
     fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {

--- a/crates/whisker/tests/native_element.rs
+++ b/crates/whisker/tests/native_element.rs
@@ -1,0 +1,218 @@
+//! `#[whisker::native_element]` end-to-end tests.
+//!
+//! Verifies the proc-macro lowers a tag-name + prop list into:
+//! - `XxxProps::builder().<prop>(v).build()` shape
+//! - a body that calls `view::create_element_by_name(tag)`
+//! - per-prop `apply_styles` / `apply_attr` (Static set-once,
+//!   Dynamic effect-wrapped) routing
+//!
+//! The in-memory `Recorder` captures every dispatched op into
+//! `Op::*` so assertions can verify the underlying tag-name + per-
+//! attribute set sequence.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use whisker::prelude::*;
+use whisker::runtime::reactive::{__reset_for_tests, create_owner, dispose_owner};
+use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
+use whisker::{flush, with_owner};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Op {
+    CreateByName { id: u32, tag_name: String },
+    SetAttr { id: u32, key: String, value: String },
+    SetStyles { id: u32, css: String },
+}
+
+#[derive(Default)]
+struct Recorder {
+    next: u32,
+    log: Rc<RefCell<Vec<Op>>>,
+}
+
+impl Recorder {
+    fn with_log() -> (Self, Rc<RefCell<Vec<Op>>>) {
+        let r = Self::default();
+        let log = r.log.clone();
+        (r, log)
+    }
+}
+
+impl DynRenderer for Recorder {
+    fn create_element(&mut self, _tag: ElementTag) -> Element {
+        let id = self.next;
+        self.next += 1;
+        Element::from_raw(id)
+    }
+    fn create_element_by_name(&mut self, tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::CreateByName {
+            id,
+            tag_name: tag_name.into(),
+        });
+        Element::from_raw(id)
+    }
+    fn release_element(&mut self, _h: Element) {}
+    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
+        self.log.borrow_mut().push(Op::SetAttr {
+            id: h.id(),
+            key: k.into(),
+            value: v.into(),
+        });
+    }
+    fn set_inline_styles(&mut self, h: Element, css: &str) {
+        self.log.borrow_mut().push(Op::SetStyles {
+            id: h.id(),
+            css: css.into(),
+        });
+    }
+    fn append_child(&mut self, _p: Element, _c: Element) {}
+    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn set_event_listener(&mut self, _h: Element, _name: &str, _cb: Box<dyn Fn() + 'static>) {}
+    fn set_root(&mut self, _p: Element) {}
+    fn flush(&mut self) {}
+}
+
+fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
+    __reset_for_tests();
+    let (rec, log) = Recorder::with_log();
+    let prev = install_renderer(Box::new(rec));
+    let owner = create_owner(None);
+    let out = with_owner(owner, || f(log));
+    dispose_owner(owner);
+    uninstall_renderer(prev);
+    out
+}
+
+// ---- Native element declarations ------------------------------------------
+
+#[whisker::native_element("x-zero-props")]
+pub fn x_zero_props() {}
+
+#[whisker::native_element("x-styled")]
+pub fn x_styled(style: Signal<String>) {}
+
+#[whisker::native_element("x-input")]
+pub fn x_input(value: Signal<String>, placeholder: Signal<String>) {}
+
+// ---- Tests -----------------------------------------------------------------
+
+#[test]
+fn zero_props_creates_element_with_tag_name() {
+    with_recorder_and_owner(|log| {
+        let _h = render! {
+            XZeroProps()
+        };
+        let creates: Vec<_> = log
+            .borrow()
+            .iter()
+            .filter_map(|op| match op {
+                Op::CreateByName { tag_name, .. } => Some(tag_name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(creates, vec!["x-zero-props".to_string()]);
+    });
+}
+
+#[test]
+fn style_prop_routes_through_set_inline_styles() {
+    // The `style` prop is special — it must call set_inline_styles
+    // (Lynx's SetRawInlineStyles), not set_attribute. Mirrors what
+    // built-in `view(style: …)` does.
+    with_recorder_and_owner(|log| {
+        let _h = render! {
+            XStyled(style: "background: red; height: 8px;")
+        };
+        let styles: Vec<_> = log
+            .borrow()
+            .iter()
+            .filter_map(|op| match op {
+                Op::SetStyles { css, .. } => Some(css.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(styles, vec!["background: red; height: 8px;".to_string()]);
+    });
+}
+
+#[test]
+fn dynamic_style_re_runs_on_signal_change() {
+    with_recorder_and_owner(|log| {
+        let (color, set_color) = signal("red".to_string());
+        let css = computed(move || format!("background: {};", color.get()));
+        let _h = render! {
+            XStyled(style: css)
+        };
+        set_color.set("blue".into());
+        flush();
+        let styles: Vec<_> = log
+            .borrow()
+            .iter()
+            .filter_map(|op| match op {
+                Op::SetStyles { css, .. } => Some(css.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            styles,
+            vec![
+                "background: red;".to_string(),
+                "background: blue;".to_string()
+            ]
+        );
+    });
+}
+
+#[test]
+fn non_style_props_route_through_set_attribute_with_kebab_case() {
+    // `value` and `placeholder` are regular SetAttribute calls.
+    // Snake-case prop name → kebab-case attribute name (matches the
+    // built-in `attr()` mapping in __tags). For these two props the
+    // names are already single-word so kebab == snake.
+    with_recorder_and_owner(|log| {
+        let _h = render! {
+            XInput(value: "hello", placeholder: "type here")
+        };
+        let attrs: Vec<_> = log
+            .borrow()
+            .iter()
+            .filter_map(|op| match op {
+                Op::SetAttr { key, value, .. } => Some((key.clone(), value.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            attrs,
+            vec![
+                ("value".to_string(), "hello".to_string()),
+                ("placeholder".to_string(), "type here".to_string()),
+            ]
+        );
+    });
+}
+
+#[test]
+fn read_signal_prop_tracks_underlying_signal() {
+    with_recorder_and_owner(|log| {
+        let (value, set_value) = signal("alpha".to_string());
+        let _h = render! {
+            XInput(value: value, placeholder: "static")
+        };
+        set_value.set("beta".into());
+        flush();
+        set_value.set("gamma".into());
+        flush();
+        let value_sets: Vec<_> = log
+            .borrow()
+            .iter()
+            .filter_map(|op| match op {
+                Op::SetAttr { key, value, .. } if key == "value" => Some(value.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(value_sets, vec!["alpha", "beta", "gamma"]);
+    });
+}

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -60,6 +60,15 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, h: Element) {
         self.log.borrow_mut().push(Op::Release { id: h.id() });
     }

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -44,6 +44,15 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, _h: Element) {}
     fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -57,6 +57,15 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, h: Element) {
         self.log.borrow_mut().push(Op::Release { id: h.id() });
     }

--- a/examples/counter/tests/counter_renders.rs
+++ b/examples/counter/tests/counter_renders.rs
@@ -47,6 +47,15 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, _h: Element) {}
     fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -447,6 +447,19 @@ fn scroll_body(state: AppState) -> Element {
 
 // ---- Main app ---------------------------------------------------------------
 
+// Phase 7-Φ.D smoke test: a `#[whisker::native_element("x-hello")]`
+// declaration. The bridge has a `WhiskerHelloElement` LynxUI subclass
+// registered under that tag (see
+// `crates/whisker-driver-sys/bridge/src/whisker_hello_element.mm`)
+// that renders as a system-pink UIView. A thin pink bar at the top
+// of the home screen confirms the full end-to-end native-element
+// path: render! → XHello() → XHelloProps::builder() → create_element_by_name
+// → whisker_bridge_create_element_by_name → lynx_create_fiber_element_by_name
+// → ElementManager::CreateFiberNode("x-hello") → LynxUI registry →
+// WhiskerHelloElement.createView.
+#[whisker::native_element("x-hello")]
+pub fn x_hello(style: Signal<String>) {}
+
 #[whisker::main]
 fn app() -> Element {
     // Allocate every app-wide signal in the bootstrap owner. `AppState`
@@ -460,6 +473,7 @@ fn app() -> Element {
     );
     render! {
         page(style: page_style) {
+            XHello(style: "width: 100%; height: 8px;")
             Header()
             ScrollBody(state: state)
             NowPlaying(state: state)

--- a/examples/hn-reader/tests/render.rs
+++ b/examples/hn-reader/tests/render.rs
@@ -46,6 +46,15 @@ impl DynRenderer for Recorder {
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        self.log.borrow_mut().push(Op::Create {
+            id,
+            tag: ElementTag::View,
+        });
+        Element::from_raw(id)
+    }
     fn release_element(&mut self, _h: Element) {}
     fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {


### PR DESCRIPTION
First-class native UI elements for Whisker. Bridges the Lynx behaviour registry (\`LYNX_REGISTER_UI(\"x-foo\")\` Obj-C classes / \`@WhiskerElement\` Kotlin classes — Android lands later) to a Rust-side API that matches built-in tags and \`#[component]\` for ergonomic call-site reuse of the Signal\<T\> reactivity machinery from Phase 7-Φ.A/B/C.

## Two commits

### \`c3cc9cc\` — Layers 1-3 (plumbing)

| Layer | What |
|-------|------|
| **1** — Lynx C ABI | \`lynx_create_fiber_element_by_name(shell, tag_name)\` in the vendored CAPI header + impl. Delegates to \`ElementManager::CreateFiberNode(base::String(tag_name))\` — Lynx's generic factory for any registered tag. |
| **2** — Whisker bridge | \`whisker_bridge_create_element_by_name(engine, tag_name)\` pass-through. extern \"C\" decl + iOS Mach-O export. |
| **3** — Rust runtime | \`DynRenderer::create_element_by_name(&str) -> Element\` trait method. \`BridgeRenderer\` impl. Free fn \`view::create_element_by_name(tag_name)\` (owner-tracking + invalid-handle guard). Test recorders stub the trait method. |

Largely cherry-picked from the closed PR #29's commit 8a7d181 (which used a render!-macro escape-hatch syntax we've since dropped). Re-applied here with the test-stub adjustments for the post-Phase 7-Φ.B builder API.

### \`HEAD\` — Layers 4-5 (macro + smoke test)

**Layer 4 — \`#[whisker::native_element]\` proc-macro**

\`\`\`rust
#[whisker::native_element(\"x-hello\")]
pub fn x_hello(style: Signal<String>) {}
\`\`\`

Discards the user-supplied body / return type and emits the same \`<Name>Props\` + builder + PascalCase-alias surface as \`#[component]\`, but the auto-generated function body issues \`create_element_by_name(tag)\` + per-prop \`apply_styles\` / \`apply_attr\` calls. \`Signal::Dynamic\` props flow through the same effect-wrapping helpers built-in tags use — every native element gets reactive attribute updates for free.

\`apply_styles\` and \`apply_attr\` were \`fn\` (module-private) inside \`__tags\`; flipped to \`pub fn\` so the proc-macro can reach them via the absolute path. \`__tags\` itself stays \`#[doc(hidden)]\` so the change isn't part of the stable surface.

**Layer 5 — iOS smoke test**

\`whisker_hello_element.mm\` (\`LynxUI<UIView*>\` subclass, registered as \`x-hello\` via \`LYNX_REGISTER_UI\`, renders a \`systemPinkColor\` UIView) lands in the bridge static archive. Hello-world declares \`#[whisker::native_element(\"x-hello\")] fn x_hello(style: Signal<String>) {}\` and places \`XHello(style: \"width: 100%; height: 8px;\")\` at the top of its page tree.

Verified end-to-end on iOS sim: an 8px pink bar appears above the music-app UI, confirming the full proc-macro → create_element_by_name → bridge → Lynx → LYNX_REGISTER_UI chain.

## Tests

5 new tests in \`crates/whisker/tests/native_element.rs\`:

| Test | What it covers |
|------|---------------|
| \`zero_props_creates_element_with_tag_name\` | Bare \`XZeroProps()\` issues exactly one create_element_by_name call with the right tag name |
| \`style_prop_routes_through_set_inline_styles\` | \`style\` prop → SetRawInlineStyles, not SetAttribute |
| \`dynamic_style_re_runs_on_signal_change\` | ReadSignal\<String> prop → effect-wrapped, fires on signal write |
| \`non_style_props_route_through_set_attribute_with_kebab_case\` | Regular props → SetAttribute with snake_case → kebab-case attr name |
| \`read_signal_prop_tracks_underlying_signal\` | Set on the source signal propagates to the right SetAttribute call |

Plus \`cargo test --workspace\` and \`cargo clippy --workspace --all-targets -- -D warnings\` green.

## Limits / future work

- **Children**: no way to declare an \`x-card { children }\` style nesting yet. Bridge has \`whisker_bridge_append_child\`; macro needs a \`children: Children\` prop story (mirror \`#[component]\`).
- **Event handlers**: \`on_tap: || …\` prop style not supported on native_elements yet. Same shape as \`__tags::*::on(...)\`, just guarded by an \`on_\`-prefix in the macro.
- **Typed props**: every native_element prop must be \`Signal<String>\` in v1. Boolean / numeric attrs (\`disabled: Signal<bool>\`) need the macro to extract \`T\` from \`Signal<T>\` and route through a type-erased ToString path.
- **Android**: only the iOS side is wired up here. The Lynx fork's Android module needs the same \`CreateFiberNode\`-by-name registration, plus a \`@WhiskerElement\` Kotlin equivalent of \`LYNX_REGISTER_UI\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)