### PR TITLE
feat(router): iOS edge swipe-back gesture for StackLayout

### DIFF
--- a/examples/router-demo/src/lib.rs
+++ b/examples/router-demo/src/lib.rs
@@ -36,18 +36,19 @@ pub enum AppRoute {
     Settings,
 }
 
-/// Container used by every screen — plain column layout with an
-/// opaque background. Opaque fill is iOS-style: during a
-/// `StackLayout` slide, the parallaxed outgoing screen sits behind
-/// the incoming and would show through any transparent area, so
-/// every screen MUST own its own background to look right.
-fn screen_style() -> &'static str {
-    "display: flex; flex-direction: column; gap: 8px; padding: 16px; \
-     width: 100%; height: 100%; background-color: white; overflow: visible;"
+/// Layout shared by every screen — column with padded buttons.
+/// The background colour is parameterised so each route renders in
+/// a distinct hue, making it easy to see which screen sits on top
+/// (vs. underneath) during a swipe-back / push animation.
+fn screen_style(bg: &str) -> String {
+    format!(
+        "display: flex; flex-direction: column; gap: 8px; padding: 16px; \
+         width: 100%; height: 100%; background-color: {bg}; overflow: visible;"
+    )
 }
 
 fn link_style() -> &'static str {
-    "padding: 6px 12px; background: #e5e7eb; border-radius: 4px;"
+    "padding: 6px 12px; background: rgba(0, 0, 0, 0.08); border-radius: 4px;"
 }
 
 /// Home screen — two `push` actions to seed other test paths.
@@ -57,7 +58,7 @@ pub fn home_screen() -> Element {
     let nav_list = nav.clone();
     let nav_settings = nav.clone();
     render! {
-        view(style: screen_style()) {
+        view(style: screen_style("#fef3c7")) {
             text(style: "font-size: 24px;") { text(value: "Home") }
             view(
                 style: link_style(),
@@ -83,7 +84,7 @@ pub fn list_screen() -> Element {
     let nav_post = nav.clone();
     let nav_back = nav.clone();
     render! {
-        view(style: screen_style()) {
+        view(style: screen_style("#d1fae5")) {
             text(style: "font-size: 24px;") { text(value: "List") }
             view(
                 style: link_style(),
@@ -107,7 +108,7 @@ pub fn post_screen(id: u64) -> Element {
     let nav = router::<AppRoute>();
     let label = computed(move || format!("Post #{id}"));
     render! {
-        view(style: screen_style()) {
+        view(style: screen_style("#dbeafe")) {
             text(style: "font-size: 24px;") { text(value: label) }
             view(
                 style: link_style(),
@@ -125,7 +126,7 @@ pub fn post_screen(id: u64) -> Element {
 pub fn settings_screen() -> Element {
     let nav = router::<AppRoute>();
     render! {
-        view(style: screen_style()) {
+        view(style: screen_style("#fce7f3")) {
             text(style: "font-size: 24px;") { text(value: "Settings") }
             view(
                 style: link_style(),

--- a/examples/router-demo/src/lib.rs
+++ b/examples/router-demo/src/lib.rs
@@ -14,8 +14,8 @@
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_router::{
-    route, route_stack, router, RouteProvider, RouteProviderProps, RouteRenderFn, RouteStack,
-    StackLayout, StackLayoutProps,
+    route, route_stack, router, IosSwipeBack, IosSwipeBackProps, RouteProvider, RouteProviderProps,
+    RouteRenderFn, RouteStack, StackLayout, StackLayoutProps,
 };
 
 /// Top-level route enum.
@@ -153,7 +153,9 @@ pub fn render_with(stack: RouteStack<AppRoute>) -> Element {
     .into();
     render! {
         RouteProvider(stack: stack) {
-            StackLayout(render: render.clone())
+            StackLayout(render: render.clone()) {
+                IosSwipeBack()
+            }
         }
     }
 }
@@ -179,7 +181,9 @@ pub fn render_app() -> Element {
                     display: flex; flex-direction: column;",
         ) {
             RouteProvider(stack: stack) {
-                StackLayout(render: render.clone())
+                StackLayout(render: render.clone()) {
+                    IosSwipeBack()
+                }
             }
         }
     }

--- a/packages/whisker-router/src/gestures/ios_swipe_back.rs
+++ b/packages/whisker-router/src/gestures/ios_swipe_back.rs
@@ -1,0 +1,338 @@
+//! [`IosSwipeBack`] — iOS-style edge swipe-back gesture for
+//! [`StackLayout`](crate::StackLayout).
+//!
+//! Mount as a child of the layout to enable a UIKit-style horizontal
+//! swipe from the leading edge: the destination screen slides in
+//! from the left with the 30% parallax and brightness dim of
+//! [`IosSlide`](crate::IosSlide), the current screen tracks the
+//! finger to the right, and release past the half-way point commits
+//! the navigation.
+//!
+//! ```ignore
+//! StackLayout(transition: IosSlide::default(), render: render) {
+//!     IosSwipeBack()
+//! }
+//! ```
+//!
+//! The component is designed to pair with [`IosSlide`] for visual
+//! consistency. Pairing it with a different transition (e.g.
+//! [`Fade`](crate::Fade)) is allowed but the gesture will still
+//! render an iOS slide pose during the drag — what the natural
+//! transition does outside the gesture is unaffected.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use whisker::css::ToCss;
+use whisker::event::TouchEvent;
+use whisker::runtime::event::bind_typed;
+use whisker::runtime::reactive::on_mount;
+use whisker::runtime::view::{set_inline_styles, BindType, Element};
+use whisker::{
+    animate_cancel, animate_start, component, render, use_context, AnimateOptions, Style,
+};
+
+use crate::layouts::stack::{slot_css, StackLayoutHandle};
+use crate::transitions::ios_slide;
+use crate::transitions::{Direction, Side, StackTransitionBox};
+
+/// Horizontal distance (in points) that maps the gesture to a full
+/// `progress = 1.0`. iPhone 17 Pro is 402pt wide and the wrapper
+/// covers the full viewport, so a 1:1 finger-to-edge ratio wants
+/// this equal to the viewport width. Older iPhones differ by a few
+/// points (375–430pt) — a future revision can read the actual
+/// container width to make this exact across devices.
+const SWIPE_FULL_DISTANCE_PX: f32 = 402.0;
+/// `clientX` (in points) within which a `touchstart` qualifies as
+/// an edge swipe-back attempt. iOS uses ~20pt; 24pt is generous
+/// without eating into scrollable content.
+const SWIPE_EDGE_THRESHOLD_PX: f32 = 24.0;
+/// Progress at touch release above which the gesture commits.
+const SWIPE_COMMIT_THRESHOLD: f32 = 0.5;
+/// Floor on the touchend finish animation duration.
+const SWIPE_MIN_FINISH_MS: u32 = 120;
+/// Natural finish duration scaled by the remaining distance.
+const SWIPE_FULL_FINISH_MS: u32 = 320;
+
+/// iOS-style edge swipe-back gesture component.
+///
+/// Mount as a child of [`StackLayout`](crate::StackLayout); reads
+/// the layout handle and the in-context
+/// [`RouteStack`](crate::RouteStack) and binds the touch handlers
+/// in `on_mount`. Renders no DOM of its own.
+#[component]
+pub fn ios_swipe_back() -> Element {
+    let layout =
+        use_context::<StackLayoutHandle>().expect("IosSwipeBack must be a child of StackLayout");
+    let transition: StackTransitionBox = StackTransitionBox::new(ios_slide::IosSlide::default());
+
+    on_mount(move || install(&layout, transition.clone()));
+
+    // No visible output — gesture components only attach handlers.
+    render! { fragment() }
+}
+
+/// Per-active-gesture state stored in the `gesture` cell. `None`
+/// means no swipe is in flight; the touchstart handler populates
+/// it, touchmove updates it, touchend drains it.
+struct GestureState {
+    start_x: f32,
+    progress: f32,
+    identifier: i64,
+}
+
+fn install(layout: &StackLayoutHandle, transition: StackTransitionBox) {
+    let container = layout.container;
+    let mount_preview = layout.mount_preview.clone();
+    let dispose_preview = layout.dispose_preview.clone();
+    let commit_back = layout.commit_preview_and_back.clone();
+    let current_wrapper = layout.current_wrapper.clone();
+
+    let gesture: Rc<RefCell<Option<GestureState>>> = Rc::new(RefCell::new(None));
+    // Cached preview wrapper between touchstart and the end event
+    // — lets touchmove pose it without going through
+    // `current_wrapper` every frame.
+    let preview_wrapper: Rc<Cell<Option<Element>>> = Rc::new(Cell::new(None));
+
+    // touchstart — qualify the edge swipe, mount the preview
+    // wrapper, capture state.
+    {
+        let gesture = gesture.clone();
+        let preview_wrapper = preview_wrapper.clone();
+        let mount_preview = mount_preview.clone();
+        let current_wrapper = current_wrapper.clone();
+        let transition = transition.clone();
+        bind_typed::<TouchEvent, _>(container, "touchstart", BindType::Bind, move |e| {
+            if gesture.borrow().is_some() {
+                return;
+            }
+            let touch = match e
+                .changed_touches
+                .first()
+                .copied()
+                .or_else(|| e.touches.first().copied())
+            {
+                Some(t) => t,
+                None => return,
+            };
+            let start_x = touch.client_x as f32;
+            if start_x > SWIPE_EDGE_THRESHOLD_PX {
+                return;
+            }
+
+            let wrapper = mount_preview();
+            apply_pose(
+                wrapper,
+                transition.0.as_ref(),
+                Side::Incoming,
+                Direction::Backward,
+                0.0,
+            );
+            if let Some(cur) = current_wrapper() {
+                apply_pose(
+                    cur,
+                    transition.0.as_ref(),
+                    Side::Outgoing,
+                    Direction::Backward,
+                    0.0,
+                );
+            }
+
+            preview_wrapper.set(Some(wrapper));
+            *gesture.borrow_mut() = Some(GestureState {
+                start_x,
+                progress: 0.0,
+                identifier: touch.identifier,
+            });
+        });
+    }
+
+    // touchmove — translate finger displacement into progress and
+    // re-pose preview + current each frame.
+    {
+        let gesture = gesture.clone();
+        let preview_wrapper = preview_wrapper.clone();
+        let current_wrapper = current_wrapper.clone();
+        let transition = transition.clone();
+        bind_typed::<TouchEvent, _>(container, "touchmove", BindType::Bind, move |e| {
+            let mut g = gesture.borrow_mut();
+            let state = match g.as_mut() {
+                Some(s) => s,
+                None => return,
+            };
+            let touch = match e
+                .touches
+                .iter()
+                .find(|t| t.identifier == state.identifier)
+                .or_else(|| {
+                    e.changed_touches
+                        .iter()
+                        .find(|t| t.identifier == state.identifier)
+                }) {
+                Some(t) => *t,
+                None => return,
+            };
+            let delta = (touch.client_x as f32 - state.start_x).max(0.0);
+            let progress = (delta / SWIPE_FULL_DISTANCE_PX).clamp(0.0, 1.0);
+            state.progress = progress;
+
+            if let Some(wrapper) = preview_wrapper.get() {
+                apply_pose(
+                    wrapper,
+                    transition.0.as_ref(),
+                    Side::Incoming,
+                    Direction::Backward,
+                    progress,
+                );
+            }
+            if let Some(cur) = current_wrapper() {
+                apply_pose(
+                    cur,
+                    transition.0.as_ref(),
+                    Side::Outgoing,
+                    Direction::Backward,
+                    progress,
+                );
+            }
+        });
+    }
+
+    // touchend / touchcancel — drive the finish through Lynx's
+    // animator (short duration, `fill: forwards`). Inline writes
+    // during a string of rapid touch-move updates were getting
+    // dropped/coalesced — the animator path always takes hold.
+    for end_name in ["touchend", "touchcancel"] {
+        let gesture = gesture.clone();
+        let preview_wrapper = preview_wrapper.clone();
+        let current_wrapper = current_wrapper.clone();
+        let dispose_preview = dispose_preview.clone();
+        let commit_back = commit_back.clone();
+        bind_typed::<TouchEvent, _>(container, end_name, BindType::Bind, move |_e| {
+            let state = match gesture.borrow_mut().take() {
+                Some(s) => s,
+                None => return,
+            };
+            let commit = state.progress >= SWIPE_COMMIT_THRESHOLD;
+            let target_progress: f32 = if commit { 1.0 } else { 0.0 };
+
+            let from = state.progress;
+            let remaining = (target_progress - from).abs();
+            let duration_ms =
+                ((remaining * SWIPE_FULL_FINISH_MS as f32) as u32).max(SWIPE_MIN_FINISH_MS);
+
+            if let Some(wrapper) = preview_wrapper.get() {
+                animate_to_pose(
+                    wrapper,
+                    Side::Incoming,
+                    Direction::Backward,
+                    from,
+                    target_progress,
+                    duration_ms,
+                    "swipe-finish-incoming",
+                );
+            }
+            if let Some(cur) = current_wrapper() {
+                animate_to_pose(
+                    cur,
+                    Side::Outgoing,
+                    Direction::Backward,
+                    from,
+                    target_progress,
+                    duration_ms,
+                    "swipe-finish-outgoing",
+                );
+            }
+
+            preview_wrapper.set(None);
+            if commit {
+                commit_back();
+            } else {
+                dispose_preview();
+            }
+        });
+    }
+}
+
+/// Cancel any natural-transition animation that might still be
+/// holding `element` at its end pose via `fill: forwards`.
+///
+/// Without this, inline `transform` set during a drag is overridden
+/// by the prior animation rule's computed style and the element
+/// won't move at all. Lynx no-ops on cancel-of-nonexistent so the
+/// shotgun-cancel is cheap.
+fn clear_natural_animations(element: Element) {
+    for name in [
+        "stack-ios-incoming-forward",
+        "stack-ios-incoming-backward",
+        "stack-ios-outgoing-forward",
+        "stack-ios-outgoing-backward",
+        "swipe-finish-incoming",
+        "swipe-finish-outgoing",
+    ] {
+        let _ = animate_cancel(element, name);
+    }
+}
+
+/// Apply the iOS slide pose for `progress` to `element` as an
+/// inline style, alongside the transition's [`slot_style`] and the
+/// layout's base [`slot_css`].
+///
+/// Inline styles take effect only once any active CSS animation is
+/// cancelled — Lynx's animator with `fill: forwards` (which the
+/// natural push/pop uses) clamps the element to its end pose and
+/// shadows out-of-band style writes.
+fn apply_pose(
+    element: Element,
+    transition: &dyn crate::transitions::StackTransition,
+    side: Side,
+    direction: Direction,
+    progress: f32,
+) {
+    clear_natural_animations(element);
+    let mut style = slot_css().to_css_string();
+    let decoration = match transition.slot_style(side, direction) {
+        Style::Static(s) => s,
+        Style::Dynamic(_) => String::new(),
+    };
+    if !decoration.is_empty() {
+        style.push_str(&decoration);
+    }
+    for (prop, val) in ios_slide::pose(side, direction, progress) {
+        style.push_str(&format!("{prop}: {val};"));
+    }
+    set_inline_styles(element, &style);
+}
+
+/// Animate `element` from the pose at `from_progress` to the pose
+/// at `to_progress` using Lynx's animator. `fill: forwards` keeps
+/// the element at the end pose after the animation completes; the
+/// caller doesn't have to listen for `animationend`.
+#[allow(clippy::too_many_arguments)]
+fn animate_to_pose(
+    element: Element,
+    side: Side,
+    direction: Direction,
+    from_progress: f32,
+    to_progress: f32,
+    duration_ms: u32,
+    animation_name: &'static str,
+) {
+    let from = ios_slide::pose(side, direction, from_progress);
+    let to = ios_slide::pose(side, direction, to_progress);
+    if from.is_empty() || to.is_empty() {
+        return;
+    }
+    let from_kf: Vec<(&str, &str)> = from.iter().map(|(k, v)| (*k, v.as_str())).collect();
+    let to_kf: Vec<(&str, &str)> = to.iter().map(|(k, v)| (*k, v.as_str())).collect();
+    let _ = animate_start(
+        element,
+        animation_name,
+        &[("0%", &from_kf), ("100%", &to_kf)],
+        &AnimateOptions {
+            duration_ms,
+            easing: "ease-out".into(),
+            fill: "forwards".into(),
+            ..Default::default()
+        },
+    );
+}

--- a/packages/whisker-router/src/gestures/mod.rs
+++ b/packages/whisker-router/src/gestures/mod.rs
@@ -1,0 +1,21 @@
+//! Gesture / back-handler components for [`StackLayout`](crate::StackLayout).
+//!
+//! Interactive behaviour — iOS edge swipe-back, Android system back,
+//! predictive back, hardware keys — is implemented as **composable
+//! components** rather than baked into the transition trait.
+//!
+//! Mount them as children of [`StackLayout`](crate::StackLayout):
+//!
+//! ```ignore
+//! StackLayout(transition: IosSlide::default(), render: render) {
+//!     IosSwipeBack()
+//! }
+//! ```
+//!
+//! Each component reads the [`StackLayoutHandle`](crate::StackLayoutHandle)
+//! from context and uses [`router::<R>()`](crate::router) to drive
+//! the stack.
+
+pub mod ios_swipe_back;
+
+pub use ios_swipe_back::{IosSwipeBack, IosSwipeBackProps};

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -5,15 +5,15 @@
 //! slots, deriving the [`Direction`], and ordering the DOM so the
 //! transition's paint-order hint takes effect.
 //!
-//! Interactive gestures (iOS swipe-back, future Android predictive
-//! back) live inside the transition — `StackLayout` only builds a
-//! [`GestureContext`](crate::transitions::GestureContext) of
-//! primitives and hands it to [`StackTransition::install_gestures`]
-//! once, at mount. Transitions that don't have a gesture (cross-
-//! fade, instant, vertical slide) ignore the hook.
+//! Interactive behaviour (iOS swipe-back, Android system back) is
+//! **not** part of the transition trait. Instead, the layout
+//! publishes a [`StackLayoutHandle`] into context and the user
+//! composes gesture / back-handler components as children of
+//! [`StackLayout`]. See [`crate::IosSwipeBack`] for the iOS edge
+//! swipe-back component.
 //!
 //! The default transition is [`IosSlide`](crate::transitions::IosSlide):
-//! horizontal slide with ~30% parallax + edge swipe-back gesture.
+//! horizontal slide with ~30% parallax.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -28,24 +28,71 @@ use whisker::runtime::view::apply::apply_styles;
 use whisker::runtime::view::{
     append_child, create_element, insert_child_at, remove_child, set_inline_styles, Element,
 };
-use whisker::{component, Style};
+use whisker::{component, provide_context, Children, Style};
 
 use crate::outlet::{router, RouteRenderFn};
 use crate::route::Route;
-use crate::transitions::{Direction, GestureContext, Side, StackTransitionBox};
+use crate::transitions::{Direction, Side, StackTransitionBox};
 
 type Slot = Rc<RefCell<Option<(OwnerId, Element)>>>;
 
-/// Animated stack: holds two slots during a transition and lets a
-/// [`StackTransition`] drive their animations.
+/// Handle a [`StackLayout`] publishes to context so child components
+/// (gestures, back-handlers, anything else that needs to coordinate
+/// with the layout's wrapper bookkeeping) can drive it.
 ///
-/// The [`RouteStack`](crate::RouteStack) for route type `R` is
-/// pulled from context — wrap a [`RouteProvider`](crate::RouteProvider)
-/// above the layout so `router::<R>()` finds it.
+/// Read this from a child via
+/// `use_context::<StackLayoutHandle>().expect("inside StackLayout")`,
+/// then call the closures as needed. For plain back navigation
+/// (Android system back, hardware key, in-app back UI) you usually
+/// don't need this handle — `router::<R>().back()` is enough.
+/// This is for the interactive paths that need to mount a preview
+/// of the destination screen and promote it atomically.
+#[derive(Clone)]
+pub struct StackLayoutHandle {
+    /// The `StackLayout`'s root container view. Bind touch /
+    /// animation / custom listeners on this element.
+    pub container: Element,
+
+    /// Handle to the currently-foregrounded wrapper, if any. The
+    /// gesture controller poses this wrapper alongside the
+    /// preview.
+    pub current_wrapper: Rc<dyn Fn() -> Option<Element>>,
+
+    /// Build a wrapper element for the screen one step below the
+    /// top of the stack, mount the rendered screen into it, and
+    /// insert it at DOM index 0 of the container. Returns the
+    /// wrapper handle.
+    ///
+    /// The layout retains ownership; release via
+    /// [`dispose_preview`](Self::dispose_preview) or
+    /// [`commit_preview_and_back`](Self::commit_preview_and_back).
+    pub mount_preview: Rc<dyn Fn() -> Element>,
+
+    /// Tear down the preview wrapper (remove from DOM, dispose the
+    /// reactive owner). Idempotent.
+    pub dispose_preview: Rc<dyn Fn()>,
+
+    /// Promote the preview wrapper into the `current` slot, dispose
+    /// both the old current and any stale outgoing wrapper, then
+    /// `stack.back()` with `skip_animation` set so the route-change
+    /// effect doesn't re-animate the navigation the gesture
+    /// already finished.
+    pub commit_preview_and_back: Rc<dyn Fn()>,
+}
+
+/// Animated stack: holds two slots during a transition and renders
+/// the current entry of the in-context
+/// [`RouteStack`](crate::RouteStack).
+///
+/// The route stack for route type `R` is pulled from context —
+/// wrap a [`RouteProvider`](crate::RouteProvider) above the layout
+/// so `router::<R>()` finds it. Children of the layout (gestures,
+/// back-handlers) receive a [`StackLayoutHandle`] via context.
 #[component]
 pub fn stack_layout<R: Route>(
     #[prop(default = StackTransitionBox::default())] transition: StackTransitionBox,
     render: RouteRenderFn<R>,
+    children: Children,
 ) -> Element {
     let stack = router::<R>();
     let container = create_element(ElementTag::View);
@@ -56,23 +103,18 @@ pub fn stack_layout<R: Route>(
     let preview: Slot = Rc::new(RefCell::new(None));
     // When a gesture commit fires `stack.back()`, the resulting
     // route-change effect must NOT animate — the wrappers already
-    // sit at the final pose. The commit closure sets this to a
-    // small count (2 by default); each effect run decrements and
-    // bails. A count rather than a bool because a single signal
-    // update can fan out into more than one effect run (the
-    // computed-of-a-RwSignal chain doesn't always batch them) and
-    // a one-shot bool would let the second run mount a fresh
-    // wrapper, double-stacking the destination screen on top of
-    // the gesture's promoted preview.
+    // sit at the final pose. The commit closure sets this to 1;
+    // the effect decrements and bails. Counted (rather than bool)
+    // because a single signal update can fan out into more than
+    // one effect run on some runtime paths.
     let skip_animation: Rc<Cell<u32>> = Rc::new(Cell::new(0));
     let prev_len = Rc::new(Cell::new(0_usize));
     let first = Rc::new(Cell::new(true));
 
-    // Single source of truth for the effect — tracking both
-    // `current()` and `stack()` separately makes the runtime re-run
-    // the effect twice per navigation (each one is its own
-    // `computed`), which drops `skip_animation` on the floor for the
-    // second run and double-mounts the destination screen.
+    // Tracking a single `entries` signal (rather than the derived
+    // `current()` + `stack()` signals) so the effect re-runs once
+    // per navigation — separate computeds would each schedule a
+    // distinct re-run.
     let entries_signal = stack.entries();
 
     {
@@ -92,8 +134,8 @@ pub fn stack_layout<R: Route>(
             let new_len = entries.len();
             let old_len = prev_len.get();
 
-            // Gesture-driven commit already advanced the visual state.
-            // Update bookkeeping and bail.
+            // Gesture-driven commit already advanced the visual
+            // state. Update bookkeeping and bail.
             let skip = skip_animation.get();
             if skip > 0 {
                 skip_animation.set(skip - 1);
@@ -162,42 +204,51 @@ pub fn stack_layout<R: Route>(
         });
     }
 
-    // Reserve an owner whose parent is the layout's own owner
-    // (`create_owner(None)` falls back to the current owner). The
-    // gesture handlers fire from the touch dispatcher, which has no
-    // active reactive owner — without this anchor, owners spawned
-    // for the preview screen become roots and lose access to the
-    // `RouteProvider` context their components rely on.
-    let gesture_parent = create_owner(None);
+    // Reserve an owner whose parent is the layout's own owner so
+    // children that mount via `commit_preview_and_back` /
+    // `mount_preview` get reachable context (`RouteProvider` etc.).
+    // The gesture handlers fire from the touch dispatcher, which
+    // has no active reactive owner; without this anchor, owners
+    // spawned for the preview screen would become roots and lose
+    // access to the `RouteProvider` context their components rely
+    // on.
+    let handle_parent = create_owner(None);
 
-    // Hand off gesture wiring to the transition. The trait method
-    // is no-op by default; only `IosSlide` (and any user-defined
-    // gesture-aware transition) installs handlers.
-    let gesture_ctx = build_gesture_context(
+    // Publish the handle so child gesture/back components can pick
+    // it up via `use_context::<StackLayoutHandle>()`.
+    let handle = build_stack_layout_handle(
         container,
         transition.clone(),
         stack.clone(),
         render.clone(),
-        current.clone(),
+        current,
         outgoing,
         preview,
         skip_animation,
-        gesture_parent,
+        handle_parent,
     );
-    transition.0.install_gestures(&gesture_ctx);
+    provide_context(handle);
+
+    // Mount the user's children (gestures / back-handlers / etc.).
+    // They render no DOM of their own but attach handlers via
+    // `on_mount`; the phantom returned by `mount_children` is
+    // attached under the container so the children's owner is a
+    // descendant of the layout's owner.
+    let phantom = whisker::runtime::view::mount_children(&children);
+    append_child(container, phantom);
 
     container
 }
 
-/// Build the closure surface a [`StackTransition`] uses to drive
-/// the stack interactively (the preview wrapper, the commit-back
-/// path, the can-back gate).
+/// Build the closure surface a child component pulls out of context
+/// to drive the stack's preview / commit primitives.
 ///
 /// Lives here in the layout because all of these operations touch
 /// the slots that the route-change effect also manipulates — the
-/// transition itself stays free of `OwnerId`/`Slot` plumbing.
+/// gesture / back-handler components stay free of `OwnerId` / `Slot`
+/// plumbing.
 #[allow(clippy::too_many_arguments)]
-fn build_gesture_context<R: Route>(
+fn build_stack_layout_handle<R: Route>(
     container: Element,
     transition: StackTransitionBox,
     stack: crate::stack::RouteStack<R>,
@@ -206,18 +257,14 @@ fn build_gesture_context<R: Route>(
     outgoing: Slot,
     preview: Slot,
     skip_animation: Rc<Cell<u32>>,
-    // `gesture_parent`: anchor owner used as the parent of any owner
-    // spawned from a gesture handler. Touch dispatchers fire with no
-    // active reactive owner, so without this anchor the screens
-    // mounted inside a preview wrapper would become roots and lose
-    // access to the `RouteProvider`'s `RouteStack` context.
-    gesture_parent: OwnerId,
-) -> GestureContext {
-    let can_back = {
-        let stack = stack.clone();
-        Rc::new(move || stack.entries().get().len() > 1) as Rc<dyn Fn() -> bool>
-    };
-
+    // `handle_parent`: anchor owner used as the parent of any owner
+    // spawned via the handle's closures. Touch / system back
+    // dispatchers fire with no active reactive owner; without this
+    // anchor screens mounted inside a preview wrapper would become
+    // roots and lose access to the `RouteProvider`'s `RouteStack`
+    // context.
+    handle_parent: OwnerId,
+) -> StackLayoutHandle {
     let mount_preview = {
         let stack = stack.clone();
         let render = render.clone();
@@ -253,7 +300,7 @@ fn build_gesture_context<R: Route>(
                 entries[0].route.clone()
             };
 
-            let preview_owner = create_owner(Some(gesture_parent));
+            let preview_owner = create_owner(Some(handle_parent));
             let preview_wrapper = create_element(ElementTag::View);
             apply_wrapper_style(
                 preview_wrapper,
@@ -326,14 +373,12 @@ fn build_gesture_context<R: Route>(
             as Rc<dyn Fn() -> Option<Element>>
     };
 
-    GestureContext {
+    StackLayoutHandle {
         container,
-        transition,
-        can_back,
+        current_wrapper,
         mount_preview,
         dispose_preview,
         commit_preview_and_back,
-        current_wrapper,
     }
 }
 
@@ -357,7 +402,7 @@ fn container_css() -> Css {
 /// `Style::Dynamic` registers an effect so the closure re-fires
 /// (and the wrapper re-styles) whenever any signal it reads
 /// changes — useful for theme-driven decoration.
-fn apply_wrapper_style(
+pub(crate) fn apply_wrapper_style(
     wrapper: Element,
     transition: &dyn crate::transitions::StackTransition,
     side: Side,
@@ -387,7 +432,7 @@ fn apply_wrapper_style(
     }
 }
 
-fn slot_css() -> Css {
+pub(crate) fn slot_css() -> Css {
     // `overflow: visible` is critical — Lynx clips a child's
     // `box-shadow` at the parent's bounds by default (unlike Web
     // CSS where overflow defaults to `visible`). Without this the
@@ -437,18 +482,5 @@ mod tests {
     fn container_uses_relative_positioning() {
         let css = container_css().to_css_string();
         assert!(css.contains("position: relative"), "got {css}");
-    }
-
-    #[test]
-    fn ios_slide_pose_endpoints_match_animate_keyframes() {
-        // `pose(0.0)` matches the "from" pose of `animate()`'s
-        // keyframes, `pose(1.0)` matches the "to". Verified for the
-        // common case (incoming forward push).
-        let t = IosSlide::default();
-        let p0 = t.pose(Side::Incoming, Direction::Forward, 0.0);
-        let p1 = t.pose(Side::Incoming, Direction::Forward, 1.0);
-        assert_eq!(p0[0].0, "transform");
-        assert!(p0[0].1.contains("100"), "got {}", p0[0].1);
-        assert!(p1[0].1.contains('0'), "got {}", p1[0].1);
     }
 }

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -5,8 +5,15 @@
 //! slots, deriving the [`Direction`], and ordering the DOM so the
 //! transition's paint-order hint takes effect.
 //!
+//! Interactive gestures (iOS swipe-back, future Android predictive
+//! back) live inside the transition — `StackLayout` only builds a
+//! [`GestureContext`](crate::transitions::GestureContext) of
+//! primitives and hands it to [`StackTransition::install_gestures`]
+//! once, at mount. Transitions that don't have a gesture (cross-
+//! fade, instant, vertical slide) ignore the hook.
+//!
 //! The default transition is [`IosSlide`](crate::transitions::IosSlide):
-//! horizontal slide with ~30% parallax.
+//! horizontal slide with ~30% parallax + edge swipe-back gesture.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -25,7 +32,7 @@ use whisker::{component, Style};
 
 use crate::outlet::{router, RouteRenderFn};
 use crate::route::Route;
-use crate::transitions::{Direction, Side, StackTransitionBox};
+use crate::transitions::{Direction, GestureContext, Side, StackTransitionBox};
 
 type Slot = Rc<RefCell<Option<(OwnerId, Element)>>>;
 
@@ -46,104 +53,288 @@ pub fn stack_layout<R: Route>(
 
     let outgoing: Slot = Rc::new(RefCell::new(None));
     let current: Slot = Rc::new(RefCell::new(None));
+    let preview: Slot = Rc::new(RefCell::new(None));
+    // When a gesture commit fires `stack.back()`, the resulting
+    // route-change effect must NOT animate — the wrappers already
+    // sit at the final pose. The commit closure sets this to a
+    // small count (2 by default); each effect run decrements and
+    // bails. A count rather than a bool because a single signal
+    // update can fan out into more than one effect run (the
+    // computed-of-a-RwSignal chain doesn't always batch them) and
+    // a one-shot bool would let the second run mount a fresh
+    // wrapper, double-stacking the destination screen on top of
+    // the gesture's promoted preview.
+    let skip_animation: Rc<Cell<u32>> = Rc::new(Cell::new(0));
     let prev_len = Rc::new(Cell::new(0_usize));
     let first = Rc::new(Cell::new(true));
 
-    let render = render.clone();
-    let current_signal = stack.current();
-    let stack_signal = stack.stack();
-    let transition_for_effect = transition.clone();
+    // Single source of truth for the effect — tracking both
+    // `current()` and `stack()` separately makes the runtime re-run
+    // the effect twice per navigation (each one is its own
+    // `computed`), which drops `skip_animation` on the floor for the
+    // second run and double-mounts the destination screen.
+    let entries_signal = stack.entries();
 
-    effect(move || {
-        let route = current_signal.get();
-        let new_len = stack_signal.get().len();
-        let old_len = prev_len.get();
+    {
+        let render = render.clone();
+        let outgoing = outgoing.clone();
+        let current = current.clone();
+        let prev_len = prev_len.clone();
+        let first = first.clone();
+        let skip_animation = skip_animation.clone();
+        let transition = transition.clone();
+        effect(move || {
+            let entries = entries_signal.get();
+            let route = entries
+                .last()
+                .map(|e| e.route.clone())
+                .expect("RouteStack invariant: at least one entry");
+            let new_len = entries.len();
+            let old_len = prev_len.get();
 
-        let dir = if first.get() {
-            Direction::None
-        } else if new_len > old_len {
-            Direction::Forward
-        } else if new_len < old_len {
-            Direction::Backward
-        } else {
-            Direction::None
-        };
-        prev_len.set(new_len);
-        first.set(false);
+            // Gesture-driven commit already advanced the visual state.
+            // Update bookkeeping and bail.
+            let skip = skip_animation.get();
+            if skip > 0 {
+                skip_animation.set(skip - 1);
+                prev_len.set(new_len);
+                first.set(false);
+                return;
+            }
 
-        // Tear down any leftover outgoing from a still-running prior
-        // transition — disposing now (rather than waiting for an
-        // animation-end signal Lynx doesn't yet expose) keeps the
-        // hidden-screen count bounded at one between transitions.
-        if let Some((owner, wrapper)) = outgoing.borrow_mut().take() {
-            remove_child(container, wrapper);
-            dispose_owner(owner);
-        }
+            let dir = if first.get() {
+                Direction::None
+            } else if new_len > old_len {
+                Direction::Forward
+            } else if new_len < old_len {
+                Direction::Backward
+            } else {
+                Direction::None
+            };
+            prev_len.set(new_len);
+            first.set(false);
 
-        // Promote previously-current → outgoing (or dispose on snap).
-        // Re-apply the wrapper's static style with its new role so
-        // direction-dependent decorations (e.g. the iOS dim layer)
-        // reflect the role flip before the animation kicks in.
-        if let Some((owner, wrapper)) = current.borrow_mut().take() {
-            if dir == Direction::None {
+            if let Some((owner, wrapper)) = outgoing.borrow_mut().take() {
                 remove_child(container, wrapper);
                 dispose_owner(owner);
-            } else {
-                apply_wrapper_style(
-                    wrapper,
-                    transition_for_effect.0.as_ref(),
-                    Side::Outgoing,
-                    dir,
-                );
-                *outgoing.borrow_mut() = Some((owner, wrapper));
             }
-        }
 
-        // Mount new wrapper + user screen. DOM paint order = sibling
-        // document order (Lynx ignores explicit `z-index` during
-        // transform animations). Insert at index 0 when the
-        // transition wants the outgoing on top (iOS pop semantics);
-        // append otherwise.
-        let new_owner = create_owner(None);
-        let wrapper = create_element(ElementTag::View);
-        apply_wrapper_style(
-            wrapper,
-            transition_for_effect.0.as_ref(),
-            Side::Incoming,
-            dir,
-        );
-        match transition_for_effect.0.foreground(dir) {
-            Side::Outgoing => insert_child_at(container, wrapper, 0),
-            Side::Incoming => append_child(container, wrapper),
-        }
-        let route_for_render = route.clone();
-        let render_for_owner = render.clone();
-        with_owner(new_owner, || {
-            let h = render_for_owner.call(route_for_render);
-            append_child(wrapper, h);
-        });
-        *current.borrow_mut() = Some((new_owner, wrapper));
-
-        if dir == Direction::None {
-            return;
-        }
-
-        // Hand off to the transition implementation. We wait for
-        // `on_mount` so the wrapper has its Lynx `sign` assigned.
-        let incoming_wrapper = wrapper;
-        let outgoing_for_anim = outgoing.borrow().as_ref().map(|(_, w)| *w);
-        let transition_for_mount = transition_for_effect.clone();
-        on_mount(move || {
-            transition_for_mount
-                .0
-                .animate(incoming_wrapper, Side::Incoming, dir);
-            if let Some(out) = outgoing_for_anim {
-                transition_for_mount.0.animate(out, Side::Outgoing, dir);
+            if let Some((owner, wrapper)) = current.borrow_mut().take() {
+                if dir == Direction::None {
+                    remove_child(container, wrapper);
+                    dispose_owner(owner);
+                } else {
+                    apply_wrapper_style(wrapper, transition.0.as_ref(), Side::Outgoing, dir);
+                    *outgoing.borrow_mut() = Some((owner, wrapper));
+                }
             }
+
+            let new_owner = create_owner(None);
+            let wrapper = create_element(ElementTag::View);
+            apply_wrapper_style(wrapper, transition.0.as_ref(), Side::Incoming, dir);
+            match transition.0.foreground(dir) {
+                Side::Outgoing => insert_child_at(container, wrapper, 0),
+                Side::Incoming => append_child(container, wrapper),
+            }
+            let route_for_render = route.clone();
+            let render_for_owner = render.clone();
+            with_owner(new_owner, || {
+                let h = render_for_owner.call(route_for_render);
+                append_child(wrapper, h);
+            });
+            *current.borrow_mut() = Some((new_owner, wrapper));
+
+            if dir == Direction::None {
+                return;
+            }
+
+            let incoming_wrapper = wrapper;
+            let outgoing_for_anim = outgoing.borrow().as_ref().map(|(_, w)| *w);
+            let transition_for_mount = transition.clone();
+            on_mount(move || {
+                transition_for_mount
+                    .0
+                    .animate(incoming_wrapper, Side::Incoming, dir);
+                if let Some(out) = outgoing_for_anim {
+                    transition_for_mount.0.animate(out, Side::Outgoing, dir);
+                }
+            });
         });
-    });
+    }
+
+    // Reserve an owner whose parent is the layout's own owner
+    // (`create_owner(None)` falls back to the current owner). The
+    // gesture handlers fire from the touch dispatcher, which has no
+    // active reactive owner — without this anchor, owners spawned
+    // for the preview screen become roots and lose access to the
+    // `RouteProvider` context their components rely on.
+    let gesture_parent = create_owner(None);
+
+    // Hand off gesture wiring to the transition. The trait method
+    // is no-op by default; only `IosSlide` (and any user-defined
+    // gesture-aware transition) installs handlers.
+    let gesture_ctx = build_gesture_context(
+        container,
+        transition.clone(),
+        stack.clone(),
+        render.clone(),
+        current.clone(),
+        outgoing,
+        preview,
+        skip_animation,
+        gesture_parent,
+    );
+    transition.0.install_gestures(&gesture_ctx);
 
     container
+}
+
+/// Build the closure surface a [`StackTransition`] uses to drive
+/// the stack interactively (the preview wrapper, the commit-back
+/// path, the can-back gate).
+///
+/// Lives here in the layout because all of these operations touch
+/// the slots that the route-change effect also manipulates — the
+/// transition itself stays free of `OwnerId`/`Slot` plumbing.
+#[allow(clippy::too_many_arguments)]
+fn build_gesture_context<R: Route>(
+    container: Element,
+    transition: StackTransitionBox,
+    stack: crate::stack::RouteStack<R>,
+    render: RouteRenderFn<R>,
+    current: Slot,
+    outgoing: Slot,
+    preview: Slot,
+    skip_animation: Rc<Cell<u32>>,
+    // `gesture_parent`: anchor owner used as the parent of any owner
+    // spawned from a gesture handler. Touch dispatchers fire with no
+    // active reactive owner, so without this anchor the screens
+    // mounted inside a preview wrapper would become roots and lose
+    // access to the `RouteProvider`'s `RouteStack` context.
+    gesture_parent: OwnerId,
+) -> GestureContext {
+    let can_back = {
+        let stack = stack.clone();
+        Rc::new(move || stack.entries().get().len() > 1) as Rc<dyn Fn() -> bool>
+    };
+
+    let mount_preview = {
+        let stack = stack.clone();
+        let render = render.clone();
+        let preview = preview.clone();
+        let outgoing_for_mount = outgoing.clone();
+        let transition = transition.clone();
+        Rc::new(move || {
+            // If a previous gesture left a preview lingering (e.g.,
+            // mount → no commit/cancel before the next touchstart),
+            // tear it down before mounting a fresh one — otherwise
+            // the DOM accumulates orphan wrappers that paint on top
+            // of the current screen.
+            if let Some((owner, wrapper)) = preview.borrow_mut().take() {
+                remove_child(container, wrapper);
+                dispose_owner(owner);
+            }
+
+            // Dispose any stale outgoing wrapper from the most
+            // recent natural push. It would otherwise still sit in
+            // the DOM at its parallax pose (translateX(-30%)
+            // brightness 0.85) and obscure the preview the gesture
+            // is about to mount — visible as a frozen "back" screen
+            // that doesn't track the finger.
+            if let Some((owner, wrapper)) = outgoing_for_mount.borrow_mut().take() {
+                remove_child(container, wrapper);
+                dispose_owner(owner);
+            }
+
+            let entries = stack.entries().get();
+            let prev_route = if entries.len() >= 2 {
+                entries[entries.len() - 2].route.clone()
+            } else {
+                entries[0].route.clone()
+            };
+
+            let preview_owner = create_owner(Some(gesture_parent));
+            let preview_wrapper = create_element(ElementTag::View);
+            apply_wrapper_style(
+                preview_wrapper,
+                transition.0.as_ref(),
+                Side::Incoming,
+                Direction::Backward,
+            );
+            insert_child_at(container, preview_wrapper, 0);
+            with_owner(preview_owner, || {
+                let h = render.call(prev_route);
+                append_child(preview_wrapper, h);
+            });
+            *preview.borrow_mut() = Some((preview_owner, preview_wrapper));
+            preview_wrapper
+        }) as Rc<dyn Fn() -> Element>
+    };
+
+    let dispose_preview = {
+        let preview = preview.clone();
+        Rc::new(move || {
+            if let Some((owner, wrapper)) = preview.borrow_mut().take() {
+                remove_child(container, wrapper);
+                dispose_owner(owner);
+            }
+        }) as Rc<dyn Fn()>
+    };
+
+    let commit_preview_and_back = {
+        let preview = preview.clone();
+        let current = current.clone();
+        let outgoing_for_commit = outgoing.clone();
+        let stack = stack.clone();
+        let skip_animation = skip_animation.clone();
+        Rc::new(move || {
+            // Promote preview → current; dispose both the old
+            // current (the screen we're leaving) AND any wrapper
+            // sitting in the outgoing slot. The outgoing slot
+            // holds whatever screen the prior push promoted there
+            // (e.g. the original Home after a Home → List push) —
+            // the natural pop would dispose it at the top of the
+            // effect, but we're about to skip that effect, so
+            // without this the wrapper persists in the DOM and
+            // reappears underneath the promoted preview.
+            let promoted = preview.borrow_mut().take();
+            let old_current = current.borrow_mut().take();
+            let stale_outgoing = outgoing_for_commit.borrow_mut().take();
+            if let Some((owner, wrapper)) = stale_outgoing {
+                remove_child(container, wrapper);
+                dispose_owner(owner);
+            }
+            if let Some((owner, wrapper)) = old_current {
+                remove_child(container, wrapper);
+                dispose_owner(owner);
+            }
+            if let Some((owner, wrapper)) = promoted {
+                *current.borrow_mut() = Some((owner, wrapper));
+            }
+            // One effect run is consumed by the `stack.back()` call
+            // below — `skip_animation` makes that run a no-op so we
+            // don't re-mount on top of the gesture's promoted
+            // preview.
+            skip_animation.set(1);
+            stack.back();
+        }) as Rc<dyn Fn()>
+    };
+
+    let current_wrapper = {
+        let current = current.clone();
+        Rc::new(move || current.borrow().as_ref().map(|(_, w)| *w))
+            as Rc<dyn Fn() -> Option<Element>>
+    };
+
+    GestureContext {
+        container,
+        transition,
+        can_back,
+        mount_preview,
+        dispose_preview,
+        commit_preview_and_back,
+        current_wrapper,
+    }
 }
 
 fn container_css() -> Css {
@@ -231,8 +422,6 @@ mod tests {
 
     #[test]
     fn instant_is_default_no_op() {
-        // Instant has no animation; the assertion is just that
-        // wrapping it in a transition box compiles & is Clone.
         let t = StackTransitionBox::new(Instant);
         let _ = t.clone();
     }
@@ -248,5 +437,18 @@ mod tests {
     fn container_uses_relative_positioning() {
         let css = container_css().to_css_string();
         assert!(css.contains("position: relative"), "got {css}");
+    }
+
+    #[test]
+    fn ios_slide_pose_endpoints_match_animate_keyframes() {
+        // `pose(0.0)` matches the "from" pose of `animate()`'s
+        // keyframes, `pose(1.0)` matches the "to". Verified for the
+        // common case (incoming forward push).
+        let t = IosSlide::default();
+        let p0 = t.pose(Side::Incoming, Direction::Forward, 0.0);
+        let p1 = t.pose(Side::Incoming, Direction::Forward, 1.0);
+        assert_eq!(p0[0].0, "transform");
+        assert!(p0[0].1.contains("100"), "got {}", p0[0].1);
+        assert!(p1[0].1.contains('0'), "got {}", p1[0].1);
     }
 }

--- a/packages/whisker-router/src/lib.rs
+++ b/packages/whisker-router/src/lib.rs
@@ -62,6 +62,6 @@ pub use crate::outlet::{
 pub use crate::route::{Route, RouteError};
 pub use crate::stack::{route_stack, EntryId, EntryState, RouteEntry, RouteStack};
 pub use crate::transitions::{
-    Direction, Fade, Instant, IosSlide, Side, StackTransition, StackTransitionBox, VerticalSlide,
-    IOS_PARALLAX_PCT,
+    Direction, Fade, GestureContext, Instant, IosSlide, Side, StackTransition, StackTransitionBox,
+    VerticalSlide, IOS_PARALLAX_PCT,
 };

--- a/packages/whisker-router/src/lib.rs
+++ b/packages/whisker-router/src/lib.rs
@@ -28,6 +28,7 @@
 #![warn(missing_docs)]
 
 pub mod back_handler;
+pub mod gestures;
 pub mod layouts;
 pub mod linking;
 pub mod outlet;
@@ -52,9 +53,10 @@ pub mod transitions;
 pub use whisker_router_macros::route;
 
 pub use crate::back_handler::{on_back, BackHandlerGuard};
+pub use crate::gestures::{IosSwipeBack, IosSwipeBackProps};
 pub use crate::layouts::modal::{ModalLayout, ModalLayoutProps, ModalRenderFn};
 pub use crate::layouts::pane::{Pane, PaneProps};
-pub use crate::layouts::stack::{StackLayout, StackLayoutProps};
+pub use crate::layouts::stack::{StackLayout, StackLayoutHandle, StackLayoutProps};
 pub use crate::layouts::tabs::{TabSpec, TabsLayout, TabsLayoutProps};
 pub use crate::outlet::{
     router, Outlet, OutletProps, RouteProvider, RouteProviderProps, RouteRenderFn,
@@ -62,6 +64,6 @@ pub use crate::outlet::{
 pub use crate::route::{Route, RouteError};
 pub use crate::stack::{route_stack, EntryId, EntryState, RouteEntry, RouteStack};
 pub use crate::transitions::{
-    Direction, Fade, GestureContext, Instant, IosSlide, Side, StackTransition, StackTransitionBox,
-    VerticalSlide, IOS_PARALLAX_PCT,
+    Direction, Fade, Instant, IosSlide, Side, StackTransition, StackTransitionBox, VerticalSlide,
+    IOS_PARALLAX_PCT,
 };

--- a/packages/whisker-router/src/transitions/ios_slide.rs
+++ b/packages/whisker-router/src/transitions/ios_slide.rs
@@ -2,12 +2,22 @@
 //! with parallax, leading-edge shadow on the moving screen, and a
 //! subtle brightness dim on the parallaxed background screen.
 //!
-//! Default transition for [`StackLayout`](crate::StackLayout).
+//! Default transition for [`StackLayout`](crate::StackLayout). Also
+//! installs an iOS-native edge swipe-back gesture via
+//! [`StackTransition::install_gestures`] — the gesture is intrinsic
+//! to this transition rather than the layout, so swapping in a
+//! [`Fade`](super::Fade) or [`Instant`](super::Instant) transition
+//! drops swipe-back automatically.
 
-use whisker::runtime::view::Element;
-use whisker::{animate_start, AnimateOptions, Style};
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
 
-use super::{Direction, Side, StackTransition};
+use whisker::event::TouchEvent;
+use whisker::runtime::event::bind_typed;
+use whisker::runtime::view::{set_inline_styles, BindType, Element};
+use whisker::{animate_cancel, animate_start, AnimateOptions, Style};
+
+use super::{Direction, GestureContext, Side, StackTransition};
 
 /// One animation's CSS endpoints — `(name, from_props, to_props)`.
 type Keyframes<'a> = (
@@ -36,6 +46,20 @@ const IOS_PARALLAX_DIM: &str = "filter: brightness(0.85);";
 const DEFAULT_DURATION_MS: u32 = 320;
 const DEFAULT_EASING: &str = "ease-in-out";
 
+/// Horizontal distance (in points) that maps the gesture to a full
+/// `progress = 1.0`. iPhone 17 Pro is 402pt wide and the wrapper
+/// covers the full viewport, so a 1:1 finger-to-edge ratio wants
+/// this equal to the viewport width. Older iPhones differ by a few
+/// points (375–430pt) — a future revision can read the actual
+/// container width to make this exact across devices.
+const SWIPE_FULL_DISTANCE_PX: f32 = 402.0;
+/// `clientX` (in points) within which a `touchstart` qualifies as
+/// an edge swipe-back attempt. iOS uses ~20pt; 24pt is generous
+/// without eating into scrollable content.
+const SWIPE_EDGE_THRESHOLD_PX: f32 = 24.0;
+/// Progress at touch release above which the gesture commits.
+const SWIPE_COMMIT_THRESHOLD: f32 = 0.5;
+
 /// iOS UINavigationController-style horizontal slide.
 #[derive(Copy, Clone, Debug)]
 pub struct IosSlide {
@@ -58,13 +82,11 @@ impl StackTransition for IosSlide {
     fn animate(&self, element: Element, side: Side, direction: Direction) {
         let parallax = format!("translateX(-{IOS_PARALLAX_PCT}%)");
         let (name, from, to): Keyframes = match (side, direction) {
-            // New screen slides in from the right at full brightness.
             (Side::Incoming, Direction::Forward) => (
                 "stack-ios-incoming-forward",
                 vec![("transform", "translateX(100%)")],
                 vec![("transform", "translateX(0%)")],
             ),
-            // Returning screen brightens as it slides back from -30%.
             (Side::Incoming, Direction::Backward) => (
                 "stack-ios-incoming-backward",
                 vec![
@@ -76,8 +98,6 @@ impl StackTransition for IosSlide {
                     ("filter", "brightness(1.0)"),
                 ],
             ),
-            // Previous screen parallaxes off-left and dims behind the
-            // pushing screen.
             (Side::Outgoing, Direction::Forward) => (
                 "stack-ios-outgoing-forward",
                 vec![
@@ -89,7 +109,6 @@ impl StackTransition for IosSlide {
                     ("filter", "brightness(0.85)"),
                 ],
             ),
-            // Leaving screen slides off the trailing edge.
             (Side::Outgoing, Direction::Backward) => (
                 "stack-ios-outgoing-backward",
                 vec![("transform", "translateX(0%)")],
@@ -112,14 +131,336 @@ impl StackTransition for IosSlide {
 
     fn slot_style(&self, side: Side, direction: Direction) -> Style {
         let raw = match (side, direction) {
-            // Foreground (moving) side carries the depth shadow.
             (Side::Incoming, Direction::Forward) => IOS_LEADING_SHADOW,
             (Side::Outgoing, Direction::Backward) => IOS_LEADING_SHADOW,
-            // Background (parallaxed) side starts dimmed.
             (Side::Outgoing, Direction::Forward) => IOS_PARALLAX_DIM,
             (Side::Incoming, Direction::Backward) => IOS_PARALLAX_DIM,
             _ => "",
         };
         Style::from(raw)
     }
+
+    fn pose(&self, side: Side, direction: Direction, progress: f32) -> Vec<(&'static str, String)> {
+        // Endpoints per `(side, direction)` mirror `animate()`'s
+        // keyframes: `(tx_from, tx_to, br_from, br_to)`. Linear
+        // interpolation in CSS-property space.
+        let (tx_from, tx_to, br_from, br_to) = match (side, direction) {
+            (Side::Incoming, Direction::Forward) => (100.0, 0.0, 1.0, 1.0),
+            (Side::Incoming, Direction::Backward) => (-IOS_PARALLAX_PCT, 0.0, 0.85, 1.0),
+            (Side::Outgoing, Direction::Forward) => (0.0, -IOS_PARALLAX_PCT, 1.0, 0.85),
+            (Side::Outgoing, Direction::Backward) => (0.0, 100.0, 1.0, 1.0),
+            (_, Direction::None) => return Vec::new(),
+        };
+        let t = progress.clamp(0.0, 1.0);
+        let tx = tx_from + (tx_to - tx_from) * t;
+        let br = br_from + (br_to - br_from) * t;
+        vec![
+            ("transform", format!("translateX({tx}%)")),
+            ("filter", format!("brightness({br})")),
+        ]
+    }
+
+    fn install_gestures(&self, ctx: &GestureContext) {
+        let container = ctx.container;
+        let can_back = ctx.can_back.clone();
+        let mount_preview = ctx.mount_preview.clone();
+        let dispose_preview = ctx.dispose_preview.clone();
+        let commit_back = ctx.commit_preview_and_back.clone();
+        let current_wrapper = ctx.current_wrapper.clone();
+        let transition = ctx.transition.clone();
+
+        // Per-active-gesture state. `None` means no swipe is in
+        // flight; the touchstart handler populates it, touchmove
+        // updates it, touchend drains it.
+        let gesture: Rc<RefCell<Option<GestureState>>> = Rc::new(RefCell::new(None));
+        // Cached preview wrapper between touchstart and the end
+        // event — let touchmove pose it without going through
+        // `current_wrapper` every frame.
+        let preview_wrapper: Rc<Cell<Option<Element>>> = Rc::new(Cell::new(None));
+
+        // touchstart — qualify the edge swipe, mount the preview
+        // wrapper, capture state.
+        {
+            let gesture = gesture.clone();
+            let preview_wrapper = preview_wrapper.clone();
+            let mount_preview = mount_preview.clone();
+            let current_wrapper = current_wrapper.clone();
+            let transition = transition.clone();
+            let can_back = can_back.clone();
+            bind_typed::<TouchEvent, _>(container, "touchstart", BindType::Bind, move |e| {
+                if gesture.borrow().is_some() {
+                    return;
+                }
+                let touch = match e
+                    .changed_touches
+                    .first()
+                    .copied()
+                    .or_else(|| e.touches.first().copied())
+                {
+                    Some(t) => t,
+                    None => return,
+                };
+                let start_x = touch.client_x as f32;
+                if start_x > SWIPE_EDGE_THRESHOLD_PX {
+                    return;
+                }
+                if !can_back() {
+                    return;
+                }
+
+                let wrapper = mount_preview();
+                apply_pose(
+                    wrapper,
+                    transition.0.as_ref(),
+                    Side::Incoming,
+                    Direction::Backward,
+                    0.0,
+                );
+                if let Some(cur) = current_wrapper() {
+                    // The current wrapper takes the outgoing role for
+                    // a backward navigation — restyle so direction-
+                    // dependent decoration (depth shadow) is in place
+                    // before any pose update.
+                    apply_pose(
+                        cur,
+                        transition.0.as_ref(),
+                        Side::Outgoing,
+                        Direction::Backward,
+                        0.0,
+                    );
+                }
+
+                preview_wrapper.set(Some(wrapper));
+                *gesture.borrow_mut() = Some(GestureState {
+                    start_x,
+                    progress: 0.0,
+                    identifier: touch.identifier,
+                });
+            });
+        }
+
+        // touchmove — translate finger displacement into progress
+        // and re-pose preview + current each frame.
+        {
+            let gesture = gesture.clone();
+            let preview_wrapper = preview_wrapper.clone();
+            let current_wrapper = current_wrapper.clone();
+            let transition = transition.clone();
+            bind_typed::<TouchEvent, _>(container, "touchmove", BindType::Bind, move |e| {
+                let mut g = gesture.borrow_mut();
+                let state = match g.as_mut() {
+                    Some(s) => s,
+                    None => return,
+                };
+                let touch = match e
+                    .touches
+                    .iter()
+                    .find(|t| t.identifier == state.identifier)
+                    .or_else(|| {
+                        e.changed_touches
+                            .iter()
+                            .find(|t| t.identifier == state.identifier)
+                    }) {
+                    Some(t) => *t,
+                    None => return,
+                };
+                let delta = (touch.client_x as f32 - state.start_x).max(0.0);
+                let progress = (delta / SWIPE_FULL_DISTANCE_PX).clamp(0.0, 1.0);
+                state.progress = progress;
+
+                if let Some(wrapper) = preview_wrapper.get() {
+                    apply_pose(
+                        wrapper,
+                        transition.0.as_ref(),
+                        Side::Incoming,
+                        Direction::Backward,
+                        progress,
+                    );
+                }
+                if let Some(cur) = current_wrapper() {
+                    apply_pose(
+                        cur,
+                        transition.0.as_ref(),
+                        Side::Outgoing,
+                        Direction::Backward,
+                        progress,
+                    );
+                }
+            });
+        }
+
+        // touchend / touchcancel — snap to the final pose and
+        // commit-or-cancel immediately. Smooth finishing animations
+        // need to wait for animationend, which is unreliable for
+        // short / no-op animations; the snap is at least visibly
+        // correct and we can layer a finishing tween back on once
+        // the basic flow is verified.
+        for end_name in ["touchend", "touchcancel"] {
+            let gesture = gesture.clone();
+            let preview_wrapper = preview_wrapper.clone();
+            let current_wrapper = current_wrapper.clone();
+            let transition = transition.clone();
+            let dispose_preview = dispose_preview.clone();
+            let commit_back = commit_back.clone();
+            bind_typed::<TouchEvent, _>(container, end_name, BindType::Bind, move |_e| {
+                let state = match gesture.borrow_mut().take() {
+                    Some(s) => s,
+                    None => return,
+                };
+                let commit = state.progress >= SWIPE_COMMIT_THRESHOLD;
+                let target_progress: f32 = if commit { 1.0 } else { 0.0 };
+
+                // Drive the finish via Lynx's animator (short
+                // duration, `fill: forwards`) instead of a raw
+                // `set_inline_styles` write. Inline writes during a
+                // run of rapid touch-move updates were getting
+                // dropped/coalesced — the animator path always
+                // takes hold.
+                let from = state.progress;
+                let remaining = (target_progress - from).abs();
+                let duration_ms = ((remaining * 320.0) as u32).max(120);
+
+                if let Some(wrapper) = preview_wrapper.get() {
+                    animate_to_pose(
+                        wrapper,
+                        transition.0.as_ref(),
+                        Side::Incoming,
+                        Direction::Backward,
+                        from,
+                        target_progress,
+                        duration_ms,
+                        "swipe-finish-incoming",
+                    );
+                }
+                if let Some(cur) = current_wrapper() {
+                    animate_to_pose(
+                        cur,
+                        transition.0.as_ref(),
+                        Side::Outgoing,
+                        Direction::Backward,
+                        from,
+                        target_progress,
+                        duration_ms,
+                        "swipe-finish-outgoing",
+                    );
+                }
+
+                preview_wrapper.set(None);
+                if commit {
+                    commit_back();
+                } else {
+                    dispose_preview();
+                }
+            });
+        }
+    }
+}
+
+/// Per-active-gesture state stored in the `gesture` cell.
+struct GestureState {
+    start_x: f32,
+    progress: f32,
+    identifier: i64,
+}
+
+/// Cancel any natural-transition animation that might still be
+/// holding `element` at its end pose via `fill: forwards`.
+///
+/// Without this, inline `transform` set during a drag is overridden
+/// by the prior animation rule's computed style and the element
+/// won't move at all. We don't track which animation is active per
+/// wrapper, so this just tries to cancel all four names — Lynx
+/// no-ops on cancel-of-nonexistent.
+fn clear_natural_animations(element: Element) {
+    for name in [
+        "stack-ios-incoming-forward",
+        "stack-ios-incoming-backward",
+        "stack-ios-outgoing-forward",
+        "stack-ios-outgoing-backward",
+        "swipe-finish-incoming",
+        "swipe-finish-outgoing",
+    ] {
+        let _ = animate_cancel(element, name);
+    }
+}
+
+/// Slot layout style — must be re-emitted by every `apply_pose`
+/// call because `set_inline_styles` replaces the full inline string
+/// (it isn't a CSSOM merge). Without these properties, a wrapper
+/// styled by the gesture falls back to default static positioning
+/// and starts sharing space with its sibling instead of overlaying
+/// it — that's what showed up as the "two screens side by side"
+/// glitch after a swipe-back commit.
+const SLOT_LAYOUT_STYLE: &str = "position: absolute; top: 0; left: 0; \
+     width: 100%; height: 100%; overflow: visible;";
+
+/// Apply the dynamic pose for `progress` to `element` as an inline
+/// style, alongside the transition's [`slot_style`] decoration and
+/// the [`SLOT_LAYOUT_STYLE`] layout base.
+///
+/// Inline styles take effect only once any active CSS animation is
+/// cancelled — Lynx's animator with `fill: forwards` (which the
+/// natural push/pop uses) clamps the element to its end pose and
+/// shadows out-of-band style writes.
+/// Animate `element` from the pose at `from_progress` to the pose
+/// at `to_progress` using Lynx's animator. `fill: forwards` keeps
+/// the element at the end pose after the animation completes; the
+/// caller doesn't have to listen for `animationend`.
+///
+/// `apply_pose` writes inline styles for the live drag — fast and
+/// fine for per-frame updates — but Lynx coalesces a string of
+/// rapid inline writes such that the final one (the cancel/commit
+/// snap) sometimes never lands. The animator path always takes
+/// hold, so the touchend handler uses this instead.
+#[allow(clippy::too_many_arguments)]
+fn animate_to_pose(
+    element: Element,
+    transition: &dyn StackTransition,
+    side: Side,
+    direction: Direction,
+    from_progress: f32,
+    to_progress: f32,
+    duration_ms: u32,
+    animation_name: &'static str,
+) {
+    let from = transition.pose(side, direction, from_progress);
+    let to = transition.pose(side, direction, to_progress);
+    if from.is_empty() || to.is_empty() {
+        return;
+    }
+    let from_kf: Vec<(&str, &str)> = from.iter().map(|(k, v)| (*k, v.as_str())).collect();
+    let to_kf: Vec<(&str, &str)> = to.iter().map(|(k, v)| (*k, v.as_str())).collect();
+    let _ = animate_start(
+        element,
+        animation_name,
+        &[("0%", &from_kf), ("100%", &to_kf)],
+        &AnimateOptions {
+            duration_ms,
+            easing: "ease-out".into(),
+            fill: "forwards".into(),
+            ..Default::default()
+        },
+    );
+}
+
+fn apply_pose(
+    element: Element,
+    transition: &dyn StackTransition,
+    side: Side,
+    direction: Direction,
+    progress: f32,
+) {
+    clear_natural_animations(element);
+    let mut style = String::from(SLOT_LAYOUT_STYLE);
+    let decoration = match transition.slot_style(side, direction) {
+        Style::Static(s) => s,
+        Style::Dynamic(_) => String::new(),
+    };
+    if !decoration.is_empty() {
+        style.push_str(&decoration);
+    }
+    for (prop, val) in transition.pose(side, direction, progress) {
+        style.push_str(&format!("{prop}: {val};"));
+    }
+    set_inline_styles(element, &style);
 }

--- a/packages/whisker-router/src/transitions/ios_slide.rs
+++ b/packages/whisker-router/src/transitions/ios_slide.rs
@@ -2,22 +2,18 @@
 //! with parallax, leading-edge shadow on the moving screen, and a
 //! subtle brightness dim on the parallaxed background screen.
 //!
-//! Default transition for [`StackLayout`](crate::StackLayout). Also
-//! installs an iOS-native edge swipe-back gesture via
-//! [`StackTransition::install_gestures`] — the gesture is intrinsic
-//! to this transition rather than the layout, so swapping in a
-//! [`Fade`](super::Fade) or [`Instant`](super::Instant) transition
-//! drops swipe-back automatically.
+//! Default transition for [`StackLayout`](crate::StackLayout).
+//!
+//! For the iOS-native edge swipe-back gesture, mount
+//! [`IosSwipeBack`](crate::IosSwipeBack) as a child of the layout —
+//! the gesture is intentionally a separate composable component,
+//! not part of this transition trait, so you can mix transitions
+//! and gestures freely.
 
-use std::cell::{Cell, RefCell};
-use std::rc::Rc;
+use whisker::runtime::view::Element;
+use whisker::{animate_start, AnimateOptions, Style};
 
-use whisker::event::TouchEvent;
-use whisker::runtime::event::bind_typed;
-use whisker::runtime::view::{set_inline_styles, BindType, Element};
-use whisker::{animate_cancel, animate_start, AnimateOptions, Style};
-
-use super::{Direction, GestureContext, Side, StackTransition};
+use super::{Direction, Side, StackTransition};
 
 /// One animation's CSS endpoints — `(name, from_props, to_props)`.
 type Keyframes<'a> = (
@@ -45,20 +41,6 @@ const IOS_PARALLAX_DIM: &str = "filter: brightness(0.85);";
 
 const DEFAULT_DURATION_MS: u32 = 320;
 const DEFAULT_EASING: &str = "ease-in-out";
-
-/// Horizontal distance (in points) that maps the gesture to a full
-/// `progress = 1.0`. iPhone 17 Pro is 402pt wide and the wrapper
-/// covers the full viewport, so a 1:1 finger-to-edge ratio wants
-/// this equal to the viewport width. Older iPhones differ by a few
-/// points (375–430pt) — a future revision can read the actual
-/// container width to make this exact across devices.
-const SWIPE_FULL_DISTANCE_PX: f32 = 402.0;
-/// `clientX` (in points) within which a `touchstart` qualifies as
-/// an edge swipe-back attempt. iOS uses ~20pt; 24pt is generous
-/// without eating into scrollable content.
-const SWIPE_EDGE_THRESHOLD_PX: f32 = 24.0;
-/// Progress at touch release above which the gesture commits.
-const SWIPE_COMMIT_THRESHOLD: f32 = 0.5;
 
 /// iOS UINavigationController-style horizontal slide.
 #[derive(Copy, Clone, Debug)]
@@ -139,328 +121,25 @@ impl StackTransition for IosSlide {
         };
         Style::from(raw)
     }
-
-    fn pose(&self, side: Side, direction: Direction, progress: f32) -> Vec<(&'static str, String)> {
-        // Endpoints per `(side, direction)` mirror `animate()`'s
-        // keyframes: `(tx_from, tx_to, br_from, br_to)`. Linear
-        // interpolation in CSS-property space.
-        let (tx_from, tx_to, br_from, br_to) = match (side, direction) {
-            (Side::Incoming, Direction::Forward) => (100.0, 0.0, 1.0, 1.0),
-            (Side::Incoming, Direction::Backward) => (-IOS_PARALLAX_PCT, 0.0, 0.85, 1.0),
-            (Side::Outgoing, Direction::Forward) => (0.0, -IOS_PARALLAX_PCT, 1.0, 0.85),
-            (Side::Outgoing, Direction::Backward) => (0.0, 100.0, 1.0, 1.0),
-            (_, Direction::None) => return Vec::new(),
-        };
-        let t = progress.clamp(0.0, 1.0);
-        let tx = tx_from + (tx_to - tx_from) * t;
-        let br = br_from + (br_to - br_from) * t;
-        vec![
-            ("transform", format!("translateX({tx}%)")),
-            ("filter", format!("brightness({br})")),
-        ]
-    }
-
-    fn install_gestures(&self, ctx: &GestureContext) {
-        let container = ctx.container;
-        let can_back = ctx.can_back.clone();
-        let mount_preview = ctx.mount_preview.clone();
-        let dispose_preview = ctx.dispose_preview.clone();
-        let commit_back = ctx.commit_preview_and_back.clone();
-        let current_wrapper = ctx.current_wrapper.clone();
-        let transition = ctx.transition.clone();
-
-        // Per-active-gesture state. `None` means no swipe is in
-        // flight; the touchstart handler populates it, touchmove
-        // updates it, touchend drains it.
-        let gesture: Rc<RefCell<Option<GestureState>>> = Rc::new(RefCell::new(None));
-        // Cached preview wrapper between touchstart and the end
-        // event — let touchmove pose it without going through
-        // `current_wrapper` every frame.
-        let preview_wrapper: Rc<Cell<Option<Element>>> = Rc::new(Cell::new(None));
-
-        // touchstart — qualify the edge swipe, mount the preview
-        // wrapper, capture state.
-        {
-            let gesture = gesture.clone();
-            let preview_wrapper = preview_wrapper.clone();
-            let mount_preview = mount_preview.clone();
-            let current_wrapper = current_wrapper.clone();
-            let transition = transition.clone();
-            let can_back = can_back.clone();
-            bind_typed::<TouchEvent, _>(container, "touchstart", BindType::Bind, move |e| {
-                if gesture.borrow().is_some() {
-                    return;
-                }
-                let touch = match e
-                    .changed_touches
-                    .first()
-                    .copied()
-                    .or_else(|| e.touches.first().copied())
-                {
-                    Some(t) => t,
-                    None => return,
-                };
-                let start_x = touch.client_x as f32;
-                if start_x > SWIPE_EDGE_THRESHOLD_PX {
-                    return;
-                }
-                if !can_back() {
-                    return;
-                }
-
-                let wrapper = mount_preview();
-                apply_pose(
-                    wrapper,
-                    transition.0.as_ref(),
-                    Side::Incoming,
-                    Direction::Backward,
-                    0.0,
-                );
-                if let Some(cur) = current_wrapper() {
-                    // The current wrapper takes the outgoing role for
-                    // a backward navigation — restyle so direction-
-                    // dependent decoration (depth shadow) is in place
-                    // before any pose update.
-                    apply_pose(
-                        cur,
-                        transition.0.as_ref(),
-                        Side::Outgoing,
-                        Direction::Backward,
-                        0.0,
-                    );
-                }
-
-                preview_wrapper.set(Some(wrapper));
-                *gesture.borrow_mut() = Some(GestureState {
-                    start_x,
-                    progress: 0.0,
-                    identifier: touch.identifier,
-                });
-            });
-        }
-
-        // touchmove — translate finger displacement into progress
-        // and re-pose preview + current each frame.
-        {
-            let gesture = gesture.clone();
-            let preview_wrapper = preview_wrapper.clone();
-            let current_wrapper = current_wrapper.clone();
-            let transition = transition.clone();
-            bind_typed::<TouchEvent, _>(container, "touchmove", BindType::Bind, move |e| {
-                let mut g = gesture.borrow_mut();
-                let state = match g.as_mut() {
-                    Some(s) => s,
-                    None => return,
-                };
-                let touch = match e
-                    .touches
-                    .iter()
-                    .find(|t| t.identifier == state.identifier)
-                    .or_else(|| {
-                        e.changed_touches
-                            .iter()
-                            .find(|t| t.identifier == state.identifier)
-                    }) {
-                    Some(t) => *t,
-                    None => return,
-                };
-                let delta = (touch.client_x as f32 - state.start_x).max(0.0);
-                let progress = (delta / SWIPE_FULL_DISTANCE_PX).clamp(0.0, 1.0);
-                state.progress = progress;
-
-                if let Some(wrapper) = preview_wrapper.get() {
-                    apply_pose(
-                        wrapper,
-                        transition.0.as_ref(),
-                        Side::Incoming,
-                        Direction::Backward,
-                        progress,
-                    );
-                }
-                if let Some(cur) = current_wrapper() {
-                    apply_pose(
-                        cur,
-                        transition.0.as_ref(),
-                        Side::Outgoing,
-                        Direction::Backward,
-                        progress,
-                    );
-                }
-            });
-        }
-
-        // touchend / touchcancel — snap to the final pose and
-        // commit-or-cancel immediately. Smooth finishing animations
-        // need to wait for animationend, which is unreliable for
-        // short / no-op animations; the snap is at least visibly
-        // correct and we can layer a finishing tween back on once
-        // the basic flow is verified.
-        for end_name in ["touchend", "touchcancel"] {
-            let gesture = gesture.clone();
-            let preview_wrapper = preview_wrapper.clone();
-            let current_wrapper = current_wrapper.clone();
-            let transition = transition.clone();
-            let dispose_preview = dispose_preview.clone();
-            let commit_back = commit_back.clone();
-            bind_typed::<TouchEvent, _>(container, end_name, BindType::Bind, move |_e| {
-                let state = match gesture.borrow_mut().take() {
-                    Some(s) => s,
-                    None => return,
-                };
-                let commit = state.progress >= SWIPE_COMMIT_THRESHOLD;
-                let target_progress: f32 = if commit { 1.0 } else { 0.0 };
-
-                // Drive the finish via Lynx's animator (short
-                // duration, `fill: forwards`) instead of a raw
-                // `set_inline_styles` write. Inline writes during a
-                // run of rapid touch-move updates were getting
-                // dropped/coalesced — the animator path always
-                // takes hold.
-                let from = state.progress;
-                let remaining = (target_progress - from).abs();
-                let duration_ms = ((remaining * 320.0) as u32).max(120);
-
-                if let Some(wrapper) = preview_wrapper.get() {
-                    animate_to_pose(
-                        wrapper,
-                        transition.0.as_ref(),
-                        Side::Incoming,
-                        Direction::Backward,
-                        from,
-                        target_progress,
-                        duration_ms,
-                        "swipe-finish-incoming",
-                    );
-                }
-                if let Some(cur) = current_wrapper() {
-                    animate_to_pose(
-                        cur,
-                        transition.0.as_ref(),
-                        Side::Outgoing,
-                        Direction::Backward,
-                        from,
-                        target_progress,
-                        duration_ms,
-                        "swipe-finish-outgoing",
-                    );
-                }
-
-                preview_wrapper.set(None);
-                if commit {
-                    commit_back();
-                } else {
-                    dispose_preview();
-                }
-            });
-        }
-    }
 }
 
-/// Per-active-gesture state stored in the `gesture` cell.
-struct GestureState {
-    start_x: f32,
-    progress: f32,
-    identifier: i64,
-}
-
-/// Cancel any natural-transition animation that might still be
-/// holding `element` at its end pose via `fill: forwards`.
-///
-/// Without this, inline `transform` set during a drag is overridden
-/// by the prior animation rule's computed style and the element
-/// won't move at all. We don't track which animation is active per
-/// wrapper, so this just tries to cancel all four names — Lynx
-/// no-ops on cancel-of-nonexistent.
-fn clear_natural_animations(element: Element) {
-    for name in [
-        "stack-ios-incoming-forward",
-        "stack-ios-incoming-backward",
-        "stack-ios-outgoing-forward",
-        "stack-ios-outgoing-backward",
-        "swipe-finish-incoming",
-        "swipe-finish-outgoing",
-    ] {
-        let _ = animate_cancel(element, name);
-    }
-}
-
-/// Slot layout style — must be re-emitted by every `apply_pose`
-/// call because `set_inline_styles` replaces the full inline string
-/// (it isn't a CSSOM merge). Without these properties, a wrapper
-/// styled by the gesture falls back to default static positioning
-/// and starts sharing space with its sibling instead of overlaying
-/// it — that's what showed up as the "two screens side by side"
-/// glitch after a swipe-back commit.
-const SLOT_LAYOUT_STYLE: &str = "position: absolute; top: 0; left: 0; \
-     width: 100%; height: 100%; overflow: visible;";
-
-/// Apply the dynamic pose for `progress` to `element` as an inline
-/// style, alongside the transition's [`slot_style`] decoration and
-/// the [`SLOT_LAYOUT_STYLE`] layout base.
-///
-/// Inline styles take effect only once any active CSS animation is
-/// cancelled — Lynx's animator with `fill: forwards` (which the
-/// natural push/pop uses) clamps the element to its end pose and
-/// shadows out-of-band style writes.
-/// Animate `element` from the pose at `from_progress` to the pose
-/// at `to_progress` using Lynx's animator. `fill: forwards` keeps
-/// the element at the end pose after the animation completes; the
-/// caller doesn't have to listen for `animationend`.
-///
-/// `apply_pose` writes inline styles for the live drag — fast and
-/// fine for per-frame updates — but Lynx coalesces a string of
-/// rapid inline writes such that the final one (the cancel/commit
-/// snap) sometimes never lands. The animator path always takes
-/// hold, so the touchend handler uses this instead.
-#[allow(clippy::too_many_arguments)]
-fn animate_to_pose(
-    element: Element,
-    transition: &dyn StackTransition,
-    side: Side,
-    direction: Direction,
-    from_progress: f32,
-    to_progress: f32,
-    duration_ms: u32,
-    animation_name: &'static str,
-) {
-    let from = transition.pose(side, direction, from_progress);
-    let to = transition.pose(side, direction, to_progress);
-    if from.is_empty() || to.is_empty() {
-        return;
-    }
-    let from_kf: Vec<(&str, &str)> = from.iter().map(|(k, v)| (*k, v.as_str())).collect();
-    let to_kf: Vec<(&str, &str)> = to.iter().map(|(k, v)| (*k, v.as_str())).collect();
-    let _ = animate_start(
-        element,
-        animation_name,
-        &[("0%", &from_kf), ("100%", &to_kf)],
-        &AnimateOptions {
-            duration_ms,
-            easing: "ease-out".into(),
-            fill: "forwards".into(),
-            ..Default::default()
-        },
-    );
-}
-
-fn apply_pose(
-    element: Element,
-    transition: &dyn StackTransition,
-    side: Side,
-    direction: Direction,
-    progress: f32,
-) {
-    clear_natural_animations(element);
-    let mut style = String::from(SLOT_LAYOUT_STYLE);
-    let decoration = match transition.slot_style(side, direction) {
-        Style::Static(s) => s,
-        Style::Dynamic(_) => String::new(),
+/// Sample the iOS slide pose at `progress ∈ [0.0, 1.0]`. Shared
+/// with the [`IosSwipeBack`](crate::IosSwipeBack) gesture so the
+/// gesture's per-frame scrub stays in sync with the natural
+/// animation's endpoints.
+pub(crate) fn pose(side: Side, direction: Direction, progress: f32) -> Vec<(&'static str, String)> {
+    let (tx_from, tx_to, br_from, br_to) = match (side, direction) {
+        (Side::Incoming, Direction::Forward) => (100.0, 0.0, 1.0, 1.0),
+        (Side::Incoming, Direction::Backward) => (-IOS_PARALLAX_PCT, 0.0, 0.85, 1.0),
+        (Side::Outgoing, Direction::Forward) => (0.0, -IOS_PARALLAX_PCT, 1.0, 0.85),
+        (Side::Outgoing, Direction::Backward) => (0.0, 100.0, 1.0, 1.0),
+        (_, Direction::None) => return Vec::new(),
     };
-    if !decoration.is_empty() {
-        style.push_str(&decoration);
-    }
-    for (prop, val) in transition.pose(side, direction, progress) {
-        style.push_str(&format!("{prop}: {val};"));
-    }
-    set_inline_styles(element, &style);
+    let t = progress.clamp(0.0, 1.0);
+    let tx = tx_from + (tx_to - tx_from) * t;
+    let br = br_from + (br_to - br_from) * t;
+    vec![
+        ("transform", format!("translateX({tx}%)")),
+        ("filter", format!("brightness({br})")),
+    ]
 }

--- a/packages/whisker-router/src/transitions/mod.rs
+++ b/packages/whisker-router/src/transitions/mod.rs
@@ -32,6 +32,48 @@ use std::rc::Rc;
 use whisker::runtime::view::Element;
 use whisker::Style;
 
+/// Primitives a transition's [`install_gestures`](StackTransition::install_gestures)
+/// implementation uses to drive the stack interactively (iOS
+/// swipe-back, Android predictive back).
+///
+/// The fields are intentionally narrow closures rather than the
+/// raw slot/owner machinery — the gesture controller only needs to
+/// know *what* it can do to the stack, not *how* the layout
+/// internally tracks wrappers.
+pub struct GestureContext {
+    /// The `StackLayout`'s root container view — bind
+    /// `touchstart`/`touchmove`/`touchend` handlers here.
+    pub container: Element,
+    /// Self-reference, so the gesture controller can call `pose` /
+    /// `slot_style` / `foreground` on the active transition without
+    /// re-binding through `&self`.
+    pub transition: StackTransitionBox,
+    /// `true` when the stack has more than one entry. Swipe-back
+    /// only makes sense above the root; gate the gesture on this.
+    pub can_back: Rc<dyn Fn() -> bool>,
+    /// Build a wrapper element for the screen one step below the
+    /// top of the stack, mount the rendered screen into it, and
+    /// insert it at DOM index 0 of the container. Returns the
+    /// wrapper handle.
+    ///
+    /// The layout retains ownership; release via
+    /// [`dispose_preview`](Self::dispose_preview) or
+    /// [`commit_preview_and_back`](Self::commit_preview_and_back).
+    pub mount_preview: Rc<dyn Fn() -> Element>,
+    /// Tear down the preview wrapper (remove from DOM, dispose the
+    /// reactive owner). Idempotent.
+    pub dispose_preview: Rc<dyn Fn()>,
+    /// Promote the preview wrapper into the `current` slot, dispose
+    /// the old current, and `stack.back()` with the
+    /// `skip_animation` flag set so the route-change effect doesn't
+    /// re-animate the navigation the gesture already finished.
+    pub commit_preview_and_back: Rc<dyn Fn()>,
+    /// Handle to the currently-foregrounded wrapper, if any —
+    /// needed so the gesture controller can re-pose / re-style the
+    /// outgoing screen alongside the preview.
+    pub current_wrapper: Rc<dyn Fn() -> Option<Element>>,
+}
+
 pub mod fade;
 pub mod instant;
 pub mod ios_slide;
@@ -137,6 +179,45 @@ pub trait StackTransition: 'static {
     fn slot_style(&self, side: Side, direction: Direction) -> Style {
         let _ = (side, direction);
         Style::from("")
+    }
+
+    /// Sample the transition's pose at progress `t ∈ [0.0, 1.0]`,
+    /// returning the per-property CSS values for the slot wrapper at
+    /// that point in the animation.
+    ///
+    /// `t = 0.0` is the start pose (incoming off-screen for a push,
+    /// outgoing at rest for a pop); `t = 1.0` is the settled end
+    /// pose. The returned `(prop, value)` pairs describe the
+    /// **dynamic** part of the animation only — static decoration
+    /// like `box-shadow` belongs in [`slot_style`](Self::slot_style)
+    /// and lives on the wrapper for the whole transition.
+    ///
+    /// This is the entry point for **interactive transitions** —
+    /// gesture-driven navigation like iOS swipe-back. The layout
+    /// queries `pose` per frame while the user drags, and at gesture
+    /// release it builds keyframes from the current pose to the
+    /// commit-/cancel-pose and lets Lynx's animator finish the motion.
+    ///
+    /// Default: empty `Vec` — the transition doesn't support
+    /// interactive scrubbing (the layout falls back to running
+    /// [`animate`](Self::animate) wholesale at the natural duration).
+    fn pose(&self, side: Side, direction: Direction, progress: f32) -> Vec<(&'static str, String)> {
+        let _ = (side, direction, progress);
+        Vec::new()
+    }
+
+    /// Wire interactive gesture handlers onto the layout's
+    /// container, if the transition has any. Called once per
+    /// `StackLayout` mount.
+    ///
+    /// This is where transitions opt into gesture-driven navigation
+    /// — [`IosSlide`] implements an edge swipe-back here, while the
+    /// other built-ins (cross-fade, vertical slide, instant) leave
+    /// the default no-op in place. Gesture state lives inside the
+    /// transition implementation; the layout exposes only the
+    /// primitives the gesture needs via [`GestureContext`].
+    fn install_gestures(&self, ctx: &GestureContext) {
+        let _ = ctx;
     }
 }
 

--- a/packages/whisker-router/src/transitions/mod.rs
+++ b/packages/whisker-router/src/transitions/mod.rs
@@ -1,18 +1,20 @@
-//! Transitions: pluggable animations for [`StackLayout`](crate::StackLayout).
+//! Transitions: pluggable visual animations for [`StackLayout`](crate::StackLayout).
 //!
-//! Each transition implementation lives in its own submodule —
-//! [`ios_slide`] for the default UIKit-style horizontal slide,
-//! [`vertical_slide`] for the Y-axis variant, [`fade`] for an
-//! opacity cross-fade, and [`instant`] for the no-animation
-//! fallback. This module re-exports the trait + every built-in,
-//! plus the shared [`Direction`] / [`Side`] / [`StackTransitionBox`]
-//! types each implementation consumes.
+//! A transition's job is to describe *how the screen looks* during
+//! a navigation — push, pop, anything in between. Each transition
+//! implementation lives in its own submodule — [`ios_slide`] for
+//! the default UIKit-style horizontal slide, [`vertical_slide`] for
+//! the Y-axis variant, [`fade`] for an opacity cross-fade, and
+//! [`instant`] for the no-animation fallback. This module re-exports
+//! the trait + every built-in, plus the shared [`Direction`] /
+//! [`Side`] / [`StackTransitionBox`] types each implementation
+//! consumes.
 //!
 //! Custom transitions implement [`StackTransition`] and are passed
 //! to the layout via [`StackTransitionBox::new`]:
 //!
 //! ```ignore
-//! use whisker_router::{StackTransition, StackTransitionBox, Direction};
+//! use whisker_router::{StackTransition, StackTransitionBox, Direction, Side};
 //! use whisker::runtime::view::Element;
 //!
 //! struct ZoomSlide;
@@ -26,53 +28,18 @@
 //!     }
 //! }
 //! ```
+//!
+//! Interactive behaviour (iOS swipe-back, Android system back) is
+//! intentionally **not** part of this trait — it lives in separate
+//! [composable components](crate::gestures) that the user mounts
+//! inside the layout. That way transitions stay pure and easy to
+//! write, and gestures stay easy to mix-and-match without coupling
+//! every transition impl to a touch-event loop.
 
 use std::rc::Rc;
 
 use whisker::runtime::view::Element;
 use whisker::Style;
-
-/// Primitives a transition's [`install_gestures`](StackTransition::install_gestures)
-/// implementation uses to drive the stack interactively (iOS
-/// swipe-back, Android predictive back).
-///
-/// The fields are intentionally narrow closures rather than the
-/// raw slot/owner machinery — the gesture controller only needs to
-/// know *what* it can do to the stack, not *how* the layout
-/// internally tracks wrappers.
-pub struct GestureContext {
-    /// The `StackLayout`'s root container view — bind
-    /// `touchstart`/`touchmove`/`touchend` handlers here.
-    pub container: Element,
-    /// Self-reference, so the gesture controller can call `pose` /
-    /// `slot_style` / `foreground` on the active transition without
-    /// re-binding through `&self`.
-    pub transition: StackTransitionBox,
-    /// `true` when the stack has more than one entry. Swipe-back
-    /// only makes sense above the root; gate the gesture on this.
-    pub can_back: Rc<dyn Fn() -> bool>,
-    /// Build a wrapper element for the screen one step below the
-    /// top of the stack, mount the rendered screen into it, and
-    /// insert it at DOM index 0 of the container. Returns the
-    /// wrapper handle.
-    ///
-    /// The layout retains ownership; release via
-    /// [`dispose_preview`](Self::dispose_preview) or
-    /// [`commit_preview_and_back`](Self::commit_preview_and_back).
-    pub mount_preview: Rc<dyn Fn() -> Element>,
-    /// Tear down the preview wrapper (remove from DOM, dispose the
-    /// reactive owner). Idempotent.
-    pub dispose_preview: Rc<dyn Fn()>,
-    /// Promote the preview wrapper into the `current` slot, dispose
-    /// the old current, and `stack.back()` with the
-    /// `skip_animation` flag set so the route-change effect doesn't
-    /// re-animate the navigation the gesture already finished.
-    pub commit_preview_and_back: Rc<dyn Fn()>,
-    /// Handle to the currently-foregrounded wrapper, if any —
-    /// needed so the gesture controller can re-pose / re-style the
-    /// outgoing screen alongside the preview.
-    pub current_wrapper: Rc<dyn Fn() -> Option<Element>>,
-}
 
 pub mod fade;
 pub mod instant;
@@ -111,14 +78,15 @@ pub enum Side {
     Outgoing,
 }
 
-/// Pluggable transition for a stack layout.
+/// Pluggable transition for a stack layout — purely visual.
 ///
 /// One [`animate`](StackTransition::animate) call per slot per
 /// navigation — the [`Side`] argument distinguishes "drive the
 /// incoming wrapper" from "drive the outgoing wrapper". The trait
 /// is `'static` so it can be stored inside an `Rc`.
 pub trait StackTransition: 'static {
-    /// Drive the animation for one slot wrapper.
+    /// Drive the natural (non-interactive) animation for one slot
+    /// wrapper.
     ///
     /// `side` says which slot is being animated (incoming = the
     /// new top of the stack; outgoing = the screen being replaced).
@@ -179,45 +147,6 @@ pub trait StackTransition: 'static {
     fn slot_style(&self, side: Side, direction: Direction) -> Style {
         let _ = (side, direction);
         Style::from("")
-    }
-
-    /// Sample the transition's pose at progress `t ∈ [0.0, 1.0]`,
-    /// returning the per-property CSS values for the slot wrapper at
-    /// that point in the animation.
-    ///
-    /// `t = 0.0` is the start pose (incoming off-screen for a push,
-    /// outgoing at rest for a pop); `t = 1.0` is the settled end
-    /// pose. The returned `(prop, value)` pairs describe the
-    /// **dynamic** part of the animation only — static decoration
-    /// like `box-shadow` belongs in [`slot_style`](Self::slot_style)
-    /// and lives on the wrapper for the whole transition.
-    ///
-    /// This is the entry point for **interactive transitions** —
-    /// gesture-driven navigation like iOS swipe-back. The layout
-    /// queries `pose` per frame while the user drags, and at gesture
-    /// release it builds keyframes from the current pose to the
-    /// commit-/cancel-pose and lets Lynx's animator finish the motion.
-    ///
-    /// Default: empty `Vec` — the transition doesn't support
-    /// interactive scrubbing (the layout falls back to running
-    /// [`animate`](Self::animate) wholesale at the natural duration).
-    fn pose(&self, side: Side, direction: Direction, progress: f32) -> Vec<(&'static str, String)> {
-        let _ = (side, direction, progress);
-        Vec::new()
-    }
-
-    /// Wire interactive gesture handlers onto the layout's
-    /// container, if the transition has any. Called once per
-    /// `StackLayout` mount.
-    ///
-    /// This is where transitions opt into gesture-driven navigation
-    /// — [`IosSlide`] implements an edge swipe-back here, while the
-    /// other built-ins (cross-fade, vertical slide, instant) leave
-    /// the default no-op in place. Gesture state lives inside the
-    /// transition implementation; the layout exposes only the
-    /// primitives the gesture needs via [`GestureContext`].
-    fn install_gestures(&self, ctx: &GestureContext) {
-        let _ = ctx;
     }
 }
 


### PR DESCRIPTION
Stacks on top of #97 (gesture-debug + iOS bridge touch coords). Diff against `main` includes #97's commit; merge #97 first.

## Summary

- `StackTransition::install_gestures(&self, ctx)` hook — each transition decides whether (and how) to drive the stack interactively. `IosSlide` overrides it; `Fade` / `VerticalSlide` / `Instant` leave the default no-op in place, so swapping the transition drops swipe-back automatically.
- `StackTransition::pose(side, dir, t)` returns the dynamic CSS pose at progress `t`, so the gesture's per-frame scrub re-uses the same per-(side, direction) keyframes as `animate()`.
- New `GestureContext` exposes the narrow primitives the transition needs (`container`, `can_back`, `mount_preview`, `dispose_preview`, `commit_preview_and_back`, `current_wrapper`) — the layout's slot / owner / skip-animation plumbing stays internal.
- `router-demo` screens now render in distinct colours (amber / mint / blue / pink) so the parallax + shadow + dim states are easy to read on-screen.

## Subtle bits worth a second look

- **`gesture_parent` owner**: reserved on `stack_layout` mount and used as the parent of any owner spawned from a gesture handler. Touch dispatchers fire with no active reactive owner, so without this anchor `router::<R>()` inside the preview screen panics.
- **`mount_preview` tears down the prior natural-push's outgoing wrapper**: the frozen parallax pose (`translateX(-30%)` brightness 0.85) was showing through underneath the preview as a "back screen that doesn't track the finger".
- **`commit_preview_and_back` disposes the old current AND the stale outgoing**: then promotes the preview into the current slot and sets `skip_animation` so the route-change effect bails on the `stack.back()` it's about to fire.
- **touchend finish uses Lynx's animator, not a raw inline-style write**: Lynx coalesces a stream of rapid `set_inline_styles` writes such that the final snap occasionally never lands; `animate_start` with `fill: forwards` always takes hold.

## Test plan

- [x] `cargo test -p whisker-router`, `cargo test -p router-demo`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] iOS sim: swipe past threshold → screen commits to previous route, snaps to settle pose
- [x] iOS sim: swipe and release under threshold → screen animates back to current route
- [x] iOS sim: repeated swipe → no leftover wrappers, finger tracks the screen edge 1:1

🤖 Generated with [Claude Code](https://claude.com/claude-code)