### PR TITLE
feat(reactive): pause / resume owners + freeze suspended StackLayout routes

### DIFF
--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -56,7 +56,10 @@ pub use component::{
 pub use computed::computed;
 pub use context::{provide_context, use_context, with_context};
 pub use effect::effect;
-pub use owner::{create_owner, dispose_owner, on_cleanup, with_owner};
+pub use owner::{
+    create_owner, dispose_owner, is_owner_paused, on_cleanup, pause_owner, resume_owner,
+    with_owner,
+};
 pub use prop::Signal;
 pub use resource::{resource, resource_sync, Resource, ResourceState};
 pub use runtime::{NodeId, OwnerId};

--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -57,8 +57,7 @@ pub use computed::computed;
 pub use context::{provide_context, use_context, with_context};
 pub use effect::effect;
 pub use owner::{
-    create_owner, dispose_owner, is_owner_paused, on_cleanup, pause_owner, resume_owner,
-    with_owner,
+    create_owner, dispose_owner, is_owner_paused, on_cleanup, pause_owner, resume_owner, with_owner,
 };
 pub use prop::Signal;
 pub use resource::{resource, resource_sync, Resource, ResourceState};

--- a/crates/whisker-runtime/src/reactive/owner.rs
+++ b/crates/whisker-runtime/src/reactive/owner.rs
@@ -17,10 +17,20 @@ use super::with_runtime;
 /// Create a new owner. If `parent` is `None` the current top-of-stack
 /// owner is used (or the owner becomes a root if the stack is empty).
 /// Returns the new owner's id.
+///
+/// The new owner inherits its parent's `paused` flag — so a sub-
+/// component mounted while its containing route is suspended starts
+/// paused, and its effects won't fire until the route resumes.
 pub fn create_owner(parent: Option<OwnerId>) -> OwnerId {
     with_runtime(|rt| {
         let parent = parent.or_else(|| rt.current_owner());
-        let id = rt.owners.insert(Owner::new(parent));
+        let parent_paused = parent
+            .and_then(|p| rt.owners.get(p))
+            .map(|o| o.paused)
+            .unwrap_or(false);
+        let mut owner = Owner::new(parent);
+        owner.paused = parent_paused;
+        let id = rt.owners.insert(owner);
         if let Some(p) = parent {
             if let Some(parent_owner) = rt.owners.get_mut(p) {
                 parent_owner.children.push(id);
@@ -172,8 +182,11 @@ pub fn dispose_owner(owner: OwnerId) {
                     out.push((arc_src, *node_id));
                 }
             }
-            // Strip these nodes from the pending queue if any were scheduled.
+            // Strip these nodes from the pending and deferred queues
+            // if any were scheduled — otherwise a later flush /
+            // resume_owner would try to re-run a freed slot.
             rt.pending.retain(|n| !nodes.contains(n));
+            rt.deferred.retain(|n| !nodes.contains(n));
             out
         });
 
@@ -203,6 +216,95 @@ pub fn dispose_owner(owner: OwnerId) {
     for cleanup in cleanups.into_iter().rev() {
         cleanup();
     }
+}
+
+/// Pause `owner` (and its descendants): effects and computeds whose
+/// scope is the paused subtree skip flush. Their scheduled re-runs
+/// land on the runtime's `deferred` list until [`resume_owner`]
+/// drains them back.
+///
+/// Idempotent — pausing an already-paused owner is a no-op. The
+/// cascade walks the children tree breadth-first; new descendants
+/// created while paused inherit the flag via [`create_owner`].
+///
+/// Used by `StackLayout` to freeze back-stack entries that are
+/// mounted-but-off-screen, matching iOS `UINavigationController` /
+/// Android Fragment back-stack semantics: state survives but no
+/// CPU is spent on signal-driven re-renders behind the top route.
+pub fn pause_owner(owner: OwnerId) {
+    with_runtime(|rt| {
+        let mut stack = vec![owner];
+        while let Some(id) = stack.pop() {
+            let Some(o) = rt.owners.get_mut(id) else {
+                continue;
+            };
+            if o.paused {
+                continue;
+            }
+            o.paused = true;
+            stack.extend(o.children.iter().copied());
+        }
+    });
+}
+
+/// Resume `owner` (and its descendants): clear the paused flag and
+/// move any of its deferred effects back onto the pending queue so
+/// they fire on the next flush.
+///
+/// Idempotent. Iterates [`ReactiveRuntime::deferred`] and re-queues
+/// every node whose owner is no longer paused — including descendants
+/// resumed by this cascade, and any deferred node whose owner happens
+/// to have been unpaused by an earlier call.
+pub fn resume_owner(owner: OwnerId) {
+    let any_resumed = with_runtime(|rt| {
+        let mut stack = vec![owner];
+        let mut any = false;
+        while let Some(id) = stack.pop() {
+            let Some(o) = rt.owners.get_mut(id) else {
+                continue;
+            };
+            if !o.paused {
+                continue;
+            }
+            o.paused = false;
+            any = true;
+            stack.extend(o.children.iter().copied());
+        }
+        if !any {
+            return false;
+        }
+        // Drain deferred → pending for every node whose owner is no
+        // longer paused. Stale entries (node disposed under a paused
+        // owner) are dropped here.
+        let deferred = std::mem::take(&mut rt.deferred);
+        for node in deferred {
+            let still_paused = rt
+                .nodes
+                .get(node)
+                .and_then(|n| rt.owners.get(n.owner))
+                .map(|o| o.paused);
+            match still_paused {
+                Some(false) => {
+                    if !rt.pending.contains(&node) {
+                        rt.pending.push(node);
+                    }
+                }
+                Some(true) => rt.deferred.push(node),
+                None => {} // node or owner is gone; drop silently
+            }
+        }
+        true
+    });
+    if any_resumed {
+        crate::host_wake::wake_runtime();
+    }
+}
+
+/// Whether `owner` is currently paused. Mainly for tests; production
+/// code should drive pause / resume from the lifecycle layer and not
+/// branch on the flag directly.
+pub fn is_owner_paused(owner: OwnerId) -> bool {
+    with_runtime(|rt| rt.owners.get(owner).map(|o| o.paused).unwrap_or(false))
 }
 
 /// Register a callback to run when the current owner is disposed.

--- a/crates/whisker-runtime/src/reactive/runtime.rs
+++ b/crates/whisker-runtime/src/reactive/runtime.rs
@@ -166,6 +166,15 @@ pub struct Owner {
     /// `WhiskerElement*` pointers across `<Show>` flips, `<For>`
     /// item removals, and per-component remounts.
     pub elements: Vec<crate::view::Element>,
+    /// When `true`, effects / computeds owned by this scope skip
+    /// flush — they're deferred onto [`ReactiveRuntime::deferred`]
+    /// until the owner is resumed.
+    ///
+    /// Cascades down the owner tree: `pause_owner` / `resume_owner`
+    /// walk descendants and mirror the flag; new owners inherit the
+    /// parent's flag at `create_owner` time. Used by `StackLayout`
+    /// to freeze back-stack entries that are mounted-but-off-screen.
+    pub paused: bool,
 }
 
 impl Owner {
@@ -178,6 +187,7 @@ impl Owner {
             cleanups: Vec::new(),
             mount_fn: None,
             elements: Vec::new(),
+            paused: false,
         }
     }
 }
@@ -213,6 +223,11 @@ pub struct ReactiveRuntime {
     /// Queue of effect/computed nodes scheduled to re-run on the next flush.
     /// Populated by signal writes; drained by [`flush_pending`].
     pub pending: Vec<NodeId>,
+    /// Nodes that were scheduled to run but whose owner is `paused`.
+    /// Sit here until their owner is resumed; on resume, drain back
+    /// into [`Self::pending`] so the deferred work fires. See
+    /// `pause_owner` / `resume_owner` for the lifecycle.
+    pub deferred: Vec<NodeId>,
     /// True while [`flush_pending`] is actively draining `pending`.
     /// Used to avoid recursive flushes (signal writes inside a running
     /// effect just enqueue; we keep draining the queue until empty
@@ -251,6 +266,7 @@ impl ReactiveRuntime {
             owner_stack: Vec::new(),
             current_tracker: None,
             pending: Vec::new(),
+            deferred: Vec::new(),
             flushing: false,
             component_owners: HashMap::new(),
             pending_mounts: Vec::new(),

--- a/crates/whisker-runtime/src/reactive/scheduler.rs
+++ b/crates/whisker-runtime/src/reactive/scheduler.rs
@@ -130,11 +130,24 @@ fn run_node_if_alive(node: NodeId) {
     let prep = with_runtime(|rt| {
         let n = rt.nodes.get(node)?;
         let owner = n.owner;
+        // Paused-owner gate: defer the run and skip. The node lands
+        // on `rt.deferred`; `resume_owner` moves it back into
+        // `pending` so the effect catches up once its scope is
+        // active again. We snapshot the kind early — pure Signal
+        // nodes never need the gate (they have no compute), so we
+        // only check the flag for Effect / Computed.
         let compute = match &n.data {
             NodeData::Effect { compute } => compute.clone(),
             NodeData::Computed { compute, .. } => compute.clone(),
             NodeData::Signal { .. } => return None,
         };
+        let paused = rt.owners.get(owner).map(|o| o.paused).unwrap_or(false);
+        if paused {
+            if !rt.deferred.contains(&node) {
+                rt.deferred.push(node);
+            }
+            return None;
+        }
         // Detach from existing arena sources before re-tracking.
         let sources: Vec<_> = rt.nodes.get(node)?.sources.iter().copied().collect();
         for src in sources {

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -1327,3 +1327,199 @@ fn arc_signal_inside_oncelock_outlives_caller_owner() {
     flush();
     assert_eq!(*observed.borrow(), Some(99));
 }
+
+// ----- Owner pause / resume -------------------------------------------------
+
+#[test]
+fn paused_owner_defers_effect_runs_until_resumed() {
+    fresh();
+    let runs = Rc::new(RefCell::new(0_u32));
+    let (read, write) = signal(0_i32);
+
+    let owner = create_owner(None);
+    let runs_clone = runs.clone();
+    with_owner(owner, || {
+        effect(move || {
+            let _ = read.get();
+            *runs_clone.borrow_mut() += 1;
+        });
+    });
+    assert_eq!(*runs.borrow(), 1, "initial registration runs the effect once");
+
+    pause_owner(owner);
+    assert!(is_owner_paused(owner));
+
+    write.set(1);
+    flush();
+    assert_eq!(*runs.borrow(), 1, "paused effect must not run on flush");
+
+    resume_owner(owner);
+    assert!(!is_owner_paused(owner));
+    flush();
+    assert_eq!(
+        *runs.borrow(),
+        2,
+        "resume must drain the deferred re-run into pending"
+    );
+}
+
+#[test]
+fn pause_cascades_to_descendants() {
+    fresh();
+    let parent_runs = Rc::new(RefCell::new(0_u32));
+    let child_runs = Rc::new(RefCell::new(0_u32));
+    let (read, write) = signal(0_i32);
+
+    let parent = create_owner(None);
+    let child = create_owner(Some(parent));
+
+    let pr = parent_runs.clone();
+    with_owner(parent, || {
+        effect(move || {
+            let _ = read.get();
+            *pr.borrow_mut() += 1;
+        });
+    });
+    let cr = child_runs.clone();
+    with_owner(child, || {
+        effect(move || {
+            let _ = read.get();
+            *cr.borrow_mut() += 1;
+        });
+    });
+    assert_eq!(*parent_runs.borrow(), 1);
+    assert_eq!(*child_runs.borrow(), 1);
+
+    pause_owner(parent);
+    assert!(is_owner_paused(parent));
+    assert!(is_owner_paused(child), "pause cascades down the tree");
+
+    write.set(1);
+    flush();
+    assert_eq!(*parent_runs.borrow(), 1);
+    assert_eq!(*child_runs.borrow(), 1);
+
+    resume_owner(parent);
+    flush();
+    assert_eq!(*parent_runs.borrow(), 2);
+    assert_eq!(*child_runs.borrow(), 2);
+}
+
+#[test]
+fn create_owner_inherits_paused_from_parent() {
+    fresh();
+    let parent = create_owner(None);
+    pause_owner(parent);
+
+    let child = create_owner(Some(parent));
+    assert!(
+        is_owner_paused(child),
+        "owner created under a paused parent must inherit paused"
+    );
+}
+
+#[test]
+fn effect_registered_under_paused_owner_defers_initial_run_until_resume() {
+    // The initial registration of an effect goes through the same
+    // schedule + flush path as a re-run, so the pause gate also
+    // applies. The closure fires on the first resume.
+    //
+    // StackLayout sidesteps this in practice by creating route owners
+    // unpaused, running render (which fires every initial effect),
+    // and only pausing the non-top routes at the end of the
+    // navigation effect.
+    fresh();
+    let runs = Rc::new(RefCell::new(0_u32));
+    let owner = create_owner(None);
+    pause_owner(owner);
+
+    let runs_clone = runs.clone();
+    with_owner(owner, || {
+        effect(move || {
+            *runs_clone.borrow_mut() += 1;
+        });
+    });
+    assert_eq!(
+        *runs.borrow(),
+        0,
+        "paused at registration: initial run deferred"
+    );
+
+    resume_owner(owner);
+    flush();
+    assert_eq!(*runs.borrow(), 1, "resume fires the deferred initial run");
+}
+
+#[test]
+fn pause_is_idempotent() {
+    fresh();
+    let owner = create_owner(None);
+    pause_owner(owner);
+    pause_owner(owner);
+    assert!(is_owner_paused(owner));
+    resume_owner(owner);
+    assert!(!is_owner_paused(owner));
+    resume_owner(owner);
+    assert!(!is_owner_paused(owner));
+}
+
+#[test]
+fn dispose_while_paused_drops_deferred_entries() {
+    fresh();
+    let runs = Rc::new(RefCell::new(0_u32));
+    let (read, write) = signal(0_i32);
+
+    let owner = create_owner(None);
+    let runs_clone = runs.clone();
+    with_owner(owner, || {
+        effect(move || {
+            let _ = read.get();
+            *runs_clone.borrow_mut() += 1;
+        });
+    });
+    pause_owner(owner);
+    write.set(1);
+    flush();
+    assert_eq!(*runs.borrow(), 1, "paused: still 1");
+
+    dispose_owner(owner);
+    // The deferred queue had this effect's node; disposal must
+    // strip it so a later flush / resume doesn't dereference a
+    // freed slot.
+    flush();
+    // No panic, no extra run.
+    assert_eq!(*runs.borrow(), 1);
+}
+
+#[test]
+fn multiple_paused_signal_writes_collapse_to_one_run_on_resume() {
+    fresh();
+    let runs = Rc::new(RefCell::new(0_u32));
+    let (read, write) = signal(0_i32);
+
+    let owner = create_owner(None);
+    let runs_clone = runs.clone();
+    with_owner(owner, || {
+        effect(move || {
+            let _ = read.get();
+            *runs_clone.borrow_mut() += 1;
+        });
+    });
+    pause_owner(owner);
+
+    write.set(1);
+    flush();
+    write.set(2);
+    flush();
+    write.set(3);
+    flush();
+    assert_eq!(*runs.borrow(), 1, "no re-runs while paused");
+
+    resume_owner(owner);
+    flush();
+    assert_eq!(
+        *runs.borrow(),
+        2,
+        "resume coalesces the deferred re-runs into a single fire"
+    );
+}

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -1344,7 +1344,11 @@ fn paused_owner_defers_effect_runs_until_resumed() {
             *runs_clone.borrow_mut() += 1;
         });
     });
-    assert_eq!(*runs.borrow(), 1, "initial registration runs the effect once");
+    assert_eq!(
+        *runs.borrow(),
+        1,
+        "initial registration runs the effect once"
+    );
 
     pause_owner(owner);
     assert!(is_owner_paused(owner));

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -104,10 +104,10 @@ macro_rules! module {
 // for callers that prefer the long path.
 pub use whisker_runtime::reactive::{
     arc_signal, computed, create_owner, dispose_owner, effect, flush, flush_mounts,
-    mount_component, on_cleanup, on_mount, provide_context, resource, resource_sync, signal,
-    unmount_component, use_context, with_context, with_owner, ArcReadSignal, ArcRwSignal,
-    ArcWriteSignal, ReadSignal, Resource, ResourceState, RwSignal, Signal, StoredValue,
-    WriteSignal,
+    is_owner_paused, mount_component, on_cleanup, on_mount, pause_owner, provide_context,
+    resource, resource_sync, resume_owner, signal, unmount_component, use_context, with_context,
+    with_owner, ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, Resource, ResourceState,
+    RwSignal, Signal, StoredValue, WriteSignal,
 };
 // Async task host. `resource()` uses these internally, but they're
 // also part of the user surface: components spawn ad-hoc async work

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -104,10 +104,10 @@ macro_rules! module {
 // for callers that prefer the long path.
 pub use whisker_runtime::reactive::{
     arc_signal, computed, create_owner, dispose_owner, effect, flush, flush_mounts,
-    is_owner_paused, mount_component, on_cleanup, on_mount, pause_owner, provide_context,
-    resource, resource_sync, resume_owner, signal, unmount_component, use_context, with_context,
-    with_owner, ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, Resource, ResourceState,
-    RwSignal, Signal, StoredValue, WriteSignal,
+    is_owner_paused, mount_component, on_cleanup, on_mount, pause_owner, provide_context, resource,
+    resource_sync, resume_owner, signal, unmount_component, use_context, with_context, with_owner,
+    ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, Resource, ResourceState, RwSignal,
+    Signal, StoredValue, WriteSignal,
 };
 // Async task host. `resource()` uses these internally, but they're
 // also part of the user surface: components spawn ad-hoc async work

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -47,7 +47,7 @@ use whisker::css::ext::*;
 use whisker::css::{Css, Overflow, PositionKind, ToCss};
 use whisker::runtime::element::ElementTag;
 use whisker::runtime::reactive::{
-    create_owner, dispose_owner, effect, on_mount, with_owner, OwnerId,
+    create_owner, dispose_owner, effect, on_mount, pause_owner, resume_owner, with_owner, OwnerId,
 };
 use whisker::runtime::view::apply::apply_styles;
 use whisker::runtime::view::{
@@ -285,6 +285,7 @@ fn run_navigation_effect<R: Route>(
             }
         }
         first.set(false);
+        sync_owner_paused_state(state);
         return;
     }
 
@@ -446,6 +447,32 @@ fn run_navigation_effect<R: Route>(
                 remove_child(container, entry.wrapper);
                 dispose_owner(entry.owner);
             }
+        }
+    }
+
+    // Step 9: sync paused state across all mounted owners. The top
+    // of `order` runs effects; everything else (mounted-but-hidden
+    // back-stack) is paused until it surfaces. Idempotent, so it's
+    // safe to call on every navigation, including the very first.
+    sync_owner_paused_state(state);
+}
+
+/// Walk `state.mounted` and align each entry's owner with the
+/// expected paused state: the topmost (last in [`LayoutState::order`])
+/// is active; everything else is paused.
+///
+/// Idempotent — `pause_owner` / `resume_owner` no-op on the matching
+/// state, so calling this every navigation costs at most one set
+/// flip per owner.
+fn sync_owner_paused_state(state: &LayoutState) {
+    let order = state.order.borrow();
+    let mounted = state.mounted.borrow();
+    let top_id = order.last().copied();
+    for (id, entry) in mounted.iter() {
+        if Some(*id) == top_id {
+            resume_owner(entry.owner);
+        } else {
+            pause_owner(entry.owner);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an owner-level `paused` flag plus `pause_owner` / `resume_owner` that cascade down the owner tree, and wires `StackLayout` to pause every back-stack entry below the active top.

- New `Owner.paused: bool`; effects and computeds whose owner is paused skip flush and land on `Runtime.deferred`. `resume_owner` drains the deferred queue back into `pending`.
- `create_owner` inherits the parent's `paused` flag at construction time, so sub-components mounted under a paused route start paused as well.
- `StackLayout` calls a new `sync_owner_paused_state` at the end of every navigation pass (and the gesture commit path): the topmost mounted route stays active; every other entry is paused.
- `dispose_owner` strips disposed nodes from both `pending` and `deferred`.

Off-screen routes still keep their state, but no longer spend CPU on signal-driven re-renders behind the visible screen — finishes the freeze-when-hidden invariant that #117 deferred. Matches iOS `UINavigationController` / Android Fragment back-stack semantics.

Public surface added on `whisker` / `whisker::runtime::reactive`: `pause_owner`, `resume_owner`, `is_owner_paused`.

## Test plan

- [x] `cargo test -p whisker-runtime -p whisker-router` (164 + new tests pass)
  - paused effect defers re-runs, resume drains
  - pause cascades to descendants
  - `create_owner` under paused parent inherits paused
  - initial effect run is also gated by pause (documented)
  - idempotent pause / resume
  - dispose-while-paused strips deferred entries (no panic on later flush)
  - multiple paused writes coalesce to one run on resume
- [x] Android emulator: Browse ↔ Detail round-trip preserves state, no visual regressions over repeated navigation
- [x] iOS simulator: same as Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)