### PR TITLE
feat(safe-area): whisker-safe-area module + Android edge-to-edge enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,6 +989,7 @@ dependencies = [
  "podcast-theme",
  "whisker",
  "whisker-image",
+ "whisker-safe-area",
 ]
 
 [[package]]
@@ -1947,6 +1948,13 @@ dependencies = [
  "serde",
  "serde_json",
  "slotmap",
+]
+
+[[package]]
+name = "whisker-safe-area"
+version = "0.1.0"
+dependencies = [
+ "whisker",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "packages/whisker-local-store",
     "packages/whisker-router",
     "packages/whisker-router-macros",
+    "packages/whisker-safe-area",
     "packages/whisker-video",
 ]
 exclude = [

--- a/crates/whisker-cng/src/templates/android/app/src/main/kotlin/MainActivity.kt
+++ b/crates/whisker-cng/src/templates/android/app/src/main/kotlin/MainActivity.kt
@@ -1,22 +1,15 @@
 package {{android_application_id}}
 
-import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
-import rs.whisker.runtime.WhiskerView
+import rs.whisker.runtime.WhiskerActivity
 
-class MainActivity : AppCompatActivity() {
-    private var whiskerView: WhiskerView? = null
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val view = WhiskerView(this)
-        whiskerView = view
-        setContentView(view)
-    }
-
-    override fun onDestroy() {
-        whiskerView?.destroy()
-        whiskerView = null
-        super.onDestroy()
-    }
-}
+/**
+ * Host Activity for the Whisker app.
+ *
+ * Empty by design — [WhiskerActivity] handles WhiskerView instantiation,
+ * lifecycle forwarding, edge-to-edge window configuration, and system-bar
+ * styling. Override `onCreate(savedInstanceState)` here only if the app
+ * needs to wire something **before** the WhiskerView is set as the
+ * content view (e.g. installing a SplashScreen). Always call
+ * `super.onCreate(savedInstanceState)` last in that case.
+ */
+class MainActivity : WhiskerActivity()

--- a/examples/podcast/crates/podcast-ui-kit/Cargo.toml
+++ b/examples/podcast/crates/podcast-ui-kit/Cargo.toml
@@ -16,5 +16,10 @@ whisker = { workspace = true }
 # (which Whisker doesn't ship), so we use the module-component path
 # instead. See `WhiskerImage`'s crate docs for the rationale.
 whisker-image = { path = "../../../../packages/whisker-image" }
+# `whisker-safe-area` exposes the host view's safe-area insets as a
+# reactive `ReadSignal<SafeAreaInsets>`. `top_nav` reads it to pad the
+# bar correctly under the notch / Dynamic Island instead of hard-
+# coding 44pt.
+whisker-safe-area = { path = "../../../../packages/whisker-safe-area" }
 podcast-theme = { path = "../podcast-theme" }
 podcast-domain = { path = "../podcast-domain" }

--- a/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
@@ -9,6 +9,7 @@
 use podcast_theme as theme;
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
+use whisker_safe_area::safe_area_insets;
 
 /// Title shown centred in the bar. Action label shown trailing.
 /// Both are plain strings so the host screen can localise without
@@ -22,16 +23,22 @@ pub fn top_nav(title: String, action_label: String) -> Element {
     // wrapper / row keeps `NAV_HEIGHT` purely about the nav
     // content area.
     //
-    // Lynx doesn't expose `env(safe-area-inset-top)` yet, so we
-    // hard-code 44pt — works on every iPhone since the notch and
-    // is harmless on Android (the host already inset-pads the
-    // WhiskerView for status bar).
-    let wrapper_style = format!(
-        "width: 100%; padding-top: 44px; \
-         flex-shrink: 0; \
-         background-color: {bg};",
-        bg = theme::BG,
-    );
+    // `safe_area_insets()` returns a process-wide `ReadSignal` —
+    // re-fires on rotation / Dynamic Island / notch / Android edge-
+    // to-edge toggle. `computed` derives a `ReadSignal<String>` the
+    // `style:` prop wires as a reactive style binding, so the bar
+    // re-pads automatically without us touching state from the
+    // component body.
+    let insets = safe_area_insets();
+    let bg = theme::BG;
+    let wrapper_style = computed(move || {
+        format!(
+            "width: 100%; padding-top: {top}px; \
+             flex-shrink: 0; \
+             background-color: {bg};",
+            top = insets.get().top,
+        )
+    });
     let bar_style = format!(
         "width: 100%; min-height: {h}; \
          flex-shrink: 0; \

--- a/packages/whisker-safe-area/Cargo.toml
+++ b/packages/whisker-safe-area/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "whisker-safe-area"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Whisker module exposing the host view's safe-area insets as a reactive ReadSignal<SafeAreaInsets>. iOS reads UIView.safeAreaInsets; Android reads WindowInsetsCompat (systemBars + displayCutout). Android edge-to-edge off → all-zero insets (graceful degrade)."
+
+# Explicit `include` list — mirrors `whisker-image` / `whisker-video`.
+# `cargo publish` ships the Kotlin + Swift platform sources alongside
+# `src/lib.rs`, but never the local Gradle / Xcode build artifacts.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "src/lib.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker. The bare table identifies this cargo
+# crate as a Whisker module; `whisker-build` walks the consuming app's
+# dep tree, picks out every dep carrying it, and wires the Android
+# Gradle subproject + iOS SwiftPM package into the host build.
+[package.metadata.whisker]
+
+[dependencies]
+whisker = { workspace = true }

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -1,0 +1,53 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for the `whisker-safe-area` module package.
+//
+// Mirrors `whisker-image` / `whisker-video`'s shape: one library
+// target with sources under `ios/Sources/WhiskerSafeArea`, the
+// WhiskerModuleCodegenPlugin wired so the Module subclass
+// registration lands in `<Target>+Generated.swift` at build time.
+//
+// `whisker-build` injects the absolute location of Whisker's iOS
+// runtime + macros packages via these env vars, so this module
+// resolves them no matter where the crate lives — in the monorepo,
+// in a user's whisker project, or unpacked from the cargo registry.
+
+import PackageDescription
+
+guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
+      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
+else {
+    fatalError("""
+        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
+        module through `whisker run` / `whisker build`, which inject these paths.
+        """)
+}
+
+let package = Package(
+    name: "whisker-safe-area",
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
+    ],
+    dependencies: [
+        .package(name: "macros", path: whiskerMacrosPath),
+        .package(name: "WhiskerRuntime", path: whiskerRuntimePath),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerSafeArea",
+            dependencies: [
+                // WhiskerRuntime re-exports both WhiskerModule (the
+                // Module base + DSL) and WhiskerDriver (the
+                // NotificationCenter name constant the safeAreaInsetsDidChange
+                // hook posts under).
+                .product(name: "WhiskerModule", package: "WhiskerRuntime"),
+                .product(name: "WhiskerRuntime", package: "WhiskerRuntime"),
+            ],
+            path: "ios/Sources/WhiskerSafeArea",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "macros"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-safe-area/android/src/main/kotlin/rs/whisker/modules/safe_area/SafeAreaModule.kt
+++ b/packages/whisker-safe-area/android/src/main/kotlin/rs/whisker/modules/safe_area/SafeAreaModule.kt
@@ -1,0 +1,148 @@
+// `whisker-safe-area` Module (Android).
+//
+// View-less. Hooks `ViewCompat.setOnApplyWindowInsetsListener` onto
+// the host Activity's decor view while at least one Rust listener is
+// registered against the `insetsChanged` event; converts the system-
+// bar + display-cutout insets to dp and dispatches.
+//
+// The Rust side (`packages/whisker-safe-area/src/lib.rs`) is the only
+// consumer — it holds the `RwSignal<SafeAreaInsets>` returned by
+// `safe_area_insets()` and updates it from this module's events.
+//
+// ## Inset semantics
+//
+// `WhiskerActivity` enforces edge-to-edge
+// (`WindowCompat.setDecorFitsSystemWindows(window, false)` +
+// `isNavigationBarContrastEnforced = false`), so WhiskerView always
+// fills the entire window. The values forwarded here — read from
+// `getRootWindowInsets(decorView).getInsets(systemBars() or
+// displayCutout())` — therefore map 1:1 to padding on the WhiskerView
+// (no double-padding to dodge, regardless of theme).
+//
+// ## Lifecycle + configuration change handling
+//
+// Activities without `android:configChanges="orientation|screenSize"`
+// get destroyed + recreated on rotation; the new WhiskerView calls
+// `WhiskerAppContext.pushHost`, which re-fires every registered
+// `HostAttachedListener`. We exploit that: the inset listener is
+// (re)installed inside the HostAttachedListener body so each
+// recreation transparently picks up the fresh decor view. The old
+// listener pins nothing (Android stores it on the dead view) and
+// gets GC'd with its host.
+//
+// * `OnStartObserving("insetsChanged")` — register a permanent
+//   HostAttachedListener. It fires synchronously if a host is
+//   already attached (covering steady-state), and every subsequent
+//   `pushHost` (covering rotation, multi-window resize that
+//   recreates the activity, etc.).
+// * `OnStopObserving("insetsChanged")` — drop the host listener.
+//   The most recently installed inset listener stays on its view
+//   until the view dies, but no more Rust events fire because the
+//   bridge has no Rust subscribers.
+
+package rs.whisker.modules.safe_area
+
+import android.app.Activity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import rs.whisker.runtime.HostAttachedListener
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerValue
+
+public class SafeAreaModule : Module() {
+
+    /**
+     * Live host-attached listener. `null` between `OnStopObserving`
+     * tearing it down and the next `OnStartObserving` re-registering.
+     * The listener body re-installs the inset listener on whichever
+     * decor view is current at fire time, so a config-change
+     * Activity recreation transparently rewires.
+     */
+    private var attachListener: HostAttachedListener? = null
+
+    public override fun definition(): ModuleDefinition = ModuleDefinition {
+        Name("SafeArea")
+        Events("insetsChanged")
+
+        OnStartObserving("insetsChanged") {
+            if (attachListener != null) return@OnStartObserving
+
+            val listener = HostAttachedListener { installOnCurrentHost() }
+            attachListener = listener
+            // `addOnHostAttachedListener` fires synchronously once if
+            // a host is already attached (the steady-state case) and
+            // every time a new host attaches afterwards (the rotation
+            // case). Either way we end up with the inset listener
+            // installed on the live decor view.
+            appContext.addOnHostAttachedListener(listener)
+        }
+
+        OnStopObserving("insetsChanged") {
+            attachListener?.let {
+                appContext.removeOnHostAttachedListener(it)
+            }
+            attachListener = null
+            // Note: we don't bother clearing the inset listener off
+            // the most recently used decor view — when the Rust side
+            // has no subscribers, `sendEvent` becomes a no-op on the
+            // bridge, so the listener firing harmlessly drops into
+            // the void. The view will GC its listener slot when it
+            // itself goes away.
+        }
+    }
+
+    /**
+     * Install (or re-install) the inset listener on the current host
+     * Activity's decor view, and seed the Rust signal with the
+     * currently-known insets so a fresh activity doesn't sit at the
+     * last rotation's values until the next genuine inset change.
+     */
+    private fun installOnCurrentHost() {
+        val activity = appContext.currentActivity ?: return
+        val decor = activity.window?.decorView ?: return
+
+        ViewCompat.setOnApplyWindowInsetsListener(decor) { _, insetsCompat ->
+            dispatch(activity, insetsCompat)
+            // Pass through unmodified so other consumers in the
+            // hierarchy (e.g. Lynx's own listeners) still see the
+            // same `WindowInsetsCompat`. Consuming here would mask
+            // the insets from the rest of the view tree.
+            insetsCompat
+        }
+
+        // Seed with current insets so a late subscriber (or a
+        // post-rotation freshly-attached activity) doesn't sit at
+        // `default()` until the next genuine WindowInsets dispatch.
+        // `getRootWindowInsets` returns null until the view has been
+        // measured at least once — that's fine, the listener will
+        // pick the first real fire up.
+        ViewCompat.getRootWindowInsets(decor)?.let { dispatch(activity, it) }
+    }
+
+    /**
+     * Convert system-bar + display-cutout insets to dp and forward as
+     * a `WhiskerValue.Map` payload.
+     *
+     * `decorFitsSystemWindows = true` (Whisker default) means the
+     * activity has already cut out the insets before they reach
+     * `decorView`, so `getInsets(systemBars() or displayCutout())`
+     * returns zero — see the module-level doc for the graceful-
+     * degrade reasoning.
+     */
+    private fun dispatch(activity: Activity, insets: WindowInsetsCompat) {
+        val mask = WindowInsetsCompat.Type.systemBars() or
+            WindowInsetsCompat.Type.displayCutout()
+        val raw = insets.getInsets(mask)
+
+        val density = activity.resources.displayMetrics.density.takeIf { it > 0f } ?: 1f
+
+        val payload = mapOf(
+            "top" to WhiskerValue.Float((raw.top / density).toDouble()),
+            "leading" to WhiskerValue.Float((raw.left / density).toDouble()),
+            "trailing" to WhiskerValue.Float((raw.right / density).toDouble()),
+            "bottom" to WhiskerValue.Float((raw.bottom / density).toDouble()),
+        )
+        sendEvent("insetsChanged", WhiskerValue.Map(payload))
+    }
+}

--- a/packages/whisker-safe-area/build.gradle.kts
+++ b/packages/whisker-safe-area/build.gradle.kts
@@ -1,0 +1,57 @@
+// Gradle build for `whisker-safe-area`'s Android half.
+//
+// Mirrors `whisker-image` / `whisker-video`'s shape: one KSP-processed
+// module subproject with sources under `android/src/main/kotlin`,
+// depending on Whisker's runtime + AndroidX core for the
+// `WindowInsetsCompat` API.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.safe_area"
+    compileSdk = 34
+
+    defaultConfig {
+        // AndroidX core's `WindowInsetsCompat` works back to API 14;
+        // we keep Whisker's standard minSdk = 21 baseline.
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    // Source set redirection so AGP only scans the `android/` subtree;
+    // Rust's `src/` next to this file stays out of the Kotlin
+    // compiler's view.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerSafeArea")
+    arg("whisker.crateName", "whisker-safe-area")
+}
+
+dependencies {
+    implementation(project(":module"))
+    ksp("rs.whisker:ksp")
+
+    // `WindowInsetsCompat` + `ViewCompat.setOnApplyWindowInsetsListener`
+    // — the AndroidX wrappers that paper over the API-30 introduction
+    // of typed inset categories. Keeping the dep on `core-ktx`
+    // (rather than vanilla `core`) lets us use the inline
+    // `getInsets(systemBars() or displayCutout())` syntax.
+    implementation("androidx.core:core-ktx:1.13.1")
+}

--- a/packages/whisker-safe-area/ios/Sources/WhiskerSafeArea/SafeAreaModule.swift
+++ b/packages/whisker-safe-area/ios/Sources/WhiskerSafeArea/SafeAreaModule.swift
@@ -1,0 +1,125 @@
+// `whisker-safe-area` Module (iOS).
+//
+// View-less module. Subscribes to `WhiskerView`'s
+// `safeAreaInsetsDidChangeNotification` once at least one Rust
+// listener is registered against the `insetsChanged` event; converts
+// the firing view's `UIEdgeInsets` into a `WhiskerValue.map` payload
+// and dispatches.
+//
+// The Rust side (`packages/whisker-safe-area/src/lib.rs`) is the only
+// consumer — it holds the `RwSignal<SafeAreaInsets>` `safe_area_insets()`
+// returns and updates it from this module's events.
+//
+// ## Lifecycle
+//
+// * `OnStartObserving("insetsChanged")` — register the
+//   `NotificationCenter` observer **and** push the current insets of
+//   any already-attached `WhiskerView` so the signal isn't stuck at
+//   `default()` after a late subscription (e.g. a component that
+//   mounts after the host view has finished laying out).
+// * `OnStopObserving("insetsChanged")` — remove the observer. The
+//   bridge guarantees this fires on the 1→0 transition, so we don't
+//   leak the closure.
+
+import Foundation
+import UIKit
+import WhiskerModule
+import WhiskerRuntime
+
+public final class SafeAreaModule: Module {
+
+    /// Live `NotificationCenter` observer token. `nil` between the
+    /// `OnStopObserving` removal and the next `OnStartObserving`
+    /// install. Stored so the matching remove call targets the same
+    /// token (`NotificationCenter.removeObserver(_:)` keys on
+    /// identity).
+    private var observerToken: NSObjectProtocol?
+
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("SafeArea")
+            Events("insetsChanged")
+
+            OnStartObserving("insetsChanged") { [weak self] in
+                self?.startObserving()
+            }
+            OnStopObserving("insetsChanged") { [weak self] in
+                self?.stopObserving()
+            }
+        }
+    }
+
+    private func startObserving() {
+        if observerToken != nil { return }
+
+        observerToken = NotificationCenter.default.addObserver(
+            forName: WhiskerView.safeAreaInsetsDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let insets = note.userInfo?[WhiskerView.safeAreaInsetsKey]
+                as? UIEdgeInsets else { return }
+            self?.sendEvent("insetsChanged", Self.encode(insets))
+        }
+
+        // Late-subscription priming: if a WhiskerView is already
+        // attached and laid out, its `safeAreaInsetsDidChange` has
+        // already fired (before our observer existed). Walk the
+        // connected scenes and push the current value of any
+        // matching key window's root so the Rust signal moves off
+        // `default()` immediately.
+        if let insets = currentAttachedInsets() {
+            sendEvent("insetsChanged", Self.encode(insets))
+        }
+    }
+
+    private func stopObserving() {
+        if let token = observerToken {
+            NotificationCenter.default.removeObserver(token)
+        }
+        observerToken = nil
+    }
+
+    /// Find the first attached `WhiskerView`'s safe-area insets among
+    /// the connected scenes. Returns `nil` if no `WhiskerView` is on
+    /// screen yet (cold start before first attach) — the regular
+    /// notification path takes over once one mounts.
+    private func currentAttachedInsets() -> UIEdgeInsets? {
+        for scene in UIApplication.shared.connectedScenes {
+            guard let windowScene = scene as? UIWindowScene else { continue }
+            for window in windowScene.windows {
+                if let view = findWhiskerView(in: window) {
+                    return view.safeAreaInsets
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Recursive search for the first `WhiskerView` in a view tree.
+    /// Linear in the number of subviews — fine for the one-shot
+    /// startObserving priming. Apps with multiple WhiskerViews get the
+    /// first one in tree order; the regular notification path
+    /// thereafter handles the per-instance broadcast.
+    private func findWhiskerView(in view: UIView) -> WhiskerView? {
+        if let v = view as? WhiskerView { return v }
+        for child in view.subviews {
+            if let v = findWhiskerView(in: child) { return v }
+        }
+        return nil
+    }
+
+    /// `UIEdgeInsets` → `WhiskerValue.map` with the keys the Rust
+    /// side's `decode_payload` expects. iOS's `UIEdgeInsets` uses
+    /// `left` / `right` (not `leading` / `trailing`) — map directly,
+    /// LTR-only for now. RTL-aware modules can read
+    /// `effectiveUserInterfaceLayoutDirection` later if needed.
+    static func encode(_ insets: UIEdgeInsets) -> WhiskerValue {
+        .map([
+            "top": .float(Double(insets.top)),
+            "leading": .float(Double(insets.left)),
+            "trailing": .float(Double(insets.right)),
+            "bottom": .float(Double(insets.bottom)),
+        ])
+    }
+}

--- a/packages/whisker-safe-area/src/lib.rs
+++ b/packages/whisker-safe-area/src/lib.rs
@@ -1,0 +1,192 @@
+//! `whisker-safe-area` — reactive accessor for the host view's
+//! safe-area insets.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use whisker::prelude::*;
+//! use whisker_safe_area::safe_area_insets;
+//!
+//! #[component]
+//! fn screen() -> Element {
+//!     let insets = safe_area_insets();
+//!     let outer_style = move || {
+//!         let i = insets.get();
+//!         format!(
+//!             "padding-top: {}px; padding-bottom: {}px; \
+//!              padding-left: {}px; padding-right: {}px;",
+//!             i.top, i.bottom, i.leading, i.trailing,
+//!         )
+//!     };
+//!     render! {
+//!         view(style: outer_style()) {
+//!             // ...
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! ## Platform behaviour
+//!
+//! - **iOS**: reads `UIView.safeAreaInsets` from the host
+//!   `WhiskerView`. Re-fires on `safeAreaInsetsDidChange()`
+//!   (rotation, multitasking, notch / Dynamic Island, home indicator).
+//! - **Android**: reads
+//!   `WindowInsetsCompat.getInsets(systemBars() | displayCutout())`
+//!   from the host Activity's decor view. Re-fires through
+//!   `OnApplyWindowInsetsListener`, and the module re-installs the
+//!   listener on each new host attach so a config-change Activity
+//!   recreation (the default behaviour without
+//!   `android:configChanges="orientation|screenSize"` on the manifest)
+//!   transparently rewires.
+//!
+//! Both platforms report values that map 1:1 to padding on the host
+//! `WhiskerView`. Whisker's `WhiskerActivity` enforces Android edge-
+//! to-edge (`setDecorFitsSystemWindows(false)` +
+//! `isNavigationBarContrastEnforced = false`), so the WhiskerView
+//! always fills the entire window and `padding-top: insets.top`
+//! applied to a child of WhiskerView lines up exactly with the
+//! status bar's bottom edge. No double-padding caveat to track —
+//! same semantics as iOS.
+//!
+//! ## Single source of truth
+//!
+//! Every `safe_area_insets()` call hands back a `ReadSignal` cloned
+//! from one global `RwSignal<SafeAreaInsets>`. The first call kicks
+//! off the native-event subscription; subsequent calls are free.
+//! Values stay live for the entire process — the module never
+//! unsubscribes.
+
+use std::sync::OnceLock;
+
+use whisker::module;
+use whisker::{signal, ReadSignal, WhiskerValue, WriteSignal};
+
+/// Safe-area inset amounts in **points (iOS) / dp (Android)** — the
+/// same density-independent units that the rest of Whisker's CSS
+/// pipeline uses for `px` literals.
+///
+/// `leading` / `trailing` follow the
+/// `NSDirectionalEdgeInsets`-style RTL-aware convention. Whisker
+/// itself doesn't formally support RTL yet, so for LTR-only layouts
+/// `leading == left` and `trailing == right` — read them as such
+/// when composing CSS `padding-left` / `padding-right`.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct SafeAreaInsets {
+    pub top: f64,
+    pub leading: f64,
+    pub trailing: f64,
+    pub bottom: f64,
+}
+
+/// Reactive accessor for the current safe-area insets.
+///
+/// All calls share one underlying signal pair, so reading from many
+/// components or effects is cheap (no extra subscription, no extra
+/// cross-platform round-trip). The signal starts at
+/// `SafeAreaInsets::default()` and updates as soon as the native side
+/// can push the host view's current values.
+///
+/// **Must be called from the main thread.** The underlying reactive
+/// runtime is thread-local; calling from a worker thread would either
+/// allocate a fresh detached signal (silently broken) or panic.
+pub fn safe_area_insets() -> ReadSignal<SafeAreaInsets> {
+    install();
+    SLOT.get().expect("install() ran above").inner
+}
+
+// ---- Internals -------------------------------------------------------------
+
+/// One-shot install of the global signal + the native subscription.
+/// Idempotent — re-entry on subsequent `safe_area_insets()` calls is
+/// a single `OnceLock::get()` check.
+fn install() {
+    SLOT.get_or_init(|| {
+        let (read, write) = signal(SafeAreaInsets::default());
+        // The bridge's `on_event` callback may fire from any thread
+        // depending on the host; the `WriteSignal` is `!Send`. We
+        // assert main-thread-only via [`MainThreadOnly`] and trust
+        // the platform contract (iOS posts from `safeAreaInsetsDidChange`
+        // on UI thread; Android posts from `OnApplyWindowInsetsListener`
+        // on UI thread). If a future host changes that, swap the
+        // closure body to `run_on_main_thread` first.
+        subscribe_to_native(MainThreadOnly { inner: write });
+        MainThreadOnly { inner: read }
+    });
+}
+
+/// Wire the global signal to the native module's `insetsChanged`
+/// event. The returned `ModuleSubscription` is intentionally leaked
+/// — the signal lives for the process lifetime, so the listener
+/// should too. Letting the subscription `Drop` would also drop the
+/// underlying closure pointer the bridge holds.
+fn subscribe_to_native(writer: MainThreadOnly<WriteSignal<SafeAreaInsets>>) {
+    let module = module!("SafeArea");
+    let sub = module.on_event("insetsChanged", move |payload| {
+        if let Some(insets) = decode_payload(payload) {
+            // Bind the wrapper (not `.inner`) so Rust 2021 disjoint
+            // captures move the `Send + Sync` impl as a whole.
+            let w = &writer;
+            w.inner.set(insets);
+        }
+    });
+    if let Some(err) = sub.error() {
+        eprintln!("[whisker-safe-area] failed to subscribe: {err}");
+    }
+    // Leak — see fn doc.
+    std::mem::forget(sub);
+}
+
+/// Decode a `{ top, leading, trailing, bottom }` map payload into the
+/// typed struct. Missing or non-numeric keys default to `0.0` — a
+/// malformed message degrades silently rather than wedging the
+/// subscription.
+fn decode_payload(value: WhiskerValue) -> Option<SafeAreaInsets> {
+    let WhiskerValue::Map(fields) = value else {
+        return None;
+    };
+    let f = |k: &str| -> f64 {
+        match fields.get(k) {
+            Some(WhiskerValue::Float(v)) => *v,
+            Some(WhiskerValue::Int(v)) => *v as f64,
+            _ => 0.0,
+        }
+    };
+    Some(SafeAreaInsets {
+        top: f("top"),
+        leading: f("leading"),
+        trailing: f("trailing"),
+        bottom: f("bottom"),
+    })
+}
+
+/// Static slot for the global signal pair + the subscription closure
+/// wrapper. `OnceLock` requires `Sync`; the inner value is `!Send` /
+/// `!Sync` because `ReadSignal` / `WriteSignal` are thread-local
+/// handles. We wrap in [`MainThreadOnly`] to satisfy the bound by
+/// asserting main-thread-only access; the contract is that
+/// `safe_area_insets()` callers run on the main thread (the reactive
+/// runtime constraint already requires that anyway).
+static SLOT: OnceLock<MainThreadOnly<ReadSignal<SafeAreaInsets>>> = OnceLock::new();
+
+/// Locally-scoped wrapper asserting main-thread-only access to
+/// `inner`. Used twice here: once for the static slot (so the
+/// `OnceLock<…>` static-Sync bound is satisfied), once for the
+/// `on_event` closure capture (so the `Send + Sync` bound on the
+/// bridge's callback is satisfied).
+///
+/// Same pattern `whisker-router::AndroidPredictiveBack` uses for its
+/// `Rc<dyn Fn()>` capture — see the comment there for the soundness
+/// argument. Lives here (not in `whisker-runtime`) until the bridge
+/// gains a proper main-thread-only listener API.
+#[derive(Copy, Clone)]
+struct MainThreadOnly<T> {
+    inner: T,
+}
+// Safety: every access path (signal read in `safe_area_insets`,
+// signal write in the `on_event` callback) is documented to run on
+// the Lynx TASM thread (= Whisker main thread). Misuse would
+// corrupt the reactive arena, but that's the same risk as calling
+// any signal API from a worker thread directly.
+unsafe impl<T> Send for MainThreadOnly<T> {}
+unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerActivity.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerActivity.kt
@@ -1,24 +1,166 @@
 package rs.whisker.runtime
 
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
 
 /**
  * Base Activity for Whisker apps.
  *
- * The CNG-generated `MainActivity` extends this and sets a `WhiskerView` as
- * its content view. Lifecycle events are forwarded to the Rust runtime via
- * JNI, but plugins are the typical consumers — user app code does not see
- * lifecycle events directly.
+ * Extends `androidx.activity.ComponentActivity` (NOT
+ * `AppCompatActivity`) on purpose: AppCompat injects a `subDecor`
+ * LinearLayout + status-bar-guard view between the decor view and
+ * the user's content. The guard takes up status-bar height even with
+ * `setDecorFitsSystemWindows(false)`, which prevents WhiskerView from
+ * actually filling the window and ruins the edge-to-edge story. Apps
+ * built on Whisker don't use AppCompat's actual feature set (themed
+ * dialogs, toolbar action bar, day-night, …) — they render exclusively
+ * through Lynx — so the dependency was carrying nothing but the bug.
+ *
+ * The CNG-generated `MainActivity` extends this and sets a
+ * `WhiskerView` as its content view. Lifecycle events forward to the
+ * Rust runtime via JNI; plugins are the typical consumers — user app
+ * code doesn't see lifecycle events directly.
+ *
+ * ## Edge-to-edge
+ *
+ * Whisker forces every host into edge-to-edge mode — `WhiskerView`
+ * always fills the entire window, including the area behind the
+ * status bar and navigation bar. Apps respect system UI by reading
+ * `safe_area_insets()` from `whisker-safe-area` and laying padding
+ * accordingly, **not** by relying on the activity to inset the
+ * content frame.
+ *
+ * Two motivations:
+ *
+ * 1. **API 35+ mandates it.** Apps targeting Android 15+ get
+ *    edge-to-edge unconditionally — `setDecorFitsSystemWindows(true)`
+ *    is silently ignored. Pre-empting that change here means Whisker
+ *    behaves the same across every supported Android version.
+ * 2. **Consistent inset semantics.** With the activity-inset path,
+ *    the insets `safe_area_insets()` reports (the window-level
+ *    system-bar dimensions) are *already* accounted for in the
+ *    WhiskerView's frame, so naively applying `padding-top: insets.top`
+ *    double-pads. Edge-to-edge collapses that ambiguity — the
+ *    reported values are exactly the padding the user component
+ *    needs.
+ *
+ * The corollary: `setStatusBarContrastEnforced` /
+ * `setNavigationBarContrastEnforced` (API 29+) are both forced to
+ * `false` so the system doesn't paint its own translucent scrim
+ * behind either bar — the app's background draws through cleanly.
  */
-open class WhiskerActivity : AppCompatActivity() {
+open class WhiskerActivity : ComponentActivity() {
 
     private var whiskerView: WhiskerView? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Edge-to-edge. AndroidX wrapper handles the API-level branching
+        // (the underlying platform call is `Window.setDecorFitsSystemWindows`,
+        // API 30+; below that the wrapper sets the legacy `SYSTEM_UI_FLAG_*`
+        // bits that achieve the same effect).
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        // Drop the theme-provided window background. With edge-to-edge
+        // + transparent system bars, anything WhiskerView doesn't paint
+        // over shows through; the default `Theme.*.NoActionBar` window
+        // background bleeds visibly through the status-bar area on
+        // dark-themed apps. Black is a safer default — apps that
+        // render light backgrounds tend to do so via a full-bleed root
+        // view that covers the window anyway, so an unseen black
+        // background hurts nobody.
+        window.setBackgroundDrawable(ColorDrawable(Color.BLACK))
+
+        // Drop the theme-provided system-bar background colours so the
+        // app's own background paints all the way to the screen edges.
+        // Modern Android (API 35+) ignores both setters — they're a
+        // no-op there — but on 21..34 they're how we actually clear the
+        // status / nav bar tint that themes default to.
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
+
+        // Stop the system from forcing its own translucent scrims behind
+        // status / navigation bars. The contrast-enforcement heuristic
+        // decides when to apply each based on the app's drawn pixel
+        // contrast against the system-bar foreground — we always want
+        // the app's own background to show through unmodified. Both
+        // setters are available from API 29; on API 35+ they're the
+        // *only* way to suppress the scrim, since the platform ignores
+        // `statusBarColor` / `navigationBarColor` from that release on.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isStatusBarContrastEnforced = false
+            window.isNavigationBarContrastEnforced = false
+        }
+
         val view = WhiskerView(this).also { whiskerView = it }
         setContentView(view)
+
+        // `windowDrawsSystemBarBackgrounds=true` (AppCompat default,
+        // inherited by `Theme.AppCompat.NoActionBar` even when we
+        // base on ComponentActivity) inflates a screen layout that
+        // includes a `statusBarBackground` / `navigationBarBackground`
+        // pair as sibling Views of the content frame inside a
+        // LinearLayout. Their non-zero `layout_height` /
+        // `layout_width` pushes the content down by the status-bar
+        // height (and right by the nav-bar width in landscape), so
+        // WhiskerView still doesn't actually fill the window even
+        // with edge-to-edge enabled. Walk the tree and collapse each
+        // to zero so the content frame snaps to (0,0).
+        view.post { collapseSystemBarGuards(window.decorView) }
+
+        // Force light foreground (icons / time) on the system bars.
+        // Default is light-when-the-window-background-is-dark, which
+        // the system computes from the *window* background colour
+        // (which we already pinned to black above). Setting both flags
+        // to `false` (= light foreground) is explicit, matches the
+        // dark baseline Whisker apps actually render, and survives a
+        // hosting MainActivity that flips the window background later.
+        // Hosts shipping a light theme can flip these in their own
+        // `onCreate` after calling `super.onCreate`.
+        WindowInsetsControllerCompat(window, view).apply {
+            isAppearanceLightStatusBars = false
+            isAppearanceLightNavigationBars = false
+        }
+    }
+
+    /**
+     * Walk `root` and collapse any `statusBarBackground` /
+     * `navigationBarBackground` View added by the platform's screen
+     * layout (PhoneWindow.generateLayout) when
+     * `windowDrawsSystemBarBackgrounds=true`. The guards sit as
+     * siblings of the content frame inside a LinearLayout, taking
+     * up status-bar / nav-bar dimensions — the LinearLayout's
+     * sequential positioning is what pushes the content (and our
+     * WhiskerView) down. Zeroing them out lets the content snap
+     * to (0, 0).
+     */
+    private fun collapseSystemBarGuards(root: android.view.View) {
+        if (root.id != android.view.View.NO_ID) {
+            val entryName = try {
+                root.resources.getResourceEntryName(root.id)
+            } catch (_: android.content.res.Resources.NotFoundException) {
+                null
+            }
+            if (entryName == "statusBarBackground" ||
+                entryName == "navigationBarBackground"
+            ) {
+                val lp = root.layoutParams
+                lp.height = 0
+                lp.width = 0
+                root.layoutParams = lp
+            }
+        }
+        if (root is android.view.ViewGroup) {
+            for (i in 0 until root.childCount) {
+                collapseSystemBarGuards(root.getChildAt(i))
+            }
+        }
     }
 
     override fun onResume() {

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -114,4 +114,38 @@ public final class WhiskerView: LynxView {
     public override func onEnterBackground() {
         super.onEnterBackground()
     }
+
+    // MARK: - Safe-area broadcast
+
+    /// Called by UIKit whenever the host view's `safeAreaInsets`
+    /// recompute — on first layout after attach, on rotation, on
+    /// multitasking split-screen resize, on notch / Dynamic Island
+    /// reveal. We re-broadcast through `NotificationCenter` so the
+    /// `whisker-safe-area:SafeArea` module can pick the change up
+    /// without holding a direct reference to this view.
+    ///
+    /// Loose-coupling through the notification keeps the runtime
+    /// agnostic of the safe-area module: the consumer crate is opt-
+    /// in. Apps that don't depend on `whisker-safe-area` pay only the
+    /// cost of one `NotificationCenter.post` per insets change, which
+    /// is rare and cheap.
+    public override func safeAreaInsetsDidChange() {
+        super.safeAreaInsetsDidChange()
+        NotificationCenter.default.post(
+            name: WhiskerView.safeAreaInsetsDidChangeNotification,
+            object: self,
+            userInfo: [WhiskerView.safeAreaInsetsKey: safeAreaInsets]
+        )
+    }
+
+    /// Posted on every `safeAreaInsetsDidChange()` fire. `object` is
+    /// the firing `WhiskerView`; `userInfo[safeAreaInsetsKey]` is a
+    /// `UIEdgeInsets`. Loose-coupling hook for the `whisker-safe-area`
+    /// module.
+    public static let safeAreaInsetsDidChangeNotification =
+        Notification.Name("WhiskerViewSafeAreaInsetsDidChange")
+
+    /// `userInfo` key carrying the `UIEdgeInsets` payload of
+    /// [`safeAreaInsetsDidChangeNotification`].
+    public static let safeAreaInsetsKey = "WhiskerViewSafeAreaInsets"
 }


### PR DESCRIPTION
## Summary

- New `packages/whisker-safe-area` — view-less `whisker-module` that exposes the host view's safe-area insets as a process-wide `ReadSignal<SafeAreaInsets>`. Single public surface: `safe_area_insets()`.
- Enforces Android **edge-to-edge** in `WhiskerActivity` so the WhiskerView fills the entire window and the inset values returned by `safe_area_insets()` map 1:1 to padding on the WhiskerView (same semantics as iOS).
- Updates podcast `top_nav` to demonstrate the consumer pattern — previously hard-coded `padding-top: 44px`, now derived via `computed(move || ... insets.get().top)`.

## API

```rust
use whisker_safe_area::{safe_area_insets, SafeAreaInsets};

pub struct SafeAreaInsets {
    pub top: f64,
    pub leading: f64,
    pub trailing: f64,
    pub bottom: f64,
}

pub fn safe_area_insets() -> ReadSignal<SafeAreaInsets>;
```

Reads in pt (iOS) / dp (Android) — same density-independent unit as Whisker's CSS `px`. `leading` / `trailing` follow the `NSDirectionalEdgeInsets` convention (forward-compatible with RTL; LTR-only today, so `leading == left`).

## Platform plumbing

- **iOS** — `WhiskerView.safeAreaInsetsDidChange()` posts a `NotificationCenter` notification; `SafeAreaModule.swift` observes it. Re-fires on rotation, multitasking, notch / Dynamic Island reveal, home indicator changes.
- **Android** — `SafeAreaModule.kt` keeps a `HostAttachedListener` registered for the module's whole lifetime, re-installing the `OnApplyWindowInsetsListener` on every new host attach so a config-change Activity recreation transparently re-wires.

## Edge-to-edge enforcement (Android)

- `WhiskerActivity` switched from `AppCompatActivity` → `ComponentActivity`. AppCompat's `subDecor` LinearLayout + status-bar guard kept the WhiskerView offset down by status-bar height even with `setDecorFitsSystemWindows(false)`; Whisker apps render through Lynx and don't use AppCompat's actual feature set, so the dependency was carrying nothing but the bug.
- Forces `setDecorFitsSystemWindows(false)`, transparent status/nav bars, `isStatusBarContrastEnforced=false`, `isNavigationBarContrastEnforced=false`, light-foreground system-bar appearance.
- Walks `decorView` post-`setContentView` to collapse any platform-injected `statusBarBackground` / `navigationBarBackground` siblings.
- CNG-generated `MainActivity.kt` template simplifies to a one-liner `class MainActivity : WhiskerActivity()` — the previous template inlined AppCompat directly and bypassed every WhiskerActivity setting (the original symptom).

## Verified

- API 36 emulator (Android 16): podcast TopNav renders with `padding-top: 52dp` (= status bar height) under transparent system bars, app's dark background paints through everywhere, screen rotation re-fires `safe_area_insets()` with the new Activity's values.
- iOS Simulator (iPhone 17 Pro): `UIView.safeAreaInsets` reaches the Rust signal, TopNav lands under the Dynamic Island.
- `cargo check --workspace` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --all --check` / `cargo test --workspace` all green.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --workspace` green
- [x] Android emulator (API 36): edge-to-edge visual confirmation, rotation behaviour
- [x] iOS Simulator: safe-area inset reaches signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)