### PR TITLE
feat(control-flow): wrapper-less For/Show via phantom-anchor (closes #84)

### DIFF
--- a/crates/whisker-runtime/src/view/control_flow.rs
+++ b/crates/whisker-runtime/src/view/control_flow.rs
@@ -1,107 +1,65 @@
-//! Control-flow components: [`show`] (if/else) and [`for_each`]
-//! (keyed list).
+//! Control-flow primitives — [`show`] (if/else) and [`for_each`]
+//! (keyed list) — implemented as wrapper-less [`ControlFlow`] views
+//! per [`docs/wrapper-less-control-flow-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/wrapper-less-control-flow-design.md).
 //!
-//! Both create a wrapper `view` element and an effect that watches
-//! a reactive source (`when` for `show`, `each` for `for_each`).
-//! When the source changes, the effect rebuilds the wrapper's
-//! children — disposing item owners that disappear and creating
-//! new ones for additions. Items that survive across re-renders
-//! keep their owners (and therefore their reactive state) intact.
+//! ## Two attach paths
 //!
-//! The `render!` macro recognises `Show { ... }` / `For { ... }`
-//! call sites and emits calls into this module; users can also
-//! call these functions directly for non-macro programmatic use.
+//! - **Generic parent** (`view`, `scroll_view`, …): the control flow
+//!   creates a single *phantom* anchor element
+//!   ([`super::create_phantom_element`]) and installs an effect that
+//!   inserts items as the anchor's preceding siblings. Phantoms live
+//!   in Whisker's mirror only — Lynx is never told about them, so
+//!   the rendered tree has **zero extra elements** vs the user's
+//!   markup. The anchor still serves as a stable positional marker
+//!   for the mirror's [`child_index`](super::child_index) lookup,
+//!   which is what makes reactive updates survive hot-reload-induced
+//!   sibling churn.
+//!
+//! - **`<list>` parent**: the control flow writes `(handle, sign)`
+//!   tuples directly into the list's shared
+//!   [`ListItemsHandle`](super::ListItemsHandle) and broadcasts the
+//!   item count via [`super::set_update_list_info`] on every update.
+//!   The list's native-item provider closure (installed in
+//!   `list.__h()`) reads from the same `Rc<RefCell<…>>`, so the next
+//!   `componentAtIndex` lookup sees the new state. No anchor — the
+//!   items Vec **is** the positional index.
+//!
+//! ## Owner cascade
+//!
+//! Each item gets a detached owner (`create_owner(None)`); the
+//! control flow's effect explicitly disposes the per-item owner when
+//! the item leaves the diff. This matches the pre-refactor behaviour
+//! — when the surrounding component is disposed, its owner cascade
+//! reaches this module's effect owner, the effect cleanup detaches
+//! attached children, and the per-item owners are disposed
+//! individually so their reactive state + element handles release.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::marker::PhantomData;
 use std::rc::Rc;
 
-use crate::element::ElementTag;
-use crate::reactive::{create_owner, dispose_owner, effect, with_owner};
+use crate::reactive::{create_owner, dispose_owner, effect, with_owner, OwnerId};
 
 use super::handle::Element;
-use super::into_view::{IntoView, View};
-use super::renderer::create_element;
+use super::into_view::{ControlFlow, IntoView, ListItemsHandle, View};
+use super::renderer::{
+    append_child, child_index, create_phantom_element, remove_child, set_attribute,
+    set_update_list_info,
+};
+use super::{element_sign, insert_child_at};
 
-/// Conditional rendering. When `when()` is true the `children`
-/// closure's view is mounted into the returned wrapper element; when
-/// false, the `fallback` closure (if any) is mounted instead.
-///
-/// On every flip the mounted side's owner is disposed (cascading
-/// cleanups + freeing reactive nodes) before the other side is
-/// instantiated, so state from the previous branch is not
-/// accidentally retained.
-///
-/// Returns the wrapper [`Element`] — the parent attaches this
-/// once and the inner content swaps in place.
-pub fn show(
-    when: impl Fn() -> bool + 'static,
-    children: impl Fn() -> View + 'static,
-    fallback: Option<Box<dyn Fn() -> View + 'static>>,
-) -> Element {
-    let wrapper = create_element(ElementTag::View);
-    // Track the currently-mounted owner so we can dispose it on the
-    // next flip. `Rc<RefCell>` because the effect closure runs many
-    // times and needs interior mutability.
-    let mounted: Rc<RefCell<Option<crate::reactive::OwnerId>>> = Rc::new(RefCell::new(None));
+// ---------------------------------------------------------------------------
+// `For` (keyed list)
+// ---------------------------------------------------------------------------
 
-    effect(move || {
-        // 1. Detach every current child of the wrapper before
-        // disposing the previous branch owner. `#[component]`
-        // bodies inside the branch register their own detached
-        // owners (`mount_component_remountable` uses
-        // `create_owner(None)`), so `dispose_owner(branch_owner)`'s
-        // cascade can't reach them and their elements would stay
-        // attached to the wrapper through the `when` flip. Explicit
-        // `remove_child` is the safety net.
-        for child in super::children_of(wrapper) {
-            super::remove_child(wrapper, child);
-        }
-
-        // 2. Dispose whatever's currently mounted, if anything.
-        let prev = mounted.borrow_mut().take();
-        if let Some(o) = prev {
-            dispose_owner(o);
-        }
-
-        // 3. Mount the appropriate branch under a fresh owner.
-        let branch_owner = create_owner(None);
-        let cond = when();
-        with_owner(branch_owner, || {
-            let view = if cond {
-                children()
-            } else if let Some(fb) = fallback.as_ref() {
-                fb()
-            } else {
-                View::Empty
-            };
-            view.attach_to(wrapper);
-        });
-        *mounted.borrow_mut() = Some(branch_owner);
-    });
-
-    wrapper
-}
-
-/// Keyed list rendering. `each` is re-evaluated on every dep change
-/// (it's the effect's tracked input); for each item in the returned
-/// vector, the macro/runtime calls `key(&item)` to derive a stable
-/// identity. Items whose keys match a previous render are reused
-/// (their owners and per-item reactive state survive); items that
-/// disappear have their owners disposed.
-///
-/// **Reordering**: when reused items appear in a different order,
-/// we detach them all (in the previous order) and re-attach them
-/// (in the new order) so the wrapper's child list reflects the new
-/// position. This is the simplest correct reorder strategy; if list
-/// churn ever becomes a perf concern, a smarter LIS-based moves
-/// path can replace the detach-all step.
-pub fn for_each<T, K, V, EachFn, KeyFn, ChildFn>(
-    each: EachFn,
-    key: KeyFn,
-    children: ChildFn,
-) -> Element
+/// Keyed-list control flow. `for_each(...)` constructs one; the
+/// surrounding container builder (`view`, `scroll_view`, `list`)
+/// receives it via its `.child(impl IntoView)` and either dispatches
+/// to [`ControlFlow::attach_generic`] (anchor pattern) or
+/// [`ControlFlow::attach_to_list`] (items-Vec pattern).
+pub struct For<T, K, V, EachFn, KeyFn, ChildFn>
 where
     T: 'static,
     K: Eq + Hash + Clone + 'static,
@@ -110,86 +68,415 @@ where
     KeyFn: Fn(&T) -> K + 'static,
     ChildFn: Fn(T) -> V + 'static,
 {
-    let wrapper = create_element(ElementTag::View);
-    // Default to a vertical list. Lynx `view` defaults to
-    // `flex-direction: row` (memory: lynx_view_flex_direction_default);
-    // for lists that's almost always the wrong axis.
-    super::set_inline_styles(wrapper, "display: flex; flex-direction: column;");
-    // Per-key bookkeeping. We track the owner so we can dispose
-    // removed items, plus the attached element handles so we can
-    // re-attach in the new order during a reorder.
-    struct Entry {
-        owner: crate::reactive::OwnerId,
-        handles: Vec<Element>,
+    each: EachFn,
+    key: KeyFn,
+    children: ChildFn,
+    _t: PhantomData<(T, K, V)>,
+}
+
+/// Per-key bookkeeping for one item kept across an effect rerun.
+/// `handles` is a `Vec` because one item's `children(item)` view may
+/// itself be a fragment — multiple leaf elements all owned by the
+/// same per-item owner. The native-list path collapses this to one
+/// (`list_item`) handle per key in practice; the generic path
+/// tolerates fragments transparently.
+struct ItemEntry {
+    owner: OwnerId,
+    handles: Vec<Element>,
+}
+
+impl<T, K, V, EachFn, KeyFn, ChildFn> For<T, K, V, EachFn, KeyFn, ChildFn>
+where
+    T: 'static,
+    K: Eq + Hash + Clone + 'static,
+    V: IntoView + 'static,
+    EachFn: Fn() -> Vec<T> + 'static,
+    KeyFn: Fn(&T) -> K + 'static,
+    ChildFn: Fn(T) -> V + 'static,
+{
+}
+
+impl<T, K, V, EachFn, KeyFn, ChildFn> IntoView for For<T, K, V, EachFn, KeyFn, ChildFn>
+where
+    T: 'static,
+    K: Eq + Hash + Clone + 'static,
+    V: IntoView + 'static,
+    EachFn: Fn() -> Vec<T> + 'static,
+    KeyFn: Fn(&T) -> K + 'static,
+    ChildFn: Fn(T) -> V + 'static,
+{
+    fn into_view(self) -> View {
+        View::ControlFlow(Box::new(self))
     }
-    let entries: Rc<RefCell<HashMap<K, Entry>>> = Rc::new(RefCell::new(HashMap::new()));
+}
 
-    effect(move || {
-        let items = each();
-        let mut new_entries: HashMap<K, Entry> = HashMap::new();
-        let mut new_keys_in_order: Vec<K> = Vec::with_capacity(items.len());
+impl<T, K, V, EachFn, KeyFn, ChildFn> ControlFlow for For<T, K, V, EachFn, KeyFn, ChildFn>
+where
+    T: 'static,
+    K: Eq + Hash + Clone + 'static,
+    V: IntoView + 'static,
+    EachFn: Fn() -> Vec<T> + 'static,
+    KeyFn: Fn(&T) -> K + 'static,
+    ChildFn: Fn(T) -> V + 'static,
+{
+    fn attach_generic(self: Box<Self>, parent: Element) {
+        let For {
+            each,
+            key,
+            children,
+            ..
+        } = *self;
 
-        // Pull the old map out so we can move entries across
-        // without holding the borrow during user-code calls
-        // (`children()`).
-        let mut old = std::mem::take(&mut *entries.borrow_mut());
+        // Anchor marks the end of `For`'s range in `parent`'s mirror
+        // child list. It survives across effect reruns; items get
+        // inserted ahead of it. Phantom = mirror-only; no Lynx
+        // element is allocated for the anchor.
+        let anchor = create_phantom_element();
+        append_child(parent, anchor);
 
-        for item in items {
-            let k = key(&item);
-            if let Some(existing) = old.remove(&k) {
-                new_entries.insert(k.clone(), existing);
-            } else {
-                let item_owner = create_owner(None);
-                let handles = with_owner(item_owner, || {
-                    let view = children(item).into_view();
-                    view.attach_to(wrapper)
-                });
-                new_entries.insert(
-                    k.clone(),
-                    Entry {
-                        owner: item_owner,
-                        handles,
-                    },
-                );
+        let entries: Rc<RefCell<HashMap<K, ItemEntry>>> = Rc::new(RefCell::new(HashMap::new()));
+
+        effect(move || {
+            let items = each();
+            let mut new_entries: HashMap<K, ItemEntry> = HashMap::new();
+            let mut new_keys_in_order: Vec<K> = Vec::with_capacity(items.len());
+
+            // Pull the old map out so we can move entries across
+            // without holding the borrow during user-code calls
+            // (`children()` may itself touch reactive state).
+            let mut old = std::mem::take(&mut *entries.borrow_mut());
+
+            for item in items {
+                let k = key(&item);
+                if let Some(existing) = old.remove(&k) {
+                    new_entries.insert(k.clone(), existing);
+                } else {
+                    let item_owner = create_owner(None);
+                    let handles = with_owner(item_owner, || {
+                        // Materialise into `parent`; we'll detach +
+                        // reinsert all handles in the new order
+                        // immediately below, so position here is
+                        // transient.
+                        children(item).into_view().attach_to(parent)
+                    });
+                    new_entries.insert(
+                        k.clone(),
+                        ItemEntry {
+                            owner: item_owner,
+                            handles,
+                        },
+                    );
+                }
+                new_keys_in_order.push(k);
             }
-            new_keys_in_order.push(k);
-        }
 
-        // Anything still in `old` has been removed — dispose so
-        // reactive nodes + cleanups fire. We detach the elements
-        // first, then dispose the owner. Order matters: dispose
-        // before detach would leave the now-freed-owner trying to
-        // touch the renderer for no reason.
-        for (_, entry) in old.drain() {
-            for h in &entry.handles {
-                super::remove_child(wrapper, *h);
-            }
-            dispose_owner(entry.owner);
-        }
-
-        // Re-attach all kept entries in the new order. We're
-        // unconditional here (rather than diffing) — for v1 the
-        // simpler implementation wins; the typical churn shape
-        // (append, prepend, single-row insert) is still cheap.
-        // First detach everything we kept...
-        for k in &new_keys_in_order {
-            if let Some(entry) = new_entries.get(k) {
+            // Anything still in `old` was removed in this update —
+            // detach + dispose owner. Detach before dispose so the
+            // owner cascade doesn't try to release elements still
+            // attached to the parent (mirror cleanup ordering).
+            for (_, entry) in old.drain() {
                 for h in &entry.handles {
-                    super::remove_child(wrapper, *h);
+                    remove_child(parent, *h);
+                }
+                dispose_owner(entry.owner);
+            }
+
+            // Detach every kept handle (some may have just been
+            // inserted at the wrong position above), then re-insert
+            // in the new order ahead of the anchor. The anchor's
+            // mirror index is what tells us "where my range ends" —
+            // we recompute it after each insertion because each
+            // `insert_child_at` shifts the anchor right by 1.
+            for k in &new_keys_in_order {
+                if let Some(entry) = new_entries.get(k) {
+                    for h in &entry.handles {
+                        remove_child(parent, *h);
+                    }
                 }
             }
-        }
-        // ...then re-attach in the desired order.
-        for k in &new_keys_in_order {
-            if let Some(entry) = new_entries.get(k) {
-                for h in &entry.handles {
-                    super::append_child(wrapper, *h);
+            for k in &new_keys_in_order {
+                if let Some(entry) = new_entries.get(k) {
+                    for h in &entry.handles {
+                        let anchor_idx = child_index(parent, anchor).unwrap_or(0);
+                        insert_child_at(parent, *h, anchor_idx);
+                    }
                 }
             }
-        }
 
-        *entries.borrow_mut() = new_entries;
-    });
+            *entries.borrow_mut() = new_entries;
+        });
+    }
 
-    wrapper
+    fn attach_to_list(self: Box<Self>, list_handle: Element, items_handle: ListItemsHandle) {
+        let For {
+            each,
+            key,
+            children,
+            ..
+        } = *self;
+
+        // Per-key entries — same shape as `attach_generic`, except
+        // each item must be a `<list-item>` element (or one whose
+        // top-level handle Lynx will accept as a list slot).
+        let entries: Rc<RefCell<HashMap<K, ItemEntry>>> = Rc::new(RefCell::new(HashMap::new()));
+        // Stable key ordering across reruns lets the items Vec
+        // reflect the latest source order without ever rebuilding
+        // it from a HashMap iteration (which would be
+        // non-deterministic).
+        let order: Rc<RefCell<Vec<K>>> = Rc::new(RefCell::new(Vec::new()));
+
+        effect(move || {
+            let new_items = each();
+            let mut new_entries: HashMap<K, ItemEntry> = HashMap::new();
+            let mut new_keys: Vec<K> = Vec::with_capacity(new_items.len());
+
+            let mut old = std::mem::take(&mut *entries.borrow_mut());
+
+            for (idx, item) in new_items.into_iter().enumerate() {
+                let k = key(&item);
+                if let Some(existing) = old.remove(&k) {
+                    new_entries.insert(k.clone(), existing);
+                } else {
+                    let item_owner = create_owner(None);
+                    let handles = with_owner(item_owner, || {
+                        children(item).into_view().attach_to(list_handle)
+                    });
+                    // Tag each item handle with the positional key
+                    // Lynx's `update-list-info` map expects. The list
+                    // builder's static path uses the same convention.
+                    for h in &handles {
+                        set_attribute(*h, "item-key", &format!("w_{}", idx));
+                    }
+                    new_entries.insert(
+                        k.clone(),
+                        ItemEntry {
+                            owner: item_owner,
+                            handles,
+                        },
+                    );
+                }
+                new_keys.push(k);
+            }
+
+            // Detach + dispose anything that disappeared from the
+            // diff.
+            for (_, entry) in old.drain() {
+                for h in &entry.handles {
+                    remove_child(list_handle, *h);
+                }
+                dispose_owner(entry.owner);
+            }
+
+            // Rebuild the items Vec in the new key order, capturing
+            // a fresh Lynx sign for each leaf handle (`element_sign`
+            // looks the impl_id up in the renderer's side map).
+            let mut new_items_vec: Vec<(Element, i32)> = Vec::with_capacity(new_keys.len());
+            for k in &new_keys {
+                if let Some(entry) = new_entries.get(k) {
+                    for h in &entry.handles {
+                        let sign = element_sign(*h);
+                        new_items_vec.push((*h, sign));
+                    }
+                }
+            }
+
+            let count = new_items_vec.len() as i32;
+            *items_handle.borrow_mut() = new_items_vec;
+            *order.borrow_mut() = new_keys;
+            *entries.borrow_mut() = new_entries;
+
+            // Tell Lynx how many slots to lay out. The native item
+            // provider closure already reads from `items_handle` via
+            // its own Rc clone, so no provider re-install is needed.
+            set_update_list_info(list_handle, count);
+        });
+    }
+}
+
+/// Keyed list rendering. `each` is re-evaluated on every dep change
+/// (it's the effect's tracked input); for each item the macro/runtime
+/// calls `key(&item)` to derive a stable identity. Items whose keys
+/// match a previous render are reused (their owners and per-item
+/// reactive state survive); items that disappear have their owners
+/// disposed.
+///
+/// Returns a [`For`] value that implements [`IntoView`] →
+/// [`View::ControlFlow`]. Container builders dispatch to either
+/// [`ControlFlow::attach_generic`] (a phantom anchor + reactive
+/// siblings) or [`ControlFlow::attach_to_list`] (items go into the
+/// `<list>`'s shared Vec).
+pub fn for_each<T, K, V, EachFn, KeyFn, ChildFn>(
+    each: EachFn,
+    key: KeyFn,
+    children: ChildFn,
+) -> For<T, K, V, EachFn, KeyFn, ChildFn>
+where
+    T: 'static,
+    K: Eq + Hash + Clone + 'static,
+    V: IntoView + 'static,
+    EachFn: Fn() -> Vec<T> + 'static,
+    KeyFn: Fn(&T) -> K + 'static,
+    ChildFn: Fn(T) -> V + 'static,
+{
+    For {
+        each,
+        key,
+        children,
+        _t: PhantomData,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `Show` (conditional)
+// ---------------------------------------------------------------------------
+
+/// Conditional control flow. Built by [`show`]; the surrounding
+/// builder dispatches to [`ControlFlow::attach_generic`] (phantom
+/// anchor + branch as anchor's preceding sibling) or
+/// [`ControlFlow::attach_to_list`] (0 or 1 item in the list's items
+/// Vec, depending on `when`).
+pub struct Show {
+    when: Box<dyn Fn() -> bool + 'static>,
+    children: Box<dyn Fn() -> View + 'static>,
+    fallback: Option<Box<dyn Fn() -> View + 'static>>,
+}
+
+impl IntoView for Show {
+    fn into_view(self) -> View {
+        View::ControlFlow(Box::new(self))
+    }
+}
+
+impl ControlFlow for Show {
+    fn attach_generic(self: Box<Self>, parent: Element) {
+        let Show {
+            when,
+            children,
+            fallback,
+        } = *self;
+
+        let anchor = create_phantom_element();
+        append_child(parent, anchor);
+
+        // Track the currently-mounted branch (one or zero handles
+        // depending on whether `children`/`fallback` materialised an
+        // element) and the owner under which it was instantiated.
+        let mounted_owner: Rc<RefCell<Option<OwnerId>>> = Rc::new(RefCell::new(None));
+        let mounted_handles: Rc<RefCell<Vec<Element>>> = Rc::new(RefCell::new(Vec::new()));
+
+        effect(move || {
+            // 1. Detach the previous branch's elements + dispose its
+            // owner. `#[component]` bodies inside the branch register
+            // their own detached owners — explicit `remove_child` is
+            // the safety net.
+            let prev_handles = std::mem::take(&mut *mounted_handles.borrow_mut());
+            for h in prev_handles {
+                remove_child(parent, h);
+            }
+            if let Some(o) = mounted_owner.borrow_mut().take() {
+                dispose_owner(o);
+            }
+
+            // 2. Mount the branch chosen by `when()` under a fresh
+            // owner.
+            let branch_owner = create_owner(None);
+            let cond = when();
+            let new_handles = with_owner(branch_owner, || {
+                let view = if cond {
+                    children()
+                } else if let Some(fb) = fallback.as_ref() {
+                    fb()
+                } else {
+                    View::Empty
+                };
+                view.attach_to(parent)
+            });
+
+            // 3. Reposition the freshly-attached handles ahead of
+            // the anchor (they landed at the parent's tail).
+            for h in &new_handles {
+                remove_child(parent, *h);
+                let anchor_idx = child_index(parent, anchor).unwrap_or(0);
+                insert_child_at(parent, *h, anchor_idx);
+            }
+
+            *mounted_owner.borrow_mut() = Some(branch_owner);
+            *mounted_handles.borrow_mut() = new_handles;
+        });
+    }
+
+    fn attach_to_list(self: Box<Self>, list_handle: Element, items_handle: ListItemsHandle) {
+        let Show {
+            when,
+            children,
+            fallback,
+        } = *self;
+
+        let mounted_owner: Rc<RefCell<Option<OwnerId>>> = Rc::new(RefCell::new(None));
+        let mounted_handles: Rc<RefCell<Vec<Element>>> = Rc::new(RefCell::new(Vec::new()));
+
+        effect(move || {
+            // Tear down the previously-mounted branch (if any).
+            let prev_handles = std::mem::take(&mut *mounted_handles.borrow_mut());
+            for h in prev_handles {
+                remove_child(list_handle, h);
+            }
+            if let Some(o) = mounted_owner.borrow_mut().take() {
+                dispose_owner(o);
+            }
+
+            let branch_owner = create_owner(None);
+            let cond = when();
+            let new_handles = with_owner(branch_owner, || {
+                let view = if cond {
+                    children()
+                } else if let Some(fb) = fallback.as_ref() {
+                    fb()
+                } else {
+                    View::Empty
+                };
+                view.attach_to(list_handle)
+            });
+
+            for (idx, h) in new_handles.iter().enumerate() {
+                set_attribute(*h, "item-key", &format!("w_show_{}", idx));
+            }
+
+            let new_items_vec: Vec<(Element, i32)> = new_handles
+                .iter()
+                .map(|h| (*h, element_sign(*h)))
+                .collect();
+            let count = new_items_vec.len() as i32;
+            *items_handle.borrow_mut() = new_items_vec;
+            *mounted_owner.borrow_mut() = Some(branch_owner);
+            *mounted_handles.borrow_mut() = new_handles;
+
+            set_update_list_info(list_handle, count);
+        });
+    }
+}
+
+/// Conditional rendering. When `when()` is true the `children`
+/// closure's view is mounted; when false, the `fallback` closure
+/// (if any) is mounted instead.
+///
+/// On every flip the mounted side's owner is disposed (cascading
+/// cleanups + freeing reactive nodes) before the other side is
+/// instantiated, so state from the previous branch is not
+/// accidentally retained.
+///
+/// Returns a [`Show`] value that implements [`IntoView`] →
+/// [`View::ControlFlow`]; container builders dispatch via
+/// [`ControlFlow::attach_generic`] or
+/// [`ControlFlow::attach_to_list`].
+pub fn show(
+    when: impl Fn() -> bool + 'static,
+    children: impl Fn() -> View + 'static,
+    fallback: Option<Box<dyn Fn() -> View + 'static>>,
+) -> Show {
+    Show {
+        when: Box::new(when),
+        children: Box::new(children),
+        fallback,
+    }
 }

--- a/crates/whisker-runtime/src/view/into_view.rs
+++ b/crates/whisker-runtime/src/view/into_view.rs
@@ -7,8 +7,11 @@
 //!
 //! The trait is intentionally minimal: every implementor produces a
 //! `View`. A `View` is either a single element, a fragment of
-//! children, or a "marker" view (used by `Show`/`For` to mark
-//! reactive boundaries — Phase 6.5a A3 Step 4).
+//! children, a control-flow node (`Show`/`For` reactive boundary,
+//! attaches itself via [`ControlFlow`]), or empty.
+
+use std::cell::RefCell;
+use std::rc::Rc;
 
 use super::handle::Element;
 
@@ -36,8 +39,50 @@ pub trait IntoView {
 ///   handle — `Rc<dyn Fn>` is one machine word.
 pub type Children = ::std::rc::Rc<dyn ::std::ops::Fn() -> View + 'static>;
 
+/// Shared list-item state owned by the [`list`](crate::view) builder
+/// and handed to every [`ControlFlow::attach_to_list`] call. The
+/// native-item-provider closure installed in `list.__h()` reads
+/// from the same `Rc<RefCell<…>>`, so a control flow's effect can
+/// mutate the items on every reactive update and the next
+/// `componentAtIndex` lookup sees the new state.
+///
+/// Each entry is `(child element handle, Lynx `impl_id` sign)`.
+/// The sign is captured eagerly at insert time because the provider
+/// closure runs from inside Lynx's layout C++ which is itself
+/// already inside [`with_renderer`](super::renderer)'s borrow — a
+/// reentrant `element_sign` call would panic on the `RefCell::borrow_mut`.
+pub type ListItemsHandle = Rc<RefCell<Vec<(Element, i32)>>>;
+
+/// A view that takes responsibility for its own attachment instead
+/// of being `append_child`-ed directly by the parent builder.
+///
+/// Used by the wrapper-less `For` / `Show` control flow — see
+/// [`docs/wrapper-less-control-flow-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/wrapper-less-control-flow-design.md).
+/// Today there are exactly two implementors; the trait is
+/// extension-ready for other reactive-children primitives.
+///
+/// `Box<dyn ControlFlow>` is the carrier inside [`View::ControlFlow`].
+/// Container builders dispatch via [`View::materialise_into`] or, for
+/// `<list>`, by pattern-matching `View::ControlFlow` and routing to
+/// [`ControlFlow::attach_to_list`] explicitly.
+pub trait ControlFlow {
+    /// Attach into a generic container (`view`, `scroll_view`, …).
+    /// The implementor inserts a *phantom* anchor at `parent`'s
+    /// current end (via [`super::create_phantom_element`]) to mark
+    /// its range, then mounts reactive children as siblings *before*
+    /// the anchor on every effect run.
+    fn attach_generic(self: Box<Self>, parent: Element);
+
+    /// Attach into a `<list>` container. The implementor writes
+    /// `(handle, sign)` tuples directly into the list's shared
+    /// [`ListItemsHandle`] and broadcasts the count via
+    /// [`super::set_update_list_info`] on every update. Items go
+    /// straight into the list's children (no anchor needed — the
+    /// list's native-item-provider indexes into the items Vec).
+    fn attach_to_list(self: Box<Self>, list_handle: Element, items: ListItemsHandle);
+}
+
 /// A rendered (or about-to-be-rendered) tree fragment.
-#[derive(Debug, Clone)]
 pub enum View {
     /// A single element handle the caller has already created.
     Element(Element),
@@ -52,6 +97,14 @@ pub enum View {
     /// option-none → empty, iterator flattening, and the macro's
     /// multi-child `Show` children all use this.
     Fragment(Vec<View>),
+    /// A control-flow node (`For` / `Show`) that takes
+    /// responsibility for its own attachment. Container builders
+    /// hand it the parent via [`ControlFlow::attach_generic`]; the
+    /// `<list>` builder calls [`ControlFlow::attach_to_list`]
+    /// instead. The wrapped value is `Box<dyn ControlFlow>` — not
+    /// `Clone` and not `Debug`, which is why this enum dropped its
+    /// previous `Debug + Clone` derives.
+    ControlFlow(Box<dyn ControlFlow>),
     /// A view with no on-screen footprint — `Show { when: false }`
     /// and `Option::None`.
     Empty,
@@ -87,6 +140,17 @@ impl View {
                     child.materialise_into(parent, out);
                 }
             }
+            View::ControlFlow(cf) => {
+                // Control flow owns its own range — it allocates an
+                // anchor, installs an effect, and inserts/updates
+                // children itself. It contributes no leaf handles
+                // to the caller's `out` because none exist yet
+                // (and the ones the effect creates later live
+                // under the control flow's internal owners, not
+                // the surrounding `{expr}` effect that would have
+                // used `out` to detach old children).
+                cf.attach_generic(parent);
+            }
             View::Empty => {}
         }
     }
@@ -109,7 +173,12 @@ impl View {
                     c.collect_into(out);
                 }
             }
-            View::Text(_) | View::Empty => {}
+            // Control-flow children aren't yet realised when this
+            // is called (no anchor, no effect run, no items). The
+            // caller is asking for the "already-materialised leaf
+            // handles I contribute"; that set is empty for control
+            // flow.
+            View::Text(_) | View::ControlFlow(_) | View::Empty => {}
         }
     }
 }

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -34,18 +34,18 @@ pub mod renderer;
 mod tests;
 
 pub use apply::{apply_attr, apply_attr_owned, apply_styles};
-pub use control_flow::{for_each, show};
+pub use control_flow::{for_each, show, For, Show};
 pub use handle::Element;
-pub use into_view::{Children, IntoView, View};
+pub use into_view::{Children, ControlFlow, IntoView, ListItemsHandle, View};
 pub use list_mount::list_mount;
 pub use list_provider::{NativeItemProvider, INVALID_ITEM_INDEX};
 #[doc(hidden)]
 pub use renderer::__reset_children_mirror_for_tests;
 pub use renderer::{
     append_child, child_index, children_of, create_element, create_element_by_name,
-    current_renderer_id, dispatch_event, element_sign, flush, insert_child_at,
-    install_list_native_item_provider, install_renderer, module_component_ptr, previous_sibling,
-    release_element, remove_child, set_attribute, set_event_listener, set_inline_styles, set_root,
-    set_update_list_info, uninstall_renderer, with_installed_renderer, BindType, DynRenderer,
-    EventDispatchPlan,
+    create_phantom_element, current_renderer_id, dispatch_event, element_sign, flush,
+    insert_child_at, install_list_native_item_provider, install_renderer, is_phantom,
+    module_component_ptr, previous_sibling, release_element, remove_child, set_attribute,
+    set_event_listener, set_inline_styles, set_root, set_update_list_info, uninstall_renderer,
+    with_installed_renderer, BindType, DynRenderer, EventDispatchPlan, PHANTOM_BASE,
 };

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -18,8 +18,8 @@
 //! In production the bridge driver installs the Lynx-backed renderer
 //! once at startup and keeps it for the life of the process.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use super::handle::Element;
@@ -213,6 +213,116 @@ thread_local! {
     /// shimming when we ship the wrapper-less remount path).
     static CHILDREN_OF: RefCell<HashMap<Element, Vec<Element>>> =
         RefCell::new(HashMap::new());
+
+    /// IDs the runtime has handed out as phantom (`Whisker`-side-only)
+    /// elements. A phantom occupies a slot in [`CHILDREN_OF`] but is
+    /// **not** present in the Lynx tree; the FFI dispatchers skip
+    /// every phantom they're handed. See [`create_phantom_element`]
+    /// for the use case (zero-cost positional markers for `For` /
+    /// `Show` control flow).
+    static PHANTOM_ELEMENTS: RefCell<HashSet<Element>> =
+        RefCell::new(HashSet::new());
+
+    /// Monotonic counter for phantom IDs. Starts above
+    /// [`PHANTOM_BASE`] (`1 << 31`) so phantom IDs are guaranteed
+    /// disjoint from the bridge renderer's allocations (which start
+    /// at 0 and increment one per real element creation — a session
+    /// would need 2 billion real elements to reach the phantom
+    /// range).
+    static NEXT_PHANTOM_ID: Cell<u32> = const { Cell::new(PHANTOM_BASE) };
+}
+
+/// Phantom IDs start at the high half of `u32`. The bridge renderer
+/// allocates real IDs from 0 upward (one per `create_element` call),
+/// so the two ranges can't collide in any realistic session.
+pub const PHANTOM_BASE: u32 = 1 << 31;
+
+/// Allocate a phantom [`Element`] — an opaque positional marker the
+/// runtime can attach to a parent in [`CHILDREN_OF`] without telling
+/// Lynx anything about it. All bridge-touching dispatchers
+/// ([`append_child`], [`remove_child`], [`insert_child_at`],
+/// [`release_element`], …) detect phantom IDs and skip the FFI step,
+/// so a phantom contributes zero Lynx elements + zero layout cost
+/// while still serving as a stable index reference for the mirror.
+///
+/// Intended for the wrapper-less `For` / `Show` control flow: each
+/// `attach_generic` call creates one phantom to mark "where my range
+/// of items lives" inside the parent's mirror child list, then
+/// inserts items via [`insert_child_at`] using
+/// [`child_index`]`(parent, anchor)` as the position.
+///
+/// **No effect for**:
+///
+///   - [`set_attribute`] / [`set_inline_styles`] — silently no-op on
+///     phantoms (there's no Lynx element to style).
+///   - [`set_event_listener`] — silently no-op (nothing fires).
+///   - [`element_sign`] — returns 0 (phantoms have no Lynx
+///     `impl_id`).
+///   - [`set_update_list_info`] /
+///     [`install_list_native_item_provider`] — silently no-op.
+///
+/// A phantom is owner-tracked exactly like a real element: it's
+/// added to the current reactive owner's `elements` list, and
+/// [`release_element`] (which the owner cascade calls on dispose)
+/// removes it from [`CHILDREN_OF`] + [`PHANTOM_ELEMENTS`].
+pub fn create_phantom_element() -> Element {
+    let id = NEXT_PHANTOM_ID.with(|c| {
+        let id = c.get();
+        c.set(id.wrapping_add(1));
+        id
+    });
+    let handle = Element::from_raw(id);
+    PHANTOM_ELEMENTS.with_borrow_mut(|s| {
+        s.insert(handle);
+    });
+    crate::reactive::with_runtime(|rt| {
+        if let Some(owner_id) = rt.current_owner() {
+            if let Some(owner) = rt.owners.get_mut(owner_id) {
+                owner.elements.push(handle);
+            }
+        }
+    });
+    handle
+}
+
+/// Whether `handle` was allocated by [`create_phantom_element`].
+/// Cheap thread-local set lookup — the dispatchers below call this
+/// on every tree mutation to decide whether to skip the FFI step.
+pub fn is_phantom(handle: Element) -> bool {
+    if handle.id() < PHANTOM_BASE {
+        return false;
+    }
+    PHANTOM_ELEMENTS.with_borrow(|s| s.contains(&handle))
+}
+
+/// Count the **real** (non-phantom) children of `parent` strictly
+/// before `mirror_idx`. Used by [`insert_child_at`] to translate a
+/// mirror-side index (which counts phantoms) into the Lynx-side
+/// index the bridge FFI expects (which does not). Cheap O(mirror_idx)
+/// scan; the rotation already inside `insert_child_at` is the
+/// dominant cost.
+fn real_index_before(parent: Element, mirror_idx: usize) -> usize {
+    CHILDREN_OF.with_borrow(|m| {
+        m.get(&parent)
+            .map(|children| {
+                children
+                    .iter()
+                    .take(mirror_idx)
+                    .filter(|h| !is_phantom_unchecked(**h))
+                    .count()
+            })
+            .unwrap_or(0)
+    })
+}
+
+/// Cheaper [`is_phantom`] for hot-loop callers that already borrowed
+/// [`CHILDREN_OF`] / similar — only checks the ID range, missing the
+/// PHANTOM_ELEMENTS set membership. Safe to use inside an existing
+/// borrow because it touches a different thread_local. The high
+/// bit unambiguously marks phantoms in the documented protocol so
+/// the set membership check is belt-and-braces in production.
+fn is_phantom_unchecked(handle: Element) -> bool {
+    handle.id() >= PHANTOM_BASE
 }
 
 /// Install `r` as the current renderer for this thread, returning
@@ -309,24 +419,48 @@ pub fn create_element(tag: ElementTag) -> Element {
 }
 
 pub fn release_element(handle: Element) {
+    if is_phantom(handle) {
+        // Phantom never reached Lynx; tear down the mirror-side
+        // state and skip the bridge call.
+        PHANTOM_ELEMENTS.with_borrow_mut(|s| {
+            s.remove(&handle);
+        });
+        CHILDREN_OF.with_borrow_mut(|map| {
+            map.remove(&handle);
+        });
+        return;
+    }
     with_renderer(|r| r.release_element(handle), ())
 }
 
 pub fn set_attribute(handle: Element, key: &str, value: &str) {
+    if is_phantom(handle) {
+        return; // phantoms carry no styling — silently no-op
+    }
     with_renderer(|r| r.set_attribute(handle, key, value), ())
 }
 
 pub fn set_inline_styles(handle: Element, css: &str) {
+    if is_phantom(handle) {
+        return;
+    }
     with_renderer(|r| r.set_inline_styles(handle, css), ())
 }
 
 /// See [`DynRenderer::element_sign`]. Returns 0 when no renderer is
-/// installed (e.g. test setups using the mock renderer).
+/// installed (e.g. test setups using the mock renderer) or `handle`
+/// is a phantom (phantoms have no Lynx `impl_id`).
 pub fn element_sign(handle: Element) -> i32 {
+    if is_phantom(handle) {
+        return 0;
+    }
     with_renderer(|r| r.element_sign(handle), 0)
 }
 
 pub fn set_update_list_info(handle: Element, count: i32) {
+    if is_phantom(handle) {
+        return;
+    }
     with_renderer(|r| r.set_update_list_info(handle, count), ())
 }
 
@@ -334,6 +468,10 @@ pub fn install_list_native_item_provider(
     handle: Element,
     provider: super::list_provider::NativeItemProvider,
 ) -> bool {
+    if is_phantom(handle) {
+        drop(provider);
+        return false;
+    }
     with_renderer(
         |r| r.install_list_native_item_provider(handle, provider),
         false,
@@ -341,7 +479,17 @@ pub fn install_list_native_item_provider(
 }
 
 pub fn append_child(parent: Element, child: Element) {
-    with_renderer(|r| r.append_child(parent, child), ());
+    // The mirror update always happens. The Lynx call is skipped when
+    // either side of the edge is a phantom — phantom children must
+    // never reach the bridge (no Lynx element to attach), and a
+    // phantom parent can't host real Lynx children (it has no Lynx
+    // tree position to host them in). The latter shouldn't happen in
+    // well-formed code — phantoms are leaf-only by convention — but
+    // we guard against it anyway so a misuse can't pollute Lynx
+    // state.
+    if !is_phantom(parent) && !is_phantom(child) {
+        with_renderer(|r| r.append_child(parent, child), ());
+    }
     CHILDREN_OF.with_borrow_mut(|map| {
         map.entry(parent).or_default().push(child);
     });
@@ -352,7 +500,9 @@ pub fn append_child(parent: Element, child: Element) {
 }
 
 pub fn remove_child(parent: Element, child: Element) {
-    with_renderer(|r| r.remove_child(parent, child), ());
+    if !is_phantom(parent) && !is_phantom(child) {
+        with_renderer(|r| r.remove_child(parent, child), ());
+    }
     CHILDREN_OF.with_borrow_mut(|map| {
         if let Some(children) = map.get_mut(&parent) {
             children.retain(|c| *c != child);
@@ -360,8 +510,8 @@ pub fn remove_child(parent: Element, child: Element) {
     });
 }
 
-/// Insert `child` into `parent`'s child list at position `index`.
-/// If `index >= current_len`, behaves like [`append_child`].
+/// Insert `child` into `parent`'s mirror child list at position
+/// `index`. If `index >= current_len`, behaves like [`append_child`].
 ///
 /// First-pass implementation: Lynx's C ABI doesn't yet expose
 /// `insert_before` / `insert_at`, so we simulate ordered insertion
@@ -370,6 +520,13 @@ pub fn remove_child(parent: Element, child: Element) {
 /// O(N) cost is fine for `<For>` reorders and #[component] remounts
 /// where N is the parent's current child count. Replace with a
 /// direct Lynx API once the bridge gains one.
+///
+/// **Phantom handling**: `index` is a **mirror-side** index — it
+/// counts phantom siblings. Phantoms in the rotation snapshot are
+/// re-appended through [`append_child`], which is itself
+/// phantom-aware and skips the bridge FFI for phantom edges, so
+/// they stay invisible to Lynx through the rotation. Inserting a
+/// phantom is a mirror-only edit by the same mechanism.
 pub fn insert_child_at(parent: Element, child: Element, index: usize) {
     let to_re_append: Vec<Element> = CHILDREN_OF.with_borrow(|map| {
         map.get(&parent)
@@ -389,6 +546,12 @@ pub fn insert_child_at(parent: Element, child: Element, index: usize) {
     for c in to_re_append {
         append_child(parent, c);
     }
+    // `real_index_before` is intentionally unused for now — the
+    // detach/reappend rotation handles phantom invariants
+    // implicitly. Kept around so a future direct-insert FFI can
+    // translate mirror_idx → lynx_idx without re-deriving the
+    // logic.
+    let _ = real_index_before;
 }
 
 /// Return the element handle that appears immediately before `child`
@@ -438,6 +601,12 @@ pub fn set_event_listener(
     bind_type: BindType,
     callback: Box<dyn Fn(WhiskerValue) + 'static>,
 ) {
+    if is_phantom(handle) {
+        // Phantoms aren't in Lynx's event chain. Drop the callback
+        // to free it; matches the no-renderer-installed fallback.
+        drop(callback);
+        return;
+    }
     with_renderer(
         |r| r.set_event_listener(handle, event_name, bind_type, callback),
         (),
@@ -478,6 +647,9 @@ pub fn flush() {
 /// installed or the renderer doesn't have a native pointer for
 /// `handle`.
 pub fn module_component_ptr(handle: Element) -> usize {
+    if is_phantom(handle) {
+        return 0;
+    }
     CURRENT_RENDERER.with_borrow(|slot| match slot.as_ref() {
         Some(r) => r.module_component_ptr(handle),
         None => 0,

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -693,9 +693,24 @@ pub mod __tags {
 
         // ---- Children ---------------------------------------------------
 
-        /// Append a child handle.
-        fn child(self, child: Element) -> Self {
-            append_child(self.__element(), child);
+        /// Attach a child view. Accepts anything that implements
+        /// [`IntoView`](::whisker_runtime::view::IntoView): a bare
+        /// `Element` handle, a `For` / `Show` control flow (which
+        /// allocates its own phantom anchor under this parent and
+        /// installs its reactive effect), a `View::Fragment` of
+        /// children, or `View::Text` / primitives.
+        ///
+        /// The list builder overrides this to route
+        /// `View::ControlFlow` through
+        /// [`attach_to_list`](::whisker_runtime::view::ControlFlow::attach_to_list)
+        /// instead of the generic anchor path so the items end up in
+        /// the list's shared items Vec (the native-item provider
+        /// closure reads from there).
+        fn child<V>(self, child: V) -> Self
+        where
+            V: ::whisker_runtime::view::IntoView,
+        {
+            child.into_view().attach_to(self.__element());
             self
         }
 
@@ -1214,12 +1229,14 @@ pub mod __tags {
     #[allow(non_camel_case_types)]
     pub struct list {
         handle: Element,
-        // Children captured by `child()`, paired with the Lynx
-        // `impl_id` (sign) we eagerly computed for each. The closure
-        // installed in `__h` returns the sign verbatim from this
-        // cache — see the `child()` comment for why we can't re-
-        // enter the renderer from inside the closure.
-        items: ::std::vec::Vec<(Element, i32)>,
+        // Items live behind a shared `Rc<RefCell<…>>` so a `For` /
+        // `Show` control flow (handed via `.child(For(...))`) can
+        // mutate the same Vec the native-item provider closure
+        // installed in `__h` reads from. The provider closure
+        // captures `items.clone()` and reads by index; the control
+        // flow's effect captures another clone and rewrites the Vec
+        // + re-broadcasts the count on each reactive update.
+        items: ::whisker_runtime::view::ListItemsHandle,
     }
     #[allow(non_snake_case)]
     pub fn __list_ctor() -> list {
@@ -1231,68 +1248,116 @@ pub mod __tags {
         apply_attr::<_, ::std::string::String>(handle, "custom-list-name", "list-container");
         list {
             handle,
-            items: ::std::vec::Vec::new(),
+            items: ::std::rc::Rc::new(::std::cell::RefCell::new(::std::vec::Vec::new())),
         }
     }
     impl ElementBuilder for list {
         fn __element(&self) -> Element {
             self.handle
         }
-        // Attach the item eagerly + cache its Lynx `impl_id` (sign).
+        // `list`'s `.child(...)` dispatches on the View enum:
         //
-        // The native item provider closure (installed in `__h`) is
-        // invoked from inside the Lynx layout C++ — which is itself
-        // running inside our `with_renderer` borrow on the renderer's
-        // `RefCell`. Any call from the closure that re-enters
-        // `with_renderer` (`append_child`, `element_sign`, …) would
-        // panic on the re-entrant `borrow_mut`; that panic is caught
-        // at the C trampoline and turned into a sentinel return,
-        // leaving the list permanently empty. So instead: attach now
-        // (one `with_renderer` from a safe scope) and capture the
-        // sign so the closure only needs to read from a cached Vec.
-        fn child(mut self, child: Element) -> Self {
-            apply_attr_owned::<_, ::std::string::String>(
-                child,
-                ::std::string::String::from("item-key"),
-                ::std::format!("w_{}", self.items.len()),
-            );
-            append_child(self.handle, child);
-            let sign = ::whisker_runtime::view::element_sign(child);
-            self.items.push((child, sign));
-            self
+        //   • `View::Element` — a static `<list-item>` (or other
+        //     item-shaped element). Attach eagerly + cache its Lynx
+        //     `impl_id` (sign). The native-item provider closure
+        //     installed in `__h` is invoked from inside Lynx's
+        //     layout C++, which is itself already inside
+        //     `with_renderer`'s `RefCell` borrow — any call from the
+        //     closure that re-enters `with_renderer`
+        //     (`append_child`, `element_sign`, …) would panic on
+        //     the re-entrant borrow_mut. The panic is caught at the
+        //     C trampoline + turned into a sentinel return, leaving
+        //     the list permanently empty. So we attach + capture
+        //     the sign HERE (one `with_renderer` from a safe scope)
+        //     and the closure only reads from the cached Vec.
+        //
+        //   • `View::ControlFlow` — a `For` / `Show` reactive items
+        //     source. Route to `attach_to_list` which installs an
+        //     effect that mutates the same items Vec on every
+        //     reactive update and broadcasts `update-list-info`.
+        //
+        //   • `View::Fragment` / `View::Text` / `View::Empty` —
+        //     unusual inside a list; fall through to the generic
+        //     attach path. `View::Fragment` recurses, treating
+        //     each child as if it were its own `.child(...)` arg.
+        fn child<VV>(self, child: VV) -> Self
+        where
+            VV: ::whisker_runtime::view::IntoView,
+        {
+            self.child_view_impl(child.into_view())
         }
         // Wire the `<list>` for Lynx's native-driven path:
         //   1. install a `NativeItemProvider` so when Lynx's list
         //      machinery calls `componentAtIndex(i)`, our closure
-        //      attaches the captured child to the list and returns
-        //      its `Element::id` (sign) — no lepus, no crash. Re-
-        //      entrant calls for the same index are deduped via
-        //      `attached`.
+        //      reads the cached (handle, sign) from `items` and
+        //      returns the sign — no lepus, no crash.
         //   2. broadcast the item count via `update-list-info` so
         //      Lynx knows how many slots to lay out.
         fn __h(self) -> Element {
             let handle = self.handle;
-            let count = self.items.len() as i32;
-            let items = self.items;
+            let items_for_provider = self.items.clone();
+            let initial_count = self.items.borrow().len() as i32;
             let provider = ::whisker_runtime::view::list_provider::NativeItemProvider {
                 component_at_index: ::std::boxed::Box::new(move |index, _op, _reuse| {
-                    // Read the pre-computed (handle, sign) cache —
-                    // every Lynx-facing side effect already ran in
-                    // `child()` so this closure stays
-                    // re-entrancy-safe (no `with_renderer` from
-                    // inside the layout C++).
-                    items
+                    // Read the (handle, sign) cache — every
+                    // Lynx-facing side effect already ran in
+                    // `child_view_impl` / the control-flow effect
+                    // so this closure stays re-entrancy-safe (no
+                    // `with_renderer` from inside the layout C++).
+                    items_for_provider
+                        .borrow()
                         .get(index as usize)
                         .map(|&(_, sign)| sign)
                         .unwrap_or(::whisker_runtime::view::list_provider::INVALID_ITEM_INDEX)
                 }),
-                // Static list: no recycling notification needed — items
-                // stay attached for the list's lifetime.
+                // Recycling notifications not used yet — items
+                // stay attached for the list's lifetime, and the
+                // control-flow effect handles removal itself.
                 enqueue_component: ::std::option::Option::None,
             };
             install_list_native_item_provider(handle, provider);
-            set_update_list_info(handle, count);
+            set_update_list_info(handle, initial_count);
             handle
+        }
+    }
+    impl list {
+        /// Internal `View` dispatcher used by the
+        /// [`ElementBuilder::child`] override above. Lives here as
+        /// an associated method (rather than inline in the trait
+        /// override) so the View pattern-match is easy to read and
+        /// can be extended without touching the trait signature.
+        fn child_view_impl(self, view: ::whisker_runtime::view::View) -> Self {
+            use ::whisker_runtime::view::View;
+            match view {
+                View::Element(handle) => {
+                    let idx = self.items.borrow().len();
+                    apply_attr_owned::<_, ::std::string::String>(
+                        handle,
+                        ::std::string::String::from("item-key"),
+                        ::std::format!("w_{}", idx),
+                    );
+                    append_child(self.handle, handle);
+                    let sign = ::whisker_runtime::view::element_sign(handle);
+                    self.items.borrow_mut().push((handle, sign));
+                    self
+                }
+                View::ControlFlow(cf) => {
+                    // Hand the control flow a clone of the items
+                    // Rc. Its effect rewrites the Vec + broadcasts
+                    // the new count via `update-list-info` on
+                    // every reactive update.
+                    cf.attach_to_list(self.handle, self.items.clone());
+                    self
+                }
+                View::Fragment(children) => {
+                    let mut s = self;
+                    for c in children {
+                        s = s.child_view_impl(c);
+                    }
+                    s
+                }
+                View::Text(_) | View::Empty => self,
+            }
         }
     }
     impl list {

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -653,9 +653,15 @@ fn signal_only_updates_elements_that_read_it() {
 fn show_renders_children_when_true() {
     with_recorder_and_owner(|log| {
         let (cond, _set) = signal(true);
+        // Wrap in a `view` so the wrapper-less control flow has a
+        // parent to anchor against. The phantom anchor never reaches
+        // Lynx, so the renderer log records only the inner `text`
+        // creation + `text` attribute set — exactly what we assert.
         let _h = render! {
-            Show(when: move || cond.get()) {
-                text(value: "main")
+            view {
+                Show(when: move || cond.get()) {
+                    text(value: "main")
+                }
             }
         };
         let texts: Vec<_> = log
@@ -675,11 +681,13 @@ fn show_renders_fallback_when_false() {
     with_recorder_and_owner(|log| {
         let (cond, _set) = signal(false);
         let _h = render! {
-            Show(
-                when: move || cond.get(),
-                fallback: || render! { text(value: "fallback") },
-            ) {
-                text(value: "main")
+            view {
+                Show(
+                    when: move || cond.get(),
+                    fallback: || render! { text(value: "fallback") },
+                ) {
+                    text(value: "main")
+                }
             }
         };
         let texts: Vec<_> = log
@@ -699,11 +707,13 @@ fn show_swaps_on_condition_flip() {
     with_recorder_and_owner(|log| {
         let (cond, set_cond) = signal(true);
         let _h = render! {
-            Show(
-                when: move || cond.get(),
-                fallback: || render! { text(value: "fb") },
-            ) {
-                text(value: "main")
+            view {
+                Show(
+                    when: move || cond.get(),
+                    fallback: || render! { text(value: "fb") },
+                ) {
+                    text(value: "main")
+                }
             }
         };
         log.borrow_mut().clear();
@@ -728,8 +738,10 @@ fn show_without_fallback_renders_nothing_when_false() {
     with_recorder_and_owner(|log| {
         let (cond, _set) = signal(false);
         let _h = render! {
-            Show(when: move || cond.get()) {
-                text(value: "only")
+            view {
+                Show(when: move || cond.get()) {
+                    text(value: "only")
+                }
             }
         };
         let texts: Vec<_> = log
@@ -761,11 +773,13 @@ fn for_renders_initial_items() {
             Item { id: 3, name: "c" },
         ]);
         let _h = render! {
-            For(
-                each: move || items.get(),
-                key: |i: &Item| i.id,
-                children: move |i: Item| render! { text(value: i.name) },
-            )
+            view {
+                For(
+                    each: move || items.get(),
+                    key: |i: &Item| i.id,
+                    children: move |i: Item| render! { text(value: i.name) },
+                )
+            }
         };
 
         let texts: Vec<_> = log
@@ -788,11 +802,13 @@ fn for_adds_new_items_on_update() {
     with_recorder_and_owner(|log| {
         let (items, set_items) = signal(vec![1_u32, 2]);
         let _h = render! {
-            For(
-                each: move || items.get(),
-                key: |x: &u32| *x,
-                children: move |x: u32| render! { text(value: x.to_string()) },
-            )
+            view {
+                For(
+                    each: move || items.get(),
+                    key: |x: &u32| *x,
+                    children: move |x: u32| render! { text(value: x.to_string()) },
+                )
+            }
         };
         log.borrow_mut().clear();
 
@@ -827,11 +843,13 @@ fn for_reorders_existing_items_visually() {
     with_recorder_and_owner(|log| {
         let (items, set_items) = signal(vec![1_u32, 2, 3]);
         let _h = render! {
-            For(
-                each: move || items.get(),
-                key: |x: &u32| *x,
-                children: move |x: u32| render! { text(value: x.to_string()) },
-            )
+            view {
+                For(
+                    each: move || items.get(),
+                    key: |x: &u32| *x,
+                    children: move |x: u32| render! { text(value: x.to_string()) },
+                )
+            }
         };
         log.borrow_mut().clear();
 
@@ -855,11 +873,13 @@ fn for_removes_items_on_update() {
     with_recorder_and_owner(|log| {
         let (items, set_items) = signal(vec![1_u32, 2, 3]);
         let _h = render! {
-            For(
-                each: move || items.get(),
-                key: |x: &u32| *x,
-                children: move |x: u32| render! { text(value: x.to_string()) },
-            )
+            view {
+                For(
+                    each: move || items.get(),
+                    key: |x: &u32| *x,
+                    children: move |x: u32| render! { text(value: x.to_string()) },
+                )
+            }
         };
         log.borrow_mut().clear();
 

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -234,12 +234,17 @@ fn show_flips_when_signal_holding_option_transitions() {
     // tests don't exercise.
     with_recorder_and_owner(|log| {
         let (state, set_state) = signal::<Option<&'static str>>(None);
+        // Wrap in `view` so the wrapper-less `Show` has a parent to
+        // anchor against (the phantom anchor never reaches Lynx, so
+        // the log only records the inner branch's ops).
         let _h = render! {
-            Show(
-                when: move || state.get().is_some(),
-                fallback: move || render! { ColoredTile(color: "loading") },
-            ) {
-                ColoredTile(color: "loaded")
+            view {
+                Show(
+                    when: move || state.get().is_some(),
+                    fallback: move || render! { ColoredTile(color: "loading") },
+                ) {
+                    ColoredTile(color: "loaded")
+                }
             }
         };
         // Initial: fallback mounted → "loading" attribute set.

--- a/docs/wrapper-less-control-flow-design.md
+++ b/docs/wrapper-less-control-flow-design.md
@@ -1,0 +1,406 @@
+# Wrapper-less Control Flow — `For` / `Show` redesign
+
+Tracks the design for [#84](https://github.com/whiskerrs/whisker/issues/84).
+The end-to-end acceptance signal is **`hn-reader` switches from
+`scroll_view { For(...) }` to `list { For(...) }` and renders all
+30 stories through Lynx's native virtualisation, with no extra
+wrapper element in the tree**.
+
+---
+
+## 1. Problem
+
+Today `For` and `Show` each create a `<view>` wrapper element so the
+runtime has a stable parent to mount their reactive contents into:
+
+```text
+view                   ←  user wrote `view { For(...) text(...) }`
+  view  (For wrapper)  ←  inserted by `for_each(...)`
+    list-item × N
+  text
+```
+
+Two consequences fall out of that:
+
+1. **Extra elements**. Every `For` and `Show` is one more node in the
+   tree than the markup suggests. Compounded across a screen this
+   adds non-trivial work to layout / hit-testing.
+
+2. **`<list>` can't see the items**. The list builder's
+   `.child(child: Element)` receives the `For` wrapper as a single
+   child, not the N `<list-item>` elements that live inside it. The
+   native-item provider then advertises a 1-element list, and
+   `list { For(...) }` renders nothing useful. The wrapper hides the
+   items from list's eager-attach + `update-list-info` path
+   (`whisker_list_3_bugs_breakthrough` memory has the full trace of
+   that discovery).
+
+The hn-reader workaround today is to use `scroll_view { For(...) }`,
+which gives up the list's recycling / large-list scrolling and pays a
+full render cost for every story up-front.
+
+## 2. Goal
+
+Wrapper-less, React-Fragment-style control flow:
+
+- `For` and `Show` insert zero or one extra element in the DOM
+  (only an invisible **anchor** in the generic-parent case; nothing
+  at all in the `<list>` parent case).
+- Reactive updates re-render in place, preserving sibling order
+  relative to non-control-flow siblings.
+- The native `<list>` path sees each item individually so its
+  `NativeItemProvider` cache + `update-list-info` count are right.
+
+The `hn-reader` change closes the loop:
+
+```rust
+// Before
+scroll_view(scroll_orientation: "vertical", style: list_style) {
+    For(each: …, key: |s| s.object_id.clone(), children: |s| render! { story_row(story: s) })
+}
+
+// After
+list(style: list_style) {
+    For(each: …, key: |s| s.object_id.clone(), children: |s| render! { list_item { story_row(story: s) } })
+}
+```
+
+The macro-emitted call sites stay nearly identical; the entire
+behaviour shift lives behind `For`'s implementation + the list
+builder's `.child()`.
+
+## 3. Surface change in `View`
+
+`View` grows a `ControlFlow` variant carrying a trait object:
+
+```rust
+// crates/whisker-runtime/src/view/into_view.rs
+
+pub enum View {
+    Element(Element),
+    Text(String),
+    Fragment(Vec<View>),
+    ControlFlow(Box<dyn ControlFlow>),  // ← new
+    Empty,
+}
+
+/// A view that participates in its own attachment instead of being
+/// `append_child`-ed directly. `For` / `Show` are the only two
+/// implementors today; other reactive-children primitives can
+/// follow the same pattern.
+pub trait ControlFlow {
+    /// Attach into a generic container (`view`, `scroll_view`, …).
+    /// The control flow inserts an invisible anchor at `parent`'s
+    /// current end (or wherever `materialise_into` placed it) and
+    /// mounts its reactive children as siblings *before* the anchor.
+    fn attach_generic(self: Box<Self>, parent: Element);
+
+    /// Attach into a `<list>` container. The control flow writes its
+    /// items directly into the list's shared `items` Vec and
+    /// re-broadcasts `set_update_list_info(count)` on every update.
+    /// `list_handle` is the `<list>` element; `items` is the shared
+    /// state the native-item provider closure reads from.
+    fn attach_to_list(
+        self: Box<Self>,
+        list_handle: Element,
+        items: ListItemsHandle,
+    );
+}
+
+/// Shared list-item state, owned by the list builder, handed to
+/// every `ControlFlow::attach_to_list` call (and to the provider
+/// closure installed in `list::__h`).
+pub type ListItemsHandle = ::std::rc::Rc<::std::cell::RefCell<Vec<(Element, i32)>>>;
+```
+
+`View::ControlFlow` participates in `attach_to` / `materialise_into`
+via `attach_generic`. `View::ControlFlow` returns nothing from
+`elements()` — its contents are owned by the control-flow's effect,
+not the caller's `Vec<Element>` of "leaf handles" used for
+detach-on-update of `{expr}` children.
+
+## 4. Anchor strategy (generic parent)
+
+Picking **one** anchor (not two) keeps the element count at +1 vs
+today's +1 wrapper, and the runtime can locate "the range that
+belongs to me" cheaply by remembering the handles it last attached.
+
+### 4.1 Layout
+
+```text
+parent
+  ...
+  child_before_For
+  [ items in order ]    ← the control flow's range
+  anchor   ← invisible 0×0 <view>; stays in place across updates
+  child_after_For
+```
+
+The anchor goes in at the position the parent had reached when the
+control flow was being attached (= the natural source-order position
+of the `For` / `Show`). Items are inserted **before** the anchor on
+every (re)render.
+
+### 4.2 Anchor element shape
+
+A regular `<view>` with `width: 0; height: 0; flex-shrink: 0;` and no
+content. Flex layout collapses it to zero footprint without
+`display: none` (which would skip layout entirely and break sibling
+ordering in some Lynx versions). We document this convention so a
+future "anchor element type" can replace it if Lynx ever exposes a
+`<template>` / `<fragment>` primitive.
+
+### 4.3 Insertion sequence (generic path)
+
+`attach_generic(parent)`:
+
+1. Create the anchor view (one-shot), apply zero-size style, append
+   to `parent`. The anchor's current child index in `parent` is
+   `anchor_idx`.
+2. Install an `effect(...)` that:
+   - Reads the reactive source (`each()` / `when()`).
+   - Diffs against `self.tracked_handles` — items kept by key reuse
+     their owners; new items get fresh `create_owner(None)` +
+     `with_owner(|| view.into_view().materialise_into(...))`; removed
+     items get their owners disposed and their handles `remove_child`-ed.
+   - Re-inserts in the new order via
+     `insert_child_at(parent, item, anchor_idx)`. After each
+     insertion the anchor moves right by 1; we recompute
+     `anchor_idx = child_index(parent, anchor)?` before the next
+     insertion so order stays correct.
+
+The tracked-handles step is the only state the effect carries
+across reruns — the anchor handle and the parent are captured by
+the closure.
+
+### 4.4 Sibling order correctness
+
+For `view { text("hdr") For(...) text("ftr") }`:
+
+- Mount: `text("hdr")` appended, anchor for `For` appended (`anchor_idx = 1`),
+  items inserted before anchor at index 1, then `text("ftr")` appended.
+  Tree: `[hdr, item0, item1, ..., anchor, ftr]`.
+- Update: detach old items, re-insert new items before anchor at its
+  current index. `hdr` and `ftr` stay put.
+
+For nested `For` (a `For` whose `children` body contains another
+`For`), the inner `For`'s anchor is inserted relative to the outer
+items' parent — which is `parent` (the outer flow flattens its
+items as siblings, not nested). So nesting works without further
+machinery.
+
+## 5. `<list>` parent path
+
+`<list>` differs from generic parents in three ways:
+
+1. Items must end up as direct `<list-item>` children of the list
+   handle (Lynx's iteration assumes that shape).
+2. The list maintains an eagerly-computed `Vec<(Element, i32)>` of
+   `(handle, sign)` pairs — the native-item provider closure reads
+   from it.
+3. The list calls `set_update_list_info(handle, count)` so Lynx
+   knows the slot count at layout.
+
+### 5.1 List builder refactor
+
+```rust
+pub struct list {
+    handle: Element,
+    items: ListItemsHandle,  // ← was `Vec<(Element, i32)>`
+}
+```
+
+`items` is `Rc<RefCell<Vec<(Element, i32)>>>` instead of a plain
+`Vec` so the control flow's effect can mutate the same store the
+provider closure already reads from. The closure captures
+`items.clone()`; the control flow's effect captures another clone.
+
+### 5.2 list's `.child()` becomes view-aware
+
+```rust
+fn child<V: IntoView>(mut self, child: V) -> Self {
+    match child.into_view() {
+        View::Element(handle) => self.attach_one_item(handle),
+        View::ControlFlow(cf) => cf.attach_to_list(self.handle, self.items.clone()),
+        View::Fragment(children) => {
+            for c in children { self = self.child(c); }
+        }
+        View::Text(_) | View::Empty => {}
+    }
+    self
+}
+```
+
+The old static-children path lives in `attach_one_item` (set
+`item-key`, `append_child`, `element_sign`, push to items Vec).
+
+### 5.3 For/Show's `attach_to_list`
+
+For `For`:
+
+1. Install an `effect(...)` that:
+   - Reads `each()`, builds the new `(key, handle, sign)` list,
+     reusing per-key owners across reruns.
+   - For new items: create owner, materialise child via
+     `view.into_view().attach_to(list_handle)`, set `item-key`,
+     compute sign, push.
+   - For removed items: `remove_child(list_handle, handle)` + dispose
+     owner.
+   - Write the new ordered `Vec<(handle, sign)>` into
+     `*items.borrow_mut()`.
+   - Call `set_update_list_info(list_handle, items.len())`.
+
+For `Show`, the effect rebuilds one branch's contents on each `when`
+flip — same general shape but the per-item map collapses to a single
+"is-currently-showing-A-vs-B" piece of state.
+
+### 5.4 No anchor needed inside `<list>`
+
+The list owns its own item ordering through the items Vec; the
+provider closure indexes into that Vec. We bypass the generic
+anchor path entirely. No invisible element ends up inside the list.
+
+## 6. `render!` macro: how user code hits the new path
+
+The macro's `For` / `Show` lowering already emits a function call
+into `whisker::for_each(...)` / `whisker::show(...)`. The only shift
+is that those functions now return concrete `For<...>` / `Show`
+structs (instead of `Element`), and those structs `impl IntoView`
+returning `View::ControlFlow(Box<Self>)`.
+
+Container builders' `.child()` becomes generic over `impl IntoView`
+(see §5.2 for `list`; the same pattern applies to `view`,
+`scroll_view`, etc.). The macro's `.child(#inner)` token site
+doesn't change — the only thing different is that `#inner` may now
+be a `For<...>` or `Show` rather than an `Element`, and the
+builder's `.child` dispatches.
+
+Pre-existing callers that compose with `.child(elem)` directly keep
+working because `impl IntoView for Element` already exists.
+
+## 7. Phasing
+
+The roadmap mirrors §6 of the issue, slightly refined:
+
+### Phase 1 — Plumbing (non-breaking)
+
+- Add `View::ControlFlow(Box<dyn ControlFlow>)` + the `ControlFlow`
+  trait + `ListItemsHandle` typedef.
+- `View::attach_to` / `materialise_into` / `elements` handle the
+  new variant.
+- Tests: a `MockControlFlow` that records its `attach_generic` calls
+  proves the dispatch wires through `view.attach_to(parent)` and via
+  `IntoView`.
+
+### Phase 2 — `For` struct
+
+- Replace `for_each(...) -> Element` with
+  `for_each(...) -> For<...>` and an `IntoView for For<...>` impl.
+- Implement `For::attach_generic` (anchor + insert-before pattern).
+- Re-run `examples/hello-world` and existing scroll_view-based
+  `For` callers to verify no regression in the generic path.
+
+### Phase 3 — `Show` struct
+
+- Same shape: `show(...) -> Show` impls `IntoView` →
+  `View::ControlFlow(Box::new(self))`.
+- `Show::attach_generic` reuses the anchor pattern but the
+  per-key map collapses to a single mounted-branch owner.
+
+### Phase 4 — `<list>` plumbing
+
+- Refactor `list` to `items: ListItemsHandle`.
+- Generic `.child()` on the list builder, with the `View::Element`
+  static path and the `View::ControlFlow` reactive path.
+- `For::attach_to_list` + `Show::attach_to_list` (Show inside a
+  list is rare but for symmetry; if cost outweighs value we can
+  ship `attach_to_list` as a `compile_error!`-style runtime panic
+  for `Show` and revisit later).
+
+### Phase 5 — `hn-reader` switch
+
+- Replace `scroll_view { For }` with `list { For }`. Wrap each
+  story in a `list_item { story_row(...) }` inside `For`'s
+  `children`.
+- Verify on iOS Simulator (Lynx fork v3.8.0-whisker.1 already
+  ships the native list pieces) and Android emulator (real
+  devices preferred per the `whisker_adb_input_tap_no_handler`
+  memory, but rendering doesn't need touches).
+
+### Phase 6 — Cleanup
+
+- Drop the now-obsolete "wrapper view" notes from
+  `whisker_list_3_bugs_breakthrough` and any inline comments that
+  refer to the wrapper as the reason a particular kludge exists.
+- Document the anchor convention (§4.2) in the render-macro doc so a
+  future contributor doesn't try to re-introduce a wrapper.
+
+## 8. Open questions
+
+### 8.1 `Show` inside `<list>`
+
+`list { Show(when, children) }` is unusual — `<list>` is a flat
+collection of items, and `Show` flips between two single subtrees,
+which would mean "the list has one item that comes and goes." For
+v1 we implement `Show::attach_to_list` as the obvious
+single-or-zero-item branch (mount one item when `when` is true, zero
+items when false, re-broadcasting `set_update_list_info(0|1)`). If
+that turns out to surprise users we revisit.
+
+### 8.2 Anchor element type
+
+`<view>` works but is a noisy nine-character element name in any
+DOM dump. Lynx has no `<fragment>` / `<template>` element today; a
+future fork PR could add a zero-cost marker tag, at which point the
+anchor switches over without changing the rest of the architecture.
+
+### 8.3 Reordering perf
+
+The current `for_each` does a "detach all kept, re-attach in new
+order" per update. With the anchor pattern we do the same — every
+reorder is O(N). LIS-based minimal-move reordering is a known
+follow-up; the issue notes typical hn-reader churn (append,
+prepend, single insert) stays cheap with the simple path. We defer
+LIS until a real workload shows the cost.
+
+### 8.4 `View::ControlFlow` inside `View::Fragment`
+
+A fragment containing a control flow + plain elements
+(`(text("hi"), For(...))`) needs the control flow's anchor to land
+in source order. `Fragment::materialise_into` already iterates in
+order; passing `parent` through and letting `ControlFlow` attach as
+each child is visited preserves that. Edge case: control flow as the
+only child of an empty fragment — works identically since there are
+no surrounding siblings to anchor against.
+
+## 9. Acceptance test plan
+
+Per the user-facing goal:
+
+1. `whisker build --target ios-sim` on `hn-reader` succeeds (no
+   build regression from the API changes).
+2. `whisker run --target ios-sim` launches hn-reader; the loading
+   banner shows, then the list of 30 stories appears.
+3. Scrolling the list reaches the bottom (Lynx's native
+   virtualisation does its job — items 0..29 all renderable).
+4. No "For wrapper view" appears in element inspector / DOM dump.
+5. `whisker build --target android` on hn-reader succeeds and
+   runs on an Android emulator with the same item count.
+
+`hello-world` and `counter` continue to pass their existing build
+checks — both use `scroll_view`-style containers so they exercise the
+generic-parent path through the new ControlFlow surface.
+
+## 10. Out of scope
+
+- The general "tuple / iterator-flatten / arbitrary IntoView in
+  every child slot" surface — `.child(impl IntoView)` is what this
+  PR ships for the containers `For`/`Show` need to compose against,
+  not a universal builder overhaul.
+- Removing the `flex-direction: column` default `for_each` sets on
+  the wrapper today. Since the wrapper is gone, the default
+  vanishes; if user code relied on it implicitly, fix-ups land in
+  the same PR with an explicit doc note.
+- LIS-based minimal-move reordering (deferred, §8.3).
+- Any change to the `<list>` Lynx fork — the fork already supports
+  the native-item-provider model this design relies on.

--- a/examples/hn-reader/src/lib.rs
+++ b/examples/hn-reader/src/lib.rs
@@ -180,6 +180,10 @@ pub fn hn_reader() -> Element {
     // boilerplate collapses into this one call.
     let stories = resource(fetch_stories);
 
+    // Native `<list>` virtualises off-screen items + scroll for us.
+    // `flex-grow: 1` lets it expand to fill the page below the
+    // header; `flex-direction: column` puts items in a vertical
+    // stack (Lynx defaults to row).
     let list_style: &'static str =
         "flex-grow: 1; flex-shrink: 1; width: 100%; display: flex; flex-direction: column;";
 
@@ -207,7 +211,16 @@ pub fn hn_reader() -> Element {
                     render! { status_banner(message: msg) }
                 },
             ) {
-                scroll_view(scroll_orientation: "vertical", style: list_style) {
+                // Native `<list>` virtualisation. The `For` returns a
+                // `View::ControlFlow`; the list builder's
+                // `.child(impl IntoView)` detects that and routes via
+                // `attach_to_list`, which writes each item's
+                // (handle, sign) directly into the list's shared
+                // items Vec + broadcasts the count to Lynx via
+                // `update-list-info`. No wrapper element, no
+                // anchor — Whisker's phantom anchor mechanism keeps
+                // the positional bookkeeping mirror-side only.
+                list(style: list_style) {
                     For(
                         // `stories` is a Copy Resource handle, so the
                         // closure can re-read on each effect run.
@@ -216,7 +229,14 @@ pub fn hn_reader() -> Element {
                         // call and reuses item owners.
                         each: move || stories.get().unwrap_or_default(),
                         key: |s: &Story| s.object_id.clone(),
-                        children: |s: Story| render! { story_row(story: s) },
+                        // Each item must be a `<list-item>` (or
+                        // similar) for Lynx's list machinery to
+                        // accept it as a slot.
+                        children: |s: Story| render! {
+                            list_item {
+                                story_row(story: s)
+                            }
+                        },
                     )
                 }
             }


### PR DESCRIPTION
## Summary

Closes #84.

`For` and `Show` no longer produce a wrapping `<view>` element in
the rendered tree. They allocate a single **phantom anchor** —
an ID the runtime tracks in its parent → children mirror
(`CHILDREN_OF`) but never forwards to Lynx — and insert their
reactive children as siblings of that anchor. Net Lynx-element
delta: **-1 per control flow**.

The `<list>` parent path is doubly improved: `for_each` returns a
`For` struct that the list builder's `.child(impl IntoView)`
detects as a `View::ControlFlow` and routes through
`attach_to_list`, which writes `(handle, sign)` tuples directly
into the list's shared items `Rc<RefCell<Vec<…>>>` and re-
broadcasts `update-list-info` on every reactive update. The
native-item provider closure (installed in `list.__h()`) reads
from the same Rc clone — no provider re-install needed.

## hn-reader (the e2e acceptance signal)

| Before | After |
|---|---|
| `scroll_view(...) { For(...) }` | `list(...) { For(...) }` |
| Full eager render of all stories | Native virtualisation |
| For wrapper view in the tree | Zero extra elements |

Verified on iOS Simulator: header + ~12 visible stories render via
the phantom-anchor path, the list scrolls smoothly through all 30
stories.

## What changed

### `whisker-runtime` (commit `decba3f`)

Phantom-element infrastructure in `renderer.rs`:
  - `PHANTOM_BASE: u32 = 1 << 31` — phantom IDs occupy the high
    half of `u32`, disjoint from real-element allocations.
  - `create_phantom_element() -> Element` — owner-tracked
    (releases with the surrounding reactive owner) but never
    reaches Lynx.
  - `is_phantom(handle) -> bool` — cheap range + set check the
    bridge dispatchers gate on.
  - All bridge-touching dispatchers (`append_child`,
    `remove_child`, `insert_child_at`, `release_element`,
    `set_attribute`, `set_inline_styles`,
    `set_event_listener`, `element_sign`,
    `set_update_list_info`, `install_list_native_item_provider`,
    `module_component_ptr`) detect phantom edges and skip the FFI
    step.

### Control-flow rewrite (commit `3fee808`)

  - `View` grows a `ControlFlow(Box<dyn ControlFlow>)` variant.
  - `ControlFlow` trait has `attach_generic(parent)` and
    `attach_to_list(list_handle, items_handle)`.
  - `for_each` returns `For<...>`; `show` returns `Show`.
    Both impl `IntoView -> View::ControlFlow` and impl
    `ControlFlow`.
  - `ElementBuilder.child` is generic over `impl IntoView`.
    Default impl forwards through `view.attach_to(parent)`.
  - `list` builder overrides `.child` to pattern-match
    `View::ControlFlow` and route to `attach_to_list`.
  - `list.items` is now `ListItemsHandle` =
    `Rc<RefCell<Vec<(Element, i32)>>>`.

### hn-reader + tests (commit `0659a02`)

  - hn-reader switches `scroll_view { For }` to `list { For }`
    with each item wrapped in `list_item { story_row(...) }`.
  - `render_macro` and `signal_props` For/Show tests wrap their
    control flow in a `view { ... }` so the wrapper-less effect
    has a parent to anchor against (the old tests relied on the
    wrapper being the implicit self-parent).

### Design doc (commit `0f19809`)

`docs/wrapper-less-control-flow-design.md` — captures the
trade-off matrix (Option A/B/C/D from the design discussion) and
the rationale for picking the phantom-anchor (Option D) over a
real Lynx-side anchor: zero Lynx elements + full anchor-based
robustness against hot-reload-induced sibling churn.

## Build verification

  - `cargo check --workspace`: clean.
  - `cargo test --workspace --no-fail-fast`: all targets pass
    (27 `render_macro` tests, 5 `signal_props` tests, 83
    runtime tests, …).
  - `whisker build --target android` on hn-reader: BUILD
    SUCCESSFUL, APK produced.
  - `whisker build --target ios-sim` on hn-reader: .app produced,
    launches in Simulator, list renders.

## Acceptance against the issue's checklist

  - [x] `For` and `Show` insert zero `<view>` wrapper elements.
  - [x] `hn-reader` uses `list { For }` and renders all 30
    stories via native list virtualisation.
  - [x] Sibling order preserved (anchor-based + phantom-anchor
    survives hot-reload-induced sibling churn; see design doc
    §8 for the trade-off analysis).
  - [x] Nested control flow continues to work (For inside Show
    inside view, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)