### PR TITLE
feat(build): wire whisker-build android body (Step 4)

### DIFF
--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -268,8 +268,7 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
 /// `<buildDir>/intermediates/whisker_jni_libs/<variant>/<abi>/` and
 /// passes it in via `--jni-libs-dir`.
 pub fn stage_so_files(abi_dir: &Path, so: &Path, tc: &AndroidToolchain, abi: &str) -> Result<()> {
-    std::fs::create_dir_all(abi_dir)
-        .with_context(|| format!("mkdir -p {}", abi_dir.display()))?;
+    std::fs::create_dir_all(abi_dir).with_context(|| format!("mkdir -p {}", abi_dir.display()))?;
 
     let so_name = so
         .file_name()

--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -260,26 +260,26 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
 
 // ----- jniLibs staging ------------------------------------------------------
 
-/// Copy `so` plus the NDK-shipped `libc++_shared.so` into
-/// `gen/android/app/src/main/jniLibs/<abi>/`.
-pub fn stage_jni_libs(
-    gen_android: &Path,
-    abi: &str,
-    so: &Path,
-    tc: &AndroidToolchain,
-) -> Result<()> {
-    let dst_dir = gen_android.join("app/src/main/jniLibs").join(abi);
-    std::fs::create_dir_all(&dst_dir).with_context(|| format!("mkdir -p {}", dst_dir.display()))?;
+/// Copy `so` plus the NDK-shipped `libc++_shared.so` into `abi_dir`.
+/// Lower-level than [`stage_jni_libs`] — the caller hands in the
+/// already-resolved abi leaf directory rather than the gen-android
+/// root. Used by the `whisker-build android` binary path, where the
+/// Gradle plugin computes the destination as
+/// `<buildDir>/intermediates/whisker_jni_libs/<variant>/<abi>/` and
+/// passes it in via `--jni-libs-dir`.
+pub fn stage_so_files(abi_dir: &Path, so: &Path, tc: &AndroidToolchain, abi: &str) -> Result<()> {
+    std::fs::create_dir_all(abi_dir)
+        .with_context(|| format!("mkdir -p {}", abi_dir.display()))?;
 
     let so_name = so
         .file_name()
         .ok_or_else(|| anyhow!("so path has no filename: {}", so.display()))?;
-    let dst_so = dst_dir.join(so_name);
+    let dst_so = abi_dir.join(so_name);
     std::fs::copy(so, &dst_so)
         .with_context(|| format!("copy {} → {}", so.display(), dst_so.display()))?;
 
     let libcxx = find_libcxx_shared(&tc.ndk, abi)?;
-    let dst_libcxx = dst_dir.join("libc++_shared.so");
+    let dst_libcxx = abi_dir.join("libc++_shared.so");
     std::fs::copy(&libcxx, &dst_libcxx)
         .with_context(|| format!("copy {} → {}", libcxx.display(), dst_libcxx.display()))?;
 
@@ -288,6 +288,20 @@ pub fn stage_jni_libs(
         so_name.to_string_lossy(),
     ));
     Ok(())
+}
+
+/// Copy `so` plus the NDK-shipped `libc++_shared.so` into
+/// `gen/android/app/src/main/jniLibs/<abi>/`. Used by the cng-driven
+/// `whisker build` CLI path; the Gradle-plugin path goes through
+/// [`stage_so_files`] directly.
+pub fn stage_jni_libs(
+    gen_android: &Path,
+    abi: &str,
+    so: &Path,
+    tc: &AndroidToolchain,
+) -> Result<()> {
+    let dst_dir = gen_android.join("app/src/main/jniLibs").join(abi);
+    stage_so_files(&dst_dir, so, tc, abi)
 }
 
 /// Generate the per-app Gradle module-aggregator artefacts under

--- a/crates/whisker-build/src/main.rs
+++ b/crates/whisker-build/src/main.rs
@@ -55,9 +55,10 @@
 //! cross-compile + artefact placement once the cng templates start
 //! invoking this binary.
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
+use whisker_build::Profile;
 
 #[derive(Parser)]
 #[command(
@@ -184,19 +185,20 @@ fn run_ios(args: IosArgs) -> Result<()> {
         args.built_products_dir.display(),
     );
 
-    // Step 4 will fill in:
+    // The iOS body is still a diagnostic stub. Filling it in needs:
     //   - cargo rustc --target=<triple> --crate-type=cdylib per
-    //     requested arch
+    //     requested arch (mirrors what `whisker build --target
+    //     ios-sim` already drives through the lib's `ios::*` helpers
+    //     in whisker-cli)
     //   - lipo of the simulator slices when ARCHS contains both
     //     arm64 + x86_64
-    //   - generate whisker_modules/Package.swift +
-    //     RegisterAll.swift via ios::stage_module_swift_sources
+    //   - whisker_modules/Package.swift + RegisterAll.swift emission
+    //     via ios::stage_module_swift_sources
     //   - copy the dylib into
-    //     $BUILT_PRODUCTS_DIR/Frameworks/Whisker.framework/
-    // Today the binary just validates the arg surface and exercises
-    // module discovery so the cng-rendered pbxproj has something
-    // safe to invoke during a build.
-    eprintln!("[whisker-build ios] cargo cross-compile + module aux placement wired in Step 4",);
+    //     $BUILT_PRODUCTS_DIR/Frameworks/Whisker.framework/Whisker
+    // Tracked as the next sub-step (Step 4-iOS); the Android body
+    // above is the verified path that unblocks the Gradle plugin.
+    eprintln!("[whisker-build ios] cargo cross-compile + module aux placement still pending (Step 4-iOS)");
 
     Ok(())
 }
@@ -206,34 +208,49 @@ fn run_android(args: AndroidArgs) -> Result<()> {
     let modules = whisker_build::modules::discover(&cargo_toml, &args.package)
         .with_context(|| format!("discover whisker modules in {}", cargo_toml.display()))?;
 
-    let triple = whisker_build::android::abi_to_triple(&args.abi)
-        .with_context(|| format!("unrecognised ABI `{}`", args.abi))?;
+    let profile = parse_profile(&args.profile)?;
+
+    // `whisker-driver-sys`'s build.rs reads Lynx Android headers +
+    // .so from `<workspace>/target/lynx-android*`. Fetch the pinned
+    // tarball + create the symlinks before cargo runs so the cc-rs
+    // include search finds Lynx without a pre-existing whisker CLI
+    // bootstrap.
+    let _cache = whisker_build::ensure_lynx_android()
+        .context("fetch pinned Lynx Android artifacts")?;
+    whisker_build::link_lynx_into_workspace(&args.workspace, whisker_build::LynxPlatform::Android)
+        .context("symlink target/lynx-android* into workspace")?;
+
+    let toolchain = whisker_build::android::resolve_toolchain(&args.abi, args.min_sdk)
+        .with_context(|| format!("resolve NDK toolchain for {} (api {})", args.abi, args.min_sdk))?;
+
+    let so_path = whisker_build::android::cargo_build_dylib(&whisker_build::android::CargoBuild {
+        workspace_root: &args.workspace,
+        package: &args.package,
+        toolchain: &toolchain,
+        profile,
+        features: &[],
+        capture: None,
+    })
+    .context("cargo cross-compile for Android")?;
+
+    whisker_build::android::stage_so_files(&args.jni_libs_dir, &so_path, &toolchain, &args.abi)
+        .with_context(|| format!("stage .so + libc++_shared.so into {}", args.jni_libs_dir.display()))?;
 
     eprintln!(
-        "[whisker-build android] workspace={} package={} profile={} abi={} triple={} modules={}",
-        args.workspace.display(),
-        args.package,
-        args.profile,
-        args.abi,
-        triple,
+        "[whisker-build android] {} module(s) discovered (gradle-subproject wiring is the Gradle plugin's job)",
         modules.len(),
     );
-    eprintln!(
-        "[whisker-build android] jni-libs-dir={} min-sdk={}",
-        args.jni_libs_dir.display(),
-        args.min_sdk,
-    );
-
-    // Step 4 will fill in:
-    //   - android::resolve_toolchain(abi, min_sdk) → NDK paths
-    //   - android::cargo_build_dylib(&CargoBuild { ... })
-    //   - android::stage_jni_libs(jni_libs_dir, abi, so_path, &toolchain)
-    //   - whisker_modules.settings.gradle.kts +
-    //     whisker_module_deps.gradle.kts emission so the gradle
-    //     plugin's `apply(from = ...)` references resolve
-    // Today the binary just validates the arg surface + ABI mapping
-    // + module discovery.
-    eprintln!("[whisker-build android] cargo cross-compile + jniLibs staging wired in Step 4",);
-
     Ok(())
+}
+
+/// Translate the `--profile` string the Gradle plugin (or CLI caller)
+/// passes into the typed [`Profile`] the library API expects. The
+/// plugin currently emits exactly `"debug"` / `"release"` so the
+/// match is closed; any other value is a wiring bug worth surfacing.
+fn parse_profile(s: &str) -> Result<Profile> {
+    match s {
+        "debug" => Ok(Profile::Debug),
+        "release" => Ok(Profile::Release),
+        other => Err(anyhow!("--profile must be 'debug' or 'release' (got `{other}`)")),
+    }
 }

--- a/crates/whisker-build/src/main.rs
+++ b/crates/whisker-build/src/main.rs
@@ -198,7 +198,9 @@ fn run_ios(args: IosArgs) -> Result<()> {
     //     $BUILT_PRODUCTS_DIR/Frameworks/Whisker.framework/Whisker
     // Tracked as the next sub-step (Step 4-iOS); the Android body
     // above is the verified path that unblocks the Gradle plugin.
-    eprintln!("[whisker-build ios] cargo cross-compile + module aux placement still pending (Step 4-iOS)");
+    eprintln!(
+        "[whisker-build ios] cargo cross-compile + module aux placement still pending (Step 4-iOS)"
+    );
 
     Ok(())
 }
@@ -215,13 +217,18 @@ fn run_android(args: AndroidArgs) -> Result<()> {
     // tarball + create the symlinks before cargo runs so the cc-rs
     // include search finds Lynx without a pre-existing whisker CLI
     // bootstrap.
-    let _cache = whisker_build::ensure_lynx_android()
-        .context("fetch pinned Lynx Android artifacts")?;
+    let _cache =
+        whisker_build::ensure_lynx_android().context("fetch pinned Lynx Android artifacts")?;
     whisker_build::link_lynx_into_workspace(&args.workspace, whisker_build::LynxPlatform::Android)
         .context("symlink target/lynx-android* into workspace")?;
 
     let toolchain = whisker_build::android::resolve_toolchain(&args.abi, args.min_sdk)
-        .with_context(|| format!("resolve NDK toolchain for {} (api {})", args.abi, args.min_sdk))?;
+        .with_context(|| {
+            format!(
+                "resolve NDK toolchain for {} (api {})",
+                args.abi, args.min_sdk
+            )
+        })?;
 
     let so_path = whisker_build::android::cargo_build_dylib(&whisker_build::android::CargoBuild {
         workspace_root: &args.workspace,
@@ -234,7 +241,12 @@ fn run_android(args: AndroidArgs) -> Result<()> {
     .context("cargo cross-compile for Android")?;
 
     whisker_build::android::stage_so_files(&args.jni_libs_dir, &so_path, &toolchain, &args.abi)
-        .with_context(|| format!("stage .so + libc++_shared.so into {}", args.jni_libs_dir.display()))?;
+        .with_context(|| {
+            format!(
+                "stage .so + libc++_shared.so into {}",
+                args.jni_libs_dir.display()
+            )
+        })?;
 
     eprintln!(
         "[whisker-build android] {} module(s) discovered (gradle-subproject wiring is the Gradle plugin's job)",
@@ -251,6 +263,8 @@ fn parse_profile(s: &str) -> Result<Profile> {
     match s {
         "debug" => Ok(Profile::Debug),
         "release" => Ok(Profile::Release),
-        other => Err(anyhow!("--profile must be 'debug' or 'release' (got `{other}`)")),
+        other => Err(anyhow!(
+            "--profile must be 'debug' or 'release' (got `{other}`)"
+        )),
     }
 }


### PR DESCRIPTION
## Summary

Step 4 of the build-system migration — fills in the body of `whisker-build android` so the Gradle plugin (#142) actually receives a real `.so`.

The Step 2 binary stopped at arg validation + module discovery. This PR wires the four stages the comment-block listed as deferred:

1. `ensure_lynx_android()` + `link_lynx_into_workspace(workspace, Android)` — fetch the pinned Lynx tarball and create the `target/lynx-android*` symlinks before cargo runs.
2. `android::resolve_toolchain(abi, min_sdk)` — NDK clang / ar / sysroot paths for the ABI.
3. `android::cargo_build_dylib(&CargoBuild { ... })` — same code path `whisker run` / `whisker build` already exercise. No Tier 1 capture shims (`capture: None`) — that stays a dev-server concern.
4. `android::stage_so_files(jni_libs_dir, so, toolchain, abi)` — copies the produced `.so` plus the NDK-shipped `libc++_shared.so` into the dir the Gradle plugin's task points at.

`stage_jni_libs` (cng-driven CLI path) is refactored as a one-liner on top of the new `stage_so_files` so both paths share the actual copy logic.

## Still pending

- **`run_ios`** body — needs cargo per-arch + lipo + Package.swift emission + dylib copy into `$BUILT_PRODUCTS_DIR/Frameworks/Whisker.framework/`. The lib has all the helpers; sub-step \"Step 4-iOS\".
- **Module-system gradle-subproject wiring** — `whisker_modules.settings.gradle.kts` + `whisker_module_deps.gradle.kts` emission. The `stage_module_kotlin_sources` helper exists; the Gradle plugin needs `apply(from = ...)` references to consume them. Follow-up.

## Test plan

- [x] `cargo test -p whisker-build --lib` — all 32 tests pass (the `stage_jni_libs` refactor preserved its contract).
- [x] End-to-end against the router example:
  ```
  whisker-build android --workspace . --package whisker-router-example \\
      --profile release --abi arm64-v8a \\
      --jni-libs-dir /tmp/test-jni/arm64-v8a --min-sdk 24
  ```
  Produces `/tmp/test-jni/arm64-v8a/{libwhisker_router_example.so, libc++_shared.so}`.
- [ ] Drive the binary through the Gradle plugin (#142) once that's merged — currently the plugin compiles but isn't applied anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)