### PR TITLE
chore(cli): pin SDK to 0.1.1 (Lynx whisker.6 propagation)

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -56,7 +56,15 @@ pub struct PlatformSync {
 /// SDK version pinned into the cng-generated
 /// `app/build.gradle.kts` (`rs.whisker:whisker-runtime-android:<this>`).
 /// Bumped alongside the `sdk-v*` release tag.
-const WHISKER_SDK_VERSION: &str = "0.1.0";
+///
+/// 0.1.1 rolls forward the transitive Lynx pin baked into the SDK's
+/// POM from `v3.8.0-whisker.4` (initial SDK release) to
+/// `v3.8.0-whisker.6`. The newer Lynx exposes `lynx_capi_abi_version()`
+/// which the Step-6 dlopen-based bridge requires; without this bump,
+/// downstream apps that pull `whisker-runtime-android:0.1.0`
+/// transitively get the older Lynx and the bridge loader aborts on
+/// "undefined symbol: lynx_capi_abi_version" at engine_attach time.
+const WHISKER_SDK_VERSION: &str = "0.1.1";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the


### PR DESCRIPTION
## Summary

Bumps `WHISKER_SDK_VERSION` from 0.1.0 to 0.1.1 so cng-generated `gen/android/app/build.gradle.kts` references `rs.whisker:whisker-runtime-android:0.1.1`.

After this PR merges, push the `sdk-v0.1.1` tag against main to trigger `.github/workflows/publish-sdk.yml`. The workflow:
1. Stamps `0.1.1` into the three platforms/android `build.gradle.kts` files
2. Publishes AARs with `-PwhiskerSdkRelease=true` (Lynx fork dep form)
3. The published POM picks up the `lynxFork` default already bumped to `v3.8.0-whisker.6` (#153)

The result: downstream `whisker-runtime-android:0.1.1` transitively pins `lynx-android:3.8.0-whisker.6`, so Step 6's bridge loader sees `lynx_capi_abi_version()` and the dlsym ABI handshake succeeds.

## Why this is a separate PR

The bridge refactor (#153) doesn't bind to an SDK version — the bridge itself lives in `whisker-driver-sys`, not in the published Android SDK. But downstream apps that depend on the SDK AARs need the new Lynx ABI baked into the SDK's POM. That's a publish-flow concern decoupled from the source change.

## Migration

- **New apps (`whisker new`)**: pick up 0.1.1 automatically once this PR + the sdk-v0.1.1 tag both land.
- **Existing apps**: their `gen/android/app/build.gradle.kts` keeps `whisker-runtime-android:0.1.0` until the user re-runs `whisker build` (which regenerates from the updated cng template). The pre-regenerated app crashes on engine_attach with "undefined symbol: lynx_capi_abi_version".

## Test plan

- [x] `cargo build -p whisker-cli`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p whisker-cli -- -D warnings`
- [ ] CI passes
- [ ] After merge: push `sdk-v0.1.1` tag, watch `publish-sdk.yml`, verify gh-pages Maven has `whisker-runtime-android-0.1.1.pom` listing `lynx-android:3.8.0-whisker.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)