### PR TITLE
docs(modules): comment sweep per style guide

### DIFF
--- a/packages/whisker-audio/src/lib.rs
+++ b/packages/whisker-audio/src/lib.rs
@@ -1,13 +1,15 @@
 //! `whisker-audio` — audio playback for Whisker apps.
 //!
-//! View-less module backed by AndroidX Media3 ExoPlayer (Android)
-//! and AVPlayer (iOS). Construct a [`Player`] anywhere a normal Rust
-//! value can live — no element to mount, no `ref:` wiring; the
-//! handle owns a native player instance, releases it on drop, and
-//! exposes a reactive [`PlaybackStatus`] signal driven by native
-//! playback callbacks.
+//! **API shape — 3 (Clone value-type handle).** See
+//! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
+//! §"Shape 3". A view-less native resource: [`Player::new`] returns
+//! a `Clone` handle, methods (`play` / `pause` / `seek_to` / …)
+//! drive the underlying engine, and [`Player::status`] exposes a
+//! reactive [`PlaybackStatus`] signal driven by native playback
+//! callbacks. The native player releases when the last clone drops.
 //!
-//! The API surface mirrors the imperative half of
+//! Backed by AVPlayer (iOS) and AndroidX Media3 ExoPlayer (Android).
+//! The surface mirrors the imperative half of
 //! [Expo's `expo-audio`](https://docs.expo.dev/versions/latest/sdk/audio/):
 //! a player object you call `play` / `pause` / `seek_to` on, plus a
 //! status field that ticks as the underlying engine reports
@@ -46,7 +48,7 @@
 //! }
 //! ```
 //!
-//! ## Shape
+//! ## Implementation notes
 //!
 //! - [`Player`] is `Clone` — internally an `Rc<PlayerInner>`. Each
 //!   clone shares the same native player; the underlying player is
@@ -58,7 +60,14 @@
 //!   every time playback state changes (and at a ~200 ms cadence
 //!   while playing); [`Player::status`] lazily installs the
 //!   dispatch table on first call and routes events to the matching
-//!   handle's [`RwSignal<PlaybackStatus>`].
+//!   handle's signal.
+//!
+//! ## Native source
+//!
+//! Contributors: the matching platform module lives at
+//!
+//! - iOS: `packages/whisker-audio/ios/Sources/WhiskerAudio/AudioModule.swift`
+//! - Android: `packages/whisker-audio/android/src/main/kotlin/rs/whisker/modules/audio/AudioModule.kt`
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
@@ -103,28 +112,38 @@ pub struct PlaybackStatus {
     pub is_playing: bool,
 }
 
-/// Typed handle for one audio player. Cheap to clone (an `Rc`-based
-/// refcount); the underlying native player is released only after
-/// every clone drops.
+/// Typed handle for one audio player. Cheap to clone (`Rc`-based
+/// refcount); the underlying native player releases only after the
+/// last clone drops.
+///
+/// # Example
+///
+/// ```ignore
+/// use whisker_audio::Player;
+///
+/// let player = Player::new("https://example.com/clip.mp3");
+/// player.play();
+/// // Drop the last `player` clone to release the native engine.
+/// ```
+///
+/// Methods are fire-and-forget — the native side reports state
+/// changes through [`Player::status`] rather than method returns.
 #[derive(Clone)]
 pub struct Player {
     inner: Rc<PlayerInner>,
 }
 
-/// The owned half of [`Player`]. Stashes the bridge-side id and
-/// runs `release` from `Drop`, so disposing the owner of the
-/// last clone releases the native player without manual book-
-/// keeping.
+// Owned half of `Player`. Stashes the bridge-side id and runs
+// `release` from `Drop`, so the last clone disposing releases the
+// native player without manual book-keeping.
 struct PlayerInner {
     id: u64,
 }
 
 impl PlayerInner {
     fn invoke(&self, method: &str, mut args: Vec<WhiskerValue>) -> WhiskerValue {
-        // Every dispatch carries the player id as the first arg —
-        // the native side keys its player map on it. Inserting
-        // up-front keeps each caller from having to remember the
-        // calling convention.
+        // Native side keys its player map on arg 0; prepend so
+        // callers don't have to remember the convention.
         args.insert(0, WhiskerValue::Int(self.id as i64));
         module!("WhiskerAudio").invoke(method, args)
     }
@@ -132,10 +151,8 @@ impl PlayerInner {
 
 impl Drop for PlayerInner {
     fn drop(&mut self) {
-        // Best-effort release — if the bridge tears down before us
-        // the invoke fails silently (returns `WhiskerValue::Error`)
-        // and the native player gets cleaned up by the process exit
-        // anyway.
+        // Best-effort: a bridge teardown before us turns this into a
+        // silent `WhiskerValue::Error`; the OS reclaims at exit.
         let _ = module!("WhiskerAudio").invoke("release", vec![WhiskerValue::Int(self.id as i64)]);
         unregister_status(self.id);
     }
@@ -287,23 +304,15 @@ impl Player {
 
 // ---- Process-global status subscription dispatch --------------------------
 
-/// Monotonic source of fresh player ids. The atomic increment lets
-/// any thread that managed to instantiate a `Player` allocate
-/// without coordination; the bridge dispatch path that consumes
-/// the id is main-thread-only.
+// Atomic so any thread that managed to construct a `Player` can
+// allocate; the dispatch path that consumes the id is main-thread-only.
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
-/// Player id → reactive signal. Lives behind an `Rc<RefCell<…>>`
-/// so the bridge-callback closure and the `register_status` insert
-/// path share one table, and the whole thing rides in a
-/// [`MainThreadOnly`] wrapper so the `Sync` bound on `OnceLock<T>`
-/// passes (access is on the bridge's main thread by contract —
-/// same model as `whisker-safe-area`).
+// Shared between the bridge-callback closure and `register_status`
+// inserts. Wrapped in `MainThreadOnly` so `OnceLock<T>`'s `T: Sync`
+// bound passes — see [`MainThreadOnly`] below.
 type StatusEntries = Rc<RefCell<HashMap<u64, ArcRwSignal<PlaybackStatus>>>>;
 
-/// Process-global dispatch table. Wraps [`StatusEntries`] so the
-/// `OnceLock<StatusTable>` `Sync` requirement is satisfied by the
-/// surrounding `MainThreadOnly` rather than by the `Rc` itself.
 struct StatusTable {
     entries: MainThreadOnly<StatusEntries>,
 }
@@ -325,9 +334,8 @@ fn register_status(id: u64) -> ReadSignal<PlaybackStatus> {
     read.into()
 }
 
-/// Remove the entry for `id` from the dispatch table — called from
-/// `PlayerInner::drop` so a long-lived process doesn't accumulate
-/// dead per-player signal slots.
+/// Remove `id` from the dispatch table on player drop so a long-
+/// lived process doesn't accumulate dead per-player slots.
 fn unregister_status(id: u64) {
     if let Some(table) = STATUS_TABLE.get() {
         if let Ok(mut entries) = table.entries.inner.try_borrow_mut() {
@@ -336,10 +344,8 @@ fn unregister_status(id: u64) {
     }
 }
 
-/// One-shot install of the `statusChanged` subscription. The
-/// closure pulls the player id out of the event payload, looks
-/// up the matching signal, and writes the decoded status. Stale
-/// events for ids that were already released are dropped silently.
+/// One-shot install of the `statusChanged` subscription. Stale
+/// events for ids that were already released drop silently.
 fn install_status_listener() -> StatusTable {
     let entries: StatusEntries = Rc::new(RefCell::new(HashMap::new()));
     let entries_for_listener = MainThreadOnly {
@@ -361,17 +367,15 @@ fn install_status_listener() -> StatusTable {
             is_playing: read_bool(&fields, "isPlaying"),
         };
         // Bind the wrapper (not `.inner`) so Rust 2021 disjoint
-        // captures move the `Send + Sync` impl as a whole. Same
-        // dance as `whisker-safe-area` does for its writer.
+        // captures move the `Send + Sync` impl as a whole.
         let table = &entries_for_listener;
         let borrow = table.inner.borrow();
         if let Some(rw) = borrow.get(&id) {
             rw.set(status);
         }
     });
-    // Leak — the listener lives for the process lifetime; dropping
-    // the subscription would also drop the closure pointer the
-    // bridge holds.
+    // Leak: listener lives for the process; dropping the
+    // subscription would also drop the closure the bridge holds.
     std::mem::forget(sub);
     StatusTable {
         entries: MainThreadOnly { inner: entries },
@@ -390,17 +394,16 @@ fn read_bool(fields: &BTreeMap<String, WhiskerValue>, key: &str) -> bool {
     matches!(fields.get(key), Some(WhiskerValue::Bool(true)))
 }
 
-/// Main-thread-only wrapper, same shape as the one in
-/// `whisker-safe-area`. The contract is that every access path
-/// runs on the Lynx TASM thread; the unsafe `Send + Sync` impls
-/// satisfy `OnceLock<T>`'s `T: Sync` bound by asserting that
-/// constraint rather than enforcing it at compile time.
+/// Main-thread-only wrapper (mirrors `whisker-safe-area`'s). Asserts
+/// the Lynx TASM-thread contract so `OnceLock<T>`'s `T: Sync` bound
+/// passes without making `Rc` actually `Sync`.
 #[derive(Clone)]
 struct MainThreadOnly<T> {
     inner: T,
 }
-// Safety: see module docs — every consumer runs on the reactive
-// thread; misuse would corrupt the arena, but that's the standard
-// risk for any signal-touching code off the main thread.
+// Safety: every consumer runs on the reactive thread by contract
+// (the bridge dispatches status events on the main thread). Misuse
+// would corrupt the arena — same risk as any signal-touching code
+// off the main thread.
 unsafe impl<T> Send for MainThreadOnly<T> {}
 unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/packages/whisker-icons/src/lib.rs
+++ b/packages/whisker-icons/src/lib.rs
@@ -1,5 +1,11 @@
 //! `whisker-icons` — Lucide-icons widget for Whisker.
 //!
+//! **API shape — 1 (pure Component) + constants module.** See
+//! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
+//! §"Shape 1". The [`Icon`] component is a pure `whisker_svg::Svg`
+//! forwarder; the icon library itself is exposed as a set of
+//! `pub const &str` items under [`lucide`] (codegen, see `build.rs`).
+//!
 //! ```ignore
 //! use whisker::prelude::*;
 //! use whisker_icons::{Icon, lucide};
@@ -35,6 +41,13 @@
 //! `whisker_icons::heroicons` (or `::phosphor`, …) module can
 //! emit its own constants under its own attribute conventions and
 //! plug into the exact same `Icon`.
+//!
+//! ## Native source
+//!
+//! This crate has no native side — rendering is delegated to
+//! `whisker-svg`, whose platform replayers live at
+//! `packages/whisker-svg/{ios,android}/`. Icon bytes are vendored
+//! under `packages/whisker-icons/vendor/lucide/`.
 
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
@@ -61,8 +74,8 @@ pub fn icon(svg: Signal<String>, color: Signal<String>, size: Signal<String>) ->
         computed(move || {
             let raw = size.get();
             let t = raw.trim();
-            // Recognise the common CSS length units; everything
-            // else is treated as a unit-less pixel count.
+            // Common CSS length units pass through; bare numbers
+            // are treated as `px`.
             let has_unit = ["px", "em", "rem", "%", "vw", "vh"]
                 .iter()
                 .any(|u| t.ends_with(u));
@@ -102,10 +115,8 @@ mod tests {
 
     #[test]
     fn well_known_icons_resolve_to_nonempty_svg() {
-        // Spot-check that the PascalCase rule + the build.rs walk
-        // wired the constants up. If any of these panic at compile
-        // time, the codegen broke; if they pass at runtime, the
-        // icon string actually has bytes.
+        // Compile-time existence checks the PascalCase rule + the
+        // build.rs walk; runtime non-empty checks that bytes landed.
         for (label, body) in [
             ("Heart", lucide::Heart),
             ("ChevronRight", lucide::ChevronRight),
@@ -121,11 +132,8 @@ mod tests {
 
     #[test]
     fn icons_round_trip_through_whisker_svg_compiler() {
-        // The display-list pipeline is the only thing that ever
-        // looks at these strings on a device. If the icon's SVG
-        // shape happens to use something the compiler can't handle
-        // (e.g. an attribute we don't parse), we want a test
-        // failure here, not a silent blank tile on the screen.
+        // The display-list pipeline is the only consumer on-device;
+        // catch compiler-unsupported attrs here, not as a blank tile.
         let sample = [lucide::Heart, lucide::ChevronRight, lucide::AlarmClock];
         for svg in sample {
             let compiled = whisker_svg::compile(svg).expect("compile");

--- a/packages/whisker-image/src/lib.rs
+++ b/packages/whisker-image/src/lib.rs
@@ -1,6 +1,9 @@
 //! `whisker-image` — networked image component.
 //!
-//! Mounts a `whisker-image:Image` element backed by:
+//! **API shape — 1 (pure Component).** See
+//! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
+//! §"Shape 1". All state is captured by props; no imperative
+//! handle. Mounts a `whisker-image:Image` element backed by:
 //!
 //! - **iOS**: `UIImageView` + [Kingfisher](https://github.com/onevcat/Kingfisher)
 //!   for URL fetching, in-memory `NSCache`, and on-disk cache.
@@ -48,6 +51,15 @@
 //!   set on the element (or via flex sizing) — Kingfisher / Coil
 //!   target-size the fetched bitmap against the rendered size, so an
 //!   element with `width: 0; height: 0;` would never paint.
+//!
+//! ## Native source
+//!
+//! Contributors: the matching platform module lives at
+//!
+//! - iOS: `packages/whisker-image/ios/Sources/WhiskerImage/ImageModule.swift`
+//!   (view: `ImageView.swift`)
+//! - Android: `packages/whisker-image/android/src/main/kotlin/rs/whisker/elements/image/ImageModule.kt`
+//!   (view: `WhiskerImageView.kt`)
 
 use whisker::Signal;
 

--- a/packages/whisker-local-store/src/lib.rs
+++ b/packages/whisker-local-store/src/lib.rs
@@ -1,6 +1,13 @@
-//! `whisker-local-store` — reference Whisker platform module.
+//! `whisker-local-store` — persistent string-keyed key-value store.
 //!
-//! Persistent string-keyed key-value store backed by:
+//! **API shape — 5 (Static methods).** See
+//! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
+//! §"Shape 5". Stateless one-shot operations, namespaced under the
+//! unit struct [`WhiskerLocalStore`]. No identity to carry across
+//! calls, no observable state to bind — just `save` / `load` /
+//! `remove`, each returning a `Result`.
+//!
+//! Backed by:
 //!   - **iOS**: `UserDefaults.standard`
 //!   - **Android**: `SharedPreferences` (named `"WhiskerLocalStore"`)
 //!
@@ -9,20 +16,22 @@
 //! data — not for large blobs (use a real file API or database for
 //! anything > ~1 MB per entry).
 //!
-//! The module is also the documented template for first-party
-//! Whisker function-only modules. Shape:
+//! ## Module template
 //!
-//!   - A hand-written typed wrapper — `pub struct WhiskerLocalStore`
-//!     — whose methods (`save` / `load` / `remove`) build the raw
-//!     `Vec<WhiskerValue>` arg list, dispatch via
-//!     `whisker::module!("WhiskerLocalStore").invoke(method, args)`,
-//!     and lift the returned `WhiskerValue` into a typed `Result`.
-//!     This is where validation / defaults / ergonomic types live;
-//!     the framework primitive (`PlatformModule::invoke`) stays a
-//!     `WhiskerValue`-only pass-through.
+//! `whisker-local-store` is also the documented reference for
+//! first-party function-only modules:
+//!
+//! - A hand-written typed wrapper — `pub struct WhiskerLocalStore` —
+//!   whose methods build the raw `Vec<WhiskerValue>` arg list,
+//!   dispatch via
+//!   `whisker::module!("WhiskerLocalStore").invoke(method, args)`,
+//!   and lift the returned `WhiskerValue` into a typed `Result`.
+//!   Validation / defaults / ergonomic types live here; the
+//!   framework primitive (`PlatformModule::invoke`) stays a
+//!   `WhiskerValue`-only pass-through.
 //!
 //! The platform side declares the matching `@WhiskerModule` DSL
-//! (`Name("WhiskerLocalStore")` + module-level `Function`s) — the
+//! (`Name("WhiskerLocalStore")` + module-level `Function`s); the
 //! per-platform codegen registers a dispatch shim under the
 //! crate-namespaced `<crate>:WhiskerLocalStore` key, which is what
 //! `module!` resolves to.
@@ -52,6 +61,15 @@
 //! but Whisker's bridge reports any class-lookup / dispatch
 //! issue through the same channel so callers handle every error
 //! uniformly.
+//!
+//! ## Native source
+//!
+//! Contributors: the matching platform module lives at
+//!
+//! - iOS: `packages/whisker-local-store/ios/Sources/WhiskerLocalStore/LocalStoreModule.swift`
+//!   (storage: `LocalStore.swift`)
+//! - Android: `packages/whisker-local-store/android/src/main/kotlin/rs/whisker/modules/localstore/LocalStoreModule.kt`
+//!   (storage: `LocalStore.kt`)
 
 use whisker::platform_module::{WhiskerModuleError, WhiskerValue};
 
@@ -116,10 +134,8 @@ impl WhiskerLocalStore {
         match result {
             WhiskerValue::Null => Ok(()),
             WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
-            // Be permissive: any non-error return is treated as
-            // success. The platform-side contract for `remove`
-            // is "side effect only, return null", but a stale
-            // return shape shouldn't fail the call.
+            // Permissive: `remove` is documented as side-effect-only
+            // (returns null), but a stale return shape shouldn't fail.
             _ => Ok(()),
         }
     }

--- a/packages/whisker-safe-area/src/lib.rs
+++ b/packages/whisker-safe-area/src/lib.rs
@@ -1,6 +1,12 @@
 //! `whisker-safe-area` — reactive accessor for the host view's
 //! safe-area insets.
 //!
+//! **API shape — 4 (Free fn → signal).** See
+//! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
+//! §"Shape 4". A singleton observable: [`safe_area_insets`] returns
+//! a process-global `ReadSignal<SafeAreaInsets>`, lazily wired to
+//! the native event on first call.
+//!
 //! ## Usage
 //!
 //! ```ignore
@@ -56,6 +62,13 @@
 //! off the native-event subscription; subsequent calls are free.
 //! Values stay live for the entire process — the module never
 //! unsubscribes.
+//!
+//! ## Native source
+//!
+//! Contributors: the matching platform module lives at
+//!
+//! - iOS: `packages/whisker-safe-area/ios/Sources/WhiskerSafeArea/SafeAreaModule.swift`
+//! - Android: `packages/whisker-safe-area/android/src/main/kotlin/rs/whisker/modules/safe_area/SafeAreaModule.kt`
 
 use std::sync::OnceLock;
 
@@ -110,38 +123,31 @@ pub fn safe_area_insets() -> ReadSignal<SafeAreaInsets> {
 
 // ---- Internals -------------------------------------------------------------
 
-/// Slot contents — both halves of the global Arc signal. The read
-/// half is what `safe_area_insets()` hands out (as a converted Copy
-/// `ReadSignal`); the write half stays here so the native event
-/// callback can `set()` through it.
+// Slot contents — both halves of the global Arc signal. The read
+// half is what `safe_area_insets()` hands out; the write half stays
+// here so the native event callback can `set()` through it.
 struct Slot {
     read: MainThreadOnly<ArcReadSignal<SafeAreaInsets>>,
-    /// Held only to keep the write side reachable from the on-event
-    /// callback below — not exposed externally. The `Drop` glue runs
-    /// at process teardown along with the `OnceLock`.
+    // Kept reachable from the on-event closure; never read here.
     #[allow(dead_code)]
     write: MainThreadOnly<ArcWriteSignal<SafeAreaInsets>>,
 }
 
 /// One-shot install of the global signal + the native subscription.
-/// Idempotent — re-entry on subsequent `safe_area_insets()` calls is
-/// a single `OnceLock::get()` check.
+/// Idempotent — re-entry is a single `OnceLock::get()` check.
 ///
 /// The signal is allocated as an [`ArcRwSignal`] so its lifetime is
-/// governed by the [`SLOT`]'s Arc strong count rather than the
-/// caller's owner. The owner that triggered the first call can come
-/// and go without affecting subsequent reads — no `with_detached_owner`
-/// gymnastics, no `panic_cannot_unwind` on a disposed read.
+/// governed by [`SLOT`]'s Arc strong count rather than the caller's
+/// owner; the owner that triggered the first call can come and go
+/// without affecting subsequent reads.
 fn install() {
     SLOT.get_or_init(|| {
         let (read, write) = ArcRwSignal::new(SafeAreaInsets::default()).split();
-        // The bridge's `on_event` callback may fire from any thread
-        // depending on the host; the `ArcWriteSignal` is `!Send`. We
-        // assert main-thread-only via [`MainThreadOnly`] and trust
-        // the platform contract (iOS posts from `safeAreaInsetsDidChange`
-        // on UI thread; Android posts from `OnApplyWindowInsetsListener`
-        // on UI thread). If a future host changes that, swap the
-        // closure body to `run_on_main_thread` first.
+        // `ArcWriteSignal` is `!Send`; both platforms post their
+        // events from the UI thread (iOS `safeAreaInsetsDidChange`,
+        // Android `OnApplyWindowInsetsListener`), so wrap in
+        // `MainThreadOnly` and trust the contract. If a future host
+        // breaks it, route through `run_on_main_thread` first.
         subscribe_to_native(MainThreadOnly {
             inner: write.clone(),
         });
@@ -154,9 +160,8 @@ fn install() {
 
 /// Wire the global signal to the native module's `insetsChanged`
 /// event. The returned `ModuleSubscription` is intentionally leaked
-/// — the signal lives for the process lifetime, so the listener
-/// should too. Letting the subscription `Drop` would also drop the
-/// underlying closure pointer the bridge holds.
+/// — the signal lives for the process lifetime; dropping the
+/// subscription would also drop the closure the bridge holds.
 fn subscribe_to_native(writer: MainThreadOnly<ArcWriteSignal<SafeAreaInsets>>) {
     let module = module!("SafeArea");
     let sub = module.on_event("insetsChanged", move |payload| {
@@ -170,14 +175,12 @@ fn subscribe_to_native(writer: MainThreadOnly<ArcWriteSignal<SafeAreaInsets>>) {
     if let Some(err) = sub.error() {
         eprintln!("[whisker-safe-area] failed to subscribe: {err}");
     }
-    // Leak — see fn doc.
     std::mem::forget(sub);
 }
 
-/// Decode a `{ top, leading, trailing, bottom }` map payload into the
-/// typed struct. Missing or non-numeric keys default to `0.0` — a
-/// malformed message degrades silently rather than wedging the
-/// subscription.
+// Decode a `{ top, leading, trailing, bottom }` map payload. Missing
+// or non-numeric keys default to `0.0` — a malformed message
+// degrades silently rather than wedging the subscription.
 fn decode_payload(value: WhiskerValue) -> Option<SafeAreaInsets> {
     let WhiskerValue::Map(fields) = value else {
         return None;
@@ -197,33 +200,26 @@ fn decode_payload(value: WhiskerValue) -> Option<SafeAreaInsets> {
     })
 }
 
-/// Static slot for the global Arc signal pair. `OnceLock` requires
-/// `Sync`; `ArcReadSignal` / `ArcWriteSignal` are `!Send` / `!Sync`
-/// because the underlying `Rc` is thread-local. We wrap both halves
-/// in [`MainThreadOnly`] to satisfy the bound by asserting main-
-/// thread-only access; the contract is that `safe_area_insets()`
-/// callers run on the main thread (the reactive runtime constraint
-/// already requires that anyway).
+// `OnceLock<T>` requires `T: Sync`; the inner `ArcReadSignal` /
+// `ArcWriteSignal` are `!Send` / `!Sync` because the underlying
+// `Rc` is thread-local. `MainThreadOnly` asserts the contract
+// rather than enforcing it.
 static SLOT: OnceLock<Slot> = OnceLock::new();
 
 /// Locally-scoped wrapper asserting main-thread-only access to
-/// `inner`. Used twice here: once for the static slot (so the
-/// `OnceLock<…>` static-Sync bound is satisfied), once for the
-/// `on_event` closure capture (so the `Send + Sync` bound on the
-/// bridge's callback is satisfied).
-///
-/// Same pattern `whisker-router::AndroidPredictiveBack` uses for its
-/// `Rc<dyn Fn()>` capture — see the comment there for the soundness
-/// argument. Lives here (not in `whisker-runtime`) until the bridge
-/// gains a proper main-thread-only listener API.
+/// `inner`. Used twice: once for the static slot
+/// (`OnceLock<…>: Sync`), once for the `on_event` closure capture
+/// (bridge callback's `Send + Sync`). Mirrors the pattern
+/// `whisker-router::AndroidPredictiveBack` uses for its
+/// `Rc<dyn Fn()>` capture. Lives here (not in `whisker-runtime`)
+/// until the bridge gains a proper main-thread-only listener API.
 #[derive(Copy, Clone)]
 struct MainThreadOnly<T> {
     inner: T,
 }
 // Safety: every access path (signal read in `safe_area_insets`,
-// signal write in the `on_event` callback) is documented to run on
-// the Lynx TASM thread (= Whisker main thread). Misuse would
-// corrupt the reactive arena, but that's the same risk as calling
-// any signal API from a worker thread directly.
+// signal write in the `on_event` callback) runs on the Lynx TASM
+// thread by contract. Misuse would corrupt the reactive arena —
+// same risk as touching any signal API from a worker thread.
 unsafe impl<T> Send for MainThreadOnly<T> {}
 unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/packages/whisker-svg/src/compile.rs
+++ b/packages/whisker-svg/src/compile.rs
@@ -129,13 +129,10 @@ pub fn compile(svg_xml: &str) -> Result<Compiled, CompileError> {
     let mut ctx = Ctx {
         warnings: Vec::new(),
     };
-    // Read paint state off the root `<svg>` itself before walking
-    // its children. Lucide-style icon sets put `fill="none"
-    // stroke="currentColor" stroke-width="2"` on the `<svg>` element
-    // (not on each inner `<path>`), and rely on those cascading
-    // down. Without this step every Lucide icon would draw as a
-    // solid black silhouette (the SVG default fill) instead of the
-    // intended stroke outline.
+    // Read paint state off `<svg>` itself before descending: Lucide
+    // sets `fill="none" stroke="currentColor" stroke-width="2"` on
+    // the root, expecting it to cascade. Skipping this would paint
+    // every Lucide icon as a black silhouette.
     let mut initial_state = PaintState::default();
     update_paint(&root, &mut initial_state, &mut ctx);
     for child in root.children() {
@@ -150,7 +147,7 @@ pub fn compile(svg_xml: &str) -> Result<Compiled, CompileError> {
     })
 }
 
-/// Inherited paint state — `walk()` clones + overrides per element.
+// Inherited paint state — `walk()` clones + overrides per element.
 #[derive(Debug, Clone)]
 struct PaintState {
     fill: Paint,
@@ -162,7 +159,7 @@ struct PaintState {
 impl Default for PaintState {
     fn default() -> Self {
         Self {
-            // SVG default for shapes is black solid.
+            // SVG spec default for shapes is black solid.
             fill: Paint::Color(Color::BLACK),
             stroke: Paint::None,
             stroke_width: 1.0,
@@ -184,13 +181,9 @@ struct Ctx {
 
 fn walk(node: &roxmltree::Node, b: &mut DisplayListBuilder, ctx: &mut Ctx, inherited: &PaintState) {
     let mut state = inherited.clone();
-    // Update paint state from this node's own attributes (inherited
-    // from parent if unset).
     update_paint(node, &mut state, ctx);
 
     let name = node.tag_name().name();
-    // <g> and <svg>-as-inner-group: wrap children in SAVE/RESTORE
-    // so transforms / opacity stack properly.
     if name == "g" {
         b.save();
         if let Some(t) = parse_transform(node.attribute("transform"), ctx) {
@@ -208,7 +201,6 @@ fn walk(node: &roxmltree::Node, b: &mut DisplayListBuilder, ctx: &mut Ctx, inher
         return;
     }
 
-    // Leaf shapes — collect their path commands and emit.
     let cmds = shape_to_path(node, ctx);
     if cmds.is_empty() && name != "defs" && name != "title" && name != "desc" {
         ctx.warnings.push(format!("unsupported element <{name}>"));
@@ -216,7 +208,7 @@ fn walk(node: &roxmltree::Node, b: &mut DisplayListBuilder, ctx: &mut Ctx, inher
     }
 
     if !cmds.is_empty() {
-        // Per-shape SAVE/RESTORE if transform present, so it
+        // SAVE/RESTORE around the shape's own transform so it
         // doesn't leak to siblings.
         let local_t = parse_transform(node.attribute("transform"), ctx);
         if local_t.is_some() {
@@ -246,7 +238,7 @@ fn walk(node: &roxmltree::Node, b: &mut DisplayListBuilder, ctx: &mut Ctx, inher
             (false, false) => b.fill_and_stroke(),
             (false, true) => b.fill(),
             (true, false) => b.stroke(),
-            (true, true) => {} // both none — emit no execution op
+            (true, true) => {} // no paint → no execution op
         }
 
         if local_t.is_some() {
@@ -257,7 +249,7 @@ fn walk(node: &roxmltree::Node, b: &mut DisplayListBuilder, ctx: &mut Ctx, inher
 
 fn emit_paint(b: &mut DisplayListBuilder, s: &PaintState) {
     match s.fill {
-        Paint::None => {} // OP_PATH_FILL won't be emitted either
+        Paint::None => {} // walk() also skips OP_PATH_FILL
         Paint::Color(c) => b.fill_color(c),
         Paint::Tint => b.fill_tint(),
     }
@@ -294,8 +286,8 @@ fn update_paint(node: &roxmltree::Node, s: &mut PaintState, ctx: &mut Ctx) {
     }
 }
 
-/// Look up an attribute by name, falling back to the `style="…"`
-/// declarations. SVG icons in the wild mix the two interchangeably.
+// Look up an attribute by name, falling back to `style="…"`
+// declarations. SVG icons in the wild mix the two interchangeably.
 fn attr_or_style<'a>(node: &'a roxmltree::Node, name: &str) -> Option<&'a str> {
     if let Some(v) = node.attribute(name) {
         return Some(v);
@@ -349,7 +341,8 @@ fn parse_color(s: &str) -> Option<Color> {
             return Some(Color::rgba(r, g, b, a));
         }
     }
-    // Limited named-colour subset — enough for the in-tree fixtures.
+    // Limited named-colour subset — enough for the in-tree fixtures;
+    // expand here if real-world icons start tripping it.
     Some(match s {
         "black" => Color::BLACK,
         "white" => Color::rgb(255, 255, 255),
@@ -481,7 +474,8 @@ fn resolve_viewbox(svg: &roxmltree::Node) -> Option<(f32, f32, f32, f32)> {
             return Some((parts[0], parts[1], parts[2], parts[3]));
         }
     }
-    // Fall back to width / height if both present and unitless.
+    // No viewBox: derive one from `width`/`height` if both are
+    // present and unitless.
     let w = svg.attribute("width").and_then(strip_unit_f32);
     let h = svg.attribute("height").and_then(strip_unit_f32);
     if let (Some(w), Some(h)) = (w, h) {

--- a/packages/whisker-svg/src/lib.rs
+++ b/packages/whisker-svg/src/lib.rs
@@ -1,5 +1,13 @@
 //! `whisker-svg` — inline SVG widget.
 //!
+//! **API shape — 1 (pure Component).** See
+//! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
+//! §"Shape 1". All state is captured by props; no imperative
+//! handle. The user-facing surface is [`Svg`] plus
+//! [`compile`] / [`Compiled`] / [`CompileError`] for callers who
+//! want to drive the compiler directly; everything else under this
+//! crate is `#[doc(hidden)]` internal.
+//!
 //! ```ignore
 //! use whisker::prelude::*;
 //! use whisker_svg::Svg;
@@ -38,15 +46,20 @@
 //! the compiler emits `OP_PAINT_FILL_TINT` / `OP_PAINT_STROKE_TINT`
 //! instead of a literal colour — the replayer substitutes the host's
 //! `color:` value at draw time. See `SPEC.md` §"Tint propagation".
+//!
+//! ## Native source
+//!
+//! Contributors: the matching platform replayer lives at
+//!
+//! - iOS: `packages/whisker-svg/ios/Sources/WhiskerSvg/SvgModule.swift`
+//!   (view: `WhiskerSvgView.swift`, decoder: `DisplayListReplayer.swift`)
+//! - Android: `packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/SvgModule.kt`
+//!   (view: `WhiskerSvgView.kt`, decoder: `DisplayListReplayer.kt`)
 
-// Public API: the `Svg` widget, the user-callable `compile()`
-// entry point, and its result/error types. Everything else under
-// this crate is internal — kept reachable so the crate's own
-// integration tests under `tests/` can exercise it, but flagged
-// `#[doc(hidden)]` so rustdoc / IDE completion don't surface it
-// and consumers don't grow accidental dependencies on the
-// display-list machinery. The SemVer contract is "anything not in
-// rustdoc may change without notice."
+// Modules below are `#[doc(hidden)]` — `pub` for the `tests/` crate
+// integration tests, but not part of the SemVer surface. The
+// user-facing API is `Svg` + `compile` / `Compiled` / `CompileError`
+// re-exported below.
 #[doc(hidden)]
 pub mod builder;
 #[doc(hidden)]
@@ -86,20 +99,17 @@ use whisker::runtime::view::Element;
 ///   `preserveAspectRatio="xMidYMid meet"` semantics.
 #[component]
 pub fn svg(content: Signal<String>, color: Signal<String>, style: Signal<String>) -> Element {
-    // Re-compile on every content change. The closure clones
-    // `content` (Signal isn't Copy because the Static variant
-    // owns its T) so the FnMut `#[component]` body can re-fire
-    // without consuming the prop. The resulting `ReadSignal<String>`
-    // is the base64-cased display list passed to the platform.
+    // Clone `content` before the move closure: `Signal` isn't `Copy`
+    // (the Static variant owns its T), and the `#[component]` body
+    // re-fires as a FnMut.
     let display_list = {
         let content = content.clone();
         computed(move || encode(&content.get()))
     };
 
-    // Same clone trick for the pass-through props — the `render!`
-    // macro internally captures each prop in a Fn closure to set
-    // up reactive re-application, and a non-Copy `Signal` would
-    // be moved out of the outer FnMut on the first re-fire.
+    // Same clone dance for pass-through props — `render!` internally
+    // re-applies via Fn closures, so a non-Copy `Signal` moved on
+    // first fire wouldn't be available on subsequent re-fires.
     render! {
         SvgRenderer(
             display_list: display_list,
@@ -163,14 +173,13 @@ mod tests {
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(&b64)
             .expect("valid base64");
-        // Decoded bytes must start with the SPEC's magic.
         assert_eq!(&bytes[0..4], b"WSDL");
     }
 
     #[test]
     fn invalid_xml_yields_empty_string_not_panic() {
-        // Producer must be forgiving — surfacing CompileError back
-        // through Signal<String> doesn't compose. Stderr is enough.
+        // `encode` must be forgiving — surfacing CompileError through
+        // Signal<String> doesn't compose.
         assert_eq!(encode("<svg>"), "");
     }
 }

--- a/packages/whisker-svg/src/path_parse.rs
+++ b/packages/whisker-svg/src/path_parse.rs
@@ -29,24 +29,18 @@ pub enum PathCommand {
 pub fn parse(d: &str) -> Vec<PathCommand> {
     let mut out: Vec<PathCommand> = Vec::new();
     let mut p = Parser::new(d);
-    // Pen position. Reset by every M / m. Tracked through all
-    // commands so relative offsets resolve correctly.
+    // Pen position — reset by every M/m so relative offsets resolve.
     let mut cx: f32 = 0.0;
     let mut cy: f32 = 0.0;
     // Subpath start — Close returns here.
     let mut sx: f32 = 0.0;
     let mut sy: f32 = 0.0;
-    // Last cubic control point (for S smoothing).
+    // Reflection sources for S (cubic) and T (quad) smoothing.
     let mut last_c2: Option<(f32, f32)> = None;
-    // Last quadratic control point (for T smoothing).
     let mut last_q: Option<(f32, f32)> = None;
-    // Previous explicit command, for repeated implicit commands
-    // (e.g. `M 0 0 10 10` after the initial moveto switches to
-    // implicit LineTo per SVG spec).
     let mut last_cmd: u8 = 0;
 
     while let Some(cmd) = p.peek_command() {
-        // Set the implicit-followup command and skip the letter.
         p.skip_command();
         let mut upper = cmd.to_ascii_uppercase();
         let abs = cmd.is_ascii_uppercase();
@@ -65,10 +59,8 @@ pub fn parse(d: &str) -> Vec<PathCommand> {
                     sy = ty;
                     last_c2 = None;
                     last_q = None;
-                    // Per SVG spec, additional coord pairs after M
-                    // become L (preserving absolute / relative). Switch
-                    // `upper` so the next inner-loop iteration picks
-                    // the L branch instead of repeating M.
+                    // SVG spec: additional coord pairs after M
+                    // become L (preserving abs/rel).
                     upper = b'L';
                     last_cmd = b'L';
                 }
@@ -119,10 +111,9 @@ pub fn parse(d: &str) -> Vec<PathCommand> {
                     last_q = None;
                 }
                 b'S' => {
-                    // Smooth cubic: implicit first control point is the
-                    // reflection of the previous cubic's c2 through the
-                    // pen position (or the pen itself if the previous
-                    // command wasn't a cubic).
+                    // Smooth cubic: implicit c1 is the reflection of
+                    // the previous cubic's c2 through the pen (or the
+                    // pen itself if the previous command wasn't a cubic).
                     let (Some(c2x), Some(c2y), Some(x), Some(y)) =
                         (p.coord(), p.coord(), p.coord(), p.coord())
                     else {
@@ -157,7 +148,7 @@ pub fn parse(d: &str) -> Vec<PathCommand> {
                 b'T' => {
                     // Smooth quad: implicit control point is the
                     // reflection of the previous quad's control through
-                    // the pen position (or the pen itself).
+                    // the pen (or the pen itself).
                     let (Some(x), Some(y)) = (p.coord(), p.coord()) else {
                         break;
                     };
@@ -217,16 +208,14 @@ pub fn parse(d: &str) -> Vec<PathCommand> {
                     cy = sy;
                     last_c2 = None;
                     last_q = None;
-                    // Z takes no coords — break out so the outer loop
-                    // moves to the next command letter.
+                    // Z takes no coords — break to the outer loop.
                     break;
                 }
                 _ => break,
             }
-            // After consuming one command's worth of coords, peek at
-            // the next byte: if it's a digit / sign / dot, SVG repeats
-            // the previous command implicitly. Otherwise drop to the
-            // outer loop so the next letter resets `cmd`.
+            // SVG repeats the previous command implicitly when the
+            // next non-ws byte starts a number; otherwise the outer
+            // loop reads the next command letter.
             if !p.peek_implicit_continuation() {
                 break;
             }
@@ -326,7 +315,7 @@ fn arc_to_cubics(
         dtheta += std::f32::consts::TAU;
     }
 
-    // Split into ≤ 90° pieces and emit cubics.
+    // Step 6: split into ≤ 90° pieces and emit one cubic each.
     let segs = ((dtheta.abs() / (std::f32::consts::FRAC_PI_2)).ceil() as usize).max(1);
     let step = dtheta / segs as f32;
     let k = (4.0 / 3.0) * (step / 4.0).tan();

--- a/packages/whisker-svg/src/replay.rs
+++ b/packages/whisker-svg/src/replay.rs
@@ -147,9 +147,8 @@ pub fn replay<V: Visitor>(bytes: &[u8], visitor: &mut V) -> Result<(), ReplayErr
     }
 }
 
-/// Internal byte-cursor — fans out checked little-endian reads
-/// against the replay loop. Centralised here so a `Truncated` is
-/// produced from one branch.
+// Byte-cursor — fans out checked little-endian reads against the
+// replay loop. Centralised so `Truncated` comes from one branch.
 struct Cursor<'a> {
     buf: &'a [u8],
     pos: usize,
@@ -329,9 +328,9 @@ impl Visitor for TraceVisitor {
     }
 }
 
-/// Compact float formatter for trace output. Strips a trailing
-/// `.0` so `42.0` prints as `42` (matches what humans write in
-/// fixture trace files) and otherwise renders Rust's `{}` form.
+// Compact float formatter for trace output: strips a trailing `.0`
+// (so `42.0` prints `42`, matching hand-written fixtures) and
+// otherwise renders Rust's `{}` form.
 fn fmt_f(v: f32) -> String {
     if v.fract() == 0.0 && v.is_finite() {
         format!("{}", v as i64)

--- a/packages/whisker-video/src/lib.rs
+++ b/packages/whisker-video/src/lib.rs
@@ -1,16 +1,11 @@
-//! `whisker-video` — sample Whisker view module: a `whisker-video:Video`
-//! element backed by AVPlayer (iOS) / Media3 ExoPlayer (Android),
-//! with imperative `play` / `pause` / `seek` methods.
+//! `whisker-video` — video playback element with imperative controls.
 //!
-//! ## Shape
-//!
-//! - `#[whisker::module_component("Video")]` declares the element for
-//!   `render!`. The Lynx tag is `whisker-video:Video` (the crate name
-//!   is auto-prepended).
-//! - `VideoHandle` is the typed, imperative API end-users hold. It
-//!   wraps an `ElementRef` (the element-id handle bound on mount) and
-//!   each method dispatches through `ElementRef::invoke(method, args)`
-//!   — the raw `Vec<WhiskerValue>` wire (case ②).
+//! **API shape — 2 (Component + ref-bound handle).** See
+//! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
+//! §"Shape 2". A native UI element ([`Video`]) plus a typed handle
+//! ([`VideoHandle`]) bound on mount via `ref:`; methods dispatch
+//! through the element handle. Backed by AVPlayer (iOS) and Media3
+//! ExoPlayer (Android).
 //!
 //! ## Usage
 //!
@@ -36,6 +31,28 @@
 //!     }
 //! }
 //! ```
+//!
+//! ## Implementation notes
+//!
+//! - `#[whisker::module_component("Video")]` declares the element for
+//!   `render!`. The Lynx tag is `whisker-video:Video` (the crate name
+//!   is auto-prepended).
+//! - [`VideoHandle`] wraps an `ElementRef` (the element-id handle
+//!   bound on mount); methods dispatch through
+//!   `ElementRef::invoke(method, args)` over the raw
+//!   `Vec<WhiskerValue>` wire.
+//! - No `status()` signal yet — see
+//!   [#128](https://github.com/whiskerrs/whisker/issues/128) for
+//!   the pending observable-state decision.
+//!
+//! ## Native source
+//!
+//! Contributors: the matching platform module lives at
+//!
+//! - iOS: `packages/whisker-video/ios/Sources/WhiskerVideo/VideoModule.swift`
+//!   (view: `VideoView.swift`)
+//! - Android: `packages/whisker-video/android/src/main/kotlin/rs/whisker/elements/video/VideoModule.kt`
+//!   (view: `VideoView.kt`)
 
 use whisker::platform_module::WhiskerValue;
 use whisker::{ElementRef, Signal};


### PR DESCRIPTION
Part of the comment-overhaul sweep (style guide: PR #133).

Applies docs/comment-style.md across all 7 user-facing module crates: whisker-audio, whisker-video, whisker-image, whisker-svg, whisker-icons, whisker-safe-area, whisker-local-store.

## What changed
- Each //! identifies its API shape per docs/module-api-design.md
- Pub items get usable rustdoc per the standard
- Internal // comments trimmed
- No code changes outside comments

## Test plan
- cargo check + cargo doc on all 7 crates: clean