### PR TITLE
Phase 7-Φ.H.1: Lynx symbol hiding

### DIFF
--- a/native/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerLynxAliases.kt
+++ b/native/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerLynxAliases.kt
@@ -1,0 +1,98 @@
+package rs.whisker.runtime
+
+/**
+ * Phase 7-Φ.H.1: Lynx symbol hiding (Android).
+ *
+ * Module authors writing `@WhiskerElement(...)`-annotated classes
+ * previously had to import Lynx types directly:
+ *
+ * ```kotlin
+ * import com.lynx.tasm.behavior.LynxContext
+ * import com.lynx.tasm.behavior.ui.LynxUI
+ *
+ * @WhiskerElement("x-hello")
+ * class WhiskerHelloElement(context: LynxContext) : LynxUI<View>(context) { ... }
+ * ```
+ *
+ * The bridge is built on Lynx and that won't change in the
+ * foreseeable future, but the Lynx-ness leaking into every
+ * module's public API surface makes Whisker feel like a thin
+ * Lynx wrapper. These typealiases give module authors
+ * `Whisker*` symbols that resolve to their Lynx counterparts at
+ * Kotlin's type-system level — same runtime classes, just a
+ * presentation rename.
+ *
+ * ```kotlin
+ * import rs.whisker.runtime.WhiskerContext
+ * import rs.whisker.runtime.WhiskerUI
+ *
+ * @WhiskerElement("x-hello")
+ * class WhiskerHelloElement(context: WhiskerContext) : WhiskerUI<View>(context) { ... }
+ * ```
+ *
+ * Stack traces / debugger views still surface the real `LynxUI`
+ * class names (typealiases are purely a source-level concept).
+ * Renaming the underlying classes themselves would require
+ * patching the Lynx fork — a separate, larger effort planned
+ * for the long-term roadmap.
+ *
+ * Note: Kotlin's `typealias` keyword cannot alias annotation
+ * types. `@LynxProp` therefore needs a separate KSP-forwarder
+ * mechanism (see `@WhiskerProp` + the KSP processor) rather than
+ * a typealias here.
+ */
+
+public typealias WhiskerUI<V> = com.lynx.tasm.behavior.ui.LynxUI<V>
+
+public typealias WhiskerContext = com.lynx.tasm.behavior.LynxContext
+
+public typealias WhiskerCustomEventBase = com.lynx.tasm.event.LynxCustomEvent
+
+public typealias WhiskerBehavior = com.lynx.tasm.behavior.Behavior
+
+public typealias WhiskerEnv = com.lynx.tasm.LynxEnv
+
+// MARK: - Custom-event dispatch helper
+
+/**
+ * Whisker-branded façade over `LynxCustomEvent` +
+ * `LynxContext.eventEmitter.dispatchCustomEvent(...)`.
+ *
+ * Module authors that need to push events back to Rust (e.g. an
+ * `<x-input>` text-change firing `on_input:` on the consumer
+ * crate) call:
+ *
+ * ```kotlin
+ * WhiskerCustomEvent.dispatch(
+ *     from = this,                                    // WhiskerUI subclass
+ *     name = "input",
+ *     params = mapOf("value" to editText.text.toString()))
+ * ```
+ *
+ * instead of manually constructing `LynxCustomEvent` and
+ * reaching into `lynxContext.eventEmitter`. The function looks
+ * at the UI's `sign` + `lynxContext` to wire the event back to
+ * the host's bridge reporter, which delivers the JSON-serialised
+ * params to the matching Rust `on_<event>: String` callback.
+ */
+public object WhiskerCustomEvent {
+    /**
+     * Build and dispatch a `LynxCustomEvent` from [ui]. No-op if
+     * the UI's context is null (e.g. before mount or after
+     * detach).
+     */
+    @JvmStatic
+    public fun dispatch(
+        ui: WhiskerUI<*>,
+        name: String,
+        params: Map<String, Any?> = emptyMap(),
+    ) {
+        val ctx = ui.lynxContext ?: return
+        val emitter = ctx.eventEmitter ?: return
+        val event = com.lynx.tasm.event.LynxCustomEvent(ui.sign, name, params)
+        // Android's `EventEmitter` exposes `sendCustomEvent(...)`
+        // (whereas iOS's equivalent is `dispatchCustomEvent`).
+        // Same end behaviour — the reporter sees the event.
+        emitter.sendCustomEvent(event)
+    }
+}

--- a/native/ios/Sources/WhiskerRuntime/WhiskerLynxAliases.swift
+++ b/native/ios/Sources/WhiskerRuntime/WhiskerLynxAliases.swift
@@ -1,0 +1,114 @@
+// Phase 7-Φ.H.1: Lynx symbol hiding (iOS).
+//
+// Module authors writing `@WhiskerElement(...)`-annotated classes
+// previously had to import Lynx types directly:
+//
+// ```swift
+// import Lynx
+//
+// @WhiskerElement("x-hello")
+// public class WhiskerHelloElement: LynxUI<UIView> {
+//     @objc public override func createView() -> UIView { … }
+// }
+// ```
+//
+// The bridge runtime is built on Lynx and that won't change in
+// the foreseeable future, but the Lynx-ness leaking into every
+// module's public API surface makes Whisker feel like a thin
+// Lynx wrapper rather than its own framework. These typealiases
+// give module authors `Whisker*` symbols that resolve to their
+// Lynx counterparts at the Swift type-system level — same
+// runtime classes, just a presentation rename.
+//
+// ```swift
+// import WhiskerRuntime
+//
+// @WhiskerElement("x-hello")
+// public class WhiskerHelloElement: WhiskerUI<UIView> {
+//     @objc public override func createView() -> UIView { … }
+// }
+// ```
+//
+// Stack traces / debugger views still surface the real `LynxUI`
+// class names (typealiases are purely a source-level concept).
+// Renaming the underlying classes themselves would require
+// patching the Lynx fork — a separate, larger effort planned for
+// the long-term roadmap.
+
+// `@_exported` so module-author `.swift` files can `import
+// WhiskerRuntime` alone — the typealias targets (`LynxUI`,
+// `LynxContext`, …) get pulled into scope transitively, no
+// separate `import Lynx` required. Without this the typealiases
+// resolve at WhiskerRuntime's own compile but fail at the
+// consumer's call site with "cannot find type 'LynxUI' in scope".
+@_exported import Lynx
+
+/// Whisker's preferred alias for Lynx's `LynxUI` generic base.
+/// Subclass this in `@WhiskerElement`-annotated classes.
+///
+/// The generic parameter is the native view type the element
+/// wraps (`UIView` / `UITextField` / …). Lynx's create / layout
+/// / event hooks all surface through this base unchanged.
+public typealias WhiskerUI = LynxUI
+
+/// Per-`WhiskerView` context, identical to Lynx's `LynxContext`.
+/// Module code typically only needs it for
+/// `lynxContext.eventEmitter.dispatchCustomEvent(...)` (see
+/// [`WhiskerCustomEvent`] for the high-level wrapper).
+public typealias WhiskerContext = LynxContext
+
+/// Custom-event payload type for `WhiskerUI` subclasses that
+/// emit events the host app's `on_<event>:` Rust callbacks
+/// receive. Use [`WhiskerCustomEvent`] for the dispatch helper.
+public typealias WhiskerCustomEventBase = LynxCustomEvent
+
+/// Lynx's component-registration entry point. Module authors
+/// rarely call this directly — the `WhiskerElementsCodegenPlugin`
+/// generates the registration code from `@WhiskerElement`
+/// annotations.
+public typealias WhiskerComponentRegistry = LynxComponentRegistry
+
+// MARK: - Custom-event dispatch helper
+
+/// Whisker-branded façade over Lynx's `LynxCustomEvent` +
+/// `LynxUIContext.eventEmitter.dispatchCustomEvent(_:)`.
+///
+/// Module authors that need to push events back to Rust (e.g. an
+/// `<x-input>` text-change firing `on_input:` on the consumer
+/// crate) call:
+///
+/// ```swift
+/// WhiskerCustomEvent.dispatch(
+///     from: self,                       // the WhiskerUI subclass
+///     name: "input",
+///     params: ["value": textField.text ?? ""])
+/// ```
+///
+/// instead of manually constructing `LynxCustomEvent` and
+/// reaching into `context.eventEmitter`. The function looks at
+/// the UI's `sign` + `context` to wire the event back to the
+/// host's `whisker_bridge_set_event_listener_with_payload`
+/// reporter, which delivers the JSON-serialised params to the
+/// matching Rust `on_<event>: String` callback.
+public enum WhiskerCustomEvent {
+    /// Build and dispatch a `LynxCustomEvent` from `ui`.
+    /// No-op if the UI has been detached from its context
+    /// (Lynx holds `context` weakly).
+    public static func dispatch<V>(
+        from ui: WhiskerUI<V>,
+        name: String,
+        params: [AnyHashable: Any]? = nil
+    ) {
+        guard let ctx = ui.context else { return }
+        let event = LynxCustomEvent(
+            name: name,
+            targetSign: ui.sign,
+            params: params
+        )
+        // `eventEmitter` is `nullable` in LynxUIContext.h, so the
+        // imported Swift type is `LynxEventEmitter?`. Skip dispatch
+        // when the emitter hasn't been wired yet (pre-mount or
+        // post-teardown).
+        ctx.eventEmitter?.dispatchCustomEvent(event)
+    }
+}

--- a/packages/whisker-android-ksp/annotations/src/main/kotlin/rs/whisker/annotations/WhiskerProp.kt
+++ b/packages/whisker-android-ksp/annotations/src/main/kotlin/rs/whisker/annotations/WhiskerProp.kt
@@ -1,0 +1,49 @@
+package rs.whisker.annotations
+
+/**
+ * Marks a `@WhiskerElement`-annotated class's method as a prop
+ * setter that should be wired up to Lynx's attribute-dispatch
+ * machinery.
+ *
+ * Author writes:
+ *
+ * ```kotlin
+ * @WhiskerElement("x-input")
+ * open class WhiskerInput(context: WhiskerContext) : WhiskerUI<EditText>(context) {
+ *     override fun createView(context: Context): EditText = EditText(context)
+ *
+ *     @WhiskerProp("value")
+ *     open fun setValue(value: String) {
+ *         view?.setText(value)
+ *     }
+ * }
+ * ```
+ *
+ * The `:ksp` companion processor scans `@WhiskerElement`-annotated
+ * classes for `@WhiskerProp`-tagged methods and generates a
+ * `<Class>_LynxBridge` subclass alongside the per-module behaviors
+ * file. The bridge subclass declares matching `@LynxProp(name =
+ * ...)` wrapper methods that forward to the original, then the
+ * generated `Behaviors.registerAll()` registers the BRIDGE class
+ * with Lynx instead of the user class. Lynx's reflection-based
+ * prop dispatch finds the `@LynxProp`-tagged wrappers on the
+ * bridge and Whisker module authors never have to mention Lynx
+ * symbols in their own code.
+ *
+ * Why a separate annotation instead of typealiasing `@LynxProp`:
+ * Kotlin's `typealias` keyword does not support annotation types
+ * (the compiler refuses `typealias WhiskerProp = LynxProp`). The
+ * KSP-generated subclass is the next-cleanest workaround.
+ *
+ * The annotated method MUST be `open` so the bridge subclass can
+ * forward through it. (Lynx's own `@LynxProp` does not require
+ * `open` because reflection invokes the method directly, but our
+ * bridge needs Kotlin-level call-through.)
+ *
+ * `SOURCE` retention — the annotation has no runtime role once
+ * the bridge code is generated.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.SOURCE)
+@MustBeDocumented
+public annotation class WhiskerProp(val name: String)

--- a/packages/whisker-android-ksp/ksp/src/main/kotlin/rs/whisker/ksp/WhiskerElementProcessor.kt
+++ b/packages/whisker-android-ksp/ksp/src/main/kotlin/rs/whisker/ksp/WhiskerElementProcessor.kt
@@ -64,6 +64,9 @@ public class WhiskerElementProcessor(
     /** FQN of the `@WhiskerModule` annotation — Phase 7-Φ.E.6. */
     private val moduleAnnotationFqn = "rs.whisker.annotations.WhiskerModule"
 
+    /** FQN of the `@WhiskerProp` annotation — Phase 7-Φ.H.1. */
+    private val propAnnotationFqn = "rs.whisker.annotations.WhiskerProp"
+
     /**
      * KSP invokes `process` at least twice per compilation: once
      * when the user code is first processed (annotations visible)
@@ -143,10 +146,76 @@ public class WhiskerElementProcessor(
             w.appendLine("import com.lynx.tasm.LynxEnv")
             w.appendLine("import com.lynx.tasm.behavior.Behavior")
             w.appendLine("import com.lynx.tasm.behavior.LynxContext")
+            w.appendLine("import com.lynx.tasm.behavior.LynxProp")
             w.appendLine("import com.lynx.tasm.behavior.ui.LynxUI")
             w.appendLine("import rs.whisker.runtime.WhiskerModuleRegistry")
             w.appendLine("import rs.whisker.runtime.WhiskerValue")
             w.appendLine("import java.util.concurrent.atomic.AtomicBoolean")
+
+            // Per-element bridge subclasses for @WhiskerProp forwarding.
+            // Kotlin's `typealias` keyword can't alias annotation
+            // types, so we can't surface `@LynxProp` as `@WhiskerProp`
+            // directly. Instead, for every @WhiskerElement class
+            // that carries @WhiskerProp-tagged setters, emit a
+            // `<Class>_LynxBridge` subclass with `@LynxProp(name =
+            // ...)` wrapper methods that forward to the user's
+            // setter. The element registration further down
+            // instantiates the bridge subclass rather than the
+            // user class, so Lynx's reflection-based prop dispatch
+            // finds the @LynxProp-tagged wrappers on the bridge
+            // without the module author ever mentioning Lynx in
+            // their own code.
+            for (cls in elements) {
+                val fqn = cls.qualifiedName?.asString() ?: continue
+                val simple = cls.simpleName.asString()
+                val props = propMethods(cls)
+                if (props.isEmpty()) continue
+
+                w.appendLine()
+                w.appendLine("/**")
+                w.appendLine(" * @WhiskerProp -> @LynxProp forwarding bridge for")
+                w.appendLine(" * `$fqn`. Generated so module authors avoid the")
+                w.appendLine(" * direct `@LynxProp` import (Kotlin doesn't allow")
+                w.appendLine(" * typealiasing annotations).")
+                w.appendLine(" */")
+                w.appendLine("private class ${simple}_LynxBridge(context: LynxContext) : $fqn(context) {")
+                for (m in props) {
+                    val methodName = m.decl.simpleName.asString()
+                    val propName = m.propName
+                    val params = m.decl.parameters
+                    // Each @WhiskerProp method takes a single value
+                    // parameter — Lynx's reflection contract for
+                    // prop setters. We render exactly that one
+                    // parameter; multi-param setters would need
+                    // adjustment but aren't supported by Lynx
+                    // anyway.
+                    if (params.size != 1) {
+                        logger.error(
+                            "@WhiskerProp methods must take exactly one parameter; " +
+                                "`$fqn.$methodName` has ${params.size}",
+                            m.decl,
+                        )
+                        continue
+                    }
+                    val param = params[0]
+                    val paramName = param.name?.asString() ?: "value"
+                    // Render the param type via KSP's resolved
+                    // representation. For built-ins (`kotlin.String`,
+                    // `kotlin.Int`, `kotlin.Boolean`, …) this yields
+                    // a fully-qualified name that Kotlin source
+                    // accepts unchanged. Generic args + nullability
+                    // markers come through via `toString()`.
+                    val paramTypeRendered = param.type.resolve().let { t ->
+                        val base = t.declaration.qualifiedName?.asString() ?: t.toString()
+                        if (t.isMarkedNullable) "$base?" else base
+                    }
+                    w.appendLine("    @LynxProp(name = \"$propName\")")
+                    w.appendLine("    fun lynxSet_$methodName($paramName: $paramTypeRendered) {")
+                    w.appendLine("        $methodName($paramName)")
+                    w.appendLine("    }")
+                }
+                w.appendLine("}")
+            }
 
             // Per-module dispatch objects are emitted at file scope
             // (companion to the generated `WhiskerModuleBehaviors`
@@ -211,11 +280,23 @@ public class WhiskerElementProcessor(
                     )
                     continue
                 }
+                // If the class has @WhiskerProp methods, instantiate
+                // the bridge subclass (which carries the @LynxProp
+                // wrappers) rather than the user class. The user
+                // class doesn't itself participate in Lynx's
+                // attribute-dispatch reflection, but its sub-class
+                // (the bridge) does.
+                val simple = cls.simpleName.asString()
+                val instantiated = if (propMethods(cls).isNotEmpty()) {
+                    "${simple}_LynxBridge"
+                } else {
+                    fqn
+                }
                 w.appendLine("        env.addBehavior(object : Behavior(\"$tag\") {")
                 w.appendLine("            override fun createUI(context: LynxContext): LynxUI<*> =")
-                w.appendLine("                $fqn(context)")
+                w.appendLine("                $instantiated(context)")
                 w.appendLine("            override fun createUIFiber(context: LynxContext): LynxUI<*> =")
-                w.appendLine("                $fqn(context)")
+                w.appendLine("                $instantiated(context)")
                 w.appendLine("        })")
             }
 
@@ -252,6 +333,41 @@ public class WhiskerElementProcessor(
             w.appendLine("    }")
             w.appendLine("}")
         }
+    }
+
+    /** One discovered `@WhiskerProp("name") fun setX(...)` setter. */
+    data class PropMethod(val decl: KSFunctionDeclaration, val propName: String)
+
+    /**
+     * Find every `@WhiskerProp("name")`-annotated instance method
+     * on `cls`. Phase 7-Φ.H.1 — used to emit `<Class>_LynxBridge`
+     * subclasses that carry the real `@LynxProp(name = …)` setters.
+     *
+     * Skips methods missing the `name` argument (KSP-level error
+     * logged separately) so the rest of the bridge still compiles.
+     */
+    private fun propMethods(cls: KSClassDeclaration): List<PropMethod> {
+        val out = mutableListOf<PropMethod>()
+        for (decl in cls.declarations) {
+            if (decl !is KSFunctionDeclaration) continue
+            if (decl.simpleName.asString() == "<init>") continue
+            val annotation = decl.annotations.firstOrNull {
+                it.annotationType.resolve().declaration.qualifiedName?.asString() == propAnnotationFqn
+            } ?: continue
+            val name = annotation.arguments
+                .firstOrNull { it.name?.asString() == "name" || it.name == null }
+                ?.value as? String
+            if (name == null) {
+                logger.error(
+                    "@WhiskerProp on `${cls.qualifiedName?.asString()}.${decl.simpleName.asString()}` " +
+                        "has no `name` argument",
+                    decl,
+                )
+                continue
+            }
+            out.add(PropMethod(decl, name))
+        }
+        return out
     }
 
     /**

--- a/packages/whisker-hello-element/src/android/WhiskerHelloElement.kt
+++ b/packages/whisker-hello-element/src/android/WhiskerHelloElement.kt
@@ -1,47 +1,27 @@
-// `<x-hello>` Whisker native element on Android, registered via the
-// `@WhiskerElement` Kotlin annotation (Phase 7-Φ.H.2 — companion of
-// the iOS `@WhiskerElement` Swift Macro).
+// `<x-hello>` Whisker native element on Android — Phase 7-Φ.H.1
+// migration target. Demonstrates the Whisker-only API surface
+// (no `com.lynx.tasm.*` imports in author code).
 //
-// The `whisker-android-ksp` KSP processor consumes this annotation
-// at the user app's compile time and generates
-// `rs.whisker.runtime.generated.WhiskerModuleBehaviors`, whose
-// `registerAll()` call (driven from `WhiskerApplication.onCreate()`)
-// registers `WhiskerHelloElement` against Lynx's behaviour registry
-// before any `WhiskerView` is constructed.
-//
-// The Whisker module-system staging path
-// (`whisker-build::android::stage_module_kotlin_sources`) copies
-// this file into the consuming app's gen tree at
-// `gen/android/app/src/main/whisker_modules/whisker-hello-element/
-// WhiskerHelloElement.kt`, which gradle's main source-set
-// (`kotlin.srcDirs(..., "src/main/whisker_modules")`) picks up.
-// KSP then scans the resulting compilation graph for
-// `@WhiskerElement` applications — finds this class, emits the
-// registration.
+// `WhiskerUI` / `WhiskerContext` are typealiases provided by
+// `rs.whisker.runtime` that resolve to the underlying Lynx types
+// at Kotlin's type-system level. Stack traces / debugger views
+// still show the real `LynxUI` class names — typealiases are a
+// source-level concept only.
 
 package rs.whisker.elements.hello
 
 import android.content.Context
 import android.graphics.Color
 import android.view.View
-import com.lynx.tasm.behavior.LynxContext
-import com.lynx.tasm.behavior.ui.LynxUI
 import rs.whisker.annotations.WhiskerElement
+import rs.whisker.runtime.WhiskerContext
+import rs.whisker.runtime.WhiskerUI
 
-/**
- * `<x-hello>` Whisker native element on Android. Renders as a yellow
- * rectangle; the consuming app sets size + position via the
- * `style:` prop on `XHello`.
- */
 @WhiskerElement("x-hello")
-open class WhiskerHelloElement(context: LynxContext) : LynxUI<View>(context) {
+open class WhiskerHelloElement(context: WhiskerContext) : WhiskerUI<View>(context) {
 
     override fun createView(context: Context): View {
         val view = View(context)
-        // System yellow to make the smoke test visually obvious —
-        // if you see a yellow rectangle, the tag-by-name dispatch
-        // is working end-to-end (render! → Rust → C ABI → Lynx →
-        // this class).
         view.setBackgroundColor(Color.YELLOW)
         return view
     }

--- a/packages/whisker-hello-element/src/ios/WhiskerHelloElement.swift
+++ b/packages/whisker-hello-element/src/ios/WhiskerHelloElement.swift
@@ -1,46 +1,22 @@
-// `<x-hello>` Whisker native element on iOS, in pure Swift.
+// `<x-hello>` Whisker native element on iOS — Phase 7-Φ.H.1
+// migration target. Demonstrates the Whisker-only API surface
+// (no `import Lynx`, no `LynxUI` mentions in author code).
 //
-// Phase 7-Φ.D migration target: replaces the previous Obj-C++
-// `whisker_hello_element.mm` with a `@WhiskerElement`-annotated
-// Swift class. The module-system path no longer relies on the
-// `.mm`'s `+load`-time `LYNX_REGISTER_UI` macro — instead the
-// `[ios].behaviors` entry in `whisker.module.toml` carries through
-// to whisker-build's generated `WhiskerModuleBehaviors.swift`,
-// which `AppDelegate.application(_:didFinishLaunchingWithOptions:)`
-// invokes once at launch.
-//
-// The `@WhiskerElement("x-hello")` annotation itself is purely
-// declarative in v1 — it injects a `__whiskerElementTag` constant
-// for compile-time visibility, but the runtime registration call
-// is generated from the manifest. v2 will drop the manifest entry
-// once whisker-build parses macro applications via SwiftSyntax.
-//
-// Class name MUST match `[ios].behaviors[].class` in the manifest —
-// `WhiskerModuleBehaviors.registerAll()` does
-// `NSClassFromString("WhiskerHelloElement")`, and Swift's default
-// Obj-C-runtime name for classes in a SwiftPM library is just the
-// bare class name (no mangling) as long as the class is exposed
-// to Obj-C. `LynxUI<UIView>` subclasses inherit from Lynx's own
-// NSObject hierarchy so the Obj-C name matches automatically.
+// `WhiskerUI` / `WhiskerContext` are typealiases provided by
+// WhiskerRuntime that resolve to the underlying Lynx types at
+// the Swift type-system level. Stack traces / debugger views
+// still show the real `LynxUI` class name — typealiases are a
+// source-level concept only.
 
 import UIKit
-import Lynx
 import WhiskerElements
+import WhiskerRuntime
 
 @WhiskerElement("x-hello")
 @objc(WhiskerHelloElement)
-public final class WhiskerHelloElement: LynxUI<UIView> {
-    // `@objc override` keeps the Swift override visible to Obj-C
-    // dispatch — LynxUI's `createView` is an Obj-C method, so the
-    // Lynx engine calls it via `objc_msgSend` rather than Swift's
-    // vtable. Without `@objc`, Swift may inline the override only
-    // for Swift-side callers and Lynx ends up invoking the parent
-    // `LynxUI.createView` instead.
+public final class WhiskerHelloElement: WhiskerUI<UIView> {
     @objc public override func createView() -> UIView {
         let v = UIView()
-        // System pink to make the smoke test visually obvious —
-        // if you see a pink rectangle, the tag-by-name dispatch +
-        // module-system registration are working end-to-end.
         v.backgroundColor = .systemPink
         return v
     }


### PR DESCRIPTION
## Summary

Module authors writing `@WhiskerElement`-annotated classes no longer need to import or mention Lynx types in their own code. Whisker ships `Whisker*` aliases for the common public Lynx surface + a KSP-driven forwarder that papers over the one piece Kotlin won't let us typealias (annotations).

## Author DX before → after

**Before** (Kotlin):
\`\`\`kotlin
import com.lynx.tasm.behavior.LynxContext
import com.lynx.tasm.behavior.LynxProp
import com.lynx.tasm.behavior.ui.LynxUI
import com.lynx.tasm.event.LynxCustomEvent

@WhiskerElement("x-input")
open class WhiskerInput(ctx: LynxContext) : LynxUI<EditText>(ctx) {
    @LynxProp(name = "value")
    open fun setValue(v: String) { ... }

    fun onTextChanged(s: String) {
        val event = LynxCustomEvent(sign, "input", mapOf("value" to s))
        lynxContext.eventEmitter.dispatchCustomEvent(event)
    }
}
\`\`\`

**After**:
\`\`\`kotlin
import rs.whisker.annotations.WhiskerElement
import rs.whisker.annotations.WhiskerProp
import rs.whisker.runtime.WhiskerContext
import rs.whisker.runtime.WhiskerCustomEvent
import rs.whisker.runtime.WhiskerUI

@WhiskerElement("x-input")
open class WhiskerInput(ctx: WhiskerContext) : WhiskerUI<EditText>(ctx) {
    @WhiskerProp("value")
    open fun setValue(v: String) { ... }

    fun onTextChanged(s: String) {
        WhiskerCustomEvent.dispatch(ui = this, name = "input",
            params = mapOf("value" to s))
    }
}
\`\`\`

iOS gets the same treatment via Swift typealiases + `WhiskerCustomEvent.dispatch(from:name:params:)`.

## What's included

- `WhiskerUI`, `WhiskerContext`, `WhiskerCustomEventBase`, `WhiskerComponentRegistry` (iOS) / `WhiskerBehavior`, `WhiskerEnv` (Android) typealiases
- `WhiskerCustomEvent.dispatch(...)` helper (iOS Swift + Android Kotlin)
- `@WhiskerProp("name")` Kotlin annotation
- KSP forwarder: scans each `@WhiskerElement` class for `@WhiskerProp` methods, emits a `<Class>_LynxBridge` subclass with matching `@LynxProp` wrappers, registers the bridge with Lynx
- iOS `@_exported import Lynx` so consumers only need `import WhiskerRuntime`
- whisker-hello-element sample migrated to use Whisker-only symbols

## Caveat

Stack traces / debugger views still surface the real `LynxUI` class names — typealiases are a source-level concept only. Fully renaming the underlying runtime classes requires patching the Lynx fork itself, tracked for the long-term roadmap.

## Test plan

- [x] cargo test --workspace
- [x] cargo fmt + cargo clippy
- [x] whisker build --target ios-sim → HelloWorld.app
- [x] whisker build --target android → app-release-unsigned.apk
- [x] Generated `WhiskerModuleBehaviors.kt` aggregator inspected; no breakage in existing element/module dispatch chain

Next: Phase H.2 (Element method-call mechanism — `ElementRef<T>` + Lynx fork patch for sign→instance lookup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)