### PR TITLE
chore(api): tighten public surface ahead of release

### DIFF
--- a/packages/whisker-audio/src/lib.rs
+++ b/packages/whisker-audio/src/lib.rs
@@ -76,7 +76,17 @@ use whisker::{module, ArcReadSignal, ArcRwSignal, ReadSignal};
 /// player has finished its async load — UI that renders a progress
 /// bar can branch on `is_loaded` to fade in once the value is
 /// meaningful.
+///
+/// `#[non_exhaustive]` so the surface can grow (e.g. a future
+/// `is_buffering` flag, an `error: Option<...>`) without breaking
+/// downstream code. Users read fields directly but should not
+/// match the struct exhaustively — `PlaybackStatus { position,
+/// duration, .. }` is the supported destructure form, and
+/// construction from outside the crate is intentionally not
+/// supported (the value is produced by the native module, never by
+/// the consumer).
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[non_exhaustive]
 pub struct PlaybackStatus {
     /// Current playback position from the start, in seconds.
     pub position: f64,

--- a/packages/whisker-svg/src/lib.rs
+++ b/packages/whisker-svg/src/lib.rs
@@ -39,14 +39,30 @@
 //! instead of a literal colour — the replayer substitutes the host's
 //! `color:` value at draw time. See `SPEC.md` §"Tint propagation".
 
+// Public API: the `Svg` widget, the user-callable `compile()`
+// entry point, and its result/error types. Everything else under
+// this crate is internal — kept reachable so the crate's own
+// integration tests under `tests/` can exercise it, but flagged
+// `#[doc(hidden)]` so rustdoc / IDE completion don't surface it
+// and consumers don't grow accidental dependencies on the
+// display-list machinery. The SemVer contract is "anything not in
+// rustdoc may change without notice."
+#[doc(hidden)]
 pub mod builder;
+#[doc(hidden)]
 pub mod compile;
+#[doc(hidden)]
 pub mod format;
+#[doc(hidden)]
 pub mod path_parse;
+#[doc(hidden)]
 pub mod replay;
 
-pub use builder::{Color, DisplayListBuilder, Transform};
 pub use compile::{compile, CompileError, Compiled};
+
+#[doc(hidden)]
+pub use builder::{Color, DisplayListBuilder, Transform};
+#[doc(hidden)]
 pub use replay::{replay, ReplayError, TraceVisitor, Visitor};
 
 use base64::Engine;


### PR DESCRIPTION
## Summary

Two release-blocker items from the public-API audit:

1. **`PlaybackStatus` is now `#[non_exhaustive]`.** Today it derives `Clone, Copy, Default, PartialEq` with four `pub` fields. Adding a new field later (`is_buffering`, `error: Option<...>`, ...) would break consumers who pattern-match exhaustively. The struct is constructed only by the native module — consumers only read fields — so `#[non_exhaustive]` costs nothing on the consumer side.

2. **`whisker-svg` internal modules are `#[doc(hidden)]`.** `builder` / `compile` / `format` / `path_parse` / `replay` were `pub mod` at the crate root. They have to stay reachable so the crate's own `tests/*.rs` (which compile as separate crates) can exercise them, but `#[doc(hidden)]` keeps them off rustdoc and IDE completion. The truly public surface stays at the crate root: `Svg` / `SvgProps` / `compile` / `Compiled` / `CompileError`. Items re-exported for tests (`Color`, `DisplayListBuilder`, `Transform`, `replay`, `ReplayError`, `TraceVisitor`, `Visitor`) are also `#[doc(hidden)]`.

The audit identifies two more "release-week" follow-ups (an API-design doc and a `mode:` rustdoc pass) that we'll handle in a separate session.

## Test plan
- [x] `cargo check -p whisker-audio -p whisker-audio-example` — clean
- [x] `cargo check -p whisker-svg -p whisker-svg-example -p whisker-icons` — clean
- [x] `cargo test -p whisker-svg` — 3 + 9 + 13 + 2 + 12 = 39 passed
- [x] `cargo clippy -p whisker-audio -p whisker-svg --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean