### PR TITLE
feat(build): wire whisker-build ios body (Step 4-iOS)

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -493,6 +493,206 @@ fn build_framework_dir(
     Ok(fw_dir)
 }
 
+// ----- Xcode Run Script Phase entry point -----------------------------------
+
+/// Inputs from an Xcode Run Script Build Phase invocation of the
+/// `whisker-build` binary. Mirrors the Xcode environment 1:1 — the
+/// caller (binary's `run_ios`) parses argv into one of these and
+/// hands it to [`build_framework_for_xcode_run_script`].
+pub struct XcodeRunScriptInputs<'a> {
+    pub workspace_root: &'a Path,
+    pub package: &'a str,
+    /// `PLATFORM_NAME` — `"iphoneos"` or `"iphonesimulator"`. Drives
+    /// the (arch → rust triple) mapping inside
+    /// [`map_arch_to_triple`].
+    pub platform: &'a str,
+    /// `ARCHS`, split on whitespace by the caller. Each entry is
+    /// `"arm64"` or `"x86_64"`. Multi-arch is only meaningful when
+    /// `platform == "iphonesimulator"` — the iphoneos slice is always
+    /// arm64 today.
+    pub archs: &'a [&'a str],
+}
+
+/// Cross-compile + framework-wrap path for the Xcode Run Script
+/// Phase. Mirrors what `whisker build --target ios-sim` already
+/// drives (`build_xcframework_with`), minus the multi-platform
+/// xcframework wrap — Xcode only needs the slices for the current
+/// destination, dropped straight into
+/// `<built_products_dir>/Frameworks/<FRAMEWORK_NAME>.framework/`.
+///
+/// Returns the path to the produced `.framework` directory.
+pub fn build_framework_for_xcode_run_script(
+    inputs: &XcodeRunScriptInputs<'_>,
+    built_products_dir: &Path,
+) -> Result<PathBuf> {
+    if inputs.archs.is_empty() {
+        return Err(anyhow!("--archs is empty; Xcode passed no ARCHS"));
+    }
+
+    // Header trees the framework's `Headers/` dir copies from. Same
+    // search the xcframework path does — kept inline rather than
+    // factored out because the helper is only two paths.
+    let rust_headers_src = inputs.workspace_root.join("crates/whisker-driver/include");
+    let bridge_headers_src = inputs
+        .workspace_root
+        .join("crates/whisker-driver-sys/bridge/include");
+    for required in ["whisker.h", "module.modulemap"] {
+        if !rust_headers_src.join(required).is_file() {
+            return Err(anyhow!(
+                "missing header {} (expected at {})",
+                required,
+                rust_headers_src.display(),
+            ));
+        }
+    }
+    if !bridge_headers_src.join("whisker_bridge.h").is_file() {
+        return Err(anyhow!(
+            "missing whisker_bridge.h (expected at {})",
+            bridge_headers_src.display(),
+        ));
+    }
+
+    // Same module discovery the xcframework path runs — pulls the
+    // `[package.metadata.whisker]` deps and stuffs their iOS native
+    // sources into `WHISKER_IOS_MODULE_NATIVE_SOURCES` so
+    // `whisker-driver-sys`'s build.rs folds them into the bridge cc
+    // build.
+    let workspace_manifest = inputs.workspace_root.join("Cargo.toml");
+    let modules =
+        crate::modules::discover(&workspace_manifest, inputs.package).with_context(|| {
+            format!(
+                "discover whisker modules for `{}` (workspace_manifest={})",
+                inputs.package,
+                workspace_manifest.display(),
+            )
+        })?;
+    let modules_env = crate::modules::ios_sources_env_value(&modules);
+
+    let lib_stem = inputs.package.replace('-', "_");
+    let cargo_dylib_name = format!("lib{lib_stem}.dylib");
+
+    // Build one dylib per requested arch.
+    let mut slice_paths: Vec<PathBuf> = Vec::with_capacity(inputs.archs.len());
+    for arch in inputs.archs {
+        let triple = map_arch_to_triple(inputs.platform, arch)?;
+        let s = crate::ui::step("compile", format!("{} ({triple})", inputs.package));
+        cargo_build_ios_dylib(
+            inputs.workspace_root,
+            inputs.package,
+            triple,
+            &[],
+            None,
+            &modules_env,
+            &s,
+        )?;
+        s.done("");
+        slice_paths.push(
+            inputs
+                .workspace_root
+                .join("target")
+                .join(triple)
+                .join("release")
+                .join(&cargo_dylib_name),
+        );
+    }
+
+    // Workspace-local scratch area: lipo + wrap happens here, then
+    // the final framework dir is copied into `built_products_dir`.
+    // Under `target/` so `cargo clean` reaps it.
+    let out_dir = inputs
+        .workspace_root
+        .join("target/whisker-driver/run-script");
+    if out_dir.exists() {
+        std::fs::remove_dir_all(&out_dir)
+            .with_context(|| format!("rm -rf {}", out_dir.display()))?;
+    }
+    std::fs::create_dir_all(&out_dir).with_context(|| format!("mkdir -p {}", out_dir.display()))?;
+
+    // Single-arch → use the slice directly. Multi-arch → lipo into a
+    // fat binary in `out_dir`.
+    let combined_dylib: PathBuf = if slice_paths.len() == 1 {
+        slice_paths.into_iter().next().expect("checked len == 1")
+    } else {
+        let fat = out_dir.join(&cargo_dylib_name);
+        crate::ui::debug(format!("lipo {}", fat.display()));
+        let mut cmd = Command::new("lipo");
+        cmd.arg("-create");
+        for p in &slice_paths {
+            if !p.is_file() {
+                return Err(anyhow!("expected dylib not built: {}", p.display()));
+            }
+            cmd.arg(p);
+        }
+        cmd.args(["-output"]).arg(&fat);
+        let status = cmd.status().context("spawn lipo")?;
+        if !status.success() {
+            return Err(anyhow!("lipo failed ({status})"));
+        }
+        fat
+    };
+
+    let staged_fw = build_framework_dir(
+        &out_dir,
+        &combined_dylib,
+        &rust_headers_src,
+        &bridge_headers_src,
+    )?;
+
+    // Publish into `<built_products_dir>/Frameworks/`. Xcode's
+    // embed-frameworks build phase scans that directory at link time.
+    let frameworks_dst = built_products_dir.join("Frameworks");
+    std::fs::create_dir_all(&frameworks_dst)
+        .with_context(|| format!("mkdir -p {}", frameworks_dst.display()))?;
+    let published_fw = frameworks_dst.join(format!("{FRAMEWORK_NAME}.framework"));
+    if published_fw.exists() {
+        std::fs::remove_dir_all(&published_fw)
+            .with_context(|| format!("rm -rf {}", published_fw.display()))?;
+    }
+    copy_dir_recursive(&staged_fw, &published_fw)?;
+    crate::ui::info(format!(
+        "publish {}.framework → {}",
+        FRAMEWORK_NAME,
+        published_fw.display(),
+    ));
+    Ok(published_fw)
+}
+
+/// Translate Xcode's `(PLATFORM_NAME, ARCH)` pair into the matching
+/// Rust target triple. Pairs that can't appear in a real Xcode
+/// build (`iphoneos` + `x86_64`, the long-deprecated armv7 device
+/// slice) hit the catch-all so the binary surfaces a clear error
+/// before cargo even starts.
+fn map_arch_to_triple(platform: &str, arch: &str) -> Result<&'static str> {
+    match (platform, arch) {
+        ("iphoneos", "arm64") => Ok("aarch64-apple-ios"),
+        ("iphonesimulator", "arm64") => Ok("aarch64-apple-ios-sim"),
+        ("iphonesimulator", "x86_64") => Ok("x86_64-apple-ios"),
+        (p, a) => Err(anyhow!(
+            "unsupported (PLATFORM_NAME, ARCH) pair: ({p}, {a})"
+        )),
+    }
+}
+
+/// `cp -R src dst` — file by file so we don't drag in a `fs_extra`
+/// dep just for one call site. The framework dir is shallow enough
+/// (Headers/, Modules/, plus the binary + Info.plist) that an
+/// inline walk is cheaper than vendoring a crate.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst).with_context(|| format!("mkdir -p {}", dst.display()))?;
+    for entry in std::fs::read_dir(src).with_context(|| format!("readdir {}", src.display()))? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)
+                .with_context(|| format!("copy {} → {}", from.display(), to.display()))?;
+        }
+    }
+    Ok(())
+}
+
 /// Minimal Info.plist that satisfies codesign + dyld for an embedded
 /// iOS framework. CFBundleExecutable must match the binary filename
 /// (= `FRAMEWORK_NAME`).

--- a/crates/whisker-build/src/main.rs
+++ b/crates/whisker-build/src/main.rs
@@ -167,41 +167,44 @@ fn main() -> Result<()> {
 }
 
 fn run_ios(args: IosArgs) -> Result<()> {
-    let cargo_toml = args.workspace.join("Cargo.toml");
-    let modules = whisker_build::modules::discover(&cargo_toml, &args.package)
-        .with_context(|| format!("discover whisker modules in {}", cargo_toml.display()))?;
+    // Lynx iOS xcframework needs to be on disk before the bridge cc
+    // build resolves `<staged>/Lynx/...` includes. Mirrors the
+    // Android path's `ensure_lynx_android()`.
+    let _cache = whisker_build::ensure_lynx_ios().context("fetch pinned Lynx iOS artifacts")?;
+    whisker_build::link_lynx_into_workspace(&args.workspace, whisker_build::LynxPlatform::Ios)
+        .context("symlink target/lynx-ios into workspace")?;
 
+    let archs: Vec<&str> = args.archs.split_whitespace().collect();
+    let fw = whisker_build::ios::build_framework_for_xcode_run_script(
+        &whisker_build::ios::XcodeRunScriptInputs {
+            workspace_root: &args.workspace,
+            package: &args.package,
+            platform: &args.platform,
+            archs: &archs,
+        },
+        &args.built_products_dir,
+    )
+    .with_context(|| {
+        format!(
+            "build framework for ({}/{}) → {}",
+            args.platform,
+            args.archs,
+            args.built_products_dir.display(),
+        )
+    })?;
+
+    // `configuration` is currently informational — the iOS cargo
+    // build is always `--release` (matches what `cargo_build_ios_dylib`
+    // already pins for the xcframework path; subsecond's Tier 1
+    // capture wants the same optimised codegen prod ships). Logged
+    // here so a Debug-mode Xcode build that's surprised by
+    // release-tier optimisation has the mismatch visible.
     eprintln!(
-        "[whisker-build ios] workspace={} package={} config={} platform={} archs=[{}] modules={}",
-        args.workspace.display(),
-        args.package,
+        "[whisker-build ios] published {} (configuration={}, archs=[{}])",
+        fw.display(),
         args.configuration,
-        args.platform,
         args.archs,
-        modules.len(),
     );
-    eprintln!(
-        "[whisker-build ios] built-products-dir={}",
-        args.built_products_dir.display(),
-    );
-
-    // The iOS body is still a diagnostic stub. Filling it in needs:
-    //   - cargo rustc --target=<triple> --crate-type=cdylib per
-    //     requested arch (mirrors what `whisker build --target
-    //     ios-sim` already drives through the lib's `ios::*` helpers
-    //     in whisker-cli)
-    //   - lipo of the simulator slices when ARCHS contains both
-    //     arm64 + x86_64
-    //   - whisker_modules/Package.swift + RegisterAll.swift emission
-    //     via ios::stage_module_swift_sources
-    //   - copy the dylib into
-    //     $BUILT_PRODUCTS_DIR/Frameworks/Whisker.framework/Whisker
-    // Tracked as the next sub-step (Step 4-iOS); the Android body
-    // above is the verified path that unblocks the Gradle plugin.
-    eprintln!(
-        "[whisker-build ios] cargo cross-compile + module aux placement still pending (Step 4-iOS)"
-    );
-
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Symmetric to #143 (Android body) — fills in `whisker-build ios` so the cng-rendered Xcode Run Script Phase can drive a real `.framework` build.

## What's in this PR

| Surface | Detail |
|---|---|
| `whisker_build::ios::XcodeRunScriptInputs` | new pub struct: workspace, package, platform, archs |
| `whisker_build::ios::build_framework_for_xcode_run_script` | new pub fn: orchestrates per-arch cargo + lipo + framework wrap + publish to `<BUILT_PRODUCTS_DIR>/Frameworks/WhiskerDriver.framework/` |
| `run_ios` in `main.rs` | wires the above; also fetches Lynx iOS xcframework + symlinks `target/lynx-ios` |

The new helper reuses the same private helpers the xcframework path exercises (`cargo_build_ios_dylib`, `build_framework_dir`), composed differently for the Run Script Phase shape:

- `(iphoneos, arm64)` → `aarch64-apple-ios`
- `(iphonesimulator, arm64)` → `aarch64-apple-ios-sim`
- `(iphonesimulator, x86_64)` → `x86_64-apple-ios`
- Multi-arch → `lipo -create` into a fat binary
- Framework dir wrap (Headers, Modules, Info.plist) → copy into `<BUILT_PRODUCTS_DIR>/Frameworks/`

## What's unchanged

- `cargo_build_ios_dylib` stays `--release`-pinned (iOS Tier 1 capture wants prod codegen). A Debug Xcode build still produces a release-optimised Rust dylib; the new helper logs the requested configuration so the mismatch is visible.
- The cng-driven CLI path (`whisker build --target ios-sim`) still routes through `build_xcframework_with` — no change.

## Still pending

- `stage_module_swift_sources` emission (Package.swift + RegisterAll.swift for the consuming Xcode project) — same scope as Android's `whisker_modules.settings.gradle.kts` follow-up.

## Test plan

- [x] `cargo check -p whisker-build`
- [x] `cargo fmt -p whisker-build`
- [x] `cargo clippy -p whisker-build --all-targets` clean
- [x] `cargo test -p whisker-build --lib` — all 32 tests pass
- [ ] End-to-end Xcode Run Script invocation — needs cng template wiring (Step 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)