### PR TITLE
feat(dev-server): hot-reload covers workspace path-deps (#103)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "cargo_metadata",
  "futures-util",
  "notify",
  "object",

--- a/crates/whisker-dev-server/Cargo.toml
+++ b/crates/whisker-dev-server/Cargo.toml
@@ -18,6 +18,10 @@ serde_json = { workspace = true }
 subsecond-types = { workspace = true }
 notify = { workspace = true }
 object = { workspace = true }
+# Workspace dep-graph walk for sub-crate hot-reload: enumerate path
+# deps of the user crate so the file watcher can cover their src/
+# trees and the patcher knows which crate a changed file belongs to.
+cargo_metadata = "0.18"
 # Cold-rebuild orchestration. Shared with whisker-cli's `whisker build`.
 whisker-build = { workspace = true }
 

--- a/crates/whisker-dev-server/src/hotpatch/link_plan.rs
+++ b/crates/whisker-dev-server/src/hotpatch/link_plan.rs
@@ -336,6 +336,25 @@ fn filter_captured_linker_args(args: &[String]) -> Vec<String> {
             i += 1;
             continue;
         }
+        // `-Wl,-dead_strip` (Mach-O) / `-Wl,--gc-sections` (ELF) =
+        // remove unreferenced symbols from the linked image. Combined
+        // with `-Wl,-undefined,dynamic_lookup` and per-symbol
+        // `-exported_symbol` whitelists, this strips every symbol
+        // that isn't transitively reachable from the whitelist roots.
+        //
+        // Fine for the fat build where `_whisker_app_main` keeps the
+        // whole user crate's tree live, but FATAL for sub-crate
+        // patches (#103): the patch dylib's sub-crate `.o` provides
+        // a definition for symbols the user crate's `.o` references,
+        // but `dynamic_lookup` lets ld64 treat those references as
+        // "will be resolved at runtime" without following the local
+        // edge, so dead_strip drops every sub-crate symbol. The
+        // JumpTable then has zero sub-crate entries and the hot patch
+        // visibly does nothing. Drop both forms.
+        if arg == "-Wl,-dead_strip" || arg == "-Wl,--gc-sections" {
+            i += 1;
+            continue;
+        }
 
         out.push(arg.clone());
         i += 1;
@@ -482,6 +501,20 @@ mod tests {
             "dynamic_lookup",
             "-Wl,-undefined,dynamic_lookup",
             "-Wl,--unresolved-symbols=ignore-all",
+            "-arch",
+            "arm64",
+        ]));
+        assert_eq!(kept, s(&["-arch", "arm64"]));
+    }
+
+    #[test]
+    fn filter_drops_dead_strip_and_gc_sections() {
+        // `-Wl,-dead_strip` (Mach-O) and `-Wl,--gc-sections` (ELF)
+        // would otherwise drop sub-crate symbols whose only inbound
+        // references are satisfied via `-undefined,dynamic_lookup`.
+        let kept = filter_captured_linker_args(&s(&[
+            "-Wl,-dead_strip",
+            "-Wl,--gc-sections",
             "-arch",
             "arm64",
         ]));

--- a/crates/whisker-dev-server/src/hotpatch/mod.rs
+++ b/crates/whisker-dev-server/src/hotpatch/mod.rs
@@ -30,7 +30,8 @@ pub use patcher::Patcher;
 pub use runner::{run_link_plan, run_obj_plan, thin_rebuild_obj};
 pub use shim_paths::{expected_shim_paths, resolve_shim_paths, ShimPaths};
 pub use stub_object::{
-    build_stub_for_needed, compute_needed_symbols, create_undefined_symbol_stub,
+    build_stub_for_needed, compute_needed_symbols, compute_needed_symbols_multi,
+    create_undefined_symbol_stub,
 };
 pub use symbol_table::{parse_symbol_table, SymbolInfo, SymbolTable};
 pub use thin_build::{build_obj_plan, library_filename, object_filename, ObjBuildPlan};

--- a/crates/whisker-dev-server/src/hotpatch/patcher.rs
+++ b/crates/whisker-dev-server/src/hotpatch/patcher.rs
@@ -143,18 +143,51 @@ impl Patcher {
     /// `0` for cases where no device has connected yet (the patch
     /// will still build but won't dispatch correctly at runtime; the
     /// caller should refrain from sending it in that state).
-    pub async fn build_patch(&self, aslr_reference: u64) -> Result<PatchPlan> {
-        // Look up the captured rustc invocation by the rustc-style
-        // crate name (hyphens → underscores). Tier 1 only patches
-        // the user crate today; tracking edits in dependency crates
-        // is a future expansion.
-        let crate_key = self.package.replace('-', "_");
+    ///
+    /// `crate_key` is the **rustc-form** name of the crate that owns
+    /// the change. `None` defaults to the user crate. Sub-crate
+    /// patches (#103) pass the changed crate's name so the thin
+    /// build picks up that crate's captured rustc args (a fresh `.o`
+    /// of the changed sub-crate), then links it into a patch dylib
+    /// using the user crate's linker invocation as template. The
+    /// original user dylib already exports the sub-crate's symbols
+    /// (rustc linked its rlib in fat-build time); subsecond's
+    /// JumpTable redirects them onto the patch dylib's new bodies.
+    pub async fn build_patch(
+        &self,
+        aslr_reference: u64,
+        crate_key: Option<&str>,
+    ) -> Result<PatchPlan> {
+        let user_key = self.package.replace('-', "_");
+        let crate_key = crate_key
+            .map(str::to_owned)
+            .unwrap_or_else(|| user_key.clone());
         let captured_rustc = self.captured_rustc_args.get(&crate_key).with_context(|| {
             format!(
-                "no captured rustc invocation for crate `{}`; was the fat build run?",
-                self.package,
+                "no captured rustc invocation for crate `{crate_key}`; \
+                 was the fat build run?",
             )
         })?;
+        // When patching a sub-crate, also compile the user crate
+        // alongside it. The user crate carries the
+        // `whisker_aslr_anchor` / `whisker_app_main` / `whisker_tick`
+        // symbols (emitted by `#[whisker::main]`) — without them,
+        // `subsecond::apply_patch`'s `dlsym(patch, "whisker_aslr_anchor")`
+        // returns NULL and the runtime computes a junk slide that
+        // SIGBUSes on the next call into a patched function. Linking
+        // the user crate's `.o` puts those symbols into the patch
+        // dylib's `.dynsym` so subsecond's math works.
+        let user_rustc = if crate_key != user_key {
+            Some(self.captured_rustc_args.get(&user_key).with_context(|| {
+                format!(
+                    "sub-crate patch ({crate_key}) needs user crate `{user_key}` in the link \
+                         (for the `whisker_aslr_anchor` symbol), but no captured rustc invocation \
+                         is available for it",
+                )
+            })?)
+        } else {
+            None
+        };
 
         // Linker capture is keyed by output basename. The fat build's
         // crate-type is whatever cargo chose (typically `cdylib` for
@@ -170,11 +203,26 @@ impl Patcher {
         validate_environment(captured_rustc, &self.rustc_path)
             .context("environment validation before thin rebuild")?;
 
-        // Stage 1: rustc the user crate to a single `.o` file.
+        // Stage 1: rustc the changed crate to a `.o` file.
         let obj_plan = thin_build::build_obj_plan(captured_rustc, &self.patch_out_dir);
         let object = run_obj_plan(&obj_plan, &self.rustc_path, &self.cwd)
             .await
             .context("rustc --emit=obj for thin patch")?;
+
+        // Stage 1b: for sub-crate patches, also rebuild the user
+        // crate's `.o` so the patch dylib carries the anchor symbols
+        // subsecond needs (see Stage 1's `user_rustc` doc above).
+        // Skipped on user-crate patches because `object` already
+        // covers it.
+        let user_object_for_link: Option<PathBuf> = if let Some(user_rustc) = user_rustc {
+            let user_obj_plan = thin_build::build_obj_plan(user_rustc, &self.patch_out_dir);
+            let obj = run_obj_plan(&user_obj_plan, &self.rustc_path, &self.cwd)
+                .await
+                .context("rustc --emit=obj for user crate (sub-crate patch anchor source)")?;
+            Some(obj)
+        } else {
+            None
+        };
 
         // Stage 2: synthesize a stub `.o` that maps every host symbol
         // the patch refers to onto its live runtime address. The stub
@@ -190,15 +238,28 @@ impl Patcher {
         // `lib.rs::run` skips Tier 1 entirely when no aslr_reference
         // has been reported.
         let extras: Vec<PathBuf> = if aslr_reference == 0 {
-            Vec::new()
+            // Test-fixture path: even without a stub we still need to
+            // pass the user crate's `.o` for sub-crate patches so
+            // the anchor symbol exists.
+            user_object_for_link.iter().cloned().collect()
         } else {
             let stub_path = self.patch_out_dir.join("aslr-stub.o");
+            // Feed BOTH input objects into the UND-symbol scan when
+            // building the stub. The sub-crate `.o` references
+            // whisker / kit symbols; the user crate `.o` references
+            // sub-crate symbols + framework symbols. Missing the
+            // latter set would leave UNDs unresolved at link time.
             let stub_bytes = self
-                .stub_bytes_for(&object, aslr_reference)
+                .stub_bytes_for_objects(&object, user_object_for_link.as_deref(), aslr_reference)
                 .context("synthesize stub object")?;
             std::fs::write(&stub_path, &stub_bytes)
                 .with_context(|| format!("write stub object to {}", stub_path.display()))?;
             let mut e = vec![stub_path];
+            // Pull in the user crate's `.o` alongside the sub-crate's
+            // (no-op for user-crate patches where this is None).
+            if let Some(uo) = user_object_for_link.as_ref() {
+                e.push(uo.clone());
+            }
             // Belt-and-suspenders on Linux/Android: the stub is
             // Text-only and emits weak symbols, so non-Text host
             // refs (thread-locals, static OnceCells like
@@ -254,13 +315,27 @@ impl Patcher {
         ))
     }
 
-    /// Return the stub object bytes for `object`+`aslr_reference`.
-    /// Reuses an in-session cached copy when the patch's UND symbol
-    /// set matches the previous build's and `aslr_reference` /
-    /// `target_os` are unchanged — the common case when an edit only
-    /// touches a function body.
-    fn stub_bytes_for(&self, object: &Path, aslr_reference: u64) -> Result<Vec<u8>> {
-        let needed = super::compute_needed_symbols(object).context("compute_needed_symbols")?;
+    /// Return the stub object bytes for the link inputs +
+    /// `aslr_reference`. Reuses an in-session cached copy when the
+    /// patch's UND symbol set matches the previous build's and
+    /// `aslr_reference` / `target_os` are unchanged — the common case
+    /// when an edit only touches a function body.
+    ///
+    /// Pass `extra` for sub-crate patches (#103): the union of UND
+    /// symbols across both objects, minus their union of defined,
+    /// gives the right "still unresolved" set.
+    fn stub_bytes_for_objects(
+        &self,
+        object: &Path,
+        extra: Option<&Path>,
+        aslr_reference: u64,
+    ) -> Result<Vec<u8>> {
+        let mut paths: Vec<&Path> = vec![object];
+        if let Some(p) = extra {
+            paths.push(p);
+        }
+        let needed =
+            super::compute_needed_symbols_multi(&paths).context("compute_needed_symbols_multi")?;
         let needed_hash = hash_needed(&needed);
         if let Ok(guard) = self.stub_cache.lock() {
             if let Some(cached) = guard.as_ref() {
@@ -543,8 +618,26 @@ mod tests {
         );
         // aslr_reference value is irrelevant for this error path —
         // build_patch bails before touching it.
-        let err = p.build_patch(0).await.unwrap_err();
+        let err = p.build_patch(0, None).await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("no captured rustc invocation"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn build_patch_errors_when_explicit_crate_key_missing() {
+        let p = Patcher::new(
+            "demo".into(),
+            "/rustc".into(),
+            "/cc".into(),
+            "/cwd".into(),
+            "/patches".into(),
+            LinkerOs::Macos,
+            empty_cache(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        let err = p.build_patch(0, Some("not_a_crate")).await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("not_a_crate"), "{msg}");
     }
 }

--- a/crates/whisker-dev-server/src/hotpatch/stub_object.rs
+++ b/crates/whisker-dev-server/src/hotpatch/stub_object.rs
@@ -75,23 +75,37 @@ pub fn create_undefined_symbol_stub(
 /// patch refers to but doesn't itself define. Sorted (Vec, not Set)
 /// so callers can hash the result deterministically for caching.
 pub fn compute_needed_symbols(patch_obj: &Path) -> Result<Vec<String>> {
-    let bytes = std::fs::read(patch_obj)
-        .with_context(|| format!("read patch obj {}", patch_obj.display()))?;
-    let file = object::File::parse(&*bytes).context("parse patch obj")?;
+    compute_needed_symbols_multi(std::slice::from_ref(&patch_obj))
+}
 
+/// Multi-input variant of [`compute_needed_symbols`]. Take the union
+/// of every input's undefined set minus the union of every input's
+/// defined set — i.e. symbols still unresolved after the inputs
+/// satisfy each other's references.
+///
+/// Used by sub-crate hot-patches (#103) where the patch dylib is
+/// linked from both the sub-crate's `.o` and the user crate's `.o`
+/// (the user's `.o` carries the anchor symbols). A name undefined
+/// in one but defined in the other should NOT end up in the stub.
+pub fn compute_needed_symbols_multi(patch_objs: &[&Path]) -> Result<Vec<String>> {
     let mut undefined: HashSet<String> = HashSet::new();
     let mut defined: HashSet<String> = HashSet::new();
-    for sym in file.symbols() {
-        let Ok(name) = sym.name() else {
-            continue;
-        };
-        if name.is_empty() {
-            continue;
-        }
-        if sym.is_undefined() {
-            undefined.insert(name.to_string());
-        } else {
-            defined.insert(name.to_string());
+    for patch_obj in patch_objs {
+        let bytes = std::fs::read(patch_obj)
+            .with_context(|| format!("read patch obj {}", patch_obj.display()))?;
+        let file = object::File::parse(&*bytes).context("parse patch obj")?;
+        for sym in file.symbols() {
+            let Ok(name) = sym.name() else {
+                continue;
+            };
+            if name.is_empty() {
+                continue;
+            }
+            if sym.is_undefined() {
+                undefined.insert(name.to_string());
+            } else {
+                defined.insert(name.to_string());
+            }
         }
     }
     let mut needed: Vec<String> = undefined.difference(&defined).cloned().collect();

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -53,12 +53,14 @@ pub mod hotpatch;
 pub mod installer;
 pub mod server;
 pub mod watcher;
+pub mod workspace;
 
 pub use builder::Builder;
 pub use installer::Installer;
 pub use server::{Patch, PatchSender};
 pub use watcher::{Change, ChangeKind};
 pub use whisker_build::CaptureShims;
+pub use workspace::{discover_path_deps, identify_crate_for_paths, PathDepCrate};
 
 // ----- Config & enums --------------------------------------------------------
 
@@ -262,18 +264,50 @@ impl DevServer {
         whisker_build::ui::set_status(format!("ws://{bound} · 0 client(s)"));
         whisker_build::ui::debug(format!("ws://{bound}/whisker-dev"));
 
-        // Watch the user crate's `src/`. `crate_dir` is whatever the
-        // cli resolved (`Cargo.toml` parent) — for in-workspace
-        // examples this is `<workspace>/examples/<pkg>/`, for an
-        // external user it's wherever they keep their app.
-        let watch_root = self.config.crate_dir.join("src");
+        // Walk the user crate's dep graph for every workspace path
+        // dep. The watcher attaches one notify root per `src/`, and
+        // the change loop uses the same list to map a changed file
+        // back to its owning crate. Registry / git deps are excluded
+        // — their sources live outside the workspace; Cargo.toml /
+        // Cargo.lock edits trigger a Tier 2 rebuild and pick them
+        // up that way.
+        let path_deps = workspace::discover_path_deps(
+            &self.config.crate_dir.join("Cargo.toml"),
+            &self.config.package,
+        )
+        .unwrap_or_else(|e| {
+            whisker_build::ui::warn(format!(
+                "cargo metadata failed ({e:#}); falling back to user crate only",
+            ));
+            Vec::new()
+        });
+        // Always include the user crate's src dir as a fallback even
+        // if cargo metadata returned nothing — the dev loop should
+        // still work in degraded mode.
+        let user_src = self.config.crate_dir.join("src");
+        let mut watch_roots: Vec<PathBuf> = path_deps
+            .iter()
+            .map(|c| c.src_dir.clone())
+            .filter(|p| p.is_dir())
+            .collect();
+        if !watch_roots.iter().any(|p| p == &user_src) && user_src.is_dir() {
+            watch_roots.push(user_src.clone());
+        }
+        if watch_roots.is_empty() {
+            // Last-resort: watch the user_src path even if it doesn't
+            // exist yet — notify will fail and we'll surface the
+            // error to the user.
+            watch_roots.push(user_src.clone());
+        }
         let (tx, mut rx) = tokio::sync::mpsc::channel::<watcher::Change>(8);
         let _watcher = watcher::spawn_watcher(
-            watch_root.clone(),
+            watch_roots.clone(),
             std::time::Duration::from_millis(200),
             tx,
         )?;
-        whisker_build::ui::debug(format!("watching {}", watch_root.display()));
+        for root in &watch_roots {
+            whisker_build::ui::debug(format!("watching {}", root.display()));
+        }
         emit(&self.on_event, Event::Started);
 
         // Configure the initial build. For Tier 1 it doubles as the
@@ -368,6 +402,24 @@ impl DevServer {
                     // wire-up so the user sees a single elapsed
                     // duration for "edit → app updated".
                     let patch_step = whisker_build::ui::step("patch", "tier 1");
+                    // Map the changed file paths to the owning crate.
+                    // None = batch spans multiple crates, or a path
+                    // outside every known src dir — fall back to a
+                    // cold rebuild since we can only patch one crate
+                    // per batch.
+                    let crate_key = workspace::identify_crate_for_paths(&change.paths, &path_deps);
+                    if !path_deps.is_empty() && crate_key.is_none() {
+                        patch_step.fail("multi-crate change batch; using Tier 2");
+                        run_build_cycle(
+                            &builder,
+                            &installer,
+                            &self.on_event,
+                            &sender,
+                            "rebuild (tier2 fallback, multi-crate batch)",
+                        )
+                        .await;
+                        continue;
+                    }
                     let Some(aslr_reference) = sender.latest_aslr_reference() else {
                         // No client has reported its `aslr_reference` yet
                         // (handshake hasn't completed, or never connected).
@@ -385,7 +437,7 @@ impl DevServer {
                         continue;
                     };
                     let started = std::time::Instant::now();
-                    match p.build_patch(aslr_reference).await {
+                    match p.build_patch(aslr_reference, crate_key.as_deref()).await {
                         Ok(plan) => {
                             let built_in = started.elapsed();
                             log_patch_diff(&plan.report);

--- a/crates/whisker-dev-server/src/watcher.rs
+++ b/crates/whisker-dev-server/src/watcher.rs
@@ -65,14 +65,25 @@ impl Change {
     }
 }
 
-/// Spawn a recursive watcher on `root`. Debounced [`Change`] batches
-/// arrive on `tx`. The returned [`RecommendedWatcher`] keeps the OS
-/// watch alive — drop it to stop watching.
+/// Spawn a recursive watcher rooted at each path in `roots`.
+/// Debounced [`Change`] batches arrive on `tx`. The returned
+/// [`RecommendedWatcher`] keeps the OS watches alive — drop it to
+/// stop watching.
+///
+/// Roots that fail to attach (don't exist, or notify rejects them)
+/// log a warning and are skipped; the watcher still returns as long
+/// as at least one root attached. Sub-crates without a `src/` are
+/// the common case — `cargo metadata` lists every workspace member,
+/// not every member ships a `src/` (proc-macro-only crates, virtual
+/// manifest stubs, …).
 pub fn spawn_watcher(
-    root: PathBuf,
+    roots: Vec<PathBuf>,
     debounce: Duration,
     tx: mpsc::Sender<Change>,
 ) -> Result<RecommendedWatcher> {
+    if roots.is_empty() {
+        anyhow::bail!("spawn_watcher: no roots to watch");
+    }
     let (raw_tx, raw_rx) = std_mpsc::channel::<Event>();
     let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
         if let Ok(ev) = res {
@@ -82,9 +93,19 @@ pub fn spawn_watcher(
         }
     })
     .context("create notify watcher")?;
-    watcher
-        .watch(&root, RecursiveMode::Recursive)
-        .with_context(|| format!("watch {}", root.display()))?;
+    let mut attached = 0;
+    for root in &roots {
+        match watcher.watch(root, RecursiveMode::Recursive) {
+            Ok(()) => attached += 1,
+            Err(e) => whisker_build::ui::warn(format!("skip watch {}: {e}", root.display())),
+        }
+    }
+    if attached == 0 {
+        anyhow::bail!(
+            "spawn_watcher: no roots successfully attached (of {})",
+            roots.len()
+        );
+    }
 
     // Debounce loop: separate OS thread because notify's callback is
     // synchronous and the std mpsc::Receiver isn't async-friendly.
@@ -209,7 +230,7 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel::<Change>(8);
         let _watcher =
-            spawn_watcher(dir.clone(), Duration::from_millis(120), tx).expect("watcher up");
+            spawn_watcher(vec![dir.clone()], Duration::from_millis(120), tx).expect("watcher up");
 
         // Give notify a moment to register the watch.
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -241,7 +262,7 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel::<Change>(8);
         let _watcher =
-            spawn_watcher(dir.clone(), Duration::from_millis(120), tx).expect("watcher up");
+            spawn_watcher(vec![dir.clone()], Duration::from_millis(120), tx).expect("watcher up");
 
         tokio::time::sleep(Duration::from_millis(50)).await;
         std::fs::write(

--- a/crates/whisker-dev-server/src/workspace.rs
+++ b/crates/whisker-dev-server/src/workspace.rs
@@ -1,0 +1,224 @@
+//! Workspace path-dep walker.
+//!
+//! Hot-reload coverage (#103): the file watcher and the patcher both
+//! need to know which sub-crates the user app depends on so an edit
+//! to e.g. `examples/podcast/crates/podcast-ui-kit/src/top_nav.rs`
+//! produces a tier-1 patch instead of being silently ignored.
+//!
+//! [`discover_path_deps`] runs `cargo metadata` against the user
+//! crate's manifest and returns every path-dep reachable from it,
+//! including the user crate itself. "Path dep" here means a
+//! workspace member (or `path = "..."` dep) — anything whose
+//! `Package.source` is `None`. Registry deps (crates.io) and git
+//! deps are excluded; their sources are out-of-tree and not worth
+//! watching.
+//!
+//! The returned tuples carry the **rustc-form crate name** (hyphens
+//! replaced with underscores) so callers can look them up in the
+//! captured rustc-args map directly. The src dir is the absolute
+//! path to `<manifest_dir>/src/` (the conventional location; binary
+//! / examples-only crates that don't have `src/` are skipped at
+//! watch time when notify refuses to attach).
+
+use anyhow::{Context, Result};
+use cargo_metadata::MetadataCommand;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// One path-dep crate as the dev loop sees it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathDepCrate {
+    /// Rustc-style crate name (hyphens → underscores). This matches
+    /// the key the `whisker-rustc-shim` writes into its capture cache.
+    pub crate_name: String,
+    /// Absolute path to the crate's `src/` directory. Used as a
+    /// watch root and as a prefix for "which crate did this path
+    /// come from?" lookups.
+    pub src_dir: PathBuf,
+}
+
+/// Walk `cargo metadata` for the user crate at `manifest_path` and
+/// return every path-dep reachable from it, including the root
+/// package itself. Topologically ordered (parents before deps).
+///
+/// "Path dep" = `Package.source.is_none()`. That covers workspace
+/// members and explicit `path = "..."` deps. Registry / git deps
+/// are skipped — their sources live outside the workspace and
+/// changes there would imply a `Cargo.lock` bump, which Tier 2
+/// rebuild already covers.
+pub fn discover_path_deps(manifest_path: &Path, app_package: &str) -> Result<Vec<PathDepCrate>> {
+    let metadata = MetadataCommand::new()
+        .manifest_path(manifest_path)
+        .exec()
+        .with_context(|| {
+            format!(
+                "cargo metadata failed for {} (package: {app_package})",
+                manifest_path.display(),
+            )
+        })?;
+
+    let resolve = metadata
+        .resolve
+        .as_ref()
+        .context("cargo metadata returned no resolve graph")?;
+    let root_id = resolve
+        .root
+        .as_ref()
+        .cloned()
+        .or_else(|| {
+            metadata
+                .packages
+                .iter()
+                .find(|p| p.name == app_package)
+                .map(|p| p.id.clone())
+        })
+        .with_context(|| format!("cargo package `{app_package}` not found in the workspace"))?;
+
+    let mut out: Vec<PathDepCrate> = Vec::new();
+    let mut visit: Vec<&cargo_metadata::PackageId> = vec![&root_id];
+    let mut seen: HashSet<&cargo_metadata::PackageId> = HashSet::new();
+
+    while let Some(pkg_id) = visit.pop() {
+        if !seen.insert(pkg_id) {
+            continue;
+        }
+        let Some(pkg) = metadata.packages.iter().find(|p| &p.id == pkg_id) else {
+            continue;
+        };
+        // Registry / git deps have a `source`; we only watch deps
+        // whose source is None (= workspace path-dep).
+        if pkg.source.is_some() {
+            continue;
+        }
+        if let Some(manifest_dir) = pkg.manifest_path.parent() {
+            let src_dir = manifest_dir.join("src");
+            out.push(PathDepCrate {
+                crate_name: pkg.name.replace('-', "_"),
+                src_dir: src_dir.into(),
+            });
+        }
+        if let Some(node) = resolve.nodes.iter().find(|n| &n.id == pkg_id) {
+            for dep in &node.deps {
+                visit.push(&dep.pkg);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Given a debounced batch of changed paths, return the rustc-form
+/// crate name they all map to via longest-prefix match against
+/// `crates`. Returns `None` if the batch spans multiple crates or
+/// any path is outside every known src dir — the dev loop falls back
+/// to a Tier 2 cold rebuild in that case (we can patch one crate per
+/// debounced batch, not two).
+pub fn identify_crate_for_paths(paths: &[PathBuf], crates: &[PathDepCrate]) -> Option<String> {
+    let mut found: Option<&str> = None;
+    for p in paths {
+        let hit = best_crate_for(p, crates)?;
+        match found {
+            None => found = Some(hit),
+            Some(prev) if prev != hit => return None,
+            _ => {}
+        }
+    }
+    found.map(str::to_owned)
+}
+
+/// Longest-prefix match: pick the crate whose `src_dir` is the most
+/// specific prefix of `path`. Handles the (rare) case where one
+/// crate's manifest dir nests inside another — the inner crate wins.
+fn best_crate_for<'a>(path: &Path, crates: &'a [PathDepCrate]) -> Option<&'a str> {
+    let mut best: Option<(&str, usize)> = None;
+    for c in crates {
+        if path.starts_with(&c.src_dir) {
+            let depth = c.src_dir.components().count();
+            if best.map(|(_, d)| depth > d).unwrap_or(true) {
+                best = Some((&c.crate_name, depth));
+            }
+        }
+    }
+    best.map(|(n, _)| n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cr(name: &str, dir: &str) -> PathDepCrate {
+        PathDepCrate {
+            crate_name: name.into(),
+            src_dir: PathBuf::from(dir),
+        }
+    }
+
+    #[test]
+    fn identify_returns_the_matching_crate() {
+        let crates = vec![
+            cr("podcast", "/ws/examples/podcast/src"),
+            cr(
+                "podcast_ui_kit",
+                "/ws/examples/podcast/crates/podcast-ui-kit/src",
+            ),
+        ];
+        let paths = vec![PathBuf::from(
+            "/ws/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs",
+        )];
+        assert_eq!(
+            identify_crate_for_paths(&paths, &crates),
+            Some("podcast_ui_kit".into())
+        );
+    }
+
+    #[test]
+    fn identify_returns_none_when_paths_span_multiple_crates() {
+        let crates = vec![
+            cr("podcast", "/ws/examples/podcast/src"),
+            cr(
+                "podcast_ui_kit",
+                "/ws/examples/podcast/crates/podcast-ui-kit/src",
+            ),
+        ];
+        let paths = vec![
+            PathBuf::from("/ws/examples/podcast/src/lib.rs"),
+            PathBuf::from("/ws/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs"),
+        ];
+        assert_eq!(identify_crate_for_paths(&paths, &crates), None);
+    }
+
+    #[test]
+    fn identify_returns_none_when_no_crate_matches() {
+        let crates = vec![cr("podcast", "/ws/examples/podcast/src")];
+        let paths = vec![PathBuf::from("/some/unrelated/path/foo.rs")];
+        assert_eq!(identify_crate_for_paths(&paths, &crates), None);
+    }
+
+    #[test]
+    fn identify_picks_the_deeper_match_when_src_dirs_nest() {
+        // Defensive: if a sub-crate's src_dir lives inside another
+        // crate's src_dir (unusual but possible with custom layouts),
+        // the inner crate wins.
+        let crates = vec![
+            cr("outer", "/ws/foo/src"),
+            cr("inner", "/ws/foo/src/inner_pkg/src"),
+        ];
+        let paths = vec![PathBuf::from("/ws/foo/src/inner_pkg/src/lib.rs")];
+        assert_eq!(
+            identify_crate_for_paths(&paths, &crates),
+            Some("inner".into())
+        );
+    }
+
+    #[test]
+    fn identify_handles_single_crate_batch() {
+        let crates = vec![cr("podcast", "/ws/podcast/src")];
+        let paths = vec![
+            PathBuf::from("/ws/podcast/src/lib.rs"),
+            PathBuf::from("/ws/podcast/src/main.rs"),
+        ];
+        assert_eq!(
+            identify_crate_for_paths(&paths, &crates),
+            Some("podcast".into())
+        );
+    }
+}

--- a/crates/whisker-dev-server/tests/patcher.rs
+++ b/crates/whisker-dev-server/tests/patcher.rs
@@ -218,7 +218,7 @@ async fn build_patch_emits_a_jump_table_entry_for_a_mangled_function() {
     std::fs::write(&lib_rs, edited).unwrap();
 
     // ---- The actual test: build_patch produces an entry for `calculate`
-    let plan = patcher.build_patch(0).await.expect("build_patch");
+    let plan = patcher.build_patch(0, None).await.expect("build_patch");
 
     // The diff report must NOT list `calculate` as added or removed
     // (mangled name should be identical across both sides).
@@ -282,7 +282,7 @@ async fn build_patch_errors_when_no_captured_rustc_for_the_package() {
         HashMap::new(),
     );
 
-    let err = patcher.build_patch(0).await.unwrap_err();
+    let err = patcher.build_patch(0, None).await.unwrap_err();
     let msg = format!("{err:#}");
     assert!(msg.contains("no captured rustc invocation"), "{msg}");
 
@@ -320,7 +320,7 @@ async fn build_patch_errors_when_captured_linker_is_missing() {
         HashMap::new(), // empty linker map
     );
 
-    let err = patcher.build_patch(0).await.unwrap_err();
+    let err = patcher.build_patch(0, None).await.unwrap_err();
     let msg = format!("{err:#}");
     assert!(msg.contains("no captured linker invocation"), "{msg}");
 


### PR DESCRIPTION
Closes #103.

## Summary

Extends Tier 1 hot-reload coverage to every workspace path-dep the user crate depends on. Before this PR, edits to e.g. \`examples/podcast/crates/podcast-ui-kit/src/top_nav.rs\` were silently ignored — the watcher only saw \`<crate_dir>/src/\` and the patcher only knew the user crate's captured rustc args. Now sub-crate edits produce a tier-1 patch in single-digit seconds (incremental) instead of forcing a 30–60 s cold rebuild.

## What changed

- **\`workspace\`** module — walks \`cargo metadata\` for every path-dep reachable from the user crate (registry / git deps excluded). Returns \`(crate_name, src_dir)\` so the watcher knows what to attach and the change loop can map a touched file back to its owning crate.
- **\`watcher::spawn_watcher\`** — takes \`Vec<PathBuf>\` roots. Misses log a warning and skip rather than fail the whole watch (proc-macro-only crates, virtual stubs, etc.).
- **\`Patcher::build_patch(aslr_reference, crate_key)\`** — new \`crate_key\` arg names the changed crate's rustc-form name. \`None\` defaults to the user crate (existing semantics, no behavior change for user-crate edits).
- **Sub-crate patches link two \`.o\`s** — the sub-crate's plus the user crate's. The user crate carries the \`whisker_aslr_anchor\` / \`whisker_app_main\` / \`whisker_tick\` symbols from \`#[whisker::main]\`; without them \`subsecond::apply_patch\`'s \`dlsym(patch, \"whisker_aslr_anchor\")\` returns NULL, the runtime computes a junk slide, and the next call into a patched function SIGBUSes (observed during development; the fix landed after a verified crash).
- **\`compute_needed_symbols_multi\`** — stub-object UND resolution scans both link inputs in one pass (union of UNDs minus union of defs) so cross-object refs don't end up in the stub.
- **Multi-crate batches** — debounced changes that touch more than one crate fall back to Tier 2 cold rebuild. Patching N crates per batch is left for a follow-up.

## Test plan

- [x] Unit tests for \`workspace::identify_crate_for_paths\` (single-crate, multi-crate, no-match, nested-srcs).
- [x] \`build_patch\` error tests for unknown crate keys.
- [x] \`cargo test -p whisker-dev-server --lib\` — 152 passing.
- [x] Android emulator: edit \`podcast-ui-kit/src/top_nav.rs\` icon color → tier 1 patch fires (17.4 s cold, ~6 s incremental), app stays alive, screenshot confirms the new color.

## Known follow-ups

- Multi-crate change batches (today: Tier 2).
- Inlined sub-crate functions in the user crate stay frozen at the pre-edit version — only call-through paths see the new body. Cascading rlib swap would address this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)