### PR TITLE
Phase 7-Φ.E.5: #[whisker::native_module] proc macro

### DIFF
--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
@@ -1,0 +1,85 @@
+// Host-build stub for the C ABI surface.
+//
+// Compiled by `build.rs` ONLY when the cargo target isn't iOS or
+// Android — `cargo test` / `cargo build` on a developer's macOS /
+// Linux box lands here so the Rust crates that consume the bridge
+// (whisker-driver, whisker, the proc-macro-generated proxies) link
+// cleanly. The stub returns a `WHISKER_VALUE_ERROR` for every
+// invoke; real platform dispatch lives in `whisker_bridge_ios.mm`
+// (NSInvocation) and `whisker_bridge_android.cc` (JNI).
+//
+// Symbols mirror the contracts in `whisker_bridge.h`; ownership
+// rules match the platform impls (the returned Error variant
+// carries a heap-malloc'd message that `value_release` frees).
+//
+// Phase 7-Φ.E.5 added this file so host unit tests for the
+// `#[whisker::native_module]` proc macro (under
+// `crates/whisker/tests/native_module.rs`) can verify the
+// generated proxies dispatch to the bridge and gracefully wrap
+// the resulting error in `WhiskerModuleError`.
+
+#include "whisker_bridge.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+WhiskerValue MakeHostStubError(const char* message) {
+    WhiskerValue v;
+    std::memset(&v, 0, sizeof(v));
+    v.type = WHISKER_VALUE_ERROR;
+    if (message != nullptr) {
+        size_t len = std::strlen(message);
+        char* buf = static_cast<char*>(std::malloc(len + 1));
+        std::memcpy(buf, message, len + 1);
+        v.v.s.ptr = buf;
+        v.v.s.len = len;
+    }
+    return v;
+}
+
+}  // namespace
+
+extern "C" WhiskerValue whisker_bridge_invoke_module(
+    const char* /*module_name*/,
+    const char* /*method_name*/,
+    const WhiskerValue* /*args*/,
+    size_t /*arg_count*/) {
+    return MakeHostStubError(
+        "whisker_bridge_invoke_module: host build has no platform "
+        "dispatch — link against the iOS / Android bridge for real "
+        "module invocation");
+}
+
+extern "C" bool whisker_bridge_invoke_module_async(
+    const char* /*module_name*/,
+    const char* /*method_name*/,
+    const WhiskerValue* /*args*/,
+    size_t /*arg_count*/,
+    WhiskerModuleCallback callback,
+    void* user_data) {
+    if (callback == nullptr) return false;
+    WhiskerValue err = MakeHostStubError(
+        "whisker_bridge_invoke_module_async: host build has no "
+        "platform dispatch");
+    callback(user_data, &err);
+    std::free(const_cast<char*>(err.v.s.ptr));
+    return true;
+}
+
+extern "C" void whisker_bridge_value_release(WhiskerValue* value) {
+    if (value == nullptr) return;
+    if (value->type == WHISKER_VALUE_STRING || value->type == WHISKER_VALUE_ERROR) {
+        std::free(const_cast<char*>(value->v.s.ptr));
+        value->v.s.ptr = nullptr;
+        value->v.s.len = 0;
+    } else if (value->type == WHISKER_VALUE_BYTES) {
+        std::free(const_cast<uint8_t*>(value->v.bytes.ptr));
+        value->v.bytes.ptr = nullptr;
+        value->v.bytes.len = 0;
+    }
+    // Array / Map host stubs never produce nested allocations
+    // — only Error and Bytes need freeing.
+    value->type = WHISKER_VALUE_NULL;
+}

--- a/crates/whisker-driver-sys/build.rs
+++ b/crates/whisker-driver-sys/build.rs
@@ -20,8 +20,30 @@ fn main() -> Result<()> {
     match target_os.as_str() {
         "android" => compile_android(),
         "ios" => compile_ios(),
-        _ => Ok(()),
+        _ => compile_host_stub(),
     }
+}
+
+/// Compile the host-build stub on non-iOS / non-Android targets
+/// (typically a developer's macOS / Linux box running
+/// `cargo test`). Provides the C ABI surface as a tiny `.cc`
+/// returning `WHISKER_VALUE_ERROR` for every invoke — enough to
+/// link cleanly and let host tests verify the
+/// `#[whisker::native_module]` proxies dispatch + handle the
+/// Error variant. Real dispatch lives in the platform-specific
+/// .mm / .cc files.
+fn compile_host_stub() -> Result<()> {
+    let bridge_src = bridge_root().join("src");
+    let mut build = cc::Build::new();
+    build
+        .cpp(true)
+        .flag_if_supported("-std=gnu++17")
+        .file(bridge_src.join("whisker_bridge_host_stub.cc"))
+        .include(bridge_root().join("include"));
+    build
+        .try_compile("whisker_bridge_host_stub")
+        .map_err(|e| anyhow::anyhow!("compile whisker_bridge_host_stub.cc: {e}"))?;
+    Ok(())
 }
 
 // --- Paths -----------------------------------------------------------

--- a/crates/whisker-driver/src/module.rs
+++ b/crates/whisker-driver/src/module.rs
@@ -103,6 +103,27 @@ impl WhiskerValue {
     }
 }
 
+/// Failure surface for the `#[whisker::native_module]` proc-macro-
+/// generated proxy methods.
+///
+/// Wraps the UTF-8 description the bridge returned via
+/// [`WhiskerValue::Error`] (unknown module / missing method /
+/// platform-side exception / etc.), plus type-mismatch messages
+/// the proxy synthesises when the bridge returned an unexpected
+/// variant for the declared return type. Implements
+/// [`std::error::Error`] so callers can `?`-propagate through
+/// `Result` chains.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhiskerModuleError(pub String);
+
+impl std::fmt::Display for WhiskerModuleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for WhiskerModuleError {}
+
 // ----- From impls — let callers pass primitives directly ------------------
 
 impl From<()> for WhiskerValue {

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -17,6 +17,7 @@ use syn::{parse_macro_input, ItemFn};
 
 mod component;
 mod native_element;
+mod native_module;
 mod render;
 
 /// Annotates the user's app function (returning `whisker::Element`) and
@@ -231,4 +232,52 @@ pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn native_element(attr: TokenStream, item: TokenStream) -> TokenStream {
     native_element::expand(attr.into(), item.into()).into()
+}
+
+/// Declare a typed Rust proxy for a Lynx-registered native module.
+///
+/// ```ignore
+/// #[whisker::native_module(name = "WhiskerStorage")]
+/// pub trait WhiskerStorage {
+///     fn save(key: String, value: String) -> bool;
+///     fn load(key: String) -> Option<String>;
+///     async fn fetch(url: String) -> Vec<u8>;
+/// }
+/// ```
+///
+/// Emits a same-named unit struct with associated functions
+/// matching each trait method. Each function marshals its args
+/// into [`whisker::native_module::WhiskerValue`], invokes the
+/// bridge via [`invoke`](whisker::native_module::invoke) (sync)
+/// or [`invoke_async`](whisker::native_module::invoke_async)
+/// (`async fn`), then converts the returned `WhiskerValue` back
+/// into the declared return type. Mismatched return shapes
+/// (bridge returned `Bool` but the method declared `String`,
+/// platform raised an error, etc.) surface as
+/// `Err(WhiskerModuleError(_))`.
+///
+/// **Module name**: `name = "..."` overrides the trait name as
+/// the registration string. The platform-side class registers
+/// against `WhiskerModuleRegistry` using this same name.
+///
+/// **Supported types** (args + returns):
+/// - Scalars: `bool`, `i32`/`i64`/`u32`/`u64`, `f32`/`f64`.
+/// - `String`.
+/// - `Vec<u8>` (bytes — zero-copy on the platform side for
+///   large blobs).
+/// - `Option<T>` where T is any of the above (maps to
+///   `WhiskerValue::Null` for None).
+/// - `WhiskerValue` (raw passthrough — useful for module methods
+///   that return polymorphic data).
+///
+/// Sync methods (no `async` keyword) generate
+/// `pub fn NAME(...) -> Result<RET, WhiskerModuleError>`. Async
+/// methods generate `pub async fn NAME(...) -> Result<RET,
+/// WhiskerModuleError>` that awaits the bridge's callback.
+///
+/// See `crates/whisker-macros/src/native_module.rs` for the
+/// emission details.
+#[proc_macro_attribute]
+pub fn native_module(attr: TokenStream, item: TokenStream) -> TokenStream {
+    native_module::expand(attr.into(), item.into()).into()
 }

--- a/crates/whisker-macros/src/native_module.rs
+++ b/crates/whisker-macros/src/native_module.rs
@@ -1,0 +1,350 @@
+//! `#[whisker::native_module]` — type-safe Rust proxy generator
+//! for Whisker native modules.
+//!
+//! Input shape: a trait declaration listing one fn per method.
+//! Each method's args + return are typed Rust; the macro wraps
+//! them in [`WhiskerValue`] marshalling around a call to
+//! `whisker::native_module::invoke` (sync) or `invoke_async`
+//! (`async fn`).
+//!
+//! Output: a unit struct with the same name as the trait + an
+//! `impl` block exposing each method as an associated function
+//! returning `Result<T, WhiskerModuleError>`.
+//!
+//! The trait itself is consumed — there is no `impl<T> SomeTrait
+//! for T` left over. Treating the input as a trait is purely
+//! syntactic convenience (lets the user write familiar
+//! `fn name(args)` declarations); the platform-side class is
+//! the only true implementer of the module's API contract.
+
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{
+    parse2, FnArg, GenericArgument, ItemTrait, Lit, Meta, Pat, PatType, PathArguments, ReturnType,
+    TraitItem, TraitItemFn, Type,
+};
+
+pub fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input: ItemTrait = match parse2(item.clone()) {
+        Ok(t) => t,
+        Err(e) => {
+            return quote_spanned! { e.span() =>
+                compile_error!(concat!(
+                    "`#[whisker::native_module]` expects a trait declaration, e.g.\n",
+                    "    #[whisker::native_module(name = \"MyStorage\")]\n",
+                    "    pub trait MyStorage {\n",
+                    "        fn save(key: String, value: String) -> bool;\n",
+                    "    }\n",
+                ));
+            };
+        }
+    };
+
+    let module_name = match parse_module_name(&attr, &input) {
+        Ok(s) => s,
+        Err(e) => return e.into_compile_error(),
+    };
+
+    let trait_name = &input.ident;
+    let vis = &input.vis;
+    let mut method_impls = Vec::with_capacity(input.items.len());
+
+    for item in &input.items {
+        let TraitItem::Fn(method) = item else {
+            return syn::Error::new_spanned(
+                item,
+                "`#[whisker::native_module]` only supports `fn` items in the trait body",
+            )
+            .into_compile_error();
+        };
+        match emit_method(&module_name, method) {
+            Ok(tokens) => method_impls.push(tokens),
+            Err(e) => return e.into_compile_error(),
+        }
+    }
+
+    quote! {
+        #vis struct #trait_name;
+
+        impl #trait_name {
+            #(#method_impls)*
+        }
+    }
+}
+
+fn parse_module_name(attr: &TokenStream, input: &ItemTrait) -> syn::Result<String> {
+    if attr.is_empty() {
+        return Ok(input.ident.to_string());
+    }
+    // Parse `name = "..."`. The only attr key supported in v1.
+    let meta: Meta = parse2(attr.clone())?;
+    let Meta::NameValue(nv) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "`#[whisker::native_module]` accepts `name = \"...\"`",
+        ));
+    };
+    if !nv.path.is_ident("name") {
+        return Err(syn::Error::new_spanned(
+            &nv.path,
+            "unexpected attribute key — only `name = \"...\"` is recognised",
+        ));
+    }
+    let syn::Expr::Lit(lit) = &nv.value else {
+        return Err(syn::Error::new_spanned(
+            &nv.value,
+            "`name = ...` value must be a string literal",
+        ));
+    };
+    let Lit::Str(s) = &lit.lit else {
+        return Err(syn::Error::new_spanned(
+            &lit.lit,
+            "`name = ...` value must be a string literal",
+        ));
+    };
+    Ok(s.value())
+}
+
+fn emit_method(module_name: &str, method: &TraitItemFn) -> syn::Result<TokenStream> {
+    let sig = &method.sig;
+    let name = &sig.ident;
+    let name_str = name.to_string();
+    let is_async = sig.asyncness.is_some();
+
+    // Extract positional args, skipping `self` if present (we
+    // accept but ignore it — the proxy is a unit struct).
+    let mut arg_names: Vec<syn::Ident> = Vec::new();
+    let mut arg_decls: Vec<TokenStream> = Vec::new();
+    for input in &sig.inputs {
+        match input {
+            FnArg::Receiver(_) => continue,
+            FnArg::Typed(PatType { pat, ty, .. }) => {
+                let Pat::Ident(ident_pat) = pat.as_ref() else {
+                    return Err(syn::Error::new_spanned(
+                        pat,
+                        "native_module method args must be plain identifiers",
+                    ));
+                };
+                let ident = ident_pat.ident.clone();
+                arg_decls.push(quote! { #ident: #ty });
+                arg_names.push(ident);
+            }
+        }
+    }
+
+    let return_type = match &sig.output {
+        ReturnType::Default => syn::parse2::<Type>(quote!(()))?,
+        ReturnType::Type(_, ty) => (**ty).clone(),
+    };
+    let unwrap_expr = emit_return_unwrap(&return_type)?;
+
+    let invoke_path = if is_async {
+        quote! { ::whisker::native_module::invoke_async }
+    } else {
+        quote! { ::whisker::native_module::invoke }
+    };
+    let dot_await = if is_async {
+        quote! { .await }
+    } else {
+        quote! {}
+    };
+
+    let async_kw = if is_async {
+        quote! { async }
+    } else {
+        quote! {}
+    };
+
+    Ok(quote! {
+        pub #async_kw fn #name (#(#arg_decls),*)
+            -> ::core::result::Result<#return_type, ::whisker::native_module::WhiskerModuleError>
+        {
+            let __args: ::std::vec::Vec<::whisker::native_module::WhiskerValue> =
+                ::std::vec![ #( ::whisker::native_module::WhiskerValue::from(#arg_names) ),* ];
+            let __result = #invoke_path (#module_name, #name_str, __args) #dot_await;
+            #unwrap_expr
+        }
+    })
+}
+
+/// Build the match expression that unwraps a `WhiskerValue` into
+/// the declared return type. Each supported type gets a
+/// `match` arm; anything unrecognised falls through to
+/// `Err(WhiskerModuleError::type_mismatch(_))`.
+fn emit_return_unwrap(ty: &Type) -> syn::Result<TokenStream> {
+    // The `__result` binding is the `WhiskerValue` produced by the
+    // invoke call. The Error variant short-circuits to Err for
+    // every return type.
+
+    // Recognise the type by its surface syntax. `syn` doesn't
+    // expose "is this type bool" directly — we match on the path's
+    // last segment plus generic-args presence (for Option<T> /
+    // Vec<u8> / WhiskerValue).
+    if type_is_path(ty, &["bool"]) {
+        return Ok(quote! {
+            match __result {
+                ::whisker::native_module::WhiskerValue::Bool(v) => ::core::result::Result::Ok(v),
+                ::whisker::native_module::WhiskerValue::Error(msg) =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(msg)),
+                __other =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(
+                        ::std::format!("expected Bool, got {:?}", __other))),
+            }
+        });
+    }
+
+    if type_is_path(ty, &["i32"])
+        || type_is_path(ty, &["i64"])
+        || type_is_path(ty, &["u32"])
+        || type_is_path(ty, &["u64"])
+        || type_is_path(ty, &["isize"])
+        || type_is_path(ty, &["usize"])
+    {
+        return Ok(quote! {
+            match __result {
+                ::whisker::native_module::WhiskerValue::Int(v) =>
+                    ::core::result::Result::Ok(v as #ty),
+                ::whisker::native_module::WhiskerValue::Error(msg) =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(msg)),
+                __other =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(
+                        ::std::format!("expected Int, got {:?}", __other))),
+            }
+        });
+    }
+
+    if type_is_path(ty, &["f32"]) || type_is_path(ty, &["f64"]) {
+        return Ok(quote! {
+            match __result {
+                ::whisker::native_module::WhiskerValue::Float(v) =>
+                    ::core::result::Result::Ok(v as #ty),
+                ::whisker::native_module::WhiskerValue::Error(msg) =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(msg)),
+                __other =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(
+                        ::std::format!("expected Float, got {:?}", __other))),
+            }
+        });
+    }
+
+    if type_is_path(ty, &["String"]) || type_is_path(ty, &["std", "string", "String"]) {
+        return Ok(quote! {
+            match __result {
+                ::whisker::native_module::WhiskerValue::String(v) =>
+                    ::core::result::Result::Ok(v),
+                ::whisker::native_module::WhiskerValue::Error(msg) =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(msg)),
+                __other =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(
+                        ::std::format!("expected String, got {:?}", __other))),
+            }
+        });
+    }
+
+    // Vec<u8> → Bytes
+    if let Some(inner) = type_single_generic(ty, "Vec") {
+        if type_is_path(inner, &["u8"]) {
+            return Ok(quote! {
+                match __result {
+                    ::whisker::native_module::WhiskerValue::Bytes(v) =>
+                        ::core::result::Result::Ok(v),
+                    ::whisker::native_module::WhiskerValue::Error(msg) =>
+                        ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(msg)),
+                    __other =>
+                        ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(
+                            ::std::format!("expected Bytes, got {:?}", __other))),
+                }
+            });
+        }
+    }
+
+    // Option<T>
+    if let Some(inner) = type_single_generic(ty, "Option") {
+        let inner_unwrap = emit_return_unwrap(inner)?;
+        return Ok(quote! {
+            match __result {
+                ::whisker::native_module::WhiskerValue::Null =>
+                    ::core::result::Result::Ok(::core::option::Option::None),
+                ::whisker::native_module::WhiskerValue::Error(msg) =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(msg)),
+                __result => {
+                    let __inner: ::core::result::Result<#inner, ::whisker::native_module::WhiskerModuleError> = #inner_unwrap;
+                    __inner.map(::core::option::Option::Some)
+                }
+            }
+        });
+    }
+
+    // WhiskerValue passthrough
+    if type_is_path(ty, &["WhiskerValue"])
+        || type_is_path(ty, &["whisker", "native_module", "WhiskerValue"])
+    {
+        return Ok(quote! {
+            match __result {
+                ::whisker::native_module::WhiskerValue::Error(msg) =>
+                    ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(msg)),
+                __other => ::core::result::Result::Ok(__other),
+            }
+        });
+    }
+
+    // Unit return — accept anything (typically Null).
+    if let Type::Tuple(t) = ty {
+        if t.elems.is_empty() {
+            return Ok(quote! {
+                match __result {
+                    ::whisker::native_module::WhiskerValue::Error(msg) =>
+                        ::core::result::Result::Err(::whisker::native_module::WhiskerModuleError(msg)),
+                    _ => ::core::result::Result::Ok(()),
+                }
+            });
+        }
+    }
+
+    Err(syn::Error::new_spanned(
+        ty,
+        "unsupported return type — native_module v1 accepts \
+         bool / i32 / i64 / u32 / u64 / f32 / f64 / String / Vec<u8> / Option<T> / WhiskerValue / ()",
+    ))
+}
+
+/// Returns true when `ty` is `T1::T2::...::Tn` (a simple path
+/// without generics) matching `segments`. The check ignores
+/// leading `::` and any leading-module-path differences (e.g.
+/// `String` vs `std::string::String` both work via separate
+/// calls).
+fn type_is_path(ty: &Type, segments: &[&str]) -> bool {
+    let Type::Path(tp) = ty else {
+        return false;
+    };
+    if tp.qself.is_some() {
+        return false;
+    }
+    let path_segments: Vec<_> = tp
+        .path
+        .segments
+        .iter()
+        .map(|s| s.ident.to_string())
+        .collect();
+    path_segments == segments
+}
+
+/// If `ty` is `Outer<Inner>` (single generic arg), returns
+/// `&Inner`. Used for `Option<T>` / `Vec<u8>` recognition.
+fn type_single_generic<'a>(ty: &'a Type, outer: &str) -> Option<&'a Type> {
+    let Type::Path(tp) = ty else { return None };
+    let last = tp.path.segments.last()?;
+    if last.ident != outer {
+        return None;
+    }
+    let PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+    if args.args.len() != 1 {
+        return None;
+    }
+    match args.args.first()? {
+        GenericArgument::Type(inner) => Some(inner),
+        _ => None,
+    }
+}

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -25,7 +25,7 @@ pub use whisker_runtime as runtime;
 // the same enum.
 pub use whisker_runtime::element::ElementTag;
 
-pub use whisker_macros::{component, main, native_element, render};
+pub use whisker_macros::{component, main, native_element, native_module, render};
 
 // Phase 6.5a reactive surface, lifted to the top-level namespace so
 // user code can `use whisker::*` and reach the typical primitives
@@ -650,7 +650,9 @@ pub use whisker_runtime::main_thread::run_on_main_thread;
 /// [`invoke_async`] — direct callers use `whisker::native_module`
 /// when they need access to the raw `WhiskerValue` enum.
 pub mod native_module {
-    pub use whisker_driver::module::{from_raw, invoke, invoke_async, WhiskerValue};
+    pub use whisker_driver::module::{
+        from_raw, invoke, invoke_async, WhiskerModuleError, WhiskerValue,
+    };
 }
 
 /// Internal runtime entry points used by code the `#[whisker::main]` macro

--- a/crates/whisker/tests/native_module.rs
+++ b/crates/whisker/tests/native_module.rs
@@ -1,0 +1,87 @@
+//! `#[whisker::native_module]` integration tests.
+//!
+//! We can't exercise the bridge end-to-end here — the bridge
+//! requires a registered platform-side module (Obj-C class on
+//! iOS, Kotlin class on Android). Host tests instead verify:
+//!
+//! 1. The macro expands cleanly for the documented input shapes
+//!    (compile-time only; nothing run-time-exercised).
+//! 2. Calls into the macro-emitted methods on host return
+//!    `Err(WhiskerModuleError)` rather than crashing — the
+//!    bridge's `whisker_bridge_invoke_module` stub responds
+//!    with `WhiskerValue::Error("module not registered")` when
+//!    no platform module class is in the registry.
+//!
+//! Real end-to-end verification lives in Phase 7-Φ.E.8
+//! (whisker-storage-module + hello-world integration on iOS
+//! simulator + Android emulator).
+
+use whisker::native_module::WhiskerModuleError;
+
+// ----- Sync proxy ---------------------------------------------------------
+
+#[whisker::native_module(name = "WhiskerStorage")]
+pub trait WhiskerStorage {
+    fn save(key: String, value: String) -> bool;
+    fn load(key: String) -> Option<String>;
+    fn clear(key: String) -> ();
+}
+
+#[test]
+fn sync_proxy_unregistered_module_returns_err() {
+    // No platform module registered → bridge returns an Error
+    // WhiskerValue. The proxy lifts it into Err.
+    let result = WhiskerStorage::save("k".into(), "v".into());
+    assert!(matches!(result, Err(WhiskerModuleError(_))));
+}
+
+#[test]
+fn sync_proxy_option_return_unregistered() {
+    let result = WhiskerStorage::load("k".into());
+    assert!(matches!(result, Err(WhiskerModuleError(_))));
+}
+
+#[test]
+fn sync_proxy_unit_return_unregistered() {
+    let result = WhiskerStorage::clear("k".into());
+    assert!(matches!(result, Err(WhiskerModuleError(_))));
+}
+
+// ----- Async proxy --------------------------------------------------------
+
+#[whisker::native_module(name = "WhiskerHttp")]
+pub trait WhiskerHttp {
+    async fn fetch(url: String) -> Vec<u8>;
+}
+
+#[test]
+fn async_proxy_compiles() {
+    // We can't `await` here without an executor — just confirm
+    // the macro emits a callable signature. The future itself
+    // can be constructed safely (constructing doesn't dispatch).
+    let _fut = WhiskerHttp::fetch("https://example.com".into());
+}
+
+// ----- Custom module name -------------------------------------------------
+
+#[whisker::native_module(name = "OverriddenName")]
+pub trait MyLocalTrait {
+    fn ping() -> bool;
+}
+
+#[test]
+fn custom_module_name_compiles() {
+    let _ = MyLocalTrait::ping();
+}
+
+// ----- Default name (= trait name) ----------------------------------------
+
+#[whisker::native_module]
+pub trait UnnamedModule {
+    fn echo(value: String) -> String;
+}
+
+#[test]
+fn default_module_name_compiles() {
+    let _ = UnnamedModule::echo("x".into());
+}


### PR DESCRIPTION
Type-safe Rust proxy generator for native modules. Users write a trait declaration listing one \`fn\` per method; the macro emits an inherent-impl block on a same-named unit struct with each method marshalling args + return through \`whisker::native_module::invoke\` (sync) or \`invoke_async\` (\`async fn\`).

## API

\`\`\`rust
#[whisker::native_module(name = \"WhiskerStorage\")]
pub trait WhiskerStorage {
    fn save(key: String, value: String) -> bool;
    fn load(key: String) -> Option<String>;
    async fn fetch(url: String) -> Vec<u8>;
}

// Call site:
let saved = WhiskerStorage::save(\"user_id\".into(), \"abc\".into())?;
let loaded = WhiskerStorage::load(\"user_id\".into())?;
let blob = WhiskerStorage::fetch(\"https://...\".into()).await?;
\`\`\`

Each method returns \`Result<T, WhiskerModuleError>\`. Errors from the bridge (unknown module / missing method / platform exception) AND return-type mismatches both surface as \`Err(WhiskerModuleError(_))\`.

## Supported return types (v1)

\`bool\` / \`i32\`/\`i64\`/\`u32\`/\`u64\`/\`isize\`/\`usize\` / \`f32\`/\`f64\` / \`String\` / \`Vec<u8>\` / \`Option<T>\` / \`WhiskerValue\` (raw passthrough) / \`()\`.

Args use the \`From<T> for WhiskerValue\` impls from E.4.

## Macro internals

- \`parse_module_name\` reads \`name = \"...\"\` or defaults to trait identifier.
- \`emit_method\` extracts args (skipping \`&self\` if present), builds \`vec![...into()]\`, dispatches to \`invoke\` / \`invoke_async\` per \`async\` keyword.
- \`emit_return_unwrap\` recognises the declared return type via surface syntax (\`syn::Type::Path\` segment matching) and emits the matching arm.

## Host-build stub

Bridge dispatch lives in iOS .mm / Android .cc — only compiled on those targets. On host (cargo test), symbols would be unresolved.

Added \`whisker_bridge_host_stub.cc\` — a tiny \`.cc\` returning \`WHISKER_VALUE_ERROR\` for every invoke, compiled by build.rs when target_os is neither ios nor android. Unblocks host tests for the proc-macro proxies.

## Tests

\`crates/whisker/tests/native_module.rs\` covers sync proxy (bool / Option / unit returns), async proxy (compile + future construction), custom name attribute, default name.

End-to-end verification with a registered platform module lands in Phase 7-Φ.E.7 / E.8.

\`cargo build\` / \`test\` / \`fmt\` / \`clippy -- -D warnings\` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)