### PR TITLE
feat(router): RouteStack + StackLayout with iOS-style transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "anim-demo"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1096,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "router-demo"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+ "whisker-router",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1915,23 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "whisker-router"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+ "whisker-router-macros",
+]
+
+[[package]]
+name = "whisker-router-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,16 @@ members = [
     "crates/whisker-css",
     "crates/whisker-runtime",
     "crates/whisker-subsecond",
+    "examples/anim-demo",
     "examples/counter",
     "examples/hello-world",
     "examples/hn-reader",
+    "examples/router-demo",
     "examples/subsecond-poc",
     "packages/whisker-hello-element",
     "packages/whisker-local-store",
+    "packages/whisker-router",
+    "packages/whisker-router-macros",
     "packages/whisker-video",
 ]
 exclude = [
@@ -51,6 +55,8 @@ whisker-driver-sys = { path = "crates/whisker-driver-sys", version = "0.1.0" }
 whisker-macros = { path = "crates/whisker-macros", version = "0.1.0" }
 whisker-css = { path = "crates/whisker-css", version = "0.1.0" }
 whisker-runtime = { path = "crates/whisker-runtime", version = "0.1.0" }
+whisker-router = { path = "packages/whisker-router", version = "0.1.0" }
+whisker-router-macros = { path = "packages/whisker-router-macros", version = "0.1.0" }
 
 anyhow = "1"
 thiserror = "2"

--- a/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_native_renderer_capi.h
@@ -293,6 +293,30 @@ LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_ui_invoke_method_async_with_params
     lynx_ui_method_result_cb callback,
     void* user_data);
 
+// ----- Element-level animation dispatch -------------------------------------
+//
+// Exposes `Element::Animate` from the DOM layer (distinct from
+// `lynx_ui_invoke_method`, which targets the UI layer below). Mirrors the
+// JS-side `element.animate()` argument shape:
+//
+//   [operation, animation_name, keyframes_map, options_map]
+//
+// `operation` follows `JavaScriptElement::AnimationOperation`:
+//   0 = START, 1 = PLAY, 2 = PAUSE, 3 = CANCEL, 4 = FINISH
+//
+// START requires the full quartet; PLAY/PAUSE/CANCEL/FINISH only consult
+// `animation_name`. `keyframes` is a MAP of `"0%" / "50%" / "100%"` keys
+// (each key's value is itself a MAP of CSS property → string). `options`
+// is a MAP of `name` / `duration` / `easing` / `iterations` / `direction`
+// / `fill` / `delay` / `play-state`. NULL values degrade to lepus-null.
+LYNX_NATIVE_RENDERER_CAPI_EXPORT int32_t lynx_element_animate(
+    lynx_shell_t* shell,
+    lynx_fiber_element_t* element,
+    int32_t operation,
+    const char* animation_name,
+    const lynx_ui_method_value_t* keyframes,
+    const lynx_ui_method_value_t* options);
+
 // ----- subsecond ASLR anchor ------------------------------------------------
 
 // Whisker's subsecond hot-patcher dlsym's this symbol on startup to

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -456,6 +456,24 @@ WHISKER_BRIDGE_EXPORT bool whisker_bridge_invoke_element_method_async_with_param
     WhiskerModuleCallback callback,
     void* user_data);
 
+// Element-level animation dispatch — wraps `lynx_element_animate`
+// (DOM layer, distinct from the UI-method dispatch above). Mirrors the
+// JS-side `element.animate(...)` shape:
+//
+//   [operation, animation_name, keyframes_map, options_map]
+//
+// `operation` follows `JavaScriptElement::AnimationOperation`:
+//   0 = START, 1 = PLAY, 2 = PAUSE, 3 = CANCEL, 4 = FINISH.
+//
+// START requires the full quartet. PLAY / PAUSE / CANCEL / FINISH only
+// consult `animation_name` — pass NULL for `keyframes` / `options`.
+WHISKER_BRIDGE_EXPORT WhiskerValueRaw whisker_bridge_element_animate(
+    WhiskerElement* element,
+    int32_t operation,
+    const char* animation_name,
+    const WhiskerValueRaw* keyframes,
+    const WhiskerValueRaw* options);
+
 // ---- Phase 0–3 leftovers (kept temporarily for compatibility) ------------
 
 WHISKER_BRIDGE_EXPORT void whisker_bridge_log_hello(void);

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -651,6 +651,48 @@ lynx_ui_method_value_t BuildCapiParamValue(const WhiskerValueRaw& v,
 }
 }  // namespace
 
+// -------- Element-level animation dispatch ---------------------------------
+//
+// Thin wrapper around `lynx_element_animate` (Lynx fork's new capi). Routes
+// `keyframes` / `options` through the same `BuildCapiParamValue` arena the
+// `_with_params` element-method path uses, so the C++ side gets a single
+// recursive `lynx_ui_method_value_t` for each. `keyframes` / `options` may be
+// NULL (PLAY / PAUSE / CANCEL / FINISH only need `animation_name`).
+extern "C" WhiskerValueRaw whisker_bridge_element_animate(
+    WhiskerElement* element,
+    int32_t operation,
+    const char* animation_name,
+    const WhiskerValueRaw* keyframes,
+    const WhiskerValueRaw* options) {
+    if (element == nullptr || element->handle == nullptr ||
+        element->shell == nullptr) {
+        return MakeBridgeErrorValue(
+            "whisker_bridge_element_animate: NULL element / shell");
+    }
+    CapiArena arena;
+    lynx_ui_method_value_t kf{};
+    lynx_ui_method_value_t opt{};
+    if (keyframes != nullptr) {
+        kf = BuildCapiParamValue(*keyframes, arena);
+    }
+    if (options != nullptr) {
+        opt = BuildCapiParamValue(*options, arena);
+    }
+    int32_t code = lynx_element_animate(
+        element->shell, element->handle, operation, animation_name,
+        keyframes != nullptr ? &kf : nullptr,
+        options != nullptr ? &opt : nullptr);
+    if (code != 0) {
+        return MakeBridgeErrorValue(
+            ("lynx_element_animate returned non-zero (code=" +
+             std::to_string(code) + ")").c_str());
+    }
+    WhiskerValueRaw ok;
+    std::memset(&ok, 0, sizeof(ok));
+    ok.type = WHISKER_VALUE_NULL;
+    return ok;
+}
+
 extern "C" WhiskerValueRaw whisker_bridge_invoke_element_method_with_params(
     WhiskerElement* element,
     const char* method_name,

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
@@ -116,6 +116,20 @@ extern "C" WhiskerValueRaw whisker_bridge_invoke_element_method_with_params(
         "UI-method dispatch");
 }
 
+extern "C" WhiskerValueRaw whisker_bridge_element_animate(
+    WhiskerElement* /*element*/,
+    int32_t /*operation*/,
+    const char* /*animation_name*/,
+    const WhiskerValueRaw* /*keyframes*/,
+    const WhiskerValueRaw* /*options*/) {
+    // Host builds have no Lynx animator — same error-path shape as the
+    // other element-method stubs. Real dispatch happens on iOS /
+    // Android via `lynx_element_animate`.
+    return MakeHostStubError(
+        "whisker_bridge_element_animate: host build has no Lynx — link "
+        "against the iOS / Android bridge for real animation dispatch");
+}
+
 extern "C" bool whisker_bridge_invoke_module_async(
     const char* module_name,
     const char* method_name,

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -373,6 +373,30 @@ extern "C" {
         params: *const WhiskerValueRaw,
     ) -> WhiskerValueRaw;
 
+    /// Element-level animation dispatch — `element.animate(...)` shape.
+    ///
+    /// Wraps the new `lynx_element_animate` capi (DOM layer, distinct
+    /// from `lynx_ui_invoke_method_*`). `operation` follows
+    /// `JavaScriptElement::AnimationOperation`:
+    ///   0 = START, 1 = PLAY, 2 = PAUSE, 3 = CANCEL, 4 = FINISH.
+    ///
+    /// For `START` the full quartet is required: `animation_name` plus a
+    /// `WHISKER_VALUE_MAP` of `"0%"/"50%"/"100%"` → CSS-prop map for
+    /// `keyframes`, and a `WHISKER_VALUE_MAP` of
+    /// `name`/`duration`/`easing`/`iterations`/`direction`/`fill`/`delay`
+    /// for `options`. Other operations only consult `animation_name` —
+    /// pass NULL for `keyframes` / `options`.
+    ///
+    /// Returns `WHISKER_VALUE_NULL` on dispatch success;
+    /// `WHISKER_VALUE_ERROR` on precondition failure.
+    pub fn whisker_bridge_element_animate(
+        element: *mut WhiskerElement,
+        operation: i32,
+        animation_name: *const c_char,
+        keyframes: *const WhiskerValueRaw,
+        options: *const WhiskerValueRaw,
+    ) -> WhiskerValueRaw;
+
     /// Async, result-returning element-method dispatch
     /// (`boundingClientRect` / `takeScreenshot`). Returns immediately;
     /// `callback(user_data, &result)` fires once the method completes

--- a/crates/whisker-driver/src/lib.rs
+++ b/crates/whisker-driver/src/lib.rs
@@ -124,6 +124,209 @@ pub fn invoke_element_method_with_params(
     result
 }
 
+/// Typed timing options for [`animate_start`]. Field names mirror the
+/// JS Web-Animations options object (and Lynx's `Element::Animate`
+/// `animation_data` table).
+#[derive(Clone, Debug)]
+pub struct AnimateOptions {
+    /// Duration in milliseconds.
+    pub duration_ms: u32,
+    /// Easing string — `"linear"`, `"ease-in"`, `"ease-out"`,
+    /// `"ease-in-out"`, or a `"cubic-bezier(...)"` literal.
+    pub easing: String,
+    /// Iteration count. Use `f64::INFINITY` for `"infinite"` —
+    /// the bridge serialises that through Lynx's special-case.
+    pub iterations: f64,
+    /// `"normal" | "reverse" | "alternate" | "alternate-reverse"`.
+    pub direction: String,
+    /// `"none" | "forwards" | "backwards" | "both"`.
+    pub fill: String,
+    /// Delay before the animation starts, milliseconds.
+    pub delay_ms: u32,
+}
+
+impl Default for AnimateOptions {
+    fn default() -> Self {
+        Self {
+            duration_ms: 300,
+            easing: "linear".into(),
+            iterations: 1.0,
+            direction: "normal".into(),
+            fill: "forwards".into(),
+            delay_ms: 0,
+        }
+    }
+}
+
+/// High-level wrapper around [`invoke_element_animate`] for the
+/// `START` operation: starts a named animation with explicit
+/// keyframes + timing.
+///
+/// `keyframes` is a slice of `(offset, css_props)` where `offset` is
+/// a percent string like `"0%"` / `"50%"` / `"100%"` and `css_props`
+/// is the property → value map applied at that frame. Order matches
+/// the slice (Lynx is offset-driven, not order-driven, but stable
+/// order keeps the serialised JSON readable).
+///
+/// Returns `Ok(())` on dispatch success; `Err(message)` if the bridge
+/// reports a precondition failure.
+pub fn animate_start(
+    handle: Element,
+    animation_name: &str,
+    keyframes: &[(&str, &[(&str, &str)])],
+    options: &AnimateOptions,
+) -> Result<(), String> {
+    let kf_map: std::collections::BTreeMap<String, WhiskerValue> = keyframes
+        .iter()
+        .map(|(offset, props)| {
+            let prop_map: std::collections::BTreeMap<String, WhiskerValue> = props
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), WhiskerValue::String((*v).to_string())))
+                .collect();
+            ((*offset).to_string(), WhiskerValue::Map(prop_map))
+        })
+        .collect();
+    let kf = WhiskerValue::Map(kf_map);
+
+    let mut opt_map = std::collections::BTreeMap::new();
+    opt_map.insert(
+        "name".to_string(),
+        WhiskerValue::String(animation_name.into()),
+    );
+    opt_map.insert(
+        "duration".to_string(),
+        WhiskerValue::Int(options.duration_ms as i64),
+    );
+    opt_map.insert(
+        "easing".to_string(),
+        WhiskerValue::String(options.easing.clone()),
+    );
+    opt_map.insert(
+        "iterations".to_string(),
+        WhiskerValue::Float(options.iterations),
+    );
+    opt_map.insert(
+        "direction".to_string(),
+        WhiskerValue::String(options.direction.clone()),
+    );
+    opt_map.insert(
+        "fill".to_string(),
+        WhiskerValue::String(options.fill.clone()),
+    );
+    opt_map.insert(
+        "delay".to_string(),
+        WhiskerValue::Int(options.delay_ms as i64),
+    );
+    let opt = WhiskerValue::Map(opt_map);
+
+    match invoke_element_animate(handle, AnimateOp::Start as i32, animation_name, kf, opt) {
+        WhiskerValue::Null => Ok(()),
+        WhiskerValue::Error(e) => Err(e),
+        other => Err(format!("unexpected animate return: {:?}", other)),
+    }
+}
+
+/// Cancel a running named animation — drops styles, clears state.
+pub fn animate_cancel(handle: Element, animation_name: &str) -> Result<(), String> {
+    match invoke_element_animate(
+        handle,
+        AnimateOp::Cancel as i32,
+        animation_name,
+        WhiskerValue::Null,
+        WhiskerValue::Null,
+    ) {
+        WhiskerValue::Null => Ok(()),
+        WhiskerValue::Error(e) => Err(e),
+        other => Err(format!("unexpected animate return: {:?}", other)),
+    }
+}
+
+/// Lynx-side animation lifecycle operations exposed by
+/// `Element::Animate`. Matches `JavaScriptElement::AnimationOperation`
+/// in the Lynx fork — same numeric values, same semantics.
+#[repr(i32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AnimateOp {
+    /// Start (or restart) a named animation with keyframes + options.
+    Start = 0,
+    /// Resume a paused animation.
+    Play = 1,
+    /// Pause a running animation in place.
+    Pause = 2,
+    /// Cancel — clear styles, drop the animation entirely.
+    Cancel = 3,
+    /// Snap to the animation's end state and stop.
+    Finish = 4,
+}
+
+/// Element-level animation dispatch — wraps `lynx_element_animate`
+/// via [`whisker_bridge_element_animate`](ffi::whisker_bridge_element_animate).
+///
+/// This is the DOM-layer animation entry point (`element.animate(...)` in
+/// JS), distinct from [`invoke_element_method_with_params`] which targets
+/// the UI layer below. `operation` follows the Lynx enum:
+///
+///   0 = START, 1 = PLAY, 2 = PAUSE, 3 = CANCEL, 4 = FINISH.
+///
+/// For `START` the caller must supply `keyframes` (`WhiskerValue::Map` of
+/// `"0%" / "50%" / "100%"` → CSS-prop map) and `options` (`WhiskerValue::Map`
+/// of `name` / `duration` / `easing` / `iterations` / `direction` / `fill` /
+/// `delay`). Other operations only consult `animation_name` — pass
+/// [`WhiskerValue::Null`] for the rest.
+///
+/// Returns [`WhiskerValue::Null`] on dispatch success;
+/// [`WhiskerValue::Error`] on precondition failure.
+pub fn invoke_element_animate(
+    handle: Element,
+    operation: i32,
+    animation_name: &str,
+    keyframes: WhiskerValue,
+    options: WhiskerValue,
+) -> WhiskerValue {
+    let ptr_usize = module_component_ptr(handle);
+    if ptr_usize == 0 {
+        return WhiskerValue::Error(format!(
+            "invoke_element_animate: no platform component for handle {} \
+             (renderer not installed, or element released)",
+            handle.id()
+        ));
+    }
+    let name_c = match CString::new(animation_name) {
+        Ok(c) => c,
+        Err(_) => return WhiskerValue::Error("animation_name contained NUL byte".into()),
+    };
+
+    let mut builder = RawBuilder::default();
+    let raw_kf = builder.encode(&keyframes);
+    let raw_opt = builder.encode(&options);
+    let kf_ptr = match keyframes {
+        WhiskerValue::Null => std::ptr::null(),
+        _ => &raw_kf as *const _,
+    };
+    let opt_ptr = match options {
+        WhiskerValue::Null => std::ptr::null(),
+        _ => &raw_opt as *const _,
+    };
+
+    let raw_result = unsafe {
+        ffi::whisker_bridge_element_animate(
+            ptr_usize as *mut WhiskerElement,
+            operation,
+            name_c.as_ptr(),
+            kf_ptr,
+            opt_ptr,
+        )
+    };
+
+    let result = unsafe { from_raw(&raw_result) };
+    unsafe {
+        let mut mutable = raw_result;
+        ffi::whisker_bridge_value_release(&mut mutable as *mut _);
+    }
+    drop(builder);
+    result
+}
+
 /// Async, **result-returning** element-method invoke — the path for
 /// `boundingClientRect` / `takeScreenshot` etc., whose return value
 /// arrives via Lynx's UI-method callback (typically on the UI thread)

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -48,7 +48,8 @@ pub use whisker_macros::{component, main, module_component, render};
 // allocates a fresh, unbound ref; the `#[whisker::module_component]`
 // macro binds it on mount when passed as the `ref:` prop.
 pub use whisker_driver::{
-    element_ref, BoundingClientRect, ElementHandle, ElementRef, ImageHandle, RefError, ScrollInfo,
+    animate_cancel, animate_start, element_ref, invoke_element_animate, AnimateOp, AnimateOptions,
+    BoundingClientRect, ElementHandle, ElementRef, ImageHandle, RefError, ScrollInfo,
     ScrollViewHandle, TextBoundingRect, TextHandle, UiInfo,
 };
 

--- a/examples/anim-demo/Cargo.toml
+++ b/examples/anim-demo/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "anim-demo"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Isolated Animatable debugging — one signal, one tween, two visualisations (numeric + transform)."
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+whisker = { workspace = true }

--- a/examples/anim-demo/src/lib.rs
+++ b/examples/anim-demo/src/lib.rs
@@ -1,0 +1,75 @@
+//! Lynx `element.animate()` smoke test.
+//!
+//! Calls `animate_start` against the blue box via the new
+//! `lynx_element_animate` bridge. If the bridge + Lynx native
+//! animator are wired correctly the box slides from the left to
+//! 250px on the right over 1 second.
+
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+use whisker::{animate_start, AnimateOptions, ElementHandle};
+
+#[whisker::main]
+pub fn render_app() -> Element {
+    let box_handle = ElementHandle::new();
+    let trigger_handle = box_handle;
+
+    // Mount-time auto-animate: as soon as the box mounts, kick off a
+    // slide. Re-runnable via the button below.
+    on_mount(move || {
+        run_slide(box_handle);
+    });
+
+    render! {
+        page(
+            style: "width: 100vw; height: 100vh; background-color: white; \
+                    display: flex; flex-direction: column; gap: 24px; padding: 48px 16px;",
+        ) {
+            text(
+                style: "font-size: 18px; font-family: monospace;",
+                value: "lynx_element_animate smoke test",
+            )
+
+            view(style: "width: 100%; height: 80px; background-color: #f3f4f6; border-radius: 12px; position: relative;") {
+                view(
+                    ref: box_handle.r(),
+                    style: "width: 80px; height: 80px; background-color: #3b82f6; \
+                            border-radius: 12px;",
+                )
+            }
+
+            view(
+                style: "padding: 12px; background-color: #1d4ed8; border-radius: 8px;",
+                on_tap: move |_| run_slide(trigger_handle),
+            ) {
+                text(
+                    style: "color: white; font-weight: 700;",
+                    value: "Re-run slide",
+                )
+            }
+        }
+    }
+}
+
+fn run_slide(handle: ElementHandle) {
+    let Some(el) = handle.r().element() else {
+        return;
+    };
+    let result = animate_start(
+        el,
+        "slide",
+        &[
+            ("0%", &[("transform", "translateX(0px)")]),
+            ("100%", &[("transform", "translateX(250px)")]),
+        ],
+        &AnimateOptions {
+            duration_ms: 1000,
+            easing: "ease-in-out".into(),
+            fill: "forwards".into(),
+            ..Default::default()
+        },
+    );
+    if let Err(e) = result {
+        eprintln!("animate_start failed: {e}");
+    }
+}

--- a/examples/anim-demo/whisker.rs
+++ b/examples/anim-demo/whisker.rs
@@ -1,0 +1,23 @@
+// `whisker.rs` for the anim-demo example. Mirrors the router-demo
+// shape — minimal config, no platform modules.
+
+pub fn configure(app: &mut whisker_app_config::AppConfig) {
+    app.name("AnimDemo")
+        .bundle_id("rs.whisker.examples.animDemo")
+        .version("0.1.0")
+        .build_number(1);
+
+    app.android(|a| {
+        a.package("rs.whisker.examples.animdemo")
+            .application_id("rs.whisker.examples.animdemo")
+            .launcher_activity(".MainActivity")
+            .min_sdk(24)
+            .target_sdk(34);
+    });
+
+    app.ios(|i| {
+        i.bundle_id("rs.whisker.examples.animDemo")
+            .scheme("AnimDemo")
+            .deployment_target("13.0");
+    });
+}

--- a/examples/router-demo/Cargo.toml
+++ b/examples/router-demo/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "router-demo"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "End-to-end exercise of whisker-router: #[route] macro, NavStack, Router, StackLayout, TabsLayout."
+
+# Plain rlib — same shape as examples/counter. The recording-renderer
+# integration test in `tests/` is the only entry point until the
+# production bootstrap learns about routing.
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+whisker = { workspace = true }
+whisker-router = { workspace = true }

--- a/examples/router-demo/src/lib.rs
+++ b/examples/router-demo/src/lib.rs
@@ -1,0 +1,185 @@
+//! Router demo — exercises the `whisker-router` public API end-to-end.
+//!
+//! Routes are declared with the `#[route]` attribute macro. The
+//! `render_app` entry creates a [`RouteStack`] and pushes it into
+//! context via [`RouteProvider`]; [`StackLayout`] then renders the
+//! current entry with iOS-style slide animations. Screens reach the
+//! stack through `router::<AppRoute>()` and call `push` / `back` from
+//! event handlers.
+//!
+//! The integration test in `tests/navigates_through_screens.rs`
+//! installs a recording renderer and walks the app through home →
+//! list → post(7) → back → settings.
+
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+use whisker_router::{
+    route, route_stack, router, RouteProvider, RouteProviderProps, RouteRenderFn, RouteStack,
+    StackLayout, StackLayoutProps,
+};
+
+/// Top-level route enum.
+///
+/// `#[route]` reads each variant's `#[at("…")]` pattern and
+/// generates a `Route` impl. The derived `Clone + Debug + PartialEq`
+/// are required by the trait bound on `RouteStack`.
+#[route]
+#[derive(Clone, Debug, PartialEq)]
+pub enum AppRoute {
+    #[at("/")]
+    Home,
+    #[at("/list")]
+    List,
+    #[at("/post/:id")]
+    Post { id: u64 },
+    #[at("/settings")]
+    Settings,
+}
+
+/// Container used by every screen — plain column layout with an
+/// opaque background. Opaque fill is iOS-style: during a
+/// `StackLayout` slide, the parallaxed outgoing screen sits behind
+/// the incoming and would show through any transparent area, so
+/// every screen MUST own its own background to look right.
+fn screen_style() -> &'static str {
+    "display: flex; flex-direction: column; gap: 8px; padding: 16px; \
+     width: 100%; height: 100%; background-color: white; overflow: visible;"
+}
+
+fn link_style() -> &'static str {
+    "padding: 6px 12px; background: #e5e7eb; border-radius: 4px;"
+}
+
+/// Home screen — two `push` actions to seed other test paths.
+#[component]
+pub fn home_screen() -> Element {
+    let nav = router::<AppRoute>();
+    let nav_list = nav.clone();
+    let nav_settings = nav.clone();
+    render! {
+        view(style: screen_style()) {
+            text(style: "font-size: 24px;") { text(value: "Home") }
+            view(
+                style: link_style(),
+                on_tap: move |_| nav_list.push(AppRoute::List),
+            ) {
+                text(value: "Open list")
+            }
+            view(
+                style: link_style(),
+                on_tap: move |_| nav_settings.push(AppRoute::Settings),
+            ) {
+                text(value: "Open settings")
+            }
+        }
+    }
+}
+
+/// List screen — pushes a `Post { id }` to demonstrate a route with
+/// a parameter.
+#[component]
+pub fn list_screen() -> Element {
+    let nav = router::<AppRoute>();
+    let nav_post = nav.clone();
+    let nav_back = nav.clone();
+    render! {
+        view(style: screen_style()) {
+            text(style: "font-size: 24px;") { text(value: "List") }
+            view(
+                style: link_style(),
+                on_tap: move |_| nav_post.push(AppRoute::Post { id: 7 }),
+            ) {
+                text(value: "Open post 7")
+            }
+            view(
+                style: link_style(),
+                on_tap: move |_| { nav_back.back(); },
+            ) {
+                text(value: "Back")
+            }
+        }
+    }
+}
+
+/// Post screen — reads its `id` prop, demonstrates `back()`.
+#[component]
+pub fn post_screen(id: u64) -> Element {
+    let nav = router::<AppRoute>();
+    let label = computed(move || format!("Post #{id}"));
+    render! {
+        view(style: screen_style()) {
+            text(style: "font-size: 24px;") { text(value: label) }
+            view(
+                style: link_style(),
+                on_tap: move |_| { nav.back(); },
+            ) {
+                text(value: "Back")
+            }
+        }
+    }
+}
+
+/// Settings screen — demonstrates `replace_all` (jump back to the
+/// root of the stack).
+#[component]
+pub fn settings_screen() -> Element {
+    let nav = router::<AppRoute>();
+    render! {
+        view(style: screen_style()) {
+            text(style: "font-size: 24px;") { text(value: "Settings") }
+            view(
+                style: link_style(),
+                on_tap: move |_| nav.replace_all(AppRoute::Home),
+            ) {
+                text(value: "Reset to home")
+            }
+        }
+    }
+}
+
+/// Build the app rooted at `stack`.
+///
+/// Exposed (rather than baked into `render_app`) so the integration
+/// test can hold the same `RouteStack` handle the UI uses, and drive
+/// it via `push` / `back` between renders.
+pub fn render_with(stack: RouteStack<AppRoute>) -> Element {
+    let render: RouteRenderFn<AppRoute> = (|r: AppRoute| match r {
+        AppRoute::Home => render! { HomeScreen() },
+        AppRoute::List => render! { ListScreen() },
+        AppRoute::Post { id } => render! { PostScreen(id: id) },
+        AppRoute::Settings => render! { SettingsScreen() },
+    })
+    .into();
+    render! {
+        RouteProvider(stack: stack) {
+            StackLayout(render: render.clone())
+        }
+    }
+}
+
+/// Production entry — fresh `RouteStack` rooted at `AppRoute::Home`.
+///
+/// Wraps everything in a viewport-sized `page` so the in-app content
+/// has a width/height to lay out against on iOS/Android. Background
+/// is white; each screen draws its own padded content on top.
+#[whisker::main]
+pub fn render_app() -> Element {
+    let stack = route_stack(AppRoute::Home);
+    let render: RouteRenderFn<AppRoute> = (|r: AppRoute| match r {
+        AppRoute::Home => render! { HomeScreen() },
+        AppRoute::List => render! { ListScreen() },
+        AppRoute::Post { id } => render! { PostScreen(id: id) },
+        AppRoute::Settings => render! { SettingsScreen() },
+    })
+    .into();
+    render! {
+        page(
+            style: "width: 100vw; height: 100vh; background-color: white; \
+                    display: flex; flex-direction: column;",
+        ) {
+            RouteProvider(stack: stack) {
+                StackLayout(render: render.clone())
+            }
+        }
+    }
+}

--- a/examples/router-demo/tests/navigates_through_screens.rs
+++ b/examples/router-demo/tests/navigates_through_screens.rs
@@ -1,0 +1,206 @@
+//! Integration test: drive the router-demo app through several
+//! navigation events and verify the recording renderer sees the
+//! expected text content at each step.
+//!
+//! Mirrors the shape of `examples/counter/tests/counter_renders.rs`.
+//! The point isn't pixel-perfect equivalence — it's that:
+//!  - `#[route]` generates a working `Route` impl,
+//!  - `RouteStack::push/back/replace_all` flow through `Router`'s
+//!    effect into actual mount / unmount calls on the renderer.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use router_demo::{render_with, AppRoute};
+use whisker::flush;
+use whisker::prelude::*;
+use whisker::runtime::reactive::{__reset_for_tests, create_owner, with_owner};
+use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
+use whisker_router::{route::Route, route_stack};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Op {
+    SetAttr { id: u32, key: String, value: String },
+}
+
+#[derive(Default)]
+struct Recorder {
+    next: u32,
+    log: Rc<RefCell<Vec<Op>>>,
+}
+
+impl Recorder {
+    fn new() -> (Self, Rc<RefCell<Vec<Op>>>) {
+        let r = Self::default();
+        let log = r.log.clone();
+        (r, log)
+    }
+}
+
+impl DynRenderer for Recorder {
+    fn create_element(&mut self, _tag: ElementTag) -> Element {
+        let id = self.next;
+        self.next += 1;
+        Element::from_raw(id)
+    }
+    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
+        let id = self.next;
+        self.next += 1;
+        Element::from_raw(id)
+    }
+    fn release_element(&mut self, _h: Element) {}
+    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
+        self.log.borrow_mut().push(Op::SetAttr {
+            id: h.id(),
+            key: k.into(),
+            value: v.into(),
+        });
+    }
+    fn set_inline_styles(&mut self, _h: Element, _css: &str) {}
+    fn append_child(&mut self, _p: Element, _c: Element) {}
+    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn set_event_listener(
+        &mut self,
+        _h: Element,
+        _name: &str,
+        _bind_type: whisker::runtime::view::BindType,
+        _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
+    ) {
+    }
+    fn set_root(&mut self, _p: Element) {}
+    fn flush(&mut self) {}
+}
+
+fn texts(log: &[Op]) -> Vec<String> {
+    log.iter()
+        .filter_map(|Op::SetAttr { key, value, .. }| match key.as_str() {
+            "text" => Some(value.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn route_macro_round_trips() {
+    // Pure macro check — no renderer needed.
+    assert_eq!(AppRoute::Home.to_path(), "/");
+    assert_eq!(AppRoute::Post { id: 7 }.to_path(), "/post/7");
+    assert_eq!(
+        AppRoute::parse("/post/12").unwrap(),
+        AppRoute::Post { id: 12 }
+    );
+    assert_eq!(AppRoute::parse("/list").unwrap(), AppRoute::List);
+}
+
+#[test]
+fn initial_mount_shows_home() {
+    __reset_for_tests();
+    let (rec, log) = Recorder::new();
+    let _prev = install_renderer(Box::new(rec));
+    let owner = create_owner(None);
+
+    let nav = route_stack(AppRoute::Home);
+    let _root = with_owner(owner, || render_with(nav.clone()));
+
+    let ts = texts(&log.borrow());
+    assert!(ts.contains(&"Home".to_string()), "got {ts:?}");
+    assert!(!ts.contains(&"List".to_string()), "got {ts:?}");
+
+    uninstall_renderer(None);
+}
+
+#[test]
+fn push_swaps_to_target_screen() {
+    __reset_for_tests();
+    let (rec, log) = Recorder::new();
+    let _prev = install_renderer(Box::new(rec));
+    let owner = create_owner(None);
+
+    let nav = route_stack(AppRoute::Home);
+    let _root = with_owner(owner, || render_with(nav.clone()));
+
+    log.borrow_mut().clear();
+    nav.push(AppRoute::List);
+    flush();
+
+    let ts = texts(&log.borrow());
+    assert!(ts.contains(&"List".to_string()), "got {ts:?}");
+
+    uninstall_renderer(None);
+}
+
+#[test]
+fn nested_push_with_param_renders_post() {
+    __reset_for_tests();
+    let (rec, log) = Recorder::new();
+    let _prev = install_renderer(Box::new(rec));
+    let owner = create_owner(None);
+
+    let nav = route_stack(AppRoute::Home);
+    let _root = with_owner(owner, || render_with(nav.clone()));
+
+    nav.push(AppRoute::List);
+    flush();
+    log.borrow_mut().clear();
+
+    nav.push(AppRoute::Post { id: 7 });
+    flush();
+
+    let ts = texts(&log.borrow());
+    assert!(ts.contains(&"Post #7".to_string()), "got {ts:?}");
+
+    uninstall_renderer(None);
+}
+
+#[test]
+fn back_returns_to_previous_screen() {
+    __reset_for_tests();
+    let (rec, log) = Recorder::new();
+    let _prev = install_renderer(Box::new(rec));
+    let owner = create_owner(None);
+
+    let nav = route_stack(AppRoute::Home);
+    let _root = with_owner(owner, || render_with(nav.clone()));
+
+    nav.push(AppRoute::List);
+    flush();
+    nav.push(AppRoute::Post { id: 3 });
+    flush();
+    log.borrow_mut().clear();
+
+    let popped = nav.back();
+    flush();
+
+    assert!(popped, "expected back() to report a pop");
+    let ts = texts(&log.borrow());
+    // After popping the Post screen we should be back on List.
+    assert!(ts.contains(&"List".to_string()), "got {ts:?}");
+
+    uninstall_renderer(None);
+}
+
+#[test]
+fn replace_all_drops_history() {
+    __reset_for_tests();
+    let (rec, _log) = Recorder::new();
+    let _prev = install_renderer(Box::new(rec));
+    let owner = create_owner(None);
+
+    let nav = route_stack(AppRoute::Home);
+    let _root = with_owner(owner, || render_with(nav.clone()));
+
+    nav.push(AppRoute::List);
+    flush();
+    nav.push(AppRoute::Post { id: 1 });
+    flush();
+    nav.push(AppRoute::Settings);
+    flush();
+
+    nav.replace_all(AppRoute::Home);
+    flush();
+
+    // Only one entry left, calling back() again is a no-op.
+    assert!(!nav.back(), "back() at root must return false");
+
+    uninstall_renderer(None);
+}

--- a/examples/router-demo/whisker.rs
+++ b/examples/router-demo/whisker.rs
@@ -1,0 +1,27 @@
+// `whisker.rs` for the router-demo example.
+//
+// Same shape as `examples/hello-world/whisker.rs`: `whisker run`
+// compiles this file into a probe binary, runs it to get JSON, and
+// feeds that into the dev-server config + platform sync (Android
+// gradle / iOS xcodeproj generation).
+
+pub fn configure(app: &mut whisker_app_config::AppConfig) {
+    app.name("RouterDemo")
+        .bundle_id("rs.whisker.examples.routerDemo")
+        .version("0.1.0")
+        .build_number(1);
+
+    app.android(|a| {
+        a.package("rs.whisker.examples.routerdemo")
+            .application_id("rs.whisker.examples.routerdemo")
+            .launcher_activity(".MainActivity")
+            .min_sdk(24)
+            .target_sdk(34);
+    });
+
+    app.ios(|i| {
+        i.bundle_id("rs.whisker.examples.routerDemo")
+            .scheme("RouterDemo")
+            .deployment_target("13.0");
+    });
+}

--- a/packages/whisker-router-macros/Cargo.toml
+++ b/packages/whisker-router-macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "whisker-router-macros"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Procedural macros for whisker-router: #[route] attribute on enums"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/packages/whisker-router-macros/src/lib.rs
+++ b/packages/whisker-router-macros/src/lib.rs
@@ -1,0 +1,305 @@
+//! Procedural macros for `whisker-router`.
+//!
+//! At present the crate exports a single attribute macro:
+//!
+//! ```ignore
+//! use whisker_router::route;
+//!
+//! #[route]
+//! #[derive(Clone, Debug, PartialEq)]
+//! pub enum AppRoute {
+//!     #[at("/")]
+//!     Home,
+//!     #[at("/profile/:id")]
+//!     Profile { id: u64 },
+//!     #[at("/settings")]
+//!     Settings,
+//! }
+//! ```
+//!
+//! `#[route]` reads each variant's `#[at("…")]` pattern and generates
+//! a `Route` impl whose `parse` / `to_path` are byte-for-byte equivalent
+//! to the hand-written example in `whisker-router::route::tests`.
+//!
+//! Path patterns are split on `/`; segments starting with `:` bind
+//! that variant's named field with the matching name (`:id` → field
+//! `id`). The field's type must implement `FromStr` for `parse` and
+//! `Display` for `to_path` — `u64`, `String`, custom enums all work.
+//! Tuple-struct variants (`Profile(u64)`) aren't supported in v1;
+//! switch to a named-field form (`Profile { id: u64 }`) instead.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, Data, DeriveInput, Fields, LitStr, Variant};
+
+/// `#[route]` attribute on an enum — generates `impl Route for Enum`.
+///
+/// See the crate-level docs for the supported variant + path forms.
+#[proc_macro_attribute]
+pub fn route(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(item as DeriveInput);
+    let enum_ident = input.ident.clone();
+
+    let Data::Enum(data_enum) = &mut input.data else {
+        return syn::Error::new_spanned(&input, "#[route] can only be applied to enums")
+            .to_compile_error()
+            .into();
+    };
+
+    let mut parse_arms = Vec::<TokenStream2>::new();
+    let mut to_path_arms = Vec::<TokenStream2>::new();
+
+    for variant in data_enum.variants.iter_mut() {
+        let at = match read_at(variant) {
+            Ok(v) => v,
+            Err(e) => return e.to_compile_error().into(),
+        };
+        // `#[at(...)]` is consumed here — strip it from the variant
+        // so the re-emitted enum doesn't carry an unrecognised
+        // attribute (rustc would reject it; helper-attribute
+        // registration only works on derive macros).
+        variant.attrs.retain(|a| !a.path().is_ident("at"));
+
+        let pattern_segments = split_path(&at.value());
+
+        match build_arms(&enum_ident, variant, &pattern_segments, at.span()) {
+            Ok((parse_arm, to_path_arm)) => {
+                parse_arms.push(parse_arm);
+                to_path_arms.push(to_path_arm);
+            }
+            Err(e) => return e.to_compile_error().into(),
+        }
+    }
+
+    let expanded = quote! {
+        #input
+
+        impl ::whisker_router::route::Route for #enum_ident {
+            fn parse(
+                __path: &str,
+            ) -> ::core::result::Result<Self, ::whisker_router::route::RouteError> {
+                let __n = __path.trim_end_matches('/');
+                let __n = __n.strip_prefix('/').unwrap_or(__n);
+                let __segments: ::std::vec::Vec<&str> = if __n.is_empty() {
+                    ::std::vec::Vec::new()
+                } else {
+                    __n.split('/').collect()
+                };
+                match __segments.as_slice() {
+                    #(#parse_arms)*
+                    _ => ::core::result::Result::Err(
+                        ::whisker_router::route::RouteError::NoMatch(__path.to_string()),
+                    ),
+                }
+            }
+
+            fn to_path(&self) -> ::std::string::String {
+                match self {
+                    #(#to_path_arms)*
+                }
+            }
+        }
+    };
+    expanded.into()
+}
+
+/// Pull the `#[at("…")]` literal off a variant. Variants without one
+/// are rejected — the macro can't reasonably guess a path.
+fn read_at(variant: &Variant) -> syn::Result<LitStr> {
+    for attr in &variant.attrs {
+        if attr.path().is_ident("at") {
+            return attr.parse_args::<LitStr>();
+        }
+    }
+    Err(syn::Error::new_spanned(
+        variant,
+        "every #[route] variant needs an #[at(\"…\")] attribute",
+    ))
+}
+
+/// `/profile/:id/edit` → `["profile", ":id", "edit"]`.
+/// Empty / "/" path → empty Vec (the "this is the index" case).
+fn split_path(s: &str) -> Vec<String> {
+    let n = s.trim_end_matches('/');
+    let n = n.strip_prefix('/').unwrap_or(n);
+    if n.is_empty() {
+        Vec::new()
+    } else {
+        n.split('/').map(str::to_string).collect()
+    }
+}
+
+/// Generate the two match arms (one for `parse`, one for `to_path`)
+/// for a single variant.
+fn build_arms(
+    enum_ident: &syn::Ident,
+    variant: &Variant,
+    pattern: &[String],
+    at_span: proc_macro2::Span,
+) -> syn::Result<(TokenStream2, TokenStream2)> {
+    let variant_ident = &variant.ident;
+
+    // Collect param-name → static-segment information.
+    // A "param" segment is `:foo`; everything else is a literal we
+    // pattern-match on as `&str`.
+    let mut params: Vec<String> = Vec::new();
+    let mut slice_pattern: Vec<TokenStream2> = Vec::new();
+    for seg in pattern {
+        if let Some(name) = seg.strip_prefix(':') {
+            let binding = format_ident!("__seg_{}", name);
+            params.push(name.to_string());
+            slice_pattern.push(quote! { #binding });
+        } else {
+            slice_pattern.push(quote! { #seg });
+        }
+    }
+
+    match &variant.fields {
+        Fields::Unit => {
+            if !params.is_empty() {
+                return Err(syn::Error::new(
+                    at_span,
+                    format!(
+                        "variant {variant_ident} is a unit variant — the `#[at]` \
+                         pattern has {} parameter(s) but the variant has no fields \
+                         to bind them to",
+                        params.len()
+                    ),
+                ));
+            }
+            let parse_arm = quote! {
+                [#(#slice_pattern),*] => ::core::result::Result::Ok(
+                    #enum_ident::#variant_ident
+                ),
+            };
+            let to_path_lit = render_path(pattern, |p| format!("{{{p}}}"));
+            // Unit variants have no field bindings, so render_path's
+            // formatting is just the literal pattern (no params).
+            debug_assert!(params.is_empty());
+            let _ = to_path_lit;
+            let to_path_arm = build_unit_to_path(pattern, enum_ident, variant_ident);
+            Ok((parse_arm, to_path_arm))
+        }
+        Fields::Named(named) => {
+            let field_names: Vec<&syn::Ident> = named
+                .named
+                .iter()
+                .map(|f| f.ident.as_ref().expect("named field has ident"))
+                .collect();
+
+            // Every `:foo` must match a field; every field must be
+            // covered by a `:foo`. (Order is the *field declaration*
+            // order in the struct — params can appear in any order
+            // inside the path.)
+            for p in &params {
+                if !field_names.iter().any(|f| *f == p) {
+                    return Err(syn::Error::new(
+                        at_span,
+                        format!(
+                            "path param `:{p}` doesn't match any field on \
+                             variant {variant_ident}"
+                        ),
+                    ));
+                }
+            }
+            for f in &field_names {
+                let f_name = f.to_string();
+                if !params.contains(&f_name) {
+                    return Err(syn::Error::new(
+                        at_span,
+                        format!(
+                            "field `{f_name}` on variant {variant_ident} isn't \
+                             bound by the `#[at]` pattern — add `:{f_name}` to it"
+                        ),
+                    ));
+                }
+            }
+
+            // parse arm
+            let parse_bindings = field_names.iter().map(|f| {
+                let seg_ident = format_ident!("__seg_{}", f);
+                let f_str = f.to_string();
+                quote! {
+                    let #f = (*#seg_ident).parse().map_err(|_| {
+                        ::whisker_router::route::RouteError::BadParam {
+                            param: #f_str,
+                            value: (*#seg_ident).to_string(),
+                        }
+                    })?;
+                }
+            });
+            let parse_arm = quote! {
+                [#(#slice_pattern),*] => {
+                    #(#parse_bindings)*
+                    ::core::result::Result::Ok(#enum_ident::#variant_ident { #(#field_names),* })
+                }
+            };
+
+            // to_path arm
+            let to_path_arm = build_named_to_path(pattern, enum_ident, variant_ident, &field_names);
+            Ok((parse_arm, to_path_arm))
+        }
+        Fields::Unnamed(_) => Err(syn::Error::new_spanned(
+            variant,
+            "tuple-struct variants aren't supported by #[route] v1 — \
+             use a named-field form like `Profile { id: u64 }`",
+        )),
+    }
+}
+
+/// Helper used by debug-formatting code paths inside `build_arms` —
+/// kept generic enough to be reused if we ever want a non-rust
+/// string output. For now only the param-named branch calls it.
+fn render_path(pattern: &[String], on_param: impl Fn(&str) -> String) -> String {
+    let mut out = String::from("/");
+    for (i, seg) in pattern.iter().enumerate() {
+        if i > 0 {
+            out.push('/');
+        }
+        match seg.strip_prefix(':') {
+            Some(name) => out.push_str(&on_param(name)),
+            None => out.push_str(seg),
+        }
+    }
+    out
+}
+
+fn build_unit_to_path(
+    pattern: &[String],
+    enum_ident: &syn::Ident,
+    variant_ident: &syn::Ident,
+) -> TokenStream2 {
+    let path = if pattern.is_empty() {
+        "/".to_string()
+    } else {
+        let mut p = String::from("/");
+        for (i, seg) in pattern.iter().enumerate() {
+            if i > 0 {
+                p.push('/');
+            }
+            p.push_str(seg);
+        }
+        p
+    };
+    quote! {
+        #enum_ident::#variant_ident => #path.to_string(),
+    }
+}
+
+fn build_named_to_path(
+    pattern: &[String],
+    enum_ident: &syn::Ident,
+    variant_ident: &syn::Ident,
+    fields: &[&syn::Ident],
+) -> TokenStream2 {
+    // Build a format! template — `:id` → `{id}`, literals stay as
+    // themselves. The matching `{id}` is fed by the field bindings
+    // unpacked in the match arm.
+    let template = render_path(pattern, |p| format!("{{{p}}}"));
+    quote! {
+        #enum_ident::#variant_ident { #(#fields),* } => {
+            ::std::format!(#template, #(#fields = #fields),*)
+        }
+    }
+}

--- a/packages/whisker-router/CROSS_CRATE_DEPS.md
+++ b/packages/whisker-router/CROSS_CRATE_DEPS.md
@@ -1,0 +1,127 @@
+# Cross-crate dependencies discovered while building whisker-router
+
+This file tracks every place where the router design requires
+extending another crate. Per the agreed working rule, none of these
+changes are made unilaterally — each is surfaced here and discussed
+with the project owner before landing.
+
+Status legend: 🟡 needed soon · 🟠 blocking next phase · 🔴 blocking
+something already attempted.
+
+## 🟠 1. `Animatable<T>` primitive in `whisker-runtime`
+
+**Why**: Stack-push / pop transitions and the interactive pop
+gesture both need a per-frame interpolation driver. CSS
+`transition` covers the declarative cases, but anything driven by
+a signal (gesture-tracking transforms, programmatic
+`animate_to(target, duration, easing)`) needs a Rust-side animator
+tied to the runtime tick.
+
+**Proposed API** (sketch):
+
+```rust
+pub struct Animatable<T> { ... }
+
+impl Animatable<f32> {
+    pub fn new(initial: f32) -> Self;
+    pub fn read(&self) -> ReadSignal<f32>;
+    pub fn set_immediately(&self, v: f32);
+    pub fn animate_to(&self, target: f32, duration: Duration, easing: Easing);
+}
+```
+
+**Affected layouts**: `StackLayout` (slide-in / slide-out, pop
+animation), `ModalLayout` (slide-up), `TabsLayout` (cross-fade
+between panes if we add it).
+
+**Required from runtime**: hook into the frame tick callback the
+host already drives, plus a `Easing` enum (likely just
+`Linear` / `EaseIn` / `EaseOut` / `EaseInOut` / `Spring` for v1).
+
+## 🟠 2. `Owner::pause()` / `Owner::resume()` for screen freeze
+
+**Why**: When a screen transitions to `EntryState::Suspended`
+(beneath top of stack), its effects should pause so it doesn't
+churn signals while invisible. RN's `enableFreeze` is the same
+idea, retrofitted via Suspense.
+
+**Proposed API**:
+
+```rust
+impl OwnerId {
+    pub fn pause(self);   // stop firing effects under this owner
+    pub fn resume(self);
+}
+```
+
+**Alternatives considered**: a per-entry "active" signal that
+every effect manually gates on. Rejected — error-prone and breaks
+the implicit-reactivity model.
+
+## 🟡 3. `on_global_event` accessible from package crates
+
+**Why**: Deep-link Level 2 wires native-side `whisker_url` global
+events into Whisker subscribers. The runtime has the
+`GlobalEventEmitter` plumbing for `<lynx-view>` events, but it
+isn't exposed as a `pub fn on_global_event(name, handler)` in
+`whisker::event`.
+
+**Current state**: `whisker-router/src/linking.rs` returns
+`None` / `()` as a placeholder; the API shape is finalized but the
+implementation is gated on the runtime export.
+
+**Required from runtime**: a `pub fn on_global_event(name: &str,
+handler: impl Fn(CustomEvent) + 'static) -> impl Drop`-ish guard.
+
+## 🟡 4. Touch events in `render!` kwargs
+
+**Why**: Pure-Whisker interactive pop gesture needs
+`view(on_touchstart: …, on_touchmove: …, on_touchend: …,
+on_touchcancel: …)` at the call site.
+
+**Audit needed**: `whisker-runtime/src/event.rs` defines
+`TouchEvent` and `bind_typed`, but I haven't confirmed which kwarg
+names the `render!` builder surface accepts. Likely a small
+addition in `whisker-macros/src/render.rs` (the `is_known_event_method`
+list) + matching `on_touchstart` etc. methods on the universal
+`ElementBuilder` trait in `whisker/src/lib.rs`.
+
+**Risk**: if the names already exist under different identifiers
+(e.g. `on_tap_start`), call sites need to match.
+
+## 🟡 5. `#[whisker::route]` proc macro
+
+**Why**: Hand-writing `Route::parse` / `to_path` per enum is
+boilerplate-heavy, especially with nested groups and path
+parameters. The proc macro generates both, plus the URL grammar
+from `#[at("/profile/:id")]` attributes.
+
+**Current state**: v1 ships without it — users write the impl by
+hand, following the canonical example in
+`whisker-router/src/route.rs` test module. Derive lands as a
+follow-up RFC.
+
+**Required from `whisker-macros`**: a new proc-macro-attribute (or
+derive) entry point that parses the variant attrs (`#[at(...)]`,
+`#[layout(LayoutComponent)]`) and emits the parser + builder +
+optional `RouteLayout` impl.
+
+## 🟡 6. `expect_context::<T>("reason")` helper
+
+**Why**: `outlet::router::<R>()` currently uses
+`use_context::<T>().expect("...")` inline. A canonical
+`expect_context` would surface a better message and keep the
+panic site in one place.
+
+**Trivial addition** to `whisker-runtime/src/reactive/context.rs`,
+re-exported through the prelude — punt until something else needs
+the same pattern.
+
+## Status snapshot
+
+The router skeleton, `NavStack`, `Route` trait, `Outlet`,
+`Router`, `BackHandler` chain, and a stub `StackLayout` are all in
+the crate and tested without touching any other crate. Items 1, 2,
+4 are blockers for the next implementation phase (interactive
+gestures + transitions); items 3 and 5 are quality-of-life that
+can wait until the surface is exercised by a real example.

--- a/packages/whisker-router/Cargo.toml
+++ b/packages/whisker-router/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "whisker-router"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Type-safe signal-backed routing for Whisker — single-engine, custom animations, nested layouts (tabs/modal). RFC: https://github.com/whiskerrs/whisker/issues/95"
+
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "src/**/*.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+# rlib only — the module-system distribution path handles the native
+# sources separately. Same pattern as whisker-local-store /
+# whisker-hello-element.
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker. The Whisker build pipeline scans dep
+# trees for this table to discover module crates and stage their
+# `ios/` + `android/` directories into the platform builds.
+[package.metadata.whisker]
+
+[dependencies]
+whisker = { workspace = true }
+whisker-router-macros = { workspace = true }

--- a/packages/whisker-router/src/back_handler.rs
+++ b/packages/whisker-router/src/back_handler.rs
@@ -1,0 +1,181 @@
+//! [`on_back`] — LIFO back-handler chain.
+//!
+//! Components register a closure that returns `true` if it
+//! consumed the back event, `false` to forward it down the chain.
+//! Walking from most-recently-registered to oldest matches both
+//! React Native's `BackHandler` and Android's
+//! `OnBackPressedDispatcher` priority semantics.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+thread_local! {
+    /// LIFO of registered back handlers. Each entry is wrapped in
+    /// an `Rc` so guards can identify their own slot for removal
+    /// without an O(n) sweep over the closures themselves.
+    static HANDLERS: RefCell<Vec<HandlerSlot>> = const { RefCell::new(Vec::new()) };
+}
+
+struct HandlerSlot {
+    id: u64,
+    cb: Rc<dyn Fn() -> bool>,
+}
+
+thread_local! {
+    static NEXT_ID: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// RAII guard returned by [`on_back`]. Dropping it removes the
+/// handler from the chain — typically called automatically when
+/// the owning component unmounts (via `on_cleanup`).
+pub struct BackHandlerGuard {
+    id: u64,
+    /// Set to `false` by [`Self::forget`] to detach without
+    /// removing the handler from the chain.
+    active: bool,
+}
+
+impl BackHandlerGuard {
+    /// Disarm the guard so dropping it does NOT remove the handler.
+    /// Useful when the handler should outlive the local binding.
+    pub fn forget(mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for BackHandlerGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let id = self.id;
+        HANDLERS.with(|h| {
+            let mut h = h.borrow_mut();
+            if let Some(pos) = h.iter().position(|s| s.id == id) {
+                h.remove(pos);
+            }
+        });
+    }
+}
+
+/// Register a back handler. Returns a [`BackHandlerGuard`] that
+/// removes the handler on drop.
+pub fn on_back<F>(handler: F) -> BackHandlerGuard
+where
+    F: Fn() -> bool + 'static,
+{
+    let id = NEXT_ID.with(|c| {
+        let v = c.get();
+        c.set(v.wrapping_add(1));
+        v
+    });
+    HANDLERS.with(|h| {
+        h.borrow_mut().push(HandlerSlot {
+            id,
+            cb: Rc::new(handler),
+        });
+    });
+    BackHandlerGuard { id, active: true }
+}
+
+/// Dispatch a back event through the chain.
+///
+/// Walks from most-recently-registered to oldest, stopping at the
+/// first handler that returns `true`. Returns the same `bool`: the
+/// caller (host platform glue) interprets `false` as "let the OS
+/// handle it" (finish the activity / dismiss the view controller).
+pub fn dispatch_back() -> bool {
+    // Snapshot the chain so handlers can register/unregister
+    // during dispatch without confusing the iteration.
+    let snapshot: Vec<Rc<dyn Fn() -> bool>> =
+        HANDLERS.with(|h| h.borrow().iter().rev().map(|s| Rc::clone(&s.cb)).collect());
+    for cb in snapshot {
+        if cb() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Test helper: wipe the back-handler chain. Useful between unit
+/// tests since the storage is thread-local.
+#[doc(hidden)]
+pub fn __reset_for_tests() {
+    HANDLERS.with(|h| h.borrow_mut().clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn no_handlers_returns_false() {
+        __reset_for_tests();
+        assert!(!dispatch_back());
+    }
+
+    #[test]
+    fn single_handler_consumes() {
+        __reset_for_tests();
+        let _g = on_back(|| true);
+        assert!(dispatch_back());
+    }
+
+    #[test]
+    fn lifo_walk_stops_at_first_true() {
+        __reset_for_tests();
+        let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+        let l1 = Rc::clone(&log);
+        let _g1 = on_back(move || {
+            l1.borrow_mut().push("oldest");
+            true
+        });
+        let l2 = Rc::clone(&log);
+        let _g2 = on_back(move || {
+            l2.borrow_mut().push("newest");
+            true
+        });
+        assert!(dispatch_back());
+        // newest fires first, returns true, oldest never runs
+        assert_eq!(log.borrow().as_slice(), ["newest"]);
+    }
+
+    #[test]
+    fn false_handler_yields_to_next() {
+        __reset_for_tests();
+        let count = Rc::new(Cell::new(0));
+        let c1 = Rc::clone(&count);
+        let _g1 = on_back(move || {
+            c1.set(c1.get() + 1);
+            true
+        });
+        let c2 = Rc::clone(&count);
+        let _g2 = on_back(move || {
+            c2.set(c2.get() + 10);
+            false
+        });
+        assert!(dispatch_back());
+        // newest ran (+10, returned false), then oldest ran (+1, returned true)
+        assert_eq!(count.get(), 11);
+    }
+
+    #[test]
+    fn guard_drop_removes_handler() {
+        __reset_for_tests();
+        {
+            let _g = on_back(|| true);
+            assert!(dispatch_back());
+        }
+        assert!(!dispatch_back());
+    }
+
+    #[test]
+    fn forget_detaches_drop_no_op() {
+        __reset_for_tests();
+        let g = on_back(|| true);
+        g.forget();
+        assert!(dispatch_back());
+        __reset_for_tests(); // cleanup since we leaked
+    }
+}

--- a/packages/whisker-router/src/layouts/mod.rs
+++ b/packages/whisker-router/src/layouts/mod.rs
@@ -1,0 +1,17 @@
+//! Layout components: `StackLayout`, `TabsLayout`, `ModalLayout`.
+//!
+//! Each layout consumes one variant of a parent route enum and
+//! decides how to render its slice (stack push/pop semantics, tab
+//! switching, modal presentation). They are intentionally
+//! standalone components — users can implement their own layout
+//! by following the same pattern (route variant in, element out).
+
+pub mod modal;
+pub mod pane;
+pub mod stack;
+pub mod tabs;
+
+pub use modal::{ModalLayout, ModalLayoutProps, ModalRenderFn};
+pub use pane::{Pane, PaneProps};
+pub use stack::{StackLayout, StackLayoutProps};
+pub use tabs::{TabSpec, TabsLayout, TabsLayoutProps};

--- a/packages/whisker-router/src/layouts/modal.rs
+++ b/packages/whisker-router/src/layouts/modal.rs
@@ -1,0 +1,140 @@
+//! `ModalLayout` — slide-from-bottom modal presentation driven by
+//! Lynx's native animator via [`animate_start`].
+//!
+//! On mount the sheet slides up from below the viewport over the
+//! same `slot_wrapper + on_mount + animate_start` pattern
+//! [`StackLayout`] uses. A scrim sits beneath as a fixed-opacity
+//! overlay (no fade animation for v1 — Lynx's animator chokes on
+//! same-frame opacity transitions in our wrapper-less setup; the
+//! sheet slide is the dominant cue).
+
+use std::rc::Rc;
+
+use whisker::css::ext::*;
+use whisker::css::{AlignItems, Color, Css, PositionKind, ToCss};
+use whisker::runtime::element::ElementTag;
+use whisker::runtime::reactive::on_mount;
+use whisker::runtime::view::apply::apply_styles;
+use whisker::runtime::view::{append_child, create_element, Element};
+use whisker::{animate_start, component, AnimateOptions};
+
+use crate::route::Route;
+
+const DEFAULT_DURATION_MS: u32 = 320;
+const DEFAULT_EASING: &str = "ease-out";
+const SCRIM_RGBA: (u8, u8, u8, f32) = (0, 0, 0, 0.45);
+
+/// Type-erased renderer for a single modal route.
+#[derive(Clone)]
+pub struct ModalRenderFn<R: Route>(pub Rc<dyn Fn(R) -> Element + 'static>);
+
+impl<R: Route> ModalRenderFn<R> {
+    /// Invoke the renderer with `route`.
+    pub fn call(&self, route: R) -> Element {
+        (self.0)(route)
+    }
+}
+
+impl<R, F> From<F> for ModalRenderFn<R>
+where
+    R: Route,
+    F: Fn(R) -> Element + 'static,
+{
+    fn from(f: F) -> Self {
+        ModalRenderFn(Rc::new(f))
+    }
+}
+
+/// Modal presentation — single route, slide-up entry via
+/// `animate_start`.
+#[component]
+pub fn modal_layout<R: Route>(route: R, render: ModalRenderFn<R>) -> Element {
+    let container = create_element(ElementTag::View);
+    apply_styles(container, container_css().to_css_string());
+
+    let scrim = create_element(ElementTag::View);
+    apply_styles(scrim, scrim_css().to_css_string());
+    append_child(container, scrim);
+
+    let sheet = create_element(ElementTag::View);
+    // Start the sheet offscreen-bottom so the very first paint shows
+    // it at translateY(100%); the on_mount animation slides it to 0.
+    apply_styles(sheet, sheet_css_initial().to_css_string());
+    append_child(container, sheet);
+
+    let content = render.call(route.clone());
+    append_child(sheet, content);
+
+    on_mount(move || {
+        let _ = animate_start(
+            sheet,
+            "whisker-modal-rise",
+            &[
+                ("0%", &[("transform", "translateY(100%)")]),
+                ("100%", &[("transform", "translateY(0%)")]),
+            ],
+            &AnimateOptions {
+                duration_ms: DEFAULT_DURATION_MS,
+                easing: DEFAULT_EASING.into(),
+                fill: "forwards".into(),
+                ..Default::default()
+            },
+        );
+    });
+
+    container
+}
+
+fn container_css() -> Css {
+    Css::new()
+        .position(PositionKind::Absolute)
+        .top(0.px())
+        .left(0.px())
+        .right(0.px())
+        .bottom(0.px())
+        .display_flex()
+        .align_items(AlignItems::FlexEnd)
+}
+
+fn scrim_css() -> Css {
+    let (r, g, b, a) = SCRIM_RGBA;
+    Css::new()
+        .position(PositionKind::Absolute)
+        .top(0.px())
+        .left(0.px())
+        .right(0.px())
+        .bottom(0.px())
+        .background_color(Color::rgba(r, g, b, a))
+}
+
+fn sheet_css_initial() -> Css {
+    use whisker::css::TransformFn;
+    Css::new()
+        .position(PositionKind::Relative)
+        .width(100.percent())
+        .transform([TransformFn::TranslateY(100.percent().into())])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrim_uses_configured_alpha() {
+        let css = scrim_css().to_css_string();
+        assert!(css.contains("0.45"), "got {css}");
+    }
+
+    #[test]
+    fn sheet_initial_pose_is_offscreen_bottom() {
+        let css = sheet_css_initial().to_css_string();
+        assert!(css.contains("translateY(100%)"), "got {css}");
+    }
+
+    #[test]
+    fn container_pins_to_viewport_bottom_aligned() {
+        let css = container_css().to_css_string();
+        assert!(css.contains("position: absolute"));
+        assert!(css.contains("align-items: flex-end"));
+    }
+}

--- a/packages/whisker-router/src/layouts/pane.rs
+++ b/packages/whisker-router/src/layouts/pane.rs
@@ -1,0 +1,55 @@
+//! `Pane` — display-toggleable container that keeps its children
+//! mounted while hidden.
+//!
+//! Tabs are the canonical caller: each tab's content lives inside
+//! a `Pane`, only one is visible at a time, and the inactive
+//! panes' state (scroll position, form inputs, in-flight effects)
+//! survives the switch because their elements are never unmounted.
+//!
+//! ```ignore
+//! use whisker::prelude::*;
+//! use whisker_router::layouts::Pane;
+//!
+//! let tab = RwSignal::new(Tab::Home);
+//!
+//! render! {
+//!     view(style: css!(flex_grow: 1)) {
+//!         Pane(visible: move || tab.get() == Tab::Home)    { Home() }
+//!         Pane(visible: move || tab.get() == Tab::Search)  { Search() }
+//!         Pane(visible: move || tab.get() == Tab::Profile) { Profile() }
+//!     }
+//! }
+//! ```
+
+use whisker::css::ext::*;
+use whisker::css::{Css, Display, FlexDirection, ToCss};
+use whisker::runtime::view::Element;
+use whisker::{component, computed, Children, WhenFn};
+
+/// Container that toggles between `display: flex` (children visible)
+/// and `display: none` (children hidden but still mounted).
+///
+/// `visible` is a `Fn() -> bool` — the call site writes a closure
+/// over its reactive deps, same shape as `Show`'s `when`.
+#[component]
+pub fn pane(visible: WhenFn, children: Children) -> Element {
+    let visible = visible.clone();
+    let style = computed(move || {
+        let on = visible.call();
+        let mut css = Css::new()
+            .flex_direction(FlexDirection::Column)
+            .width(100.percent())
+            .height(100.percent());
+        css = if on {
+            css.display(Display::Flex)
+        } else {
+            css.display(Display::None)
+        };
+        css.to_css_string()
+    });
+    whisker::render! {
+        view(style: style) {
+            children()
+        }
+    }
+}

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -1,0 +1,252 @@
+//! `StackLayout` — push/pop with both screens visible during the
+//! transition. Animation specifics are delegated to a
+//! [`StackTransition`](crate::StackTransition) implementation; the
+//! layout itself is responsible only for mounting / promoting
+//! slots, deriving the [`Direction`], and ordering the DOM so the
+//! transition's paint-order hint takes effect.
+//!
+//! The default transition is [`IosSlide`](crate::transitions::IosSlide):
+//! horizontal slide with ~30% parallax.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use whisker::css::ext::*;
+use whisker::css::{Css, Overflow, PositionKind, ToCss};
+use whisker::runtime::element::ElementTag;
+use whisker::runtime::reactive::{
+    create_owner, dispose_owner, effect, on_mount, with_owner, OwnerId,
+};
+use whisker::runtime::view::apply::apply_styles;
+use whisker::runtime::view::{
+    append_child, create_element, insert_child_at, remove_child, set_inline_styles, Element,
+};
+use whisker::{component, Style};
+
+use crate::outlet::{router, RouteRenderFn};
+use crate::route::Route;
+use crate::transitions::{Direction, Side, StackTransitionBox};
+
+type Slot = Rc<RefCell<Option<(OwnerId, Element)>>>;
+
+/// Animated stack: holds two slots during a transition and lets a
+/// [`StackTransition`] drive their animations.
+///
+/// The [`RouteStack`](crate::RouteStack) for route type `R` is
+/// pulled from context — wrap a [`RouteProvider`](crate::RouteProvider)
+/// above the layout so `router::<R>()` finds it.
+#[component]
+pub fn stack_layout<R: Route>(
+    #[prop(default = StackTransitionBox::default())] transition: StackTransitionBox,
+    render: RouteRenderFn<R>,
+) -> Element {
+    let stack = router::<R>();
+    let container = create_element(ElementTag::View);
+    apply_styles(container, container_css().to_css_string());
+
+    let outgoing: Slot = Rc::new(RefCell::new(None));
+    let current: Slot = Rc::new(RefCell::new(None));
+    let prev_len = Rc::new(Cell::new(0_usize));
+    let first = Rc::new(Cell::new(true));
+
+    let render = render.clone();
+    let current_signal = stack.current();
+    let stack_signal = stack.stack();
+    let transition_for_effect = transition.clone();
+
+    effect(move || {
+        let route = current_signal.get();
+        let new_len = stack_signal.get().len();
+        let old_len = prev_len.get();
+
+        let dir = if first.get() {
+            Direction::None
+        } else if new_len > old_len {
+            Direction::Forward
+        } else if new_len < old_len {
+            Direction::Backward
+        } else {
+            Direction::None
+        };
+        prev_len.set(new_len);
+        first.set(false);
+
+        // Tear down any leftover outgoing from a still-running prior
+        // transition — disposing now (rather than waiting for an
+        // animation-end signal Lynx doesn't yet expose) keeps the
+        // hidden-screen count bounded at one between transitions.
+        if let Some((owner, wrapper)) = outgoing.borrow_mut().take() {
+            remove_child(container, wrapper);
+            dispose_owner(owner);
+        }
+
+        // Promote previously-current → outgoing (or dispose on snap).
+        // Re-apply the wrapper's static style with its new role so
+        // direction-dependent decorations (e.g. the iOS dim layer)
+        // reflect the role flip before the animation kicks in.
+        if let Some((owner, wrapper)) = current.borrow_mut().take() {
+            if dir == Direction::None {
+                remove_child(container, wrapper);
+                dispose_owner(owner);
+            } else {
+                apply_wrapper_style(
+                    wrapper,
+                    transition_for_effect.0.as_ref(),
+                    Side::Outgoing,
+                    dir,
+                );
+                *outgoing.borrow_mut() = Some((owner, wrapper));
+            }
+        }
+
+        // Mount new wrapper + user screen. DOM paint order = sibling
+        // document order (Lynx ignores explicit `z-index` during
+        // transform animations). Insert at index 0 when the
+        // transition wants the outgoing on top (iOS pop semantics);
+        // append otherwise.
+        let new_owner = create_owner(None);
+        let wrapper = create_element(ElementTag::View);
+        apply_wrapper_style(
+            wrapper,
+            transition_for_effect.0.as_ref(),
+            Side::Incoming,
+            dir,
+        );
+        match transition_for_effect.0.foreground(dir) {
+            Side::Outgoing => insert_child_at(container, wrapper, 0),
+            Side::Incoming => append_child(container, wrapper),
+        }
+        let route_for_render = route.clone();
+        let render_for_owner = render.clone();
+        with_owner(new_owner, || {
+            let h = render_for_owner.call(route_for_render);
+            append_child(wrapper, h);
+        });
+        *current.borrow_mut() = Some((new_owner, wrapper));
+
+        if dir == Direction::None {
+            return;
+        }
+
+        // Hand off to the transition implementation. We wait for
+        // `on_mount` so the wrapper has its Lynx `sign` assigned.
+        let incoming_wrapper = wrapper;
+        let outgoing_for_anim = outgoing.borrow().as_ref().map(|(_, w)| *w);
+        let transition_for_mount = transition_for_effect.clone();
+        on_mount(move || {
+            transition_for_mount
+                .0
+                .animate(incoming_wrapper, Side::Incoming, dir);
+            if let Some(out) = outgoing_for_anim {
+                transition_for_mount.0.animate(out, Side::Outgoing, dir);
+            }
+        });
+    });
+
+    container
+}
+
+fn container_css() -> Css {
+    // `overflow: visible` rather than the Web default — Lynx clips
+    // children's `box-shadow` at the parent's bounds by default, so
+    // we have to declare visibility explicitly all the way down for
+    // [`IosSlide`]'s leading-edge shadow to show through.
+    Css::new()
+        .position(PositionKind::Relative)
+        .width(100.percent())
+        .height(100.percent())
+        .flex_grow(1.0)
+        .overflow(Overflow::Visible)
+}
+
+/// Apply the layout's slot positioning plus the transition's
+/// per-role decoration to a wrapper.
+///
+/// `Style::Static` collapses to one `set_inline_styles` write;
+/// `Style::Dynamic` registers an effect so the closure re-fires
+/// (and the wrapper re-styles) whenever any signal it reads
+/// changes — useful for theme-driven decoration.
+fn apply_wrapper_style(
+    wrapper: Element,
+    transition: &dyn crate::transitions::StackTransition,
+    side: Side,
+    direction: Direction,
+) {
+    let base = slot_css().to_css_string();
+    match transition.slot_style(side, direction) {
+        Style::Static(extra) => {
+            let combined = if extra.is_empty() {
+                base
+            } else {
+                format!("{base}{extra}")
+            };
+            set_inline_styles(wrapper, &combined);
+        }
+        Style::Dynamic(f) => {
+            effect(move || {
+                let extra = f();
+                let combined = if extra.is_empty() {
+                    base.clone()
+                } else {
+                    format!("{base}{extra}")
+                };
+                set_inline_styles(wrapper, &combined);
+            });
+        }
+    }
+}
+
+fn slot_css() -> Css {
+    // `overflow: visible` is critical — Lynx clips a child's
+    // `box-shadow` at the parent's bounds by default (unlike Web
+    // CSS where overflow defaults to `visible`). Without this the
+    // leading-edge shadow that `IosSlide` paints stays invisible.
+    Css::new()
+        .position(PositionKind::Absolute)
+        .top(0.px())
+        .left(0.px())
+        .width(100.percent())
+        .height(100.percent())
+        .overflow(Overflow::Visible)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transitions::{Fade, Instant, IosSlide, StackTransition, VerticalSlide};
+
+    #[test]
+    fn ios_slide_pop_keeps_outgoing_in_front() {
+        let t = IosSlide::default();
+        assert_eq!(t.foreground(Direction::Backward), Side::Outgoing);
+        assert_eq!(t.foreground(Direction::Forward), Side::Incoming);
+    }
+
+    #[test]
+    fn fade_keeps_incoming_in_front_in_both_directions() {
+        let t = Fade::default();
+        assert_eq!(t.foreground(Direction::Forward), Side::Incoming);
+        assert_eq!(t.foreground(Direction::Backward), Side::Incoming);
+    }
+
+    #[test]
+    fn instant_is_default_no_op() {
+        // Instant has no animation; the assertion is just that
+        // wrapping it in a transition box compiles & is Clone.
+        let t = StackTransitionBox::new(Instant);
+        let _ = t.clone();
+    }
+
+    #[test]
+    fn vertical_slide_inherits_default_easing() {
+        let t = VerticalSlide::default();
+        assert_eq!(t.easing, "ease-in-out");
+        assert_eq!(t.duration_ms, 320);
+    }
+
+    #[test]
+    fn container_uses_relative_positioning() {
+        let css = container_css().to_css_string();
+        assert!(css.contains("position: relative"), "got {css}");
+    }
+}

--- a/packages/whisker-router/src/layouts/tabs.rs
+++ b/packages/whisker-router/src/layouts/tabs.rs
@@ -1,0 +1,240 @@
+//! `TabsLayout` — keep-alive tab switcher driven by a single
+//! [`RouteStack`].
+//!
+//! Each tab is a `(matches, content)` pair: `matches` decides which
+//! current route belongs to this tab, `content` renders that tab's
+//! subtree. All tabs are mounted simultaneously and toggled between
+//! `display: flex` / `display: none` so state (scroll position,
+//! in-flight requests, signal values) survives switching — the same
+//! technique React Native's `BottomTabNavigator` and SwiftUI's
+//! `TabView` use.
+//!
+//! The expo-router-style nested-route design lives one level up: a
+//! parent enum's `#[layout(TabsLayout)]` variants each correspond to
+//! one tab, and the per-tab subtree is itself a `StackLayout` over
+//! that variant's inner route enum. From the `RouteStack`'s point of
+//! view the global stack is still a single sequence; tabs are pure
+//! projection.
+//!
+//! ```ignore
+//! use whisker::prelude::*;
+//! use whisker_router::{route_stack, TabSpec, TabsLayout};
+//!
+//! let nav = route_stack(AppRoute::Home(HomeRoute::Index));
+//!
+//! render! {
+//!     TabsLayout(
+//!         nav: nav.clone(),
+//!         tabs: vec![
+//!             TabSpec::new(
+//!                 |r: &AppRoute| matches!(r, AppRoute::Home(_)),
+//!                 || render! { HomeStack() },
+//!             ),
+//!             TabSpec::new(
+//!                 |r: &AppRoute| matches!(r, AppRoute::Search(_)),
+//!                 || render! { SearchStack() },
+//!             ),
+//!         ],
+//!         bar: BottomBar(nav: nav.clone()).into(),
+//!     )
+//! }
+//! ```
+
+use std::rc::Rc;
+
+use whisker::css::ext::*;
+use whisker::css::{Css, Display, FlexDirection, ToCss};
+use whisker::runtime::element::ElementTag;
+use whisker::runtime::view::apply::apply_styles;
+use whisker::runtime::view::{append_child, create_element, Element};
+use whisker::{component, computed};
+
+use crate::outlet::router;
+use crate::route::Route;
+
+/// One tab in a [`TabsLayout`] — a predicate over the current route
+/// plus the renderer for that tab's body.
+///
+/// Both closures are held in `Rc` so the struct is `Clone` (the
+/// `#[component]` macro re-clones every prop on each `FnMut` body
+/// invocation). `matches` is invoked inside a reactive `computed`
+/// every time the current route changes, so keep it cheap — usually
+/// a `matches!()` against an enum variant.
+pub struct TabSpec<R: Route> {
+    matches: Rc<dyn Fn(&R) -> bool + 'static>,
+    content: Rc<dyn Fn() -> Element + 'static>,
+}
+
+impl<R: Route> Clone for TabSpec<R> {
+    fn clone(&self) -> Self {
+        TabSpec {
+            matches: Rc::clone(&self.matches),
+            content: Rc::clone(&self.content),
+        }
+    }
+}
+
+impl<R: Route> TabSpec<R> {
+    /// Build a tab from a predicate and a body renderer.
+    pub fn new<M, C>(matches: M, content: C) -> Self
+    where
+        M: Fn(&R) -> bool + 'static,
+        C: Fn() -> Element + 'static,
+    {
+        TabSpec {
+            matches: Rc::new(matches),
+            content: Rc::new(content),
+        }
+    }
+}
+
+/// Keep-alive tab switcher.
+///
+/// Renders each tab's body inside its own pane; only the pane whose
+/// `matches` predicate accepts the current route is set to
+/// `display: flex`, the rest are `display: none`. An optional `bar`
+/// element (typically a bottom tab bar) is appended below the panes
+/// in column order.
+///
+/// The [`RouteStack`](crate::RouteStack) for route type `R` is
+/// pulled from context — wrap a [`RouteProvider`](crate::RouteProvider)
+/// above the layout so `router::<R>()` finds it.
+///
+/// Built directly against the runtime API rather than via `render!`
+/// for two reasons: (1) the macro can't take an arbitrary
+/// `Vec<TabSpec>` and unroll it, and (2) the bar is an already-built
+/// `Element` value which the macro doesn't accept as a child slot.
+#[component]
+pub fn tabs_layout<R: Route>(
+    tabs: Vec<TabSpec<R>>,
+    #[prop(default = None)] bar: Option<Element>,
+) -> Element {
+    let stack = router::<R>();
+    let container = create_element(ElementTag::View);
+    apply_styles(container, container_css().to_css_string());
+
+    // Pane area — grows to fill the space above the bar.
+    let pane_area = create_element(ElementTag::View);
+    apply_styles(pane_area, pane_area_css().to_css_string());
+    append_child(container, pane_area);
+
+    let current = stack.current();
+    // Clone the tab list out of the FnMut capture so we can consume
+    // it. `TabSpec` is cheap to clone (two `Rc` bumps each).
+    for tab in tabs.clone().into_iter() {
+        let pane = create_element(ElementTag::View);
+        let matches = tab.matches.clone();
+        let current_for_pane = current;
+        let style = computed(move || {
+            let on = matches(&current_for_pane.get());
+            pane_css(on).to_css_string()
+        });
+        apply_styles::<_, String>(pane, style);
+
+        let body = (tab.content)();
+        append_child(pane, body);
+        append_child(pane_area, pane);
+    }
+
+    if let Some(bar_el) = bar {
+        append_child(container, bar_el);
+    }
+
+    container
+}
+
+fn container_css() -> Css {
+    Css::new()
+        .flex_direction(FlexDirection::Column)
+        .width(100.percent())
+        .height(100.percent())
+}
+
+fn pane_area_css() -> Css {
+    // `flex: 1` equivalent — grow to consume vertical space left
+    // over by the bar.
+    Css::new()
+        .flex_grow(1.0)
+        .flex_direction(FlexDirection::Column)
+        .width(100.percent())
+}
+
+fn pane_css(visible: bool) -> Css {
+    // Each pane covers the full pane area; only one is visible at a
+    // time. `position: absolute` would also work but `display: none`
+    // + flex-grow lets layout fall through naturally to the bar.
+    let base = Css::new()
+        .flex_direction(FlexDirection::Column)
+        .width(100.percent())
+        .height(100.percent());
+    if visible {
+        base.display(Display::Flex)
+    } else {
+        base.display(Display::None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::route::RouteError;
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum TestRoute {
+        Home,
+        Search,
+    }
+
+    impl Route for TestRoute {
+        fn parse(_: &str) -> Result<Self, RouteError> {
+            unimplemented!()
+        }
+        fn to_path(&self) -> String {
+            String::new()
+        }
+    }
+
+    #[test]
+    fn tab_spec_predicate_runs() {
+        let spec: TabSpec<TestRoute> = TabSpec::new(
+            |r| matches!(r, TestRoute::Home),
+            whisker::runtime::view::create_phantom_element,
+        );
+        assert!((spec.matches)(&TestRoute::Home));
+        assert!(!(spec.matches)(&TestRoute::Search));
+    }
+
+    #[test]
+    fn tab_spec_is_clone() {
+        // Static check: `#[component]` requires Clone for FnMut
+        // captures. If `TabSpec` ever stops being Clone, this fails
+        // at compile time before showing up as a downstream macro
+        // error.
+        fn assert_clone<T: Clone>() {}
+        assert_clone::<TabSpec<TestRoute>>();
+    }
+
+    #[test]
+    fn pane_css_visible_emits_flex() {
+        let css = pane_css(true).to_css_string();
+        assert!(css.contains("display: flex"), "got {css}");
+    }
+
+    #[test]
+    fn pane_css_hidden_emits_none() {
+        let css = pane_css(false).to_css_string();
+        assert!(css.contains("display: none"), "got {css}");
+    }
+
+    #[test]
+    fn container_uses_column_layout() {
+        let css = container_css().to_css_string();
+        assert!(css.contains("flex-direction: column"), "got {css}");
+    }
+
+    #[test]
+    fn pane_area_grows() {
+        let css = pane_area_css().to_css_string();
+        assert!(css.contains("flex-grow: 1"), "got {css}");
+    }
+}

--- a/packages/whisker-router/src/lib.rs
+++ b/packages/whisker-router/src/lib.rs
@@ -1,0 +1,67 @@
+//! # whisker-router
+//!
+//! Type-safe, signal-backed routing for Whisker.
+//!
+//! Design lives in [issue #95](https://github.com/whiskerrs/whisker/issues/95).
+//! The crate ships:
+//!
+//! - [`Route`] — trait that ties a typed enum to its URL form.
+//! - [`RouteStack`] — first-class signal-backed back stack.
+//! - [`RouteProvider`] — pushes a [`RouteStack`] into context so
+//!   the layouts (and screens) below can resolve it with
+//!   [`router::<R>()`](router).
+//! - Layouts in [`layouts`] — [`StackLayout`], [`TabsLayout`],
+//!   [`ModalLayout`], [`Pane`]. Each layout pulls its stack from
+//!   the nearest ancestor [`RouteProvider`].
+//! - [`Outlet`] — mount-only variant of [`StackLayout`] (no
+//!   transition machinery), also context-driven.
+//! - [`on_back`] — LIFO back-handler chain.
+//! - [`linking`] — minimal deep-link surface: `initial_url` +
+//!   `on_url`.
+//!
+//! All routing logic runs inside a single [`whisker::runtime`]
+//! instance — there is intentionally no per-screen
+//! `UIViewController` / `Fragment`. Gestures, transitions, and
+//! freeze are implemented entirely on the Whisker side for
+//! cross-platform parity.
+
+#![warn(missing_docs)]
+
+pub mod back_handler;
+pub mod layouts;
+pub mod linking;
+pub mod outlet;
+pub mod route;
+pub mod stack;
+pub mod transitions;
+
+/// `#[route]` attribute macro — generates a `Route` impl from a
+/// per-variant `#[at("/...")]` pattern.
+///
+/// ```ignore
+/// use whisker_router::route;
+///
+/// #[route]
+/// #[derive(Clone, Debug, PartialEq)]
+/// pub enum AppRoute {
+///     #[at("/")]                Home,
+///     #[at("/profile/:id")]     Profile { id: u64 },
+///     #[at("/settings")]        Settings,
+/// }
+/// ```
+pub use whisker_router_macros::route;
+
+pub use crate::back_handler::{on_back, BackHandlerGuard};
+pub use crate::layouts::modal::{ModalLayout, ModalLayoutProps, ModalRenderFn};
+pub use crate::layouts::pane::{Pane, PaneProps};
+pub use crate::layouts::stack::{StackLayout, StackLayoutProps};
+pub use crate::layouts::tabs::{TabSpec, TabsLayout, TabsLayoutProps};
+pub use crate::outlet::{
+    router, Outlet, OutletProps, RouteProvider, RouteProviderProps, RouteRenderFn,
+};
+pub use crate::route::{Route, RouteError};
+pub use crate::stack::{route_stack, EntryId, EntryState, RouteEntry, RouteStack};
+pub use crate::transitions::{
+    Direction, Fade, Instant, IosSlide, Side, StackTransition, StackTransitionBox, VerticalSlide,
+    IOS_PARALLAX_PCT,
+};

--- a/packages/whisker-router/src/linking.rs
+++ b/packages/whisker-router/src/linking.rs
@@ -1,0 +1,37 @@
+//! Deep-link surface — Level 1 only.
+//!
+//! ```ignore
+//! use whisker_router::linking;
+//!
+//! let initial = linking::initial_url()
+//!     .and_then(|u| AppRoute::parse(&u).ok())
+//!     .unwrap_or(AppRoute::default_root());
+//!
+//! linking::on_url(move |url| {
+//!     // user decides routing / fallback
+//! });
+//! ```
+//!
+//! Wiring through the `whisker::module!` mechanism is implemented
+//! in a follow-up — this module is currently a documentation +
+//! API-shape placeholder while the runtime-side `on_global_event`
+//! primitive is confirmed (issue #95 deps).
+
+#![allow(unused_variables)]
+
+/// Returns the URL the app was cold-launched with, if any.
+///
+/// Stubbed until the `WhiskerLinking` Lynx module is wired up.
+pub fn initial_url() -> Option<String> {
+    None
+}
+
+/// Subscribe to URLs delivered after launch.
+///
+/// Stubbed until the global-event API is exposed from the runtime
+/// — tracked as part of the cross-crate dependency audit.
+pub fn on_url<F>(_handler: F)
+where
+    F: Fn(String) + 'static,
+{
+}

--- a/packages/whisker-router/src/outlet.rs
+++ b/packages/whisker-router/src/outlet.rs
@@ -1,0 +1,186 @@
+//! Provider + Outlet — wire a [`RouteStack`] into context and
+//! render the current route through a user-supplied closure.
+//!
+//! The pattern follows [`whisker::Show`] (control_flow.rs): a
+//! phantom element acts as the mount slot; an effect observes
+//! `stack.current()` and on each change disposes the previous
+//! branch before mounting the new one.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use whisker::runtime::reactive::{create_owner, dispose_owner, effect, with_owner, OwnerId};
+use whisker::runtime::view::{append_child, create_phantom_element, remove_child, Element};
+use whisker::{component, provide_context, use_context, Children};
+
+use crate::route::Route;
+use crate::stack::RouteStack;
+
+/// Function prop for [`Outlet`]: maps a route value to its rendered
+/// element. Wrapped in `Rc` so closures with non-`Copy` captures
+/// (e.g. a [`RouteStack`] handle) can be shared between the
+/// component's outer remount body and the inner mount effect.
+#[derive(Clone)]
+pub struct RouteRenderFn<R: Route>(pub Rc<dyn Fn(R) -> Element + 'static>);
+
+impl<R: Route> RouteRenderFn<R> {
+    /// Invoke the renderer with a route value.
+    pub fn call(&self, route: R) -> Element {
+        (self.0)(route)
+    }
+}
+
+impl<R, F> From<F> for RouteRenderFn<R>
+where
+    R: Route,
+    F: Fn(R) -> Element + 'static,
+{
+    fn from(f: F) -> Self {
+        RouteRenderFn(Rc::new(f))
+    }
+}
+
+/// Look up the [`RouteStack`] for route type `R` from context.
+///
+/// Panics if no [`RouteProvider`] of that route type is mounted
+/// above the caller — routing is unambiguous at the call site and
+/// silently returning `None` would hide the misuse.
+pub fn router<R: Route>() -> RouteStack<R> {
+    use_context::<RouteStack<R>>()
+        .expect("router::<R>() called outside a RouteProvider<R> ancestor")
+}
+
+/// `RouteProvider` — push a [`RouteStack`] into context so the
+/// layouts and screens below can look it up via [`router`].
+///
+/// Renders nothing of its own — the `children` slot carries the
+/// layout (typically [`StackLayout`](crate::StackLayout) or
+/// [`TabsLayout`](crate::TabsLayout)) plus everything underneath.
+/// Each provider provides one stack type; nested providers of
+/// different `R` coexist (type-keyed lookup picks the nearest
+/// ancestor for `R`), which is how tab-per-stack patterns get
+/// expressed.
+#[component]
+pub fn route_provider<R: Route>(stack: RouteStack<R>, children: Children) -> Element {
+    // `#[component]` wraps the body in `FnMut` so it can re-run on
+    // hot-reload, so the prop is cloned per invocation. `RouteStack`
+    // is `Rc`-backed — cheap.
+    provide_context(stack.clone());
+    whisker::render! {
+        children()
+    }
+}
+
+/// `Outlet` — renders the topmost entry of the in-context
+/// [`RouteStack`] via `render`.
+///
+/// Re-runs the renderer whenever the current route changes. The
+/// previously-mounted branch is fully disposed (signals + effects
+/// + async tasks inside it are dropped) before the new branch
+/// mounts, so screens don't leak across navigation events.
+///
+/// Pulls its [`RouteStack`] from context; wrap a containing
+/// [`RouteProvider`] above it. Useful as the *mount-only* path —
+/// no animation machinery; use [`StackLayout`](crate::StackLayout)
+/// when you want transitions.
+#[component]
+pub fn outlet<R: Route>(render: RouteRenderFn<R>) -> Element {
+    let stack = router::<R>();
+    let frag = create_phantom_element();
+
+    type Mounted = Rc<RefCell<Option<(OwnerId, Element)>>>;
+    let mounted: Mounted = Rc::new(RefCell::new(None));
+
+    let current = stack.current();
+    let render = render.clone();
+
+    effect(move || {
+        // Tear down the previously-mounted branch (if any).
+        if let Some((owner, handle)) = mounted.borrow_mut().take() {
+            remove_child(frag, handle);
+            dispose_owner(owner);
+        }
+
+        // Read the current route and mount its renderer under a
+        // fresh owner so all signals/effects/spawned tasks created
+        // inside live and die with this entry.
+        let route = current.get();
+        let owner = create_owner(None);
+        let handle = with_owner(owner, || {
+            let h = render.call(route);
+            append_child(frag, h);
+            h
+        });
+        *mounted.borrow_mut() = Some((owner, handle));
+    });
+
+    frag
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::route::RouteError;
+    use crate::stack::route_stack;
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum TestRoute {
+        Home,
+        Profile(u64),
+    }
+
+    impl Route for TestRoute {
+        fn parse(_: &str) -> Result<Self, RouteError> {
+            unimplemented!()
+        }
+        fn to_path(&self) -> String {
+            String::new()
+        }
+    }
+
+    fn with_runtime<F: FnOnce() -> T, T>(f: F) -> T {
+        whisker::runtime::reactive::__reset_for_tests();
+        let owner = create_owner(None);
+        let out = with_owner(owner, f);
+        dispose_owner(owner);
+        out
+    }
+
+    #[test]
+    fn router_lookup_via_context() {
+        with_runtime(|| {
+            let stack = route_stack(TestRoute::Home);
+            provide_context(stack.clone());
+
+            let found = router::<TestRoute>();
+            assert_eq!(found.current().get(), TestRoute::Home);
+
+            found.push(TestRoute::Profile(7));
+            assert_eq!(stack.current().get(), TestRoute::Profile(7));
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "outside a RouteProvider<R> ancestor")]
+    fn router_lookup_panics_without_context() {
+        with_runtime(|| {
+            let _ = router::<TestRoute>();
+        });
+    }
+
+    #[test]
+    fn render_fn_wraps_arbitrary_closure() {
+        with_runtime(|| {
+            let f: RouteRenderFn<TestRoute> = (|r: TestRoute| {
+                // The renderer is meant to return an Element; for
+                // unit testing we just confirm it's invoked.
+                match r {
+                    TestRoute::Home => create_phantom_element(),
+                    TestRoute::Profile(_) => create_phantom_element(),
+                }
+            })
+            .into();
+            let _ = f.call(TestRoute::Home);
+        });
+    }
+}

--- a/packages/whisker-router/src/route.rs
+++ b/packages/whisker-router/src/route.rs
@@ -1,0 +1,164 @@
+//! [`Route`] trait + supporting types.
+//!
+//! Concrete impls are hand-written for v1; the
+//! `#[whisker::route]` derive lands in a follow-up (requires
+//! `whisker-macros` extension — tracked separately).
+
+use core::fmt;
+
+/// A typed routing target. Implementors round-trip between an
+/// in-memory enum value and the canonical URL path.
+///
+/// The blanket bounds (`Clone + PartialEq + 'static`) are required
+/// by [`RouteStack`](crate::RouteStack) so the runtime can put the
+/// value in a signal and compare entries for equality.
+pub trait Route: Clone + PartialEq + 'static {
+    /// Parse a path (e.g. `/profile/42`) into a route value.
+    fn parse(path: &str) -> Result<Self, RouteError>
+    where
+        Self: Sized;
+
+    /// Canonical URL path for this route value.
+    fn to_path(&self) -> String;
+}
+
+/// Errors surfaced from [`Route::parse`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteError {
+    /// The input didn't match any defined route.
+    NoMatch(String),
+    /// A path parameter failed to parse (e.g. `id` not a valid `u64`).
+    BadParam {
+        /// Parameter name whose conversion failed.
+        param: &'static str,
+        /// Raw value that didn't parse.
+        value: String,
+    },
+}
+
+impl fmt::Display for RouteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RouteError::NoMatch(p) => write!(f, "no route matches path {p:?}"),
+            RouteError::BadParam { param, value } => {
+                write!(f, "bad param {param} = {value:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RouteError {}
+
+// ---- Test-only helpers ----------------------------------------
+//
+// Until the `#[whisker::route]` derive lands we hand-write `Route`
+// impls. This section also acts as the canonical "what an impl
+// looks like" example for documentation.
+
+#[cfg(test)]
+mod hand_written_example {
+    use super::*;
+
+    /// Typical app's top-level route.
+    #[derive(Clone, Debug, PartialEq)]
+    pub enum AppRoute {
+        Home,
+        Profile { id: u64 },
+        Settings,
+    }
+
+    impl Route for AppRoute {
+        fn parse(path: &str) -> Result<Self, RouteError> {
+            // Strip trailing slash + the leading one so segments
+            // line up regardless of how the URL was written.
+            let normalized = path.trim_end_matches('/');
+            let normalized = normalized.strip_prefix('/').unwrap_or(normalized);
+            let segments: Vec<&str> = if normalized.is_empty() {
+                Vec::new()
+            } else {
+                normalized.split('/').collect()
+            };
+
+            match segments.as_slice() {
+                [] => Ok(AppRoute::Home),
+                ["profile", id_str] => {
+                    let id = id_str.parse::<u64>().map_err(|_| RouteError::BadParam {
+                        param: "id",
+                        value: (*id_str).to_string(),
+                    })?;
+                    Ok(AppRoute::Profile { id })
+                }
+                ["settings"] => Ok(AppRoute::Settings),
+                _ => Err(RouteError::NoMatch(path.to_string())),
+            }
+        }
+
+        fn to_path(&self) -> String {
+            match self {
+                AppRoute::Home => "/".into(),
+                AppRoute::Profile { id } => format!("/profile/{id}"),
+                AppRoute::Settings => "/settings".into(),
+            }
+        }
+    }
+
+    #[test]
+    fn round_trip_home() {
+        let r = AppRoute::parse("/").unwrap();
+        assert_eq!(r, AppRoute::Home);
+        assert_eq!(r.to_path(), "/");
+    }
+
+    #[test]
+    fn round_trip_profile() {
+        let r = AppRoute::parse("/profile/42").unwrap();
+        assert_eq!(r, AppRoute::Profile { id: 42 });
+        assert_eq!(r.to_path(), "/profile/42");
+    }
+
+    #[test]
+    fn round_trip_settings() {
+        let r = AppRoute::parse("/settings").unwrap();
+        assert_eq!(r, AppRoute::Settings);
+        assert_eq!(r.to_path(), "/settings");
+    }
+
+    #[test]
+    fn trailing_slash_tolerated() {
+        assert_eq!(AppRoute::parse("/settings/").unwrap(), AppRoute::Settings);
+    }
+
+    #[test]
+    fn empty_path_is_home() {
+        // Some callers strip everything before handing off.
+        assert_eq!(AppRoute::parse("").unwrap(), AppRoute::Home);
+    }
+
+    #[test]
+    fn unknown_path_no_match() {
+        let err = AppRoute::parse("/blog/123").unwrap_err();
+        assert!(matches!(err, RouteError::NoMatch(_)));
+        assert_eq!(format!("{err}"), "no route matches path \"/blog/123\"");
+    }
+
+    #[test]
+    fn bad_param_surfaces_name_and_value() {
+        let err = AppRoute::parse("/profile/notanumber").unwrap_err();
+        match err {
+            RouteError::BadParam { param, value } => {
+                assert_eq!(param, "id");
+                assert_eq!(value, "notanumber");
+            }
+            other => panic!("expected BadParam, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_error_display_for_bad_param() {
+        let err = RouteError::BadParam {
+            param: "id",
+            value: "x".into(),
+        };
+        assert_eq!(format!("{err}"), "bad param id = \"x\"");
+    }
+}

--- a/packages/whisker-router/src/stack.rs
+++ b/packages/whisker-router/src/stack.rs
@@ -1,0 +1,356 @@
+//! [`RouteStack`] — signal-backed back stack.
+//!
+//! Designed as a *first-class value*: callers can create one with
+//! [`route_stack`], pass it as a prop, clone the handle, or hold
+//! several in parallel (tab patterns hold one per tab).
+//!
+//! Internally a single `RwSignal<Vec<RouteEntry<R>>>` drives reads;
+//! the per-entry [`EntryState`] signal coordinates animation and
+//! freeze metadata without churning the outer vector.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use whisker::{computed, ReadSignal, RwSignal};
+
+use crate::route::Route;
+
+/// Lifecycle stage of one [`RouteEntry`].
+///
+/// `Outlet` reads this to decide what styles to apply (slide-in vs
+/// settled vs slide-out) and whether to pause effects for entries
+/// that are out of view. The two `*ing` states are intentionally
+/// short-lived: layouts flip them to `Active` / `Suspended` once
+/// any transition animation finishes.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EntryState {
+    /// Just pushed; animation in progress, becomes [`Active`].
+    Entering,
+    /// Settled on top of the stack.
+    Active,
+    /// Settled beneath the top of the stack (kept mounted, frozen).
+    Suspended,
+    /// Just popped; animation in progress, then the entry is dropped.
+    Leaving,
+}
+
+/// Unique identifier for a [`RouteEntry`].
+///
+/// Stable across the entry's lifetime in the stack. Used as a key
+/// for animations / DOM diffing so the same physical screen keeps
+/// the same element handle even as the surrounding stack shifts.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EntryId(pub u64);
+
+/// One slot in a [`RouteStack`].
+#[derive(Clone)]
+pub struct RouteEntry<R: Route> {
+    /// The route this entry represents.
+    pub route: R,
+    /// Lifecycle signal; updated by layouts as animations progress.
+    pub state: RwSignal<EntryState>,
+    /// Stable id for this entry's lifetime.
+    pub id: EntryId,
+}
+
+impl<R: Route + PartialEq> PartialEq for RouteEntry<R> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.route == other.route
+    }
+}
+
+/// A signal-backed back stack of routes.
+///
+/// `RouteStack` is a *handle*: cloning it shares the underlying
+/// reactive storage with the original, so a stack can be passed
+/// freely between components / closures without wrapping in `Rc`.
+pub struct RouteStack<R: Route> {
+    entries: RwSignal<Vec<RouteEntry<R>>>,
+    next_id: Rc<Cell<u64>>,
+}
+
+impl<R: Route> Clone for RouteStack<R> {
+    fn clone(&self) -> Self {
+        Self {
+            entries: self.entries,
+            next_id: Rc::clone(&self.next_id),
+        }
+    }
+}
+
+impl<R: Route> RouteStack<R> {
+    /// Construct a stack with one initial entry.
+    pub fn new(initial: R) -> Self {
+        let next_id = Rc::new(Cell::new(0_u64));
+        let id = mint_id(&next_id);
+        let entry = RouteEntry {
+            route: initial,
+            state: RwSignal::new(EntryState::Active),
+            id,
+        };
+        Self {
+            entries: RwSignal::new(vec![entry]),
+            next_id,
+        }
+    }
+
+    // ---- writers ----
+
+    /// Push a new route onto the top of the stack.
+    ///
+    /// The previous top transitions to [`EntryState::Suspended`];
+    /// the new entry starts as [`EntryState::Entering`] so animated
+    /// layouts can run their slide-in.
+    pub fn push(&self, route: R) {
+        let id = mint_id(&self.next_id);
+        let new_entry = RouteEntry {
+            route,
+            state: RwSignal::new(EntryState::Entering),
+            id,
+        };
+        self.entries.update(|v| {
+            if let Some(last) = v.last() {
+                last.state.set(EntryState::Suspended);
+            }
+            v.push(new_entry);
+        });
+    }
+
+    /// Pop the topmost entry, if more than one remains.
+    ///
+    /// Returns `true` when something was popped, `false` when the
+    /// stack was already at its root (callers typically forward
+    /// that case to native back).
+    pub fn back(&self) -> bool {
+        let mut popped = false;
+        self.entries.update(|v| {
+            if v.len() > 1 {
+                v.pop();
+                if let Some(last) = v.last() {
+                    last.state.set(EntryState::Active);
+                }
+                popped = true;
+            }
+        });
+        popped
+    }
+
+    /// Pop entries until `predicate` returns true on the new top.
+    pub fn back_to(&self, predicate: impl Fn(&R) -> bool) {
+        self.entries.update(|v| {
+            while v.len() > 1 {
+                let keep = v.last().map(|e| predicate(&e.route)).unwrap_or(false);
+                if keep {
+                    break;
+                }
+                v.pop();
+            }
+            if let Some(last) = v.last() {
+                last.state.set(EntryState::Active);
+            }
+        });
+    }
+
+    /// Replace the topmost entry with `route` (no history growth).
+    pub fn replace(&self, route: R) {
+        let id = mint_id(&self.next_id);
+        self.entries.update(|v| {
+            v.pop();
+            v.push(RouteEntry {
+                route,
+                state: RwSignal::new(EntryState::Active),
+                id,
+            });
+        });
+    }
+
+    /// Clear the stack and start over with `route` at the root.
+    pub fn replace_all(&self, route: R) {
+        let id = mint_id(&self.next_id);
+        self.entries.set(vec![RouteEntry {
+            route,
+            state: RwSignal::new(EntryState::Active),
+            id,
+        }]);
+    }
+
+    // ---- readers ----
+
+    /// Reactive read of the topmost route.
+    pub fn current(&self) -> ReadSignal<R> {
+        let entries = self.entries;
+        computed(move || {
+            entries
+                .get()
+                .last()
+                .map(|e| e.route.clone())
+                .expect("RouteStack invariant: at least one entry")
+        })
+    }
+
+    /// Reactive read of the full stack (as `Vec<R>`).
+    pub fn stack(&self) -> ReadSignal<Vec<R>> {
+        let entries = self.entries;
+        computed(move || entries.get().iter().map(|e| e.route.clone()).collect())
+    }
+
+    /// Reactive read of the entries themselves — needed by layouts
+    /// that animate per-entry state.
+    pub fn entries(&self) -> ReadSignal<Vec<RouteEntry<R>>> {
+        let entries = self.entries;
+        computed(move || entries.get())
+    }
+
+    /// Reactive flag indicating whether [`Self::back`] would pop.
+    pub fn can_back(&self) -> ReadSignal<bool> {
+        let entries = self.entries;
+        computed(move || entries.get().len() > 1)
+    }
+
+    /// Reactive stack depth.
+    pub fn depth(&self) -> ReadSignal<usize> {
+        let entries = self.entries;
+        computed(move || entries.get().len())
+    }
+}
+
+fn mint_id(counter: &Rc<Cell<u64>>) -> EntryId {
+    let v = counter.get();
+    counter.set(v.wrapping_add(1));
+    EntryId(v)
+}
+
+/// Construct a fresh [`RouteStack`] with `initial` as its root entry.
+pub fn route_stack<R: Route>(initial: R) -> RouteStack<R> {
+    RouteStack::new(initial)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum TestRoute {
+        Home,
+        Profile(u64),
+        Settings,
+    }
+
+    impl Route for TestRoute {
+        fn parse(_path: &str) -> Result<Self, crate::RouteError> {
+            unimplemented!("parser not used in stack tests")
+        }
+        fn to_path(&self) -> String {
+            match self {
+                TestRoute::Home => "/".into(),
+                TestRoute::Profile(id) => format!("/profile/{id}"),
+                TestRoute::Settings => "/settings".into(),
+            }
+        }
+    }
+
+    fn with_runtime<F: FnOnce() -> T, T>(f: F) -> T {
+        whisker::runtime::reactive::__reset_for_tests();
+        let owner = whisker::runtime::reactive::create_owner(None);
+        let out = whisker::runtime::reactive::with_owner(owner, f);
+        whisker::runtime::reactive::dispose_owner(owner);
+        out
+    }
+
+    #[test]
+    fn new_stack_has_initial_entry() {
+        with_runtime(|| {
+            let nav = route_stack(TestRoute::Home);
+            assert_eq!(nav.current().get(), TestRoute::Home);
+            assert_eq!(nav.depth().get(), 1);
+            assert!(!nav.can_back().get());
+        });
+    }
+
+    #[test]
+    fn push_grows_stack_and_marks_top_active() {
+        with_runtime(|| {
+            let nav = route_stack(TestRoute::Home);
+            nav.push(TestRoute::Profile(7));
+            assert_eq!(nav.current().get(), TestRoute::Profile(7));
+            assert_eq!(nav.depth().get(), 2);
+            assert!(nav.can_back().get());
+
+            let entries = nav.entries().get();
+            assert_eq!(entries[0].state.get(), EntryState::Suspended);
+            assert_eq!(entries[1].state.get(), EntryState::Entering);
+        });
+    }
+
+    #[test]
+    fn back_pops_top_and_reactivates_previous() {
+        with_runtime(|| {
+            let nav = route_stack(TestRoute::Home);
+            nav.push(TestRoute::Profile(7));
+            nav.push(TestRoute::Settings);
+
+            assert!(nav.back());
+            assert_eq!(nav.current().get(), TestRoute::Profile(7));
+            assert_eq!(
+                nav.entries().get().last().unwrap().state.get(),
+                EntryState::Active
+            );
+        });
+    }
+
+    #[test]
+    fn back_at_root_returns_false() {
+        with_runtime(|| {
+            let nav = route_stack(TestRoute::Home);
+            assert!(!nav.back());
+            assert_eq!(nav.current().get(), TestRoute::Home);
+        });
+    }
+
+    #[test]
+    fn back_to_pops_until_predicate() {
+        with_runtime(|| {
+            let nav = route_stack(TestRoute::Home);
+            nav.push(TestRoute::Profile(1));
+            nav.push(TestRoute::Profile(2));
+            nav.push(TestRoute::Settings);
+            nav.back_to(|r| matches!(r, TestRoute::Home));
+            assert_eq!(nav.current().get(), TestRoute::Home);
+            assert_eq!(nav.depth().get(), 1);
+        });
+    }
+
+    #[test]
+    fn replace_swaps_top_only() {
+        with_runtime(|| {
+            let nav = route_stack(TestRoute::Home);
+            nav.push(TestRoute::Profile(1));
+            nav.replace(TestRoute::Settings);
+            assert_eq!(nav.depth().get(), 2);
+            assert_eq!(nav.current().get(), TestRoute::Settings);
+        });
+    }
+
+    #[test]
+    fn replace_all_resets_root() {
+        with_runtime(|| {
+            let nav = route_stack(TestRoute::Home);
+            nav.push(TestRoute::Profile(1));
+            nav.push(TestRoute::Profile(2));
+            nav.replace_all(TestRoute::Settings);
+            assert_eq!(nav.depth().get(), 1);
+            assert_eq!(nav.current().get(), TestRoute::Settings);
+        });
+    }
+
+    #[test]
+    fn clones_share_state() {
+        with_runtime(|| {
+            let a = route_stack(TestRoute::Home);
+            let b = a.clone();
+            b.push(TestRoute::Profile(42));
+            assert_eq!(a.current().get(), TestRoute::Profile(42));
+            assert_eq!(a.depth().get(), 2);
+        });
+    }
+}

--- a/packages/whisker-router/src/transitions/fade.rs
+++ b/packages/whisker-router/src/transitions/fade.rs
@@ -1,0 +1,57 @@
+//! [`Fade`] — cross-fade transition between two stack entries.
+
+use whisker::runtime::view::Element;
+use whisker::{animate_start, AnimateOptions};
+
+use super::{Direction, Side, StackTransition};
+
+const DEFAULT_DURATION_MS: u32 = 320;
+
+/// Cross-fade. Incoming opacity 0→1, outgoing 1→0.
+#[derive(Copy, Clone, Debug)]
+pub struct Fade {
+    /// Duration in milliseconds.
+    pub duration_ms: u32,
+    /// Easing function string. Default `"linear"` — fades feel
+    /// most natural without acceleration.
+    pub easing: &'static str,
+}
+
+impl Default for Fade {
+    fn default() -> Self {
+        Self {
+            duration_ms: DEFAULT_DURATION_MS,
+            easing: "linear",
+        }
+    }
+}
+
+impl StackTransition for Fade {
+    fn animate(&self, element: Element, side: Side, direction: Direction) {
+        if direction == Direction::None {
+            return;
+        }
+        let (name, from, to) = match side {
+            Side::Incoming => ("stack-fade-incoming", "0", "1"),
+            Side::Outgoing => ("stack-fade-outgoing", "1", "0"),
+        };
+        let _ = animate_start(
+            element,
+            name,
+            &[("0%", &[("opacity", from)]), ("100%", &[("opacity", to)])],
+            &AnimateOptions {
+                duration_ms: self.duration_ms,
+                easing: self.easing.into(),
+                fill: "forwards".into(),
+                ..Default::default()
+            },
+        );
+    }
+
+    fn foreground(&self, _direction: Direction) -> Side {
+        // Crossfade doesn't depend on layering — both screens are
+        // partially transparent throughout. Keep incoming on top so
+        // its final fully-opaque state covers correctly at the end.
+        Side::Incoming
+    }
+}

--- a/packages/whisker-router/src/transitions/instant.rs
+++ b/packages/whisker-router/src/transitions/instant.rs
@@ -1,0 +1,14 @@
+//! [`Instant`] — no-op transition: entries swap in a single frame.
+
+use whisker::runtime::view::Element;
+
+use super::{Direction, Side, StackTransition};
+
+/// No animation: entries swap immediately. Useful for programmatic
+/// resets (`replace_all`) or unit-test paths.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Instant;
+
+impl StackTransition for Instant {
+    fn animate(&self, _element: Element, _side: Side, _direction: Direction) {}
+}

--- a/packages/whisker-router/src/transitions/ios_slide.rs
+++ b/packages/whisker-router/src/transitions/ios_slide.rs
@@ -1,0 +1,125 @@
+//! [`IosSlide`] — UINavigationController-style horizontal slide
+//! with parallax, leading-edge shadow on the moving screen, and a
+//! subtle brightness dim on the parallaxed background screen.
+//!
+//! Default transition for [`StackLayout`](crate::StackLayout).
+
+use whisker::runtime::view::Element;
+use whisker::{animate_start, AnimateOptions, Style};
+
+use super::{Direction, Side, StackTransition};
+
+/// One animation's CSS endpoints — `(name, from_props, to_props)`.
+type Keyframes<'a> = (
+    &'static str,
+    Vec<(&'static str, &'a str)>,
+    Vec<(&'static str, &'a str)>,
+);
+
+/// Outgoing screen translates ~30% of viewport toward the leading
+/// edge during a horizontal push — UIKit's parallax amount.
+pub const IOS_PARALLAX_PCT: f32 = 30.0;
+
+/// Depth shadow declared as static inline style on the foreground
+/// wrapper. Lynx's animator drops `box-shadow` from `@keyframes`
+/// rules, so it has to ride along as a `slot_style` declaration
+/// rather than an animated property. 5-part syntax is required.
+const IOS_LEADING_SHADOW: &str = "box-shadow: -4px 0px 16px 0px rgba(0, 0, 0, 0.06);";
+
+/// Parallaxed (background) screen sits one notch dimmer than fully
+/// lit. Carried via `slot_style` as the initial state; the matching
+/// `animate` interpolates `filter: brightness(...)` between this
+/// and `brightness(1.0)` so the screen brightens as it returns to
+/// the foreground (or dims as it leaves).
+const IOS_PARALLAX_DIM: &str = "filter: brightness(0.85);";
+
+const DEFAULT_DURATION_MS: u32 = 320;
+const DEFAULT_EASING: &str = "ease-in-out";
+
+/// iOS UINavigationController-style horizontal slide.
+#[derive(Copy, Clone, Debug)]
+pub struct IosSlide {
+    /// Duration in milliseconds (default 320ms).
+    pub duration_ms: u32,
+    /// Easing function string (default `"ease-in-out"`).
+    pub easing: &'static str,
+}
+
+impl Default for IosSlide {
+    fn default() -> Self {
+        Self {
+            duration_ms: DEFAULT_DURATION_MS,
+            easing: DEFAULT_EASING,
+        }
+    }
+}
+
+impl StackTransition for IosSlide {
+    fn animate(&self, element: Element, side: Side, direction: Direction) {
+        let parallax = format!("translateX(-{IOS_PARALLAX_PCT}%)");
+        let (name, from, to): Keyframes = match (side, direction) {
+            // New screen slides in from the right at full brightness.
+            (Side::Incoming, Direction::Forward) => (
+                "stack-ios-incoming-forward",
+                vec![("transform", "translateX(100%)")],
+                vec![("transform", "translateX(0%)")],
+            ),
+            // Returning screen brightens as it slides back from -30%.
+            (Side::Incoming, Direction::Backward) => (
+                "stack-ios-incoming-backward",
+                vec![
+                    ("transform", parallax.as_str()),
+                    ("filter", "brightness(0.85)"),
+                ],
+                vec![
+                    ("transform", "translateX(0%)"),
+                    ("filter", "brightness(1.0)"),
+                ],
+            ),
+            // Previous screen parallaxes off-left and dims behind the
+            // pushing screen.
+            (Side::Outgoing, Direction::Forward) => (
+                "stack-ios-outgoing-forward",
+                vec![
+                    ("transform", "translateX(0%)"),
+                    ("filter", "brightness(1.0)"),
+                ],
+                vec![
+                    ("transform", parallax.as_str()),
+                    ("filter", "brightness(0.85)"),
+                ],
+            ),
+            // Leaving screen slides off the trailing edge.
+            (Side::Outgoing, Direction::Backward) => (
+                "stack-ios-outgoing-backward",
+                vec![("transform", "translateX(0%)")],
+                vec![("transform", "translateX(100%)")],
+            ),
+            (_, Direction::None) => return,
+        };
+        let _ = animate_start(
+            element,
+            name,
+            &[("0%", &from), ("100%", &to)],
+            &AnimateOptions {
+                duration_ms: self.duration_ms,
+                easing: self.easing.into(),
+                fill: "forwards".into(),
+                ..Default::default()
+            },
+        );
+    }
+
+    fn slot_style(&self, side: Side, direction: Direction) -> Style {
+        let raw = match (side, direction) {
+            // Foreground (moving) side carries the depth shadow.
+            (Side::Incoming, Direction::Forward) => IOS_LEADING_SHADOW,
+            (Side::Outgoing, Direction::Backward) => IOS_LEADING_SHADOW,
+            // Background (parallaxed) side starts dimmed.
+            (Side::Outgoing, Direction::Forward) => IOS_PARALLAX_DIM,
+            (Side::Incoming, Direction::Backward) => IOS_PARALLAX_DIM,
+            _ => "",
+        };
+        Style::from(raw)
+    }
+}

--- a/packages/whisker-router/src/transitions/mod.rs
+++ b/packages/whisker-router/src/transitions/mod.rs
@@ -1,0 +1,162 @@
+//! Transitions: pluggable animations for [`StackLayout`](crate::StackLayout).
+//!
+//! Each transition implementation lives in its own submodule —
+//! [`ios_slide`] for the default UIKit-style horizontal slide,
+//! [`vertical_slide`] for the Y-axis variant, [`fade`] for an
+//! opacity cross-fade, and [`instant`] for the no-animation
+//! fallback. This module re-exports the trait + every built-in,
+//! plus the shared [`Direction`] / [`Side`] / [`StackTransitionBox`]
+//! types each implementation consumes.
+//!
+//! Custom transitions implement [`StackTransition`] and are passed
+//! to the layout via [`StackTransitionBox::new`]:
+//!
+//! ```ignore
+//! use whisker_router::{StackTransition, StackTransitionBox, Direction};
+//! use whisker::runtime::view::Element;
+//!
+//! struct ZoomSlide;
+//! impl StackTransition for ZoomSlide {
+//!     fn animate(&self, el: Element, side: Side, _dir: Direction) {
+//!         if side != Side::Incoming { return; }
+//!         whisker::animate_start(el, "zoom-in", &[
+//!             ("0%",   &[("transform", "scale(0.85)"), ("opacity", "0")]),
+//!             ("100%", &[("transform", "scale(1.0)"),  ("opacity", "1")]),
+//!         ], &whisker::AnimateOptions::default()).ok();
+//!     }
+//! }
+//! ```
+
+use std::rc::Rc;
+
+use whisker::runtime::view::Element;
+use whisker::Style;
+
+pub mod fade;
+pub mod instant;
+pub mod ios_slide;
+pub mod vertical_slide;
+
+pub use fade::Fade;
+pub use instant::Instant;
+pub use ios_slide::{IosSlide, IOS_PARALLAX_PCT};
+pub use vertical_slide::VerticalSlide;
+
+/// Direction of the current navigation, derived from the
+/// [`RouteStack`](crate::RouteStack) length delta.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Direction {
+    /// Stack grew (a `push`).
+    Forward,
+    /// Stack shrank (a `back`).
+    Backward,
+    /// No animation: replace, replace_all-to-same-depth, or the
+    /// first mount.
+    None,
+}
+
+/// One of the two screens involved in a transition.
+///
+/// `Incoming` is the screen the navigation is bringing in (becomes
+/// the new top of the stack after the transition). `Outgoing` is
+/// the screen being replaced (was the top before the navigation,
+/// slides away during the transition).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Side {
+    /// The new top of the stack.
+    Incoming,
+    /// The screen being replaced.
+    Outgoing,
+}
+
+/// Pluggable transition for a stack layout.
+///
+/// One [`animate`](StackTransition::animate) call per slot per
+/// navigation — the [`Side`] argument distinguishes "drive the
+/// incoming wrapper" from "drive the outgoing wrapper". The trait
+/// is `'static` so it can be stored inside an `Rc`.
+pub trait StackTransition: 'static {
+    /// Drive the animation for one slot wrapper.
+    ///
+    /// `side` says which slot is being animated (incoming = the
+    /// new top of the stack; outgoing = the screen being replaced).
+    /// `direction` says which way the navigation is going. Called
+    /// from `on_mount` so the element already has a `sign` and is in
+    /// Lynx's fiber tree. Invoked twice per transition — once with
+    /// `Side::Incoming`, then immediately with `Side::Outgoing` if
+    /// there is one — in the same mount tick.
+    fn animate(&self, element: Element, side: Side, direction: Direction);
+
+    /// Which side paints on top during the transition.
+    ///
+    /// Default: `Incoming` on `Forward` / `None`, `Outgoing` on
+    /// `Backward`. iOS push covers the previous screen with the new
+    /// one; iOS pop keeps the current screen on top while it slides
+    /// off, revealing the returning screen from underneath.
+    ///
+    /// Override when the "covering" screen of your transition is
+    /// always one side regardless of direction (e.g. cross-fade
+    /// where layering is cosmetic; modal-style presentations where
+    /// the modal always sits on top).
+    ///
+    /// (Implementation note: Lynx's animator ignores explicit
+    /// `z-index` while a transform animation is in flight, so
+    /// [`StackLayout`](crate::StackLayout) reads this value to
+    /// choose the wrapper's DOM insertion order — a sibling later
+    /// in the document paints on top. Returning a value here is
+    /// enough; you don't need to touch z-index yourself.)
+    fn foreground(&self, direction: Direction) -> Side {
+        match direction {
+            Direction::Backward => Side::Outgoing,
+            _ => Side::Incoming,
+        }
+    }
+
+    /// Inline CSS appended to a slot wrapper, varying by side and
+    /// direction.
+    ///
+    /// Lynx's animator silently drops some properties from
+    /// `@keyframes` rules — notably `box-shadow` — and some effects
+    /// look right only as an initial state that the animation then
+    /// interpolates from (e.g. a brightness dim that fades to full
+    /// when the previous screen returns on pop). Anything that
+    /// needs to live on the wrapper alongside the layout positioning
+    /// goes here.
+    ///
+    /// Returning a [`Style::Dynamic`](whisker::Style::Dynamic) value
+    /// makes the decoration reactive — the wrapper is re-styled
+    /// whenever any signal the closure reads fires (useful for
+    /// theme-driven shadow colours, etc.). [`Style::Static`] applies
+    /// once when the slot mounts and once again when its role flips
+    /// at the next navigation.
+    ///
+    /// The decoration is appended verbatim to the wrapper's
+    /// `style` attribute, so include trailing semicolons.
+    ///
+    /// Returns an empty static style by default.
+    fn slot_style(&self, side: Side, direction: Direction) -> Style {
+        let _ = (side, direction);
+        Style::from("")
+    }
+}
+
+/// Cheap-to-clone handle wrapping any [`StackTransition`]
+/// implementation. The `#[component]` macro re-clones every prop on
+/// every body invocation, so the prop type must be `Clone` — this
+/// wrapper makes any `dyn StackTransition` satisfy that.
+#[derive(Clone)]
+pub struct StackTransitionBox(pub Rc<dyn StackTransition>);
+
+impl StackTransitionBox {
+    /// Wrap a [`StackTransition`] implementation.
+    pub fn new<T: StackTransition>(t: T) -> Self {
+        Self(Rc::new(t))
+    }
+}
+
+impl Default for StackTransitionBox {
+    /// The default transition is [`IosSlide`].
+    fn default() -> Self {
+        Self::new(IosSlide::default())
+    }
+}

--- a/packages/whisker-router/src/transitions/vertical_slide.rs
+++ b/packages/whisker-router/src/transitions/vertical_slide.rs
@@ -1,0 +1,71 @@
+//! [`VerticalSlide`] — Y-axis variant of [`super::IosSlide`] for
+//! stack-driven modal-style presentations.
+
+use whisker::runtime::view::Element;
+use whisker::{animate_start, AnimateOptions};
+
+use super::{Direction, Side, StackTransition};
+
+const DEFAULT_DURATION_MS: u32 = 320;
+const DEFAULT_EASING: &str = "ease-in-out";
+
+/// Vertical analogue of [`super::IosSlide`] — incoming slides up
+/// from below on push, parallaxes down on pop.
+#[derive(Copy, Clone, Debug)]
+pub struct VerticalSlide {
+    /// Duration in milliseconds.
+    pub duration_ms: u32,
+    /// Easing function string.
+    pub easing: &'static str,
+}
+
+impl Default for VerticalSlide {
+    fn default() -> Self {
+        Self {
+            duration_ms: DEFAULT_DURATION_MS,
+            easing: DEFAULT_EASING,
+        }
+    }
+}
+
+impl StackTransition for VerticalSlide {
+    fn animate(&self, element: Element, side: Side, direction: Direction) {
+        let (name, from, to) = match (side, direction) {
+            (Side::Incoming, Direction::Forward) => (
+                "stack-vertical-incoming-forward",
+                "translateY(100%)",
+                "translateY(0%)",
+            ),
+            (Side::Incoming, Direction::Backward) => (
+                "stack-vertical-incoming-backward",
+                "translateY(-30%)",
+                "translateY(0%)",
+            ),
+            (Side::Outgoing, Direction::Forward) => (
+                "stack-vertical-outgoing-forward",
+                "translateY(0%)",
+                "translateY(-30%)",
+            ),
+            (Side::Outgoing, Direction::Backward) => (
+                "stack-vertical-outgoing-backward",
+                "translateY(0%)",
+                "translateY(100%)",
+            ),
+            (_, Direction::None) => return,
+        };
+        let _ = animate_start(
+            element,
+            name,
+            &[
+                ("0%", &[("transform", from)]),
+                ("100%", &[("transform", to)]),
+            ],
+            &AnimateOptions {
+                duration_ms: self.duration_ms,
+                easing: self.easing.into(),
+                fill: "forwards".into(),
+                ..Default::default()
+            },
+        );
+    }
+}

--- a/packages/whisker-router/tests/route_macro.rs
+++ b/packages/whisker-router/tests/route_macro.rs
@@ -1,0 +1,80 @@
+//! End-to-end check that the `#[whisker_router::route]` macro
+//! generates a `Route` impl byte-for-byte equivalent to the
+//! hand-written one in `whisker_router::route::tests`.
+
+use whisker_router::route::{Route, RouteError};
+
+#[whisker_router::route]
+#[derive(Clone, Debug, PartialEq)]
+pub enum AppRoute {
+    #[at("/")]
+    Home,
+    #[at("/profile/:id")]
+    Profile { id: u64 },
+    #[at("/profile/:id/posts/:slug")]
+    Post { id: u64, slug: String },
+    #[at("/settings")]
+    Settings,
+}
+
+#[test]
+fn home_round_trips() {
+    let r = AppRoute::parse("/").unwrap();
+    assert_eq!(r, AppRoute::Home);
+    assert_eq!(r.to_path(), "/");
+}
+
+#[test]
+fn profile_round_trips_with_numeric_param() {
+    let r = AppRoute::parse("/profile/42").unwrap();
+    assert_eq!(r, AppRoute::Profile { id: 42 });
+    assert_eq!(r.to_path(), "/profile/42");
+}
+
+#[test]
+fn settings_round_trips() {
+    let r = AppRoute::parse("/settings").unwrap();
+    assert_eq!(r, AppRoute::Settings);
+    assert_eq!(r.to_path(), "/settings");
+}
+
+#[test]
+fn multi_param_with_string_field() {
+    let r = AppRoute::parse("/profile/7/posts/hello-world").unwrap();
+    assert_eq!(
+        r,
+        AppRoute::Post {
+            id: 7,
+            slug: "hello-world".into()
+        }
+    );
+    assert_eq!(r.to_path(), "/profile/7/posts/hello-world");
+}
+
+#[test]
+fn empty_path_resolves_to_home() {
+    assert_eq!(AppRoute::parse("").unwrap(), AppRoute::Home);
+}
+
+#[test]
+fn trailing_slash_tolerated() {
+    assert_eq!(AppRoute::parse("/settings/").unwrap(), AppRoute::Settings);
+}
+
+#[test]
+fn no_match_returns_no_match_error() {
+    let err = AppRoute::parse("/blog/123").unwrap_err();
+    assert!(matches!(err, RouteError::NoMatch(_)));
+}
+
+#[test]
+fn bad_param_surfaces_field_name() {
+    let err = AppRoute::parse("/profile/notanumber").unwrap_err();
+    match err {
+        RouteError::BadParam { param, value } => {
+            assert_eq!(param, "id");
+            assert_eq!(value, "notanumber");
+        }
+        other => panic!("expected BadParam, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- New crate `whisker-router` — type-safe routing with web-style `Router` / `Outlet` semantics.
- `#[route]` attribute generates a `Route` impl from `#[at(\"/path/:param\")]` patterns (in `whisker-router-macros`).
- `RouteStack<R>` is a reactive stack (`push` / `back` / `back_to` / `replace` / `replace_all`); `RouteProvider` puts it in context so multiple layouts can share one stack.
- `StackLayout` renders the current entry and animates push/pop via a pluggable `StackTransition` impl.
- Transitions: `IosSlide` (default — parallax + leading-edge shadow + background dim), `VerticalSlide`, `Fade`, `Instant`.
- Lynx native animator bridge — new `lynx_element_animate` capi (Lynx fork v3.8.0-whisker.1) wired through `whisker_bridge_element_animate` and surfaced as `animate_start` / `AnimateOp` / `AnimateOptions` in the driver. `anim-demo` exercises the bridge in isolation.
- Additional layouts (used by the same `RouteStack`): `TabsLayout` (keep-alive switcher), `ModalLayout` (slide-from-bottom), `Pane` (display-toggleable, keeps children mounted).

## Notes

- `slot_style` returns inline CSS that lives on the wrapper for the whole transition — needed because Lynx's animator drops `box-shadow` from `@keyframes`.
- `foreground` selects DOM paint order: Lynx ignores explicit `z-index` during transform animations, so iOS pop semantics need the outgoing wrapper inserted at index 0.
- Interactive (gesture-driven) navigation — iOS swipe-back and Android predictive back — is deferred to a follow-up PR.

## Test plan

- [x] `cargo test -p whisker-router` (route macro, transitions)
- [x] `cargo test -p router-demo` (recording-renderer integration: home → list → post(7) → back → settings)
- [x] `cargo test --workspace`
- [x] iOS sim: push/pop transitions look right (parallax + shadow + dim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)