### PR TITLE
chore(lynx): bump LYNX_VERSION to 3.7.0-whisker.2

### DIFF
--- a/crates/whisker-build/src/lynx.rs
+++ b/crates/whisker-build/src/lynx.rs
@@ -57,23 +57,36 @@ use std::path::{Path, PathBuf};
 /// Schema: `<lynx-upstream-version>-whisker.<patch-iteration>` so a
 /// reader can tell at a glance which upstream Lynx is wrapped, and
 /// our own patch iterations bump independently.
-pub const LYNX_FORK_TAG: &str = "v3.7.0-whisker.1";
+pub const LYNX_FORK_TAG: &str = "v3.7.0-whisker.2";
 
 /// Version segment that appears in cache paths + tarball filenames.
 /// Derived from [`LYNX_FORK_TAG`] minus the leading `v`.
-pub const LYNX_VERSION: &str = "3.7.0-whisker.1";
+pub const LYNX_VERSION: &str = "3.7.0-whisker.2";
 
 /// SHA-256 of `whisker-lynx-android-<LYNX_VERSION>.tar.gz` as
 /// produced by the fork's CI. Pinned to the
-/// [v3.7.0-whisker.1 release](https://github.com/whiskerrs/lynx/releases/tag/v3.7.0-whisker.1).
+/// [v3.7.0-whisker.2 release](https://github.com/whiskerrs/lynx/releases/tag/v3.7.0-whisker.2).
+///
+/// Bump from `.1`: rebuilds Android `liblynx.so` against
+/// whiskerrs/lynx#1, which adds `lynx_create_fiber_element_by_name`
+/// to `core/native_renderer_capi`. Required for the
+/// `#[whisker::native_element]` Android path — without this symbol
+/// in liblynx.so, `XHello()` and any other custom native element
+/// call breaks at the FFI boundary on Android.
 pub const LYNX_ANDROID_SHA256: &str =
-    "67f898067fee6f1ad8788fa3d432bd944fd7cae997f6e464ff32c3d8e2e20c37";
+    "692deb849606e76cda1c3ff60de9e3f29dac9a50daa527446eae82c8559b9201";
 
 /// SHA-256 of `whisker-lynx-ios-<LYNX_VERSION>.tar.gz`. Pinned to
 /// the same release as Android — the fork's CI builds both halves
 /// in parallel and uploads them as a pair.
+///
+/// The iOS xcframework doesn't strictly need the `.2` bump (Whisker
+/// compiles `core/native_renderer_capi/lynx_native_renderer.cc`
+/// itself on iOS — see `whisker-driver-sys/build.rs`), but keeping
+/// both halves on the same Lynx tag avoids the "Android against
+/// .2, iOS against .1" version-skew footgun.
 pub const LYNX_IOS_SHA256: &str =
-    "39c3e40365f950606173ad0df16546541e90e003d93f606cda0eb401b57f2b20";
+    "e79ec33a11b2d0e74243a0ac2b95b5e3a97854ae6fcca7a1ef383c33f25167ff";
 
 /// GitHub Releases URL template. The `<{ver}>` and `<{plat}>`
 /// placeholders are filled by [`download_url`].


### PR DESCRIPTION
Picks up [whiskerrs/lynx#1](https://github.com/whiskerrs/lynx/pull/1)'s \`lynx_create_fiber_element_by_name\` addition. The Lynx fork's \`3.7.0-whisker.1\` Android \`liblynx.so\` only exported the enum-tag variant (\`lynx_create_fiber_element\`); \`#[whisker::native_element]\`'s Android path falls over at the FFI boundary without the by-name variant.

iOS sidestepped this because Whisker compiles \`core/native_renderer_capi/lynx_native_renderer.cc\` itself there (\`whisker-driver-sys/build.rs\` iOS branch), but Android relies on liblynx.so for the symbol.

## SHA-256 verification

Both halves of the fork's CI built cleanly on tag push. Verified locally:

\`\`\`
$ nm -D --defined-only liblynx.so | grep fiber_element
00000000001b05ac T lynx_create_fiber_element
00000000001b0884 T lynx_create_fiber_element_by_name   ← new
\`\`\`

Tarball checksums:

- Android: \`692deb849606e76cda1c3ff60de9e3f29dac9a50daa527446eae82c8559b9201\`
- iOS:     \`e79ec33a11b2d0e74243a0ac2b95b5e3a97854ae6fcca7a1ef383c33f25167ff\`

Both pulled from the [v3.7.0-whisker.2 release](https://github.com/whiskerrs/lynx/releases/tag/v3.7.0-whisker.2) and verified by \`shasum -a 256\`.

## Sanity check

Ran \`whisker run --target ios\` against \`examples/hello-world\` on the bumped pin. iOS xcframework fetches + verifies cleanly; \`XHello\`'s pink bar still renders at the top of the home screen.

## Follow-up

The Android emulator smoke-test (yellow bar) is the next verification step. It needs **both**:
1. **PR #36** — Android module-system path (gen-tree Kotlin staging, JNI payload sig)
2. **This PR** — Lynx pin with the by-name symbol

Once both land, \`whisker run --target android\` from \`examples/hello-world\` should produce a yellow rectangle above the music-app UI (Android mirror of iOS's pink bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)