### PR TITLE
Phase 7-Φ.E.7+E.8: whisker-local-store reference module + hello-world integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ version = "0.1.0"
 dependencies = [
  "whisker",
  "whisker-hello-element",
+ "whisker-local-store",
 ]
 
 [[package]]
@@ -1869,6 +1870,13 @@ dependencies = [
 
 [[package]]
 name = "whisker-hello-element"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+]
+
+[[package]]
+name = "whisker-local-store"
 version = "0.1.0"
 dependencies = [
  "whisker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "examples/hn-reader",
     "examples/subsecond-poc",
     "packages/whisker-hello-element",
+    "packages/whisker-local-store",
 ]
 exclude = [
     # Throwaway cdylib the dev-server's `thin_rebuild` integration

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -63,6 +63,14 @@ const BRIDGE_EXPORTS: &[&str] = &[
     "_whisker_bridge_invoke_module_async",
     "_whisker_bridge_value_release",
     "_whisker_bridge_log_hello",
+    // Obj-C class symbol — `WhiskerModuleRegistry` is referenced
+    // from the auto-generated `WhiskerModuleBehaviors.swift` to
+    // call `registerModuleClass(_:forName:)`. Without this export
+    // ld64 dead-strips the class from the framework's dylib (no
+    // C-side caller references it), and the consuming SwiftPM
+    // target fails to link with "Undefined symbols:
+    // _OBJC_CLASS_$_WhiskerModuleRegistry". Phase 7-Φ.E.6.
+    "_OBJC_CLASS_$_WhiskerModuleRegistry",
 ];
 
 /// Build the WhiskerDriver.xcframework that wraps `package`'s dylib

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
@@ -23,7 +23,10 @@
 #import <objc/runtime.h>
 
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <string>
+#include <vector>
 
 #include "whisker_bridge.h"
 #include "whisker_bridge_internal.h"

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -27,3 +27,11 @@ whisker = { workspace = true }
 # bar from the rendered output — a useful smoke test of the
 # module-discovery pipeline.
 whisker-hello-element = { path = "../../packages/whisker-hello-element" }
+
+# Phase 7-Φ.E.8 demo: persist the heart-toggle bitmask in
+# UserDefaults (iOS) / SharedPreferences (Android) so the liked
+# mixes survive app restarts. The dep walk picks up the module's
+# `whisker.module.toml`, stages the Swift / Kotlin
+# `WhiskerLocalStoreImpl` into the gen tree, and the platform-side
+# annotation discovery wires the registration end-to-end.
+whisker-local-store = { path = "../../packages/whisker-local-store" }

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -49,13 +49,35 @@ struct AppState {
 
 impl AppState {
     fn new() -> Self {
+        // Phase 7-Φ.E.8 demo: hydrate the heart-bitmask from
+        // `WhiskerLocalStore` so liked mixes survive app restarts.
+        // The store is registered automatically through the
+        // `@WhiskerModule("WhiskerLocalStore")` annotation
+        // discovery — no manual registration needed in the user
+        // app.
+        //
+        // The bridge stub on host targets (e.g. `cargo test`)
+        // returns `WhiskerValue::Error`; the proxy lifts that into
+        // `Err`, which we silently fall back to the default for.
+        // Mobile launches go through the real platform-side
+        // dispatch so this returns the persisted value.
+        let initial_liked = whisker_local_store::WhiskerLocalStore::load(LIKED_MIXES_KEY.into())
+            .ok()
+            .flatten()
+            .and_then(|s| s.parse::<u8>().ok())
+            .unwrap_or(0b000_010_u8);
         Self {
             selected_tab: RwSignal::new(0_usize),
-            liked_mixes: RwSignal::new(0b000_010_u8),
+            liked_mixes: RwSignal::new(initial_liked),
             is_playing: RwSignal::new(true),
         }
     }
 }
+
+/// Storage key for the heart-bitmask. Single source of truth so a
+/// future schema change (versioning, e.g. `liked_mixes_v2`) lands
+/// in one place.
+const LIKED_MIXES_KEY: &str = "hello_world.liked_mixes";
 
 // ---- Palette / constants ----------------------------------------------------
 
@@ -478,6 +500,15 @@ fn app() -> Element {
     // is `Copy`, so threading it through `#[component]` props below
     // doesn't introduce any `move ||` boilerplate.
     let state = AppState::new();
+
+    // Persist the heart bitmask on every change. The effect reads
+    // `state.liked_mixes` (subscribing) and writes to the local
+    // store so an app restart restores the same toggles.
+    effect(move || {
+        let bits = state.liked_mixes.get();
+        let _ =
+            whisker_local_store::WhiskerLocalStore::save(LIKED_MIXES_KEY.into(), bits.to_string());
+    });
 
     let page_style = format!(
         "width: 100vw; height: 100vh; background-color: {BG}; \

--- a/native/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerApplication.kt
+++ b/native/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerApplication.kt
@@ -1,6 +1,7 @@
 package rs.whisker.runtime
 
 import android.app.Application
+import android.content.Context
 import com.lynx.tasm.LynxEnv
 
 /**
@@ -17,10 +18,34 @@ import com.lynx.tasm.LynxEnv
  * before `super.onCreate()` — the bridge resolves `whisker_app_main` from
  * `RTLD_DEFAULT`, which only sees libraries the process has already
  * loaded.
+ *
+ * Also stashes a process-wide [appContext] reference for Whisker
+ * native modules instantiated reflectively by the C bridge (their
+ * `cls.getDeclaredConstructor().newInstance()` zero-arg ctor has no
+ * Context to pull from). Modules read [appContext] lazily on first
+ * dispatch — by that time `onCreate` has long since run.
  */
 open class WhiskerApplication : Application() {
+    public companion object {
+        /**
+         * The ApplicationContext, set in [onCreate]. Module classes
+         * (`@WhiskerModule(...)`) reach this lazily because the bridge
+         * instantiates them with a zero-arg ctor — there's no Context
+         * to inject at construction time.
+         *
+         * Reading from arbitrary background threads is safe; the
+         * value is a stable per-process reference, written once
+         * before any module dispatch happens.
+         */
+        @JvmStatic
+        @Volatile
+        public var appContext: Context? = null
+            private set
+    }
+
     override fun onCreate() {
         super.onCreate()
+        appContext = applicationContext
         for (name in listOf("c++_shared", "quick", "lynxbase", "lynxtrace", "lynx")) {
             System.loadLibrary(name)
         }

--- a/packages/whisker-ios-macros/Sources/WhiskerElementsMacros/WhiskerElementMacro.swift
+++ b/packages/whisker-ios-macros/Sources/WhiskerElementsMacros/WhiskerElementMacro.swift
@@ -36,7 +36,64 @@ import SwiftSyntaxMacros
 struct WhiskerElementsPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
         WhiskerElementMacro.self,
+        WhiskerModuleMacro.self,
     ]
+}
+
+/// `@WhiskerModule("Name")` — emit a static `__whiskerModuleName`
+/// constant on the annotated class so the SwiftPM build-tool
+/// plugin (`WhiskerElementsCodegen`) can introspect the
+/// registration name via SwiftSyntax parse. Mirror of
+/// `WhiskerElementMacro`'s `__whiskerElementTag`; same DX shape,
+/// different generated registration target
+/// (`WhiskerModuleRegistry` instead of `LynxComponentRegistry`).
+///
+/// Phase 7-Φ.E.6.
+public struct WhiskerModuleMacro: MemberMacro, MemberAttributeMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let name = whiskerModuleFirstStringArgument(of: node) else {
+            return []
+        }
+        return [
+            """
+            @objc public static let __whiskerModuleName: String = \(literal: name)
+            """
+        ]
+    }
+
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingAttributesFor member: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [AttributeSyntax] {
+        // MemberAttributeMacro is invoked per-member — emit nothing
+        // per-method. The `@objc` class-runtime-name pin needed for
+        // `NSClassFromString` lookup is the author's responsibility
+        // via an explicit `@objc(ClassName)` on the class, mirroring
+        // the `@WhiskerElement` policy.
+        []
+    }
+}
+
+/// First positional string-literal argument of an `@Attr("...")`
+/// invocation. Shared shape — `@WhiskerElement(_ tag:)` and
+/// `@WhiskerModule(_ name:)` both take exactly one string arg.
+private func whiskerModuleFirstStringArgument(of node: AttributeSyntax) -> String? {
+    guard
+        let arguments = node.arguments?.as(LabeledExprListSyntax.self),
+        let firstArg = arguments.first,
+        let stringLiteral = firstArg.expression.as(StringLiteralExprSyntax.self),
+        stringLiteral.segments.count == 1,
+        let firstSegment = stringLiteral.segments.first?.as(StringSegmentSyntax.self)
+    else {
+        return nil
+    }
+    return firstSegment.content.text
 }
 
 public struct WhiskerElementMacro: MemberMacro, MemberAttributeMacro {

--- a/packages/whisker-local-store/Cargo.toml
+++ b/packages/whisker-local-store/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "whisker-local-store"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Reference Whisker native module — persistent key-value local store wrapping UserDefaults on iOS and SharedPreferences on Android. Doubles as the documented template for first-party Whisker native modules."
+
+# rlib only. The Whisker module system handles native-source
+# distribution out-of-band via `whisker.module.toml` — we don't
+# ship a cdylib here. Sibling of `whisker-hello-element`.
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+whisker = { workspace = true }

--- a/packages/whisker-local-store/src/android/WhiskerLocalStoreImpl.kt
+++ b/packages/whisker-local-store/src/android/WhiskerLocalStoreImpl.kt
@@ -1,0 +1,82 @@
+// Android implementation of `WhiskerLocalStore` — backs the
+// `whisker::native_module::invoke("WhiskerLocalStore", ...)` calls
+// with `SharedPreferences` (private to the host app under the name
+// "WhiskerLocalStore").
+//
+// Activated by `@WhiskerModule("WhiskerLocalStore")` — the
+// `whisker-android-ksp` KSP processor finds the annotation at the
+// user-app's compile time and emits a
+// `WhiskerModuleRegistry.registerModuleClass(name, cls)` call into
+// the auto-generated `WhiskerModuleBehaviors.kt`. The JNI bridge
+// (`whisker_bridge_android.cc`) then looks up this class by name
+// on every `invoke_module` from Rust.
+//
+// Method-shape contract (shared with iOS): one `Array<Any?>`
+// argument + an `Any?` return; the JNI dispatch (see
+// `whisker_bridge_android.cc::GetCachedMethod`) signature is
+// `([Ljava/lang/Object;)Ljava/lang/Object;`. Returning `null`
+// maps to `WhiskerValue::Null` Rust-side, which the proxy lifts
+// into `Option::None` / `()` for the matching return type.
+//
+// Per-WhiskerView Context: the bridge instantiates the registered
+// class via `cls.getDeclaredConstructor().newInstance()` — i.e.
+// zero-arg ctor. We don't have access to a `Context` at
+// construction time, so we resolve it lazily through
+// `WhiskerApplication.appContext`. The generated WhiskerApplication
+// stores a process-wide ApplicationContext reference at
+// `onCreate()`, before any module dispatch happens, so this lookup
+// is always safe by the time a method runs.
+
+package rs.whisker.modules.localstore
+
+import android.content.Context
+import android.content.SharedPreferences
+import rs.whisker.annotations.WhiskerModule
+import rs.whisker.runtime.WhiskerApplication
+
+@WhiskerModule("WhiskerLocalStore")
+class WhiskerLocalStoreImpl {
+
+    /** SharedPreferences-bucket name. App-private — not visible to other apps. */
+    private val prefsName = "WhiskerLocalStore"
+
+    /**
+     * Resolve the app-private SharedPreferences instance. Lazy so
+     * the no-arg ctor doesn't need an injected Context — the
+     * Application has installed `appContext` before any dispatch
+     * could reach this method.
+     */
+    private fun prefs(): SharedPreferences {
+        val ctx = WhiskerApplication.appContext
+            ?: throw IllegalStateException(
+                "WhiskerLocalStore: WhiskerApplication.appContext not initialised — " +
+                    "ensure your Application class extends WhiskerApplication " +
+                    "and super.onCreate() runs before any module dispatch",
+            )
+        return ctx.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+    }
+
+    /** Save args[0] (String key) → args[1] (String value). Returns true on success. */
+    fun save(args: Array<Any?>): Any {
+        val key = args.getOrNull(0) as? String ?: return false
+        val value = args.getOrNull(1) as? String ?: return false
+        return prefs().edit().putString(key, value).commit()
+    }
+
+    /**
+     * Load the value for args[0]. Returns the value String on hit,
+     * null on miss — the JNI bridge converts null → WhiskerValue::Null,
+     * which the proxy lifts into Option::None.
+     */
+    fun load(args: Array<Any?>): Any? {
+        val key = args.getOrNull(0) as? String ?: return null
+        return prefs().getString(key, null)
+    }
+
+    /** Drop args[0]'s entry. Returns null (→ `()` on the Rust side). */
+    fun remove(args: Array<Any?>): Any? {
+        val key = args.getOrNull(0) as? String ?: return null
+        prefs().edit().remove(key).apply()
+        return null
+    }
+}

--- a/packages/whisker-local-store/src/ios/WhiskerLocalStoreImpl.swift
+++ b/packages/whisker-local-store/src/ios/WhiskerLocalStoreImpl.swift
@@ -1,0 +1,82 @@
+// iOS implementation of `WhiskerLocalStore` — backs the
+// `whisker::native_module::invoke("WhiskerLocalStore", ...)` calls
+// with `UserDefaults.standard`.
+//
+// Activated by the `@WhiskerModule("WhiskerLocalStore")` annotation
+// — the `WhiskerElementsCodegen` SwiftPM build-tool plugin scans
+// for it at build time and emits a
+// `WhiskerModuleRegistry.registerModuleClass(_:forName:)` call into
+// the auto-generated `WhiskerModuleBehaviors.swift`. The C bridge's
+// `whisker_bridge_invoke_module` then looks up this class by name
+// when the Rust proxy dispatches.
+//
+// Method shape contract (shared with Android):
+//   Each method takes a single `NSArray*` arg and returns `NSObject?`.
+//   The Obj-C runtime selector is `<methodName>:` — the C bridge
+//   appends the colon when building its NSInvocation.
+//
+// Args + returns marshal via `WhiskerValueToFoundation` /
+// `FoundationToWhiskerValue` (see `whisker_bridge_ios.mm`):
+//
+//   Rust          C ABI            Foundation           Swift here
+//   --------------------------------------------------------------
+//   String  →  WHISKER_VALUE_STRING → NSString    →  args[i] as String
+//   bool    ←  WHISKER_VALUE_BOOL   ← NSNumber    ←  NSNumber(value: true)
+//   None    ←  WHISKER_VALUE_NULL   ← NSNull      ←  NSNull() (or return nil)
+//
+// The proxy on the Rust side handles dispatch failures (unknown
+// module / wrong return type) by returning
+// `WhiskerValue::Error("...")`, so this Swift code only needs to
+// handle the happy path + arg-shape mismatches.
+
+import Foundation
+import WhiskerElements
+
+@WhiskerModule("WhiskerLocalStore")
+@objc(WhiskerLocalStoreImpl)
+public class WhiskerLocalStoreImpl: NSObject {
+    /// Save args[0] (String key) → args[1] (String value) in
+    /// UserDefaults. Returns NSNumber(true) on success.
+    @objc public func save(_ args: NSArray) -> NSObject {
+        guard
+            args.count >= 2,
+            let key = args[0] as? String,
+            let value = args[1] as? String
+        else {
+            return NSNumber(value: false)
+        }
+        UserDefaults.standard.set(value, forKey: key)
+        return NSNumber(value: true)
+    }
+
+    /// Load the value for args[0] (String key). Returns the value
+    /// as NSString on success, NSNull on no-such-key — the bridge's
+    /// FoundationToWhiskerValue maps NSNull → WhiskerValue::Null,
+    /// which the `#[whisker::native_module]` proxy lifts into
+    /// `Option::None`.
+    @objc public func load(_ args: NSArray) -> NSObject {
+        guard
+            args.count >= 1,
+            let key = args[0] as? String
+        else {
+            return NSNull()
+        }
+        if let value = UserDefaults.standard.string(forKey: key) {
+            return value as NSString
+        }
+        return NSNull()
+    }
+
+    /// Remove args[0]'s entry from UserDefaults. Returns NSNull
+    /// (bridge → WhiskerValue::Null → `()` on the Rust side).
+    @objc public func remove(_ args: NSArray) -> NSObject {
+        guard
+            args.count >= 1,
+            let key = args[0] as? String
+        else {
+            return NSNull()
+        }
+        UserDefaults.standard.removeObject(forKey: key)
+        return NSNull()
+    }
+}

--- a/packages/whisker-local-store/src/lib.rs
+++ b/packages/whisker-local-store/src/lib.rs
@@ -1,0 +1,81 @@
+//! `whisker-local-store` — reference Whisker native module.
+//!
+//! Persistent string-keyed key-value store backed by:
+//!   - **iOS**: `UserDefaults.standard`
+//!   - **Android**: `SharedPreferences` (named `"WhiskerLocalStore"`)
+//!
+//! Both platforms persist across app launches but don't sync across
+//! devices. For app-level preferences, small state, and similar
+//! data — not for large blobs (use a real file API or database for
+//! anything > ~1 MB per entry).
+//!
+//! The module is also the documented template for first-party
+//! Whisker native modules: cargo-discoverable manifest + Rust trait
+//! marked `#[whisker::native_module(name = "...")]` + a
+//! `@WhiskerModule(...)`-annotated class on each platform. Phase
+//! 7-Φ.E follow-up modules (`whisker-network`, `whisker-clipboard`,
+//! …) follow the same shape.
+//!
+//! ## Usage
+//!
+//! Add the crate to your app's `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! whisker-local-store = { path = "../whisker/packages/whisker-local-store" }
+//! ```
+//!
+//! Call from anywhere reactive runs (component bodies, event
+//! handlers, effects):
+//!
+//! ```ignore
+//! use whisker_local_store::WhiskerLocalStore;
+//!
+//! let _ = WhiskerLocalStore::save("user_id".into(), "abc".into())?;
+//! let loaded = WhiskerLocalStore::load("user_id".into())?;
+//! // -> Some("abc".to_string())
+//! ```
+//!
+//! Each method returns `Result<T, whisker::native_module::WhiskerModuleError>` —
+//! the platform side (UserDefaults / SharedPreferences) can't
+//! reasonably fail under normal conditions, but Whisker's bridge
+//! reports any class-lookup / dispatch issue through the same
+//! channel so callers handle every error uniformly.
+
+// `#![deny(missing_docs)]` would fire on the unit struct +
+// methods the `#[whisker::native_module]` proc macro emits — the
+// macro doesn't propagate the trait method docs onto the emitted
+// proxy methods. Doc comments on the trait itself + the
+// public-facing module are what users see in IDE hovers; the
+// generated struct is an implementation detail.
+
+/// Typed Rust proxy for the `WhiskerLocalStore` native module.
+///
+/// The `#[whisker::native_module]` proc macro (Phase 7-Φ.E.5)
+/// generates a unit struct + associated `pub fn save / load /
+/// remove` methods that marshal args + return through
+/// `whisker::native_module::invoke`. The platform-side class
+/// (`WhiskerLocalStoreImpl` — `src/ios/WhiskerLocalStoreImpl.swift`
+/// / `src/android/WhiskerLocalStoreImpl.kt`) provides the actual
+/// UserDefaults / SharedPreferences storage.
+#[whisker::native_module(name = "WhiskerLocalStore")]
+pub trait WhiskerLocalStore {
+    /// Persist `value` under `key`. Returns `true` on success.
+    ///
+    /// Subsequent [`load`](WhiskerLocalStore::load) calls with the
+    /// same key resolve to `Some(value)` even across app launches.
+    /// Overwrites any previously-stored value for that key.
+    fn save(key: String, value: String) -> bool;
+
+    /// Look up the value previously stored under `key`.
+    ///
+    /// Returns `None` when no entry exists. Doesn't distinguish
+    /// "never saved" from "saved then removed" — both surface as
+    /// `None`. Use [`save`](WhiskerLocalStore::save) to set a
+    /// sentinel value if you need that distinction.
+    fn load(key: String) -> Option<String>;
+
+    /// Drop `key`'s entry (if any). No-op when the key isn't
+    /// present.
+    fn remove(key: String) -> ();
+}

--- a/packages/whisker-local-store/whisker.module.toml
+++ b/packages/whisker-local-store/whisker.module.toml
@@ -1,0 +1,18 @@
+# Whisker module manifest (v1).
+#
+# Declares the platform-side source files for `whisker-local-store`,
+# the reference Whisker native module (Phase 7-Φ.E.7). The
+# consuming app's `whisker run` / `whisker build` CLI fold these
+# sources into the host iOS framework / Android APK alongside the
+# user app's other module crates.
+#
+# Module-name string: `"WhiskerLocalStore"` — referenced by the
+# Rust-side `#[whisker::native_module(name = "WhiskerLocalStore")]`
+# proxy + the platform-side `@WhiskerModule("WhiskerLocalStore")`
+# class annotations.
+
+[ios]
+swift_sources = ["src/ios/WhiskerLocalStoreImpl.swift"]
+
+[android]
+kotlin_sources = ["src/android/WhiskerLocalStoreImpl.kt"]


### PR DESCRIPTION
Closes Phase 7-Φ.E with a working end-to-end reference: persistent key-value store backed by UserDefaults / SharedPreferences, discovered via the annotation-discovery pipeline from E.6, called through the typed Rust proxy from E.5, exercised live in hello-world for liked-mix persistence across app restarts.

## packages/whisker-local-store/ (E.7)

Reference Whisker native module + documented template for first-party native modules (storage / network / clipboard / device-info / …):

- **\`src/lib.rs\`**: typed Rust proxy via \`#[whisker::native_module(name = \"WhiskerLocalStore\")]\` — three methods (\`save\` / \`load\` / \`remove\`) returning \`Result<T, WhiskerModuleError>\`.
- **\`src/ios/WhiskerLocalStoreImpl.swift\`**: \`@WhiskerModule(\"WhiskerLocalStore\")\` decorating an Obj-C class wrapping \`UserDefaults.standard\`.
- **\`src/android/WhiskerLocalStoreImpl.kt\`**: \`@WhiskerModule(\"WhiskerLocalStore\")\` decorating a Kotlin class wrapping \`SharedPreferences\` (private bucket).
- **\`whisker.module.toml\`**: iOS / Android source-file declarations.

The Kotlin impl resolves \`Context\` lazily through \`WhiskerApplication.appContext\` (companion-object field set in \`onCreate\` before any module dispatch).

## hello-world integration (E.8)

- \`AppState::new()\` calls \`WhiskerLocalStore::load(\"hello_world.liked_mixes\")\` to hydrate the bitmask on startup.
- An \`effect\` reads \`state.liked_mixes\` and calls \`WhiskerLocalStore::save(...)\` on every change.

End-to-end smoke test for the bridge dispatch.

## Verification

**iOS (Xcode 26 / iPhone 17 Pro sim)**: pink bar renders, \`defaults read\` shows \`hello_world.liked_mixes = \"2\"\` post-launch. Manually overriding the plist to \"63\" then re-launching preserves \"63\" — confirming the load path.

**Android (Pixel API 30 emulator)**: yellow bar renders, \`shared_prefs/WhiskerLocalStore.xml\` shows \`<string name=\"hello_world.liked_mixes\">2</string>\` — confirming the JNI + Kotlin \`SharedPreferences\` write path.

## Supporting fixes

- iOS bridge \`whisker_bridge_ios.mm\` missing \`<cstdlib>\` / \`<cstring>\` / \`<vector>\` (async dispatch used \`std::vector\`).
- \`WhiskerModuleMacro\` was declared but never landed in the macro plugin's \`providingMacros\` list — moved in.
- \`_OBJC_CLASS_$_WhiskerModuleRegistry\` was being dead-stripped by ld64 — added to \`BRIDGE_EXPORTS\`.

## Tests

\`cargo build\` / \`test\` / \`fmt\` / \`clippy -- -D warnings\` all pass. iOS sim + Android emulator verified.

End of Phase 7-Φ.E — native-module dispatch works end-to-end on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)