### PR TITLE
docs(router): comment sweep per style guide

### DIFF
--- a/packages/whisker-router-macros/src/lib.rs
+++ b/packages/whisker-router-macros/src/lib.rs
@@ -1,6 +1,8 @@
 //! Procedural macros for `whisker-router`.
 //!
-//! At present the crate exports a single attribute macro:
+//! At present the crate exports a single attribute macro,
+//! re-exported by `whisker-router` as
+//! [`whisker_router::route`](https://docs.rs/whisker-router/latest/whisker_router/attr.route.html):
 //!
 //! ```ignore
 //! use whisker_router::route;
@@ -12,30 +14,70 @@
 //!     Home,
 //!     #[at("/profile/:id")]
 //!     Profile { id: u64 },
+//!     #[at("/blog/:slug/edit")]
+//!     EditPost { slug: String },
 //!     #[at("/settings")]
 //!     Settings,
 //! }
 //! ```
 //!
 //! `#[route]` reads each variant's `#[at("…")]` pattern and generates
-//! a `Route` impl whose `parse` / `to_path` are byte-for-byte equivalent
-//! to the hand-written example in `whisker-router::route::tests`.
+//! a `Route` impl whose `parse` / `to_path` are byte-for-byte
+//! equivalent to the hand-written example in
+//! `whisker_router::route::tests::hand_written_example`.
 //!
-//! Path patterns are split on `/`; segments starting with `:` bind
-//! that variant's named field with the matching name (`:id` → field
-//! `id`). The field's type must implement `FromStr` for `parse` and
-//! `Display` for `to_path` — `u64`, `String`, custom enums all work.
-//! Tuple-struct variants (`Profile(u64)`) aren't supported in v1;
-//! switch to a named-field form (`Profile { id: u64 }`) instead.
+//! ## Path grammar
+//!
+//! - Patterns are split on `/`. A leading `/` is required; a trailing
+//!   `/` is tolerated on input and elided on output.
+//! - `:foo` segments are **parameters** — each binds the variant's
+//!   named field of the same name. The field's type must implement
+//!   `FromStr` (for `parse`) and `Display` (for `to_path`); `u64`,
+//!   `String`, custom enums all work.
+//! - Any other segment is a **literal** — matched verbatim.
+//!
+//! ## Variant kinds
+//!
+//! - **Unit variants** (`Home`) — must use a pattern with no
+//!   parameters (`"/"`, `"/settings"`, ...).
+//! - **Named-field variants** (`Profile { id: u64 }`) — every field
+//!   must be bound by exactly one `:name` segment; every `:name`
+//!   segment must match a field. Field order in the struct and
+//!   `:param` order in the path can differ.
+//! - **Tuple-struct variants** (`Profile(u64)`) — **not supported**
+//!   in v1. The macro emits a `compile_error!` directing you to the
+//!   named-field form.
+//!
+//! ## Errors at the call site
+//!
+//! Compile-time errors fire for: missing `#[at(...)]` on a variant,
+//! parameter naming a non-existent field, named field with no
+//! `:name` binding, tuple-struct variants, and `#[route]` on a
+//! non-enum item. Runtime errors come back as
+//! [`whisker_router::RouteError`](https://docs.rs/whisker-router/latest/whisker_router/enum.RouteError.html).
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, Data, DeriveInput, Fields, LitStr, Variant};
 
-/// `#[route]` attribute on an enum — generates `impl Route for Enum`.
+/// `#[route]` attribute on an enum — generates
+/// `impl whisker_router::route::Route for Enum`.
 ///
-/// See the crate-level docs for the supported variant + path forms.
+/// See the [crate-level docs](self) for the supported variant + path
+/// forms, the path grammar, and the diagnostic surface.
+///
+/// ```ignore
+/// use whisker_router::route;
+///
+/// #[route]
+/// #[derive(Clone, Debug, PartialEq)]
+/// pub enum AppRoute {
+///     #[at("/")]              Home,
+///     #[at("/profile/:id")]   Profile { id: u64 },
+///     #[at("/settings")]      Settings,
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn route(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(item as DeriveInput);
@@ -55,10 +97,9 @@ pub fn route(_attr: TokenStream, item: TokenStream) -> TokenStream {
             Ok(v) => v,
             Err(e) => return e.to_compile_error().into(),
         };
-        // `#[at(...)]` is consumed here — strip it from the variant
-        // so the re-emitted enum doesn't carry an unrecognised
-        // attribute (rustc would reject it; helper-attribute
-        // registration only works on derive macros).
+        // Strip `#[at(...)]` from the re-emitted enum — rustc rejects
+        // unknown attributes, and helper-attribute registration only
+        // works for derive macros (not attribute macros).
         variant.attrs.retain(|a| !a.path().is_ident("at"));
 
         let pattern_segments = split_path(&at.value());
@@ -104,8 +145,8 @@ pub fn route(_attr: TokenStream, item: TokenStream) -> TokenStream {
     expanded.into()
 }
 
-/// Pull the `#[at("…")]` literal off a variant. Variants without one
-/// are rejected — the macro can't reasonably guess a path.
+// Pull the `#[at("…")]` literal off a variant. Variants without one
+// are rejected at compile time — the macro can't guess a path.
 fn read_at(variant: &Variant) -> syn::Result<LitStr> {
     for attr in &variant.attrs {
         if attr.path().is_ident("at") {
@@ -118,8 +159,8 @@ fn read_at(variant: &Variant) -> syn::Result<LitStr> {
     ))
 }
 
-/// `/profile/:id/edit` → `["profile", ":id", "edit"]`.
-/// Empty / "/" path → empty Vec (the "this is the index" case).
+// `/profile/:id/edit` → `["profile", ":id", "edit"]`. Empty / "/"
+// becomes the empty Vec — the "this is the index route" case.
 fn split_path(s: &str) -> Vec<String> {
     let n = s.trim_end_matches('/');
     let n = n.strip_prefix('/').unwrap_or(n);
@@ -130,8 +171,8 @@ fn split_path(s: &str) -> Vec<String> {
     }
 }
 
-/// Generate the two match arms (one for `parse`, one for `to_path`)
-/// for a single variant.
+// Generate the two match arms (one for parse, one for to_path) for
+// a single variant.
 fn build_arms(
     enum_ident: &syn::Ident,
     variant: &Variant,
@@ -140,9 +181,8 @@ fn build_arms(
 ) -> syn::Result<(TokenStream2, TokenStream2)> {
     let variant_ident = &variant.ident;
 
-    // Collect param-name → static-segment information.
-    // A "param" segment is `:foo`; everything else is a literal we
-    // pattern-match on as `&str`.
+    // `:foo` segments are params; everything else is a literal we
+    // pattern-match against as `&str`.
     let mut params: Vec<String> = Vec::new();
     let mut slice_pattern: Vec<TokenStream2> = Vec::new();
     for seg in pattern {
@@ -173,11 +213,9 @@ fn build_arms(
                     #enum_ident::#variant_ident
                 ),
             };
-            let to_path_lit = render_path(pattern, |p| format!("{{{p}}}"));
-            // Unit variants have no field bindings, so render_path's
-            // formatting is just the literal pattern (no params).
+            // Unit variants have no field bindings; render_path's
+            // formatting is just the literal pattern.
             debug_assert!(params.is_empty());
-            let _ = to_path_lit;
             let to_path_arm = build_unit_to_path(pattern, enum_ident, variant_ident);
             Ok((parse_arm, to_path_arm))
         }
@@ -189,9 +227,9 @@ fn build_arms(
                 .collect();
 
             // Every `:foo` must match a field; every field must be
-            // covered by a `:foo`. (Order is the *field declaration*
-            // order in the struct — params can appear in any order
-            // inside the path.)
+            // covered by a `:foo`. Field declaration order is what
+            // the parse arm binds to — `:param` order in the path
+            // can differ.
             for p in &params {
                 if !field_names.iter().any(|f| *f == p) {
                     return Err(syn::Error::new(
@@ -216,7 +254,6 @@ fn build_arms(
                 }
             }
 
-            // parse arm
             let parse_bindings = field_names.iter().map(|f| {
                 let seg_ident = format_ident!("__seg_{}", f);
                 let f_str = f.to_string();
@@ -236,7 +273,6 @@ fn build_arms(
                 }
             };
 
-            // to_path arm
             let to_path_arm = build_named_to_path(pattern, enum_ident, variant_ident, &field_names);
             Ok((parse_arm, to_path_arm))
         }
@@ -248,9 +284,9 @@ fn build_arms(
     }
 }
 
-/// Helper used by debug-formatting code paths inside `build_arms` —
-/// kept generic enough to be reused if we ever want a non-rust
-/// string output. For now only the param-named branch calls it.
+// Walk `pattern`, writing each literal segment verbatim and each
+// `:name` segment through `on_param`. Used by build_named_to_path
+// to construct the `format!` template.
 fn render_path(pattern: &[String], on_param: impl Fn(&str) -> String) -> String {
     let mut out = String::from("/");
     for (i, seg) in pattern.iter().enumerate() {
@@ -293,9 +329,8 @@ fn build_named_to_path(
     variant_ident: &syn::Ident,
     fields: &[&syn::Ident],
 ) -> TokenStream2 {
-    // Build a format! template — `:id` → `{id}`, literals stay as
-    // themselves. The matching `{id}` is fed by the field bindings
-    // unpacked in the match arm.
+    // `:id` → `{id}`, literals stay as themselves. The `{id}` slots
+    // are fed by the field bindings unpacked in the match arm.
     let template = render_path(pattern, |p| format!("{{{p}}}"));
     quote! {
         #enum_ident::#variant_ident { #(#fields),* } => {

--- a/packages/whisker-router/src/back_handler.rs
+++ b/packages/whisker-router/src/back_handler.rs
@@ -1,18 +1,25 @@
-//! [`on_back`] — LIFO back-handler chain.
+//! [`on_back`] — LIFO back-handler chain for ad-hoc consumers.
 //!
-//! Components register a closure that returns `true` if it
-//! consumed the back event, `false` to forward it down the chain.
-//! Walking from most-recently-registered to oldest matches both
-//! React Native's `BackHandler` and Android's
-//! `OnBackPressedDispatcher` priority semantics.
+//! Components register a closure that returns `true` to consume the
+//! back event or `false` to forward it down the chain. Walking from
+//! most-recently-registered to oldest matches both React Native's
+//! `BackHandler` and Android's `OnBackPressedDispatcher` priority
+//! semantics — the modal you just opened wins over the screen
+//! underneath it.
+//!
+//! This is the *imperative* back-handler — useful when a screen
+//! wants to intercept back for confirmation, dismissal of an
+//! in-screen overlay, etc. The structural back path for
+//! [`StackLayout`](crate::StackLayout) is owned by
+//! [`AndroidPredictiveBack`](crate::AndroidPredictiveBack) and
+//! [`IosSwipeBack`](crate::IosSwipeBack) instead.
 
 use std::cell::RefCell;
 use std::rc::Rc;
 
 thread_local! {
-    /// LIFO of registered back handlers. Each entry is wrapped in
-    /// an `Rc` so guards can identify their own slot for removal
-    /// without an O(n) sweep over the closures themselves.
+    // Identified by id rather than by `Rc::ptr_eq` so a guard can
+    // find its own slot for removal without iterating the closures.
     static HANDLERS: RefCell<Vec<HandlerSlot>> = const { RefCell::new(Vec::new()) };
 }
 
@@ -25,19 +32,22 @@ thread_local! {
     static NEXT_ID: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
-/// RAII guard returned by [`on_back`]. Dropping it removes the
-/// handler from the chain — typically called automatically when
-/// the owning component unmounts (via `on_cleanup`).
+/// RAII guard returned by [`on_back`].
+///
+/// Dropping the guard removes the handler from the chain. The usual
+/// pattern is to bind it inside a component body and let the
+/// component's [`on_cleanup`](whisker::runtime::reactive::owner::on_cleanup)
+/// drop it on unmount. Use [`Self::forget`] to detach the guard from
+/// its handler and let the handler outlive the local binding.
 pub struct BackHandlerGuard {
     id: u64,
-    /// Set to `false` by [`Self::forget`] to detach without
-    /// removing the handler from the chain.
     active: bool,
 }
 
 impl BackHandlerGuard {
-    /// Disarm the guard so dropping it does NOT remove the handler.
-    /// Useful when the handler should outlive the local binding.
+    /// Disarm the guard so dropping it does **not** remove the
+    /// handler. The handler then lives for the duration of the
+    /// process (or until [`__reset_for_tests`] is called).
     pub fn forget(mut self) {
         self.active = false;
     }
@@ -58,8 +68,23 @@ impl Drop for BackHandlerGuard {
     }
 }
 
-/// Register a back handler. Returns a [`BackHandlerGuard`] that
-/// removes the handler on drop.
+/// Register a back handler at the top of the LIFO chain.
+///
+/// `handler` should return `true` if it consumed the back press, or
+/// `false` to forward the event to the next handler down the chain
+/// (and, ultimately, to the host platform). The returned
+/// [`BackHandlerGuard`] removes the handler on drop.
+///
+/// ```ignore
+/// let _guard = on_back(|| {
+///     if dialog_open.get() {
+///         dialog_open.set(false);
+///         true
+///     } else {
+///         false
+///     }
+/// });
+/// ```
 pub fn on_back<F>(handler: F) -> BackHandlerGuard
 where
     F: Fn() -> bool + 'static,
@@ -81,12 +106,16 @@ where
 /// Dispatch a back event through the chain.
 ///
 /// Walks from most-recently-registered to oldest, stopping at the
-/// first handler that returns `true`. Returns the same `bool`: the
-/// caller (host platform glue) interprets `false` as "let the OS
-/// handle it" (finish the activity / dismiss the view controller).
+/// first handler that returns `true`. The returned `bool` propagates
+/// the same meaning: the caller (host platform glue) interprets
+/// `false` as "let the OS handle it" — finish the Activity, dismiss
+/// the view controller, etc.
+///
+/// Called by the platform glue when the user invokes the system
+/// back gesture; not generally invoked from user code.
 pub fn dispatch_back() -> bool {
-    // Snapshot the chain so handlers can register/unregister
-    // during dispatch without confusing the iteration.
+    // Snapshot before iterating so handlers may register/unregister
+    // during dispatch without invalidating the walk.
     let snapshot: Vec<Rc<dyn Fn() -> bool>> =
         HANDLERS.with(|h| h.borrow().iter().rev().map(|s| Rc::clone(&s.cb)).collect());
     for cb in snapshot {
@@ -97,8 +126,8 @@ pub fn dispatch_back() -> bool {
     false
 }
 
-/// Test helper: wipe the back-handler chain. Useful between unit
-/// tests since the storage is thread-local.
+/// Test helper: wipe the back-handler chain. Thread-local storage,
+/// so unit tests should call this in setup/teardown.
 #[doc(hidden)]
 pub fn __reset_for_tests() {
     HANDLERS.with(|h| h.borrow_mut().clear());

--- a/packages/whisker-router/src/gestures/android_predictive_back.rs
+++ b/packages/whisker-router/src/gestures/android_predictive_back.rs
@@ -3,42 +3,41 @@
 //!
 //! Mount as a child of the layout. Subscribes to the
 //! `whisker-router:PredictiveBack` native module's `backInvoked`
-//! event (Kotlin side: registers an
+//! event — the Kotlin side registers an
 //! `OnBackPressedDispatcher.OnBackPressedCallback` against the host
-//! Activity). On press, calls [`StackLayoutHandle::back`] to pop the
-//! current entry — the layout's natural route-change effect handles
-//! the backward slide animation.
-//!
-//! Unlike [`IosSwipeBack`](crate::IosSwipeBack) we do NOT use
-//! `commit_preview_and_back`: the predictive-back press is a single
-//! discrete event with no interactive drag, so there's no preview
-//! wrapper to promote — the natural route-change effect, with its
-//! built-in backward animation, is the right path.
+//! Activity. On press, calls [`StackLayoutHandle::back`] to pop the
+//! current entry; the layout's natural route-change effect plays the
+//! backward slide.
 //!
 //! ```ignore
-//! StackLayout(transition: IosSlide::default(), render: render) {
+//! StackLayout(transition: IosSlide::default(), render: render.into()) {
 //!     AndroidPredictiveBack()
 //! }
 //! ```
 //!
-//! Mounting the component while the host Activity has no other back
-//! consumer takes over the system back press. Unmounting (e.g. when
-//! the user pops back to the root of the stack and the component
-//! tears down with the layout) releases it, so the platform's normal
-//! back behaviour (finish the Activity) resumes.
+//! Mounting takes over the system back press while the component is
+//! alive. Unmounting (e.g. when the layout tears down) releases the
+//! callback so the platform's normal back behaviour (finish the
+//! Activity) resumes.
 //!
-//! ## What's NOT here (yet)
+//! Unlike [`IosSwipeBack`](crate::IosSwipeBack) this component does
+//! **not** use `commit_preview_and_back`: a predictive-back press is
+//! a single discrete event with no interactive drag, so there's no
+//! preview wrapper to promote — the natural route-change effect's
+//! built-in backward animation is the right path.
 //!
-//! The current implementation only listens for the commit event —
-//! no interactive preview during the drag. API 34+'s
-//! `BackEventCompat` progress / cancel callbacks would let the layout
-//! pose the outgoing wrapper as the user drags. Adding it means
-//! declaring more events (`backProgressed`, `backCancelled`,
-//! `backStarted`) in the Kotlin module and routing them through
-//! `StackLayoutHandle`'s preview API the same way
-//! [`IosSwipeBack`](crate::IosSwipeBack) does. Out of scope for the
-//! first cut — the commit-only path already drives the layout
-//! transition correctly.
+//! ## What's not here yet
+//!
+//! Only the commit event is wired today — no interactive preview
+//! during the drag. API 34+'s `BackEventCompat` progress / cancel
+//! callbacks would let the layout pose the outgoing wrapper as the
+//! user drags. Adding it means declaring more events
+//! (`backProgressed`, `backCancelled`, `backStarted`) in the Kotlin
+//! module and routing them through
+//! [`StackLayoutHandle`]'s preview API the same way
+//! [`IosSwipeBack`](crate::IosSwipeBack) does.
+//!
+//! [`StackLayoutHandle`]: crate::StackLayoutHandle
 
 use std::rc::Rc;
 
@@ -49,12 +48,14 @@ use whisker::{component, render, use_context};
 use crate::layouts::stack::StackLayoutHandle;
 use whisker::runtime::view::Element;
 
-/// Android predictive-back gesture component.
+/// Android predictive-back gesture component for
+/// [`StackLayout`](crate::StackLayout).
 ///
-/// Mount as a child of [`StackLayout`](crate::StackLayout); reads
-/// the layout handle from context and subscribes to the
-/// `whisker-router:PredictiveBack` module's `backInvoked` event in
-/// the component body. Renders no DOM of its own.
+/// Renders no DOM of its own; reads the
+/// [`StackLayoutHandle`](crate::StackLayoutHandle) from context and
+/// subscribes to the `whisker-router:PredictiveBack` module's
+/// `backInvoked` event. See the [module docs](self) for the
+/// user-facing summary.
 #[component]
 pub fn android_predictive_back() -> Element {
     let handle = use_context::<StackLayoutHandle>()
@@ -64,22 +65,17 @@ pub fn android_predictive_back() -> Element {
     // The bridge stores callbacks in a Send + Sync box (the C side
     // can fire from any thread that calls `module_send_event`). For
     // predictive back the Kotlin sender is always the
-    // `OnBackPressedDispatcher` callback, which runs on the UI
-    // thread — same thread as Whisker's main loop — so the Rc<dyn
-    // Fn> is in practice only touched from one thread.
-    //
-    // To satisfy the type system without paying a per-callback
-    // marshal hop, we wrap the Rc in [`MainThreadOnly`]. Soundness
-    // rests on: every `sendEvent("backInvoked")` originates from
-    // the Kotlin OnBackPressedCallback, which is main-thread.
+    // `OnBackPressedDispatcher` callback on the UI thread — same
+    // thread as Whisker's main loop. `MainThreadOnly` papers over
+    // the type bound without a per-callback marshal hop.
     let holder = MainThreadOnly { inner: back };
 
     let module = module!("PredictiveBack");
     let sub = module.on_event("backInvoked", move |_payload| {
         // Bind `holder` (not `holder.inner`) so Rust 2021 disjoint
-        // closure captures take the wrapper as a whole — moving the
-        // wrapper's `Send + Sync` impls onto the closure. Capturing
-        // only `inner: Rc<...>` would re-introduce the !Sync error.
+        // closure captures move the wrapper as a whole, carrying its
+        // Send + Sync impls. Capturing `.inner: Rc<...>` would
+        // re-introduce the !Sync error.
         let h = &holder;
         (h.inner)();
     });
@@ -88,28 +84,24 @@ pub fn android_predictive_back() -> Element {
         eprintln!("[whisker-router] AndroidPredictiveBack failed to subscribe: {err}");
     }
 
-    // Drop the subscription when the component's owner is disposed
-    // (unmount). The bridge's `module_remove_event_listener` runs
-    // inside `Drop`, so the Kotlin OnStopObserving fires and the
-    // host Activity's back dispatcher releases the callback.
+    // Subscription drop runs `module_remove_event_listener` inside
+    // its Drop impl → Kotlin OnStopObserving fires → host Activity
+    // releases the back dispatcher callback.
     on_cleanup(move || drop(sub));
 
     render! { fragment() }
 }
 
-/// Locally-scoped wrapper that asserts main-thread-only access to
-/// `inner`. The unsafe `Send + Sync` is bounded by the closure
-/// callsite: `AndroidPredictiveBack`'s sole event source is the
-/// Kotlin `OnBackPressedCallback`, which fires on the UI thread.
-///
-/// Lives here (not in `whisker-runtime`) until the bridge gains a
-/// proper main-thread-only listener API. When that lands, this
-/// shim goes away.
+// Asserts main-thread-only access to `inner`. The unsafe Send + Sync
+// is bounded by the gesture's sole event source — the Kotlin
+// OnBackPressedCallback fires on the UI thread, same thread as the
+// Whisker main loop. Lives here until the bridge gains a proper
+// main-thread-only listener API; then this shim goes away.
 struct MainThreadOnly<T> {
     inner: T,
 }
 // Safety: see the type-level comment. Never expose this beyond the
-// gesture module — moving the inner value across threads would
-// break the Rc invariant.
+// gesture module — moving the inner value across threads breaks
+// the Rc invariant.
 unsafe impl<T> Send for MainThreadOnly<T> {}
 unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/packages/whisker-router/src/gestures/ios_swipe_back.rs
+++ b/packages/whisker-router/src/gestures/ios_swipe_back.rs
@@ -3,22 +3,22 @@
 //!
 //! Mount as a child of the layout to enable a UIKit-style horizontal
 //! swipe from the leading edge: the destination screen slides in
-//! from the left with the 30% parallax and brightness dim of
-//! [`IosSlide`](crate::IosSlide), the current screen tracks the
-//! finger to the right, and release past the half-way point commits
-//! the navigation.
+//! from the left with [`IosSlide`](crate::IosSlide)'s 30% parallax
+//! and brightness dim, the current screen tracks the finger to the
+//! right, and release past the half-way point commits the back
+//! navigation.
 //!
 //! ```ignore
-//! StackLayout(transition: IosSlide::default(), render: render) {
+//! StackLayout(transition: IosSlide::default(), render: render.into()) {
 //!     IosSwipeBack()
 //! }
 //! ```
 //!
-//! The component is designed to pair with [`IosSlide`] for visual
-//! consistency. Pairing it with a different transition (e.g.
-//! [`Fade`](crate::Fade)) is allowed but the gesture will still
-//! render an iOS slide pose during the drag — what the natural
-//! transition does outside the gesture is unaffected.
+//! Designed to pair with [`IosSlide`](crate::IosSlide) for visual
+//! consistency. Pairing with a different transition (e.g.
+//! [`Fade`](crate::Fade)) is allowed — the gesture renders the iOS
+//! slide pose during the drag regardless, and the natural transition
+//! is unaffected outside the gesture.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -36,30 +36,27 @@ use crate::layouts::stack::{slot_css, StackLayoutHandle};
 use crate::transitions::ios_slide;
 use crate::transitions::{Direction, Side, StackTransitionBox};
 
-/// Horizontal distance (in points) that maps the gesture to a full
-/// `progress = 1.0`. iPhone 17 Pro is 402pt wide and the wrapper
-/// covers the full viewport, so a 1:1 finger-to-edge ratio wants
-/// this equal to the viewport width. Older iPhones differ by a few
-/// points (375–430pt) — a future revision can read the actual
-/// container width to make this exact across devices.
+// 1:1 finger-to-edge ratio wants this equal to the viewport width.
+// 402pt is iPhone 17 Pro; older iPhones differ by 375-430pt. A
+// future revision can read the actual container width.
 const SWIPE_FULL_DISTANCE_PX: f32 = 402.0;
-/// `clientX` (in points) within which a `touchstart` qualifies as
-/// an edge swipe-back attempt. iOS uses ~20pt; 24pt is generous
-/// without eating into scrollable content.
+// `clientX` within which a touchstart qualifies as an edge swipe.
+// iOS uses ~20pt; 24pt is generous without eating into scroll.
 const SWIPE_EDGE_THRESHOLD_PX: f32 = 24.0;
-/// Progress at touch release above which the gesture commits.
+// Progress at touch release above which the gesture commits.
 const SWIPE_COMMIT_THRESHOLD: f32 = 0.5;
-/// Floor on the touchend finish animation duration.
+// Touchend finish animation duration floor.
 const SWIPE_MIN_FINISH_MS: u32 = 120;
-/// Natural finish duration scaled by the remaining distance.
+// Natural finish duration scaled by remaining distance.
 const SWIPE_FULL_FINISH_MS: u32 = 320;
 
-/// iOS-style edge swipe-back gesture component.
+/// iOS-style edge swipe-back gesture component for
+/// [`StackLayout`](crate::StackLayout).
 ///
-/// Mount as a child of [`StackLayout`](crate::StackLayout); reads
-/// the layout handle and the in-context
-/// [`RouteStack`](crate::RouteStack) and binds the touch handlers
-/// in `on_mount`. Renders no DOM of its own.
+/// Renders no DOM of its own; reads the
+/// [`StackLayoutHandle`](crate::StackLayoutHandle) from context and
+/// binds touch handlers in `on_mount`. See the [module docs](self)
+/// for the user-facing summary.
 #[component]
 pub fn ios_swipe_back() -> Element {
     let layout =
@@ -68,13 +65,11 @@ pub fn ios_swipe_back() -> Element {
 
     on_mount(move || install(&layout, transition.clone()));
 
-    // No visible output — gesture components only attach handlers.
     render! { fragment() }
 }
 
-/// Per-active-gesture state stored in the `gesture` cell. `None`
-/// means no swipe is in flight; the touchstart handler populates
-/// it, touchmove updates it, touchend drains it.
+// `None` = no swipe in flight; touchstart populates, touchmove
+// updates, touchend drains.
 struct GestureState {
     start_x: f32,
     progress: f32,
@@ -89,13 +84,11 @@ fn install(layout: &StackLayoutHandle, transition: StackTransitionBox) {
     let current_wrapper = layout.current_wrapper.clone();
 
     let gesture: Rc<RefCell<Option<GestureState>>> = Rc::new(RefCell::new(None));
-    // Cached preview wrapper between touchstart and the end event
-    // — lets touchmove pose it without going through
-    // `current_wrapper` every frame.
+    // Cache the preview wrapper across the gesture so touchmove
+    // doesn't have to re-resolve through `current_wrapper` per frame.
     let preview_wrapper: Rc<Cell<Option<Element>>> = Rc::new(Cell::new(None));
 
-    // touchstart — qualify the edge swipe, mount the preview
-    // wrapper, capture state.
+    // touchstart — qualify the edge swipe and capture state.
     {
         let gesture = gesture.clone();
         let preview_wrapper = preview_wrapper.clone();
@@ -120,9 +113,8 @@ fn install(layout: &StackLayoutHandle, transition: StackTransitionBox) {
                 return;
             }
 
-            // `mount_preview` returns the just-below-top wrapper from
-            // the back stack. `None` means the stack is at its root
-            // (`back` would be invalid) — abort the gesture.
+            // `None` = stack at the root, no back-target to reveal —
+            // abort the gesture.
             let Some(wrapper) = mount_preview() else {
                 return;
             };
@@ -152,8 +144,7 @@ fn install(layout: &StackLayoutHandle, transition: StackTransitionBox) {
         });
     }
 
-    // touchmove — translate finger displacement into progress and
-    // re-pose preview + current each frame.
+    // touchmove — finger delta → progress, re-pose each frame.
     {
         let gesture = gesture.clone();
         let preview_wrapper = preview_wrapper.clone();
@@ -203,9 +194,9 @@ fn install(layout: &StackLayoutHandle, transition: StackTransitionBox) {
     }
 
     // touchend / touchcancel — drive the finish through Lynx's
-    // animator (short duration, `fill: forwards`). Inline writes
-    // during a string of rapid touch-move updates were getting
-    // dropped/coalesced — the animator path always takes hold.
+    // animator (short duration, fill: forwards). Inline writes get
+    // dropped/coalesced under rapid touchmoves; the animator path
+    // always takes hold.
     for end_name in ["touchend", "touchcancel"] {
         let gesture = gesture.clone();
         let preview_wrapper = preview_wrapper.clone();
@@ -258,13 +249,11 @@ fn install(layout: &StackLayoutHandle, transition: StackTransitionBox) {
     }
 }
 
-/// Cancel any natural-transition animation that might still be
-/// holding `element` at its end pose via `fill: forwards`.
-///
-/// Without this, inline `transform` set during a drag is overridden
-/// by the prior animation rule's computed style and the element
-/// won't move at all. Lynx no-ops on cancel-of-nonexistent so the
-/// shotgun-cancel is cheap.
+// Cancel any prior natural-transition animation. Without this, the
+// previous animation's `fill: forwards` keeps the element at its end
+// pose and shadows inline writes — the drag would appear frozen.
+// Lynx no-ops on cancel-of-nonexistent, so the shotgun-cancel is
+// cheap.
 fn clear_natural_animations(element: Element) {
     for name in [
         "stack-ios-incoming-forward",
@@ -278,14 +267,10 @@ fn clear_natural_animations(element: Element) {
     }
 }
 
-/// Apply the iOS slide pose for `progress` to `element` as an
-/// inline style, alongside the transition's [`slot_style`] and the
-/// layout's base [`slot_css`].
-///
-/// Inline styles take effect only once any active CSS animation is
-/// cancelled — Lynx's animator with `fill: forwards` (which the
-/// natural push/pop uses) clamps the element to its end pose and
-/// shadows out-of-band style writes.
+// Write the iOS slide pose at `progress` inline, alongside the
+// transition's `slot_style` and the layout's base `slot_css`. Inline
+// styles only take effect after the active CSS animation is
+// cancelled (see `clear_natural_animations`).
 fn apply_pose(
     element: Element,
     transition: &dyn crate::transitions::StackTransition,
@@ -308,10 +293,9 @@ fn apply_pose(
     set_inline_styles(element, &style);
 }
 
-/// Animate `element` from the pose at `from_progress` to the pose
-/// at `to_progress` using Lynx's animator. `fill: forwards` keeps
-/// the element at the end pose after the animation completes; the
-/// caller doesn't have to listen for `animationend`.
+// Animate `element` from the pose at `from_progress` to the pose at
+// `to_progress` using Lynx's animator. `fill: forwards` keeps the
+// element at the end pose without an `animationend` listener.
 #[allow(clippy::too_many_arguments)]
 fn animate_to_pose(
     element: Element,

--- a/packages/whisker-router/src/gestures/mod.rs
+++ b/packages/whisker-router/src/gestures/mod.rs
@@ -1,20 +1,22 @@
-//! Gesture / back-handler components for [`StackLayout`](crate::StackLayout).
+//! Gesture / back-handler components for
+//! [`StackLayout`](crate::StackLayout).
 //!
-//! Interactive behaviour — iOS edge swipe-back, Android system back,
-//! predictive back, hardware keys — is implemented as **composable
-//! components** rather than baked into the transition trait.
-//!
-//! Mount them as children of [`StackLayout`](crate::StackLayout):
+//! Interactive back behaviour — iOS edge swipe-back, Android system
+//! back — is implemented as **composable components** rather than
+//! baked into [`StackTransition`](crate::StackTransition). Mix and
+//! match them as children of [`StackLayout`](crate::StackLayout):
 //!
 //! ```ignore
-//! StackLayout(transition: IosSlide::default(), render: render) {
+//! StackLayout(transition: IosSlide::default(), render: render.into()) {
 //!     IosSwipeBack()
+//!     AndroidPredictiveBack()
 //! }
 //! ```
 //!
 //! Each component reads the [`StackLayoutHandle`](crate::StackLayoutHandle)
-//! from context and uses [`router::<R>()`](crate::router) to drive
-//! the stack.
+//! from context and drives the stack through it — they render no DOM
+//! of their own. Pairing both is safe: each component is a no-op on
+//! the platform it doesn't target.
 
 pub mod android_predictive_back;
 pub mod ios_swipe_back;

--- a/packages/whisker-router/src/layouts/mod.rs
+++ b/packages/whisker-router/src/layouts/mod.rs
@@ -1,10 +1,24 @@
-//! Layout components: `StackLayout`, `TabsLayout`, `ModalLayout`.
+//! Layout components — render the current
+//! [`RouteStack`](crate::RouteStack) in a particular shape.
 //!
-//! Each layout consumes one variant of a parent route enum and
-//! decides how to render its slice (stack push/pop semantics, tab
-//! switching, modal presentation). They are intentionally
-//! standalone components — users can implement their own layout
-//! by following the same pattern (route variant in, element out).
+//! Each layout consumes the in-context stack via
+//! [`router::<R>()`](crate::router) and decides how to display its
+//! contents:
+//!
+//! - [`StackLayout`] — back-stack-preserving stack navigator with
+//!   pluggable [`StackTransition`](crate::StackTransition) animation.
+//!   The default for screen-stack navigation.
+//! - [`TabsLayout`] — keep-alive tab switcher driven by per-tab
+//!   predicates; combine with nested [`StackLayout`]s for
+//!   tab-per-stack patterns.
+//! - [`ModalLayout`] — slide-from-bottom modal sheet with scrim.
+//! - [`Pane`] — display-toggleable container; the building block
+//!   that powers [`TabsLayout`] internally and is useful for custom
+//!   keep-alive layouts.
+//!
+//! Layouts are intentionally standalone components. Users can
+//! implement their own (route value in, element out) by following
+//! the same pattern.
 
 pub mod modal;
 pub mod pane;

--- a/packages/whisker-router/src/layouts/modal.rs
+++ b/packages/whisker-router/src/layouts/modal.rs
@@ -1,12 +1,22 @@
-//! `ModalLayout` — slide-from-bottom modal presentation driven by
-//! Lynx's native animator via [`animate_start`].
+//! [`ModalLayout`] — slide-from-bottom modal presentation.
 //!
-//! On mount the sheet slides up from below the viewport over the
-//! same `slot_wrapper + on_mount + animate_start` pattern
-//! [`StackLayout`] uses. A scrim sits beneath as a fixed-opacity
-//! overlay (no fade animation for v1 — Lynx's animator chokes on
-//! same-frame opacity transitions in our wrapper-less setup; the
-//! sheet slide is the dominant cue).
+//! On mount the sheet slides up from below the viewport via Lynx's
+//! native animator. A scrim sits beneath as a fixed-opacity overlay
+//! (no fade animation in v1 — Lynx's animator chokes on same-frame
+//! opacity transitions in our wrapper-less setup; the sheet slide is
+//! the dominant cue).
+//!
+//! Unlike [`StackLayout`](crate::StackLayout) the modal is driven by
+//! a single route value rather than a stack — used as a leaf of an
+//! [`Outlet`](crate::Outlet) or as a sibling of a stack, not as a
+//! navigator in its own right.
+//!
+//! ```ignore
+//! ModalLayout(route: AppRoute::ProfileSheet, render: |r| match r {
+//!     AppRoute::ProfileSheet => render! { ProfileSheet() },
+//!     _ => render! { fragment() },
+//! }.into())
+//! ```
 
 use std::rc::Rc;
 
@@ -24,12 +34,17 @@ const DEFAULT_DURATION_MS: u32 = 320;
 const DEFAULT_EASING: &str = "ease-out";
 const SCRIM_RGBA: (u8, u8, u8, f32) = (0, 0, 0, 0.45);
 
-/// Type-erased renderer for a single modal route.
+/// Function prop for [`ModalLayout`]: maps a route value to its
+/// rendered element.
+///
+/// Same shape as [`RouteRenderFn`](crate::RouteRenderFn) but kept
+/// separate so the prop type is explicit at the call site. Use the
+/// [`From`] impl: `(|r: AppRoute| ...).into()`.
 #[derive(Clone)]
 pub struct ModalRenderFn<R: Route>(pub Rc<dyn Fn(R) -> Element + 'static>);
 
 impl<R: Route> ModalRenderFn<R> {
-    /// Invoke the renderer with `route`.
+    /// Invoke the renderer with `route` and return the element.
     pub fn call(&self, route: R) -> Element {
         (self.0)(route)
     }
@@ -45,8 +60,13 @@ where
     }
 }
 
-/// Modal presentation — single route, slide-up entry via
-/// `animate_start`.
+/// Slide-from-bottom modal sheet.
+///
+/// Renders `route` through `render` inside a sheet that animates
+/// up from below the viewport on mount. A dimmed scrim sits behind
+/// the sheet. The sheet does not interact with a
+/// [`RouteStack`](crate::RouteStack) — callers control presentation
+/// by mounting / unmounting `ModalLayout` themselves.
 #[component]
 pub fn modal_layout<R: Route>(route: R, render: ModalRenderFn<R>) -> Element {
     let container = create_element(ElementTag::View);
@@ -57,8 +77,8 @@ pub fn modal_layout<R: Route>(route: R, render: ModalRenderFn<R>) -> Element {
     append_child(container, scrim);
 
     let sheet = create_element(ElementTag::View);
-    // Start the sheet offscreen-bottom so the very first paint shows
-    // it at translateY(100%); the on_mount animation slides it to 0.
+    // First paint at translateY(100%); the on_mount animation
+    // slides it to 0.
     apply_styles(sheet, sheet_css_initial().to_css_string());
     append_child(container, sheet);
 

--- a/packages/whisker-router/src/layouts/pane.rs
+++ b/packages/whisker-router/src/layouts/pane.rs
@@ -1,14 +1,18 @@
-//! `Pane` — display-toggleable container that keeps its children
+//! [`Pane`] — display-toggleable container that keeps its children
 //! mounted while hidden.
 //!
-//! Tabs are the canonical caller: each tab's content lives inside
-//! a `Pane`, only one is visible at a time, and the inactive
-//! panes' state (scroll position, form inputs, in-flight effects)
-//! survives the switch because their elements are never unmounted.
+//! The building block behind [`TabsLayout`](crate::TabsLayout). Use
+//! directly when you want keep-alive semantics without `TabsLayout`'s
+//! `(matches, content)` shape — e.g. a master-detail surface where
+//! one of two panes is shown at a time without unmounting the other.
+//!
+//! Inactive panes' state (scroll position, form input, in-flight
+//! effects) survives the toggle because their elements are never
+//! unmounted — only their `display` flips between `flex` and `none`.
 //!
 //! ```ignore
 //! use whisker::prelude::*;
-//! use whisker_router::layouts::Pane;
+//! use whisker_router::Pane;
 //!
 //! let tab = RwSignal::new(Tab::Home);
 //!
@@ -29,8 +33,11 @@ use whisker::{component, computed, Children, WhenFn};
 /// Container that toggles between `display: flex` (children visible)
 /// and `display: none` (children hidden but still mounted).
 ///
-/// `visible` is a `Fn() -> bool` — the call site writes a closure
-/// over its reactive deps, same shape as `Show`'s `when`.
+/// `visible` is a `Fn() -> bool` — same shape as [`whisker::Show`]'s
+/// `when`, so the call site writes a closure over its reactive
+/// dependencies.
+///
+/// See the [module docs](self) for a tabbed-pane example.
 #[component]
 pub fn pane(visible: WhenFn, children: Children) -> Element {
     let visible = visible.clone();

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -1,43 +1,54 @@
-//! `StackLayout` — back-stack-preserving stack navigator.
+//! [`StackLayout`] — back-stack-preserving stack navigator with
+//! pluggable animation.
 //!
 //! Behaviour matches the established native stack-navigator semantics
 //! (iOS `UINavigationController`, Android Fragment back stack, React
 //! Navigation): every entry currently in the
 //! [`RouteStack`](crate::RouteStack) stays **mounted** in the DOM and
 //! keeps its reactive owner alive. Going back doesn't re-mount the
-//! previous screen; it reveals the one that was already there.
-//! Owners are only disposed for entries that have been **popped off
-//! the stack** (and dispose is deferred until the next navigation so
-//! the popped wrapper survives long enough to animate out).
+//! previous screen — it reveals the one that was already there, so
+//! scroll position, form input, and in-flight resources survive a
+//! push/back round-trip. Owners are only disposed for entries that
+//! have been **popped off the stack**, and disposal is deferred until
+//! the next navigation so the popped wrapper survives long enough to
+//! animate out.
 //!
-//! This is a change from the earlier model that held a single
-//! `current` / `outgoing` slot pair and disposed the previous route
-//! on every transition. The earlier model lost component state
-//! (scroll position, in-flight resources, child component
-//! lifecycles) on back-navigation, and forced module authors who
-//! cached signals into route owners to fight an extra owner-tree
-//! complication. The preserve-back-stack model fixes both: scroll
-//! position survives a push/back round-trip, and per-route owners
-//! survive disposal of *other* routes.
+//! ```ignore
+//! use whisker_router::{
+//!     route_stack, RouteProvider, StackLayout, IosSlide, IosSwipeBack,
+//! };
 //!
-//! Animation specifics are still delegated to a
-//! [`StackTransition`](crate::StackTransition) implementation; the
-//! layout is responsible for: tracking the entry-to-wrapper map,
-//! diffing it against the latest `entries` signal, choosing which
-//! wrapper plays the incoming / outgoing role on push or pop,
-//! ordering the container's child list so the transition's
-//! foreground hint paints in the right z-order, and deferring
-//! dispose of popped wrappers until after their animation runs.
+//! let nav = route_stack(AppRoute::Home);
+//!
+//! render! {
+//!     RouteProvider(stack: nav.clone()) {
+//!         StackLayout(
+//!             transition: StackTransitionBox::new(IosSlide::default()),
+//!             render: render.into(),
+//!         ) {
+//!             // Opt in to the iOS edge swipe gesture as a child.
+//!             IosSwipeBack()
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Animation is delegated to a [`StackTransition`](crate::StackTransition)
+//! implementation; the layout itself handles bookkeeping: tracking
+//! the entry-to-wrapper map, diffing it against the latest `entries`
+//! signal, choosing which wrapper plays the incoming / outgoing role
+//! on push or pop, ordering the container's child list so the
+//! transition's foreground hint paints in the right z-order, and
+//! deferring dispose of popped wrappers until after their animation
+//! runs.
 //!
 //! Interactive behaviour (iOS swipe-back, Android system back) is
-//! **not** part of the transition trait. Instead, the layout
-//! publishes a [`StackLayoutHandle`] into context and the user
-//! composes gesture / back-handler components as children of
-//! [`StackLayout`]. See [`crate::IosSwipeBack`] for the iOS edge
-//! swipe-back component.
-//!
-//! The default transition is [`IosSlide`](crate::transitions::IosSlide):
-//! horizontal slide with ~30% parallax.
+//! **not** part of the transition trait. The layout publishes a
+//! [`StackLayoutHandle`] into context and the user composes
+//! [`crate::IosSwipeBack`] / [`crate::AndroidPredictiveBack`] (or
+//! custom gesture components) as children. The default transition
+//! is [`IosSlide`](crate::transitions::IosSlide) — horizontal slide
+//! with ~30% parallax.
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -58,65 +69,60 @@ use crate::route::Route;
 use crate::stack::EntryId;
 use crate::transitions::{Direction, Side, StackTransitionBox};
 
-/// One mounted entry's bookkeeping: the reactive owner that holds the
-/// rendered tree, plus the wrapper `view` it lives inside. The wrapper
-/// is what the transition animates; the owner is what gets disposed
-/// when the entry is popped off the stack.
+// Wrapper `view` plus the reactive owner of the rendered subtree.
+// The wrapper is what the transition animates; the owner is what
+// gets disposed when the entry is popped off the stack.
 #[derive(Clone, Copy)]
 struct MountedEntry {
     owner: Owner,
     wrapper: Element,
 }
 
-/// Mutable state shared between the route-change effect and the
-/// gesture / back-handler closures published through the
-/// [`StackLayoutHandle`]. Held in `Rc<RefCell<...>>` because the
-/// closures live in different reactive scopes (the effect's, the
-/// gesture component's) but coordinate on the same data.
+// Shared mutable state between the route-change effect and the
+// gesture / back-handler closures published through the
+// `StackLayoutHandle`. The two run in different reactive scopes but
+// coordinate on the same maps.
 #[derive(Clone)]
 struct LayoutState {
-    /// Every entry currently mounted under [`container`], keyed by its
-    /// stable [`EntryId`]. Insertion happens when an entry is pushed
-    /// onto the stack; removal happens when an entry is popped off
-    /// (with dispose deferred via [`Self::pending_dispose`]).
-    ///
-    /// The `last` of [`Self::order`] is the active (visible) entry.
+    // Every entry currently mounted under `container`, keyed by its
+    // stable EntryId. Insertion on push; removal on pop (dispose
+    // deferred via `pending_dispose`).
     mounted: Rc<RefCell<HashMap<EntryId, MountedEntry>>>,
-    /// IDs in the order they appear in [`RouteStack::entries`]. Last
-    /// element is the current visible route; everything before is
-    /// the back stack, kept mounted at the suspended pose.
+    // EntryId order as in `RouteStack::entries`. Last is the visible
+    // top; earlier entries are the back stack at the suspended pose.
     order: Rc<RefCell<Vec<EntryId>>>,
-    /// Entries whose owners are scheduled for disposal **on the
-    /// next effect run**. Dispose is deferred so the wrapper stays
-    /// alive long enough to animate out — Lynx's `Element::Animate`
-    /// has no completion callback, so we can't dispose at "end of
-    /// animation" precisely; the next-nav drain is a memory-bounded
-    /// approximation (max one popped wrapper queued at a time).
+    // Drained on the next effect run — dispose is deferred so the
+    // popped wrapper survives long enough to animate out. Lynx's
+    // `Element::Animate` has no completion callback, so this is a
+    // memory-bounded approximation (max one popped wrapper queued
+    // at a time).
     pending_dispose: Rc<RefCell<Vec<MountedEntry>>>,
-    /// Counter the gesture commit closures use to suppress the
-    /// route-change effect's natural animation. The gesture has
-    /// already moved wrappers to their final pose by hand, so the
-    /// next effect run reads `> 0`, decrements, and skips animation
-    /// + DOM reordering.
+    // Gesture commit suppresses the natural animation by setting
+    // this to 1; the next effect run decrements and skips animation
+    // + DOM reordering. Counted (not bool) for safety against rare
+    // multi-fire effect paths.
     skip_animation: Rc<Cell<u32>>,
 }
 
-/// Handle a [`StackLayout`] publishes to context so child components
-/// (gestures, back-handlers, anything else that needs to coordinate
-/// with the layout's wrapper bookkeeping) can drive it.
+/// Handle a [`StackLayout`] publishes into context so child gesture
+/// / back-handler components can drive it.
 ///
-/// Read this from a child via
-/// `use_context::<StackLayoutHandle>().expect("inside StackLayout")`,
-/// then call the closures as needed. For plain back navigation
-/// (Android system back, hardware key, in-app back UI) you usually
-/// don't need this handle — `router::<R>().back()` is enough.
-/// This is for the interactive paths that need to reach the
-/// just-below-top wrapper that the back-stack model now keeps
-/// pre-mounted for them.
+/// Retrieve it from a child via
+/// [`use_context::<StackLayoutHandle>()`](whisker::use_context). The
+/// handle is **erased over the route type `R`** so children that
+/// don't know `R` (e.g. [`AndroidPredictiveBack`](crate::AndroidPredictiveBack))
+/// can drive the layout.
+///
+/// For plain back navigation (in-app back button, hardware key) you
+/// usually don't need this handle — `router::<R>().back()` is enough.
+/// `StackLayoutHandle` is for the interactive paths that need to
+/// reach the just-below-top wrapper that the back-stack model keeps
+/// pre-mounted for them, and to coordinate animation suppression
+/// when a gesture has already settled the wrappers by hand.
 #[derive(Clone)]
 pub struct StackLayoutHandle {
-    /// The `StackLayout`'s root container view. Bind touch /
-    /// animation / custom listeners on this element.
+    /// The `StackLayout`'s root container view. Bind touch and
+    /// custom listeners on this element.
     pub container: Element,
 
     /// Returns the wrapper for the currently-foregrounded entry
@@ -145,28 +151,31 @@ pub struct StackLayoutHandle {
     pub dispose_preview: Rc<dyn Fn()>,
 
     /// Commit an in-progress swipe-back gesture: call
-    /// [`RouteStack::back`] and tell the route-change effect to
-    /// skip its natural animation (the gesture has already settled
+    /// [`RouteStack::back`](crate::RouteStack::back) and suppress the
+    /// next natural pop animation (the gesture has already settled
     /// the wrappers at their final pose). The popped entry's owner
     /// is disposed on the next effect run.
     pub commit_preview_and_back: Rc<dyn Fn()>,
 
-    /// Plain back navigation — calls the in-context
+    /// Plain back navigation — calls
     /// [`RouteStack::back`](crate::RouteStack::back). The natural
-    /// route-change effect handles the pop animation. Erased over
-    /// the route type `R` so children that don't know `R`
-    /// (e.g. [`AndroidPredictiveBack`](crate::gestures::AndroidPredictiveBack))
-    /// can drive it.
+    /// route-change effect handles the pop animation.
     pub back: Rc<dyn Fn()>,
 }
 
-/// Back-stack-preserving stack navigator.
+/// Back-stack-preserving stack navigator with pluggable animation.
 ///
 /// Reads the in-context [`RouteStack`](crate::RouteStack) and mirrors
 /// it into the DOM as a stack of wrappers, keeping every entry
 /// mounted until it's popped off the stack. Animation between top
 /// transitions is delegated to the configured
-/// [`StackTransition`](crate::StackTransition).
+/// [`StackTransition`](crate::StackTransition) — defaults to
+/// [`IosSlide`](crate::IosSlide).
+///
+/// See the [module docs](self) for the full conceptual model. Mount
+/// gesture children ([`crate::IosSwipeBack`],
+/// [`crate::AndroidPredictiveBack`]) inside the layout's body to
+/// opt into platform-native back gestures.
 #[component]
 pub fn stack_layout<R: Route>(
     #[prop(default = StackTransitionBox::default())] transition: StackTransitionBox,
@@ -185,10 +194,9 @@ pub fn stack_layout<R: Route>(
     };
     let first = Rc::new(Cell::new(true));
 
-    // Tracking a single `entries` signal (rather than the derived
-    // `current()` + `stack()` signals) so the effect re-runs once
-    // per navigation — separate computeds would each schedule a
-    // distinct re-run.
+    // Track the raw `entries` signal — derived signals each schedule
+    // their own re-run, so subscribing to one signal keeps the effect
+    // to one run per navigation.
     let entries_signal = stack.entries();
 
     {
@@ -208,32 +216,27 @@ pub fn stack_layout<R: Route>(
         });
     }
 
-    // Reserve an owner whose parent is the layout's own owner so
-    // children that mount via `commit_preview_and_back` get reachable
-    // context (`RouteProvider` etc.). The gesture handlers fire from
-    // the touch dispatcher, which has no active reactive owner;
-    // without this anchor, owners spawned for entries the gesture
-    // interacts with would become roots and lose access to the
-    // `RouteProvider` context their components rely on.
+    // Reserve a parent owner for gesture-triggered mounts. The touch
+    // dispatcher has no active reactive owner; without this anchor,
+    // owners spawned by `commit_preview_and_back` would become roots
+    // and lose access to the `RouteProvider` context.
     let _handle_parent = Owner::new(None);
 
     let handle = build_stack_layout_handle(container, stack.clone(), state);
     provide_context(handle);
 
-    // Mount the user's children (gestures / back-handlers / etc.).
-    // They render no DOM of their own but attach handlers via
-    // `on_mount`; the phantom returned by `mount_children` is
-    // attached under the container so the children's owner is a
-    // descendant of the layout's owner.
+    // Children render no DOM of their own but attach handlers via
+    // `on_mount`. Mounting them under the container puts their owner
+    // in the layout's subtree so context lookups succeed.
     let phantom = whisker::runtime::view::mount_children(&children);
     append_child(container, phantom);
 
     container
 }
 
-/// One pass of the route-change effect. Pulled out of the `effect`
-/// closure so the steps read top-to-bottom without an extra
-/// indentation level.
+// One pass of the route-change effect. Pulled out of the `effect`
+// closure so the steps read top-to-bottom without an extra
+// indentation level.
 fn run_navigation_effect<R: Route>(
     state: &LayoutState,
     first: &Rc<Cell<bool>>,
@@ -242,11 +245,9 @@ fn run_navigation_effect<R: Route>(
     render: &RouteRenderFn<R>,
     entries: Vec<crate::stack::RouteEntry<R>>,
 ) {
-    // Step 1: drain the previous navigation's pending dispose —
-    // wrappers that were popped off the stack last time and need
-    // their owners freed now that their animation has had time to
-    // play. Done first so a tight push-back-push cycle doesn't
-    // leave stale wrappers in the DOM during the new transition.
+    // Drain the previous navigation's deferred-dispose queue first
+    // so a tight push-back-push cycle doesn't leave stale wrappers
+    // in the DOM during the new transition.
     {
         let mut pending = state.pending_dispose.borrow_mut();
         for entry in pending.drain(..) {
@@ -258,12 +259,9 @@ fn run_navigation_effect<R: Route>(
     let new_ids: Vec<EntryId> = entries.iter().map(|e| e.id).collect();
     let new_id_set: std::collections::HashSet<EntryId> = new_ids.iter().copied().collect();
 
-    // Step 2: skip-animation guard. The gesture commit path
-    // (`commit_preview_and_back`) sets `skip_animation` so the
-    // natural pop animation doesn't fire — the gesture already
-    // settled the wrappers at their final pose. We still need to
-    // *bookkeep* the stack change: the popped entry has to leave
-    // `mounted`, and any owner it held has to be disposed.
+    // Skip-animation guard: gesture commit settled the wrappers by
+    // hand, so we skip the natural animation but still bookkeep
+    // (drop popped entries from `mounted`, dispose their owners).
     let skip = state.skip_animation.get();
     if skip > 0 {
         state.skip_animation.set(skip - 1);
@@ -275,9 +273,8 @@ fn run_navigation_effect<R: Route>(
             .collect();
         for id in removed {
             if let Some(entry) = state.mounted.borrow_mut().remove(&id) {
-                // Gesture already animated this wrapper to its
-                // offscreen pose, so dispose right away — no
-                // pending queue.
+                // Gesture already animated this wrapper offscreen,
+                // so dispose right away (no pending queue).
                 remove_child(container, entry.wrapper);
                 entry.owner.dispose();
             }
@@ -290,7 +287,6 @@ fn run_navigation_effect<R: Route>(
     let old_ids = state.order.borrow().clone();
     let old_id_set: std::collections::HashSet<EntryId> = old_ids.iter().copied().collect();
 
-    // Step 3: compute the diff.
     let added: Vec<EntryId> = new_ids
         .iter()
         .filter(|id| !old_id_set.contains(id))
@@ -302,17 +298,17 @@ fn run_navigation_effect<R: Route>(
         .copied()
         .collect();
 
-    // Step 4: determine direction. We only animate the top transition
-    // — replace_all / back_to / replace shapes either don't change
-    // the top, or change it from / to something not in the previous
-    // stack, in which case we still pick Forward or Backward by
+    // Direction picks the animation: only the top transition is
+    // animated. `replace_all` / `back_to` / `replace` shapes either
+    // don't change the top, or replace it with something not in the
+    // previous stack — we then still pick Forward/Backward by
     // whether the new top was already in `old_id_set`.
     let new_top = new_ids.last().copied();
     let old_top = old_ids.last().copied();
     let dir = if first.get() {
         Direction::None
     } else if new_top == old_top {
-        // Top didn't change — maybe a non-top mutation (rare).
+        // Top unchanged — non-top mutation, no animation needed.
         Direction::None
     } else if new_top.is_some_and(|t| old_id_set.contains(&t)) {
         Direction::Backward
@@ -321,10 +317,9 @@ fn run_navigation_effect<R: Route>(
     };
     first.set(false);
 
-    // Step 5: mount any newly-added entries. They start at the
-    // "below top" suspended pose; the top-transition step below
-    // overrides the wrapper for the new top into its Incoming
-    // animation pose.
+    // Mount newly-added entries at the suspended pose; the top
+    // transition step below overrides the new top's wrapper into
+    // its Incoming animation pose.
     for id in &added {
         let entry = entries
             .iter()
@@ -339,10 +334,8 @@ fn run_navigation_effect<R: Route>(
             Side::Outgoing,
             Direction::Forward,
         );
-        // Insert at the position the entry occupies in the new
-        // stack. DOM order matches stack order — root at index 0,
-        // current top at the last index — so z-stacking naturally
-        // puts the top entry on top.
+        // DOM order matches stack order — root at index 0, top at
+        // the last index — so the top entry paints on top naturally.
         let position = new_ids
             .iter()
             .position(|i| *i == *id)
@@ -361,19 +354,16 @@ fn run_navigation_effect<R: Route>(
         );
     }
 
-    // Step 6: persist the new order so the next run can diff.
     *state.order.borrow_mut() = new_ids.clone();
 
-    // Step 7: set the top transition's animation start poses, then
-    // schedule the actual animation in `on_mount` so the renderer
-    // has a chance to commit the start frame.
+    // Set the top transition's start poses, then schedule the
+    // actual animation in `on_mount` so the renderer commits the
+    // start frame before the animator runs.
     if dir != Direction::None {
         let incoming = new_top.and_then(|id| state.mounted.borrow().get(&id).copied());
-        // `outgoing` might be in `removed` (when we're popping the
-        // top), but at this point in the effect run we haven't moved
-        // anything to `pending_dispose` yet — the wrapper is still
-        // in `mounted` until step 8 below. So a single lookup works
-        // for both push and pop cases.
+        // `outgoing` may be `removed` (we're popping the top) but
+        // hasn't been moved to `pending_dispose` yet — a single
+        // `mounted` lookup works for both push and pop cases.
         let outgoing = old_top.and_then(|id| state.mounted.borrow().get(&id).copied());
 
         if let Some(inc) = incoming {
@@ -383,22 +373,18 @@ fn run_navigation_effect<R: Route>(
             apply_wrapper_style(out.wrapper, transition.0.as_ref(), Side::Outgoing, dir);
         }
 
-        // Reorder for z-stacking based on the transition's
-        // foreground hint. iOS slide's Backward keeps `Outgoing`
-        // (= the leaving top) in front so it visibly slides off
-        // the screen revealing the incoming behind it; the default
-        // child order at this point has the incoming below already,
-        // so we only have to act for the Incoming foreground case.
+        // Reorder for z-stacking from the transition's foreground
+        // hint. iOS pop keeps the leaving top in front so it slides
+        // off revealing the incoming behind it. Lynx animator
+        // ignores explicit z-index during transform animations (see
+        // memory: lynx_zindex_animation_quirk) — DOM order is the
+        // only reliable knob.
         if matches!(transition.0.foreground(dir), Side::Incoming) {
             if let Some(inc) = incoming {
-                // Move incoming to last child so it paints on top.
-                // (No-op for Forward since we already inserted the
-                // newly-mounted incoming at the last index.)
                 remove_child(container, inc.wrapper);
                 append_child(container, inc.wrapper);
             }
         } else if let Some(out) = outgoing {
-            // Outgoing foreground: ensure outgoing paints last.
             remove_child(container, out.wrapper);
             append_child(container, out.wrapper);
         }
@@ -417,9 +403,8 @@ fn run_navigation_effect<R: Route>(
             }
         });
     } else if let Some(top_id) = new_top {
-        // No animation — just make sure the top wrapper sits at the
-        // active (centred) pose. Important for the very first run
-        // and for replace_all-style transitions.
+        // No animation — pin the top wrapper to the active (centred)
+        // pose. Matters for the first mount and for replace_all.
         if let Some(entry) = state.mounted.borrow().get(&top_id) {
             apply_wrapper_style(
                 entry.wrapper,
@@ -430,13 +415,10 @@ fn run_navigation_effect<R: Route>(
         }
     }
 
-    // Step 8: process removed entries.
-    //   - The popped *top* (in a Backward navigation) is mid-
-    //     animation — its wrapper has to stay alive long enough to
-    //     play out. Move it to `pending_dispose`; the next effect
-    //     run drains the queue.
-    //   - Any other removed entries (replace_all, back_to multiple
-    //     levels, replace) don't animate — dispose right away.
+    // Process removed entries: the popped top of a Backward nav is
+    // mid-animation, so defer its dispose. Other removals
+    // (replace_all, multi-level back_to, replace) don't animate, so
+    // dispose immediately.
     for id in &removed {
         if let Some(entry) = state.mounted.borrow_mut().remove(id) {
             if dir == Direction::Backward && Some(*id) == old_top {
@@ -448,20 +430,13 @@ fn run_navigation_effect<R: Route>(
         }
     }
 
-    // Step 9: sync paused state across all mounted owners. The top
-    // of `order` runs effects; everything else (mounted-but-hidden
-    // back-stack) is paused until it surfaces. Idempotent, so it's
-    // safe to call on every navigation, including the very first.
+    // Sync owner pause state: only the topmost runs effects; the
+    // mounted-but-hidden back stack is paused until it surfaces.
     sync_owner_paused_state(state);
 }
 
-/// Walk `state.mounted` and align each entry's owner with the
-/// expected paused state: the topmost (last in [`LayoutState::order`])
-/// is active; everything else is paused.
-///
-/// Idempotent — `Owner::pause` / `Owner::resume` no-op on the matching
-/// state, so calling this every navigation costs at most one set
-/// flip per owner.
+// Pause every non-top owner; resume the top. Idempotent —
+// `Owner::pause` / `Owner::resume` no-op on the matching state.
 fn sync_owner_paused_state(state: &LayoutState) {
     let order = state.order.borrow();
     let mounted = state.mounted.borrow();
@@ -493,11 +468,6 @@ fn build_stack_layout_handle<R: Route>(
     let mount_preview = {
         let state = state.clone();
         Rc::new(move || {
-            // In the preserve-back-stack model the entry one step
-            // below the top is already mounted at the suspended
-            // pose — return its wrapper so the gesture can drive
-            // it. Returns None if there's no entry below the top
-            // (i.e. the stack is at the root and back is invalid).
             let order = state.order.borrow();
             if order.len() < 2 {
                 return None;
@@ -507,30 +477,21 @@ fn build_stack_layout_handle<R: Route>(
         }) as Rc<dyn Fn() -> Option<Element>>
     };
 
-    let dispose_preview = {
-        // The just-below-top wrapper is a real back-stack entry, so
-        // we don't dispose it. This closure exists to let the
-        // gesture signal "cancel the drag" — the gesture component
-        // itself is responsible for animating the wrapper back to
-        // its suspended pose (it owns the touch progress and the
-        // re-pose animation). We only need to keep the closure for
-        // API compatibility; no-op is the right semantic now.
-        Rc::new(|| {}) as Rc<dyn Fn()>
-    };
+    // The just-below-top wrapper is a real back-stack entry, never a
+    // throwaway preview. The gesture re-poses it back to suspended on
+    // cancel; nothing here owns the visual state, so this is a no-op
+    // kept for API parity with the earlier "mount preview on demand"
+    // model.
+    let dispose_preview = Rc::new(|| {}) as Rc<dyn Fn()>;
 
     let commit_preview_and_back = {
         let stack = stack.clone();
         let skip_animation = state.skip_animation.clone();
         Rc::new(move || {
-            // The gesture has already animated the just-below-top
-            // wrapper to centre and the previous top wrapper to its
-            // offscreen pose. Tell the route-change effect to skip
-            // its natural animation so the next `stack.back()` doesn't
-            // re-fire the transition; the effect still does the
-            // bookkeeping (dispose the popped entry's owner, update
-            // mounted_order). Counted because rare-but-possible
-            // multi-fire signal paths could land more than one
-            // effect run on a single back.
+            // Suppress the natural animation; the gesture already
+            // settled the wrappers. The effect still does the
+            // bookkeeping (drop popped entry from `mounted`,
+            // dispose its owner).
             skip_animation.set(1);
             let _ = stack.back();
         }) as Rc<dyn Fn()>
@@ -539,10 +500,9 @@ fn build_stack_layout_handle<R: Route>(
     let back = {
         let stack = stack.clone();
         Rc::new(move || {
-            // `back()` returns false if already at the stack root —
-            // plain back handlers don't surface that to the host,
-            // the platform's natural back-when-empty behaviour
-            // takes over.
+            // `back()` returns false at the stack root; the host
+            // platform's natural back-when-empty behaviour takes
+            // over via the gesture component's caller.
             let _ = stack.back();
         }) as Rc<dyn Fn()>
     };
@@ -558,10 +518,10 @@ fn build_stack_layout_handle<R: Route>(
 }
 
 fn container_css() -> Css {
-    // `overflow: visible` rather than the Web default — Lynx clips
-    // children's `box-shadow` at the parent's bounds by default, so
-    // we have to declare visibility explicitly all the way down for
-    // [`IosSlide`]'s leading-edge shadow to show through.
+    // `overflow: visible` is critical — Lynx clips children's
+    // `box-shadow` at the parent's bounds by default (unlike Web
+    // CSS). Required all the way down for IosSlide's leading-edge
+    // shadow to show through.
     Css::new()
         .position(PositionKind::Relative)
         .width(100.percent())
@@ -570,13 +530,9 @@ fn container_css() -> Css {
         .overflow(Overflow::Visible)
 }
 
-/// Apply the layout's slot positioning plus the transition's
-/// per-role decoration to a wrapper.
-///
-/// `Style::Static` collapses to one `set_inline_styles` write;
-/// `Style::Dynamic` registers an effect so the closure re-fires
-/// (and the wrapper re-styles) whenever any signal it reads
-/// changes — useful for theme-driven decoration.
+// Apply the layout's slot positioning plus the transition's per-role
+// decoration to a wrapper. `Style::Static` collapses to one
+// `set_inline_styles` write; `Style::Dynamic` registers an effect.
 pub(crate) fn apply_wrapper_style(
     wrapper: Element,
     transition: &dyn crate::transitions::StackTransition,
@@ -608,10 +564,8 @@ pub(crate) fn apply_wrapper_style(
 }
 
 pub(crate) fn slot_css() -> Css {
-    // `overflow: visible` is critical — Lynx clips a child's
-    // `box-shadow` at the parent's bounds by default (unlike Web
-    // CSS where overflow defaults to `visible`). Without this the
-    // leading-edge shadow that `IosSlide` paints stays invisible.
+    // See container_css: `overflow: visible` keeps IosSlide's
+    // leading-edge shadow visible.
     Css::new()
         .position(PositionKind::Absolute)
         .top(0.px())

--- a/packages/whisker-router/src/layouts/tabs.rs
+++ b/packages/whisker-router/src/layouts/tabs.rs
@@ -1,42 +1,42 @@
-//! `TabsLayout` — keep-alive tab switcher driven by a single
-//! [`RouteStack`].
+//! [`TabsLayout`] — keep-alive tab switcher driven by the
+//! in-context [`RouteStack`](crate::RouteStack).
 //!
 //! Each tab is a `(matches, content)` pair: `matches` decides which
 //! current route belongs to this tab, `content` renders that tab's
 //! subtree. All tabs are mounted simultaneously and toggled between
-//! `display: flex` / `display: none` so state (scroll position,
-//! in-flight requests, signal values) survives switching — the same
+//! `display: flex` / `display: none` so state — scroll position,
+//! in-flight requests, signal values — survives switching. Same
 //! technique React Native's `BottomTabNavigator` and SwiftUI's
 //! `TabView` use.
 //!
-//! The expo-router-style nested-route design lives one level up: a
-//! parent enum's `#[layout(TabsLayout)]` variants each correspond to
-//! one tab, and the per-tab subtree is itself a `StackLayout` over
-//! that variant's inner route enum. From the `RouteStack`'s point of
-//! view the global stack is still a single sequence; tabs are pure
-//! projection.
+//! For tab-per-stack patterns, wrap each tab's `content` in a nested
+//! [`RouteProvider`](crate::RouteProvider) +
+//! [`StackLayout`](crate::StackLayout). From the outer stack's point
+//! of view the global stack is still a single sequence; tabs are
+//! pure projection.
 //!
 //! ```ignore
 //! use whisker::prelude::*;
-//! use whisker_router::{route_stack, TabSpec, TabsLayout};
+//! use whisker_router::{route_stack, RouteProvider, TabSpec, TabsLayout};
 //!
 //! let nav = route_stack(AppRoute::Home(HomeRoute::Index));
 //!
 //! render! {
-//!     TabsLayout(
-//!         nav: nav.clone(),
-//!         tabs: vec![
-//!             TabSpec::new(
-//!                 |r: &AppRoute| matches!(r, AppRoute::Home(_)),
-//!                 || render! { HomeStack() },
-//!             ),
-//!             TabSpec::new(
-//!                 |r: &AppRoute| matches!(r, AppRoute::Search(_)),
-//!                 || render! { SearchStack() },
-//!             ),
-//!         ],
-//!         bar: BottomBar(nav: nav.clone()).into(),
-//!     )
+//!     RouteProvider(stack: nav.clone()) {
+//!         TabsLayout(
+//!             tabs: vec![
+//!                 TabSpec::new(
+//!                     |r: &AppRoute| matches!(r, AppRoute::Home(_)),
+//!                     || render! { HomeStack() },
+//!                 ),
+//!                 TabSpec::new(
+//!                     |r: &AppRoute| matches!(r, AppRoute::Search(_)),
+//!                     || render! { SearchStack() },
+//!                 ),
+//!             ],
+//!             bar: BottomBar(nav: nav.clone()).into(),
+//!         )
+//!     }
 //! }
 //! ```
 
@@ -53,13 +53,15 @@ use crate::outlet::router;
 use crate::route::Route;
 
 /// One tab in a [`TabsLayout`] — a predicate over the current route
-/// plus the renderer for that tab's body.
+/// plus a renderer for that tab's body.
 ///
-/// Both closures are held in `Rc` so the struct is `Clone` (the
-/// `#[component]` macro re-clones every prop on each `FnMut` body
-/// invocation). `matches` is invoked inside a reactive `computed`
-/// every time the current route changes, so keep it cheap — usually
-/// a `matches!()` against an enum variant.
+/// `matches` is invoked inside a reactive `computed` on every route
+/// change, so keep it cheap — usually a `matches!()` against an
+/// enum variant. `content` is invoked exactly once at layout-mount
+/// time (the pane is then kept alive).
+///
+/// Both closures are held in `Rc` so the struct is `Clone` — the
+/// `#[component]` macro re-clones every prop on each body run.
 pub struct TabSpec<R: Route> {
     matches: Rc<dyn Fn(&R) -> bool + 'static>,
     content: Rc<dyn Fn() -> Element + 'static>,
@@ -75,7 +77,15 @@ impl<R: Route> Clone for TabSpec<R> {
 }
 
 impl<R: Route> TabSpec<R> {
-    /// Build a tab from a predicate and a body renderer.
+    /// Build a tab from a `matches` predicate and a `content`
+    /// renderer.
+    ///
+    /// ```ignore
+    /// TabSpec::new(
+    ///     |r: &AppRoute| matches!(r, AppRoute::Home(_)),
+    ///     || render! { HomeStack() },
+    /// );
+    /// ```
     pub fn new<M, C>(matches: M, content: C) -> Self
     where
         M: Fn(&R) -> bool + 'static,
@@ -96,14 +106,11 @@ impl<R: Route> TabSpec<R> {
 /// element (typically a bottom tab bar) is appended below the panes
 /// in column order.
 ///
-/// The [`RouteStack`](crate::RouteStack) for route type `R` is
-/// pulled from context — wrap a [`RouteProvider`](crate::RouteProvider)
-/// above the layout so `router::<R>()` finds it.
+/// Pulls the [`RouteStack`](crate::RouteStack) for route type `R`
+/// from context — wrap a [`RouteProvider`](crate::RouteProvider)
+/// above the layout so [`router::<R>()`](crate::router) finds it.
 ///
-/// Built directly against the runtime API rather than via `render!`
-/// for two reasons: (1) the macro can't take an arbitrary
-/// `Vec<TabSpec>` and unroll it, and (2) the bar is an already-built
-/// `Element` value which the macro doesn't accept as a child slot.
+/// See the [module docs](self) for a full example.
 #[component]
 pub fn tabs_layout<R: Route>(
     tabs: Vec<TabSpec<R>>,
@@ -113,14 +120,13 @@ pub fn tabs_layout<R: Route>(
     let container = create_element(ElementTag::View);
     apply_styles(container, container_css().to_css_string());
 
-    // Pane area — grows to fill the space above the bar.
     let pane_area = create_element(ElementTag::View);
     apply_styles(pane_area, pane_area_css().to_css_string());
     append_child(container, pane_area);
 
     let current = stack.current();
-    // Clone the tab list out of the FnMut capture so we can consume
-    // it. `TabSpec` is cheap to clone (two `Rc` bumps each).
+    // Clone out of the FnMut capture so we can consume; TabSpec is
+    // cheap to clone (two Rc bumps each).
     for tab in tabs.clone().into_iter() {
         let pane = create_element(ElementTag::View);
         let matches = tab.matches.clone();
@@ -151,8 +157,7 @@ fn container_css() -> Css {
 }
 
 fn pane_area_css() -> Css {
-    // `flex: 1` equivalent — grow to consume vertical space left
-    // over by the bar.
+    // `flex: 1` equivalent — consume vertical space above the bar.
     Css::new()
         .flex_grow(1.0)
         .flex_direction(FlexDirection::Column)
@@ -160,9 +165,9 @@ fn pane_area_css() -> Css {
 }
 
 fn pane_css(visible: bool) -> Css {
-    // Each pane covers the full pane area; only one is visible at a
-    // time. `position: absolute` would also work but `display: none`
-    // + flex-grow lets layout fall through naturally to the bar.
+    // `display: none` + flex-grow lets layout fall through to the
+    // bar naturally; `position: absolute` would work but require
+    // explicit sizing.
     let base = Css::new()
         .flex_direction(FlexDirection::Column)
         .width(100.percent())
@@ -206,10 +211,9 @@ mod tests {
 
     #[test]
     fn tab_spec_is_clone() {
-        // Static check: `#[component]` requires Clone for FnMut
-        // captures. If `TabSpec` ever stops being Clone, this fails
-        // at compile time before showing up as a downstream macro
-        // error.
+        // `#[component]` requires Clone for FnMut captures; surface
+        // the requirement at this crate's test boundary rather than
+        // as a downstream macro error.
         fn assert_clone<T: Clone>() {}
         assert_clone::<TabSpec<TestRoute>>();
     }

--- a/packages/whisker-router/src/lib.rs
+++ b/packages/whisker-router/src/lib.rs
@@ -2,28 +2,78 @@
 //!
 //! Type-safe, signal-backed routing for Whisker.
 //!
-//! Design lives in [issue #95](https://github.com/whiskerrs/whisker/issues/95).
-//! The crate ships:
+//! ## The layer cake
 //!
-//! - [`Route`] — trait that ties a typed enum to its URL form.
-//! - [`RouteStack`] — first-class signal-backed back stack.
-//! - [`RouteProvider`] — pushes a [`RouteStack`] into context so
-//!   the layouts (and screens) below can resolve it with
-//!   [`router::<R>()`](router).
-//! - Layouts in [`layouts`] — [`StackLayout`], [`TabsLayout`],
-//!   [`ModalLayout`], [`Pane`]. Each layout pulls its stack from
-//!   the nearest ancestor [`RouteProvider`].
-//! - [`Outlet`] — mount-only variant of [`StackLayout`] (no
-//!   transition machinery), also context-driven.
-//! - [`on_back`] — LIFO back-handler chain.
-//! - [`linking`] — minimal deep-link surface: `initial_url` +
-//!   `on_url`.
+//! The crate is built as a small stack of layers — pick the lowest
+//! one that does the job and let the rest stay out of your way:
+//!
+//! 1. [`Route`] — trait that ties a typed enum to its URL form.
+//!    Either hand-write `parse` / `to_path`, or annotate the enum with
+//!    [`#[route]`](macro@route) and let the macro derive them from per-variant
+//!    `#[at("/...")]` patterns.
+//! 2. [`RouteStack`] — the cloneable handle holding the back stack.
+//!    Created with [`route_stack`]; carries `push` / `back` / `replace`
+//!    plus reactive readers ([`RouteStack::current`],
+//!    [`RouteStack::depth`], [`RouteStack::can_back`]).
+//! 3. [`RouteProvider`] — context provider that publishes the stack
+//!    so descendants can look it up via [`router::<R>()`](router).
+//!    One provider per route type; nested providers of different `R`
+//!    coexist (this is how tab-per-stack patterns are built).
+//! 4. **Renderers** — pick the one that fits the surface area:
+//!    - [`Outlet`] — mount-only, no animation; the cheapest path.
+//!    - [`StackLayout`] — back-stack-preserving stack navigator with
+//!      pluggable animation. The canonical choice for screen stacks.
+//!    - [`TabsLayout`] — keep-alive tab switcher driven by the same
+//!      stack via per-tab predicates.
+//!    - [`ModalLayout`] — slide-from-bottom modal sheet.
+//!    - [`Pane`] — display-toggleable container; a building block
+//!      for custom layouts (used internally by [`TabsLayout`]).
+//! 5. [`StackTransition`] — pluggable animation interface used by
+//!    [`StackLayout`]. Built-ins: [`IosSlide`] (default), [`Fade`],
+//!    [`VerticalSlide`], [`Instant`].
+//! 6. **Gesture components** — opt-in interactivity, mounted as
+//!    children of [`StackLayout`]: [`IosSwipeBack`] for the iOS edge
+//!    swipe, [`AndroidPredictiveBack`] for the Android system back.
+//! 7. [`on_back`] — LIFO back-handler chain for ad-hoc consumers
+//!    (modals, search bars) that want to intercept a back press.
+//! 8. [`linking`] — minimal deep-link surface: [`linking::initial_url`]
+//!    + [`linking::on_url`].
+//!
+//! ## Design notes
 //!
 //! All routing logic runs inside a single [`whisker::runtime`]
-//! instance — there is intentionally no per-screen
-//! `UIViewController` / `Fragment`. Gestures, transitions, and
-//! freeze are implemented entirely on the Whisker side for
-//! cross-platform parity.
+//! instance — there is intentionally no per-screen `UIViewController`
+//! / `Fragment`. Gestures, transitions, and freeze are implemented
+//! entirely on the Whisker side for cross-platform parity.
+//!
+//! Design lives in [issue #95](https://github.com/whiskerrs/whisker/issues/95).
+//!
+//! ## Minimal usage
+//!
+//! ```ignore
+//! use whisker::prelude::*;
+//! use whisker_router::{route, route_stack, RouteProvider, StackLayout};
+//!
+//! #[route]
+//! #[derive(Clone, Debug, PartialEq)]
+//! pub enum AppRoute {
+//!     #[at("/")]            Home,
+//!     #[at("/profile/:id")] Profile { id: u64 },
+//! }
+//!
+//! #[component]
+//! fn app() -> Element {
+//!     let nav = route_stack(AppRoute::Home);
+//!     render! {
+//!         RouteProvider(stack: nav.clone()) {
+//!             StackLayout(render: (|r: AppRoute| match r {
+//!                 AppRoute::Home          => render! { Home() },
+//!                 AppRoute::Profile { id } => render! { Profile(id: id) },
+//!             }).into())
+//!         }
+//!     }
+//! }
+//! ```
 
 #![warn(missing_docs)]
 
@@ -36,8 +86,15 @@ pub mod route;
 pub mod stack;
 pub mod transitions;
 
-/// `#[route]` attribute macro — generates a `Route` impl from a
+/// `#[route]` attribute macro — generates a [`Route`] impl from a
 /// per-variant `#[at("/...")]` pattern.
+///
+/// `:foo` segments bind to named fields of the same name; literal
+/// segments match verbatim. Field types must implement `FromStr`
+/// (for `parse`) and `Display` (for `to_path`). Tuple-struct variants
+/// aren't supported in v1 — switch to a named-field form.
+///
+/// See [`whisker_router_macros`] for the full grammar.
 ///
 /// ```ignore
 /// use whisker_router::route;

--- a/packages/whisker-router/src/linking.rs
+++ b/packages/whisker-router/src/linking.rs
@@ -1,35 +1,51 @@
-//! Deep-link surface — Level 1 only.
+//! Deep-link surface — cold-launch URL + post-launch URL subscription.
+//!
+//! Two functions, in the shape every major mobile framework uses:
+//!
+//! - [`initial_url`] — synchronous read of the URL the app was
+//!   cold-launched with, if any. Used to seed the
+//!   [`RouteStack`](crate::RouteStack) at boot.
+//! - [`on_url`] — subscription for URLs delivered after launch
+//!   (e.g. a deep-link tap into an already-running app).
 //!
 //! ```ignore
-//! use whisker_router::linking;
+//! use whisker_router::{linking, route_stack, Route};
 //!
 //! let initial = linking::initial_url()
 //!     .and_then(|u| AppRoute::parse(&u).ok())
-//!     .unwrap_or(AppRoute::default_root());
+//!     .unwrap_or(AppRoute::Home);
+//! let nav = route_stack(initial);
 //!
 //! linking::on_url(move |url| {
-//!     // user decides routing / fallback
+//!     if let Ok(r) = AppRoute::parse(&url) {
+//!         nav.push(r);
+//!     }
 //! });
 //! ```
 //!
-//! Wiring through the `whisker::module!` mechanism is implemented
-//! in a follow-up — this module is currently a documentation +
-//! API-shape placeholder while the runtime-side `on_global_event`
-//! primitive is confirmed (issue #95 deps).
+//! # Status
+//!
+//! Both functions are stubs in the current revision — wiring through
+//! the `whisker::module!` mechanism is tracked as part of issue #95
+//! (the runtime-side `on_global_event` primitive needs to ship
+//! first). The API surface here is what callers should code against
+//! in the meantime.
 
 #![allow(unused_variables)]
 
 /// Returns the URL the app was cold-launched with, if any.
 ///
 /// Stubbed until the `WhiskerLinking` Lynx module is wired up.
+/// Always returns `None` today.
 pub fn initial_url() -> Option<String> {
     None
 }
 
 /// Subscribe to URLs delivered after launch.
 ///
-/// Stubbed until the global-event API is exposed from the runtime
-/// — tracked as part of the cross-crate dependency audit.
+/// `handler` is invoked once per delivered URL on the runtime
+/// thread. Stubbed until the global-event API is exposed from the
+/// runtime — `handler` is currently never invoked.
 pub fn on_url<F>(_handler: F)
 where
     F: Fn(String) + 'static,

--- a/packages/whisker-router/src/outlet.rs
+++ b/packages/whisker-router/src/outlet.rs
@@ -1,10 +1,21 @@
-//! Provider + Outlet — wire a [`RouteStack`] into context and
-//! render the current route through a user-supplied closure.
+//! [`RouteProvider`] + [`Outlet`] + [`router`] — the context-driven
+//! foundation that every renderer in this crate stands on.
 //!
-//! The pattern follows [`whisker::Show`] (control_flow.rs): a
-//! phantom element acts as the mount slot; an effect observes
-//! `stack.current()` and on each change disposes the previous
-//! branch before mounting the new one.
+//! [`RouteProvider`] publishes a [`RouteStack`] into Whisker's context.
+//! Descendant components retrieve it with [`router::<R>()`]. Every
+//! "real" layout — [`StackLayout`](crate::StackLayout),
+//! [`TabsLayout`](crate::TabsLayout), and [`Outlet`] itself — is
+//! built on this pattern.
+//!
+//! [`Outlet`] is the *mount-only* renderer: it observes
+//! `stack.current()`, disposes the previous branch on each change,
+//! and mounts a fresh one. No transition machinery, no back-stack
+//! preservation. Reach for it when you don't need animation; reach
+//! for [`StackLayout`](crate::StackLayout) when you do.
+//!
+//! The pattern follows [`whisker::Show`]: a phantom element acts as
+//! the mount slot; an effect observes the reactive route and swaps
+//! the previously-mounted branch for a freshly-rendered one.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -16,15 +27,27 @@ use whisker::{component, provide_context, use_context, Children};
 use crate::route::Route;
 use crate::stack::RouteStack;
 
-/// Function prop for [`Outlet`]: maps a route value to its rendered
-/// element. Wrapped in `Rc` so closures with non-`Copy` captures
-/// (e.g. a [`RouteStack`] handle) can be shared between the
-/// component's outer remount body and the inner mount effect.
+/// Function prop for [`Outlet`] and [`StackLayout`](crate::StackLayout):
+/// maps a route value to its rendered element.
+///
+/// Wrapped in `Rc` so closures with non-`Copy` captures (e.g. a
+/// [`RouteStack`] handle, theme tokens) can be shared between the
+/// component's outer body — which `#[component]` re-runs on
+/// hot-reload — and the inner mount effect. The [`From`] impl makes
+/// `(|r: AppRoute| ...).into()` the usual call-site shape.
+///
+/// ```ignore
+/// let render: RouteRenderFn<AppRoute> = (|r: AppRoute| match r {
+///     AppRoute::Home          => render! { Home() },
+///     AppRoute::Profile { id } => render! { Profile(id: id) },
+/// }).into();
+/// ```
 #[derive(Clone)]
 pub struct RouteRenderFn<R: Route>(pub Rc<dyn Fn(R) -> Element + 'static>);
 
 impl<R: Route> RouteRenderFn<R> {
-    /// Invoke the renderer with a route value.
+    /// Invoke the renderer with `route` and return the resulting
+    /// element.
     pub fn call(&self, route: R) -> Element {
         (self.0)(route)
     }
@@ -42,47 +65,82 @@ where
 
 /// Look up the [`RouteStack`] for route type `R` from context.
 ///
+/// The standard way to drive navigation from inside a screen
+/// component without threading the stack handle through every prop:
+///
+/// ```ignore
+/// let nav = router::<AppRoute>();
+/// nav.push(AppRoute::Profile { id: 7 });
+/// ```
+///
+/// # Panics
+///
 /// Panics if no [`RouteProvider`] of that route type is mounted
-/// above the caller — routing is unambiguous at the call site and
-/// silently returning `None` would hide the misuse.
+/// above the caller. Routing is unambiguous at the call site and
+/// silently returning `None` would hide the misuse — the panic
+/// message names the missing provider type.
 pub fn router<R: Route>() -> RouteStack<R> {
     use_context::<RouteStack<R>>()
         .expect("router::<R>() called outside a RouteProvider<R> ancestor")
 }
 
-/// `RouteProvider` — push a [`RouteStack`] into context so the
-/// layouts and screens below can look it up via [`router`].
+/// Push a [`RouteStack`] into context so the layouts and screens
+/// below can look it up via [`router::<R>()`](router).
 ///
 /// Renders nothing of its own — the `children` slot carries the
 /// layout (typically [`StackLayout`](crate::StackLayout) or
 /// [`TabsLayout`](crate::TabsLayout)) plus everything underneath.
-/// Each provider provides one stack type; nested providers of
-/// different `R` coexist (type-keyed lookup picks the nearest
-/// ancestor for `R`), which is how tab-per-stack patterns get
-/// expressed.
+///
+/// # Nesting
+///
+/// Each provider provides one stack type. Nested providers of
+/// different `R` coexist — Whisker's type-keyed context lookup picks
+/// the nearest ancestor for `R`. That's how the tab-per-stack
+/// pattern works: an outer `RouteProvider<TabRoot>` plus one inner
+/// `RouteProvider<HomeRoute>` / `RouteProvider<SearchRoute>` per
+/// tab, each driving its own `StackLayout`.
+///
+/// ```ignore
+/// render! {
+///     RouteProvider(stack: nav.clone()) {
+///         StackLayout(render: render.into())
+///     }
+/// }
+/// ```
 #[component]
 pub fn route_provider<R: Route>(stack: RouteStack<R>, children: Children) -> Element {
-    // `#[component]` wraps the body in `FnMut` so it can re-run on
-    // hot-reload, so the prop is cloned per invocation. `RouteStack`
-    // is `Rc`-backed — cheap.
+    // `#[component]` wraps the body in `FnMut`, so each invocation
+    // re-publishes the (cheap, Rc-backed) handle into context.
     provide_context(stack.clone());
     whisker::render! {
         children()
     }
 }
 
-/// `Outlet` — renders the topmost entry of the in-context
-/// [`RouteStack`] via `render`.
+/// Mount-only renderer: shows the topmost entry of the in-context
+/// [`RouteStack`] via `render`, and nothing else.
 ///
 /// Re-runs the renderer whenever the current route changes. The
-/// previously-mounted branch is fully disposed (signals + effects
-/// + async tasks inside it are dropped) before the new branch
-/// mounts, so screens don't leak across navigation events.
+/// previously-mounted branch is fully disposed (signals, effects,
+/// spawned tasks inside it are dropped) before the new branch
+/// mounts — screens don't leak across navigation events, but they
+/// also don't survive a back-navigation. If you want a screen's
+/// scroll position / form state to come back when the user navigates
+/// back, use [`StackLayout`](crate::StackLayout) instead.
 ///
-/// Pulls its [`RouteStack`] from context; wrap a containing
-/// [`RouteProvider`] above it. Useful as the *mount-only* path —
-/// no animation machinery; use [`StackLayout`](crate::StackLayout)
-/// when you want transitions.
+/// Pulls its [`RouteStack`] from context — wrap a
+/// [`RouteProvider`] above it.
+///
+/// ```ignore
+/// render! {
+///     RouteProvider(stack: nav) {
+///         Outlet(render: (|r: AppRoute| match r {
+///             AppRoute::Home          => render! { Home() },
+///             AppRoute::Profile { id } => render! { Profile(id: id) },
+///         }).into())
+///     }
+/// }
+/// ```
 #[component]
 pub fn outlet<R: Route>(render: RouteRenderFn<R>) -> Element {
     let stack = router::<R>();
@@ -95,15 +153,13 @@ pub fn outlet<R: Route>(render: RouteRenderFn<R>) -> Element {
     let render = render.clone();
 
     effect(move || {
-        // Tear down the previously-mounted branch (if any).
         if let Some((owner, handle)) = mounted.borrow_mut().take() {
             remove_child(frag, handle);
             owner.dispose();
         }
 
-        // Read the current route and mount its renderer under a
-        // fresh owner so all signals/effects/spawned tasks created
-        // inside live and die with this entry.
+        // Mount the new branch under a fresh owner so its signals,
+        // effects, and spawned tasks live and die with this entry.
         let route = current.get();
         let owner = Owner::new(None);
         let handle = owner.with(|| {

--- a/packages/whisker-router/src/route.rs
+++ b/packages/whisker-router/src/route.rs
@@ -1,37 +1,74 @@
-//! [`Route`] trait + supporting types.
+//! [`Route`] trait + [`RouteError`] — the typed-enum ↔ URL bridge.
 //!
-//! Concrete impls are hand-written for v1; the
-//! `#[whisker::route]` derive lands in a follow-up (requires
-//! `whisker-macros` extension — tracked separately).
+//! Implement [`Route`] manually for full control, or use the
+//! [`#[route]`](macro@crate::route) attribute macro to derive `parse` and
+//! `to_path` from per-variant `#[at("/...")]` patterns. The hidden
+//! `hand_written_example` test module shows what a derived impl
+//! looks like under the hood.
 
 use core::fmt;
 
-/// A typed routing target. Implementors round-trip between an
-/// in-memory enum value and the canonical URL path.
+/// A typed routing target — the value pushed onto a
+/// [`RouteStack`](crate::RouteStack).
 ///
-/// The blanket bounds (`Clone + PartialEq + 'static`) are required
-/// by [`RouteStack`](crate::RouteStack) so the runtime can put the
-/// value in a signal and compare entries for equality.
+/// Implementors round-trip between an in-memory enum value and the
+/// canonical URL path. The crate uses `parse` to resolve deep links
+/// and the `#[at(...)]` macro tests; `to_path` is the inverse used by
+/// linking helpers and debug formatting.
+///
+/// # Bounds
+///
+/// `Clone + PartialEq + 'static` are required by
+/// [`RouteStack`](crate::RouteStack) so the runtime can put values in
+/// a signal, compare entries for equality, and ferry the value into
+/// reactive closures without lifetime gymnastics.
+///
+/// # Example
+///
+/// The common path is the [`#[route]`](macro@crate::route) macro:
+///
+/// ```ignore
+/// use whisker_router::route;
+///
+/// #[route]
+/// #[derive(Clone, Debug, PartialEq)]
+/// pub enum AppRoute {
+///     #[at("/")]             Home,
+///     #[at("/profile/:id")]  Profile { id: u64 },
+/// }
+/// ```
+///
+/// Hand-written impls are also supported — see this file's tests for
+/// the canonical shape.
 pub trait Route: Clone + PartialEq + 'static {
-    /// Parse a path (e.g. `/profile/42`) into a route value.
+    /// Parse a URL path (e.g. `/profile/42`) into a route value.
+    ///
+    /// Implementations should tolerate a trailing slash and an
+    /// optional leading slash — the macro-generated impl does both.
     fn parse(path: &str) -> Result<Self, RouteError>
     where
         Self: Sized;
 
-    /// Canonical URL path for this route value.
+    /// Canonical URL path for this route value. Must round-trip with
+    /// [`Self::parse`].
     fn to_path(&self) -> String;
 }
 
 /// Errors surfaced from [`Route::parse`].
+///
+/// Implements [`std::error::Error`] so callers can bubble it through
+/// `?` in deep-link handlers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RouteError {
-    /// The input didn't match any defined route.
+    /// The input didn't match any defined route. Payload is the
+    /// original path for diagnostics.
     NoMatch(String),
-    /// A path parameter failed to parse (e.g. `id` not a valid `u64`).
+    /// A path parameter (e.g. `:id`) failed to parse into the field's
+    /// declared type.
     BadParam {
         /// Parameter name whose conversion failed.
         param: &'static str,
-        /// Raw value that didn't parse.
+        /// Raw segment value that didn't parse.
         value: String,
     },
 }
@@ -49,12 +86,9 @@ impl fmt::Display for RouteError {
 
 impl std::error::Error for RouteError {}
 
-// ---- Test-only helpers ----------------------------------------
-//
-// Until the `#[whisker::route]` derive lands we hand-write `Route`
-// impls. This section also acts as the canonical "what an impl
-// looks like" example for documentation.
-
+// Canonical hand-written shape — kept compiled under cfg(test) so it
+// stays in sync with the macro's emitted code and doubles as a
+// reference for users who want to bypass the macro.
 #[cfg(test)]
 mod hand_written_example {
     use super::*;

--- a/packages/whisker-router/src/stack.rs
+++ b/packages/whisker-router/src/stack.rs
@@ -1,8 +1,17 @@
 //! [`RouteStack`] — signal-backed back stack.
 //!
-//! Designed as a *first-class value*: callers can create one with
+//! Designed as a *first-class value*: callers create one with
 //! [`route_stack`], pass it as a prop, clone the handle, or hold
-//! several in parallel (tab patterns hold one per tab).
+//! several in parallel (the tab-per-stack pattern holds one per tab).
+//! Cloning shares the underlying reactive storage — there is no
+//! "owner" of the stack, just handles into the same vec.
+//!
+//! Most apps publish the stack through
+//! [`RouteProvider`](crate::RouteProvider) and let the layout
+//! ([`StackLayout`](crate::StackLayout), [`TabsLayout`](crate::TabsLayout),
+//! [`Outlet`](crate::Outlet)) look it up via [`router::<R>()`](crate::router)
+//! — the explicit handle is only needed when imperative code (event
+//! handlers, deep-link callbacks, tab bars) wants to drive navigation.
 //!
 //! Internally a single `RwSignal<Vec<RouteEntry<R>>>` drives reads;
 //! the per-entry [`EntryState`] signal coordinates animation and
@@ -17,14 +26,15 @@ use crate::route::Route;
 
 /// Lifecycle stage of one [`RouteEntry`].
 ///
-/// `Outlet` reads this to decide what styles to apply (slide-in vs
-/// settled vs slide-out) and whether to pause effects for entries
-/// that are out of view. The two `*ing` states are intentionally
-/// short-lived: layouts flip them to `Active` / `Suspended` once
-/// any transition animation finishes.
+/// Layouts (notably [`StackLayout`](crate::StackLayout)) read this to
+/// decide what styles to apply — slide-in vs settled vs slide-out —
+/// and whether to pause effects for entries that are out of view.
+/// The two `*ing` states are intentionally short-lived: layouts flip
+/// them to `Active` / `Suspended` once the transition animation
+/// finishes.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum EntryState {
-    /// Just pushed; animation in progress, becomes [`Active`].
+    /// Just pushed; animation in progress, becomes [`Self::Active`].
     Entering,
     /// Settled on top of the stack.
     Active,
@@ -36,20 +46,25 @@ pub enum EntryState {
 
 /// Unique identifier for a [`RouteEntry`].
 ///
-/// Stable across the entry's lifetime in the stack. Used as a key
-/// for animations / DOM diffing so the same physical screen keeps
-/// the same element handle even as the surrounding stack shifts.
+/// Stable across the entry's lifetime in the stack — even if the
+/// surrounding entries reshuffle. Used as the diff key for animations
+/// and DOM reconciliation so a physical screen keeps the same
+/// wrapper element handle through a navigation.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EntryId(pub u64);
 
-/// One slot in a [`RouteStack`].
+/// One slot in a [`RouteStack`] — the route value plus its lifecycle
+/// signal and stable id.
+///
+/// Equality compares both [`Self::id`] and [`Self::route`] so two
+/// pushes of the "same" route value are still distinguishable.
 #[derive(Clone)]
 pub struct RouteEntry<R: Route> {
     /// The route this entry represents.
     pub route: R,
     /// Lifecycle signal; updated by layouts as animations progress.
     pub state: RwSignal<EntryState>,
-    /// Stable id for this entry's lifetime.
+    /// Stable id for this entry's lifetime in the stack.
     pub id: EntryId,
 }
 
@@ -59,11 +74,32 @@ impl<R: Route + PartialEq> PartialEq for RouteEntry<R> {
     }
 }
 
-/// A signal-backed back stack of routes.
+/// A signal-backed back stack of routes — the canonical navigation
+/// primitive.
 ///
 /// `RouteStack` is a *handle*: cloning it shares the underlying
 /// reactive storage with the original, so a stack can be passed
 /// freely between components / closures without wrapping in `Rc`.
+/// The stack maintains the invariant that **at least one entry is
+/// always present** — [`Self::back`] is a no-op (returns `false`) at
+/// the root rather than emptying the stack.
+///
+/// # Example
+///
+/// ```ignore
+/// use whisker_router::route_stack;
+///
+/// let nav = route_stack(AppRoute::Home);
+/// nav.push(AppRoute::Profile { id: 7 });
+/// nav.back();
+/// assert_eq!(nav.current().get(), AppRoute::Home);
+/// ```
+///
+/// Usually you don't keep the handle around — wrap your tree in a
+/// [`RouteProvider`](crate::RouteProvider) and let descendants call
+/// [`router::<R>()`](crate::router) to retrieve it. The explicit
+/// handle is for imperative call sites (event handlers, deep-link
+/// callbacks, tab bars).
 pub struct RouteStack<R: Route> {
     entries: RwSignal<Vec<RouteEntry<R>>>,
     next_id: Rc<Cell<u64>>,
@@ -79,7 +115,10 @@ impl<R: Route> Clone for RouteStack<R> {
 }
 
 impl<R: Route> RouteStack<R> {
-    /// Construct a stack with one initial entry.
+    /// Construct a stack with `initial` as the root entry.
+    ///
+    /// Prefer the free function [`route_stack`] for symmetry with
+    /// other Whisker constructors.
     pub fn new(initial: R) -> Self {
         let next_id = Rc::new(Cell::new(0_u64));
         let id = mint_id(&next_id);
@@ -93,8 +132,6 @@ impl<R: Route> RouteStack<R> {
             next_id,
         }
     }
-
-    // ---- writers ----
 
     /// Push a new route onto the top of the stack.
     ///
@@ -135,7 +172,14 @@ impl<R: Route> RouteStack<R> {
         popped
     }
 
-    /// Pop entries until `predicate` returns true on the new top.
+    /// Pop entries until `predicate` returns `true` on the new top.
+    ///
+    /// Stops at the root regardless of the predicate. Useful for
+    /// "pop back to the home tab" patterns:
+    ///
+    /// ```ignore
+    /// nav.back_to(|r| matches!(r, AppRoute::Home));
+    /// ```
     pub fn back_to(&self, predicate: impl Fn(&R) -> bool) {
         self.entries.update(|v| {
             while v.len() > 1 {
@@ -151,7 +195,11 @@ impl<R: Route> RouteStack<R> {
         });
     }
 
-    /// Replace the topmost entry with `route` (no history growth).
+    /// Replace the topmost entry with `route` — depth unchanged.
+    ///
+    /// Use this for "redirect" navigations (e.g. login → home) where
+    /// the user should not be able to swipe back into the replaced
+    /// entry.
     pub fn replace(&self, route: R) {
         let id = mint_id(&self.next_id);
         self.entries.update(|v| {
@@ -165,6 +213,9 @@ impl<R: Route> RouteStack<R> {
     }
 
     /// Clear the stack and start over with `route` at the root.
+    ///
+    /// Typical use: logout, deep-link cold-launch into a non-home
+    /// destination, end-of-onboarding handoff.
     pub fn replace_all(&self, route: R) {
         let id = mint_id(&self.next_id);
         self.entries.set(vec![RouteEntry {
@@ -174,9 +225,10 @@ impl<R: Route> RouteStack<R> {
         }]);
     }
 
-    // ---- readers ----
-
     /// Reactive read of the topmost route.
+    ///
+    /// Re-fires whenever the top changes. The most common reader —
+    /// most screens just want "what route is showing right now".
     pub fn current(&self) -> ReadSignal<R> {
         let entries = self.entries;
         computed(move || {
@@ -188,20 +240,25 @@ impl<R: Route> RouteStack<R> {
         })
     }
 
-    /// Reactive read of the full stack (as `Vec<R>`).
+    /// Reactive read of the full stack as `Vec<R>` — useful for tab
+    /// bars or breadcrumbs that need to render every level.
     pub fn stack(&self) -> ReadSignal<Vec<R>> {
         let entries = self.entries;
         computed(move || entries.get().iter().map(|e| e.route.clone()).collect())
     }
 
-    /// Reactive read of the entries themselves — needed by layouts
-    /// that animate per-entry state.
+    /// Reactive read of the entries themselves (including
+    /// [`EntryState`] and [`EntryId`]) — used by layouts that animate
+    /// per-entry state. Most app code wants [`Self::stack`] instead.
     pub fn entries(&self) -> ReadSignal<Vec<RouteEntry<R>>> {
         let entries = self.entries;
         computed(move || entries.get())
     }
 
-    /// Reactive flag indicating whether [`Self::back`] would pop.
+    /// Reactive flag indicating whether [`Self::back`] would pop —
+    /// `true` once there's something on top of the root.
+    ///
+    /// Drive your in-app back button's visibility from this signal.
     pub fn can_back(&self) -> ReadSignal<bool> {
         let entries = self.entries;
         computed(move || entries.get().len() > 1)
@@ -221,6 +278,10 @@ fn mint_id(counter: &Rc<Cell<u64>>) -> EntryId {
 }
 
 /// Construct a fresh [`RouteStack`] with `initial` as its root entry.
+///
+/// ```ignore
+/// let nav = whisker_router::route_stack(AppRoute::Home);
+/// ```
 pub fn route_stack<R: Route>(initial: R) -> RouteStack<R> {
     RouteStack::new(initial)
 }

--- a/packages/whisker-router/src/transitions/fade.rs
+++ b/packages/whisker-router/src/transitions/fade.rs
@@ -1,4 +1,4 @@
-//! [`Fade`] — cross-fade transition between two stack entries.
+//! [`Fade`] — opacity cross-fade between two stack entries.
 
 use whisker::runtime::view::Element;
 use whisker::{animate_start, AnimateOptions};
@@ -7,10 +7,15 @@ use super::{Direction, Side, StackTransition};
 
 const DEFAULT_DURATION_MS: u32 = 320;
 
-/// Cross-fade. Incoming opacity 0→1, outgoing 1→0.
+/// Cross-fade transition: incoming opacity 0→1, outgoing 1→0.
+///
+/// Layering is cosmetic in a cross-fade (both screens are partially
+/// transparent throughout) so [`foreground`](Self::foreground) is
+/// always [`Side::Incoming`] — the incoming screen ends fully opaque
+/// on top of the outgoing.
 #[derive(Copy, Clone, Debug)]
 pub struct Fade {
-    /// Duration in milliseconds.
+    /// Duration in milliseconds. Default 320ms.
     pub duration_ms: u32,
     /// Easing function string. Default `"linear"` — fades feel
     /// most natural without acceleration.
@@ -49,9 +54,8 @@ impl StackTransition for Fade {
     }
 
     fn foreground(&self, _direction: Direction) -> Side {
-        // Crossfade doesn't depend on layering — both screens are
-        // partially transparent throughout. Keep incoming on top so
-        // its final fully-opaque state covers correctly at the end.
+        // Cross-fade is symmetric optically; keep incoming on top so
+        // its final fully-opaque state covers correctly.
         Side::Incoming
     }
 }

--- a/packages/whisker-router/src/transitions/instant.rs
+++ b/packages/whisker-router/src/transitions/instant.rs
@@ -4,8 +4,11 @@ use whisker::runtime::view::Element;
 
 use super::{Direction, Side, StackTransition};
 
-/// No animation: entries swap immediately. Useful for programmatic
-/// resets (`replace_all`) or unit-test paths.
+/// No animation — entries swap immediately.
+///
+/// Useful for programmatic resets (`replace_all`), unit tests, or
+/// platforms where animation is unwanted. `animate` is a no-op so
+/// the wrapper paints at its settled pose with no transient frame.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Instant;
 

--- a/packages/whisker-router/src/transitions/ios_slide.rs
+++ b/packages/whisker-router/src/transitions/ios_slide.rs
@@ -1,8 +1,9 @@
-//! [`IosSlide`] — UINavigationController-style horizontal slide
-//! with parallax, leading-edge shadow on the moving screen, and a
-//! subtle brightness dim on the parallaxed background screen.
+//! [`IosSlide`] — UINavigationController-style horizontal slide.
 //!
-//! Default transition for [`StackLayout`](crate::StackLayout).
+//! The default transition for [`StackLayout`](crate::StackLayout).
+//! Horizontal slide with [`IOS_PARALLAX_PCT`] parallax, a
+//! leading-edge shadow on the moving screen, and a brightness dim
+//! on the parallaxed background screen.
 //!
 //! For the iOS-native edge swipe-back gesture, mount
 //! [`IosSwipeBack`](crate::IosSwipeBack) as a child of the layout —
@@ -15,39 +16,41 @@ use whisker::{animate_start, AnimateOptions, Style};
 
 use super::{Direction, Side, StackTransition};
 
-/// One animation's CSS endpoints — `(name, from_props, to_props)`.
+// `(animation-name, from_props, to_props)` triple.
 type Keyframes<'a> = (
     &'static str,
     Vec<(&'static str, &'a str)>,
     Vec<(&'static str, &'a str)>,
 );
 
-/// Outgoing screen translates ~30% of viewport toward the leading
-/// edge during a horizontal push — UIKit's parallax amount.
+/// Outgoing screen translates this percent of the viewport toward
+/// the leading edge during a horizontal push — UIKit's parallax
+/// amount. Also exposed for callers (e.g. swipe-back) that want to
+/// match the natural transition's endpoint.
 pub const IOS_PARALLAX_PCT: f32 = 30.0;
 
-/// Depth shadow declared as static inline style on the foreground
-/// wrapper. Lynx's animator drops `box-shadow` from `@keyframes`
-/// rules, so it has to ride along as a `slot_style` declaration
-/// rather than an animated property. 5-part syntax is required.
+// Lynx's animator drops `box-shadow` from `@keyframes` rules, so
+// the depth shadow rides along as a `slot_style` declaration instead
+// of an animated property. 5-part syntax is required.
 const IOS_LEADING_SHADOW: &str = "box-shadow: -4px 0px 16px 0px rgba(0, 0, 0, 0.06);";
 
-/// Parallaxed (background) screen sits one notch dimmer than fully
-/// lit. Carried via `slot_style` as the initial state; the matching
-/// `animate` interpolates `filter: brightness(...)` between this
-/// and `brightness(1.0)` so the screen brightens as it returns to
-/// the foreground (or dims as it leaves).
+// Background screen sits one notch dimmer than fully lit. Carried
+// via `slot_style` as the initial state; `animate` interpolates
+// `filter: brightness(...)` from here to `brightness(1.0)`.
 const IOS_PARALLAX_DIM: &str = "filter: brightness(0.85);";
 
 const DEFAULT_DURATION_MS: u32 = 320;
 const DEFAULT_EASING: &str = "ease-in-out";
 
 /// iOS UINavigationController-style horizontal slide.
+///
+/// Tuneable via [`Self::duration_ms`] and [`Self::easing`]; the
+/// shadow + brightness decorations are not configurable in v1.
 #[derive(Copy, Clone, Debug)]
 pub struct IosSlide {
-    /// Duration in milliseconds (default 320ms).
+    /// Duration in milliseconds. Default 320ms.
     pub duration_ms: u32,
-    /// Easing function string (default `"ease-in-out"`).
+    /// Easing function string. Default `"ease-in-out"`.
     pub easing: &'static str,
 }
 
@@ -123,10 +126,9 @@ impl StackTransition for IosSlide {
     }
 }
 
-/// Sample the iOS slide pose at `progress ∈ [0.0, 1.0]`. Shared
-/// with the [`IosSwipeBack`](crate::IosSwipeBack) gesture so the
-/// gesture's per-frame scrub stays in sync with the natural
-/// animation's endpoints.
+// Sample the iOS slide pose at `progress ∈ [0.0, 1.0]`. Shared with
+// the IosSwipeBack gesture so its per-frame scrub matches the
+// natural animation's endpoints exactly.
 pub(crate) fn pose(side: Side, direction: Direction, progress: f32) -> Vec<(&'static str, String)> {
     let (tx_from, tx_to, br_from, br_to) = match (side, direction) {
         (Side::Incoming, Direction::Forward) => (100.0, 0.0, 1.0, 1.0),

--- a/packages/whisker-router/src/transitions/mod.rs
+++ b/packages/whisker-router/src/transitions/mod.rs
@@ -1,24 +1,32 @@
-//! Transitions: pluggable visual animations for [`StackLayout`](crate::StackLayout).
+//! Transitions: pluggable visual animations for
+//! [`StackLayout`](crate::StackLayout).
 //!
 //! A transition's job is to describe *how the screen looks* during
-//! a navigation — push, pop, anything in between. Each transition
-//! implementation lives in its own submodule — [`ios_slide`] for
-//! the default UIKit-style horizontal slide, [`vertical_slide`] for
-//! the Y-axis variant, [`fade`] for an opacity cross-fade, and
-//! [`instant`] for the no-animation fallback. This module re-exports
-//! the trait + every built-in, plus the shared [`Direction`] /
-//! [`Side`] / [`StackTransitionBox`] types each implementation
-//! consumes.
+//! a navigation — push, pop, anything in between. The
+//! [`StackTransition`] trait has one core method ([`animate`](StackTransition::animate))
+//! and two optional hooks ([`foreground`](StackTransition::foreground),
+//! [`slot_style`](StackTransition::slot_style)) for layering and
+//! per-side decoration.
 //!
-//! Custom transitions implement [`StackTransition`] and are passed
-//! to the layout via [`StackTransitionBox::new`]:
+//! ## Built-ins
+//!
+//! - [`IosSlide`] — UINavigationController-style horizontal slide
+//!   with 30% parallax and a leading-edge shadow. **Default.**
+//! - [`Fade`] — cross-fade between two stack entries.
+//! - [`VerticalSlide`] — Y-axis analogue of [`IosSlide`].
+//! - [`Instant`] — no animation; entries swap in one frame.
+//!
+//! ## Custom transitions
+//!
+//! Implement [`StackTransition`] and wrap in
+//! [`StackTransitionBox::new`]:
 //!
 //! ```ignore
 //! use whisker_router::{StackTransition, StackTransitionBox, Direction, Side};
 //! use whisker::runtime::view::Element;
 //!
-//! struct ZoomSlide;
-//! impl StackTransition for ZoomSlide {
+//! struct ZoomIn;
+//! impl StackTransition for ZoomIn {
 //!     fn animate(&self, el: Element, side: Side, _dir: Direction) {
 //!         if side != Side::Incoming { return; }
 //!         whisker::animate_start(el, "zoom-in", &[
@@ -27,14 +35,21 @@
 //!         ], &whisker::AnimateOptions::default()).ok();
 //!     }
 //! }
+//!
+//! StackLayout(
+//!     transition: StackTransitionBox::new(ZoomIn),
+//!     render: render.into(),
+//! );
 //! ```
+//!
+//! ## Why pluggable + decoupled
 //!
 //! Interactive behaviour (iOS swipe-back, Android system back) is
 //! intentionally **not** part of this trait — it lives in separate
-//! [composable components](crate::gestures) that the user mounts
-//! inside the layout. That way transitions stay pure and easy to
-//! write, and gestures stay easy to mix-and-match without coupling
-//! every transition impl to a touch-event loop.
+//! [composable gesture components](crate::gestures) that the user
+//! mounts inside the layout. That way transitions stay pure and easy
+//! to write, and gestures stay easy to mix and match without
+//! coupling every transition impl to a touch-event loop.
 
 use std::rc::Rc;
 
@@ -51,39 +66,46 @@ pub use instant::Instant;
 pub use ios_slide::{IosSlide, IOS_PARALLAX_PCT};
 pub use vertical_slide::VerticalSlide;
 
-/// Direction of the current navigation, derived from the
-/// [`RouteStack`](crate::RouteStack) length delta.
+/// Direction of the current navigation — derived by
+/// [`StackLayout`](crate::StackLayout) from the
+/// [`RouteStack`](crate::RouteStack) diff.
+///
+/// Passed to [`StackTransition::animate`] so the transition can pick
+/// per-direction keyframes (e.g. iOS push covers, iOS pop reveals).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Direction {
-    /// Stack grew (a `push`).
+    /// Stack grew — a `push`.
     Forward,
-    /// Stack shrank (a `back`).
+    /// Stack shrank — a `back`.
     Backward,
-    /// No animation: replace, replace_all-to-same-depth, or the
+    /// No animation: `replace`, `replace_all`-to-same-route, or the
     /// first mount.
     None,
 }
 
 /// One of the two screens involved in a transition.
 ///
-/// `Incoming` is the screen the navigation is bringing in (becomes
-/// the new top of the stack after the transition). `Outgoing` is
-/// the screen being replaced (was the top before the navigation,
-/// slides away during the transition).
+/// Layouts call [`StackTransition::animate`] once per side per
+/// navigation, so the implementation can drive the incoming and
+/// outgoing wrappers independently.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Side {
-    /// The new top of the stack.
+    /// The new top of the stack — the screen being brought in.
     Incoming,
-    /// The screen being replaced.
+    /// The screen being replaced — was the top before this navigation.
     Outgoing,
 }
 
-/// Pluggable transition for a stack layout — purely visual.
+/// Pluggable transition for [`StackLayout`](crate::StackLayout) —
+/// purely visual.
 ///
-/// One [`animate`](StackTransition::animate) call per slot per
-/// navigation — the [`Side`] argument distinguishes "drive the
-/// incoming wrapper" from "drive the outgoing wrapper". The trait
-/// is `'static` so it can be stored inside an `Rc`.
+/// Layouts call [`animate`](Self::animate) once per slot per
+/// navigation (one Incoming + one Outgoing). The trait is `'static`
+/// so it can live inside an `Rc` via [`StackTransitionBox`].
+///
+/// See [`IosSlide`] / [`Fade`] / [`VerticalSlide`] / [`Instant`] for
+/// reference implementations; the [module docs](self) cover the
+/// custom-transition shape.
 pub trait StackTransition: 'static {
     /// Drive the natural (non-interactive) animation for one slot
     /// wrapper.
@@ -133,7 +155,7 @@ pub trait StackTransition: 'static {
     /// needs to live on the wrapper alongside the layout positioning
     /// goes here.
     ///
-    /// Returning a [`Style::Dynamic`](whisker::Style::Dynamic) value
+    /// Returning a [`Style::Dynamic`] value
     /// makes the decoration reactive — the wrapper is re-styled
     /// whenever any signal the closure reads fires (useful for
     /// theme-driven shadow colours, etc.). [`Style::Static`] applies
@@ -150,10 +172,19 @@ pub trait StackTransition: 'static {
     }
 }
 
-/// Cheap-to-clone handle wrapping any [`StackTransition`]
-/// implementation. The `#[component]` macro re-clones every prop on
-/// every body invocation, so the prop type must be `Clone` — this
-/// wrapper makes any `dyn StackTransition` satisfy that.
+/// Cheap-to-clone handle wrapping any [`StackTransition`].
+///
+/// `#[component]` re-clones every prop on each body invocation, so
+/// the prop type must be `Clone`. `StackTransitionBox` makes any
+/// `dyn StackTransition` satisfy that bound. Default is
+/// [`IosSlide`].
+///
+/// ```ignore
+/// StackLayout(
+///     transition: StackTransitionBox::new(Fade::default()),
+///     render: render.into(),
+/// );
+/// ```
 #[derive(Clone)]
 pub struct StackTransitionBox(pub Rc<dyn StackTransition>);
 

--- a/packages/whisker-router/src/transitions/vertical_slide.rs
+++ b/packages/whisker-router/src/transitions/vertical_slide.rs
@@ -1,5 +1,5 @@
-//! [`VerticalSlide`] — Y-axis variant of [`super::IosSlide`] for
-//! stack-driven modal-style presentations.
+//! [`VerticalSlide`] — Y-axis analogue of
+//! [`super::IosSlide`] for stack-driven modal-style presentations.
 
 use whisker::runtime::view::Element;
 use whisker::{animate_start, AnimateOptions};
@@ -11,11 +11,15 @@ const DEFAULT_EASING: &str = "ease-in-out";
 
 /// Vertical analogue of [`super::IosSlide`] — incoming slides up
 /// from below on push, parallaxes down on pop.
+///
+/// Useful for stack-driven sheet-style presentations where the
+/// horizontal slide of [`super::IosSlide`] doesn't fit the visual
+/// model.
 #[derive(Copy, Clone, Debug)]
 pub struct VerticalSlide {
-    /// Duration in milliseconds.
+    /// Duration in milliseconds. Default 320ms.
     pub duration_ms: u32,
-    /// Easing function string.
+    /// Easing function string. Default `"ease-in-out"`.
     pub easing: &'static str,
 }
 


### PR DESCRIPTION
Part of the comment-overhaul sweep (style guide: PR #133).

Applies docs/comment-style.md to packages/whisker-router and packages/whisker-router-macros.

## What changed
- Module docs orient readers across the layer cake (Route → RouteStack → RouteProvider → Outlet/StackLayout/TabsLayout → StackTransition → gesture components)
- Pub items get usable rustdoc with cross-references between layers
- #[route] macro gets a usage example, full path grammar, and an explicit list of supported variant kinds + compile-time errors
- Internal // comments trimmed per keep/delete rules — load-bearing "why" notes and memory-note references kept, code paraphrase and step-counters dropped

## Test plan
- cargo check -p whisker-router -p whisker-router-macros: clean
- cargo doc --no-deps -p whisker-router -p whisker-router-macros: 0 warnings
- cargo test -p whisker-router --lib: 39 passed