### PR TITLE
docs(runtime): comment sweep per style guide

### DIFF
--- a/crates/whisker-runtime/src/event.rs
+++ b/crates/whisker-runtime/src/event.rs
@@ -299,7 +299,7 @@ pub struct Size {
     pub height: f64,
 }
 
-// ---- scroll_view -----------------------------------------------------------
+// scroll_view events.
 
 /// `<scroll_view>` scroll events — `scroll`, `scrolltoupper`,
 /// `scrolltolower`, `scrollend`, `contentsizechanged`. The `detail`
@@ -348,7 +348,7 @@ pub struct ScrollDetail {
     pub is_dragging: bool,
 }
 
-// ---- text ------------------------------------------------------------------
+// text events.
 
 /// `layout` on `<text>` — fired after text layout completes.
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/crates/whisker-runtime/src/reactive/arc_signal.rs
+++ b/crates/whisker-runtime/src/reactive/arc_signal.rs
@@ -156,10 +156,6 @@ fn notify_subscribers<T: 'static>(inner: &Rc<ArcSignalInner<T>>) {
     }
 }
 
-// ---------------------------------------------------------------------------
-// ArcRwSignal — combined read/write Arc handle
-// ---------------------------------------------------------------------------
-
 /// Refcount-backed combined read/write signal.
 ///
 /// `Clone` (refcount bump), **not** `Copy`. To pass into multiple
@@ -269,10 +265,6 @@ impl<T: 'static + Clone> ArcRwSignal<T> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// ArcReadSignal — read-only Arc handle
-// ---------------------------------------------------------------------------
-
 /// Refcount-backed read-only handle. Clone-cheap (`Rc` bump),
 /// `!Copy`. The companion to [`ArcRwSignal::read_only`].
 pub struct ArcReadSignal<T: 'static> {
@@ -310,10 +302,6 @@ impl<T: 'static + Clone> ArcReadSignal<T> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// ArcWriteSignal — write-only Arc handle
-// ---------------------------------------------------------------------------
-
 /// Refcount-backed write-only handle. Clone-cheap (`Rc` bump),
 /// `!Copy`. The companion to [`ArcRwSignal::write_only`].
 pub struct ArcWriteSignal<T: 'static> {
@@ -344,10 +332,6 @@ impl<T: 'static> ArcWriteSignal<T> {
         f(&mut self.inner.value.borrow_mut());
     }
 }
-
-// ---------------------------------------------------------------------------
-// Top-level constructor — Solid-style `(read, write)` tuple
-// ---------------------------------------------------------------------------
 
 /// Allocate a fresh Arc-backed signal and split into read/write
 /// halves. The Arc analog of [`signal`](super::signal::signal):

--- a/crates/whisker-runtime/src/reactive/computed.rs
+++ b/crates/whisker-runtime/src/reactive/computed.rs
@@ -45,35 +45,27 @@ use super::{untrack, with_runtime};
 pub fn computed<T: 'static + Clone + PartialEq>(
     mut f: impl FnMut() -> T + 'static,
 ) -> ReadSignal<T> {
-    // We need access to the node id inside the compute closure so it
-    // can write back to its own value slot. Allocate the node first
-    // with a placeholder value of the right type, then replace the
-    // compute with one that knows the id.
-    //
-    // Run the seed inside `untrack` so the read graph it produces
-    // doesn't leak into whatever outer reactive node we may be
-    // constructed inside. The seed exists only to give the cache a
-    // value of the right shape; the real dependency edges are
-    // registered by the explicit `schedule(node_id); flush()` below,
-    // which runs under the scheduler's own tracker scope. Without the
-    // untrack guard, calling `computed(move || sig.get())` from
-    // inside an effect makes that effect a subscriber of `sig` — a
-    // write to `sig` then re-runs the outer effect (often a route /
-    // component mount) and silently leaks a fresh computed node on
-    // every tick.
+    // Seed inside `untrack` so the read graph it produces doesn't
+    // leak into whatever outer reactive node we may be constructed
+    // inside. The seed only initialises the cache; real dependency
+    // edges are registered by the explicit `schedule + flush` below.
+    // Without this guard, calling `computed(move || sig.get())` from
+    // inside an effect makes that effect a subscriber of `sig` — and
+    // a write to `sig` then re-runs the outer effect (often a route /
+    // component mount), silently leaking a fresh computed node every
+    // tick.
     let initial = untrack(&mut f);
     let value: Rc<RefCell<dyn Any>> = Rc::new(RefCell::new(initial));
 
-    // The compute closure needs to be set after we know the NodeId,
-    // since recomputing must write back into the same value slot and
-    // notify subscribers if the new value differs.
+    // Compute closure is set after we know the NodeId, so recomputes
+    // can write back into the same slot and notify subscribers on
+    // change.
     type ComputeCell = Rc<RefCell<Option<Box<dyn FnMut()>>>>;
     let compute_cell: ComputeCell = Rc::new(RefCell::new(None));
     let compute_cell_clone = compute_cell.clone();
     let trampoline: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(move || {
-        // Take ownership of the inner closure, call it, put it back.
-        // Mirrors the scheduler's pattern for the compute Rc itself —
-        // we never hold the cell's borrow across the user closure.
+        // Take/run/put-back so we never hold the cell's borrow across
+        // user code — mirrors the scheduler's pattern for the compute Rc.
         let mut taken = compute_cell_clone.borrow_mut().take();
         if let Some(ref mut inner) = taken {
             inner();
@@ -107,8 +99,8 @@ pub fn computed<T: 'static + Clone + PartialEq>(
         id
     });
 
-    // Now we can build the actual compute closure that knows the node
-    // id and can notify subscribers on value changes.
+    // Real compute closure: knows the node id, writes back to the
+    // value slot, notifies subscribers on change.
     let value_clone = value.clone();
     *compute_cell.borrow_mut() = Some(Box::new(move || {
         let new = f();
@@ -127,7 +119,6 @@ pub fn computed<T: 'static + Clone + PartialEq>(
                     .expect("computed: type mismatch on write-back");
                 *slot = new;
             }
-            // Notify subscribers.
             let subscribers: Vec<NodeId> = with_runtime(|rt| {
                 rt.nodes
                     .get(node_id)
@@ -140,12 +131,10 @@ pub fn computed<T: 'static + Clone + PartialEq>(
         }
     }));
 
-    // First run: register dependencies. We've already computed the
-    // initial value above, but we need a tracked run so the source
-    // graph is populated. Triggering a flush walks the pending queue
-    // which is currently empty, so we'd miss the tracking — instead
-    // we explicitly schedule + flush, which the scheduler will treat
-    // as the first run.
+    // First tracked run: populates the source graph. The initial
+    // value was already cached via the untracked seed above; we
+    // explicitly schedule + flush here because a bare `flush()` over
+    // an empty pending queue would miss tracking.
     scheduler::schedule(node_id);
     scheduler::flush();
 

--- a/crates/whisker-runtime/src/reactive/effect.rs
+++ b/crates/whisker-runtime/src/reactive/effect.rs
@@ -24,10 +24,9 @@ use super::with_runtime;
 /// `Option<R>`-of-previous-value variant from Solid/Leptos is omitted
 /// in v1 — it can be layered on later without breaking this API.
 pub fn effect(f: impl FnMut() + 'static) -> NodeId {
-    // Allocate the node first (with a placeholder compute we replace
-    // before running) so the closure can see its own id if it ever
-    // needs to. The Rc<RefCell<...>> wrapper lets the scheduler clone
-    // a handle out of the runtime in a short borrow.
+    // Wrap in `Rc<RefCell<dyn FnMut()>>` so the scheduler can clone a
+    // handle out of the runtime in a short borrow before invoking
+    // user code (avoiding a runtime double-borrow on re-entrant reads).
     let compute: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(f));
 
     let needs_warning = with_runtime(|rt| rt.current_owner().is_none());
@@ -55,8 +54,8 @@ pub fn effect(f: impl FnMut() + 'static) -> NodeId {
         id
     });
 
-    // Run it immediately so dependencies are recorded and the side
-    // effect runs by the time `effect()` returns.
+    // Synchronous first run: dependencies are recorded and the side
+    // effect has executed by the time `effect()` returns.
     scheduler::schedule(node_id);
     scheduler::flush();
 

--- a/crates/whisker-runtime/src/reactive/prop.rs
+++ b/crates/whisker-runtime/src/reactive/prop.rs
@@ -142,15 +142,13 @@ impl<T: 'static + Clone> Signal<T> {
     }
 }
 
-// ---------------------------------------------------------------------------
 // From impls — the conversions builder methods rely on.
 //
 // `impl<T> From<T> for Signal<T>` is the catch-all "plain value
-// becomes Static" path. The other From impls handle the reactive
-// handles. Per Rust's coherence rules they don't conflict because
-// the source types are concrete (ReadSignal<T>, RwSignal<T>) — they
-// match for the specific generic instantiation, not for any T.
-// ---------------------------------------------------------------------------
+// becomes Static" path; the others handle reactive handles. Coherence
+// holds because the source types are concrete (`ReadSignal<T>`,
+// `RwSignal<T>`) — they match a specific generic instantiation, not
+// any `T`.
 
 impl<T: 'static> From<T> for Signal<T> {
     fn from(v: T) -> Self {
@@ -177,9 +175,8 @@ impl<T: 'static + Clone> From<ReadSignal<T>> for Signal<T> {
 
 impl<T: 'static + Clone> From<RwSignal<T>> for Signal<T> {
     fn from(s: RwSignal<T>) -> Self {
-        // RwSignal and ReadSignal share an arena `NodeId`; convert
-        // by reconstituting the read-only handle. Direct field
-        // access is fine within the same crate.
+        // RwSignal and ReadSignal share an arena `NodeId`; project to
+        // the read-only handle for storage.
         Signal::Dynamic(s.read_only())
     }
 }

--- a/crates/whisker-runtime/src/reactive/signal.rs
+++ b/crates/whisker-runtime/src/reactive/signal.rs
@@ -21,10 +21,6 @@ use super::runtime::{NodeData, NodeId, ReactiveNode, Scope};
 use super::scheduler;
 use super::with_runtime;
 
-// ---------------------------------------------------------------------------
-// Construction
-// ---------------------------------------------------------------------------
-
 /// Allocate a fresh signal in the current owner. Returns a
 /// `(ReadSignal, WriteSignal)` pair — Solid-style separation.
 ///
@@ -55,12 +51,10 @@ fn alloc_signal_node<T: 'static>(initial: T) -> NodeId {
     }
     with_runtime(|rt| {
         let owner = rt.current_owner().unwrap_or_else(|| {
-            // No current owner — fall back to a "global" detached owner.
-            // We create one lazily so primitives created outside of any
-            // explicit `Owner::with` (e.g. in tests, or at app startup
-            // before the first component mounts) still have a place to
-            // live. They will only be freed by `__reset_for_tests` or
-            // explicit dispose.
+            // Detached fallback owner: primitives allocated outside any
+            // `Owner::with` (tests, pre-mount startup) still need a
+            // lifecycle pin; only `__reset_for_tests` / explicit dispose
+            // will free them.
             let detached = rt.owners.insert(Scope::new(None));
             rt.owner_stack.push(detached);
             detached
@@ -78,10 +72,6 @@ fn alloc_signal_node<T: 'static>(initial: T) -> NodeId {
         id
     })
 }
-
-// ---------------------------------------------------------------------------
-// ReadSignal — read-only handle
-// ---------------------------------------------------------------------------
 
 /// Read-only signal handle. `Copy`; safe to clone freely and move
 /// into closures.
@@ -116,11 +106,9 @@ impl<T: 'static> ReadSignal<T> {
     /// expensive to clone or doesn't implement `Clone`.
     pub fn with<R>(self, f: impl FnOnce(&T) -> R) -> R {
         let value = fetch_value(self.id);
-        // First try the arc-backed storage shape (this signal was
-        // built via `RwSignal::from(arc_rw_signal)` or similar). When
-        // present, forward to `ArcRwSignal`'s tracker-aware path
-        // which subscribes through `arc_sources` — the arena
-        // subscribers HashSet stays empty for arc-backed entries.
+        // Arc-backed storage routes through `ArcRwSignal`'s
+        // tracker-aware path, which subscribes via `arc_sources`; the
+        // arena `subscribers` set stays empty for these entries.
         let arc_handle: Option<super::arc_signal::ArcRwSignal<T>> = {
             let borrow = value.borrow();
             borrow
@@ -130,7 +118,6 @@ impl<T: 'static> ReadSignal<T> {
         if let Some(arc) = arc_handle {
             return arc.with(f);
         }
-        // Direct-T storage shape (the canonical `signal()` path).
         track_node(self.id);
         let borrow = value.borrow();
         let typed = borrow
@@ -158,10 +145,6 @@ impl<T: 'static> ReadSignal<T> {
         f(typed)
     }
 }
-
-// ---------------------------------------------------------------------------
-// WriteSignal — write-only handle
-// ---------------------------------------------------------------------------
 
 /// Write-only signal handle. `Copy`. Setting or updating notifies all
 /// subscribers; the notifications are enqueued (not run synchronously)
@@ -200,10 +183,6 @@ impl<T: 'static> WriteSignal<T> {
         write_and_notify(self.id, f, /* notify = */ false);
     }
 }
-
-// ---------------------------------------------------------------------------
-// RwSignal — combined read/write handle
-// ---------------------------------------------------------------------------
 
 /// Combined read-write signal handle. Equivalent to holding both a
 /// `ReadSignal<T>` and `WriteSignal<T>` for the same underlying node.
@@ -331,22 +310,16 @@ impl<T: 'static + Clone> RwSignal<T> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Conversions: Arc-backed handle → arena-backed `Copy` handle
-// ---------------------------------------------------------------------------
+// Conversions: Arc-backed handle → arena-backed `Copy` handle.
 //
-// The standard module pattern: stash an [`ArcRwSignal`] in a
-// `OnceLock` so the value lives for the process; at the API surface,
-// convert to [`RwSignal`] / [`ReadSignal`] / [`WriteSignal`] so the
-// caller gets a `Copy` handle with the same ergonomics as a
-// component-local signal. The resulting arena entry is just a
-// lifecycle pin: when its owner disposes, one Arc strong count
-// decrements, but every other holder (the `OnceLock`, any other
-// component that converted independently, the effects that captured
-// the Arc into their `arc_sources`) keeps the underlying value
-// alive. Reads on the converted handles forward through the Arc, so
-// every handle observes the same value and the same subscriber
-// graph.
+// Module pattern: stash an [`ArcRwSignal`] in a `OnceLock` so the
+// value lives for the process; expose it as [`RwSignal`] /
+// [`ReadSignal`] / [`WriteSignal`] so callers get a `Copy` handle
+// with the same ergonomics as a component-local signal. The arena
+// entry is a lifecycle pin only: when its owner disposes, one Arc
+// strong count decrements but every other holder keeps the value
+// alive. Reads forward through the Arc, so every handle observes the
+// same value and the same subscriber graph.
 
 fn register_arc_in_current_owner<T: 'static>(arc: super::arc_signal::ArcRwSignal<T>) -> NodeId {
     let value: Rc<RefCell<dyn Any>> = Rc::new(RefCell::new(arc));
@@ -416,9 +389,7 @@ impl<T: 'static> From<super::arc_signal::ArcWriteSignal<T>> for WriteSignal<T> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers — keep the runtime borrow window narrow
-// ---------------------------------------------------------------------------
+// Internal helpers — keep the runtime borrow window narrow.
 
 /// Register the current tracker as an arena subscriber of `id`.
 /// Used only for direct-`T` signals (the arc-backed path tracks via
@@ -461,16 +432,15 @@ fn write_and_notify<T: 'static>(id: NodeId, f: impl FnOnce(&mut T), notify: bool
 /// `on_cleanup` callback after the underlying RwSignal's owner has
 /// already freed its nodes.
 fn try_write_and_notify<T: 'static>(id: NodeId, f: impl FnOnce(&mut T), notify: bool) -> bool {
-    // Step 1: pull a clone of the Rc handle in a short borrow.
+    // Short borrow to pull the Rc handle, then drop before mutating.
     let Some(value) = with_runtime(|rt| rt.nodes.get(id).and_then(|n| n.data.value().cloned()))
     else {
         return false;
     };
 
-    // Step 2: branch on storage shape — arc-backed entries forward
-    // to `ArcRwSignal::update` so the change propagates through the
-    // shared inner (every other handle, including the original
-    // `OnceLock`-stashed Arc, sees it).
+    // Arc-backed entries forward to `ArcRwSignal::update` so the
+    // change propagates through the shared inner (every other handle,
+    // including the original `OnceLock`-stashed Arc, sees it).
     let arc_handle: Option<super::arc_signal::ArcRwSignal<T>> = {
         let borrow = value.borrow();
         borrow
@@ -486,8 +456,8 @@ fn try_write_and_notify<T: 'static>(id: NodeId, f: impl FnOnce(&mut T), notify: 
         return true;
     }
 
-    // Step 3: direct-T storage shape — mutate under the borrow,
-    // then schedule arena subscribers.
+    // Direct-T storage: mutate under the borrow, then schedule
+    // arena subscribers.
     {
         let mut borrow = value.borrow_mut();
         let typed = borrow

--- a/crates/whisker-runtime/src/tasks.rs
+++ b/crates/whisker-runtime/src/tasks.rs
@@ -141,22 +141,18 @@ where
             let _ = tx.send(value);
         });
     });
-    // Map the channel error away so the user just awaits `T`.
-    // Cancellation produces a never-resolving future (the dropped
-    // sender path means the user's awaiting task is dead anyway,
-    // so it doesn't matter that we'd panic on `unwrap`). We expose
-    // a custom adapter to avoid that panic in tests where the
-    // receiver lives but the test ends before the worker writes.
+    // Wrap the receiver so user code awaits `T`. Cancellation (sender
+    // dropped because the awaiting owner was disposed) parks the
+    // future forever — the task will be GC'd when its owner cascade
+    // fires.
     BlockingResult { rx }
 }
 
 /// Adapter so `run_blocking`'s return type doesn't leak
 /// `futures_channel::oneshot::Receiver`. Pollable as a
-/// `Future<Output = T>`; if the underlying sender is dropped (owner
-/// disposed mid-fetch), the future resolves to `T::default()` —
-/// **NO**, scratch that — most `T` don't impl `Default`. Instead the
-/// future stays `Pending` forever; the awaiting task is then
-/// garbage-collected when its owner is disposed.
+/// `Future<Output = T>`; if the sender is dropped (owner disposed
+/// mid-fetch) the future parks forever rather than panicking, and the
+/// awaiting task is collected when its enclosing owner cascade fires.
 struct BlockingResult<T> {
     rx: futures_channel::oneshot::Receiver<T>,
 }
@@ -170,10 +166,7 @@ impl<T> Future for BlockingResult<T> {
         use std::task::Poll;
         match std::pin::Pin::new(&mut self.rx).poll(cx) {
             Poll::Ready(Ok(v)) => Poll::Ready(v),
-            // Sender dropped → owner was disposed. Park forever.
-            // The awaiting task will be dropped by the executor
-            // once its enclosing future is itself dropped (e.g.
-            // when the resource's owner cascade fires).
+            // Sender dropped → owner disposed; park forever.
             Poll::Ready(Err(_)) => Poll::Pending,
             Poll::Pending => Poll::Pending,
         }

--- a/crates/whisker-runtime/src/value.rs
+++ b/crates/whisker-runtime/src/value.rs
@@ -174,13 +174,11 @@ impl WhiskerValue {
     }
 }
 
-// ----- Deserialize — lets `WhiskerValue` itself be a target type ----------
-//
-// So a typed event struct can hold an arbitrary sub-tree (a
-// `data-*` dataset, a custom event's `detail`) as a `WhiskerValue`
-// field without leaking `serde_json::Value` into the public event
-// API. Mirrors `serde_json::Value`'s own visitor: each serde scalar
-// / seq / map maps to the matching variant.
+// Deserialize impl: lets a typed event struct hold an arbitrary
+// sub-tree (a `data-*` dataset, a custom event's `detail`) as a
+// `WhiskerValue` field without leaking `serde_json::Value` into the
+// public event API. Mirrors `serde_json::Value`'s own visitor — each
+// serde scalar / seq / map maps to the matching variant.
 impl<'de> Deserialize<'de> for WhiskerValue {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -274,8 +272,6 @@ impl std::fmt::Display for WhiskerModuleError {
 
 impl std::error::Error for WhiskerModuleError {}
 
-// ----- From impls — let callers pass primitives directly ------------------
-
 impl From<()> for WhiskerValue {
     fn from(_: ()) -> Self {
         WhiskerValue::Null
@@ -335,12 +331,10 @@ where
     }
 }
 
-// ----- TryFrom impls — extract primitives back out of WhiskerValue --------
-//
-// Used by `ElementRef::invoke_typed<T>` so authors can write
-// `r.invoke_typed::<f64>("currentTime", vec![])`. The `Error` payload
-// is a `String` so it folds cleanly into `RefError::DispatchFailed.
-// message` without an extra map step.
+// TryFrom impls — used by `ElementRef::invoke_typed<T>` so authors
+// can write `r.invoke_typed::<f64>("currentTime", vec![])`. The
+// `Error` payload is a `String` so it folds cleanly into
+// `RefError::DispatchFailed.message` without an extra map step.
 
 impl TryFrom<WhiskerValue> for () {
     type Error = String;

--- a/crates/whisker-runtime/src/view/into_view.rs
+++ b/crates/whisker-runtime/src/view/into_view.rs
@@ -60,27 +60,13 @@ pub fn mount_children(children: &Children) -> Element {
     ph
 }
 
-// ---------------------------------------------------------------------------
-// Function-shaped prop types for control-flow components
-// ---------------------------------------------------------------------------
+// Function-shaped prop types for control-flow components.
 //
-// These newtypes let `#[component]` annotated control-flow functions
+// These newtypes let `#[component]`-annotated control-flow functions
 // (`For`, `Show`, user-defined ones) accept closure literals via
-// `Into` in the `Props` builder. Each one wraps a `Box<dyn Fn>` so
-// the Props field has a concrete type, and a blanket `From<F>` impl
-// converts any closure with the right signature.
-//
-// The user writes:
-//   ```ignore
-//   For(each: move || items.get(), key: |i| i.id, children: |i| render! { ... })
-//   ```
-// and the macro emits `.each(closure).key(closure).children(closure)`.
-// The `setter(into)` (default in typed-builder) does the boxing.
-
-// Each one wraps `Rc<dyn Fn>` (not `Box<dyn Fn>`) so the newtype is
-// `Clone` — that's a hard requirement of `#[component]` props
-// (which the `#[component]` macro re-clones on every render).
-// `Rc<dyn Fn>` is also what [`Children`] uses for the same reason.
+// `Into` in the typed-builder `Props`. Each wraps `Rc<dyn Fn>` (not
+// `Box`) so the newtype is `Clone` — `#[component]` re-clones every
+// prop on each body invocation, matching what [`Children`] does.
 
 /// `Fn() -> Vec<T>` — the "what items to render" closure for a
 /// keyed-list control flow. Wrapping in a newtype gives typed-builder
@@ -279,10 +265,6 @@ impl View {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Stock IntoView impls
-// ---------------------------------------------------------------------------
 
 impl IntoView for View {
     fn into_view(self) -> View {

--- a/crates/whisker-runtime/src/view/list_mount.rs
+++ b/crates/whisker-runtime/src/view/list_mount.rs
@@ -93,22 +93,20 @@ pub fn list_mount<T, K, ItemsFn, KeyFn, BodyFn>(
     let slots: Rc<RefCell<HashMap<i32, Slot>>> = Rc::new(RefCell::new(HashMap::new()));
     let body = Rc::new(body);
 
-    // (1) Effect: items() → snapshot + count broadcast.
+    // Effect: items() → snapshot + count broadcast. After the count
+    // changes Lynx asks the provider for newly-visible indices and
+    // enqueues out any slot whose index is no longer represented.
     {
         let current_items = current_items.clone();
         effect(move || {
             let new_items = items();
             let count = new_items.len() as i32;
             *current_items.borrow_mut() = new_items;
-            // Tell Lynx the new count. The list will then call the
-            // native provider for any newly-visible index and
-            // `enqueue_component` for any slot whose index is no
-            // longer represented.
             set_update_list_info(handle, count);
         });
     }
 
-    // (2) Native item provider: pulls from `current_items` on demand.
+    // Native item provider: pulls from `current_items` on demand.
     let provider = NativeItemProvider {
         component_at_index: {
             let current_items = current_items.clone();
@@ -119,10 +117,8 @@ pub fn list_mount<T, K, ItemsFn, KeyFn, BodyFn>(
                     Some(t) => t.clone(),
                     None => return INVALID_ITEM_INDEX,
                 };
-                // Each slot lives under its own owner so reactive
-                // effects inside the body (signal subscriptions
-                // etc.) get cleaned up cleanly when the slot is
-                // enqueued out.
+                // Per-slot owner: signal subscriptions inside the
+                // body get cleaned up when the slot is enqueued out.
                 let owner = Owner::new(None);
                 let element = owner.with(|| (body)(item));
                 let sign = element.id() as i32;
@@ -141,12 +137,9 @@ pub fn list_mount<T, K, ItemsFn, KeyFn, BodyFn>(
     };
     install_list_native_item_provider(handle, provider);
 
-    // (3) Cleanup: on owner disposal (e.g. surrounding component
-    // unmount) tear down any slots still alive. The provider itself
-    // is released via the bridge's `trampoline_free` when the list
-    // element dies, which drops the `Box<dyn FnMut>`s — but that
-    // doesn't reach the per-slot owners, so we have to dispose them
-    // here.
+    // The provider's closures are released by the bridge's
+    // `trampoline_free` when the list element dies, which doesn't
+    // reach the per-slot owners — dispose those explicitly here.
     on_cleanup(move || {
         let mut slots = slots.borrow_mut();
         for (_, slot) in slots.drain() {

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -320,10 +320,8 @@ fn with_renderer<R>(f: impl FnOnce(&mut dyn DynRenderer) -> R, default: R) -> R 
     })
 }
 
-// ---------------------------------------------------------------------------
 // Free-function dispatch — what the `render!` macro and reactive
 // effects call.
-// ---------------------------------------------------------------------------
 
 /// Free-fn helper used by the `render!` macro and reactive effects to
 /// allocate an element of any tag the bridge knows. Routes both the
@@ -345,13 +343,10 @@ pub fn create_element_by_name(tag_name: &str) -> Element {
 
 pub fn create_element(tag: ElementTag) -> Element {
     let handle = with_renderer(|r| r.create_element(tag), Element(u32::MAX));
-    // Track the freshly-created element in whichever reactive owner
-    // is currently active. `Owner::dispose` later releases everything
-    // in this list via `release_element`. This is what stops
-    // `BridgeRenderer::elements` (and the underlying Lynx
-    // FiberElement refcounts) from accumulating across `<Show>`
-    // branch flips, `<For>` item removals, and per-component
-    // remounts.
+    // Register the element with the current reactive owner so
+    // `Owner::dispose` releases it. Without this, `BridgeRenderer`'s
+    // element map (and Lynx FiberElement refcounts) accumulate across
+    // `<Show>` flips, `<For>` removals, and component remounts.
     if handle.id() != u32::MAX {
         crate::reactive::with_runtime(|rt| {
             if let Some(owner_id) = rt.current_owner() {
@@ -380,10 +375,6 @@ pub fn release_element(handle: Element) {
     }
     with_renderer(|r| r.release_element(handle), ())
 }
-
-// ---------------------------------------------------------------------------
-// Phantom-element API + hoisting helpers
-// ---------------------------------------------------------------------------
 
 /// Allocate a phantom element — an opaque positional marker the
 /// runtime registers in the mirror but **never** forwards to Lynx.
@@ -601,7 +592,7 @@ pub fn install_list_native_item_provider(
 ///     phantom is later attached to a real ancestor, the same
 ///     replay path handles the queued descendants in source order.
 pub fn append_child(parent: Element, child: Element) {
-    // 1. Mirror update — always.
+    // Mirror update — unconditional.
     CHILDREN_OF.with_borrow_mut(|map| {
         map.entry(parent).or_default().push(child);
     });
@@ -609,21 +600,14 @@ pub fn append_child(parent: Element, child: Element) {
         map.insert(child, parent);
     });
 
-    // 2. Lynx-side effect.
+    // Lynx-side effect depends on phantom-ness of either end.
     let parent_is_phantom = is_phantom(parent);
     let child_is_phantom = is_phantom(child);
     if parent_is_phantom {
-        // Hoist: locate the nearest real ancestor of `parent` (could
-        // be its grandparent or higher). If there isn't one (the
-        // phantom chain is still detached) we leave the bridge
-        // untouched and let the next attach replay things.
-        // `nearest_real_ancestor` already returns `None` when the
-        // phantom chain has no real ancestor (the topmost phantom is
-        // detached). The if-let just skips the bridge step in that
-        // case; the next attach replays things.
+        // Hoist into the nearest real ancestor. When no real ancestor
+        // exists yet (topmost phantom still detached), skip the
+        // bridge step — the next attach will replay things.
         if let Some(real_anc) = nearest_real_ancestor(parent) {
-            // Replay real descendants of `child` (or `child` itself
-            // if it's real) into `real_anc` at the right positions.
             let to_attach: Vec<Element> = if child_is_phantom {
                 collect_transparent_real_descendants(child)
             } else {
@@ -634,26 +618,21 @@ pub fn append_child(parent: Element, child: Element) {
                 bridge_insert_or_append(real_anc, real, pos);
             }
         }
-    } else {
-        // Parent is real.
-        if child_is_phantom {
-            // Phantom child carries a transparent subtree; replay any
-            // real descendants now (in DFS pre-order).
-            for real in collect_transparent_real_descendants(child) {
-                let pos = count_real_descendants_before(parent, real);
-                bridge_insert_or_append(parent, real, pos);
-            }
-        } else {
-            // Both real — straight append on Lynx.
-            with_renderer(|r| r.append_child(parent, child), ());
+    } else if child_is_phantom {
+        // Phantom child carries a transparent subtree; replay any
+        // real descendants now in DFS pre-order.
+        for real in collect_transparent_real_descendants(child) {
+            let pos = count_real_descendants_before(parent, real);
+            bridge_insert_or_append(parent, real, pos);
         }
+    } else {
+        with_renderer(|r| r.append_child(parent, child), ());
     }
 
-    // 3. Notify the component-mount machinery: if `child` is the
-    // body root of a freshly-mounted `#[component]`, this is when
-    // its MountSite learns where it landed (parent + previous
-    // sibling). Hot-reload uses this signal to keep mount sites
-    // anchored across remounts.
+    // Wrapper-less component mount handshake: if `child` is the body
+    // root of a freshly-mounted `#[component]`, its MountSite now
+    // learns where it landed (parent + previous sibling). Hot-reload
+    // remount uses this to keep mount sites anchored across patches.
     crate::reactive::on_component_root_attached(parent, child);
 }
 
@@ -701,19 +680,18 @@ pub fn remove_child(parent: Element, child: Element) {
 /// detached and re-appended, ending up to the right of the new
 /// child. O(siblings_to_move) bridge calls.
 fn bridge_insert_or_append(real_parent: Element, real_child: Element, position: usize) {
-    // 1. Append the child to Lynx — it lands at the tail.
+    // Append lands the child at the tail in Lynx.
     with_renderer(|r| r.append_child(real_parent, real_child), ());
 
-    // 2. Compute the mirror's DFS real-only order of `real_parent`.
-    // The mirror has already been updated before this call so the
-    // result includes `real_child` at the position it should sit
-    // in Lynx.
+    // Mirror already includes the child at its target slot; compute
+    // the DFS real-only order to find the siblings that need to be
+    // rotated past it.
     let real_descendants = collect_transparent_real_descendants(real_parent);
 
-    // 3. Everything after `position` in the mirror order needs to be
-    // detached + re-appended so it ends up to the right of
-    // `real_child` in Lynx. (The "after" slice excludes
-    // `real_child` itself, which sits at `real_descendants[position]`.)
+    // Everything after `position` in mirror order must end up to the
+    // right of `real_child` in Lynx — detach and re-append in order.
+    // The "after" slice excludes `real_child` itself (at
+    // `real_descendants[position]`).
     if position + 1 < real_descendants.len() {
         let to_move: Vec<Element> = real_descendants[position + 1..].to_vec();
         for sib in &to_move {


### PR DESCRIPTION
Part of the comment-overhaul sweep (style guide: PR #133).

Applies docs/comment-style.md to crates/whisker-runtime.

## What changed
- Module rustdoc on lib.rs and major submodules expanded (already in good shape — light touch only)
- Pub items have summary + concept + example + 'why' where non-obvious
- Internal // comments trimmed per keep/delete rules:
  - Removed decorative section banners (`// ---- Setup ----`)
  - Trimmed code-paraphrasing comments
  - Folded multi-line procedure step labels into prose
  - Removed a diary-style entry in `tasks::BlockingResult` rustdoc
- Kept memory-note references, invariant statements, bug references, TODOs with concrete triggers, hot-reload anchor explanations
- No code changes outside comments

## Files touched
- `src/event.rs`, `src/value.rs`, `src/tasks.rs`
- `src/reactive/{signal,computed,effect,prop,arc_signal}.rs`
- `src/view/{renderer,into_view,list_mount}.rs`

## Test plan
- [x] cargo check -p whisker-runtime: clean
- [x] cargo doc --no-deps -p whisker-runtime: 45 warnings (same as baseline; all pre-existing on items not touched)
- [x] cargo test -p whisker-runtime: 117 passed