### PR TITLE
Phase 7-Φ.E.2: iOS bridge dispatch via NSInvocation + WhiskerModuleRegistry

### DIFF
--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_android.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_android.cc
@@ -335,4 +335,74 @@ Java_rs_whisker_runtime_WhiskerView_nativeOnLynxEvent(
     return handled ? JNI_TRUE : JNI_FALSE;
 }
 
+// ---- Native module invocation stubs (Phase 7-Φ.E.2 placeholder) ----------
+//
+// The iOS path landed in E.2 (whisker_bridge_ios.mm). Android's
+// real dispatch (JNI cached jmethodID + CallObjectMethodA against
+// the `WhiskerModuleRegistry` Kotlin object) lands in E.3 — until
+// then, Android returns the same "not implemented" error shape as
+// the C ABI surfaces, so the bridge still links cleanly on the
+// Android target.
+
+#include <cstring>
+#include <cstdlib>
+
+namespace {
+
+WhiskerValue WhiskerMakeErrorValueAndroid(const char* message) {
+    WhiskerValue v;
+    std::memset(&v, 0, sizeof(v));
+    v.type = WHISKER_VALUE_ERROR;
+    if (message != nullptr) {
+        size_t len = std::strlen(message);
+        char* buf = static_cast<char*>(std::malloc(len + 1));
+        std::memcpy(buf, message, len + 1);
+        v.v.s.ptr = buf;
+        v.v.s.len = len;
+    }
+    return v;
+}
+
+}  // namespace
+
+extern "C" WhiskerValue whisker_bridge_invoke_module(
+    const char* /*module_name*/,
+    const char* /*method_name*/,
+    const WhiskerValue* /*args*/,
+    size_t /*arg_count*/) {
+    return WhiskerMakeErrorValueAndroid(
+        "whisker_bridge_invoke_module: Android dispatch not yet "
+        "implemented (lands in Phase 7-Φ.E.3)");
+}
+
+extern "C" bool whisker_bridge_invoke_module_async(
+    const char* /*module_name*/,
+    const char* /*method_name*/,
+    const WhiskerValue* /*args*/,
+    size_t /*arg_count*/,
+    WhiskerModuleCallback callback,
+    void* user_data) {
+    if (callback != nullptr) {
+        WhiskerValue err = WhiskerMakeErrorValueAndroid(
+            "whisker_bridge_invoke_module_async: Android dispatch not yet "
+            "implemented");
+        callback(user_data, &err);
+        std::free(const_cast<char*>(err.v.s.ptr));
+    }
+    return false;
+}
+
+extern "C" void whisker_bridge_value_release(WhiskerValue* value) {
+    if (value == nullptr) return;
+    // Stubs only allocate the error message — free that and zero
+    // the discriminant so a double-release is safe.
+    if (value->type == WHISKER_VALUE_STRING ||
+        value->type == WHISKER_VALUE_ERROR) {
+        std::free(const_cast<char*>(value->v.s.ptr));
+        value->v.s.ptr = nullptr;
+        value->v.s.len = 0;
+    }
+    value->type = WHISKER_VALUE_NULL;
+}
+
 #endif  // __ANDROID__

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -358,64 +358,12 @@ extern "C" void whisker_bridge_flush(WhiskerEngine* engine) {
     lynx_shell_flush(engine->shell);
 }
 
-// ---- Native module invocation stubs (Phase 7-Φ.E.1) -----------------------
-//
-// Foundation-only commit — the platform-specific dispatch
-// (NSInvocation on iOS, JNI reflection on Android) lands in
-// Phase 7-Φ.E.2/E.3. Until then, every call returns a
-// WHISKER_VALUE_ERROR carrying a "not yet implemented" message so
-// the FFI shape is verifiable end-to-end (build, link, Rust-side
-// type checks) without committing to dispatch internals.
-//
-// `value_release` is a real no-op — there are no heap allocations
-// to free in the error case. Once the dispatch lands, this fn
-// gains real cleanup of strings/bytes/arrays/maps the bridge
-// produces.
-
-#include <cstring>
-#include <cstdlib>
-
-namespace {
-
-WhiskerValue MakeErrorValue(const char* message) {
-    WhiskerValue v;
-    std::memset(&v, 0, sizeof(v));
-    v.type = WHISKER_VALUE_ERROR;
-    // Stash the message as a borrowed string — caller copies before
-    // calling value_release.
-    v.v.s.ptr = message;
-    v.v.s.len = std::strlen(message);
-    return v;
-}
-
-}  // namespace
-
-extern "C" WhiskerValue whisker_bridge_invoke_module(
-    const char* /*module_name*/,
-    const char* /*method_name*/,
-    const WhiskerValue* /*args*/,
-    size_t /*arg_count*/) {
-    return MakeErrorValue(
-        "whisker_bridge_invoke_module: not yet implemented "
-        "(Phase 7-Φ.E.1 foundation — dispatch lands in E.2/E.3)");
-}
-
-extern "C" bool whisker_bridge_invoke_module_async(
-    const char* /*module_name*/,
-    const char* /*method_name*/,
-    const WhiskerValue* /*args*/,
-    size_t /*arg_count*/,
-    WhiskerModuleCallback callback,
-    void* user_data) {
-    if (callback != nullptr) {
-        WhiskerValue err = MakeErrorValue(
-            "whisker_bridge_invoke_module_async: not yet implemented");
-        callback(user_data, &err);
-    }
-    return false;
-}
-
-extern "C" void whisker_bridge_value_release(WhiskerValue* /*value*/) {
-    // Foundation stub: nothing to free. Once dispatch lands, this
-    // gains case-by-type cleanup of string/bytes/array/map.
-}
+// Native module invocation (`whisker_bridge_invoke_module*` +
+// `whisker_bridge_value_release`) is implemented per-platform —
+// iOS lives in `whisker_bridge_ios.mm` (NSInvocation against the
+// `WhiskerModuleRegistry`), Android in `whisker_bridge_android.cc`
+// (JNI cached-jmethodID against the Kotlin registry). The Phase
+// 7-Φ.E.1 stubs that previously lived here were removed once the
+// iOS path landed in E.2 — common.cc has no reason to provide a
+// dispatch fallback, and an empty stub would collide with the
+// platform-specific impl at link time.

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
@@ -124,4 +124,359 @@ extern "C" void whisker_bridge_log_hello(void) {
     NSLog(@"[WhiskerBridge] Hello from the Obj-C++ bridge");
 }
 
+// ---- Native module invocation (Phase 7-Φ.E.2) ----------------------------
+//
+// Replaces the common-side stub (which always returned
+// WHISKER_VALUE_ERROR) with the real iOS dispatch: look up the class
+// via WhiskerModuleRegistry, build an NSInvocation against the
+// single-`NSArray*`-arg selector, convert WhiskerValue ↔ Foundation
+// types, invoke, return the converted result.
+//
+// Method convention: each Whisker module method is declared with a
+// single `NSArray*` argument and an `id` return type. The Obj-C
+// selector is `<methodName>:` (the leading word + one colon). The
+// `NSArray*` carries the positional args after WhiskerValue →
+// Foundation conversion. Author-facing types are recovered by the
+// `#[whisker::native_module]` proc-macro-generated proxy + the
+// `@WhiskerMethod` Swift Macro on the platform side (both arrive in
+// later sub-phases).
+
+#import "whisker_module_registry.h"
+#import <objc/runtime.h>
+
+namespace {
+
+// `MakeErrorValue` lives in whisker_bridge_common.cc as a static
+// — duplicate it here so the iOS bridge unit doesn't depend on
+// the common stubs once they're removed in a follow-up.
+WhiskerValue WhiskerMakeErrorValue(const char* message) {
+    WhiskerValue v;
+    std::memset(&v, 0, sizeof(v));
+    v.type = WHISKER_VALUE_ERROR;
+    if (message != nullptr) {
+        // Strings returned from invoke_module are heap-owned by the
+        // bridge — caller frees via whisker_bridge_value_release.
+        size_t len = std::strlen(message);
+        char* buf = (char*)std::malloc(len + 1);
+        std::memcpy(buf, message, len + 1);
+        v.v.s.ptr = buf;
+        v.v.s.len = len;
+    }
+    return v;
+}
+
+// Convert a single `WhiskerValue` (borrowed from the caller) into
+// a Foundation object suitable for stuffing into an `NSArray`.
+// Returns `NSNull` for the null variant; the array-variant
+// recursively converts each element; the map-variant builds an
+// `NSDictionary` keyed by UTF-8 string.
+id WhiskerValueToFoundation(const WhiskerValue* v) {
+    if (v == nullptr) return [NSNull null];
+    switch (v->type) {
+        case WHISKER_VALUE_NULL:
+            return [NSNull null];
+        case WHISKER_VALUE_BOOL:
+            return @(v->v.b);
+        case WHISKER_VALUE_INT:
+            return @(v->v.i);
+        case WHISKER_VALUE_FLOAT:
+            return @(v->v.f);
+        case WHISKER_VALUE_STRING: {
+            if (v->v.s.ptr == nullptr) return @"";
+            return [[NSString alloc] initWithBytes:v->v.s.ptr
+                                            length:v->v.s.len
+                                          encoding:NSUTF8StringEncoding] ?: @"";
+        }
+        case WHISKER_VALUE_BYTES: {
+            if (v->v.bytes.ptr == nullptr || v->v.bytes.len == 0) {
+                return [NSData data];
+            }
+            return [NSData dataWithBytes:v->v.bytes.ptr length:v->v.bytes.len];
+        }
+        case WHISKER_VALUE_ARRAY: {
+            NSMutableArray* arr = [NSMutableArray arrayWithCapacity:v->v.array.count];
+            for (size_t i = 0; i < v->v.array.count; i++) {
+                [arr addObject:WhiskerValueToFoundation(&v->v.array.items[i])];
+            }
+            return arr;
+        }
+        case WHISKER_VALUE_MAP: {
+            NSMutableDictionary* dict =
+                [NSMutableDictionary dictionaryWithCapacity:v->v.map.count];
+            for (size_t i = 0; i < v->v.map.count; i++) {
+                NSString* key = nil;
+                if (v->v.map.entries[i].key.ptr != nullptr) {
+                    key = [[NSString alloc]
+                        initWithBytes:v->v.map.entries[i].key.ptr
+                               length:v->v.map.entries[i].key.len
+                             encoding:NSUTF8StringEncoding];
+                }
+                if (key == nil) continue;
+                id value = WhiskerValueToFoundation(&v->v.map.entries[i].value);
+                dict[key] = value;
+            }
+            return dict;
+        }
+        case WHISKER_VALUE_ERROR:
+        default:
+            return [NSNull null];
+    }
+}
+
+// Convert a Foundation object back into a `WhiskerValue`. Heap
+// allocations attached to the result are owned by the bridge —
+// callers free via whisker_bridge_value_release once they've
+// copied any inner data they need.
+WhiskerValue FoundationToWhiskerValue(id obj) {
+    WhiskerValue v;
+    std::memset(&v, 0, sizeof(v));
+    if (obj == nil || obj == [NSNull null]) {
+        v.type = WHISKER_VALUE_NULL;
+        return v;
+    }
+    if ([obj isKindOfClass:[NSNumber class]]) {
+        NSNumber* n = obj;
+        // `objCType` distinguishes the underlying scalar — `c` /
+        // `B` for BOOL, `q`/`l`/`i`/... for integers, `d`/`f` for
+        // floats. Bool is a special case in Obj-C: `@YES`'s
+        // `objCType` is `c` but `kCFBooleanTrue` is the canonical
+        // singleton, so we compare instance identity to handle it
+        // reliably.
+        if ((__bridge CFBooleanRef)obj == kCFBooleanTrue ||
+            (__bridge CFBooleanRef)obj == kCFBooleanFalse) {
+            v.type = WHISKER_VALUE_BOOL;
+            v.v.b = [n boolValue];
+            return v;
+        }
+        const char* t = [n objCType];
+        if (t != nullptr &&
+            (*t == 'd' || *t == 'f')) {
+            v.type = WHISKER_VALUE_FLOAT;
+            v.v.f = [n doubleValue];
+            return v;
+        }
+        v.type = WHISKER_VALUE_INT;
+        v.v.i = [n longLongValue];
+        return v;
+    }
+    if ([obj isKindOfClass:[NSString class]]) {
+        NSString* s = obj;
+        const char* utf8 = [s UTF8String];
+        size_t len = (utf8 != nullptr) ? std::strlen(utf8) : 0;
+        char* buf = (char*)std::malloc(len + 1);
+        if (utf8 != nullptr) {
+            std::memcpy(buf, utf8, len + 1);
+        } else {
+            buf[0] = '\0';
+        }
+        v.type = WHISKER_VALUE_STRING;
+        v.v.s.ptr = buf;
+        v.v.s.len = len;
+        return v;
+    }
+    if ([obj isKindOfClass:[NSData class]]) {
+        NSData* d = obj;
+        size_t len = (size_t)d.length;
+        uint8_t* buf = (uint8_t*)std::malloc(len);
+        if (len > 0) std::memcpy(buf, d.bytes, len);
+        v.type = WHISKER_VALUE_BYTES;
+        v.v.bytes.ptr = buf;
+        v.v.bytes.len = len;
+        return v;
+    }
+    if ([obj isKindOfClass:[NSArray class]]) {
+        NSArray* a = obj;
+        size_t count = (size_t)a.count;
+        WhiskerValue* items =
+            (WhiskerValue*)std::malloc(count * sizeof(WhiskerValue));
+        for (size_t i = 0; i < count; i++) {
+            items[i] = FoundationToWhiskerValue(a[i]);
+        }
+        v.type = WHISKER_VALUE_ARRAY;
+        v.v.array.items = items;
+        v.v.array.count = count;
+        return v;
+    }
+    if ([obj isKindOfClass:[NSDictionary class]]) {
+        NSDictionary* d = obj;
+        size_t count = (size_t)d.count;
+        WhiskerKeyValue* entries =
+            (WhiskerKeyValue*)std::malloc(count * sizeof(WhiskerKeyValue));
+        size_t i = 0;
+        for (NSString* key in d.allKeys) {
+            const char* utf8 = [key UTF8String];
+            size_t key_len = (utf8 != nullptr) ? std::strlen(utf8) : 0;
+            char* key_buf = (char*)std::malloc(key_len + 1);
+            if (utf8 != nullptr) {
+                std::memcpy(key_buf, utf8, key_len + 1);
+            } else {
+                key_buf[0] = '\0';
+            }
+            entries[i].key.ptr = key_buf;
+            entries[i].key.len = key_len;
+            entries[i].value = FoundationToWhiskerValue(d[key]);
+            i++;
+        }
+        v.type = WHISKER_VALUE_MAP;
+        v.v.map.entries = entries;
+        v.v.map.count = count;
+        return v;
+    }
+    // Unknown / unsupported Foundation type — return null rather
+    // than crashing; the proxy on the Rust side reports it as a
+    // "type mismatch" if the user asked for a specific shape.
+    v.type = WHISKER_VALUE_NULL;
+    return v;
+}
+
+void WhiskerValueRelease(WhiskerValue* v) {
+    if (v == nullptr) return;
+    switch (v->type) {
+        case WHISKER_VALUE_STRING:
+        case WHISKER_VALUE_ERROR:
+            std::free((void*)v->v.s.ptr);
+            v->v.s.ptr = nullptr;
+            v->v.s.len = 0;
+            break;
+        case WHISKER_VALUE_BYTES:
+            std::free((void*)v->v.bytes.ptr);
+            v->v.bytes.ptr = nullptr;
+            v->v.bytes.len = 0;
+            break;
+        case WHISKER_VALUE_ARRAY:
+            for (size_t i = 0; i < v->v.array.count; i++) {
+                WhiskerValueRelease(&v->v.array.items[i]);
+            }
+            std::free(v->v.array.items);
+            v->v.array.items = nullptr;
+            v->v.array.count = 0;
+            break;
+        case WHISKER_VALUE_MAP:
+            for (size_t i = 0; i < v->v.map.count; i++) {
+                std::free((void*)v->v.map.entries[i].key.ptr);
+                WhiskerValueRelease(&v->v.map.entries[i].value);
+            }
+            std::free(v->v.map.entries);
+            v->v.map.entries = nullptr;
+            v->v.map.count = 0;
+            break;
+        default:
+            break;
+    }
+    v->type = WHISKER_VALUE_NULL;
+}
+
+}  // namespace
+
+// `__attribute__((used))` so the iOS dispatch overrides the
+// common-stub symbol once linked into the bridge static archive
+// — the linker's last-definition-wins behavior under `-ObjC`
+// pulls our impl in.
+__attribute__((used))
+extern "C" WhiskerValue whisker_bridge_invoke_module(
+    const char* module_name,
+    const char* method_name,
+    const WhiskerValue* args,
+    size_t arg_count) {
+    @autoreleasepool {
+        if (module_name == nullptr || method_name == nullptr) {
+            return WhiskerMakeErrorValue("module/method name is NULL");
+        }
+        NSString* nameStr = [NSString stringWithUTF8String:module_name];
+        id instance = [WhiskerModuleRegistry moduleInstanceForName:nameStr];
+        if (instance == nil) {
+            return WhiskerMakeErrorValue("module not registered");
+        }
+        NSString* selStr = [NSString stringWithFormat:@"%s:", method_name];
+        SEL selector = NSSelectorFromString(selStr);
+        if (![instance respondsToSelector:selector]) {
+            return WhiskerMakeErrorValue("module method not found");
+        }
+
+        NSMutableArray* argsArr = [NSMutableArray arrayWithCapacity:arg_count];
+        for (size_t i = 0; i < arg_count; i++) {
+            id obj = WhiskerValueToFoundation(&args[i]);
+            [argsArr addObject:(obj ?: [NSNull null])];
+        }
+
+        NSMethodSignature* sig =
+            [[instance class] instanceMethodSignatureForSelector:selector];
+        NSInvocation* inv = [NSInvocation invocationWithMethodSignature:sig];
+        [inv setTarget:instance];
+        [inv setSelector:selector];
+        [inv setArgument:&argsArr atIndex:2];  // 0 = self, 1 = _cmd
+
+        @try {
+            [inv invoke];
+        } @catch (NSException* e) {
+            return WhiskerMakeErrorValue([e.reason UTF8String] ?: "exception");
+        }
+
+        // Read the return value as an `id` (Whisker module methods
+        // are required to return an object — primitives must be
+        // wrapped in NSNumber on the platform side).
+        id returnValue = nil;
+        if (sig.methodReturnLength == sizeof(id)) {
+            __unsafe_unretained id raw = nil;
+            [inv getReturnValue:&raw];
+            returnValue = raw;
+        }
+        return FoundationToWhiskerValue(returnValue);
+    }
+}
+
+__attribute__((used))
+extern "C" void whisker_bridge_value_release(WhiskerValue* value) {
+    WhiskerValueRelease(value);
+}
+
+// Async path: foundation only — dispatches to the sync path on a
+// background queue, then calls the callback on the same queue.
+// Callers that need main-thread delivery should bounce via
+// `dispatch_async(dispatch_get_main_queue(), ...)` inside their
+// callback. Real async storage / network ops will land in
+// dedicated module implementations (Phase 7-Φ.E.7+).
+__attribute__((used))
+extern "C" bool whisker_bridge_invoke_module_async(
+    const char* module_name,
+    const char* method_name,
+    const WhiskerValue* args,
+    size_t arg_count,
+    WhiskerModuleCallback callback,
+    void* user_data) {
+    if (callback == nullptr) return false;
+
+    // Copy args + names into heap so the dispatch_async block can
+    // outlive this stack frame. `WhiskerValueRelease` runs on the
+    // bridge side after the callback returns; deep-copy avoids
+    // surprising lifetimes if the caller frees the originals.
+    std::string mod = module_name ? module_name : "";
+    std::string method = method_name ? method_name : "";
+
+    std::vector<WhiskerValue> args_copy(arg_count);
+    for (size_t i = 0; i < arg_count; i++) {
+        // Note: this copies the tagged union by-value but does
+        // *not* deep-copy the heap allocations under string /
+        // bytes / array / map. The async-impl follow-up will add
+        // a `WhiskerValueDeepCopy` once we have a real consumer
+        // for async; for now this is safe iff the caller keeps
+        // the args alive until the callback fires. The sync
+        // path's semantics (args borrowed for the call's
+        // duration only) doesn't apply to async — caller MUST
+        // own the storage.
+        args_copy[i] = args[i];
+    }
+
+    dispatch_async(
+        dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+          WhiskerValue result = whisker_bridge_invoke_module(
+              mod.c_str(), method.c_str(),
+              args_copy.empty() ? nullptr : args_copy.data(),
+              args_copy.size());
+          callback(user_data, &result);
+          WhiskerValueRelease(&result);
+        });
+    return true;
+}
+
 #endif  // __APPLE__

--- a/crates/whisker-driver-sys/bridge/src/whisker_module_registry.h
+++ b/crates/whisker-driver-sys/bridge/src/whisker_module_registry.h
@@ -1,0 +1,55 @@
+// `WhiskerModuleRegistry` — Whisker-owned native-module name→class
+// map on iOS.
+//
+// Lynx has its own `LynxModule` registration path for the JS engine;
+// Whisker keeps a parallel map keyed by Whisker's module names so
+// the C bridge can find a module class by string without round-
+// tripping through Lynx's JSValue dispatch (which would also
+// require a JS engine to be alive — Whisker has none).
+//
+// Modules are registered at app launch by the auto-generated
+// `WhiskerModuleRegistration.swift` (the SwiftPM `BuildToolPlugin`
+// adds `@WhiskerModule` discovery in Phase 7-Φ.E.6). Until then,
+// modules can register manually from Swift / Obj-C via
+// `[WhiskerModuleRegistry registerModuleClass:forName:]`.
+//
+// Instances are lazy-singleton — one shared instance per registered
+// class, created on first lookup. Module authors who need
+// per-WhiskerView instances should drop down to manual lookup +
+// allocation from the consuming code instead of using the bridge's
+// shared-instance path.
+
+#ifndef WHISKER_MODULE_REGISTRY_H_
+#define WHISKER_MODULE_REGISTRY_H_
+
+#ifdef __OBJC__
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WhiskerModuleRegistry : NSObject
+
+/// Register a module class under `name`. Subsequent
+/// `moduleInstanceForName:`/`moduleClassForName:` calls resolve to
+/// `cls`. Replaces any previously-registered class for the same
+/// name — last-write-wins, mirroring Lynx's own UI-class registry
+/// semantics.
++ (void)registerModuleClass:(Class)cls forName:(NSString*)name;
+
+/// Resolve a module name to its registered class, or nil if no
+/// registration matches.
++ (nullable Class)moduleClassForName:(NSString*)name;
+
+/// Resolve a module name to its shared instance (creating one
+/// lazily via `[[cls alloc] init]` on first lookup). Returns nil
+/// if no class is registered or the class has no zero-arg init.
++ (nullable id)moduleInstanceForName:(NSString*)name;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // __OBJC__
+
+#endif  // WHISKER_MODULE_REGISTRY_H_

--- a/crates/whisker-driver-sys/bridge/src/whisker_module_registry.mm
+++ b/crates/whisker-driver-sys/bridge/src/whisker_module_registry.mm
@@ -1,0 +1,77 @@
+#import "whisker_module_registry.h"
+
+// Backing storage: two parallel dicts, one for the class
+// registration (set at app launch, read on every invoke) and one
+// for the lazy-singleton instances (read-mostly after the first
+// invoke per module). Both guarded by a single `NSLock` — module
+// dispatch isn't on the hot path, so coarse locking is fine.
+
+@implementation WhiskerModuleRegistry
+
++ (NSMutableDictionary<NSString *, Class> *)classesMap {
+    static NSMutableDictionary<NSString *, Class> *m;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+      m = [NSMutableDictionary new];
+    });
+    return m;
+}
+
++ (NSMutableDictionary<NSString *, id> *)instancesMap {
+    static NSMutableDictionary<NSString *, id> *m;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+      m = [NSMutableDictionary new];
+    });
+    return m;
+}
+
++ (NSLock *)mapLock {
+    static NSLock *l;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+      l = [NSLock new];
+    });
+    return l;
+}
+
++ (void)registerModuleClass:(Class)cls forName:(NSString *)name {
+    if (cls == nil || name == nil) return;
+    NSLock *lock = [self mapLock];
+    [lock lock];
+    [self classesMap][name] = cls;
+    // Drop any cached instance — the new class supersedes the
+    // previous lazy-singleton (rare in practice; mostly relevant
+    // when hot-patches reload a module class).
+    [[self instancesMap] removeObjectForKey:name];
+    [lock unlock];
+}
+
++ (Class)moduleClassForName:(NSString *)name {
+    if (name == nil) return nil;
+    NSLock *lock = [self mapLock];
+    [lock lock];
+    Class cls = [self classesMap][name];
+    [lock unlock];
+    return cls;
+}
+
++ (id)moduleInstanceForName:(NSString *)name {
+    if (name == nil) return nil;
+    NSLock *lock = [self mapLock];
+    [lock lock];
+    id instance = [self instancesMap][name];
+    if (instance == nil) {
+        Class cls = [self classesMap][name];
+        if (cls != nil) {
+            instance = [[cls alloc] init];
+            if (instance != nil) {
+                [self instancesMap][name] = instance;
+            }
+        }
+    }
+    [lock unlock];
+    return instance;
+}
+
+@end

--- a/crates/whisker-driver-sys/build.rs
+++ b/crates/whisker-driver-sys/build.rs
@@ -236,6 +236,7 @@ fn compile_ios() -> Result<()> {
         .flag("-fobjc-arc")
         .file(bridge_src.join("whisker_bridge_common.cc"))
         .file(bridge_src.join("whisker_bridge_ios.mm"))
+        .file(bridge_src.join("whisker_module_registry.mm"))
         .file(bridge_src.join("lynx_native_renderer.cc"))
         .include(bridge_root().join("include"))
         .include(&bridge_src);


### PR DESCRIPTION
Replaces the Phase E.1 stub on iOS with real bridge dispatch: registry lookup → \`NSInvocation\` → \`WhiskerValue\` ↔ Foundation conversion. Android stays as a stub returning \`WHISKER_VALUE_ERROR\` (real Android impl lands in E.3); the C ABI links cleanly on both targets.

## Components

### \`WhiskerModuleRegistry\` (Obj-C class)

Whisker-owned name→class map keyed by the module's registration string. Separate from Lynx's \`LynxModule\` registry — Whisker has no JS engine to route through; we look up classes by string from C directly. Lazy-singleton instances (one per registered class).

Authoring code calls \`[WhiskerModuleRegistry registerModuleClass:forName:]\` at app launch. Phase 7-Φ.E.6 adds auto-generation of those calls from \`@WhiskerModule\` Swift annotations.

### iOS dispatch (\`whisker_bridge_ios.mm\`)

- \`whisker_bridge_invoke_module\` looks up the registered class, resolves selector \`<methodName>:\`, builds an \`NSInvocation\` with one \`NSArray*\` argument carrying WhiskerValue → Foundation converted args, invokes, converts return.
- \`whisker_bridge_invoke_module_async\` dispatches the sync path on a USER_INITIATED global queue, fires callback there.
- \`whisker_bridge_value_release\` frees heap allocations.

### Method-signature convention

Each Whisker module method takes **one** \`NSArray*\` argument + returns \`id\`. The Obj-C selector is \`<methodName>:\`. Authors unpack:

\`\`\`swift
@objc public func save(_ args: NSArray) -> NSObject {
    guard args.count >= 2,
          let key = args[0] as? String,
          let value = args[1] as? String else {
        return NSNumber(value: false)
    }
    UserDefaults.standard.set(value, forKey: key)
    return NSNumber(value: true)
}
\`\`\`

Type safety is recovered at the consuming end via the \`#[whisker::native_module]\` proc macro (E.5).

### Value conversion (WhiskerValueToFoundation / FoundationToWhiskerValue)

| WhiskerValue | Foundation |
|---|---|
| NULL | NSNull |
| BOOL | NSNumber (CFBoolean identity check) |
| INT | NSNumber (\`objCType\` q/l/i/...) |
| FLOAT | NSNumber (\`objCType\` d/f) |
| STRING | NSString |
| BYTES | NSData |
| ARRAY | NSArray (recursive) |
| MAP | NSDictionary (UTF-8 keys, recursive) |

Heap allocations are bridge-owned on return; caller frees via \`whisker_bridge_value_release\` once read.

## What's NOT in this PR

- **Real Android dispatch (E.3)** — Android currently stubs to \`WHISKER_VALUE_ERROR\`.
- **Rust runtime invoke API (E.4)** — bridge calls aren't reachable from Rust callers yet.
- **Proc-macro / annotation discovery (E.5 / E.6)** — authors register manually.
- **Sample storage module + verification (E.7 / E.8)** — no end-to-end smoke test yet.

## Tests

\`cargo build --workspace\`, \`cargo test --workspace\`, \`cargo fmt\`, \`cargo clippy -- -D warnings\` all pass. The new iOS dispatch isn't exercised end-to-end yet (no Rust caller, no registered module) — E.4 / E.7 / E.8 add the runtime test path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)