### PR TITLE
feat: async built-in element methods (boundingClientRect / takeScreenshot)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,6 +1855,7 @@ name = "whisker-driver"
 version = "0.1.0"
 dependencies = [
  "futures-channel",
+ "serde",
  "whisker-dev-runtime",
  "whisker-driver-sys",
  "whisker-runtime",

--- a/crates/whisker-build/src/lynx.rs
+++ b/crates/whisker-build/src/lynx.rs
@@ -57,42 +57,35 @@ use std::path::{Path, PathBuf};
 /// Schema: `<lynx-upstream-version>-whisker.<patch-iteration>` so a
 /// reader can tell at a glance which upstream Lynx is wrapped, and
 /// our own patch iterations bump independently.
-pub const LYNX_FORK_TAG: &str = "v3.7.0-whisker.4";
+pub const LYNX_FORK_TAG: &str = "v3.7.0-whisker.5";
 
 /// Version segment that appears in cache paths + tarball filenames.
 /// Derived from [`LYNX_FORK_TAG`] minus the leading `v`.
-pub const LYNX_VERSION: &str = "3.7.0-whisker.4";
+pub const LYNX_VERSION: &str = "3.7.0-whisker.5";
 
 /// SHA-256 of `whisker-lynx-android-<LYNX_VERSION>.tar.gz` as
 /// produced by the fork's CI. Pinned to the
-/// [v3.7.0-whisker.4 release](https://github.com/whiskerrs/lynx/releases/tag/v3.7.0-whisker.4).
+/// [v3.7.0-whisker.5 release](https://github.com/whiskerrs/lynx/releases/tag/v3.7.0-whisker.5).
 ///
-/// Bump from `.3`: rebuilds Android `liblynx.so` against
-/// whiskerrs/lynx#3, which adds Class-explicit overloads to
-/// `PropsUpdater.registerSetter(Class, Settable)` and
-/// `LynxUIMethodsExecutor.registerMethodInvoker(Class, Invoker)`.
-/// Required for the Phase L `ModuleDefinition` DSL — without those
-/// overloads the KSP-emitted setter / invoker classes can't be
-/// registered against arbitrary target UI classes (the existing
-/// single-arg overload of `registerMethodInvoker` had a key-mismatch
-/// bug that made it effectively unusable; the single-arg
-/// `registerSetter` only worked under the `<UIClass>$$PropsSetter`
-/// name convention).
+/// Bump from `.4`: rebuilds Android `liblynx.so` against
+/// whiskerrs/lynx#4, which adds `lynx_ui_invoke_method_async` to
+/// `core/native_renderer_capi/` (result-returning UI-method dispatch).
+/// Required so `ElementRef::invoke_async` / `bounding_client_rect()` /
+/// `take_screenshot()` work on Android — the prior pin's liblynx.so
+/// only exported the fire-and-forget `lynx_ui_invoke_method`.
 pub const LYNX_ANDROID_SHA256: &str =
-    "4f5dc0025e3a64aad659f08f44bae24c376ead6ce0e899d40c3bc5fbf874e6f0";
+    "e0239e4099daeb0ff5fc568e78450d49b37ce12b96bd21844b7e4493fab00fb0";
 
 /// SHA-256 of `whisker-lynx-ios-<LYNX_VERSION>.tar.gz`. Pinned to
 /// the same release as Android — the fork's CI builds both halves
 /// in parallel and uploads them as a pair.
 ///
-/// The iOS xcframework doesn't strictly need the `.4` bump (the
-/// Phase L registration-API additions are Android-side only, and
-/// iOS already exposes `LYNX_UI_METHOD` macros as first-class
-/// public API), but keeping both halves on the same Lynx tag
-/// avoids the "Android against .4, iOS against .3" version-skew
-/// footgun.
+/// The iOS xcframework doesn't carry `core/native_renderer_capi/`
+/// (Whisker compiles `lynx_native_renderer.cc` itself on iOS), so
+/// the `.5` `lynx_ui_invoke_method_async` addition is Android-only;
+/// but both halves stay on the same Lynx tag to avoid version skew.
 pub const LYNX_IOS_SHA256: &str =
-    "64221632feed79957e0f5bfd9b6d1b2027b35f83529aad9f79e39cd9eec1d819";
+    "21fafd09a7c2018bb9b90b65efaef4c35aa88398c363e634058c9aeae7db3fa4";
 
 /// GitHub Releases URL template. The `<{ver}>` and `<{plat}>`
 /// placeholders are filled by [`download_url`].

--- a/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
@@ -152,6 +152,33 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method(
     const lynx_ui_method_value_t* args,
     size_t arg_count);
 
+// Async UI-method dispatch — the result-returning variant used for
+// `boundingClientRect` / `takeScreenshot` etc. Lynx's
+// `Catalyzer::Invoke` callback fires (typically on the UI thread,
+// after the platform method runs); `lynx_native_renderer.cc` converts
+// the callback's `lynx::pub::Value` into a `WhiskerValueRaw` tree and
+// invokes `callback(code, &result, user_data)`. The `result` pointer
+// is borrowed for the duration of the callback only — the wrapper
+// frees it (via `whisker_bridge_value_release`) once `callback`
+// returns, so the callee must copy out before returning.
+//
+// `WhiskerValueRec` is the FFI value struct defined in
+// `whisker_bridge.h`; forward-declared here so this header stays
+// free of the bridge include (the .cc that implements this pulls in
+// `whisker_bridge.h` for the full definition + the converter).
+struct WhiskerValueRec;
+typedef void (*lynx_ui_method_result_cb)(int32_t code,
+                                          const struct WhiskerValueRec* result,
+                                          void* user_data);
+LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method_async(
+    lynx_shell_t* shell,
+    int32_t sign,
+    const char* method_name,
+    const lynx_ui_method_value_t* args,
+    size_t arg_count,
+    lynx_ui_method_result_cb callback,
+    void* user_data);
+
 // ----- subsecond ASLR anchor ------------------------------------------------
 
 // Whisker's subsecond hot-patcher dlsym's this symbol on startup to

--- a/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
@@ -133,7 +133,30 @@ typedef enum lynx_ui_method_value_type_e {
   LYNX_UI_METHOD_VALUE_INT = 2,
   LYNX_UI_METHOD_VALUE_DOUBLE = 3,
   LYNX_UI_METHOD_VALUE_STRING = 4,
+  // Recursive variants — used for method *results* (a
+  // `boundingClientRect` map, etc.). Args only ever use the scalar
+  // variants above.
+  LYNX_UI_METHOD_VALUE_ARRAY = 5,
+  LYNX_UI_METHOD_VALUE_MAP = 6,
 } lynx_ui_method_value_type_e;
+
+// Forward-declared so `array`/`map` can hold them recursively. The
+// map holds a *pointer* to `kv` (incomplete-type OK), and `kv` holds
+// `value` *by value* — so `kv` is defined AFTER the full
+// `lynx_ui_method_value_t` below. Same ordering trick as
+// `WhiskerValueRec`/`WhiskerKeyValueRec` in `whisker_bridge.h`.
+struct lynx_ui_method_value_t;
+struct lynx_ui_method_kv_t;
+
+typedef struct lynx_ui_method_value_array_t {
+  struct lynx_ui_method_value_t* items;  // length = count
+  size_t count;
+} lynx_ui_method_value_array_t;
+
+typedef struct lynx_ui_method_value_map_t {
+  struct lynx_ui_method_kv_t* entries;  // length = count
+  size_t count;
+} lynx_ui_method_value_map_t;
 
 typedef struct lynx_ui_method_value_t {
   lynx_ui_method_value_type_e type;
@@ -141,9 +164,16 @@ typedef struct lynx_ui_method_value_t {
     bool b;
     int64_t i;
     double f;
-    const char* s;
+    const char* s;  // NUL-terminated UTF-8
+    lynx_ui_method_value_array_t array;
+    lynx_ui_method_value_map_t map;
   } v;
 } lynx_ui_method_value_t;
+
+typedef struct lynx_ui_method_kv_t {
+  const char* key;  // NUL-terminated UTF-8
+  lynx_ui_method_value_t value;
+} lynx_ui_method_kv_t;
 
 LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method(
     lynx_shell_t* shell,
@@ -156,19 +186,18 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method(
 // `boundingClientRect` / `takeScreenshot` etc. Lynx's
 // `Catalyzer::Invoke` callback fires (typically on the UI thread,
 // after the platform method runs); `lynx_native_renderer.cc` converts
-// the callback's `lynx::pub::Value` into a `WhiskerValueRaw` tree and
-// invokes `callback(code, &result, user_data)`. The `result` pointer
-// is borrowed for the duration of the callback only — the wrapper
-// frees it (via `whisker_bridge_value_release`) once `callback`
-// returns, so the callee must copy out before returning.
+// the callback's `lynx::pub::Value` into a `lynx_ui_method_value_t`
+// tree (Lynx-neutral — no dependency on the Whisker bridge, so this
+// translation unit compiles identically whether built into liblynx.so
+// for Android or into WhiskerDriver for iOS) and invokes
+// `callback(code, &result, user_data)`.
 //
-// `WhiskerValueRec` is the FFI value struct defined in
-// `whisker_bridge.h`; forward-declared here so this header stays
-// free of the bridge include (the .cc that implements this pulls in
-// `whisker_bridge.h` for the full definition + the converter).
-struct WhiskerValueRec;
+// `result` is owned by the wrapper and only valid for the duration of
+// the callback — the wrapper frees the tree once `callback` returns,
+// so the callee must copy out (the Whisker bridge converts it into a
+// `WhiskerValueRaw` before returning).
 typedef void (*lynx_ui_method_result_cb)(int32_t code,
-                                          const struct WhiskerValueRec* result,
+                                          const lynx_ui_method_value_t* result,
                                           void* user_data);
 LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method_async(
     lynx_shell_t* shell,

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -347,6 +347,29 @@ WHISKER_BRIDGE_EXPORT WhiskerValueRaw whisker_bridge_invoke_element_method(
     const WhiskerValueRaw* args,
     size_t arg_count);
 
+// Async variant — the **result-returning** element-method path used
+// for `boundingClientRect` / `takeScreenshot` etc. Lynx routes the UI
+// method to the main thread and the result arrives via a callback, so
+// (unlike the sync fire-and-forget variant above) this is the only
+// way to read a method's return value. Returns immediately; the
+// bridge calls `callback(user_data, &result)` once the method
+// completes (typically on the UI thread). `result` is borrowed inside
+// the callback only — the bridge frees it once the callback returns
+// (same ownership as `whisker_bridge_invoke_module_async`).
+//
+// Returns `true` if the call was scheduled. On a precondition failure
+// (NULL element/shell, no sign) or where the platform lacks the
+// result-async wrapper (Android, pending a Lynx fork release), the
+// bridge invokes `callback` synchronously with a
+// `WHISKER_VALUE_ERROR` and returns `false`.
+WHISKER_BRIDGE_EXPORT bool whisker_bridge_invoke_element_method_async(
+    WhiskerElement* element,
+    const char* method_name,
+    const WhiskerValueRaw* args,
+    size_t arg_count,
+    WhiskerModuleCallback callback,
+    void* user_data);
+
 // ---- Phase 0–3 leftovers (kept temporarily for compatibility) ------------
 
 WHISKER_BRIDGE_EXPORT void whisker_bridge_log_hello(void);

--- a/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
+++ b/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
@@ -17,13 +17,6 @@
 #include <utility>
 #include <vector>
 
-// `WhiskerValueRaw` + `whisker_bridge_value_release` — the async
-// UI-method result crosses back as this FFI value tree. Including the
-// bridge header here couples this Lynx-side translation unit to the
-// bridge value type, but keeps the result conversion in the one place
-// that can see `lynx::pub::Value` (the Catalyzer callback).
-#include "whisker_bridge.h"
-
 #include "base/include/value/base_string.h"
 #include "base/include/value/array.h"
 #include "base/include/value/table.h"
@@ -290,6 +283,11 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method(
         args_array->emplace_back(lynx::lepus::Value(
             lynx::base::String(v.v.s != nullptr ? v.v.s : "")));
         break;
+      default:
+        // Array / map args aren't supported by the dispatch ABI;
+        // treat as null. (Results use the recursive variants.)
+        args_array->emplace_back(lynx::lepus::Value());
+        break;
     }
   }
   auto params_dict = lynx::lepus::Dictionary::Create();
@@ -317,93 +315,118 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method(
 
 namespace {
 
-// A heap-owned `WhiskerStringRef` copy (len-based, not NUL-terminated).
-// Released by `whisker_bridge_value_release`.
-WhiskerStringRef WhiskerDupString(const std::string& s) {
-  WhiskerStringRef ref{nullptr, 0};
-  char* buf = static_cast<char*>(std::malloc(s.empty() ? 1 : s.size()));
-  if (!s.empty()) std::memcpy(buf, s.data(), s.size());
-  ref.ptr = buf;
-  ref.len = s.size();
-  return ref;
+// `malloc` a NUL-terminated copy of `s` (freed by
+// `lynx_ui_method_value_free`).
+char* CapiDupCStr(const std::string& s) {
+  char* buf = static_cast<char*>(std::malloc(s.size() + 1));
+  std::memcpy(buf, s.c_str(), s.size() + 1);
+  return buf;
 }
 
 // Convert a Lynx `pub::Value` (the Catalyzer callback's result) into a
-// heap-owned `WhiskerValueRaw` tree. Mirrors the value model used by
-// module args/returns and events. Allocations match
-// `whisker_bridge_value_release`'s free pattern.
-WhiskerValueRaw PubValueToRaw(const lynx::pub::Value& v) {
-  WhiskerValueRaw out;
+// heap-owned `lynx_ui_method_value_t` tree. **Lynx-neutral** — no
+// dependency on the Whisker bridge, so this file compiles identically
+// into liblynx.so (Android) and WhiskerDriver (iOS). The Whisker side
+// converts this into a `WhiskerValueRaw`.
+lynx_ui_method_value_t PubValueToCapi(const lynx::pub::Value& v) {
+  lynx_ui_method_value_t out;
   std::memset(&out, 0, sizeof(out));
   if (v.IsNil() || v.IsUndefined()) {
-    out.type = WHISKER_VALUE_NULL;
+    out.type = LYNX_UI_METHOD_VALUE_NULL;
     return out;
   }
   if (v.IsBool()) {
-    out.type = WHISKER_VALUE_BOOL;
+    out.type = LYNX_UI_METHOD_VALUE_BOOL;
     out.v.b = v.Bool();
     return out;
   }
   if (v.IsInt64()) {
-    out.type = WHISKER_VALUE_INT;
+    out.type = LYNX_UI_METHOD_VALUE_INT;
     out.v.i = v.Int64();
     return out;
   }
   if (v.IsUInt64()) {
-    out.type = WHISKER_VALUE_INT;
+    out.type = LYNX_UI_METHOD_VALUE_INT;
     out.v.i = static_cast<int64_t>(v.UInt64());
     return out;
   }
   if (v.IsDouble()) {
-    out.type = WHISKER_VALUE_FLOAT;
+    out.type = LYNX_UI_METHOD_VALUE_DOUBLE;
     out.v.f = v.Double();
     return out;
   }
   if (v.IsNumber()) {
-    out.type = WHISKER_VALUE_FLOAT;
+    out.type = LYNX_UI_METHOD_VALUE_DOUBLE;
     out.v.f = v.Number();
     return out;
   }
   if (v.IsString()) {
-    out.type = WHISKER_VALUE_STRING;
-    out.v.s = WhiskerDupString(v.str());
+    out.type = LYNX_UI_METHOD_VALUE_STRING;
+    out.v.s = CapiDupCStr(v.str());
     return out;
   }
   if (v.IsArray()) {
     int n = v.Length();
     if (n < 0) n = 0;
-    out.type = WHISKER_VALUE_ARRAY;
+    out.type = LYNX_UI_METHOD_VALUE_ARRAY;
     out.v.array.count = static_cast<size_t>(n);
-    out.v.array.items = n > 0 ? static_cast<WhiskerValueRaw*>(
-                                    std::malloc(sizeof(WhiskerValueRaw) * n))
-                              : nullptr;
+    out.v.array.items =
+        n > 0 ? static_cast<lynx_ui_method_value_t*>(
+                    std::malloc(sizeof(lynx_ui_method_value_t) * n))
+              : nullptr;
     for (int i = 0; i < n; i++) {
       auto child = v.GetValueAtIndex(static_cast<uint32_t>(i));
       out.v.array.items[i] =
-          child ? PubValueToRaw(*child) : WhiskerValueRaw{};
+          child ? PubValueToCapi(*child) : lynx_ui_method_value_t{};
     }
     return out;
   }
   if (v.IsMap()) {
-    std::vector<std::pair<std::string, WhiskerValueRaw>> tmp;
+    std::vector<std::pair<std::string, lynx_ui_method_value_t>> tmp;
     v.ForeachMap([&tmp](const lynx::pub::Value& key,
                         const lynx::pub::Value& val) {
-      tmp.emplace_back(key.str(), PubValueToRaw(val));
+      tmp.emplace_back(key.str(), PubValueToCapi(val));
     });
     size_t n = tmp.size();
-    out.type = WHISKER_VALUE_MAP;
+    out.type = LYNX_UI_METHOD_VALUE_MAP;
     out.v.map.count = n;
-    out.v.map.entries = n > 0 ? static_cast<WhiskerKeyValueRaw*>(
-                                    std::malloc(sizeof(WhiskerKeyValueRaw) * n))
-                              : nullptr;
+    out.v.map.entries =
+        n > 0 ? static_cast<lynx_ui_method_kv_t*>(
+                    std::malloc(sizeof(lynx_ui_method_kv_t) * n))
+              : nullptr;
     for (size_t i = 0; i < n; i++) {
-      out.v.map.entries[i].key = WhiskerDupString(tmp[i].first);
+      out.v.map.entries[i].key = CapiDupCStr(tmp[i].first);
       out.v.map.entries[i].value = tmp[i].second;
     }
     return out;
   }
-  out.type = WHISKER_VALUE_NULL;
+  out.type = LYNX_UI_METHOD_VALUE_NULL;
   return out;
+}
+
+// Recursively free a tree produced by `PubValueToCapi`.
+void CapiValueFree(lynx_ui_method_value_t* v) {
+  if (v == nullptr) return;
+  switch (v->type) {
+    case LYNX_UI_METHOD_VALUE_STRING:
+      std::free(const_cast<char*>(v->v.s));
+      break;
+    case LYNX_UI_METHOD_VALUE_ARRAY:
+      for (size_t i = 0; i < v->v.array.count; i++) {
+        CapiValueFree(&v->v.array.items[i]);
+      }
+      std::free(v->v.array.items);
+      break;
+    case LYNX_UI_METHOD_VALUE_MAP:
+      for (size_t i = 0; i < v->v.map.count; i++) {
+        std::free(const_cast<char*>(v->v.map.entries[i].key));
+        CapiValueFree(&v->v.map.entries[i].value);
+      }
+      std::free(v->v.map.entries);
+      break;
+    default:
+      break;
+  }
 }
 
 }  // namespace
@@ -445,6 +468,11 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method_async(
         args_array->emplace_back(lynx::lepus::Value(
             lynx::base::String(v.v.s != nullptr ? v.v.s : "")));
         break;
+      default:
+        // Array / map args aren't supported by the dispatch ABI;
+        // treat as null. (Results use the recursive variants.)
+        args_array->emplace_back(lynx::lepus::Value());
+        break;
     }
   }
   auto params_dict = lynx::lepus::Dictionary::Create();
@@ -454,17 +482,17 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method_async(
 
   // The callback fires (typically on the UI thread) once the platform
   // method completes. Convert the result `pub::Value` into a
-  // heap-owned `WhiskerValueRaw`, hand it to the C callback, then free
-  // it once the callback returns (it copies out via the Rust
-  // `from_raw`).
+  // heap-owned `lynx_ui_method_value_t` tree, hand it to the C
+  // callback, then free it once the callback returns (the callee
+  // copies out — the Whisker bridge converts it to a `WhiskerValueRaw`).
   catalyzer->Invoke(
       static_cast<int64_t>(sign), std::string(method_name),
       lynx::pub::ValueImplLepus(params_lepus),
       [callback, user_data](int32_t code, const lynx::pub::Value& data) {
         if (callback == nullptr) return;
-        WhiskerValueRaw result = PubValueToRaw(data);
+        lynx_ui_method_value_t result = PubValueToCapi(data);
         callback(code, &result, user_data);
-        whisker_bridge_value_release(&result);
+        CapiValueFree(&result);
       });
   return 0;
 }

--- a/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
+++ b/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
@@ -11,8 +11,18 @@
 
 #include "lynx_native_renderer_capi.h"
 
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <utility>
+#include <vector>
+
+// `WhiskerValueRaw` + `whisker_bridge_value_release` — the async
+// UI-method result crosses back as this FFI value tree. Including the
+// bridge header here couples this Lynx-side translation unit to the
+// bridge value type, but keeps the result conversion in the one place
+// that can see `lynx::pub::Value` (the Catalyzer callback).
+#include "whisker_bridge.h"
 
 #include "base/include/value/base_string.h"
 #include "base/include/value/array.h"
@@ -30,6 +40,7 @@
 #include "core/renderer/utils/base/tasm_constants.h"
 #include "core/renderer/ui_wrapper/painting/catalyzer.h"
 #include "core/shell/lynx_shell.h"
+#include "core/public/pub_value.h"
 #include "core/template_bundle/template_codec/binary_decoder/page_config.h"
 #include "core/value_wrapper/value_impl_lepus.h"
 
@@ -299,6 +310,162 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method(
                     std::string(method_name),
                     lynx::pub::ValueImplLepus(params_lepus),
                     noop_callback);
+  return 0;
+}
+
+// ----- Async UI-method dispatch (result-returning) --------------------------
+
+namespace {
+
+// A heap-owned `WhiskerStringRef` copy (len-based, not NUL-terminated).
+// Released by `whisker_bridge_value_release`.
+WhiskerStringRef WhiskerDupString(const std::string& s) {
+  WhiskerStringRef ref{nullptr, 0};
+  char* buf = static_cast<char*>(std::malloc(s.empty() ? 1 : s.size()));
+  if (!s.empty()) std::memcpy(buf, s.data(), s.size());
+  ref.ptr = buf;
+  ref.len = s.size();
+  return ref;
+}
+
+// Convert a Lynx `pub::Value` (the Catalyzer callback's result) into a
+// heap-owned `WhiskerValueRaw` tree. Mirrors the value model used by
+// module args/returns and events. Allocations match
+// `whisker_bridge_value_release`'s free pattern.
+WhiskerValueRaw PubValueToRaw(const lynx::pub::Value& v) {
+  WhiskerValueRaw out;
+  std::memset(&out, 0, sizeof(out));
+  if (v.IsNil() || v.IsUndefined()) {
+    out.type = WHISKER_VALUE_NULL;
+    return out;
+  }
+  if (v.IsBool()) {
+    out.type = WHISKER_VALUE_BOOL;
+    out.v.b = v.Bool();
+    return out;
+  }
+  if (v.IsInt64()) {
+    out.type = WHISKER_VALUE_INT;
+    out.v.i = v.Int64();
+    return out;
+  }
+  if (v.IsUInt64()) {
+    out.type = WHISKER_VALUE_INT;
+    out.v.i = static_cast<int64_t>(v.UInt64());
+    return out;
+  }
+  if (v.IsDouble()) {
+    out.type = WHISKER_VALUE_FLOAT;
+    out.v.f = v.Double();
+    return out;
+  }
+  if (v.IsNumber()) {
+    out.type = WHISKER_VALUE_FLOAT;
+    out.v.f = v.Number();
+    return out;
+  }
+  if (v.IsString()) {
+    out.type = WHISKER_VALUE_STRING;
+    out.v.s = WhiskerDupString(v.str());
+    return out;
+  }
+  if (v.IsArray()) {
+    int n = v.Length();
+    if (n < 0) n = 0;
+    out.type = WHISKER_VALUE_ARRAY;
+    out.v.array.count = static_cast<size_t>(n);
+    out.v.array.items = n > 0 ? static_cast<WhiskerValueRaw*>(
+                                    std::malloc(sizeof(WhiskerValueRaw) * n))
+                              : nullptr;
+    for (int i = 0; i < n; i++) {
+      auto child = v.GetValueAtIndex(static_cast<uint32_t>(i));
+      out.v.array.items[i] =
+          child ? PubValueToRaw(*child) : WhiskerValueRaw{};
+    }
+    return out;
+  }
+  if (v.IsMap()) {
+    std::vector<std::pair<std::string, WhiskerValueRaw>> tmp;
+    v.ForeachMap([&tmp](const lynx::pub::Value& key,
+                        const lynx::pub::Value& val) {
+      tmp.emplace_back(key.str(), PubValueToRaw(val));
+    });
+    size_t n = tmp.size();
+    out.type = WHISKER_VALUE_MAP;
+    out.v.map.count = n;
+    out.v.map.entries = n > 0 ? static_cast<WhiskerKeyValueRaw*>(
+                                    std::malloc(sizeof(WhiskerKeyValueRaw) * n))
+                              : nullptr;
+    for (size_t i = 0; i < n; i++) {
+      out.v.map.entries[i].key = WhiskerDupString(tmp[i].first);
+      out.v.map.entries[i].value = tmp[i].second;
+    }
+    return out;
+  }
+  out.type = WHISKER_VALUE_NULL;
+  return out;
+}
+
+}  // namespace
+
+LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method_async(
+    lynx_shell_t* shell,
+    int32_t sign,
+    const char* method_name,
+    const lynx_ui_method_value_t* args,
+    size_t arg_count,
+    lynx_ui_method_result_cb callback,
+    void* user_data) {
+  if (shell == nullptr || shell->manager == nullptr ||
+      method_name == nullptr) {
+    return -1;
+  }
+  auto* catalyzer = shell->manager->catalyzer();
+  if (catalyzer == nullptr) {
+    return -2;
+  }
+
+  auto args_array = lynx::lepus::CArray::Create();
+  for (size_t i = 0; args != nullptr && i < arg_count; i++) {
+    const lynx_ui_method_value_t& v = args[i];
+    switch (v.type) {
+      case LYNX_UI_METHOD_VALUE_NULL:
+        args_array->emplace_back(lynx::lepus::Value());
+        break;
+      case LYNX_UI_METHOD_VALUE_BOOL:
+        args_array->emplace_back(lynx::lepus::Value(v.v.b));
+        break;
+      case LYNX_UI_METHOD_VALUE_INT:
+        args_array->emplace_back(lynx::lepus::Value(v.v.i));
+        break;
+      case LYNX_UI_METHOD_VALUE_DOUBLE:
+        args_array->emplace_back(lynx::lepus::Value(v.v.f));
+        break;
+      case LYNX_UI_METHOD_VALUE_STRING:
+        args_array->emplace_back(lynx::lepus::Value(
+            lynx::base::String(v.v.s != nullptr ? v.v.s : "")));
+        break;
+    }
+  }
+  auto params_dict = lynx::lepus::Dictionary::Create();
+  BASE_STATIC_STRING_DECL(kArgs, "args");
+  params_dict->SetValue(kArgs, lynx::lepus::Value(std::move(args_array)));
+  lynx::lepus::Value params_lepus(std::move(params_dict));
+
+  // The callback fires (typically on the UI thread) once the platform
+  // method completes. Convert the result `pub::Value` into a
+  // heap-owned `WhiskerValueRaw`, hand it to the C callback, then free
+  // it once the callback returns (it copies out via the Rust
+  // `from_raw`).
+  catalyzer->Invoke(
+      static_cast<int64_t>(sign), std::string(method_name),
+      lynx::pub::ValueImplLepus(params_lepus),
+      [callback, user_data](int32_t code, const lynx::pub::Value& data) {
+        if (callback == nullptr) return;
+        WhiskerValueRaw result = PubValueToRaw(data);
+        callback(code, &result, user_data);
+        whisker_bridge_value_release(&result);
+      });
   return 0;
 }
 

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -498,6 +498,44 @@ extern "C" bool whisker_bridge_invoke_module_async(
 // Returns `WHISKER_VALUE_NULL` on dispatch-scheduled-OK, or an
 // Error if preconditions fail (NULL element, NULL shell, NUL byte
 // in method name, manager not initialised).
+// Convert WhiskerValueRaw[] → lynx_ui_method_value_t[]. Lynx owns
+// string buffers transiently — they're copied into `base::String`
+// inside the wrapper before returning, so the pointers we hand over
+// only need to outlive the call. Arrays / maps / bytes / errors
+// aren't representable in the scalar `lynx_ui_method_value_t` arg ABI
+// (they'd need a recursive lepus builder); treated as NULL.
+static void BuildLynxUiArgs(const WhiskerValueRaw* args, size_t arg_count,
+                            std::vector<lynx_ui_method_value_t>& lynx_args) {
+    lynx_args.reserve(arg_count);
+    for (size_t i = 0; i < arg_count; i++) {
+        lynx_ui_method_value_t out;
+        std::memset(&out, 0, sizeof(out));
+        const WhiskerValueRaw& v = args[i];
+        switch (v.type) {
+            case WHISKER_VALUE_BOOL:
+                out.type = LYNX_UI_METHOD_VALUE_BOOL;
+                out.v.b = v.v.b;
+                break;
+            case WHISKER_VALUE_INT:
+                out.type = LYNX_UI_METHOD_VALUE_INT;
+                out.v.i = v.v.i;
+                break;
+            case WHISKER_VALUE_FLOAT:
+                out.type = LYNX_UI_METHOD_VALUE_DOUBLE;
+                out.v.f = v.v.f;
+                break;
+            case WHISKER_VALUE_STRING:
+                out.type = LYNX_UI_METHOD_VALUE_STRING;
+                out.v.s = v.v.s.ptr;  // borrowed for the call
+                break;
+            default:
+                out.type = LYNX_UI_METHOD_VALUE_NULL;
+                break;
+        }
+        lynx_args.push_back(out);
+    }
+}
+
 extern "C" WhiskerValueRaw whisker_bridge_invoke_element_method(
     WhiskerElement* element,
     const char* method_name,
@@ -515,46 +553,8 @@ extern "C" WhiskerValueRaw whisker_bridge_invoke_element_method(
             "(was it flushed into the tree?)");
     }
 
-    // Convert WhiskerValueRaw[] → lynx_ui_method_value_t[]. Lynx
-    // owns string buffers transiently — they're copied into
-    // `base::String` inside the wrapper before returning, so the
-    // pointers we hand over only need to outlive the call.
     std::vector<lynx_ui_method_value_t> lynx_args;
-    lynx_args.reserve(arg_count);
-    for (size_t i = 0; i < arg_count; i++) {
-        lynx_ui_method_value_t out;
-        std::memset(&out, 0, sizeof(out));
-        const WhiskerValueRaw& v = args[i];
-        switch (v.type) {
-            case WHISKER_VALUE_NULL:
-                out.type = LYNX_UI_METHOD_VALUE_NULL;
-                break;
-            case WHISKER_VALUE_BOOL:
-                out.type = LYNX_UI_METHOD_VALUE_BOOL;
-                out.v.b = v.v.b;
-                break;
-            case WHISKER_VALUE_INT:
-                out.type = LYNX_UI_METHOD_VALUE_INT;
-                out.v.i = v.v.i;
-                break;
-            case WHISKER_VALUE_FLOAT:
-                out.type = LYNX_UI_METHOD_VALUE_DOUBLE;
-                out.v.f = v.v.f;
-                break;
-            case WHISKER_VALUE_STRING:
-                out.type = LYNX_UI_METHOD_VALUE_STRING;
-                out.v.s = v.v.s.ptr;  // borrowed for the call
-                break;
-            // Arrays / maps / bytes / errors aren't supported by the
-            // sync v1 ABI — they'd need a recursive lepus::Value
-            // builder. Skip silently (treat as NULL). Author code
-            // ranges for play/pause/seek don't hit this.
-            default:
-                out.type = LYNX_UI_METHOD_VALUE_NULL;
-                break;
-        }
-        lynx_args.push_back(out);
-    }
+    BuildLynxUiArgs(args, arg_count, lynx_args);
 
     int32_t code = lynx_ui_invoke_method(
         element->shell, sign, method_name,
@@ -570,6 +570,93 @@ extern "C" WhiskerValueRaw whisker_bridge_invoke_element_method(
     std::memset(&ok, 0, sizeof(ok));
     ok.type = WHISKER_VALUE_NULL;
     return ok;
+}
+
+namespace {
+// Carries the Rust callback + user_data across `lynx_ui_invoke_method_
+// async`'s `(code, result, user_data)` callback shape down to the
+// bridge's `(user_data, result)` shape. Heap-allocated, freed after
+// the (single) result callback fires.
+struct ElementMethodAsyncCtx {
+    WhiskerModuleCallback rust_cb;
+    void* rust_user_data;
+};
+
+void element_method_async_adapter(int32_t /*code*/,
+                                  const WhiskerValueRaw* result,
+                                  void* user_data) {
+    auto* ctx = static_cast<ElementMethodAsyncCtx*>(user_data);
+    if (ctx == nullptr) return;
+    if (ctx->rust_cb != nullptr) {
+        ctx->rust_cb(ctx->rust_user_data, result);
+    }
+    delete ctx;
+}
+
+// Synchronously hand `callback` a `WHISKER_VALUE_ERROR(message)` and
+// release it. For precondition / unsupported-platform failures.
+void FailElementMethodAsync(WhiskerModuleCallback callback, void* user_data,
+                            const char* message) {
+    if (callback == nullptr) return;
+    WhiskerValueRaw err = MakeBridgeErrorValue(message);
+    callback(user_data, &err);
+    whisker_bridge_value_release(&err);
+}
+}  // namespace
+
+extern "C" bool whisker_bridge_invoke_element_method_async(
+    WhiskerElement* element,
+    const char* method_name,
+    const WhiskerValueRaw* args,
+    size_t arg_count,
+    WhiskerModuleCallback callback,
+    void* user_data) {
+    if (element == nullptr || element->handle == nullptr ||
+        element->shell == nullptr || method_name == nullptr) {
+        FailElementMethodAsync(
+            callback, user_data,
+            "whisker_bridge_invoke_element_method_async: NULL element / shell / method");
+        return false;
+    }
+    int32_t sign = lynx_element_id(element->handle);
+    if (sign <= 0) {
+        FailElementMethodAsync(
+            callback, user_data,
+            "whisker_bridge_invoke_element_method_async: element has no sign yet");
+        return false;
+    }
+
+#if defined(__APPLE__)
+    std::vector<lynx_ui_method_value_t> lynx_args;
+    BuildLynxUiArgs(args, arg_count, lynx_args);
+    auto* ctx = new ElementMethodAsyncCtx{callback, user_data};
+    int32_t code = lynx_ui_invoke_method_async(
+        element->shell, sign, method_name,
+        lynx_args.empty() ? nullptr : lynx_args.data(), lynx_args.size(),
+        element_method_async_adapter, ctx);
+    if (code != 0) {
+        delete ctx;
+        FailElementMethodAsync(
+            callback, user_data,
+            ("lynx_ui_invoke_method_async returned non-zero (code=" +
+             std::to_string(code) + ")")
+                .c_str());
+        return false;
+    }
+    return true;
+#else
+    // Android: `lynx_ui_invoke_method_async` lives in liblynx.so,
+    // which the current Lynx fork pin doesn't export yet. Surface a
+    // clear error so `ElementRef::invoke_async` resolves to an Error
+    // rather than hanging. Lifted once the fork release lands.
+    (void)args;
+    (void)arg_count;
+    FailElementMethodAsync(
+        callback, user_data,
+        "element method results are not yet available on Android "
+        "(pending a Lynx fork release exporting lynx_ui_invoke_method_async)");
+    return false;
+#endif
 }
 
 extern "C" void whisker_bridge_value_release(WhiskerValueRaw* value) {

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -573,6 +573,79 @@ extern "C" WhiskerValueRaw whisker_bridge_invoke_element_method(
 }
 
 namespace {
+// Deep-copy a Lynx-neutral `lynx_ui_method_value_t` result tree into a
+// `WhiskerValueRaw` (heap-owned, matching `whisker_bridge_value_release`'s
+// free pattern). The capi tree itself is owned + freed by
+// `lynx_native_renderer.cc` after the callback returns.
+WhiskerValueRaw CapiValueToWhisker(const lynx_ui_method_value_t* v) {
+    WhiskerValueRaw out;
+    std::memset(&out, 0, sizeof(out));
+    if (v == nullptr) {
+        out.type = WHISKER_VALUE_NULL;
+        return out;
+    }
+    switch (v->type) {
+        case LYNX_UI_METHOD_VALUE_BOOL:
+            out.type = WHISKER_VALUE_BOOL;
+            out.v.b = v->v.b;
+            break;
+        case LYNX_UI_METHOD_VALUE_INT:
+            out.type = WHISKER_VALUE_INT;
+            out.v.i = v->v.i;
+            break;
+        case LYNX_UI_METHOD_VALUE_DOUBLE:
+            out.type = WHISKER_VALUE_FLOAT;
+            out.v.f = v->v.f;
+            break;
+        case LYNX_UI_METHOD_VALUE_STRING: {
+            const char* s = v->v.s != nullptr ? v->v.s : "";
+            size_t len = std::strlen(s);
+            char* buf = static_cast<char*>(std::malloc(len == 0 ? 1 : len));
+            if (len > 0) std::memcpy(buf, s, len);
+            out.type = WHISKER_VALUE_STRING;
+            out.v.s.ptr = buf;
+            out.v.s.len = len;
+            break;
+        }
+        case LYNX_UI_METHOD_VALUE_ARRAY: {
+            size_t n = v->v.array.count;
+            out.type = WHISKER_VALUE_ARRAY;
+            out.v.array.count = n;
+            out.v.array.items = n > 0 ? static_cast<WhiskerValueRaw*>(
+                                            std::malloc(sizeof(WhiskerValueRaw) * n))
+                                      : nullptr;
+            for (size_t i = 0; i < n; i++) {
+                out.v.array.items[i] = CapiValueToWhisker(&v->v.array.items[i]);
+            }
+            break;
+        }
+        case LYNX_UI_METHOD_VALUE_MAP: {
+            size_t n = v->v.map.count;
+            out.type = WHISKER_VALUE_MAP;
+            out.v.map.count = n;
+            out.v.map.entries = n > 0 ? static_cast<WhiskerKeyValueRaw*>(
+                                            std::malloc(sizeof(WhiskerKeyValueRaw) * n))
+                                      : nullptr;
+            for (size_t i = 0; i < n; i++) {
+                const char* k = v->v.map.entries[i].key != nullptr
+                                    ? v->v.map.entries[i].key
+                                    : "";
+                size_t klen = std::strlen(k);
+                char* kbuf = static_cast<char*>(std::malloc(klen == 0 ? 1 : klen));
+                if (klen > 0) std::memcpy(kbuf, k, klen);
+                out.v.map.entries[i].key.ptr = kbuf;
+                out.v.map.entries[i].key.len = klen;
+                out.v.map.entries[i].value = CapiValueToWhisker(&v->v.map.entries[i].value);
+            }
+            break;
+        }
+        default:
+            out.type = WHISKER_VALUE_NULL;
+            break;
+    }
+    return out;
+}
+
 // Carries the Rust callback + user_data across `lynx_ui_invoke_method_
 // async`'s `(code, result, user_data)` callback shape down to the
 // bridge's `(user_data, result)` shape. Heap-allocated, freed after
@@ -583,12 +656,14 @@ struct ElementMethodAsyncCtx {
 };
 
 void element_method_async_adapter(int32_t /*code*/,
-                                  const WhiskerValueRaw* result,
+                                  const lynx_ui_method_value_t* capi_result,
                                   void* user_data) {
     auto* ctx = static_cast<ElementMethodAsyncCtx*>(user_data);
     if (ctx == nullptr) return;
     if (ctx->rust_cb != nullptr) {
-        ctx->rust_cb(ctx->rust_user_data, result);
+        WhiskerValueRaw result = CapiValueToWhisker(capi_result);
+        ctx->rust_cb(ctx->rust_user_data, &result);
+        whisker_bridge_value_release(&result);
     }
     delete ctx;
 }
@@ -626,7 +701,9 @@ extern "C" bool whisker_bridge_invoke_element_method_async(
         return false;
     }
 
-#if defined(__APPLE__)
+    // `lynx_ui_invoke_method_async` is exported by liblynx.so on
+    // Android (Lynx fork v3.7.0-whisker.5+) and compiled into
+    // WhiskerDriver on iOS — same dispatch on both platforms.
     std::vector<lynx_ui_method_value_t> lynx_args;
     BuildLynxUiArgs(args, arg_count, lynx_args);
     auto* ctx = new ElementMethodAsyncCtx{callback, user_data};
@@ -644,19 +721,6 @@ extern "C" bool whisker_bridge_invoke_element_method_async(
         return false;
     }
     return true;
-#else
-    // Android: `lynx_ui_invoke_method_async` lives in liblynx.so,
-    // which the current Lynx fork pin doesn't export yet. Surface a
-    // clear error so `ElementRef::invoke_async` resolves to an Error
-    // rather than hanging. Lifted once the fork release lands.
-    (void)args;
-    (void)arg_count;
-    FailElementMethodAsync(
-        callback, user_data,
-        "element method results are not yet available on Android "
-        "(pending a Lynx fork release exporting lynx_ui_invoke_method_async)");
-    return false;
-#endif
 }
 
 extern "C" void whisker_bridge_value_release(WhiskerValueRaw* value) {

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
@@ -119,6 +119,23 @@ extern "C" bool whisker_bridge_invoke_module_async(
     return true;
 }
 
+extern "C" bool whisker_bridge_invoke_element_method_async(
+    WhiskerElement* /*element*/,
+    const char* /*method_name*/,
+    const WhiskerValueRaw* /*args*/,
+    size_t /*arg_count*/,
+    WhiskerModuleCallback callback,
+    void* user_data) {
+    // Host build has no Lynx — resolve to an error so the Rust future
+    // completes rather than hanging.
+    if (callback == nullptr) return false;
+    WhiskerValueRaw result = MakeHostStubError(
+        "whisker_bridge_invoke_element_method_async: host build has no Lynx");
+    callback(user_data, &result);
+    whisker_bridge_value_release(&result);
+    return false;
+}
+
 extern "C" void whisker_bridge_value_release(WhiskerValueRaw* value) {
     if (value == nullptr) return;
     switch (value->type) {

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -274,4 +274,19 @@ extern "C" {
         args: *const WhiskerValueRaw,
         arg_count: usize,
     ) -> WhiskerValueRaw;
+
+    /// Async, result-returning element-method dispatch
+    /// (`boundingClientRect` / `takeScreenshot`). Returns immediately;
+    /// `callback(user_data, &result)` fires once the method completes
+    /// (typically on the UI thread). On precondition failure / an
+    /// unsupported platform the bridge invokes `callback` synchronously
+    /// with a `WHISKER_VALUE_ERROR` and returns `false`.
+    pub fn whisker_bridge_invoke_element_method_async(
+        element: *mut WhiskerElement,
+        method_name: *const c_char,
+        args: *const WhiskerValueRaw,
+        arg_count: usize,
+        callback: WhiskerModuleCallback,
+        user_data: *mut c_void,
+    ) -> bool;
 }

--- a/crates/whisker-driver/Cargo.toml
+++ b/crates/whisker-driver/Cargo.toml
@@ -33,5 +33,9 @@ whisker-driver-sys = { workspace = true }
 # oneshot channel. Pulled directly rather than full `futures` to
 # keep the dep graph small (no executor, no Stream, no Sink).
 futures-channel = "0.3"
+# Typed element-method results (`BoundingClientRect`, …) derive
+# `Deserialize` and decode out of the `WhiskerValue` the async invoke
+# returns via `WhiskerValue::deserialize_into`.
+serde = { workspace = true }
 subsecond = { workspace = true, optional = true }
 whisker-dev-runtime = { workspace = true, optional = true }

--- a/crates/whisker-driver/src/element_ref.rs
+++ b/crates/whisker-driver/src/element_ref.rs
@@ -27,10 +27,36 @@
 //! app-level code see `VideoHandle`, `TextInputHandle`, ..., never
 //! `ElementRef` directly.
 
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
 use whisker_runtime::reactive::{computed, RwSignal, Signal};
 use whisker_runtime::view::Element;
 
 use crate::module::WhiskerValue;
+
+// ---------------------------------------------------------------------------
+// Typed element-method results
+// ---------------------------------------------------------------------------
+
+/// Result of [`ElementRef::bounding_client_rect`] — the element's
+/// layout box in LynxView coordinates (Lynx's `boundingClientRect`
+/// UI method). Every field is `#[serde(default)]`, so any key the
+/// platform omits reads back as `0.0` rather than failing the decode.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Deserialize)]
+pub struct BoundingClientRect {
+    #[serde(default)]
+    pub left: f64,
+    #[serde(default)]
+    pub top: f64,
+    #[serde(default)]
+    pub right: f64,
+    #[serde(default)]
+    pub bottom: f64,
+    #[serde(default)]
+    pub width: f64,
+    #[serde(default)]
+    pub height: f64,
+}
 
 // ---------------------------------------------------------------------------
 // RefError — explicit error surface for `try_invoke` / `invoke_typed`.
@@ -194,6 +220,76 @@ impl ElementRef {
         crate::invoke_element_method(elem, method, args)
     }
 
+    /// Async, **result-returning** invoke — for UI methods whose
+    /// return value arrives via Lynx's callback (`boundingClientRect`,
+    /// `takeScreenshot`, …) rather than synchronously. Returns the raw
+    /// [`WhiskerValue`], with `WhiskerValue::Error` standing in for
+    /// "not bound" / dispatch failure. Typed wrappers (e.g.
+    /// [`bounding_client_rect`](Self::bounding_client_rect)) build on
+    /// this.
+    ///
+    /// Run it from an event handler / effect via `spawn_local`:
+    /// `spawn_local(async move { let v = r.invoke_async("m", vec![]).await; })`.
+    pub async fn invoke_async(&self, method: &str, args: Vec<WhiskerValue>) -> WhiskerValue {
+        let Some(elem) = self.inner.get_untracked() else {
+            return WhiskerValue::Error(format!(
+                "ElementRef::invoke_async(\"{method}\"): ref is not bound to a \
+                 mounted element"
+            ));
+        };
+        crate::invoke_element_method_async(elem, method, args).await
+    }
+
+    /// Async invoke that deserializes the result into `T`. `NotBound`
+    /// when unbound; `DispatchFailed` on a platform error or a
+    /// result-shape mismatch. The building block for the typed
+    /// method wrappers below.
+    pub async fn invoke_typed_async<T: DeserializeOwned>(
+        &self,
+        method: &'static str,
+        args: Vec<WhiskerValue>,
+    ) -> Result<T, RefError> {
+        if !self.is_bound() {
+            return Err(RefError::NotBound);
+        }
+        match self.invoke_async(method, args).await {
+            WhiskerValue::Error(message) => Err(RefError::DispatchFailed {
+                method: method.into(),
+                message,
+            }),
+            other => other
+                .deserialize_into::<T>()
+                .map_err(|message| RefError::DispatchFailed {
+                    method: method.into(),
+                    message,
+                }),
+        }
+    }
+
+    /// `boundingClientRect` — the element's layout box in LynxView
+    /// coordinates. Async: the result arrives via Lynx's UI-method
+    /// callback (typically on the UI thread).
+    ///
+    /// ```ignore
+    /// let card = ElementRef::new();   // view(ref: card) { … }
+    /// spawn_local(async move {
+    ///     if let Ok(rect) = card.bounding_client_rect().await {
+    ///         // rect.width, rect.height, …
+    ///     }
+    /// });
+    /// ```
+    pub async fn bounding_client_rect(&self) -> Result<BoundingClientRect, RefError> {
+        self.invoke_typed_async::<BoundingClientRect>("boundingClientRect", vec![])
+            .await
+    }
+
+    /// `takeScreenshot` — a base64-encoded image of the element
+    /// (async). Returns the encoded string.
+    pub async fn take_screenshot(&self) -> Result<String, RefError> {
+        self.invoke_typed_async::<String>("takeScreenshot", vec![])
+            .await
+    }
+
     /// Bind the ref to `handle`. Invoked by `#[whisker::platform_
     /// component]`-generated code after `create_element_by_name`.
     ///
@@ -281,4 +377,37 @@ impl std::fmt::Debug for ElementRef {
 pub fn element_ref<T: ?Sized>() -> ElementRef {
     let _ = std::marker::PhantomData::<*const T>;
     ElementRef::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounding_client_rect_deserializes_from_value_map() {
+        // Shape mirrors what Lynx's `boundingClientRect` UI method
+        // returns through the async invoke path.
+        let v = WhiskerValue::map([
+            ("left", WhiskerValue::Float(10.0)),
+            ("top", WhiskerValue::Float(20.0)),
+            ("right", WhiskerValue::Float(110.0)),
+            ("bottom", WhiskerValue::Float(70.0)),
+            ("width", WhiskerValue::Float(100.0)),
+            ("height", WhiskerValue::Float(50.0)),
+        ]);
+        let rect: BoundingClientRect = v.deserialize_into().expect("deserialize rect");
+        assert_eq!(rect.left, 10.0);
+        assert_eq!(rect.width, 100.0);
+        assert_eq!(rect.height, 50.0);
+    }
+
+    #[test]
+    fn bounding_client_rect_missing_fields_default_to_zero() {
+        // Integer-valued numbers + a partial body still decode (Int
+        // widens to f64, missing keys default to 0.0).
+        let v = WhiskerValue::map([("width", WhiskerValue::Int(42))]);
+        let rect: BoundingClientRect = v.deserialize_into().expect("partial rect");
+        assert_eq!(rect.width, 42.0);
+        assert_eq!(rect.height, 0.0);
+    }
 }

--- a/crates/whisker-driver/src/lib.rs
+++ b/crates/whisker-driver/src/lib.rs
@@ -15,13 +15,13 @@ pub use element_ref::{element_ref, ElementRef, RefError};
 pub use lynx::bootstrap;
 pub use lynx::renderer::BridgeRenderer;
 
-use std::ffi::CString;
+use std::ffi::{c_void, CString};
 
 use whisker_driver_sys as ffi;
 use whisker_driver_sys::WhiskerElement;
 use whisker_runtime::view::{module_component_ptr, Element};
 
-use crate::module::{from_raw, RawBuilder, WhiskerValue};
+use crate::module::{async_trampoline, from_raw, RawBuilder, WhiskerValue};
 
 /// Synchronously invoke `method` on the platform component identified
 /// by `handle`. Routes through the C bridge
@@ -73,4 +73,63 @@ pub fn invoke_element_method(
     }
     drop(builder);
     result
+}
+
+/// Async, **result-returning** element-method invoke — the path for
+/// `boundingClientRect` / `takeScreenshot` etc., whose return value
+/// arrives via Lynx's UI-method callback (typically on the UI thread)
+/// rather than synchronously. Resolves once the bridge fires the C
+/// callback.
+///
+/// The bridge invokes the callback exactly once (synchronously with a
+/// `WhiskerValue::Error` on a precondition / unsupported-platform
+/// failure, asynchronously with the result on success), so the boxed
+/// oneshot sender is always consumed by [`async_trampoline`] — the
+/// caller never recovers it.
+pub async fn invoke_element_method_async(
+    handle: Element,
+    method: &str,
+    args: Vec<WhiskerValue>,
+) -> WhiskerValue {
+    let ptr_usize = module_component_ptr(handle);
+    if ptr_usize == 0 {
+        return WhiskerValue::Error(format!(
+            "invoke_element_method_async({method}): no platform component for handle {} \
+             (renderer not installed, or element released)",
+            handle.id()
+        ));
+    }
+    let method_c = match CString::new(method) {
+        Ok(c) => c,
+        Err(_) => return WhiskerValue::Error("method name contained NUL byte".into()),
+    };
+
+    let mut builder = RawBuilder::default();
+    let raw_args: Vec<ffi::WhiskerValueRaw> = args.iter().map(|v| builder.encode(v)).collect();
+
+    let (tx, rx) = futures_channel::oneshot::channel::<WhiskerValue>();
+    let tx_box: Box<Option<futures_channel::oneshot::Sender<WhiskerValue>>> = Box::new(Some(tx));
+    let tx_ptr = Box::into_raw(tx_box) as *mut c_void;
+
+    // Return value is advisory — `async_trampoline` always consumes the
+    // boxed sender (the bridge guarantees one callback either way), so
+    // we just await the channel.
+    let _scheduled = unsafe {
+        ffi::whisker_bridge_invoke_element_method_async(
+            ptr_usize as *mut WhiskerElement,
+            method_c.as_ptr(),
+            if raw_args.is_empty() {
+                std::ptr::null()
+            } else {
+                raw_args.as_ptr()
+            },
+            raw_args.len(),
+            async_trampoline,
+            tx_ptr,
+        )
+    };
+    drop(builder);
+
+    rx.await
+        .unwrap_or_else(|_| WhiskerValue::Error("element-method async callback never fired".into()))
 }

--- a/crates/whisker-driver/src/module.rs
+++ b/crates/whisker-driver/src/module.rs
@@ -212,7 +212,16 @@ pub async fn invoke_async(name: &str, method: &str, args: Vec<WhiskerValue>) -> 
         .unwrap_or_else(|_| WhiskerValue::Error("async callback never fired".into()))
 }
 
-extern "C" fn async_trampoline(user_data: *mut c_void, result: *const ffi::WhiskerValueRaw) {
+/// C callback for the async invoke paths (`invoke_async` /
+/// `invoke_element_method_async`). Reconstructs the boxed oneshot
+/// sender from `user_data`, decodes the result, and resolves the
+/// channel. The bridge guarantees exactly one call per dispatch (sync
+/// on failure, async on success), so the box is consumed here and
+/// never recovered by the caller.
+pub(crate) extern "C" fn async_trampoline(
+    user_data: *mut c_void,
+    result: *const ffi::WhiskerValueRaw,
+) {
     if user_data.is_null() || result.is_null() {
         return;
     }

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -489,6 +489,12 @@ impl ElementNode {
             // (`From<T>` for static / `From<ReadSignal<T>>` etc.
             // for reactive).
             quote_spanned! {span=> .#name(#value) }
+        } else if name_str == "ref" {
+            // `ref: <ElementRef>` on a built-in element → bind the ref
+            // to this element so its UI methods are invokable after
+            // mount. (`ref` is a keyword, so the builder method is
+            // `bind_ref`.)
+            quote_spanned! {span=> .bind_ref(#value) }
         } else if is_known_event_method(&name_str) {
             // Typed event helper on `ElementBuilder` — `.on_tap(f)`,
             // `.on_longpress(f)`, … — where `f` receives a typed
@@ -840,6 +846,23 @@ mod tests {
         assert!(
             output.contains(". __h ()"),
             "builder chain must finalise with `.__h()`; output was: {output}"
+        );
+    }
+
+    #[test]
+    fn ref_kwarg_on_builtin_routes_to_bind_ref() {
+        // `ref:` on a built-in element binds an ElementRef to the
+        // element (vs the catch-all `.attr("ref", …)`), so its UI
+        // methods (bounding_client_rect, …) are invokable after mount.
+        let input: TokenStream2 = quote::quote! { view(ref: my_ref) };
+        let output = super::expand_test(input).to_string();
+        assert!(
+            output.contains(". bind_ref"),
+            "ref: on a built-in must emit `.bind_ref(value)`; output was: {output}"
+        );
+        assert!(
+            !output.contains("\"ref\""),
+            "ref: must NOT fall through to `.attr(\"ref\", …)`; output was: {output}"
         );
     }
 

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -406,6 +406,17 @@ pub mod __tags {
             self
         }
 
+        // ---- Ref --------------------------------------------------------
+
+        /// Bind an [`ElementRef`](crate::ElementRef) to this element so
+        /// its methods (`bounding_client_rect`, `take_screenshot`, …)
+        /// can be invoked after mount. `render!` routes the `ref:`
+        /// kwarg here (`view(ref: my_ref) { … }`).
+        fn bind_ref(self, r: crate::ElementRef) -> Self {
+            r.__bind(self.__element());
+            self
+        }
+
         /// Finish building and return the underlying handle.
         #[doc(hidden)]
         fn __h(self) -> Element {

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -556,30 +556,29 @@ pub fn measure_demo() -> Element {
     let label = computed(move || {
         let d = dims.get();
         if d.is_empty() {
-            "measuring…".to_string()
+            "tap to measure".to_string()
         } else {
             d
         }
     });
-    // Measure once the ref binds (mount). The effect subscribes to
-    // `card.bound()` and re-fires when `__bind` flips it true, then
-    // schedules the async `boundingClientRect` — the bridge callback
-    // resolves (after layout, on the UI thread) and the result flows
-    // back through the binary `WhiskerValueRaw` wire to update `dims`.
-    effect(move || {
-        if !card.bound().get() {
-            return;
-        }
+    // Measure on tap — `boundingClientRect` is async (the result
+    // arrives via Lynx's UI-method callback after layout), so we
+    // `spawn_local` it and update `dims` reactively when it resolves.
+    // The result crosses back through the binary `WhiskerValueRaw`
+    // wire. Tap-triggered (rather than on-mount) so the platform UI
+    // is reliably laid out before we measure on both platforms.
+    let on_measure = move |_| {
         spawn_local(async move {
             match card.bounding_client_rect().await {
                 Ok(r) => dims.set(format!("{}×{} px", r.width as i32, r.height as i32)),
                 Err(e) => dims.set(format!("err: {e}")),
             }
         });
-    });
+    };
     render! {
         view(
             ref: card,
+            on_tap: on_measure,
             style: "width: 200px; height: 56px; margin: 8px 16px; \
                     background-color: #1a1330; border-radius: 8px; \
                     display: flex; flex-direction: column; \

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -543,6 +543,56 @@ pub fn video_demo() -> Element {
     }
 }
 
+/// Phase 4 demo — built-in element method invocation. Binds an
+/// `ElementRef` to a sized box, then measures it via the async
+/// `boundingClientRect` UI method once the box appears on screen
+/// (`on_uiappear` fires post-layout, so no tap needed). The result
+/// flows back through the binary `WhiskerValueRaw` wire and updates
+/// the label reactively.
+#[component]
+pub fn measure_demo() -> Element {
+    let card = ElementRef::new();
+    let dims = RwSignal::new(String::new());
+    let label = computed(move || {
+        let d = dims.get();
+        if d.is_empty() {
+            "measuring…".to_string()
+        } else {
+            d
+        }
+    });
+    // Measure once the ref binds (mount). The effect subscribes to
+    // `card.bound()` and re-fires when `__bind` flips it true, then
+    // schedules the async `boundingClientRect` — the bridge callback
+    // resolves (after layout, on the UI thread) and the result flows
+    // back through the binary `WhiskerValueRaw` wire to update `dims`.
+    effect(move || {
+        if !card.bound().get() {
+            return;
+        }
+        spawn_local(async move {
+            match card.bounding_client_rect().await {
+                Ok(r) => dims.set(format!("{}×{} px", r.width as i32, r.height as i32)),
+                Err(e) => dims.set(format!("err: {e}")),
+            }
+        });
+    });
+    render! {
+        view(
+            ref: card,
+            style: "width: 200px; height: 56px; margin: 8px 16px; \
+                    background-color: #1a1330; border-radius: 8px; \
+                    display: flex; flex-direction: column; \
+                    align-items: center; justify-content: center;",
+        ) {
+            text(
+                value: label,
+                style: "color: #b9a9ff; font-size: 14px; font-weight: 600;",
+            )
+        }
+    }
+}
+
 #[whisker::main]
 fn app() -> Element {
     // Allocate every app-wide signal in the bootstrap owner. `AppState`
@@ -567,6 +617,7 @@ fn app() -> Element {
         page(style: page_style) {
             Hello(style: "width: 100%; height: 8px;")
             VideoDemo()
+            MeasureDemo()
             Header()
             ScrollBody(state: state)
             NowPlaying(state: state)


### PR DESCRIPTION
## 概要

Phase 4 — **組み込み要素のメソッド呼び出し**(結果取得つき)。`boundingClientRect` / `takeScreenshot` のように戻り値が必要なUIメソッドを Rust から呼べるようにします。これらの結果は Lynx の UI-method コールバック(UIスレッド、レイアウト後)で非同期に届くため、既存の fire-and-forget 経路(`video.play()` 等)とは別の新規インフラです。

**iOS先行**で実装(Androidは結果取得に Lynx フォークリリースが必要なため、ビルド維持の graceful error。フォロー予定)。

## 主な変更

- **`lynx_native_renderer.cc`**(iOSコンパイル): `lynx::pub::Value → WhiskerValueRaw` 変換 + `lynx_ui_invoke_method_async`(`Catalyzer::Invoke` の結果コールバックを捕捉)。JSON不使用、モジュール引数/イベントと同じバイナリワイヤ
- **C ABI** `whisker_bridge_invoke_element_method_async`(`WhiskerModuleCallback` 再利用)。コールバックは必ず1回発火(同期エラー / 非同期結果)
- **Rust** `ElementRef::invoke_async` / `invoke_typed_async::<T>` + 型付き `bounding_client_rect() -> BoundingClientRect` / `take_screenshot() -> String`
- **組み込み要素の `ref:`**: `render!` が `view(ref: r) { … }` を `ElementBuilder::bind_ref` に振り分け、マウント後にメソッド呼び出し可能に

## API例
```rust
let card = ElementRef::new();
effect(move || if card.bound().get() {
    spawn_local(async move {
        if let Ok(r) = card.bounding_client_rect().await {
            // r.width, r.height, …
        }
    });
});
// render! { view(ref: card, …) { … } }
```

## 検証
- `cargo test --workspace` 全件緑(RA補完8件 + 新規: ref:→bind_ref ルーティング, BoundingClientRect deserialize)、clippy / fmt クリーン
- **iOS 実機**: `boundingClientRect` デモが実測値 `200×21 px` を表示 — 非同期結果経路(pub::Value→WhiskerValueRaw→from_raw→deserialize→reactive更新)+ **クロススレッド executor wake** が端から端まで動作 ✅
- **Android 実機**: ビルド/リンク成功(未定義シンボルなし)、`err: platform method…` を優雅に表示しクラッシュなし ✅(async future はエラーで再開 = Androidでもクロススレッド resume 動作)

## Android フォローアップ(別PR)
`lynx_native_renderer.cc` は Android では liblynx.so(Lynxフォークのビルド済み)から来るため、`lynx_ui_invoke_method_async` を **`whiskerrs/lynx` フォークに追加 → liblynx 再ビルド → 再pin** すれば Android でも結果取得が点灯します。現状は `#if defined(__APPLE__)` ゲートで graceful degradation。

## コミット構成
1. `feat(elements)`: 非同期 element-method インフラ + ref バインド + 型付きラッパ
2. `feat(hello-world)`: MeasureDemo サンプル

🤖 Generated with [Claude Code](https://claude.com/claude-code)