### PR TITLE
feat(events): event propagation control (catch/capture/bind), reconstructed in Rust

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -57,6 +57,11 @@ const BRIDGE_EXPORTS: &[&str] = &[
     "_whisker_bridge_remove_child",
     "_whisker_bridge_set_event_listener",
     "_whisker_bridge_set_event_listener_with_value",
+    // Phase 5: Rust-side event propagation. The driver registers a
+    // dispatcher the reporter hook forwards to, and queries element
+    // signs to key its tree + listener maps.
+    "_whisker_bridge_register_event_dispatcher",
+    "_whisker_bridge_element_sign",
     "_whisker_bridge_set_root",
     "_whisker_bridge_flush",
     "_whisker_bridge_invoke_module",

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -236,25 +236,44 @@ typedef struct WhiskerKeyValueRec {
     WhiskerValueRaw value;
 } WhiskerKeyValueRaw;
 
-// Register a native event listener that receives the event body as a
-// `WhiskerValueRaw` tree — the same tagged-union wire as module
-// args/returns, no JSON round-trip. When the event fires the bridge
-// builds the value from the platform-side event body (Lynx's
-// `LynxEvent.generateEventBody` dict on iOS, the event-params map on
-// Android) and hands `callback(user_data, &value)` from the TASM
-// thread.
-//
-// `payload` is owned by the bridge and only valid for the duration of
-// the call (the callback copies out via the Rust `from_raw`). For a
-// bodyless event the bridge passes a `WHISKER_VALUE_NULL` value, never
-// NULL pointer. Calling more than once for the same `(element,
-// event_name)` replaces the prior listener.
+// NOTE (Phase 5): event listeners no longer live in the bridge. Lynx's
+// reporter hook fires once at the hit-tested target, *before* the
+// engine walks its capture/bubble chain (whose per-element firings go
+// to the absent JS runtime), so the bridge can't observe Lynx-native
+// propagation. Whisker instead reconstructs propagation in Rust: the
+// `whisker-driver` renderer owns the element tree + per-element
+// listeners (with their bind/catch/capture type) and replays
+// Lynx's capture→bubble→catch algorithm. The two functions below are
+// retained as no-op stubs for ABI stability; the Rust driver no longer
+// calls them. Dispatch flows through `whisker_bridge_register_event_dispatcher`.
 typedef void (*WhiskerEventValueCallback)(void* user_data, const WhiskerValueRaw* payload);
 WHISKER_BRIDGE_EXPORT void whisker_bridge_set_event_listener_with_value(
     WhiskerElement* element,
     const char* event_name,
     WhiskerEventValueCallback callback,
     void* user_data);
+
+// The Rust-side event dispatcher. The platform reporter hook calls it
+// (via `whisker_bridge_internal_dispatch_event`) with the hit-tested
+// target's element sign, the event name, and the event body. The
+// driver walks its own element tree from `target_sign` up to the root,
+// runs the capture phase (root→target) then the bubble phase
+// (target→root) honoring each listener's bind/catch/capture type, and
+// returns whether the event was consumed (so the reporter can tell
+// Lynx to skip its own native chain). `body` is borrowed for the call.
+typedef bool (*WhiskerEventDispatcher)(int32_t target_sign,
+                                       const char* event_name,
+                                       const WhiskerValueRaw* body);
+
+// Register (or clear, with NULL) the Rust event dispatcher. Called once
+// by the driver at bootstrap.
+WHISKER_BRIDGE_EXPORT void whisker_bridge_register_event_dispatcher(
+    WhiskerEventDispatcher dispatcher);
+
+// The Lynx element sign (impl id) for `element` — the same identifier
+// the reporter reports as the event target, and the key the driver
+// uses for its tree + listener maps. Returns 0 for a null element.
+WHISKER_BRIDGE_EXPORT int32_t whisker_bridge_element_sign(WhiskerElement* element);
 
 // Per-module dispatch function — the platform-side Swift Macro or
 // KSP processor emits one of these per `@WhiskerModule`-annotated

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -57,57 +57,31 @@ struct WhiskerElement {
     lynx_shell_t* shell = nullptr;
 };
 
-// Native event listener registry. Lynx dispatches physical touches
-// through `Element::SetEventHandler(EventHandler*)` consumed by
+// Event dispatch hook. Lynx dispatches physical touches through
+// `Element::SetEventHandler(EventHandler*)` consumed by
 // `TouchEventHandler` (whose ultimate target is the JS runtime), not
 // through the EventTarget / AddEventListener path — so we can't just
 // hang a `lynx::event::EventListener` off a FiberElement and expect
-// taps to fire it.
+// taps to fire it. We also can't observe Lynx's native capture/bubble
+// CHAIN: each platform's glue installs a "reporter" hook on the host's
+// event emitter (LynxEventEmitter on iOS / Android), but that hook
+// fires once, at the hit-tested TARGET, *before* the engine walks the
+// chain (whose per-element firings go to the absent JS runtime). See
+// `whisker/memory/lynx_event_dispatch`.
 //
-// Instead, each platform's glue installs a "reporter" hook on the
-// host's event emitter (LynxEventEmitter on iOS). The hook calls
-// `whisker_bridge_internal_dispatch_event` below; that looks up
-// (element_sign, event_name) here and fires the C callback if present.
+// So Whisker reconstructs propagation itself: the reporter calls
+// `whisker_bridge_internal_dispatch_event` with the target sign +
+// event body, and that forwards to a dispatcher the Rust driver
+// registers (`whisker_bridge_register_event_dispatcher`). The driver
+// owns the element tree + the per-element listeners (with their
+// bind/catch/capture type) and replays Lynx's capture→bubble→catch
+// algorithm in Rust. Returning `true` tells the reporter the event
+// was consumed (Lynx then skips its own native chain for it).
 namespace {
 
-struct EventKey {
-    int32_t element_sign;
-    std::string event_name;
-    bool operator==(const EventKey& other) const {
-        return element_sign == other.element_sign && event_name == other.event_name;
-    }
-};
-struct EventKeyHash {
-    size_t operator()(const EventKey& k) const noexcept {
-        return std::hash<int32_t>{}(k.element_sign) ^
-               (std::hash<std::string>{}(k.event_name) << 1);
-    }
-};
-// Tagged union covering both the no-payload event-listener
-// (`whisker_bridge_set_event_listener`) and the value-payload variant
-// (`whisker_bridge_set_event_listener_with_value`). Each registry
-// slot is one or the other; dispatch picks the right arm based on
-// `kind`.
-struct EventCallback {
-    enum class Kind {
-        NoPayload,
-        ValuePayload,
-    };
-    Kind kind;
-    union {
-        WhiskerEventCallback no_payload;
-        WhiskerEventValueCallback value_payload;
-    } func;
-    void* user_data;
-};
-
-std::mutex& RegistryMutex() {
-    static std::mutex m;
-    return m;
-}
-std::unordered_map<EventKey, EventCallback, EventKeyHash>& Registry() {
-    static std::unordered_map<EventKey, EventCallback, EventKeyHash> r;
-    return r;
+WhiskerEventDispatcher& EventDispatcher() {
+    static WhiskerEventDispatcher dispatcher = nullptr;
+    return dispatcher;
 }
 
 }  // namespace
@@ -136,38 +110,14 @@ bool whisker_bridge_internal_dispatch_event(int32_t element_sign,
                                             const char* event_name,
                                             const WhiskerValueRaw* payload) {
     if (event_name == nullptr) return false;
-    EventCallback hit{};
-    bool found = false;
-    {
-        std::lock_guard<std::mutex> lock(RegistryMutex());
-        EventKey key{element_sign, std::string(event_name)};
-        auto it = Registry().find(key);
-        if (it != Registry().end()) {
-            hit = it->second;
-            found = true;
-        }
-    }
-    if (!found) return false;
+    WhiskerEventDispatcher dispatcher = EventDispatcher();
+    if (dispatcher == nullptr) return false;
     // Normalise a NULL payload to a stack `WHISKER_VALUE_NULL` so the
-    // value callback always receives a valid pointer ("no body").
+    // dispatcher always receives a valid pointer ("no body").
     WhiskerValueRaw null_value{};
     null_value.type = WHISKER_VALUE_NULL;
     const WhiskerValueRaw* p = payload != nullptr ? payload : &null_value;
-    switch (hit.kind) {
-        case EventCallback::Kind::NoPayload:
-            if (hit.func.no_payload != nullptr) {
-                hit.func.no_payload(hit.user_data);
-                return true;
-            }
-            return false;
-        case EventCallback::Kind::ValuePayload:
-            if (hit.func.value_payload != nullptr) {
-                hit.func.value_payload(hit.user_data, p);
-                return true;
-            }
-            return false;
-    }
-    return false;
+    return dispatcher(element_sign, event_name, p);
 }
 
 // ----------------------------------------------------------------------------
@@ -251,18 +201,10 @@ extern "C" WhiskerElement* whisker_bridge_create_element_by_name(
 
 extern "C" void whisker_bridge_release_element(WhiskerElement* element) {
     if (element == nullptr) return;
-    // Drop any registered native event callbacks for this element so
-    // its sign can't accidentally collide with a future element's id.
+    // Listeners + the sign→parent map are owned by the Rust driver's
+    // renderer now (it drops them in its own `release_element`, keyed
+    // by the same sign), so there's nothing to clean up here.
     if (element->handle != nullptr) {
-        int32_t sign = lynx_element_id(element->handle);
-        std::lock_guard<std::mutex> lock(RegistryMutex());
-        for (auto it = Registry().begin(); it != Registry().end(); ) {
-            if (it->first.element_sign == sign) {
-                it = Registry().erase(it);
-            } else {
-                ++it;
-            }
-        }
         lynx_element_release(element->handle);
     }
     delete element;
@@ -297,21 +239,20 @@ extern "C" void whisker_bridge_remove_child(WhiskerElement* parent,
     lynx_element_remove_child(parent->handle, child->handle);
 }
 
+// Superseded by Rust-side propagation reconstruction: listeners now
+// live in the `whisker-driver` renderer (keyed by element sign, with
+// their bind/catch/capture type), and dispatch runs through the
+// dispatcher registered below. These two symbols are retained as
+// no-ops for ABI stability (the iOS exported-symbols list still names
+// them); the Rust driver no longer calls them.
 extern "C" void whisker_bridge_set_event_listener(WhiskerElement* element,
                                                  const char* event_name,
                                                  WhiskerEventCallback callback,
                                                  void* user_data) {
-    if (element == nullptr || element->handle == nullptr ||
-        event_name == nullptr || callback == nullptr) {
-        return;
-    }
-    EventKey key{lynx_element_id(element->handle), std::string(event_name)};
-    EventCallback entry{};
-    entry.kind = EventCallback::Kind::NoPayload;
-    entry.func.no_payload = callback;
-    entry.user_data = user_data;
-    std::lock_guard<std::mutex> lock(RegistryMutex());
-    Registry()[key] = entry;
+    (void)element;
+    (void)event_name;
+    (void)callback;
+    (void)user_data;
 }
 
 extern "C" void whisker_bridge_set_event_listener_with_value(
@@ -319,17 +260,20 @@ extern "C" void whisker_bridge_set_event_listener_with_value(
     const char* event_name,
     WhiskerEventValueCallback callback,
     void* user_data) {
-    if (element == nullptr || element->handle == nullptr ||
-        event_name == nullptr || callback == nullptr) {
-        return;
-    }
-    EventKey key{lynx_element_id(element->handle), std::string(event_name)};
-    EventCallback entry{};
-    entry.kind = EventCallback::Kind::ValuePayload;
-    entry.func.value_payload = callback;
-    entry.user_data = user_data;
-    std::lock_guard<std::mutex> lock(RegistryMutex());
-    Registry()[key] = entry;
+    (void)element;
+    (void)event_name;
+    (void)callback;
+    (void)user_data;
+}
+
+extern "C" void whisker_bridge_register_event_dispatcher(
+    WhiskerEventDispatcher dispatcher) {
+    EventDispatcher() = dispatcher;
+}
+
+extern "C" int32_t whisker_bridge_element_sign(WhiskerElement* element) {
+    if (element == nullptr || element->handle == nullptr) return 0;
+    return lynx_element_id(element->handle);
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -37,6 +37,18 @@ pub type WhiskerEventCallback = extern "C" fn(user_data: *mut c_void);
 pub type WhiskerEventValueCallback =
     extern "C" fn(user_data: *mut c_void, payload: *const WhiskerValueRaw);
 
+/// The Rust event dispatcher the bridge calls when its reporter hook
+/// fires. Receives the hit-tested target's element sign, the event
+/// name (NUL-terminated), and the event body (`WhiskerValueRaw` tree,
+/// never NULL). Returns whether the event was consumed (so the
+/// reporter can tell Lynx to skip its native chain). See
+/// `whisker_bridge_register_event_dispatcher`.
+pub type WhiskerEventDispatcher = extern "C" fn(
+    target_sign: i32,
+    event_name: *const c_char,
+    body: *const WhiskerValueRaw,
+) -> bool;
+
 // ----- Platform module invocation (Phase 7-Φ.E) ------------------------------
 //
 // `#[repr(C)]` mirror of the C tagged-union in `whisker_bridge.h`.
@@ -202,6 +214,16 @@ extern "C" {
         callback: WhiskerEventValueCallback,
         user_data: *mut c_void,
     );
+
+    /// Register the Rust event dispatcher (the reporter hook forwards
+    /// to it). Called once by the driver at bootstrap. See
+    /// [`WhiskerEventDispatcher`].
+    pub fn whisker_bridge_register_event_dispatcher(dispatcher: WhiskerEventDispatcher);
+
+    /// The Lynx element sign for `element` — same id the reporter
+    /// reports as the event target, used as the key for the driver's
+    /// tree + listener maps. Returns 0 for a null element.
+    pub fn whisker_bridge_element_sign(element: *mut WhiskerElement) -> i32;
 
     pub fn whisker_bridge_set_root(engine: *mut WhiskerEngine, page: *mut WhiskerElement);
     pub fn whisker_bridge_flush(engine: *mut WhiskerEngine);

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -132,6 +132,12 @@ extern "C" fn init_callback(user_data: *mut c_void) {
         ctx.engine as *mut c_void,
     );
 
+    // Route the platform reporter's events through Whisker's Rust-side
+    // propagation reconstruction (capture/bubble/catch over the
+    // driver's own element tree). The bridge calls this dispatcher
+    // whenever its reporter hook fires.
+    super::renderer::register_event_dispatcher();
+
     // Install the bridge renderer into the thread-local before
     // running user code. The `render!` macro's `view::*` calls
     // route through whatever is installed here.

--- a/crates/whisker-driver/src/lynx/mod.rs
+++ b/crates/whisker-driver/src/lynx/mod.rs
@@ -5,4 +5,5 @@
 //! in [`bootstrap`].
 
 pub mod bootstrap;
+mod propagation;
 pub mod renderer;

--- a/crates/whisker-driver/src/lynx/propagation.rs
+++ b/crates/whisker-driver/src/lynx/propagation.rs
@@ -1,0 +1,197 @@
+//! Pure replay of Lynx's capture→bubble→catch event-propagation
+//! ordering, decoupled from the bridge so it's unit-testable.
+//!
+//! Whisker reconstructs propagation in Rust because Lynx's reporter
+//! hook fires once at the hit-tested target, *before* — and bypassing
+//! — the engine's own capture/bubble chain (whose per-element firings
+//! go to the absent JS runtime). This module is the faithful Rust
+//! port of `TouchEventHandler::HandleEventInternal`
+//! (`core/renderer/events/touch_event_handler.cc`).
+
+use whisker_runtime::view::BindType;
+
+/// Plan the firing order for an event over `chain` — the response
+/// chain, **target-first**: `[target, parent, …, root]`.
+/// `handlers_for(sign)` yields that element's `(BindType, listener)`
+/// entries (in registration order); return an empty slice for an
+/// element with no listener for this event.
+///
+/// Mirrors Lynx's `HandleEventInternal`:
+///   - **capture phase** (root → target): every `CaptureBind` fires;
+///     a `CaptureCatch` fires too but then stops *everything* — no
+///     bubble phase runs at all.
+///   - **bubble phase** (target → root), only reached if no
+///     capture-catch fired: every `Bind` fires; a `Catch` fires then
+///     stops further bubbling.
+///
+/// Within a single element all its handlers are visited before the
+/// stop takes effect (matching Lynx's inner loop + `need_break`), so
+/// an element carrying both a capture-bind and a capture-catch fires
+/// both before propagation halts.
+///
+/// Returns `(consumed, firings)`: `firings` is `(sign, listener)` in
+/// fire order, and `consumed` is whether any listener matched (relayed
+/// to the platform reporter so Lynx skips its native chain).
+pub(super) fn plan<'a, T, F>(chain: &[i32], handlers_for: F) -> (bool, Vec<(i32, T)>)
+where
+    T: Clone + 'a,
+    F: Fn(i32) -> &'a [(BindType, T)],
+{
+    let mut firings: Vec<(i32, T)> = Vec::new();
+    let mut consumed = false;
+    let mut capture_caught = false;
+
+    // Capture phase: root → target (chain is target-first, so reverse).
+    for &sign in chain.iter().rev() {
+        let mut stop = false;
+        for (bt, listener) in handlers_for(sign) {
+            match bt {
+                BindType::CaptureCatch => {
+                    firings.push((sign, listener.clone()));
+                    consumed = true;
+                    capture_caught = true;
+                    stop = true;
+                }
+                BindType::CaptureBind => {
+                    firings.push((sign, listener.clone()));
+                    consumed = true;
+                }
+                _ => {}
+            }
+        }
+        if stop {
+            break;
+        }
+    }
+
+    // Bubble phase: target → root, skipped entirely if a capture-catch
+    // already swallowed the event.
+    if !capture_caught {
+        for &sign in chain.iter() {
+            let mut stop = false;
+            for (bt, listener) in handlers_for(sign) {
+                match bt {
+                    BindType::Catch => {
+                        firings.push((sign, listener.clone()));
+                        consumed = true;
+                        stop = true;
+                    }
+                    BindType::Bind => {
+                        firings.push((sign, listener.clone()));
+                        consumed = true;
+                    }
+                    _ => {}
+                }
+            }
+            if stop {
+                break;
+            }
+        }
+    }
+
+    (consumed, firings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Build a `handlers_for` closure from a sign → handlers map.
+    fn lookup<'a>(
+        map: &'a HashMap<i32, Vec<(BindType, &'static str)>>,
+    ) -> impl Fn(i32) -> &'a [(BindType, &'static str)] + 'a {
+        move |sign| map.get(&sign).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    // Chain target-first: target=1, parent=2, root=3  (tree 3 → 2 → 1).
+    const TARGET: i32 = 1;
+    const PARENT: i32 = 2;
+    const ROOT: i32 = 3;
+    fn chain() -> Vec<i32> {
+        vec![TARGET, PARENT, ROOT]
+    }
+
+    fn order(firings: &[(i32, &'static str)]) -> Vec<&'static str> {
+        firings.iter().map(|(_, l)| *l).collect()
+    }
+
+    #[test]
+    fn bubble_runs_target_to_root() {
+        let mut m = HashMap::new();
+        m.insert(TARGET, vec![(BindType::Bind, "target")]);
+        m.insert(PARENT, vec![(BindType::Bind, "parent")]);
+        m.insert(ROOT, vec![(BindType::Bind, "root")]);
+        let (consumed, firings) = plan(&chain(), lookup(&m));
+        assert!(consumed);
+        assert_eq!(order(&firings), ["target", "parent", "root"]);
+    }
+
+    #[test]
+    fn catch_stops_bubbling_at_that_element() {
+        let mut m = HashMap::new();
+        m.insert(TARGET, vec![(BindType::Bind, "target")]);
+        m.insert(PARENT, vec![(BindType::Catch, "parent_catch")]);
+        m.insert(ROOT, vec![(BindType::Bind, "root")]);
+        let (_, firings) = plan(&chain(), lookup(&m));
+        // target fires, parent's catch fires + stops — root never runs.
+        assert_eq!(order(&firings), ["target", "parent_catch"]);
+    }
+
+    #[test]
+    fn capture_runs_root_to_target_before_bubble() {
+        let mut m = HashMap::new();
+        m.insert(ROOT, vec![(BindType::CaptureBind, "root_cap")]);
+        m.insert(PARENT, vec![(BindType::CaptureBind, "parent_cap")]);
+        m.insert(TARGET, vec![(BindType::Bind, "target_bubble")]);
+        let (_, firings) = plan(&chain(), lookup(&m));
+        // capture root→target, then bubble target→root.
+        assert_eq!(order(&firings), ["root_cap", "parent_cap", "target_bubble"]);
+    }
+
+    #[test]
+    fn capture_catch_stops_everything_including_bubble() {
+        let mut m = HashMap::new();
+        m.insert(ROOT, vec![(BindType::CaptureCatch, "root_cap_catch")]);
+        m.insert(PARENT, vec![(BindType::CaptureBind, "parent_cap")]);
+        m.insert(TARGET, vec![(BindType::Bind, "target_bubble")]);
+        let (consumed, firings) = plan(&chain(), lookup(&m));
+        assert!(consumed);
+        // root's capture-catch fires and swallows the event: no
+        // descendant capture, no bubble.
+        assert_eq!(order(&firings), ["root_cap_catch"]);
+    }
+
+    #[test]
+    fn capture_bind_does_not_stop_bubble() {
+        let mut m = HashMap::new();
+        m.insert(PARENT, vec![(BindType::CaptureBind, "parent_cap")]);
+        m.insert(TARGET, vec![(BindType::Bind, "target_bubble")]);
+        let (_, firings) = plan(&chain(), lookup(&m));
+        assert_eq!(order(&firings), ["parent_cap", "target_bubble"]);
+    }
+
+    #[test]
+    fn element_with_capture_and_bubble_both_fire() {
+        let mut m = HashMap::new();
+        // One element registers both phases.
+        m.insert(
+            TARGET,
+            vec![
+                (BindType::CaptureBind, "t_cap"),
+                (BindType::Bind, "t_bubble"),
+            ],
+        );
+        let (_, firings) = plan(&chain(), lookup(&m));
+        // capture pass fires t_cap, bubble pass fires t_bubble.
+        assert_eq!(order(&firings), ["t_cap", "t_bubble"]);
+    }
+
+    #[test]
+    fn no_handlers_not_consumed() {
+        let m: HashMap<i32, Vec<(BindType, &'static str)>> = HashMap::new();
+        let (consumed, firings) = plan(&chain(), lookup(&m));
+        assert!(!consumed);
+        assert!(firings.is_empty());
+    }
+}

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -13,13 +13,22 @@
 //! we don't currently reuse them (cheap; can be revisited if
 //! per-frame churn ever matters).
 
-use std::ffi::{c_void, CString};
+use std::collections::{BTreeMap, HashMap};
+use std::ffi::CString;
 use std::ptr::NonNull;
+use std::rc::Rc;
 
 use whisker_driver_sys::{self as ffi, WhiskerElement, WhiskerElementTag, WhiskerEngine};
 use whisker_runtime::element::ElementTag;
 use whisker_runtime::value::WhiskerValue;
-use whisker_runtime::view::{DynRenderer, Element};
+use whisker_runtime::view::{BindType, DynRenderer, Element, EventDispatchPlan};
+
+use super::propagation;
+
+/// One registered listener: its propagation [`BindType`] plus the
+/// closure to fire. `Rc` so the planner can clone it into the firing
+/// list and the closure can run after the renderer borrow is released.
+type Listener = (BindType, Rc<dyn Fn(WhiskerValue) + 'static>);
 
 pub struct BridgeRenderer {
     engine: NonNull<WhiskerEngine>,
@@ -27,14 +36,22 @@ pub struct BridgeRenderer {
     /// released. Index assigned at `create_element` time, returned in
     /// the public `Element`.
     elements: Vec<Option<NonNull<WhiskerElement>>>,
-    /// Owned per-event listener closures. Double-boxed so the inner
-    /// `Box<dyn Fn>`'s fat-pointer address stays stable as the outer
-    /// `Vec` reallocates — that address is the `user_data` the C
-    /// bridge stores and hands back to the trampoline. Every event
-    /// now carries a [`WhiskerValue`] payload (the unit / typed
-    /// closures wrap into this single shape at the builder layer).
-    #[allow(clippy::vec_box, clippy::type_complexity)]
-    listeners: Vec<Box<Box<dyn Fn(WhiskerValue) + 'static>>>,
+    /// Child Lynx-sign → parent Lynx-sign, mirroring the attached
+    /// tree. Populated in [`append_child`](Self::append_child),
+    /// cleared in [`remove_child`](Self::remove_child) /
+    /// [`release_element`](Self::release_element). The event-dispatch
+    /// chain walk (`target → root`) follows these links — Lynx's
+    /// reporter only hands us the target, so we reconstruct the
+    /// ancestor chain ourselves.
+    parent_sign: HashMap<i32, i32>,
+    /// `(element sign, event name)` → listeners registered for it.
+    /// Keyed by Lynx sign so the reporter's target sign (and the
+    /// ancestor signs we walk to) look up directly. A given
+    /// `(element, event)` can hold more than one listener when capture
+    /// and bubble handlers are both registered (mirrors Lynx storing a
+    /// handler per type).
+    #[allow(clippy::type_complexity)]
+    listeners: HashMap<(i32, String), Vec<Listener>>,
 }
 
 impl BridgeRenderer {
@@ -47,7 +64,8 @@ impl BridgeRenderer {
         NonNull::new(engine).map(|engine| Self {
             engine,
             elements: Vec::new(),
-            listeners: Vec::new(),
+            parent_sign: HashMap::new(),
+            listeners: HashMap::new(),
         })
     }
 
@@ -59,6 +77,17 @@ impl BridgeRenderer {
         self.elements
             .get(handle.id() as usize)
             .and_then(|slot| *slot)
+    }
+
+    /// The Lynx element sign for `handle`, or `None` if the handle is
+    /// unknown / released. Routes through the bridge (the sign is
+    /// `lynx_element_id` of the underlying FiberElement).
+    fn sign_of(&self, handle: Element) -> Option<i32> {
+        let ptr = self.lookup(handle)?;
+        let sign = unsafe { ffi::whisker_bridge_element_sign(ptr.as_ptr()) };
+        // 0 is the bridge's "null element" sentinel; a real element
+        // sign is non-zero.
+        (sign != 0).then_some(sign)
     }
 }
 
@@ -101,10 +130,18 @@ impl DynRenderer for BridgeRenderer {
     }
 
     fn release_element(&mut self, handle: Element) {
+        // Resolve the sign before releasing so we can drop the element's
+        // listeners + parent link. After release the underlying pointer
+        // is gone, so `sign_of` would fail.
+        let sign = self.sign_of(handle);
         if let Some(slot) = self.elements.get_mut(handle.id() as usize) {
             if let Some(ptr) = slot.take() {
                 unsafe { ffi::whisker_bridge_release_element(ptr.as_ptr()) };
             }
+        }
+        if let Some(sign) = sign {
+            self.parent_sign.remove(&sign);
+            self.listeners.retain(|(s, _), _| *s != sign);
         }
     }
 
@@ -133,40 +170,88 @@ impl DynRenderer for BridgeRenderer {
         let Some(p) = self.lookup(parent) else { return };
         let Some(c) = self.lookup(child) else { return };
         unsafe { ffi::whisker_bridge_append_child(p.as_ptr(), c.as_ptr()) };
+        // Mirror the attachment in sign space for the event chain walk.
+        // (`insert_child_at` is built on append/remove, so it flows
+        // through here too.)
+        if let (Some(cs), Some(ps)) = (self.sign_of(child), self.sign_of(parent)) {
+            self.parent_sign.insert(cs, ps);
+        }
     }
 
     fn remove_child(&mut self, parent: Element, child: Element) {
         let Some(p) = self.lookup(parent) else { return };
         let Some(c) = self.lookup(child) else { return };
         unsafe { ffi::whisker_bridge_remove_child(p.as_ptr(), c.as_ptr()) };
+        if let Some(cs) = self.sign_of(child) {
+            self.parent_sign.remove(&cs);
+        }
     }
 
     fn set_event_listener(
         &mut self,
         handle: Element,
         event_name: &str,
+        bind_type: BindType,
         callback: Box<dyn Fn(WhiskerValue) + 'static>,
     ) {
-        let Some(ptr) = self.lookup(handle) else {
+        // Listeners live here in the driver (keyed by Lynx sign), not in
+        // the bridge: Whisker reconstructs propagation in Rust because
+        // Lynx's reporter hook fires once at the target, before — and
+        // bypassing — the engine's own capture/bubble chain (which
+        // targets the absent JS runtime). See `plan_event_dispatch`.
+        let Some(sign) = self.sign_of(handle) else {
             return;
         };
-        let Ok(name_c) = CString::new(event_name) else {
-            return;
-        };
-        let outer: Box<Box<dyn Fn(WhiskerValue) + 'static>> = Box::new(callback);
-        let raw = Box::as_ref(&outer) as *const Box<dyn Fn(WhiskerValue) + 'static> as *mut c_void;
-        self.listeners.push(outer);
-        // The bridge hands the event body across as a `WhiskerValueRaw`
-        // tree (same wire as module args); the trampoline copies it
-        // into an owned `WhiskerValue` via `from_raw`.
-        unsafe {
-            ffi::whisker_bridge_set_event_listener_with_value(
-                ptr.as_ptr(),
-                name_c.as_ptr(),
-                rust_event_trampoline,
-                raw,
-            )
-        };
+        let entry = self
+            .listeners
+            .entry((sign, event_name.to_string()))
+            .or_default();
+        // Replace any handler of the SAME bind/catch/capture type for
+        // this (element, event) — mirrors Lynx's per-type handler slot.
+        // A different type (e.g. capture + bubble on one element) is
+        // kept alongside.
+        entry.retain(|(bt, _)| *bt != bind_type);
+        entry.push((bind_type, Rc::from(callback)));
+    }
+
+    fn plan_event_dispatch(
+        &self,
+        target_sign: i32,
+        event_name: &str,
+        body: &WhiskerValue,
+    ) -> EventDispatchPlan {
+        // Reconstruct the response chain (target → root) from the
+        // parent mirror — Lynx's reporter only hands us the target.
+        let mut chain = vec![target_sign];
+        let mut cur = target_sign;
+        let mut guard = 0usize;
+        while let Some(&parent) = self.parent_sign.get(&cur) {
+            chain.push(parent);
+            cur = parent;
+            guard += 1;
+            // Defensive: a malformed tree shouldn't spin forever.
+            if guard > 4096 {
+                break;
+            }
+        }
+
+        let empty: Vec<Listener> = Vec::new();
+        let (consumed, ordered) = propagation::plan(&chain, |sign| {
+            self.listeners
+                .get(&(sign, event_name.to_string()))
+                .map(Vec::as_slice)
+                .unwrap_or(&empty)
+        });
+
+        // Each listener receives the body with its `currentTarget`
+        // rewritten to the element whose handler is firing (the
+        // reporter's body always names the original target).
+        let firings = ordered
+            .into_iter()
+            .map(|(sign, listener)| (listener, with_current_target(body, sign)))
+            .collect();
+
+        EventDispatchPlan { consumed, firings }
     }
 
     fn set_root(&mut self, page: Element) {
@@ -190,21 +275,68 @@ impl DynRenderer for BridgeRenderer {
     }
 }
 
-extern "C" fn rust_event_trampoline(user_data: *mut c_void, payload: *const ffi::WhiskerValueRaw) {
-    if user_data.is_null() {
-        return;
+/// Clone `body`, rewriting its `currentTarget.uid` to `sign` — the
+/// element whose handler is about to fire. Lynx's reporter only fills
+/// the original target, so as we replay propagation up the chain each
+/// listener gets a body naming *its* element as the current target.
+/// Non-map bodies (e.g. a bodyless event's `Null`) pass through.
+fn with_current_target(body: &WhiskerValue, sign: i32) -> WhiskerValue {
+    let mut cloned = body.clone();
+    if let WhiskerValue::Map(ref mut map) = cloned {
+        let ct = map
+            .entry("currentTarget".to_string())
+            .or_insert_with(|| WhiskerValue::Map(BTreeMap::new()));
+        match ct {
+            WhiskerValue::Map(ct_map) => {
+                ct_map.insert("uid".to_string(), WhiskerValue::Int(sign as i64));
+            }
+            other => {
+                let mut ct_map = BTreeMap::new();
+                ct_map.insert("uid".to_string(), WhiskerValue::Int(sign as i64));
+                *other = WhiskerValue::Map(ct_map);
+            }
+        }
     }
-    // The bridge hands the event body as a `WhiskerValueRaw` tree
-    // (NULL / `WHISKER_VALUE_NULL` = no body). Copy it into an owned
-    // `WhiskerValue` — same value model as module args/returns.
-    let value = if payload.is_null() {
+    cloned
+}
+
+/// C entry point the bridge reporter forwards every reported event to
+/// (registered via `whisker_bridge_register_event_dispatcher` at
+/// bootstrap). Reconstructs the [`WhiskerValue`] body, runs it through
+/// the installed renderer's propagation chain, and returns whether any
+/// listener consumed it (so the reporter can tell Lynx to skip its
+/// native chain).
+///
+/// Runs on the Lynx TASM thread, where the renderer is installed.
+extern "C" fn whisker_event_dispatch_entry(
+    target_sign: i32,
+    event_name: *const std::os::raw::c_char,
+    body: *const ffi::WhiskerValueRaw,
+) -> bool {
+    if event_name.is_null() {
+        return false;
+    }
+    // SAFETY: the bridge passes a valid NUL-terminated event name for
+    // the duration of the call.
+    let name = match unsafe { std::ffi::CStr::from_ptr(event_name) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    // The bridge normalises a missing body to `WHISKER_VALUE_NULL`, so
+    // `body` is non-null; guard anyway.
+    let value = if body.is_null() {
         WhiskerValue::Null
     } else {
-        // SAFETY: `payload` points to a valid `WhiskerValueRaw` owned
-        // by the bridge, valid for the duration of this call
-        // (documented contract). `from_raw` copies the data out.
-        unsafe { crate::module::from_raw(&*payload) }
+        // SAFETY: `body` points to a valid `WhiskerValueRaw` owned by
+        // the bridge, valid for this call. `from_raw` copies it out.
+        unsafe { crate::module::from_raw(&*body) }
     };
-    let cb = unsafe { &*(user_data as *const Box<dyn Fn(WhiskerValue) + 'static>) };
-    cb(value);
+    whisker_runtime::view::dispatch_event(target_sign, name, value)
+}
+
+/// Register [`whisker_event_dispatch_entry`] with the bridge so the
+/// platform reporter routes events through Whisker's reconstructed
+/// propagation. Idempotent; called once from bootstrap.
+pub(crate) fn register_event_dispatcher() {
+    unsafe { ffi::whisker_bridge_register_event_dispatcher(whisker_event_dispatch_entry) };
 }

--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -576,13 +576,21 @@ fn prop_apply_call(p: &Prop) -> TokenStream2 {
         }
         PropKind::EventNoPayload { event } => {
             quote! {
-                ::whisker::runtime::event::bind_unit(__handle, #event, props.#i);
+                ::whisker::runtime::event::bind_unit(
+                    __handle,
+                    #event,
+                    ::whisker::runtime::event::BindType::Bind,
+                    props.#i,
+                );
             }
         }
         PropKind::EventTyped { event, payload } => {
             quote! {
                 ::whisker::runtime::event::bind_typed::<#payload, _>(
-                    __handle, #event, props.#i,
+                    __handle,
+                    #event,
+                    ::whisker::runtime::event::BindType::Bind,
+                    props.#i,
                 );
             }
         }

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -544,7 +544,8 @@ fn is_string_attr_method(tag: &str, attr: &str) -> bool {
 /// hatch. Mirrors the `on_*` methods on the trait in
 /// `whisker::__tags`.
 fn is_known_event_method(name: &str) -> bool {
-    matches!(
+    // Bubble-phase bind variant for every typed event …
+    let bind_variant = matches!(
         name,
         "on_tap"
             | "on_longpress"
@@ -563,7 +564,37 @@ fn is_known_event_method(name: &str) -> bool {
             | "on_transitionstart"
             | "on_transitionend"
             | "on_transitioncancel"
-    )
+    );
+    // … plus the catch / capture propagation variants for the touch
+    // family (`on_tap_catch`, `on_capture_tap`, `on_capture_tap_catch`,
+    // …). These map 1:1 to Lynx's `catchtap` / `capture-bindtap` /
+    // `capture-catchtap` handler kinds. Mirrors the `on_*` methods on
+    // `ElementBuilder` in `whisker::__tags`.
+    let propagation_variant = matches!(
+        name,
+        "on_tap_catch"
+            | "on_capture_tap"
+            | "on_capture_tap_catch"
+            | "on_longpress_catch"
+            | "on_capture_longpress"
+            | "on_capture_longpress_catch"
+            | "on_click_catch"
+            | "on_capture_click"
+            | "on_capture_click_catch"
+            | "on_touchstart_catch"
+            | "on_capture_touchstart"
+            | "on_capture_touchstart_catch"
+            | "on_touchmove_catch"
+            | "on_capture_touchmove"
+            | "on_capture_touchmove_catch"
+            | "on_touchend_catch"
+            | "on_capture_touchend"
+            | "on_capture_touchend_catch"
+            | "on_touchcancel_catch"
+            | "on_capture_touchcancel"
+            | "on_capture_touchcancel_catch"
+    );
+    bind_variant || propagation_variant
 }
 
 // ---- Control-flow (Show / For) ------------------------------------------

--- a/crates/whisker-runtime/src/event.rs
+++ b/crates/whisker-runtime/src/event.rs
@@ -32,6 +32,11 @@ use serde::Deserialize;
 use crate::value::WhiskerValue;
 use crate::view::{set_event_listener, Element};
 
+/// Re-export so `event::BindType` sits next to `event::bind_typed` /
+/// `event::bind_unit` — the propagation type these take. Canonical
+/// definition lives in [`crate::view`].
+pub use crate::view::BindType;
+
 /// Register a **typed** event handler on `handle`.
 ///
 /// The event body crosses the bridge as a [`WhiskerValue`]; this
@@ -47,7 +52,7 @@ use crate::view::{set_event_listener, Element};
 /// logged with the raw value so it stays diagnosable (the Case ②
 /// philosophy: conversion mistakes are loggable, not invisible)
 /// rather than silently swallowing the whole event.
-pub fn bind_typed<E, F>(handle: Element, event_name: &'static str, handler: F)
+pub fn bind_typed<E, F>(handle: Element, event_name: &'static str, bind_type: BindType, handler: F)
 where
     E: DeserializeOwned + Default + 'static,
     F: Fn(E) + 'static,
@@ -55,6 +60,7 @@ where
     set_event_listener(
         handle,
         event_name,
+        bind_type,
         Box::new(move |value: WhiskerValue| {
             let ev = value.deserialize_into::<E>().unwrap_or_else(|err| {
                 eprintln!(
@@ -73,13 +79,14 @@ where
 ///
 /// For `on_<event>: ()` props / call sites that only care that the
 /// event fired. Wraps a `Fn()` into the value-carrying primitive.
-pub fn bind_unit<F>(handle: Element, event_name: &str, handler: F)
+pub fn bind_unit<F>(handle: Element, event_name: &str, bind_type: BindType, handler: F)
 where
     F: Fn() + 'static,
 {
     set_event_listener(
         handle,
         event_name,
+        bind_type,
         Box::new(move |_value: WhiskerValue| handler()),
     );
 }

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -39,7 +39,8 @@ pub use into_view::{Children, IntoView, View};
 pub use renderer::__reset_children_mirror_for_tests;
 pub use renderer::{
     append_child, child_index, children_of, create_element, create_element_by_name,
-    current_renderer_id, flush, insert_child_at, install_renderer, module_component_ptr,
-    previous_sibling, release_element, remove_child, set_attribute, set_event_listener,
-    set_inline_styles, set_root, uninstall_renderer, with_installed_renderer, DynRenderer,
+    current_renderer_id, dispatch_event, flush, insert_child_at, install_renderer,
+    module_component_ptr, previous_sibling, release_element, remove_child, set_attribute,
+    set_event_listener, set_inline_styles, set_root, uninstall_renderer, with_installed_renderer,
+    BindType, DynRenderer, EventDispatchPlan,
 };

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -20,10 +20,57 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use super::handle::Element;
 use crate::element::ElementTag;
 use crate::value::WhiskerValue;
+
+/// Event-handler propagation type — a faithful 1:1 mapping to Lynx's
+/// four handler kinds (`bind` / `catch` / `capture-bind` /
+/// `capture-catch`). The variant chosen when registering a listener is
+/// what drives Lynx's native event chain:
+///
+///   - **phase**: capture handlers fire on the way *down* (root →
+///     target); bind/catch (bubble) handlers fire on the way *up*
+///     (target → root).
+///   - **stop**: a `catch` handler stops propagation after it fires;
+///     a `bind` handler lets the event continue along the chain.
+///
+/// The discriminants match `lynx_event_bind_type_e` in the C bridge,
+/// so the value crosses the FFI as a plain `i32`.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BindType {
+    /// `bind` — bubble phase, does not stop propagation. The default
+    /// (what plain `on_<event>` registers).
+    #[default]
+    Bind = 0,
+    /// `catch` — bubble phase, stops propagation at this element.
+    Catch = 1,
+    /// `capture-bind` — capture phase, does not stop propagation.
+    CaptureBind = 2,
+    /// `capture-catch` — capture phase, stops propagation.
+    CaptureCatch = 3,
+}
+
+/// One planned listener firing: the listener plus the event value it
+/// should receive (its `currentTarget` already rewritten to that
+/// listener's element).
+pub type EventFiring = (Rc<dyn Fn(WhiskerValue) + 'static>, WhiskerValue);
+
+/// The ordered firing plan produced by
+/// [`DynRenderer::plan_event_dispatch`]. Separates *planning* (done
+/// under the renderer borrow) from *firing* (done after the borrow is
+/// released, since a handler may re-enter the renderer).
+#[derive(Default)]
+pub struct EventDispatchPlan {
+    /// Whether any listener matched — relayed to the platform reporter
+    /// so Lynx can skip its own native chain for this event.
+    pub consumed: bool,
+    /// Listeners to invoke, in propagation order.
+    pub firings: Vec<EventFiring>,
+}
 
 /// Object-safe renderer trait. The renderer owns whatever per-element
 /// state it needs and answers in `Element` IDs.
@@ -60,8 +107,35 @@ pub trait DynRenderer {
         &mut self,
         handle: Element,
         event_name: &str,
+        bind_type: BindType,
         callback: Box<dyn Fn(WhiskerValue) + 'static>,
     );
+
+    /// Plan how a reported event (`event_name` at `target_sign`,
+    /// carrying `body`) propagates through Whisker's reconstructed
+    /// chain — capture phase (root → target) then bubble phase
+    /// (target → root), honoring each registered listener's
+    /// [`BindType`] (catch stops bubbling; capture-catch stops
+    /// everything).
+    ///
+    /// Returns the listeners to fire **in order**, each paired with the
+    /// event value it should receive (its `currentTarget` set to that
+    /// listener's element), plus whether the event was consumed.
+    ///
+    /// Crucially this only *plans* — it does not fire the listeners,
+    /// because firing happens after the renderer borrow is released
+    /// (a handler may mutate signals → effects → re-enter the
+    /// renderer). [`dispatch_event`] does the firing. The default impl
+    /// plans nothing (renderers without a native event source); the
+    /// Lynx bridge renderer overrides it.
+    fn plan_event_dispatch(
+        &self,
+        _target_sign: i32,
+        _event_name: &str,
+        _body: &WhiskerValue,
+    ) -> EventDispatchPlan {
+        EventDispatchPlan::default()
+    }
 
     fn set_root(&mut self, page: Element);
     fn flush(&mut self);
@@ -307,9 +381,32 @@ pub fn __reset_children_mirror_for_tests() {
 pub fn set_event_listener(
     handle: Element,
     event_name: &str,
+    bind_type: BindType,
     callback: Box<dyn Fn(WhiskerValue) + 'static>,
 ) {
-    with_renderer(|r| r.set_event_listener(handle, event_name, callback), ())
+    with_renderer(
+        |r| r.set_event_listener(handle, event_name, bind_type, callback),
+        (),
+    )
+}
+
+/// Dispatch a reported event through the installed renderer's
+/// reconstructed propagation chain. The driver's C entry point (the
+/// bridge reporter forwards here) calls this. Returns whether the
+/// event was consumed.
+///
+/// Planning runs under the renderer borrow; the listeners then fire
+/// **after** the borrow is released, so a handler is free to mutate
+/// signals / re-enter `view::*` without a re-entrant borrow panic.
+pub fn dispatch_event(target_sign: i32, event_name: &str, body: WhiskerValue) -> bool {
+    let plan = with_renderer(
+        |r| r.plan_event_dispatch(target_sign, event_name, &body),
+        EventDispatchPlan::default(),
+    );
+    for (listener, event) in plan.firings {
+        listener(event);
+    }
+    plan.consumed
 }
 
 pub fn set_root(page: Element) {

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -82,6 +82,7 @@ impl DynRenderer for RecordingRenderer {
         &mut self,
         h: Element,
         name: &str,
+        _bind_type: super::BindType,
         _callback: Box<dyn Fn(crate::value::WhiskerValue) + 'static>,
     ) {
         self.ops.borrow_mut().push(Op::Event {

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -54,7 +54,7 @@ pub use whisker_runtime::value::WhiskerValue;
 /// lifecycle / component-state events a [`CustomEvent`](event::CustomEvent).
 pub mod event {
     pub use whisker_runtime::event::{
-        AnimationEvent, CustomEvent, Event, Point, Target, Touch, TouchEvent,
+        AnimationEvent, BindType, CustomEvent, Event, Point, Target, Touch, TouchEvent,
     };
 }
 
@@ -124,7 +124,7 @@ pub mod __tags {
     use whisker_runtime::value::WhiskerValue;
     use whisker_runtime::view::{
         append_child, apply_attr, apply_attr_owned, apply_styles, create_element,
-        set_event_listener, Element,
+        set_event_listener, BindType, Element,
     };
 
     // ---- The common builder surface -------------------------------------
@@ -281,46 +281,170 @@ pub mod __tags {
         }
 
         // ---- Events: touch / tap / click → `TouchEvent` -----------------
+        //
+        // Each touch event exposes the four Lynx handler kinds as a
+        // 1:1 naming convention (so `on_tap` ↔ `bindtap`,
+        // `on_tap_catch` ↔ `catchtap`, `on_capture_tap` ↔
+        // `capture-bindtap`, `on_capture_tap_catch` ↔
+        // `capture-catchtap`):
+        //
+        //   - `on_<event>`              — bubble phase, doesn't stop.
+        //   - `on_<event>_catch`        — bubble phase, stops here.
+        //   - `on_capture_<event>`      — capture phase, doesn't stop.
+        //   - `on_capture_<event>_catch`— capture phase, stops here.
+        //
+        // Capture handlers fire on the way *down* the element tree
+        // (root → target), bubble handlers on the way *up* (target →
+        // root); a `catch` handler stops the event from continuing
+        // along the chain after it fires. These set real Lynx handlers
+        // so the engine's native chain does the propagation.
 
         /// `tap` — single tap (won't fire if the finger moved far).
+        /// Bubble phase, lets the event continue up the chain.
         fn on_tap<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "tap", f);
+            bind_typed(self.__element(), "tap", BindType::Bind, f);
+            self
+        }
+        /// `tap`, bubble phase — **stops** propagation at this element.
+        fn on_tap_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "tap", BindType::Catch, f);
+            self
+        }
+        /// `tap`, capture phase (fires before descendants) — doesn't stop.
+        fn on_capture_tap<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "tap", BindType::CaptureBind, f);
+            self
+        }
+        /// `tap`, capture phase — **stops** propagation before it reaches
+        /// the target.
+        fn on_capture_tap_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "tap", BindType::CaptureCatch, f);
             self
         }
 
         /// `longpress` — ~500ms press (mutually exclusive with `tap`).
         fn on_longpress<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "longpress", f);
+            bind_typed(self.__element(), "longpress", BindType::Bind, f);
+            self
+        }
+        /// `longpress`, bubble phase — **stops** propagation here.
+        fn on_longpress_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "longpress", BindType::Catch, f);
+            self
+        }
+        /// `longpress`, capture phase — doesn't stop.
+        fn on_capture_longpress<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "longpress", BindType::CaptureBind, f);
+            self
+        }
+        /// `longpress`, capture phase — **stops** propagation.
+        fn on_capture_longpress_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "longpress", BindType::CaptureCatch, f);
             self
         }
 
         /// `click` — click on the nearest listening node.
         fn on_click<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "click", f);
+            bind_typed(self.__element(), "click", BindType::Bind, f);
+            self
+        }
+        /// `click`, bubble phase — **stops** propagation here.
+        fn on_click_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "click", BindType::Catch, f);
+            self
+        }
+        /// `click`, capture phase — doesn't stop.
+        fn on_capture_click<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "click", BindType::CaptureBind, f);
+            self
+        }
+        /// `click`, capture phase — **stops** propagation.
+        fn on_capture_click_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "click", BindType::CaptureCatch, f);
             self
         }
 
         /// `touchstart` — finger touches the surface.
         fn on_touchstart<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "touchstart", f);
+            bind_typed(self.__element(), "touchstart", BindType::Bind, f);
+            self
+        }
+        /// `touchstart`, bubble phase — **stops** propagation here.
+        fn on_touchstart_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchstart", BindType::Catch, f);
+            self
+        }
+        /// `touchstart`, capture phase — doesn't stop.
+        fn on_capture_touchstart<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchstart", BindType::CaptureBind, f);
+            self
+        }
+        /// `touchstart`, capture phase — **stops** propagation.
+        fn on_capture_touchstart_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchstart", BindType::CaptureCatch, f);
             self
         }
 
         /// `touchmove` — finger moves on the surface.
         fn on_touchmove<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "touchmove", f);
+            bind_typed(self.__element(), "touchmove", BindType::Bind, f);
+            self
+        }
+        /// `touchmove`, bubble phase — **stops** propagation here.
+        fn on_touchmove_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchmove", BindType::Catch, f);
+            self
+        }
+        /// `touchmove`, capture phase — doesn't stop.
+        fn on_capture_touchmove<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchmove", BindType::CaptureBind, f);
+            self
+        }
+        /// `touchmove`, capture phase — **stops** propagation.
+        fn on_capture_touchmove_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchmove", BindType::CaptureCatch, f);
             self
         }
 
         /// `touchend` — finger leaves the surface.
         fn on_touchend<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "touchend", f);
+            bind_typed(self.__element(), "touchend", BindType::Bind, f);
+            self
+        }
+        /// `touchend`, bubble phase — **stops** propagation here.
+        fn on_touchend_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchend", BindType::Catch, f);
+            self
+        }
+        /// `touchend`, capture phase — doesn't stop.
+        fn on_capture_touchend<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchend", BindType::CaptureBind, f);
+            self
+        }
+        /// `touchend`, capture phase — **stops** propagation.
+        fn on_capture_touchend_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchend", BindType::CaptureCatch, f);
             self
         }
 
         /// `touchcancel` — touch interrupted by the system / a gesture.
         fn on_touchcancel<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "touchcancel", f);
+            bind_typed(self.__element(), "touchcancel", BindType::Bind, f);
+            self
+        }
+        /// `touchcancel`, bubble phase — **stops** propagation here.
+        fn on_touchcancel_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchcancel", BindType::Catch, f);
+            self
+        }
+        /// `touchcancel`, capture phase — doesn't stop.
+        fn on_capture_touchcancel<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchcancel", BindType::CaptureBind, f);
+            self
+        }
+        /// `touchcancel`, capture phase — **stops** propagation.
+        fn on_capture_touchcancel_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.__element(), "touchcancel", BindType::CaptureCatch, f);
             self
         }
 
@@ -328,19 +452,19 @@ pub mod __tags {
 
         /// `layoutchange` — reports position after layout completes.
         fn on_layoutchange<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "layoutchange", f);
+            bind_typed(self.__element(), "layoutchange", BindType::Bind, f);
             self
         }
 
         /// `uiappear` — node entered the visible screen area.
         fn on_uiappear<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "uiappear", f);
+            bind_typed(self.__element(), "uiappear", BindType::Bind, f);
             self
         }
 
         /// `uidisappear` — node left the visible screen area.
         fn on_uidisappear<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "uidisappear", f);
+            bind_typed(self.__element(), "uidisappear", BindType::Bind, f);
             self
         }
 
@@ -348,43 +472,43 @@ pub mod __tags {
 
         /// `animationstart` — keyframe animation began.
         fn on_animationstart<F: Fn(AnimationEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "animationstart", f);
+            bind_typed(self.__element(), "animationstart", BindType::Bind, f);
             self
         }
 
         /// `animationend` — keyframe animation completed.
         fn on_animationend<F: Fn(AnimationEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "animationend", f);
+            bind_typed(self.__element(), "animationend", BindType::Bind, f);
             self
         }
 
         /// `animationcancel` — keyframe animation interrupted.
         fn on_animationcancel<F: Fn(AnimationEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "animationcancel", f);
+            bind_typed(self.__element(), "animationcancel", BindType::Bind, f);
             self
         }
 
         /// `animationiteration` — keyframe animation cycle boundary.
         fn on_animationiteration<F: Fn(AnimationEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "animationiteration", f);
+            bind_typed(self.__element(), "animationiteration", BindType::Bind, f);
             self
         }
 
         /// `transitionstart` — transition animation began.
         fn on_transitionstart<F: Fn(AnimationEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "transitionstart", f);
+            bind_typed(self.__element(), "transitionstart", BindType::Bind, f);
             self
         }
 
         /// `transitionend` — transition animation completed.
         fn on_transitionend<F: Fn(AnimationEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "transitionend", f);
+            bind_typed(self.__element(), "transitionend", BindType::Bind, f);
             self
         }
 
         /// `transitioncancel` — transition animation interrupted.
         fn on_transitioncancel<F: Fn(AnimationEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.__element(), "transitioncancel", f);
+            bind_typed(self.__element(), "transitioncancel", BindType::Bind, f);
             self
         }
 
@@ -392,9 +516,30 @@ pub mod __tags {
 
         /// Bind any event by name, receiving the raw [`WhiskerValue`]
         /// body. For custom / dynamic event names not covered by a
-        /// typed `on_<event>` method above.
+        /// typed `on_<event>` method above. Bubble phase, doesn't stop
+        /// propagation — for the catch / capture variants use
+        /// [`bind`](Self::bind).
         fn on<F: Fn(WhiskerValue) + 'static>(self, event: &'static str, f: F) -> Self {
-            set_event_listener(self.__element(), event, ::std::boxed::Box::new(f));
+            self.bind(event, BindType::Bind, f)
+        }
+
+        /// Bind any event by name with an explicit propagation
+        /// [`BindType`] (bind / catch / capture-bind / capture-catch),
+        /// receiving the raw [`WhiskerValue`] body. The general escape
+        /// hatch behind the typed `on_<event>` / `on_<event>_catch` /
+        /// `on_capture_<event>[_catch]` methods.
+        fn bind<F: Fn(WhiskerValue) + 'static>(
+            self,
+            event: &'static str,
+            bind_type: BindType,
+            f: F,
+        ) -> Self {
+            set_event_listener(
+                self.__element(),
+                event,
+                bind_type,
+                ::std::boxed::Box::new(f),
+            );
             self
         }
 

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -80,6 +80,7 @@ impl DynRenderer for Recorder {
         &mut self,
         _h: Element,
         _name: &str,
+        _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
     }

--- a/crates/whisker/tests/element_ref.rs
+++ b/crates/whisker/tests/element_ref.rs
@@ -62,6 +62,7 @@ impl DynRenderer for Recorder {
         &mut self,
         _h: Element,
         _n: &str,
+        _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
     }

--- a/crates/whisker/tests/module_component.rs
+++ b/crates/whisker/tests/module_component.rs
@@ -83,6 +83,7 @@ impl DynRenderer for Recorder {
         &mut self,
         h: Element,
         name: &str,
+        _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
         self.log.borrow_mut().push(Op::Event {

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -101,6 +101,7 @@ impl DynRenderer for Recorder {
         &mut self,
         h: Element,
         name: &str,
+        _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
         self.log.borrow_mut().push(Op::Event {

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -11,16 +11,35 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, create_owner, dispose_owner};
-use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
+use whisker::runtime::view::{
+    install_renderer, uninstall_renderer, BindType, DynRenderer, Element,
+};
 use whisker::{flush, with_owner};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
-    Create { id: u32, tag: ElementTag },
-    SetAttr { id: u32, key: String, value: String },
-    SetStyles { id: u32, css: String },
-    Append { parent: u32, child: u32 },
-    Event { id: u32, name: String },
+    Create {
+        id: u32,
+        tag: ElementTag,
+    },
+    SetAttr {
+        id: u32,
+        key: String,
+        value: String,
+    },
+    SetStyles {
+        id: u32,
+        css: String,
+    },
+    Append {
+        parent: u32,
+        child: u32,
+    },
+    Event {
+        id: u32,
+        name: String,
+        bind_type: BindType,
+    },
 }
 
 #[derive(Default)]
@@ -78,11 +97,13 @@ impl DynRenderer for Recorder {
         &mut self,
         h: Element,
         name: &str,
+        bind_type: BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
         self.log.borrow_mut().push(Op::Event {
             id: h.id(),
             name: name.into(),
+            bind_type,
         });
     }
     fn set_root(&mut self, _p: Element) {}
@@ -246,12 +267,48 @@ fn on_tap_emits_set_event_listener() {
             view(on_tap: move |_| *f.borrow_mut() = true)
         };
         let ops = log.borrow();
-        assert!(ops
-            .iter()
-            .any(|op| matches!(op, Op::Event { name, .. } if name == "tap")));
+        assert!(ops.iter().any(|op| matches!(
+            op,
+            Op::Event { name, bind_type, .. } if name == "tap" && *bind_type == BindType::Bind
+        )));
         // The recorder stored but doesn't fire the callback —
         // verifying registration is enough at the macro layer.
         assert!(!*fired.borrow());
+    });
+}
+
+#[test]
+fn tap_propagation_variants_route_to_bind_types() {
+    // The 1:1 mapping: each `on_[capture_]tap[_catch]` kwarg registers
+    // a "tap" listener with the matching propagation `BindType`.
+    with_recorder(|log| {
+        let _ = render! {
+            view {
+                view(on_tap: |_| {})
+                view(on_tap_catch: |_| {})
+                view(on_capture_tap: |_| {})
+                view(on_capture_tap_catch: |_| {})
+            }
+        };
+        let kinds: Vec<BindType> = log
+            .borrow()
+            .iter()
+            .filter_map(|op| match op {
+                Op::Event {
+                    name, bind_type, ..
+                } if name == "tap" => Some(*bind_type),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            kinds,
+            [
+                BindType::Bind,
+                BindType::Catch,
+                BindType::CaptureBind,
+                BindType::CaptureCatch,
+            ]
+        );
     });
 }
 

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -98,6 +98,7 @@ impl DynRenderer for Recorder {
         &mut self,
         h: Element,
         name: &str,
+        _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
         self.log.borrow_mut().push(Op::Event {

--- a/examples/counter/tests/counter_renders.rs
+++ b/examples/counter/tests/counter_renders.rs
@@ -81,6 +81,7 @@ impl DynRenderer for Recorder {
         &mut self,
         h: Element,
         name: &str,
+        _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
         self.log.borrow_mut().push(Op::Event {

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -592,6 +592,85 @@ pub fn measure_demo() -> Element {
     }
 }
 
+/// Phase 5 demo — event propagation (capture / bubble / catch).
+///
+/// Three nested boxes (outer → middle → inner) each register **both**
+/// a capture-phase and a bubble-phase `tap` handler. Tapping the inner
+/// box drives Whisker's reconstructed chain and appends each handler's
+/// tag to a reactive log, so the displayed order makes the phases
+/// concrete:
+///
+/// ```text
+/// ↓outer ↓middle ↓inner   ↑inner ↑middle ↑outer
+/// └────── capture ──────┘ └────── bubble ──────┘
+/// ```
+///
+/// Capture runs root→target, bubble runs target→root — exactly Lynx's
+/// model, reconstructed in Rust (`on_capture_tap` ↔ `capture-bindtap`,
+/// `on_tap` ↔ `bindtap`). Tapping the log line resets it. Swapping an
+/// `on_tap` for `on_tap_catch` on the middle box would stop the bubble
+/// at "middle" (no `↑outer`); `on_capture_tap_catch` on the outer box
+/// would swallow everything after `↓outer`.
+#[component]
+pub fn propagation_demo() -> Element {
+    let log = RwSignal::new(String::new());
+    let push = move |tag: &'static str| {
+        log.update(|s| {
+            if !s.is_empty() {
+                s.push(' ');
+            }
+            s.push_str(tag);
+        });
+    };
+    let label = computed(move || {
+        let s = log.get();
+        if s.is_empty() {
+            "tap the inner box →".to_string()
+        } else {
+            s
+        }
+    });
+
+    let box_style = |c: &str, pad: &str| {
+        format!(
+            "background-color: {c}; padding: {pad}; border-radius: 10px; \
+             display: flex; flex-direction: column; align-items: center; \
+             justify-content: center;"
+        )
+    };
+    render! {
+        view(style: "margin: 8px 16px; display: flex; flex-direction: column; gap: 8px;") {
+            text(
+                value: label,
+                on_tap: move |_| log.set(String::new()),
+                style: "color: #b9a9ff; font-size: 13px; font-weight: 600; \
+                        font-family: monospace; padding: 6px;",
+            )
+            view(
+                style: box_style("#241946", "20px"),
+                on_capture_tap: move |_| push("\u{2193}outer"),
+                on_tap: move |_| push("\u{2191}outer"),
+            ) {
+                text(value: "outer", style: "color: rgba(255,255,255,0.5); font-size: 11px;")
+                view(
+                    style: box_style("#3a2a6b", "20px"),
+                    on_capture_tap: move |_| push("\u{2193}middle"),
+                    on_tap: move |_| push("\u{2191}middle"),
+                ) {
+                    text(value: "middle", style: "color: rgba(255,255,255,0.6); font-size: 11px;")
+                    view(
+                        style: box_style("#5b43a8", "18px"),
+                        on_capture_tap: move |_| push("\u{2193}inner"),
+                        on_tap: move |_| push("\u{2191}inner"),
+                    ) {
+                        text(value: "inner", style: "color: white; font-size: 12px; font-weight: 700;")
+                    }
+                }
+            }
+        }
+    }
+}
+
 #[whisker::main]
 fn app() -> Element {
     // Allocate every app-wide signal in the bootstrap owner. `AppState`
@@ -617,6 +696,7 @@ fn app() -> Element {
             Hello(style: "width: 100%; height: 8px;")
             VideoDemo()
             MeasureDemo()
+            PropagationDemo()
             Header()
             ScrollBody(state: state)
             NowPlaying(state: state)

--- a/examples/hn-reader/tests/render.rs
+++ b/examples/hn-reader/tests/render.rs
@@ -80,6 +80,7 @@ impl DynRenderer for Recorder {
         &mut self,
         h: Element,
         name: &str,
+        _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
         self.log.borrow_mut().push(Op::Event {


### PR DESCRIPTION
## Phase 5 — event propagation control

Adds Lynx's four event-handler kinds as a faithful 1:1 API on every built-in element, for the touch family (`tap`/`longpress`/`click`/`touch*`):

| Whisker method | Lynx | phase / stop |
|---|---|---|
| `on_tap` | `bindtap` | bubble, doesn't stop |
| `on_tap_catch` | `catchtap` | bubble, stops |
| `on_capture_tap` | `capture-bindtap` | capture, doesn't stop |
| `on_capture_tap_catch` | `capture-catchtap` | capture, stops |

Plus a raw escape hatch `bind(name, BindType, f)` for arbitrary event names.

## Why reconstructed in Rust (not native Lynx handlers)

The originally-planned approach — set real `SetJSEventHandler` handlers and let Lynx's native chain propagate, observing via the reporter — was found **infeasible** (verified from fork source): the platform reporter hook fires **once, at the hit-tested target, before** — and bypassing — the engine's own capture/bubble chain (whose per-element firings target the absent JS runtime). So native `BindType` handlers are inert to Whisker.

Instead Whisker reconstructs propagation itself: the bridge forwards every reported event to a dispatcher the driver registers; the `BridgeRenderer` owns a sign-keyed parent map + per-element listener registry (with each listener's `BindType`) and replays Lynx's `HandleEventInternal` ordering — **capture root→target, bubble target→root, catch stops bubbling, capture-catch stops everything**. The reporter's bool return = consume (skip Lynx's native chain) vs passthrough. No Lynx fork release needed; both platforms route through the same `whisker_bridge_internal_dispatch_event`.

**Plan-then-fire**: planning runs under the renderer borrow and returns the ordered firings; listeners fire *after* the borrow is released, so a handler may freely mutate signals / re-enter the renderer. Each listener receives the body with `currentTarget` rewritten to its element.

## Changes

- **runtime**: `BindType` enum, `EventDispatchPlan`, `plan_event_dispatch` trait method + free `dispatch_event`; `set_event_listener` gains `bind_type`.
- **driver**: sign-keyed tree + listener maps; pure `lynx::propagation::plan` (7 unit tests); bootstrap registers the dispatcher.
- **bridge**: `register_event_dispatcher` + `element_sign` C ABI; the old C++ listener registry is removed (`set_event_listener*` become no-op ABI stubs).
- **macro**: route `on_[capture_]<event>[_catch]` kwargs to the typed methods.
- **demo**: nested capture/bubble box in hello-world showing the fire order.

## Scope

This phase solidifies the propagation **mechanism** over the universal touch event set. Component-specific events (`scroll`, input `change`/`focus`/`blur`), mouse/wheel/keyboard, and `global-bindEvent` are reachable today via the raw `on`/`bind` escape hatch but don't yet have typed methods — a follow-up "event coverage" phase.

## Verification

- **iOS**: build + link + launch; **real-tap end-to-end** — inner tap produced `↓outer ↓middle ↓inner ↑inner ↑middle ↑outer` (capture→bubble).
- **Android**: build + link + launch; verified via logcat — inner tap → `dispatch target=33 chain=[33,30,27,24,10] firings=6`, label updated. (No fork release: same dispatcher path as iOS.)
- 7 propagation unit tests + macro routing test; full workspace test suite green; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)