### PR TITLE
feat(events): component-event coverage for built-in tags (scroll / image / text)

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -62,6 +62,7 @@ const BRIDGE_EXPORTS: &[&str] = &[
     // signs to key its tree + listener maps.
     "_whisker_bridge_register_event_dispatcher",
     "_whisker_bridge_element_sign",
+    "_whisker_bridge_set_native_event_handler",
     "_whisker_bridge_set_root",
     "_whisker_bridge_flush",
     "_whisker_bridge_invoke_module",

--- a/crates/whisker-build/src/lynx.rs
+++ b/crates/whisker-build/src/lynx.rs
@@ -57,33 +57,38 @@ use std::path::{Path, PathBuf};
 /// Schema: `<lynx-upstream-version>-whisker.<patch-iteration>` so a
 /// reader can tell at a glance which upstream Lynx is wrapped, and
 /// our own patch iterations bump independently.
-pub const LYNX_FORK_TAG: &str = "v3.7.0-whisker.5";
+pub const LYNX_FORK_TAG: &str = "v3.7.0-whisker.6";
 
 /// Version segment that appears in cache paths + tarball filenames.
 /// Derived from [`LYNX_FORK_TAG`] minus the leading `v`.
-pub const LYNX_VERSION: &str = "3.7.0-whisker.5";
+pub const LYNX_VERSION: &str = "3.7.0-whisker.6";
 
 /// SHA-256 of `whisker-lynx-android-<LYNX_VERSION>.tar.gz` as
 /// produced by the fork's CI. Pinned to the
-/// [v3.7.0-whisker.5 release](https://github.com/whiskerrs/lynx/releases/tag/v3.7.0-whisker.5).
+/// [v3.7.0-whisker.6 release](https://github.com/whiskerrs/lynx/releases/tag/v3.7.0-whisker.6).
 ///
-/// Bump from `.4`: rebuilds Android `liblynx.so` against
-/// whiskerrs/lynx#4, which adds `lynx_ui_invoke_method_async` to
-/// `core/native_renderer_capi/` (result-returning UI-method dispatch).
-/// Required so `ElementRef::invoke_async` / `bounding_client_rect()` /
-/// `take_screenshot()` work on Android — the prior pin's liblynx.so
-/// only exported the fire-and-forget `lynx_ui_invoke_method`.
+/// Bump from `.5`: rebuilds Android `liblynx.so` against
+/// whiskerrs/lynx#6, which adds `lynx_element_set_event_handler` to
+/// `core/native_renderer_capi/`. The driver calls it to populate an
+/// element's Lynx event set so the UI components actually EMIT their
+/// component-specific events (scroll / layout / uiappear / image load /
+/// …) — without a bound handler Lynx never fires them. Required for the
+/// Phase 6 component-event coverage on Android.
 pub const LYNX_ANDROID_SHA256: &str =
-    "e0239e4099daeb0ff5fc568e78450d49b37ce12b96bd21844b7e4493fab00fb0";
+    "14ad8ffafda503d41777df38ee84d464926e1edc91cf6e9769e52d87ec5b7eaa";
 
-/// SHA-256 of `whisker-lynx-ios-<LYNX_VERSION>.tar.gz`. Pinned to
-/// the same release as Android — the fork's CI builds both halves
-/// in parallel and uploads them as a pair.
+/// SHA-256 of `whisker-lynx-ios-<LYNX_VERSION>.tar.gz`.
 ///
-/// The iOS xcframework doesn't carry `core/native_renderer_capi/`
-/// (Whisker compiles `lynx_native_renderer.cc` itself on iOS), so
-/// the `.5` `lynx_ui_invoke_method_async` addition is Android-only;
-/// but both halves stay on the same Lynx tag to avoid version skew.
+/// **Republished from `.5`, byte-identical.** The `.6` change lives
+/// entirely in `core/native_renderer_capi/`, which only the Android
+/// build compiles (iOS compiles `lynx_native_renderer.cc` from the
+/// Whisker repo, and the xcframework doesn't carry it). So the iOS
+/// Lynx engine for `.6` is identical to `.5`. The fork's `.6` iOS CI
+/// build hit an unrelated environmental break (a `macos-14` runner
+/// toolchain drift surfacing a `modp_b64` symbol error in Lynx core),
+/// so rather than skew versions across platforms we republished the
+/// known-good `.5` xcframework under the `.6` filename — same content,
+/// same hash. iOS + Android therefore stay on a single Lynx version.
 pub const LYNX_IOS_SHA256: &str =
     "21fafd09a7c2018bb9b90b65efaef4c35aa88398c363e634058c9aeae7db3fa4";
 

--- a/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
@@ -106,6 +106,19 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_set_inline_styles(
     lynx_fiber_element_t* element,
     const char* css);
 
+// Register a (bubble-phase, `bindEvent`) event handler for
+// `event_name` on `element`. Whisker has no JS runtime, so the handler
+// function is a sentinel — the actual fire is observed via the
+// event-reporter hook. The point of registering it is to populate the
+// element's event set: Lynx's UI components only EMIT their
+// component-specific events (scroll, layout, uiappear, …) when the
+// element has a handler bound for that event name. Touch/gesture events
+// don't need this (they flow through the gesture pipeline → reporter
+// regardless), so Whisker only calls this for non-gesture events.
+LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_set_event_handler(
+    lynx_fiber_element_t* element,
+    const char* event_name);
+
 LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_append_child(
     lynx_fiber_element_t* parent,
     lynx_fiber_element_t* child);

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -275,6 +275,18 @@ WHISKER_BRIDGE_EXPORT void whisker_bridge_register_event_dispatcher(
 // uses for its tree + listener maps. Returns 0 for a null element.
 WHISKER_BRIDGE_EXPORT int32_t whisker_bridge_element_sign(WhiskerElement* element);
 
+// Register a bubble-phase event handler for `event_name` on `element`,
+// populating its Lynx event set. Lynx's UI components only EMIT their
+// component-specific events (scroll / layout / uiappear / …) when a
+// handler is bound for that name — so the driver calls this for
+// non-gesture events. (Touch/gesture events reach the reporter through
+// the gesture pipeline regardless, so they don't need this.) The
+// handler is a sentinel; Whisker still observes the fire via the
+// reporter → dispatcher path.
+WHISKER_BRIDGE_EXPORT void whisker_bridge_set_native_event_handler(
+    WhiskerElement* element,
+    const char* event_name);
+
 // Per-module dispatch function — the platform-side Swift Macro or
 // KSP processor emits one of these per `@WhiskerModule`-annotated
 // class. The bridge stores `(module_name → dispatch_fn)` in an

--- a/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
+++ b/crates/whisker-driver-sys/bridge/src/lynx_native_renderer.cc
@@ -24,6 +24,7 @@
 #include "core/renderer/dom/element_manager.h"
 #include "core/renderer/dom/fiber/fiber_element.h"
 #include "core/renderer/dom/fiber/page_element.h"
+#include "core/renderer/events/events.h"
 #include "core/renderer/dom/fiber/raw_text_element.h"
 #include "core/renderer/dom/fiber/scroll_element.h"
 #include "core/renderer/dom/fiber/text_element.h"
@@ -191,6 +192,24 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_set_attribute(
   element->ref->SetAttribute(
       lynx::base::String(key),
       lynx::lepus::Value(lynx::base::String(value)));
+}
+
+LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_set_event_handler(
+    lynx_fiber_element_t* element,
+    const char* event_name) {
+  if (element == nullptr || !element->ref || event_name == nullptr) {
+    return;
+  }
+  // Bind a bubble-phase (`bindEvent`) handler. The function name is a
+  // sentinel — Whisker observes the fire via the reporter, not by
+  // calling a JS function (there is no JS runtime). Registering the
+  // handler is what puts the event in the element's event set, which is
+  // what makes Lynx's UI components emit their component-specific events
+  // (scroll, layout, uiappear, …) in the first place.
+  element->ref->SetJSEventHandler(
+      lynx::base::String(event_name),
+      lynx::base::String(lynx::tasm::kEventBindEvent),
+      lynx::base::String("__whisker_native__"));
 }
 
 LYNX_NATIVE_RENDERER_CAPI_EXPORT void lynx_element_set_inline_styles(

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -285,13 +285,10 @@ extern "C" void whisker_bridge_set_native_event_handler(WhiskerElement* element,
     // event (scroll / layout / uiappear / …). The fire is still observed
     // via the reporter → dispatcher path.
     //
-    // Android: `lynx_element_set_event_handler` lives in the Lynx fork's
-    // liblynx — guard it out until the fork ships the capi (whisker.6).
-    // Until then, component events stay dark on Android (touch/gesture
-    // events are unaffected — they don't go through the event set).
-#if !defined(__ANDROID__)
+    // `lynx_element_set_event_handler` ships in the Lynx fork's liblynx
+    // as of v3.7.0-whisker.6 (whiskerrs/lynx#6), so this works on both
+    // platforms now.
     lynx_element_set_event_handler(element->handle, event_name);
-#endif
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -276,6 +276,24 @@ extern "C" int32_t whisker_bridge_element_sign(WhiskerElement* element) {
     return lynx_element_id(element->handle);
 }
 
+extern "C" void whisker_bridge_set_native_event_handler(WhiskerElement* element,
+                                                        const char* event_name) {
+    if (element == nullptr || element->handle == nullptr || event_name == nullptr) {
+        return;
+    }
+    // Populate the element's Lynx event set so its UI component emits the
+    // event (scroll / layout / uiappear / …). The fire is still observed
+    // via the reporter → dispatcher path.
+    //
+    // Android: `lynx_element_set_event_handler` lives in the Lynx fork's
+    // liblynx — guard it out until the fork ships the capi (whisker.6).
+    // Until then, component events stay dark on Android (touch/gesture
+    // events are unaffected — they don't go through the event set).
+#if !defined(__ANDROID__)
+    lynx_element_set_event_handler(element->handle, event_name);
+#endif
+}
+
 // ----------------------------------------------------------------------------
 // Pipeline
 // ----------------------------------------------------------------------------

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -225,6 +225,15 @@ extern "C" {
     /// tree + listener maps. Returns 0 for a null element.
     pub fn whisker_bridge_element_sign(element: *mut WhiskerElement) -> i32;
 
+    /// Register a bubble-phase event handler for `event_name` on
+    /// `element`, populating its Lynx event set so the UI component
+    /// emits the event. The driver calls this for non-gesture
+    /// (component) events; touch/gesture events don't need it.
+    pub fn whisker_bridge_set_native_event_handler(
+        element: *mut WhiskerElement,
+        event_name: *const c_char,
+    );
+
     pub fn whisker_bridge_set_root(engine: *mut WhiskerEngine, page: *mut WhiskerElement);
     pub fn whisker_bridge_flush(engine: *mut WhiskerEngine);
 

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -199,9 +199,26 @@ impl DynRenderer for BridgeRenderer {
         // Lynx's reporter hook fires once at the target, before — and
         // bypassing — the engine's own capture/bubble chain (which
         // targets the absent JS runtime). See `plan_event_dispatch`.
+        let Some(ptr) = self.lookup(handle) else {
+            return;
+        };
         let Some(sign) = self.sign_of(handle) else {
             return;
         };
+        // Component-specific events (scroll / layout / uiappear / …) are
+        // only EMITTED by Lynx's UI components when the element has a
+        // handler bound for that name (they're gated on its event set).
+        // Touch/gesture events bypass the event set — they flow through
+        // the gesture pipeline to the reporter regardless — so we only
+        // register a native handler for the non-gesture events, both to
+        // unblock their emission and to avoid any double-fire on touch.
+        if !is_gesture_event(event_name) {
+            if let Ok(name_c) = CString::new(event_name) {
+                unsafe {
+                    ffi::whisker_bridge_set_native_event_handler(ptr.as_ptr(), name_c.as_ptr())
+                };
+            }
+        }
         let entry = self
             .listeners
             .entry((sign, event_name.to_string()))
@@ -273,6 +290,17 @@ impl DynRenderer for BridgeRenderer {
             .map(|p| p.as_ptr() as usize)
             .unwrap_or(0)
     }
+}
+
+/// Whether `event_name` is a touch/gesture event that Lynx delivers to
+/// the reporter through its gesture pipeline regardless of the
+/// element's event set. These need no native handler registration;
+/// every other (component-emitted) event does, or Lynx never fires it.
+fn is_gesture_event(event_name: &str) -> bool {
+    matches!(
+        event_name,
+        "tap" | "longpress" | "click" | "touchstart" | "touchmove" | "touchend" | "touchcancel"
+    )
 }
 
 /// Clone `body`, rewriting its `currentTarget.uid` to `sign` — the

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -564,6 +564,22 @@ fn is_known_event_method(name: &str) -> bool {
             | "on_transitionstart"
             | "on_transitionend"
             | "on_transitioncancel"
+            // Component-specific events (CustomEvent → bind only). These
+            // are inherent methods on a single tag's builder (scroll_view
+            // / image / text), so the macro emits `.on_scroll(f)` etc.;
+            // using one on the wrong tag is a clear "no method" error.
+            | "on_scroll"
+            | "on_scrolltoupper"
+            | "on_scrolltolower"
+            | "on_scrollend"
+            | "on_contentsizechanged"
+            | "on_load"
+            | "on_error"
+            | "on_startplay"
+            | "on_currentloopcomplete"
+            | "on_finalloopcomplete"
+            | "on_layout"
+            | "on_selectionchange"
     );
     // … plus the catch / capture propagation variants for the touch
     // family (`on_tap_catch`, `on_capture_tap`, `on_capture_tap_catch`,

--- a/crates/whisker-runtime/src/event.rs
+++ b/crates/whisker-runtime/src/event.rs
@@ -25,8 +25,9 @@
 //! zero-valued field rather than dropping the handler call.
 
 use std::collections::BTreeMap;
+use std::fmt;
 
-use serde::de::DeserializeOwned;
+use serde::de::{self, DeserializeOwned, Deserializer, MapAccess, Visitor};
 use serde::Deserialize;
 
 use crate::value::WhiskerValue;
@@ -94,18 +95,84 @@ where
 /// The element an event targets / is listening on. Shared by
 /// `target` (where the event originated) and `currentTarget` (the
 /// element whose handler is firing).
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default)]
 pub struct Target {
     /// The element's `id` attribute (empty when unset).
-    #[serde(default)]
     pub id: String,
-    /// Lynx Engine's unique element identifier.
-    #[serde(default)]
+    /// Lynx Engine's unique element identifier (its "sign").
     pub uid: i64,
     /// `data-*` attributes attached to the element, keyed without
     /// the `data-` prefix.
-    #[serde(default)]
     pub dataset: BTreeMap<String, WhiskerValue>,
+}
+
+// The platform reporter hands us the *raw* event body, where `target`
+// and `currentTarget` are plain integer signs (Lynx
+// `LynxEvent.generateEventBody`: `body["target"] = targetSign`). The
+// richer `{id, dataset, uid}` object is only synthesized downstream in
+// the JS layer, which Whisker bypasses. So `Target` must deserialize
+// from EITHER an integer (→ `uid`, with empty `id`/`dataset`) or a
+// `{id, uid, dataset}` object — a hard "expected struct, got number"
+// error here would otherwise fail the *whole* event struct and blank
+// every field (including `detail`).
+impl<'de> Deserialize<'de> for Target {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TargetVisitor;
+        impl<'de> Visitor<'de> for TargetVisitor {
+            type Value = Target;
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("an element sign (integer) or a target object")
+            }
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Target, E> {
+                Ok(Target {
+                    uid: v,
+                    ..Default::default()
+                })
+            }
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Target, E> {
+                Ok(Target {
+                    uid: v as i64,
+                    ..Default::default()
+                })
+            }
+            fn visit_f64<E: de::Error>(self, v: f64) -> Result<Target, E> {
+                Ok(Target {
+                    uid: v as i64,
+                    ..Default::default()
+                })
+            }
+            fn visit_unit<E: de::Error>(self) -> Result<Target, E> {
+                Ok(Target::default())
+            }
+            fn visit_none<E: de::Error>(self) -> Result<Target, E> {
+                Ok(Target::default())
+            }
+            fn visit_map<A>(self, map: A) -> Result<Target, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Obj {
+                    #[serde(default)]
+                    id: String,
+                    #[serde(default)]
+                    uid: i64,
+                    #[serde(default)]
+                    dataset: BTreeMap<String, WhiskerValue>,
+                }
+                let o = Obj::deserialize(de::value::MapAccessDeserializer::new(map))?;
+                Ok(Target {
+                    id: o.id,
+                    uid: o.uid,
+                    dataset: o.dataset,
+                })
+            }
+        }
+        deserializer.deserialize_any(TargetVisitor)
+    }
 }
 
 /// A 2-D point in LynxView coordinates — the `detail` of a
@@ -520,5 +587,57 @@ mod tests {
         assert_eq!(e.detail.lines.len(), 2);
         assert_eq!(e.detail.lines[1].end, 18);
         assert_eq!(e.detail.lines[1].ellipsis_count, 3);
+    }
+
+    #[test]
+    fn integer_target_signs_dont_blank_the_event() {
+        // The REAL reporter body: `target` / `currentTarget` are plain
+        // integer signs (LynxEvent.generateEventBody), not objects.
+        // Target's int-or-object deserialize must accept that so the
+        // sibling `detail` still populates (a type mismatch here used
+        // to fail the whole struct → all-zero payload).
+        let v = WhiskerValue::map([
+            ("type", WhiskerValue::String("scroll".into())),
+            ("target", WhiskerValue::Int(33)),
+            ("currentTarget", WhiskerValue::Int(33)),
+            (
+                "detail",
+                WhiskerValue::map([
+                    ("scrollLeft", WhiskerValue::Float(640.0)),
+                    ("scrollWidth", WhiskerValue::Float(832.0)),
+                    ("isDragging", WhiskerValue::Bool(true)),
+                ]),
+            ),
+        ]);
+        let e: ScrollEvent = v
+            .deserialize_into()
+            .expect("deserialize with integer target");
+        assert_eq!(e.target.uid, 33); // sign mapped to uid
+        assert_eq!(e.target.id, ""); // raw body carries no id
+        assert_eq!(e.current_target.uid, 33);
+        // The sibling detail must survive the integer target.
+        assert_eq!(e.detail.scroll_left, 640.0);
+        assert_eq!(e.detail.scroll_width, 832.0);
+        assert!(e.detail.is_dragging);
+    }
+
+    #[test]
+    fn touch_event_integer_target() {
+        let v = WhiskerValue::map([
+            ("type", WhiskerValue::String("tap".into())),
+            ("target", WhiskerValue::Int(7)),
+            (
+                "detail",
+                WhiskerValue::map([
+                    ("x", WhiskerValue::Float(10.0)),
+                    ("y", WhiskerValue::Float(20.0)),
+                ]),
+            ),
+        ]);
+        let e: TouchEvent = v
+            .deserialize_into()
+            .expect("deserialize TouchEvent int target");
+        assert_eq!(e.target.uid, 7);
+        assert_eq!(e.detail.x, 10.0);
     }
 }

--- a/crates/whisker-runtime/src/event.rs
+++ b/crates/whisker-runtime/src/event.rs
@@ -223,6 +223,169 @@ pub struct CustomEvent {
     pub detail: WhiskerValue,
 }
 
+/// A 2-D size — `width` / `height` in px.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub struct Size {
+    #[serde(default)]
+    pub width: f64,
+    #[serde(default)]
+    pub height: f64,
+}
+
+// ---- scroll_view -----------------------------------------------------------
+
+/// `<scroll_view>` scroll events — `scroll`, `scrolltoupper`,
+/// `scrolltolower`, `scrollend`, `contentsizechanged`. The `detail`
+/// carries the current scroll geometry. (CustomEvent → target-only, so
+/// these have no catch/capture variants — see Lynx `CustomEvent`
+/// defaults `Capture::kNo, Bubbles::kNo`.)
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ScrollEvent {
+    #[serde(rename = "type", default)]
+    pub kind: String,
+    #[serde(default)]
+    pub timestamp: f64,
+    #[serde(default)]
+    pub target: Target,
+    #[serde(rename = "currentTarget", default)]
+    pub current_target: Target,
+    #[serde(default)]
+    pub detail: ScrollDetail,
+}
+
+/// Scroll geometry carried by a [`ScrollEvent`] (the event body's
+/// `detail` dict — see Lynx `LynxScrollEventManager`).
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScrollDetail {
+    /// Horizontal content offset (px).
+    #[serde(default)]
+    pub scroll_left: f64,
+    /// Vertical content offset (px).
+    #[serde(default)]
+    pub scroll_top: f64,
+    /// Total scrollable content width (px).
+    #[serde(default)]
+    pub scroll_width: f64,
+    /// Total scrollable content height (px).
+    #[serde(default)]
+    pub scroll_height: f64,
+    /// Horizontal delta since the previous scroll event (px).
+    #[serde(default)]
+    pub delta_x: f64,
+    /// Vertical delta since the previous scroll event (px).
+    #[serde(default)]
+    pub delta_y: f64,
+    /// Whether the user's finger is currently dragging the scroll view.
+    #[serde(default)]
+    pub is_dragging: bool,
+}
+
+// ---- image -----------------------------------------------------------------
+
+/// `load` on `<image>` — the image request succeeded; `detail` gives
+/// the intrinsic pixel size. (`error` / animated-image events surface
+/// as [`CustomEvent`] — their detail is component-specific.)
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ImageLoadEvent {
+    #[serde(rename = "type", default)]
+    pub kind: String,
+    #[serde(default)]
+    pub timestamp: f64,
+    #[serde(default)]
+    pub target: Target,
+    #[serde(rename = "currentTarget", default)]
+    pub current_target: Target,
+    #[serde(default)]
+    pub detail: ImageLoadDetail,
+}
+
+/// Intrinsic image size carried by an [`ImageLoadEvent`].
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub struct ImageLoadDetail {
+    #[serde(default)]
+    pub width: f64,
+    #[serde(default)]
+    pub height: f64,
+}
+
+// ---- text ------------------------------------------------------------------
+
+/// `layout` on `<text>` — fired after text layout completes.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TextLayoutEvent {
+    #[serde(rename = "type", default)]
+    pub kind: String,
+    #[serde(default)]
+    pub timestamp: f64,
+    #[serde(default)]
+    pub target: Target,
+    #[serde(rename = "currentTarget", default)]
+    pub current_target: Target,
+    #[serde(default)]
+    pub detail: TextLayoutDetail,
+}
+
+/// Layout info carried by a [`TextLayoutEvent`].
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextLayoutDetail {
+    /// Number of laid-out lines.
+    #[serde(default)]
+    pub line_count: i64,
+    /// Per-line ranges (and ellipsis info for truncated lines).
+    #[serde(default)]
+    pub lines: Vec<TextLineInfo>,
+    /// Laid-out content size.
+    #[serde(default)]
+    pub size: Size,
+}
+
+/// One laid-out text line inside a [`TextLayoutDetail`].
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextLineInfo {
+    /// Character index of the line's first glyph.
+    #[serde(default)]
+    pub start: i64,
+    /// Character index just past the line's last glyph.
+    #[serde(default)]
+    pub end: i64,
+    /// Number of characters replaced by the truncation ellipsis (0 if
+    /// the line isn't truncated).
+    #[serde(default)]
+    pub ellipsis_count: i64,
+}
+
+/// `selectionchange` on `<text>` — the selected text range changed.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SelectionChangeEvent {
+    #[serde(rename = "type", default)]
+    pub kind: String,
+    #[serde(default)]
+    pub timestamp: f64,
+    #[serde(default)]
+    pub target: Target,
+    #[serde(rename = "currentTarget", default)]
+    pub current_target: Target,
+    #[serde(default)]
+    pub detail: SelectionDetail,
+}
+
+/// Selection range carried by a [`SelectionChangeEvent`].
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SelectionDetail {
+    /// Start character index, or -1 when there's no selection.
+    #[serde(default)]
+    pub start: i64,
+    /// End character index, or -1 when there's no selection.
+    #[serde(default)]
+    pub end: i64,
+    /// `"forward"` or `"backward"`.
+    #[serde(default)]
+    pub direction: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,5 +452,73 @@ mod tests {
             WhiskerValue::Map(m) => assert_eq!(m.get("scrollTop"), Some(&WhiskerValue::Int(42))),
             other => panic!("expected Map detail, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn scroll_event_detail_camel_case_mapping() {
+        // Mirrors Lynx's LynxScrollEventManager detail dict.
+        let v = WhiskerValue::map([
+            ("type", WhiskerValue::String("scroll".into())),
+            (
+                "detail",
+                WhiskerValue::map([
+                    ("scrollLeft", WhiskerValue::Float(0.0)),
+                    ("scrollTop", WhiskerValue::Float(120.0)),
+                    ("scrollHeight", WhiskerValue::Float(2000.0)),
+                    ("scrollWidth", WhiskerValue::Float(375.0)),
+                    ("deltaY", WhiskerValue::Float(12.0)),
+                    ("isDragging", WhiskerValue::Bool(true)),
+                ]),
+            ),
+        ]);
+        let e: ScrollEvent = v.deserialize_into().expect("deserialize ScrollEvent");
+        assert_eq!(e.kind, "scroll");
+        assert_eq!(e.detail.scroll_top, 120.0);
+        assert_eq!(e.detail.scroll_height, 2000.0);
+        assert_eq!(e.detail.delta_y, 12.0);
+        assert!(e.detail.is_dragging);
+        // Absent key degrades to default rather than failing.
+        assert_eq!(e.detail.delta_x, 0.0);
+    }
+
+    #[test]
+    fn text_layout_event_nested_lines_and_size() {
+        let v = WhiskerValue::map([
+            ("type", WhiskerValue::String("layout".into())),
+            (
+                "detail",
+                WhiskerValue::map([
+                    ("lineCount", WhiskerValue::Int(2)),
+                    (
+                        "size",
+                        WhiskerValue::map([
+                            ("width", WhiskerValue::Float(300.0)),
+                            ("height", WhiskerValue::Float(40.0)),
+                        ]),
+                    ),
+                    (
+                        "lines",
+                        WhiskerValue::Array(vec![
+                            WhiskerValue::map([
+                                ("start", WhiskerValue::Int(0)),
+                                ("end", WhiskerValue::Int(10)),
+                                ("ellipsisCount", WhiskerValue::Int(0)),
+                            ]),
+                            WhiskerValue::map([
+                                ("start", WhiskerValue::Int(10)),
+                                ("end", WhiskerValue::Int(18)),
+                                ("ellipsisCount", WhiskerValue::Int(3)),
+                            ]),
+                        ]),
+                    ),
+                ]),
+            ),
+        ]);
+        let e: TextLayoutEvent = v.deserialize_into().expect("deserialize TextLayoutEvent");
+        assert_eq!(e.detail.line_count, 2);
+        assert_eq!(e.detail.size.width, 300.0);
+        assert_eq!(e.detail.lines.len(), 2);
+        assert_eq!(e.detail.lines[1].end, 18);
+        assert_eq!(e.detail.lines[1].ellipsis_count, 3);
     }
 }

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -54,7 +54,9 @@ pub use whisker_runtime::value::WhiskerValue;
 /// lifecycle / component-state events a [`CustomEvent`](event::CustomEvent).
 pub mod event {
     pub use whisker_runtime::event::{
-        AnimationEvent, BindType, CustomEvent, Event, Point, Target, Touch, TouchEvent,
+        AnimationEvent, BindType, CustomEvent, Event, ImageLoadDetail, ImageLoadEvent, Point,
+        ScrollDetail, ScrollEvent, SelectionChangeEvent, SelectionDetail, Size, Target,
+        TextLayoutDetail, TextLayoutEvent, TextLineInfo, Touch, TouchEvent,
     };
 }
 
@@ -119,7 +121,10 @@ pub use whisker_runtime::view::Children;
 #[doc(hidden)]
 pub mod __tags {
     use crate::ElementTag;
-    use whisker_runtime::event::{bind_typed, AnimationEvent, CustomEvent, TouchEvent};
+    use whisker_runtime::event::{
+        bind_typed, AnimationEvent, CustomEvent, ImageLoadEvent, ScrollEvent, SelectionChangeEvent,
+        TextLayoutEvent, TouchEvent,
+    };
     use whisker_runtime::reactive::Signal;
     use whisker_runtime::value::WhiskerValue;
     use whisker_runtime::view::{
@@ -637,6 +642,23 @@ pub mod __tags {
             apply_attr(raw, "text", v);
             self
         }
+
+        // ---- text-specific events (CustomEvent → bind only) ---------
+
+        /// `layout` — fired after text layout completes. The
+        /// [`TextLayoutEvent`] reports line count, per-line ranges, and
+        /// the laid-out size.
+        pub fn on_layout<F: Fn(TextLayoutEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "layout", BindType::Bind, f);
+            self
+        }
+
+        /// `selectionchange` — fired when the selected text range
+        /// changes (requires text selection to be enabled).
+        pub fn on_selectionchange<F: Fn(SelectionChangeEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "selectionchange", BindType::Bind, f);
+            self
+        }
     }
 
     /// `<raw-text>` — leaf text node carrying actual glyphs. Created
@@ -692,6 +714,42 @@ pub mod __tags {
             apply_attr(self.handle, "src", v);
             self
         }
+
+        // ---- image-specific events (CustomEvent → bind only) --------
+
+        /// `load` — the image request succeeded. The
+        /// [`ImageLoadEvent`] carries the intrinsic pixel size.
+        pub fn on_load<F: Fn(ImageLoadEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "load", BindType::Bind, f);
+            self
+        }
+
+        /// `error` — the image failed to load. The [`CustomEvent`]
+        /// `detail` carries component-specific error info.
+        pub fn on_error<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "error", BindType::Bind, f);
+            self
+        }
+
+        /// `startplay` — an animated image (APNG/GIF) started playing.
+        pub fn on_startplay<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "startplay", BindType::Bind, f);
+            self
+        }
+
+        /// `currentloopcomplete` — one loop of an animated image
+        /// finished playing.
+        pub fn on_currentloopcomplete<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "currentloopcomplete", BindType::Bind, f);
+            self
+        }
+
+        /// `finalloopcomplete` — an animated image finished all its
+        /// `loop-count` loops.
+        pub fn on_finalloopcomplete<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "finalloopcomplete", BindType::Bind, f);
+            self
+        }
     }
 
     /// `<scroll-view>` — scrollable container.
@@ -718,6 +776,42 @@ pub mod __tags {
             V: ::std::convert::Into<Signal<::std::string::String>>,
         {
             apply_attr(self.handle, "scroll-orientation", v);
+            self
+        }
+
+        // ---- scroll events (CustomEvent → bind only) ----------------
+
+        /// `scroll` — fired continuously while scrolling. The
+        /// [`ScrollEvent`] `detail` carries the current offset, content
+        /// size, per-event delta, and drag state.
+        pub fn on_scroll<F: Fn(ScrollEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "scroll", BindType::Bind, f);
+            self
+        }
+
+        /// `scrolltoupper` — the upper/left edge reached the
+        /// `upper-threshold` visible area.
+        pub fn on_scrolltoupper<F: Fn(ScrollEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "scrolltoupper", BindType::Bind, f);
+            self
+        }
+
+        /// `scrolltolower` — the lower/right edge reached the
+        /// `lower-threshold` visible area.
+        pub fn on_scrolltolower<F: Fn(ScrollEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "scrolltolower", BindType::Bind, f);
+            self
+        }
+
+        /// `scrollend` — scrolling came to rest.
+        pub fn on_scrollend<F: Fn(ScrollEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "scrollend", BindType::Bind, f);
+            self
+        }
+
+        /// `contentsizechanged` — the scrollable content size changed.
+        pub fn on_contentsizechanged<F: Fn(ScrollEvent) + 'static>(self, f: F) -> Self {
+            bind_typed(self.handle, "contentsizechanged", BindType::Bind, f);
             self
         }
     }

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -313,6 +313,74 @@ fn tap_propagation_variants_route_to_bind_types() {
 }
 
 #[test]
+fn component_specific_events_route_bind_only() {
+    // Phase 6 coverage: tag-specific CustomEvents (scroll_view / image /
+    // text) register their named listener as BindType::Bind. They have
+    // no catch/capture variants (Lynx CustomEvent = target-only).
+    with_recorder(|log| {
+        let _ = render! {
+            scroll_view {
+                image(on_load: |_| {}, on_error: |_| {})
+                text(on_layout: |_| {}, on_selectionchange: |_| {})
+            }
+        };
+        // attach scroll handlers on the scroll_view itself via a second
+        // render (kwargs + children on one element are both fine, but
+        // keep this focused).
+        let names: Vec<(String, BindType)> = log
+            .borrow()
+            .iter()
+            .filter_map(|op| match op {
+                Op::Event {
+                    name, bind_type, ..
+                } => Some((name.clone(), *bind_type)),
+                _ => None,
+            })
+            .collect();
+        for n in ["load", "error", "layout", "selectionchange"] {
+            assert!(
+                names.contains(&(n.to_string(), BindType::Bind)),
+                "missing bind listener for {n}; got {names:?}"
+            );
+        }
+    });
+}
+
+#[test]
+fn scroll_view_scroll_events_route_bind() {
+    with_recorder(|log| {
+        let _ = render! {
+            scroll_view(
+                on_scroll: |_| {},
+                on_scrolltoupper: |_| {},
+                on_scrolltolower: |_| {},
+                on_scrollend: |_| {},
+                on_contentsizechanged: |_| {},
+            )
+        };
+        let names: Vec<String> = log
+            .borrow()
+            .iter()
+            .filter_map(|op| match op {
+                Op::Event {
+                    name, bind_type, ..
+                } if *bind_type == BindType::Bind => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        for n in [
+            "scroll",
+            "scrolltoupper",
+            "scrolltolower",
+            "scrollend",
+            "contentsizechanged",
+        ] {
+            assert!(names.contains(&n.to_string()), "missing {n}; got {names:?}");
+        }
+    });
+}
+
+#[test]
 fn camel_case_event_handler_lowercased() {
     with_recorder(|log| {
         let _ = render! {

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -455,6 +455,70 @@ fn activity_feed() -> Element {
     }
 }
 
+/// Phase 6 demo — scroll event payload. A horizontal `scroll_view`
+/// whose `on_scroll` reads the typed [`ScrollEvent`] and prints the
+/// `detail` fields live, so we can confirm the payload (scroll offset,
+/// content width, per-event delta, drag state) actually arrives across
+/// the bridge. Lives inside the vertical page scroll — the orthogonal
+/// directions don't conflict.
+#[component]
+fn scroll_card(n: i32, color: &'static str) -> Element {
+    let style = format!(
+        "width: 96px; height: 56px; flex-shrink: 0; margin-right: 8px; \
+         border-radius: 10px; background-color: {color}; \
+         display: flex; align-items: center; justify-content: center;"
+    );
+    render! {
+        view(style: style) {
+            text(value: format!("{n}"), style: "color: white; font-size: 18px; font-weight: 700;")
+        }
+    }
+}
+
+#[component]
+fn scroll_demo() -> Element {
+    let info = RwSignal::new(String::new());
+    let label = computed(move || {
+        let s = info.get();
+        if s.is_empty() {
+            "← swipe the row to read ScrollEvent →".to_string()
+        } else {
+            s
+        }
+    });
+    render! {
+        view(style: "margin: 4px 20px 8px; display: flex; flex-direction: column; gap: 6px;") {
+            text(
+                value: label,
+                style: "color: #b9a9ff; font-size: 12px; font-family: monospace;",
+            )
+            scroll_view(
+                scroll_orientation: "horizontal",
+                on_scroll: move |e| {
+                    info.set(format!(
+                        "left={:.0}  width={:.0}  dx={:.0}  drag={}",
+                        e.detail.scroll_left,
+                        e.detail.scroll_width,
+                        e.detail.delta_x,
+                        e.detail.is_dragging,
+                    ))
+                },
+                style: "height: 64px; display: flex; flex-direction: row; \
+                        background-color: #1a1330; border-radius: 12px; padding: 4px;",
+            ) {
+                ScrollCard(n: 1_i32, color: "#667eea")
+                ScrollCard(n: 2_i32, color: "#f093fb")
+                ScrollCard(n: 3_i32, color: "#4facfe")
+                ScrollCard(n: 4_i32, color: "#43e97b")
+                ScrollCard(n: 5_i32, color: "#fa709a")
+                ScrollCard(n: 6_i32, color: "#30cfd0")
+                ScrollCard(n: 7_i32, color: "#ff7e5f")
+                ScrollCard(n: 8_i32, color: "#9b6bff")
+            }
+        }
+    }
+}
+
 #[component]
 fn scroll_body(state: AppState) -> Element {
     let style = format!(
@@ -463,6 +527,7 @@ fn scroll_body(state: AppState) -> Element {
     );
     render! {
         scroll_view(scroll_orientation: "vertical", style: style) {
+            ScrollDemo()
             Chips()
             SectionHeader(title: "Recently Played")
             Recents()

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -46,17 +46,31 @@ class WhiskerView @JvmOverloads constructor(
     private val eventReporter = object : EventEmitter.LynxEventReporter {
         override fun onLynxEvent(event: LynxEvent): Boolean {
             val name = event.name ?: return false
-            // Hand the event body straight to native as a raw Java
-            // `Map<String, Any?>` — the bridge marshals it into a
-            // `WhiskerValueRaw` tree (no JSON round-trip), the same
-            // wire module args/returns use. `LynxCustomEvent` is the
-            // only public subclass carrying a params dict; touch /
-            // mouse / wheel / keyboard events surface no body here, so
-            // pass `null` (the bridge dispatches with no value, and the
-            // Rust typed-event layer falls back to a default).
-            val params: Map<String, Any?>? =
+            // Normalize the body to the same shape iOS's
+            // `LynxEvent.generateEventBody` produces —
+            // `{type, target, currentTarget, detail}` — so the typed
+            // event structs in `whisker_runtime::event` deserialize
+            // identically on both platforms. Android's reporter
+            // otherwise hands us only the raw params dict
+            // (`LynxCustomEvent.eventParams()`, where component events
+            // like `scroll` put their fields directly via `addDetail`),
+            // which has no `detail` wrapper or target keys — leaving the
+            // typed `detail` (and `target`) blank. `target`/`currentTarget`
+            // are the integer sign (the Rust `Target` deserializes an
+            // int → `uid`). `detail` is the params dict for
+            // `LynxCustomEvent` (scroll / layout / …), null otherwise
+            // (touch events carry no body on Android). The marshaller
+            // turns this Java map into a `WhiskerValueRaw` tree (no JSON).
+            val detail: Map<String, Any?>? =
                 if (event is LynxCustomEvent) event.eventParams() else null
-            return nativeOnLynxEvent(engine, event.tag, name, params)
+            val body: Map<String, Any?> =
+                mapOf(
+                    "type" to name,
+                    "target" to event.tag,
+                    "currentTarget" to event.tag,
+                    "detail" to detail,
+                )
+            return nativeOnLynxEvent(engine, event.tag, name, body)
         }
         override fun onInternalEvent(event: LynxInternalEvent) {}
     }


### PR DESCRIPTION
## Phase 6 — component-event coverage

Connects every documented component-specific Lynx event on Whisker's built-in tags as typed `on_<event>` methods, and fixes the (pre-existing) reasons component events never actually fired. Verified end-to-end on **both iOS and Android**.

### API added (all bind-only — Lynx `CustomEvent` is target-only: `Capture::kNo, Bubbles::kNo`)

| tag | methods | payload |
|---|---|---|
| `scroll_view` | `on_scroll` / `on_scrolltoupper` / `on_scrolltolower` / `on_scrollend` / `on_contentsizechanged` | `ScrollEvent` (`detail`: scroll_left/top/width/height, delta_x/y, is_dragging) |
| `image` | `on_load` → `ImageLoadEvent` (width/height); `on_error` / `on_startplay` / `on_currentloopcomplete` / `on_finalloopcomplete` → `CustomEvent` | |
| `text` | `on_layout` → `TextLayoutEvent` (line_count, lines[{start,end,ellipsis_count}], size); `on_selectionchange` → `SelectionChangeEvent` (start, end, direction) | |

New payload types in `whisker-runtime::event`, re-exported from `whisker::event`, all `#[serde(default)]` for graceful degradation. Tag-specific (inherent methods on each builder), so using one on the wrong tag is a compile error.

### Three bugs that blocked component events (none affected touch/gesture events, which flow through the gesture pipeline)

1. **Event-set gating.** Lynx UI components only EMIT their events (scroll/layout/uiappear/…) when the element has a bound handler. Whisker keeps listeners in Rust and set no Lynx handler, so the event set was empty → Lynx never fired them. Re-introduced `lynx_element_set_event_handler` (capi, bind-phase sentinel) + `whisker_bridge_set_native_event_handler`; the driver calls it for non-gesture events only. (Phase 5 deemed native handlers "inert" — true for *propagation*, but they also gate component-event *emission*.)
2. **Integer target signs.** The raw reporter body has `target`/`currentTarget` as integer signs (`LynxEvent.generateEventBody`), not `{id,uid,dataset}` objects. The derived `Deserialize` failed the whole event (→ all-zero `detail`). `Target` now has a custom int-or-object deserialize.
3. **iOS/Android body-shape asymmetry.** iOS delivers `{type,target,currentTarget,detail}`; Android delivered the flat params dict (`eventParams()`). `WhiskerView.kt` now normalizes the Android body to the iOS shape.

### Lynx fork

Bumped to **v3.7.0-whisker.6** (whiskerrs/lynx#6 adds `lynx_element_set_event_handler` to the Android liblynx). The `.6` iOS xcframework CI build hit an unrelated environmental `modp_b64` break; since the iOS xcframework doesn't carry `native_renderer_capi` (Whisker compiles it from this repo on iOS), the `.6` iOS engine is byte-identical to `.5`, so the known-good `.5` iOS tarball was republished under the `.6` filename — both platforms stay on one Lynx version.

### Verification

Horizontal `scroll_view` demo in hello-world; `on_scroll` fires with live `ScrollEvent.detail`:
- **iOS**: `left=478 width=840 …`
- **Android**: `left=322 width=840 …`

Routing + deserialize unit tests (integer-sign and object target shapes, nested detail, camelCase); full workspace test suite green; fmt + clippy clean.

### Scope notes

`list` / `frame` are Lynx elements not yet added to Whisker (separate new-built-in-tag effort). `page` / `raw_text` have no component-specific events; `view`'s (layoutchange/uiappear/uidisappear) are on the shared trait. The catch/capture propagation variants remain touch-only (faithful to Lynx — `CustomEvent` doesn't bubble/capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)