### PR TITLE
feat(modules): Phase L-2b — iOS dispatch wiring for `ModuleDefinition` DSL

### DIFF
--- a/platforms/ios/Sources/WhiskerModuleApi/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModuleApi/WhiskerModuleRegistrar.swift
@@ -1,0 +1,275 @@
+// Phase L-2b — iOS dispatch wiring for the `ModuleDefinition` DSL.
+//
+// At module-registration time (typically host-app launch), the
+// framework calls `module.registerWithLynx()`. This walks the DSL
+// definition the author built in `definition()` and installs the
+// corresponding selectors on their `View(...)`-declared class via
+// Obj-C runtime APIs:
+//
+//   - For each `Prop("foo") { setter }`:
+//       + class method  `__lynx_prop_config__foo`        → `["foo", "setFoo", "id"]`
+//       + instance method `setFoo:requestReset:`         → invokes the closure
+//
+//   - For each `Function("foo") { handler }`:
+//       + class method  `__lynx_ui_method_config__foo`   → `"foo"`
+//       + instance method `foo:withResult:`              → invokes the closure
+//
+// These are exactly the shapes Lynx's `LynxPropsProcessor` and
+// `LynxUIMethodProcessor` scan for via class-method reflection, so
+// the DSL-driven setters / methods become indistinguishable at the
+// Lynx layer from those emitted by the `@WhiskerProp` /
+// `@WhiskerUIMethod` annotations.
+//
+// ## Coexistence with the annotation API
+//
+// Both paths register against the same Lynx reflection surface.
+// A class that uses *only* the DSL has no annotation-emitted
+// methods to worry about. A class that mixes both works too — the
+// emitted selectors are distinct (annotation-based methods are
+// compile-time-known, DSL-based ones are runtime-added) and Lynx's
+// reflection discovers both.
+//
+// ## Author bootstrap
+//
+// Module authors add their `WhiskerModule` subclass once to the
+// host app's startup code (or — once Phase L-2's codegen plugin
+// lands — let the build plugin generate the registration call). A
+// minimal driver:
+//
+// ```swift
+// @main
+// struct App: SwiftUI.App {
+//     init() {
+//         VideoModule().registerWithLynx()
+//     }
+//     // ...
+// }
+// ```
+
+import Foundation
+import ObjectiveC.runtime
+
+extension WhiskerModule {
+
+    /// Walk `definitionLazy` and install the Lynx-visible setters /
+    /// methods on the view class.
+    ///
+    /// Idempotent — a second call against the same view class
+    /// re-installs over the previous registration (last-write-wins).
+    /// Module-level (view-less) `Function`s are not yet wired
+    /// up here; the module-level dispatch path stays on the
+    /// `@WhiskerModule` annotation API through L-2b.
+    public func registerWithLynx() {
+        let def = self.definitionLazy
+
+        // Function-only modules (no `View(...)` block): nothing to
+        // do at the LynxUI-class layer in L-2b. The module-level
+        // dispatch stays on the existing `@WhiskerModule`
+        // annotation path through L-3.
+        guard let viewBlock = def.view else { return }
+
+        let viewClass: AnyClass = viewBlock.viewClass
+
+        for component in viewBlock.components {
+            switch component {
+            case let prop as WhiskerPropComponent:
+                WhiskerLynxInstaller.installProp(prop, on: viewClass)
+            case let fn as WhiskerFunctionComponent:
+                WhiskerLynxInstaller.installFunction(fn, on: viewClass)
+            case is WhiskerEventsComponent:
+                // Events are declaration-only metadata in L-2a/b.
+                // Dispatch is still via the imperative
+                // `WhiskerCustomEvent.dispatch(from:name:params:)` path.
+                continue
+            default:
+                continue
+            }
+        }
+    }
+}
+
+// MARK: - Installer
+
+/// Internal helper that materialises `WhiskerPropComponent` /
+/// `WhiskerFunctionComponent` values as real Obj-C selectors on a
+/// LynxUI subclass. Pulled into its own enum so the implementation
+/// surface stays separate from the `WhiskerModule` public API.
+internal enum WhiskerLynxInstaller {
+
+    // ---- Prop installation ----------------------------------------------
+
+    static func installProp(_ comp: WhiskerPropComponent, on viewClass: AnyClass) {
+        // ---- 1. Class method `__lynx_prop_config__<name>` --------------
+        //
+        // Lynx's reflection: for each class method whose name starts
+        // with `__lynx_prop_config__`, call it to recover the
+        // `[propName, shortSelector, typeName]` triple.
+        //
+        // We pick selector `set<Capitalized>:requestReset:` so the
+        // generated probe shape matches what `@WhiskerProp` would
+        // have produced for an identically-named prop.
+        let propName = comp.name
+        let setterShort = "set" + propName.uppercasingFirstLetter()
+        let configSelName = "__lynx_prop_config__" + propName
+
+        // Block receives `(_cls: AnyClass)` because the IMP is
+        // called with (self, SEL) — under
+        // `imp_implementationWithBlock`, Swift's `self` slot drops
+        // out, but Obj-C still passes the class. We accept it as
+        // first arg and ignore.
+        let configBlock: @convention(block) (AnyClass) -> [String] = { _ in
+            // Type name `id` keeps Lynx's value-unboxing in
+            // "pass through whatever the bridge handed in" mode.
+            // L-2c will tighten this for typed props once the
+            // DSL component carries explicit type info.
+            return [propName, setterShort, "id"]
+        }
+        let configIMP = imp_implementationWithBlock(configBlock)
+        addClassMethod(
+            on: viewClass,
+            selector: NSSelectorFromString(configSelName),
+            imp: configIMP,
+            // Method signature: `(NSArray *)method(id self, SEL _cmd)`
+            //   '@' = return id, '@' = self id, ':' = SEL
+            typeEncoding: "@@:"
+        )
+
+        // ---- 2. Instance method `set<Cap>:requestReset:` ---------------
+        //
+        // Two trailing args: the value (`id`) and a BOOL `requestReset`
+        // flag Lynx uses to signal "the engine asked for a re-apply
+        // of all props"; the DSL closure ignores it (the closure is
+        // declarative — re-application is harmless).
+        let setterSel = NSSelectorFromString(setterShort + ":requestReset:")
+        let setter = comp.setter
+        let setterBlock: @convention(block) (AnyObject, Any?, Bool) -> Void = { view, value, _ in
+            setter(view, value)
+        }
+        let setterIMP = imp_implementationWithBlock(setterBlock)
+        addInstanceMethod(
+            on: viewClass,
+            selector: setterSel,
+            imp: setterIMP,
+            // `v@:@B` = void return, (self id, SEL, value id, BOOL).
+            typeEncoding: "v@:@B"
+        )
+    }
+
+    // ---- Function installation ------------------------------------------
+
+    static func installFunction(_ comp: WhiskerFunctionComponent, on viewClass: AnyClass) {
+        // ---- 1. Class method `__lynx_ui_method_config__<name>` ----------
+        let methodName = comp.name
+        let configSelName = "__lynx_ui_method_config__" + methodName
+        let configBlock: @convention(block) (AnyClass) -> NSString = { _ in
+            return methodName as NSString
+        }
+        let configIMP = imp_implementationWithBlock(configBlock)
+        addClassMethod(
+            on: viewClass,
+            selector: NSSelectorFromString(configSelName),
+            imp: configIMP,
+            // Returns NSString; `@@:` again.
+            typeEncoding: "@@:"
+        )
+
+        // ---- 2. Instance method `<name>:withResult:` --------------------
+        //
+        // Signature: `-(void)<name>:(NSDictionary *)params
+        //                       withResult:(LynxUIMethodCallbackBlock)cb`.
+        //
+        // The callback block is Lynx-typed `void(^)(NSInteger code,
+        // id _Nullable data)`. Lynx's
+        // `LynxUIMethodConstants.kUIMethodSuccess` is 0; we pass 0
+        // on a normal return and pass back the result encoded as an
+        // Any? (NSNull-erased on Void closures).
+        //
+        // Args decode: Lynx hands `params` as `@{ "args":
+        //   [<positional entries>] }` (matching what the existing
+        //   `@WhiskerUIMethod` macro decodes). We pull out the array
+        //   and hand it to the closure.
+        let methodSel = NSSelectorFromString(methodName + ":withResult:")
+        let handler = comp.handler
+        let methodBlock: @convention(block) (AnyObject, NSDictionary?, LynxUIMethodCallbackBlockShim?) -> Void = { view, params, cb in
+            let rawArgs: [Any?] = {
+                guard let p = params else { return [] }
+                if let arr = p["args"] as? [Any?] { return arr }
+                if let arr = p["args"] as? NSArray { return arr.map { $0 as Any? } }
+                return []
+            }()
+            let result = handler(view, rawArgs)
+            // Lynx kUIMethodSuccess = 0; we report 0 unconditionally
+            // here since the closure-typed dispatch doesn't currently
+            // surface failure codes. Type mismatches inside the
+            // closure are silently swallowed by the type-erased
+            // wrappers (with a debug-build log).
+            cb?(0, result as AnyObject?)
+        }
+        let methodIMP = imp_implementationWithBlock(methodBlock)
+        addInstanceMethod(
+            on: viewClass,
+            selector: methodSel,
+            imp: methodIMP,
+            // `v@:@@` = void return, (self id, SEL, params id, block id).
+            // Obj-C blocks are typed as `@?` strictly, but `@` works
+            // for argument-position blocks against `imp_implementation
+            // WithBlock`-produced IMPs (the underlying ABI is the
+            // same). `@?` here gives clearer crash diagnostics when
+            // Lynx ever invokes us with a wrong shape.
+            typeEncoding: "v@:@@?"
+        )
+    }
+
+    // ---- Helpers ---------------------------------------------------------
+
+    private static func addInstanceMethod(
+        on cls: AnyClass,
+        selector: Selector,
+        imp: IMP,
+        typeEncoding: String,
+    ) {
+        if !class_addMethod(cls, selector, imp, typeEncoding) {
+            // Method already exists on the class — replace its IMP
+            // in-place. `class_replaceMethod` returns the previous
+            // IMP (or nil); we ignore that.
+            _ = class_replaceMethod(cls, selector, imp, typeEncoding)
+        }
+    }
+
+    private static func addClassMethod(
+        on cls: AnyClass,
+        selector: Selector,
+        imp: IMP,
+        typeEncoding: String,
+    ) {
+        // Class methods live on the metaclass.
+        guard let metaclass = object_getClass(cls) else { return }
+        if !class_addMethod(metaclass, selector, imp, typeEncoding) {
+            _ = class_replaceMethod(metaclass, selector, imp, typeEncoding)
+        }
+    }
+}
+
+// MARK: - Lynx callback typealias
+
+/// Local mirror of Lynx's `LynxUIMethodCallbackBlock`. We can't
+/// import Lynx here without dragging the headers into the public
+/// surface, so we redeclare the shape — Obj-C-block ABI matching
+/// is what matters at runtime, not the Swift type identity.
+///
+/// Lynx's actual declaration is roughly:
+///
+/// ```objc
+/// typedef void (^LynxUIMethodCallbackBlock)(NSInteger code, id _Nullable data);
+/// ```
+public typealias LynxUIMethodCallbackBlockShim =
+    @convention(block) (Int, AnyObject?) -> Void
+
+// MARK: - String helper
+
+extension String {
+    fileprivate func uppercasingFirstLetter() -> String {
+        guard let first = self.first else { return self }
+        return String(first).uppercased() + self.dropFirst()
+    }
+}

--- a/platforms/ios/tools/l2b_lynx_installer_smoke.swift
+++ b/platforms/ios/tools/l2b_lynx_installer_smoke.swift
@@ -1,0 +1,157 @@
+// Phase L-2b runtime smoke test for `WhiskerLynxInstaller`.
+//
+// Exercises the Obj-C-runtime install path end-to-end against a
+// fake LynxUI subclass (just an NSObject), then uses Obj-C
+// introspection (`class_respondsToSelector`,
+// `class_getMethodImplementation`) to verify the expected
+// selectors land on the class and dispatch correctly.
+//
+// Does **not** depend on the real Lynx framework — it stubs the
+// LynxUI surface as plain NSObject. The point is to verify
+// installer correctness in isolation; full Lynx-side dispatch
+// will be exercised once the Phase L-3 sample-module migration
+// drives the path through a real `whisker run`.
+//
+// ## Running
+//
+// ```
+// swiftc -o /tmp/l2b_smoke \
+//   platforms/ios/Sources/WhiskerModuleApi/ModuleDefinition.swift \
+//   platforms/ios/Sources/WhiskerModuleApi/WhiskerModule.swift \
+//   platforms/ios/Sources/WhiskerModuleApi/WhiskerModuleRegistrar.swift \
+//   platforms/ios/tools/l2b_lynx_installer_smoke.swift
+// /tmp/l2b_smoke
+// ```
+//
+// Or via the shell wrapper:
+//
+// ```
+// platforms/ios/tools/run_l2b_smoke.sh
+// ```
+
+import Foundation
+import ObjectiveC.runtime
+
+// Fake LynxUI subclass — minimal NSObject we can install Obj-C
+// methods on. Property side-effects let the test verify the
+// installed selectors actually dispatch into the DSL closures.
+@objc(SmokeFakeVideoView)
+final class SmokeFakeVideoView: NSObject {
+    @objc dynamic var lastSrc: String?
+    @objc dynamic var playCount: Int = 0
+}
+
+final class SmokeModule: WhiskerModule {
+    override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("SmokeVideo")
+            View(SmokeFakeVideoView.self) {
+                Prop("src") { (view: SmokeFakeVideoView, value: String) in
+                    view.lastSrc = value
+                }
+                Function("play") { (view: SmokeFakeVideoView) in
+                    view.playCount += 1
+                }
+            }
+        }
+    }
+}
+
+@main
+enum SmokeRunner {
+    static func main() {
+        runL2bSmoke()
+    }
+}
+
+func runL2bSmoke() {
+    let m = SmokeModule()
+    m.registerWithLynx()
+
+    // ---- 1. Class-method probe for the prop -------------------------
+    //
+    // Lynx's `LynxPropsProcessor` walks for `__lynx_prop_config__*`
+    // class methods. We verify the metaclass responds, then call
+    // the IMP and assert the returned config triple.
+
+    let propProbeSel = NSSelectorFromString("__lynx_prop_config__src")
+    let metaclass: AnyClass = object_getClass(SmokeFakeVideoView.self)!
+    precondition(
+        class_respondsToSelector(metaclass, propProbeSel),
+        "metaclass missing __lynx_prop_config__src after install"
+    )
+    print("ok  class meta responds __lynx_prop_config__src")
+
+    let probeIMP = class_getMethodImplementation(metaclass, propProbeSel)!
+    typealias ProbeFn = @convention(c) (AnyClass, Selector) -> NSArray
+    let probeFn = unsafeBitCast(probeIMP, to: ProbeFn.self)
+    let triple = probeFn(SmokeFakeVideoView.self, propProbeSel) as! [String]
+    precondition(
+        triple == ["src", "setSrc", "id"],
+        "probe triple wrong: \(triple)"
+    )
+    print("ok  __lynx_prop_config__src returns \(triple)")
+
+    // ---- 2. Instance setter dispatch --------------------------------
+    let setterSel = NSSelectorFromString("setSrc:requestReset:")
+    precondition(
+        class_respondsToSelector(SmokeFakeVideoView.self, setterSel),
+        "instance missing setSrc:requestReset:"
+    )
+    print("ok  instance responds setSrc:requestReset:")
+
+    let instance = SmokeFakeVideoView()
+    let setterIMP = class_getMethodImplementation(SmokeFakeVideoView.self, setterSel)!
+    typealias SetterFn = @convention(c) (AnyObject, Selector, NSString, Bool) -> Void
+    let setterFn = unsafeBitCast(setterIMP, to: SetterFn.self)
+    setterFn(instance, setterSel, "https://example.com/clip.mp4" as NSString, false)
+    precondition(
+        instance.lastSrc == "https://example.com/clip.mp4",
+        "setter side effect missing: lastSrc = \(String(describing: instance.lastSrc))"
+    )
+    print("ok  setter side effect (lastSrc = \(instance.lastSrc!))")
+
+    // ---- 3. Class-method probe for the function ---------------------
+    let methodProbeSel = NSSelectorFromString("__lynx_ui_method_config__play")
+    precondition(
+        class_respondsToSelector(metaclass, methodProbeSel),
+        "metaclass missing __lynx_ui_method_config__play"
+    )
+    print("ok  class meta responds __lynx_ui_method_config__play")
+
+    let methodProbeIMP = class_getMethodImplementation(metaclass, methodProbeSel)!
+    typealias MProbeFn = @convention(c) (AnyClass, Selector) -> NSString
+    let methodProbeFn = unsafeBitCast(methodProbeIMP, to: MProbeFn.self)
+    let methodKey = methodProbeFn(SmokeFakeVideoView.self, methodProbeSel) as String
+    precondition(methodKey == "play", "method config returned \(methodKey)")
+    print("ok  __lynx_ui_method_config__play returns \"\(methodKey)\"")
+
+    // ---- 4. Instance method dispatch --------------------------------
+    let methodSel = NSSelectorFromString("play:withResult:")
+    precondition(
+        class_respondsToSelector(SmokeFakeVideoView.self, methodSel),
+        "instance missing play:withResult:"
+    )
+    print("ok  instance responds play:withResult:")
+
+    var callbackInvoked = false
+    let cb: @convention(block) (Int, AnyObject?) -> Void = { code, _ in
+        precondition(code == 0, "expected success code 0, got \(code)")
+        callbackInvoked = true
+    }
+    let methodIMP = class_getMethodImplementation(SmokeFakeVideoView.self, methodSel)!
+    typealias MethodFn = @convention(c) (AnyObject, Selector, NSDictionary?, Any?) -> Void
+    let methodFn = unsafeBitCast(methodIMP, to: MethodFn.self)
+    let instance2 = SmokeFakeVideoView()
+    let cbErased: Any = unsafeBitCast(cb, to: AnyObject.self)
+    methodFn(instance2, methodSel, nil, cbErased)
+    precondition(
+        instance2.playCount == 1,
+        "play handler didn't run: count = \(instance2.playCount)"
+    )
+    precondition(callbackInvoked, "callback wasn't invoked")
+    print("ok  play handler ran (count=\(instance2.playCount)) + callback fired")
+
+    print("")
+    print("all L-2b runtime install assertions passed")
+}

--- a/platforms/ios/tools/run_l2b_smoke.sh
+++ b/platforms/ios/tools/run_l2b_smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Phase L-2b runtime smoke test runner.
+#
+# Compiles the WhiskerModuleApi DSL + registrar sources together
+# with the in-tree smoke driver, runs the binary, and reports
+# the result. No iOS simulator / Lynx framework needed — the
+# smoke test stubs the LynxUI surface and exercises only the
+# Obj-C-runtime install path.
+#
+# Used by:
+#   - Local verification (`platforms/ios/tools/run_l2b_smoke.sh`)
+#   - CI follow-up once we add a macOS Swift job (deferred).
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+tmp_bin="$(mktemp -d)/l2b_smoke"
+
+# `-parse-as-library` makes `runL2bSmoke()` at the bottom of
+# `l2b_lynx_installer_smoke.swift` legal — without it, swiftc
+# treats one of the inputs as `main.swift` and rejects top-level
+# expressions in the other files. Combined with a `@main`
+# attribute on the entry struct below.
+swiftc -o "${tmp_bin}" -parse-as-library \
+  "${repo_root}/platforms/ios/Sources/WhiskerModuleApi/ModuleDefinition.swift" \
+  "${repo_root}/platforms/ios/Sources/WhiskerModuleApi/WhiskerModule.swift" \
+  "${repo_root}/platforms/ios/Sources/WhiskerModuleApi/WhiskerModuleRegistrar.swift" \
+  "${repo_root}/platforms/ios/tools/l2b_lynx_installer_smoke.swift"
+
+"${tmp_bin}"


### PR DESCRIPTION
Second piece of **Phase L-2**. Tracking issue: #58. Parent epic: #55. Stacks on PR #66 (L-2a).

Turns a `definition()`-declared `ModuleDefinition` into real Lynx-visible setters / methods on the user's `View(...)`-declared class via Obj-C-runtime install. After this PR the iOS half of the DSL is functional end-to-end — a module subclassed from `WhiskerModule` + `.registerWithLynx()` produces selectors that Lynx's `LynxPropsProcessor` / `LynxUIMethodProcessor` discover via the same reflection probes the existing `@WhiskerProp` / `@WhiskerUIMethod` annotations satisfy.

## What `registerWithLynx()` installs

For each component inside the DSL's `View(...)` block:

- **`Prop(\"foo\") { setter }`** → installs:
  + class method `__lynx_prop_config__foo` → returns `[\"foo\", \"setFoo\", \"id\"]`
  + instance method `setFoo:requestReset:` → invokes the closure
- **`Function(\"foo\") { handler }`** → installs:
  + class method `__lynx_ui_method_config__foo` → returns `\"foo\"`
  + instance method `foo:withResult:` → decodes args, runs the closure, calls back with success code 0

`Events(...)` is declaration-only metadata (no dispatch path — emit goes through `WhiskerCustomEvent.dispatch(from:name:params:)`). Module-level (view-less) `Function`s aren't wired in L-2b; they stay on the `@WhiskerModule` path through L-3.

## How it's done

`WhiskerLynxInstaller` (internal) uses `imp_implementationWithBlock` + `class_addMethod` / `class_replaceMethod` to install each selector. The closure is captured inside the block — each installed IMP routes directly into the DSL component's setter / handler, no global dispatch table required.

Both this DSL-installed surface and the existing `@WhiskerComponent` annotation-emitted surface can coexist on the same view class: selector names differ (annotation-emitted are compile-time-known, DSL-installed are runtime-added) and Lynx's reflection picks up both.

## Verification

End-to-end runtime smoke test under `platforms/ios/tools/`. Stubs the LynxUI surface as plain NSObject so it runs on host macOS without an iOS simulator / Lynx framework.

```
$ ./platforms/ios/tools/run_l2b_smoke.sh

ok  class meta responds __lynx_prop_config__src
ok  __lynx_prop_config__src returns [\"src\", \"setSrc\", \"id\"]
ok  instance responds setSrc:requestReset:
ok  setter side effect (lastSrc = https://example.com/clip.mp4)
ok  class meta responds __lynx_ui_method_config__play
ok  __lynx_ui_method_config__play returns \"play\"
ok  instance responds play:withResult:
ok  play handler ran (count=1) + callback fired

all L-2b runtime install assertions passed
```

The smoke driver:
1. Defines a `SmokeFakeVideoView: NSObject` (no Lynx dep)
2. Builds a `WhiskerModule` subclass with a `View(...)` block containing one Prop + one Function
3. Calls `.registerWithLynx()`
4. Uses `class_respondsToSelector` + `class_getMethodImplementation` to introspect that the expected selectors landed
5. Calls each installed selector via `unsafeBitCast`-cast IMPs and asserts the captured closure ran (side effects on the view object)

Full Lynx-side dispatch (real `<Video src=\"...\">` element → `setSrcProp:` reflection → DSL closure) gets exercised once the Phase L-3 sample-module migration drives the path through a real `whisker run`.

## Verification (Rust workspace)
- [x] `cargo test --workspace`: 508 / 0 (unchanged — no Rust changes).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- [x] `cargo fmt --all --check`: clean.
- [x] `swiftc -typecheck` against all WhiskerModuleApi sources: clean.
- [x] `platforms/ios/tools/run_l2b_smoke.sh`: 8 / 8 assertions pass.

## Stack
- L-2a (PR #66) — DSL types
- **This PR (L-2b)** — iOS dispatch wiring
- L-2c — Android KSP codegen
- L-2d — `AsyncFunction` (optional)
- L-3 — migrate `whisker-video`, `whisker-hello-element`, `whisker-local-store` to the new DSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)