### PR TITLE
refactor(dev-server): move iOS Tier 1 capture from builder to installer

### DIFF
--- a/crates/whisker-build/src/lib.rs
+++ b/crates/whisker-build/src/lib.rs
@@ -32,7 +32,8 @@ pub mod modules;
 pub mod ui;
 
 pub use capture::{
-    capture_env_vars, target_linker_env_var, target_rustflags_env_var, CaptureShims,
+    capture_env_vars, capture_env_vars_for_triple, target_linker_env_var, target_rustflags_env_var,
+    CaptureShims,
 };
 pub use lynx::{
     cache_dir as lynx_cache_dir, cache_version_root as lynx_cache_version_root,

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -135,25 +135,32 @@ impl Builder {
     }
 
     async fn build_ios_simulator(&self) -> Result<()> {
-        // For iOS the dev loop produces a WhiskerDriver.xcframework
-        // that the WhiskerRuntime SPM package references. The actual
-        // `.app` build (xcodebuild) lives in `installer.rs::ios_install_and_launch` —
-        // that step needs the bundle id + scheme from `IosParams`
-        // and runs after this returns.
+        // Step 7: this method's only remaining job is to stage the
+        // module Swift sources for SwiftPM. The actual `.app` build —
+        // and the cargo cross-compile that produces
+        // `WhiskerDriver.framework` — happens during xcodebuild in
+        // `installer.rs::ios_install_and_launch`, via the cng-generated
+        // pbxproj's "Whisker Prebuild" Run Script Build Phase.
+        //
+        // Pre-Step-7 this method also ran `build_xcframework_with` to
+        // produce `target/whisker-driver/WhiskerDriver.xcframework`
+        // and to prime the Tier 1 capture shims. The xcframework is
+        // no longer referenced by anything (Step 7 dropped the SPM
+        // binaryTarget) so its output was wasted; the capture wiring
+        // moved to `installer.rs` where it gets applied as env vars
+        // on the xcodebuild Command.
         let ws = self.workspace_root.clone();
         let crate_dir = self.crate_dir.clone();
         let pkg = self.package.clone();
-        let features = self.features.clone();
-        let capture = self.capture.clone();
 
         tokio::task::spawn_blocking(move || -> Result<()> {
-            // Stage Whisker modules' iOS Swift sources before cargo
-            // build so the pbxproj's WhiskerModules SwiftPM ref
-            // resolves cleanly. Empty when no module declares
-            // `[ios].swift_sources` — the staging step still writes
-            // a no-op Package.swift + WhiskerModuleBehaviors.swift
-            // so AppDelegate's `import WhiskerModules` doesn't
-            // fail to resolve.
+            // Stage Whisker modules' iOS Swift sources before
+            // xcodebuild runs so the pbxproj's WhiskerModules SwiftPM
+            // ref resolves cleanly. Empty when no module declares
+            // `[ios].swift_sources` — the staging step still writes a
+            // no-op Package.swift + WhiskerModuleBehaviors.swift so
+            // AppDelegate's `import WhiskerModules` doesn't fail to
+            // resolve.
             let modules = whisker_build::modules::discover(&ws.join("Cargo.toml"), &pkg)?;
             let gen_ios = crate_dir.join("gen/ios");
             let whisker_runtime_path = ws.join("platforms/ios");
@@ -164,23 +171,10 @@ impl Builder {
                 &whisker_ios_macros_path,
                 &modules,
             )?;
-
-            // Dev loop only ever loads the arm64-sim slice on an
-            // Apple Silicon Mac. Building the device + x86 slices
-            // adds ~60s per initial `whisker run` for no benefit
-            // here; production `whisker build` still goes through
-            // the universal path via `whisker-cli::build`.
-            whisker_build::ios::build_xcframework_with(
-                &ws,
-                &pkg,
-                &features,
-                capture.as_ref(),
-                whisker_build::ios::IosSlices::SimulatorFat,
-            )?;
             Ok(())
         })
         .await
-        .context("spawn_blocking iOS xcframework build")?
+        .context("spawn_blocking iOS module-source stage")?
     }
 }
 

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 use tokio::process::Command;
 
 use crate::{AndroidParams, IosParams, Target};
+use whisker_build::CaptureShims;
 
 pub struct Installer {
     target: Target,
@@ -24,6 +25,16 @@ pub struct Installer {
     ios: Option<IosParams>,
     workspace_root: PathBuf,
     package: String,
+    /// Tier 1 capture shims for hot-reload. When `Some`, the
+    /// xcodebuild Command in [`ios_install_and_launch`] gets the
+    /// `RUSTC_WORKSPACE_WRAPPER` + `CARGO_TARGET_*_LINKER` +
+    /// `CARGO_TARGET_*_RUSTFLAGS` env vars set so the Step-7
+    /// Build Phase's cargo invocation runs as a fat capture build.
+    /// Pre-Step-7 the dev-server primed capture via a separate
+    /// `build_xcframework_with` call in `builder.rs`; that call now
+    /// produces an artifact xcodebuild's Build Phase rebuilds anyway,
+    /// so the capture wiring moves here.
+    capture: Option<CaptureShims>,
 }
 
 impl Installer {
@@ -33,6 +44,7 @@ impl Installer {
         ios: Option<IosParams>,
         workspace_root: PathBuf,
         package: String,
+        capture: Option<CaptureShims>,
     ) -> Self {
         Self {
             target,
@@ -40,6 +52,7 @@ impl Installer {
             ios,
             workspace_root,
             package,
+            capture,
         }
     }
 
@@ -56,7 +69,13 @@ impl Installer {
                 let p = self.ios.as_ref().context(
                     "target=IosSimulator but no IosParams — cli must populate Config.ios",
                 )?;
-                ios_install_and_launch(p, &self.workspace_root, &self.package).await
+                ios_install_and_launch(
+                    p,
+                    &self.workspace_root,
+                    &self.package,
+                    self.capture.as_ref(),
+                )
+                .await
             }
         }
     }
@@ -321,6 +340,7 @@ async fn ios_install_and_launch(
     p: &IosParams,
     workspace_root: &std::path::Path,
     package: &str,
+    capture: Option<&CaptureShims>,
 ) -> Result<()> {
     let xcode_project = p.project_dir.join(format!("{}.xcodeproj", p.scheme));
     if !xcode_project.is_dir() {
@@ -355,6 +375,22 @@ async fn ios_install_and_launch(
             "WHISKER_IOS_MACROS",
             workspace_root.join("platforms/ios/macros"),
         );
+    // Tier 1 capture wiring (hot-reload). Pre-Step-7 the dev-server
+    // ran a separate `build_xcframework_with` call to prime the rustc
+    // + linker capture caches before xcodebuild touched the framework.
+    // Step 7's Build Phase produces the framework during xcodebuild
+    // itself, so the capture envs need to ride along here — they
+    // propagate xcodebuild → shell Build Phase → `whisker-build ios`
+    // subprocess → cargo, where the shims actually intercept rustc +
+    // linker. Capture is opt-in (`HotPatchMode::Tier1Subsecond`); when
+    // `None`, xcodebuild runs without the shims and the loop falls
+    // back to Tier 2 cold rebuilds.
+    if let Some(c) = capture {
+        let sim_triple = "aarch64-apple-ios-sim";
+        for (k, v) in whisker_build::capture_env_vars_for_triple(c, Some(sim_triple)) {
+            xc_cmd.env(k, v);
+        }
+    }
     let xc_status = run_filtered(xc_cmd, SimctlNoise::Xcodebuild)
         .await
         .context("spawn xcodebuild")?;
@@ -473,7 +509,7 @@ mod tests {
 
     #[test]
     fn installer_for_host_doesnt_need_android_or_ios() {
-        let inst = Installer::new(Target::Host, None, None, PathBuf::new(), "x".into());
+        let inst = Installer::new(Target::Host, None, None, PathBuf::new(), "x".into(), None);
         // Just exercise the `host_skip` branch via the public API —
         // it doesn't await anything async so we can run it on the
         // current thread without a runtime.
@@ -485,7 +521,14 @@ mod tests {
 
     #[test]
     fn installer_for_android_without_params_errors() {
-        let inst = Installer::new(Target::Android, None, None, PathBuf::new(), "x".into());
+        let inst = Installer::new(
+            Target::Android,
+            None,
+            None,
+            PathBuf::new(),
+            "x".into(),
+            None,
+        );
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .unwrap();
@@ -497,7 +540,14 @@ mod tests {
 
     #[test]
     fn installer_for_ios_without_params_errors() {
-        let inst = Installer::new(Target::IosSimulator, None, None, PathBuf::new(), "x".into());
+        let inst = Installer::new(
+            Target::IosSimulator,
+            None,
+            None,
+            PathBuf::new(),
+            "x".into(),
+            None,
+        );
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .unwrap();

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -348,6 +348,7 @@ impl DevServer {
             self.config.ios.clone(),
             self.config.workspace_root.clone(),
             self.config.package.clone(),
+            tier1_init.as_ref().map(|p| p.capture.clone()),
         );
 
         // Initial build + install + launch. Without this the dev


### PR DESCRIPTION
Closes #158.

## Summary

Pre-Step-7, the dev-server's iOS builder did two unrelated things in one call to \`build_xcframework_with\`:

1. Built \`target/whisker-driver/WhiskerDriver.xcframework\` so the SPM \`binaryTarget(path: ...)\` resolved.
2. As a side effect, primed the Tier 1 capture caches (rustc + linker shim args) subsecond replays for thin (hot-reload) rebuilds.

Step 7 (#155) dropped the SPM binaryTarget — xcodebuild's "Whisker Prebuild" Run Script Build Phase produces the framework in-place during the .app build. The standalone xcframework became dead weight: ~30s per initial \`whisker run --target=ios-sim\` cycle writing artifacts nothing read.

This PR drops the redundant build and relies on the Build Phase's cargo invocation for both purposes. The capture wiring moves to the installer.

## What changed

\`crates/whisker-dev-server/src/builder.rs\`:
- \`build_ios_simulator\` removes the \`build_xcframework_with\` call.
- Only \`stage_module_swift_sources\` remains — still needed before xcodebuild's SPM Resolve step.

\`crates/whisker-dev-server/src/installer.rs\`:
- \`Installer\` gains \`capture: Option<CaptureShims>\` field + ctor param.
- \`ios_install_and_launch\` accepts \`Option<&CaptureShims>\`.
- When \`Some\`, sets standard cargo env vars (\`RUSTC_WORKSPACE_WRAPPER\`, \`CARGO_TARGET_AARCH64_APPLE_IOS_SIM_LINKER\`, \`CARGO_TARGET_AARCH64_APPLE_IOS_SIM_RUSTFLAGS\`, plus Whisker's cache-dir vars) on the xcodebuild Command. xcodebuild inherits them → Build Phase shell inherits → \`whisker-build ios\` subprocess inherits → cargo sees them and the shims intercept rustc + linker.

\`crates/whisker-dev-server/src/lib.rs\`:
- \`Installer::new\` call site passes \`tier1_init.as_ref().map(|p| p.capture.clone())\`.

\`crates/whisker-build/src/lib.rs\`:
- Re-export \`capture_env_vars_for_triple\` so installer can build the per-triple env-var set without cloning the helper.

## Verified

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-dev-server --no-fail-fast\` (153 + 3 + 1 tests pass)
- [x] \`whisker build --target=ios-sim\` against router-example still produces a working \`.app\` (production path; doesn't use dev-server)
- [ ] CI passes
- [ ] (not in scope of this PR but worth confirming separately) \`whisker run --target=ios-sim\` initial build + hot-reload still work — the env-var propagation path is the same shape the dev-server's other code paths already use, but a real human-driven smoke is the truth

## Follow-up (separate PR)

Drop \`build_xcframework\`, \`build_xcframework_with\`, and \`IosSlices\` from \`whisker_build::ios\` — now unused public API. Kept in place here to keep the diff focused on the semantic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)