### PR TITLE
feat(modules): Phase K — cargo-only distribution + `whisker new-module` scaffolding

### DIFF
--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -32,6 +32,7 @@ pub mod build;
 pub mod doctor;
 pub mod linker_shim;
 pub mod manifest;
+pub mod new_module;
 pub mod platforms;
 pub mod probe;
 pub mod run;
@@ -68,6 +69,10 @@ enum Command {
     /// gradle / xcodebuild without the dev-server. Output is the
     /// shippable `.apk` / `.app`.
     Build(build::Args),
+    /// Scaffold a new Whisker module crate (Cargo.toml + whisker.module.toml
+    /// + Package.swift + build.gradle.kts + skeleton Rust/Swift/Kotlin sources).
+    /// See `docs/module-author-guide.md`.
+    NewModule(new_module::NewModuleArgs),
 }
 
 pub fn run(args: impl IntoIterator<Item = String>) -> Result<()> {
@@ -88,6 +93,7 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<()> {
         Command::Doctor(a) => doctor::run(a),
         Command::Run(a) => run::run(a),
         Command::Build(a) => build::run(a),
+        Command::NewModule(a) => new_module::run(a),
     }
 }
 

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -69,9 +69,10 @@ enum Command {
     /// gradle / xcodebuild without the dev-server. Output is the
     /// shippable `.apk` / `.app`.
     Build(build::Args),
-    /// Scaffold a new Whisker module crate (Cargo.toml + whisker.module.toml
-    /// + Package.swift + build.gradle.kts + skeleton Rust/Swift/Kotlin sources).
-    /// See `docs/module-author-guide.md`.
+    /// Scaffold a new Whisker module crate — Cargo.toml,
+    /// whisker.module.toml, Package.swift, build.gradle.kts, and
+    /// skeleton Rust / Swift / Kotlin sources. See
+    /// `docs/module-author-guide.md`.
     NewModule(new_module::NewModuleArgs),
 }
 

--- a/crates/whisker-cli/src/new_module.rs
+++ b/crates/whisker-cli/src/new_module.rs
@@ -1,0 +1,596 @@
+//! `whisker new-module <name>` — scaffold a Whisker module crate.
+//!
+//! Creates a directory matching the supplied crate name with a
+//! complete module skeleton: `Cargo.toml`, `whisker.module.toml`,
+//! `Package.swift`, `build.gradle.kts`, `src/lib.rs`, an iOS Swift
+//! source, and an Android Kotlin source. The skeleton compiles
+//! standalone — the consumer just runs `cargo build` and adds the
+//! crate as a dep to their Whisker app.
+//!
+//! Naming convention: input is the cargo crate name (kebab-case,
+//! `whisker-foo`). The PascalCase tag (`Foo`) and the platform-side
+//! class name (`WhiskerFooComponent`) are derived. Lynx registers
+//! the module under `<crate-name>:<tag>` (`whisker-foo:Foo`).
+//!
+//! This is a minimal scaffolder — it copies a small set of inline
+//! templates and substitutes a handful of variables. For a richer
+//! template story (multiple module types, custom dirs, …) the
+//! `cargo whisker new-module` subcommand can grow later without
+//! breaking the contract documented in
+//! `docs/module-author-guide.md`.
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::Args;
+use std::path::{Path, PathBuf};
+
+/// `whisker new-module` CLI arguments.
+#[derive(Args, Debug)]
+pub struct NewModuleArgs {
+    /// The cargo crate name. Convention: kebab-case, prefixed with
+    /// `whisker-` (e.g. `whisker-camera`, `whisker-blur-view`). Must
+    /// be a valid cargo package name — letters / digits / `-` / `_`,
+    /// must start with a letter.
+    pub name: String,
+
+    /// Optional parent directory. Defaults to the current working
+    /// directory. The new crate lands at `<parent>/<name>/`.
+    #[arg(long)]
+    pub path: Option<PathBuf>,
+
+    /// Module shape. `view-bearing` (the default) generates a
+    /// `#[whisker::platform_component]` shim + the Kotlin / Swift
+    /// `WhiskerUI<View>` subclasses. `function-only` generates a
+    /// `#[whisker::platform_module]` proxy without a `View(...)` —
+    /// for modules that only expose function calls (e.g.
+    /// `whisker-local-store`-style key-value stores).
+    #[arg(long, value_enum, default_value_t = ModuleShape::ViewBearing)]
+    pub shape: ModuleShape,
+}
+
+#[derive(clap::ValueEnum, Clone, Debug, PartialEq, Eq)]
+pub enum ModuleShape {
+    /// View-bearing — renders a native view + supports prop / method
+    /// dispatch via `ElementRef<T>`.
+    #[value(name = "view-bearing")]
+    ViewBearing,
+    /// Function-only — Rust calls platform-side functions; no UI.
+    #[value(name = "function-only")]
+    FunctionOnly,
+}
+
+pub fn run(args: NewModuleArgs) -> Result<()> {
+    validate_crate_name(&args.name)?;
+    let parent = args.path.unwrap_or_else(|| PathBuf::from("."));
+    let target_dir = parent.join(&args.name);
+    if target_dir.exists() {
+        bail!(
+            "{}: directory already exists. Pick a different name or remove it.",
+            target_dir.display(),
+        );
+    }
+
+    let tag = pascal_case_tag(&args.name);
+    let class_name = format!("Whisker{tag}Component");
+
+    let v = Vars {
+        crate_name: &args.name,
+        tag: &tag,
+        class_name: &class_name,
+    };
+
+    std::fs::create_dir_all(target_dir.join("src/android"))
+        .with_context(|| format!("create {}/src/android", target_dir.display()))?;
+    std::fs::create_dir_all(target_dir.join("src/ios"))
+        .with_context(|| format!("create {}/src/ios", target_dir.display()))?;
+
+    write(&target_dir, "Cargo.toml", &cargo_toml(&v))?;
+    write(&target_dir, "README.md", &readme(&v))?;
+    write(&target_dir, "whisker.module.toml", &module_manifest(&v))?;
+    write(&target_dir, "Package.swift", &package_swift(&v))?;
+    write(&target_dir, "build.gradle.kts", &build_gradle(&v))?;
+
+    match args.shape {
+        ModuleShape::ViewBearing => {
+            write(&target_dir, "src/lib.rs", &lib_rs_view(&v))?;
+            write(
+                &target_dir,
+                &format!("src/ios/{class_name}.swift"),
+                &swift_view(&v),
+            )?;
+            write(
+                &target_dir,
+                &format!("src/android/{class_name}.kt"),
+                &kotlin_view(&v),
+            )?;
+        }
+        ModuleShape::FunctionOnly => {
+            write(&target_dir, "src/lib.rs", &lib_rs_module(&v))?;
+            // For function-only, the file holds the `@WhiskerModule`-
+            // tagged class. Strip the `Component` suffix from the class
+            // name so it reads `WhiskerFoo` rather than
+            // `WhiskerFooComponent` for non-View modules.
+            let module_class = format!("Whisker{tag}");
+            write(
+                &target_dir,
+                &format!("src/ios/{module_class}Impl.swift"),
+                &swift_module(&v, &module_class),
+            )?;
+            write(
+                &target_dir,
+                &format!("src/android/{module_class}Impl.kt"),
+                &kotlin_module(&v, &module_class),
+            )?;
+        }
+    }
+
+    eprintln!(
+        "Created Whisker module skeleton at {}\n\
+         \n\
+         Next steps:\n  \
+         1. cd {}\n  \
+         2. Implement the platform-side logic in src/ios/ and src/android/.\n  \
+         3. From your Whisker app: `cargo add --path {}` (or publish to crates.io).\n  \
+         4. See docs/module-author-guide.md for the full reference.",
+        target_dir.display(),
+        target_dir.display(),
+        target_dir.display(),
+    );
+    Ok(())
+}
+
+// ============================================================================
+// Template variables + rendering
+// ============================================================================
+
+struct Vars<'a> {
+    crate_name: &'a str,
+    tag: &'a str,
+    class_name: &'a str,
+}
+
+fn write(root: &Path, rel: &str, content: &str) -> Result<()> {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    std::fs::write(&path, content).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+fn cargo_toml(v: &Vars) -> String {
+    format!(
+        r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Whisker module — short tagline shown on crates.io."
+
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "whisker.module.toml",
+    "src/lib.rs",
+    "src/android/**/*.kt",
+    "src/ios/**/*.swift",
+    "README.md",
+]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+# Rename `whisker-modules-api` -> `whisker` so the proc macros' emit
+# paths (::whisker::ElementRef, ::whisker::platform_module::WhiskerValue,
+# ...) resolve. Cargo doesn't allow `package = ...` with
+# `workspace = true`, so the version is inlined here.
+whisker = {{ package = "whisker-modules-api", version = "0.1" }}
+"#,
+        name = v.crate_name,
+    )
+}
+
+fn readme(v: &Vars) -> String {
+    format!(
+        r#"# {name}
+
+A Whisker module — registers the `{name}:{tag}` element under Lynx
+and exposes `{class}` for use in Whisker app `render!` trees.
+
+## Usage
+
+```toml
+[dependencies]
+{name} = "0.1"
+```
+
+```rust
+use whisker::prelude::*;
+use {ident}::*;
+
+#[whisker::main]
+fn app() -> Element {{
+    render! {{
+        {tag}()
+    }}
+}}
+```
+
+See [the Whisker Module Author Guide](https://github.com/whiskerrs/whisker/blob/main/docs/module-author-guide.md)
+for the full reference.
+"#,
+        name = v.crate_name,
+        tag = v.tag,
+        class = v.class_name,
+        ident = v.crate_name.replace('-', "_"),
+    )
+}
+
+fn module_manifest(_v: &Vars) -> String {
+    r#"# Whisker module manifest. Tells `whisker-build` which platform
+# sources to surface from this crate into the consuming app's
+# generated host project. Paths are relative to this file.
+
+[ios]
+swift_sources = ["src/ios"]
+
+[android]
+kotlin_sources = ["src/android"]
+"#
+    .to_string()
+}
+
+fn package_swift(v: &Vars) -> String {
+    format!(
+        r#"// swift-tools-version:5.9
+//
+// SwiftPM manifest for the `{name}` module's iOS half. The consumer
+// app's `whisker-build`-generated aggregator depends on the library
+// product below via `.product(name: "{spm}", package: "{name}")`.
+
+import PackageDescription
+
+let package = Package(
+    name: "{name}",
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "{spm}", targets: ["{spm}"]),
+    ],
+    dependencies: [
+        .package(name: "macros", path: "../../platforms/ios/macros"),
+        .package(name: "WhiskerRuntime", path: "../../platforms/ios"),
+    ],
+    targets: [
+        .target(
+            name: "{spm}",
+            dependencies: [
+                .product(name: "WhiskerComponents", package: "macros"),
+                .product(name: "WhiskerModuleApi", package: "WhiskerRuntime"),
+            ],
+            path: "src/ios",
+            plugins: [
+                .plugin(name: "WhiskerComponentsCodegenPlugin", package: "macros"),
+            ]
+        ),
+    ]
+)
+"#,
+        name = v.crate_name,
+        spm = crate_to_spm_target(v.crate_name),
+    )
+}
+
+fn build_gradle(v: &Vars) -> String {
+    format!(
+        r#"// Gradle subproject for the `{name}` Whisker module on Android.
+// Wired into the consumer app's settings.gradle.kts by whisker-build.
+
+plugins {{
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}}
+
+android {{
+    namespace = "rs.whisker.modules.{ns}"
+    compileSdk = 34
+
+    defaultConfig {{
+        minSdk = 21
+    }}
+
+    compileOptions {{
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }}
+    kotlinOptions {{
+        jvmTarget = "17"
+    }}
+
+    sourceSets {{
+        getByName("main") {{
+            kotlin.srcDirs("src/android")
+        }}
+    }}
+}}
+
+ksp {{
+    arg("whisker.moduleName", "{spm}")
+    arg("whisker.crateName", "{name}")
+}}
+
+dependencies {{
+    // Single Whisker runtime dep — :module-api re-exports
+    // rs.whisker:annotations transitively. ksp(rs.whisker:ksp)
+    // stays separate because it's build-time, not runtime.
+    implementation(project(":module-api"))
+    ksp("rs.whisker:ksp")
+}}
+"#,
+        name = v.crate_name,
+        ns = v.crate_name.replace('-', "_"),
+        spm = crate_to_spm_target(v.crate_name),
+    )
+}
+
+fn lib_rs_view(v: &Vars) -> String {
+    format!(
+        r#"//! `{name}` — Whisker view-bearing module.
+//!
+//! Registers a Lynx element under `{name}:{tag}` and exposes the
+//! `{tag}` symbol for use inside `render!`. Platform-side classes
+//! live under `src/ios/` and `src/android/`.
+
+use whisker::Signal;
+
+/// View-bearing platform component. The Lynx tag the bridge
+/// registers against is `{name}:{tag}` — the crate name namespace
+/// is auto-prepended by `#[whisker::platform_component]`.
+#[whisker::platform_component("{tag}")]
+pub fn {ident}(style: Signal<String>) {{}}
+"#,
+        name = v.crate_name,
+        tag = v.tag,
+        ident = v.crate_name.replace('-', "_").trim_start_matches("whisker_"),
+    )
+}
+
+fn lib_rs_module(v: &Vars) -> String {
+    format!(
+        r#"//! `{name}` — Whisker function-only platform module.
+//!
+//! Exposes typed Rust -> Kotlin/Swift function calls without
+//! rendering UI. Platform-side classes live under `src/ios/` and
+//! `src/android/`.
+
+use whisker::platform_module::{{WhiskerModuleError, WhiskerValue}};
+
+/// Sys proxy — every method is a thin pass-through to the
+/// platform-side `Whisker{tag}` class via the C bridge.
+#[whisker::platform_module(name = "Whisker{tag}")]
+pub trait Whisker{tag}Sys {{
+    // Add your trait methods here. They MUST take
+    // `args: Vec<WhiskerValue>` and return `WhiskerValue`.
+    //
+    // Example:
+    //     fn hello(args: Vec<WhiskerValue>) -> WhiskerValue;
+    fn _placeholder(args: Vec<WhiskerValue>) -> WhiskerValue;
+}}
+
+/// Typed Rust API — hand-written wrapper above the sys proxy. Build
+/// the `Vec<WhiskerValue>` arg list, dispatch through the sys
+/// trait, and lift the `WhiskerValue` return into the matching
+/// typed result.
+pub struct Whisker{tag};
+impl Whisker{tag} {{
+    pub fn placeholder() -> Result<(), WhiskerModuleError> {{
+        let _ = Whisker{tag}Sys::_placeholder(vec![]);
+        Ok(())
+    }}
+}}
+"#,
+        name = v.crate_name,
+        tag = v.tag,
+    )
+}
+
+fn swift_view(v: &Vars) -> String {
+    format!(
+        r#"// `{class}` — iOS side of the `{name}:{tag}` Whisker component.
+
+import UIKit
+import WhiskerComponents
+import WhiskerModuleApi
+
+@WhiskerComponent("{tag}")
+@objc({class})
+public final class {class}: WhiskerUI<UIView> {{
+    @objc public override func createView() -> UIView {{
+        let v = UIView()
+        v.backgroundColor = .systemPink
+        return v
+    }}
+}}
+"#,
+        name = v.crate_name,
+        tag = v.tag,
+        class = v.class_name,
+    )
+}
+
+fn kotlin_view(v: &Vars) -> String {
+    format!(
+        r#"// `{class}` -- Android side of the `{name}:{tag}` Whisker component.
+
+package rs.whisker.modules.{ns}
+
+import android.content.Context
+import android.graphics.Color
+import android.view.View
+import rs.whisker.annotations.WhiskerComponent
+import rs.whisker.runtime.WhiskerContext
+import rs.whisker.runtime.WhiskerUI
+
+@WhiskerComponent("{tag}")
+open class {class}(context: WhiskerContext) : WhiskerUI<View>(context) {{
+    override fun createView(context: Context): View {{
+        val v = View(context)
+        v.setBackgroundColor(Color.argb(0xff, 0xff, 0x80, 0xa0))
+        return v
+    }}
+}}
+"#,
+        name = v.crate_name,
+        tag = v.tag,
+        class = v.class_name,
+        ns = v.crate_name.replace('-', "_"),
+    )
+}
+
+fn swift_module(v: &Vars, module_class: &str) -> String {
+    format!(
+        r#"// `{class}Impl` — iOS side of the `{name}` Whisker function-only module.
+
+import Foundation
+import WhiskerComponents
+import WhiskerModuleApi
+
+@WhiskerModule("{class}")
+@objc({class}Impl)
+public final class {class}Impl: NSObject {{
+    @objc public func _placeholder(_ args: [WhiskerValue]) -> WhiskerValue {{
+        // TODO: implement the function the Rust-side sys trait declares.
+        return .null
+    }}
+}}
+"#,
+        name = v.crate_name,
+        class = module_class,
+    )
+}
+
+fn kotlin_module(v: &Vars, module_class: &str) -> String {
+    format!(
+        r#"// `{class}Impl` -- Android side of the `{name}` Whisker function-only module.
+
+package rs.whisker.modules.{ns}
+
+import rs.whisker.annotations.WhiskerModule
+import rs.whisker.runtime.WhiskerValue
+
+@WhiskerModule("{class}")
+class {class}Impl {{
+    fun _placeholder(args: List<WhiskerValue>): WhiskerValue {{
+        // TODO: implement the function the Rust-side sys trait declares.
+        return WhiskerValue.Null
+    }}
+}}
+"#,
+        name = v.crate_name,
+        class = module_class,
+        ns = v.crate_name.replace('-', "_"),
+    )
+}
+
+// ============================================================================
+// Name helpers
+// ============================================================================
+
+/// Validate a cargo crate name. Rejects empty / non-letter-prefixed /
+/// non-`[a-z0-9_-]+` inputs with an actionable message.
+fn validate_crate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("crate name must not be empty");
+    }
+    let first = name.chars().next().unwrap();
+    if !first.is_ascii_alphabetic() {
+        bail!(
+            "crate name must start with a letter, got {first:?}. Try \
+             `whisker-{name}` instead."
+        );
+    }
+    for ch in name.chars() {
+        if !(ch.is_ascii_alphanumeric() || ch == '-' || ch == '_') {
+            return Err(anyhow!(
+                "crate name {name:?} contains invalid character {ch:?}. \
+                 Use only ASCII letters / digits / `-` / `_`."
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Derive the PascalCase tag from the crate name.
+///
+/// - `whisker-foo` -> `Foo`
+/// - `whisker-blur-view` -> `BlurView`
+/// - `foo-bar` -> `FooBar` (no `whisker-` prefix → tag is the whole name)
+fn pascal_case_tag(crate_name: &str) -> String {
+    let stripped = crate_name
+        .strip_prefix("whisker-")
+        .unwrap_or(crate_name);
+    let mut out = String::new();
+    let mut upper = true;
+    for ch in stripped.chars() {
+        if ch == '-' || ch == '_' {
+            upper = true;
+        } else if upper {
+            out.extend(ch.to_uppercase());
+            upper = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Same convention as `whisker_build::ios::crate_to_spm_target`:
+/// `whisker-foo-bar` -> `WhiskerFooBar`.
+fn crate_to_spm_target(crate_name: &str) -> String {
+    let mut out = String::new();
+    let mut upper = true;
+    for ch in crate_name.chars() {
+        if ch == '-' || ch == '_' {
+            upper = true;
+        } else if upper {
+            out.extend(ch.to_uppercase());
+            upper = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pascal_strips_whisker_prefix() {
+        assert_eq!(pascal_case_tag("whisker-foo"), "Foo");
+        assert_eq!(pascal_case_tag("whisker-blur-view"), "BlurView");
+    }
+
+    #[test]
+    fn pascal_keeps_full_name_when_no_whisker_prefix() {
+        assert_eq!(pascal_case_tag("foo-bar"), "FooBar");
+    }
+
+    #[test]
+    fn spm_target_pascals_full_crate_name() {
+        assert_eq!(crate_to_spm_target("whisker-foo"), "WhiskerFoo");
+        assert_eq!(crate_to_spm_target("whisker-blur-view"), "WhiskerBlurView");
+    }
+
+    #[test]
+    fn validate_rejects_invalid() {
+        assert!(validate_crate_name("").is_err());
+        assert!(validate_crate_name("1foo").is_err());
+        assert!(validate_crate_name("whisker foo").is_err());
+        assert!(validate_crate_name("whisker-foo").is_ok());
+        assert!(validate_crate_name("whisker_foo").is_ok());
+    }
+}

--- a/crates/whisker-cli/src/new_module.rs
+++ b/crates/whisker-cli/src/new_module.rs
@@ -151,8 +151,7 @@ struct Vars<'a> {
 fn write(root: &Path, rel: &str, content: &str) -> Result<()> {
     let path = root.join(rel);
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("create {}", parent.display()))?;
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
     std::fs::write(&path, content).with_context(|| format!("write {}", path.display()))?;
     Ok(())
@@ -353,7 +352,10 @@ pub fn {ident}(style: Signal<String>) {{}}
 "#,
         name = v.crate_name,
         tag = v.tag,
-        ident = v.crate_name.replace('-', "_").trim_start_matches("whisker_"),
+        ident = v
+            .crate_name
+            .replace('-', "_")
+            .trim_start_matches("whisker_"),
     )
 }
 
@@ -528,9 +530,7 @@ fn validate_crate_name(name: &str) -> Result<()> {
 /// - `whisker-blur-view` -> `BlurView`
 /// - `foo-bar` -> `FooBar` (no `whisker-` prefix → tag is the whole name)
 fn pascal_case_tag(crate_name: &str) -> String {
-    let stripped = crate_name
-        .strip_prefix("whisker-")
-        .unwrap_or(crate_name);
+    let stripped = crate_name.strip_prefix("whisker-").unwrap_or(crate_name);
     let mut out = String::new();
     let mut upper = true;
     for ch in stripped.chars() {

--- a/crates/whisker-modules-api/Cargo.toml
+++ b/crates/whisker-modules-api/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "whisker-modules-api"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
 description = "Minimal API surface third-party Whisker modules depend on. The umbrella `whisker` crate is for *app* code; module crates pull in just this."
-license = "MIT OR Apache-2.0"
 
 [dependencies]
 whisker-driver = { workspace = true }

--- a/docs/module-author-guide.md
+++ b/docs/module-author-guide.md
@@ -1,0 +1,304 @@
+# Whisker Module Author Guide
+
+This guide walks through writing a Whisker Module — a cargo crate that
+ships Rust + Kotlin + Swift sources together and publishes to
+**crates.io alone** (no separate Maven Central / SwiftPM Registry /
+CocoaPods steps).
+
+Inspired by Expo Modules, which ship iOS + Android sources inside an
+npm package; Whisker bundles them inside a cargo crate the same way.
+
+## What a Whisker Module is
+
+A Whisker Module is one of two flavors:
+
+- **Function-only module** — exposes typed Rust → Kotlin/Swift function
+  calls that don't render any UI. `whisker-local-store` is the
+  reference (wraps `UserDefaults` / `SharedPreferences`).
+- **View-bearing component** — renders a platform-native view that
+  Whisker apps can place inside a `render! { … }` tree.
+  `whisker-video` is the reference (Big Buck Bunny player on
+  `AVPlayer` / `Media3 ExoPlayer`).
+
+Both flavors live in the same Module DSL — a View is just a feature
+of the Module definition.
+
+## Distribution model — cargo only
+
+A published Whisker Module is **just a crate on crates.io**.
+The `.crate` artifact (the tarball cargo uploads) contains:
+
+```
+whisker-foo-0.1.0/
+├── Cargo.toml
+├── README.md
+├── whisker.module.toml
+├── Package.swift        ← SPM manifest for the iOS half
+├── build.gradle.kts     ← Gradle subproject for the Android half
+└── src/
+    ├── lib.rs           ← Rust-side `#[whisker::platform_component]` proxy
+    ├── ios/             ← Swift sources
+    │   └── WhiskerFooComponent.swift
+    └── android/         ← Kotlin sources
+        └── WhiskerFooComponent.kt
+```
+
+When the user app builds, `whisker-build` does the following:
+
+1. `cargo metadata` enumerates every transitive dependency of the app.
+2. For each dep, look for `whisker.module.toml` next to its
+   `Cargo.toml`. If present, the dep is a Whisker Module.
+3. Read `[ios].swift_sources` + `[android].kotlin_sources` from the
+   module's `whisker.module.toml` — these are paths *relative to the
+   crate root* that list the platform sources to surface to the host
+   project.
+4. Stage them into the user's `gen/ios/whisker_modules/` and
+   `gen/android/` source trees. SwiftPM and Gradle pick them up
+   exactly like any other source under the host project's tree.
+
+Step 3 works identically whether the dep was resolved from a local
+`path = "..."`, a git ref, or `~/.cargo/registry/src/index.crates.io-*/`.
+The cargo crate's tarball contents are the contract — no separate
+package registries are involved.
+
+## Authoring a module
+
+### 1. Create the cargo crate
+
+```toml
+# Cargo.toml
+[package]
+name = "whisker-foo"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Whisker module — short tagline that shows up on crates.io."
+
+# Explicit include so `cargo publish` ships all the non-Rust files.
+# Default would include them too, but being explicit prevents
+# accidental Gradle / Xcode build-artifact leaks if a stale build
+# dir lingers next to the manifest.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "whisker.module.toml",
+    "src/lib.rs",
+    "src/android/**/*.kt",
+    "src/ios/**/*.swift",
+    "README.md",
+]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+# Rename `whisker-modules-api` → `whisker` so the proc macros' emit
+# paths (`::whisker::ElementRef`, `::whisker::platform_module::WhiskerValue`,
+# …) resolve. Cargo doesn't allow `package = ...` with
+# `workspace = true`, so the version + path are inlined here. Drop
+# the `path = "..."` when you publish — `version = "x.y.z"` alone is
+# what consumers see from crates.io.
+whisker = { package = "whisker-modules-api", version = "0.1" }
+```
+
+### 2. Declare platform sources in `whisker.module.toml`
+
+```toml
+# whisker.module.toml — at the crate root, sibling of Cargo.toml.
+
+[ios]
+# Swift sources to stage into the host app's
+# gen/ios/whisker_modules/<crate>/. Paths are relative to this manifest.
+swift_sources = ["src/ios/WhiskerFooComponent.swift"]
+
+[android]
+# Kotlin sources for the host app's gen/android/<crate>/ subproject.
+kotlin_sources = ["src/android/WhiskerFooComponent.kt"]
+```
+
+### 3. Add per-platform `Package.swift` and `build.gradle.kts`
+
+These are SwiftPM + Gradle subproject manifests for the *consuming*
+app's host build. They depend on `WhiskerModuleApi` / `:module-api`
+respectively (provided by Whisker itself), plus whatever the module
+needs (third-party SwiftPM dep, AndroidX library, etc.).
+
+See [`packages/whisker-video/Package.swift`](../packages/whisker-video/Package.swift)
+and [`packages/whisker-video/build.gradle.kts`](../packages/whisker-video/build.gradle.kts)
+for the reference shapes.
+
+### 4. Write the Rust shim
+
+```rust
+// src/lib.rs
+use whisker::platform_module::WhiskerValue;
+use whisker::{ElementRef, Signal};
+
+#[whisker::platform_component("Foo")]
+pub fn foo(src: Signal<String>, style: Signal<String>) {}
+
+#[whisker::element_methods(FooProps)]
+pub trait FooSys {
+    fn play(&self, args: Vec<WhiskerValue>) -> WhiskerValue;
+}
+
+pub trait FooControls {
+    fn play(&self);
+}
+
+impl FooControls for ElementRef<FooProps> {
+    fn play(&self) {
+        let _ = FooSys::play(self, vec![]);
+    }
+}
+```
+
+The proc macro auto-prepends `env!("CARGO_PKG_NAME")` to the local
+tag name so the registration string becomes `whisker-foo:Foo` — two
+unrelated modules can both declare a `Foo` component without colliding
+in Lynx's behavior registry. The platform-side `@WhiskerComponent`
+annotations do the same prefixing.
+
+### 5. Write the Swift + Kotlin component classes
+
+```swift
+// src/ios/WhiskerFooComponent.swift
+import UIKit
+import WhiskerComponents
+import WhiskerModuleApi
+
+@WhiskerComponent("Foo")
+@objc(WhiskerFooComponent)
+public final class WhiskerFooComponent: WhiskerUI<UIView> {
+    @objc public override func createView() -> UIView { UIView() }
+
+    @WhiskerProp("src")
+    @objc public func setSrc(_ value: NSString, requestReset: Bool) { … }
+
+    @WhiskerUIMethod
+    public func play(_ args: [WhiskerValue]) -> WhiskerValue {
+        // …
+        return .null
+    }
+}
+```
+
+```kotlin
+// src/android/WhiskerFooComponent.kt
+package rs.whisker.modules.foo
+
+import android.content.Context
+import android.view.View
+import rs.whisker.annotations.WhiskerComponent
+import rs.whisker.annotations.WhiskerProp
+import rs.whisker.annotations.WhiskerUIMethod
+import rs.whisker.runtime.WhiskerContext
+import rs.whisker.runtime.WhiskerUI
+import rs.whisker.runtime.WhiskerValue
+
+@WhiskerComponent("Foo")
+open class WhiskerFooComponent(context: WhiskerContext) : WhiskerUI<View>(context) {
+
+    override fun createView(context: Context): View = View(context)
+
+    @WhiskerProp("src")
+    open fun setSrc(value: String) { /* … */ }
+
+    @WhiskerUIMethod
+    open fun play(args: List<WhiskerValue>): WhiskerValue {
+        // …
+        return WhiskerValue.Null
+    }
+}
+```
+
+### 6. Publish
+
+```sh
+cargo publish -p whisker-foo
+```
+
+That's it. Consumers add `cargo add whisker-foo` and Whisker's build
+pipeline finds the platform sources via `cargo metadata` against the
+registry cache.
+
+## Consumer side
+
+A Whisker app that wants to use `whisker-foo`:
+
+```toml
+# app/Cargo.toml
+[dependencies]
+whisker-foo = "0.1"
+```
+
+```rust
+// app/src/lib.rs
+use whisker::prelude::*;
+use whisker_foo::{Foo, FooControls};
+
+#[whisker::main]
+fn app() -> Element {
+    let foo_ref = element_ref::<FooProps>();
+    render! {
+        Foo(ref: foo_ref, src: "https://example.com/clip.mp4")
+        view(on_tap: move || foo_ref.play()) {
+            text(value: "Play")
+        }
+    }
+}
+```
+
+No separate `Podfile`, `Package.swift`, `build.gradle` change required
+in the consuming app. `whisker run --target ios` / `--target android`
+picks up the new dep automatically through cargo metadata + the
+host-project staging step.
+
+## Directory layout reference
+
+```
+whisker-foo/
+├── Cargo.toml              ← the cargo manifest
+├── whisker.module.toml     ← declares which platform sources exist
+├── Package.swift           ← SwiftPM subproject for the host app
+├── build.gradle.kts        ← Gradle subproject for the host app
+├── README.md
+└── src/
+    ├── lib.rs              ← Rust shim
+    ├── android/            ← Kotlin platform sources
+    │   └── …Component.kt
+    └── ios/                ← Swift platform sources
+        └── …Component.swift
+```
+
+The Rust `src/lib.rs` and the platform `src/{android,ios}/` siblings
+share the `src/` parent intentionally — cargo's default crate layout
+puts the Rust root there, and we co-locate the platform code alongside
+rather than separating into top-level `android/` / `ios/` directories.
+Keeps a single `src/` to glance at when navigating the crate.
+
+## What goes where — quick reference
+
+| Symbol | Crate / module | Used by |
+|---|---|---|
+| `#[whisker::platform_component("Tag")]` | `whisker-modules-api` (proc macro) | View-bearing modules |
+| `#[whisker::platform_module(name = "X")]` | `whisker-modules-api` (proc macro) | Function-only modules |
+| `#[whisker::element_methods(Props)]` | `whisker-modules-api` (proc macro) | Typed `ElementRef<T>::method()` dispatch |
+| `WhiskerValue`, `WhiskerModuleError` | `whisker::platform_module` | Both flavors |
+| `Signal<T>`, `ElementRef<T>`, `element_ref()` | `whisker` (top-level) | View-bearing modules' shim |
+| `@WhiskerComponent("Tag")` | `WhiskerComponents` SPM target / `rs.whisker.annotations.WhiskerComponent` | iOS / Android view classes |
+| `@WhiskerModule("Name")` | same | iOS / Android function-only classes |
+| `@WhiskerProp("name")` / `@WhiskerUIMethod` | same | iOS / Android dispatch annotations |
+| `WhiskerUI<View>` / `WhiskerContext` / `WhiskerValue` | `WhiskerModuleApi` SPM target / `rs.whisker.runtime` Kotlin package | iOS / Android view classes |
+
+## Future direction
+
+Phase L (#58) replaces the `@WhiskerComponent` / `@WhiskerProp` /
+`@WhiskerUIMethod` annotation surface with an Expo-style
+`ModuleDefinition` DSL. View-bearing and function-only modules will
+both use the same `definition() -> ModuleDefinition` entry point;
+`View(...) { Prop(...) ... }` becomes a feature of the DSL rather
+than a separate annotation set.
+
+See the Whisker Modules epic (#55) for the broader roadmap.

--- a/packages/whisker-hello-element/Cargo.toml
+++ b/packages/whisker-hello-element/Cargo.toml
@@ -1,9 +1,23 @@
 [package]
 name = "whisker-hello-element"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
 description = "Reference Whisker platform component module — registers `whisker-hello-element:Hello` (a system-pink UIView on iOS) and exposes `Hello` for use inside `render!`. Smoke-test / template for the Whisker module system."
+
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "whisker.module.toml",
+    "src/lib.rs",
+    "src/android/**/*.kt",
+    "src/ios/**/*.swift",
+    "README.md",
+]
 
 # rlib only. The Whisker module system handles native-source
 # distribution out-of-band via `whisker.module.toml` — we don't ship

--- a/packages/whisker-local-store/Cargo.toml
+++ b/packages/whisker-local-store/Cargo.toml
@@ -1,9 +1,23 @@
 [package]
 name = "whisker-local-store"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
 description = "Reference Whisker platform module — persistent key-value local store wrapping UserDefaults on iOS and SharedPreferences on Android. Doubles as the documented template for first-party Whisker platform modules."
+
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "whisker.module.toml",
+    "src/lib.rs",
+    "src/android/**/*.kt",
+    "src/ios/**/*.swift",
+    "README.md",
+]
 
 # rlib only. The Whisker module system handles native-source
 # distribution out-of-band via `whisker.module.toml` — we don't

--- a/packages/whisker-video/Cargo.toml
+++ b/packages/whisker-video/Cargo.toml
@@ -1,9 +1,28 @@
 [package]
 name = "whisker-video"
-version = "0.1.0"
-edition = "2021"
-publish = false
-description = "Whisker platform component module — `whisker-video:Video` element backed by AVPlayer on iOS / VideoView on Android. Demonstrates `@WhiskerUIMethod` (`play()`, `pause()`, `seek(position)`) and `ElementRef<T>` for imperative Rust-side control of a mounted element."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Whisker platform component module — `whisker-video:Video` element backed by AVPlayer on iOS / Media3 ExoPlayer on Android. Demonstrates `@WhiskerUIMethod` (`play()`, `pause()`, `seek(position)`) and `ElementRef<T>` for imperative Rust-side control of a mounted element."
+
+# Phase K — explicit `include` list so a `cargo publish` of this crate
+# ships the Kotlin + Swift platform sources alongside `src/lib.rs`.
+# By default cargo includes everything under the package dir, but
+# being explicit prevents accidentally publishing local Gradle / Xcode
+# build artifacts if a stale build dir lingers next to the manifest.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "whisker.module.toml",
+    "src/lib.rs",
+    "src/android/**/*.kt",
+    "src/ios/**/*.swift",
+    "README.md",
+]
 
 [lib]
 crate-type = ["rlib"]


### PR DESCRIPTION
Closes #57. Parent epic: #55. Stacks on PR #61 (Phase J).

Makes Whisker modules publishable to crates.io. After this lands, a third-party module author can author + publish entirely through cargo — no separate Maven Central / SwiftPM Registry / CocoaPods steps. Like Expo Modules ship iOS + Android sources inside an npm package, Whisker bundles them inside a cargo crate.

## Cargo metadata + publishability

`whisker-module-api`, `whisker-video`, `whisker-hello-element`, `whisker-local-store`: all switched to inheriting workspace metadata (`version` / `license` / `repository` / `authors` / `edition` / `rust-version`). `publish = false` removed so `cargo publish -p <name>` works.

Each module crate gets an explicit `[package].include` list so the published `.crate` ships exactly:

```
Cargo.toml • Package.swift • build.gradle.kts • whisker.module.toml
src/lib.rs • src/android/**/*.kt • src/ios/**/*.swift • README.md
```

No code changes needed in `whisker-build` — its `cargo metadata`-driven module discovery already resolves dep `manifest_path` whether the dep was fetched from a local `path = \"...\"`, `git = \"...\"`, or `~/.cargo/registry/src/index.crates.io-*/`.

## `whisker new-module <name>` scaffolding

New `whisker-cli` subcommand. Emits a complete module skeleton:

```
$ whisker new-module whisker-camera
Created Whisker module skeleton at ./whisker-camera

Next steps:
  1. cd ./whisker-camera
  2. Implement the platform-side logic in src/ios/ and src/android/.
  3. From your Whisker app: `cargo add --path ./whisker-camera` (or publish).
```

`--shape view-bearing` (default) generates a `#[platform_component]`-based shim + `WhiskerCameraComponent` Swift / Kotlin subclassing `WhiskerUI<View>`. `--shape function-only` generates a `#[platform_module]` proxy + `WhiskerCameraImpl` classes without a View.

## Module Author Guide

New `docs/module-author-guide.md` walks through the full path — authoring → testing → publishing. Reference layout, cargo-only distribution model, `whisker.module.toml` schema, per-platform file conventions, consumer-side `cargo add` flow.

## Verification
- [x] `cargo test --workspace`: 498/0 (4 new tests in `new_module`)
- [x] `cargo package -p whisker-video --list` includes `src/android/*.kt`, `src/ios/*.swift`, `Package.swift`, `build.gradle.kts`, `whisker.module.toml`
- [x] Generator smoke test: `whisker new-module whisker-scaffold-smoke` produces 8 files
- [ ] CI green on this branch

## Out of scope
- Actual `cargo publish` to crates.io — deferred per the parent epic (#55) until L (#58) stabilises the author surface.
- Final dir-layout reorg (案 A vs 案 B from planning). The existing shape works; revisit if it ever feels awkward.

## Follow-up
- **PR 3 (Phase L research, #58)** — `ModuleDefinition` DSL design doc. Branches off this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)