### PR TITLE
feat(podcast): wire whisker-audio into the example, mini-player overlays every route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "podcast-routing",
  "podcast-theme",
  "whisker",
+ "whisker-audio",
  "whisker-router",
 ]
 
@@ -986,10 +987,12 @@ dependencies = [
 name = "podcast-feature-detail"
 version = "0.1.0"
 dependencies = [
+ "podcast-data",
  "podcast-domain",
  "podcast-routing",
  "podcast-theme",
  "whisker",
+ "whisker-audio",
  "whisker-icons",
  "whisker-image",
  "whisker-router",
@@ -1017,6 +1020,7 @@ dependencies = [
  "podcast-domain",
  "podcast-theme",
  "whisker",
+ "whisker-audio",
  "whisker-icons",
  "whisker-image",
  "whisker-safe-area",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,7 @@ dependencies = [
  "podcast-feature-detail",
  "podcast-routing",
  "podcast-theme",
+ "podcast-ui-kit",
  "whisker",
  "whisker-audio",
  "whisker-router",

--- a/examples/podcast/Cargo.toml
+++ b/examples/podcast/Cargo.toml
@@ -14,6 +14,11 @@ crate-type = ["rlib"]
 [dependencies]
 whisker = { workspace = true }
 whisker-router = { workspace = true }
+# Playback: the shell constructs a single shared `Player` here and
+# publishes it (plus the now-playing signal) via context so the
+# detail screen can start playback and the mini-player can render
+# the running state.
+whisker-audio = { path = "../../packages/whisker-audio" }
 podcast-domain = { path = "crates/podcast-domain" }
 podcast-routing = { path = "crates/podcast-routing" }
 podcast-theme = { path = "crates/podcast-theme" }

--- a/examples/podcast/Cargo.toml
+++ b/examples/podcast/Cargo.toml
@@ -22,5 +22,6 @@ whisker-audio = { path = "../../packages/whisker-audio" }
 podcast-domain = { path = "crates/podcast-domain" }
 podcast-routing = { path = "crates/podcast-routing" }
 podcast-theme = { path = "crates/podcast-theme" }
+podcast-ui-kit = { path = "crates/podcast-ui-kit" }
 podcast-feature-browse = { path = "crates/podcast-feature-browse" }
 podcast-feature-detail = { path = "crates/podcast-feature-detail" }

--- a/examples/podcast/crates/podcast-data/src/itunes.rs
+++ b/examples/podcast/crates/podcast-data/src/itunes.rs
@@ -14,7 +14,7 @@
 //! the gap, with no intermediate DTO layer. If the shapes diverge
 //! later, introduce a `dto` submodule here and map explicitly.
 
-use podcast_domain::Podcast;
+use podcast_domain::{Episode, Podcast};
 use serde::Deserialize;
 
 /// Failure modes a `fetch_*` call can hit. `Network` covers DNS,
@@ -90,6 +90,69 @@ pub fn search_blocking(q: SearchQuery<'_>) -> Result<Vec<Podcast>, FetchError> {
     Ok(parsed.results)
 }
 
+/// One iTunes `lookup` response item — either the podcast
+/// metadata (when `wrapperType == "track"` and `kind ==
+/// "podcast"`) or an episode (when `wrapperType ==
+/// "podcastEpisode"`). The lookup endpoint mixes both in one
+/// `results` array.
+///
+/// We only care about the discriminator + the episode payload;
+/// the `Episode` variant deserialises straight into the domain
+/// type. The non-episode entry is dropped silently.
+#[derive(Debug, Deserialize)]
+struct LookupItem {
+    #[serde(rename = "wrapperType", default)]
+    wrapper_type: String,
+    #[serde(flatten)]
+    episode: Option<Episode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LookupResponse {
+    #[serde(default)]
+    results: Vec<LookupItem>,
+}
+
+/// Blocking lookup of every episode for `collection_id`. iTunes
+/// caps `limit` at 200; the call returns the show row as the
+/// first result (we drop it) followed by episodes in reverse
+/// chronological order.
+///
+/// Episodes that don't carry an `episodeUrl` are filtered out —
+/// they can't be played, and the rest of the pipeline assumes
+/// every rendered row has a URL to hand to the audio module.
+pub fn fetch_episodes_blocking(collection_id: u64, limit: u32) -> Result<Vec<Episode>, FetchError> {
+    let url = format!(
+        "https://itunes.apple.com/lookup?id={}&entity=podcastEpisode&limit={}",
+        collection_id, limit,
+    );
+
+    let response = ureq::get(&url).call().map_err(|e| match e {
+        ureq::Error::Status(code, _) => FetchError::Status(code),
+        ureq::Error::Transport(t) => FetchError::Network(t.to_string()),
+    })?;
+
+    let body = response
+        .into_string()
+        .map_err(|e| FetchError::Network(format!("read: {e}")))?;
+
+    let parsed: LookupResponse =
+        serde_json::from_str(&body).map_err(|e| FetchError::Parse(e.to_string()))?;
+
+    Ok(parsed
+        .results
+        .into_iter()
+        .filter(|i| i.wrapper_type == "podcastEpisode")
+        .filter_map(|i| i.episode)
+        .filter(|ep| {
+            ep.episode_url
+                .as_deref()
+                .map(|u| !u.is_empty())
+                .unwrap_or(false)
+        })
+        .collect())
+}
+
 /// Minimal URL-encoder for the `term` parameter. iTunes accepts
 /// `+` for spaces and percent-encodes everything else; we only
 /// need the small alphabet our hard-coded section seeds use, so
@@ -117,5 +180,80 @@ mod tests {
         assert_eq!(urlencode("news"), "news");
         assert_eq!(urlencode("true crime"), "true+crime");
         assert_eq!(urlencode("a&b"), "a%26b");
+    }
+
+    /// Sample mirroring the iTunes `entity=podcastEpisode` wire
+    /// shape — first row is the show, second is an episode. The
+    /// pipeline must drop the show row, accept the episode, and
+    /// surface the wire fields onto the domain type.
+    #[test]
+    fn lookup_response_parses_episodes_and_skips_show() {
+        let body = r#"{
+            "resultCount": 2,
+            "results": [
+                {
+                    "wrapperType": "track",
+                    "kind": "podcast",
+                    "collectionId": 1528594034,
+                    "collectionName": "The Interview"
+                },
+                {
+                    "wrapperType": "podcastEpisode",
+                    "trackId": 1000700000000,
+                    "trackName": "Episode A",
+                    "episodeUrl": "https://cdn.example.com/a.mp3",
+                    "trackTimeMillis": 1920000,
+                    "releaseDate": "2026-05-30T10:00:00Z",
+                    "description": "notes"
+                }
+            ]
+        }"#;
+        let parsed: LookupResponse = serde_json::from_str(body).expect("parse");
+        let episodes: Vec<Episode> = parsed
+            .results
+            .into_iter()
+            .filter(|i| i.wrapper_type == "podcastEpisode")
+            .filter_map(|i| i.episode)
+            .collect();
+        assert_eq!(episodes.len(), 1);
+        let ep = &episodes[0];
+        assert_eq!(ep.id, 1000700000000);
+        assert_eq!(ep.track_name, "Episode A");
+        assert_eq!(
+            ep.episode_url.as_deref(),
+            Some("https://cdn.example.com/a.mp3")
+        );
+        assert_eq!(ep.track_time_millis, Some(1920000));
+        assert_eq!(ep.release_date.as_deref(), Some("2026-05-30T10:00:00Z"));
+    }
+
+    /// Episodes with an empty / missing `episodeUrl` are unplayable;
+    /// the production filter drops them. Spot-check the filter
+    /// runs end-to-end on the parsed shape.
+    #[test]
+    fn lookup_filters_episodes_without_url() {
+        let body = r#"{
+            "resultCount": 2,
+            "results": [
+                {"wrapperType": "podcastEpisode", "trackId": 1, "trackName": "A"},
+                {"wrapperType": "podcastEpisode", "trackId": 2, "trackName": "B",
+                 "episodeUrl": "https://x/b.mp3"}
+            ]
+        }"#;
+        let parsed: LookupResponse = serde_json::from_str(body).expect("parse");
+        let playable: Vec<Episode> = parsed
+            .results
+            .into_iter()
+            .filter(|i| i.wrapper_type == "podcastEpisode")
+            .filter_map(|i| i.episode)
+            .filter(|ep| {
+                ep.episode_url
+                    .as_deref()
+                    .map(|u| !u.is_empty())
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert_eq!(playable.len(), 1);
+        assert_eq!(playable[0].id, 2);
     }
 }

--- a/examples/podcast/crates/podcast-data/src/lib.rs
+++ b/examples/podcast/crates/podcast-data/src/lib.rs
@@ -19,5 +19,5 @@
 mod itunes;
 mod repository;
 
-pub use itunes::FetchError;
+pub use itunes::{fetch_episodes_blocking as fetch_episodes, FetchError};
 pub use repository::fetch_browse_screen;

--- a/examples/podcast/crates/podcast-domain/src/lib.rs
+++ b/examples/podcast/crates/podcast-domain/src/lib.rs
@@ -110,3 +110,56 @@ pub enum SectionLayout {
     /// artwork (the "Top Shows" / "New Shows" rows).
     Ranked,
 }
+
+/// One episode of a podcast — the row the detail screen renders
+/// and the unit the playback layer hands to `whisker-audio`.
+///
+/// The wire shape is iTunes' `entity=podcastEpisode` lookup
+/// result. We keep field names verbatim so the serde mapping is
+/// mechanical; the renderer formats `release_date` and
+/// `track_time_millis` into human strings.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Episode {
+    /// iTunes track id. Stable per-episode key.
+    #[serde(rename = "trackId")]
+    pub id: u64,
+
+    /// Episode title.
+    #[serde(rename = "trackName", default)]
+    pub track_name: String,
+
+    /// Direct audio URL (mp3 / m4a). This is the URL handed to
+    /// the player. iTunes returns it for every episode.
+    #[serde(rename = "episodeUrl", default)]
+    pub episode_url: Option<String>,
+
+    /// Episode duration in milliseconds.
+    #[serde(rename = "trackTimeMillis", default)]
+    pub track_time_millis: Option<u64>,
+
+    /// ISO-8601 release timestamp (e.g. `2024-09-12T10:00:00Z`).
+    /// Rendered as a short relative / date label.
+    #[serde(rename = "releaseDate", default)]
+    pub release_date: Option<String>,
+
+    /// Short description / show notes. Plain text from iTunes
+    /// (HTML stripped upstream).
+    #[serde(rename = "description", default)]
+    pub description: Option<String>,
+}
+
+/// What the mini-player and lock-screen-style "now playing"
+/// surface needs to render. Decoupled from [`Episode`] so the
+/// mini-player crate doesn't need to know the wire shape — only
+/// the four strings it draws.
+///
+/// `audio_url` is included for symmetry with the playback layer
+/// (the mini-player can call `set_source` if a future "queue
+/// next" button gets wired) but is not rendered.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NowPlaying {
+    pub episode_title: String,
+    pub show_title: String,
+    pub artwork_url: String,
+    pub audio_url: String,
+}

--- a/examples/podcast/crates/podcast-feature-browse/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-browse/src/lib.rs
@@ -27,15 +27,13 @@
 //!   │   ┌─ section ─────────┐   │
 //!   │   │  …                │   │
 //!   │   └───────────────────┘   │
-//!   ├───────────────────────────┤
-//!   │   mini_player (float)     │
 //!   └───────────────────────────┘
 //! ```
 //!
-//! The mini player floats above the scroll view via absolute
-//! positioning, so the bottom-most card row needs trailing
-//! padding equal to its height + bottom inset — otherwise the
-//! last card hides behind the player on initial scroll-to-end.
+//! The mini player no longer renders here — it's anchored at the
+//! app shell so it overlays *every* route, not just browse. The
+//! bottom-most card row still keeps a 96 px tail margin so the
+//! floating player doesn't obscure it when something's playing.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -46,9 +44,8 @@ use podcast_domain::{ChartSection, Podcast, SectionLayout};
 use podcast_routing::Navigator;
 use podcast_theme as theme;
 use podcast_ui_kit::{
-    FeaturedCard, FeaturedCardProps, HorizontalRow, HorizontalRowProps, MiniPlayer,
-    MiniPlayerProps, RankedCard, RankedCardProps, SectionHeader, SectionHeaderProps, TopNav,
-    TopNavProps,
+    FeaturedCard, FeaturedCardProps, HorizontalRow, HorizontalRowProps, RankedCard,
+    RankedCardProps, SectionHeader, SectionHeaderProps, TopNav, TopNavProps,
 };
 use whisker::css::{AlignItems, Display, FlexDirection, JustifyContent, PositionKind};
 use whisker::prelude::*;
@@ -114,7 +111,6 @@ pub fn browse_screen() -> Element {
                     sections: sections.get().unwrap_or_default(),
                 )
             }
-            mini_player()
         }
     }
 }

--- a/examples/podcast/crates/podcast-feature-detail/Cargo.toml
+++ b/examples/podcast/crates/podcast-feature-detail/Cargo.toml
@@ -14,6 +14,10 @@ whisker-image = { path = "../../../../packages/whisker-image" }
 whisker-icons = { path = "../../../../packages/whisker-icons" }
 whisker-router = { path = "../../../../packages/whisker-router" }
 whisker-safe-area = { path = "../../../../packages/whisker-safe-area" }
+# The detail screen reads `Player` + `NowPlayingSignal` from
+# context — pushed by the shell — and writes both on tap.
+whisker-audio = { path = "../../../../packages/whisker-audio" }
 podcast-domain = { path = "../podcast-domain" }
+podcast-data = { path = "../podcast-data" }
 podcast-routing = { path = "../podcast-routing" }
 podcast-theme = { path = "../podcast-theme" }

--- a/examples/podcast/crates/podcast-feature-detail/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-detail/src/lib.rs
@@ -30,22 +30,34 @@
 //! plumb the data layer's `fetch_podcast_by_id` through `resource`
 //! to handle the deep-link case.
 //!
-//! Playback is **not** wired up — the play / follow buttons are
-//! visual-only. Adding that will be a `whisker-audio` module +
-//! plumbing on top of this screen.
+//! ## Playback wiring
+//!
+//! The detail screen reads the shared [`Player`] handle and the
+//! [`NowPlayingSignal`] from context (both provided by the shell)
+//! and writes both on tap: `Player::set_source(url) + play()`
+//! starts audio, and updating the now-playing signal flips the
+//! mini-player into "showing a track" mode.
+//!
+//! Episodes themselves come from a `resource()`-driven iTunes
+//! lookup that runs once per detail-screen mount and re-fires when
+//! a new id lands.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use podcast_domain::Podcast;
+use podcast_data::fetch_episodes;
+use podcast_domain::{Episode, NowPlaying, Podcast};
 use podcast_routing::Navigator;
 use podcast_theme as theme;
 use whisker::css::{
     AlignItems, Display, FlexDirection, FontWeight, JustifyContent, TextAlign, TextOverflow,
 };
 use whisker::prelude::*;
+use whisker::runtime::tasks::run_blocking;
 use whisker::runtime::view::Element;
+use whisker::ArcRwSignal;
+use whisker_audio::Player;
 use whisker_icons::{lucide, Icon, IconProps};
 use whisker_image::{Image, ImageProps};
 use whisker_safe_area::safe_area_insets;
@@ -55,6 +67,11 @@ use whisker_safe_area::safe_area_insets;
 /// router-agnostic (no dep on the top-level shell) but can still
 /// match the context type the host provides.
 pub type PodcastIndex = Rc<RefCell<HashMap<u64, Podcast>>>;
+
+/// Mirror of the shell-side `NowPlayingSignal` alias. TypeId-
+/// matched, so `use_context::<NowPlayingSignal>()` here finds the
+/// signal the shell provided without taking a dep on the shell.
+pub type NowPlayingSignal = ArcRwSignal<Option<NowPlaying>>;
 
 /// Show detail screen.
 ///
@@ -81,6 +98,23 @@ fn detail_body(podcast: Podcast) -> Element {
     let genre = podcast.primary_genre_name.clone();
     let track_count = podcast.track_count;
     let is_explicit = podcast.is_explicit();
+
+    // Episodes resource — fires the iTunes lookup on mount, re-fires
+    // if the screen is re-rendered with a different id (resource()
+    // is owner-scoped, the outer `match podcast` discriminant means
+    // a navigate-to-different-show remounts this body).
+    let id_for_fetch = podcast.id;
+    let episodes = resource(move || async move {
+        run_blocking(move || fetch_episodes(id_for_fetch, 50))
+            .await
+            .map_err(|e| e.to_string())
+    });
+
+    // Snapshot of podcast metadata for the episode-tap closures —
+    // they need to populate `NowPlaying` without re-reading the
+    // signal map.
+    let show_title = podcast.collection_name.clone();
+    let show_artwork = podcast.artwork_url_600.clone();
 
     // Meta line: "Genre · N episodes". Built once here so the
     // `render!` body doesn't fan out into three nested `text`s.
@@ -158,18 +192,16 @@ fn detail_body(podcast: Podcast) -> Element {
                     )
                     follow_pill()
                 }
-                // Episodes section header + placeholder list. No
-                // RSS-feed wiring yet — that's the playback PR's
-                // job. The placeholder uses the same `episode_row`
-                // shape an actual episode would render with so a
-                // future wiring doesn't move the layout around.
+                // Episodes section header + list. `Show` toggles
+                // between the loading / error placeholder and the
+                // populated list once the resource resolves.
                 view(style: css!(
                     display: Display::Flex,
                     flex_direction: FlexDirection::Column,
                     padding_left: theme::GUTTER,
                     padding_right: theme::GUTTER,
                     padding_top: px(8),
-                    padding_bottom: px(40),
+                    padding_bottom: px(96),
                 )) {
                     text(
                         style: css!(
@@ -180,7 +212,22 @@ fn detail_body(podcast: Podcast) -> Element {
                         ),
                         value: "Episodes".to_string(),
                     )
-                    episode_placeholder()
+                    Show(
+                        when: move || episodes.get().is_some(),
+                        fallback: move || render! {
+                            episode_status(message: if episodes.error().is_some() {
+                                "Couldn't load episodes.".to_string()
+                            } else {
+                                "Loading…".to_string()
+                            })
+                        },
+                    ) {
+                        episode_list(
+                            episodes: episodes.get().unwrap_or_default(),
+                            show_title: show_title.clone(),
+                            show_artwork: show_artwork.clone(),
+                        )
+                    }
                 }
             }
         }
@@ -324,11 +371,10 @@ fn follow_pill() -> Element {
     }
 }
 
-/// Placeholder strip telling the user the episode list isn't wired
-/// yet. Same vertical rhythm a real `episode_row` will take so the
-/// future swap doesn't shift the surrounding layout.
+/// Centred "Loading…" / error strip. Same surface card the prior
+/// placeholder used so layout doesn't shift between resource states.
 #[component]
-fn episode_placeholder() -> Element {
+fn episode_status(message: String) -> Element {
     render! {
         view(style: css!(
             display: Display::Flex,
@@ -346,9 +392,176 @@ fn episode_placeholder() -> Element {
                     color: theme::TEXT_SECONDARY,
                     text_align: TextAlign::Center,
                 ),
-                value: "Episode list is coming with the playback PR.".to_string(),
+                value: message.clone(),
             )
         }
+    }
+}
+
+/// Vertical stack of episode rows. The `show_*` strings get
+/// captured into each tap closure so the now-playing signal can
+/// surface the show title + artwork without a back-channel lookup.
+#[component]
+fn episode_list(episodes: Vec<Episode>, show_title: String, show_artwork: String) -> Element {
+    render! {
+        view(style: css!(
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+        )) {
+            ForEach(
+                each: {
+                    let items = episodes.clone();
+                    move || items.clone()
+                },
+                key: |ep: &Episode| ep.id,
+                children: {
+                    let show_title = show_title.clone();
+                    let show_artwork = show_artwork.clone();
+                    move |ep: Episode| render! {
+                        episode_row(
+                            episode: ep,
+                            show_title: show_title.clone(),
+                            show_artwork: show_artwork.clone(),
+                        )
+                    }
+                },
+            )
+        }
+    }
+}
+
+/// One episode row. Title on the leading edge, release date + a
+/// "•" separator + duration on the trailing edge.
+///
+/// Tapping anywhere on the row drives playback. The handler pulls
+/// the shared `Player` + `NowPlayingSignal` from context so this
+/// component stays usable without the shell wiring (a standalone
+/// harness gets a `None` and the tap is a no-op).
+#[component]
+fn episode_row(episode: Episode, show_title: String, show_artwork: String) -> Element {
+    let title = episode.track_name.clone();
+    let meta = build_episode_meta(episode.release_date.as_deref(), episode.track_time_millis);
+    let audio_url = episode.episode_url.clone().unwrap_or_default();
+    let title_for_now_playing = title.clone();
+
+    let player = use_context::<Player>();
+    let now_playing = use_context::<NowPlayingSignal>();
+    // Component bodies are re-invoked under a `FnMut` wrapper (see
+    // `whisker::call`), so anything captured into the tap closure
+    // must be `Clone`d out of the component params first — moving
+    // the original `String`s straight in would consume the outer
+    // FnMut's captures on the first body run.
+    let show_title_for_tap = show_title.clone();
+    let show_artwork_for_tap = show_artwork.clone();
+    let on_tap = move |_: _| {
+        if audio_url.is_empty() {
+            return;
+        }
+        if let Some(player) = player.as_ref() {
+            player.set_source(audio_url.clone());
+            player.play();
+        }
+        if let Some(np) = now_playing.as_ref() {
+            np.set(Some(NowPlaying {
+                episode_title: title_for_now_playing.clone(),
+                show_title: show_title_for_tap.clone(),
+                artwork_url: show_artwork_for_tap.clone(),
+                audio_url: audio_url.clone(),
+            }));
+        }
+    };
+
+    render! {
+        view(
+            style: css!(
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                padding_top: px(12),
+                padding_bottom: px(12),
+                border_radius: px(8),
+            ),
+            on_tap: on_tap,
+        ) {
+            text(
+                style: css!(
+                    font_size: px(15),
+                    color: theme::TEXT_PRIMARY,
+                    font_weight: FontWeight::Numeric(600),
+                    text_overflow: TextOverflow::Ellipsis,
+                ).raw("text-maxline", "2"),
+                value: title.clone(),
+            )
+            text(
+                style: css!(
+                    font_size: px(12),
+                    color: theme::TEXT_SECONDARY,
+                    margin_top: px(4),
+                ),
+                value: meta,
+            )
+        }
+    }
+}
+
+/// "Sep 12 · 32 min"-style meta line. Either side is optional —
+/// older RSS feeds sometimes omit the duration; iTunes itself
+/// rarely omits the release date. Empty pieces are dropped so a
+/// partial row doesn't get an orphan separator.
+fn build_episode_meta(release_date: Option<&str>, track_ms: Option<u64>) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(2);
+    if let Some(date) = release_date.and_then(short_date) {
+        parts.push(date);
+    }
+    if let Some(ms) = track_ms.filter(|ms| *ms > 0) {
+        parts.push(short_duration(ms));
+    }
+    parts.join(" · ")
+}
+
+/// ISO-8601 → "Sep 12" (year omitted unless it's not the current
+/// one). Defensive: anything not matching `YYYY-MM-DDT...` falls
+/// through to a verbatim copy so a wire-shape surprise still
+/// renders something readable instead of `None`.
+fn short_date(raw: &str) -> Option<String> {
+    let bytes = raw.as_bytes();
+    if bytes.len() < 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return Some(raw.to_string());
+    }
+    let month = &raw[5..7];
+    let day = &raw[8..10];
+    let month_name = match month {
+        "01" => "Jan",
+        "02" => "Feb",
+        "03" => "Mar",
+        "04" => "Apr",
+        "05" => "May",
+        "06" => "Jun",
+        "07" => "Jul",
+        "08" => "Aug",
+        "09" => "Sep",
+        "10" => "Oct",
+        "11" => "Nov",
+        "12" => "Dec",
+        _ => return Some(raw.to_string()),
+    };
+    let day_n: u32 = day.parse().ok()?;
+    Some(format!("{month_name} {day_n}"))
+}
+
+/// "32 min" or "1 h 12 min". Anything under a minute reads as
+/// "<1 min" rather than "0 min" so very short trailers don't
+/// appear empty.
+fn short_duration(ms: u64) -> String {
+    let total_min = ms / 60_000;
+    if total_min == 0 {
+        return "<1 min".to_string();
+    }
+    let hours = total_min / 60;
+    let mins = total_min % 60;
+    if hours == 0 {
+        format!("{mins} min")
+    } else {
+        format!("{hours} h {mins} min")
     }
 }
 

--- a/examples/podcast/crates/podcast-ui-kit/Cargo.toml
+++ b/examples/podcast/crates/podcast-ui-kit/Cargo.toml
@@ -26,5 +26,9 @@ whisker-safe-area = { path = "../../../../packages/whisker-safe-area" }
 # chevron, top-nav menu glyph, and mini-player play / skip glyphs —
 # replaces the prior hand-faked views and Unicode arrows.
 whisker-icons = { path = "../../../../packages/whisker-icons" }
+# `whisker-audio` for the mini-player: it reads the shared `Player`
+# from context to toggle play / pause and drives skip-30s seeks
+# off the reactive `PlaybackStatus` signal.
+whisker-audio = { path = "../../../../packages/whisker-audio" }
 podcast-theme = { path = "../podcast-theme" }
 podcast-domain = { path = "../podcast-domain" }

--- a/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
@@ -1,70 +1,212 @@
 //! Bottom mini-player bar.
 //!
-//! Floats above the scrolling content. Three elements: a leading
-//! placeholder artwork square (sized for the future "currently
-//! playing show art"), a play glyph, and a "skip ahead 30 s" glyph
-//! on the trailing edge. No audio wiring yet — the buttons are
-//! visual-only until the `whisker-audio` module lands. Both glyphs
-//! are now `whisker-icons` Lucide constants — the previous hand-
-//! faked `▶` text + circled "30" view layout is gone.
+//! Floats above the scrolling content. Lays out as: leading artwork
+//! square showing the now-playing podcast art, then a stacked
+//! `episode title / show title` block, then a play / pause glyph
+//! and a "skip 30 s" RotateCw glyph on the trailing edge.
+//!
+//! ## Reactivity
+//!
+//! - Reads [`NowPlayingSignal`] from context — when it's `None`,
+//!   the whole bar is hidden (via `Show`), so a cold-start page
+//!   doesn't show an empty player.
+//! - Reads [`Player`] from context and pulls its [`PlaybackStatus`]
+//!   to drive the play / pause icon swap and to compute the
+//!   skip-30s target offset.
+//! - The play / pause toggle calls `Player::play` /
+//!   `Player::pause` based on the current `is_playing` flag, so a
+//!   single tap covers both directions.
+//!
+//! ## Context contract
+//!
+//! Both contexts MUST be provided by an ancestor (the shell does
+//! this in `#[whisker::main]`). If either is missing the component
+//! panics on mount — a deliberate sharp edge because a silently-
+//! noop mini-player would mask the wiring bug.
 
+use podcast_domain::NowPlaying;
 use podcast_theme as theme;
-use whisker::css::{AlignItems, Color, Display, FlexDirection, JustifyContent, PositionKind};
+use whisker::css::{
+    AlignItems, Color, Display, FlexDirection, FontWeight, JustifyContent, PositionKind,
+    TextOverflow,
+};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
+use whisker::ArcRwSignal;
+use whisker_audio::Player;
 use whisker_icons::{lucide, Icon, IconProps};
+use whisker_image::{Image, ImageProps};
+
+/// Mirror of the shell-side alias. Same TypeId across crates
+/// because the resolver matches on `Rc`/`ArcRwSignal` instantiation,
+/// not module path.
+pub type NowPlayingSignal = ArcRwSignal<Option<NowPlaying>>;
 
 #[component]
 pub fn mini_player() -> Element {
+    // Both contexts are required. Sharp-edge `expect` rather than
+    // a graceful fall-through: a silent no-op would just shift the
+    // bug down to "play button doesn't work" which is harder to
+    // trace than a startup panic.
+    let now_playing = use_context::<NowPlayingSignal>()
+        .expect("mini_player requires NowPlayingSignal in context");
+    let player = use_context::<Player>().expect("mini_player requires Player in context");
+    let status = player.status();
+
+    // Visibility — collapse to empty fragment when nothing's queued.
+    let np_for_when = now_playing.clone();
+    let visible = move || np_for_when.get().is_some();
+
+    // Reactive bindings for the visible body. Each `computed` reads
+    // the now-playing signal so a `set(Some(_))` in the detail
+    // screen drives the artwork / title swap without a remount.
+    let np_for_artwork = now_playing.clone();
+    let artwork_src = computed(move || {
+        np_for_artwork
+            .get()
+            .map(|np| np.artwork_url)
+            .unwrap_or_default()
+    });
+    let np_for_title = now_playing.clone();
+    let title_text = computed(move || {
+        np_for_title
+            .get()
+            .map(|np| np.episode_title)
+            .unwrap_or_default()
+    });
+    let np_for_show = now_playing.clone();
+    let show_text = computed(move || {
+        np_for_show
+            .get()
+            .map(|np| np.show_title)
+            .unwrap_or_default()
+    });
+
+    // Play / pause glyph follows the live `is_playing` flag the
+    // audio module pushes through `statusChanged`. The `Icon`'s
+    // `svg:` prop is `Signal<String>` — a `computed` of
+    // `&'static str → String` plugs straight in.
+    let play_icon = computed(move || {
+        if status.get().is_playing {
+            lucide::Pause.to_string()
+        } else {
+            lucide::Play.to_string()
+        }
+    });
+
+    // `Show`'s body is invoked under an outer `Fn` closure: a
+    // visibility flip would re-run it, so the `on_tap` values
+    // can't be `move`-captured once and reused. The render! body
+    // below builds each handler inline, cloning the (Rc-backed)
+    // `Player` per build — cheap, and lets every re-mount get a
+    // fresh closure.
+    let player_for_toggle = player.clone();
+    let player_for_skip = player.clone();
+
     render! {
-        // Floats above content via absolute positioning. The parent
-        // page must use `position: relative` (default) so the floats
-        // anchor correctly. Side gutter matches the page gutter so
-        // the bar visually inset-aligns with the section content.
-        view(style: css!(
-            position: PositionKind::Absolute,
-            left: theme::GUTTER,
-            right: theme::GUTTER,
-            bottom: theme::MINI_PLAYER_BOTTOM,
-            height: theme::MINI_PLAYER_HEIGHT,
-            display: Display::Flex,
-            flex_direction: FlexDirection::Row,
-            align_items: AlignItems::Center,
-            padding_left: px(12),
-            padding_right: px(16),
-            border_radius: px(12),
-            background_color: theme::MINI_PLAYER_BG,
-        )) {
-            // Leading placeholder: 36×36 square where the now-
-            // playing show art would go.
+        Show(when: visible, fallback: || render! { fragment() }) {
+            // Floats above content via absolute positioning. The
+            // parent page must use `position: relative` (default).
             view(style: css!(
-                width: px(36),
-                height: px(36),
-                border_radius: px(6),
-                background_color: Color::rgba(255, 255, 255, 0.15),
-            ))
-            // Spacer between leading art and trailing controls.
-            view(style: css!(flex_grow: 1.0, flex_shrink: 1.0))
-            view(style: css!(
-                width: px(32),
-                height: px(32),
+                position: PositionKind::Absolute,
+                left: theme::GUTTER,
+                right: theme::GUTTER,
+                bottom: theme::MINI_PLAYER_BOTTOM,
+                height: theme::MINI_PLAYER_HEIGHT,
                 display: Display::Flex,
                 flex_direction: FlexDirection::Row,
                 align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
+                padding_left: px(8),
+                padding_right: px(8),
+                border_radius: px(12),
+                background_color: theme::MINI_PLAYER_BG,
             )) {
-                Icon(svg: lucide::Play, color: "#ffffff", size: "22")
-            }
-            view(style: css!(
-                width: px(36),
-                height: px(36),
-                display: Display::Flex,
-                flex_direction: FlexDirection::Row,
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                margin_left: px(16),
-            )) {
-                Icon(svg: lucide::RotateCw, color: "#ffffff", size: "26")
+                // Leading artwork. `aspect-ratio` keeps Lynx from
+                // collapsing the box before the image loads.
+                Image(
+                    style: css!(
+                        width: px(40),
+                        height: px(40),
+                        border_radius: px(6),
+                        background_color: Color::rgba(255, 255, 255, 0.15),
+                    ).raw("aspect-ratio", "1 / 1").to_css_string(),
+                    src: artwork_src,
+                    mode: "aspectFill",
+                )
+                // Stacked text — episode title on top, show title
+                // below. Flex-grow lets it absorb the slack so the
+                // trailing controls stay right-aligned.
+                view(style: css!(
+                    flex_grow: 1.0,
+                    flex_shrink: 1.0,
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Column,
+                    margin_left: px(10),
+                    margin_right: px(10),
+                )) {
+                    text(
+                        style: css!(
+                            font_size: px(13),
+                            color: theme::TEXT_PRIMARY,
+                            font_weight: FontWeight::Numeric(600),
+                            text_overflow: TextOverflow::Ellipsis,
+                        ).raw("text-maxline", "1"),
+                        value: title_text,
+                    )
+                    text(
+                        style: css!(
+                            font_size: px(11),
+                            color: theme::TEXT_SECONDARY,
+                            margin_top: px(2),
+                            text_overflow: TextOverflow::Ellipsis,
+                        ).raw("text-maxline", "1"),
+                        value: show_text,
+                    )
+                }
+                // Play / pause toggle.
+                view(
+                    style: css!(
+                        width: px(36),
+                        height: px(36),
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                    ),
+                    on_tap: {
+                        let p = player_for_toggle.clone();
+                        move |_| {
+                            if status.get().is_playing {
+                                p.pause();
+                            } else {
+                                p.play();
+                            }
+                        }
+                    },
+                ) {
+                    Icon(svg: play_icon, color: "#ffffff", size: "24")
+                }
+                // Skip-30s.
+                view(
+                    style: css!(
+                        width: px(36),
+                        height: px(36),
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        margin_left: px(4),
+                    ),
+                    on_tap: {
+                        let p = player_for_skip.clone();
+                        move |_| {
+                            let pos = status.get().position;
+                            p.seek_to(pos + 30.0);
+                        }
+                    },
+                ) {
+                    Icon(svg: lucide::RotateCw, color: "#ffffff", size: "22")
+                }
             }
         }
     }

--- a/examples/podcast/src/lib.rs
+++ b/examples/podcast/src/lib.rs
@@ -37,13 +37,15 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use podcast_domain::Podcast;
+use podcast_domain::{NowPlaying, Podcast};
 use podcast_feature_browse::{BrowseScreen, BrowseScreenProps};
 use podcast_feature_detail::{DetailScreen, DetailScreenProps};
 use podcast_routing::{AppRoute, Navigator};
 use whisker::css::{Display, FlexDirection};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
+use whisker::ArcRwSignal;
+use whisker_audio::Player;
 use whisker_router::stack::{route_stack, RouteStack};
 use whisker_router::{
     AndroidPredictiveBack, AndroidPredictiveBackProps, IosSwipeBack, IosSwipeBackProps,
@@ -62,6 +64,16 @@ use whisker_router::{
 /// A reactive signal would force the whole detail tree to re-render
 /// every time browse pushes a new chart row.
 pub type PodcastIndex = Rc<RefCell<HashMap<u64, Podcast>>>;
+
+/// Process-wide reactive "what's playing right now". `None` when
+/// nothing has been queued yet (cold start, before the user taps
+/// an episode); `Some` while the mini-player is showing a track.
+///
+/// Exposed as a type alias — same TypeId across crates — so the
+/// detail screen (writes on tap) and the mini-player (reads to
+/// render) match on `use_context<NowPlayingSignal>()` without
+/// importing it from this shell crate.
+pub type NowPlayingSignal = ArcRwSignal<Option<NowPlaying>>;
 
 /// Build a [`Navigator`] backed by the given route stack. Defined
 /// in the shell (not in `podcast-routing`) because it's the only
@@ -87,10 +99,22 @@ fn app() -> Element {
     let index: PodcastIndex = Rc::new(RefCell::new(HashMap::new()));
     let navigator = navigator_from_stack(stack.clone());
 
+    // One process-wide audio player. Constructed with no source —
+    // the detail screen calls `set_source` + `play` when the user
+    // taps an episode. The `Player` handle is `Clone` (Rc-backed);
+    // every consumer that pulls it from context gets a fresh
+    // ref-counted handle pointing at the same native player, so
+    // play / pause from the mini-player and the detail screen both
+    // drive the same playback.
+    let player = Player::new("");
+    let now_playing: NowPlayingSignal = ArcRwSignal::new(None);
+
     // Push the shared state into context once, on the `app()`
     // owner — the ancestor of every screen rendered below.
     provide_context(navigator);
     provide_context(index);
+    provide_context(player);
+    provide_context(now_playing);
 
     let render: RouteRenderFn<AppRoute> = (|r: AppRoute| match r {
         AppRoute::Browse => render! { BrowseScreen() },

--- a/examples/podcast/src/lib.rs
+++ b/examples/podcast/src/lib.rs
@@ -41,7 +41,8 @@ use podcast_domain::{NowPlaying, Podcast};
 use podcast_feature_browse::{BrowseScreen, BrowseScreenProps};
 use podcast_feature_detail::{DetailScreen, DetailScreenProps};
 use podcast_routing::{AppRoute, Navigator};
-use whisker::css::{Display, FlexDirection};
+use podcast_ui_kit::{MiniPlayer, MiniPlayerProps};
+use whisker::css::{Display, FlexDirection, PositionKind};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker::ArcRwSignal;
@@ -123,12 +124,17 @@ fn app() -> Element {
     .into();
 
     render! {
+        // `position: relative` anchors the absolutely-positioned
+        // mini-player to the page itself, so the bar floats above
+        // *every* route — browse and detail alike — instead of
+        // being scoped to one screen's layout.
         page(style: css!(
             width: vw(100),
             height: vh(100),
             background_color: podcast_theme::BG,
             display: Display::Flex,
             flex_direction: FlexDirection::Column,
+            position: PositionKind::Relative,
         )) {
             RouteProvider(stack: stack) {
                 StackLayout(render: render.clone()) {
@@ -136,6 +142,13 @@ fn app() -> Element {
                     AndroidPredictiveBack()
                 }
             }
+            // The mini-player renders AFTER the route stack in DOM
+            // order so it paints on top — Lynx's animator quirk on
+            // z-index during sibling animations makes paint order
+            // the reliable lever. `MiniPlayer` itself is hidden
+            // (Show fallback → fragment) while `NowPlayingSignal`
+            // is `None`, so this mount is invisible on cold start.
+            MiniPlayer()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Integrate `whisker-audio` into the podcast example: tap an episode in the detail screen → audio plays through the shared `Player`, and the mini-player overlays every screen with the live track.
- New `Episode` + `NowPlaying` domain types and an iTunes lookup fetcher (`entity=podcastEpisode`); episodes without an `episodeUrl` are filtered.
- Shell constructs one process-wide `Player` and a `NowPlayingSignal` (`ArcRwSignal<Option<NowPlaying>>`), publishes both through context via type aliases so feature crates match by TypeId without depending on the shell.
- Detail screen replaces the static placeholder with a `resource()`-driven episode list; tap calls `set_source(url) + play()` and updates the now-playing signal.
- Mini-player is mounted at the shell (sibling of the route stack, anchored on a `position: relative` page) so it floats over browse **and** detail. While `NowPlayingSignal` is `None` the `Show` falls back to a fragment — cold-start stays clean.
- Mini-player reads the contexts: `Player` drives `play()` / `pause()` / `seek_to(pos + 30.0)`; `status` (= `player.status()`) drives the Play/Pause icon swap off `is_playing`.

## Test plan
- [x] `cargo check -p podcast` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p podcast-data` — 3 passed (incl. new `lookup_response_parses_episodes_and_skips_show` and `lookup_filters_episodes_without_url`)
- [x] Android emulator: browse → detail navigation, episode tap starts audio, mini-player overlays both screens with live track + working Play/Pause and skip-30
- [ ] iOS real device verification (Simulator audio is broken at the CoreAudio layer; out-of-scope for this PR)