### PR TITLE
feat(router): whisker-module event system + Android system-back

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -75,7 +75,18 @@ const BRIDGE_EXPORTS: &[&str] = &[
     // previous `_OBJC_CLASS_$_WhiskerModuleRegistry` export (the
     // Obj-C class is gone — pure C function pointer table now).
     "_whisker_bridge_register_module_dispatch",
+    // whisker-module event system (Phase L-2c). `add/remove_event_listener`
+    // is consumed by Rust subscribers (e.g. AndroidPredictiveBack);
+    // `send_event` is the native module → Rust fan-out;
+    // `register_observer_hooks` drives OnStart/StopObserving. Without
+    // these in the whitelist iOS link drops them and
+    // `WhiskerModuleEventCenter.swift` fails to resolve at link time.
+    "_whisker_bridge_module_add_event_listener",
+    "_whisker_bridge_module_remove_event_listener",
+    "_whisker_bridge_module_send_event",
+    "_whisker_bridge_module_register_observer_hooks",
     "_whisker_bridge_log_hello",
+    "_whisker_bridge_log_info",
 ];
 
 /// Build the WhiskerDriver.xcframework that wraps `package`'s dylib

--- a/crates/whisker-build/src/lynx.rs
+++ b/crates/whisker-build/src/lynx.rs
@@ -57,11 +57,11 @@ use std::path::{Path, PathBuf};
 /// Schema: `<lynx-upstream-version>-whisker.<patch-iteration>` so a
 /// reader can tell at a glance which upstream Lynx is wrapped, and
 /// our own patch iterations bump independently.
-pub const LYNX_FORK_TAG: &str = "v3.8.0-whisker.1";
+pub const LYNX_FORK_TAG: &str = "v3.8.0-whisker.2";
 
 /// Version segment that appears in cache paths + tarball filenames.
 /// Derived from [`LYNX_FORK_TAG`] minus the leading `v`.
-pub const LYNX_VERSION: &str = "3.8.0-whisker.1";
+pub const LYNX_VERSION: &str = "3.8.0-whisker.2";
 
 /// SHA-256 of `whisker-lynx-android-<LYNX_VERSION>.tar.gz` as
 /// produced by the fork's CI. Pinned to the
@@ -86,7 +86,7 @@ pub const LYNX_VERSION: &str = "3.8.0-whisker.1";
 /// `LynxBase.podspec.json`, `LynxServiceAPI.podspec.json`) were
 /// synced to the trunk 3.8.0 source/header lists in the same release.
 pub const LYNX_ANDROID_SHA256: &str =
-    "541d586cc60ce68eb00eb984e2709d862a38caee9ff449e1410801e7e3e3d4c6";
+    "dfef0af66e874fcae01139eb94530676437eeff4fa10cea3eae7a1595819f886";
 
 /// SHA-256 of `whisker-lynx-ios-<LYNX_VERSION>.tar.gz`.
 ///
@@ -99,7 +99,7 @@ pub const LYNX_ANDROID_SHA256: &str =
 /// from `core/native_renderer_capi/`, so the bridge in
 /// `crates/whisker-driver-sys/` no longer vendors them.
 pub const LYNX_IOS_SHA256: &str =
-    "2ecbd8be9fbfea54d4144e64d3b3c0a93c8a8bb3d6ed59bfff9ffdff5944a6b0";
+    "a81beb0fe153ff446fa842f9611b98d748a8d4969b92231d4fcb6ef67861f0aa";
 
 /// GitHub Releases URL template. The `<{ver}>` and `<{plat}>`
 /// placeholders are filled by [`download_url`].

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -463,6 +463,14 @@ WHISKER_BRIDGE_EXPORT void whisker_bridge_module_register_observer_hooks(
 // no-op for scalars. NULL pointer is also safe.
 WHISKER_BRIDGE_EXPORT void whisker_bridge_value_release(WhiskerValueRaw* value);
 
+// Debug-only: write `msg` to the platform log (Android logcat / no-op
+// elsewhere — iOS keeps using `os_log` via Swift). Survives Android's
+// stderr-is-dropped policy, so it's the only way to land a Rust
+// diagnostic in `adb logcat` without going through the JNI layer.
+// `tag == NULL` defaults to "WhiskerRust".
+WHISKER_BRIDGE_EXPORT void whisker_bridge_log_info(
+    const char* tag, const char* msg);
+
 // Invoke a Lynx UI method on a mounted element synchronously.
 // Phase 7-Φ.H.2.5 stub — currently always returns
 // `WHISKER_VALUE_ERROR` because the Lynx fork doesn't yet expose

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -378,6 +378,85 @@ WHISKER_BRIDGE_EXPORT bool whisker_bridge_invoke_module_async(
     WhiskerModuleCallback callback,
     void* user_data);
 
+// ============================================================================
+// Module event subscription (Phase L-2c)
+// ============================================================================
+//
+// Modeled after Expo Modules' Events / sendEvent / OnStartObserving /
+// OnStopObserving lifecycle: a module declares the event names it
+// emits (Swift / Kotlin DSL), runtime listeners are registered on the
+// Rust side, and the native module calls `whisker_bridge_module_send_event`
+// to fan-out to every registered listener.
+//
+// Listener bookkeeping is internal to the bridge; the Rust wrapper
+// (`PlatformModule::on_event`) gets back a stable `listener_id` and
+// hands the user a `ModuleSubscription` that calls `remove_event_listener`
+// on drop.
+
+// Callback fired on the bridge's dispatch thread when a registered
+// `(module, event)` pair receives a `send_event`. `payload` is
+// borrowed for the duration of the call — the bridge frees it once
+// the callback returns (same ownership as `WhiskerModuleCallback`).
+typedef void (*WhiskerModuleEventCallback)(void* user_data,
+                                           const WhiskerValueRaw* payload);
+
+// Register `callback` against the `(module_name, event_name)` pair.
+// Returns a positive listener id on success; a value <= 0 indicates a
+// precondition failure (NULL name, NULL callback). The caller is
+// responsible for keeping `user_data` valid until
+// `whisker_bridge_module_remove_event_listener` returns.
+//
+// Multiple listeners on the same pair are supported — every
+// `send_event` fans out to all of them in registration order.
+WHISKER_BRIDGE_EXPORT int32_t whisker_bridge_module_add_event_listener(
+    const char* module_name,
+    const char* event_name,
+    WhiskerModuleEventCallback callback,
+    void* user_data);
+
+// Remove a previously-registered listener. No-op if the id is
+// unknown (already removed, never existed). `user_data` is the
+// caller's; the bridge does not free it.
+WHISKER_BRIDGE_EXPORT void whisker_bridge_module_remove_event_listener(
+    int32_t listener_id);
+
+// Dispatch `payload` to every listener registered against
+// `(module_name, event_name)`. Called from the native module side
+// (Swift / Kotlin `sendEvent` lowers to this). `payload` may be
+// NULL to send a no-data ping; otherwise it is borrowed for the
+// duration of the dispatch (the bridge does not copy it). Listeners
+// fire on the calling thread, in registration order.
+WHISKER_BRIDGE_EXPORT void whisker_bridge_module_send_event(
+    const char* module_name,
+    const char* event_name,
+    const WhiskerValueRaw* payload);
+
+// Lifecycle hooks the native side uses to start / stop an expensive
+// source (e.g. an `OnBackInvokedCallback` registration) only while
+// at least one listener is present. The native side registers
+// `started` / `stopped` once at module load (via
+// `whisker_bridge_module_register_observer_hooks`), and the bridge
+// fires:
+//
+//   - `started(module, event)` when the listener count for
+//     `(module, event)` transitions from 0 to 1.
+//   - `stopped(module, event)` when the listener count transitions
+//     from 1 to 0.
+//
+// `module` is passed back even though the hook is per-module — the
+// platform side typically registers one shared C trampoline and
+// uses `module` to index into its own per-module dispatch table.
+//
+// Passing `started=NULL` / `stopped=NULL` unregisters the hooks for
+// that module (the last write wins).
+typedef void (*WhiskerModuleObserverHook)(
+    const char* module_name,
+    const char* event_name);
+WHISKER_BRIDGE_EXPORT void whisker_bridge_module_register_observer_hooks(
+    const char* module_name,
+    WhiskerModuleObserverHook started,
+    WhiskerModuleObserverHook stopped);
+
 // Free any heap allocations the bridge attached to `value` (string
 // content, bytes content, recursive array/map contents). Safe to
 // call on a value whose `type` doesn't carry heap data — it's a

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_android.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_android.cc
@@ -409,6 +409,13 @@ struct WhiskerValueJni {
 
     jclass registry_cls = nullptr;
     jmethodID registry_dispatch = nullptr;
+
+    // Phase L-2c — event subscription routing. The C++ trampolines
+    // call back into Kotlin via these handles so the per-Module
+    // OnStart/OnStopObserving closures fire.
+    jclass event_center_cls = nullptr;
+    jmethodID event_center_fire_start = nullptr;
+    jmethodID event_center_fire_stop = nullptr;
 };
 
 WhiskerValueJni& wvjni() {
@@ -506,6 +513,24 @@ bool init_wvjni(JNIEnv* env) {
     if (h.registry_dispatch == nullptr) {
         if (env->ExceptionCheck()) env->ExceptionClear();
         return false;
+    }
+
+    // Phase L-2c — `WhiskerModuleEventCenter` handles for the
+    // observer-hook trampolines (fireStart / fireStop).
+    h.event_center_cls = make_global(
+        env, "rs/whisker/runtime/WhiskerModuleEventCenter");
+    if (h.event_center_cls != nullptr) {
+        h.event_center_fire_start = env->GetStaticMethodID(
+            h.event_center_cls, "fireStart",
+            "(Ljava/lang/String;Ljava/lang/String;)V");
+        h.event_center_fire_stop = env->GetStaticMethodID(
+            h.event_center_cls, "fireStop",
+            "(Ljava/lang/String;Ljava/lang/String;)V");
+        // Don't hard-fail if the class isn't present yet — a host
+        // app that doesn't use the event system simply never calls
+        // `nativeRegisterObserverHooks`. ExceptionCheck() prevents
+        // a sticky exception from poisoning later JNI calls.
+        if (env->ExceptionCheck()) env->ExceptionClear();
     }
     h.ready = true;
     return true;
@@ -868,6 +893,93 @@ extern "C" bool whisker_bridge_invoke_module_async(
     callback(user_data, &r);
     whisker_bridge_value_release(&r);
     return true;
+}
+
+// ============================================================================
+// Phase L-2c — module event subscription, Android side.
+// ============================================================================
+
+namespace {
+
+// Shared C trampolines registered with the bridge once per Module
+// via `whisker_bridge_module_register_observer_hooks`. C function
+// pointers can't carry per-module context, so we route the
+// `(module, event)` pair through Kotlin's `WhiskerModuleEventCenter`
+// which uses `module` to find the right `Module` instance and fires
+// every matching `OnStartObserving` / `OnStopObserving` closure.
+void AndroidEventStartHook(const char* module_name, const char* event_name) {
+    if (module_name == nullptr || event_name == nullptr) return;
+    auto& h = wvjni();
+    if (h.event_center_cls == nullptr || h.event_center_fire_start == nullptr) {
+        return;
+    }
+    ScopedJNIEnv_M guard;
+    JNIEnv* env = guard.get();
+    if (env == nullptr) return;
+    jstring jmod = env->NewStringUTF(module_name);
+    jstring jevt = env->NewStringUTF(event_name);
+    env->CallStaticVoidMethod(
+        h.event_center_cls, h.event_center_fire_start, jmod, jevt);
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
+    env->DeleteLocalRef(jmod);
+    env->DeleteLocalRef(jevt);
+}
+
+void AndroidEventStopHook(const char* module_name, const char* event_name) {
+    if (module_name == nullptr || event_name == nullptr) return;
+    auto& h = wvjni();
+    if (h.event_center_cls == nullptr || h.event_center_fire_stop == nullptr) {
+        return;
+    }
+    ScopedJNIEnv_M guard;
+    JNIEnv* env = guard.get();
+    if (env == nullptr) return;
+    jstring jmod = env->NewStringUTF(module_name);
+    jstring jevt = env->NewStringUTF(event_name);
+    env->CallStaticVoidMethod(
+        h.event_center_cls, h.event_center_fire_stop, jmod, jevt);
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
+    env->DeleteLocalRef(jmod);
+    env->DeleteLocalRef(jevt);
+}
+
+}  // namespace
+
+// rs.whisker.runtime.WhiskerModuleEventCenter.nativeRegisterObserverHooks
+extern "C" JNIEXPORT void JNICALL
+Java_rs_whisker_runtime_WhiskerModuleEventCenter_nativeRegisterObserverHooks(
+    JNIEnv* env, jclass /*self*/, jstring qname_jstr) {
+    if (qname_jstr == nullptr) return;
+    if (!init_wvjni(env)) return;
+    std::string qname = jstr_to_str(env, qname_jstr);
+    whisker_bridge_module_register_observer_hooks(
+        qname.c_str(),
+        AndroidEventStartHook,
+        AndroidEventStopHook);
+}
+
+// rs.whisker.runtime.WhiskerModuleEventCenter.nativeSendEvent
+extern "C" JNIEXPORT void JNICALL
+Java_rs_whisker_runtime_WhiskerModuleEventCenter_nativeSendEvent(
+    JNIEnv* env, jclass /*self*/,
+    jstring qname_jstr, jstring event_jstr, jobject payload_obj) {
+    if (qname_jstr == nullptr || event_jstr == nullptr) return;
+    if (!init_wvjni(env)) return;
+    std::string qname = jstr_to_str(env, qname_jstr);
+    std::string event = jstr_to_str(env, event_jstr);
+    // Encode the WhiskerValue jobject into a WhiskerValueRaw whose
+    // strings / bytes / nested arrays / maps are heap-owned. The
+    // bridge fans the payload out synchronously, so we can release
+    // the heap allocations immediately after.
+    WhiskerValueRaw raw = jvalue_to_value(env, payload_obj);
+    whisker_bridge_module_send_event(qname.c_str(), event.c_str(), &raw);
+    whisker_bridge_value_release(&raw);
 }
 
 #endif  // __ANDROID__

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -25,6 +25,14 @@
 #include <unordered_map>
 #include <vector>
 
+#if defined(__ANDROID__)
+// `dlsym(RTLD_DEFAULT, "lynx_element_animate")` — runtime resolution path
+// for the symbol that the Lynx Android fork doesn't yet export. See the
+// `whisker_bridge_element_animate` comment block below for the rationale.
+#include <dlfcn.h>
+#include <android/log.h>
+#endif
+
 #include "lynx_native_renderer_capi.h"
 
 #include "whisker_bridge.h"
@@ -540,6 +548,17 @@ int32_t NextListenerId() {
 
 }  // namespace
 
+extern "C" void whisker_bridge_log_info(const char* tag, const char* msg) {
+    if (msg == nullptr) return;
+#if defined(__ANDROID__)
+    __android_log_print(ANDROID_LOG_INFO,
+                        tag != nullptr ? tag : "WhiskerRust", "%s", msg);
+#else
+    (void)tag;
+    (void)msg;
+#endif
+}
+
 extern "C" int32_t whisker_bridge_module_add_event_listener(
     const char* module_name,
     const char* event_name,
@@ -832,6 +851,40 @@ lynx_ui_method_value_t BuildCapiParamValue(const WhiskerValueRaw& v,
 // `_with_params` element-method path uses, so the C++ side gets a single
 // recursive `lynx_ui_method_value_t` for each. `keyframes` / `options` may be
 // NULL (PLAY / PAUSE / CANCEL / FINISH only need `animation_name`).
+//
+// On Android the Lynx v3.8.0-whisker.1 fork doesn't yet export
+// `lynx_element_animate` in `liblynx.so` — the symbol exists on the iOS
+// xcframework slice only. Without intervention, linking the user crate's
+// cdylib against this bridge would let the .so build with an unresolved
+// reference and crash at `dlopen` ("cannot locate symbol
+// `lynx_element_animate`") before any Rust code runs. We side-step the link
+// dependency by resolving the symbol at runtime via `dlsym(RTLD_DEFAULT,
+// ...)`: on iOS (and on Android once the fork bump lands) the function
+// pointer comes back non-null and the call proceeds; on today's Android
+// `liblynx.so` we surface a clear "not exported" error and let the rest of
+// the app run minus animations.
+namespace {
+using LynxElementAnimateFn = int32_t (*)(
+    void*, void*, int32_t, const char*,
+    const lynx_ui_method_value_t*, const lynx_ui_method_value_t*);
+
+LynxElementAnimateFn ResolveLynxElementAnimate() {
+#if defined(__ANDROID__)
+    // Cached once per process. `dlsym(RTLD_DEFAULT, ...)` searches the
+    // default scope (every SO already loaded by the dynamic linker), so
+    // `liblynx.so`'s definition wins once the fork ships it. `nullptr`
+    // means the symbol is not yet exported — see the comment block above.
+    static LynxElementAnimateFn fn = [] {
+        return reinterpret_cast<LynxElementAnimateFn>(
+            dlsym(RTLD_DEFAULT, "lynx_element_animate"));
+    }();
+    return fn;
+#else
+    return &lynx_element_animate;
+#endif
+}
+}  // namespace
+
 extern "C" WhiskerValueRaw whisker_bridge_element_animate(
     WhiskerElement* element,
     int32_t operation,
@@ -843,6 +896,12 @@ extern "C" WhiskerValueRaw whisker_bridge_element_animate(
         return MakeBridgeErrorValue(
             "whisker_bridge_element_animate: NULL element / shell");
     }
+    LynxElementAnimateFn animate = ResolveLynxElementAnimate();
+    if (animate == nullptr) {
+        return MakeBridgeErrorValue(
+            "lynx_element_animate not exported by liblynx.so on this "
+            "platform — Lynx fork bump needed");
+    }
     CapiArena arena;
     lynx_ui_method_value_t kf{};
     lynx_ui_method_value_t opt{};
@@ -852,7 +911,7 @@ extern "C" WhiskerValueRaw whisker_bridge_element_animate(
     if (options != nullptr) {
         opt = BuildCapiParamValue(*options, arena);
     }
-    int32_t code = lynx_element_animate(
+    int32_t code = animate(
         element->shell, element->handle, operation, animation_name,
         keyframes != nullptr ? &kf : nullptr,
         options != nullptr ? &opt : nullptr);

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -26,10 +26,6 @@
 #include <vector>
 
 #if defined(__ANDROID__)
-// `dlsym(RTLD_DEFAULT, "lynx_element_animate")` — runtime resolution path
-// for the symbol that the Lynx Android fork doesn't yet export. See the
-// `whisker_bridge_element_animate` comment block below for the rationale.
-#include <dlfcn.h>
 #include <android/log.h>
 #endif
 
@@ -851,40 +847,6 @@ lynx_ui_method_value_t BuildCapiParamValue(const WhiskerValueRaw& v,
 // `_with_params` element-method path uses, so the C++ side gets a single
 // recursive `lynx_ui_method_value_t` for each. `keyframes` / `options` may be
 // NULL (PLAY / PAUSE / CANCEL / FINISH only need `animation_name`).
-//
-// On Android the Lynx v3.8.0-whisker.1 fork doesn't yet export
-// `lynx_element_animate` in `liblynx.so` — the symbol exists on the iOS
-// xcframework slice only. Without intervention, linking the user crate's
-// cdylib against this bridge would let the .so build with an unresolved
-// reference and crash at `dlopen` ("cannot locate symbol
-// `lynx_element_animate`") before any Rust code runs. We side-step the link
-// dependency by resolving the symbol at runtime via `dlsym(RTLD_DEFAULT,
-// ...)`: on iOS (and on Android once the fork bump lands) the function
-// pointer comes back non-null and the call proceeds; on today's Android
-// `liblynx.so` we surface a clear "not exported" error and let the rest of
-// the app run minus animations.
-namespace {
-using LynxElementAnimateFn = int32_t (*)(
-    void*, void*, int32_t, const char*,
-    const lynx_ui_method_value_t*, const lynx_ui_method_value_t*);
-
-LynxElementAnimateFn ResolveLynxElementAnimate() {
-#if defined(__ANDROID__)
-    // Cached once per process. `dlsym(RTLD_DEFAULT, ...)` searches the
-    // default scope (every SO already loaded by the dynamic linker), so
-    // `liblynx.so`'s definition wins once the fork ships it. `nullptr`
-    // means the symbol is not yet exported — see the comment block above.
-    static LynxElementAnimateFn fn = [] {
-        return reinterpret_cast<LynxElementAnimateFn>(
-            dlsym(RTLD_DEFAULT, "lynx_element_animate"));
-    }();
-    return fn;
-#else
-    return &lynx_element_animate;
-#endif
-}
-}  // namespace
-
 extern "C" WhiskerValueRaw whisker_bridge_element_animate(
     WhiskerElement* element,
     int32_t operation,
@@ -896,12 +858,6 @@ extern "C" WhiskerValueRaw whisker_bridge_element_animate(
         return MakeBridgeErrorValue(
             "whisker_bridge_element_animate: NULL element / shell");
     }
-    LynxElementAnimateFn animate = ResolveLynxElementAnimate();
-    if (animate == nullptr) {
-        return MakeBridgeErrorValue(
-            "lynx_element_animate not exported by liblynx.so on this "
-            "platform — Lynx fork bump needed");
-    }
     CapiArena arena;
     lynx_ui_method_value_t kf{};
     lynx_ui_method_value_t opt{};
@@ -911,7 +867,7 @@ extern "C" WhiskerValueRaw whisker_bridge_element_animate(
     if (options != nullptr) {
         opt = BuildCapiParamValue(*options, arena);
     }
-    int32_t code = animate(
+    int32_t code = lynx_element_animate(
         element->shell, element->handle, operation, animation_name,
         keyframes != nullptr ? &kf : nullptr,
         options != nullptr ? &opt : nullptr);

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -16,6 +16,7 @@
 // stay hidden; only the LYNX_CAPI_EXPORT-tagged functions cross the
 // .so boundary.
 
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <deque>
@@ -472,6 +473,179 @@ extern "C" bool whisker_bridge_invoke_module_async(
     return true;
 }
 #endif  // !__ANDROID__
+
+// ============================================================================
+// Module event subscription (Phase L-2c)
+// ============================================================================
+//
+// Listener registry is keyed on `(module, event)` and tracks an
+// ordered list of `(listener_id, callback, user_data)` triples.
+// `listener_id` is a monotonically-increasing positive integer; we
+// expose it to the Rust wrapper so `ModuleSubscription::drop()` can
+// O(1)-locate the entry to delete without re-keying by module/event.
+//
+// Observer hooks (`OnStartObserving` / `OnStopObserving` parallels)
+// fire on the 0↔1 listener-count transition for each
+// `(module, event)` pair. The native module registers them once at
+// load time; the bridge looks them up by module name on every
+// add/remove and calls them inline so the native source can spin up
+// before the next `send_event` arrives.
+
+namespace {
+
+struct ModuleEventListener {
+    int32_t id = 0;
+    std::string module_name;
+    std::string event_name;
+    WhiskerModuleEventCallback callback = nullptr;
+    void* user_data = nullptr;
+};
+
+struct ModuleObserverHooks {
+    WhiskerModuleObserverHook started = nullptr;
+    WhiskerModuleObserverHook stopped = nullptr;
+};
+
+std::mutex& EventRegistryMutex() {
+    static std::mutex m;
+    return m;
+}
+
+// Listener storage. Keyed by id so removal is O(1); a secondary
+// per-(module, event) listener-count map lets us decide whether to
+// fire OnStart / OnStop on each transition without rescanning.
+std::unordered_map<int32_t, ModuleEventListener>& EventListeners() {
+    static std::unordered_map<int32_t, ModuleEventListener> m;
+    return m;
+}
+std::unordered_map<std::string, int>& ListenerCounts() {
+    static std::unordered_map<std::string, int> m;
+    return m;
+}
+std::unordered_map<std::string, ModuleObserverHooks>& ObserverHooks() {
+    static std::unordered_map<std::string, ModuleObserverHooks> m;
+    return m;
+}
+
+std::string EventKey(const std::string& module_name, const std::string& event_name) {
+    // `\x1f` (unit separator) is forbidden inside identifier-like
+    // module / event names, so this concatenation is unambiguous.
+    return module_name + "\x1f" + event_name;
+}
+
+int32_t NextListenerId() {
+    static std::atomic<int32_t> counter{1};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+}  // namespace
+
+extern "C" int32_t whisker_bridge_module_add_event_listener(
+    const char* module_name,
+    const char* event_name,
+    WhiskerModuleEventCallback callback,
+    void* user_data) {
+    if (module_name == nullptr || event_name == nullptr || callback == nullptr) {
+        return 0;
+    }
+    int32_t id = NextListenerId();
+    std::string module_str(module_name);
+    std::string event_str(event_name);
+    std::string key = EventKey(module_str, event_str);
+
+    WhiskerModuleObserverHook start_hook = nullptr;
+    bool became_first = false;
+    {
+        std::lock_guard<std::mutex> g(EventRegistryMutex());
+        EventListeners()[id] = ModuleEventListener{
+            id, module_str, event_str, callback, user_data};
+        int& count = ListenerCounts()[key];
+        if (count == 0) {
+            became_first = true;
+            auto it = ObserverHooks().find(module_str);
+            if (it != ObserverHooks().end()) {
+                start_hook = it->second.started;
+            }
+        }
+        count += 1;
+    }
+    if (became_first && start_hook != nullptr) {
+        // Fire outside the lock — the hook may call back into the
+        // bridge (e.g. register an `OnBackInvokedCallback` that
+        // synchronously emits a startup event).
+        start_hook(module_str.c_str(), event_str.c_str());
+    }
+    return id;
+}
+
+extern "C" void whisker_bridge_module_remove_event_listener(int32_t listener_id) {
+    if (listener_id <= 0) return;
+    WhiskerModuleObserverHook stop_hook = nullptr;
+    std::string module_for_stop;
+    std::string event_for_stop;
+    {
+        std::lock_guard<std::mutex> g(EventRegistryMutex());
+        auto it = EventListeners().find(listener_id);
+        if (it == EventListeners().end()) return;
+        std::string module_str = it->second.module_name;
+        std::string event_str = it->second.event_name;
+        EventListeners().erase(it);
+        std::string key = EventKey(module_str, event_str);
+        int& count = ListenerCounts()[key];
+        if (count > 0) {
+            count -= 1;
+            if (count == 0) {
+                ListenerCounts().erase(key);
+                auto hook_it = ObserverHooks().find(module_str);
+                if (hook_it != ObserverHooks().end()) {
+                    stop_hook = hook_it->second.stopped;
+                    module_for_stop = module_str;
+                    event_for_stop = event_str;
+                }
+            }
+        }
+    }
+    if (stop_hook != nullptr) {
+        stop_hook(module_for_stop.c_str(), event_for_stop.c_str());
+    }
+}
+
+extern "C" void whisker_bridge_module_send_event(
+    const char* module_name,
+    const char* event_name,
+    const WhiskerValueRaw* payload) {
+    if (module_name == nullptr || event_name == nullptr) return;
+    // Snapshot the listener list under the lock — we don't want to
+    // hold it across the user callbacks (which may register / drop
+    // further listeners). Vector copy is cheap; listener counts in
+    // practice are small (1–2 per gesture / observer).
+    std::vector<std::pair<WhiskerModuleEventCallback, void*>> snapshot;
+    {
+        std::lock_guard<std::mutex> g(EventRegistryMutex());
+        for (const auto& kv : EventListeners()) {
+            const auto& l = kv.second;
+            if (l.module_name == module_name && l.event_name == event_name) {
+                snapshot.emplace_back(l.callback, l.user_data);
+            }
+        }
+    }
+    for (auto& entry : snapshot) {
+        entry.first(entry.second, payload);
+    }
+}
+
+extern "C" void whisker_bridge_module_register_observer_hooks(
+    const char* module_name,
+    WhiskerModuleObserverHook started,
+    WhiskerModuleObserverHook stopped) {
+    if (module_name == nullptr) return;
+    std::lock_guard<std::mutex> g(EventRegistryMutex());
+    if (started == nullptr && stopped == nullptr) {
+        ObserverHooks().erase(module_name);
+    } else {
+        ObserverHooks()[module_name] = ModuleObserverHooks{started, stopped};
+    }
+}
 
 // Phase 7-Φ.H.2.7 — `whisker_bridge_invoke_element_method` impl.
 //

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
@@ -220,3 +220,45 @@ extern "C" void whisker_bridge_log_hello(void) {
     // Empty stub — the real impl lives in the iOS / Android bridge
     // files; host code that calls this gets a no-op.
 }
+
+// ---------- whisker-module event system (Phase L-2c) ----------------------
+//
+// Host builds have no native module sending events, so the event-
+// listener registry collapses to no-ops: `add_event_listener` returns
+// a fake-positive id (so the Rust wrapper's "subscription succeeded"
+// check passes), and the rest are silent no-ops. Tests that rely on
+// real Rust ↔ native event flow have to run on iOS / Android.
+
+extern "C" int32_t whisker_bridge_module_add_event_listener(
+    const char* /*module_name*/,
+    const char* /*event_name*/,
+    WhiskerModuleEventCallback /*callback*/,
+    void* /*user_data*/) {
+    // Return a non-zero id so the Rust `ModuleSubscription::error()`
+    // path doesn't flag the registration as failed in host tests.
+    return 1;
+}
+
+extern "C" void whisker_bridge_module_remove_event_listener(
+    int32_t /*listener_id*/) {
+    // No-op — there's nothing registered in the host stub.
+}
+
+extern "C" void whisker_bridge_module_send_event(
+    const char* /*module_name*/,
+    const char* /*event_name*/,
+    const WhiskerValueRaw* /*payload*/) {
+    // No-op — no native module fires events in host tests.
+}
+
+extern "C" void whisker_bridge_module_register_observer_hooks(
+    const char* /*module_name*/,
+    WhiskerModuleObserverHook /*started*/,
+    WhiskerModuleObserverHook /*stopped*/) {
+    // No-op — no observer-driven sources in host tests.
+}
+
+extern "C" void whisker_bridge_log_info(
+    const char* /*tag*/, const char* /*msg*/) {
+    // No-op — real impl writes to logcat (Android) / os_log (iOS).
+}

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -198,6 +198,22 @@ pub struct WhiskerKeyValueRaw {
 pub type WhiskerModuleCallback =
     extern "C" fn(user_data: *mut c_void, result: *const WhiskerValueRaw);
 
+/// Callback type for module event subscriptions. Fired by the bridge
+/// when a registered `(module, event)` pair receives a
+/// `whisker_bridge_module_send_event` call. `payload` is borrowed —
+/// the bridge frees its allocations once the callback returns.
+pub type WhiskerModuleEventCallback =
+    extern "C" fn(user_data: *mut c_void, payload: *const WhiskerValueRaw);
+
+/// Callback type for `OnStartObserving` / `OnStopObserving` hooks.
+/// The bridge fires these on the 0↔1 listener-count transition for
+/// a `(module, event)` pair. Both `module_name` and `event_name` are
+/// borrowed (NUL-terminated UTF-8) — copy if you need to retain them
+/// past the call. `module_name` lets a shared platform-side
+/// trampoline index its own per-module table.
+pub type WhiskerModuleObserverHook =
+    extern "C" fn(module_name: *const c_char, event_name: *const c_char);
+
 /// Per-module dispatch function — the platform-side Swift Macro or
 /// KSP processor emits one of these per `@WhiskerModule`-annotated
 /// class. The bridge stores `(module_name → dispatch_fn)` in a
@@ -323,6 +339,47 @@ extern "C" {
     pub fn whisker_bridge_register_module_dispatch(
         module_name: *const c_char,
         dispatch: WhiskerModuleDispatchFn,
+    );
+
+    // ------------------------------------------------------------------
+    // Module event subscription (Phase L-2c)
+    // ------------------------------------------------------------------
+
+    /// Register `callback` against `(module_name, event_name)`.
+    /// Returns a positive listener id on success, or <= 0 on a
+    /// precondition failure. The Rust wrapper hands the caller a
+    /// `ModuleSubscription` that calls
+    /// `whisker_bridge_module_remove_event_listener` on drop.
+    pub fn whisker_bridge_module_add_event_listener(
+        module_name: *const c_char,
+        event_name: *const c_char,
+        callback: WhiskerModuleEventCallback,
+        user_data: *mut c_void,
+    ) -> i32;
+
+    /// Remove a previously-registered listener. No-op if `listener_id`
+    /// is unknown. The bridge does not free the caller's `user_data`.
+    pub fn whisker_bridge_module_remove_event_listener(listener_id: i32);
+
+    /// Dispatch `payload` to every listener registered against
+    /// `(module_name, event_name)`. Called from the native module
+    /// side (`sendEvent` on Swift / Kotlin). `payload` may be NULL
+    /// for an unparameterised ping.
+    pub fn whisker_bridge_module_send_event(
+        module_name: *const c_char,
+        event_name: *const c_char,
+        payload: *const WhiskerValueRaw,
+    );
+
+    /// Register OnStart / OnStopObserving hooks for `module_name`.
+    /// The bridge calls `started(event)` on the 0→1 listener-count
+    /// transition and `stopped(event)` on 1→0, so the native module
+    /// can spin up / tear down an expensive source (e.g. an
+    /// `OnBackInvokedCallback` registration) only while needed.
+    pub fn whisker_bridge_module_register_observer_hooks(
+        module_name: *const c_char,
+        started: WhiskerModuleObserverHook,
+        stopped: WhiskerModuleObserverHook,
     );
 
     /// Invoke a Lynx UI method on a mounted element. Synchronous —

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -382,6 +382,11 @@ extern "C" {
         stopped: WhiskerModuleObserverHook,
     );
 
+    /// Write `msg` to `adb logcat` (Android only — no-op on iOS;
+    /// debug print path that survives Android's stderr-is-dropped
+    /// policy). `tag == NULL` defaults to "WhiskerRust".
+    pub fn whisker_bridge_log_info(tag: *const c_char, msg: *const c_char);
+
     /// Invoke a Lynx UI method on a mounted element. Synchronous —
     /// dispatches through Lynx's `LynxUIMethodProcessor` (iOS) /
     /// `LynxUIMethodsExecutor` (Android), which in turn calls the

--- a/crates/whisker-driver/src/module.rs
+++ b/crates/whisker-driver/src/module.rs
@@ -154,6 +154,142 @@ impl PlatformModule {
     pub async fn invoke_async(&self, function: &str, args: Vec<WhiskerValue>) -> WhiskerValue {
         invoke_async(&self.name, function, args).await
     }
+
+    /// Subscribe to `event` on this module. The returned
+    /// [`ModuleSubscription`] removes the listener on drop, so the
+    /// caller controls listener lifetime by simply holding (or
+    /// dropping) the value.
+    ///
+    /// Modelled on Expo's `addListener(event, fn)` — the native side
+    /// pumps events through `whisker_bridge_module_send_event`, the
+    /// bridge fans them out to every registered Rust callback.
+    /// `OnStartObserving` / `OnStopObserving` hooks (registered
+    /// per-module on the platform side) fire on the 0↔1 listener
+    /// transition so the module can lazily attach / detach its
+    /// underlying source.
+    ///
+    /// The closure runs on whichever thread the bridge dispatches on
+    /// (typically the platform main thread). `Send + Sync` is
+    /// required because the bridge stores the pointer and the
+    /// dispatch thread may differ from the subscribing thread.
+    pub fn on_event<F>(&self, event: &str, callback: F) -> ModuleSubscription
+    where
+        F: Fn(WhiskerValue) + Send + Sync + 'static,
+    {
+        let module_c = match CString::new(self.name.as_str()) {
+            Ok(c) => c,
+            Err(_) => return ModuleSubscription::failed("module name contained NUL byte"),
+        };
+        let event_c = match CString::new(event) {
+            Ok(c) => c,
+            Err(_) => return ModuleSubscription::failed("event name contained NUL byte"),
+        };
+        // `Box<EventCallback>` gives a stable thin pointer we can
+        // stuff into `user_data`. The inner box carries the fat
+        // trait-object pointer; the outer box is just for the address.
+        let callback: EventCallback = Box::new(callback);
+        let user_data = Box::into_raw(Box::new(callback)) as *mut c_void;
+        let id = unsafe {
+            ffi::whisker_bridge_module_add_event_listener(
+                module_c.as_ptr(),
+                event_c.as_ptr(),
+                event_trampoline,
+                user_data,
+            )
+        };
+        if id <= 0 {
+            // Bridge refused — recover the box so the closure drops.
+            unsafe {
+                let _ = Box::from_raw(user_data as *mut EventCallback);
+            }
+            return ModuleSubscription::failed("bridge refused event listener registration");
+        }
+        ModuleSubscription {
+            id,
+            user_data,
+            error: None,
+        }
+    }
+}
+
+// ----- Event subscription -------------------------------------------------
+
+/// Heap-allocated Rust callback the C trampoline dispatches into.
+/// `Send + Sync` because the bridge may fire from any thread.
+type EventCallback = Box<dyn Fn(WhiskerValue) + Send + Sync>;
+
+/// C trampoline registered with the bridge. Recovers the
+/// `EventCallback` from `user_data` (by reference — ownership stays
+/// with [`ModuleSubscription`]) and invokes it with the decoded
+/// payload.
+extern "C" fn event_trampoline(user_data: *mut c_void, payload: *const ffi::WhiskerValueRaw) {
+    if user_data.is_null() {
+        return;
+    }
+    let cb = unsafe { &*(user_data as *const EventCallback) };
+    let value = if payload.is_null() {
+        WhiskerValue::Null
+    } else {
+        unsafe { from_raw(&*payload) }
+    };
+    cb(value);
+}
+
+/// RAII handle for an [`PlatformModule::on_event`] subscription.
+/// Dropping the handle removes the listener via
+/// [`whisker_bridge_module_remove_event_listener`](whisker_driver_sys::whisker_bridge_module_remove_event_listener)
+/// and frees the boxed Rust closure.
+///
+/// `error` carries a non-fatal registration failure so the caller can
+/// inspect it without unwrapping a `Result`. A failed subscription is
+/// inert — drop does nothing — so it's safe to leak.
+pub struct ModuleSubscription {
+    id: i32,
+    user_data: *mut c_void,
+    error: Option<String>,
+}
+
+impl ModuleSubscription {
+    fn failed(msg: &str) -> Self {
+        Self {
+            id: 0,
+            user_data: std::ptr::null_mut(),
+            error: Some(msg.into()),
+        }
+    }
+
+    /// `Some(_)` if registration failed; `None` for a live
+    /// subscription. The error string is suitable for logging.
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    /// Bridge-assigned listener id (positive for live subscriptions,
+    /// `0` for a failed one). Exposed primarily for tests / tracing.
+    pub fn id(&self) -> i32 {
+        self.id
+    }
+}
+
+// The `user_data` pointer references a `Box<EventCallback>` whose
+// inner closure is `Send + Sync`. The wrapper itself never reads the
+// pointer except to free it on drop, so it's safe to move across
+// threads.
+unsafe impl Send for ModuleSubscription {}
+unsafe impl Sync for ModuleSubscription {}
+
+impl Drop for ModuleSubscription {
+    fn drop(&mut self) {
+        if self.id <= 0 || self.user_data.is_null() {
+            return;
+        }
+        unsafe {
+            ffi::whisker_bridge_module_remove_event_listener(self.id);
+            // Reclaim and drop the boxed closure now that the bridge
+            // can no longer call into it.
+            let _ = Box::from_raw(self.user_data as *mut EventCallback);
+        }
+    }
 }
 
 /// Async variant. Resolves once the bridge fires the C callback

--- a/examples/router-demo/src/lib.rs
+++ b/examples/router-demo/src/lib.rs
@@ -14,8 +14,9 @@
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_router::{
-    route, route_stack, router, IosSwipeBack, IosSwipeBackProps, RouteProvider, RouteProviderProps,
-    RouteRenderFn, RouteStack, StackLayout, StackLayoutProps,
+    route, route_stack, router, AndroidPredictiveBack, AndroidPredictiveBackProps, IosSwipeBack,
+    IosSwipeBackProps, RouteProvider, RouteProviderProps, RouteRenderFn, RouteStack, StackLayout,
+    StackLayoutProps,
 };
 
 /// Top-level route enum.
@@ -155,6 +156,7 @@ pub fn render_with(stack: RouteStack<AppRoute>) -> Element {
         RouteProvider(stack: stack) {
             StackLayout(render: render.clone()) {
                 IosSwipeBack()
+                AndroidPredictiveBack()
             }
         }
     }
@@ -183,6 +185,7 @@ pub fn render_app() -> Element {
             RouteProvider(stack: stack) {
                 StackLayout(render: render.clone()) {
                     IosSwipeBack()
+                    AndroidPredictiveBack()
                 }
             }
         }

--- a/packages/whisker-router/android/src/main/kotlin/rs/whisker/router/PredictiveBackModule.kt
+++ b/packages/whisker-router/android/src/main/kotlin/rs/whisker/router/PredictiveBackModule.kt
@@ -1,0 +1,118 @@
+// Phase L-3 — Android predictive back gesture, Kotlin half.
+//
+// Subscribes to the host Activity's `OnBackPressedDispatcher`
+// while at least one Rust subscriber is registered against the
+// `backInvoked` event. Rust-side, `AndroidPredictiveBack` in
+// `packages/whisker-router/src/gestures/android_predictive_back.rs`
+// is the consumer — it reads `StackLayoutHandle` from context and
+// calls `handle.commit_preview_and_back()` when the event fires.
+//
+// We use `androidx.activity.OnBackPressedDispatcher` rather than the
+// raw `Activity.onBackInvokedDispatcher` (API 33+) so the same code
+// path works on minSdk=21 — androidx routes through the platform
+// dispatcher on 33+ automatically.
+//
+// ## Events
+//
+// * `backInvoked` — fired once when the back gesture commits. No
+//   payload (`.null`). Mirrors the iOS swipe-back commit point.
+//
+// Predictive-back progress events (`backStarted` / `backProgressed`
+// / `backCancelled`) for interactive preview animation aren't wired
+// in this first pass — the simpler commit-only event is enough to
+// drive `StackLayoutHandle::commit_preview_and_back`. Add the
+// progress hooks once we want a Rust-side preview pose during the
+// drag.
+//
+// ## Lifecycle
+//
+// `OnStartObserving("backInvoked")` registers the callback against
+// the current host Activity (resolved via `appContext.currentActivity`).
+// `OnStopObserving("backInvoked")` removes it. If no subscriber is
+// active, no callback is registered — the host's normal back
+// behaviour applies (e.g. finishing the Activity).
+
+package rs.whisker.router
+
+import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
+import rs.whisker.runtime.HostAttachedListener
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+
+/**
+ * `whisker-router:PredictiveBack` module. View-less — registers
+ * itself via the dispatch table; the only public surface is the
+ * `backInvoked` event.
+ */
+public class PredictiveBackModule : Module() {
+
+    /**
+     * Live `OnBackPressedCallback`. `null` between the
+     * `OnStopObserving` tearing it down and the next
+     * `OnStartObserving` re-registering. Reset to `null` after
+     * `remove()` so a second StartObserving creates a fresh
+     * callback bound to the (possibly rotated) Activity's
+     * dispatcher.
+     */
+    private var callback: OnBackPressedCallback? = null
+    /**
+     * Pending registration listener. Set when `OnStartObserving`
+     * fires before the WhiskerView attaches to its window — the
+     * listener fires once the host becomes available and finishes
+     * the deferred `addCallback`. Cleared on `OnStopObserving` to
+     * keep `OnBackPressedCallback` lifetime tied to the Rust-side
+     * subscription.
+     */
+    private var pendingAttachListener: HostAttachedListener? = null
+
+    override fun definition(): ModuleDefinition = ModuleDefinition {
+        Name("PredictiveBack")
+        Events("backInvoked")
+
+        OnStartObserving("backInvoked") {
+            if (callback != null) return@OnStartObserving
+            if (tryRegisterCallback()) return@OnStartObserving
+
+            // The Rust runtime renders the first tree from inside
+            // WhiskerView's constructor (before `onAttachedToWindow`
+            // fires), so on cold start the host Activity isn't
+            // resolvable yet. Defer the dispatcher registration
+            // until WhiskerAppContext signals attach.
+            val listener = HostAttachedListener {
+                if (callback != null) return@HostAttachedListener
+                tryRegisterCallback()
+            }
+            pendingAttachListener = listener
+            appContext.addOnHostAttachedListener(listener)
+        }
+
+        OnStopObserving("backInvoked") {
+            pendingAttachListener?.let {
+                appContext.removeOnHostAttachedListener(it)
+            }
+            pendingAttachListener = null
+            callback?.remove()
+            callback = null
+        }
+    }
+
+    /**
+     * Attempt to register `OnBackPressedCallback` against the host
+     * Activity's dispatcher. Returns true if registration succeeded
+     * (or the callback was already installed); false if the host
+     * isn't currently attached.
+     */
+    private fun tryRegisterCallback(): Boolean {
+        if (callback != null) return true
+        val activity = appContext.currentActivity as? ComponentActivity ?: return false
+        val cb = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                sendEvent("backInvoked")
+            }
+        }
+        activity.onBackPressedDispatcher.addCallback(cb)
+        callback = cb
+        return true
+    }
+}

--- a/packages/whisker-router/build.gradle.kts
+++ b/packages/whisker-router/build.gradle.kts
@@ -1,0 +1,64 @@
+// Gradle build for the `whisker-router` module's Android half.
+//
+// Step 2 of the Android predictive-back work: turn whisker-router
+// into a module package so we can declare a native module that
+// listens to `OnBackInvokedCallback` and publishes back-button
+// events to Rust via `whisker-module`'s event system.
+//
+// Mirrors `packages/whisker-hello-element/build.gradle.kts`. The
+// Cargo.toml's `[package.metadata.whisker]` table flips the
+// crate into module-package mode; whisker-build's android sync
+// generates a `settings.gradle.kts` include + sets `projectDir`
+// to this directory, so the user app's gradle composite sees
+// this module as `:whisker-router`.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    // KSP version pinned to the same `<kotlin>-<abi>` pair the
+    // user app uses. Bump in lockstep with Kotlin.
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.router"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    // build.gradle.kts sits at the package root (alongside
+    // Cargo.toml). Point the Kotlin source set at `android/src/main/
+    // kotlin` so AGP doesn't scan the Rust `src/`.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+// Pass the module name + crate name to KSP so the processor emits
+// a uniquely-named `WhiskerRouterBehaviors.kt` registration helper.
+ksp {
+    arg("whisker.moduleName", "WhiskerRouter")
+    arg("whisker.crateName", "whisker-router")
+}
+
+dependencies {
+    implementation(project(":module"))
+    // androidx.activity.OnBackPressedDispatcher / -Callback for
+    // PredictiveBackModule. 1.8+ is the floor that wires
+    // OnBackPressedDispatcher into the platform's OnBackInvoked
+    // path on API 33+ — older androidx routes the legacy path.
+    implementation("androidx.activity:activity:1.8.2")
+    ksp("rs.whisker:ksp")
+}

--- a/packages/whisker-router/src/gestures/android_predictive_back.rs
+++ b/packages/whisker-router/src/gestures/android_predictive_back.rs
@@ -5,9 +5,15 @@
 //! `whisker-router:PredictiveBack` native module's `backInvoked`
 //! event (Kotlin side: registers an
 //! `OnBackPressedDispatcher.OnBackPressedCallback` against the host
-//! Activity). On commit, calls [`StackLayoutHandle::commit_preview_and_back`]
-//! to pop the current entry — same hook the iOS swipe gesture
-//! lands on.
+//! Activity). On press, calls [`StackLayoutHandle::back`] to pop the
+//! current entry — the layout's natural route-change effect handles
+//! the backward slide animation.
+//!
+//! Unlike [`IosSwipeBack`](crate::IosSwipeBack) we do NOT use
+//! `commit_preview_and_back`: the predictive-back press is a single
+//! discrete event with no interactive drag, so there's no preview
+//! wrapper to promote — the natural route-change effect, with its
+//! built-in backward animation, is the right path.
 //!
 //! ```ignore
 //! StackLayout(transition: IosSlide::default(), render: render) {
@@ -53,7 +59,7 @@ use whisker::runtime::view::Element;
 pub fn android_predictive_back() -> Element {
     let handle = use_context::<StackLayoutHandle>()
         .expect("AndroidPredictiveBack must be a child of StackLayout");
-    let commit_back: Rc<dyn Fn()> = handle.commit_preview_and_back.clone();
+    let back: Rc<dyn Fn()> = handle.back.clone();
 
     // The bridge stores callbacks in a Send + Sync box (the C side
     // can fire from any thread that calls `module_send_event`). For
@@ -66,7 +72,7 @@ pub fn android_predictive_back() -> Element {
     // marshal hop, we wrap the Rc in [`MainThreadOnly`]. Soundness
     // rests on: every `sendEvent("backInvoked")` originates from
     // the Kotlin OnBackPressedCallback, which is main-thread.
-    let holder = MainThreadOnly { inner: commit_back };
+    let holder = MainThreadOnly { inner: back };
 
     let module = module!("PredictiveBack");
     let sub = module.on_event("backInvoked", move |_payload| {

--- a/packages/whisker-router/src/gestures/android_predictive_back.rs
+++ b/packages/whisker-router/src/gestures/android_predictive_back.rs
@@ -1,0 +1,109 @@
+//! [`AndroidPredictiveBack`] — Android system back gesture for
+//! [`StackLayout`](crate::StackLayout).
+//!
+//! Mount as a child of the layout. Subscribes to the
+//! `whisker-router:PredictiveBack` native module's `backInvoked`
+//! event (Kotlin side: registers an
+//! `OnBackPressedDispatcher.OnBackPressedCallback` against the host
+//! Activity). On commit, calls [`StackLayoutHandle::commit_preview_and_back`]
+//! to pop the current entry — same hook the iOS swipe gesture
+//! lands on.
+//!
+//! ```ignore
+//! StackLayout(transition: IosSlide::default(), render: render) {
+//!     AndroidPredictiveBack()
+//! }
+//! ```
+//!
+//! Mounting the component while the host Activity has no other back
+//! consumer takes over the system back press. Unmounting (e.g. when
+//! the user pops back to the root of the stack and the component
+//! tears down with the layout) releases it, so the platform's normal
+//! back behaviour (finish the Activity) resumes.
+//!
+//! ## What's NOT here (yet)
+//!
+//! The current implementation only listens for the commit event —
+//! no interactive preview during the drag. API 34+'s
+//! `BackEventCompat` progress / cancel callbacks would let the layout
+//! pose the outgoing wrapper as the user drags. Adding it means
+//! declaring more events (`backProgressed`, `backCancelled`,
+//! `backStarted`) in the Kotlin module and routing them through
+//! `StackLayoutHandle`'s preview API the same way
+//! [`IosSwipeBack`](crate::IosSwipeBack) does. Out of scope for the
+//! first cut — the commit-only path already drives the layout
+//! transition correctly.
+
+use std::rc::Rc;
+
+use whisker::module;
+use whisker::runtime::reactive::owner::on_cleanup;
+use whisker::{component, render, use_context};
+
+use crate::layouts::stack::StackLayoutHandle;
+use whisker::runtime::view::Element;
+
+/// Android predictive-back gesture component.
+///
+/// Mount as a child of [`StackLayout`](crate::StackLayout); reads
+/// the layout handle from context and subscribes to the
+/// `whisker-router:PredictiveBack` module's `backInvoked` event in
+/// the component body. Renders no DOM of its own.
+#[component]
+pub fn android_predictive_back() -> Element {
+    let handle = use_context::<StackLayoutHandle>()
+        .expect("AndroidPredictiveBack must be a child of StackLayout");
+    let commit_back: Rc<dyn Fn()> = handle.commit_preview_and_back.clone();
+
+    // The bridge stores callbacks in a Send + Sync box (the C side
+    // can fire from any thread that calls `module_send_event`). For
+    // predictive back the Kotlin sender is always the
+    // `OnBackPressedDispatcher` callback, which runs on the UI
+    // thread — same thread as Whisker's main loop — so the Rc<dyn
+    // Fn> is in practice only touched from one thread.
+    //
+    // To satisfy the type system without paying a per-callback
+    // marshal hop, we wrap the Rc in [`MainThreadOnly`]. Soundness
+    // rests on: every `sendEvent("backInvoked")` originates from
+    // the Kotlin OnBackPressedCallback, which is main-thread.
+    let holder = MainThreadOnly { inner: commit_back };
+
+    let module = module!("PredictiveBack");
+    let sub = module.on_event("backInvoked", move |_payload| {
+        // Bind `holder` (not `holder.inner`) so Rust 2021 disjoint
+        // closure captures take the wrapper as a whole — moving the
+        // wrapper's `Send + Sync` impls onto the closure. Capturing
+        // only `inner: Rc<...>` would re-introduce the !Sync error.
+        let h = &holder;
+        (h.inner)();
+    });
+
+    if let Some(err) = sub.error() {
+        eprintln!("[whisker-router] AndroidPredictiveBack failed to subscribe: {err}");
+    }
+
+    // Drop the subscription when the component's owner is disposed
+    // (unmount). The bridge's `module_remove_event_listener` runs
+    // inside `Drop`, so the Kotlin OnStopObserving fires and the
+    // host Activity's back dispatcher releases the callback.
+    on_cleanup(move || drop(sub));
+
+    render! { fragment() }
+}
+
+/// Locally-scoped wrapper that asserts main-thread-only access to
+/// `inner`. The unsafe `Send + Sync` is bounded by the closure
+/// callsite: `AndroidPredictiveBack`'s sole event source is the
+/// Kotlin `OnBackPressedCallback`, which fires on the UI thread.
+///
+/// Lives here (not in `whisker-runtime`) until the bridge gains a
+/// proper main-thread-only listener API. When that lands, this
+/// shim goes away.
+struct MainThreadOnly<T> {
+    inner: T,
+}
+// Safety: see the type-level comment. Never expose this beyond the
+// gesture module — moving the inner value across threads would
+// break the Rc invariant.
+unsafe impl<T> Send for MainThreadOnly<T> {}
+unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/packages/whisker-router/src/gestures/mod.rs
+++ b/packages/whisker-router/src/gestures/mod.rs
@@ -16,6 +16,8 @@
 //! from context and uses [`router::<R>()`](crate::router) to drive
 //! the stack.
 
+pub mod android_predictive_back;
 pub mod ios_swipe_back;
 
+pub use android_predictive_back::{AndroidPredictiveBack, AndroidPredictiveBackProps};
 pub use ios_swipe_back::{IosSwipeBack, IosSwipeBackProps};

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -78,6 +78,16 @@ pub struct StackLayoutHandle {
     /// effect doesn't re-animate the navigation the gesture
     /// already finished.
     pub commit_preview_and_back: Rc<dyn Fn()>,
+
+    /// Plain back navigation — calls the in-context
+    /// [`RouteStack::back`](crate::RouteStack::back). The natural
+    /// route-change effect handles the pop animation, so non-
+    /// interactive back handlers (Android system back, hardware key,
+    /// in-app "Back" button) don't need to touch the preview slot at
+    /// all. Erased over the route type `R` so children that don't
+    /// know `R` (e.g. [`AndroidPredictiveBack`](crate::gestures::AndroidPredictiveBack))
+    /// can drive it.
+    pub back: Rc<dyn Fn()>,
 }
 
 /// Animated stack: holds two slots during a transition and renders
@@ -373,12 +383,26 @@ fn build_stack_layout_handle<R: Route>(
             as Rc<dyn Fn() -> Option<Element>>
     };
 
+    let back = {
+        let stack = stack.clone();
+        Rc::new(move || {
+            // `back()` returns false if already at the stack root.
+            // Plain back handlers don't surface that to the host —
+            // the platform's natural back-when-empty behaviour (e.g.
+            // finishing the Activity) takes over if the route stays
+            // unchanged. Drop the bool here so the closure matches
+            // `Fn()` for the type-erased handle.
+            let _ = stack.back();
+        }) as Rc<dyn Fn()>
+    };
+
     StackLayoutHandle {
         container,
         current_wrapper,
         mount_preview,
         dispose_preview,
         commit_preview_and_back,
+        back,
     }
 }
 

--- a/packages/whisker-router/src/lib.rs
+++ b/packages/whisker-router/src/lib.rs
@@ -53,7 +53,9 @@ pub mod transitions;
 pub use whisker_router_macros::route;
 
 pub use crate::back_handler::{on_back, BackHandlerGuard};
-pub use crate::gestures::{IosSwipeBack, IosSwipeBackProps};
+pub use crate::gestures::{
+    AndroidPredictiveBack, AndroidPredictiveBackProps, IosSwipeBack, IosSwipeBackProps,
+};
 pub use crate::layouts::modal::{ModalLayout, ModalLayoutProps, ModalRenderFn};
 pub use crate::layouts::pane::{Pane, PaneProps};
 pub use crate::layouts::stack::{StackLayout, StackLayoutHandle, StackLayoutProps};

--- a/platforms/android/ksp/ksp/src/main/kotlin/rs/whisker/ksp/WhiskerModuleProcessor.kt
+++ b/platforms/android/ksp/ksp/src/main/kotlin/rs/whisker/ksp/WhiskerModuleProcessor.kt
@@ -199,6 +199,7 @@ public class WhiskerModuleProcessor(
             w.appendLine("import com.lynx.tasm.behavior.Behavior")
             w.appendLine("import com.lynx.tasm.behavior.LynxContext")
             w.appendLine("import com.lynx.tasm.behavior.ui.LynxUI")
+            w.appendLine("import rs.whisker.runtime.WhiskerModuleEventCenter")
             w.appendLine("import rs.whisker.runtime.registerWithLynx")
             w.appendLine("import java.util.concurrent.atomic.AtomicBoolean")
             w.appendLine()
@@ -250,12 +251,18 @@ public class WhiskerModuleProcessor(
                 w.appendLine("            val $nameLocal = $defLocal.name")
                 w.appendLine("            val $viewLocal = $defLocal.view")
                 w.appendLine("            if ($nameLocal != null) {")
+                // Phase L-2c — every module records its fully-qualified
+                // name (`<crate>:<Name>`) so `sendEvent` / observer-hook
+                // routing can find it via `WhiskerModuleEventCenter`.
+                val tagPrefix = if (crateName != null) "$crateName:" else ""
+                w.appendLine("                val qualifiedName = \"$tagPrefix\" + $nameLocal")
+                w.appendLine("                $instanceLocal.qualifiedName = qualifiedName")
+                w.appendLine("                WhiskerModuleEventCenter.register($instanceLocal)")
                 // View-bearing: register the Lynx Behavior so the tag
                 // resolves to the view class. View-less modules skip
                 // this — they have no element to instantiate.
-                val tagPrefix = if (crateName != null) "$crateName:" else ""
                 w.appendLine("                if ($viewLocal != null) {")
-                w.appendLine("                    val qualifiedTag = \"$tagPrefix\" + $nameLocal")
+                w.appendLine("                    val qualifiedTag = qualifiedName")
                 w.appendLine("                    val viewClass = $viewLocal.viewClass")
                 // Generic reflective instantiator. The Lynx UI
                 // subclass is required to expose a single-arg

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/Module.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/Module.kt
@@ -36,4 +36,49 @@ public abstract class Module {
      * paying for it on every call.
      */
     public val definitionLazy: ModuleDefinition by lazy { definition() }
+
+    /**
+     * Fully-qualified module name (`<crate>:<Name>`), set by the
+     * KSP-generated registration call. `null` until registered —
+     * `sendEvent` silently no-ops in that window. Authors must NOT
+     * set this themselves; the KSP processor does. (Public-set
+     * rather than `internal set` because the generated
+     * `<Module>Behaviors.kt` lives in the consumer Gradle module,
+     * not in `rs.whisker.runtime`, so `internal` is out of reach.)
+     */
+    public var qualifiedName: String? = null
+
+    /**
+     * Dispatch [payload] to every Rust subscriber of [event] on this
+     * module. The bridge fans the call out to every
+     * `PlatformModule::on_event` callback registered against
+     * `(this.qualifiedName, event)`.
+     *
+     * Defaults to [WhiskerValue.Null] for an unparameterised ping.
+     * No-op if the module hasn't been registered yet.
+     */
+    public fun sendEvent(event: String, payload: WhiskerValue = WhiskerValue.Null) {
+        val qname = qualifiedName ?: return
+        WhiskerModuleEventCenter.dispatchSend(qname, event, payload)
+    }
+
+    /**
+     * Fire every `OnStartObserving("eventName")` hook on this
+     * module. Called by [WhiskerModuleEventCenter] when the JNI
+     * trampoline routes a bridge start event back here. Public so
+     * the center (a different file) can dispatch into it; authors
+     * should not call this directly.
+     */
+    public fun fireOnStartObserving(eventName: String) {
+        for (h in definitionLazy.onStartObservingHooks) {
+            if (h.eventName == eventName) h.handler()
+        }
+    }
+
+    /** Counterpart to [fireOnStartObserving]. */
+    public fun fireOnStopObserving(eventName: String) {
+        for (h in definitionLazy.onStopObservingHooks) {
+            if (h.eventName == eventName) h.handler()
+        }
+    }
 }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/Module.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/Module.kt
@@ -49,6 +49,17 @@ public abstract class Module {
     public var qualifiedName: String? = null
 
     /**
+     * Module-host context. Mirrors Expo's `Module.appContext`.
+     * Read `appContext.currentActivity` to reach the host Activity
+     * from inside an `OnStartObserving` / `Function` body — the
+     * accessor is request-time, so a config-change rotation
+     * transparently resolves to the new Activity once the new
+     * `WhiskerView` attaches.
+     */
+    public val appContext: WhiskerAppContext
+        get() = WhiskerAppContext.shared
+
+    /**
      * Dispatch [payload] to every Rust subscriber of [event] on this
      * module. The bridge fans the call out to every
      * `PlatformModule::on_event` callback registered against

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ModuleDefinition.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ModuleDefinition.kt
@@ -111,12 +111,35 @@ public data class WhiskerFunctionComponent(
 ) : WhiskerDefinitionComponent
 
 /**
- * `Events("a", "b", ...)` — declare event names this module
- * emits. Just metadata; dispatch stays imperative via
- * `WhiskerCustomEvent.dispatch(...)`.
+ * `Events("a", "b", ...)` — declare event names this module emits.
+ * Metadata only; dispatch goes through
+ * [Module.sendEvent], which fans the payload out to every Rust
+ * subscriber registered via `PlatformModule::on_event`.
  */
 public data class WhiskerEventsComponent(public val names: List<String>) :
     WhiskerDefinitionComponent
+
+/**
+ * `OnStartObserving("name") { ... }` — fires when the listener
+ * count for `(this module, "name")` transitions from 0 to 1. Use to
+ * lazily attach an expensive source (e.g. `OnBackInvokedCallback`
+ * registration, sensor open) so the work only runs while at least
+ * one Rust subscriber is active.
+ */
+public data class WhiskerOnStartObservingComponent(
+    public val eventName: String,
+    public val handler: () -> Unit,
+) : WhiskerDefinitionComponent
+
+/**
+ * `OnStopObserving("name") { ... }` — fires when the listener count
+ * for `(this module, "name")` transitions from 1 to 0. Tears down
+ * whatever `OnStartObserving` set up.
+ */
+public data class WhiskerOnStopObservingComponent(
+    public val eventName: String,
+    public val handler: () -> Unit,
+) : WhiskerDefinitionComponent
 
 // ----- DSL builders --------------------------------------------------------
 
@@ -180,6 +203,27 @@ public class WhiskerModuleDefinitionBuilder {
     /** `Events("a", "b", ...)` — variadic event-name declaration. */
     public fun Events(vararg names: String): WhiskerDefinitionComponent =
         WhiskerEventsComponent(names.toList()).also { components.add(it) }
+
+    /**
+     * `OnStartObserving("name") { ... }` — declare a lazy-start
+     * hook for `name`. The closure fires once on the 0→1
+     * listener-count transition for `(this module, "name")`.
+     */
+    public fun OnStartObserving(
+        name: String,
+        handler: () -> Unit,
+    ): WhiskerDefinitionComponent =
+        WhiskerOnStartObservingComponent(name, handler).also { components.add(it) }
+
+    /**
+     * `OnStopObserving("name") { ... }` — pair to
+     * `OnStartObserving`. Fires on the 1→0 transition.
+     */
+    public fun OnStopObserving(
+        name: String,
+        handler: () -> Unit,
+    ): WhiskerDefinitionComponent =
+        WhiskerOnStopObservingComponent(name, handler).also { components.add(it) }
 
     // ---- Module-level (view-less) function: raw args (case ②) ----
 
@@ -269,6 +313,14 @@ public data class ModuleDefinition(public val components: List<WhiskerDefinition
     /** Module-level (view-less) [Function] declarations. */
     public val functions: List<WhiskerFunctionComponent>
         get() = components.filterIsInstance<WhiskerFunctionComponent>()
+
+    /** Module-level [OnStartObserving] hooks. */
+    public val onStartObservingHooks: List<WhiskerOnStartObservingComponent>
+        get() = components.filterIsInstance<WhiskerOnStartObservingComponent>()
+
+    /** Module-level [OnStopObserving] hooks. */
+    public val onStopObservingHooks: List<WhiskerOnStopObservingComponent>
+        get() = components.filterIsInstance<WhiskerOnStopObservingComponent>()
 
     public companion object {
         /**

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerAppContext.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerAppContext.kt
@@ -1,0 +1,203 @@
+// Phase L-2d — Module-side host context (Android).
+//
+// Modelled on Expo's `appContext.currentActivity`. A `Module` body
+// reaches the host Activity via:
+//
+//   class PredictiveBackModule : Module() {
+//       override fun definition() = ModuleDefinition {
+//           Name("PredictiveBack")
+//           OnStartObserving("backInvoked") {
+//               val act = appContext.currentActivity ?: return@OnStartObserving
+//               act.onBackInvokedDispatcher.registerOnBackInvokedCallback(...)
+//           }
+//       }
+//   }
+//
+// Whisker isn't Activity-centric — a host app can embed `WhiskerView`
+// inside any Activity / Fragment / Compose AndroidView / Dialog /
+// PopupWindow. So the host that publishes the Activity reference is
+// the **WhiskerView itself**: it implements [WhiskerModuleHost] and
+// pushes itself onto [WhiskerAppContext]'s host stack on
+// `onAttachedToWindow`, popping on `onDetachedFromWindow`.
+//
+// `appContext.currentActivity` then resolves the live host's
+// `context`, unwrapping any `ContextWrapper` chain (Dialog, Compose,
+// PopupWindow all hide the Activity behind one or more wrappers).
+//
+// Caveats — the getter returns `null` in these cases (Module body
+// must null-check):
+//
+//   * View is not (yet) attached to any window.
+//   * View's context unwraps to an `Application` / `Service`
+//     context, not an `Activity` (e.g. headless integration test).
+//   * Host Activity has been destroyed but the WeakReference hasn't
+//     been cleared yet (avoid by always clearing in
+//     `onDetachedFromWindow` AND `destroy()`).
+//
+// All other cases (multiple WhiskerViews, config-change Activity
+// rotation, Compose AndroidView nesting) are handled by the LIFO
+// stack + ContextWrapper unwrap.
+
+package rs.whisker.runtime
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Marker interface a Whisker module host implements to publish
+ * itself as a candidate for `appContext.currentActivity`. The
+ * default implementer is `WhiskerView`, but a custom host (e.g. a
+ * unit-test harness or a non-View embedding) can implement this
+ * too.
+ */
+/**
+ * Listener registered via
+ * [WhiskerAppContext.addOnHostAttachedListener]. Fires every time a
+ * `WhiskerModuleHost` attaches (and once at registration time if a
+ * host is already attached). Used by modules whose
+ * `OnStartObserving` hook runs before any host is available — they
+ * defer their Activity-touching wiring through this hook.
+ *
+ * Modeled as a SAM interface rather than `() -> Unit` so a Java
+ * caller can implement it without a Kotlin function-type adapter.
+ */
+public fun interface HostAttachedListener {
+    public fun onHostAttached()
+}
+
+public interface WhiskerModuleHost {
+    /**
+     * The host's Android `Context`. [WhiskerAppContext.currentActivity]
+     * walks the `ContextWrapper` chain to find the underlying
+     * Activity, so any Activity-derived context works.
+     *
+     * Named `hostContext` (not `context`) so a `View` implementer
+     * doesn't collide with `View.getContext()` on the JVM signature.
+     */
+    public val hostContext: Context
+}
+
+/**
+ * Process-wide host registry + `currentActivity` accessor.
+ *
+ * Singleton accessed via [shared]. `Module.appContext` returns this
+ * singleton, mirroring Expo's `Module.appContext` property.
+ */
+public class WhiskerAppContext internal constructor() {
+
+    /**
+     * The host Activity for the currently-foremost
+     * [WhiskerModuleHost], or `null` if none is attached / the
+     * host's context doesn't unwrap to an Activity.
+     *
+     * Request-time lookup — the Activity reference is never stored
+     * on the Module itself, so a config-change rotation transparently
+     * resolves to the new Activity once the new WhiskerView attaches.
+     */
+    public val currentActivity: Activity?
+        get() = currentHost()?.hostContext?.let { unwrapActivity(it) }
+
+    /**
+     * Register `listener` to fire whenever a [WhiskerModuleHost]
+     * attaches (i.e. `currentActivity` becomes non-null). If a host
+     * is already attached at registration time, fires synchronously
+     * once.
+     *
+     * Required for modules whose `OnStartObserving` hook runs
+     * BEFORE the WhiskerView attaches to its window — the Rust
+     * runtime's first render fires during `WhiskerView`'s
+     * constructor (inside `nativeAppMain`), but
+     * `onAttachedToWindow` only fires after `setContentView`
+     * inflates the view hierarchy. The
+     * [PredictiveBackModule](rs.whisker.router) defers its
+     * `addCallback` against the host Activity through this hook.
+     *
+     * Caller is responsible for [removeOnHostAttachedListener] —
+     * stale listeners pin nothing (the listener list holds Kotlin
+     * lambdas, not module references), but firing them after
+     * `OnStopObserving` would re-register a torn-down handler.
+     */
+    public fun addOnHostAttachedListener(listener: HostAttachedListener) {
+        attachListeners.add(listener)
+        if (currentActivity != null) listener.onHostAttached()
+    }
+
+    public fun removeOnHostAttachedListener(listener: HostAttachedListener) {
+        attachListeners.remove(listener)
+    }
+
+    /** Listeners registered via [addOnHostAttachedListener]. */
+    private val attachListeners: CopyOnWriteArrayList<HostAttachedListener> =
+        CopyOnWriteArrayList()
+
+    public companion object {
+        /** The single instance every [Module] reaches via `appContext`. */
+        @JvmStatic
+        public val shared: WhiskerAppContext = WhiskerAppContext()
+
+        // LIFO stack of WeakReferences. Most recently attached host
+        // wins (handles nested WhiskerView embeds + the common case
+        // of a single-host app). Weak refs so a misbehaving host
+        // that forgets to pop doesn't pin its Activity.
+        private val hostsLock = Any()
+        private val hosts: MutableList<WeakReference<WhiskerModuleHost>> =
+            mutableListOf()
+
+        /**
+         * Register `host` as the current top-of-stack host.
+         * Idempotent — a host that's already in the stack moves to
+         * the top (LIFO refresh).
+         */
+        @JvmStatic
+        public fun pushHost(host: WhiskerModuleHost) {
+            synchronized(hostsLock) {
+                // Drop any stale weak ref to this same host before pushing.
+                hosts.removeAll { it.get() === host || it.get() == null }
+                hosts.add(WeakReference(host))
+            }
+            // Fire host-attached listeners OUTSIDE the lock (their
+            // bodies may call back into the AppContext).
+            for (l in shared.attachListeners) l.onHostAttached()
+        }
+
+        /**
+         * Unregister `host`. Safe to call multiple times. Also
+         * sweeps stale (already-collected) weak refs.
+         */
+        @JvmStatic
+        public fun popHost(host: WhiskerModuleHost) {
+            synchronized(hostsLock) {
+                hosts.removeAll { it.get() === host || it.get() == null }
+            }
+        }
+
+        private fun currentHost(): WhiskerModuleHost? {
+            synchronized(hostsLock) {
+                // Walk from the top until we find a live ref. Sweep
+                // dead refs as we go so the list doesn't grow.
+                while (hosts.isNotEmpty()) {
+                    val top = hosts.last().get()
+                    if (top != null) return top
+                    hosts.removeAt(hosts.lastIndex)
+                }
+                return null
+            }
+        }
+
+        private fun unwrapActivity(ctx: Context): Activity? {
+            // Dialog, Compose AndroidView, PopupWindow, and several
+            // theme overlays all wrap the host Activity in one or
+            // more ContextWrappers. Walk until we hit an Activity or
+            // a non-wrapper terminator.
+            var c: Context? = ctx
+            while (c is ContextWrapper) {
+                if (c is Activity) return c
+                c = c.baseContext
+            }
+            return null
+        }
+    }
+}

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleEventCenter.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleEventCenter.kt
@@ -1,0 +1,113 @@
+// Phase L-2c — Android event-subscription wiring.
+//
+// Sits between the Rust subscription API (`PlatformModule::on_event`)
+// and the `Module` author's `Events("name")` +
+// `OnStartObserving` / `OnStopObserving` DSL.
+//
+// ## Roles
+//
+// 1. **sendEvent dispatch.** `Module.sendEvent(name, payload)` calls
+//    [dispatchSend], which routes through JNI into
+//    `whisker_bridge_module_send_event`. The bridge synchronously
+//    fans the payload out to every Rust subscriber registered against
+//    `(module.qualifiedName, event)`.
+//
+// 2. **Observer-hook routing.** When a `Module` is registered, the
+//    KSP-generated code calls [register]. The center stores a
+//    `qualifiedName → Module` mapping and (via a JNI native method)
+//    asks the C++ bridge to point its per-module observer hooks at
+//    the shared trampolines below. The trampolines route incoming
+//    `(module, event)` events back to the matching `Module`'s
+//    `fireOnStartObserving` / `fireOnStopObserving`.
+
+package rs.whisker.runtime
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Process-wide dispatcher + observer-hook router. All public
+ * entry points are `@JvmStatic` so the C++ JNI bridge can
+ * invoke them via a single cached `jmethodID`.
+ */
+public object WhiskerModuleEventCenter {
+
+    /**
+     * `qualifiedName → Module` lookup the JNI trampolines consult
+     * to find the OnStart / OnStop closures for an incoming
+     * `(module, event)` event.
+     */
+    private val modulesByName = ConcurrentHashMap<String, Module>()
+
+    /**
+     * Register [module] with the event center. The KSP-generated
+     * `_whiskerRegisterModules()` calls this after assigning
+     * `module.qualifiedName`. Idempotent — re-registering replaces
+     * the previous entry (useful for hot-reload).
+     */
+    @JvmStatic
+    public fun register(module: Module) {
+        val qname = module.qualifiedName ?: return
+        modulesByName[qname] = module
+        // Wire the C++ bridge's per-module observer hooks for this
+        // module. The native side stores a `(module → started,
+        // stopped)` table and fires the shared trampolines below.
+        nativeRegisterObserverHooks(qname)
+    }
+
+    /**
+     * Encode [payload] and dispatch through the bridge. Called by
+     * [Module.sendEvent].
+     */
+    internal fun dispatchSend(
+        moduleName: String,
+        eventName: String,
+        payload: WhiskerValue,
+    ) {
+        nativeSendEvent(moduleName, eventName, payload)
+    }
+
+    /**
+     * JNI trampoline target — invoked by the C++ bridge when a
+     * `(module, event)` listener count goes 0 → 1. Looks up the
+     * `Module` and fires every matching `OnStartObserving` closure.
+     *
+     * `@JvmStatic` + a flat name so the bridge can cache one
+     * `jmethodID` via `GetStaticMethodID`.
+     */
+    @JvmStatic
+    public fun fireStart(moduleName: String, eventName: String) {
+        modulesByName[moduleName]?.fireOnStartObserving(eventName)
+    }
+
+    /** Counterpart to [fireStart] — fires on 1 → 0 transitions. */
+    @JvmStatic
+    public fun fireStop(moduleName: String, eventName: String) {
+        modulesByName[moduleName]?.fireOnStopObserving(eventName)
+    }
+
+    // ----- Native methods --------------------------------------------------
+    //
+    // The C++ implementations live in
+    // `crates/whisker-driver-sys/bridge/src/whisker_bridge_android.cc`
+    // and follow the standard `Java_<fq-class>_<method>` JNI naming
+    // convention (no `RegisterNatives` call needed).
+
+    /**
+     * Tell the bridge to point its per-module observer hooks for
+     * [qualifiedName] at the shared trampolines that ultimately
+     * route back into [fireStart] / [fireStop].
+     */
+    @JvmStatic
+    private external fun nativeRegisterObserverHooks(qualifiedName: String)
+
+    /**
+     * Synchronously fan [payload] out to every Rust subscriber of
+     * `(qualifiedName, eventName)` via the C bridge.
+     */
+    @JvmStatic
+    private external fun nativeSendEvent(
+        qualifiedName: String,
+        eventName: String,
+        payload: WhiskerValue,
+    )
+}

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class WhiskerView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-) : LynxView(context, LynxViewBuilder()) {
+) : LynxView(context, LynxViewBuilder()), WhiskerModuleHost {
 
     private var engine: Long = 0
     private val scheduled = AtomicBoolean(false)
@@ -103,7 +103,39 @@ class WhiskerView @JvmOverloads constructor(
             nativeEngineRelease(engine)
             engine = 0L
         }
+        // Defensive — onDetachedFromWindow normally runs first, but
+        // some host flows call destroy() directly. Either path leaves
+        // the host stack clean.
+        WhiskerAppContext.popHost(this)
         super.destroy()
+    }
+
+    // ---- WhiskerModuleHost wiring -----------------------------------------
+    //
+    // Publish this view as the current `appContext.currentActivity`
+    // candidate while it's attached to a window. Modules use the
+    // resolved Activity to register window-scoped callbacks
+    // (`OnBackInvokedCallback`, sensor listeners, ...). The Activity
+    // accessor unwraps the view's `context` ContextWrapper chain at
+    // call time, so a config-change rotation transparently picks up
+    // the new Activity once the new view attaches.
+
+    /**
+     * Implements [WhiskerModuleHost.hostContext] by forwarding to
+     * the view's own [getContext]. Named `hostContext` (not
+     * `context`) so it doesn't collide with `View.getContext()` on
+     * the JVM `getContext()` signature.
+     */
+    override val hostContext: Context get() = getContext()
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        WhiskerAppContext.pushHost(this)
+    }
+
+    override fun onDetachedFromWindow() {
+        WhiskerAppContext.popHost(this)
+        super.onDetachedFromWindow()
     }
 
     /** Called from native (any thread) when a signal update marks the

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -109,7 +109,11 @@ let package = Package(
         // the Lynx symbols needed to subclass `LynxUI<View>`.
         .target(
             name: "WhiskerModule",
-            dependencies: ["Lynx"],
+            // `WhiskerDriver` carries the C ABI surface
+            // (`WhiskerValueRaw`, `whisker_bridge_module_send_event`,
+            // …) that `WhiskerValue.swift` and
+            // `WhiskerModuleEventCenter.swift` `@_exported import`.
+            dependencies: ["Lynx", "WhiskerDriver"],
             path: "Sources/WhiskerModule"
         ),
 

--- a/platforms/ios/Sources/WhiskerModule/Module.swift
+++ b/platforms/ios/Sources/WhiskerModule/Module.swift
@@ -37,4 +37,35 @@ open class Module {
     /// re-used afterwards so authors can do expensive setup in
     /// `definition()` without paying for it on every dispatch.
     public private(set) lazy var definitionLazy: ModuleDefinition = self.definition()
+
+    /// Fully-qualified module name (`<crate>:<Name>`), set by the
+    /// codegen-emitted registration call. `nil` until the module
+    /// has been registered — `sendEvent` will silently no-op in
+    /// that window. Authors must NOT set this themselves; the L-2c
+    /// codegen does. (Public-set rather than `internal(set)` so the
+    /// generated registration block, which lives in a different
+    /// Swift module than `WhiskerModule`, can assign it.)
+    public var qualifiedName: String?
+
+    /// Dispatch `payload` to every Rust subscriber of `event` on
+    /// this module. The bridge fans the call out to every
+    /// `PlatformModule::on_event` callback registered against
+    /// `(this.qualifiedName, event)`.
+    ///
+    /// Defaults to `.null` for an unparameterised ping (e.g. a
+    /// "back button pressed" event whose only meaning is the firing).
+    /// No-op if the module hasn't been registered yet.
+    public func sendEvent(_ event: String, _ payload: WhiskerValue = .null) {
+        guard let qname = qualifiedName else {
+            #if DEBUG
+            print("WhiskerModule: sendEvent(\"\(event)\") called before registration — dropped.")
+            #endif
+            return
+        }
+        WhiskerModuleEventCenter.dispatchSend(
+            module: qname,
+            event: event,
+            payload: payload
+        )
+    }
 }

--- a/platforms/ios/Sources/WhiskerModule/ModuleDefinition.swift
+++ b/platforms/ios/Sources/WhiskerModule/ModuleDefinition.swift
@@ -144,13 +144,44 @@ public struct WhiskerFunctionComponent: WhiskerDefinitionComponent {
 }
 
 /// Event-name declaration component. Authors declare event names
-/// they intend to emit; the runtime uses the list for
-/// type-checking + future docs generation. The dispatch site
-/// stays imperative (`WhiskerCustomEvent.dispatch(from:name:params:)`)
-/// — `Events("foo")` just records the name.
+/// they intend to emit; the runtime uses the list for type-checking
+/// + future docs generation. Dispatch from inside the module body
+/// goes through `Module.sendEvent(name, payload)` — the bridge fans
+/// the payload out to every Rust subscriber registered via
+/// `PlatformModule::on_event`.
+///
+/// Mirrors Expo's `Events("a", "b")` declaration; the matching
+/// `OnStartObserving` / `OnStopObserving` blocks below let the
+/// module lazily attach / detach its underlying source.
 public struct WhiskerEventsComponent: WhiskerDefinitionComponent {
     public let names: [String]
     public init(_ names: [String]) { self.names = names }
+}
+
+/// `OnStartObserving("name") { ... }` — fires when the listener
+/// count for `(this module, "name")` transitions from 0 to 1. The
+/// closure typically attaches the platform source (e.g. registers
+/// an `OnBackInvokedCallback`, opens a sensor) so the work only
+/// runs while subscribers are active.
+public struct WhiskerOnStartObservingComponent: WhiskerDefinitionComponent {
+    public let eventName: String
+    public let handler: () -> Void
+    public init(eventName: String, handler: @escaping () -> Void) {
+        self.eventName = eventName
+        self.handler = handler
+    }
+}
+
+/// `OnStopObserving("name") { ... }` — fires when the listener
+/// count for `(this module, "name")` transitions from 1 to 0. The
+/// closure tears down whatever `OnStartObserving` set up.
+public struct WhiskerOnStopObservingComponent: WhiskerDefinitionComponent {
+    public let eventName: String
+    public let handler: () -> Void
+    public init(eventName: String, handler: @escaping () -> Void) {
+        self.eventName = eventName
+        self.handler = handler
+    }
 }
 
 // MARK: - Result builders
@@ -272,6 +303,16 @@ public struct ModuleDefinition {
     public var functions: [WhiskerFunctionComponent] {
         components.compactMap { $0 as? WhiskerFunctionComponent }
     }
+
+    /// All `OnStartObserving(...)` hooks declared at module-level.
+    public var onStartObservingHooks: [WhiskerOnStartObservingComponent] {
+        components.compactMap { $0 as? WhiskerOnStartObservingComponent }
+    }
+
+    /// All `OnStopObserving(...)` hooks declared at module-level.
+    public var onStopObservingHooks: [WhiskerOnStopObservingComponent] {
+        components.compactMap { $0 as? WhiskerOnStopObservingComponent }
+    }
 }
 
 // MARK: - Top-level factories — the DSL surface authors call
@@ -301,10 +342,30 @@ public func View<V: AnyObject>(
 }
 
 /// `Events("a", "b", ...)` — declare event names this module
-/// emits. Just metadata; dispatch stays imperative via
-/// `WhiskerCustomEvent.dispatch(...)`.
+/// emits. Metadata only; dispatch goes through
+/// `Module.sendEvent(name, payload)`.
 public func Events(_ names: String...) -> WhiskerDefinitionComponent {
     WhiskerEventsComponent(names)
+}
+
+/// `OnStartObserving("name") { ... }` — declare a lazy-start hook
+/// for `name`. The closure fires once on the 0→1 listener-count
+/// transition. Use for sources that are expensive to keep open
+/// (`OnBackInvokedCallback`, motion sensors, network sockets).
+public func OnStartObserving(
+    _ name: String,
+    _ handler: @escaping () -> Void
+) -> WhiskerDefinitionComponent {
+    WhiskerOnStartObservingComponent(eventName: name, handler: handler)
+}
+
+/// `OnStopObserving("name") { ... }` — pair to `OnStartObserving`.
+/// The closure fires once on the 1→0 listener-count transition.
+public func OnStopObserving(
+    _ name: String,
+    _ handler: @escaping () -> Void
+) -> WhiskerDefinitionComponent {
+    WhiskerOnStopObservingComponent(eventName: name, handler: handler)
 }
 
 // MARK: - Prop factories

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleEventCenter.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleEventCenter.swift
@@ -1,0 +1,148 @@
+// Phase L-2c — iOS event subscription wiring.
+//
+// Sits between the Rust subscription API
+// (`PlatformModule::on_event`) and the `Module` author's
+// `Events("name")` + `OnStartObserving` / `OnStopObserving` DSL
+// surface.
+//
+// ## Roles
+//
+// 1. **sendEvent dispatch.** `Module.sendEvent(name, payload)` calls
+//    `dispatchSend(...)`, which encodes the payload as a heap-owned
+//    `WhiskerValueRaw`, hands it to the bridge, and releases the
+//    allocations once the bridge returns. The bridge synchronously
+//    fans the payload out to every Rust subscriber registered against
+//    `(module.qualifiedName, event)`.
+//
+// 2. **Observer-hook routing.** The bridge's
+//    `whisker_bridge_module_register_observer_hooks` takes a pair of
+//    `void(*)(const char*, const char*)` callbacks. C function
+//    pointers can't capture state, so we install ONE shared C
+//    trampoline pair (`sharedStartHook` / `sharedStopHook`) at
+//    process startup and route the (module, event) arguments through
+//    this center's `[qualifiedName: Module]` registry to reach the
+//    right `OnStartObserving` / `OnStopObserving` closure.
+//
+//    The codegen-emitted registration block calls
+//    `register(_ module:)` once per `Module` subclass after assigning
+//    its `qualifiedName`. The first registration also wires the
+//    shared trampolines into the bridge (lazy install).
+
+import Foundation
+@_exported import WhiskerDriver
+
+/// Shared dispatcher + observer-hook router. All state is internal
+/// to the `WhiskerModule` framework; `Module.sendEvent` and the
+/// codegen-emitted registration call are the only public entry
+/// points.
+public enum WhiskerModuleEventCenter {
+
+    // MARK: - Registry
+
+    /// Locked map of `qualifiedName → Module` instance the shared
+    /// observer-hook trampolines consult to find the OnStart /
+    /// OnStop closure for an incoming `(module, event)` event.
+    private static let lock = NSLock()
+    private static var modulesByName: [String: Module] = [:]
+
+    // MARK: - Module registration
+
+    /// Register `module` with the event center. Idempotent — a
+    /// second call with the same qualified name replaces the previous
+    /// registration (last-write-wins; useful for hot-reload).
+    ///
+    /// Authors don't call this directly — the codegen-emitted
+    /// `_whiskerRegisterModules_<target>()` calls it after
+    /// assigning `module.qualifiedName`.
+    public static func register(_ module: Module) {
+        guard let qname = module.qualifiedName else {
+            #if DEBUG
+            print("WhiskerModule: register() called on module without qualifiedName — skipped.")
+            #endif
+            return
+        }
+        lock.lock()
+        modulesByName[qname] = module
+        lock.unlock()
+
+        // Wire the shared observer-hook trampolines into the bridge
+        // for this module. The bridge keeps one (started, stopped)
+        // pair per module name; passing the same shared pair for
+        // every module is what lets the trampoline route by module
+        // name back through `modulesByName`.
+        qname.withCString { moduleC in
+            whisker_bridge_module_register_observer_hooks(
+                moduleC,
+                sharedStartHook,
+                sharedStopHook
+            )
+        }
+    }
+
+    // MARK: - sendEvent
+
+    /// Encode `payload`, dispatch through the bridge, then release
+    /// the heap allocations. Called from `Module.sendEvent`.
+    internal static func dispatchSend(
+        module: String,
+        event: String,
+        payload: WhiskerValue
+    ) {
+        var raw = payload.toRaw()
+        module.withCString { moduleC in
+            event.withCString { eventC in
+                whisker_bridge_module_send_event(moduleC, eventC, &raw)
+            }
+        }
+        // Bridge fans out synchronously inside `module_send_event` and
+        // doesn't retain `raw`; safe to release now.
+        whisker_bridge_value_release(&raw)
+    }
+
+    // MARK: - Observer hook routing
+
+    /// Look up the Module + event-name pair and fire any matching
+    /// `OnStartObserving` closures. Called by the shared C
+    /// trampoline below.
+    fileprivate static func fireStart(module: String, event: String) {
+        lock.lock()
+        let m = modulesByName[module]
+        lock.unlock()
+        guard let m else { return }
+        for hook in m.definitionLazy.onStartObservingHooks where hook.eventName == event {
+            hook.handler()
+        }
+    }
+
+    /// Counterpart to `fireStart`.
+    fileprivate static func fireStop(module: String, event: String) {
+        lock.lock()
+        let m = modulesByName[module]
+        lock.unlock()
+        guard let m else { return }
+        for hook in m.definitionLazy.onStopObservingHooks where hook.eventName == event {
+            hook.handler()
+        }
+    }
+}
+
+// MARK: - Shared C trampolines
+
+/// Bridge's `started` callback. Decodes the (module, event) pair and
+/// fires every `OnStartObserving("event")` block declared on the
+/// matching module. Process-global because the bridge stores the
+/// function pointer directly; one shared trampoline is enough since
+/// the `module` argument is the routing key.
+private let sharedStartHook: WhiskerModuleObserverHook = { moduleC, eventC in
+    guard let moduleC, let eventC else { return }
+    let module = String(cString: moduleC)
+    let event = String(cString: eventC)
+    WhiskerModuleEventCenter.fireStart(module: module, event: event)
+}
+
+private let sharedStopHook: WhiskerModuleObserverHook = { moduleC, eventC in
+    guard let moduleC, let eventC else { return }
+    let module = String(cString: moduleC)
+    let event = String(cString: eventC)
+    WhiskerModuleEventCenter.fireStop(module: module, event: event)
+}

--- a/platforms/ios/macros/Sources/WhiskerModuleCodegen/main.swift
+++ b/platforms/ios/macros/Sources/WhiskerModuleCodegen/main.swift
@@ -218,15 +218,22 @@ func render(
                     let module = \(instance)
                     let def = module.definitionLazy
                     if let name = def.name {
+                        // Phase L-2c — every DSL module records its
+                        // fully-qualified name so `sendEvent` /
+                        // observer-hook routing can find it.
+                        let qname = "\(tagPrefix)" + name
+                        module.qualifiedName = qname
+                        WhiskerModuleEventCenter.register(module)
+
                         if let view = def.view {
-                            LynxComponentRegistry.registerUI(view.viewClass, withName: "\(tagPrefix)" + name)
+                            LynxComponentRegistry.registerUI(view.viewClass, withName: qname)
                             module.registerWithLynx()
                         } else {
                             // Namespace the dispatch key with the crate
                             // (`<crate>:Name`) so two crates can ship
                             // same-named function-only modules — matches
                             // the Rust `module!("Name")` prefix.
-                            whisker_bridge_register_module_dispatch("\(tagPrefix)" + name, \(shim))
+                            whisker_bridge_register_module_dispatch(qname, \(shim))
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- **whisker-module event system** — Expo Modules-style `Events / OnStart/StopObserving / sendEvent` for native → Rust event fan-out. iOS (Swift) + Android (Kotlin) modules share the dispatch surface.
- **Android system back gesture** — `whisker-router:PredictiveBack` module + `AndroidPredictiveBack` Rust component. On press, calls `StackLayoutHandle.back()`; the natural backward route-change effect plays the iOS slide pop animation.
- **Lynx v3.8.0-whisker.2 bump** — `lynx_element_animate` now exported on both iOS and Android tarballs (was iOS-only in whisker.1); drops the dlsym fallback. Adds `whisker_bridge_log_info` for Rust → logcat diagnostics.
- **`StackLayoutHandle.back`** — type-erased plain back closure for non-interactive handlers (system back, hardware key, in-app back button) that don't need the preview slot.

## Out of scope (filed as #99)

This PR is intentionally minimal: Android **predictive back** with the interactive scrub animation (mounting a preview wrapper and posing it against `BackEventCompat.progress`) is NOT included. Investigation found that Lynx Android's animator latches `transform` after `fill: forwards`, and neither `animate_cancel` nor subsequent inline-style writes release the claim. See #99 for the full analysis and proposed fork-side fix.

## Test plan

- [ ] iOS: `cargo whisker run --target ios` — verify forward push (Home → List) and back via on-screen "Back" button.
- [ ] iOS: edge swipe-back gesture continues to work (regression).
- [ ] Android: `cargo whisker run --target android` — verify forward push works.
- [ ] Android: system back (gesture or button) pops the route and plays the backward iOS slide animation.
- [ ] Android: when on root (Home), system back finishes the Activity (natural behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)