### PR TITLE
refactor(reactive): owner API to method-style on Owner handle

### DIFF
--- a/crates/whisker-driver/src/element_ref.rs
+++ b/crates/whisker-driver/src/element_ref.rs
@@ -337,7 +337,7 @@ impl ElementRef {
     /// recycled `Element` ID.
     ///
     /// `try_set` because the underlying signal may have already been
-    /// disposed by the time this cleanup fires: `dispose_owner`
+    /// disposed by the time this cleanup fires: `Owner::dispose`
     /// frees the owner's signal nodes (step 4) *before* running
     /// cleanups (step 6). For the typical case (ref allocated in a
     /// parent owner, element mounted in a child owner) this is a

--- a/crates/whisker-runtime/src/reactive/arc_signal.rs
+++ b/crates/whisker-runtime/src/reactive/arc_signal.rs
@@ -76,7 +76,7 @@ use super::with_runtime;
 /// own themselves; we don't keep the subscriber alive by listing it
 /// here. Stale `NodeId`s (whose arena slot got freed) are pruned
 /// lazily on the next `notify_subscribers` call and eagerly during
-/// `dispose_owner` (see `crates/whisker-runtime/src/reactive/owner.rs`).
+/// `Owner::dispose` (see `crates/whisker-runtime/src/reactive/owner.rs`).
 pub(crate) struct ArcSignalInner<T> {
     value: RefCell<T>,
     subscribers: RefCell<Vec<NodeId>>,

--- a/crates/whisker-runtime/src/reactive/component.rs
+++ b/crates/whisker-runtime/src/reactive/component.rs
@@ -24,8 +24,7 @@
 
 use std::rc::Rc;
 
-use super::owner::{create_owner, dispose_owner, with_owner};
-use super::runtime::OwnerId;
+use super::runtime::Owner;
 use super::{untrack, with_runtime};
 use crate::view::Element;
 
@@ -33,14 +32,14 @@ use crate::view::Element;
 /// against it for hot reload, run `body` inside that owner, and
 /// return both the owner id and the body's result.
 ///
-/// The caller is responsible for keeping the returned `OwnerId` alive
+/// The caller is responsible for keeping the returned `Owner` alive
 /// (e.g. attaching it to the parent component's owner-children list
 /// via the renderer) and for disposing it when the component
 /// unmounts. The owner is already linked as a child of the
-/// current-owner-at-call-time, so calling [`dispose_owner`] on an
+/// current-owner-at-call-time, so calling [`Owner::dispose`] on an
 /// ancestor will cascade.
-pub fn mount_component<R>(fn_ptr: *const (), body: impl FnOnce() -> R) -> (OwnerId, R) {
-    let owner = create_owner(None);
+pub fn mount_component<R>(fn_ptr: *const (), body: impl FnOnce() -> R) -> (Owner, R) {
+    let owner = Owner::new(None);
     with_runtime(|rt| {
         if let Some(o) = rt.owners.get_mut(owner) {
             o.mount_fn = Some(fn_ptr);
@@ -56,14 +55,14 @@ pub fn mount_component<R>(fn_ptr: *const (), body: impl FnOnce() -> R) -> (Owner
     // Clear the tracker around the body call so a direct
     // `signal.get()` in user code doesn't silently subscribe the
     // outer node.
-    let result = untrack(|| with_owner(owner, body));
+    let result = untrack(|| owner.with(body));
     (owner, result)
 }
 
 /// Dispose a component owner *and* deregister it from
-/// `component_owners`. Use this instead of plain `dispose_owner` for
+/// `component_owners`. Use this instead of plain `Owner::dispose` for
 /// owners created via `mount_component`.
-pub fn unmount_component(owner: OwnerId) {
+pub fn unmount_component(owner: Owner) {
     let fn_ptr = with_runtime(|rt| rt.owners.get(owner).and_then(|o| o.mount_fn));
     if let Some(fp) = fn_ptr {
         with_runtime(|rt| {
@@ -75,7 +74,7 @@ pub fn unmount_component(owner: OwnerId) {
             }
         });
     }
-    dispose_owner(owner);
+    owner.dispose();
 }
 
 /// Register `f` as a post-mount callback for the current owner. Fires
@@ -123,7 +122,7 @@ pub fn flush_mounts() {
 /// a snapshot — modifying the runtime's `component_owners` after
 /// this call won't affect the returned `Vec`.
 #[doc(hidden)]
-pub fn owners_for_fn(fn_ptr: *const ()) -> Vec<OwnerId> {
+pub fn owners_for_fn(fn_ptr: *const ()) -> Vec<Owner> {
     with_runtime(|rt| {
         rt.component_owners
             .get(&fn_ptr)
@@ -201,7 +200,7 @@ pub(crate) struct MountSite {
     pub body: Rc<dyn Fn() -> Element + 'static>,
     /// Current owner — `Some` between mounts, `None` during the
     /// dispose-then-remount window.
-    pub owner: Option<OwnerId>,
+    pub owner: Option<Owner>,
     /// Element handle the body returned for its outermost element.
     /// Detached from the parent at the start of each remount, then
     /// replaced by the new body's root inserted at the same slot.
@@ -281,7 +280,7 @@ where
 
     // Initial mount: fresh owner, run body, capture root.
     let body_for_first = body.clone();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     with_runtime(|rt| {
         if let Some(o) = rt.owners.get_mut(owner) {
             o.mount_fn = Some(fn_ptr);
@@ -290,7 +289,7 @@ where
     });
     // See `mount_component` for the rationale on the `untrack`
     // bracket. Same invariant applies to the remountable variant.
-    let body_root = untrack(|| with_owner(owner, || (*body_for_first)()));
+    let body_root = untrack(|| owner.with(|| (*body_for_first)()));
 
     // Register the MountSite with parent / anchor as `None` for now
     // — the next `view::append_child` that attaches `body_root`
@@ -456,7 +455,7 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
 
     // 2. Detach every old body_root from its parent *before* any
     //    dispose runs. Element handles get invalidated by
-    //    `dispose_owner` (renderer slot becomes `None`), so once
+    //    `Owner::dispose` (renderer slot becomes `None`), so once
     //    disposed, subsequent `remove_child` calls would silently
     //    no-op against Lynx — visible as "stale subtree still on
     //    screen" after hot reload. Doing the remove first keeps the
@@ -473,7 +472,7 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
 
     // 3. Dispose old owners + run new bodies, collecting (mount_id,
     //    parent, old_root, new_root, new_owner).
-    let mut results: Vec<(MountId, Element, Element, Element, OwnerId)> =
+    let mut results: Vec<(MountId, Element, Element, Element, Owner)> =
         Vec::with_capacity(infos.len());
     for info in infos {
         let old_owner = with_runtime(|rt| {
@@ -482,10 +481,10 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
             site.owner.take()
         });
         if let Some(o) = old_owner {
-            dispose_owner(o);
+            o.dispose();
         }
 
-        let new_owner = create_owner(None);
+        let new_owner = Owner::new(None);
         with_runtime(|rt| {
             if let Some(o) = rt.owners.get_mut(new_owner) {
                 o.mount_fn = Some(info.fn_ptr);
@@ -499,7 +498,7 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
         // against its own nested `effect`/`computed`s, not against
         // whatever scheduler context happens to be active when
         // `tick_callback` calls into us.
-        let new_body_root = untrack(|| with_owner(new_owner, || (*info.body)()));
+        let new_body_root = untrack(|| new_owner.with(|| (*info.body)()));
         // The body's `mount_component_remountable` calls leave a
         // PENDING_MOUNT entry behind; we drain it here because the
         // batched path attaches the new root via `insert_child_at`

--- a/crates/whisker-runtime/src/reactive/computed.rs
+++ b/crates/whisker-runtime/src/reactive/computed.rs
@@ -21,7 +21,7 @@ use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-use super::runtime::{NodeData, NodeId, Owner, ReactiveNode};
+use super::runtime::{NodeData, NodeId, ReactiveNode, Scope};
 use super::scheduler;
 use super::signal::ReadSignal;
 use super::{untrack, with_runtime};
@@ -87,7 +87,7 @@ pub fn computed<T: 'static + Clone + PartialEq>(
     }
     let node_id = with_runtime(|rt| {
         let owner = rt.current_owner().unwrap_or_else(|| {
-            let detached = rt.owners.insert(Owner::new(None));
+            let detached = rt.owners.insert(Scope::new(None));
             rt.owner_stack.push(detached);
             detached
         });

--- a/crates/whisker-runtime/src/reactive/context.rs
+++ b/crates/whisker-runtime/src/reactive/context.rs
@@ -10,7 +10,7 @@
 
 use std::any::{Any, TypeId};
 
-use super::runtime::OwnerId;
+use super::runtime::Owner;
 use super::with_runtime;
 
 /// Provide a context value in the current owner. Subsequent
@@ -78,8 +78,8 @@ pub fn with_context<T: 'static, R>(f: impl FnOnce(&T) -> R) -> Option<R> {
 /// ancestor (including `start`) has one.
 fn find_owner_with<T: 'static>(
     rt: &super::runtime::ReactiveRuntime,
-    start: Option<OwnerId>,
-) -> Option<OwnerId> {
+    start: Option<Owner>,
+) -> Option<Owner> {
     let type_id = TypeId::of::<T>();
     let mut cursor = start;
     while let Some(id) = cursor {

--- a/crates/whisker-runtime/src/reactive/effect.rs
+++ b/crates/whisker-runtime/src/reactive/effect.rs
@@ -13,7 +13,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::runtime::{NodeData, NodeId, Owner, ReactiveNode};
+use super::runtime::{NodeData, NodeId, ReactiveNode, Scope};
 use super::scheduler;
 use super::with_runtime;
 
@@ -36,7 +36,7 @@ pub fn effect(f: impl FnMut() + 'static) -> NodeId {
     }
     let node_id = with_runtime(|rt| {
         let owner = rt.current_owner().unwrap_or_else(|| {
-            let detached = rt.owners.insert(Owner::new(None));
+            let detached = rt.owners.insert(Scope::new(None));
             rt.owner_stack.push(detached);
             detached
         });

--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -5,9 +5,11 @@
 //! Quick map:
 //!
 //! - [`runtime`] — internal data structures: [`ReactiveRuntime`],
-//!   [`Owner`], [`ReactiveNode`], [`NodeData`].
-//! - [`owner`] — owner lifecycle: [`create_owner`], [`dispose_owner`],
-//!   [`with_owner`], [`on_cleanup`].
+//!   [`runtime::Scope`], [`ReactiveNode`], [`NodeData`].
+//! - [`owner`] — public owner API: the [`Owner`] handle and its
+//!   methods ([`Owner::new`], [`Owner::with`], [`Owner::dispose`],
+//!   [`Owner::pause`], [`Owner::resume`], [`Owner::is_paused`])
+//!   plus the free function [`on_cleanup`].
 //! - [`signal`] — [`signal`] / [`RwSignal`] / [`ReadSignal`] /
 //!   [`WriteSignal`].
 //! - [`effect`] — [`effect`] + dependency tracking.
@@ -56,12 +58,15 @@ pub use component::{
 pub use computed::computed;
 pub use context::{provide_context, use_context, with_context};
 pub use effect::effect;
-pub use owner::{
-    create_owner, dispose_owner, is_owner_paused, on_cleanup, pause_owner, resume_owner, with_owner,
-};
+// `on_cleanup` lives at the module top-level because it acts on
+// whichever owner is currently on the runtime stack — the caller
+// can't name it. Everything else owner-related lives behind the
+// `owner` module path (re-exported below) so users write
+// `whisker::owner::Owner::new(None)` / `owner.with(...)` / etc.
+pub use owner::on_cleanup;
 pub use prop::Signal;
 pub use resource::{resource, resource_sync, Resource, ResourceState};
-pub use runtime::{NodeId, OwnerId};
+pub use runtime::{NodeId, Owner};
 pub use scheduler::flush;
 pub use signal::{signal, ReadSignal, RwSignal, WriteSignal};
 pub use stored::StoredValue;
@@ -88,7 +93,7 @@ thread_local! {
 /// closures.
 ///
 /// Crate-internal; the public surface is the typed `signal` / `effect`
-/// / `computed` / `dispose_owner` etc. functions. Exposing the raw
+/// / `computed` / `Owner::dispose` etc. functions. Exposing the raw
 /// runtime would let callers violate borrow-window invariants.
 pub(crate) fn with_runtime<R>(f: impl FnOnce(&mut ReactiveRuntime) -> R) -> R {
     RUNTIME.with_borrow_mut(f)

--- a/crates/whisker-runtime/src/reactive/owner.rs
+++ b/crates/whisker-runtime/src/reactive/owner.rs
@@ -1,310 +1,340 @@
-//! Owner (scope) lifecycle: create, dispose, enter/exit.
+//! Owner / scope API surface.
 //!
-//! Owners form a tree. Every reactive primitive (signal / effect /
-//! computed) belongs to exactly one owner. Disposing an owner cascades
-//! into its children, then frees every node it allocated, then runs
-//! its cleanup callbacks in LIFO order.
+//! [`Owner`] is the public-facing handle for a reactive scope —
+//! the lifetime unit that ties together signals, effects, computed
+//! values, view element handles, and cleanup callbacks. Disposing
+//! an `Owner` cascades into its children, frees every node it
+//! allocated, releases the element handles it owned, and runs its
+//! cleanup callbacks in LIFO order.
 //!
-//! Users normally don't call these directly — they use
-//! `#[component]`, `provide_context`, `on_cleanup` etc. — but tests
-//! and the renderer machinery do.
+//! ## When to reach for these methods
+//!
+//! - Application code: **almost never**. `#[component]`,
+//!   `provide_context`, `on_cleanup` etc. set up and tear down
+//!   owners for you automatically.
+//! - Framework extension code (custom control-flow primitives, a
+//!   router, a custom list virtualizer): when you need to mount
+//!   sub-trees whose lifetime is shorter than the surrounding
+//!   component — that's where `Owner::new` / `owner.with` /
+//!   `owner.dispose` come in.
+//! - Tests: hand-driving owner lifecycle is convenient for
+//!   reactive unit tests.
+//!
+//! See the crate-level docs for the conceptual model.
+//!
+//! The underlying [`Owner`] type is a `Copy` slotmap key
+//! defined in [`super::runtime`]; the methods on this page are
+//! attached to that type via an `impl` block.
 
 use std::rc::Rc;
 
-use super::runtime::{NodeId, Owner, OwnerId};
+use super::runtime::{NodeId, Owner, Scope};
 use super::with_runtime;
 
-/// Create a new owner. If `parent` is `None` the current top-of-stack
-/// owner is used (or the owner becomes a root if the stack is empty).
-/// Returns the new owner's id.
-///
-/// The new owner inherits its parent's `paused` flag — so a sub-
-/// component mounted while its containing route is suspended starts
-/// paused, and its effects won't fire until the route resumes.
-pub fn create_owner(parent: Option<OwnerId>) -> OwnerId {
-    with_runtime(|rt| {
-        let parent = parent.or_else(|| rt.current_owner());
-        let parent_paused = parent
-            .and_then(|p| rt.owners.get(p))
-            .map(|o| o.paused)
-            .unwrap_or(false);
-        let mut owner = Owner::new(parent);
-        owner.paused = parent_paused;
-        let id = rt.owners.insert(owner);
-        if let Some(p) = parent {
-            if let Some(parent_owner) = rt.owners.get_mut(p) {
-                parent_owner.children.push(id);
+impl Owner {
+    /// Create a new owner. If `parent` is `None` the current
+    /// top-of-stack owner is used (or the owner becomes a root if
+    /// the stack is empty).
+    ///
+    /// The new owner inherits its parent's `paused` flag — so a
+    /// sub-component mounted while its containing route is
+    /// suspended starts paused, and its effects won't fire until
+    /// the route resumes.
+    pub fn new(parent: Option<Owner>) -> Owner {
+        with_runtime(|rt| {
+            let parent = parent.or_else(|| rt.current_owner());
+            let parent_paused = parent
+                .and_then(|p| rt.owners.get(p))
+                .map(|o| o.paused)
+                .unwrap_or(false);
+            let mut scope = Scope::new(parent);
+            scope.paused = parent_paused;
+            let id = rt.owners.insert(scope);
+            if let Some(p) = parent {
+                if let Some(parent_scope) = rt.owners.get_mut(p) {
+                    parent_scope.children.push(id);
+                }
             }
+            id
+        })
+    }
+
+    /// Push `self` as the current scope, run `f`, pop back.
+    /// Reactive primitives (`signal()`, `effect()`, `computed()`,
+    /// view elements created via `render!`) allocated inside `f`
+    /// will belong to this owner.
+    pub fn with<R>(self, f: impl FnOnce() -> R) -> R {
+        with_runtime(|rt| rt.owner_stack.push(self));
+        let result = f();
+        with_runtime(|rt| {
+            let popped = rt.owner_stack.pop();
+            debug_assert_eq!(
+                popped,
+                Some(self),
+                "Owner::with: stack imbalance — owner pop didn't match push"
+            );
+        });
+        result
+    }
+
+    /// Dispose `self`, freeing all its descendants, nodes, and
+    /// running its cleanup callbacks.
+    ///
+    /// Recursive — disposes children first, then this owner. Safe
+    /// to call even if the owner has already been disposed (no-op).
+    pub fn dispose(self) {
+        // Step 1: collect what needs cleaning. We pull data out of
+        // the runtime in a short borrow rather than holding it
+        // through the recursion, because each level may itself need
+        // to mutate the runtime (running cleanup callbacks does not,
+        // but symmetrically we keep the pattern simple by avoiding
+        // nested borrows).
+        let children;
+        let nodes;
+        let cleanups;
+        let parent;
+        let mount_fn;
+        let elements;
+        {
+            let removed = with_runtime(|rt| rt.owners.remove(self));
+            let Some(o) = removed else { return };
+            children = o.children;
+            nodes = o.nodes;
+            cleanups = o.cleanups;
+            parent = o.parent;
+            mount_fn = o.mount_fn;
+            elements = o.elements;
         }
-        id
-    })
-}
 
-/// Push `owner` as the current scope, run `f`, pop back. Reactive
-/// primitives allocated inside `f` will belong to this owner.
-pub fn with_owner<R>(owner: OwnerId, f: impl FnOnce() -> R) -> R {
-    with_runtime(|rt| rt.owner_stack.push(owner));
-    let result = f();
-    with_runtime(|rt| {
-        let popped = rt.owner_stack.pop();
-        debug_assert_eq!(
-            popped,
-            Some(owner),
-            "with_owner: stack imbalance — owner pop didn't match push"
-        );
-    });
-    result
-}
-
-/// Dispose `owner`, freeing all its descendants, nodes, and running
-/// its cleanup callbacks.
-///
-/// Recursive — disposes children first, then this owner. Safe to call
-/// even if the owner has already been disposed (no-op).
-pub fn dispose_owner(owner: OwnerId) {
-    // Step 1: collect what needs cleaning. We pull data out of the
-    // runtime in a short borrow rather than holding it through the
-    // recursion, because each level may itself need to mutate the
-    // runtime (running cleanup callbacks does not, but symmetrically
-    // we keep the pattern simple by avoiding nested borrows).
-    let children;
-    let nodes;
-    let cleanups;
-    let parent;
-    let mount_fn;
-    let elements;
-    {
-        let removed = with_runtime(|rt| rt.owners.remove(owner));
-        let Some(o) = removed else { return };
-        children = o.children;
-        nodes = o.nodes;
-        cleanups = o.cleanups;
-        parent = o.parent;
-        mount_fn = o.mount_fn;
-        elements = o.elements;
-    }
-
-    // Step 1b: if this was a component owner, scrub the hot-reload
-    // registry so the fn pointer doesn't list a freed slot. Without
-    // this, A6's `owners_for_fn` would return a dangling OwnerId
-    // and remount logic would fault.
-    if let Some(fp) = mount_fn {
-        with_runtime(|rt| {
-            if let Some(list) = rt.component_owners.get_mut(&fp) {
-                list.retain(|o| *o != owner);
-                if list.is_empty() {
-                    rt.component_owners.remove(&fp);
-                }
-            }
-        });
-
-        // Step 1c: also clean up any remountable MountSite whose
-        // owner is this one. Without this scrub, cascading disposal
-        // (e.g. parent component re-mounts and discards its
-        // sub-tree) leaves orphan MountSites behind, and the next
-        // `remount_components_for` call processes them — operating
-        // on freed parent / body_root handles, with visible
-        // corruption (issue #17 follow-up).
-        //
-        // `site.owner` is `None` *during* a remount (the takes-then-
-        // reinstalls window in `remount_one`), so this scan won't
-        // accidentally evict the site that's mid-flight. It only
-        // matches MountSites whose component owner is the one
-        // actually being disposed.
-        with_runtime(|rt| {
-            let stale: Vec<super::component::MountId> = rt
-                .mount_sites
-                .iter()
-                .filter_map(|(id, site)| {
-                    if site.owner == Some(owner) {
-                        Some(*id)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            for id in stale {
-                rt.mount_sites.remove(&id);
-                if let Some(list) = rt.fn_ptr_mounts.get_mut(&fp) {
-                    list.retain(|m| *m != id);
+        // Step 1b: if this was a component owner, scrub the hot-
+        // reload registry so the fn pointer doesn't list a freed
+        // slot. Without this, A6's `owners_for_fn` would return a
+        // dangling Owner and remount logic would fault.
+        if let Some(fp) = mount_fn {
+            with_runtime(|rt| {
+                if let Some(list) = rt.component_owners.get_mut(&fp) {
+                    list.retain(|o| *o != self);
                     if list.is_empty() {
-                        rt.fn_ptr_mounts.remove(&fp);
+                        rt.component_owners.remove(&fp);
                     }
                 }
-            }
-        });
+            });
+
+            // Step 1c: also clean up any remountable MountSite whose
+            // owner is this one. Without this scrub, cascading
+            // disposal (e.g. parent component re-mounts and discards
+            // its sub-tree) leaves orphan MountSites behind, and
+            // the next `remount_components_for` call processes
+            // them — operating on freed parent / body_root handles,
+            // with visible corruption (issue #17 follow-up).
+            //
+            // `site.owner` is `None` *during* a remount (the
+            // takes-then-reinstalls window in `remount_one`), so
+            // this scan won't accidentally evict the site that's
+            // mid-flight. It only matches MountSites whose
+            // component owner is the one actually being disposed.
+            with_runtime(|rt| {
+                let stale: Vec<super::component::MountId> = rt
+                    .mount_sites
+                    .iter()
+                    .filter_map(|(id, site)| {
+                        if site.owner == Some(self) {
+                            Some(*id)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                for id in stale {
+                    rt.mount_sites.remove(&id);
+                    if let Some(list) = rt.fn_ptr_mounts.get_mut(&fp) {
+                        list.retain(|m| *m != id);
+                        if list.is_empty() {
+                            rt.fn_ptr_mounts.remove(&fp);
+                        }
+                    }
+                }
+            });
+        }
+
+        // Step 2: detach from parent's children list.
+        if let Some(p) = parent {
+            with_runtime(|rt| {
+                if let Some(parent_scope) = rt.owners.get_mut(p) {
+                    parent_scope.children.retain(|&c| c != self);
+                }
+            });
+        }
+
+        // Step 3: dispose descendants (post-order — bottom up).
+        for child in children {
+            child.dispose();
+        }
+
+        // Step 4: free every node this owner allocated. For effects
+        // / computed values, also detach them from any subscriber
+        // list they were on, so other live nodes don't try to
+        // notify a freed slot later.
+        //
+        // Arc-signal back-references (`arc_sources`) get collected
+        // here and unsubscribed below, outside the runtime borrow —
+        // the unsubscribe callees may re-enter the runtime.
+        let arc_unsubscribes: Vec<(Rc<dyn super::runtime::ArcSubscription>, NodeId)> =
+            with_runtime(|rt| {
+                let mut out: Vec<(Rc<dyn super::runtime::ArcSubscription>, NodeId)> = Vec::new();
+                for node_id in &nodes {
+                    let Some(node) = rt.nodes.remove(*node_id) else {
+                        continue;
+                    };
+                    // Remove ourselves from every source's subscriber list.
+                    for source in node.sources {
+                        if let Some(src_node) = rt.nodes.get_mut(source) {
+                            src_node.subscribers.remove(node_id);
+                        }
+                    }
+                    // Remove ourselves from every subscriber's source list —
+                    // a signal we owned may have been read by an outer effect.
+                    for sub in node.subscribers {
+                        if let Some(sub_node) = rt.nodes.get_mut(sub) {
+                            sub_node.sources.remove(node_id);
+                        }
+                    }
+                    // Collect arc-signal back-refs so we can call
+                    // `unsubscribe` outside the runtime borrow.
+                    for arc_src in node.arc_sources {
+                        out.push((arc_src, *node_id));
+                    }
+                }
+                // Strip these nodes from the pending and deferred queues
+                // if any were scheduled — otherwise a later flush /
+                // resume would try to re-run a freed slot.
+                rt.pending.retain(|n| !nodes.contains(n));
+                rt.deferred.retain(|n| !nodes.contains(n));
+                out
+            });
+
+        // Tell every Arc-backed signal that one of our disposed
+        // nodes used to be on its subscriber list. The signal itself
+        // stays alive (Arc refcount), but pruning here keeps its
+        // list bounded so a long-lived signal doesn't accumulate
+        // dead `NodeId`s from every transient subscriber that came
+        // and went.
+        for (arc_src, subscriber) in arc_unsubscribes {
+            arc_src.unsubscribe(subscriber);
+        }
+
+        // Step 5: release every element handle the disposed owner
+        // created. We do this AFTER recursing into children so that
+        // bottom-up disposal order matches what the renderer
+        // expects (a child element's release before its parent's
+        // is fine; the bridge only complains if a parent is missing
+        // when a child reaches up). Done with the runtime borrow
+        // released so a future renderer that wants to call back
+        // into the reactive system (e.g. to notify "element
+        // released") can do so.
+        for handle in elements {
+            crate::view::release_element(handle);
+        }
+
+        // Step 6: run cleanups in LIFO order, with no runtime
+        // borrow held (cleanups may legitimately touch other parts
+        // of the runtime).
+        for cleanup in cleanups.into_iter().rev() {
+            cleanup();
+        }
     }
 
-    // Step 2: detach from parent's children list.
-    if let Some(p) = parent {
+    /// Pause `self` (and its descendants): effects and computeds
+    /// whose scope is the paused subtree skip flush. Their
+    /// scheduled re-runs land on the runtime's `deferred` list
+    /// until [`Owner::resume`] drains them back.
+    ///
+    /// Idempotent — pausing an already-paused owner is a no-op.
+    /// The cascade walks the children tree breadth-first; new
+    /// descendants created while paused inherit the flag via
+    /// [`Owner::new`].
+    ///
+    /// Used by `StackLayout` to freeze back-stack entries that are
+    /// mounted-but-off-screen, matching iOS
+    /// `UINavigationController` / Android Fragment back-stack
+    /// semantics: state survives but no CPU is spent on
+    /// signal-driven re-renders behind the top route.
+    pub fn pause(self) {
         with_runtime(|rt| {
-            if let Some(parent_owner) = rt.owners.get_mut(p) {
-                parent_owner.children.retain(|&c| c != owner);
-            }
-        });
-    }
-
-    // Step 3: dispose descendants (post-order — bottom up).
-    for child in children {
-        dispose_owner(child);
-    }
-
-    // Step 4: free every node this owner allocated. For effects /
-    // computed values, also detach them from any subscriber list they were on,
-    // so other live nodes don't try to notify a freed slot later.
-    //
-    // Arc-signal back-references (`arc_sources`) get collected here
-    // and unsubscribed below, outside the runtime borrow — the
-    // unsubscribe callees may re-enter the runtime.
-    let arc_unsubscribes: Vec<(Rc<dyn super::runtime::ArcSubscription>, NodeId)> =
-        with_runtime(|rt| {
-            let mut out: Vec<(Rc<dyn super::runtime::ArcSubscription>, NodeId)> = Vec::new();
-            for node_id in &nodes {
-                let Some(node) = rt.nodes.remove(*node_id) else {
+            let mut stack = vec![self];
+            while let Some(id) = stack.pop() {
+                let Some(o) = rt.owners.get_mut(id) else {
                     continue;
                 };
-                // Remove ourselves from every source's subscriber list.
-                for source in node.sources {
-                    if let Some(src_node) = rt.nodes.get_mut(source) {
-                        src_node.subscribers.remove(node_id);
-                    }
+                if o.paused {
+                    continue;
                 }
-                // Remove ourselves from every subscriber's source list —
-                // a signal we owned may have been read by an outer effect.
-                for sub in node.subscribers {
-                    if let Some(sub_node) = rt.nodes.get_mut(sub) {
-                        sub_node.sources.remove(node_id);
-                    }
-                }
-                // Collect arc-signal back-refs so we can call `unsubscribe`
-                // outside the runtime borrow.
-                for arc_src in node.arc_sources {
-                    out.push((arc_src, *node_id));
-                }
+                o.paused = true;
+                stack.extend(o.children.iter().copied());
             }
-            // Strip these nodes from the pending and deferred queues
-            // if any were scheduled — otherwise a later flush /
-            // resume_owner would try to re-run a freed slot.
-            rt.pending.retain(|n| !nodes.contains(n));
-            rt.deferred.retain(|n| !nodes.contains(n));
-            out
         });
-
-    // Tell every Arc-backed signal that one of our disposed nodes used
-    // to be on its subscriber list. The signal itself stays alive
-    // (Arc refcount), but pruning here keeps its list bounded so a
-    // long-lived signal doesn't accumulate dead `NodeId`s from
-    // every transient subscriber that came and went.
-    for (arc_src, subscriber) in arc_unsubscribes {
-        arc_src.unsubscribe(subscriber);
     }
 
-    // Step 5: release every element handle the disposed owner created.
-    // We do this AFTER recursing into children so that bottom-up
-    // disposal order matches what the renderer expects (a child
-    // element's release before its parent's is fine; the bridge
-    // only complains if a parent is missing when a child reaches up).
-    // Done with the runtime borrow released so a future renderer
-    // that wants to call back into the reactive system (e.g. to
-    // notify "element released") can do so.
-    for handle in elements {
-        crate::view::release_element(handle);
-    }
-
-    // Step 6: run cleanups in LIFO order, with no runtime borrow held
-    // (cleanups may legitimately touch other parts of the runtime).
-    for cleanup in cleanups.into_iter().rev() {
-        cleanup();
-    }
-}
-
-/// Pause `owner` (and its descendants): effects and computeds whose
-/// scope is the paused subtree skip flush. Their scheduled re-runs
-/// land on the runtime's `deferred` list until [`resume_owner`]
-/// drains them back.
-///
-/// Idempotent — pausing an already-paused owner is a no-op. The
-/// cascade walks the children tree breadth-first; new descendants
-/// created while paused inherit the flag via [`create_owner`].
-///
-/// Used by `StackLayout` to freeze back-stack entries that are
-/// mounted-but-off-screen, matching iOS `UINavigationController` /
-/// Android Fragment back-stack semantics: state survives but no
-/// CPU is spent on signal-driven re-renders behind the top route.
-pub fn pause_owner(owner: OwnerId) {
-    with_runtime(|rt| {
-        let mut stack = vec![owner];
-        while let Some(id) = stack.pop() {
-            let Some(o) = rt.owners.get_mut(id) else {
-                continue;
-            };
-            if o.paused {
-                continue;
-            }
-            o.paused = true;
-            stack.extend(o.children.iter().copied());
-        }
-    });
-}
-
-/// Resume `owner` (and its descendants): clear the paused flag and
-/// move any of its deferred effects back onto the pending queue so
-/// they fire on the next flush.
-///
-/// Idempotent. Iterates [`ReactiveRuntime::deferred`] and re-queues
-/// every node whose owner is no longer paused — including descendants
-/// resumed by this cascade, and any deferred node whose owner happens
-/// to have been unpaused by an earlier call.
-pub fn resume_owner(owner: OwnerId) {
-    let any_resumed = with_runtime(|rt| {
-        let mut stack = vec![owner];
-        let mut any = false;
-        while let Some(id) = stack.pop() {
-            let Some(o) = rt.owners.get_mut(id) else {
-                continue;
-            };
-            if !o.paused {
-                continue;
-            }
-            o.paused = false;
-            any = true;
-            stack.extend(o.children.iter().copied());
-        }
-        if !any {
-            return false;
-        }
-        // Drain deferred → pending for every node whose owner is no
-        // longer paused. Stale entries (node disposed under a paused
-        // owner) are dropped here.
-        let deferred = std::mem::take(&mut rt.deferred);
-        for node in deferred {
-            let still_paused = rt
-                .nodes
-                .get(node)
-                .and_then(|n| rt.owners.get(n.owner))
-                .map(|o| o.paused);
-            match still_paused {
-                Some(false) => {
-                    if !rt.pending.contains(&node) {
-                        rt.pending.push(node);
-                    }
+    /// Resume `self` (and its descendants): clear the paused flag
+    /// and move any of its deferred effects back onto the pending
+    /// queue so they fire on the next flush.
+    ///
+    /// Idempotent. Iterates [`super::runtime::ReactiveRuntime::deferred`]
+    /// and re-queues every node whose owner is no longer paused —
+    /// including descendants resumed by this cascade, and any
+    /// deferred node whose owner happens to have been unpaused by
+    /// an earlier call.
+    pub fn resume(self) {
+        let any_resumed = with_runtime(|rt| {
+            let mut stack = vec![self];
+            let mut any = false;
+            while let Some(id) = stack.pop() {
+                let Some(o) = rt.owners.get_mut(id) else {
+                    continue;
+                };
+                if !o.paused {
+                    continue;
                 }
-                Some(true) => rt.deferred.push(node),
-                None => {} // node or owner is gone; drop silently
+                o.paused = false;
+                any = true;
+                stack.extend(o.children.iter().copied());
             }
+            if !any {
+                return false;
+            }
+            // Drain deferred → pending for every node whose owner
+            // is no longer paused. Stale entries (node disposed
+            // under a paused owner) are dropped here.
+            let deferred = std::mem::take(&mut rt.deferred);
+            for node in deferred {
+                let still_paused = rt
+                    .nodes
+                    .get(node)
+                    .and_then(|n| rt.owners.get(n.owner))
+                    .map(|o| o.paused);
+                match still_paused {
+                    Some(false) => {
+                        if !rt.pending.contains(&node) {
+                            rt.pending.push(node);
+                        }
+                    }
+                    Some(true) => rt.deferred.push(node),
+                    None => {} // node or owner is gone; drop silently
+                }
+            }
+            true
+        });
+        if any_resumed {
+            crate::host_wake::wake_runtime();
         }
-        true
-    });
-    if any_resumed {
-        crate::host_wake::wake_runtime();
     }
-}
 
-/// Whether `owner` is currently paused. Mainly for tests; production
-/// code should drive pause / resume from the lifecycle layer and not
-/// branch on the flag directly.
-pub fn is_owner_paused(owner: OwnerId) -> bool {
-    with_runtime(|rt| rt.owners.get(owner).map(|o| o.paused).unwrap_or(false))
+    /// Whether `self` is currently paused. Mainly for tests;
+    /// production code should drive pause / resume from the
+    /// lifecycle layer and not branch on the flag directly.
+    pub fn is_paused(self) -> bool {
+        with_runtime(|rt| rt.owners.get(self).map(|o| o.paused).unwrap_or(false))
+    }
 }
 
 /// Register a callback to run when the current owner is disposed.
@@ -312,13 +342,17 @@ pub fn is_owner_paused(owner: OwnerId) -> bool {
 /// `onCleanup` semantics.
 ///
 /// No-op (with a warning in `debug`) if there is no current owner.
+///
+/// Kept as a free function (not a method on [`Owner`]) because it
+/// operates on whatever owner happens to be at the top of the
+/// runtime's owner stack — the caller can't sensibly name it.
 pub fn on_cleanup(f: impl FnOnce() + 'static) {
     let registered = with_runtime(|rt| {
         let Some(owner_id) = rt.current_owner() else {
             return false;
         };
-        if let Some(owner) = rt.owners.get_mut(owner_id) {
-            owner.cleanups.push(Box::new(f));
+        if let Some(scope) = rt.owners.get_mut(owner_id) {
+            scope.cleanups.push(Box::new(f));
             return true;
         }
         false

--- a/crates/whisker-runtime/src/reactive/runtime.rs
+++ b/crates/whisker-runtime/src/reactive/runtime.rs
@@ -9,9 +9,10 @@
 //! `RwSignal`) are `Copy` newtypes around a `NodeId`. They look their
 //! value up through the runtime on every operation. Cloning a handle
 //! is just an integer copy; the lifetime of the underlying state is
-//! bounded by its owning `Owner`, not by the handle. `computed()` returns
-//! a `ReadSignal<T>` that happens to be backed by a `NodeData::Computed`
-//! node — externally indistinguishable from a primitive signal.
+//! bounded by the owning [`Scope`] (looked up via its [`Owner`] handle),
+//! not by the handle. `computed()` returns a `ReadSignal<T>` that happens
+//! to be backed by a `NodeData::Computed` node — externally
+//! indistinguishable from a primitive signal.
 //!
 //! This module defines the types only. The thread-local instance and
 //! the orchestration logic live in `mod.rs` and the sibling files.
@@ -26,11 +27,11 @@ use slotmap::{new_key_type, SlotMap};
 new_key_type! {
     /// Identifier for an [`Owner`] slot in the runtime's owner map.
     /// Generational — disposing an owner invalidates outstanding
-    /// `OwnerId`s pointing at the same slot index.
-    pub struct OwnerId;
+    /// `Owner`s pointing at the same slot index.
+    pub struct Owner;
 
     /// Identifier for a [`ReactiveNode`] slot. Generational like
-    /// [`OwnerId`].
+    /// [`Owner`].
     pub struct NodeId;
 }
 
@@ -108,7 +109,7 @@ impl NodeData {
 /// "drop me from your subscriber list" via [`ArcSubscription::unsubscribe`].
 /// The signal itself stays alive (Arc refcount) regardless.
 pub struct ReactiveNode {
-    pub owner: OwnerId,
+    pub owner: Owner,
     pub data: NodeData,
     pub sources: HashSet<NodeId>,
     pub subscribers: HashSet<NodeId>,
@@ -138,29 +139,35 @@ pub trait ArcSubscription {
     fn unsubscribe(&self, subscriber: NodeId);
 }
 
-/// A scope in the reactive tree. Created when a component mounts,
-/// disposed when the component unmounts. Tracks the reactive nodes
-/// allocated inside it (so they can be freed on disposal) and the
-/// child owners (so disposal cascades).
+/// A scope record in the reactive tree. Created when a component
+/// mounts, disposed when the component unmounts. Tracks the reactive
+/// nodes allocated inside it (so they can be freed on disposal) and
+/// the child scopes (so disposal cascades).
 ///
-/// `contexts` is the per-owner context bag for `provide_context` /
+/// The public-facing API surface is the [`super::owner::Owner`]
+/// handle (a `Copy` slotmap key); `Scope` is the data record that
+/// handle dereferences to via the runtime's `owners` slotmap. Users
+/// (and even framework extension authors) never name `Scope`
+/// directly.
+///
+/// `contexts` is the per-scope context bag for `provide_context` /
 /// `use_context`. `cleanups` is the LIFO callback queue from
 /// `on_cleanup`.
-pub struct Owner {
-    pub parent: Option<OwnerId>,
-    pub children: Vec<OwnerId>,
+pub struct Scope {
+    pub parent: Option<Owner>,
+    pub children: Vec<Owner>,
     pub nodes: Vec<NodeId>,
     pub contexts: HashMap<TypeId, Box<dyn Any>>,
     pub cleanups: Vec<Box<dyn FnOnce()>>,
     /// Function-pointer fingerprint of the component fn that created
-    /// this owner. Used by Strategy C hot reload (A6) to map
+    /// this scope. Used by Strategy C hot reload (A6) to map
     /// subsecond-patched fn pointers back to live owners. `None` for
-    /// non-component owners (e.g. the root, or manually-created
+    /// non-component scopes (e.g. the root, or manually-created
     /// scopes in tests).
     pub mount_fn: Option<*const ()>,
     /// Element handles created via `view::create_element` while this
-    /// owner was at the top of the owner stack. Released through
-    /// `view::release_element` when the owner is disposed (or its
+    /// scope was at the top of the owner stack. Released through
+    /// `view::release_element` when the scope is disposed (or its
     /// ancestor disposes via cascade), preventing the renderer-side
     /// `BridgeRenderer::elements` map from accumulating dangling
     /// `WhiskerElement*` pointers across `<Show>` flips, `<For>`
@@ -170,15 +177,15 @@ pub struct Owner {
     /// flush — they're deferred onto [`ReactiveRuntime::deferred`]
     /// until the owner is resumed.
     ///
-    /// Cascades down the owner tree: `pause_owner` / `resume_owner`
-    /// walk descendants and mirror the flag; new owners inherit the
-    /// parent's flag at `create_owner` time. Used by `StackLayout`
+    /// Cascades down the owner tree: `Owner::pause` / `Owner::resume`
+    /// walk descendants and mirror the flag; new scopes inherit the
+    /// parent's flag at `Owner::new` time. Used by `StackLayout`
     /// to freeze back-stack entries that are mounted-but-off-screen.
     pub paused: bool,
 }
 
-impl Owner {
-    pub fn new(parent: Option<OwnerId>) -> Self {
+impl Scope {
+    pub fn new(parent: Option<Owner>) -> Self {
         Self {
             parent,
             children: Vec::new(),
@@ -209,13 +216,13 @@ impl Owner {
 /// running inside a closure can re-enter the runtime (read signals,
 /// write signals, register new effects) without panicking.
 pub struct ReactiveRuntime {
-    pub owners: SlotMap<OwnerId, Owner>,
+    pub owners: SlotMap<Owner, Scope>,
     pub nodes: SlotMap<NodeId, ReactiveNode>,
     /// Owner stack: the topmost is the "current" owner — new signals,
     /// effects, computed values, and lifecycle hooks register against it. Push
-    /// when entering a `with_owner` (or `#[component]`) scope, pop on
+    /// when entering a `Owner::with` (or `#[component]`) scope, pop on
     /// exit.
-    pub owner_stack: Vec<OwnerId>,
+    pub owner_stack: Vec<Owner>,
     /// The effect/computed currently being computed, if any. Signal reads
     /// inside this effect register a `sources`/`subscribers` link
     /// against it.
@@ -226,7 +233,7 @@ pub struct ReactiveRuntime {
     /// Nodes that were scheduled to run but whose owner is `paused`.
     /// Sit here until their owner is resumed; on resume, drain back
     /// into [`Self::pending`] so the deferred work fires. See
-    /// `pause_owner` / `resume_owner` for the lifecycle.
+    /// `Owner::pause` / `Owner::resume` for the lifecycle.
     pub deferred: Vec<NodeId>,
     /// True while [`flush_pending`] is actively draining `pending`.
     /// Used to avoid recursive flushes (signal writes inside a running
@@ -237,7 +244,7 @@ pub struct ReactiveRuntime {
     /// Populated by `register_component`; consulted by the A6 hot-
     /// reload path to find which owners to dispose when a fn body
     /// gets subsecond-patched.
-    pub component_owners: HashMap<*const (), Vec<OwnerId>>,
+    pub component_owners: HashMap<*const (), Vec<Owner>>,
     /// Side table of remountable component mount sites
     /// (`#[component]` with all-`Clone` props), keyed by a stable
     /// `MountId`. Hot-reload remount walks this table on every
@@ -246,7 +253,7 @@ pub struct ReactiveRuntime {
     pub(crate) mount_sites: HashMap<super::component::MountId, super::component::MountSite>,
     /// Component-fn-pointer → list of remountable mount sites that
     /// ran that fn. Mirror of `component_owners` indexed by
-    /// `MountId` instead of `OwnerId` so it survives the dispose +
+    /// `MountId` instead of `Owner` so it survives the dispose +
     /// re-create cycle on each hot-reload remount (the owner is
     /// fresh every time, the mount id is stable).
     pub fn_ptr_mounts: HashMap<*const (), Vec<super::component::MountId>>,
@@ -278,7 +285,7 @@ impl ReactiveRuntime {
 
     /// Current top-of-stack owner. `None` outside any owner scope (the
     /// pre-mount state, basically only relevant for tests).
-    pub fn current_owner(&self) -> Option<OwnerId> {
+    pub fn current_owner(&self) -> Option<Owner> {
         self.owner_stack.last().copied()
     }
 }

--- a/crates/whisker-runtime/src/reactive/scheduler.rs
+++ b/crates/whisker-runtime/src/reactive/scheduler.rs
@@ -131,7 +131,7 @@ fn run_node_if_alive(node: NodeId) {
         let n = rt.nodes.get(node)?;
         let owner = n.owner;
         // Paused-owner gate: defer the run and skip. The node lands
-        // on `rt.deferred`; `resume_owner` moves it back into
+        // on `rt.deferred`; `Owner::resume` moves it back into
         // `pending` so the effect catches up once its scope is
         // active again. We snapshot the kind early — pure Signal
         // nodes never need the gate (they have no compute), so we

--- a/crates/whisker-runtime/src/reactive/signal.rs
+++ b/crates/whisker-runtime/src/reactive/signal.rs
@@ -17,7 +17,7 @@ use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-use super::runtime::{NodeData, NodeId, Owner, ReactiveNode};
+use super::runtime::{NodeData, NodeId, ReactiveNode, Scope};
 use super::scheduler;
 use super::with_runtime;
 
@@ -57,11 +57,11 @@ fn alloc_signal_node<T: 'static>(initial: T) -> NodeId {
         let owner = rt.current_owner().unwrap_or_else(|| {
             // No current owner — fall back to a "global" detached owner.
             // We create one lazily so primitives created outside of any
-            // explicit `with_owner` (e.g. in tests, or at app startup
+            // explicit `Owner::with` (e.g. in tests, or at app startup
             // before the first component mounts) still have a place to
             // live. They will only be freed by `__reset_for_tests` or
             // explicit dispose.
-            let detached = rt.owners.insert(Owner::new(None));
+            let detached = rt.owners.insert(Scope::new(None));
             rt.owner_stack.push(detached);
             detached
         });
@@ -356,7 +356,7 @@ fn register_arc_in_current_owner<T: 'static>(arc: super::arc_signal::ArcRwSignal
     }
     with_runtime(|rt| {
         let owner = rt.current_owner().unwrap_or_else(|| {
-            let detached = rt.owners.insert(Owner::new(None));
+            let detached = rt.owners.insert(Scope::new(None));
             rt.owner_stack.push(detached);
             detached
         });

--- a/crates/whisker-runtime/src/reactive/stored.rs
+++ b/crates/whisker-runtime/src/reactive/stored.rs
@@ -19,7 +19,7 @@ use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-use super::runtime::{NodeData, NodeId, Owner, ReactiveNode};
+use super::runtime::{NodeData, NodeId, ReactiveNode, Scope};
 use super::with_runtime;
 
 /// A non-reactive, owner-bound value slot. `Copy`.
@@ -45,7 +45,7 @@ impl<T: 'static> StoredValue<T> {
         }
         let id = with_runtime(|rt| {
             let owner = rt.current_owner().unwrap_or_else(|| {
-                let detached = rt.owners.insert(Owner::new(None));
+                let detached = rt.owners.insert(Scope::new(None));
                 rt.owner_stack.push(detached);
                 detached
             });

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -215,25 +215,25 @@ fn signals_written_during_flush_propagate_in_same_flush() {
 #[test]
 fn dispose_owner_frees_nested_signals() {
     fresh();
-    let owner = create_owner(None);
-    let (read, _write) = with_owner(owner, || signal(123_i32));
+    let owner = Owner::new(None);
+    let (read, _write) = owner.with(|| signal(123_i32));
     // Signal works while owner is alive.
     assert_eq!(read.get(), 123);
-    dispose_owner(owner);
+    owner.dispose();
     // After disposal the underlying node is gone; reads panic in debug
     // and we don't want to fault the test, so we just verify the
     // owner slot itself is freed by trying to dispose again (no-op).
-    dispose_owner(owner);
+    owner.dispose();
 }
 
 #[test]
 fn dispose_cascades_to_children() {
     fresh();
-    let parent = create_owner(None);
+    let parent = Owner::new(None);
     let mut leaf_signals = Vec::new();
-    let child = with_owner(parent, || {
-        let c = create_owner(None);
-        with_owner(c, || {
+    let child = parent.with(|| {
+        let c = Owner::new(None);
+        c.with(|| {
             let (r, _w) = signal(0_u32);
             leaf_signals.push(r);
         });
@@ -241,7 +241,7 @@ fn dispose_cascades_to_children() {
     });
 
     // Parent owns child; disposing parent disposes child too.
-    dispose_owner(parent);
+    parent.dispose();
 
     // Owner map should have neither.
     let alive = with_runtime(|rt| {
@@ -256,10 +256,10 @@ fn dispose_cascades_to_children() {
 #[test]
 fn on_cleanup_fires_lifo() {
     fresh();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
 
-    with_owner(owner, || {
+    owner.with(|| {
         let l = log.clone();
         on_cleanup(move || l.borrow_mut().push("first"));
         let l = log.clone();
@@ -268,19 +268,19 @@ fn on_cleanup_fires_lifo() {
         on_cleanup(move || l.borrow_mut().push("third"));
     });
 
-    dispose_owner(owner);
+    owner.dispose();
     assert_eq!(*log.borrow(), vec!["third", "second", "first"]);
 }
 
 #[test]
 fn disposing_owner_removes_its_effects_from_pending() {
     fresh();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let (count, set_count) = signal(0_i32);
     let runs = Rc::new(RefCell::new(0));
     let runs_clone = runs.clone();
 
-    with_owner(owner, || {
+    owner.with(|| {
         effect(move || {
             let _ = count.get();
             *runs_clone.borrow_mut() += 1;
@@ -290,7 +290,7 @@ fn disposing_owner_removes_its_effects_from_pending() {
 
     // Schedule the effect, then dispose its owner before flush.
     set_count.set(1);
-    dispose_owner(owner);
+    owner.dispose();
     flush();
 
     // The effect should NOT have re-run.
@@ -332,10 +332,10 @@ fn stored_value_does_not_trigger_effects() {
 #[test]
 fn stored_value_disposed_with_owner() {
     fresh();
-    let owner = create_owner(None);
-    let sv = with_owner(owner, || StoredValue::new(123_i32));
+    let owner = Owner::new(None);
+    let sv = owner.with(|| StoredValue::new(123_i32));
     assert_eq!(sv.get(), 123);
-    dispose_owner(owner);
+    owner.dispose();
     // Owner gone — node is gone too. We can verify indirectly: a fresh
     // owner has no leftover.
     let leftover = with_runtime(|rt| rt.owners.contains_key(owner));
@@ -401,8 +401,8 @@ fn on_mount_callback_inside_effect_does_not_leak_subscription_to_outer() {
         *outer_runs_clone.borrow_mut() += 1;
         // Build a fresh owner so `on_mount` doesn't warn about
         // "called outside any owner scope".
-        let owner = super::owner::create_owner(None);
-        super::owner::with_owner(owner, || {
+        let owner = super::Owner::new(None);
+        owner.with(|| {
             on_mount(move || {
                 let _ = mount_src.get();
             });
@@ -541,8 +541,8 @@ struct Theme(&'static str);
 #[test]
 fn context_round_trip_in_same_owner() {
     fresh();
-    let owner = create_owner(None);
-    with_owner(owner, || {
+    let owner = Owner::new(None);
+    owner.with(|| {
         provide_context(Theme("dark"));
         assert_eq!(use_context::<Theme>(), Some(Theme("dark")));
     });
@@ -551,13 +551,13 @@ fn context_round_trip_in_same_owner() {
 #[test]
 fn context_walks_parent_chain() {
     fresh();
-    let parent = create_owner(None);
+    let parent = Owner::new(None);
     let observed = Rc::new(RefCell::new(None::<Theme>));
-    with_owner(parent, || {
+    parent.with(|| {
         provide_context(Theme("from-parent"));
-        let child = create_owner(None);
+        let child = Owner::new(None);
         let observed_clone = observed.clone();
-        with_owner(child, || {
+        child.with(|| {
             *observed_clone.borrow_mut() = use_context::<Theme>();
         });
     });
@@ -567,13 +567,13 @@ fn context_walks_parent_chain() {
 #[test]
 fn context_descendant_shadows_ancestor() {
     fresh();
-    let parent = create_owner(None);
+    let parent = Owner::new(None);
     let observed = Rc::new(RefCell::new(None::<Theme>));
-    with_owner(parent, || {
+    parent.with(|| {
         provide_context(Theme("outer"));
-        let inner = create_owner(None);
+        let inner = Owner::new(None);
         let observed_clone = observed.clone();
-        with_owner(inner, || {
+        inner.with(|| {
             provide_context(Theme("inner"));
             *observed_clone.borrow_mut() = use_context::<Theme>();
         });
@@ -584,10 +584,10 @@ fn context_descendant_shadows_ancestor() {
 #[test]
 fn context_missing_returns_none() {
     fresh();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let observed = Rc::new(RefCell::new(Some(Theme("placeholder"))));
     let obs_clone = observed.clone();
-    with_owner(owner, || {
+    owner.with(|| {
         *obs_clone.borrow_mut() = use_context::<Theme>();
     });
     assert_eq!(*observed.borrow(), None);
@@ -596,10 +596,10 @@ fn context_missing_returns_none() {
 #[test]
 fn with_context_borrows_without_clone() {
     fresh();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let observed = Rc::new(RefCell::new(0_usize));
     let obs_clone = observed.clone();
-    with_owner(owner, || {
+    owner.with(|| {
         provide_context(vec![1_i32, 2, 3, 4]);
         let len = with_context::<Vec<i32>, _>(|v| v.len()).unwrap();
         *obs_clone.borrow_mut() = len;
@@ -657,10 +657,10 @@ fn mount_component_isolates_owner_state() {
 #[test]
 fn on_mount_fires_on_flush() {
     fresh();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let fired = Rc::new(RefCell::new(false));
     let fired_clone = fired.clone();
-    with_owner(owner, || {
+    owner.with(|| {
         on_mount(move || *fired_clone.borrow_mut() = true);
     });
     // Hasn't fired yet — needs a flush_mounts call.
@@ -672,9 +672,9 @@ fn on_mount_fires_on_flush() {
 #[test]
 fn on_mount_runs_in_registration_order() {
     fresh();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
-    with_owner(owner, || {
+    owner.with(|| {
         let l = log.clone();
         on_mount(move || l.borrow_mut().push("first"));
         let l = log.clone();
@@ -689,10 +689,10 @@ fn on_mount_runs_in_registration_order() {
 #[test]
 fn flush_mounts_is_idempotent() {
     fresh();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let count = Rc::new(RefCell::new(0));
     let count_clone = count.clone();
-    with_owner(owner, || {
+    owner.with(|| {
         on_mount(move || *count_clone.borrow_mut() += 1);
     });
     flush_mounts();
@@ -918,7 +918,7 @@ fn mount_component_remountable_body_runs_with_no_tracker_when_invoked_inside_eff
 }
 
 // Note: `remount_components_for`'s body invocation reuses the
-// exact same `untrack(|| with_owner(new_owner, || (*info.body)()))`
+// exact same `untrack(|| new_owner.with(|| (*info.body)()))`
 // bracket the initial mount uses. Driving the remount path through
 // a unit test requires a full renderer install + an attached parent
 // element (otherwise `info.parent` is `None` and the path
@@ -939,9 +939,9 @@ fn flush_mounts_callback_runs_with_no_tracker_when_called_inside_effect() {
     let observed = Rc::new(RefCell::new(Some(observed_tracker())));
     let observed_clone = observed.clone();
     effect(move || {
-        let owner = super::owner::create_owner(None);
+        let owner = super::Owner::new(None);
         let observed_inner = observed_clone.clone();
-        super::owner::with_owner(owner, || {
+        owner.with(|| {
             on_mount(move || {
                 *observed_inner.borrow_mut() = Some(observed_tracker());
             });
@@ -1060,8 +1060,8 @@ fn arc_signal_survives_caller_owner_disposal() {
     let stash: Rc<RefCell<Option<ArcReadSignal<i32>>>> = Rc::new(RefCell::new(None));
     let stash_for_install = stash.clone();
 
-    let owner = create_owner(None);
-    with_owner(owner, || {
+    let owner = Owner::new(None);
+    owner.with(|| {
         let (r, w) = arc_signal(99_i32);
         // Pretend `w` is the write half kept by a native module's
         // event callback; we don't need to keep it for this test.
@@ -1069,7 +1069,7 @@ fn arc_signal_survives_caller_owner_disposal() {
         *stash_for_install.borrow_mut() = Some(r);
     });
 
-    dispose_owner(owner);
+    owner.dispose();
 
     // Pre-fix this would have panicked (`expect("signal disposed")`)
     // for Copy signals. Post-fix Arc signals survive the disposal.
@@ -1104,8 +1104,8 @@ fn arc_signal_subscriber_is_pruned_when_its_owner_is_disposed() {
     let observed: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
     let observed_clone = observed.clone();
 
-    let owner = create_owner(None);
-    with_owner(owner, || {
+    let owner = Owner::new(None);
+    owner.with(|| {
         effect(move || observed_clone.borrow_mut().push(counter_for_effect.get()));
     });
     assert_eq!(*observed.borrow(), vec![0]);
@@ -1114,7 +1114,7 @@ fn arc_signal_subscriber_is_pruned_when_its_owner_is_disposed() {
     // list inside `counter` should be pruned eagerly by the
     // owner-disposal cascade so the next `set` doesn't try to
     // schedule a freed NodeId.
-    dispose_owner(owner);
+    owner.dispose();
 
     counter.set(7);
     flush();
@@ -1208,17 +1208,17 @@ fn arc_to_rw_conversion_shares_underlying_value() {
     // fresh arena entry, but both handles observe the same underlying
     // value: writes through one are visible through the other.
     fresh();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let arc = ArcRwSignal::new(0_i32);
     let arc_for_outside = arc.clone();
-    let rw: RwSignal<i32> = with_owner(owner, || arc.clone().into());
+    let rw: RwSignal<i32> = owner.with(|| arc.clone().into());
     assert_eq!(rw.get(), 0);
     arc.set(7);
     assert_eq!(rw.get(), 7);
     rw.set(42);
     assert_eq!(arc.get_untracked(), 42);
     assert_eq!(arc_for_outside.get_untracked(), 42);
-    dispose_owner(owner);
+    owner.dispose();
 }
 
 #[test]
@@ -1227,10 +1227,10 @@ fn arc_to_rw_conversion_propagates_to_effect_subscribers() {
     // when the original `ArcRwSignal` is written.
     fresh();
     let arc = ArcRwSignal::new(0_i32);
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let observed: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
     let observed_clone = observed.clone();
-    with_owner(owner, || {
+    owner.with(|| {
         let rw: RwSignal<i32> = arc.clone().into();
         effect(move || observed_clone.borrow_mut().push(rw.get()));
     });
@@ -1239,7 +1239,7 @@ fn arc_to_rw_conversion_propagates_to_effect_subscribers() {
     arc.set(2);
     flush();
     assert_eq!(*observed.borrow(), vec![0, 1, 2]);
-    dispose_owner(owner);
+    owner.dispose();
 }
 
 #[test]
@@ -1251,9 +1251,9 @@ fn arc_to_rw_conversion_survives_caller_owner_disposal_via_arc() {
     // reference.
     fresh();
     let arc = ArcRwSignal::new(0_i32);
-    let owner = create_owner(None);
-    let _: RwSignal<i32> = with_owner(owner, || arc.clone().into());
-    dispose_owner(owner);
+    let owner = Owner::new(None);
+    let _: RwSignal<i32> = owner.with(|| arc.clone().into());
+    owner.dispose();
     arc.set(99);
     assert_eq!(arc.get_untracked(), 99);
 }
@@ -1262,23 +1262,23 @@ fn arc_to_rw_conversion_survives_caller_owner_disposal_via_arc() {
 fn arc_read_signal_to_read_signal_conversion_reads_correctly() {
     fresh();
     let (r, w) = arc_signal(5_i32);
-    let owner = create_owner(None);
-    let copy: ReadSignal<i32> = with_owner(owner, || r.into());
+    let owner = Owner::new(None);
+    let copy: ReadSignal<i32> = owner.with(|| r.into());
     assert_eq!(copy.get(), 5);
     w.set(99);
     assert_eq!(copy.get(), 99);
-    dispose_owner(owner);
+    owner.dispose();
 }
 
 #[test]
 fn arc_write_signal_to_write_signal_conversion_writes_correctly() {
     fresh();
     let (r, w) = arc_signal(0_i32);
-    let owner = create_owner(None);
-    let copy: WriteSignal<i32> = with_owner(owner, || w.into());
+    let owner = Owner::new(None);
+    let copy: WriteSignal<i32> = owner.with(|| w.into());
     copy.set(123);
     assert_eq!(r.get_untracked(), 123);
-    dispose_owner(owner);
+    owner.dispose();
 }
 
 #[test]
@@ -1298,8 +1298,8 @@ fn arc_signal_inside_oncelock_outlives_caller_owner() {
     });
     let module_clone = module.clone();
 
-    let install_owner = create_owner(None);
-    with_owner(install_owner, || {
+    let install_owner = Owner::new(None);
+    install_owner.with(|| {
         // First touch installs the signal under whatever owner is
         // current — the install owner here.
         module_clone.slot.get_or_init(|| ArcRwSignal::new(0));
@@ -1307,15 +1307,15 @@ fn arc_signal_inside_oncelock_outlives_caller_owner() {
 
     // Dispose the owner that triggered the install. The OnceLock
     // still holds the only strong Arc.
-    dispose_owner(install_owner);
+    install_owner.dispose();
 
     // The signal is still readable, set-able, and propagates to new
     // subscribers under fresh owners.
     let observed: Rc<RefCell<Option<i32>>> = Rc::new(RefCell::new(None));
     let observed_clone = observed.clone();
     let module_for_use = module.clone();
-    let use_owner = create_owner(None);
-    with_owner(use_owner, || {
+    let use_owner = Owner::new(None);
+    use_owner.with(|| {
         effect(move || {
             let v = module_for_use.slot.get().unwrap().get();
             *observed_clone.borrow_mut() = Some(v);
@@ -1336,9 +1336,9 @@ fn paused_owner_defers_effect_runs_until_resumed() {
     let runs = Rc::new(RefCell::new(0_u32));
     let (read, write) = signal(0_i32);
 
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let runs_clone = runs.clone();
-    with_owner(owner, || {
+    owner.with(|| {
         effect(move || {
             let _ = read.get();
             *runs_clone.borrow_mut() += 1;
@@ -1350,15 +1350,15 @@ fn paused_owner_defers_effect_runs_until_resumed() {
         "initial registration runs the effect once"
     );
 
-    pause_owner(owner);
-    assert!(is_owner_paused(owner));
+    owner.pause();
+    assert!(owner.is_paused());
 
     write.set(1);
     flush();
     assert_eq!(*runs.borrow(), 1, "paused effect must not run on flush");
 
-    resume_owner(owner);
-    assert!(!is_owner_paused(owner));
+    owner.resume();
+    assert!(!owner.is_paused());
     flush();
     assert_eq!(
         *runs.borrow(),
@@ -1374,18 +1374,18 @@ fn pause_cascades_to_descendants() {
     let child_runs = Rc::new(RefCell::new(0_u32));
     let (read, write) = signal(0_i32);
 
-    let parent = create_owner(None);
-    let child = create_owner(Some(parent));
+    let parent = Owner::new(None);
+    let child = Owner::new(Some(parent));
 
     let pr = parent_runs.clone();
-    with_owner(parent, || {
+    parent.with(|| {
         effect(move || {
             let _ = read.get();
             *pr.borrow_mut() += 1;
         });
     });
     let cr = child_runs.clone();
-    with_owner(child, || {
+    child.with(|| {
         effect(move || {
             let _ = read.get();
             *cr.borrow_mut() += 1;
@@ -1394,16 +1394,16 @@ fn pause_cascades_to_descendants() {
     assert_eq!(*parent_runs.borrow(), 1);
     assert_eq!(*child_runs.borrow(), 1);
 
-    pause_owner(parent);
-    assert!(is_owner_paused(parent));
-    assert!(is_owner_paused(child), "pause cascades down the tree");
+    parent.pause();
+    assert!(parent.is_paused());
+    assert!(child.is_paused(), "pause cascades down the tree");
 
     write.set(1);
     flush();
     assert_eq!(*parent_runs.borrow(), 1);
     assert_eq!(*child_runs.borrow(), 1);
 
-    resume_owner(parent);
+    parent.resume();
     flush();
     assert_eq!(*parent_runs.borrow(), 2);
     assert_eq!(*child_runs.borrow(), 2);
@@ -1412,12 +1412,12 @@ fn pause_cascades_to_descendants() {
 #[test]
 fn create_owner_inherits_paused_from_parent() {
     fresh();
-    let parent = create_owner(None);
-    pause_owner(parent);
+    let parent = Owner::new(None);
+    parent.pause();
 
-    let child = create_owner(Some(parent));
+    let child = Owner::new(Some(parent));
     assert!(
-        is_owner_paused(child),
+        child.is_paused(),
         "owner created under a paused parent must inherit paused"
     );
 }
@@ -1434,11 +1434,11 @@ fn effect_registered_under_paused_owner_defers_initial_run_until_resume() {
     // navigation effect.
     fresh();
     let runs = Rc::new(RefCell::new(0_u32));
-    let owner = create_owner(None);
-    pause_owner(owner);
+    let owner = Owner::new(None);
+    owner.pause();
 
     let runs_clone = runs.clone();
-    with_owner(owner, || {
+    owner.with(|| {
         effect(move || {
             *runs_clone.borrow_mut() += 1;
         });
@@ -1449,7 +1449,7 @@ fn effect_registered_under_paused_owner_defers_initial_run_until_resume() {
         "paused at registration: initial run deferred"
     );
 
-    resume_owner(owner);
+    owner.resume();
     flush();
     assert_eq!(*runs.borrow(), 1, "resume fires the deferred initial run");
 }
@@ -1457,14 +1457,14 @@ fn effect_registered_under_paused_owner_defers_initial_run_until_resume() {
 #[test]
 fn pause_is_idempotent() {
     fresh();
-    let owner = create_owner(None);
-    pause_owner(owner);
-    pause_owner(owner);
-    assert!(is_owner_paused(owner));
-    resume_owner(owner);
-    assert!(!is_owner_paused(owner));
-    resume_owner(owner);
-    assert!(!is_owner_paused(owner));
+    let owner = Owner::new(None);
+    owner.pause();
+    owner.pause();
+    assert!(owner.is_paused());
+    owner.resume();
+    assert!(!owner.is_paused());
+    owner.resume();
+    assert!(!owner.is_paused());
 }
 
 #[test]
@@ -1473,20 +1473,20 @@ fn dispose_while_paused_drops_deferred_entries() {
     let runs = Rc::new(RefCell::new(0_u32));
     let (read, write) = signal(0_i32);
 
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let runs_clone = runs.clone();
-    with_owner(owner, || {
+    owner.with(|| {
         effect(move || {
             let _ = read.get();
             *runs_clone.borrow_mut() += 1;
         });
     });
-    pause_owner(owner);
+    owner.pause();
     write.set(1);
     flush();
     assert_eq!(*runs.borrow(), 1, "paused: still 1");
 
-    dispose_owner(owner);
+    owner.dispose();
     // The deferred queue had this effect's node; disposal must
     // strip it so a later flush / resume doesn't dereference a
     // freed slot.
@@ -1501,15 +1501,15 @@ fn multiple_paused_signal_writes_collapse_to_one_run_on_resume() {
     let runs = Rc::new(RefCell::new(0_u32));
     let (read, write) = signal(0_i32);
 
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let runs_clone = runs.clone();
-    with_owner(owner, || {
+    owner.with(|| {
         effect(move || {
             let _ = read.get();
             *runs_clone.borrow_mut() += 1;
         });
     });
-    pause_owner(owner);
+    owner.pause();
 
     write.set(1);
     flush();
@@ -1519,7 +1519,7 @@ fn multiple_paused_signal_writes_collapse_to_one_run_on_resume() {
     flush();
     assert_eq!(*runs.borrow(), 1, "no re-runs while paused");
 
-    resume_owner(owner);
+    owner.resume();
     flush();
     assert_eq!(
         *runs.borrow(),

--- a/crates/whisker-runtime/src/reactive/tests_resource.rs
+++ b/crates/whisker-runtime/src/reactive/tests_resource.rs
@@ -7,16 +7,14 @@
 //! purely-async fetchers; `run_blocking`-using fetchers do require
 //! the dispatcher and are exercised in `tasks::tests`).
 
-use crate::reactive::{
-    __reset_for_tests, create_owner, resource, resource_sync, with_owner, ResourceState,
-};
+use crate::reactive::{__reset_for_tests, resource, resource_sync, Owner, ResourceState};
 use crate::tasks;
 
 fn with_test_owner<R>(f: impl FnOnce() -> R) -> R {
     __reset_for_tests();
     tasks::__reset_for_tests();
-    let owner = create_owner(None);
-    with_owner(owner, f)
+    let owner = Owner::new(None);
+    owner.with(f)
 }
 
 #[test]

--- a/crates/whisker-runtime/src/view/list_mount.rs
+++ b/crates/whisker-runtime/src/view/list_mount.rs
@@ -47,7 +47,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
 
-use crate::reactive::{create_owner, dispose_owner, effect, on_cleanup, with_owner, OwnerId};
+use crate::reactive::{effect, on_cleanup, Owner};
 
 use super::handle::Element;
 use super::list_provider::{NativeItemProvider, INVALID_ITEM_INDEX};
@@ -60,7 +60,7 @@ use super::renderer::{install_list_native_item_provider, set_update_list_info};
 struct Slot {
     #[allow(dead_code)] // kept for future "manual remove" code paths
     element: Element,
-    owner: OwnerId,
+    owner: Owner,
 }
 
 /// Drive a Whisker-side virtualised list against an already-created
@@ -123,8 +123,8 @@ pub fn list_mount<T, K, ItemsFn, KeyFn, BodyFn>(
                 // effects inside the body (signal subscriptions
                 // etc.) get cleaned up cleanly when the slot is
                 // enqueued out.
-                let owner = create_owner(None);
-                let element = with_owner(owner, || (body)(item));
+                let owner = Owner::new(None);
+                let element = owner.with(|| (body)(item));
                 let sign = element.id() as i32;
                 slots.borrow_mut().insert(sign, Slot { element, owner });
                 sign
@@ -134,7 +134,7 @@ pub fn list_mount<T, K, ItemsFn, KeyFn, BodyFn>(
             let slots = slots.clone();
             Box::new(move |sign| {
                 if let Some(slot) = slots.borrow_mut().remove(&sign) {
-                    dispose_owner(slot.owner);
+                    slot.owner.dispose();
                 }
             })
         }),
@@ -150,7 +150,7 @@ pub fn list_mount<T, K, ItemsFn, KeyFn, BodyFn>(
     on_cleanup(move || {
         let mut slots = slots.borrow_mut();
         for (_, slot) in slots.drain() {
-            dispose_owner(slot.owner);
+            slot.owner.dispose();
         }
     });
 }
@@ -159,7 +159,7 @@ pub fn list_mount<T, K, ItemsFn, KeyFn, BodyFn>(
 mod tests {
     use super::*;
     use crate::element::ElementTag;
-    use crate::reactive::{create_owner, dispose_owner, flush, with_owner};
+    use crate::reactive::flush;
     use crate::view::renderer::{install_renderer, uninstall_renderer, DynRenderer};
     use crate::view::{create_element_by_name, BindType};
 
@@ -230,8 +230,8 @@ mod tests {
     #[test]
     fn list_mount_broadcasts_initial_count_and_installs_provider() {
         with_capturing(|count, installed| {
-            let owner = create_owner(None);
-            with_owner(owner, || {
+            let owner = Owner::new(None);
+            owner.with(|| {
                 let handle = create_element_by_name("list");
                 list_mount(
                     handle,
@@ -244,17 +244,17 @@ mod tests {
 
             assert_eq!(*count.borrow(), Some(3));
             assert!(installed.borrow().is_some());
-            dispose_owner(owner);
+            owner.dispose();
         });
     }
 
     #[test]
     fn provider_component_at_index_returns_distinct_signs_and_runs_body() {
         with_capturing(|_count, installed| {
-            let owner = create_owner(None);
+            let owner = Owner::new(None);
             let body_calls = Rc::new(RefCell::new(Vec::<i32>::new()));
             let bc = body_calls.clone();
-            with_owner(owner, || {
+            owner.with(|| {
                 let handle = create_element_by_name("list");
                 list_mount(
                     handle,
@@ -281,15 +281,15 @@ mod tests {
             assert_ne!(s1, s2);
             assert_eq!(*body_calls.borrow(), vec![100, 200, 300]);
 
-            dispose_owner(owner);
+            owner.dispose();
         });
     }
 
     #[test]
     fn provider_out_of_range_index_returns_invalid() {
         with_capturing(|_count, installed| {
-            let owner = create_owner(None);
-            with_owner(owner, || {
+            let owner = Owner::new(None);
+            owner.with(|| {
                 let handle = create_element_by_name("list");
                 list_mount(
                     handle,
@@ -305,17 +305,17 @@ mod tests {
                 (provider.component_at_index)(5, 0, false),
                 INVALID_ITEM_INDEX
             );
-            dispose_owner(owner);
+            owner.dispose();
         });
     }
 
     #[test]
     fn enqueue_component_disposes_the_slot_owner() {
         with_capturing(|_count, installed| {
-            let owner = create_owner(None);
+            let owner = Owner::new(None);
             let drop_observed = Rc::new(RefCell::new(false));
 
-            with_owner(owner, || {
+            owner.with(|| {
                 let handle = create_element_by_name("list");
                 let dr = drop_observed.clone();
                 list_mount(
@@ -350,16 +350,16 @@ mod tests {
                 "after enqueue, slot owner disposed"
             );
 
-            dispose_owner(owner);
+            owner.dispose();
         });
     }
 
     #[test]
     fn changing_items_rebroadcasts_count() {
         with_capturing(|count, _installed| {
-            let owner = create_owner(None);
+            let owner = Owner::new(None);
             let (items_read, items_write) = crate::reactive::signal(vec![1_i32, 2, 3]);
-            with_owner(owner, || {
+            owner.with(|| {
                 let handle = create_element_by_name("list");
                 list_mount(
                     handle,
@@ -379,17 +379,17 @@ mod tests {
             flush();
             assert_eq!(*count.borrow(), Some(0));
 
-            dispose_owner(owner);
+            owner.dispose();
         });
     }
 
     #[test]
     fn on_cleanup_disposes_remaining_slot_owners() {
         with_capturing(|_count, installed| {
-            let outer = create_owner(None);
+            let outer = Owner::new(None);
             let drops = Rc::new(RefCell::new(0_u32));
 
-            with_owner(outer, || {
+            outer.with(|| {
                 let handle = create_element_by_name("list");
                 let drops = drops.clone();
                 list_mount(
@@ -415,7 +415,7 @@ mod tests {
             // map drops too — the on_cleanup hook is what reaches
             // into the slot map BEFORE that to dispose owners.)
             drop(provider);
-            dispose_owner(outer);
+            outer.dispose();
             assert_eq!(
                 *drops.borrow(),
                 2,

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -346,7 +346,7 @@ pub fn create_element_by_name(tag_name: &str) -> Element {
 pub fn create_element(tag: ElementTag) -> Element {
     let handle = with_renderer(|r| r.create_element(tag), Element(u32::MAX));
     // Track the freshly-created element in whichever reactive owner
-    // is currently active. `dispose_owner` later releases everything
+    // is currently active. `Owner::dispose` later releases everything
     // in this list via `release_element`. This is what stops
     // `BridgeRenderer::elements` (and the underlying Lynx
     // FiberElement refcounts) from accumulating across `<Show>`

--- a/crates/whisker/src/control_flow.rs
+++ b/crates/whisker/src/control_flow.rs
@@ -44,7 +44,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
 
-use whisker_runtime::reactive::{create_owner, dispose_owner, effect, with_owner, OwnerId};
+use whisker_runtime::reactive::{effect, Owner};
 use whisker_runtime::view::{
     append_child, create_phantom_element, remove_child, Children, EachFn, Element, Fallback,
     ItemFn, KeyFn, WhenFn,
@@ -82,7 +82,7 @@ where
     let frag = create_phantom_element();
 
     struct Entry {
-        owner: OwnerId,
+        owner: Owner,
         handle: Element,
     }
     let entries: Rc<RefCell<HashMap<K, Entry>>> = Rc::new(RefCell::new(HashMap::new()));
@@ -106,8 +106,8 @@ where
             if let Some(existing) = old.remove(&k) {
                 new_entries.insert(k.clone(), existing);
             } else {
-                let item_owner = create_owner(None);
-                let handle = with_owner(item_owner, || {
+                let item_owner = Owner::new(None);
+                let handle = item_owner.with(|| {
                     let h = children.call(item);
                     append_child(frag, h);
                     h
@@ -126,7 +126,7 @@ where
         // Disappeared items: detach + dispose.
         for (_, entry) in old.drain() {
             remove_child(frag, entry.handle);
-            dispose_owner(entry.owner);
+            entry.owner.dispose();
         }
 
         // Reorder: detach every surviving handle, then re-attach in
@@ -170,7 +170,7 @@ pub fn show(
 
     // Track the currently-mounted (owner, leaf handles) pair so we
     // can dispose + detach on every flip.
-    type Mounted = Rc<RefCell<Option<(OwnerId, Vec<Element>)>>>;
+    type Mounted = Rc<RefCell<Option<(Owner, Vec<Element>)>>>;
     let mounted: Mounted = Rc::new(RefCell::new(None));
 
     // Clone props into the effect's capture set so the outer body
@@ -186,15 +186,15 @@ pub fn show(
             for h in handles {
                 remove_child(frag, h);
             }
-            dispose_owner(owner);
+            owner.dispose();
         }
 
         let cond = when.call();
 
         if cond {
             // Truthy branch: `children` is `Children` = `Fn() -> View`.
-            let owner = create_owner(None);
-            let handles = with_owner(owner, || {
+            let owner = Owner::new(None);
+            let handles = owner.with(|| {
                 let view = children();
                 view.attach_to(frag)
             });
@@ -202,8 +202,8 @@ pub fn show(
         } else if let Some(fb) = &fallback.0 {
             // Falsy branch: `fallback` is `Fn() -> Element` (single
             // element). Mount it directly under the fragment.
-            let owner = create_owner(None);
-            let handle = with_owner(owner, || {
+            let owner = Owner::new(None);
+            let handle = owner.with(|| {
                 let h = fb();
                 append_child(frag, h);
                 h

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -103,12 +103,21 @@ macro_rules! module {
 // directly. The underlying impl lives in `whisker_runtime::reactive`
 // for callers that prefer the long path.
 pub use whisker_runtime::reactive::{
-    arc_signal, computed, create_owner, dispose_owner, effect, flush, flush_mounts,
-    is_owner_paused, mount_component, on_cleanup, on_mount, pause_owner, provide_context, resource,
-    resource_sync, resume_owner, signal, unmount_component, use_context, with_context, with_owner,
+    arc_signal, computed, effect, flush, flush_mounts, mount_component, on_cleanup, on_mount,
+    provide_context, resource, resource_sync, signal, unmount_component, use_context, with_context,
     ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, Resource, ResourceState, RwSignal,
     Signal, StoredValue, WriteSignal,
 };
+// Owner / scope API. Application code rarely touches these —
+// `#[component]` + `on_cleanup` cover the common case. Framework
+// extension code (custom control-flow, custom routers, advanced
+// tests) reaches into this module to create and dispose reactive
+// scopes manually. See the module rustdoc for the conceptual model.
+pub use whisker_runtime::reactive::owner;
+// `Owner` (the handle) is re-exported at crate root too so users
+// can write `let scope: Owner = ...` without dragging the
+// namespace import in just for the type annotation.
+pub use whisker_runtime::reactive::Owner;
 // Async task host. `resource()` uses these internally, but they're
 // also part of the user surface: components spawn ad-hoc async work
 // through `spawn_local`, and `run_blocking` is the standard escape
@@ -1284,12 +1293,12 @@ pub mod __tags {
             // rebuilds the items Vec + broadcasts the new count.
             //
             // Owner cascade: per-item owners are detached
-            // (`create_owner(None)`); the effect explicitly disposes
+            // (`Owner::new(None)`); the effect explicitly disposes
             // them on diff. When the surrounding component disposes,
             // the released list element + items are torn down
             // through their respective owner releases.
             struct ListEntry {
-                owner: ::whisker_runtime::reactive::OwnerId,
+                owner: ::whisker_runtime::reactive::Owner,
                 handle: Element,
             }
             let entries: ::std::rc::Rc<
@@ -1310,8 +1319,8 @@ pub mod __tags {
                     if let ::std::option::Option::Some(existing) = old.remove(&k) {
                         new_entries.insert(k.clone(), existing);
                     } else {
-                        let item_owner = ::whisker_runtime::reactive::create_owner(None);
-                        let li = ::whisker_runtime::reactive::with_owner(item_owner, || {
+                        let item_owner = ::whisker_runtime::reactive::Owner::new(None);
+                        let li = item_owner.with(|| {
                             // Auto-wrap: the user's `children(item)` returns
                             // arbitrary content (a story_row view, a custom
                             // component, etc.). Lynx's <list> requires its
@@ -1341,7 +1350,7 @@ pub mod __tags {
                 // Disappeared items: detach + dispose.
                 for (_, entry) in old.drain() {
                     ::whisker_runtime::view::remove_child(handle, entry.handle);
-                    ::whisker_runtime::reactive::dispose_owner(entry.owner);
+                    entry.owner.dispose();
                 }
 
                 // Rebuild items Vec in new key order, capturing

--- a/crates/whisker/tests/children_slot.rs
+++ b/crates/whisker/tests/children_slot.rs
@@ -21,11 +21,9 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use whisker::prelude::*;
-use whisker::runtime::reactive::{
-    __reset_for_tests, __reset_pending_mount_for_tests, create_owner,
-};
+use whisker::runtime::reactive::{__reset_for_tests, __reset_pending_mount_for_tests};
 use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
-use whisker::with_owner;
+use whisker::Owner;
 
 // ----- Recording renderer ----------------------------------------------------
 //
@@ -100,8 +98,8 @@ fn with_test_env<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
     let rec = Recorder::default();
     let log = rec.log.clone();
     let prev = install_renderer(Box::new(rec));
-    let owner = create_owner(None);
-    let result = with_owner(owner, || f(log));
+    let owner = Owner::new(None);
+    let result = owner.with(|| f(log));
     uninstall_renderer(prev);
     result
 }

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -17,11 +17,9 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use whisker::prelude::*;
-use whisker::runtime::reactive::{
-    __reset_for_tests, __reset_pending_mount_for_tests, create_owner,
-};
+use whisker::runtime::reactive::{__reset_for_tests, __reset_pending_mount_for_tests};
 use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element, View};
-use whisker::with_owner;
+use whisker::Owner;
 
 // ----- Recording renderer ----------------------------------------------------
 
@@ -99,8 +97,8 @@ fn with_test_env<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
     let rec = Recorder::default();
     let log = rec.log.clone();
     let prev = install_renderer(Box::new(rec));
-    let owner = create_owner(None);
-    let result = with_owner(owner, || f(log));
+    let owner = Owner::new(None);
+    let result = owner.with(|| f(log));
     uninstall_renderer(prev);
     result
 }
@@ -474,10 +472,10 @@ fn props_struct_is_constructable_directly() {
     // go through `render!`), but it's the typed-builder API surface
     // and shouldn't break by accident.
     fresh();
-    let owner = create_owner(None);
+    let owner = Owner::new(None);
     let rec = Recorder::default();
     let prev = install_renderer(Box::new(rec));
-    with_owner(owner, || {
+    owner.with(|| {
         // Direct (non-render!) call must go through the PascalCase
         // alias the `#[component]` macro emits — the snake_case fn
         // is private inside the `__one_string_prop_inner` module.

--- a/crates/whisker/tests/element_ref.rs
+++ b/crates/whisker/tests/element_ref.rs
@@ -21,9 +21,9 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use whisker::prelude::*;
-use whisker::runtime::reactive::{__reset_for_tests, create_owner, dispose_owner, effect, flush};
+use whisker::runtime::reactive::{__reset_for_tests, effect, flush};
 use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
-use whisker::with_owner;
+use whisker::Owner;
 
 // ---- Minimal renderer ------------------------------------------------------
 
@@ -74,9 +74,9 @@ fn with_test_env<R>(f: impl FnOnce() -> R) -> R {
     __reset_for_tests();
     let (rec, _log) = Recorder::with_log();
     let prev = install_renderer(Box::new(rec));
-    let owner = create_owner(None);
-    let out = with_owner(owner, f);
-    dispose_owner(owner);
+    let owner = Owner::new(None);
+    let out = owner.with(f);
+    owner.dispose();
     uninstall_renderer(prev);
     out
 }
@@ -125,23 +125,23 @@ fn disposing_owner_unbinds_ref() {
 
     // Allocate the ref in an outer owner so the bind/unbind cycle
     // doesn't take the ref's storage with it.
-    let outer = create_owner(None);
-    let r = with_owner(outer, ElementRef::new);
+    let outer = Owner::new(None);
+    let r = outer.with(ElementRef::new);
 
     // Mount inside an inner owner — the macro emits on_cleanup
     // against the inner owner.
-    let inner = create_owner(None);
-    with_owner(inner, || {
+    let inner = Owner::new(None);
+    inner.with(|| {
         let _h = render! { XRefTarget(ref: r, value: "x") };
     });
     assert!(r.is_bound(), "ref should bind on mount");
 
     // Disposing the inner owner triggers the on_cleanup that
     // __unbinds the ref.
-    dispose_owner(inner);
+    inner.dispose();
     assert!(!r.is_bound(), "ref should unbind on inner-owner disposal");
 
-    dispose_owner(outer);
+    outer.dispose();
     uninstall_renderer(prev);
 }
 
@@ -151,14 +151,14 @@ fn bound_signal_is_reactive() {
     let (rec, _log) = Recorder::with_log();
     let prev = install_renderer(Box::new(rec));
 
-    let outer = create_owner(None);
-    let r = with_owner(outer, ElementRef::new);
+    let outer = Owner::new(None);
+    let r = outer.with(ElementRef::new);
 
     let observed = Rc::new(RefCell::new(Vec::<bool>::new()));
     let observed_clone = observed.clone();
 
     // Effect must run in *some* owner; the outer one is fine.
-    with_owner(outer, || {
+    outer.with(|| {
         let bound = r.bound();
         effect(move || {
             observed_clone.borrow_mut().push(bound.get());
@@ -167,8 +167,8 @@ fn bound_signal_is_reactive() {
     flush();
     assert_eq!(*observed.borrow(), vec![false], "initial: unbound");
 
-    let inner = create_owner(None);
-    with_owner(inner, || {
+    let inner = Owner::new(None);
+    inner.with(|| {
         let _h = render! { XRefTarget(ref: r, value: "x") };
     });
     flush();
@@ -178,7 +178,7 @@ fn bound_signal_is_reactive() {
         "effect re-runs on bind"
     );
 
-    dispose_owner(inner);
+    inner.dispose();
     flush();
     assert_eq!(
         *observed.borrow(),
@@ -186,7 +186,7 @@ fn bound_signal_is_reactive() {
         "effect re-runs on unbind"
     );
 
-    dispose_owner(outer);
+    outer.dispose();
     uninstall_renderer(prev);
 }
 

--- a/crates/whisker/tests/module_component.rs
+++ b/crates/whisker/tests/module_component.rs
@@ -13,10 +13,10 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use whisker::flush;
 use whisker::prelude::*;
-use whisker::runtime::reactive::{__reset_for_tests, create_owner, dispose_owner};
+use whisker::runtime::reactive::{Owner, __reset_for_tests};
 use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
-use whisker::{flush, with_owner};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
@@ -99,9 +99,9 @@ fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
     __reset_for_tests();
     let (rec, log) = Recorder::with_log();
     let prev = install_renderer(Box::new(rec));
-    let owner = create_owner(None);
-    let out = with_owner(owner, || f(log));
-    dispose_owner(owner);
+    let owner = Owner::new(None);
+    let out = owner.with(|| f(log));
+    owner.dispose();
     uninstall_renderer(prev);
     out
 }

--- a/crates/whisker/tests/module_component.rs
+++ b/crates/whisker/tests/module_component.rs
@@ -15,7 +15,7 @@ use std::rc::Rc;
 
 use whisker::flush;
 use whisker::prelude::*;
-use whisker::runtime::reactive::{Owner, __reset_for_tests};
+use whisker::runtime::reactive::{__reset_for_tests, Owner};
 use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -18,10 +18,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use whisker::prelude::*;
 use whisker::runtime::reactive::__reset_pending_mount_for_tests;
-use whisker::runtime::reactive::{
-    __reset_for_tests, create_owner, dispose_owner, owners_for_fn, remount_components_for,
-    with_owner,
-};
+use whisker::runtime::reactive::{__reset_for_tests, owners_for_fn, remount_components_for, Owner};
 use whisker::runtime::view::{
     __reset_children_mirror_for_tests, append_child, create_element, install_renderer,
     uninstall_renderer, DynRenderer, Element,
@@ -126,9 +123,9 @@ fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
     reset_state();
     let (rec, log) = Recorder::new();
     let _prev = install_renderer(Box::new(rec));
-    let owner = create_owner(None);
-    let result = with_owner(owner, || f(log));
-    dispose_owner(owner);
+    let owner = Owner::new(None);
+    let result = owner.with(|| f(log));
+    owner.dispose();
     uninstall_renderer(None);
     result
 }
@@ -315,7 +312,7 @@ fn remount_disposes_old_owner_and_registers_new() {
         assert_eq!(after_owners.len(), 1);
         assert_ne!(
             after_owners[0], first_owner_id,
-            "remount must create a fresh owner (different OwnerId)"
+            "remount must create a fresh owner (different Owner)"
         );
     });
 }
@@ -367,9 +364,9 @@ fn dispose_owner_releases_owned_elements() {
     let (rec, log) = Recorder::new();
     let _prev = install_renderer(Box::new(rec));
 
-    let root_owner = create_owner(None);
+    let root_owner = Owner::new(None);
     // Mount the component inside the root owner.
-    let _root = with_owner(root_owner, || render! { Leaf(label: "hi") });
+    let _root = root_owner.with(|| render! { Leaf(label: "hi") });
 
     let creates_initial = log
         .borrow()
@@ -378,7 +375,7 @@ fn dispose_owner_releases_owned_elements() {
         .count();
     log.borrow_mut().clear();
 
-    dispose_owner(root_owner);
+    root_owner.dispose();
 
     let releases = log
         .borrow()
@@ -403,7 +400,7 @@ fn nested_component_mount_sites_cleared_on_parent_remount() {
     // `remount_components_for` call processed them too — touching
     // freed parent / body_root handles and corrupting the screen.
     //
-    // The fix in `dispose_owner` scrubs `mount_sites` /
+    // The fix in `Owner::dispose` scrubs `mount_sites` /
     // `fn_ptr_mounts` for any orphaned child. This test pins that
     // behaviour: after a parent remount, the child fn pointer's
     // MountSite list should equal the count of live child

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use whisker::flush;
 use whisker::prelude::*;
-use whisker::runtime::reactive::{Owner, __reset_for_tests};
+use whisker::runtime::reactive::{__reset_for_tests, Owner};
 use whisker::runtime::view::{
     install_renderer, uninstall_renderer, BindType, DynRenderer, Element,
 };

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -9,12 +9,12 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use whisker::flush;
 use whisker::prelude::*;
-use whisker::runtime::reactive::{__reset_for_tests, create_owner, dispose_owner};
+use whisker::runtime::reactive::{Owner, __reset_for_tests};
 use whisker::runtime::view::{
     install_renderer, uninstall_renderer, BindType, DynRenderer, Element,
 };
-use whisker::{flush, with_owner};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
@@ -122,9 +122,9 @@ fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
     __reset_for_tests();
     let (rec, log) = Recorder::new();
     let prev = install_renderer(Box::new(rec));
-    let owner = create_owner(None);
-    let result = with_owner(owner, || f(log));
-    dispose_owner(owner);
+    let owner = Owner::new(None);
+    let result = owner.with(|| f(log));
+    owner.dispose();
     uninstall_renderer(prev);
     result
 }

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -18,10 +18,10 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use whisker::flush;
 use whisker::prelude::*;
-use whisker::runtime::reactive::{__reset_for_tests, create_owner, dispose_owner};
+use whisker::runtime::reactive::{Owner, __reset_for_tests};
 use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
-use whisker::{flush, with_owner};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
@@ -118,9 +118,9 @@ fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
     __reset_for_tests();
     let (rec, log) = Recorder::with_log();
     let prev = install_renderer(Box::new(rec));
-    let owner = create_owner(None);
-    let out = with_owner(owner, || f(log));
-    dispose_owner(owner);
+    let owner = Owner::new(None);
+    let out = owner.with(|| f(log));
+    owner.dispose();
     uninstall_renderer(prev);
     out
 }

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -20,7 +20,7 @@ use std::rc::Rc;
 
 use whisker::flush;
 use whisker::prelude::*;
-use whisker::runtime::reactive::{Owner, __reset_for_tests};
+use whisker::runtime::reactive::{__reset_for_tests, Owner};
 use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/whisker-router/example/src/lib.rs
+++ b/packages/whisker-router/example/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! `safe_area_insets()` allocates a process-global signal lazily on
 //! first call (`OnceLock::get_or_init`). When that first call lands
-//! inside `StackLayout`'s `with_owner(create_owner(None), || …)`
+//! inside `StackLayout`'s `Owner::new(None).with(|| …)`
 //! body, the signal becomes owned by the per-route owner. The
 //! Android side of the module fires `OnStartObserving` synchronously
 //! and `sendEvent("insetsChanged", …)` lands during the same tick

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -46,9 +46,7 @@ use std::rc::Rc;
 use whisker::css::ext::*;
 use whisker::css::{Css, Overflow, PositionKind, ToCss};
 use whisker::runtime::element::ElementTag;
-use whisker::runtime::reactive::{
-    create_owner, dispose_owner, effect, on_mount, pause_owner, resume_owner, with_owner, OwnerId,
-};
+use whisker::runtime::reactive::{effect, on_mount, Owner};
 use whisker::runtime::view::apply::apply_styles;
 use whisker::runtime::view::{
     append_child, create_element, insert_child_at, remove_child, set_inline_styles, Element,
@@ -66,7 +64,7 @@ use crate::transitions::{Direction, Side, StackTransitionBox};
 /// when the entry is popped off the stack.
 #[derive(Clone, Copy)]
 struct MountedEntry {
-    owner: OwnerId,
+    owner: Owner,
     wrapper: Element,
 }
 
@@ -217,7 +215,7 @@ pub fn stack_layout<R: Route>(
     // without this anchor, owners spawned for entries the gesture
     // interacts with would become roots and lose access to the
     // `RouteProvider` context their components rely on.
-    let _handle_parent = create_owner(None);
+    let _handle_parent = Owner::new(None);
 
     let handle = build_stack_layout_handle(container, stack.clone(), state);
     provide_context(handle);
@@ -253,7 +251,7 @@ fn run_navigation_effect<R: Route>(
         let mut pending = state.pending_dispose.borrow_mut();
         for entry in pending.drain(..) {
             remove_child(container, entry.wrapper);
-            dispose_owner(entry.owner);
+            entry.owner.dispose();
         }
     }
 
@@ -281,7 +279,7 @@ fn run_navigation_effect<R: Route>(
                 // offscreen pose, so dispose right away — no
                 // pending queue.
                 remove_child(container, entry.wrapper);
-                dispose_owner(entry.owner);
+                entry.owner.dispose();
             }
         }
         first.set(false);
@@ -333,7 +331,7 @@ fn run_navigation_effect<R: Route>(
             .find(|e| e.id == *id)
             .expect("added id must be present in new entries");
         let route = entry.route.clone();
-        let new_owner = create_owner(None);
+        let new_owner = Owner::new(None);
         let wrapper = create_element(ElementTag::View);
         apply_wrapper_style(
             wrapper,
@@ -350,7 +348,7 @@ fn run_navigation_effect<R: Route>(
             .position(|i| *i == *id)
             .expect("just inserted");
         insert_child_at(container, wrapper, position);
-        with_owner(new_owner, || {
+        new_owner.with(|| {
             let h = render.call(route);
             append_child(wrapper, h);
         });
@@ -445,7 +443,7 @@ fn run_navigation_effect<R: Route>(
                 state.pending_dispose.borrow_mut().push(entry);
             } else {
                 remove_child(container, entry.wrapper);
-                dispose_owner(entry.owner);
+                entry.owner.dispose();
             }
         }
     }
@@ -461,7 +459,7 @@ fn run_navigation_effect<R: Route>(
 /// expected paused state: the topmost (last in [`LayoutState::order`])
 /// is active; everything else is paused.
 ///
-/// Idempotent — `pause_owner` / `resume_owner` no-op on the matching
+/// Idempotent — `Owner::pause` / `Owner::resume` no-op on the matching
 /// state, so calling this every navigation costs at most one set
 /// flip per owner.
 fn sync_owner_paused_state(state: &LayoutState) {
@@ -470,9 +468,9 @@ fn sync_owner_paused_state(state: &LayoutState) {
     let top_id = order.last().copied();
     for (id, entry) in mounted.iter() {
         if Some(*id) == top_id {
-            resume_owner(entry.owner);
+            entry.owner.resume();
         } else {
-            pause_owner(entry.owner);
+            entry.owner.pause();
         }
     }
 }

--- a/packages/whisker-router/src/outlet.rs
+++ b/packages/whisker-router/src/outlet.rs
@@ -9,7 +9,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use whisker::runtime::reactive::{create_owner, dispose_owner, effect, with_owner, OwnerId};
+use whisker::runtime::reactive::{effect, Owner};
 use whisker::runtime::view::{append_child, create_phantom_element, remove_child, Element};
 use whisker::{component, provide_context, use_context, Children};
 
@@ -88,7 +88,7 @@ pub fn outlet<R: Route>(render: RouteRenderFn<R>) -> Element {
     let stack = router::<R>();
     let frag = create_phantom_element();
 
-    type Mounted = Rc<RefCell<Option<(OwnerId, Element)>>>;
+    type Mounted = Rc<RefCell<Option<(Owner, Element)>>>;
     let mounted: Mounted = Rc::new(RefCell::new(None));
 
     let current = stack.current();
@@ -98,15 +98,15 @@ pub fn outlet<R: Route>(render: RouteRenderFn<R>) -> Element {
         // Tear down the previously-mounted branch (if any).
         if let Some((owner, handle)) = mounted.borrow_mut().take() {
             remove_child(frag, handle);
-            dispose_owner(owner);
+            owner.dispose();
         }
 
         // Read the current route and mount its renderer under a
         // fresh owner so all signals/effects/spawned tasks created
         // inside live and die with this entry.
         let route = current.get();
-        let owner = create_owner(None);
-        let handle = with_owner(owner, || {
+        let owner = Owner::new(None);
+        let handle = owner.with(|| {
             let h = render.call(route);
             append_child(frag, h);
             h
@@ -140,9 +140,9 @@ mod tests {
 
     fn with_runtime<F: FnOnce() -> T, T>(f: F) -> T {
         whisker::runtime::reactive::__reset_for_tests();
-        let owner = create_owner(None);
-        let out = with_owner(owner, f);
-        dispose_owner(owner);
+        let owner = Owner::new(None);
+        let out = owner.with(f);
+        owner.dispose();
         out
     }
 

--- a/packages/whisker-router/src/stack.rs
+++ b/packages/whisker-router/src/stack.rs
@@ -251,9 +251,9 @@ mod tests {
 
     fn with_runtime<F: FnOnce() -> T, T>(f: F) -> T {
         whisker::runtime::reactive::__reset_for_tests();
-        let owner = whisker::runtime::reactive::create_owner(None);
-        let out = whisker::runtime::reactive::with_owner(owner, f);
-        whisker::runtime::reactive::dispose_owner(owner);
+        let owner = whisker::runtime::reactive::Owner::new(None);
+        let out = owner.with(f);
+        owner.dispose();
         out
     }
 


### PR DESCRIPTION
## Summary

Public-API audit follow-up — renames the reactive-scope surface so application code never touches it accidentally, and so framework extension code (router, custom control-flow) reads more naturally.

### Type renames

- `OwnerId` (the slotmap key handle) → **`Owner`**
- The previous internal data struct `Owner` → **`Scope`**, now private to `whisker_runtime::reactive::runtime`. Users (and even framework extension authors) never name `Scope` directly.

### Free functions → methods on `Owner`

| Before | After |
|---|---|
| `create_owner(parent)` | `Owner::new(parent)` |
| `with_owner(id, f)` | `id.with(f)` |
| `dispose_owner(id)` | `id.dispose()` |
| `pause_owner(id)` | `id.pause()` |
| `resume_owner(id)` | `id.resume()` |
| `is_owner_paused(id)` | `id.is_paused()` |

`on_cleanup` stays as a free function — it acts on whichever owner is currently on the runtime stack, the caller can't name it.

### Surface location

The methods live behind `whisker::owner::Owner::*` (or `whisker::Owner` for the type alone). The old crate-root re-exports (`whisker::create_owner`, etc.) are removed; they were never carried in the prelude, so application code that did `use whisker::prelude::*` is unaffected.

### Why

From the audit: Owner API is a framework-extension surface, not an application-author surface. The old `create_owner` / `dispose_owner` naming put 6 verbose, prefix-redundant verbs at the crate root next to `signal()` / `effect()`. Putting them on the handle (`o.dispose()`, `o.with(||)`) matches Solid / Leptos's `owner.with(f)` / `owner.dispose()` pattern and reads better — see the discussion in this session's audit thread for the design rationale (including why `owner::with(id, ‖)` was rejected as "owner with" awkward).

## Test plan

- [x] `cargo check --workspace --exclude whisker-cng --exclude whisker-driver-sys` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace --exclude whisker-cng --exclude whisker-driver-sys --no-fail-fast` — all green
- [x] Call sites updated: `whisker::control_flow`, `whisker-router::{outlet, stack, layouts::stack}`, `whisker-runtime::{component, list_mount, view::renderer}`, 6 test files in `crates/whisker/tests/`, 2 in `crates/whisker-runtime/src/reactive/`