### PR TITLE
chore(cng): rename "Whisker Prebuild" Build Phase to "Whisker Generate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ whisker/
 │   ├── whisker-driver           Backend driver (host shim, BridgeRenderer)
 │   ├── whisker-driver-sys       Raw FFI bindings + C++ bridge sources (bridge/)
 │   ├── whisker-macros           Proc macros (#[whisker::main], #[component], render!)
-│   ├── whisker-plugin           Plugin trait + PrebuildContext + typed mod APIs
+│   ├── whisker-plugin           Plugin trait + GenerateContext + typed mod APIs
 │   └── whisker-runtime          Core runtime (reactive arena, view layer)
 ├── native/
 │   ├── android/               Kotlin runtime (WhiskerApplication / WhiskerView etc.)
@@ -145,7 +145,7 @@ GitHub.
 | `render!` macro | ✅ |
 | `Signal<T>` unified prop reactivity (Phase 7-Φ) | ✅ |
 | `#[whisker::platform_component]` (iOS only for now) | ✅ |
-| CNG (`whisker prebuild`) | ⏳ |
+| CNG (continuous native generation, plugin-driven) | ⏳ |
 | `whisker run` (Tier 1 hot reload) | ✅ (iOS) / ⏳ (Android) |
 | iOS xcframework build | ✅ |
 | Android AAR build | ⏳ |

--- a/crates/whisker-cli/src/build.rs
+++ b/crates/whisker-cli/src/build.rs
@@ -191,7 +191,7 @@ fn build_ios_app(
     // 3. xcodebuild release.
     //
     // Step-7 dropped the explicit `build_xcframework` call here: the
-    // cng-generated pbxproj now carries a "Whisker Prebuild" Build
+    // cng-generated pbxproj now carries a "Whisker Generate" Build
     // Phase that invokes `whisker-build ios` to produce
     // `WhiskerDriver.framework` during the xcodebuild run itself.
     // Doing it here AND letting the Build Phase re-do it would burn

--- a/crates/whisker-cng/src/ios.rs
+++ b/crates/whisker-cng/src/ios.rs
@@ -273,13 +273,14 @@ pub fn inputs_from(
         whisker_modules_path,
         workspace_root,
         user_package,
-        // Bumped 7 → 8: cng now also emits a shared
-        // `xcshareddata/xcschemes/<scheme>.xcscheme` so Xcode.app
-        // opens the project with the same Build / Run / Test /
-        // Profile actions every contributor sees, instead of letting
-        // Xcode auto-create a per-user (unshared, unsourced) scheme
-        // on first open.
-        template_version: 8,
+        // Bumped 8 → 9 for RFC #164 Phase 0: the pbxproj template's
+        // Run Script Build Phase rename "Whisker Prebuild" →
+        // "Whisker Generate". Aligns with the RFC's "Generate"
+        // vocabulary (cng = Continuous Native Generation) and away
+        // from Expo's "Prebuild" loaner. Forces existing `gen/ios/`
+        // trees to regenerate so the Build Phase name in any open
+        // Xcode project window updates.
+        template_version: 9,
     })
 }
 
@@ -313,7 +314,7 @@ mod tests {
             whisker_modules_path: PathBuf::from("/abs/gen/ios/whisker_modules"),
             workspace_root: PathBuf::from("/abs/workspace"),
             user_package: "hello-world".into(),
-            template_version: 8,
+            template_version: 9,
         }
     }
 

--- a/crates/whisker-cng/src/lib.rs
+++ b/crates/whisker-cng/src/lib.rs
@@ -9,8 +9,8 @@
 //! Modelled on Expo's CNG: the source of truth is the declarative
 //! config, the platforms directory are build artifacts (never
 //! committed). Unlike Expo, regeneration is *implicit* — there's no
-//! `whisker prebuild` command. Whichever command needs the native
-//! tree (today: `whisker run` / `whisker build`) calls
+//! separate `whisker generate` command. Whichever command needs the
+//! native tree (today: `whisker run` / `whisker build`) calls
 //! [`sync_android`] / [`sync_ios`] first; the fast path (fingerprint
 //! match) is a single file read and returns instantly.
 //!

--- a/crates/whisker-cng/src/templates/ios/Project.xcodeproj/project.pbxproj
+++ b/crates/whisker-cng/src/templates/ios/Project.xcodeproj/project.pbxproj
@@ -71,7 +71,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 39A71CFC79D014E76D4445EB /* Build configuration list for PBXNativeTarget "{{ios_scheme}}" */;
 			buildPhases = (
-				7E2B91D0F46A1C73B5A5DE91 /* Whisker Prebuild */,
+				7E2B91D0F46A1C73B5A5DE91 /* Whisker Generate */,
 				4A590CB0D847DB4C38DDCDFC /* Sources */,
 				D4C57884A372C8EC69F16CAD /* Frameworks */,
 				3F69E4C8A2D75B6E81C094BB /* Whisker Embed Framework */,
@@ -92,7 +92,7 @@
 /* End PBXNativeTarget section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		7E2B91D0F46A1C73B5A5DE91 /* Whisker Prebuild */ = {
+		7E2B91D0F46A1C73B5A5DE91 /* Whisker Generate */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -102,7 +102,7 @@
 			);
 			inputPaths = (
 			);
-			name = "Whisker Prebuild";
+			name = "Whisker Generate";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -131,7 +131,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "set -euo pipefail\n# Step-7 Embed: copies WhiskerDriver.framework from the build-products\n# search path into the .app bundle's Frameworks/. The earlier\n# 'Whisker Prebuild' phase dropped it at $BUILT_PRODUCTS_DIR/Frameworks/\n# so FRAMEWORK_SEARCH_PATHS picks it up for the linker; this phase\n# completes the journey by placing it where dyld looks at app launch\n# (via LD_RUNPATH_SEARCH_PATHS=@executable_path/Frameworks).\nSRC=\"$BUILT_PRODUCTS_DIR/Frameworks/WhiskerDriver.framework\"\nDST_DIR=\"$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/Frameworks\"\nmkdir -p \"$DST_DIR\"\nrm -rf \"$DST_DIR/WhiskerDriver.framework\"\ncp -R \"$SRC\" \"$DST_DIR/\"\n# Codesign — required on device builds; harmless on simulator.\nif [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]; then\n  /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" --preserve-metadata=identifier,entitlements --timestamp=none \"$DST_DIR/WhiskerDriver.framework\"\nfi\n";
+			shellScript = "set -euo pipefail\n# Step-7 Embed: copies WhiskerDriver.framework from the build-products\n# search path into the .app bundle's Frameworks/. The earlier\n# 'Whisker Generate' phase dropped it at $BUILT_PRODUCTS_DIR/Frameworks/\n# so FRAMEWORK_SEARCH_PATHS picks it up for the linker; this phase\n# completes the journey by placing it where dyld looks at app launch\n# (via LD_RUNPATH_SEARCH_PATHS=@executable_path/Frameworks).\nSRC=\"$BUILT_PRODUCTS_DIR/Frameworks/WhiskerDriver.framework\"\nDST_DIR=\"$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/Frameworks\"\nmkdir -p \"$DST_DIR\"\nrm -rf \"$DST_DIR/WhiskerDriver.framework\"\ncp -R \"$SRC\" \"$DST_DIR/\"\n# Codesign — required on device builds; harmless on simulator.\nif [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]; then\n  /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" --preserve-metadata=identifier,entitlements --timestamp=none \"$DST_DIR/WhiskerDriver.framework\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -248,7 +248,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				// Step-7: WhiskerDriver.framework is produced by the
-				// "Whisker Prebuild" Build Phase into
+				// "Whisker Generate" Build Phase into
 				// $(BUILT_PRODUCTS_DIR)/Frameworks/. The linker needs to
 				// see it via -F + -framework at the Frameworks phase.
 				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(BUILT_PRODUCTS_DIR)/Frameworks";

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -140,7 +140,7 @@ impl Builder {
         // and the cargo cross-compile that produces
         // `WhiskerDriver.framework` — happens during xcodebuild in
         // `installer.rs::ios_install_and_launch`, via the cng-generated
-        // pbxproj's "Whisker Prebuild" Run Script Build Phase.
+        // pbxproj's "Whisker Generate" Run Script Build Phase.
         //
         // Pre-Step-7 this method also ran `build_xcframework_with` to
         // produce `target/whisker-driver/WhiskerDriver.xcframework`


### PR DESCRIPTION
Phase 0 of RFC #164. Cosmetic rename only.

## Why

The pbxproj template's Run Script Build Phase was named "Whisker Prebuild" — a loan from Expo's vocabulary that doesn't fit Whisker's own naming (`cng` = Continuous Native **Generation**). Phase 0 lands the terminology fix first so subsequent Phase 1+ work writes against the right vocabulary from the start.

## What changed

- `crates/whisker-cng/src/templates/ios/Project.xcodeproj/project.pbxproj` — Run Script Build Phase name + its 4 cross-references in the same file
- Documentation comments in `crates/whisker-cng/src/{ios.rs,lib.rs}`, `crates/whisker-cli/src/build.rs`, `crates/whisker-dev-server/src/builder.rs`, `README.md`
- `IosInputs::template_version` 8 → 9 so existing `gen/ios/` trees regenerate (the Build Phase name change shows up in any open Xcode project window after the next \`whisker build\`)

\`whisker-build\`'s scope is unchanged. This is a \`whisker-cng\` internals + docs sweep only.

## Notes

Two intentional \"Prebuild\" mentions remain:

- \`crates/whisker-cng/src/ios.rs:23\` — references Expo's actual command name \`expo prebuild\` (third-party tool reference, must stay)
- \`crates/whisker-cng/src/ios.rs:277-280\` — the new template_version 8→9 changelog comment explaining the rename history

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-cng\` (26 tests pass)
- [x] \`whisker build --target=ios-sim\` regenerates with template v9; rendered pbxproj has 0 \"Prebuild\" occurrences and 5 \"Generate\"
- [x] Standalone \`xcodebuild build\` against the regenerated project produces a working .app; build progress messages reference \"Whisker Generate\"
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)