### PR TITLE
podcast: css! inline styling + whisker-icons glyphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,9 @@ dependencies = [
 [[package]]
 name = "podcast-theme"
 version = "0.1.0"
+dependencies = [
+ "whisker-css",
+]
 
 [[package]]
 name = "podcast-ui-kit"
@@ -988,6 +991,7 @@ dependencies = [
  "podcast-domain",
  "podcast-theme",
  "whisker",
+ "whisker-icons",
  "whisker-image",
  "whisker-safe-area",
 ]

--- a/examples/podcast/crates/podcast-feature-browse/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-browse/src/lib.rs
@@ -45,6 +45,7 @@ use podcast_ui_kit::{
     MiniPlayerProps, RankedCard, RankedCardProps, SectionHeader, SectionHeaderProps, TopNav,
     TopNavProps,
 };
+use whisker::css::{AlignItems, Display, FlexDirection, JustifyContent, PositionKind};
 use whisker::prelude::*;
 use whisker::runtime::tasks::run_blocking;
 use whisker::runtime::view::Element;
@@ -54,13 +55,14 @@ use whisker::runtime::view::Element;
 pub fn browse_screen() -> Element {
     let sections = resource(fetch_sections);
 
-    let root_style = "flex-grow: 1; flex-shrink: 1; \
-                      display: flex; flex-direction: column; \
-                      position: relative;"
-        .to_string();
-
     render! {
-        view(style: root_style) {
+        view(style: css!(
+            flex_grow: 1.0,
+            flex_shrink: 1.0,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+            position: PositionKind::Relative,
+        )) {
             top_nav(title: "Podcasts", action_label: "Sign In")
             Show(
                 when: move || sections.get().is_some(),
@@ -102,14 +104,22 @@ async fn fetch_sections() -> Result<Vec<ChartSection>, String> {
 /// the layout doesn't shift when state transitions.
 #[component]
 fn status_pane(message: String) -> Element {
-    let pane_style = "flex-grow: 1; flex-shrink: 1; \
-                      display: flex; flex-direction: row; \
-                      align-items: center; justify-content: center;"
-        .to_string();
-    let text_style = format!("font-size: 14px; color: {fg};", fg = theme::TEXT_SECONDARY,);
     render! {
-        view(style: pane_style) {
-            text(style: text_style, value: message.clone())
+        view(style: css!(
+            flex_grow: 1.0,
+            flex_shrink: 1.0,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+        )) {
+            text(
+                style: css!(
+                    font_size: px(14),
+                    color: theme::TEXT_SECONDARY,
+                ),
+                value: message.clone(),
+            )
         }
     }
 }
@@ -118,15 +128,6 @@ fn status_pane(message: String) -> Element {
 /// horizontal sections.
 #[component]
 fn browse_body(sections: Vec<ChartSection>) -> Element {
-    let scroll_style = "flex-grow: 1; flex-shrink: 1; width: 100%;".to_string();
-    // The vertical column inside the scroll-view. Bottom padding
-    // = mini-player height + its bottom inset + a small breath so
-    // the last section's card row doesn't hide behind the floating
-    // player.
-    let column_style = "display: flex; flex-direction: column; \
-                        padding-top: 8px; padding-bottom: 96px;"
-        .to_string();
-
     // `each:` value computes a fresh clone INSIDE its own scope so
     // the surrounding render! Fn closure doesn't lose ownership of
     // `sections` to the each-closure's `move ||`. Bare
@@ -135,12 +136,25 @@ fn browse_body(sections: Vec<ChartSection>) -> Element {
     // and break re-render correctness.
     render! {
         scroll_view(
-            style: scroll_style,
+            style: css!(
+                flex_grow: 1.0,
+                flex_shrink: 1.0,
+                width: percent(100),
+            ),
             scroll_orientation: "vertical",
             scroll_bar_enable: false,
             bounces: true,
         ) {
-            view(style: column_style) {
+            // The vertical column inside the scroll-view. Bottom
+            // padding = mini-player height + bottom inset + a
+            // small breath so the last section's card row doesn't
+            // hide behind the floating player.
+            view(style: css!(
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                padding_top: px(8),
+                padding_bottom: px(96),
+            )) {
                 ForEach(
                     each: {
                         let items = sections.clone();
@@ -159,22 +173,22 @@ fn browse_body(sections: Vec<ChartSection>) -> Element {
 /// `section.layout`.
 #[component]
 fn section_block(section: ChartSection) -> Element {
-    let block_style = format!(
-        "display: flex; flex-direction: column; \
-         margin-top: {gap}; \
-         padding-top: 4px;",
-        gap = theme::SECTION_GAP,
-    );
-    let header_gap_style = format!("height: {gap}; width: 100%;", gap = theme::HEADER_GAP,);
-
     let layout = section.layout;
     let title = section.title.clone();
     let items_for_each = section.items.clone();
 
     render! {
-        view(style: block_style) {
+        view(style: css!(
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+            margin_top: theme::SECTION_GAP,
+            padding_top: px(4),
+        )) {
             section_header(title: title, show_chevron: layout == SectionLayout::Ranked)
-            view(style: header_gap_style)
+            view(style: css!(
+                height: theme::HEADER_GAP,
+                width: percent(100),
+            ))
             horizontal_row {
                 ForEach(
                     each: {
@@ -197,11 +211,6 @@ fn section_block(section: ChartSection) -> Element {
 /// touching the cards.
 #[component]
 fn card_with_gap(podcast: Podcast, rank: u32, layout: SectionLayout) -> Element {
-    let wrap_style = format!(
-        "margin-right: {gap}; \
-         display: flex; flex-direction: column;",
-        gap = theme::CARD_GAP,
-    );
     // Each Show child closure captures the podcast by move (render!
     // wraps them as `move ||` for re-render correctness). The same
     // outer FnMut can't move `podcast` out twice — clone once per
@@ -210,7 +219,11 @@ fn card_with_gap(podcast: Podcast, rank: u32, layout: SectionLayout) -> Element 
     let podcast_for_featured = podcast.clone();
     let podcast_for_ranked = podcast.clone();
     render! {
-        view(style: wrap_style) {
+        view(style: css!(
+            margin_right: theme::CARD_GAP,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+        )) {
             Show(when: move || layout == SectionLayout::Featured, fallback: || render! { fragment() }) {
                 featured_card(podcast: podcast_for_featured.clone())
             }

--- a/examples/podcast/crates/podcast-theme/Cargo.toml
+++ b/examples/podcast/crates/podcast-theme/Cargo.toml
@@ -3,7 +3,10 @@ name = "podcast-theme"
 version = "0.1.0"
 edition = "2021"
 publish = false
-description = "Design tokens for the podcast example: colors, type scale, spacing. No runtime deps — pure const strings so consumers can drop them into format!(\"...{token}...\") style attributes without paying for a type-system trip."
+description = "Design tokens for the podcast example: colors, type scale, spacing. Pure const `Color` / `Length` values from `whisker-css`'s data-type layer so consumers can drop them straight into `css!(color: theme::TEXT_PRIMARY, font_size: theme::T_HERO)`."
 
 [lib]
 crate-type = ["rlib"]
+
+[dependencies]
+whisker-css = { workspace = true }

--- a/examples/podcast/crates/podcast-theme/src/lib.rs
+++ b/examples/podcast/crates/podcast-theme/src/lib.rs
@@ -1,106 +1,109 @@
 //! Design tokens for the podcast example.
 //!
-//! Pure `const &str` so they can be dropped directly into Whisker
-//! `style:` attribute strings via `format!("color: {TEXT_PRIMARY};")`.
-//! No `whisker` dependency on purpose — a redesign touches this
-//! crate and nothing else, and the lower-level layers (domain,
-//! data) keep building even when the UI is gutted.
+//! Typed `Color` / `Length` constants ready to drop directly into
+//! `css!(...)` builder calls — `font_size: theme::T_HERO,
+//! color: theme::TEXT_PRIMARY`. The crate depends on `whisker-css`
+//! only (no `whisker` umbrella) so a redesign touches this crate
+//! and nothing else, and the lower-level layers (domain, data)
+//! keep building even when the UI is gutted.
 //!
 //! Tokens follow a flat-namespace, name-by-role convention (not
 //! name-by-value): a future palette change updates the constant
 //! without forcing a rename through every consumer. The exception
 //! is the type scale, where the `T_*` names encode the size class
-//! so a consumer reading `font-size: {T_HERO}` knows what they're
+//! so a consumer reading `font_size: T_HERO` knows what they're
 //! getting without jumping back to this file.
+
+use whisker_css::{Color, Length};
 
 // ----- Surfaces ------------------------------------------------------------
 
 /// Root page background. Near-black for the dark-theme browse screen.
-pub const BG: &str = "#000000";
+pub const BG: Color = Color::hex(0x000000);
 
 /// Elevated surface (cards, the mini player). Slightly lifted from
 /// `BG` so the card edge reads without a border.
-pub const SURFACE: &str = "#1c1c1e";
+pub const SURFACE: Color = Color::hex(0x1C1C1E);
 
 /// Bottom mini-player backdrop — translucent so the content behind
 /// stays visible while the player floats over it.
-pub const MINI_PLAYER_BG: &str = "rgba(40, 40, 42, 0.92)";
+pub const MINI_PLAYER_BG: Color = Color::rgba(40, 40, 42, 0.92);
 
 // ----- Text ----------------------------------------------------------------
 
 /// Primary text — section titles, card titles, hero copy.
-pub const TEXT_PRIMARY: &str = "#ffffff";
+pub const TEXT_PRIMARY: Color = Color::hex(0xFFFFFF);
 
 /// Muted text — meta labels, subtitles, secondary lines.
-pub const TEXT_SECONDARY: &str = "rgba(235, 235, 245, 0.6)";
+pub const TEXT_SECONDARY: Color = Color::rgba(235, 235, 245, 0.6);
 
 /// Even-more-muted — tertiary captions, ranking numbers when faded.
-pub const TEXT_TERTIARY: &str = "rgba(235, 235, 245, 0.3)";
+pub const TEXT_TERTIARY: Color = Color::rgba(235, 235, 245, 0.3);
 
 // ----- Accent -------------------------------------------------------------
 
 /// Interactive / brand accent — top-bar buttons and chevrons.
-pub const ACCENT: &str = "#a78bfa";
+pub const ACCENT: Color = Color::hex(0xA78BFA);
 
 // ----- Type scale ---------------------------------------------------------
 
 /// Page hero title ("New", "Top Shows" section labels).
-pub const T_HERO: &str = "28px";
+pub const T_HERO: Length = Length::Px(28.0);
 /// Section title chevron-row.
-pub const T_SECTION: &str = "22px";
+pub const T_SECTION: Length = Length::Px(22.0);
 /// Featured card's two-line title.
-pub const T_FEATURED_TITLE: &str = "20px";
+pub const T_FEATURED_TITLE: Length = Length::Px(20.0);
 /// Standard card title under artwork.
-pub const T_CARD_TITLE: &str = "13px";
+pub const T_CARD_TITLE: Length = Length::Px(13.0);
 /// Card subtitle (artist / author).
-pub const T_CARD_SUBTITLE: &str = "13px";
+pub const T_CARD_SUBTITLE: Length = Length::Px(13.0);
 /// Category label above a featured card ("NEW SEASON" etc).
-pub const T_CATEGORY: &str = "11px";
+pub const T_CATEGORY: Length = Length::Px(11.0);
 /// Top-nav title.
-pub const T_NAV_TITLE: &str = "15px";
+pub const T_NAV_TITLE: Length = Length::Px(15.0);
 
 // ----- Spacing ------------------------------------------------------------
 
 /// Horizontal page gutter — left/right edge insets.
-pub const GUTTER: &str = "16px";
+pub const GUTTER: Length = Length::Px(16.0);
 
 /// Vertical gap between major sections (between "New" and "Top Shows" etc).
-pub const SECTION_GAP: &str = "32px";
+pub const SECTION_GAP: Length = Length::Px(32.0);
 
 /// Gap between a section header and its row of cards.
-pub const HEADER_GAP: &str = "12px";
+pub const HEADER_GAP: Length = Length::Px(12.0);
 
 /// Gap between adjacent cards in a horizontal row.
-pub const CARD_GAP: &str = "12px";
+pub const CARD_GAP: Length = Length::Px(12.0);
 
 // ----- Card sizing --------------------------------------------------------
 
 /// Featured card width (the large hero items in "New").
-pub const FEATURED_CARD_WIDTH: &str = "300px";
+pub const FEATURED_CARD_WIDTH: Length = Length::Px(300.0);
 
 /// Standard ranked card artwork side length.
-pub const RANKED_CARD_SIDE: &str = "144px";
+pub const RANKED_CARD_SIDE: Length = Length::Px(144.0);
 
-/// Corner radius for all artwork. Apple-style soft-rounded. Two
-/// representations: the CSS `border-radius` string for plain `view`
-/// rounding, and the numeric value for the `whisker-image:Image`
-/// element's `corner_radius` prop (Lynx's CSS cascade doesn't reach
-/// custom UI elements' image bitmap layer on Android, so the typed
-/// prop is the consistent path — see `whisker_image::image`'s docs).
-pub const ARTWORK_RADIUS: &str = "8px";
+/// Corner radius for all artwork. Apple-style soft-rounded. The
+/// `Length` form drops into `css!(border_radius: …)`; the `f64`
+/// form is what `whisker-image:Image`'s `corner_radius` prop wants
+/// (Lynx's CSS cascade doesn't reach custom UI elements' image
+/// bitmap layer on Android, so the typed prop is the consistent
+/// path — see `whisker_image::image`'s docs).
+pub const ARTWORK_RADIUS: Length = Length::Px(8.0);
 pub const ARTWORK_RADIUS_PX: f64 = 8.0;
 
 // ----- Top nav ------------------------------------------------------------
 
 /// Top-nav bar height (status-bar inset not included — host handles
 /// safe-area separately).
-pub const NAV_HEIGHT: &str = "44px";
+pub const NAV_HEIGHT: Length = Length::Px(44.0);
 
 // ----- Mini player --------------------------------------------------------
 
 /// Mini-player floating bar height.
-pub const MINI_PLAYER_HEIGHT: &str = "56px";
+pub const MINI_PLAYER_HEIGHT: Length = Length::Px(56.0);
 
 /// Mini player bottom inset from the bottom-of-page anchor (matches
 /// the home-indicator clearance on iOS).
-pub const MINI_PLAYER_BOTTOM: &str = "16px";
+pub const MINI_PLAYER_BOTTOM: Length = Length::Px(16.0);

--- a/examples/podcast/crates/podcast-ui-kit/Cargo.toml
+++ b/examples/podcast/crates/podcast-ui-kit/Cargo.toml
@@ -21,5 +21,10 @@ whisker-image = { path = "../../../../packages/whisker-image" }
 # bar correctly under the notch / Dynamic Island instead of hard-
 # coding 44pt.
 whisker-safe-area = { path = "../../../../packages/whisker-safe-area" }
+# `whisker-icons` exposes every Lucide icon as a tree-shakable
+# `&'static str` constant under `lucide::*`. Used for the section
+# chevron, top-nav menu glyph, and mini-player play / skip glyphs —
+# replaces the prior hand-faked views and Unicode arrows.
+whisker-icons = { path = "../../../../packages/whisker-icons" }
 podcast-theme = { path = "../podcast-theme" }
 podcast-domain = { path = "../podcast-domain" }

--- a/examples/podcast/crates/podcast-ui-kit/src/featured_card.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/featured_card.rs
@@ -8,52 +8,57 @@
 
 use podcast_domain::Podcast;
 use podcast_theme as theme;
+use whisker::css::{Display, FlexDirection, FontWeight, TextOverflow, ToCss};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_image::{Image, ImageProps};
 
 #[component]
 pub fn featured_card(podcast: Podcast) -> Element {
-    let card_style = format!(
-        "width: {w}; \
-         display: flex; flex-direction: column;",
-        w = theme::FEATURED_CARD_WIDTH,
-    );
     let category_label = podcast
         .primary_genre_name
         .clone()
         .unwrap_or_else(|| "Featured".to_string())
         .to_uppercase();
-    let category_style = format!(
-        "font-size: {size}; color: {fg}; \
-         letter-spacing: 0.5px; font-weight: 600;",
-        size = theme::T_CATEGORY,
-        fg = theme::TEXT_SECONDARY,
-    );
     let title_text = podcast.collection_name.clone();
-    let title_style = format!(
-        "font-size: {size}; color: {fg}; \
-         font-weight: 600; margin-top: 6px; \
-         text-maxline: 2; text-overflow: ellipsis;",
-        size = theme::T_FEATURED_TITLE,
-        fg = theme::TEXT_PRIMARY,
-    );
-    let art_style = format!(
-        "width: {w}; height: {w}; \
-         border-radius: {r}; margin-top: 12px; \
-         background-color: {surface};",
-        w = theme::FEATURED_CARD_WIDTH,
-        r = theme::ARTWORK_RADIUS,
-        surface = theme::SURFACE,
-    );
     let artwork_src = podcast.artwork_url_600.clone();
 
     render! {
-        view(style: card_style) {
-            text(style: category_style, value: category_label)
-            text(style: title_style, value: title_text)
+        view(style: css!(
+            width: theme::FEATURED_CARD_WIDTH,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+        )) {
+            text(
+                style: css!(
+                    font_size: theme::T_CATEGORY,
+                    color: theme::TEXT_SECONDARY,
+                    font_weight: FontWeight::Numeric(600),
+                ).raw("letter-spacing", "0.5px"),
+                value: category_label,
+            )
+            // `text-maxline` is a Lynx-only extension not in the
+            // typed css! builder; `.raw(...)` appends it verbatim.
+            text(
+                style: css!(
+                    font_size: theme::T_FEATURED_TITLE,
+                    color: theme::TEXT_PRIMARY,
+                    font_weight: FontWeight::Numeric(600),
+                    margin_top: px(6),
+                    text_overflow: TextOverflow::Ellipsis,
+                ).raw("text-maxline", "2"),
+                value: title_text,
+            )
+            // `Image` is a `module_component` — its `style` prop is
+            // `Signal<String>`, no `From<Css>` impl. Serialise here.
             Image(
-                style: art_style,
+                style: css!(
+                    width: theme::FEATURED_CARD_WIDTH,
+                    height: theme::FEATURED_CARD_WIDTH,
+                    border_radius: theme::ARTWORK_RADIUS,
+                    margin_top: px(12),
+                    background_color: theme::SURFACE,
+                ).to_css_string(),
                 src: artwork_src,
                 mode: "aspectFill",
             )

--- a/examples/podcast/crates/podcast-ui-kit/src/horizontal_row.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/horizontal_row.rs
@@ -6,38 +6,35 @@
 //! their own intrinsic widths.
 
 use podcast_theme as theme;
+use whisker::css::{AlignItems, Display, FlexDirection};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker::Children;
 
 #[component]
 pub fn horizontal_row(children: Children) -> Element {
-    // scroll-view with horizontal orientation. `bounces: true` so
-    // iOS rubber-banding kicks in at the ends; `scroll_bar_enable:
-    // false` because Apple-style podcast browsers don't show one.
-    let scroll_style = "width: 100%; display: flex;".to_string();
-    // Inner content row — cards laid out left-to-right with
-    // `CARD_GAP` between them and `GUTTER` of breathing room at
-    // either side of the row.
-    let inner_style = format!(
-        "display: flex; flex-direction: row; align-items: flex-start; \
-         padding-left: {gutter}; padding-right: {gutter};",
-        gutter = theme::GUTTER,
-    );
-    // Each child gets a right margin via wrapping `view`s — done by
-    // having the children include a margin in their own style, but
-    // to keep the kit's components style-agnostic we instead leave
-    // the gap to the caller's section layout. The caller (browse
-    // screen) inserts manual spacer views when needed.
-
     render! {
+        // `bounces: true` → iOS rubber-banding at the ends;
+        // `scroll_bar_enable: false` → Apple-style podcast browsers
+        // don't show a scroll bar.
         scroll_view(
-            style: scroll_style,
+            style: css!(width: percent(100), display: Display::Flex),
             scroll_orientation: "horizontal",
             scroll_bar_enable: false,
             bounces: true,
         ) {
-            view(style: inner_style) {
+            // Inner content row — cards laid out left-to-right with
+            // `GUTTER` of breathing room at either side of the row.
+            // Card-to-card gap is the caller's concern (the browse
+            // screen inserts manual spacer views) so this component
+            // stays style-agnostic.
+            view(style: css!(
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::FlexStart,
+                padding_left: theme::GUTTER,
+                padding_right: theme::GUTTER,
+            )) {
                 children()
             }
         }

--- a/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
@@ -4,75 +4,67 @@
 //! placeholder artwork square (sized for the future "currently
 //! playing show art"), a play glyph, and a "skip ahead 30 s" glyph
 //! on the trailing edge. No audio wiring yet — the buttons are
-//! visual-only until the `whisker-audio` module lands.
+//! visual-only until the `whisker-audio` module lands. Both glyphs
+//! are now `whisker-icons` Lucide constants — the previous hand-
+//! faked `▶` text + circled "30" view layout is gone.
 
 use podcast_theme as theme;
+use whisker::css::{AlignItems, Color, Display, FlexDirection, JustifyContent, PositionKind};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
+use whisker_icons::{lucide, Icon, IconProps};
 
 #[component]
 pub fn mini_player() -> Element {
-    // Floats above content via absolute positioning. The parent
-    // page must use `position: relative` (default) so the floats
-    // anchor correctly. Side gutter matches the page gutter so the
-    // bar visually inset-aligns with the section content.
-    let bar_style = format!(
-        "position: absolute; \
-         left: {gutter}; right: {gutter}; \
-         bottom: {bottom}; height: {h}; \
-         display: flex; flex-direction: row; align-items: center; \
-         padding-left: 12px; padding-right: 16px; \
-         border-radius: 12px; \
-         background-color: {bg};",
-        gutter = theme::GUTTER,
-        bottom = theme::MINI_PLAYER_BOTTOM,
-        h = theme::MINI_PLAYER_HEIGHT,
-        bg = theme::MINI_PLAYER_BG,
-    );
-
-    // Leading placeholder: 40×40 square where the now-playing show
-    // art would go.
-    let art_style = "width: 36px; height: 36px; \
-                     border-radius: 6px; \
-                     background-color: rgba(255, 255, 255, 0.15);"
-        .to_string();
-
-    // Spacer between leading art and trailing controls.
-    let spacer_style = "flex-grow: 1; flex-shrink: 1;".to_string();
-
-    // Play glyph — a right-pointing triangle made from a rotated
-    // bordered view. (We could text-render '▶' instead; views are
-    // sturdier when font fallback is uncertain.)
-    let play_wrap_style = "width: 32px; height: 32px; \
-                           display: flex; flex-direction: row; \
-                           align-items: center; justify-content: center;"
-        .to_string();
-    let play_glyph_style = format!("font-size: 18px; color: {fg};", fg = theme::TEXT_PRIMARY,);
-
-    // Skip-30 glyph — a circular outline with "30" inside, rendered
-    // text-only.
-    let skip_wrap_style = "width: 36px; height: 36px; \
-                           display: flex; flex-direction: row; \
-                           align-items: center; justify-content: center; \
-                           border-radius: 18px; \
-                           border-width: 1.5px; border-style: solid; \
-                           border-color: rgba(255,255,255,0.85); \
-                           margin-left: 16px;"
-        .to_string();
-    let skip_label_style = format!(
-        "font-size: 11px; color: {fg}; font-weight: 600;",
-        fg = theme::TEXT_PRIMARY,
-    );
-
     render! {
-        view(style: bar_style) {
-            view(style: art_style)
-            view(style: spacer_style)
-            view(style: play_wrap_style) {
-                text(style: play_glyph_style, value: "▶")
+        // Floats above content via absolute positioning. The parent
+        // page must use `position: relative` (default) so the floats
+        // anchor correctly. Side gutter matches the page gutter so
+        // the bar visually inset-aligns with the section content.
+        view(style: css!(
+            position: PositionKind::Absolute,
+            left: theme::GUTTER,
+            right: theme::GUTTER,
+            bottom: theme::MINI_PLAYER_BOTTOM,
+            height: theme::MINI_PLAYER_HEIGHT,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            padding_left: px(12),
+            padding_right: px(16),
+            border_radius: px(12),
+            background_color: theme::MINI_PLAYER_BG,
+        )) {
+            // Leading placeholder: 36×36 square where the now-
+            // playing show art would go.
+            view(style: css!(
+                width: px(36),
+                height: px(36),
+                border_radius: px(6),
+                background_color: Color::rgba(255, 255, 255, 0.15),
+            ))
+            // Spacer between leading art and trailing controls.
+            view(style: css!(flex_grow: 1.0, flex_shrink: 1.0))
+            view(style: css!(
+                width: px(32),
+                height: px(32),
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+            )) {
+                Icon(svg: lucide::Play, color: "#ffffff", size: "22")
             }
-            view(style: skip_wrap_style) {
-                text(style: skip_label_style, value: "30")
+            view(style: css!(
+                width: px(36),
+                height: px(36),
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                margin_left: px(16),
+            )) {
+                Icon(svg: lucide::RotateCw, color: "#ffffff", size: "26")
             }
         }
     }

--- a/examples/podcast/crates/podcast-ui-kit/src/ranked_card.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/ranked_card.rs
@@ -7,69 +7,79 @@
 
 use podcast_domain::Podcast;
 use podcast_theme as theme;
+use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, TextOverflow, ToCss};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_image::{Image, ImageProps};
 
 #[component]
 pub fn ranked_card(podcast: Podcast, rank: u32) -> Element {
-    let card_style = format!(
-        "width: {w}; \
-         display: flex; flex-direction: column;",
-        w = theme::RANKED_CARD_SIDE,
-    );
-    let art_style = format!(
-        "width: {w}; height: {w}; \
-         border-radius: {r}; \
-         background-color: {surface};",
-        w = theme::RANKED_CARD_SIDE,
-        r = theme::ARTWORK_RADIUS,
-        surface = theme::SURFACE,
-    );
-    let meta_row_style = "display: flex; flex-direction: row; \
-                          margin-top: 10px; align-items: flex-start;"
-        .to_string();
-    let rank_style = format!(
-        "font-size: 18px; color: {fg}; \
-         font-weight: 700; margin-right: 8px; \
-         min-width: 18px;",
-        fg = theme::TEXT_PRIMARY,
-    );
-    let stack_style = "display: flex; flex-direction: column; \
-                       flex-grow: 1; flex-shrink: 1;"
-        .to_string();
-    let title_style = format!(
-        "font-size: {size}; color: {fg}; \
-         font-weight: 500; \
-         text-maxline: 1; text-overflow: ellipsis;",
-        size = theme::T_CARD_TITLE,
-        fg = theme::TEXT_PRIMARY,
-    );
-    let subtitle_style = format!(
-        "font-size: {size}; color: {fg}; \
-         margin-top: 2px; \
-         text-maxline: 2; text-overflow: ellipsis;",
-        size = theme::T_CARD_SUBTITLE,
-        fg = theme::TEXT_SECONDARY,
-    );
-
     let rank_text = format!("{rank}");
     let title_text = podcast.collection_name.clone();
     let subtitle_text = podcast.artist_name.clone();
     let artwork_src = podcast.artwork_url_600.clone();
 
     render! {
-        view(style: card_style) {
+        view(style: css!(
+            width: theme::RANKED_CARD_SIDE,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+        )) {
             Image(
-                style: art_style,
+                // `Image` is a `module_component` — its `style` prop
+                // is `Signal<String>` with no `From<Css>` impl, so
+                // serialise here before handing it across.
+                style: css!(
+                    width: theme::RANKED_CARD_SIDE,
+                    height: theme::RANKED_CARD_SIDE,
+                    border_radius: theme::ARTWORK_RADIUS,
+                    background_color: theme::SURFACE,
+                ).to_css_string(),
                 src: artwork_src,
                 mode: "aspectFill",
             )
-            view(style: meta_row_style) {
-                text(style: rank_style, value: rank_text)
-                view(style: stack_style) {
-                    text(style: title_style, value: title_text)
-                    text(style: subtitle_style, value: subtitle_text)
+            view(style: css!(
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                margin_top: px(10),
+                align_items: AlignItems::FlexStart,
+            )) {
+                text(
+                    style: css!(
+                        font_size: px(18),
+                        color: theme::TEXT_PRIMARY,
+                        font_weight: FontWeight::Bold,
+                        margin_right: px(8),
+                        min_width: px(18),
+                    ),
+                    value: rank_text,
+                )
+                view(style: css!(
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Column,
+                    flex_grow: 1.0,
+                    flex_shrink: 1.0,
+                )) {
+                    // `text-maxline` is a Lynx-only extension not in
+                    // the typed css! builder; `.raw(...)` appends it.
+                    text(
+                        style: css!(
+                            font_size: theme::T_CARD_TITLE,
+                            color: theme::TEXT_PRIMARY,
+                            font_weight: FontWeight::Numeric(500),
+                            text_overflow: TextOverflow::Ellipsis,
+                        ).raw("text-maxline", "1"),
+                        value: title_text,
+                    )
+                    text(
+                        style: css!(
+                            font_size: theme::T_CARD_SUBTITLE,
+                            color: theme::TEXT_SECONDARY,
+                            margin_top: px(2),
+                            text_overflow: TextOverflow::Ellipsis,
+                        ).raw("text-maxline", "2"),
+                        value: subtitle_text,
+                    )
                 }
             }
         }

--- a/examples/podcast/crates/podcast-ui-kit/src/section_header.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/section_header.rs
@@ -7,41 +7,46 @@
 //! decides which variant by passing the flag.
 
 use podcast_theme as theme;
+use whisker::css::{Display, FlexDirection, FontWeight};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
+use whisker_icons::{lucide, Icon, IconProps};
 
 #[component]
 pub fn section_header(title: String, #[prop(default = false)] show_chevron: bool) -> Element {
-    let row_style = format!(
-        "width: 100%; \
-         padding-left: {gutter}; padding-right: {gutter}; \
-         display: flex; flex-direction: row; align-items: center;",
-        gutter = theme::GUTTER,
-    );
-    let title_style = format!(
-        "font-size: {size}; font-weight: 700; color: {fg};",
-        size = theme::T_HERO,
-        fg = theme::TEXT_PRIMARY,
-    );
-
-    // Chevron style is built fresh inside the Show child closure (not
-    // captured from the outer body) — Show's `children:` closure
-    // captures by move and re-runs on `when` changes, so any moved
-    // outer String would fail the second invocation. Constructing the
-    // string inside the closure body sidesteps that.
     render! {
-        view(style: row_style) {
-            text(style: title_style, value: title.clone())
+        view(style: css!(
+            width: percent(100),
+            padding_left: theme::GUTTER,
+            padding_right: theme::GUTTER,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Row,
+            align_items: whisker::css::AlignItems::Center,
+        )) {
+            text(
+                style: css!(
+                    font_size: theme::T_HERO,
+                    font_weight: FontWeight::Bold,
+                    color: theme::TEXT_PRIMARY,
+                ),
+                value: title.clone(),
+            )
+            // `Show`'s `children:` closure re-runs on `when` changes
+            // and captures by move, so any outer-scope String would
+            // fail the second invocation. The Icon's props are
+            // built fresh inside the closure to sidestep that.
             Show(when: move || show_chevron, fallback: || render! { fragment() }) {
-                text(
-                    style: format!(
-                        "font-size: {size}; font-weight: 700; \
-                         color: {fg}; margin-left: 8px;",
-                        size = theme::T_HERO,
-                        fg = theme::TEXT_PRIMARY,
-                    ),
-                    value: ">",
-                )
+                view(style: css!(
+                    margin_left: px(8),
+                    display: Display::Flex,
+                    align_items: whisker::css::AlignItems::Center,
+                )) {
+                    Icon(
+                        svg: lucide::ChevronRight,
+                        color: "#ffffff",
+                        size: "28",
+                    )
+                }
             }
         }
     }

--- a/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
@@ -3,12 +3,13 @@
 //! Three-part bar: leading menu glyph, centred title, trailing
 //! action. Visual reference: a generic mobile media-browser header
 //! (Pocket Casts, Spotify, Castbox all ship a near-identical
-//! shape). Renders text-only — no SVG / image assets are baked in,
-//! keeping the component self-contained.
+//! shape). The menu glyph is `lucide::Menu` via `whisker-icons`.
 
 use podcast_theme as theme;
+use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, JustifyContent, ToCss};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
+use whisker_icons::{lucide, Icon, IconProps};
 use whisker_safe_area::safe_area_insets;
 
 /// Title shown centred in the bar. Action label shown trailing.
@@ -17,82 +18,101 @@ use whisker_safe_area::safe_area_insets;
 #[component]
 pub fn top_nav(title: String, action_label: String) -> Element {
     // Two-layer style: outer wrapper carries the safe-area inset
-    // via `padding-top`, inner row keeps its content height. We
+    // via `padding_top`, inner row keeps its content height. We
     // can't pile padding on top of a fixed-height row — the row's
     // children would just disappear behind the padding. Splitting
-    // wrapper / row keeps `NAV_HEIGHT` purely about the nav
-    // content area.
+    // wrapper / row keeps `NAV_HEIGHT` purely about the nav content
+    // area.
     //
     // `safe_area_insets()` returns a process-wide `ReadSignal` —
     // re-fires on rotation / Dynamic Island / notch / Android edge-
     // to-edge toggle. `computed` derives a `ReadSignal<String>` the
     // `style:` prop wires as a reactive style binding, so the bar
-    // re-pads automatically without us touching state from the
-    // component body.
+    // re-pads automatically without the component body touching
+    // state.
     let insets = safe_area_insets();
-    let bg = theme::BG;
     let wrapper_style = computed(move || {
-        format!(
-            "width: 100%; padding-top: {top}px; \
-             flex-shrink: 0; \
-             background-color: {bg};",
-            top = insets.get().top,
+        css!(
+            width: percent(100),
+            padding_top: px(insets.get().top as f32),
+            flex_shrink: 0.0,
+            background_color: theme::BG,
         )
+        .to_css_string()
     });
-    let bar_style = format!(
-        "width: 100%; min-height: {h}; \
-         flex-shrink: 0; \
-         display: flex; flex-direction: row; align-items: center; \
-         padding-left: {gutter}; padding-right: {gutter};",
-        h = theme::NAV_HEIGHT,
-        gutter = theme::GUTTER,
-    );
-    // Three flex children — leading / centre / trailing — each
-    // claiming an equal third so the title genuinely centres on
-    // the bar, not on the title text's own width. The leading
-    // slot is a stack of three short bars (a hamburger glyph
-    // rendered with views, not an icon font, so the kit doesn't
-    // need to ship glyph assets).
-    let slot_third = "flex-grow: 1; flex-shrink: 1; flex-basis: 0%; \
-                      display: flex; flex-direction: row;";
-    let leading_style = format!("{slot_third} align-items: center; justify-content: flex-start;");
-    let centre_style = format!("{slot_third} align-items: center; justify-content: center;");
-    let trailing_style = format!("{slot_third} align-items: center; justify-content: flex-end;");
-
-    let title_style = format!(
-        "font-size: {size}; color: {fg}; font-weight: 600;",
-        size = theme::T_NAV_TITLE,
-        fg = theme::TEXT_PRIMARY,
-    );
-    let action_style = format!(
-        "font-size: {size}; color: {accent}; font-weight: 500;",
-        size = theme::T_NAV_TITLE,
-        accent = theme::ACCENT,
-    );
-
-    // Hamburger glyph: three stacked 2px-tall purple lines.
-    let hamburger_wrap_style = "display: flex; flex-direction: column; width: 18px;".to_string();
-    let bar_line = format!(
-        "width: 18px; height: 2px; background-color: {accent}; \
-         border-radius: 1px; margin-top: 3px; margin-bottom: 3px;",
-        accent = theme::ACCENT,
-    );
 
     render! {
         view(style: wrapper_style) {
-            view(style: bar_style) {
-                view(style: leading_style) {
-                    view(style: hamburger_wrap_style) {
-                        view(style: bar_line.clone())
-                        view(style: bar_line.clone())
-                        view(style: bar_line.clone())
-                    }
+            view(style: css!(
+                width: percent(100),
+                min_height: theme::NAV_HEIGHT,
+                flex_shrink: 0.0,
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                padding_left: theme::GUTTER,
+                padding_right: theme::GUTTER,
+            )) {
+                // Three flex children — leading / centre / trailing
+                // — each claiming an equal third so the title
+                // genuinely centres on the bar, not on the title
+                // text's own width.
+                view(style: css!(
+                    flex_grow: 1.0,
+                    flex_shrink: 1.0,
+                    flex_basis: percent(0),
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::FlexStart,
+                )) {
+                    Icon(
+                        svg: lucide::Menu,
+                        // `whisker-icons` plumbs `color` straight
+                        // through to Lynx as a CSS colour string
+                        // (`stroke="currentColor"` in the source
+                        // SVG), so the accent hex literal is the
+                        // right shape here — there's no typed
+                        // `Color` path on `Icon`'s prop yet.
+                        color: "#a78bfa",
+                        size: "22",
+                    )
                 }
-                view(style: centre_style) {
-                    text(style: title_style, value: title.clone())
+                view(style: css!(
+                    flex_grow: 1.0,
+                    flex_shrink: 1.0,
+                    flex_basis: percent(0),
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Center,
+                )) {
+                    text(
+                        style: css!(
+                            font_size: theme::T_NAV_TITLE,
+                            color: theme::TEXT_PRIMARY,
+                            font_weight: FontWeight::Numeric(600),
+                        ),
+                        value: title.clone(),
+                    )
                 }
-                view(style: trailing_style) {
-                    text(style: action_style, value: action_label.clone())
+                view(style: css!(
+                    flex_grow: 1.0,
+                    flex_shrink: 1.0,
+                    flex_basis: percent(0),
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::FlexEnd,
+                )) {
+                    text(
+                        style: css!(
+                            font_size: theme::T_NAV_TITLE,
+                            color: theme::ACCENT,
+                            font_weight: FontWeight::Numeric(500),
+                        ),
+                        value: action_label.clone(),
+                    )
                 }
             }
         }

--- a/examples/podcast/src/lib.rs
+++ b/examples/podcast/src/lib.rs
@@ -36,26 +36,27 @@
 //! while features compose the kit into screens.
 
 use podcast_feature_browse::{BrowseScreen, BrowseScreenProps};
+use whisker::css::{Display, FlexDirection};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 
 #[whisker::main]
 fn app() -> Element {
-    // `page` needs explicit dimensions + background — without
-    // `width: 100vw; height: 100vh;` it collapses to 0 px on iOS
-    // and the host's clear color shows through. The bg is set on
-    // the page so the system-level safe-area paint matches the
-    // dark theme even before the first frame draws.
-    let page_style = format!(
-        "width: 100vw; height: 100vh; background-color: {bg}; \
-         display: flex; flex-direction: column;",
-        bg = podcast_theme::BG,
-    );
     render! {
-        page(style: page_style) {
+        // `page` needs explicit dimensions + background — without
+        // `width: 100vw; height: 100vh;` it collapses to 0 px on
+        // iOS and the host's clear color shows through. The bg
+        // sits on the page so the system-level safe-area paint
+        // matches the dark theme even before the first frame
+        // draws.
+        page(style: css!(
+            width: vw(100),
+            height: vh(100),
+            background_color: podcast_theme::BG,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+        )) {
             browse_screen()
         }
     }
 }
-// hot reload trigger
-// rebuild trigger v2


### PR DESCRIPTION
## Summary

Two follow-ups on the just-merged whisker-icons PR (#110):

- **whisker-icons** in the podcast example — the three hand-faked
  glyphs (hamburger as three colored views, `>` chevron text, `▶`
  play text, circled "30" view) get replaced with Lucide
  constants (`lucide::Menu`, `lucide::ChevronRight`, `lucide::Play`,
  `lucide::RotateCw`).
- **`css!` macro inline** — `podcast-theme` exposes typed
  `Color` / `Length` consts; the six ui-kit components,
  `podcast-feature-browse`, and the top-level `examples/podcast`
  rewrite every `style:` site as inline `css!(…)`. `text-maxline`
  is a Lynx-only extension not in the typed builder, so the two
  cards that ellipsis chain `.raw("text-maxline", "N")` onto the
  result. `module_component` props (`Image.style`) want
  `Signal<String>`, so those single sites call `.to_css_string()`.

## Test plan

- [x] `cargo check -p podcast-theme -p podcast-ui-kit -p podcast-feature-browse -p podcast` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo test -p podcast-*` (8 zero-test crates) clean.
- [x] Android emulator (Pixel 7, Android 14): top nav menu icon
      renders, "Top Shows" chevron renders, mini-player play
      triangle + circular-arrow skip-30 render, browse layout
      matches the prior format!-cased version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)