### PR TITLE
feat(audio): whisker-audio module with reactive PlaybackStatus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,6 +1850,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-audio"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+]
+
+[[package]]
+name = "whisker-audio-example"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+ "whisker-audio",
+ "whisker-safe-area",
+]
+
+[[package]]
 name = "whisker-build"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ members = [
     "packages/whisker-svg",
     "packages/whisker-svg/example",
     "packages/whisker-video",
+    "packages/whisker-audio",
+    "packages/whisker-audio/example",
 ]
 exclude = [
     # Throwaway cdylib the dev-server's `thin_rebuild` integration

--- a/crates/whisker-runtime/src/reactive/arc_signal.rs
+++ b/crates/whisker-runtime/src/reactive/arc_signal.rs
@@ -122,18 +122,32 @@ fn track<T: 'static>(inner: &Rc<ArcSignalInner<T>>) {
 /// slot has been freed. Mirrors `signal::write_and_notify` but reads
 /// the subscriber list from the Arc signal's own storage instead of
 /// from an arena node.
+///
+/// Subscribers go through [`super::scheduler::schedule`] (not a raw
+/// `rt.pending.push`) so the host wake on the empty→non-empty edge
+/// fires. Without that, writes from a bridge callback (e.g.
+/// `module.on_event(...)` updating a global `ArcRwSignal`) queued
+/// dirty effects but never flushed them until some other source
+/// happened to trigger a reactive cycle — manifesting as a UI
+/// bound to the signal that simply never re-rendered. Stale
+/// subscriber pruning is independent of the wake.
 fn notify_subscribers<T: 'static>(inner: &Rc<ArcSignalInner<T>>) {
     let subscribers: Vec<NodeId> = inner.subscribers.borrow().clone();
     let mut stale: Vec<NodeId> = Vec::new();
+    // First pass: identify stale subscribers so the dedupe walk
+    // inside `schedule()` doesn't end up with freed slots.
     with_runtime(|rt| {
         for sub in &subscribers {
-            if rt.nodes.contains_key(*sub) {
-                rt.pending.push(*sub);
-            } else {
+            if !rt.nodes.contains_key(*sub) {
                 stale.push(*sub);
             }
         }
     });
+    for sub in &subscribers {
+        if !stale.contains(sub) {
+            super::scheduler::schedule(*sub);
+        }
+    }
     if !stale.is_empty() {
         inner
             .subscribers

--- a/packages/whisker-audio/Cargo.toml
+++ b/packages/whisker-audio/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "whisker-audio"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Whisker platform module — audio playback backed by ExoPlayer (Android) / AVPlayer (iOS). Mirrors expo-audio's surface: a `<whisker-audio:Player>` element wired to a `Player` typed handle for imperative play/pause/seek, with reactive `position` / `duration` / `is_playing` signals fed by native playback events."
+
+# Phase K — explicit `include` list so a `cargo publish` of this
+# crate ships the Kotlin + Swift platform sources alongside
+# `src/lib.rs`.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "src/lib.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker. The bare table identifies this cargo
+# crate as a Whisker module; `whisker-build` walks the consuming
+# app's dep tree, picks out every dep carrying it, and wires the
+# Android Gradle subproject + iOS SwiftPM package into the host build.
+[package.metadata.whisker]
+
+[dependencies]
+whisker = { workspace = true }

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for the `whisker-audio` module package. Same
+// shape as `whisker-video`'s manifest — the SwiftPM codegen plugin
+// scans `ios/Sources/WhiskerAudio/` for `Module` subclasses and
+// auto-registers them with Lynx.
+
+import PackageDescription
+
+guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
+      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
+else {
+    fatalError("""
+        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
+        module through `whisker run` / `whisker build`, which inject these paths.
+        """)
+}
+
+let package = Package(
+    name: "whisker-audio",
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
+    ],
+    dependencies: [
+        .package(name: "macros", path: whiskerMacrosPath),
+        .package(name: "WhiskerRuntime", path: whiskerRuntimePath),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerAudio",
+            dependencies: [
+                .product(name: "WhiskerModule", package: "WhiskerRuntime"),
+            ],
+            path: "ios/Sources/WhiskerAudio",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "macros"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-audio/android/src/main/kotlin/rs/whisker/modules/audio/AudioModule.kt
+++ b/packages/whisker-audio/android/src/main/kotlin/rs/whisker/modules/audio/AudioModule.kt
@@ -1,0 +1,240 @@
+// `whisker-audio` Module (Android). View-less.
+//
+// Holds a `MutableMap<Long, ExoPlayer>` of active players; each
+// Rust-side `Player` allocation calls `create(id, source)` to
+// install a fresh entry, drives it through `play` / `pause` /
+// `seekTo` / etc, and `release(id)` from `PlayerInner::drop`
+// removes it.
+//
+// Per-player playback state is dispatched back through a
+// `statusChanged` event whose payload carries the `playerId`
+// alongside the position / duration / flags — the Rust side's
+// global dispatch table routes each event to the matching handle.
+
+package rs.whisker.modules.audio
+
+import android.os.Handler
+import android.os.Looper
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import rs.whisker.runtime.HostAttachedListener
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerValue
+
+class AudioModule : Module() {
+
+    /**
+     * Live players, keyed by the id the Rust side allocates. Map
+     * lookups happen on the main thread (Lynx's bridge dispatch
+     * thread is the UI thread on Android), so a plain
+     * `HashMap` is enough — no Concurrent variant needed.
+     */
+    private val players: MutableMap<Long, ExoPlayer> = mutableMapOf()
+    private val loopFlags: MutableMap<Long, Boolean> = mutableMapOf()
+
+    /**
+     * Pending `create` requests that arrived before any
+     * `WhiskerView` was attached as a host. `Player::new` on the
+     * Rust side fires from the first render, which runs inside
+     * `WhiskerView`'s constructor — `currentActivity` is still
+     * `null` at that moment. We stash the requests here and drain
+     * them from the [HostAttachedListener] body.
+     */
+    private val pendingCreates: MutableList<Pair<Long, String>> = mutableListOf()
+
+    /**
+     * `null` until [ensureAttachListener] runs the first time
+     * `pendingCreates` had to queue something; from then on it
+     * stays installed for the process lifetime and drains the
+     * queue on every (re-)attach.
+     */
+    private var hostListener: HostAttachedListener? = null
+
+    /**
+     * Per-player position timer. While `isPlaying` we tick at
+     * ~200 ms cadence so the Rust signal sees smooth progress;
+     * the timer is cancelled on `pause` / `stop` / `release` so a
+     * paused player doesn't pin a Handler post for nothing.
+     */
+    private val positionTicker = Handler(Looper.getMainLooper())
+    private val tickRunnables: MutableMap<Long, Runnable> = mutableMapOf()
+
+    override fun definition() = ModuleDefinition {
+        Name("WhiskerAudio")
+        Events("statusChanged")
+
+        Function("create") { args ->
+            val id = args.getOrNull(0)?.asInt() ?: return@Function WhiskerValue.Null
+            val source = args.getOrNull(1)?.asString() ?: ""
+            createPlayer(id, source)
+            WhiskerValue.Null
+        }
+        Function("setSource") { args ->
+            val id = args.getOrNull(0)?.asInt() ?: return@Function WhiskerValue.Null
+            val source = args.getOrNull(1)?.asString() ?: ""
+            players[id]?.let { p ->
+                p.setMediaItem(MediaItem.fromUri(source))
+                p.prepare()
+            }
+            WhiskerValue.Null
+        }
+        Function("play") { args ->
+            args.getOrNull(0)?.asInt()?.let { players[it]?.play() }
+            WhiskerValue.Null
+        }
+        Function("pause") { args ->
+            args.getOrNull(0)?.asInt()?.let { players[it]?.pause() }
+            WhiskerValue.Null
+        }
+        Function("stop") { args ->
+            args.getOrNull(0)?.asInt()?.let { id ->
+                players[id]?.let { p ->
+                    p.pause()
+                    p.seekTo(0)
+                }
+            }
+            WhiskerValue.Null
+        }
+        Function("seekTo") { args ->
+            val id = args.getOrNull(0)?.asInt() ?: return@Function WhiskerValue.Null
+            val seconds = args.getOrNull(1)?.asDouble() ?: 0.0
+            players[id]?.seekTo((seconds * 1000.0).toLong())
+            WhiskerValue.Null
+        }
+        Function("setVolume") { args ->
+            val id = args.getOrNull(0)?.asInt() ?: return@Function WhiskerValue.Null
+            val v = (args.getOrNull(1)?.asDouble() ?: 1.0).toFloat().coerceIn(0f, 1f)
+            players[id]?.volume = v
+            WhiskerValue.Null
+        }
+        Function("setLoop") { args ->
+            val id = args.getOrNull(0)?.asInt() ?: return@Function WhiskerValue.Null
+            val looping = args.getOrNull(1)?.asBool() ?: false
+            loopFlags[id] = looping
+            players[id]?.repeatMode =
+                if (looping) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
+            WhiskerValue.Null
+        }
+        Function("release") { args ->
+            args.getOrNull(0)?.asInt()?.let { id ->
+                tickRunnables.remove(id)?.let { positionTicker.removeCallbacks(it) }
+                players.remove(id)?.release()
+                loopFlags.remove(id)
+            }
+            WhiskerValue.Null
+        }
+    }
+
+    /**
+     * Create the ExoPlayer instance for `id` and wire its
+     * `Player.Listener` so state changes flow back to Rust via
+     * `statusChanged` events.
+     *
+     * Defers if the host Activity isn't attached yet (the common
+     * case when `Player::new` runs during the very first render).
+     * Queued requests drain via [ensureAttachListener] once the
+     * WhiskerView attaches.
+     */
+    private fun createPlayer(id: Long, source: String) {
+        val ctx = appContext.currentActivity
+        if (ctx == null) {
+            pendingCreates.add(id to source)
+            ensureAttachListener()
+            return
+        }
+        val p = ExoPlayer.Builder(ctx).build()
+        if (source.isNotEmpty()) {
+            p.setMediaItem(MediaItem.fromUri(source))
+            p.prepare()
+        }
+        p.addListener(object : Player.Listener {
+            override fun onIsPlayingChanged(isPlaying: Boolean) {
+                dispatchStatus(id)
+                if (isPlaying) startTicker(id) else stopTicker(id)
+            }
+            override fun onPlaybackStateChanged(state: Int) {
+                dispatchStatus(id)
+            }
+            override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+                dispatchStatus(id)
+            }
+        })
+        players[id] = p
+        dispatchStatus(id)
+    }
+
+    /**
+     * Snapshot the current state of player `id` and broadcast it
+     * as a `statusChanged` event. Silently no-ops if the player
+     * is no longer in the map (e.g. event fired after release).
+     */
+    private fun dispatchStatus(id: Long) {
+        val p = players[id] ?: return
+        val durationMs = p.duration
+        val payload = mapOf(
+            "playerId" to WhiskerValue.Int(id),
+            "position" to WhiskerValue.Float(p.currentPosition / 1000.0),
+            "duration" to WhiskerValue.Float(
+                if (durationMs == C.TIME_UNSET) 0.0 else durationMs / 1000.0
+            ),
+            "isLoaded" to WhiskerValue.Bool(
+                p.playbackState == Player.STATE_READY ||
+                p.playbackState == Player.STATE_BUFFERING
+            ),
+            "isPlaying" to WhiskerValue.Bool(p.isPlaying),
+        )
+        sendEvent("statusChanged", WhiskerValue.Map(payload))
+    }
+
+    /**
+     * Begin posting a status update every ~200 ms for player `id`.
+     * The Handler runs on the main thread, the only one allowed to
+     * touch ExoPlayer state.
+     */
+    private fun startTicker(id: Long) {
+        // Cancel any prior ticker before installing a fresh one —
+        // a rapid pause-play flip otherwise stacks two
+        // simultaneous post chains.
+        tickRunnables.remove(id)?.let { positionTicker.removeCallbacks(it) }
+        val runnable = object : Runnable {
+            override fun run() {
+                if (players[id] == null) return
+                dispatchStatus(id)
+                positionTicker.postDelayed(this, 200L)
+            }
+        }
+        tickRunnables[id] = runnable
+        positionTicker.post(runnable)
+    }
+
+    private fun stopTicker(id: Long) {
+        tickRunnables.remove(id)?.let { positionTicker.removeCallbacks(it) }
+    }
+
+    /**
+     * One-shot install of the host-attached listener that drains
+     * [pendingCreates]. `addOnHostAttachedListener` fires
+     * synchronously if a host is already attached, so even a late
+     * call after host-attach lands at the right place.
+     */
+    private fun ensureAttachListener() {
+        if (hostListener != null) return
+        val listener = HostAttachedListener {
+            // Snapshot then clear so a re-attach during drain
+            // (e.g. config-change rotation) doesn't see a
+            // half-drained queue.
+            val pending = pendingCreates.toList()
+            pendingCreates.clear()
+            for ((id, source) in pending) {
+                if (!players.containsKey(id)) {
+                    createPlayer(id, source)
+                }
+            }
+        }
+        hostListener = listener
+        appContext.addOnHostAttachedListener(listener)
+    }
+}

--- a/packages/whisker-audio/build.gradle.kts
+++ b/packages/whisker-audio/build.gradle.kts
@@ -1,0 +1,54 @@
+// Gradle build for `whisker-audio`'s Android half.
+//
+// Mirrors `whisker-video`'s shape (Media3 ExoPlayer-backed) but
+// without the PlayerView UI — audio playback has no on-screen
+// surface, so the view is a zero-size placeholder and the ExoPlayer
+// instance attaches to nothing.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.audio"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    // build.gradle.kts sits at the package root (alongside
+    // Package.swift + Cargo.toml). Point the Kotlin source set at
+    // the package's `android/` subdir so AGP doesn't scan the Rust
+    // `src/`, and the native code stays grouped under `android/`.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerAudio")
+    arg("whisker.crateName", "whisker-audio")
+}
+
+dependencies {
+    implementation(project(":module"))
+    ksp("rs.whisker:ksp")
+
+    // AndroidX Media3 — modern Player API. We use ExoPlayer (the
+    // engine) directly without PlayerView (the visual chrome),
+    // since audio doesn't need a render surface.
+    implementation("androidx.media3:media3-exoplayer:1.4.1")
+    implementation("androidx.media3:media3-common:1.4.1")
+}

--- a/packages/whisker-audio/example/Cargo.toml
+++ b/packages/whisker-audio/example/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "whisker-audio-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Example app for `whisker-audio`. Plays a short MP3 with play / pause / stop / seek controls so on-device verification of the ExoPlayer / AVPlayer module wiring happens in one place."
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+whisker = { workspace = true }
+whisker-audio = { path = ".." }
+whisker-safe-area = { path = "../../whisker-safe-area" }

--- a/packages/whisker-audio/example/src/lib.rs
+++ b/packages/whisker-audio/example/src/lib.rs
@@ -1,0 +1,190 @@
+//! `whisker-audio` example app.
+//!
+//! Instantiates one [`Player`] against a CDN-hosted MP3, displays
+//! the live playback position bound to a reactive signal, and
+//! renders Play / Pause / Stop / Seek tap targets.
+
+use whisker::css::{AlignItems, Color, Display, FlexDirection, FontWeight, JustifyContent, ToCss};
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+use whisker_audio::Player;
+use whisker_safe_area::safe_area_insets;
+
+/// Stable public-domain MP3 hosted on a Google CDN. Loads
+/// reliably from emulators, no auth, ~3 MB.
+const SAMPLE_URL: &str = "https://commondatastorage.googleapis.com/codeskulptor-demos/\
+    DDR_assets/Kangaroo_MusiQue_-_The_Neverwritten_Role_Playing_Game.mp3";
+
+#[whisker::main]
+pub fn app() -> Element {
+    // The player owns its native ExoPlayer/AVPlayer until every
+    // clone of this handle drops. Held by the surrounding owner
+    // (the `#[whisker::main]` body) so it lives for the app's
+    // lifetime.
+    let player = Player::new(SAMPLE_URL);
+    let status = player.status();
+    let insets = safe_area_insets();
+
+    render! {
+        page(style: computed(move || css!(
+            background_color: Color::hex(0x101012),
+            flex_grow: 1.0,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            padding_top: px(insets.get().top as f32 + 24.0),
+            padding_bottom: px(insets.get().bottom as f32 + 24.0),
+            padding_left: px(24),
+            padding_right: px(24),
+        ).to_css_string())) {
+            // Header
+            view(style: css!(
+                width: percent(100),
+                flex_shrink: 0.0,
+                margin_bottom: px(24),
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Center,
+            )) {
+                text(
+                    style: css!(
+                        color: Color::hex(0xF0F0F3),
+                        font_size: px(22),
+                        font_weight: FontWeight::Numeric(700),
+                    ),
+                    value: "whisker-audio demo",
+                )
+            }
+
+            // Live `PlaybackStatus`. Each row re-renders independently
+            // — `status.get()` inside the `computed` closure registers
+            // it as a dependent of the underlying RwSignal that the
+            // native module writes through.
+            view(style: css!(
+                width: percent(100),
+                max_width: px(320),
+                flex_shrink: 0.0,
+                margin_bottom: px(24),
+                padding: px(16),
+                background_color: Color::hex(0x18181B),
+                border_radius: px(12),
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+            )) {
+                status_row(label: "is_playing", value: computed(move || {
+                    fmt_bool(status.get().is_playing)
+                }))
+                status_row(label: "is_loaded", value: computed(move || {
+                    fmt_bool(status.get().is_loaded)
+                }))
+                status_row(label: "position", value: computed(move || {
+                    format!("{:.2}s", status.get().position)
+                }))
+                status_row(label: "duration", value: computed(move || {
+                    let d = status.get().duration;
+                    if d > 0.0 { format!("{:.2}s", d) } else { "—".into() }
+                }))
+                // Progress fraction — only meaningful once `duration`
+                // is non-zero. The `format!` is cheap; the surrounding
+                // computed re-runs on every status tick.
+                status_row(label: "progress", value: computed(move || {
+                    let s = status.get();
+                    if s.duration > 0.0 {
+                        format!("{:.1}%", 100.0 * s.position / s.duration)
+                    } else {
+                        "—".into()
+                    }
+                }))
+            }
+
+            // Controls. Each closure captures its own clone of the
+            // handle. Inline `style:` to keep the example focused.
+            view(style: button_style(), on_tap: {
+                let p = player.clone();
+                move |_| p.play()
+            }) { text(style: button_text_style(), value: "Play") }
+            view(style: button_style(), on_tap: {
+                let p = player.clone();
+                move |_| p.pause()
+            }) { text(style: button_text_style(), value: "Pause") }
+            view(style: button_style(), on_tap: {
+                let p = player.clone();
+                move |_| p.stop()
+            }) { text(style: button_text_style(), value: "Stop") }
+            view(style: button_style(), on_tap: {
+                let p = player.clone();
+                move |_| p.seek_to(30.0)
+            }) { text(style: button_text_style(), value: "Seek to 30s") }
+        }
+    }
+}
+
+fn button_style() -> String {
+    css!(
+        width: percent(100),
+        max_width: px(280),
+        height: px(48),
+        background_color: Color::hex(0x1C1C1F),
+        border_radius: px(12),
+        margin_top: px(8),
+        margin_bottom: px(8),
+        display: Display::Flex,
+        align_items: AlignItems::Center,
+        justify_content: JustifyContent::Center,
+    )
+    .to_css_string()
+}
+
+fn button_text_style() -> String {
+    css!(
+        color: Color::hex(0xF0F0F3),
+        font_size: px(15),
+        font_weight: FontWeight::Numeric(600),
+    )
+    .to_css_string()
+}
+
+fn fmt_bool(b: bool) -> String {
+    if b {
+        "true".into()
+    } else {
+        "false".into()
+    }
+}
+
+/// One labelled row in the status card. Two `<text>` siblings — the
+/// label pinned to the left, the live value to the right, separated
+/// by a `flex_grow: 1` filler so the value column right-aligns.
+#[component]
+fn status_row(label: &'static str, value: ReadSignal<String>) -> Element {
+    render! {
+        view(style: css!(
+            display: Display::Flex,
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            margin_top: px(4),
+            margin_bottom: px(4),
+        )) {
+            text(
+                style: css!(
+                    color: Color::hex(0x9090A0),
+                    font_size: px(13),
+                    font_weight: FontWeight::Numeric(500),
+                    width: px(96),
+                    flex_shrink: 0.0,
+                ),
+                value: label,
+            )
+            text(
+                style: css!(
+                    color: Color::hex(0xF0F0F3),
+                    font_size: px(13),
+                    font_weight: FontWeight::Numeric(500),
+                    flex_grow: 1.0,
+                ),
+                value: value,
+            )
+        }
+    }
+}

--- a/packages/whisker-audio/example/whisker.rs
+++ b/packages/whisker-audio/example/whisker.rs
@@ -1,0 +1,22 @@
+// `whisker.rs` for the `whisker-audio` example.
+
+pub fn configure(app: &mut whisker_app_config::AppConfig) {
+    app.name("WhiskerAudioExample")
+        .bundle_id("rs.whisker.audioexample")
+        .version("0.1.0")
+        .build_number(1);
+
+    app.android(|a| {
+        a.package("rs.whisker.audioexample")
+            .application_id("rs.whisker.audioexample")
+            .launcher_activity(".MainActivity")
+            .min_sdk(24)
+            .target_sdk(34);
+    });
+
+    app.ios(|i| {
+        i.bundle_id("rs.whisker.audioexample")
+            .scheme("WhiskerAudioExample")
+            .deployment_target("13.0");
+    });
+}

--- a/packages/whisker-audio/ios/Sources/WhiskerAudio/AudioModule.swift
+++ b/packages/whisker-audio/ios/Sources/WhiskerAudio/AudioModule.swift
@@ -1,0 +1,271 @@
+// `whisker-audio` Module (iOS). View-less.
+//
+// Mirrors the Android side: a `[Int64: AVPlayer]` keyed on the
+// Rust-allocated id, prop-style functions (`create`, `play`,
+// `pause`, `setLoop`, etc.), and a `statusChanged` event whose
+// payload carries `{ playerId, position, duration, isLoaded,
+// isPlaying }`.
+//
+// AVPlayer has no built-in loop / status callback API equivalent
+// to Media3's `Player.Listener` — looping rides on
+// `AVPlayerItemDidPlayToEndTime`, and status updates ride on
+// `KVO` (`status`, `rate`) + a periodic time observer at
+// ~200 ms cadence.
+
+import AVFoundation
+import Foundation
+import WhiskerModule
+import WhiskerRuntime
+
+public final class AudioModule: Module {
+
+    /// Per-player state. Owned by the module, indexed by the id
+    /// the Rust side allocates on `Player::new`.
+    private final class PlayerEntry {
+        let player: AVPlayer
+        var loop: Bool = false
+        var endObserver: NSObjectProtocol?
+        var statusObservation: NSKeyValueObservation?
+        var rateObservation: NSKeyValueObservation?
+        /// Foundation Timer driving position dispatch while
+        /// playback is active. `addPeriodicTimeObserver` was
+        /// unreliable on iOS Simulator (token returned non-nil but
+        /// the closure never fired), so we hand-tick instead.
+        var progressTimer: Timer?
+
+        init(player: AVPlayer) {
+            self.player = player
+        }
+    }
+
+    private var players: [Int64: PlayerEntry] = [:]
+
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("WhiskerAudio")
+            Events("statusChanged")
+
+            Function("create") { (args: [WhiskerValue]) -> WhiskerValue in
+                guard let id = args.first?.asInt else { return .null }
+                let source = args.count > 1 ? (args[1].asString ?? "") : ""
+                self.createPlayer(id: id, source: source)
+                return .null
+            }
+            Function("setSource") { (args: [WhiskerValue]) -> WhiskerValue in
+                guard let id = args.first?.asInt,
+                      let entry = self.players[id] else { return .null }
+                let source = args.count > 1 ? (args[1].asString ?? "") : ""
+                self.swapItem(for: entry, id: id, source: source)
+                return .null
+            }
+            Function("play") { (args: [WhiskerValue]) -> WhiskerValue in
+                if let id = args.first?.asInt { self.players[id]?.player.play() }
+                return .null
+            }
+            Function("pause") { (args: [WhiskerValue]) -> WhiskerValue in
+                if let id = args.first?.asInt { self.players[id]?.player.pause() }
+                return .null
+            }
+            Function("stop") { (args: [WhiskerValue]) -> WhiskerValue in
+                if let id = args.first?.asInt, let entry = self.players[id] {
+                    entry.player.pause()
+                    entry.player.seek(to: .zero)
+                }
+                return .null
+            }
+            Function("seekTo") { (args: [WhiskerValue]) -> WhiskerValue in
+                guard let id = args.first?.asInt, let entry = self.players[id] else {
+                    return .null
+                }
+                let seconds = args.count > 1 ? (args[1].asDouble ?? 0) : 0
+                let time = CMTime(seconds: seconds, preferredTimescale: 600)
+                entry.player.seek(to: time)
+                return .null
+            }
+            Function("setVolume") { (args: [WhiskerValue]) -> WhiskerValue in
+                guard let id = args.first?.asInt, let entry = self.players[id] else {
+                    return .null
+                }
+                let raw = args.count > 1 ? (args[1].asDouble ?? 1.0) : 1.0
+                entry.player.volume = Float(max(0, min(1, raw)))
+                return .null
+            }
+            Function("setLoop") { (args: [WhiskerValue]) -> WhiskerValue in
+                guard let id = args.first?.asInt, let entry = self.players[id] else {
+                    return .null
+                }
+                let looping = args.count > 1 ? (args[1].asBool ?? false) : false
+                entry.loop = looping
+                self.installEndObserver(for: entry, id: id)
+                return .null
+            }
+            Function("release") { (args: [WhiskerValue]) -> WhiskerValue in
+                if let id = args.first?.asInt { self.releasePlayer(id: id) }
+                return .null
+            }
+        }
+    }
+
+    // MARK: - Player lifecycle
+
+    private func createPlayer(id: Int64, source: String) {
+        // iOS audio output is gated on an active AVAudioSession.
+        // Without `.playback` + `setActive(true)`, AVPlayer reports
+        // rate=1 after `play()` but the audio render loop never
+        // pulls samples — currentTime stays at 0 and no audio
+        // reaches the speaker. Activating the session is
+        // idempotent across players; we re-call on every create
+        // so a new player picks up the session even if the host
+        // app deactivated it.
+        ensureAudioSessionActive()
+
+        let player: AVPlayer
+        if !source.isEmpty, let url = URL(string: source) {
+            player = AVPlayer(url: url)
+        } else {
+            player = AVPlayer()
+        }
+        let entry = PlayerEntry(player: player)
+        players[id] = entry
+        installKVO(for: entry, id: id)
+        installEndObserver(for: entry, id: id)
+        dispatchStatus(id: id)
+    }
+
+    private func swapItem(for entry: PlayerEntry, id: Int64, source: String) {
+        if source.isEmpty {
+            entry.player.replaceCurrentItem(with: nil)
+        } else if let url = URL(string: source) {
+            entry.player.replaceCurrentItem(with: AVPlayerItem(url: url))
+        }
+        // Loop observer is item-scoped; reinstall on the fresh
+        // playerItem so end-of-source seeking still fires when
+        // appropriate.
+        installEndObserver(for: entry, id: id)
+        dispatchStatus(id: id)
+    }
+
+    private func releasePlayer(id: Int64) {
+        guard let entry = players.removeValue(forKey: id) else { return }
+        entry.progressTimer?.invalidate()
+        if let token = entry.endObserver {
+            NotificationCenter.default.removeObserver(token)
+        }
+        entry.statusObservation?.invalidate()
+        entry.rateObservation?.invalidate()
+        entry.player.pause()
+        entry.player.replaceCurrentItem(with: nil)
+    }
+
+    // MARK: - Observation
+
+    /// Re-broadcast `statusChanged` whenever the AVPlayer's loaded
+    /// state or play / pause flag transitions. The rate observer
+    /// also starts / stops the position-progress Timer so a
+    /// paused player doesn't pin a runloop callback.
+    private func installKVO(for entry: PlayerEntry, id: Int64) {
+        entry.rateObservation = entry.player.observe(\.rate, options: [.new]) { [weak self] player, _ in
+            self?.dispatchStatus(id: id)
+            guard let self else { return }
+            if player.rate > 0 {
+                self.startProgressTimer(for: id)
+            } else {
+                self.stopProgressTimer(for: id)
+            }
+        }
+        // `status` lives on AVPlayerItem; observe transitions
+        // through replaceCurrentItem too — KVO continues across
+        // item swaps because we re-look up `.currentItem` inside
+        // the closure on every fire.
+        entry.statusObservation = entry.player.observe(\.currentItem?.status, options: [.new]) { [weak self] _, _ in
+            self?.dispatchStatus(id: id)
+        }
+    }
+
+    /// Start (or restart) a ~200 ms Timer that re-broadcasts
+    /// playback status while the player rate is non-zero.
+    ///
+    /// We use a hand-rolled Timer instead of
+    /// `AVPlayer.addPeriodicTimeObserver` because the latter
+    /// silently never fires on iOS Simulator (token comes back
+    /// non-nil; the closure is never invoked). Real devices honour
+    /// the periodic observer correctly, but the dev loop runs on
+    /// the sim so a portable solution wins.
+    private func startProgressTimer(for id: Int64) {
+        guard let entry = players[id] else { return }
+        entry.progressTimer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { [weak self] _ in
+            self?.dispatchStatus(id: id)
+        }
+        // Also schedule on `.common` modes so a touch-driven runloop
+        // mode (e.g. tracking a scroll) doesn't pause the tick.
+        RunLoop.main.add(timer, forMode: .common)
+        entry.progressTimer = timer
+    }
+
+    private func stopProgressTimer(for id: Int64) {
+        players[id]?.progressTimer?.invalidate()
+        players[id]?.progressTimer = nil
+    }
+
+    /// Activate a `.playback` AVAudioSession so AVPlayer's render
+    /// loop actually pulls samples. Whisker apps don't currently
+    /// take a stance on session category (no recording, mixing,
+    /// etc), so `.playback` is the safe default — it solo-routes
+    /// audio to the device speaker and survives a screen lock.
+    private func ensureAudioSessionActive() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playback, mode: .default)
+            try session.setActive(true, options: [])
+        } catch {
+            NSLog("[whisker-audio] AVAudioSession activate failed: \(error)")
+        }
+    }
+
+    /// (Re-)install the loop-on-end observer. Removes the prior
+    /// token before adding a fresh one so a sequence of
+    /// `setLoop(true)` / `setLoop(false)` / `setLoop(true)` calls
+    /// doesn't stack handlers.
+    private func installEndObserver(for entry: PlayerEntry, id: Int64) {
+        if let token = entry.endObserver {
+            NotificationCenter.default.removeObserver(token)
+            entry.endObserver = nil
+        }
+        guard entry.loop, let item = entry.player.currentItem else { return }
+        entry.endObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: item,
+            queue: .main
+        ) { [weak self] _ in
+            self?.players[id]?.player.seek(to: .zero)
+            self?.players[id]?.player.play()
+        }
+    }
+
+    // MARK: - Status payload
+
+    private func dispatchStatus(id: Int64) {
+        guard let entry = players[id] else { return }
+        let player = entry.player
+        let position = CMTimeGetSeconds(player.currentTime())
+        let duration = player.currentItem.map { CMTimeGetSeconds($0.duration) } ?? 0
+        let safeDuration = duration.isFinite ? duration : 0
+        // `currentItem.status == .readyToPlay` is the canonical
+        // "loaded" signal, but iOS Simulator hides the
+        // transition behind a KVO event that doesn't always
+        // fire — derive from "we have a finite duration" instead
+        // so the flag flips as soon as the asset metadata
+        // resolves, regardless of the status KVO path.
+        let isLoaded = safeDuration > 0 || (player.currentItem?.status == .readyToPlay)
+        let isPlaying = player.rate > 0 && (player.error == nil)
+        let payload: WhiskerValue = .map([
+            "playerId": .int(id),
+            "position": .float(position.isFinite ? position : 0),
+            "duration": .float(safeDuration),
+            "isLoaded": .bool(isLoaded),
+            "isPlaying": .bool(isPlaying),
+        ])
+        sendEvent("statusChanged", payload)
+    }
+}

--- a/packages/whisker-audio/src/lib.rs
+++ b/packages/whisker-audio/src/lib.rs
@@ -1,0 +1,329 @@
+//! `whisker-audio` — audio playback for Whisker apps.
+//!
+//! View-less module backed by AndroidX Media3 ExoPlayer (Android)
+//! and AVPlayer (iOS). Construct a [`Player`] anywhere a normal Rust
+//! value can live — no element to mount, no `ref:` wiring; the
+//! handle owns a native player instance, releases it on drop, and
+//! exposes a reactive [`PlaybackStatus`] signal driven by native
+//! playback callbacks.
+//!
+//! The API surface mirrors the imperative half of
+//! [Expo's `expo-audio`](https://docs.expo.dev/versions/latest/sdk/audio/):
+//! a player object you call `play` / `pause` / `seek_to` on, plus a
+//! status field that ticks as the underlying engine reports
+//! progress.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use whisker::prelude::*;
+//! use whisker_audio::Player;
+//!
+//! #[component]
+//! fn screen() -> Element {
+//!     // Constructed once on mount; the handle owns the native
+//!     // player and releases it when the surrounding owner disposes.
+//!     let player = Player::new("https://example.com/clip.mp3");
+//!     let status = player.status();
+//!
+//!     render! {
+//!         view(style: "flex-direction: column; padding: 16px;") {
+//!             text(value: move || format!(
+//!                 "{:.1}s / {:.1}s",
+//!                 status.get().position,
+//!                 status.get().duration,
+//!             ))
+//!             view(on_tap: {
+//!                 let p = player.clone();
+//!                 move |_| p.play()
+//!             }) { text(value: "play") }
+//!             view(on_tap: {
+//!                 let p = player.clone();
+//!                 move |_| p.pause()
+//!             }) { text(value: "pause") }
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! ## Shape
+//!
+//! - [`Player`] is `Clone` — internally an `Rc<PlayerInner>`. Each
+//!   clone shares the same native player; the underlying player is
+//!   released only after the last clone drops.
+//! - Methods (`play`, `pause`, `stop`, `seek_to`, `set_source`,
+//!   `set_volume`, `set_loop`) dispatch through
+//!   `whisker::module!("WhiskerAudio").invoke(method, args)`.
+//! - The native module emits a per-player `statusChanged` event
+//!   every time playback state changes (and at a ~200 ms cadence
+//!   while playing); [`Player::status`] lazily installs the
+//!   dispatch table on first call and routes events to the matching
+//!   handle's [`RwSignal<PlaybackStatus>`].
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+use whisker::platform_module::WhiskerValue;
+use whisker::{module, ArcReadSignal, ArcRwSignal, ReadSignal};
+
+/// Current playback state. Updated by the native side and read
+/// through the reactive signal returned by [`Player::status`].
+///
+/// All times are in seconds. `duration` is `0.0` until the native
+/// player has finished its async load — UI that renders a progress
+/// bar can branch on `is_loaded` to fade in once the value is
+/// meaningful.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct PlaybackStatus {
+    /// Current playback position from the start, in seconds.
+    pub position: f64,
+    /// Total media duration in seconds. `0.0` while still loading
+    /// or for live streams without a known length.
+    pub duration: f64,
+    /// `true` once the player has loaded the source headers and
+    /// reported a meaningful duration. `false` during the initial
+    /// load and after a seek to an unbuffered region.
+    pub is_loaded: bool,
+    /// `true` while the engine is actively producing audio. Flips
+    /// to `false` on `pause()`, `stop()`, and at end-of-media
+    /// (unless `set_loop(true)` is set).
+    pub is_playing: bool,
+}
+
+/// Typed handle for one audio player. Cheap to clone (an `Rc`-based
+/// refcount); the underlying native player is released only after
+/// every clone drops.
+#[derive(Clone)]
+pub struct Player {
+    inner: Rc<PlayerInner>,
+}
+
+/// The owned half of [`Player`]. Stashes the bridge-side id and
+/// runs `release` from `Drop`, so disposing the owner of the
+/// last clone releases the native player without manual book-
+/// keeping.
+struct PlayerInner {
+    id: u64,
+}
+
+impl PlayerInner {
+    fn invoke(&self, method: &str, mut args: Vec<WhiskerValue>) -> WhiskerValue {
+        // Every dispatch carries the player id as the first arg —
+        // the native side keys its player map on it. Inserting
+        // up-front keeps each caller from having to remember the
+        // calling convention.
+        args.insert(0, WhiskerValue::Int(self.id as i64));
+        module!("WhiskerAudio").invoke(method, args)
+    }
+}
+
+impl Drop for PlayerInner {
+    fn drop(&mut self) {
+        // Best-effort release — if the bridge tears down before us
+        // the invoke fails silently (returns `WhiskerValue::Error`)
+        // and the native player gets cleaned up by the process exit
+        // anyway.
+        let _ = module!("WhiskerAudio").invoke("release", vec![WhiskerValue::Int(self.id as i64)]);
+        unregister_status(self.id);
+    }
+}
+
+impl Player {
+    /// Construct a new player playing from `source` (HTTP/HTTPS or
+    /// `file://`). The native player starts loading immediately;
+    /// playback begins when [`Player::play`] is called.
+    ///
+    /// Returns a `Player` handle. The native player stays alive as
+    /// long as at least one clone of the handle does — drop the
+    /// last clone (typically by letting the surrounding component
+    /// owner dispose) to release.
+    pub fn new(source: impl Into<String>) -> Self {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let source = source.into();
+        module!("WhiskerAudio").invoke(
+            "create",
+            vec![WhiskerValue::Int(id as i64), WhiskerValue::String(source)],
+        );
+        Self {
+            inner: Rc::new(PlayerInner { id }),
+        }
+    }
+
+    /// Start or resume playback from the current position.
+    pub fn play(&self) {
+        let _ = self.inner.invoke("play", vec![]);
+    }
+
+    /// Pause playback at the current position.
+    pub fn pause(&self) {
+        let _ = self.inner.invoke("pause", vec![]);
+    }
+
+    /// Stop playback and rewind to position 0. The native player
+    /// stays loaded — [`Player::play`] resumes from the start
+    /// without re-fetching.
+    pub fn stop(&self) {
+        let _ = self.inner.invoke("stop", vec![]);
+    }
+
+    /// Seek to an absolute position (seconds from the start).
+    pub fn seek_to(&self, position_seconds: f64) {
+        let _ = self
+            .inner
+            .invoke("seekTo", vec![WhiskerValue::Float(position_seconds)]);
+    }
+
+    /// Replace the loaded media. Pass an empty string to release
+    /// the current source without queueing a new one.
+    pub fn set_source(&self, source: impl Into<String>) {
+        let _ = self
+            .inner
+            .invoke("setSource", vec![WhiskerValue::String(source.into())]);
+    }
+
+    /// Set output gain on `[0.0, 1.0]`. Values outside the range
+    /// get clamped on the native side.
+    pub fn set_volume(&self, value: f64) {
+        let _ = self
+            .inner
+            .invoke("setVolume", vec![WhiskerValue::Float(value)]);
+    }
+
+    /// Loop the source: when playback reaches the end, the native
+    /// player rewinds to 0 and resumes. Idempotent.
+    pub fn set_loop(&self, looping: bool) {
+        let _ = self
+            .inner
+            .invoke("setLoop", vec![WhiskerValue::Bool(looping)]);
+    }
+
+    /// Reactive playback status (position / duration / loaded /
+    /// playing flags). First call from any clone installs the
+    /// per-player signal and the process-level subscription that
+    /// dispatches `statusChanged` events to the matching handle.
+    ///
+    /// Reads from the returned `ReadSignal<PlaybackStatus>` register
+    /// the calling effect / computed as a dependent, so a `text`
+    /// bound to `status.get().position` re-renders as the native
+    /// player ticks through the file.
+    pub fn status(&self) -> ReadSignal<PlaybackStatus> {
+        register_status(self.inner.id)
+    }
+}
+
+// ---- Process-global status subscription dispatch --------------------------
+
+/// Monotonic source of fresh player ids. The atomic increment lets
+/// any thread that managed to instantiate a `Player` allocate
+/// without coordination; the bridge dispatch path that consumes
+/// the id is main-thread-only.
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Map from player id to its reactive signal. Lives in a
+/// [`MainThreadOnly`] wrapper so the `Sync` bound on `OnceLock<T>`
+/// passes; access is on the bridge's main thread by contract (same
+/// model as `whisker-safe-area`).
+struct StatusTable {
+    entries: MainThreadOnly<Rc<RefCell<HashMap<u64, ArcRwSignal<PlaybackStatus>>>>>,
+}
+
+static STATUS_TABLE: OnceLock<StatusTable> = OnceLock::new();
+
+/// Install the global `statusChanged` listener (once) and return
+/// the per-player signal handle. Re-entering for the same id
+/// returns the existing signal so two clones of the same `Player`
+/// see identical updates.
+fn register_status(id: u64) -> ReadSignal<PlaybackStatus> {
+    let table = STATUS_TABLE.get_or_init(install_status_listener);
+    let entries = &table.entries.inner;
+    let mut entries = entries.borrow_mut();
+    let signal = entries
+        .entry(id)
+        .or_insert_with(|| ArcRwSignal::new(PlaybackStatus::default()));
+    let (read, _write): (ArcReadSignal<_>, _) = signal.clone().split();
+    read.into()
+}
+
+/// Remove the entry for `id` from the dispatch table — called from
+/// `PlayerInner::drop` so a long-lived process doesn't accumulate
+/// dead per-player signal slots.
+fn unregister_status(id: u64) {
+    if let Some(table) = STATUS_TABLE.get() {
+        if let Ok(mut entries) = table.entries.inner.try_borrow_mut() {
+            entries.remove(&id);
+        }
+    }
+}
+
+/// One-shot install of the `statusChanged` subscription. The
+/// closure pulls the player id out of the event payload, looks
+/// up the matching signal, and writes the decoded status. Stale
+/// events for ids that were already released are dropped silently.
+fn install_status_listener() -> StatusTable {
+    let entries: Rc<RefCell<HashMap<u64, ArcRwSignal<PlaybackStatus>>>> =
+        Rc::new(RefCell::new(HashMap::new()));
+    let entries_for_listener = MainThreadOnly {
+        inner: entries.clone(),
+    };
+    let sub = module!("WhiskerAudio").on_event("statusChanged", move |payload| {
+        let WhiskerValue::Map(fields) = payload else {
+            return;
+        };
+        let id = match fields.get("playerId") {
+            Some(WhiskerValue::Int(v)) => *v as u64,
+            Some(WhiskerValue::Float(v)) => *v as u64,
+            _ => return,
+        };
+        let status = PlaybackStatus {
+            position: read_f64(&fields, "position"),
+            duration: read_f64(&fields, "duration"),
+            is_loaded: read_bool(&fields, "isLoaded"),
+            is_playing: read_bool(&fields, "isPlaying"),
+        };
+        // Bind the wrapper (not `.inner`) so Rust 2021 disjoint
+        // captures move the `Send + Sync` impl as a whole. Same
+        // dance as `whisker-safe-area` does for its writer.
+        let table = &entries_for_listener;
+        let borrow = table.inner.borrow();
+        if let Some(rw) = borrow.get(&id) {
+            rw.set(status);
+        }
+    });
+    // Leak — the listener lives for the process lifetime; dropping
+    // the subscription would also drop the closure pointer the
+    // bridge holds.
+    std::mem::forget(sub);
+    StatusTable {
+        entries: MainThreadOnly { inner: entries },
+    }
+}
+
+fn read_f64(fields: &BTreeMap<String, WhiskerValue>, key: &str) -> f64 {
+    match fields.get(key) {
+        Some(WhiskerValue::Float(v)) => *v,
+        Some(WhiskerValue::Int(v)) => *v as f64,
+        _ => 0.0,
+    }
+}
+
+fn read_bool(fields: &BTreeMap<String, WhiskerValue>, key: &str) -> bool {
+    matches!(fields.get(key), Some(WhiskerValue::Bool(true)))
+}
+
+/// Main-thread-only wrapper, same shape as the one in
+/// `whisker-safe-area`. The contract is that every access path
+/// runs on the Lynx TASM thread; the unsafe `Send + Sync` impls
+/// satisfy `OnceLock<T>`'s `T: Sync` bound by asserting that
+/// constraint rather than enforcing it at compile time.
+#[derive(Clone)]
+struct MainThreadOnly<T> {
+    inner: T,
+}
+// Safety: see module docs — every consumer runs on the reactive
+// thread; misuse would corrupt the arena, but that's the standard
+// risk for any signal-touching code off the main thread.
+unsafe impl<T> Send for MainThreadOnly<T> {}
+unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/packages/whisker-audio/src/lib.rs
+++ b/packages/whisker-audio/src/lib.rs
@@ -222,12 +222,19 @@ impl Player {
 /// the id is main-thread-only.
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
-/// Map from player id to its reactive signal. Lives in a
+/// Player id → reactive signal. Lives behind an `Rc<RefCell<…>>`
+/// so the bridge-callback closure and the `register_status` insert
+/// path share one table, and the whole thing rides in a
 /// [`MainThreadOnly`] wrapper so the `Sync` bound on `OnceLock<T>`
-/// passes; access is on the bridge's main thread by contract (same
-/// model as `whisker-safe-area`).
+/// passes (access is on the bridge's main thread by contract —
+/// same model as `whisker-safe-area`).
+type StatusEntries = Rc<RefCell<HashMap<u64, ArcRwSignal<PlaybackStatus>>>>;
+
+/// Process-global dispatch table. Wraps [`StatusEntries`] so the
+/// `OnceLock<StatusTable>` `Sync` requirement is satisfied by the
+/// surrounding `MainThreadOnly` rather than by the `Rc` itself.
 struct StatusTable {
-    entries: MainThreadOnly<Rc<RefCell<HashMap<u64, ArcRwSignal<PlaybackStatus>>>>>,
+    entries: MainThreadOnly<StatusEntries>,
 }
 
 static STATUS_TABLE: OnceLock<StatusTable> = OnceLock::new();
@@ -263,8 +270,7 @@ fn unregister_status(id: u64) {
 /// up the matching signal, and writes the decoded status. Stale
 /// events for ids that were already released are dropped silently.
 fn install_status_listener() -> StatusTable {
-    let entries: Rc<RefCell<HashMap<u64, ArcRwSignal<PlaybackStatus>>>> =
-        Rc::new(RefCell::new(HashMap::new()));
+    let entries: StatusEntries = Rc::new(RefCell::new(HashMap::new()));
     let entries_for_listener = MainThreadOnly {
         inner: entries.clone(),
     };


### PR DESCRIPTION
## Summary

Adds \`whisker-audio\`, a view-less audio playback module mirroring the imperative half of [Expo's \`expo-audio\`](https://docs.expo.dev/versions/latest/sdk/audio/), plus a runtime-level reactivity fix that surfaced during the work.

\`\`\`rust
let player = Player::new(\"https://…/clip.mp3\");
let status = player.status();        // ReadSignal<PlaybackStatus>
player.play();
player.seek_to(30.0);
\`\`\`

- **Android**: AndroidX Media3 ExoPlayer
- **iOS**: AVPlayer + \`AVAudioSession(.playback)\`
- \`Player\` is \`Clone\` (Rc-backed); the native player is released on last-clone drop.
- \`Player::status()\` returns a per-id \`ReadSignal<PlaybackStatus>\` (position / duration / is_loaded / is_playing) driven by a process-level \`module.on_event(\"statusChanged\")\` subscription that fans events out by \`playerId\`.

## Runtime fix bundled in this PR

\`ArcRwSignal::set\` → \`notify_subscribers\` was pushing dirty subscribers into \`rt.pending\` **directly** instead of through \`scheduler::schedule()\` — bypassing the empty→non-empty edge \`host_wake\` call. The symptom: writes from a bridge callback (e.g. \`module.on_event(...)\` updating a global \`ArcRwSignal\`) queued effects but never flushed them until some other source happened to wake the runtime. A UI bound to the signal simply never re-rendered.

\`whisker-safe-area\` worked despite this because its writes coincide with system-bar / inset transitions that trigger an unrelated layout pass, masking the wake bug. Audio playback has no such co-traveller — the wake omission shows up plainly.

Route through \`schedule()\` and the wake fires every time:

\`\`\`rust
// crates/whisker-runtime/src/reactive/arc_signal.rs
for sub in &subscribers {
    if !stale.contains(sub) {
        super::scheduler::schedule(*sub);  // ← was rt.pending.push
    }
}
\`\`\`

Existing \`whisker-runtime\` reactive tests (117) still pass.

## Platform-specific notes

### Android
- Defers \`createPlayer\` until the host Activity attaches. \`Player::new\` fires from the first render inside \`WhiskerView\`'s constructor — at that moment \`appContext.currentActivity\` is \`null\` because \`setContentView\` hasn't run yet. Same \`addOnHostAttachedListener\` queue-drain pattern as \`whisker-safe-area\`.
- \`Player.Listener.onIsPlayingChanged\` drives a per-player \`Handler.postDelayed\` ticker at ~200 ms cadence.

### iOS
- \`AVAudioSession.setCategory(.playback) + setActive(true)\` so AVPlayer's render loop actually pulls samples on device.
- Falls back to a hand-rolled \`Foundation.Timer\` (added to RunLoop in \`.common\` mode) for progress ticks — \`AVPlayer.addPeriodicTimeObserver\` silently never fires on iOS Simulator (token returns non-nil; the closure is never invoked).
- \`is_loaded\` is duration-derived (\`safeDuration > 0 || currentItem.status == .readyToPlay\`) — the canonical \`status == .readyToPlay\` KVO is unreliable on Simulator.

## Test plan

- [x] \`cargo test -p whisker-runtime --lib\` — 117 passing (includes the reactive tests that exercise \`ArcRwSignal\`).
- [x] Android emulator: example app, taps Play, status card ticks position / progress live, audio audible.
- [ ] iOS Simulator: status flips \`is_playing\` / \`is_loaded\` correctly, but \`position\` stays at 0 and no audio is audible — confirmed an iOS Simulator CoreAudio limitation (other apps also fail to play audio in the same sim). Real-device verification pending.
- [x] No regression in \`whisker-safe-area\` reactivity (sanity: app boots, insets still flow into \`safe_area_insets()\`).

## Known limitations / follow-ups

- iOS Simulator audio output is broken at the CoreAudio level; \`AVPlayer.rate\` flips to 1 but \`currentTime\` never advances. Real device should be unaffected because both \`AVAudioSession\` activation and the Timer-based progress dispatch are sim-bug workarounds, not sim-only hacks.
- No recording / capture (\`AudioRecorder\` equivalent) yet — out of scope for v1.
- No \`AudioPlayerStatus\` aggregation hook (\`useAudioPlayerStatus\` in Expo) — users can subscribe directly with \`computed(move || player.status().get())\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)