### PR TITLE
feat(plugin,app-config): PluginConfig trait + AppConfig.plugin builder (RFC #164 Phase 1 PR 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,8 @@ name = "whisker-app-config"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
+ "whisker-plugin",
 ]
 
 [[package]]

--- a/crates/whisker-app-config/Cargo.toml
+++ b/crates/whisker-app-config/Cargo.toml
@@ -16,3 +16,11 @@ description = "AppConfig types used in whisker.rs to declare app metadata."
 # what makes the probe build cheap (single-digit seconds first time,
 # cached afterwards).
 serde = { workspace = true }
+# `app.plugin::<Cfg>(|c| ...)` serializes the typed Config into a
+# `serde_json::Value` stored under `plugins[Cfg::NAME]`. The probe
+# already pulls serde_json transitively, so adding it here just
+# makes the dep explicit.
+serde_json = { workspace = true }
+# `PluginConfig` trait — `app.plugin::<T>()` is generic over it and
+# reads `T::NAME` to key the entry inside `plugins`.
+whisker-plugin = { workspace = true }

--- a/crates/whisker-app-config/src/lib.rs
+++ b/crates/whisker-app-config/src/lib.rs
@@ -16,6 +16,13 @@
 //!         .bundle_id("dev.example.MyApp")
 //!         .scheme("MyApp")
 //!         .deployment_target("14.0"));
+//!
+//!     // Whisker CNG plugin declarations live alongside the platform
+//!     // blocks. The Config struct's `PluginConfig::NAME` keys the
+//!     // entry inside `plugins`, so this call replaces any prior
+//!     // configuration for the same plugin.
+//!     app.plugin::<FirebaseCfg>(|c| c
+//!         .google_service_path("ios/GoogleService-Info.plist"));
 //! }
 //! ```
 //!
@@ -27,6 +34,8 @@
 //! dev-server itself does not depend on this crate.
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use whisker_plugin::PluginConfig;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AppConfig {
@@ -36,6 +45,16 @@ pub struct AppConfig {
     pub build_number: Option<u32>,
     pub ios: IosConfig,
     pub android: AndroidConfig,
+    /// Per-plugin Config serialized as JSON, keyed by the Config
+    /// struct's `PluginConfig::NAME`. `whisker-cng` reads this map
+    /// when composing the plugin pipeline — every entry corresponds
+    /// to one `app.plugin::<T>(|cfg| ...)` call in `whisker.rs`.
+    ///
+    /// `BTreeMap` over `HashMap` for deterministic iteration order:
+    /// `whisker-cng`'s fingerprint hashes the serialized AppConfig,
+    /// and HashMap's random ordering would break the skip path.
+    #[serde(default)]
+    pub plugins: BTreeMap<String, serde_json::Value>,
 }
 
 impl AppConfig {
@@ -66,6 +85,42 @@ impl AppConfig {
 
     pub fn android(&mut self, f: impl FnOnce(&mut AndroidConfig)) -> &mut Self {
         f(&mut self.android);
+        self
+    }
+
+    /// Declare a Whisker CNG plugin and configure its options.
+    ///
+    /// `T` is the plugin's Config struct, which carries the plugin's
+    /// stable name as `T::NAME`. The closure receives a fresh
+    /// `T::default()` and mutates it through whatever builder
+    /// methods the plugin author exposed. The resulting Config is
+    /// serialized as JSON and stored under `plugins[T::NAME]`.
+    ///
+    /// Calling `plugin::<T>` twice for the same `T` replaces the
+    /// prior entry — last call wins. Use this when a downstream
+    /// `configure` extension wants to override what an upstream
+    /// helper installed.
+    ///
+    /// # Panics
+    ///
+    /// If `serde_json::to_value(&cfg)` fails. In practice
+    /// `PluginConfig::serialize` is total for any sane Config
+    /// struct (the bound is enforced statically), so this only
+    /// fires if the Config holds something inexpressible in JSON
+    /// (e.g. a non-string map key or an enum without
+    /// `#[serde(tag = ...)]`). Plugin authors should fix their
+    /// Config; we don't return `Result` because `whisker.rs` is
+    /// meant to be ergonomic builder code, not error-handling code.
+    pub fn plugin<T: PluginConfig>(&mut self, f: impl FnOnce(&mut T)) -> &mut Self {
+        let mut cfg = T::default();
+        f(&mut cfg);
+        let json = serde_json::to_value(&cfg).unwrap_or_else(|e| {
+            panic!(
+                "AppConfig::plugin: failed to serialize Config for plugin `{}`: {e}",
+                T::NAME,
+            )
+        });
+        self.plugins.insert(T::NAME.to_string(), json);
         self
     }
 }
@@ -143,5 +198,146 @@ impl AndroidConfig {
     pub fn launcher_activity(&mut self, a: impl Into<String>) -> &mut Self {
         self.launcher_activity = Some(a.into());
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default, Serialize, Deserialize)]
+    struct PermissionsCfg {
+        camera_reason: Option<String>,
+        permissions: Vec<String>,
+    }
+
+    impl PluginConfig for PermissionsCfg {
+        const NAME: &'static str = "whisker-permissions";
+    }
+
+    impl PermissionsCfg {
+        fn camera_reason(&mut self, r: impl Into<String>) -> &mut Self {
+            self.camera_reason = Some(r.into());
+            self
+        }
+        fn add(&mut self, p: impl Into<String>) -> &mut Self {
+            self.permissions.push(p.into());
+            self
+        }
+    }
+
+    #[derive(Default, Serialize, Deserialize)]
+    struct FirebaseCfg {
+        google_service_path: Option<String>,
+    }
+
+    impl PluginConfig for FirebaseCfg {
+        const NAME: &'static str = "whisker-firebase";
+    }
+
+    impl FirebaseCfg {
+        fn google_service_path(&mut self, p: impl Into<String>) -> &mut Self {
+            self.google_service_path = Some(p.into());
+            self
+        }
+    }
+
+    #[test]
+    fn plugin_call_stores_serialized_config_keyed_by_name() {
+        let mut app = AppConfig::default();
+        app.plugin::<FirebaseCfg>(|c| {
+            c.google_service_path("ios/GoogleService-Info.plist");
+        });
+
+        assert_eq!(app.plugins.len(), 1);
+        let v = app
+            .plugins
+            .get("whisker-firebase")
+            .expect("entry keyed by PluginConfig::NAME");
+        assert_eq!(
+            v.get("google_service_path").and_then(|x| x.as_str()),
+            Some("ios/GoogleService-Info.plist"),
+        );
+    }
+
+    #[test]
+    fn plugin_default_config_round_trips() {
+        let mut app = AppConfig::default();
+        // closure leaves the config at default — entry should still
+        // exist (the plugin was declared, just unconfigured).
+        app.plugin::<FirebaseCfg>(|_| {});
+        let v = app.plugins.get("whisker-firebase").unwrap();
+        assert!(v.is_object());
+        assert!(v.get("google_service_path").unwrap().is_null());
+    }
+
+    #[test]
+    fn plugin_call_replaces_prior_entry_for_same_type() {
+        let mut app = AppConfig::default();
+        app.plugin::<FirebaseCfg>(|c| {
+            c.google_service_path("old.plist");
+        });
+        app.plugin::<FirebaseCfg>(|c| {
+            c.google_service_path("new.plist");
+        });
+
+        assert_eq!(app.plugins.len(), 1);
+        assert_eq!(
+            app.plugins["whisker-firebase"]["google_service_path"],
+            "new.plist",
+        );
+    }
+
+    #[test]
+    fn multiple_distinct_plugins_coexist() {
+        let mut app = AppConfig::default();
+        app.plugin::<FirebaseCfg>(|c| {
+            c.google_service_path("ios/GoogleService-Info.plist");
+        });
+        app.plugin::<PermissionsCfg>(|c| {
+            c.camera_reason("Take photos for the app")
+                .add("android.permission.CAMERA");
+        });
+
+        assert_eq!(app.plugins.len(), 2);
+        let keys: Vec<_> = app.plugins.keys().cloned().collect();
+        // BTreeMap → deterministic alphabetical order
+        assert_eq!(keys, vec!["whisker-firebase", "whisker-permissions"]);
+        assert_eq!(
+            app.plugins["whisker-permissions"]["permissions"][0],
+            "android.permission.CAMERA",
+        );
+    }
+
+    #[test]
+    fn appconfig_round_trips_through_json_with_plugins_field() {
+        let mut app = AppConfig::default();
+        app.name("Demo");
+        app.plugin::<FirebaseCfg>(|c| {
+            c.google_service_path("ios/GoogleService-Info.plist");
+        });
+
+        let json = serde_json::to_string(&app).unwrap();
+        let back: AppConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.name.as_deref(), Some("Demo"));
+        assert_eq!(back.plugins.len(), 1);
+        assert!(back.plugins.contains_key("whisker-firebase"));
+    }
+
+    #[test]
+    fn appconfig_deserializes_without_plugins_field() {
+        // Pre-PR-2 wire format: no `plugins` key at all. The
+        // `#[serde(default)]` on `plugins` should give us an empty
+        // map rather than failing — this is what keeps an
+        // already-deployed dev-server compatible with an older
+        // probe binary.
+        //
+        // (`ios` / `android` are pre-PR-2 required fields, so the
+        // probe always emits them. Including them keeps this test
+        // focused on the plugins-field omission.)
+        let json = r#"{"name":"OldApp","ios":{},"android":{}}"#;
+        let back: AppConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(back.name.as_deref(), Some("OldApp"));
+        assert!(back.plugins.is_empty());
     }
 }

--- a/crates/whisker-plugin/src/lib.rs
+++ b/crates/whisker-plugin/src/lib.rs
@@ -111,11 +111,10 @@ use std::path::PathBuf;
 /// Trait implemented by the typed config struct each plugin defines.
 ///
 /// Carries the plugin's stable kebab-case identifier as a const so
-/// the [`AppConfig::plugin`](https://docs.rs/whisker-app-config/)
-/// builder can derive the plugin name from the *type alone* —
-/// `app.plugin::<FirebaseCfg>(|c| ...)` only sees `FirebaseCfg`, not
-/// the `Plugin` impl that runs against it, so the binding has to
-/// live on the Config side.
+/// the `app.plugin::<Cfg>(|c| ...)` builder in `whisker-app-config`
+/// can derive the plugin name from the *type alone* — the call site
+/// only sees `Cfg`, not the [`Plugin`] impl that runs against it,
+/// so the binding has to live on the Config side.
 ///
 /// ## Why `Serialize + DeserializeOwned`
 ///
@@ -139,8 +138,10 @@ use std::path::PathBuf;
 /// ## Convention for `NAME`
 ///
 /// Kebab-case; prefix 1st-party plugins with `whisker-`
-/// (e.g. `whisker-info-plist`, `whisker-permissions`). Must match
-/// the `Plugin::name()` of the plugin that consumes this Config.
+/// (e.g. `whisker-info-plist`, `whisker-permissions`). The default
+/// [`Plugin::name`] implementation returns this value, so under
+/// normal use the plugin's name and its Config's `NAME` are the
+/// same string by construction.
 pub trait PluginConfig: Serialize + for<'de> Deserialize<'de> + Default {
     const NAME: &'static str;
 }
@@ -164,8 +165,10 @@ pub trait Plugin {
     ///
     /// Defaults to `Self::Config::NAME` so the binding between the
     /// plugin's Config type and the plugin's name only has to be
-    /// declared once. Override only when a single Plugin impl
-    /// wraps multiple Config types (rare).
+    /// declared once (on the Config). The override slot is mostly
+    /// there for tests and shims that want to expose the same
+    /// Config under a different identifier; production plugins
+    /// should leave it at the default.
     fn name(&self) -> &'static str {
         <Self::Config as PluginConfig>::NAME
     }

--- a/crates/whisker-plugin/src/lib.rs
+++ b/crates/whisker-plugin/src/lib.rs
@@ -20,28 +20,32 @@
 //!
 //! ## Writing a 3rd-party plugin
 //!
-//! Add `whisker-plugin` as a dep, implement [`Plugin`] on a unit
-//! struct, and call [`run_as_subprocess`] from `main`:
+//! Implement [`PluginConfig`] on a Config struct (this gives the
+//! plugin its name) and [`Plugin`] on a unit struct that owns the
+//! apply logic, then call [`run_as_subprocess`] from `main`:
 //!
 //! ```no_run
-//! use whisker_plugin::{Operation, Plugin, GenerateContext, PlistValue, Target};
+//! use whisker_plugin::{Operation, Plugin, PluginConfig, GenerateContext, PlistValue, Target};
 //!
 //! #[derive(Default, serde::Serialize, serde::Deserialize)]
 //! struct MyConfig {
 //!     bundle_suffix: String,
 //! }
 //!
+//! impl PluginConfig for MyConfig {
+//!     const NAME: &'static str = "example-plugin";
+//! }
+//!
 //! struct MyPlugin;
 //!
 //! impl Plugin for MyPlugin {
 //!     type Config = MyConfig;
-//!     fn name(&self) -> &'static str { "example-plugin" }
 //!     fn apply(&self, ctx: &mut GenerateContext, cfg: &MyConfig) -> anyhow::Result<()> {
 //!         if let Some(ios) = ctx.ios.as_mut() {
 //!             let key = "CFBundleSuffix".to_string();
 //!             ios.info_plist.insert(key.clone(), PlistValue::String(cfg.bundle_suffix.clone()));
 //!             ctx.journal.record(
-//!                 "example-plugin",
+//!                 MyConfig::NAME,
 //!                 Target::Ios,
 //!                 &format!("info_plist.{key}"),
 //!                 Operation::Set,
@@ -101,43 +105,70 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 
 // ----------------------------------------------------------------------------
-// Plugin trait
+// PluginConfig trait
 // ----------------------------------------------------------------------------
 
-/// What a plugin implements.
+/// Trait implemented by the typed config struct each plugin defines.
 ///
-/// ## Why `Config` is `Serialize + DeserializeOwned`
+/// Carries the plugin's stable kebab-case identifier as a const so
+/// the [`AppConfig::plugin`](https://docs.rs/whisker-app-config/)
+/// builder can derive the plugin name from the *type alone* —
+/// `app.plugin::<FirebaseCfg>(|c| ...)` only sees `FirebaseCfg`, not
+/// the `Plugin` impl that runs against it, so the binding has to
+/// live on the Config side.
+///
+/// ## Why `Serialize + DeserializeOwned`
 ///
 /// Three reasons, all wire-related:
 ///
-/// 1. The user's `whisker.rs` declares plugin config as a Rust
-///    struct via `app.plugin::<MyPluginCfg>(|cfg| ...)`. That value
-///    has to ride along through the config probe → whisker-cli →
-///    whisker-cng path, all of which use JSON.
+/// 1. `whisker.rs` builds the Config struct, then `whisker-cli`
+///    serializes the resulting `AppConfig` (including this Config
+///    nested under `plugins[NAME]`) to JSON via the config probe.
 /// 2. 3rd-party plugins are subprocesses — their config arrives as
-///    JSON in the stdin envelope.
+///    JSON in the [`PluginRequest`] envelope.
 /// 3. The mutation journal records the config that produced each
 ///    mutation, so we can attribute "plugin X with config Y" in
 ///    error messages.
 ///
-/// `Default` is required so config blocks omitted in `whisker.rs`
-/// fall back to a sensible value instead of erroring.
+/// ## Why `Default`
+///
+/// `app.plugin::<Cfg>(|c| ...)` starts from `Cfg::default()` and
+/// lets the closure mutate it. A user who declares a plugin without
+/// touching any options should still get a working config.
+///
+/// ## Convention for `NAME`
+///
+/// Kebab-case; prefix 1st-party plugins with `whisker-`
+/// (e.g. `whisker-info-plist`, `whisker-permissions`). Must match
+/// the `Plugin::name()` of the plugin that consumes this Config.
+pub trait PluginConfig: Serialize + for<'de> Deserialize<'de> + Default {
+    const NAME: &'static str;
+}
+
+// ----------------------------------------------------------------------------
+// Plugin trait
+// ----------------------------------------------------------------------------
+
+/// What a plugin implements.
 pub trait Plugin {
     /// Plugin-specific config. The user passes this in via
     /// `app.plugin::<Cfg>(|c| c.field(...))` inside `whisker.rs`.
-    type Config: Serialize + for<'de> Deserialize<'de> + Default;
+    type Config: PluginConfig;
 
     /// Stable plugin identifier, used in:
     ///
-    /// - The `[package.metadata.whisker.plugins.<name>]` declaration
-    ///   in a user crate's `Cargo.toml`
     /// - `after()` / `before()` cross-references
     /// - The mutation journal
     /// - Error messages
+    /// - The [`PluginRequest`] envelope's `name` field
     ///
-    /// Convention: kebab-case, prefix 1st-party plugins with
-    /// `whisker-` (e.g. `whisker-info-plist`, `whisker-permissions`).
-    fn name(&self) -> &'static str;
+    /// Defaults to `Self::Config::NAME` so the binding between the
+    /// plugin's Config type and the plugin's name only has to be
+    /// declared once. Override only when a single Plugin impl
+    /// wraps multiple Config types (rare).
+    fn name(&self) -> &'static str {
+        <Self::Config as PluginConfig>::NAME
+    }
 
     /// Plugins this one must run **after**. Used by the topological
     /// sort in `whisker-cng::compose`. Default: empty (no ordering
@@ -678,11 +709,12 @@ mod tests {
         flag: bool,
     }
 
+    impl PluginConfig for NullConfig {
+        const NAME: &'static str = "null";
+    }
+
     impl Plugin for NullPlugin {
         type Config = NullConfig;
-        fn name(&self) -> &'static str {
-            "null"
-        }
         fn apply(&self, _ctx: &mut GenerateContext, _config: &Self::Config) -> anyhow::Result<()> {
             Ok(())
         }
@@ -724,20 +756,21 @@ mod tests {
         permission: String,
     }
 
+    impl PluginConfig for PermissionCfg {
+        const NAME: &'static str = "test-permission";
+    }
+
     struct PermissionPlugin;
 
     impl Plugin for PermissionPlugin {
         type Config = PermissionCfg;
-        fn name(&self) -> &'static str {
-            "test-permission"
-        }
         fn apply(&self, ctx: &mut GenerateContext, cfg: &PermissionCfg) -> anyhow::Result<()> {
             let android = ctx.android.as_mut().ok_or_else(|| {
                 anyhow::anyhow!("test-permission requires android target enabled")
             })?;
             android.manifest.permissions.push(cfg.permission.clone());
             ctx.journal.record(
-                "test-permission",
+                PermissionCfg::NAME,
                 Target::Android,
                 "manifest.permissions",
                 Operation::ArrayPush { count: 1 },


### PR DESCRIPTION
## Summary

Wires the second leg of RFC #164's plugin composition system: users can now declare typed plugin configuration from \`whisker.rs\`. The engine (PR 3) consumes the resulting \`AppConfig.plugins\` map.

### \`whisker-plugin\`

- New **\`PluginConfig\`** trait that carries the plugin's stable kebab-case identifier as \`const NAME: &'static str\` on the Config type itself. The \`app.plugin::<Cfg>(|c| ...)\` builder only sees the Config type at the call site, so the binding has to live on the Config side.
- \`Plugin::Config\` tightened to \`: PluginConfig\`. \`Plugin::name()\` picks up a default impl returning \`Self::Config::NAME\` — typical plugins now spell the name only once.
- Crate-level rustdoc example + both internal test plugins updated.

### \`whisker-app-config\`

- New \`AppConfig.plugins: BTreeMap<String, serde_json::Value>\` field with \`#[serde(default)]\` for pre-PR-2 wire format compatibility. \`BTreeMap\` over \`HashMap\` for deterministic iteration — \`whisker-cng\`'s fingerprint hashes the serialized \`AppConfig\` and random ordering would break the skip path.
- New \`app.plugin::<T: PluginConfig>(|cfg| ...)\` builder: starts from \`T::default()\`, hands the closure \`&mut T\`, serializes the result and stores under \`T::NAME\`. Second call for same \`T\` replaces (last call wins).
- Panics on serialize failure rather than returning \`Result\` — \`whisker.rs\` is ergonomic builder code, and a Config that can't round-trip through JSON is a static design bug.

### User-facing whisker.rs shape

\`\`\`rust
app.plugin::<FirebaseCfg>(|c| c
    .google_service_path(\"ios/GoogleService-Info.plist\"));

app.plugin::<PermissionsCfg>(|c| c
    .camera_reason(\"Take photos for the app\")
    .add(\"android.permission.CAMERA\"));
\`\`\`

## What's intentionally NOT in this PR

- No \`whisker-cng\` engine that actually consumes \`AppConfig.plugins\`. That's PR 3 — topo-sort, validate/apply pipeline, conflict detection from the mutation journal, subprocess spawner for 3rd-party binaries.
- No built-in plugins. That's Phase 2 once the engine is in place.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo fmt -p whisker-app-config -p whisker-plugin\`
- [x] \`cargo clippy -p whisker-app-config -p whisker-plugin --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-app-config -p whisker-plugin\` — 14 tests + 1 compile-checked doctest, all pass
  - 6 new app-config tests cover: keyed-by-name insert, default-config insert, replace-same-type, multi-plugin coexistence (alphabetical order), JSON round-trip, pre-PR-2 forward-compat deserialization
  - whisker-plugin tests carried over with PluginConfig impls added

🤖 Generated with [Claude Code](https://claude.com/claude-code)