### PR TITLE
docs(modules): Phase L (ModuleDefinition DSL) + Phase N (Ref API) design docs

### DIFF
--- a/docs/phase-l-moduledefinition-dsl-design.md
+++ b/docs/phase-l-moduledefinition-dsl-design.md
@@ -140,64 +140,164 @@ The existing `WhiskerComponentProcessor` is extended (or replaced):
 
 ### 3c. Rust shim
 
-The Rust side adopts a **plain struct + impl** pattern that mirrors the
-Phase N standardized Ref API (see `docs/phase-n-ref-api-design.md`).
-Module authors write:
+The Rust side adopts the **`ElementRef` + `Handle`** two-tier pattern
+from the Phase N design (see `docs/phase-n-ref-api-design.md`). The
+module author writes three things:
+
+1. **`VideoHandle`** — a plain `Clone` struct holding signals; this is
+   what end-users call methods on.
+2. **`fn video(...)`** — a `#[whisker::component]` wrapper that owns an
+   internal `ElementRef`, bridges `VideoHandle`'s command signals to
+   `ElementRef::invoke(...)` via `effect(...)`, and pushes native
+   events back into the handle's query signals.
+3. **`fn video_sys(...)`** — the `#[whisker::modules::component]`
+   platform-component declaration whose `ref: ElementRef` prop is what
+   the wrapper feeds.
 
 ```rust
-#[whisker::modules::component("Video")]
-pub fn video(r: VideoRef, src: Signal<String>, style: Signal<String>) {}
+use std::cell::Cell;
+use whisker::{ElementRef, WhiskerEvent, WhiskerValue};
+use whisker::reactive::{RwSignal, Signal, effect, signal};
 
+// 1. Handle: pure signals, no framework hooks.
 #[derive(Clone)]
-pub struct VideoRef {
-    handle: RefHandle,
+pub struct VideoHandle {
+    play_tick:    RwSignal<u64>,
+    pause_tick:   RwSignal<u64>,
+    seek_to:      RwSignal<Option<f64>>,
+    current_time: RwSignal<f64>,
+    duration:     RwSignal<f64>,
 }
 
-impl VideoRef {
-    pub fn new() -> Self { Self { handle: RefHandle::new() } }
+impl VideoHandle {
+    pub fn new() -> Self {
+        Self {
+            play_tick: signal(0), pause_tick: signal(0),
+            seek_to: signal(None),
+            current_time: signal(0.0), duration: signal(0.0),
+        }
+    }
+    pub fn play(&self)         { self.play_tick.update(|n| *n += 1); }
+    pub fn pause(&self)        { self.pause_tick.update(|n| *n += 1); }
+    pub fn seek(&self, t: f64) { self.seek_to.set(Some(t)); }
 
-    pub fn play(&self) -> Result<(), RefError> {
-        self.handle.invoke("play", vec![]).map(|_| ())
-    }
-    pub fn pause(&self) -> Result<(), RefError> {
-        self.handle.invoke("pause", vec![]).map(|_| ())
-    }
-    pub fn seek(&self, position_seconds: f64) -> Result<(), RefError> {
-        self.handle.invoke("seek", vec![WhiskerValue::Float(position_seconds)]).map(|_| ())
-    }
-
-    pub fn try_play(&self) { let _ = self.play(); }
-    pub fn try_pause(&self) { let _ = self.pause(); }
-    pub fn try_seek(&self, seconds: f64) { let _ = self.seek(seconds); }
+    pub fn current_time(&self) -> Signal<f64> { self.current_time.read_only().into() }
+    pub fn duration(&self)     -> Signal<f64> { self.duration.read_only().into() }
 }
 
-impl WhiskerRef for VideoRef {
-    fn handle(&self) -> &RefHandle { &self.handle }
+// 2. Wrapper component: bridge handle ↔ ElementRef.
+#[whisker::component]
+pub fn video(handle: VideoHandle, src: Signal<String>) -> Element {
+    let sys = ElementRef::new();
+
+    // play_tick → invoke("play"). Counter pattern needs first-fire
+    // suppression (effect runs once on creation; without the guard it
+    // would emit a stray play() on every mount).
+    effect({
+        let sys = sys.clone();
+        let h = handle.clone();
+        let first = Cell::new(true);
+        move || {
+            h.play_tick.get();
+            if first.replace(false) { return; }
+            let _ = sys.invoke("play", vec![]);
+        }
+    });
+    effect({
+        let sys = sys.clone();
+        let h = handle.clone();
+        let first = Cell::new(true);
+        move || {
+            h.pause_tick.get();
+            if first.replace(false) { return; }
+            let _ = sys.invoke("pause", vec![]);
+        }
+    });
+    // Option pattern: dispatch then reset so re-setting same value re-dispatches.
+    effect({
+        let sys = sys.clone();
+        let h = handle.clone();
+        move || {
+            if let Some(t) = h.seek_to.get() {
+                let _ = sys.invoke("seek", vec![WhiskerValue::Float(t)]);
+                h.seek_to.set(None);
+            }
+        }
+    });
+
+    // Native events → query signals.
+    let on_time_update = {
+        let h = handle.clone();
+        move |e: WhiskerEvent| {
+            if let Some(t) = e.get_float("currentTime") { h.current_time.set(t); }
+        }
+    };
+    let on_loaded_metadata = {
+        let h = handle.clone();
+        move |e: WhiskerEvent| {
+            if let Some(d) = e.get_float("duration") { h.duration.set(d); }
+        }
+    };
+
+    render! {
+        VideoSys(ref: sys, src: src,
+                 on_time_update: on_time_update,
+                 on_loaded_metadata: on_loaded_metadata)
+    }
+}
+
+// 3. Platform-component declaration — the only place ElementRef appears
+// in a #[modules::component] signature.
+#[whisker::modules::component("Video")]
+pub fn video_sys(
+    r: ElementRef,
+    src: Signal<String>,
+    on_time_update: impl Fn(WhiskerEvent),
+    on_loaded_metadata: impl Fn(WhiskerEvent),
+) {}
+```
+
+End-user code only ever sees `VideoHandle` + `Video`:
+
+```rust
+let v = VideoHandle::new();
+let progress = v.current_time();
+let v_play = v.clone();
+
+render! {
+    Video(handle: v.clone(), src: signal("video.mp4".into()))
+    text(value: move || format!("{:.1}s", progress.get()))
+    text(on_tap: move || v_play.play(), value: "▶")
 }
 ```
 
-This replaces the current `#[whisker::element_methods] trait VideoSys + impl VideoControls for ElementRef<VideoProps>` triple-declaration with a single hand-written struct. Tradeoffs and full design rationale are in
-the [Phase N Ref API design doc](./phase-n-ref-api-design.md). Highlights:
+This replaces the current `#[whisker::element_methods] trait VideoSys
++ impl VideoControls for ElementRef<VideoProps>` triple-declaration
+with three explicit Rust pieces — handle, wrapper component, platform
+component — each doing one thing. Full design rationale and the four
+command-signal patterns are in the [Phase N Ref API design
+doc](./phase-n-ref-api-design.md). Highlights:
 
-- **All plain Rust** — no Rust-side macros for the methods themselves;
-  the `#[whisker::modules::component]` macro only needs to recognize
-  the `r: VideoRef` parameter (any type implementing `WhiskerRef`) and
-  emit mount-time `RefHandle::__bind(...)` wiring.
-- **Symmetric with Kotlin / Swift surface** — the platform-side
-  `definition()` DSL declares prop names + method names; the Rust-side
-  `impl VideoRef` declares matching methods that dispatch via the same
-  names. Both halves describe the same component from their own
-  language's perspective.
-- **Composite custom refs** (`CustomInputRef`, `FormRef`, …) compose
-  built-in refs as struct fields and forward methods — see Phase N
-  §5 for the pattern. No special Whisker support needed; it's just
-  Rust struct composition.
+- **No `WhiskerRef` trait, no derive, no auto-binding.** A handle is
+  just a `Clone` struct; the framework has no opinion about its shape.
+  Only `#[modules::component]` recognizes `ref: ElementRef` and emits
+  `__bind` / `__unbind` calls on the underlying native element.
+- **Custom components without a native counterpart need no
+  `ElementRef`.** `ModalHandle` (or any signal-only handle) drives a
+  `#[component]` that reads its signals via `show!` / `effect`, and
+  no bridge code is needed at all.
+- **Symmetric with the Kotlin / Swift surface.** Platform-side
+  `definition()` declares prop names + method names; Rust-side
+  `impl VideoHandle` writes methods of the same names. The wrapper
+  component is the routing table that ties the two sides together.
+- **Composite handles are plain struct composition.** A
+  `CustomInputHandle` holds a `TextInputHandle` as a field and
+  forwards methods — see Phase N §5.
 
 A future Rust-side declarative macro (`whisker::module! { ... }`)
-that derives both the platform-side DSL and the Rust struct from a
-single source-of-truth declaration is **out of scope for Phase L** —
-the per-platform manual declaration is fine for v1 and keeps the
-codegen story simpler.
+that derives all three pieces from a single source-of-truth
+declaration is **out of scope for Phase L** — the per-piece manual
+declaration is fine for v1 and keeps the codegen story simpler.
 
 ## 4. Migration story
 
@@ -233,7 +333,7 @@ Phase M (#59) then deprecates → removes the annotation surface in a follow-up 
 
 ## 7. Out of scope for Phase L
 
-- A Rust-side `whisker::module! { ... }` declarative macro that derives both halves (Rust struct + platform-side DSL) from a single source-of-truth declaration. Rust authors write the `XxxRef` struct by hand per the [Phase N Ref API design](./phase-n-ref-api-design.md); the platform-side `definition()` is declared separately. Single-source-of-truth comes later if the redundancy ever bites.
+- A Rust-side `whisker::module! { ... }` declarative macro that derives all three Rust pieces (Handle, wrapper component, platform-component declaration) from a single source-of-truth declaration. Rust authors write each piece by hand per the [Phase N Ref API design](./phase-n-ref-api-design.md); the platform-side `definition()` is declared separately. Single-source-of-truth comes later if the redundancy ever bites.
 - View-less `Function(...)` blocks outside the `View(...) { ... }` scope (i.e. module-level functions). These map to the function-only flavor and need separate bridge plumbing — track as a sub-issue if it comes up.
 - Code-generation perf optimizations beyond what's needed to ship (e.g. KSP incremental processing for individual module files). Defer to a polish PR if/when build times become noticeable.
 
@@ -255,6 +355,8 @@ Phase M is a follow-up; not included in this estimate.
 - [ ] Async function semantics (callback vs Swift `async`).
 - [ ] Whether to keep `WhiskerCustomEvent.dispatch` as the runtime emit API or fold it into the `WhiskerModule` base class.
 
-Phase N's Ref API is **settled** — see [`docs/phase-n-ref-api-design.md`](./phase-n-ref-api-design.md). The Rust shim path in §3c assumes that design and lands before or alongside L-2.
+Phase N's imperative-control API (`ElementRef` primitive + `Handle`
+pattern) is **settled** — see [`docs/phase-n-ref-api-design.md`](./phase-n-ref-api-design.md). The
+Rust shim path in §3c assumes that design and lands before or alongside L-2.
 
 Once these are resolved, L-2 implementation can start.

--- a/docs/phase-l-moduledefinition-dsl-design.md
+++ b/docs/phase-l-moduledefinition-dsl-design.md
@@ -1,0 +1,211 @@
+# Phase L design: `ModuleDefinition` DSL
+
+**Status**: design (no implementation yet). Tracking issue: #58. Parent epic: #55.
+
+This doc proposes the implementation path for Whisker's `ModuleDefinition` DSL — an Expo-Modules-style API surface that replaces the current `@WhiskerComponent` / `@WhiskerModule` / `@WhiskerProp` / `@WhiskerUIMethod` annotation set on both iOS and Android. View-bearing and function-only modules will share the same `definition() -> ModuleDefinition` entry point; the View dispatch table becomes a feature of the DSL.
+
+A secondary goal: stop routing through Lynx's `@LynxProp` / `@LynxUIMethod` reflection in the codegen output, and dispatch directly into the Lynx-internal prop / method registries instead. Removes the "method name must match exactly" footgun (the `lynxInvoke_pause` bug, PR #52), makes the dispatch table inspectable, and decouples Whisker's surface from changes in Lynx's annotation contract.
+
+## 1. Target shape
+
+**Swift**:
+
+```swift
+public final class VideoModule: WhiskerModule {
+  public func definition() -> ModuleDefinition {
+    Name("Video")
+
+    Constants([
+      "maxResolution": "1080p",
+    ])
+
+    View(WhiskerVideoView.self) {
+      Prop("src") { (view, value: String) in view.setSrc(value) }
+      Function("play") { (view) in view.play() }
+      Function("pause") { (view) in view.pause() }
+      Function("seek") { (view, seconds: Double) in view.seek(seconds) }
+      Events("onCompleted")
+    }
+  }
+}
+```
+
+**Kotlin**:
+
+```kotlin
+class VideoModule : WhiskerModule() {
+  override fun definition() = ModuleDefinition {
+    Name("Video")
+
+    Constants("maxResolution" to "1080p")
+
+    View(WhiskerVideoView::class) {
+      Prop("src") { view, value: String -> view.setSrc(value) }
+      Function("play") { view -> view.play() }
+      Function("pause") { view -> view.pause() }
+      Function("seek") { view, seconds: Double -> view.seek(seconds) }
+      Events("onCompleted")
+    }
+  }
+}
+```
+
+`Function(...)` is the sync form — the closure returns synchronously
+and the caller awaits nothing. Use `AsyncFunction(...)` only when the
+work is genuinely async (a network fetch, a permission prompt, a long
+disk read) and the platform side wants to defer completion to a
+later runloop turn. `play()` / `pause()` / `seek()` are immediate
+state mutations on a Media3 / AVPlayer instance — sync.
+
+**Function-only module** (same DSL, no `View(...)` block):
+
+```swift
+public final class LocalStoreModule: WhiskerModule {
+  public func definition() -> ModuleDefinition {
+    Name("WhiskerLocalStore")
+    Function("save") { (key: String, value: String) in
+      UserDefaults.standard.set(value, forKey: key)
+      return true
+    }
+    Function("load") { (key: String) -> String? in
+      UserDefaults.standard.string(forKey: key)
+    }
+  }
+}
+```
+
+Single API. View is just a feature. Same shape on both platforms.
+
+## 2. Lynx dispatch layer mapping
+
+| DSL block | Maps to (Android) | Maps to (iOS) |
+|---|---|---|
+| `Prop("name") { view, value -> ... }` | a `LynxUISetter<T>` impl pre-registered in `PropsUpdater.PRE_REGISTER_MAP` | an Obj-C setter on the `LynxUI` subclass (`-(void)setNameProp:(Type)v`) emitted as a category |
+| `Function("name") { ... }` (sync) / `AsyncFunction("name") { ... }` (callback) | a `LynxUIMethodInvoker<T>` impl pre-registered via `LynxUIMethodsExecutor.registerMethodInvoker(...)` | a `LYNX_UI_METHOD(name:withResult:)` macro expansion on the `LynxUI` subclass |
+| `Events("name", ...)` | call `eventEmitter.dispatchCustomEvent(LynxCustomEvent(...))` directly when the module fires the event | same — `[eventEmitter dispatchCustomEvent:event]` directly |
+| `Name("Foo")` | `addBehavior(Behavior("<crate>:Foo"))` registration (unchanged from today) | same |
+| `Constants([...])` | per-class static map exposed via a new `getConstants()` accessor on `WhiskerModule` | same |
+| `View(MyView.self) { ... }` | inner block scopes prop / method registrations to that view's `LynxUI<View>` subclass | same |
+
+**Crucial property**: none of the codegen output references `@LynxProp` or `@LynxUIMethod`. Lynx's reflection layer is bypassed end-to-end for Whisker modules.
+
+### 2a. Pre-registration vs lazy reflection
+
+Both Lynx Android entrypoints currently look up generated `$$PropsSetter` / `$$MethodInvoker` classes by reflection at first use, falling back to the annotation-scanning `Fallback*` invoker when none is registered. The Whisker codegen plan:
+
+1. KSP / Swift Macro processes `ModuleDefinition` declarations at build time.
+2. Emits a hand-rolled implementation of `LynxUISetter<T>` and `LynxUIMethodInvoker<T>` per `WhiskerModule` class.
+3. Emits a registration call that runs from the host's `WhiskerModuleBehaviors.registerAll()` — same plumbing PR #61 already wires up — but in addition to `addBehavior(...)`, also calls:
+   - Android: `PropsUpdater.registerSetter(WhiskerVideoView.class, GeneratedSetter())` + `LynxUIMethodsExecutor.registerMethodInvoker(GeneratedInvoker())`
+   - iOS: nothing extra. The `LYNX_UI_METHOD` macro + setter category methods are picked up at class load time by Lynx's first-use scan; we keep that scan since it's already efficient (one pass per class).
+
+The Lynx engine's existing fallback paths stay intact for non-Whisker LynxUI subclasses, so this change is fully additive on the Lynx side.
+
+### 2b. Lynx fork changes required
+
+The Android registration APIs are currently package-private in the Lynx upstream. Whisker fork additions (small, targeted):
+
+1. `PropsUpdater.registerSetter(Class<? extends LynxBaseUI>, LynxUISetter<?>)` — expose `PRE_REGISTER_MAP` insertion as a public static method. Currently `PRE_REGISTER_MAP` is `static final HashMap` populated only at class init — needs a `public synchronized` setter.
+2. `LynxUIMethodsExecutor.registerMethodInvoker(Class<? extends LynxBaseUI>, LynxUIMethodInvoker<?>)` — same shape. Today the method exists but is package-private.
+
+iOS needs no Lynx fork changes — `LYNX_UI_METHOD` macros and category methods are already first-class citizens of the public API.
+
+These bumps go into a `v3.7.0-whisker.4` Lynx fork release alongside the `lynx_ui_invoke_method` symbol added in `.3` (PR #52's Lynx-side patch).
+
+## 3. Code generation pipeline
+
+### 3a. iOS (Swift Macro)
+
+The `WhiskerModule` base class is annotated with `@WhiskerModuleMacro` (or similar) — a member-attached Swift Macro that:
+
+1. Parses the `definition()` body's DSL via SwiftSyntax (matches calls to `Name`, `View`, `Prop`, `Function`, `AsyncFunction`, `Constants`, `Events`).
+2. Emits per-DSL-block helper methods on the `WhiskerModule` subclass:
+   - `Prop("src") { ... }` → emits a category method `-(void)setSrc:(NSString*)v` on the `View(WhiskerVideoView.self)` target. The closure body gets inlined.
+   - `Function("pause") { ... }` → emits `LYNX_UI_METHOD(pauseWithResult:)` on the target, invoking the closure synchronously and packing the return value into the result block before returning. The `withResult:` block is called inline before `LYNX_UI_METHOD` returns — the caller (Rust via `ElementRef::invoke`) sees a synchronous round-trip.
+   - `AsyncFunction("fetchThumbnail") { ... }` → also emits `LYNX_UI_METHOD(fetchThumbnailWithResult:)`, but the closure is wrapped in a `DispatchQueue.global().async { ... }` so the work runs off the dispatch thread; the `withResult:` block is captured and called from the worker once the closure completes. Same underlying Lynx hook; different scheduling.
+   - `Name("Video")` → emits a `+ NSString *whiskerComponentTagName()` accessor the registry calls.
+3. The aggregator scaffolding from PR #61 finds every `WhiskerModule` subclass and calls `WhiskerComponentRegistry.shared.register(MyModule.self)` at app launch.
+
+### 3b. Android (KSP)
+
+The existing `WhiskerComponentProcessor` is extended (or replaced):
+
+1. Scans for classes extending `WhiskerModule`.
+2. Parses the `definition() = ModuleDefinition { ... }` block by traversing the Kotlin AST — KSP gives us symbol-level access to lambda bodies and their captured `Prop("...") { ... }` invocations.
+3. Emits a generated `<ModuleClassName>Generated.kt` file per module containing:
+   - A `<Module>_PropSetter : LynxUISetter<TargetUI>` implementation with a `when` switch over prop names.
+   - A `<Module>_MethodInvoker : LynxUIMethodInvoker<TargetUI>` implementation with a `when` switch over method names.
+   - A `<Module>_registerAll()` function that calls `PropsUpdater.registerSetter(...)` + `LynxUIMethodsExecutor.registerMethodInvoker(...)` + `LynxEnv.inst().addBehavior(Behavior("<crate>:<name>") { ... })`.
+4. The aggregator KSP entrypoint (also from PR #61) accumulates per-module `registerAll()` calls into the existing `WhiskerModuleBehaviors.registerAll()`.
+
+### 3c. Rust shim
+
+The Rust side stays close to today's shape:
+
+```rust
+#[whisker::platform_component("Video")]
+pub fn video(src: Signal<String>, style: Signal<String>) {}
+```
+
+The proc macro keeps emitting the Props struct + render-time apply logic. What changes:
+
+- The `#[whisker::element_methods]` trait's typed dispatch (`r.pause()`, `r.seek(10.0)`) still routes through `whisker_bridge_invoke_element_method`. The bridge now uses the *new* Lynx Android `LynxUIMethodInvoker<T>` direct-table lookup — much less Lynx-version-coupled than the old reflection path. No Rust-side change visible to users.
+- A future Rust-side `ModuleDefinition` macro (think `module! { ... }`) could let Rust authors declare modules without writing the Swift/Kotlin halves — but that's out of Phase L's scope. Phase L only replaces the *platform-side* author surface.
+
+## 4. Migration story
+
+Phase L ships the new DSL **alongside** the existing annotation set:
+
+1. PR L-1 (Lynx fork): expose `PropsUpdater.registerSetter` + `LynxUIMethodsExecutor.registerMethodInvoker` as public; bump fork to `v3.7.0-whisker.4`; bump Whisker's `LYNX_FORK_TAG`.
+2. PR L-2 (Whisker): add `WhiskerModule` base class + `ModuleDefinition` DSL types + Swift Macro impl + KSP processor extensions. Both annotation and DSL paths work in parallel.
+3. PR L-3 (samples): migrate `whisker-video`, `whisker-hello-element`, `whisker-local-store`, hello-world's video demo to the new DSL.
+4. PR L-4 (Module Author Guide): update `docs/module-author-guide.md` to lead with the DSL; demote the annotation surface to a "legacy" section.
+
+Phase M (#59) then deprecates → removes the annotation surface in a follow-up release window.
+
+## 5. Open questions
+
+- **Closure capture in KSP-emitted Kotlin code.** When `Prop("src") { view, value: String -> view.setSrc(value) }` is processed, KSP needs to extract the closure body and emit it as the body of the generated `<Module>_PropSetter.setSrc()` method. Two paths:
+  - **A. Re-emit the closure verbatim** by reading the source range from KSP's `KSExpression`. Simple but rigid — anything referencing private members of the module class breaks.
+  - **B. Keep the closure in the module class** and emit a generated `<Module>_PropSetter` that calls `module.definition().getPropClosure("src")(view, value)`. Loses static dispatch but is robust.
+  - Lean toward **A** for the common case (small closures) and **B** as a fallback when KSP can't statically parse the body.
+- **`AsyncFunction` semantics on iOS.** `Function(...)` is settled — sync round-trip; the `withResult:` block fires synchronously. `AsyncFunction(...)` is the open question: do we expose it as a Swift `async` closure (forwards-compatible with Swift concurrency), or as a callback closure that calls a handler when work completes? Expo uses Swift `async`. The simpler v1 is **callback-based** (a `(result) -> Void` parameter), with Swift `async` as a v2 sugar layer on top. Same question for Kotlin — `suspend` lambda vs `(callback) -> Unit`. v1 = callback.
+- **`Constants` semantics.** Expo's constants are evaluated once at module init. Whisker has no JS host yet — constants are read from Rust at compile time via the `WhiskerModule.getConstants()` accessor. Q: do we want a way to declare *dynamic* constants (e.g. computed from the platform's locale)? Defer; start with static-only.
+- **Should `View(...)` accept a closure or a class reference?** Expo uses `View(MyView.self) { ... }`. We follow that — the class reference scopes the inner DSL to a specific `LynxUI<V>` subclass. Multi-view modules are rare; if they come up, support `View(A.self) { ... }` + `View(B.self) { ... }` blocks in the same `definition()`.
+- **Backward compatibility for `WhiskerCustomEvent.dispatch(...)`.** Today modules call `WhiskerCustomEvent.dispatch(from: ui, name: "...", params: [...])` to emit events. The new DSL declares `Events("onTap")` upfront but the *dispatch site* is still imperative. Keep `WhiskerCustomEvent.dispatch` as the dispatch helper (unchanged); `Events(...)` just records the event names for type-checking / future doc generation.
+
+## 6. Risk + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| KSP closure-body extraction breaks under unusual Kotlin syntax (multi-line returns, type ascriptions, etc.) | Option B above as fallback; document the supported subset. |
+| Swift Macro performance on large modules with many `Prop` / `Function` declarations | Profile during L-2; cap at e.g. 100 declarations per module; bigger modules can be split. |
+| Lynx fork divergence — every Lynx upstream bump may touch `PropsUpdater` / `LynxUIMethodsExecutor` | Keep the registration APIs minimal (one method per registry); rebase fork patches each Lynx bump. |
+| Module authors mix DSL and annotation styles in the same file | KSP / Swift Macro errors out with a clear diagnostic; document "pick one" up front. |
+| Existing third-party Whisker modules break | Annotation surface stays alive through Phase L; deprecated via warning in Phase M; removed only in M.2. |
+
+## 7. Out of scope for Phase L
+
+- A Rust-side `ModuleDefinition` macro (declaring modules from Rust). The platform-side DSL is the primary deliverable; Rust shim stays as `#[whisker::platform_component]` for now.
+- View-less `Function(...)` blocks outside the `View(...) { ... }` scope (i.e. module-level functions). These map to the function-only flavor and need separate bridge plumbing — track as a sub-issue if it comes up.
+- Code-generation perf optimizations beyond what's needed to ship (e.g. KSP incremental processing for individual module files). Defer to a polish PR if/when build times become noticeable.
+
+## 8. Estimated work
+
+| Sub-task | Estimate |
+|---|---|
+| L-1: Lynx fork API exposure + `v3.7.0-whisker.4` bump | 0.5 day |
+| L-2: Swift Macro + KSP processor + `WhiskerModule` base class | 4–7 days |
+| L-3: migrate three reference modules + hello-world | 1 day |
+| L-4: Module Author Guide rewrite + samples | 0.5 day |
+| Total | ~7–10 days |
+
+Phase M is a follow-up; not included in this estimate.
+
+## 9. Decision needed before L-2 starts
+
+- [ ] Closure-body strategy (A vs B from §5).
+- [ ] Async function semantics (callback vs Swift `async`).
+- [ ] Whether to keep `WhiskerCustomEvent.dispatch` as the runtime emit API or fold it into the `WhiskerModule` base class.
+
+Once these are resolved, L-2 implementation can start.

--- a/docs/phase-l-moduledefinition-dsl-design.md
+++ b/docs/phase-l-moduledefinition-dsl-design.md
@@ -140,17 +140,64 @@ The existing `WhiskerComponentProcessor` is extended (or replaced):
 
 ### 3c. Rust shim
 
-The Rust side stays close to today's shape:
+The Rust side adopts a **plain struct + impl** pattern that mirrors the
+Phase N standardized Ref API (see `docs/phase-n-ref-api-design.md`).
+Module authors write:
 
 ```rust
-#[whisker::platform_component("Video")]
-pub fn video(src: Signal<String>, style: Signal<String>) {}
+#[whisker::modules::component("Video")]
+pub fn video(r: VideoRef, src: Signal<String>, style: Signal<String>) {}
+
+#[derive(Clone)]
+pub struct VideoRef {
+    handle: RefHandle,
+}
+
+impl VideoRef {
+    pub fn new() -> Self { Self { handle: RefHandle::new() } }
+
+    pub fn play(&self) -> Result<(), RefError> {
+        self.handle.invoke("play", vec![]).map(|_| ())
+    }
+    pub fn pause(&self) -> Result<(), RefError> {
+        self.handle.invoke("pause", vec![]).map(|_| ())
+    }
+    pub fn seek(&self, position_seconds: f64) -> Result<(), RefError> {
+        self.handle.invoke("seek", vec![WhiskerValue::Float(position_seconds)]).map(|_| ())
+    }
+
+    pub fn try_play(&self) { let _ = self.play(); }
+    pub fn try_pause(&self) { let _ = self.pause(); }
+    pub fn try_seek(&self, seconds: f64) { let _ = self.seek(seconds); }
+}
+
+impl WhiskerRef for VideoRef {
+    fn handle(&self) -> &RefHandle { &self.handle }
+}
 ```
 
-The proc macro keeps emitting the Props struct + render-time apply logic. What changes:
+This replaces the current `#[whisker::element_methods] trait VideoSys + impl VideoControls for ElementRef<VideoProps>` triple-declaration with a single hand-written struct. Tradeoffs and full design rationale are in
+the [Phase N Ref API design doc](./phase-n-ref-api-design.md). Highlights:
 
-- The `#[whisker::element_methods]` trait's typed dispatch (`r.pause()`, `r.seek(10.0)`) still routes through `whisker_bridge_invoke_element_method`. The bridge now uses the *new* Lynx Android `LynxUIMethodInvoker<T>` direct-table lookup — much less Lynx-version-coupled than the old reflection path. No Rust-side change visible to users.
-- A future Rust-side `ModuleDefinition` macro (think `module! { ... }`) could let Rust authors declare modules without writing the Swift/Kotlin halves — but that's out of Phase L's scope. Phase L only replaces the *platform-side* author surface.
+- **All plain Rust** — no Rust-side macros for the methods themselves;
+  the `#[whisker::modules::component]` macro only needs to recognize
+  the `r: VideoRef` parameter (any type implementing `WhiskerRef`) and
+  emit mount-time `RefHandle::__bind(...)` wiring.
+- **Symmetric with Kotlin / Swift surface** — the platform-side
+  `definition()` DSL declares prop names + method names; the Rust-side
+  `impl VideoRef` declares matching methods that dispatch via the same
+  names. Both halves describe the same component from their own
+  language's perspective.
+- **Composite custom refs** (`CustomInputRef`, `FormRef`, …) compose
+  built-in refs as struct fields and forward methods — see Phase N
+  §5 for the pattern. No special Whisker support needed; it's just
+  Rust struct composition.
+
+A future Rust-side declarative macro (`whisker::module! { ... }`)
+that derives both the platform-side DSL and the Rust struct from a
+single source-of-truth declaration is **out of scope for Phase L** —
+the per-platform manual declaration is fine for v1 and keeps the
+codegen story simpler.
 
 ## 4. Migration story
 
@@ -186,7 +233,7 @@ Phase M (#59) then deprecates → removes the annotation surface in a follow-up 
 
 ## 7. Out of scope for Phase L
 
-- A Rust-side `ModuleDefinition` macro (declaring modules from Rust). The platform-side DSL is the primary deliverable; Rust shim stays as `#[whisker::platform_component]` for now.
+- A Rust-side `whisker::module! { ... }` declarative macro that derives both halves (Rust struct + platform-side DSL) from a single source-of-truth declaration. Rust authors write the `XxxRef` struct by hand per the [Phase N Ref API design](./phase-n-ref-api-design.md); the platform-side `definition()` is declared separately. Single-source-of-truth comes later if the redundancy ever bites.
 - View-less `Function(...)` blocks outside the `View(...) { ... }` scope (i.e. module-level functions). These map to the function-only flavor and need separate bridge plumbing — track as a sub-issue if it comes up.
 - Code-generation perf optimizations beyond what's needed to ship (e.g. KSP incremental processing for individual module files). Defer to a polish PR if/when build times become noticeable.
 
@@ -207,5 +254,7 @@ Phase M is a follow-up; not included in this estimate.
 - [ ] Closure-body strategy (A vs B from §5).
 - [ ] Async function semantics (callback vs Swift `async`).
 - [ ] Whether to keep `WhiskerCustomEvent.dispatch` as the runtime emit API or fold it into the `WhiskerModule` base class.
+
+Phase N's Ref API is **settled** — see [`docs/phase-n-ref-api-design.md`](./phase-n-ref-api-design.md). The Rust shim path in §3c assumes that design and lands before or alongside L-2.
 
 Once these are resolved, L-2 implementation can start.

--- a/docs/phase-n-ref-api-design.md
+++ b/docs/phase-n-ref-api-design.md
@@ -1,45 +1,51 @@
-# Phase N design: `Ref` API standardization
+# Phase N design: `ElementRef` + `Handle` API standardization
 
 **Status**: design (no implementation yet). Tracking issue: #60. Parent epic: #55.
 
-This doc proposes the standardized Ref API that all Whisker imperative
-handles (`TextInputRef`, `ScrollViewRef`, `VideoRef`, custom-component
-refs that compose them) build on top of.
+This doc proposes the imperative-control layer that all of Whisker's
+"call a method on a mounted thing" use cases build on (`videoHandle.play()`,
+`textInputHandle.focus()`, `modalHandle.open()`, application-level composite
+handles).
 
-The design grew out of the Phase L discussion (#58) where the question
-"how does a Rust author declare ref methods on a platform component?"
-expanded into a broader question about whether Whisker should have any
-ref API at all (vs leaning entirely on signals). The answer settled on:
+The design grew out of the Phase L discussion (#58). After a few iterations
+the conclusion was that **a single "Ref" abstraction conflates two very
+different things**, and splitting them makes the whole picture much simpler:
 
-- **State** lives in `Signal<T>` / `RwSignal<T>` — Leptos / SolidJS style
-  controller pattern for everything stateful.
-- **Commands** (FFI dispatches, focus / scroll / play / pause, etc.)
-  go through a thin, standardized Ref API. Refs are needed where
-  signals don't model the operation cleanly.
+| Layer | Name | Role | Who writes it |
+|---|---|---|---|
+| **FFI primitive** | `ElementRef` | Receives a mounted element's id; exposes `invoke()` to call platform methods | Framework |
+| **User-facing imperative API** | `XxxHandle` (`VideoHandle`, `ModalHandle`, …) | Plain `Clone` struct, internally `RwSignal<...>` for commands and reactive `ReadSignal<T>` for queries. End-users call methods on it. | Module / app authors |
 
-Phase N standardizes the bottom layer (one primitive `RefHandle` +
-`WhiskerRef` trait + `RefError` enum). Above that, every typed ref
-(`TextInputRef`, `VideoRef`, application-level `CustomInputRef`, …)
-is **plain Rust struct + impl** with no Whisker-specific macro support
-needed.
+Handles are pure-Rust signal-backed structs. There is **no `WhiskerRef`
+trait, no derive, no auto-bind**. The connection from a `Handle` down to
+an `ElementRef` (and from there to native) happens inside the
+`#[whisker::component]` that wraps the platform component, written by
+the module author as ordinary `effect(...)` blocks.
 
-## 1. Primitive: `RefHandle`
+This design fully embraces Whisker's signal-first philosophy: the
+imperative-feeling user surface (`handle.play()`) is just sugar over
+"write to a signal", and the bridge to native is one more `effect(...)`
+subscribing to that signal.
 
-The single FFI-dispatch primitive every typed ref builds on.
+## 1. Primitive: `ElementRef`
+
+A small framework-provided type. Module authors use it when wiring up
+their platform-component wrappers; end-users normally never see it.
 
 ```rust
-// crates/whisker-modules-api (or whisker)
-use std::cell::Cell;
-use std::rc::Rc;
+// crates/whisker-modules-api
+use whisker::reactive::{RwSignal, Signal, signal};
 
 #[derive(Clone)]
-pub struct RefHandle {
-    inner: Rc<Cell<Option<Element>>>,
+pub struct ElementRef {
+    // Single source of truth: holds the bound Element (None while
+    // unmounted) and is reactive so `bound()` can be observed.
+    inner: RwSignal<Option<Element>>,
 }
 
-impl RefHandle {
+impl ElementRef {
     pub fn new() -> Self {
-        Self { inner: Rc::new(Cell::new(None)) }
+        Self { inner: signal(None) }
     }
 
     /// Run a platform method through the C bridge. Returns `Err` when
@@ -50,7 +56,9 @@ impl RefHandle {
         method: &'static str,
         args: Vec<WhiskerValue>,
     ) -> Result<WhiskerValue, RefError> {
-        let elem = self.inner.get().ok_or(RefError::NotBound)?;
+        // get_untracked: `invoke` is imperative and must not subscribe
+        // its caller to the binding signal.
+        let elem = self.inner.get_untracked().ok_or(RefError::NotBound)?;
         match whisker_bridge_invoke_element_method(elem, method, args) {
             WhiskerValue::Err(msg) => Err(RefError::DispatchFailed {
                 method: method.into(),
@@ -60,12 +68,35 @@ impl RefHandle {
         }
     }
 
-    pub fn is_bound(&self) -> bool {
-        self.inner.get().is_some()
+    /// Ergonomic typed wrapper around `invoke`.
+    pub fn invoke_typed<T>(
+        &self,
+        method: &'static str,
+        args: Vec<WhiskerValue>,
+    ) -> Result<T, RefError>
+    where
+        T: TryFrom<WhiskerValue, Error = String>,
+    {
+        let v = self.invoke(method, args)?;
+        T::try_from(v).map_err(|message| RefError::DispatchFailed {
+            method: method.into(),
+            message,
+        })
     }
 
-    /// Framework-internal: render! / #[component] / #[platform_component]
-    /// macros call this on mount. Authors should not call it.
+    /// `true` iff bound to a live element right now. Non-reactive read.
+    pub fn is_bound(&self) -> bool {
+        self.inner.get_untracked().is_some()
+    }
+
+    /// Reactive: subscribe inside `effect(...)` / `computed(...)` to
+    /// react to mount / unmount events.
+    pub fn bound(&self) -> Signal<bool> {
+        let inner = self.inner;
+        Signal::derive(move || inner.get().is_some())
+    }
+
+    /// Framework-internal: `#[platform_component]` macro calls this on mount.
     #[doc(hidden)]
     pub fn __bind(&self, element: Element) {
         self.inner.set(Some(element));
@@ -79,314 +110,455 @@ impl RefHandle {
 }
 ```
 
-The `Rc<Cell<Option<Element>>>` shape gives `RefHandle` three
-properties at once:
+Key properties:
 
-- **`Clone` is cheap** — multiple closures can hold their own copy.
-  All clones point to the same `Rc`, so mount/unmount is visible
-  through every clone simultaneously.
-- **No mutable borrow needed for invoke** — `Cell::get` on a `Copy`
-  payload (`Option<Element>` is `Copy` because `Element` is a small
-  newtype) lets `invoke(&self, …)` work without `&mut self`.
-- **Runtime-checked binding** — the `Option` distinguishes "haven't
-  mounted yet" / "unmounted" from a real `Element`.
+- **Single source of truth.** Both the binding state and reactive
+  observation flow from one `RwSignal<Option<Element>>`. There is no
+  separate `Cell` to keep in sync.
+- **`Clone` is cheap.** `RwSignal<T>` is internally `Copy`-handle to
+  an arena slot, so passing `ElementRef` to multiple closures is free.
+- **`bound()` is reactive, `is_bound()` is not.** Hot-path `invoke()`
+  uses `get_untracked()` to avoid accidentally subscribing the caller
+  to the binding signal. Authors wanting to react to mount/unmount
+  read `bound()` from inside an `effect`.
+- **Where `ElementRef` is bound.** Only `#[platform_component]` macros
+  bind `ElementRef` (to the underlying native element they create).
+  `#[component]` (custom components) never auto-binds anything —
+  there is no element to bind to in a pure Rust component.
 
-## 2. Trait: `WhiskerRef`
+### `ElementRef` is module-author surface, not app surface
 
-The opt-in marker for "this type is a Ref the framework can bind to a
-mounted element."
+App authors don't pass `ElementRef` around. They construct a `Handle`
+(see §2 / §3), pass it to a component, and call methods on it. The
+`ElementRef` lives internally in the platform-component wrapper that
+the module author wrote.
 
-```rust
-pub trait WhiskerRef {
-    /// The underlying handle the framework binds on mount.
-    fn handle(&self) -> &RefHandle;
-}
-```
+## 2. User-facing `Handle` pattern
 
-Just one method. Authors implement it on their `XxxRef` structs so
-the `#[component]` / `#[platform_component]` macros can find the
-`RefHandle` they own and wire up mount-time binding.
+A **Handle** is whatever struct the module / app author defines to give
+end-users an imperative-feeling API for a component. There is **no
+trait** to implement, no `derive`, no Whisker-specific macro: a Handle
+is just a `Clone`-able plain Rust struct whose fields are reactive
+signals.
 
-Composite custom refs (`CustomInputRef`, `FormRef` — see §5) do **not**
-implement `WhiskerRef` because they don't bind to a single Lynx
-element. They compose `WhiskerRef`-implementing inner refs and the
-binding happens through those.
+The conventions:
 
-## 3. Errors: `RefError`
+- Field name suffix: `XxxHandle` (`VideoHandle`, `ModalHandle`, …).
+- All command / state fields are `RwSignal<T>`.
+- Methods are sugar: a method either writes a signal, reads a signal,
+  or composes child-handle methods.
+- The wrapping `#[whisker::component]` bridges the handle's command
+  signals to native via `ElementRef` (only needed when the handle
+  controls a native element).
 
-```rust
-#[derive(Debug, thiserror::Error)]
-pub enum RefError {
-    /// Ref isn't bound to a mounted element. Either the component
-    /// hasn't been rendered yet, or it has unmounted.
-    #[error("ref is not bound to a mounted element")]
-    NotBound,
-
-    /// Platform side surfaced a dispatch error
-    /// (method not found, exception thrown, type mismatch, …).
-    #[error("platform method `{method}` failed: {message}")]
-    DispatchFailed { method: String, message: String },
-}
-```
-
-The two-variant split lets callers distinguish "haven't been mounted
-yet" (often a UI race the caller should silently ignore) from "the
-platform side broke" (often a bug worth surfacing).
-
-For the common fire-and-forget UI handler case, each typed ref
-provides a paired strict / lenient method (see §4).
-
-## 4. Typed refs: plain struct + impl
-
-Every typed ref Whisker / a module crate / an app crate exposes is a
-**regular Rust struct that owns a `RefHandle` and implements
-`WhiskerRef`**. No macro, no special syntax, no DSL.
-
-Example — `VideoRef` shipped by `whisker-video`:
+### Canonical example: `VideoHandle`
 
 ```rust
-use whisker::{RefError, RefHandle, WhiskerRef, WhiskerValue};
+use std::cell::Cell;
+use whisker::reactive::{RwSignal, Signal, signal};
 
 #[derive(Clone)]
-pub struct VideoRef {
-    handle: RefHandle,
+pub struct VideoHandle {
+    // --- command signals (write side) ---
+    // Counter pattern: increment to dispatch one play.
+    play_tick:  RwSignal<u64>,
+    pause_tick: RwSignal<u64>,
+    // Argument-bearing one-shot: seek-to-position.
+    seek_to:    RwSignal<Option<f64>>,
+
+    // --- query signals (read side; the bridge writes, users read) ---
+    current_time: RwSignal<f64>,
+    duration:     RwSignal<f64>,
 }
 
-impl VideoRef {
+impl VideoHandle {
     pub fn new() -> Self {
-        Self { handle: RefHandle::new() }
+        Self {
+            play_tick: signal(0),
+            pause_tick: signal(0),
+            seek_to: signal(None),
+            current_time: signal(0.0),
+            duration: signal(0.0),
+        }
     }
 
-    // Strict variant — caller handles RefError.
-    pub fn play(&self) -> Result<(), RefError> {
-        self.handle.invoke("play", vec![]).map(|_| ())
-    }
-    pub fn pause(&self) -> Result<(), RefError> {
-        self.handle.invoke("pause", vec![]).map(|_| ())
-    }
-    pub fn seek(&self, position_seconds: f64) -> Result<(), RefError> {
-        self.handle.invoke("seek", vec![WhiskerValue::Float(position_seconds)]).map(|_| ())
-    }
+    // ---- commands: write a signal ----
+    pub fn play(&self)         { self.play_tick.update(|n| *n += 1); }
+    pub fn pause(&self)        { self.pause_tick.update(|n| *n += 1); }
+    pub fn seek(&self, t: f64) { self.seek_to.set(Some(t)); }
 
-    // Lenient variant — silently no-ops when unbound. For
-    // fire-and-forget UI handlers (on_tap closures etc.).
-    pub fn try_play(&self) { let _ = self.play(); }
-    pub fn try_pause(&self) { let _ = self.pause(); }
-    pub fn try_seek(&self, seconds: f64) { let _ = self.seek(seconds); }
-}
-
-impl WhiskerRef for VideoRef {
-    fn handle(&self) -> &RefHandle { &self.handle }
+    // ---- queries: hand out a ReadSignal ----
+    pub fn current_time(&self) -> Signal<f64> { self.current_time.read_only().into() }
+    pub fn duration(&self)     -> Signal<f64> { self.duration.read_only().into() }
 }
 ```
 
-That's the entire pattern. ~25 lines per ref type, all plain Rust:
-
-- `cargo doc` lists `VideoRef` and its methods on its own page.
-- rust-analyzer's go-to-definition lands on the impl block, not
-  inside a macro expansion.
-- Adding custom validation (logging, retries, type conversions) is
-  just editing the impl block.
-- Tests can construct a `VideoRef` and observe its `handle().is_bound()`
-  directly.
-
-Use site:
+End-user code:
 
 ```rust
-let r = VideoRef::new();
-let r_play = r.clone();
-let r_pause = r.clone();
+let v = VideoHandle::new();
+let progress = v.current_time();           // Signal<f64> — reactive everywhere
+
+let v_play = v.clone();
+let v_restart = v.clone();
 
 render! {
-    Video(ref: r, src: "https://...", style: "width: 100%; height: 240px;")
-    view {
-        text(on_tap: move || r_play.try_play(),   value: "▶")
-        text(on_tap: move || r_pause.try_pause(), value: "⏸")
+    Video(handle: v.clone(), src: signal("video.mp4".into()))
+    text(value: move || format!("{:.1}s", progress.get()))
+    text(on_tap: move || v_play.play(),               value: "▶")
+    text(on_tap: move || v_restart.seek(0.0),         value: "⏮")
+}
+```
+
+### Canonical example: `ModalHandle` (no native bridge needed)
+
+For custom components that don't talk to native, the handle is
+*entirely* signal-based and there is no `ElementRef` anywhere.
+
+```rust
+#[derive(Clone)]
+pub struct ModalHandle {
+    open: RwSignal<bool>,
+}
+
+impl ModalHandle {
+    pub fn new() -> Self { Self { open: signal(false) } }
+    pub fn open(&self)   { self.open.set(true); }
+    pub fn close(&self)  { self.open.set(false); }
+    pub fn toggle(&self) { self.open.update(|o| *o = !*o); }
+    pub fn is_open(&self) -> Signal<bool> { self.open.read_only().into() }
+}
+```
+
+```rust
+#[whisker::component]
+pub fn modal(handle: ModalHandle, children: Children) -> Element {
+    render! {
+        show!(handle.is_open(), {
+            view(class: "modal-backdrop", on_tap: {
+                let h = handle.clone();
+                move || h.close()
+            }) {
+                view(class: "modal-content") { children() }
+            }
+        })
     }
 }
 ```
 
-## 5. Composite custom refs
+`modal` is just a custom `#[component]` — no `ElementRef`, no
+framework-level binding logic, no `WhiskerRef` trait. The component
+body subscribes to `handle.is_open()` via `show!`, and the user calls
+`handle.open()` to flip the signal.
 
-Application authors that build a custom component wrapping a built-in
-(e.g. a `CustomInput` that puts a label next to a `TextInput`) can
-compose existing refs:
+## 3. Bridging a `Handle` to an `ElementRef`
+
+When a Handle controls a native element (like `VideoHandle` driving the
+`<video>` element), the **wrapping `#[whisker::component]` builds the
+bridge** by hand using `effect(...)`. Whisker provides no framework-level
+auto-bridging — the boundary is explicit so authors can see and tune it.
+
+```rust
+use std::cell::Cell;
+use whisker::reactive::effect;
+
+#[whisker::component]
+pub fn video(handle: VideoHandle, src: Signal<String>) -> Element {
+    // Internal: ElementRef bound by `#[platform_component]` on mount.
+    let sys = ElementRef::new();
+
+    // --- command bridges (write side: signal -> invoke) ---
+
+    // Counter pattern needs first-fire suppression (effects run once on
+    // creation; the signal starts at 0, so without this guard the
+    // component would call `play()` on every mount).
+    effect({
+        let sys = sys.clone();
+        let h = handle.clone();
+        let first = Cell::new(true);
+        move || {
+            h.play_tick.get();                  // subscribe
+            if first.replace(false) { return; }
+            let _ = sys.invoke("play", vec![]);
+        }
+    });
+    effect({
+        let sys = sys.clone();
+        let h = handle.clone();
+        let first = Cell::new(true);
+        move || {
+            h.pause_tick.get();
+            if first.replace(false) { return; }
+            let _ = sys.invoke("pause", vec![]);
+        }
+    });
+
+    // Option pattern: dispatch and reset to None so re-setting the
+    // same value re-dispatches.
+    effect({
+        let sys = sys.clone();
+        let h = handle.clone();
+        move || {
+            if let Some(t) = h.seek_to.get() {
+                let _ = sys.invoke("seek", vec![WhiskerValue::Float(t)]);
+                h.seek_to.set(None);
+            }
+        }
+    });
+
+    // --- query bridges (read side: native event -> signal) ---
+
+    let on_time_update = {
+        let h = handle.clone();
+        move |e: WhiskerEvent| {
+            if let Some(t) = e.get_float("currentTime") { h.current_time.set(t); }
+        }
+    };
+    let on_loaded_metadata = {
+        let h = handle.clone();
+        move |e: WhiskerEvent| {
+            if let Some(d) = e.get_float("duration") { h.duration.set(d); }
+        }
+    };
+
+    render! {
+        VideoSys(
+            ref: sys.clone(),
+            src: src,
+            on_time_update: on_time_update,
+            on_loaded_metadata: on_loaded_metadata,
+        )
+    }
+}
+```
+
+Conceptually: a Handle is a **signal-shaped specification of an
+imperative API**, and the wrapper component is the **interpreter** that
+turns those signal changes into native calls + native events back into
+signal writes.
+
+## 4. Command signal patterns
+
+Four idiomatic shapes covering ~all imperative use cases:
+
+| Use case | Signal shape | Method body |
+|---|---|---|
+| Idempotent toggle (`open`, `close`, `focus`) | `RwSignal<bool>` | `open.set(true)` |
+| Re-firable side effect (`play`, `toast.show`) | `RwSignal<u64>` counter | `n.update(|x| *x += 1)` |
+| Argument-bearing one-shot (`seek(t)`, `scroll_to(y)`) | `RwSignal<Option<T>>` | `s.set(Some(t))` — bridge resets to `None` after dispatch |
+| Ordered queue (`enqueue(op)` series) | `RwSignal<Vec<Cmd>>` | `q.update(|v| v.push(c))` — bridge drains in `effect` |
+
+The bridge `effect`s match the signal shape:
+
+- `bool` → subscribe, dispatch when value goes high (use first-fire
+  guard or pattern-match on the new value).
+- counter → subscribe, dispatch on every change except the initial
+  effect creation (first-fire guard via `Cell<bool>`).
+- `Option<T>` → match `Some(t)`, dispatch, reset to `None`.
+- `Vec<Cmd>` → match non-empty, drain, dispatch each.
+
+These four patterns are documented as the standard idioms. Authors can
+combine them in a single Handle (e.g. `VideoHandle` mixes counters and
+`Option`).
+
+## 5. Composite Handles
+
+App-level handles compose framework / module handles as plain struct
+fields. No special Whisker support is needed because Handles are just
+Rust structs.
+
+### Wrapping a built-in (forward methods)
 
 ```rust
 #[derive(Clone)]
-pub struct CustomInputRef {
-    text_input: TextInputRef,
-    // Free to add more internal refs / signals here as the component grows:
-    //   wrapper_view: ViewRef,
-    //   error_message: RwSignal<Option<String>>,
+pub struct CustomInputHandle {
+    text_input: TextInputHandle,    // built-in handle from whisker
+    // could add internal signals too:
+    //   error: RwSignal<Option<String>>,
 }
 
-impl CustomInputRef {
+impl CustomInputHandle {
     pub fn new() -> Self {
-        Self { text_input: TextInputRef::new() }
+        Self { text_input: TextInputHandle::new() }
     }
 
-    pub fn focus(&self) -> Result<(), RefError> { self.text_input.focus() }
-    pub fn blur(&self)  -> Result<(), RefError> { self.text_input.blur() }
+    // Forwarders — plain Rust:
+    pub fn focus(&self) { self.text_input.focus(); }
+    pub fn blur(&self)  { self.text_input.blur(); }
 
-    // Methods that compose multiple inner-ref calls are just plain Rust:
-    pub fn focus_and_select_all(&self) -> Result<(), RefError> {
-        self.text_input.focus()?;
-        self.text_input.select(0, usize::MAX)?;
-        Ok(())
+    // Compositions — plain Rust:
+    pub fn focus_and_select_all(&self) {
+        self.text_input.focus();
+        self.text_input.select_all();
     }
+
+    pub fn value(&self) -> Signal<String> { self.text_input.value() }
 }
+```
 
-// CustomInputRef does NOT implement WhiskerRef — it doesn't bind
-// to a single element. The binding flows through `text_input`.
-
+```rust
 #[whisker::component]
-pub fn custom_input(r: CustomInputRef, label: Signal<String>) -> Element {
+pub fn custom_input(handle: CustomInputHandle, label: Signal<String>) -> Element {
+    let t = handle.text_input.clone();   // share — same Rc-backed signals
     render! {
         view {
             text(value: label)
-            // r.text_input.clone() shares the same Rc — when this
-            // TextInput mounts, the same RefHandle the parent holds
-            // (via r.text_input) becomes bound.
-            TextInput(ref: r.text_input.clone())
+            TextInput(handle: t)
         }
     }
 }
 ```
 
-### Three-layer composition just works
+Cloning `handle.text_input` shares the same backing signals, so calling
+`handle.focus()` on the outer `CustomInputHandle` propagates through the
+inner `TextInputHandle` → into the `TextInput`'s wrapper component's
+bridge `effect` → `sys.invoke("focus", _)`.
+
+### Mixed handles (signal-only + native-bridge)
+
+A `TooltipHandle` could combine its own `RwSignal<bool>` (visibility) with
+a child `ViewHandle` (for positioning calls). All composition is plain
+struct fields — no Whisker awareness needed.
+
+### Three layers deep is the same
 
 ```rust
 #[derive(Clone)]
-pub struct FormRef {
-    email: CustomInputRef,
-    password: CustomInputRef,
+pub struct FormHandle {
+    email: CustomInputHandle,
+    password: CustomInputHandle,
 }
 
-impl FormRef {
+impl FormHandle {
     pub fn new() -> Self {
         Self {
-            email: CustomInputRef::new(),
-            password: CustomInputRef::new(),
+            email: CustomInputHandle::new(),
+            password: CustomInputHandle::new(),
         }
     }
-    pub fn focus_email(&self) -> Result<(), RefError> {
-        self.email.focus()
-        // → CustomInputRef::focus
-        // → TextInputRef::focus
-        // → RefHandle::invoke("focus", …)
-        // → C bridge → Lynx → native UITextField / EditText
+    pub fn focus_email(&self) {
+        self.email.focus();
+        // → TextInputHandle.focus → focus_tick.update
+        // → wrapping `text_input` component's bridge effect
+        // → sys.invoke("focus", _)
+        // → C bridge → Lynx → native EditText / UITextField
     }
 }
 ```
-
-No macro is involved in any of this. The Ref hierarchy is just struct
-fields all the way down to the leaf `RefHandle`.
 
 ## 6. Lifetime / unmount semantics
 
-The unmount problem ("what happens when a method is called on a ref
-whose component has been removed from the tree?") cannot be expressed
-in Rust's lifetime system because:
+Handles **do not have a binding state**. They are pure-signal structs
+that live as long as the `Rc` graph keeps them alive. Calling
+`handle.play()` on an unmounted component just writes to a signal — the
+bridge `effect` may or may not still be alive:
 
-- Refs are `Rc<…>`-shared across closures, parent components, child
-  components, and reactive scopes. The compile-time lifetime is "as
-  long as anyone holds a clone."
-- Mount / unmount is a runtime event driven by Lynx's reactive
-  reconciliation. The compile-time graph can't see when an element
-  appears or disappears.
-- A single ref instance often outlives multiple mount-unmount cycles
-  (e.g. a component that toggles a child View on/off).
+- **If the bridge is still alive** (component is mounted): the effect
+  fires, calls `sys.invoke("play")`. If `sys` happens to be momentarily
+  unbound, `invoke` returns `Err(RefError::NotBound)` and the effect
+  swallows it (since the bridge writes `let _ = sys.invoke(...)`).
+- **If the bridge has been disposed** (component unmounted, owner
+  dropped): the signal write is observed by nothing — silently no-ops.
 
-So binding state is **runtime-checked** via `RefHandle.inner.get()`'s
-`Option`. The framework's mount machinery calls `RefHandle.__bind(elem)`
-on mount and `RefHandle.__unbind()` on unmount. Method dispatch
-returns `Err(RefError::NotBound)` in the unbound window.
+So the unmount handling is:
 
-The `try_*` lenient variants on each typed ref make
-fire-and-forget call sites read cleanly:
+- **`ElementRef`** is the only thing that carries explicit "bound /
+  unbound" state. `invoke()` returns `Result<_, RefError::NotBound>`.
+- **`Handle`** never returns errors. Calling `handle.play()` after
+  unmount is always silently a no-op, which matches what end-users want
+  for fire-and-forget UI handlers.
 
-```rust
-text(on_tap: move || r.try_play(), value: "▶")
-```
-
-without an `unwrap` or a `let _ =`.
+This is a strict improvement over the earlier `RefHandle + WhiskerRef`
+design: the lifetime-from-signal-system handles cleanup automatically,
+and users never need to write `try_*` paired methods or unwrap
+`Result<_, RefError>` in `on_tap` closures.
 
 ## 7. Where this leaves `Signal<T>`
 
-Phase N's "Ref API standardization" doesn't displace signals — it
-complements them. The decision table:
+Signals stay the foundation. Handles **are** sugar over signals. The
+decision table:
 
 | Use case | Mechanism |
 |---|---|
-| State the parent and child both read / write | `RwSignal<T>` in a shared struct (controller pattern) |
+| Stateful value (form input value, scroll position, selection, …) | `Signal<T>` / `RwSignal<T>` directly, or wrapped in a Handle |
 | Derived state | `computed(...)` / `effect(...)` |
-| One-shot commands on a mounted element (`focus()`, `play()`, `scrollTo()`) | `XxxRef` via `RefHandle` |
-| Custom-component imperative API (rare) | Composite Ref struct + plain method forwarding |
-| Events fired from the platform side back to Rust (`on_completed`, …) | Callback props (unchanged from today) |
+| Imperative command on a custom component (`modal.open()`, `drawer.toggle()`) | `XxxHandle` (signal-backed, no native bridge) |
+| Imperative command that talks to native (`video.play()`, `textInput.focus()`) | `XxxHandle` (signal-backed) + wrapper component with `ElementRef` bridge |
+| Reactive read of native state (`video.current_time()`, `textInput.value()`) | `Handle` exposes `Signal<T>`; wrapper pushes native events into the signal |
+| Events fired from native back to Rust (`on_completed`, `on_change`, …) | Callback props on the platform component (unchanged) |
 
-In practice, custom components rarely need their own Ref. The
-controller pattern + signals covers ~all user-component use cases.
-Refs are mostly for **platform components and built-in views where
-the platform side owns the authoritative state**.
+In contrast to typical React refs, **Whisker has no "current value"
+sync read API** — every "reading platform state" goes through a signal.
+This is the right call for a signal-first framework: any read can
+power a `text(value: ...)` or an `effect(|| ...)`. If a one-shot
+non-reactive read is genuinely needed (rare), `Signal::get_untracked()`
+is the escape hatch.
 
-## 8. Migration from today's `ElementRef<T>`
+## 8. Migration from today's `ElementRef<T>` / `#[element_methods]`
 
-The current `ElementRef<T>` + `#[whisker::element_methods]` pair is
-roughly today's working version of this layer. Phase N migration:
+The current implementation has `ElementRef<T>` doing the work of both
+Phase N's `ElementRef` and `Handle`, with `#[whisker::element_methods]`
+generating typed-wrapper traits. Phase N splits this:
 
 | Today | Phase N |
 |---|---|
-| `ElementRef<VideoProps>` | `VideoRef` (plain struct) |
-| `element_ref::<VideoProps>()` | `VideoRef::new()` |
-| `trait VideoSys` (sys proxy) + `trait VideoControls` (typed wrapper) + `impl VideoControls for ElementRef<VideoProps>` | `impl VideoRef { fn play(&self) -> Result<(), RefError>; ... }` |
-| `r.invoke("play", vec![])` (low-level) | `r.handle().invoke("play", vec![])` |
+| `ElementRef<VideoProps>` | `VideoHandle` (plain struct + impl) |
+| `element_ref::<VideoProps>()` | `VideoHandle::new()` |
+| `trait VideoSys` + `trait VideoControls` + `impl VideoControls for ElementRef<VideoProps>` | `impl VideoHandle { fn play(&self) { ... } }` |
+| `#[whisker::element_methods]` proc macro | Deleted — authors write the impl block by hand |
+| Implicit "this ref binds to a native element" | Explicit: module author wires a wrapper `#[whisker::component]` that owns an internal `ElementRef` and bridges signals to it |
 
-Transitional `ElementRef<T> = RefHandle` alias can stay during the
-deprecation window so existing module crates keep compiling.
-`element_ref` proc macro emits both the new struct + the old trait
-impls so the typed-wrapper trait existing callers depend on stays
-reachable.
-
-The `#[whisker::element_methods]` macro itself becomes unnecessary
-in the new world — authors write `impl VideoRef { ... }` directly.
+Transitional `ElementRef<T> = ElementRef` alias (with the generic param
+ignored) can stay during the deprecation window so existing module
+crates keep compiling. The proc macro is deleted; existing
+`#[element_methods]` annotations become a compile-time `unknown
+attribute` error, prompting authors to migrate.
 
 ## 9. Open / deferred questions
 
-- **`new()` taking arguments**: deferred (§5 of Phase L design).
-  Authors that need richer initialization can add their own
-  `with_initial_state(...)` constructors on top of `new()`.
-- **`#[derive(WhiskerRef)]`** to skip the 4-line trait impl: out of
-  scope. The trait is one method; deriving it would save 3 lines and
-  cost a macro definition.
-- **Ref binding across `provide_context` / `use_context`**: Refs are
-  `Clone`, so passing a ref through context is just a plain `clone()`.
-  No special handling needed.
-- **SSR / hydrate without a real element**: `invoke()` returns
-  `Err(NotBound)` because the inner `Option<Element>` is `None`. The
-  `try_*` lenient methods absorb this transparently. Out of scope for
-  Phase N — Whisker doesn't have SSR yet.
+- **Bridge boilerplate helper.** Per-command `effect(..)` blocks with
+  first-fire guards are tedious. A future ergonomics layer (e.g. a
+  `whisker::bridge!` declarative DSL or a `HandleBridge` trait) could
+  generate them, but Phase N intentionally ships only the primitives.
+- **Initial-fire suppression.** The counter pattern needs an
+  `if first.replace(false) { return; }` line. We could add a
+  `whisker::reactive::effect_skip_initial` helper but it's not strictly
+  necessary; leaving as a documented idiom for now.
+- **Type conversions in `invoke_typed`.** `TryFrom<WhiskerValue,
+  Error = String>` is the conventional shape; the actual bound may need
+  tweaking once we see ergonomics in practice.
+- **`new()` taking arguments.** A handle with required init parameters
+  (e.g. `VideoHandle::with_initial_volume(0.5)`) is just a regular Rust
+  constructor on top of `new()`. No framework support needed.
+- **Handle through `provide_context` / `use_context`.** Handles are
+  `Clone`, so passing through context is `clone()`. No special
+  handling.
+- **SSR / no-element environments.** Bridges simply never fire
+  (`sys.invoke` returns `NotBound`, swallowed by `let _ =`). Out of
+  scope for Phase N.
 
 ## 10. Phasing
 
 | Step | Scope |
 |---|---|
-| **N-1** | Add `RefHandle`, `WhiskerRef`, `RefError` to `whisker-modules-api`. Existing `ElementRef<T>` aliased to `RefHandle`. No behavior change. |
-| **N-2** | `#[component]` / `#[platform_component]` macros recognize `ref:` props whose type implements `WhiskerRef` and emit mount/unmount binding code that calls `__bind` / `__unbind`. |
-| **N-3** | Migrate `whisker-video`, `whisker-hello-element`, `whisker-local-store` to hand-written `XxxRef` structs in place of `#[element_methods]`. |
-| **N-4** | Migrate built-in `TextInput`, `ScrollView`, etc. to expose `TextInputRef`, `ScrollViewRef` via the same pattern. |
-| **N-5** | Deprecate `ElementRef<T>` alias + `#[whisker::element_methods]` macro. Land removal in a separate release window (Phase M follow-up). |
+| **N-1** | Add `ElementRef`, `RefError`, `WhiskerValue::try_into_*` helpers to `whisker-modules-api`. Existing `RefHandle` aliased. |
+| **N-2** | `#[platform_component]` macro recognizes `ref:` props of type `ElementRef` and emits mount/unmount `__bind` / `__unbind` calls. `#[component]` no longer treats `ref:` specially — Handle props are ordinary `Clone` props. |
+| **N-3** | Migrate `whisker-video`, `whisker-hello-element`, `whisker-local-store` to the `VideoHandle` + wrapper-component + bridge-effects pattern. |
+| **N-4** | Built-in handles: `TextInputHandle`, `ScrollViewHandle`, `ViewHandle`. Update built-in platform components to expose them. |
+| **N-5** | Deprecate `ElementRef<T>` alias + delete `#[whisker::element_methods]`. Land removal in a separate release window (Phase M follow-up). |
 
 ## 11. Estimated work
 
 | Sub-task | Estimate |
 |---|---|
-| N-1 + N-2 (primitives + macro binding) | 2 days |
-| N-3 (migrate three reference modules) | 0.5 day |
-| N-4 (migrate built-ins) | 1 day |
+| N-1 + N-2 (primitives + macro plumbing) | 2 days |
+| N-3 (migrate three reference modules) | 1 day (more than the old design because of bridge code, less because no `WhiskerRef` impl) |
+| N-4 (built-ins) | 1 day |
 | N-5 (deprecation cycle) | 0.5 day after deprecation window |
-| Total | ~3–4 days, plus the Phase M-style deprecation runway |
+| Total | ~3.5–4.5 days, plus the Phase M-style deprecation runway |
 
-The standardization is intentionally small — most of the Ref API
-lives in user-space (typed-ref structs that authors write), not in
-the framework.
+The framework surface is intentionally small (`ElementRef` + one error
+enum). The Handle layer is fully in user-space — module authors write
+plain Rust structs, and the bridge between Handle ↔ native lives inside
+the wrapper component using ordinary `effect(...)` calls. No new traits
+to implement, no derives, no auto-binding.

--- a/docs/phase-n-ref-api-design.md
+++ b/docs/phase-n-ref-api-design.md
@@ -1,0 +1,392 @@
+# Phase N design: `Ref` API standardization
+
+**Status**: design (no implementation yet). Tracking issue: #60. Parent epic: #55.
+
+This doc proposes the standardized Ref API that all Whisker imperative
+handles (`TextInputRef`, `ScrollViewRef`, `VideoRef`, custom-component
+refs that compose them) build on top of.
+
+The design grew out of the Phase L discussion (#58) where the question
+"how does a Rust author declare ref methods on a platform component?"
+expanded into a broader question about whether Whisker should have any
+ref API at all (vs leaning entirely on signals). The answer settled on:
+
+- **State** lives in `Signal<T>` / `RwSignal<T>` — Leptos / SolidJS style
+  controller pattern for everything stateful.
+- **Commands** (FFI dispatches, focus / scroll / play / pause, etc.)
+  go through a thin, standardized Ref API. Refs are needed where
+  signals don't model the operation cleanly.
+
+Phase N standardizes the bottom layer (one primitive `RefHandle` +
+`WhiskerRef` trait + `RefError` enum). Above that, every typed ref
+(`TextInputRef`, `VideoRef`, application-level `CustomInputRef`, …)
+is **plain Rust struct + impl** with no Whisker-specific macro support
+needed.
+
+## 1. Primitive: `RefHandle`
+
+The single FFI-dispatch primitive every typed ref builds on.
+
+```rust
+// crates/whisker-modules-api (or whisker)
+use std::cell::Cell;
+use std::rc::Rc;
+
+#[derive(Clone)]
+pub struct RefHandle {
+    inner: Rc<Cell<Option<Element>>>,
+}
+
+impl RefHandle {
+    pub fn new() -> Self {
+        Self { inner: Rc::new(Cell::new(None)) }
+    }
+
+    /// Run a platform method through the C bridge. Returns `Err` when
+    /// the ref isn't currently bound to a mounted element, or the
+    /// platform side surfaces a `WhiskerValue::Err`.
+    pub fn invoke(
+        &self,
+        method: &'static str,
+        args: Vec<WhiskerValue>,
+    ) -> Result<WhiskerValue, RefError> {
+        let elem = self.inner.get().ok_or(RefError::NotBound)?;
+        match whisker_bridge_invoke_element_method(elem, method, args) {
+            WhiskerValue::Err(msg) => Err(RefError::DispatchFailed {
+                method: method.into(),
+                message: msg,
+            }),
+            v => Ok(v),
+        }
+    }
+
+    pub fn is_bound(&self) -> bool {
+        self.inner.get().is_some()
+    }
+
+    /// Framework-internal: render! / #[component] / #[platform_component]
+    /// macros call this on mount. Authors should not call it.
+    #[doc(hidden)]
+    pub fn __bind(&self, element: Element) {
+        self.inner.set(Some(element));
+    }
+
+    /// Framework-internal: unmount sentinel.
+    #[doc(hidden)]
+    pub fn __unbind(&self) {
+        self.inner.set(None);
+    }
+}
+```
+
+The `Rc<Cell<Option<Element>>>` shape gives `RefHandle` three
+properties at once:
+
+- **`Clone` is cheap** — multiple closures can hold their own copy.
+  All clones point to the same `Rc`, so mount/unmount is visible
+  through every clone simultaneously.
+- **No mutable borrow needed for invoke** — `Cell::get` on a `Copy`
+  payload (`Option<Element>` is `Copy` because `Element` is a small
+  newtype) lets `invoke(&self, …)` work without `&mut self`.
+- **Runtime-checked binding** — the `Option` distinguishes "haven't
+  mounted yet" / "unmounted" from a real `Element`.
+
+## 2. Trait: `WhiskerRef`
+
+The opt-in marker for "this type is a Ref the framework can bind to a
+mounted element."
+
+```rust
+pub trait WhiskerRef {
+    /// The underlying handle the framework binds on mount.
+    fn handle(&self) -> &RefHandle;
+}
+```
+
+Just one method. Authors implement it on their `XxxRef` structs so
+the `#[component]` / `#[platform_component]` macros can find the
+`RefHandle` they own and wire up mount-time binding.
+
+Composite custom refs (`CustomInputRef`, `FormRef` — see §5) do **not**
+implement `WhiskerRef` because they don't bind to a single Lynx
+element. They compose `WhiskerRef`-implementing inner refs and the
+binding happens through those.
+
+## 3. Errors: `RefError`
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum RefError {
+    /// Ref isn't bound to a mounted element. Either the component
+    /// hasn't been rendered yet, or it has unmounted.
+    #[error("ref is not bound to a mounted element")]
+    NotBound,
+
+    /// Platform side surfaced a dispatch error
+    /// (method not found, exception thrown, type mismatch, …).
+    #[error("platform method `{method}` failed: {message}")]
+    DispatchFailed { method: String, message: String },
+}
+```
+
+The two-variant split lets callers distinguish "haven't been mounted
+yet" (often a UI race the caller should silently ignore) from "the
+platform side broke" (often a bug worth surfacing).
+
+For the common fire-and-forget UI handler case, each typed ref
+provides a paired strict / lenient method (see §4).
+
+## 4. Typed refs: plain struct + impl
+
+Every typed ref Whisker / a module crate / an app crate exposes is a
+**regular Rust struct that owns a `RefHandle` and implements
+`WhiskerRef`**. No macro, no special syntax, no DSL.
+
+Example — `VideoRef` shipped by `whisker-video`:
+
+```rust
+use whisker::{RefError, RefHandle, WhiskerRef, WhiskerValue};
+
+#[derive(Clone)]
+pub struct VideoRef {
+    handle: RefHandle,
+}
+
+impl VideoRef {
+    pub fn new() -> Self {
+        Self { handle: RefHandle::new() }
+    }
+
+    // Strict variant — caller handles RefError.
+    pub fn play(&self) -> Result<(), RefError> {
+        self.handle.invoke("play", vec![]).map(|_| ())
+    }
+    pub fn pause(&self) -> Result<(), RefError> {
+        self.handle.invoke("pause", vec![]).map(|_| ())
+    }
+    pub fn seek(&self, position_seconds: f64) -> Result<(), RefError> {
+        self.handle.invoke("seek", vec![WhiskerValue::Float(position_seconds)]).map(|_| ())
+    }
+
+    // Lenient variant — silently no-ops when unbound. For
+    // fire-and-forget UI handlers (on_tap closures etc.).
+    pub fn try_play(&self) { let _ = self.play(); }
+    pub fn try_pause(&self) { let _ = self.pause(); }
+    pub fn try_seek(&self, seconds: f64) { let _ = self.seek(seconds); }
+}
+
+impl WhiskerRef for VideoRef {
+    fn handle(&self) -> &RefHandle { &self.handle }
+}
+```
+
+That's the entire pattern. ~25 lines per ref type, all plain Rust:
+
+- `cargo doc` lists `VideoRef` and its methods on its own page.
+- rust-analyzer's go-to-definition lands on the impl block, not
+  inside a macro expansion.
+- Adding custom validation (logging, retries, type conversions) is
+  just editing the impl block.
+- Tests can construct a `VideoRef` and observe its `handle().is_bound()`
+  directly.
+
+Use site:
+
+```rust
+let r = VideoRef::new();
+let r_play = r.clone();
+let r_pause = r.clone();
+
+render! {
+    Video(ref: r, src: "https://...", style: "width: 100%; height: 240px;")
+    view {
+        text(on_tap: move || r_play.try_play(),   value: "▶")
+        text(on_tap: move || r_pause.try_pause(), value: "⏸")
+    }
+}
+```
+
+## 5. Composite custom refs
+
+Application authors that build a custom component wrapping a built-in
+(e.g. a `CustomInput` that puts a label next to a `TextInput`) can
+compose existing refs:
+
+```rust
+#[derive(Clone)]
+pub struct CustomInputRef {
+    text_input: TextInputRef,
+    // Free to add more internal refs / signals here as the component grows:
+    //   wrapper_view: ViewRef,
+    //   error_message: RwSignal<Option<String>>,
+}
+
+impl CustomInputRef {
+    pub fn new() -> Self {
+        Self { text_input: TextInputRef::new() }
+    }
+
+    pub fn focus(&self) -> Result<(), RefError> { self.text_input.focus() }
+    pub fn blur(&self)  -> Result<(), RefError> { self.text_input.blur() }
+
+    // Methods that compose multiple inner-ref calls are just plain Rust:
+    pub fn focus_and_select_all(&self) -> Result<(), RefError> {
+        self.text_input.focus()?;
+        self.text_input.select(0, usize::MAX)?;
+        Ok(())
+    }
+}
+
+// CustomInputRef does NOT implement WhiskerRef — it doesn't bind
+// to a single element. The binding flows through `text_input`.
+
+#[whisker::component]
+pub fn custom_input(r: CustomInputRef, label: Signal<String>) -> Element {
+    render! {
+        view {
+            text(value: label)
+            // r.text_input.clone() shares the same Rc — when this
+            // TextInput mounts, the same RefHandle the parent holds
+            // (via r.text_input) becomes bound.
+            TextInput(ref: r.text_input.clone())
+        }
+    }
+}
+```
+
+### Three-layer composition just works
+
+```rust
+#[derive(Clone)]
+pub struct FormRef {
+    email: CustomInputRef,
+    password: CustomInputRef,
+}
+
+impl FormRef {
+    pub fn new() -> Self {
+        Self {
+            email: CustomInputRef::new(),
+            password: CustomInputRef::new(),
+        }
+    }
+    pub fn focus_email(&self) -> Result<(), RefError> {
+        self.email.focus()
+        // → CustomInputRef::focus
+        // → TextInputRef::focus
+        // → RefHandle::invoke("focus", …)
+        // → C bridge → Lynx → native UITextField / EditText
+    }
+}
+```
+
+No macro is involved in any of this. The Ref hierarchy is just struct
+fields all the way down to the leaf `RefHandle`.
+
+## 6. Lifetime / unmount semantics
+
+The unmount problem ("what happens when a method is called on a ref
+whose component has been removed from the tree?") cannot be expressed
+in Rust's lifetime system because:
+
+- Refs are `Rc<…>`-shared across closures, parent components, child
+  components, and reactive scopes. The compile-time lifetime is "as
+  long as anyone holds a clone."
+- Mount / unmount is a runtime event driven by Lynx's reactive
+  reconciliation. The compile-time graph can't see when an element
+  appears or disappears.
+- A single ref instance often outlives multiple mount-unmount cycles
+  (e.g. a component that toggles a child View on/off).
+
+So binding state is **runtime-checked** via `RefHandle.inner.get()`'s
+`Option`. The framework's mount machinery calls `RefHandle.__bind(elem)`
+on mount and `RefHandle.__unbind()` on unmount. Method dispatch
+returns `Err(RefError::NotBound)` in the unbound window.
+
+The `try_*` lenient variants on each typed ref make
+fire-and-forget call sites read cleanly:
+
+```rust
+text(on_tap: move || r.try_play(), value: "▶")
+```
+
+without an `unwrap` or a `let _ =`.
+
+## 7. Where this leaves `Signal<T>`
+
+Phase N's "Ref API standardization" doesn't displace signals — it
+complements them. The decision table:
+
+| Use case | Mechanism |
+|---|---|
+| State the parent and child both read / write | `RwSignal<T>` in a shared struct (controller pattern) |
+| Derived state | `computed(...)` / `effect(...)` |
+| One-shot commands on a mounted element (`focus()`, `play()`, `scrollTo()`) | `XxxRef` via `RefHandle` |
+| Custom-component imperative API (rare) | Composite Ref struct + plain method forwarding |
+| Events fired from the platform side back to Rust (`on_completed`, …) | Callback props (unchanged from today) |
+
+In practice, custom components rarely need their own Ref. The
+controller pattern + signals covers ~all user-component use cases.
+Refs are mostly for **platform components and built-in views where
+the platform side owns the authoritative state**.
+
+## 8. Migration from today's `ElementRef<T>`
+
+The current `ElementRef<T>` + `#[whisker::element_methods]` pair is
+roughly today's working version of this layer. Phase N migration:
+
+| Today | Phase N |
+|---|---|
+| `ElementRef<VideoProps>` | `VideoRef` (plain struct) |
+| `element_ref::<VideoProps>()` | `VideoRef::new()` |
+| `trait VideoSys` (sys proxy) + `trait VideoControls` (typed wrapper) + `impl VideoControls for ElementRef<VideoProps>` | `impl VideoRef { fn play(&self) -> Result<(), RefError>; ... }` |
+| `r.invoke("play", vec![])` (low-level) | `r.handle().invoke("play", vec![])` |
+
+Transitional `ElementRef<T> = RefHandle` alias can stay during the
+deprecation window so existing module crates keep compiling.
+`element_ref` proc macro emits both the new struct + the old trait
+impls so the typed-wrapper trait existing callers depend on stays
+reachable.
+
+The `#[whisker::element_methods]` macro itself becomes unnecessary
+in the new world — authors write `impl VideoRef { ... }` directly.
+
+## 9. Open / deferred questions
+
+- **`new()` taking arguments**: deferred (§5 of Phase L design).
+  Authors that need richer initialization can add their own
+  `with_initial_state(...)` constructors on top of `new()`.
+- **`#[derive(WhiskerRef)]`** to skip the 4-line trait impl: out of
+  scope. The trait is one method; deriving it would save 3 lines and
+  cost a macro definition.
+- **Ref binding across `provide_context` / `use_context`**: Refs are
+  `Clone`, so passing a ref through context is just a plain `clone()`.
+  No special handling needed.
+- **SSR / hydrate without a real element**: `invoke()` returns
+  `Err(NotBound)` because the inner `Option<Element>` is `None`. The
+  `try_*` lenient methods absorb this transparently. Out of scope for
+  Phase N — Whisker doesn't have SSR yet.
+
+## 10. Phasing
+
+| Step | Scope |
+|---|---|
+| **N-1** | Add `RefHandle`, `WhiskerRef`, `RefError` to `whisker-modules-api`. Existing `ElementRef<T>` aliased to `RefHandle`. No behavior change. |
+| **N-2** | `#[component]` / `#[platform_component]` macros recognize `ref:` props whose type implements `WhiskerRef` and emit mount/unmount binding code that calls `__bind` / `__unbind`. |
+| **N-3** | Migrate `whisker-video`, `whisker-hello-element`, `whisker-local-store` to hand-written `XxxRef` structs in place of `#[element_methods]`. |
+| **N-4** | Migrate built-in `TextInput`, `ScrollView`, etc. to expose `TextInputRef`, `ScrollViewRef` via the same pattern. |
+| **N-5** | Deprecate `ElementRef<T>` alias + `#[whisker::element_methods]` macro. Land removal in a separate release window (Phase M follow-up). |
+
+## 11. Estimated work
+
+| Sub-task | Estimate |
+|---|---|
+| N-1 + N-2 (primitives + macro binding) | 2 days |
+| N-3 (migrate three reference modules) | 0.5 day |
+| N-4 (migrate built-ins) | 1 day |
+| N-5 (deprecation cycle) | 0.5 day after deprecation window |
+| Total | ~3–4 days, plus the Phase M-style deprecation runway |
+
+The standardization is intentionally small — most of the Ref API
+lives in user-space (typed-ref structs that authors write), not in
+the framework.


### PR DESCRIPTION
Parent issues: #58 (Phase L), #60 (Phase N). Parent epic: #55. Stacks on PR #62 (Phase K).

**Research / design PR — no code changes**. Adds two design docs that together describe the next module-system step:

## What's inside

### `docs/phase-l-moduledefinition-dsl-design.md` (Phase L)

Expo-style `ModuleDefinition` DSL on Swift Macro + Kotlin KSP that replaces the current `@WhiskerComponent` / `@WhiskerModule` / `@WhiskerProp` / `@WhiskerUIMethod` annotations. Single DSL covers both function-only modules and view-bearing modules:

```swift
public final class VideoModule: WhiskerModule {
  public func definition() -> ModuleDefinition {
    Name(\"Video\")
    View(WhiskerVideoView.self) {
      Prop(\"src\") { (view, value: String) in view.setSrc(value) }
      Function(\"play\")  { (view) in view.play()  }
      Function(\"pause\") { (view) in view.pause() }
      Function(\"seek\")  { (view, seconds: Double) in view.seek(seconds) }
      Events(\"onCompleted\")
    }
  }
}
```

Codegen bypasses Lynx's `@LynxProp` / `@LynxUIMethod` reflection by registering directly with `PropsUpdater.PRE_REGISTER_MAP` + `LynxUIMethodsExecutor.registerMethodInvoker(...)` — removes the \"method name must match exactly\" footgun (the `lynxInvoke_pause` bug from PR #52) at the source.

### `docs/phase-n-ref-api-design.md` (Phase N)

**Two-tier imperative-control API**. A single \"Ref\" abstraction was conflating two things; pulling them apart simplifies everything:

```rust
// Tier 1: framework primitive — module authors only.
pub struct ElementRef { /* RwSignal<Option<Element>> */ }
impl ElementRef {
    pub fn invoke(&self, method: &'static str, args: Vec<WhiskerValue>) -> Result<WhiskerValue, RefError>;
    pub fn bound(&self) -> Signal<bool>;       // reactive
    // __bind / __unbind: only #[platform_component] macro calls these
}
```

```rust
// Tier 2: end-user-facing Handle — plain Clone struct, no trait, no derive.
#[derive(Clone)]
pub struct VideoHandle {
    play_tick:    RwSignal<u64>,                // command (counter pattern)
    seek_to:      RwSignal<Option<f64>>,        // command with arg
    current_time: RwSignal<f64>,                // query (bridge writes, user reads)
}

impl VideoHandle {
    pub fn play(&self)         { self.play_tick.update(|n| *n += 1); }
    pub fn seek(&self, t: f64) { self.seek_to.set(Some(t)); }
    pub fn current_time(&self) -> Signal<f64> { self.current_time.read_only().into() }
}
```

```rust
// Bridge: ordinary effect(...) inside a wrapping #[whisker::component].
#[whisker::component]
pub fn video(handle: VideoHandle, src: Signal<String>) -> Element {
    let sys = ElementRef::new();
    effect({
        let sys = sys.clone(); let h = handle.clone();
        let first = std::cell::Cell::new(true);
        move || {
            h.play_tick.get();
            if first.replace(false) { return; }
            let _ = sys.invoke(\"play\", vec![]);
        }
    });
    // ... pause, seek, on_time_update event → handle.current_time.set(t)
    render! { VideoSys(ref: sys, src: src, on_time_update: ...) }
}
```

Why the split:

- **Signal-first.** `handle.play()` is sugar over a signal write; reactivity flows naturally to native and back via query signals.
- **ModalHandle / DrawerHandle work with zero `ElementRef`.** Pure-signal handles drive `#[component]`s that read signals via `show!`. No bridge, no framework binding, no FFI involvement.
- **Composite handles are plain Rust struct composition.** `CustomInputHandle { text_input: TextInputHandle }` with `fn focus() -> self.text_input.focus()`. Three layers deep is the same.
- **No `WhiskerRef` trait, no derive, no auto-bind, no single-root constraint.** Handles are framework-agnostic plain Rust.
- **Reactive queries replace `ref.current.value`.** `videoHandle.current_time()` returns `Signal<f64>` that updates from native events, directly usable in `effect` / `computed` / `text(value: ...)`.

Four documented command-signal patterns (idempotent toggle, counter, Option, queue) cover all imperative use cases.

## Why two phases land together

Phase L's Rust shim (§3c of the L doc) assumes the Phase N split as its foundation. Phase N lands first (or together with L-2) so the platform-component surface — `pub fn video_sys(r: ElementRef, ...)` and the wrapper `pub fn video(handle: VideoHandle, ...)` — has primitives to compile against.

## Verification
- [x] `cargo test --workspace`: 498/0 (unchanged from PR #62)
- [x] `cargo clippy --workspace -- -D warnings`: clean
- [x] `cargo fmt --all --check`: clean
- [ ] CI green on this branch

## Stack
- **PR #61** (Phase J — `whisker-modules-api` minimal surface)
- **PR #62** (Phase K — cargo-only distribution + scaffolding) — base
- **This PR** (Phase L design doc + Phase N design doc)

## Next implementation PRs (separate, not in this stack)
- **L-1** Lynx fork: expose `PropsUpdater.registerSetter` + `LynxUIMethodsExecutor.registerMethodInvoker` as public; \`v3.7.0-whisker.4\`.
- **L-2** Whisker: `WhiskerModule` base class + `ModuleDefinition` DSL + Swift Macro / KSP processor.
- **N-1+N-2**: `ElementRef` + `RefError` primitives + `#[platform_component]` mount binding.
- **L-3 + N-3**: migrate `whisker-video`, `whisker-hello-element`, `whisker-local-store` to both new DSLs.
- **L-4 + Module Author Guide rewrite**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)