### PR TITLE
docs(macros, css): comment sweep per style guide

### DIFF
--- a/crates/whisker-css/src/shorthand/border.rs
+++ b/crates/whisker-css/src/shorthand/border.rs
@@ -13,7 +13,7 @@ use crate::keyword::BorderStyle;
 pub struct Border {
     /// Width to apply.
     pub width: Option<LengthPercentage>,
-    /// Css to apply.
+    /// Line style to apply.
     pub style: Option<BorderStyle>,
     /// Color to apply.
     pub color: Option<Color>,

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -28,8 +28,8 @@
 //! time with a clear "required field `xxx` was not set" message.
 //!
 //! The function signature change (positional args → single Props arg)
-//! deliberately breaks the old `xxx(arg1, arg2)` calling convention
-//! (issue #18 Q4): user components must be invoked through `render!`'s
+//! deliberately breaks the old `xxx(arg1, arg2)` calling convention:
+//! user components must be invoked through `render!`'s
 //! `XxxName(kwarg: value)` syntax, which expands to
 //! `XxxName(XxxProps::builder().kwarg(value).build())`.
 
@@ -297,13 +297,10 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
                 let #props_name { #(#prop_idents),* } = __props;
                 #(#captures)*
 
-                // Mirrors the pre-rewrite #[component] body shape
-                // — see `crates/whisker-macros/src/lib.rs`'s
-                // history for the rationale on the two-closure
-                // layering (outer keeps re-clone bookkeeping out
-                // of the subsecond-dispatched inner, which has to
-                // live at the user crate's source position for
-                // hot reload to find it).
+                // Two-closure layering: the outer closure keeps the
+                // re-clone bookkeeping out of the subsecond-dispatched
+                // inner, which has to live at the user crate's source
+                // position for hot reload to find it.
                 let __body: ::std::boxed::Box<
                     dyn ::std::ops::Fn() -> ::whisker::runtime::view::Element + 'static,
                 > = ::std::boxed::Box::new(move || {

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -8,8 +8,8 @@
 //!   `crates/whisker-macros/src/render.rs` for the grammar.
 //! - [`component`] — wraps a function so it runs inside a fresh
 //!   reactive owner. The owner is registered against the function's
-//!   fn pointer so the Strategy C hot-reload path (Phase 6.5a A6)
-//!   can find it. See `docs/reactivity-design.md`.
+//!   fn pointer so the hot-reload remount path can find it. See
+//!   `docs/reactivity-design.md`.
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -128,10 +128,9 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     expanded.into()
 }
 
-/// Phase 6.5a fine-grained renderer macro. Emits imperative
-/// element-creation code that calls into
-/// [`whisker::runtime::view`] through the thread-local installed
-/// renderer, and returns an [`Element`].
+/// Fine-grained renderer macro. Emits imperative element-creation
+/// code that calls into [`whisker::runtime::view`] through the
+/// thread-local installed renderer, and returns an [`Element`].
 ///
 /// ```ignore
 /// use whisker::prelude::*;
@@ -140,15 +139,15 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     view {
 ///         style: "padding: 16px;",
 ///         on_tap: || println!("tapped"),
-///         text { "Hello, world" }
+///         text { value: "Hello, world" }
 ///     }
 /// };
 /// ```
 ///
-/// See `crates/whisker-macros/src/render.rs` for the full grammar
-/// (matches `rsx!`) and the differences from `rsx!`. `{expr}`
-/// interpolation lands in Phase 6.5a A3 Step 3; for now use string
-/// literals or assign to a variable outside the macro.
+/// See `crates/whisker-macros/src/render.rs` for the full kwarg
+/// grammar. Dynamic values flow through `Signal<T>` props; bare
+/// `{expr}` blocks inside a children list are rejected (use
+/// `text(value: <expr>)` instead).
 #[proc_macro]
 pub fn render(input: TokenStream) -> TokenStream {
     render::expand(input)

--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -218,23 +218,13 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
         }
     };
 
-    // Phase 7-Φ.H.2.4 — every platform component implicitly carries
-    // a `__ref: Option<ElementRef<#props_name>>` Props field.
-    // `render!` recognises `ref: <expr>` at the call site and
-    // routes it to the `.with_ref(expr)` setter the macro emits
-    // below. Inside the body we `bind(__handle)` the ref after
-    // creating the element, so the `ElementRef<T>` returned by
-    // `element_ref::<T>()` reaches a live `Element` handle as
-    // soon as the call site hits this code path.
-    //
-    // The marker type for the ref is the Props struct itself
-    // (e.g. `VideoProps`). User code writes
-    // `element_ref::<VideoProps>()` and passes the resulting
-    // handle as the `ref:` kwarg. We picked the Props struct
-    // rather than the PascalCase fn alias because the latter is
-    // a value-namespace re-export (`use ... as Video`), not a
-    // type — `ElementRef<Video>` would fail to resolve to a type
-    // argument.
+    // Every platform component implicitly carries a `__ref:
+    // Option<ElementRef>` Props field. `render!` recognises
+    // `ref: <expr>` at the call site and routes it to the
+    // `.with_ref(expr)` setter the macro emits below. Inside the
+    // body we `bind(__handle)` the ref after creating the element,
+    // so the `ElementRef` reaches a live `Element` handle as soon
+    // as the call site hits this code path.
 
     quote! {
         #[doc(hidden)]
@@ -243,12 +233,9 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
 
             pub struct #props_name {
                 #(#props_fields,)*
-                /// Phase 7-Φ.H.2.4 — implicit `ref:` prop. Bound
-                /// to the freshly-created element inside the
-                /// macro-emitted body. Phase N: the type is the
-                /// non-generic `ElementRef`; the wrapping
-                /// `#[component]` owns it and bridges Handle
-                /// signals through `effect(...)` blocks.
+                /// Implicit `ref:` prop. Bound to the freshly-created
+                /// element inside the macro-emitted body so user code
+                /// can invoke element methods after mount.
                 pub __ref: ::std::option::Option<::whisker::ElementRef>,
             }
 
@@ -271,10 +258,9 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
                 #(#setters)*
 
                 /// Bind an `ElementRef` to this element on mount.
-                /// Phase 7-Φ.H.2.4 — `render!` routes the `ref:`
-                /// kwarg to this setter. Takes the ref by value
-                /// (a `Copy` slotmap-handle) so callers can keep
-                /// theirs for later `invoke` calls.
+                /// `render!` routes the `ref:` kwarg here. Takes
+                /// the ref by value (a `Copy` slotmap handle) so
+                /// callers can keep theirs for later `invoke` calls.
                 pub fn with_ref(
                     mut self,
                     r: ::whisker::ElementRef,
@@ -311,19 +297,18 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
                 // SwiftPM plugin / KSP processor prepends the same
                 // namespace when emitting the matching
                 // `LynxComponentRegistry.registerUI` / `addBehavior`
-                // call, so the lookup matches end-to-end. Phase 7-Φ.H.2.
+                // call, so the lookup matches end-to-end.
                 let __handle = ::whisker::runtime::view::create_element_by_name(
                     concat!(env!("CARGO_PKG_NAME"), ":", #tag_name)
                 );
                 #(#apply_calls)*
-                // Phase N — bind the user-supplied `ElementRef` (if
-                // any) to the freshly-created handle so subsequent
-                // `sys.invoke("play", ...)` calls can route through
-                // the C bridge. Phase N-2 adds the matching
-                // `on_cleanup(...)` that clears the binding on
-                // unmount so post-unmount calls surface as
-                // `RefError::NotBound` rather than dispatching
-                // against a recycled `Element` ID.
+                // Bind the user-supplied `ElementRef` (if any) to the
+                // freshly-created handle so `ref.invoke("play", ...)`
+                // calls route through the C bridge. The matching
+                // `on_cleanup(...)` clears the binding on unmount so
+                // post-unmount calls surface as `RefError::NotBound`
+                // rather than dispatching against a recycled
+                // `Element` ID.
                 if let ::std::option::Option::Some(__r) = props.__ref {
                     __r.__bind(__handle);
                     ::whisker::on_cleanup(move || __r.__unbind());
@@ -543,13 +528,12 @@ fn prop_build_assignment(p: &Prop, tag_name: &str) -> TokenStream2 {
                 })
             }
         }
-        // Phase 7-Φ.H.2 follow-up — Style/Attr props are
-        // optional by default. `Signal<String>` defaults to
-        // `Signal::Static("")` when omitted, matching what Lynx
-        // would see if the attribute wasn't declared. Event
-        // handler props stay required because their `dyn Fn`
-        // types don't have a sensible default and a missing
-        // callback is almost always an author bug.
+        // Style/Attr props are optional by default. `Signal<String>`
+        // defaults to `Signal::Static("")` when omitted, matching
+        // what Lynx would see if the attribute wasn't declared.
+        // Event handler props stay required because their `dyn Fn`
+        // types don't have a sensible default and a missing callback
+        // is almost always an author bug.
         PropKind::Style { .. } | PropKind::Attr { .. } => {
             quote! { #i: self.#i.unwrap_or_default() }
         }

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -216,14 +216,13 @@ impl Parse for Node {
             parenthesized!(body in input);
             while !body.is_empty() {
                 // `Ident::peek_any` / `Ident::parse_any` admits
-                // raw-style identifiers AND Rust keywords. The
-                // latter matters for Phase 7-Φ.H.2.4's `ref:` kwarg
-                // (the most natural call-site name; `ref` itself
-                // is a Rust keyword). Plain `body.peek(Ident)`
-                // would reject `ref` outright; `peek_any` lets it
-                // through as an `Ident` whose text is `"ref"` and
-                // the later `name_str == "ref"` branch routes it
-                // to the `.with_ref(...)` setter.
+                // raw-style identifiers AND Rust keywords. Required
+                // for the `ref:` kwarg (the most natural call-site
+                // name; `ref` itself is a Rust keyword). Plain
+                // `body.peek(Ident)` would reject `ref` outright;
+                // `peek_any` lets it through as an `Ident` whose text
+                // is `"ref"`, and the `name_str == "ref"` branch below
+                // routes it to the `.with_ref(...)` setter.
                 if !body.peek(syn::Ident::peek_any) {
                     return Err(body.error(
                         "kwargs must be `name: expr` — positional arguments \
@@ -405,23 +404,20 @@ impl Node {
 
 impl ElementNode {
     /// Lower a built-in element to a builder chain on
-    /// `::whisker::__tags::<tag>`. Inline-chain form matches the
-    /// earlier-experiment-verified `__tags::__view_ctor().style(…).…__h()`
-    /// shape — no intermediate `let __h = …; __h` binding when the
-    /// element has no children (the let-binding form broke RA's
-    /// receiver-type threading; see `tests/ra_completion.rs`).
+    /// `::whisker::__tags::<tag>`. The inline-chain form
+    /// (`__tags::__view_ctor().style(…).…__h()` with no intermediate
+    /// `let __h = …; __h` binding) is load-bearing: a let-binding
+    /// breaks RA's receiver-type threading and kills kwarg
+    /// completion. See `tests/ra_completion.rs`.
     fn to_tokens(&self) -> TokenStream2 {
         let tag_ident = &self.tag;
         let tag_name = tag_ident.to_string();
         let tag_span = tag_ident.span();
         let ctor_ident = format_ident!("__{}_ctor", tag_ident, span = tag_span);
-        // Inline the entire `::whisker::__tags::__<tag>_ctor()` path
-        // directly into the outer `quote!`s below — same layout as
-        // earlier-experiment compose_a. Storing it into an intermediate
-        // TokenStream and interpolating may capture span/grouping
-        // info differently, which we suspect is why kwarg completion
-        // worked for compose_a but not for render! (same shape on
-        // the surface, different behaviour in practice).
+        // Inline the full `::whisker::__tags::__<tag>_ctor()` path
+        // into the outer `quote!`s below. Storing it into an
+        // intermediate TokenStream and interpolating captures span /
+        // grouping info differently and breaks RA's kwarg completion.
 
         // One `.kwarg(value)` token group per attr, span-anchored
         // at the user's kwarg-name source position so RA's
@@ -432,16 +428,13 @@ impl ElementNode {
             .filter_map(|kw| self.kwarg_to_setter(kw))
             .collect();
 
-        // No more ident-ref side block. Every partial kwarg now
-        // routes through the setter chain as a method call — see
-        // the long comment in `kwarg_to_setter` for the
-        // ra-fixup-vs-prefix-match rationale.
+        // Every partial kwarg routes through the setter chain as a
+        // method call — see the long comment in `kwarg_to_setter`.
         let ident_refs: Vec<TokenStream2> = Vec::new();
         let _ = tag_name;
 
         // Children: each child becomes a `.child({ inner_chain })`
-        // method call on the builder. Same shape verified by the
-        // earlier RA experiments.
+        // method call on the builder.
         let child_calls: Vec<TokenStream2> = self
             .children
             .iter()
@@ -451,9 +444,9 @@ impl ElementNode {
             })
             .collect();
 
-        // No children AND no ident-refs to emit → bare expression
-        // form. Matches the earlier-experiment-verified completion shape
-        // for the partial-kwarg case.
+        // No children AND no ident-refs → bare expression form.
+        // Keeps the chain on RA's happy path for partial-kwarg
+        // completion.
         if child_calls.is_empty() && ident_refs.is_empty() {
             return quote! {
                 {
@@ -507,33 +500,20 @@ impl ElementNode {
         let tag_name = self.tag.to_string();
 
         if name_str == "key" && tag_name != "list" {
-            // `key:` was a For-reconciliation hint historically and
-            // is silently ignored on direct elements. The `list`
-            // render-props builder has its own typed `key` setter
-            // (the key extractor closure for the keyed-list effect),
-            // so we keep the kwarg there.
+            // `key:` on a direct element is a no-op (reconciliation
+            // hint with no semantic effect outside keyed lists). The
+            // `list` builder has its own typed `key` setter for the
+            // keyed-list key extractor closure, so let it through.
             return None;
         }
 
         if kw.partial {
-            // ALWAYS emit a method call for partial kwargs. We
-            // used to gate this behind a prefix-match heuristic
-            // (only emit `.sty(())` if some method name on the
-            // builder started with `sty`), falling through to a
-            // `let _ = name;` ident-ref otherwise so RA could do
-            // identifier completion in the surrounding scope.
-            //
-            // The heuristic broke RA's macro completion when the
-            // partial prefix wasn't a real prefix on its own.
-            // Concretely, RA injects a sentinel suffix at the
-            // cursor (`sty` becomes `stysomething` during the
-            // expansion-for-completion pass) — the prefix check
-            // then resolves to `false` and we fall through to
-            // the ident-ref path, robbing RA of the method-call
-            // shape it needed for kwarg completion. The earlier experiment
-            // proves this: `compose_a!` always emits the method
-            // call and completes correctly; `render!` used the
-            // heuristic and didn't.
+            // ALWAYS emit a method call for partial kwargs. RA
+            // injects a sentinel suffix at the cursor during its
+            // expansion-for-completion pass, so any prefix-match
+            // heuristic (e.g. "only emit `.sty(())` if some builder
+            // method starts with `sty`") sees the suffixed name and
+            // returns false, breaking method-name completion.
             return Some(quote_spanned! {span=> .#name(()) });
         }
 
@@ -728,11 +708,6 @@ fn is_known_event_method(name: &str) -> bool {
     bind_variant || propagation_variant
 }
 
-// ---- Control-flow (Show / For) ------------------------------------------
-
-// (Old `ControlFlowNode` codegen removed — `ForEach` / `Show` now
-// take the standard UserComponent path via `#[component]`.)
-
 // ---- User-component codegen ---------------------------------------------
 
 impl UserComponentNode {
@@ -753,13 +728,10 @@ impl UserComponentNode {
                     // setter shows up under RA's method completion.
                     quote_spanned! {span=> .#name(()) }
                 } else if name_str == "ref" {
-                    // Phase 7-Φ.H.2.4 — `ref:` is the canonical
-                    // call-site name for the implicit ElementRef
-                    // prop. `ref` is a Rust keyword though, so
-                    // typed-builder can't expose `.ref(...)` as a
-                    // setter — the module_component macro emits
-                    // `.with_ref(...)` instead and we re-route
-                    // here.
+                    // `ref:` is the canonical call-site name for the
+                    // implicit ElementRef prop. `ref` is a Rust
+                    // keyword so the setter is exposed as
+                    // `.with_ref(...)`; re-route here.
                     let value = &kw.value;
                     quote_spanned! {span=> .with_ref(#value) }
                 } else {
@@ -769,11 +741,9 @@ impl UserComponentNode {
             })
             .collect();
 
-        // `key` was previously restricted to direct children of
-        // `For`. With `ForEach` now a regular `#[component]` (and
-        // user-defined keyed-list control flow following the same
-        // shape), `key` is just a normal `Props` field — let it
-        // through.
+        // `key` flows as a regular Props field — control-flow
+        // components like `ForEach` are themselves `#[component]`s
+        // and read it directly off `XxxProps`.
 
         let children_call = if self.children.is_empty() {
             quote! {}
@@ -907,8 +877,8 @@ mod tests {
 
     #[test]
     fn no_children_emits_bare_chain_expression() {
-        // Verifies the earlier-experiment-verified "no `let __h =` binding"
-        // shape for the no-children case.
+        // No-children case must stay a bare chain expression — a
+        // `let __h = …; __h` wrapper breaks RA's kwarg completion.
         let input: TokenStream2 = quote::quote! { view(style: "x") };
         let output = super::expand_test(input).to_string();
         assert!(
@@ -932,12 +902,10 @@ mod tests {
 
     #[test]
     fn every_partial_kwarg_emits_method_call() {
-        // All partial kwargs route through `.name(())` now —
-        // even prefixes that don't match any builder method.
-        // (RA injects a sentinel suffix during completion, which
-        // makes a "does this prefix match a method" heuristic
-        // unreliable; always emitting the method-call shape is
-        // what the earlier-experiment compose_a does.)
+        // All partial kwargs route through `.name(())` — even
+        // prefixes that don't match any builder method. RA's
+        // sentinel-suffix injection during completion makes any
+        // "does this prefix match a method" heuristic unreliable.
         let input: TokenStream2 = quote::quote! { view(v) };
         let output = super::expand_test(input).to_string();
         assert!(


### PR DESCRIPTION
Part of the comment-overhaul sweep (style guide: PR #133).

Applies docs/comment-style.md to crates/whisker-macros and crates/whisker-css.

## What changed
- macros: top-level + attribute-macro rustdoc was already comprehensive (usage forms, generated code, error cases). Trimmed outdated phase/diary references in internal `//` comments (`Phase 6.5a`, `Phase 7-Φ.H.2.4`, `earlier-experiment`, "Old `ControlFlowNode` removed" stub) and tightened the surrounding "why" notes
- css: per-item rustdoc + Lynx-quirk warnings on each enum already conform to the guide. Single typo fix on `Border.style` doc
- No code changes outside comments

## Test plan
- [x] cargo check -p whisker-macros -p whisker-css: clean
- [x] cargo doc --no-deps -p whisker-macros -p whisker-css: only pre-existing cross-crate link warnings
- [x] cargo test -p whisker-macros -p whisker-css --lib: 76 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)