### PR TITLE
docs(driver): comment sweep per style guide

### DIFF
--- a/crates/whisker-driver/src/element_ref.rs
+++ b/crates/whisker-driver/src/element_ref.rs
@@ -1,34 +1,36 @@
 //! `ElementRef` — Rust-side handle for invoking methods on a mounted
-//! Whisker platform component.
+//! Whisker platform component, plus the typed `XxxHandle` family that
+//! wraps it for end-user code.
 //!
-//! Phase N redesign (see `docs/phase-n-ref-api-design.md`):
+//! ## Design
 //!
 //! - **Non-generic** — `ElementRef` carries no marker type. End-users
 //!   never see `ElementRef` in component signatures; they hold typed
 //!   `XxxHandle` structs and let the wrapping `#[whisker::component]`
 //!   own the internal `ElementRef` that bridges native invocations.
 //! - **`RwSignal`-backed binding** — the inner `Option<Element>` lives
-//!   in the reactive runtime so `bound()` returns a `Signal<bool>`
-//!   that `effect(...)` / `computed(...)` / `text(value: ...)` can
-//!   observe. The hot-path `invoke()` reads via `get_untracked()` so
-//!   imperative dispatch never accidentally subscribes its caller.
+//!   in the reactive runtime so [`ElementRef::bound`] returns a
+//!   `Signal<bool>` that `effect(...)` / `computed(...)` /
+//!   `text(value: ...)` can observe. The hot-path
+//!   [`ElementRef::invoke`] reads via `get_untracked()` so imperative
+//!   dispatch never accidentally subscribes its caller.
 //! - **One invoke shape** — `invoke(method, args: WhiskerValue) ->
 //!   WhiskerValue` (sync, fire-and-forget) + `invoke_async` /
 //!   `invoke_typed<T>` (async, result-returning), mirroring
 //!   `PlatformModule::invoke` / `invoke_async`. `args` is a single
 //!   `WhiskerValue` passed straight through as the method's params
 //!   object; the result comes back as a `WhiskerValue`. `invoke_typed`
-//!   surfaces "not bound" / "platform-side error" as `RefError`
-//!   variants; `invoke` collapses both into `WhiskerValue::Error`.
+//!   surfaces "not bound" / "platform-side error" as [`RefError`]
+//!   variants; `invoke` collapses both into [`WhiskerValue::Error`].
 //!
 //! ## Where `ElementRef` appears
 //!
 //! Only in the signatures of `#[whisker::module_component]`-declared
 //! functions, as a hidden `__ref` prop the macro emits, and inside
 //! module-author-written `#[whisker::component]` wrappers that bridge
-//! a Handle struct to native via `effect(...)` blocks. End-users at
-//! app-level code see `VideoHandle`, `TextInputHandle`, ..., never
-//! `ElementRef` directly.
+//! a Handle struct to native via `effect(...)` blocks. End-user app
+//! code sees [`ElementHandle`], [`ScrollViewHandle`], [`TextHandle`],
+//! and similar typed handles — never `ElementRef` directly.
 
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -216,7 +218,7 @@ impl ElementRef {
     }
 
     /// `true` iff bound to a live element right now. Non-reactive.
-    /// For reactive observation, use [`bound()`].
+    /// For reactive observation, use [`bound`](Self::bound).
     pub fn is_bound(&self) -> bool {
         self.inner.get_untracked().is_some()
     }
@@ -348,15 +350,15 @@ impl ElementRef {
         let _ = self.inner.try_set(None);
     }
 
-    /// Deprecated public alias for [`__bind`] kept until Phase N-3
-    /// migration. Don't call from author code.
+    /// Deprecated public alias for [`__bind`](Self::__bind). Don't
+    /// call from author code.
     #[doc(hidden)]
     pub fn bind(&self, handle: Element) {
         self.__bind(handle);
     }
 
-    /// Deprecated public alias for [`__unbind`] kept until Phase N-3
-    /// migration. Don't call from author code.
+    /// Deprecated public alias for [`__unbind`](Self::__unbind). Don't
+    /// call from author code.
     #[doc(hidden)]
     pub fn clear(&self) {
         self.__unbind();
@@ -453,6 +455,22 @@ macro_rules! generic_element_methods {
 ///
 /// `Copy` (the inner `ElementRef` is an arena handle), so it can be
 /// captured by value into multiple event closures.
+///
+/// ```ignore
+/// let card = ElementHandle::new();
+/// effect({
+///     let card = card;
+///     move || if card.r().bound().get() {
+///         spawn_local(async move {
+///             if let Ok(rect) = card.bounding_client_rect().await {
+///                 println!("card is {}x{}", rect.width, rect.height);
+///             }
+///         });
+///     }
+/// });
+///
+/// render! { view(ref: card.r()) { /* … */ } }
+/// ```
 #[derive(Copy, Clone)]
 pub struct ElementHandle {
     r: ElementRef,
@@ -687,9 +705,8 @@ impl Default for TextHandle {
 ///
 /// The generic parameter is **ignored**. It's kept on the function
 /// signature so existing callers like `element_ref::<VideoProps>()`
-/// keep compiling through the Phase N migration window. Phase N-3
-/// will drop this shim in favour of typed `XxxHandle::new()`
-/// constructors.
+/// keep compiling; a future cleanup will drop this shim in favour of
+/// typed `XxxHandle::new()` constructors.
 ///
 /// ```ignore
 /// let r = ElementRef::new();

--- a/crates/whisker-driver/src/lib.rs
+++ b/crates/whisker-driver/src/lib.rs
@@ -2,10 +2,22 @@
 //!
 //! Today there is one backend ([`lynx`]) that talks to the C++ Lynx
 //! bridge shipped under `whisker-driver-sys/bridge/`. Future backends
-//! (web, wgpu, …) would
-//! land as sibling modules behind cfg gates. Users never touch this
-//! crate directly — `#[whisker::main]` re-exports the `run` / `tick`
-//! helpers from here as `whisker::__main_runtime::{run,tick}`.
+//! (web, wgpu, …) would land as sibling modules behind cfg gates.
+//! Users never touch this crate directly — `#[whisker::main]`
+//! re-exports the `run` / `tick` helpers from here as
+//! `whisker::__main_runtime::{run,tick}`.
+//!
+//! The crate splits along three seams:
+//!
+//! - [`element_ref`](mod@element_ref) — [`ElementRef`] + the typed
+//!   `XxxHandle` family that user code holds to dispatch imperative
+//!   element methods (`scrollTo`, `boundingClientRect`, …).
+//! - [`module`] — [`PlatformModule`](module::PlatformModule), the
+//!   user-facing handle for native modules registered on the host side
+//!   (`whisker::module!("Foo")`).
+//! - [`lynx`] — contributor-only: the [`BridgeRenderer`] that backs the
+//!   `whisker_runtime::view` thread-local, plus event-propagation
+//!   replay and list-provider trampolines.
 
 pub mod element_ref;
 pub mod lynx;
@@ -27,14 +39,14 @@ use whisker_runtime::view::{module_component_ptr, Element};
 use crate::module::{async_trampoline, from_raw, RawBuilder, WhiskerValue};
 
 /// Synchronously invoke `method` on the platform component identified
-/// by `handle`. Routes through the C bridge
-/// (`whisker_bridge_invoke_element_method`) — itself a stub in
-/// Phase 7-Φ.H.2.5, returning a Lynx-fork-pending Error until
-/// Phase 7-Φ.H.2.7 wires in the real dispatch.
+/// by `handle`, with `args` passed positionally through Lynx's
+/// `params.args` field. Routes through the C bridge
+/// (`whisker_bridge_invoke_element_method`).
 ///
 /// Direct callers are mostly the proc macros — `ElementRef::invoke`
 /// and the `#[whisker::element_methods]`-emitted bodies. User code
-/// uses the typed wrappers, not this entry point.
+/// uses the typed wrappers ([`ElementRef`], [`ElementHandle`], …),
+/// not this entry point.
 pub fn invoke_element_method(
     handle: Element,
     method: &str,
@@ -124,9 +136,29 @@ pub fn invoke_element_method_with_params(
     result
 }
 
-/// Typed timing options for [`animate_start`]. Field names mirror the
-/// JS Web-Animations options object (and Lynx's `Element::Animate`
-/// `animation_data` table).
+/// Typed timing options for [`animate_start`].
+///
+/// Field names mirror the JS Web-Animations options object (and Lynx's
+/// `Element::Animate` `animation_data` table). [`Default`] yields a
+/// 300ms linear forwards animation that plays once.
+///
+/// ```ignore
+/// use whisker_driver::{animate_start, AnimateOptions};
+///
+/// animate_start(
+///     handle,
+///     "fade-in",
+///     &[
+///         ("0%",   &[("opacity", "0")]),
+///         ("100%", &[("opacity", "1")]),
+///     ],
+///     &AnimateOptions {
+///         duration_ms: 200,
+///         easing: "ease-out".into(),
+///         ..AnimateOptions::default()
+///     },
+/// )?;
+/// ```
 #[derive(Clone, Debug)]
 pub struct AnimateOptions {
     /// Duration in milliseconds.
@@ -336,8 +368,8 @@ pub fn invoke_element_animate(
 /// The bridge invokes the callback exactly once (synchronously with a
 /// `WhiskerValue::Error` on a precondition / unsupported-platform
 /// failure, asynchronously with the result on success), so the boxed
-/// oneshot sender is always consumed by [`async_trampoline`] — the
-/// caller never recovers it.
+/// oneshot sender is always consumed by the trampoline — the caller
+/// never recovers it.
 pub async fn invoke_element_method_async(
     handle: Element,
     method: &str,
@@ -363,8 +395,8 @@ pub async fn invoke_element_method_async(
     let tx_box: Box<Option<futures_channel::oneshot::Sender<WhiskerValue>>> = Box::new(Some(tx));
     let tx_ptr = Box::into_raw(tx_box) as *mut c_void;
 
-    // Return value is advisory — `async_trampoline` always consumes the
-    // boxed sender (the bridge guarantees one callback either way), so
+    // The bridge guarantees exactly one callback (sync error or async
+    // result), so `async_trampoline` always consumes the boxed sender —
     // we just await the channel.
     let _scheduled = unsafe {
         ffi::whisker_bridge_invoke_element_method_async(

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -331,9 +331,8 @@ impl DynRenderer for BridgeRenderer {
     fn module_component_ptr(&self, handle: Element) -> usize {
         // Cast the per-element `WhiskerElement*` to `usize` so the
         // runtime crate doesn't need to import bridge types. The
-        // driver's `ElementRef::invoke` casts back to
-        // `*mut WhiskerElement` before calling
-        // `whisker_bridge_invoke_element_method`. Phase 7-Φ.H.2.3.
+        // driver's element-method dispatch casts back to
+        // `*mut WhiskerElement` before calling the bridge.
         self.lookup(handle)
             .map(|p| p.as_ptr() as usize)
             .unwrap_or(0)

--- a/crates/whisker-driver/src/module.rs
+++ b/crates/whisker-driver/src/module.rs
@@ -7,7 +7,7 @@
 //! `crates/whisker-driver-sys/bridge/src/`; this module wraps the
 //! raw `WhiskerValueRaw` C-mirror in a typed [`WhiskerValue`]
 //! Rust enum and provides ergonomic [`invoke`] / [`invoke_async`]
-//! callers.
+//! callers, plus the user-facing [`PlatformModule`] handle.
 //!
 //! ## Threading
 //!
@@ -20,26 +20,21 @@
 //! marshal themselves to the main thread (typical UI-platform
 //! contract).
 //!
-//! [`invoke_async`] uses the bridge's async entry point. v1's
-//! implementation dispatches sync; a follow-up wires it through
-//! a worker queue with cancel semantics alongside the first
-//! actual async-API module.
-//!
-//! ## Foundation v1
+//! ## Value model
 //!
 //! [`WhiskerValue`] mirrors the C tagged union but as a safe,
 //! Rust-idiomatic enum. Conversions to the platform side allocate
 //! through `malloc` (matching the bridge's expected ownership);
-//! [`WhiskerValue::from_raw`] copies data OUT of bridge-allocated
-//! buffers so the caller can immediately
+//! [`from_raw`] copies data OUT of bridge-allocated buffers so the
+//! caller can immediately
 //! [`whisker_bridge_value_release`](whisker_driver_sys::whisker_bridge_value_release)
 //! the underlying allocation.
 //!
 //! Errors from the bridge (unknown module, missing method,
-//! exception thrown) surface as the [`WhiskerValue::Error`]
-//! variant carrying a UTF-8 description. The matching
-//! `#[whisker::platform_module]` proc macro layer (Phase 7-Φ.E.5)
-//! folds those into typed `Result<T, ModuleError>` returns.
+//! exception thrown) surface as the [`WhiskerValue::Error`] variant
+//! carrying a UTF-8 description. The matching
+//! `#[whisker::platform_module]` proc macro layer folds those into
+//! typed `Result<T, ModuleError>` returns.
 
 use std::collections::BTreeMap;
 use std::ffi::CString;
@@ -124,6 +119,15 @@ pub fn invoke(name: &str, method: &str, args: Vec<WhiskerValue>) -> WhiskerValue
 /// dispatch through `invoke`, lift the returned `WhiskerValue` into a
 /// typed `Result`). The raw `WhiskerValue` surface stays so a
 /// conversion mistake is loggable rather than silently lost.
+///
+/// ```ignore
+/// let module = whisker::module!("Battery");
+/// match module.invoke("getLevel", vec![]) {
+///     WhiskerValue::Float(level) => println!("battery: {level:.0}%"),
+///     WhiskerValue::Error(msg) => eprintln!("battery dispatch failed: {msg}"),
+///     other => eprintln!("unexpected reply: {other:?}"),
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct PlatformModule {
     name: String,
@@ -292,13 +296,12 @@ impl Drop for ModuleSubscription {
     }
 }
 
-/// Async variant. Resolves once the bridge fires the C callback
-/// with the result.
+/// Async variant of [`invoke`]. Resolves once the bridge fires the C
+/// callback with the result.
 ///
-/// v1 dispatches the work on the bridge's underlying thread (iOS:
-/// global dispatch queue; Android: same-thread for now). Cancel
-/// semantics + worker-pool dispatch land alongside the first
-/// async-API module.
+/// Dispatch happens on the bridge's underlying thread (iOS global
+/// dispatch queue; Android same-thread). No cancel semantics today —
+/// dropping the future leaks the oneshot until the callback fires.
 pub async fn invoke_async(name: &str, method: &str, args: Vec<WhiskerValue>) -> WhiskerValue {
     let module_c = match CString::new(name) {
         Ok(c) => c,
@@ -372,15 +375,13 @@ pub(crate) extern "C" fn async_trampoline(
 
 // ----- Raw conversion plumbing -------------------------------------------
 
-/// Owns the heap allocations a [`WhiskerValue`] tree needs when
-/// it crosses the FFI boundary. The `WhiskerValueRaw`s the
-/// builder produces reference into these allocations; dropping
-/// the builder after the FFI call frees everything.
-#[derive(Default)]
 /// Pinned storage for the heap allocations referenced by a flat
-/// `WhiskerValueRaw[]` handed to the C bridge. Keep the builder
-/// alive until the FFI call returns; the bridge borrows pointers
-/// out of it for the duration of the call.
+/// `WhiskerValueRaw[]` handed to the C bridge.
+///
+/// The `WhiskerValueRaw`s the builder produces hold raw pointers into
+/// these allocations; keep the builder alive until the FFI call
+/// returns, then dropping it frees everything in one shot.
+#[derive(Default)]
 pub(crate) struct RawBuilder {
     /// `CString`s back the `WhiskerValueRaw::s` pointers. The
     /// FFI pointer points to the CString's internal buffer (a


### PR DESCRIPTION
Part of the comment-overhaul sweep (style guide: PR #133).

Applies docs/comment-style.md to crates/whisker-driver (the Lynx bridge + element-method dispatch layer).

## What changed
- User-facing types (ElementRef, ElementHandle, BoundingClientRect, ScrollInfo, ScrollViewHandle, TextHandle, PlatformModule, AnimateOp, AnimateOptions) get expanded rustdoc; ElementHandle / PlatformModule / AnimateOptions now carry concrete `ignore`-fenced usage snippets
- Lynx bridge internals (src/lynx/) get tightened module docs; fn-level docs stay terse since they're contributor-only
- Internal // comments trimmed; bridge invariants + memory notes preserved
- Stale phase-tracker references (Phase 7-Φ.H.2.x, Phase N-3, "v1", "Foundation v1") removed in favour of capability-level descriptions
- Doc-link warnings cleaned up (bound, async_trampoline, element_ref module/fn collision, WhiskerValue::from_raw)

## Test plan
- [x] cargo check -p whisker-driver: clean
- [x] cargo doc --no-deps -p whisker-driver: zero warnings (down from 3 pre-existing)