### PR TITLE
feat(attrs): typed attribute methods for built-in tags (image / scroll_view / text + common)

### DIFF
--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -476,18 +476,16 @@ impl ElementNode {
             return Some(quote_spanned! {span=> .#name(()) });
         }
 
-        let call = if is_string_attr_method(&tag_name, &name_str) {
-            // String-shaped attr (`style`, `class`, plus tag-
-            // specific ones like `image::src`,
-            // `scroll_view::scroll_orientation`,
-            // `raw_text::text`, `text::value`). Phase 7-Φ.B
-            // pivot: the builder method now takes
-            // `impl Into<Signal<T>>` and handles Static / Dynamic
-            // dispatch internally. The macro no longer wraps in
-            // `move || …to_string()` — the value flows as-is and
-            // type inference picks the correct `From` impl
-            // (`From<T>` for static / `From<ReadSignal<T>>` etc.
-            // for reactive).
+        let call = if is_known_attr_method(&tag_name, &name_str) {
+            // Named builder attribute method (`style`, `class`, the
+            // universal trait attrs, and per-tag ones like `image::mode`,
+            // `scroll_view::bounces`, `text::text_maxline`). The method
+            // takes `impl Into<Signal<T>>` for its semantic `T` and
+            // handles Static / Dynamic dispatch internally; the value
+            // flows as-is and type inference picks the right `From`
+            // (`From<T>` static / `From<ReadSignal<T>>` reactive) — so
+            // `bounces: true` / `text_maxline: 3` / `mode: "aspectFit"`
+            // all just work.
             quote_spanned! {span=> .#name(#value) }
         } else if name_str == "ref" {
             // `ref: <ElementRef>` on a built-in element → bind the ref
@@ -521,19 +519,80 @@ impl ElementNode {
     }
 }
 
-/// String-attribute methods on the builder (take `Fn() -> impl
-/// ToString`). The catch-all `.attr(name, …)` path uses the same
-/// shape for unknown attrs.
-fn is_string_attr_method(tag: &str, attr: &str) -> bool {
-    if matches!(attr, "style" | "class") {
+/// Kwargs that map to a **named** builder attribute method
+/// (`.#name(value)`) rather than the catch-all `.attr("kebab", value)`.
+/// Each method takes `impl Into<Signal<T>>` for its semantic `T`
+/// (bool / number / String), so the value flows through unchanged and
+/// type inference picks the right `From` — crucial for bool/number
+/// attrs, which `.attr` (String-only) couldn't accept. Mirrors the
+/// methods on `ElementBuilder` + the per-tag inherent impls in
+/// `whisker::__tags`; tag-specific names only match their tag, so using
+/// one on the wrong element is a clear "no method" error.
+fn is_known_attr_method(tag: &str, attr: &str) -> bool {
+    // Universal attributes (the `ElementBuilder` trait — any tag).
+    let common = matches!(
+        attr,
+        "style"
+            | "class"
+            | "id"
+            | "name"
+            | "event_through"
+            | "exposure_id"
+            | "exposure_scene"
+            | "exposure_area"
+            | "accessibility_label"
+            | "accessibility_trait"
+            | "accessibility_element"
+            | "accessibility_elements"
+            | "accessibility_elements_hidden"
+            | "accessibility_exclusive_focus"
+            | "a11y_id"
+            | "user_interaction_enabled"
+            | "native_interaction_enabled"
+            | "block_native_event"
+            | "consume_slide_event"
+            | "pan_intercept_direction"
+            | "pan_intercept_scope"
+            | "hit_slop"
+            | "flatten"
+    );
+    if common {
         return true;
     }
+    // Tag-specific inherent attributes.
     matches!(
         (tag, attr),
-        ("image", "src")
-            | ("scroll_view", "scroll_orientation")
-            | ("raw_text", "text")
+        ("raw_text", "text")
             | ("text", "value")
+            | ("text", "text_maxline")
+            | ("text", "text_selection")
+            | ("text", "include_font_padding")
+            | ("text", "tail_color_convert")
+            | ("text", "text_single_line_vertical_align")
+            | ("text", "custom_context_menu")
+            | ("text", "custom_text_selection")
+            | ("image", "src")
+            | ("image", "mode")
+            | ("image", "placeholder")
+            | ("image", "blur_radius")
+            | ("image", "auto_size")
+            | ("image", "tint_color")
+            | ("image", "cap_insets")
+            | ("image", "cap_insets_scale")
+            | ("image", "loop_count")
+            | ("image", "autoplay")
+            | ("image", "prefetch_width")
+            | ("image", "prefetch_height")
+            | ("image", "image_config")
+            | ("image", "defer_src_invalidation")
+            | ("scroll_view", "scroll_orientation")
+            | ("scroll_view", "bounces")
+            | ("scroll_view", "enable_scroll")
+            | ("scroll_view", "scroll_bar_enable")
+            | ("scroll_view", "initial_scroll_offset")
+            | ("scroll_view", "initial_scroll_to_index")
+            | ("scroll_view", "upper_threshold")
+            | ("scroll_view", "lower_threshold")
     )
 }
 

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -285,6 +285,145 @@ pub mod __tags {
             self
         }
 
+        /// `exposure-scene` — exposure scene identifier (pairs with
+        /// `exposure-id` for scoping exposure monitoring).
+        fn exposure_scene<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<String>>,
+        {
+            apply_attr(self.__element(), "exposure-scene", v);
+            self
+        }
+
+        /// `exposure-area` — viewport-intersection ratio threshold that
+        /// counts as "exposed" (e.g. `"0.5"` or `"50%"`).
+        fn exposure_area<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<String>>,
+        {
+            apply_attr(self.__element(), "exposure-area", v);
+            self
+        }
+
+        /// `a11y-id` — separate identifier for accessibility nodes.
+        fn a11y_id<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<String>>,
+        {
+            apply_attr(self.__element(), "a11y-id", v);
+            self
+        }
+
+        /// `accessibility-elements` — customize child focus order by a
+        /// comma-separated list of element ids.
+        fn accessibility_elements<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<String>>,
+        {
+            apply_attr(self.__element(), "accessibility-elements", v);
+            self
+        }
+
+        /// `accessibility-elements-hidden` — hide this node and its
+        /// children from accessibility.
+        fn accessibility_elements_hidden<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<bool>>,
+        {
+            apply_attr(self.__element(), "accessibility-elements-hidden", v);
+            self
+        }
+
+        /// `accessibility-exclusive-focus` — restrict accessibility
+        /// focus to this node's children.
+        fn accessibility_exclusive_focus<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<bool>>,
+        {
+            apply_attr(self.__element(), "accessibility-exclusive-focus", v);
+            self
+        }
+
+        // ---- Native touch / gesture coordination ------------------------
+        //
+        // Whisker delivers events through Lynx's hit-testing + reporter,
+        // so these tune what reaches it: expand the hit area, hand
+        // gestures to / withhold them from Lynx's native scroll, etc.
+        // Advanced — most apps never need them.
+
+        /// `hit-slop` — expand the touch-responsive area beyond the
+        /// element's bounds (e.g. `"10px"`, or per-side
+        /// `"{top:10,bottom:10}"`).
+        fn hit_slop<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<String>>,
+        {
+            apply_attr(self.__element(), "hit-slop", v);
+            self
+        }
+
+        /// `native-interaction-enabled` — let the platform layer consume
+        /// gestures on this node.
+        fn native_interaction_enabled<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<bool>>,
+        {
+            apply_attr(self.__element(), "native-interaction-enabled", v);
+            self
+        }
+
+        /// `block-native-event` — block platform gestures (e.g. an
+        /// underlying native scroll) from firing outside Lynx while a
+        /// touch is on this node.
+        fn block_native_event<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<bool>>,
+        {
+            apply_attr(self.__element(), "block-native-event", v);
+            self
+        }
+
+        /// `consume-slide-event` — consume swipes within given angle
+        /// ranges so an ancestor scroll doesn't also act on them
+        /// (e.g. `"[[0,45]]"`).
+        fn consume_slide_event<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<String>>,
+        {
+            apply_attr(self.__element(), "consume-slide-event", v);
+            self
+        }
+
+        /// `pan-intercept-direction` — block swipe gestures in a
+        /// direction: `horizontal` / `vertical` / `none`.
+        fn pan_intercept_direction<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<String>>,
+        {
+            apply_attr(self.__element(), "pan-intercept-direction", v);
+            self
+        }
+
+        /// `pan-intercept-scope` — scope of [`pan_intercept_direction`]:
+        /// `self` / `ancestors` / `descendants` / ….
+        fn pan_intercept_scope<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<String>>,
+        {
+            apply_attr(self.__element(), "pan-intercept-scope", v);
+            self
+        }
+
+        /// `flatten` — Android-only: force a real Android View for this
+        /// node (opts out of flattening). `false` lets Lynx flatten it.
+        fn flatten<V>(self, v: V) -> Self
+        where
+            V: Into<Signal<bool>>,
+        {
+            apply_attr(self.__element(), "flatten", v);
+            self
+        }
+
         // ---- Events: touch / tap / click → `TouchEvent` -----------------
         //
         // Each touch event exposes the four Lynx handler kinds as a
@@ -643,6 +782,66 @@ pub mod __tags {
             self
         }
 
+        // ---- text attributes (reactive-capable) ---------------------
+
+        /// `text-maxline` — max displayed lines (-1 = unlimited).
+        pub fn text_maxline<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<i32>>,
+        {
+            apply_attr(self.handle, "text-maxline", v);
+            self
+        }
+        /// `text-selection` — allow the user to select the text.
+        pub fn text_selection<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "text-selection", v);
+            self
+        }
+        /// `include-font-padding` — add font padding (Android).
+        pub fn include_font_padding<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "include-font-padding", v);
+            self
+        }
+        /// `tail-color-convert` — control ellipsis color inheritance.
+        pub fn tail_color_convert<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "tail-color-convert", v);
+            self
+        }
+        /// `text-single-line-vertical-align` — `normal` (default) /
+        /// `top` / `center` / `bottom`.
+        pub fn text_single_line_vertical_align<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<::std::string::String>>,
+        {
+            apply_attr(self.handle, "text-single-line-vertical-align", v);
+            self
+        }
+        /// `custom-context-menu` — enable a custom selection context menu.
+        pub fn custom_context_menu<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "custom-context-menu", v);
+            self
+        }
+        /// `custom-text-selection` — developer-controlled selection logic.
+        pub fn custom_text_selection<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "custom-text-selection", v);
+            self
+        }
+
         // ---- text-specific events (CustomEvent → bind only) ---------
 
         /// `layout` — fired after text layout completes. The
@@ -715,6 +914,115 @@ pub mod __tags {
             self
         }
 
+        // ---- image attributes (every method reactive-capable) -------
+
+        /// `mode` — crop/scale: `scaleToFill` (default) / `aspectFit` /
+        /// `aspectFill` / `center`.
+        pub fn mode<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<::std::string::String>>,
+        {
+            apply_attr(self.handle, "mode", v);
+            self
+        }
+        /// `placeholder` — fallback image shown while loading.
+        pub fn placeholder<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<::std::string::String>>,
+        {
+            apply_attr(self.handle, "placeholder", v);
+            self
+        }
+        /// `blur-radius` — blur intensity, e.g. `"10px"`.
+        pub fn blur_radius<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<::std::string::String>>,
+        {
+            apply_attr(self.handle, "blur-radius", v);
+            self
+        }
+        /// `auto-size` — size the element to the image's intrinsic size.
+        pub fn auto_size<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "auto-size", v);
+            self
+        }
+        /// `tint-color` — recolor non-transparent pixels.
+        pub fn tint_color<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<::std::string::String>>,
+        {
+            apply_attr(self.handle, "tint-color", v);
+            self
+        }
+        /// `cap-insets` — 9-patch stretchable area (`"top right bottom left"`).
+        pub fn cap_insets<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<::std::string::String>>,
+        {
+            apply_attr(self.handle, "cap-insets", v);
+            self
+        }
+        /// `cap-insets-scale` — scale of the 9-patch stretchable area.
+        pub fn cap_insets_scale<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<f64>>,
+        {
+            apply_attr(self.handle, "cap-insets-scale", v);
+            self
+        }
+        /// `loop-count` — animated-image play count (0 = infinite).
+        pub fn loop_count<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<i32>>,
+        {
+            apply_attr(self.handle, "loop-count", v);
+            self
+        }
+        /// `autoplay` — start an animated image automatically on load.
+        pub fn autoplay<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "autoplay", v);
+            self
+        }
+        /// `prefetch-width` — load even when element width is 0, e.g. `"100px"`.
+        pub fn prefetch_width<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<::std::string::String>>,
+        {
+            apply_attr(self.handle, "prefetch-width", v);
+            self
+        }
+        /// `prefetch-height` — load even when element height is 0, e.g. `"100px"`.
+        pub fn prefetch_height<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<::std::string::String>>,
+        {
+            apply_attr(self.handle, "prefetch-height", v);
+            self
+        }
+        /// `image-config` — bitmap memory format: `ARGB_8888` / `RGB_565`.
+        pub fn image_config<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<::std::string::String>>,
+        {
+            apply_attr(self.handle, "image-config", v);
+            self
+        }
+        /// `defer-src-invalidation` — keep the old image until the new
+        /// one loads successfully.
+        pub fn defer_src_invalidation<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "defer-src-invalidation", v);
+            self
+        }
+
         // ---- image-specific events (CustomEvent → bind only) --------
 
         /// `load` — the image request succeeded. The
@@ -776,6 +1084,67 @@ pub mod __tags {
             V: ::std::convert::Into<Signal<::std::string::String>>,
         {
             apply_attr(self.handle, "scroll-orientation", v);
+            self
+        }
+
+        // ---- scroll_view attributes (reactive-capable) --------------
+
+        /// `bounces` — bounce effect at the scroll edges.
+        pub fn bounces<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "bounces", v);
+            self
+        }
+        /// `enable-scroll` — allow the user to drag-scroll.
+        pub fn enable_scroll<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "enable-scroll", v);
+            self
+        }
+        /// `scroll-bar-enable` — show the scrollbar indicator.
+        pub fn scroll_bar_enable<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<bool>>,
+        {
+            apply_attr(self.handle, "scroll-bar-enable", v);
+            self
+        }
+        /// `initial-scroll-offset` — starting scroll position (px).
+        pub fn initial_scroll_offset<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<i32>>,
+        {
+            apply_attr(self.handle, "initial-scroll-offset", v);
+            self
+        }
+        /// `initial-scroll-to-index` — child index to jump to on load.
+        pub fn initial_scroll_to_index<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<i32>>,
+        {
+            apply_attr(self.handle, "initial-scroll-to-index", v);
+            self
+        }
+        /// `upper-threshold` — distance (px) from the top/left edge that
+        /// triggers `scrolltoupper`.
+        pub fn upper_threshold<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<i32>>,
+        {
+            apply_attr(self.handle, "upper-threshold", v);
+            self
+        }
+        /// `lower-threshold` — distance (px) from the bottom/right edge
+        /// that triggers `scrolltolower`.
+        pub fn lower_threshold<V>(self, v: V) -> Self
+        where
+            V: ::std::convert::Into<Signal<i32>>,
+        {
+            apply_attr(self.handle, "lower-threshold", v);
             self
         }
 

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -259,6 +259,63 @@ fn arbitrary_attribute_emits_set_attribute() {
 }
 
 #[test]
+fn typed_attribute_methods_route_to_named_setters() {
+    // Phase: built-in attribute coverage. Named attribute methods route
+    // to `.method(v)` (not the String-only `.attr`), so bool / number /
+    // enum-string values stringify to the right Lynx attribute name.
+    let has = |ops: &[Op], key: &str, val: &str| {
+        ops.iter()
+            .any(|op| matches!(op, Op::SetAttr { key: k, value: v, .. } if k == key && v == val))
+    };
+
+    // scroll_view: bool + number attrs.
+    with_recorder(|log| {
+        let _ = render! {
+            scroll_view(bounces: true, enable_scroll: false, upper_threshold: 50)
+        };
+        let ops = log.borrow();
+        assert!(has(&ops, "bounces", "true"), "got {ops:?}");
+        assert!(has(&ops, "enable-scroll", "false"), "got {ops:?}");
+        assert!(has(&ops, "upper-threshold", "50"), "got {ops:?}");
+    });
+
+    // image: enum-string + bool + number(0).
+    with_recorder(|log| {
+        let _ = render! {
+            image(mode: "aspectFit", auto_size: true, loop_count: 0)
+        };
+        let ops = log.borrow();
+        assert!(has(&ops, "mode", "aspectFit"), "got {ops:?}");
+        assert!(has(&ops, "auto-size", "true"), "got {ops:?}");
+        assert!(has(&ops, "loop-count", "0"), "got {ops:?}");
+    });
+
+    // text: number + bool.
+    with_recorder(|log| {
+        let _ = render! {
+            text(value: "hi", text_maxline: 2, text_selection: true)
+        };
+        let ops = log.borrow();
+        assert!(has(&ops, "text-maxline", "2"), "got {ops:?}");
+        assert!(has(&ops, "text-selection", "true"), "got {ops:?}");
+    });
+
+    // common (trait) attrs on a plain view: bool + string.
+    with_recorder(|log| {
+        let _ = render! {
+            view(flatten: true, hit_slop: "10px", pan_intercept_direction: "horizontal")
+        };
+        let ops = log.borrow();
+        assert!(has(&ops, "flatten", "true"), "got {ops:?}");
+        assert!(has(&ops, "hit-slop", "10px"), "got {ops:?}");
+        assert!(
+            has(&ops, "pan-intercept-direction", "horizontal"),
+            "got {ops:?}"
+        );
+    });
+}
+
+#[test]
 fn on_tap_emits_set_event_listener() {
     with_recorder(|log| {
         let fired = Rc::new(RefCell::new(false));


### PR DESCRIPTION
## Built-in attribute coverage

Adds named, semantically-typed attribute methods covering Lynx's documented **non-CSS** attribute surface for the built-in tags. (CSS stays in `style`; functional coverage was already complete via the catch-all `attr(name, v)` — this adds typed, discoverable convenience methods.)

Each method takes `impl Into<Signal<T>>` for its semantic `T` (bool / i32 / f64 / String), so it's reactive-capable and `bounces: true` / `text_maxline: 3` / `mode: "aspectFit"` all just work; the value stringifies to the Lynx attribute.

| target | attributes |
|---|---|
| **image** (13) | mode, placeholder, blur_radius, auto_size, tint_color, cap_insets, cap_insets_scale, loop_count, autoplay, prefetch_width, prefetch_height, image_config, defer_src_invalidation |
| **scroll_view** (7) | bounces, enable_scroll, scroll_bar_enable, initial_scroll_offset, initial_scroll_to_index, upper_threshold, lower_threshold |
| **text** (7) | text_maxline, text_selection, include_font_padding, tail_color_convert, text_single_line_vertical_align, custom_context_menu, custom_text_selection |
| **common** (ElementBuilder, 13) | exposure_scene, exposure_area, a11y_id, accessibility_elements(/_hidden/_exclusive_focus), + native-touch coordination (hit_slop, native_interaction_enabled, block_native_event, consume_slide_event, pan_intercept_direction/scope), flatten |

### Scope rationale

The native-touch knobs (hit_slop, consume_slide_event, block_native_event, pan_intercept_*) are included because **Whisker's events ride on Lynx's hit-testing + reporter**, so they still affect delivery (expand the hit area, coordinate with native scroll). Deliberately **left to `attr(name, v)`** (Whisker-irrelevant or deep-niche): `enable-touch-pseudo-propagation` (CSS `:active` bubbling), `event-through-active-regions`, `exposure-*-margin-*`, `ios-*` platform quirks, `__lynx_timing_flag`, `className`.

### Macro

`is_string_attr_method` → `is_known_attr_method` routes these kwargs to the named setter (`.method(v)`) instead of the String-only `.attr` — required for bool/number values (`.attr("bounces", true)` wouldn't type-check). Tag-specific names only match their tag, so using one on the wrong element is a clear "no method" compile error.

### Tests

Routing test covers bool / number / enum-string across all four builders + the kebab attribute names + stringification. Full workspace test suite green; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)