### PR TITLE
feat(ios): Xcode Build Phase drives Rust build (Step 7)

### DIFF
--- a/crates/whisker-cli/src/build.rs
+++ b/crates/whisker-cli/src/build.rs
@@ -188,11 +188,14 @@ fn build_ios_app(
         &modules,
     )?;
 
-    // 3. xcframework wrap (cargo per-triple → lipo sim slices → wrap).
-    //    Self-contained in `whisker_build::ios`.
-    ios::build_xcframework(workspace_root, &m.package, &[], None)?;
-
     // 3. xcodebuild release.
+    //
+    // Step-7 dropped the explicit `build_xcframework` call here: the
+    // cng-generated pbxproj now carries a "Whisker Prebuild" Build
+    // Phase that invokes `whisker-build ios` to produce
+    // `WhiskerDriver.framework` during the xcodebuild run itself.
+    // Doing it here AND letting the Build Phase re-do it would burn
+    // a redundant cargo cross-compile.
     let scheme = m
         .config
         .ios

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -33,7 +33,7 @@ pub fn sync_for_target(
 ) -> Result<PlatformSync> {
     match target {
         Target::Android => sync_android(app_config, crate_dir, workspace_root, package),
-        Target::IosSimulator => sync_ios(app_config, crate_dir, workspace_root),
+        Target::IosSimulator => sync_ios(app_config, crate_dir, workspace_root, package),
         Target::Host => Ok(PlatformSync {
             gen_dir: crate_dir.to_path_buf(),
             regenerated: false,
@@ -115,6 +115,7 @@ fn sync_ios(
     app_config: &AppConfig,
     crate_dir: &Path,
     workspace_root: &Path,
+    package: &str,
 ) -> Result<PlatformSync> {
     let gen_dir = crate_dir.join("gen/ios");
     let whisker_runtime = workspace_root.join("platforms/ios");
@@ -125,7 +126,13 @@ fn sync_ios(
     // needs an *absolute* path to that directory at sync time, so we
     // pre-compute it here even though the contents will land later.
     let whisker_modules = gen_dir.join("whisker_modules");
-    let inputs = whisker_cng::ios::inputs_from(app_config, whisker_runtime, whisker_modules)?;
+    let inputs = whisker_cng::ios::inputs_from(
+        app_config,
+        whisker_runtime,
+        whisker_modules,
+        workspace_root.to_path_buf(),
+        package.to_string(),
+    )?;
     // whisker-cng renders the full Xcode project directly (pbxproj +
     // xcworkspacedata + sources). No xcodegen subprocess needed —
     // see crates/whisker-cng/src/ios.rs for the rationale.

--- a/crates/whisker-cng/src/ios.rs
+++ b/crates/whisker-cng/src/ios.rs
@@ -64,6 +64,15 @@ pub struct IosInputs {
     /// `[ios].swift_sources` and the generated
     /// `WhiskerModuleBehaviors.swift`.
     pub whisker_modules_path: PathBuf,
+    /// Absolute path to the cargo workspace root that contains the
+    /// user app crate's top-level `Cargo.toml` (the one with
+    /// `[workspace]`). Embedded into the pbxproj's Run Script Build
+    /// Phase as `--workspace=...` so Xcode-driven builds invoke
+    /// `whisker-build ios` without the user typing it. Step 7.
+    pub workspace_root: PathBuf,
+    /// Cargo package name (the user app crate) — the Rust side of
+    /// `whisker-build ios --package=...`. Step 7.
+    pub user_package: String,
     pub template_version: u32,
 }
 
@@ -105,6 +114,11 @@ pub(crate) fn template_vars(inputs: &IosInputs) -> HashMap<&'static str, String>
         "whisker_modules_ios_path",
         inputs.whisker_modules_path.display().to_string(),
     );
+    v.insert(
+        "whisker_workspace_root",
+        inputs.workspace_root.display().to_string(),
+    );
+    v.insert("whisker_user_package", inputs.user_package.clone());
     v
 }
 
@@ -198,6 +212,8 @@ pub fn inputs_from(
     app_config: &AppConfig,
     whisker_runtime_path: PathBuf,
     whisker_modules_path: PathBuf,
+    workspace_root: PathBuf,
+    user_package: String,
 ) -> Result<IosInputs> {
     let app_name = app_config
         .name
@@ -237,16 +253,15 @@ pub fn inputs_from(
         deployment_target,
         whisker_runtime_path,
         whisker_modules_path,
-        // Bumped 4 → 5: backed the pbxproj's WhiskerRuntime ref off
-        // `XCRemoteSwiftPackageReference` and onto
-        // `XCLocalSwiftPackageReference` for the monorepo flow. The
-        // remote-ref form needs every Whisker module's `Package.swift`
-        // to also move off the env-var local-path resolution onto the
-        // same remote URL, otherwise SwiftPM treats the local and
-        // remote `Whisker` packages as separate package identities
-        // and rejects the build with "products with conflicting
-        // name". Tracked as a follow-up.
-        template_version: 5,
+        workspace_root,
+        user_package,
+        // Bumped 5 → 6 for Step 7: pbxproj template now embeds a
+        // PBXShellScriptBuildPhase that calls `whisker-build ios` to
+        // produce `WhiskerDriver.framework` during the build, plus
+        // FRAMEWORK_SEARCH_PATHS / OTHER_LDFLAGS pointing at it.
+        // WhiskerDriver is no longer an SPM binaryTarget — see
+        // `platforms/ios/Package.swift` for the rationale.
+        template_version: 6,
     })
 }
 
@@ -278,7 +293,9 @@ mod tests {
             deployment_target: "13.0".into(),
             whisker_runtime_path: PathBuf::from("/abs/platforms/ios"),
             whisker_modules_path: PathBuf::from("/abs/gen/ios/whisker_modules"),
-            template_version: 5,
+            workspace_root: PathBuf::from("/abs/workspace"),
+            user_package: "hello-world".into(),
+            template_version: 6,
         }
     }
 
@@ -367,7 +384,14 @@ mod tests {
             name: Some("X".into()),
             ..AppConfig::default()
         };
-        let err = inputs_from(&cfg, PathBuf::new(), PathBuf::new()).unwrap_err();
+        let err = inputs_from(
+            &cfg,
+            PathBuf::new(),
+            PathBuf::new(),
+            PathBuf::new(),
+            String::new(),
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("bundle_id"), "got: {err:#}");
     }
 }

--- a/crates/whisker-cng/src/templates/ios/Project.xcodeproj/project.pbxproj
+++ b/crates/whisker-cng/src/templates/ios/Project.xcodeproj/project.pbxproj
@@ -71,8 +71,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 39A71CFC79D014E76D4445EB /* Build configuration list for PBXNativeTarget "{{ios_scheme}}" */;
 			buildPhases = (
+				7E2B91D0F46A1C73B5A5DE91 /* Whisker Prebuild */,
 				4A590CB0D847DB4C38DDCDFC /* Sources */,
 				D4C57884A372C8EC69F16CAD /* Frameworks */,
+				3F69E4C8A2D75B6E81C094BB /* Whisker Embed Framework */,
 			);
 			buildRules = (
 			);
@@ -88,6 +90,50 @@
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		7E2B91D0F46A1C73B5A5DE91 /* Whisker Prebuild */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Whisker Prebuild";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/Frameworks/WhiskerDriver.framework/WhiskerDriver",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -euo pipefail\n# Step-7 Build Phase: produces WhiskerDriver.framework into\n# $BUILT_PRODUCTS_DIR/Frameworks/ before Xcode's link step runs.\n# The framework wraps the Rust user crate + C++ bridge — it can't\n# be pre-built because it contains user `#[whisker::main]` code,\n# so the per-app pbxproj invokes whisker-build here. The CLI\n# itself fetches Lynx, runs cargo, runs install_name_tool, copies\n# headers, and writes Info.plist.\nif ! command -v whisker-build >/dev/null 2>&1; then\n  echo \"error: 'whisker-build' not on PATH. Run 'cargo install whisker-build' from the workspace root.\" >&2\n  exit 1\nfi\nwhisker-build ios \\\n  --workspace=\"{{whisker_workspace_root}}\" \\\n  --package=\"{{whisker_user_package}}\" \\\n  --configuration=\"$CONFIGURATION\" \\\n  --platform=\"$PLATFORM_NAME\" \\\n  --archs=\"$ARCHS\" \\\n  --built-products-dir=\"$BUILT_PRODUCTS_DIR\"\n";
+		};
+		3F69E4C8A2D75B6E81C094BB /* Whisker Embed Framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/Frameworks/WhiskerDriver.framework/WhiskerDriver",
+			);
+			name = "Whisker Embed Framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_FOLDER_PATH)/Frameworks/WhiskerDriver.framework/WhiskerDriver",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -euo pipefail\n# Step-7 Embed: copies WhiskerDriver.framework from the build-products\n# search path into the .app bundle's Frameworks/. The earlier\n# 'Whisker Prebuild' phase dropped it at $BUILT_PRODUCTS_DIR/Frameworks/\n# so FRAMEWORK_SEARCH_PATHS picks it up for the linker; this phase\n# completes the journey by placing it where dyld looks at app launch\n# (via LD_RUNPATH_SEARCH_PATHS=@executable_path/Frameworks).\nSRC=\"$BUILT_PRODUCTS_DIR/Frameworks/WhiskerDriver.framework\"\nDST_DIR=\"$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/Frameworks\"\nmkdir -p \"$DST_DIR\"\nrm -rf \"$DST_DIR/WhiskerDriver.framework\"\ncp -R \"$SRC\" \"$DST_DIR/\"\n# Codesign — required on device builds; harmless on simulator.\nif [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]; then\n  /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" --preserve-metadata=identifier,entitlements --timestamp=none \"$DST_DIR/WhiskerDriver.framework\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXProject section */
 		993C38E6B55CB9C6F082FDCA /* Project object */ = {
@@ -201,6 +247,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				// Step-7: WhiskerDriver.framework is produced by the
+				// "Whisker Prebuild" Build Phase into
+				// $(BUILT_PRODUCTS_DIR)/Frameworks/. The linker needs to
+				// see it via -F + -framework at the Frameworks phase.
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(BUILT_PRODUCTS_DIR)/Frameworks";
+				OTHER_LDFLAGS = "$(inherited) -framework WhiskerDriver";
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "{{ios_bundle_id}}";
@@ -214,6 +266,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				// See the matching Debug config for the rationale.
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(BUILT_PRODUCTS_DIR)/Frameworks";
+				OTHER_LDFLAGS = "$(inherited) -framework WhiskerDriver";
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "{{ios_bundle_id}}";

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -24,6 +24,8 @@ import PackageDescription
 // from the CLI may or may not be in the inherited environment. The
 // monorepo fallback lets the resolve succeed in either case.
 
+import Foundation
+
 let whiskerRuntimePath: String
 let whiskerMacrosPath: String
 if let r = Context.environment["WHISKER_IOS_RUNTIME"],
@@ -31,8 +33,15 @@ if let r = Context.environment["WHISKER_IOS_RUNTIME"],
     whiskerRuntimePath = r
     whiskerMacrosPath = m
 } else {
-    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
-    whiskerMacrosPath = whiskerRuntimePath + "/macros"
+    // URL.standardized resolves `../` so SwiftPM sees the same
+    // canonical absolute path the cng-rendered
+    // `gen/ios/whisker_modules/Package.swift` uses. Otherwise the
+    // build graph treats this and the aggregator as two instances
+    // of the same package and the WhiskerModuleCodegenPlugin's
+    // executable dep doesn't land in `Build/Products/Release/`.
+    let raw = Context.packageDirectory + "/../../platforms/ios"
+    whiskerRuntimePath = URL(fileURLWithPath: raw).standardized.path
+    whiskerMacrosPath = URL(fileURLWithPath: whiskerRuntimePath + "/macros").standardized.path
 }
 
 let package = Package(

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -7,13 +7,32 @@
 
 import PackageDescription
 
-guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
-      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
-else {
-    fatalError("""
-        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
-        module through `whisker run` / `whisker build`, which inject these paths.
-        """)
+// Resolve WhiskerRuntime + macros paths. Order of preference:
+//   1. WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS env vars. The whisker
+//      CLI's orchestrated flow (`whisker build` / `whisker run`) sets
+//      these. Xcode-driven builds where the scheme sets them via env
+//      vars also land here.
+//   2. Monorepo fallback: this package lives at `packages/<crate>/`,
+//      so `../../platforms/ios` resolves to WhiskerRuntime and
+//      `../../platforms/ios/macros` to the macros package. This is
+//      what makes Xcode-driven `xcodebuild` (Step 7) succeed without
+//      a wrapping CLI invocation.
+//
+// Step-7 note: the cng-rendered `gen/ios/whisker_modules/Package.swift`
+// reaches its module deps by absolute path (the cng renderer baked it
+// in at sync time), so by the time SPM resolves THIS file, env vars
+// from the CLI may or may not be in the inherited environment. The
+// monorepo fallback lets the resolve succeed in either case.
+
+let whiskerRuntimePath: String
+let whiskerMacrosPath: String
+if let r = Context.environment["WHISKER_IOS_RUNTIME"],
+   let m = Context.environment["WHISKER_IOS_MACROS"] {
+    whiskerRuntimePath = r
+    whiskerMacrosPath = m
+} else {
+    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
+    whiskerMacrosPath = whiskerRuntimePath + "/macros"
 }
 
 let package = Package(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -36,6 +36,8 @@ import PackageDescription
 // from the CLI may or may not be in the inherited environment. The
 // monorepo fallback lets the resolve succeed in either case.
 
+import Foundation
+
 let whiskerRuntimePath: String
 let whiskerMacrosPath: String
 if let r = Context.environment["WHISKER_IOS_RUNTIME"],
@@ -43,8 +45,15 @@ if let r = Context.environment["WHISKER_IOS_RUNTIME"],
     whiskerRuntimePath = r
     whiskerMacrosPath = m
 } else {
-    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
-    whiskerMacrosPath = whiskerRuntimePath + "/macros"
+    // URL.standardized resolves `../` so SwiftPM sees the same
+    // canonical absolute path the cng-rendered
+    // `gen/ios/whisker_modules/Package.swift` uses. Otherwise the
+    // build graph treats this and the aggregator as two instances
+    // of the same package and the WhiskerModuleCodegenPlugin's
+    // executable dep doesn't land in `Build/Products/Release/`.
+    let raw = Context.packageDirectory + "/../../platforms/ios"
+    whiskerRuntimePath = URL(fileURLWithPath: raw).standardized.path
+    whiskerMacrosPath = URL(fileURLWithPath: whiskerRuntimePath + "/macros").standardized.path
 }
 
 let package = Package(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -19,13 +19,32 @@
 
 import PackageDescription
 
-guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
-      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
-else {
-    fatalError("""
-        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
-        module through `whisker run` / `whisker build`, which inject these paths.
-        """)
+// Resolve WhiskerRuntime + macros paths. Order of preference:
+//   1. WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS env vars. The whisker
+//      CLI's orchestrated flow (`whisker build` / `whisker run`) sets
+//      these. Xcode-driven builds where the scheme sets them via env
+//      vars also land here.
+//   2. Monorepo fallback: this package lives at `packages/<crate>/`,
+//      so `../../platforms/ios` resolves to WhiskerRuntime and
+//      `../../platforms/ios/macros` to the macros package. This is
+//      what makes Xcode-driven `xcodebuild` (Step 7) succeed without
+//      a wrapping CLI invocation.
+//
+// Step-7 note: the cng-rendered `gen/ios/whisker_modules/Package.swift`
+// reaches its module deps by absolute path (the cng renderer baked it
+// in at sync time), so by the time SPM resolves THIS file, env vars
+// from the CLI may or may not be in the inherited environment. The
+// monorepo fallback lets the resolve succeed in either case.
+
+let whiskerRuntimePath: String
+let whiskerMacrosPath: String
+if let r = Context.environment["WHISKER_IOS_RUNTIME"],
+   let m = Context.environment["WHISKER_IOS_MACROS"] {
+    whiskerRuntimePath = r
+    whiskerMacrosPath = m
+} else {
+    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
+    whiskerMacrosPath = whiskerRuntimePath + "/macros"
 }
 
 let package = Package(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -30,6 +30,8 @@ import PackageDescription
 // from the CLI may or may not be in the inherited environment. The
 // monorepo fallback lets the resolve succeed in either case.
 
+import Foundation
+
 let whiskerRuntimePath: String
 let whiskerMacrosPath: String
 if let r = Context.environment["WHISKER_IOS_RUNTIME"],
@@ -37,8 +39,15 @@ if let r = Context.environment["WHISKER_IOS_RUNTIME"],
     whiskerRuntimePath = r
     whiskerMacrosPath = m
 } else {
-    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
-    whiskerMacrosPath = whiskerRuntimePath + "/macros"
+    // URL.standardized resolves `../` so SwiftPM sees the same
+    // canonical absolute path the cng-rendered
+    // `gen/ios/whisker_modules/Package.swift` uses. Otherwise the
+    // build graph treats this and the aggregator as two instances
+    // of the same package and the WhiskerModuleCodegenPlugin's
+    // executable dep doesn't land in `Build/Products/Release/`.
+    let raw = Context.packageDirectory + "/../../platforms/ios"
+    whiskerRuntimePath = URL(fileURLWithPath: raw).standardized.path
+    whiskerMacrosPath = URL(fileURLWithPath: whiskerRuntimePath + "/macros").standardized.path
 }
 
 let package = Package(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -13,13 +13,32 @@ import PackageDescription
 // a user's whisker project, or unpacked from the cargo registry. No
 // relative fallback: a Whisker module is only ever built through
 // `whisker run` / `whisker build`, never standalone `swift build`.
-guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
-      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
-else {
-    fatalError("""
-        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
-        module through `whisker run` / `whisker build`, which inject these paths.
-        """)
+// Resolve WhiskerRuntime + macros paths. Order of preference:
+//   1. WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS env vars. The whisker
+//      CLI's orchestrated flow (`whisker build` / `whisker run`) sets
+//      these. Xcode-driven builds where the scheme sets them via env
+//      vars also land here.
+//   2. Monorepo fallback: this package lives at `packages/<crate>/`,
+//      so `../../platforms/ios` resolves to WhiskerRuntime and
+//      `../../platforms/ios/macros` to the macros package. This is
+//      what makes Xcode-driven `xcodebuild` (Step 7) succeed without
+//      a wrapping CLI invocation.
+//
+// Step-7 note: the cng-rendered `gen/ios/whisker_modules/Package.swift`
+// reaches its module deps by absolute path (the cng renderer baked it
+// in at sync time), so by the time SPM resolves THIS file, env vars
+// from the CLI may or may not be in the inherited environment. The
+// monorepo fallback lets the resolve succeed in either case.
+
+let whiskerRuntimePath: String
+let whiskerMacrosPath: String
+if let r = Context.environment["WHISKER_IOS_RUNTIME"],
+   let m = Context.environment["WHISKER_IOS_MACROS"] {
+    whiskerRuntimePath = r
+    whiskerMacrosPath = m
+} else {
+    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
+    whiskerMacrosPath = whiskerRuntimePath + "/macros"
 }
 
 let package = Package(

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -14,13 +14,32 @@
 
 import PackageDescription
 
-guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
-      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
-else {
-    fatalError("""
-        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
-        module through `whisker run` / `whisker build`, which inject these paths.
-        """)
+// Resolve WhiskerRuntime + macros paths. Order of preference:
+//   1. WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS env vars. The whisker
+//      CLI's orchestrated flow (`whisker build` / `whisker run`) sets
+//      these. Xcode-driven builds where the scheme sets them via env
+//      vars also land here.
+//   2. Monorepo fallback: this package lives at `packages/<crate>/`,
+//      so `../../platforms/ios` resolves to WhiskerRuntime and
+//      `../../platforms/ios/macros` to the macros package. This is
+//      what makes Xcode-driven `xcodebuild` (Step 7) succeed without
+//      a wrapping CLI invocation.
+//
+// Step-7 note: the cng-rendered `gen/ios/whisker_modules/Package.swift`
+// reaches its module deps by absolute path (the cng renderer baked it
+// in at sync time), so by the time SPM resolves THIS file, env vars
+// from the CLI may or may not be in the inherited environment. The
+// monorepo fallback lets the resolve succeed in either case.
+
+let whiskerRuntimePath: String
+let whiskerMacrosPath: String
+if let r = Context.environment["WHISKER_IOS_RUNTIME"],
+   let m = Context.environment["WHISKER_IOS_MACROS"] {
+    whiskerRuntimePath = r
+    whiskerMacrosPath = m
+} else {
+    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
+    whiskerMacrosPath = whiskerRuntimePath + "/macros"
 }
 
 let package = Package(

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -31,6 +31,8 @@ import PackageDescription
 // from the CLI may or may not be in the inherited environment. The
 // monorepo fallback lets the resolve succeed in either case.
 
+import Foundation
+
 let whiskerRuntimePath: String
 let whiskerMacrosPath: String
 if let r = Context.environment["WHISKER_IOS_RUNTIME"],
@@ -38,8 +40,15 @@ if let r = Context.environment["WHISKER_IOS_RUNTIME"],
     whiskerRuntimePath = r
     whiskerMacrosPath = m
 } else {
-    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
-    whiskerMacrosPath = whiskerRuntimePath + "/macros"
+    // URL.standardized resolves `../` so SwiftPM sees the same
+    // canonical absolute path the cng-rendered
+    // `gen/ios/whisker_modules/Package.swift` uses. Otherwise the
+    // build graph treats this and the aggregator as two instances
+    // of the same package and the WhiskerModuleCodegenPlugin's
+    // executable dep doesn't land in `Build/Products/Release/`.
+    let raw = Context.packageDirectory + "/../../platforms/ios"
+    whiskerRuntimePath = URL(fileURLWithPath: raw).standardized.path
+    whiskerMacrosPath = URL(fileURLWithPath: whiskerRuntimePath + "/macros").standardized.path
 }
 
 let package = Package(

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -29,6 +29,8 @@ import PackageDescription
 // from the CLI may or may not be in the inherited environment. The
 // monorepo fallback lets the resolve succeed in either case.
 
+import Foundation
+
 let whiskerRuntimePath: String
 let whiskerMacrosPath: String
 if let r = Context.environment["WHISKER_IOS_RUNTIME"],
@@ -36,8 +38,15 @@ if let r = Context.environment["WHISKER_IOS_RUNTIME"],
     whiskerRuntimePath = r
     whiskerMacrosPath = m
 } else {
-    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
-    whiskerMacrosPath = whiskerRuntimePath + "/macros"
+    // URL.standardized resolves `../` so SwiftPM sees the same
+    // canonical absolute path the cng-rendered
+    // `gen/ios/whisker_modules/Package.swift` uses. Otherwise the
+    // build graph treats this and the aggregator as two instances
+    // of the same package and the WhiskerModuleCodegenPlugin's
+    // executable dep doesn't land in `Build/Products/Release/`.
+    let raw = Context.packageDirectory + "/../../platforms/ios"
+    whiskerRuntimePath = URL(fileURLWithPath: raw).standardized.path
+    whiskerMacrosPath = URL(fileURLWithPath: whiskerRuntimePath + "/macros").standardized.path
 }
 
 let package = Package(

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -12,13 +12,32 @@
 
 import PackageDescription
 
-guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
-      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
-else {
-    fatalError("""
-        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
-        module through `whisker run` / `whisker build`, which inject these paths.
-        """)
+// Resolve WhiskerRuntime + macros paths. Order of preference:
+//   1. WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS env vars. The whisker
+//      CLI's orchestrated flow (`whisker build` / `whisker run`) sets
+//      these. Xcode-driven builds where the scheme sets them via env
+//      vars also land here.
+//   2. Monorepo fallback: this package lives at `packages/<crate>/`,
+//      so `../../platforms/ios` resolves to WhiskerRuntime and
+//      `../../platforms/ios/macros` to the macros package. This is
+//      what makes Xcode-driven `xcodebuild` (Step 7) succeed without
+//      a wrapping CLI invocation.
+//
+// Step-7 note: the cng-rendered `gen/ios/whisker_modules/Package.swift`
+// reaches its module deps by absolute path (the cng renderer baked it
+// in at sync time), so by the time SPM resolves THIS file, env vars
+// from the CLI may or may not be in the inherited environment. The
+// monorepo fallback lets the resolve succeed in either case.
+
+let whiskerRuntimePath: String
+let whiskerMacrosPath: String
+if let r = Context.environment["WHISKER_IOS_RUNTIME"],
+   let m = Context.environment["WHISKER_IOS_MACROS"] {
+    whiskerRuntimePath = r
+    whiskerMacrosPath = m
+} else {
+    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
+    whiskerMacrosPath = whiskerRuntimePath + "/macros"
 }
 
 let package = Package(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -17,13 +17,32 @@ import PackageDescription
 // a user's whisker project, or unpacked from the cargo registry. No
 // relative fallback: a Whisker module is only ever built through
 // `whisker run` / `whisker build`, never standalone `swift build`.
-guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
-      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
-else {
-    fatalError("""
-        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
-        module through `whisker run` / `whisker build`, which inject these paths.
-        """)
+// Resolve WhiskerRuntime + macros paths. Order of preference:
+//   1. WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS env vars. The whisker
+//      CLI's orchestrated flow (`whisker build` / `whisker run`) sets
+//      these. Xcode-driven builds where the scheme sets them via env
+//      vars also land here.
+//   2. Monorepo fallback: this package lives at `packages/<crate>/`,
+//      so `../../platforms/ios` resolves to WhiskerRuntime and
+//      `../../platforms/ios/macros` to the macros package. This is
+//      what makes Xcode-driven `xcodebuild` (Step 7) succeed without
+//      a wrapping CLI invocation.
+//
+// Step-7 note: the cng-rendered `gen/ios/whisker_modules/Package.swift`
+// reaches its module deps by absolute path (the cng renderer baked it
+// in at sync time), so by the time SPM resolves THIS file, env vars
+// from the CLI may or may not be in the inherited environment. The
+// monorepo fallback lets the resolve succeed in either case.
+
+let whiskerRuntimePath: String
+let whiskerMacrosPath: String
+if let r = Context.environment["WHISKER_IOS_RUNTIME"],
+   let m = Context.environment["WHISKER_IOS_MACROS"] {
+    whiskerRuntimePath = r
+    whiskerMacrosPath = m
+} else {
+    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
+    whiskerMacrosPath = whiskerRuntimePath + "/macros"
 }
 
 let package = Package(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -34,6 +34,8 @@ import PackageDescription
 // from the CLI may or may not be in the inherited environment. The
 // monorepo fallback lets the resolve succeed in either case.
 
+import Foundation
+
 let whiskerRuntimePath: String
 let whiskerMacrosPath: String
 if let r = Context.environment["WHISKER_IOS_RUNTIME"],
@@ -41,8 +43,15 @@ if let r = Context.environment["WHISKER_IOS_RUNTIME"],
     whiskerRuntimePath = r
     whiskerMacrosPath = m
 } else {
-    whiskerRuntimePath = Context.packageDirectory + "/../../platforms/ios"
-    whiskerMacrosPath = whiskerRuntimePath + "/macros"
+    // URL.standardized resolves `../` so SwiftPM sees the same
+    // canonical absolute path the cng-rendered
+    // `gen/ios/whisker_modules/Package.swift` uses. Otherwise the
+    // build graph treats this and the aggregator as two instances
+    // of the same package and the WhiskerModuleCodegenPlugin's
+    // executable dep doesn't land in `Build/Products/Release/`.
+    let raw = Context.packageDirectory + "/../../platforms/ios"
+    whiskerRuntimePath = URL(fileURLWithPath: raw).standardized.path
+    whiskerMacrosPath = URL(fileURLWithPath: whiskerRuntimePath + "/macros").standardized.path
 }
 
 let package = Package(

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -4,17 +4,38 @@ import PackageDescription
 // WhiskerRuntime is the SPM package the iOS host app depends on. It
 // composes:
 //
-//   WhiskerDriver.xcframework  — Rust crate (the user's `#[whisker::main]`
-//                             code) + the C++ Lynx bridge, packaged as
-//                             a dynamic `.framework` so subsecond can
-//                             hot-patch it at runtime. Build by:
-//                             `cargo xtask ios build-xcframework`.
 //   Lynx*.xcframework       — Lynx engine + PrimJS, dynamic frameworks
-//                             built from the upstream CocoaPods source
-//                             pods. Build by:
-//                             `cargo xtask ios build-lynx-frameworks`.
-//   WhiskerRuntime (Swift)     — thin Swift API: WhiskerView, WhiskerAppDelegate,
-//                             CADisplayLink-driven render loop.
+//                             fetched at SPM resolve time from the
+//                             monorepo-local `target/lynx-ios/` cache
+//                             (`whisker-build` ensures it exists).
+//   WhiskerCBridge          — header-only systemLibrary exposing the
+//                             Whisker C ABI declarations. The actual
+//                             implementation lives in
+//                             `WhiskerDriver.framework`, which is built
+//                             per-app by an Xcode Run Script Build
+//                             Phase (Step 7) — see below.
+//   WhiskerRuntime (Swift)  — thin Swift API: WhiskerView,
+//                             WhiskerAppDelegate, CADisplayLink-driven
+//                             render loop.
+//
+// Step-7 change: `WhiskerDriver` is NOT declared here as a `binaryTarget`.
+// The Rust crate it wraps contains user `#[whisker::main]` code, so it
+// can't be pre-built and shipped — it has to be compiled per-app. Pre-
+// Step-7 the monorepo flow staged it under `target/whisker-driver/` so
+// SPM could resolve a path-based binaryTarget, but that forced every
+// build to go through the `whisker-build` CLI before Xcode opened. The
+// Run Script Build Phase that whisker-cng injects into the per-app
+// pbxproj now produces `WhiskerDriver.framework` inside
+// `$(BUILT_PRODUCTS_DIR)/Frameworks/` during the build itself; the
+// project's `OTHER_LDFLAGS` adds `-framework WhiskerDriver` so Xcode's
+// link step picks it up, and `LD_RUNPATH_SEARCH_PATHS` includes
+// `@executable_path/Frameworks` so dyld resolves it at app launch.
+//
+// The C-ABI surface Swift code calls into (`whisker_bridge_*`,
+// `WhiskerValueRaw`, …) is declared by `WhiskerCBridge`'s
+// module.modulemap. WhiskerRuntime's Swift sources do
+// `@_exported import WhiskerCBridge` — at link time the consumer's app
+// resolves the undefined refs against `WhiskerDriver.framework`.
 //
 // The bridge is intentionally NOT an SPM target. We used to have a
 // `WhiskerBridge` C++ target here that compiled bridge sources via SPM;
@@ -22,17 +43,6 @@ import PackageDescription
 // bridge sources, so keeping the build in `crates/whisker-driver-sys/
 // build.rs` (where it already lived for Android) means a single source
 // of truth. The bridge now lives under `crates/whisker-driver-sys/bridge/`.
-//
-// Build pre-reqs (run before opening Xcode):
-//   cargo xtask ios build-lynx-frameworks
-//   cargo xtask ios build-xcframework
-//
-// Runtime layout: the host app embeds WhiskerDriver.framework under
-// `<App>.app/Frameworks/`. The dylib's LC_ID_DYLIB is
-// `@rpath/WhiskerDriver.framework/WhiskerDriver` (set by xtask via
-// `install_name_tool -id`), so the host app needs
-// `@executable_path/Frameworks` in `LD_RUNPATH_SEARCH_PATHS` — set in
-// `examples/<pkg>/ios/project.yml` (XcodeGen → Xcode project setting).
 
 let package = Package(
     name: "WhiskerRuntime",
@@ -49,13 +59,6 @@ let package = Package(
         // including WhiskerView / WhiskerViewController / AppDelegate).
         .library(name: "WhiskerModule", targets: ["WhiskerModule"]),
         .library(name: "WhiskerRuntime", targets: ["WhiskerRuntime"]),
-        // Re-export the binary `WhiskerDriver` framework so external
-        // packages can `import WhiskerDriver` to see the C ABI
-        // declarations (`whisker_bridge_register_module_dispatch`,
-        // `WhiskerValueRaw`, …) the codegen-emitted dispatch shim
-        // references. Without this product the binary target stays
-        // scoped to WhiskerRuntime's own sources.
-        .library(name: "WhiskerDriver", targets: ["WhiskerDriver"]),
         // Phase 7-Φ.G: each module package is now its own SwiftPM
         // library and needs to `import Lynx` (etc.) directly to
         // subclass `LynxUI<UIView>`. Expose the binary frameworks
@@ -67,16 +70,6 @@ let package = Package(
         .library(name: "PrimJS", targets: ["PrimJS"]),
     ],
     targets: [
-        // Rust runtime + C++ bridge, packaged as a dynamic xcframework
-        // (one `.framework` per slice). The cargo dylib's build.rs
-        // emits dependent-dylib refs (LC_LOAD_DYLIB) to the Lynx
-        // frameworks below, so dyld resolves them at app launch when
-        // SPM auto-embeds the Lynx xcframeworks into the host app.
-        .binaryTarget(
-            name: "WhiskerDriver",
-            path: "../../target/whisker-driver/WhiskerDriver.xcframework"
-        ),
-
         // Lynx engine + dependencies, as xcframeworks built from upstream
         // CocoaPods source via `cargo xtask ios build-lynx-frameworks`.
         .binaryTarget(
@@ -107,17 +100,16 @@ let package = Package(
         // `WhiskerLynxAliases.swift` does `@_exported import Lynx`,
         // so a consumer's `import WhiskerModule` transitively pulls
         // the Lynx symbols needed to subclass `LynxUI<View>`.
-        // Header-only mirror of `WhiskerDriver`'s public C ABI.
-        // The Swift sources `@_exported import WhiskerCBridge` so
-        // the same source tree builds both here (monorepo,
-        // WhiskerDriver binaryTarget present) and from the root
-        // `Package.swift` (no WhiskerDriver, host app provides
-        // symbols via per-app build). `WhiskerCBridge`'s
-        // module.modulemap re-declares the same headers
-        // WhiskerDriver's xcframework ships, so the symbol
-        // namespace overlaps cleanly at link time — the
-        // monorepo-local link picks WhiskerDriver's
-        // implementations.
+        //
+        // Header-only mirror of `WhiskerDriver`'s public C ABI. The
+        // Swift sources `@_exported import WhiskerCBridge` so the
+        // call-site signatures are visible at compile time; the
+        // implementing symbols come from `WhiskerDriver.framework`
+        // (built per-app by an Xcode Run Script Build Phase — see
+        // file header) and resolve at the host app's link step.
+        // `WhiskerCBridge`'s `module.modulemap` carries the same C
+        // declarations the framework's `Headers/` directory would
+        // expose, so the symbol namespace overlaps cleanly.
         .systemLibrary(
             name: "WhiskerCBridge",
             path: "Sources/WhiskerCBridge/include"
@@ -125,7 +117,7 @@ let package = Package(
 
         .target(
             name: "WhiskerModule",
-            dependencies: ["Lynx", "WhiskerDriver", "WhiskerCBridge"],
+            dependencies: ["Lynx", "WhiskerCBridge"],
             path: "Sources/WhiskerModule"
         ),
 
@@ -133,7 +125,6 @@ let package = Package(
             name: "WhiskerRuntime",
             dependencies: [
                 "WhiskerModule",
-                "WhiskerDriver",
                 "WhiskerCBridge",
                 "Lynx",
                 "LynxBase",
@@ -143,24 +134,15 @@ let package = Package(
             path: "Sources/WhiskerRuntime",
             linkerSettings: [
                 // System frameworks Lynx depends on transitively.
-                // WhiskerDriver.dylib already declares LC_LOAD_DYLIB
-                // for these (see `whisker-driver-sys/build.rs`), so
-                // dyld would load them anyway, but keeping the
-                // declaration here lets the host app's static-analysis
-                // tooling see the dependency.
+                // WhiskerDriver.framework's dylib already declares
+                // LC_LOAD_DYLIB for these (see
+                // `whisker-driver-sys/build.rs`), so dyld would load
+                // them anyway, but keeping the declaration here lets
+                // the host app's static-analysis tooling see the
+                // dependency.
                 .linkedFramework("JavaScriptCore"),
                 .linkedFramework("NaturalLanguage"),
                 .linkedLibrary("c++"),
-                // `-ObjC` is no longer required here: when iOS was a
-                // staticlib, the host app's link step had to be told
-                // to pull every Obj-C class from the archived `.o`
-                // files. With the dylib path, that responsibility
-                // moves into the dylib's own link step in
-                // `whisker-driver-sys/build.rs`
-                // (`cargo:rustc-link-arg=-Wl,-ObjC`). The Obj-C classes
-                // end up in the dylib's `__objc_classlist` and dyld
-                // picks them up at load time, so the host app no
-                // longer needs the flag.
             ]
         ),
     ]


### PR DESCRIPTION
## Summary

Closes the iOS gap that pre-Step-6 required `whisker build` orchestration before Xcode could open the project. **Goal achieved**: open `gen/ios/<scheme>.xcodeproj` in Xcode (or invoke `xcodebuild` directly), hit Build, get a runnable `.app` — `whisker-build` CLI runs internally via Build Phase scripts (Flutter / Expo pattern).

## What changed

### Drop `WhiskerDriver` from SPM

- `platforms/ios/Package.swift`: removed `binaryTarget(name: "WhiskerDriver", path: ...)`, removed the `WhiskerDriver` library product, removed `"WhiskerDriver"` from `WhiskerRuntime` / `WhiskerModule` target deps.
- Swift sources already `@_exported import WhiskerCBridge` for the C ABI declarations; the implementing symbols come from `WhiskerDriver.framework` produced by the Build Phase + resolved at link time via `OTHER_LDFLAGS += -framework WhiskerDriver`.

### Two new Build Phases (cng `project.pbxproj`)

1. **"Whisker Prebuild"** (runs before Sources): invokes `whisker-build ios --workspace=... --package=... --configuration=$CONFIGURATION --platform=$PLATFORM_NAME --archs=$ARCHS --built-products-dir=$BUILT_PRODUCTS_DIR`. Existing `build_framework_for_xcode_run_script` handles cargo cross-compile + lipo + framework wrap + drops the result at `$BUILT_PRODUCTS_DIR/Frameworks/WhiskerDriver.framework`.
2. **"Whisker Embed Framework"** (runs after Frameworks link): copies the framework into `$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/Frameworks/` and codesigns if `EXPANDED_CODE_SIGN_IDENTITY` is set.

Per-target build settings: `FRAMEWORK_SEARCH_PATHS += $(BUILT_PRODUCTS_DIR)/Frameworks` (link visibility), `OTHER_LDFLAGS += -framework WhiskerDriver` (link), `LD_RUNPATH_SEARCH_PATHS += @executable_path/Frameworks` (already there from earlier work — runtime resolution).

### Plumbing

- `IosInputs` gains `workspace_root: PathBuf` + `user_package: String`; template substitutes them into the Build Phase script. `template_version` 5 → 6 so existing `gen/ios/` trees regenerate.
- `whisker-cli/src/build.rs` drops the explicit `ios::build_xcframework(..)` call — the Build Phase produces the framework now, doing both would burn a redundant cargo cross-compile.

### Module Package.swift monorepo fallback (with canonicalization)

Each module's `Package.swift` no longer hard-fails when `WHISKER_IOS_RUNTIME` / `WHISKER_IOS_MACROS` env vars are absent. Falls back to a path discovered via `Context.packageDirectory + "/../../platforms/ios"`, **normalized through `URL(fileURLWithPath:).standardized.path`** so SPM's path-string comparison sees the same canonical identity as the cng-rendered aggregator's baked-in absolute path. Without the normalization, SPM treats them as two instances of the same package, breaking the `WhiskerModuleCodegenPlugin → WhiskerModuleCodegen` dependency chain and crashing the build with "Build input file cannot be found: .../Build/Products/Release/WhiskerModuleCodegen".

Files: `packages/{whisker-audio,whisker-image,whisker-local-store,whisker-safe-area,whisker-svg,whisker-video}/Package.swift`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p whisker-cng` (template_version bump verified)
- [x] `whisker build --target=ios-sim` still works end-to-end (regression check)
- [x] **Standalone `xcodebuild build` (no whisker CLI, no env vars) produces a working `.app`** — the Step 7 success criterion
- [x] Launching the standalone-built `.app` on iOS sim renders the router-example home screen (confirms Step 6's dlopen loader resolves Lynx correctly under the new Build Phase pipeline)
- [ ] CI passes

## After this lands

- Generate an `xcscheme` so opening the project in Xcode.app gets a pre-configured scheme out of the box (xcodebuild already works without one)
- Decide whether `whisker run`'s dev-server should also drop its `build_xcframework_with` call (currently redundant with the Build Phase but harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)