### PR TITLE
Phase 7-Φ.F: docs — Signal<T> + native_element design notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,35 @@ use whisker::runtime::view::Element;
 #[whisker::main]
 fn app() -> Element {
     let count = RwSignal::new(0);
+    let label = computed(move || format!("Count: {}", count.get()));
     render! {
-        page {
-            style: "padding: 20px; display: flex; flex-direction: column; gap: 12px;",
-            text { "Count: " {count.get()} }
-            view {
+        page(style: "padding: 20px; display: flex; flex-direction: column; gap: 12px;") {
+            text(value: label)
+            view(
                 style: "padding: 8px 16px; background: #3b82f6; border-radius: 6px;",
                 on_tap: move || count.update(|n| *n += 1),
-                text { style: "color: white;", "+1" }
+            ) {
+                text(style: "color: white;", value: "+1")
             }
         }
     }
 }
 ```
+
+The reactive contract at a glance:
+
+| Pass                                         | Behaviour                                                                   |
+|----------------------------------------------|-----------------------------------------------------------------------------|
+| `text(value: "hi")`                          | static — set the attribute once                                             |
+| `text(value: my_string)` (or `&str`)         | static — set once                                                           |
+| `text(value: my_signal)` / `my_rw_signal`    | **dynamic** — the element re-updates when the signal changes                |
+| `text(value: computed(move \|\| …))`         | **dynamic** — the `computed`'s memo re-runs, the element re-updates with it |
+| `text(value: my_signal.get())`               | static — read happens at the call site, no subscription                     |
+
+Same rule for built-in tags, `#[component]`s, and
+`#[whisker::native_element]`s. See
+[`docs/reactivity-design.md`](docs/reactivity-design.md#signalt--the-prop-value-type-phase-7-φ)
+for the full design.
 
 ## Why Whisker
 
@@ -77,6 +93,12 @@ Major decisions made so far:
   `render!` macro wires up per-property effects so a signal write
   updates only the affected element attribute. No virtual DOM, no
   diff pass.
+- **Unified prop reactivity via `Signal<T>`** (Phase 7-Φ) —
+  built-in tags, `#[component]`, and `#[whisker::native_element]`
+  all accept the same `Signal<T> = Static(T) | Dynamic(ReadSignal<T>)`
+  prop shape, so call sites have one rule across every component
+  surface (pass a signal handle → reactive; pass a value or
+  `.get()` → static snapshot).
 
 See `docs/` for design notes:
 
@@ -117,13 +139,15 @@ GitHub.
 | Component | Status |
 |---|---|
 | Workspace scaffold | ✅ |
-| Lynx prebuilt integration | ⏳ |
-| Element PAPI JNI bridge | ⏳ |
-| Reactive runtime | ⏳ |
-| `rsx!` macro | ⏳ |
+| Lynx prebuilt integration | ✅ |
+| Element PAPI Obj-C++/JNI bridge | ✅ |
+| Reactive runtime (signals, effects, computed, resource) | ✅ |
+| `render!` macro | ✅ |
+| `Signal<T>` unified prop reactivity (Phase 7-Φ) | ✅ |
+| `#[whisker::native_element]` (iOS only for now) | ✅ |
 | CNG (`whisker prebuild`) | ⏳ |
-| `whisker dev` (hot reload) | ⏳ |
-| iOS xcframework build | ⏳ |
+| `whisker run` (Tier 1 hot reload) | ✅ (iOS) / ⏳ (Android) |
+| iOS xcframework build | ✅ |
 | Android AAR build | ⏳ |
 
 ## License

--- a/docs/reactivity-design.md
+++ b/docs/reactivity-design.md
@@ -139,6 +139,136 @@ let history: StoredValue<Vec<String>> = StoredValue::new(Vec::new());
 effect(move || history.update(|h| h.push(format!("count={}", count.get()))));
 ```
 
+### `Signal<T>` — the prop-value type (Phase 7-Φ)
+
+A 2-variant sum used by built-in tag builders, `#[component]`, and
+`#[whisker::native_element]` to receive prop values that may be
+either a static `T` or a reactive `ReadSignal<T>`. The unified
+type lets all three component surfaces share one calling
+convention.
+
+```rust
+pub enum Signal<T: 'static> {
+    Static(T),                // set once, no subscription
+    Dynamic(ReadSignal<T>),   // tracked: builder wraps the read in effect
+}
+```
+
+`From` impls:
+
+| Source                | Variant                              |
+|-----------------------|--------------------------------------|
+| `T`                   | `Static(value)`                      |
+| `ReadSignal<T>`       | `Dynamic(signal)`                    |
+| `RwSignal<T>`         | `Dynamic(rw.read_only())`            |
+| `&str` (when T=String)| `Static(s.to_string())` — ergonomic  |
+
+Builder methods accept `impl Into<Signal<T>>`, so the call-site
+conversion is implicit:
+
+```rust
+text(value: "static literal")         // → Signal::Static
+text(value: my_string)                // → Signal::Static
+text(value: my_signal)                // → Signal::Dynamic (tracked)
+text(value: my_rw_signal)             // → Signal::Dynamic (tracked)
+text(value: computed(move || …))      // → Signal::Dynamic (computed's
+                                      //   return is a ReadSignal<T>)
+text(value: my_signal.get())          // → Signal::Static (snapshot — read
+                                      //   happens at the call site, before
+                                      //   any effect is on the stack)
+```
+
+The `Static` vs `Dynamic` decision is **visible at the call site**:
+pass the signal handle for reactive binding; pass `.get()` (or any
+already-resolved value) for a one-shot snapshot. Same rule for
+built-in tags, `#[component]`s, and `#[whisker::native_element]`s.
+
+#### Inside the builder
+
+The Static / Dynamic dispatch happens once per `.style(v)` /
+`.class(v)` / `.value(v)` / etc. call. Static → set the attribute
+exactly once; Dynamic → wrap the read in an `effect` so the
+underlying signal becomes a dependency:
+
+```rust
+match v.into() {
+    Signal::Static(t) => set_attribute(h, name, &t.to_string()),
+    Signal::Dynamic(sig) => {
+        effect(move || set_attribute(h, name, &sig.get().to_string()));
+    }
+}
+```
+
+#### Reading `Signal<T>` props inside a `#[component]` body
+
+For props declared as `Signal<T>`, the body reads via
+`Signal::<T>::get()`, which dispatches:
+
+- `Static`: returns a clone of the held value.
+- `Dynamic`: forwards to `ReadSignal::get`, which registers the
+  underlying signal as a dependency of whatever effect or
+  `computed` is currently on the observer stack.
+
+```rust
+#[component]
+fn dynamic_tile(color: Signal<String>) -> Element {
+    // `color.clone()` is cheap — Dynamic clones the NodeId,
+    // Static clones the value. Required because the component's
+    // `__hot::call(move || …)` wrap is FnMut-typed and we want
+    // to move `color` into a downstream `computed` closure
+    // without consuming the outer capture.
+    let style = {
+        let color = color.clone();
+        computed(move || format!("background: {};", color.get()))
+    };
+    render! { view(style: style) }
+}
+```
+
+Used externally:
+
+```rust
+let (color, set_color) = signal("red".to_string());
+render! {
+    DynamicTile(color: color)        // → Dynamic, reactive
+}
+set_color.set("blue".into());        // tile re-renders automatically
+flush();
+```
+
+#### Why not auto-wrap kwargs in `render!`?
+
+Pre-Phase 7-Φ, the `render!` macro silently wrapped each kwarg
+expression in `move || …to_string()` and the builder accepted
+a closure. That made `text(value: signal.get())` reactive
+without any user effort — the read happened *inside* the
+emitted closure, which the builder then placed inside an effect.
+
+Three things made that wrong:
+
+1. **Asymmetric across component types.** Built-in tags got the
+   auto-wrap; `#[component]` calls didn't. So
+   `text(value: signal.get())` was reactive but
+   `MyComponent(value: signal.get())` wasn't, with no surface
+   indication of the difference.
+2. **Hidden DX.** New users were surprised that
+   `text(value: format!("…{}", signal.get()))` reactively
+   updated — there was no syntactic marker telling them where
+   the reactive boundary was.
+3. **Closure-only API for the builders.** Static values couldn't
+   skip the effect overhead — every kwarg got wrapped, even the
+   pure-string-literal ones.
+
+Phase 7-Φ.B made the wrap explicit: kwargs flow verbatim into
+the builder, the builder dispatches on `Signal::Static` vs
+`Signal::Dynamic`, and the user controls reactivity by choosing
+to pass the signal handle vs `.get()`. Derived expressions go
+through `computed(move || …)` so the closure (and the resulting
+memo's `ReadSignal<T>`) are named, observable, and reusable.
+
+This is the same model Leptos uses (`MaybeSignal<T>`) and
+Solid's JSX (`<X prop={signal}>` vs `<X prop={signal()}>`).
+
 ## Arena + Owner
 
 All reactive state lives in a thread-local `ReactiveRuntime`. Whisker
@@ -230,6 +360,105 @@ fn my_inner_comp() -> impl IntoView {
     /* … */
 }
 ```
+
+### Props (Phase 7-Φ)
+
+The macro emits a `<Name>Props` struct + hand-rolled builder for
+every component. Required fields take `impl Into<Type>` so call
+sites can omit explicit conversions. For props declared as
+`Signal<T>`, that Into-conversion is the one documented in
+[`Signal<T>`](#signalt--the-prop-value-type-phase-7-φ): any of
+`T`, `ReadSignal<T>`, `RwSignal<T>`, `Memo<T>` (= `ReadSignal<T>`)
+all coerce in.
+
+```rust
+#[component]
+fn art_tile(color: Signal<String>, size: u32) -> Element {
+    // color.get() in a tracking scope subscribes to the source
+    // signal; size is plain static data.
+    let style = {
+        let color = color.clone();
+        computed(move || format!("background: {}; width: {}px;", color.get(), size))
+    };
+    render! { view(style: style) }
+}
+
+// Call site:
+let (color, set_color) = signal("red".to_string());
+render! {
+    ArtTile(color: color, size: 48)
+}
+set_color.set("blue".into());   // tile re-paints
+flush();
+```
+
+## native_element (Phase 7-Φ.D)
+
+```rust
+#[whisker::native_element("x-input")]
+pub fn x_input(value: Signal<String>, placeholder: Signal<String>) {}
+//                                                                ^^
+//                                          empty body — auto-generated
+```
+
+`#[whisker::native_element(tag)]` is a sibling of `#[component]`:
+same `<Name>Props` + builder + PascalCase-alias surface, but
+the body is **auto-generated** rather than supplied by the user.
+The macro emits:
+
+1. `XInput(props) -> Element` whose body calls
+   `view::create_element_by_name("x-input")` to allocate a Lynx
+   `FiberElement` of the given tag (which the host's behaviour
+   registry must know about — see below).
+2. Per-prop `apply_styles(h, props.style)` (if the prop is
+   literally named `style`) or `apply_attr(h, kebab-name, props.<prop>)`
+   for everything else — same helpers built-in tags use, so
+   `Signal::Dynamic` props transparently effect-wrap the underlying
+   `SetAttribute` / `SetRawInlineStyles` call.
+
+Call site mirrors built-in tags + user components:
+
+```rust
+render! {
+    XInput(value: my_string_signal, placeholder: "Type here")
+}
+```
+
+### Tag-name → host element class
+
+`create_element_by_name("x-input")` routes through
+`whisker_bridge_create_element_by_name` → Lynx CAPI
+`lynx_create_fiber_element_by_name(shell, tag_name)` →
+`ElementManager::CreateFiberNode(base::String(tag_name))`. Lynx's
+behaviour registry then looks up the registered class for the
+tag and instantiates it:
+
+- **iOS**: `LYNX_REGISTER_UI("x-input")` decorates a `LynxUI<UIView*>`
+  subclass that lives in the app's Mach-O image. The bridge's
+  `whisker_hello_element.mm` is the canonical sample.
+- **Android** (planned): `@WhiskerElement` Kotlin annotation
+  generates the same registration as Lynx's existing
+  `@LynxBehavior` machinery.
+
+If the host hasn't registered a class for the tag, `CreateFiberNode`
+returns nullptr; the Rust side surfaces that as a sentinel
+`Element` whose subsequent operations are silent no-ops (logged
+in debug). No null-pointer surprises propagate to user code.
+
+### Constraints
+
+v1 of `#[whisker::native_element]` is intentionally narrow:
+
+- **Every prop must be `Signal<T>`** for the macro to wire up
+  reactivity automatically. Future extension: extract `T` from
+  `Signal<T>` and route static / numeric / boolean props through
+  the `ToString` path.
+- **No children**: nesting under a native element isn't supported
+  yet. Bridge has `whisker_bridge_append_child`; macro needs a
+  `children: Children` prop story (mirrors `#[component]`).
+- **No event handlers**: `on_<event>: …` props need a separate
+  prop classifier (`on_` prefix → `set_event_listener` instead of
+  `apply_attr`). Trivial follow-up.
 
 ## render! macro
 


### PR DESCRIPTION
Big-picture rewrite of the reactive-design and README docs to match the API the runtime + macros actually ship as of Phase 7-Φ (PRs #30, #31, #32).

## What changes

### docs/reactivity-design.md

- New \`### Signal<T> — the prop-value type (Phase 7-Φ)\` section under \`## Primitives\`. Covers the 2-variant enum, From impls, builder dispatch (Static → set-once, Dynamic → effect-wrapped), and the "read inside the body via \`signal.get()\`" pattern. Spells out *why* the macro auto-wrap was dropped (asymmetric across component types, hidden DX, no static-path optimisation).
- \`### Props (Phase 7-Φ)\` subsection under \`## Component model\` showing the call-site shape and the cheap-clone pattern for moving \`Signal<T>\` props into downstream \`computed\`s.
- New \`## native_element (Phase 7-Φ.D)\` section covering \`#[whisker::native_element(\"x-tag\")]\`, the tag-name → host class registry chain (Lynx CAPI → ElementManager → LYNX_REGISTER_UI), and the v1 limitations (Signal<String>-only, no children, no event handlers).

### README.md

- Hello-world snippet uses the actual current syntax: \`page(style: …) { text(value: …) }\` rather than the old brace-block rsx form. The reactive \`text(value: format!(…))\` becomes \`text(value: computed(move || format!(…)))\` to keep the count label live.
- New "reactive contract at a glance" table documenting the Static / Dynamic call-site rule across every prop shape.
- Status table reflects merged work: reactive runtime, \`render!\` macro, \`Signal<T>\` prop unification, native_element (iOS), and \`whisker run\` Tier 1 hot reload are all ✅.
- Added Signal<T> bullet to the "Design decisions" list.

## Scope

Docs-only. No source changes; CI's fmt/clippy/test/coverage jobs will pass through trivially.

## Why now

PR #30 (Signal<T> foundation), #31 (hello-world reactive helper migration), and #32 (native_element proc-macro + iOS smoke test) ship a coherent slice of Phase 7-Φ. The framework's surface has changed enough that the original \`docs/reactivity-design.md\` (pre-Phase-7) and the README example are now actively misleading — newcomers reading them get a different mental model than the code actually implements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)