### PR TITLE
chore(build): bump lynx pin to v3.8.0-whisker.4

### DIFF
--- a/crates/whisker-build/src/lynx.rs
+++ b/crates/whisker-build/src/lynx.rs
@@ -57,11 +57,11 @@ use std::path::{Path, PathBuf};
 /// Schema: `<lynx-upstream-version>-whisker.<patch-iteration>` so a
 /// reader can tell at a glance which upstream Lynx is wrapped, and
 /// our own patch iterations bump independently.
-pub const LYNX_FORK_TAG: &str = "v3.8.0-whisker.3";
+pub const LYNX_FORK_TAG: &str = "v3.8.0-whisker.4";
 
 /// Version segment that appears in cache paths + tarball filenames.
 /// Derived from [`LYNX_FORK_TAG`] minus the leading `v`.
-pub const LYNX_VERSION: &str = "3.8.0-whisker.3";
+pub const LYNX_VERSION: &str = "3.8.0-whisker.4";
 
 /// SHA-256 of `whisker-lynx-android-<LYNX_VERSION>.tar.gz` as
 /// produced by the fork's CI. Pinned to the
@@ -86,7 +86,7 @@ pub const LYNX_VERSION: &str = "3.8.0-whisker.3";
 /// `LynxBase.podspec.json`, `LynxServiceAPI.podspec.json`) were
 /// synced to the trunk 3.8.0 source/header lists in the same release.
 pub const LYNX_ANDROID_SHA256: &str =
-    "4d58a410f62e3b80434b96db49710c1b99613e75f5128c3bcad0a8f6de62db60";
+    "f7609438119d842d06d022a671ffa40e34c377b1a5377aaeb32e7ff8a3ee0728";
 
 /// SHA-256 of `whisker-lynx-ios-<LYNX_VERSION>.tar.gz`.
 ///
@@ -99,7 +99,7 @@ pub const LYNX_ANDROID_SHA256: &str =
 /// from `core/native_renderer_capi/`, so the bridge in
 /// `crates/whisker-driver-sys/` no longer vendors them.
 pub const LYNX_IOS_SHA256: &str =
-    "11aa8391b7cd513f2219ee40a82f5a7b13c6c8288cea3547ed9aa6bfad24b767";
+    "73f5b8adbcea42747d663abdbc1f868743fcea4a789ae6be42f01fafd1dee6c9";
 
 /// GitHub Releases URL template. The `<{ver}>` and `<{plat}>`
 /// placeholders are filled by [`download_url`].


### PR DESCRIPTION
## Summary

- Bumps `LYNX_FORK_TAG` / `LYNX_VERSION` / `LYNX_ANDROID_SHA256` / `LYNX_IOS_SHA256` in `crates/whisker-build/src/lynx.rs` from `3.8.0-whisker.3` → `3.8.0-whisker.4`.
- `v3.8.0-whisker.4` is the first fork release that publishes both the gh-pages Maven repo (`https://whiskerrs.github.io/lynx/maven/`) and the GitHub Release xcframework zips + SwiftPM checksums alongside the existing legacy tarballs. Lynx C++ source is unchanged from `.3`.
- The legacy `whisker-lynx-{android,ios}-3.8.0-whisker.4.tar.gz` tarballs that this crate's `ensure_lynx_*` fetcher consumes are still produced, so no functional change to the build pipeline — just newer artefacts.

## Test plan

- [x] `whisker build --target android` on `packages/whisker-router/example` — `ensure_lynx_android` downloads `whisker-lynx-android-3.8.0-whisker.4.tar.gz`, SHA256 verifies against the new constant, cache lands at `~/.cache/whisker/lynx/3.8.0-whisker.4/android/`, `target/lynx-android*` symlinks refresh.
- [x] APK installs on emulator-5554, back-gesture animation works.
- [ ] iOS build verification (xcframework path) — to be covered when the consumer-side SwiftPM migration lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)