### PR TITLE
docs: fill in semantic gaps on player / video / svg surfaces

### DIFF
--- a/packages/whisker-audio/src/lib.rs
+++ b/packages/whisker-audio/src/lib.rs
@@ -163,31 +163,73 @@ impl Player {
     }
 
     /// Start or resume playback from the current position.
+    ///
+    /// No-op if no source is loaded yet — the player will not start
+    /// queuing playback ahead of the load completing; call again
+    /// after `is_loaded` transitions to `true` (or simply call once
+    /// at user gesture time and let the native player schedule).
+    ///
+    /// `PlaybackStatus` effect: `is_playing` → `true` (the next
+    /// status tick); `position` resumes ticking from the current
+    /// value.
     pub fn play(&self) {
         let _ = self.inner.invoke("play", vec![]);
     }
 
     /// Pause playback at the current position.
+    ///
+    /// `PlaybackStatus` effect: `is_playing` → `false`; `position`
+    /// stops advancing but keeps its current value. The source and
+    /// loaded state are untouched, so [`Self::play`] resumes from
+    /// the same spot.
     pub fn pause(&self) {
         let _ = self.inner.invoke("pause", vec![]);
     }
 
     /// Stop playback and rewind to position 0. The native player
-    /// stays loaded — [`Player::play`] resumes from the start
+    /// stays loaded — [`Self::play`] resumes from the start
     /// without re-fetching.
+    ///
+    /// `PlaybackStatus` effect: `is_playing` → `false`; `position`
+    /// → `0.0`. `duration` and `is_loaded` are preserved.
     pub fn stop(&self) {
         let _ = self.inner.invoke("stop", vec![]);
     }
 
     /// Seek to an absolute position (seconds from the start).
+    ///
+    /// Values outside `[0, duration]` are clamped on the native
+    /// side. Seeking on a paused player keeps it paused; seeking
+    /// while playing keeps it playing — there is no implicit
+    /// play / pause toggle.
+    ///
+    /// `PlaybackStatus` effect: `position` jumps to the requested
+    /// value on the next status tick. If the destination falls
+    /// outside the buffered region the native player may stall
+    /// briefly while re-buffering — surface to users via the
+    /// `is_loaded` flag if needed (the platform side flips
+    /// `is_loaded` back to `false` while it waits).
     pub fn seek_to(&self, position_seconds: f64) {
         let _ = self
             .inner
             .invoke("seekTo", vec![WhiskerValue::Float(position_seconds)]);
     }
 
-    /// Replace the loaded media. Pass an empty string to release
-    /// the current source without queueing a new one.
+    /// Replace the loaded media with `source`. Pass an empty string
+    /// to release the current source without queueing a new one.
+    ///
+    /// **The player is reset by this call.** `PlaybackStatus`
+    /// effects: `is_loaded` → `false` (until the new source's
+    /// headers arrive); `duration` → `0.0`; `position` → `0.0`;
+    /// `is_playing` → `false`. Equivalently to constructing a fresh
+    /// [`Player`], you should re-call [`Self::play`] after the
+    /// status reports `is_loaded = true` if you want auto-resume
+    /// behaviour across source swaps.
+    ///
+    /// Passing the same source string again is *not* a no-op — the
+    /// native player still tears down and re-loads. Compare with
+    /// the previous source in user code if you want to skip the
+    /// reload.
     pub fn set_source(&self, source: impl Into<String>) {
         let _ = self
             .inner
@@ -196,6 +238,11 @@ impl Player {
 
     /// Set output gain on `[0.0, 1.0]`. Values outside the range
     /// get clamped on the native side.
+    ///
+    /// Does not affect `PlaybackStatus` — `is_playing` and
+    /// `position` stay where they are. Setting volume to `0.0` is
+    /// the conventional "mute" path; the native player keeps
+    /// running.
     pub fn set_volume(&self, value: f64) {
         let _ = self
             .inner
@@ -203,7 +250,13 @@ impl Player {
     }
 
     /// Loop the source: when playback reaches the end, the native
-    /// player rewinds to 0 and resumes. Idempotent.
+    /// player rewinds to 0 and resumes. Idempotent — calling with
+    /// the same flag again is a no-op.
+    ///
+    /// Does not affect `PlaybackStatus` until a loop boundary
+    /// actually fires. At the wrap point the `position` resets to
+    /// `0.0` and `is_playing` stays `true` (no momentary
+    /// `false`-tick).
     pub fn set_loop(&self, looping: bool) {
         let _ = self
             .inner
@@ -219,6 +272,14 @@ impl Player {
     /// the calling effect / computed as a dependent, so a `text`
     /// bound to `status.get().position` re-renders as the native
     /// player ticks through the file.
+    ///
+    /// Tick cadence: ≈ 200 ms while playing, plus an immediate
+    /// tick on every state transition (`play` / `pause` / `stop`
+    /// / `seekTo` / `setSource` / load-completion / loop-wrap).
+    /// The first tick after `Player::new` lands once the native
+    /// side has resolved the source URL and reports a non-zero
+    /// `duration` — at that point `is_loaded` flips to `true`.
+    /// All clones of the same `Player` see the identical signal.
     pub fn status(&self) -> ReadSignal<PlaybackStatus> {
         register_status(self.inner.id)
     }

--- a/packages/whisker-svg/src/compile.rs
+++ b/packages/whisker-svg/src/compile.rs
@@ -34,7 +34,7 @@
 //! ## Error tolerance
 //!
 //! A malformed colour / transform / number on one element is
-//! reported in [`CompileError::warnings`] but doesn't abort
+//! reported in [`Compiled::warnings`] but doesn't abort
 //! compilation — partial display lists with one bad element
 //! skipped are usually better than rendering nothing.
 
@@ -42,25 +42,74 @@ use crate::builder::{Color, DisplayListBuilder, Transform};
 use crate::path_parse::{self, PathCommand};
 
 /// Output of [`compile`].
+///
+/// The bytes are ready to hand to the platform replayer; warnings
+/// are diagnostic and never block rendering.
 #[derive(Debug)]
 pub struct Compiled {
-    /// The byte stream — pass to platform via `WhiskerValue::Bytes`.
+    /// The display-list byte stream, framed by the `WSDL` magic
+    /// described in `packages/whisker-svg/SPEC.md`. Always non-
+    /// empty on a successful compile: the `VIEWPORT` opcode is
+    /// emitted unconditionally, and at minimum every successful
+    /// compile contains that opcode plus the trailing end marker.
+    ///
+    /// Pass straight through `WhiskerValue::Bytes` (or, in the
+    /// current transport, the base64-encoded `display_list:` prop)
+    /// to the platform replayer. The bytes carry no input-side
+    /// references — they're freely copyable across the FFI
+    /// boundary and don't depend on `svg_xml` staying alive.
     pub bytes: Vec<u8>,
-    /// Non-fatal issues encountered (bad colour, unknown element, …).
-    /// Producers might surface these to the user as a console warn.
+
+    /// Non-fatal issues the compiler chose to skip over: a path's
+    /// `d` attribute contained an unrecognised command, a colour
+    /// failed to parse, an `<svg>` child uses an element type the
+    /// v1 compiler doesn't support yet, etc.
+    ///
+    /// Empty on a clean compile. When non-empty, the partial
+    /// display list in [`Self::bytes`] is still safe to render —
+    /// it just won't contain the dropped shapes / attributes.
+    /// Producers may want to surface these to a developer console;
+    /// users typically shouldn't see them.
     pub warnings: Vec<String>,
 }
 
-/// Hard errors that stop compilation entirely.
+/// Hard errors that stop compilation entirely — the returned
+/// [`Result`] is `Err(_)` and no [`Compiled::bytes`] are produced.
+///
+/// Distinct from [`Compiled::warnings`], which are best-effort
+/// recoveries the compiler made while still producing a usable
+/// display list. These are unrecoverable: there is no useful
+/// fallback bytestream to render.
+///
+/// `#[non_exhaustive]` — the v1 set is small (XML / non-svg
+/// root / missing viewBox), but future tightenings (e.g. a
+/// missing required `<g transform>` form) may add variants
+/// without bumping SemVer.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CompileError {
-    /// `roxmltree` couldn't parse the XML at all.
+    /// `roxmltree` couldn't parse the input as XML. The wrapped
+    /// `String` is the parser's own diagnostic ("expected element
+    /// at offset N"). Typically: an unbalanced tag, a missing
+    /// closing bracket, or non-XML bytes (a binary file passed in
+    /// by mistake).
     XmlParse(String),
-    /// The root element wasn't `<svg>`.
+
+    /// The root element of the parsed document wasn't `<svg>` —
+    /// the input is well-formed XML, but not an SVG document.
+    /// E.g. an `<html>` snippet or a `<path>` with no surrounding
+    /// `<svg>` wrapper.
     NotSvg,
-    /// `<svg>` had no `viewBox` and no `width`+`height` from which
-    /// to derive one. We need an explicit user-unit coordinate
-    /// system to emit the `VIEWPORT` opcode.
+
+    /// `<svg>` had no `viewBox` and the compiler couldn't derive
+    /// one from `width` + `height`. The v1 compiler needs an
+    /// explicit user-unit coordinate system to emit the `VIEWPORT`
+    /// opcode; without one the bytes would describe coordinates
+    /// in an undefined space and the platform replayer would have
+    /// no scale anchor.
+    ///
+    /// Fix: add `viewBox="0 0 W H"` to the `<svg>` root, where
+    /// `W`/`H` are the natural width / height in user units.
     NoViewBox,
 }
 

--- a/packages/whisker-video/src/lib.rs
+++ b/packages/whisker-video/src/lib.rs
@@ -77,17 +77,35 @@ impl VideoHandle {
         self.r
     }
 
-    /// Start or resume playback.
+    /// Start or resume playback from the current position.
+    ///
+    /// No-op if the element isn't mounted yet (the underlying
+    /// `ElementRef::invoke` swallows the dispatch) or if the
+    /// native player is still loading `src`. Safe to call from a
+    /// user gesture before the source finishes loading — the
+    /// native player will start as soon as it's ready.
     pub fn play(&self) {
         let _ = self.r.invoke("play", WhiskerValue::args([]));
     }
 
     /// Pause playback at the current position.
+    ///
+    /// The native player stays loaded and seekable; [`Self::play`]
+    /// resumes from the same spot without re-fetching. No-op if
+    /// nothing is currently playing or if the element isn't
+    /// mounted.
     pub fn pause(&self) {
         let _ = self.r.invoke("pause", WhiskerValue::args([]));
     }
 
     /// Seek to an absolute position (seconds from the start).
+    ///
+    /// Values outside `[0, duration]` are clamped on the native
+    /// side. Seeking on a paused player keeps it paused; seeking
+    /// while playing keeps it playing. The seek may stall briefly
+    /// if the destination falls outside the buffered region —
+    /// `whisker-video` does not currently expose a buffering
+    /// signal (track via the platform's native controls instead).
     pub fn seek(&self, position_seconds: f64) {
         let _ = self.r.invoke(
             "seek",


### PR DESCRIPTION
Closes #129.

## What the audit asked for

The pre-1.0 API audit (§3.6) called out a handful of public surfaces whose rustdoc was technically correct but missed important *semantic* details — the kind of \"what will this actually do to my reactive state\" question that should be answered without reading the native module's source.

Items 1 (\`whisker-image::ImageProps::mode\`) and 4 (other string-keyed enum props) were resolved by #130's typed-enum migration. The remaining items are addressed here.

## Changes

### whisker-audio

Every \`Player\` mutator now documents its effect on \`PlaybackStatus\`:

- **\`play\`**: \`is_playing\` → \`true\`; no-op if no source loaded yet.
- **\`pause\`**: \`is_playing\` → \`false\`; \`position\` stops advancing.
- **\`stop\`**: \`is_playing\` → \`false\`; \`position\` → \`0.0\`; loaded state preserved.
- **\`seek_to\`**: clamp behaviour, play/pause preservation, buffer-stall flagged via \`is_loaded\`.
- **\`set_source\`**: **flagged as a full reset** (\`is_loaded\` → \`false\`, \`duration\` → \`0.0\`, \`position\` → \`0.0\`, \`is_playing\` → \`false\`). Documents that re-passing the same URL is *not* a no-op.
- **\`set_volume\`** / **\`set_loop\`**: documents no-impact on \`is_playing\` / \`position\`.

\`status()\` gains the ≈ 200 ms tick cadence + first-tick timing description.

### whisker-svg

- **\`Compiled\`**: \`bytes\` doc explains the WSDL framing, FFI-copy semantics; \`warnings\` doc clarifies when non-empty + that the partial display list is safe to render.
- **\`CompileError\`**: per-variant guidance on what triggers each + how to fix \`NoViewBox\`. \`#[non_exhaustive]\` added so future variants don't break SemVer.
- Fixed a broken intra-doc link (\`CompileError::warnings\` → \`Compiled::warnings\`).

### whisker-video

Handle methods (\`play\`, \`pause\`, \`seek\`) now document mount-time / loading no-op behaviour and clamping semantics. \`whisker-video\`'s lack of a buffering signal is called out explicitly (track via #128).

## Test plan

- [x] \`cargo check\` — clean
- [x] \`cargo test -p whisker-svg -p whisker-audio -p whisker-video\` — green
- [x] \`cargo clippy -p whisker-svg -p whisker-audio -p whisker-video --all-targets -- -D warnings\` — clean
- [x] \`cargo doc --no-deps\` — no new warnings (one broken-link fix included; the two pre-existing warnings on unrelated items are not introduced here)

No code changes outside rustdoc + the \`#[non_exhaustive]\` on \`CompileError\`.