### PR TITLE
feat(image): whisker-image module (Kingfisher / Coil) + drop built-in <image>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-image"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+]
+
+[[package]]
 name = "whisker-local-store"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "examples/router-demo",
     "examples/subsecond-poc",
     "packages/whisker-hello-element",
+    "packages/whisker-image",
     "packages/whisker-local-store",
     "packages/whisker-router",
     "packages/whisker-router-macros",

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -55,14 +55,17 @@ typedef struct WhiskerEngine WhiskerEngine;
 typedef struct WhiskerElement WhiskerElement;
 
 // Tag type passed to create functions that need a tag string. Numeric
-// IDs map to HTML-style tag names ("view", "text", "image", ...).
+// IDs map to HTML-style tag names ("view", "text", "scroll-view", ...).
+// `image` is intentionally not built-in — use the `whisker-image`
+// module (Kingfisher / Coil-backed) instead. The Lynx-native `<image>`
+// has no `LynxServiceImageProtocol` registered in the Whisker
+// distribution, so the tag would never paint anyway.
 typedef enum {
     WhiskerElementTagPage       = 1,
     WhiskerElementTagView       = 2,
     WhiskerElementTagText       = 3,
     WhiskerElementTagRawText    = 4,
-    WhiskerElementTagImage      = 5,
-    WhiskerElementTagScrollView = 6,
+    WhiskerElementTagScrollView = 5,
 } WhiskerElementTag;
 
 // ---- Engine lifecycle -----------------------------------------------------

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -176,7 +176,6 @@ lynx_element_tag_e MapTag(WhiskerElementTag tag) {
         case WhiskerElementTagView:       return LYNX_ELEMENT_TAG_VIEW;
         case WhiskerElementTagText:       return LYNX_ELEMENT_TAG_TEXT;
         case WhiskerElementTagRawText:    return LYNX_ELEMENT_TAG_RAW_TEXT;
-        case WhiskerElementTagImage:      return LYNX_ELEMENT_TAG_IMAGE;
         case WhiskerElementTagScrollView: return LYNX_ELEMENT_TAG_SCROLL_VIEW;
     }
     return LYNX_ELEMENT_TAG_VIEW;

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -23,8 +23,7 @@ pub enum WhiskerElementTag {
     View = 2,
     Text = 3,
     RawText = 4,
-    Image = 5,
-    ScrollView = 6,
+    ScrollView = 5,
 }
 
 pub type WhiskerTasmCallback = extern "C" fn(user_data: *mut c_void);

--- a/crates/whisker-driver/src/element_ref.rs
+++ b/crates/whisker-driver/src/element_ref.rs
@@ -481,62 +481,6 @@ impl Default for ElementHandle {
     }
 }
 
-/// Imperative handle to a mounted `<image>`. Allocate with
-/// [`ImageHandle::new`], bind via `image(ref: handle.r())` in
-/// `render!`, then drive animated-image (GIF / APNG) playback.
-///
-/// `Copy` (the inner `ElementRef` is an arena handle), so it can be
-/// captured by value into multiple event closures.
-#[derive(Copy, Clone)]
-pub struct ImageHandle {
-    r: ElementRef,
-}
-
-impl ImageHandle {
-    /// Allocate a fresh, unbound image handle.
-    pub fn new() -> Self {
-        Self {
-            r: ElementRef::new(),
-        }
-    }
-
-    /// The underlying [`ElementRef`] — pass to a `ref:` prop to bind
-    /// it on mount (`image(ref: handle.r())`).
-    pub fn r(&self) -> ElementRef {
-        self.r
-    }
-
-    generic_element_methods!();
-
-    /// `pauseAnimation` — pause a playing animated image, holding the
-    /// current frame.
-    pub fn pause_animation(&self) {
-        let _ = self.r.invoke("pauseAnimation", WhiskerValue::Null);
-    }
-
-    /// `resumeAnimation` — resume a paused animated image from the
-    /// held frame.
-    pub fn resume_animation(&self) {
-        let _ = self.r.invoke("resumeAnimation", WhiskerValue::Null);
-    }
-
-    /// `stopAnimation` — stop playback and reset to the first frame.
-    pub fn stop_animation(&self) {
-        let _ = self.r.invoke("stopAnimation", WhiskerValue::Null);
-    }
-
-    /// `startAnimate` — (re)start playback from the first frame.
-    pub fn start_animate(&self) {
-        let _ = self.r.invoke("startAnimate", WhiskerValue::Null);
-    }
-}
-
-impl Default for ImageHandle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Imperative handle to a mounted `<scroll-view>`. Allocate with
 /// [`ScrollViewHandle::new`], bind via `scroll_view(ref: handle.r())`
 /// in `render!`, then query scroll state.

--- a/crates/whisker-driver/src/lib.rs
+++ b/crates/whisker-driver/src/lib.rs
@@ -12,7 +12,7 @@ pub mod lynx;
 pub mod module;
 
 pub use element_ref::{
-    element_ref, BoundingClientRect, ElementHandle, ElementRef, ImageHandle, RefError, ScrollInfo,
+    element_ref, BoundingClientRect, ElementHandle, ElementRef, RefError, ScrollInfo,
     ScrollViewHandle, TextBoundingRect, TextHandle, UiInfo,
 };
 pub use lynx::bootstrap;

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -97,7 +97,6 @@ fn map_tag(tag: ElementTag) -> WhiskerElementTag {
         ElementTag::View => WhiskerElementTag::View,
         ElementTag::Text => WhiskerElementTag::Text,
         ElementTag::RawText => WhiskerElementTag::RawText,
-        ElementTag::Image => WhiskerElementTag::Image,
         ElementTag::ScrollView => WhiskerElementTag::ScrollView,
     }
 }

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -10,7 +10,7 @@
 //!
 //! Each `node` is classified by its leading ident:
 //!
-//! - Built-in tag (`view`, `page`, `text`, `raw_text`, `image`,
+//! - Built-in tag (`view`, `page`, `text`, `raw_text`,
 //!   `scroll_view`) → lowered to a builder chain
 //!   `::whisker::__tags::__<tag>_ctor().style(…).…__h()`.
 //! - `Show` / `For` → lowered to the matching `whisker::show` /
@@ -345,7 +345,7 @@ fn snake_to_pascal(name: &str) -> String {
 fn is_builtin_tag(name: &str) -> bool {
     matches!(
         name,
-        "page" | "view" | "text" | "raw_text" | "image" | "scroll_view" | "list" | "fragment"
+        "page" | "view" | "text" | "raw_text" | "scroll_view" | "list" | "fragment"
     )
     // `list_item` is intentionally NOT exposed as a user-writable
     // tag. The `list` render-props builder auto-wraps every
@@ -539,7 +539,7 @@ impl ElementNode {
 
         let call = if is_known_attr_method(&tag_name, &name_str) {
             // Named builder attribute method (`style`, `class`, the
-            // universal trait attrs, and per-tag ones like `image::mode`,
+            // universal trait attrs, and per-tag ones like
             // `scroll_view::bounces`, `text::text_maxline`). The method
             // takes `impl Into<Signal<T>>` for its semantic `T` and
             // handles Static / Dynamic dispatch internally; the value
@@ -632,20 +632,6 @@ fn is_known_attr_method(tag: &str, attr: &str) -> bool {
             | ("text", "text_single_line_vertical_align")
             | ("text", "custom_context_menu")
             | ("text", "custom_text_selection")
-            | ("image", "src")
-            | ("image", "mode")
-            | ("image", "placeholder")
-            | ("image", "blur_radius")
-            | ("image", "auto_size")
-            | ("image", "tint_color")
-            | ("image", "cap_insets")
-            | ("image", "cap_insets_scale")
-            | ("image", "loop_count")
-            | ("image", "autoplay")
-            | ("image", "prefetch_width")
-            | ("image", "prefetch_height")
-            | ("image", "image_config")
-            | ("image", "defer_src_invalidation")
             | ("scroll_view", "scroll_orientation")
             | ("scroll_view", "bounces")
             | ("scroll_view", "enable_scroll")
@@ -699,18 +685,13 @@ fn is_known_event_method(name: &str) -> bool {
             | "on_transitioncancel"
             // Component-specific events (CustomEvent → bind only). These
             // are inherent methods on a single tag's builder (scroll_view
-            // / image / text), so the macro emits `.on_scroll(f)` etc.;
+            // / text), so the macro emits `.on_scroll(f)` etc.;
             // using one on the wrong tag is a clear "no method" error.
             | "on_scroll"
             | "on_scrolltoupper"
             | "on_scrolltolower"
             | "on_scrollend"
             | "on_contentsizechanged"
-            | "on_load"
-            | "on_error"
-            | "on_startplay"
-            | "on_currentloopcomplete"
-            | "on_finalloopcomplete"
             | "on_layout"
             | "on_selectionchange"
     );
@@ -867,7 +848,7 @@ mod tests {
 
     #[test]
     fn builtin_tags_recognised() {
-        for t in ["page", "view", "text", "raw_text", "image", "scroll_view"] {
+        for t in ["page", "view", "text", "raw_text", "scroll_view"] {
             assert!(is_builtin_tag(t));
         }
     }

--- a/crates/whisker-runtime/src/element.rs
+++ b/crates/whisker-runtime/src/element.rs
@@ -18,8 +18,7 @@ pub enum ElementTag {
     View = 2,
     Text = 3,
     RawText = 4,
-    Image = 5,
-    ScrollView = 6,
+    ScrollView = 5,
 }
 
 impl ElementTag {
@@ -29,7 +28,6 @@ impl ElementTag {
             ElementTag::View => "view",
             ElementTag::Text => "text",
             ElementTag::RawText => "raw-text",
-            ElementTag::Image => "image",
             ElementTag::ScrollView => "scroll-view",
         }
     }

--- a/crates/whisker-runtime/src/event.rs
+++ b/crates/whisker-runtime/src/event.rs
@@ -348,34 +348,6 @@ pub struct ScrollDetail {
     pub is_dragging: bool,
 }
 
-// ---- image -----------------------------------------------------------------
-
-/// `load` on `<image>` — the image request succeeded; `detail` gives
-/// the intrinsic pixel size. (`error` / animated-image events surface
-/// as [`CustomEvent`] — their detail is component-specific.)
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct ImageLoadEvent {
-    #[serde(rename = "type", default)]
-    pub kind: String,
-    #[serde(default)]
-    pub timestamp: f64,
-    #[serde(default)]
-    pub target: Target,
-    #[serde(rename = "currentTarget", default)]
-    pub current_target: Target,
-    #[serde(default)]
-    pub detail: ImageLoadDetail,
-}
-
-/// Intrinsic image size carried by an [`ImageLoadEvent`].
-#[derive(Debug, Clone, Copy, Default, Deserialize)]
-pub struct ImageLoadDetail {
-    #[serde(default)]
-    pub width: f64,
-    #[serde(default)]
-    pub height: f64,
-}
-
 // ---- text ------------------------------------------------------------------
 
 /// `layout` on `<text>` — fired after text layout completes.

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -49,8 +49,8 @@ pub use whisker_macros::{component, main, module_component, render};
 // macro binds it on mount when passed as the `ref:` prop.
 pub use whisker_driver::{
     animate_cancel, animate_start, element_ref, invoke_element_animate, AnimateOp, AnimateOptions,
-    BoundingClientRect, ElementHandle, ElementRef, ImageHandle, RefError, ScrollInfo,
-    ScrollViewHandle, TextBoundingRect, TextHandle, UiInfo,
+    BoundingClientRect, ElementHandle, ElementRef, RefError, ScrollInfo, ScrollViewHandle,
+    TextBoundingRect, TextHandle, UiInfo,
 };
 
 // Function-only module dispatch. `PlatformModule` is the name-keyed
@@ -74,9 +74,9 @@ pub use whisker_runtime::value::WhiskerValue;
 /// lifecycle / component-state events a [`CustomEvent`](event::CustomEvent).
 pub mod event {
     pub use whisker_runtime::event::{
-        AnimationEvent, BindType, CustomEvent, Event, ImageLoadDetail, ImageLoadEvent, Point,
-        ScrollDetail, ScrollEvent, SelectionChangeEvent, SelectionDetail, Size, Target,
-        TextLayoutDetail, TextLayoutEvent, TextLineInfo, Touch, TouchEvent,
+        AnimationEvent, BindType, CustomEvent, Event, Point, ScrollDetail, ScrollEvent,
+        SelectionChangeEvent, SelectionDetail, Size, Target, TextLayoutDetail, TextLayoutEvent,
+        TextLineInfo, Touch, TouchEvent,
     };
 }
 
@@ -154,7 +154,7 @@ pub use whisker_runtime::view::{EachFn, Fallback, ItemFn, KeyFn, WhenFn};
 pub mod __tags {
     use crate::ElementTag;
     use whisker_runtime::event::{
-        bind_typed, AnimationEvent, CustomEvent, ImageLoadEvent, ScrollEvent, SelectionChangeEvent,
+        bind_typed, AnimationEvent, CustomEvent, ScrollEvent, SelectionChangeEvent,
         TextLayoutEvent, TouchEvent,
     };
     use whisker_runtime::reactive::Signal;
@@ -928,178 +928,6 @@ pub mod __tags {
         }
     }
 
-    /// `<image>` — bitmap element. `src` is the image URL / resource.
-    #[allow(non_camel_case_types)]
-    pub struct image {
-        handle: Element,
-    }
-    #[allow(non_snake_case)]
-    pub fn __image_ctor() -> image {
-        image {
-            handle: create_element(ElementTag::Image),
-        }
-    }
-    impl ElementBuilder for image {
-        fn __element(&self) -> Element {
-            self.handle
-        }
-    }
-    impl image {
-        /// `src` — image URL or resource name. Reactive-capable.
-        pub fn src<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "src", v);
-            self
-        }
-
-        // ---- image attributes (every method reactive-capable) -------
-
-        /// `mode` — crop/scale: `scaleToFill` (default) / `aspectFit` /
-        /// `aspectFill` / `center`.
-        pub fn mode<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "mode", v);
-            self
-        }
-        /// `placeholder` — fallback image shown while loading.
-        pub fn placeholder<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "placeholder", v);
-            self
-        }
-        /// `blur-radius` — blur intensity, e.g. `"10px"`.
-        pub fn blur_radius<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "blur-radius", v);
-            self
-        }
-        /// `auto-size` — size the element to the image's intrinsic size.
-        pub fn auto_size<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<bool>>,
-        {
-            apply_attr(self.handle, "auto-size", v);
-            self
-        }
-        /// `tint-color` — recolor non-transparent pixels.
-        pub fn tint_color<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "tint-color", v);
-            self
-        }
-        /// `cap-insets` — 9-patch stretchable area (`"top right bottom left"`).
-        pub fn cap_insets<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "cap-insets", v);
-            self
-        }
-        /// `cap-insets-scale` — scale of the 9-patch stretchable area.
-        pub fn cap_insets_scale<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<f64>>,
-        {
-            apply_attr(self.handle, "cap-insets-scale", v);
-            self
-        }
-        /// `loop-count` — animated-image play count (0 = infinite).
-        pub fn loop_count<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<i32>>,
-        {
-            apply_attr(self.handle, "loop-count", v);
-            self
-        }
-        /// `autoplay` — start an animated image automatically on load.
-        pub fn autoplay<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<bool>>,
-        {
-            apply_attr(self.handle, "autoplay", v);
-            self
-        }
-        /// `prefetch-width` — load even when element width is 0, e.g. `"100px"`.
-        pub fn prefetch_width<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "prefetch-width", v);
-            self
-        }
-        /// `prefetch-height` — load even when element height is 0, e.g. `"100px"`.
-        pub fn prefetch_height<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "prefetch-height", v);
-            self
-        }
-        /// `image-config` — bitmap memory format: `ARGB_8888` / `RGB_565`.
-        pub fn image_config<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "image-config", v);
-            self
-        }
-        /// `defer-src-invalidation` — keep the old image until the new
-        /// one loads successfully.
-        pub fn defer_src_invalidation<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<bool>>,
-        {
-            apply_attr(self.handle, "defer-src-invalidation", v);
-            self
-        }
-
-        // ---- image-specific events (CustomEvent → bind only) --------
-
-        /// `load` — the image request succeeded. The
-        /// [`ImageLoadEvent`] carries the intrinsic pixel size.
-        pub fn on_load<F: Fn(ImageLoadEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.handle, "load", BindType::Bind, f);
-            self
-        }
-
-        /// `error` — the image failed to load. The [`CustomEvent`]
-        /// `detail` carries component-specific error info.
-        pub fn on_error<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.handle, "error", BindType::Bind, f);
-            self
-        }
-
-        /// `startplay` — an animated image (APNG/GIF) started playing.
-        pub fn on_startplay<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.handle, "startplay", BindType::Bind, f);
-            self
-        }
-
-        /// `currentloopcomplete` — one loop of an animated image
-        /// finished playing.
-        pub fn on_currentloopcomplete<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.handle, "currentloopcomplete", BindType::Bind, f);
-            self
-        }
-
-        /// `finalloopcomplete` — an animated image finished all its
-        /// `loop-count` loops.
-        pub fn on_finalloopcomplete<F: Fn(CustomEvent) + 'static>(self, f: F) -> Self {
-            bind_typed(self.handle, "finalloopcomplete", BindType::Bind, f);
-            self
-        }
-    }
-
     /// `<scroll-view>` — scrollable container.
     #[allow(non_camel_case_types)]
     pub struct scroll_view {
@@ -1723,8 +1551,8 @@ pub mod prelude {
     pub use crate::{ForEach, ForEachProps, Show, ShowProps};
     // Function-shaped prop types for control-flow components.
     pub use crate::{
-        element_ref, BoundingClientRect, ElementHandle, ElementRef, ImageHandle, RefError,
-        ScrollInfo, ScrollViewHandle, TextBoundingRect, TextHandle,
+        element_ref, BoundingClientRect, ElementHandle, ElementRef, RefError, ScrollInfo,
+        ScrollViewHandle, TextBoundingRect, TextHandle,
     };
     pub use crate::{EachFn, Fallback, ItemFn, KeyFn, WhenFn};
     // Type-safe CSS builder. Pulled into the prelude so
@@ -1756,7 +1584,7 @@ pub mod prelude {
     // these blocked kwarg completion was a separate bug — the
     // prefix-match heuristic that's since been removed.)
     #[doc(hidden)]
-    pub use crate::__tags::{fragment, image, list, page, raw_text, scroll_view, text, view};
+    pub use crate::__tags::{fragment, list, page, raw_text, scroll_view, text, view};
     // `list_item` intentionally absent — the `list` render-props
     // builder auto-wraps every item internally; user code never
     // reaches for `list_item` directly.

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -232,8 +232,8 @@ fn style_attribute_emits_set_inline_styles() {
 fn arbitrary_attribute_emits_set_attribute() {
     with_recorder(|log| {
         let _ = render! {
-            image(
-                src: "https://example.com/x.png",
+            view(
+                role: "banner",
                 alt: "example",
             )
         };
@@ -242,13 +242,13 @@ fn arbitrary_attribute_emits_set_attribute() {
             ops[0],
             Op::Create {
                 id: 0,
-                tag: ElementTag::Image
+                tag: ElementTag::View
             }
         );
         assert!(ops.contains(&Op::SetAttr {
             id: 0,
-            key: "src".into(),
-            value: "https://example.com/x.png".into(),
+            key: "role".into(),
+            value: "banner".into(),
         }));
         assert!(ops.contains(&Op::SetAttr {
             id: 0,
@@ -277,17 +277,6 @@ fn typed_attribute_methods_route_to_named_setters() {
         assert!(has(&ops, "bounces", "true"), "got {ops:?}");
         assert!(has(&ops, "enable-scroll", "false"), "got {ops:?}");
         assert!(has(&ops, "upper-threshold", "50"), "got {ops:?}");
-    });
-
-    // image: enum-string + bool + number(0).
-    with_recorder(|log| {
-        let _ = render! {
-            image(mode: "aspectFit", auto_size: true, loop_count: 0)
-        };
-        let ops = log.borrow();
-        assert!(has(&ops, "mode", "aspectFit"), "got {ops:?}");
-        assert!(has(&ops, "auto-size", "true"), "got {ops:?}");
-        assert!(has(&ops, "loop-count", "0"), "got {ops:?}");
     });
 
     // text: number + bool.
@@ -371,19 +360,15 @@ fn tap_propagation_variants_route_to_bind_types() {
 
 #[test]
 fn component_specific_events_route_bind_only() {
-    // Phase 6 coverage: tag-specific CustomEvents (scroll_view / image /
+    // Phase 6 coverage: tag-specific CustomEvents (scroll_view /
     // text) register their named listener as BindType::Bind. They have
     // no catch/capture variants (Lynx CustomEvent = target-only).
     with_recorder(|log| {
         let _ = render! {
             scroll_view {
-                image(on_load: |_| {}, on_error: |_| {})
                 text(on_layout: |_| {}, on_selectionchange: |_| {})
             }
         };
-        // attach scroll handlers on the scroll_view itself via a second
-        // render (kwargs + children on one element are both fine, but
-        // keep this focused).
         let names: Vec<(String, BindType)> = log
             .borrow()
             .iter()
@@ -394,7 +379,7 @@ fn component_specific_events_route_bind_only() {
                 _ => None,
             })
             .collect();
-        for n in ["load", "error", "layout", "selectionchange"] {
+        for n in ["layout", "selectionchange"] {
             assert!(
                 names.contains(&(n.to_string(), BindType::Bind)),
                 "missing bind listener for {n}; got {names:?}"
@@ -557,7 +542,7 @@ fn dynamic_attribute_re_runs_on_dep_change() {
         // Already a `ReadSignal<String>` — pass the handle directly,
         // it converts to `Signal::Dynamic`.
         let _h = render! {
-            image(src: src)
+            view(src: src)
         };
         set_src.set("b.png".into());
         flush();
@@ -895,12 +880,12 @@ fn for_removes_items_on_update() {
 }
 
 #[test]
-fn page_view_image_scroll_view_tags_supported() {
+fn page_view_scroll_view_tags_supported() {
     with_recorder(|log| {
         let _ = render! {
             page {
                 scroll_view {
-                    image()
+                    view()
                 }
             }
         };
@@ -914,7 +899,7 @@ fn page_view_image_scroll_view_tags_supported() {
             .collect();
         assert_eq!(
             creates,
-            vec![ElementTag::Page, ElementTag::ScrollView, ElementTag::Image]
+            vec![ElementTag::Page, ElementTag::ScrollView, ElementTag::View]
         );
     });
 }

--- a/packages/whisker-image/Cargo.toml
+++ b/packages/whisker-image/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "whisker-image"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Whisker platform component module — `whisker-image:Image` element backed by Kingfisher on iOS / Coil on Android. Fetches HTTP(S) URLs and renders into a UIImageView / ImageView with built-in memory + disk cache. Demonstrates the `@WhiskerModule` `Prop` setter pattern from `whisker-video` against a network-fetching native widget."
+
+# Explicit `include` list — mirrors `whisker-video`. A `cargo publish`
+# ships the Kotlin + Swift platform sources alongside `src/lib.rs`,
+# but never the local Gradle / Xcode build artifacts that would
+# accidentally bloat the published crate if a stale build dir lingers.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "src/lib.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker. The bare table identifies this cargo
+# crate as a Whisker module; `whisker-build` walks the consuming app's
+# dep tree, picks out every dep carrying it, and wires the Android
+# Gradle subproject + iOS SwiftPM package into the host build.
+[package.metadata.whisker]
+
+[dependencies]
+whisker = { workspace = true }

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -1,0 +1,62 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for the `whisker-image` module package.
+//
+// Mirrors `whisker-video`'s shape: one library target with sources
+// under `ios/Sources/WhiskerImage`, the WhiskerModuleCodegenPlugin
+// wired so `@WhiskerModule`-driven Kotlin/Swift registration lands
+// in `<Target>+Generated.swift` at build time, and a Kingfisher SPM
+// dep that the `ImageView` Swift class uses to fetch URLs.
+//
+// `whisker-build` injects the absolute location of Whisker's iOS
+// runtime + macros packages via these env vars (the same paths it
+// writes into the generated aggregator Package.swift), so this
+// module resolves them no matter where the crate lives — in the
+// monorepo, in a user's whisker project, or unpacked from the cargo
+// registry. No relative fallback: a Whisker module is only ever
+// built through `whisker run` / `whisker build`, never standalone
+// `swift build`.
+
+import PackageDescription
+
+guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
+      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
+else {
+    fatalError("""
+        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
+        module through `whisker run` / `whisker build`, which inject these paths.
+        """)
+}
+
+let package = Package(
+    name: "whisker-image",
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
+    ],
+    dependencies: [
+        .package(name: "macros", path: whiskerMacrosPath),
+        .package(name: "WhiskerRuntime", path: whiskerRuntimePath),
+        // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
+        // via Core Image, animated GIF via `AnimatedImageView`, in-
+        // memory `NSCache` + disk cache out of the box. WebP requires
+        // the separate KingfisherWebP package (opt-in); not pulled in
+        // here so the base module stays slim.
+        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.12.0"),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerImage",
+            dependencies: [
+                // WhiskerModule re-exports Lynx transitively, so a
+                // separate `Lynx` product dep isn't needed.
+                .product(name: "WhiskerModule", package: "WhiskerRuntime"),
+                .product(name: "Kingfisher", package: "Kingfisher"),
+            ],
+            path: "ios/Sources/WhiskerImage",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "macros"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-image/android/src/main/kotlin/rs/whisker/elements/image/ImageModule.kt
+++ b/packages/whisker-image/android/src/main/kotlin/rs/whisker/elements/image/ImageModule.kt
@@ -1,0 +1,29 @@
+// `whisker-image` ModuleDefinition (Android).
+//
+// Mirrors `whisker-video`'s `VideoModule` shape — KSP scans this
+// module's sources for any concrete `Module` subclass and emits the
+// registration block into `WhiskerImageBehaviors.registerAll()`.
+//
+// The `WhiskerImageView` Lynx UI subclass this references lives in
+// `WhiskerImageView.kt`. Same split on iOS (`ImageModule.swift` +
+// `ImageView.swift`).
+
+package rs.whisker.elements.image
+
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerValue
+
+class ImageModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("Image")
+        View(WhiskerImageView::class.java) {
+            Prop("src") { view: WhiskerImageView, value ->
+                view.setSrc(value.asString() ?: "")
+            }
+            Prop("mode") { view: WhiskerImageView, value ->
+                view.setMode(value.asString() ?: "aspectFill")
+            }
+        }
+    }
+}

--- a/packages/whisker-image/android/src/main/kotlin/rs/whisker/elements/image/WhiskerImageView.kt
+++ b/packages/whisker-image/android/src/main/kotlin/rs/whisker/elements/image/WhiskerImageView.kt
@@ -1,0 +1,139 @@
+// Lynx UI subclass hosting an ImageView + Coil-driven URL loading.
+// A plain `WhiskerUI` subclass — no Whisker annotations; registration
+// is driven by `ImageModule`'s `definition()` (see `ImageModule.kt`).
+
+package rs.whisker.elements.image
+
+import android.content.Context
+import android.widget.ImageView
+import coil.dispose
+import coil.load
+import coil.request.CachePolicy
+import coil.request.Disposable
+import coil.transform.RoundedCornersTransformation
+import com.lynx.tasm.behavior.StylesDiffMap
+import rs.whisker.runtime.WhiskerContext
+import rs.whisker.runtime.WhiskerUI
+
+open class WhiskerImageView(context: WhiskerContext) : WhiskerUI<ImageView>(context) {
+
+    private var currentSrc: String? = null
+    private var currentRequest: Disposable? = null
+    /// Active corner radius in **device pixels** — the value Lynx's
+    /// CSS pipeline has already converted from the `8px` source. Fed
+    /// directly to Coil's `RoundedCornersTransformation`, which also
+    /// takes pixels. `0f` means "no rounding".
+    private var cornerRadiusPx: Float = 0f
+
+    override fun createView(context: Context): ImageView {
+        val v = ImageView(context)
+        // Default to `aspectFill` (`CENTER_CROP`) to match the Lynx
+        // `mode` default; `setMode(_)` flips it as soon as a non-
+        // default value lands.
+        v.scaleType = ImageView.ScaleType.CENTER_CROP
+        return v
+    }
+
+    /// Intercept the CSS `border-radius` cascade before the base
+    /// implementation runs. Whisker-registered custom UIs ship without
+    /// an APT-generated `$$PropsSetter`, so Lynx's per-key dispatch
+    /// path can't reach the typed `setBorderRadius(int, ReadableArray)`
+    /// hook on `LynxBaseUI`. The kebab-case `border-*-radius` entries
+    /// DO reach `StylesDiffMap.mBackingMap` though — we pull them out
+    /// here and forward to Coil's bitmap transformation.
+    ///
+    /// Lynx splits the CSS shorthand into four per-corner properties.
+    /// Each value is a 4-element `[x_px, x_unit, y_px, y_unit]` array
+    /// (PlatformLength quartet, x_px already density-multiplied).
+    /// `RoundedCornersTransformation` takes one uniform float, so we
+    /// collapse to the largest corner.
+    override fun updatePropertiesInterval(props: StylesDiffMap?) {
+        super.updatePropertiesInterval(props)
+        val map = props?.mBackingMap ?: return
+        var maxPx = 0f
+        var sawAny = false
+        for (k in CORNER_KEYS) {
+            if (!map.hasKey(k)) continue
+            val arr = map.getArray(k) ?: continue
+            if (arr.size() < 1) continue
+            sawAny = true
+            val px = arr.getDouble(0).toFloat()
+            if (px > maxPx) maxPx = px
+        }
+        if (sawAny && maxPx != cornerRadiusPx) {
+            cornerRadiusPx = maxPx
+            reload()
+        }
+    }
+
+    /**
+     * Backing of the `src` prop. Kicks off a Coil request bound to
+     * the ImageView itself. A second `setSrc` cancels the in-flight
+     * request automatically — `ImageView.load { ... }` returns a
+     * Disposable we cancel before issuing the next one.
+     */
+    fun setSrc(value: String) {
+        // No-op on equal — avoids re-fetching on a benign re-render
+        // (e.g. a parent re-renders but the src signal didn't
+        // actually change). Coil would short-circuit via its memory
+        // cache, but the request construction itself is non-zero.
+        if (currentSrc == value) return
+        currentSrc = value
+        reload()
+    }
+
+    /**
+     * Backing of the `mode` prop. Maps the Lynx-convention mode
+     * strings onto `ImageView.ScaleType`. Unknown values fall back
+     * to `aspectFill` (CENTER_CROP).
+     */
+    fun setMode(value: String) {
+        val imageView = view ?: return
+        imageView.scaleType = when (value) {
+            "aspectFill" -> ImageView.ScaleType.CENTER_CROP
+            "aspectFit" -> ImageView.ScaleType.FIT_CENTER
+            "scaleToFill" -> ImageView.ScaleType.FIT_XY
+            "center" -> ImageView.ScaleType.CENTER
+            else -> ImageView.ScaleType.CENTER_CROP
+        }
+    }
+
+    /**
+     * Issue (or re-issue) a Coil request for the current `src` with
+     * the current `cornerRadiusPx`. Called from `setSrc` and from
+     * `updatePropertiesInterval` when the radius changes.
+     */
+    private fun reload() {
+        val src = currentSrc ?: return
+        val imageView = view ?: return
+
+        // Cancel any prior request. `dispose()` is a no-op if the
+        // disposable has already completed.
+        currentRequest?.dispose()
+        imageView.dispose()
+
+        if (src.isBlank()) {
+            imageView.setImageDrawable(null)
+            currentRequest = null
+            return
+        }
+
+        currentRequest = imageView.load(src) {
+            crossfade(200)
+            memoryCachePolicy(CachePolicy.ENABLED)
+            diskCachePolicy(CachePolicy.ENABLED)
+            if (cornerRadiusPx > 0f) {
+                transformations(RoundedCornersTransformation(cornerRadiusPx))
+            }
+        }
+    }
+
+    private companion object {
+        val CORNER_KEYS = listOf(
+            "border-top-left-radius",
+            "border-top-right-radius",
+            "border-bottom-right-radius",
+            "border-bottom-left-radius",
+        )
+    }
+}

--- a/packages/whisker-image/build.gradle.kts
+++ b/packages/whisker-image/build.gradle.kts
@@ -1,0 +1,59 @@
+// Gradle build for `whisker-image`'s Android half.
+//
+// Mirrors `whisker-video`'s shape: one KSP-processed module subproject
+// with sources under `android/src/main/kotlin`, depending on Whisker's
+// runtime + Coil for URL-based image loading.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.image"
+    compileSdk = 34
+
+    defaultConfig {
+        // Coil 2.7 needs API 21+, which lines up with Whisker's
+        // baseline. We don't drop to anything lower — Coil 1.x is
+        // unmaintained and lacks the coroutine-native API the
+        // ImageView code below leans on.
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    // Source set redirection so AGP only scans the `android/` subtree;
+    // Rust's `src/` next to this file stays out of the Kotlin
+    // compiler's view.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerImage")
+    arg("whisker.crateName", "whisker-image")
+}
+
+dependencies {
+    implementation(project(":module"))
+    ksp("rs.whisker:ksp")
+
+    // Coil 2.7 — Kotlin-first, coroutine-native image loader. Base
+    // artifact covers PNG / JPEG / static WebP (Android 14+ native
+    // for WebP / AVIF — older OS WebP falls through to the GIF
+    // backport). GIF / SVG / animated WebP backport are separate
+    // artifacts and intentionally not pulled here; the base module
+    // stays slim, consumers add what they need.
+    implementation("io.coil-kt:coil:2.7.0")
+}

--- a/packages/whisker-image/ios/Sources/WhiskerImage/ImageModule.swift
+++ b/packages/whisker-image/ios/Sources/WhiskerImage/ImageModule.swift
@@ -1,0 +1,33 @@
+// `whisker-image` ModuleDefinition (iOS).
+//
+// Mirrors `whisker-video`'s `VideoModule` shape — the codegen plugin
+// scans this Swift target for any concrete subclass of `Module` and
+// emits a registration block in `<Target>+Generated.swift` that:
+//
+//   - Reads `definitionLazy.view!.viewClass` (== `WhiskerImageView`).
+//   - Calls `LynxComponentRegistry.registerUI(viewClass, withName:
+//     "whisker-image:Image")`.
+//   - Calls `module.registerWithLynx()` so the DSL's `Prop("src")` +
+//     `Prop("mode")` install via the Obj-C-runtime path (L-2b).
+//
+// The `WhiskerImageView` Lynx UI subclass this references lives in
+// `ImageView.swift`. Same split on Android (`ImageModule.kt` +
+// `WhiskerImageView.kt`).
+
+import WhiskerModule
+
+public final class ImageModule: Module {
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("Image")
+            View(WhiskerImageView.self) {
+                Prop("src") { (view: WhiskerImageView, value: WhiskerValue) in
+                    view.setSrc(value.asString ?? "")
+                }
+                Prop("mode") { (view: WhiskerImageView, value: WhiskerValue) in
+                    view.setMode(value.asString ?? "aspectFill")
+                }
+            }
+        }
+    }
+}

--- a/packages/whisker-image/ios/Sources/WhiskerImage/ImageView.swift
+++ b/packages/whisker-image/ios/Sources/WhiskerImage/ImageView.swift
@@ -1,0 +1,113 @@
+// Lynx UI subclass hosting a UIImageView + Kingfisher-driven URL
+// loading. A plain `WhiskerUI<UIImageView>` subclass — no Whisker
+// annotations; registration is driven by `ImageModule`'s
+// `definition()` (see `ImageModule.swift`).
+//
+// `@objc(WhiskerImageView)` pins the Obj-C class name to the bare
+// `WhiskerImageView` so the codegen plugin's `NSClassFromString`
+// lookup can find it under either the SwiftPM-target-prefixed form
+// (`whisker_image.WhiskerImageView`) or the bare form.
+//
+// ## Corners — iOS does it natively
+//
+// CSS `border-radius` Just Works on iOS without any subclass-side
+// help. Lynx iOS dispatches props via the Obj-C runtime (the
+// `LYNX_PROP_DEFINE("border-radius", setBorderRadius, …)` macro on
+// `LynxUI`), so the base class's setter resolves through the normal
+// class hierarchy and reaches every custom subclass. The base then
+// updates `_backgroundManager.borderRadius` and the `clipOnBorderRadius`
+// flag (default `YES`) clips the view's CALayer — UIImageView's
+// bitmap is rounded along with it.
+//
+// Android can't piggy-back on this because it uses APT-generated
+// `$$PropsSetter` static dispatch tables that don't extend to
+// runtime-registered custom modules. See `WhiskerImageView.kt` for
+// the corresponding workaround.
+
+import Foundation
+import Kingfisher
+import UIKit
+import WhiskerModule
+
+@objc(WhiskerImageView)
+public final class WhiskerImageView: WhiskerUI<UIImageView> {
+
+    private var currentSrc: String?
+
+    @objc public override func createView() -> UIImageView {
+        let v = UIImageView()
+        // Default to `aspectFill` to match the Lynx `mode` default;
+        // `setMode(_:)` flips it as soon as a non-default value
+        // lands. `clipsToBounds` is required for `aspectFill` so the
+        // overflowing edges don't paint beyond the element's frame.
+        v.contentMode = .scaleAspectFill
+        v.clipsToBounds = true
+        return v
+    }
+
+    /// Backing of the `src` prop. Kicks off a Kingfisher fetch on
+    /// the image view itself — Kingfisher tracks the in-flight
+    /// request against the view, so a second `setSrc` cancels the
+    /// first automatically.
+    public func setSrc(_ value: String) {
+        // No-op on equal — avoids re-fetching on a benign re-render
+        // (e.g. a parent re-renders but the src signal didn't
+        // actually change). Kingfisher would itself short-circuit
+        // via its cache, but the work to ask the cache + recreate
+        // the request is non-zero.
+        if currentSrc == value { return }
+        currentSrc = value
+
+        let imageView: UIImageView = self.view()
+        guard let url = URL(string: value) else {
+            // Bad URL — clear any previous image so the element
+            // doesn't keep showing a stale shot.
+            imageView.kf.cancelDownloadTask()
+            imageView.image = nil
+            return
+        }
+
+        // Kingfisher request. Options worth turning on by default:
+        //   - `.transition(.fade(0.2))` — soft fade-in avoids the
+        //     flash from placeholder to image. 200ms matches iOS-
+        //     system convention.
+        //   - `.cacheOriginalImage` — store the decoded original
+        //     alongside the resized variant so a `mode` change
+        //     (which usually doesn't trigger a reload) doesn't have
+        //     to redecode from disk.
+        //   - `.scaleFactor(UIScreen.main.scale)` — request 2x / 3x
+        //     bitmaps on Retina so the rendered image is sharp.
+        let options: KingfisherOptionsInfo = [
+            .transition(.fade(0.2)),
+            .cacheOriginalImage,
+            .scaleFactor(UIScreen.main.scale),
+        ]
+        imageView.kf.setImage(with: url, options: options)
+    }
+
+    /// Backing of the `mode` prop. Maps the Lynx-convention mode
+    /// strings onto `UIView.ContentMode`. Unknown values fall back
+    /// to `aspectFill` (the most common choice for square artwork).
+    ///
+    /// `clipsToBounds = true` is also what makes Lynx's
+    /// CSS-driven `cornerRadius` actually clip the painted bitmap.
+    /// We keep the flag enabled even for the `aspectFit` /
+    /// `scaleToFill` cases where the scale itself wouldn't
+    /// otherwise need clipping.
+    public func setMode(_ value: String) {
+        let imageView: UIImageView = self.view()
+        switch value {
+        case "aspectFill":
+            imageView.contentMode = .scaleAspectFill
+        case "aspectFit":
+            imageView.contentMode = .scaleAspectFit
+        case "scaleToFill":
+            imageView.contentMode = .scaleToFill
+        case "center":
+            imageView.contentMode = .center
+        default:
+            imageView.contentMode = .scaleAspectFill
+        }
+        imageView.clipsToBounds = true
+    }
+}

--- a/packages/whisker-image/src/lib.rs
+++ b/packages/whisker-image/src/lib.rs
@@ -1,0 +1,63 @@
+//! `whisker-image` — networked image component.
+//!
+//! Mounts a `whisker-image:Image` element backed by:
+//!
+//! - **iOS**: `UIImageView` + [Kingfisher](https://github.com/onevcat/Kingfisher)
+//!   for URL fetching, in-memory `NSCache`, and on-disk cache.
+//! - **Android**: `ImageView` + [Coil](https://coil-kt.github.io/coil/)
+//!   for URL fetching, `LruCache`, and disk cache.
+//!
+//! ## Why a separate module instead of Lynx's `<image>`?
+//!
+//! Lynx ships a `LynxServiceImageProtocol` interface that's expected
+//! to be implemented + registered by the host app (Lynx's own
+//! `LynxImageService` uses SDWebImage on iOS / Fresco on Android,
+//! but it's a separate subspec that consumers wire themselves). The
+//! Whisker iOS / Android distribution doesn't include any
+//! implementation, so a bare `<image src="…">` mounts a `UIImageView`
+//! whose `image` property never gets assigned. `whisker-image` skips
+//! the Lynx image stack entirely and drives the URL load from the
+//! native module directly — same idea as `whisker-video` for media
+//! playback.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use whisker::prelude::*;
+//! use whisker_image::{Image, ImageProps};
+//!
+//! #[whisker::main]
+//! fn app() -> Element {
+//!     render! {
+//!         Image(
+//!             src: "https://example.com/cover.jpg",
+//!             mode: "aspectFill",
+//!             style: "width: 240px; height: 240px; border-radius: 8px;",
+//!         )
+//!     }
+//! }
+//! ```
+//!
+//! ## Props
+//!
+//! - `src` — image URL (HTTPS recommended; `http://` works if the
+//!   host app's network security config allows cleartext).
+//! - `mode` — content fit. `"aspectFill"` (centre-crop, default),
+//!   `"aspectFit"` (letterbox), `"scaleToFill"` (stretch).
+//! - `style` — standard Whisker style string. Width / height must be
+//!   set on the element (or via flex sizing) — Kingfisher / Coil
+//!   target-size the fetched bitmap against the rendered size, so an
+//!   element with `width: 0; height: 0;` would never paint.
+
+use whisker::Signal;
+
+/// `whisker-image:Image` element. All props are reactive — the
+/// platform-side setters re-apply whenever the bound signals change,
+/// so a `src` swap re-fetches and a `mode` swap re-lays-out without
+/// remount. Corners follow the standard CSS `border-radius` in the
+/// `style:` cascade (iOS clips via `UIView.layer.cornerRadius` +
+/// `clipsToBounds`; Android extracts the parsed radius from Lynx's
+/// `onBorderRadiusUpdated` callback and feeds it to Coil's
+/// `RoundedCornersTransformation`).
+#[whisker::module_component("Image")]
+pub fn image(src: Signal<String>, mode: Signal<String>, style: Signal<String>) {}


### PR DESCRIPTION
## Summary

- New `packages/whisker-image` — `whisker-module` component hosting UIImageView (iOS, **Kingfisher**) / ImageView (Android, **Coil**). Exposes `Image(src:, mode:, style:)`. The Whisker distribution ships no `LynxServiceImageProtocol` impl, so Lynx-native `<image>` never paints; `whisker-image` is the de-facto image library going forward.
- Drops the built-in `<image>` element entirely — `ElementTag::Image` / the `image()` builder + 14 inherent attrs + 5 typed event hooks / `ImageHandle` / `ImageLoadEvent`. One image story, no dead surface.

A production-grade consumer example (`examples/podcast`) is split into PR #105 stacked on top of this branch.

## CSS `border-radius` story

- **iOS** works out of the box. Lynx dispatches CSS via the Obj-C runtime (\`LYNX_PROP_DEFINE(\"border-radius\", setBorderRadius, …)\`), so the base class setter resolves through normal inheritance and \`clipOnBorderRadius\` (default \`YES\`) clips the UIView layer.
- **Android** dispatches CSS through APT-generated \`<UIClass>\$\$PropsSetter\` classes that don't extend to runtime-registered custom modules — the typed \`setBorderRadius\` hook never fires for \`WhiskerImageView\`. CSS *does* still arrive via the legacy \`StylesDiffMap.mBackingMap\` (kebab-case keys), so the Android side overrides \`updatePropertiesInterval\` and forwards the 4 corner radii (already density-multiplied to px) to Coil's \`RoundedCornersTransformation\`.

Single user-facing surface on both platforms: \`style: \"border-radius: 8px;\"\`.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo test --workspace\` green
- [ ] PR #105 (podcast example consumer): iOS / Android visual check

🤖 Generated with [Claude Code](https://claude.com/claude-code)