### PR TITLE
feat(cng): in-process plugin engine (RFC #164 Phase 1 PR 3a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,6 +1913,7 @@ dependencies = [
  "serde",
  "serde_json",
  "whisker-app-config",
+ "whisker-plugin",
 ]
 
 [[package]]

--- a/crates/whisker-cng/Cargo.toml
+++ b/crates/whisker-cng/Cargo.toml
@@ -23,3 +23,8 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 whisker-app-config = { workspace = true }
+# `Plugin` / `PluginConfig` trait + IR types the engine drives the
+# plugin pipeline against. The compose module turns each user-side
+# `AppConfig.plugins[name]` JSON entry back into the plugin's typed
+# Config via this crate's helpers.
+whisker-plugin = { workspace = true }

--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -45,7 +45,13 @@ use whisker_plugin::{
 /// Which platform targets the current `compose` invocation should
 /// produce IRs for. Plugins see `ctx.ios.is_some()` /
 /// `ctx.android.is_some()` matching these flags.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+///
+/// No `Default` impl — "neither target enabled" is almost always a
+/// misconfiguration, so callers spell their intent via
+/// [`ios_only`](Self::ios_only) / [`android_only`](Self::android_only) /
+/// [`both`](Self::both). Construct the literal yourself if you
+/// genuinely want a no-op pipeline (e.g. validate-without-build).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnabledTargets {
     pub ios: bool,
     pub android: bool,
@@ -255,7 +261,9 @@ fn check_no_unregistered_plugin_configs(
 /// `(plugins, AppConfig)` pair always produces the same execution
 /// order. The fingerprint path downstream depends on this.
 fn topo_sort(plugins: &[Box<dyn DynPlugin>]) -> Result<Vec<usize>> {
-    // name → index, deterministic via BTreeMap iteration
+    // name → index. Only used for `after()` / `before()` lookups;
+    // determinism of the final order comes from sort_by_key on the
+    // ready-queue below, not from iteration of this map.
     let mut name_to_idx: BTreeMap<&'static str, usize> = BTreeMap::new();
     for (i, p) in plugins.iter().enumerate() {
         if name_to_idx.insert(p.name(), i).is_some() {

--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -1,0 +1,858 @@
+//! In-process plugin engine.
+//!
+//! Takes a registered set of [`Plugin`]s plus a user `AppConfig`,
+//! topologically orders the plugins via their `after()` / `before()`
+//! constraints, runs each one with its user-supplied config (or the
+//! Config's default when the user didn't declare it), and returns
+//! the post-pipeline [`GenerateContext`]. The CNG renderer pass
+//! (Phase 3) consumes the context to write `gen/{android,ios}/`.
+//!
+//! ## Scope (Phase 1 PR 3a)
+//!
+//! Only the in-process case. 3rd-party plugin subprocesses and
+//! Cargo-metadata-driven discovery come in follow-up PRs; this
+//! module wires the typed-Plugin → erased-trait dispatch path and
+//! the ordering / conflict-detection skeleton everything else
+//! sits on top of.
+//!
+//! ## Type erasure
+//!
+//! [`Plugin`] has an associated `Config` type. Storing different
+//! plugins in one collection means erasing it. [`DynPlugin`] is the
+//! internal erased trait: `name` / `after` / `before` forward
+//! verbatim, while `run` consumes a JSON-encoded config (or `None`
+//! for "use the Config's `Default`"), deserializes it into the
+//! plugin's typed Config, then drives `validate` + `apply`.
+//!
+//! `DynPlugin` is `pub(crate)` because callers should always go
+//! through [`Engine::register`] — handing them the erased trait
+//! invites trying to instantiate a plugin without registering it
+//! with the engine, which loses the topo-sort / conflict checks.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use whisker_app_config::AppConfig;
+use whisker_plugin::{
+    AndroidProjectIr, AppMeta, GenerateContext, IosProjectIr, MutationJournal, MutationRecord,
+    Operation, Plugin, Target,
+};
+
+// ============================================================================
+// Public surface
+// ============================================================================
+
+/// Which platform targets the current `compose` invocation should
+/// produce IRs for. Plugins see `ctx.ios.is_some()` /
+/// `ctx.android.is_some()` matching these flags.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EnabledTargets {
+    pub ios: bool,
+    pub android: bool,
+}
+
+impl EnabledTargets {
+    pub fn ios_only() -> Self {
+        Self {
+            ios: true,
+            android: false,
+        }
+    }
+    pub fn android_only() -> Self {
+        Self {
+            ios: false,
+            android: true,
+        }
+    }
+    pub fn both() -> Self {
+        Self {
+            ios: true,
+            android: true,
+        }
+    }
+}
+
+/// Registry of plugins the engine runs against an [`AppConfig`].
+///
+/// Holds a homogeneous list of erased plugins regardless of their
+/// concrete `Config` type. Construct via [`Engine::new`], add
+/// plugins via [`Engine::register`], run via [`Engine::compose`].
+#[derive(Default)]
+pub struct Engine {
+    plugins: Vec<Box<dyn DynPlugin>>,
+}
+
+impl Engine {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a typed [`Plugin`] with the engine. The engine
+    /// retains ownership for the rest of its lifetime; plugins are
+    /// run in topologically-sorted order on every `compose` call,
+    /// not in registration order.
+    pub fn register<P: Plugin + 'static>(&mut self, plugin: P) -> &mut Self {
+        self.plugins.push(Box::new(plugin));
+        self
+    }
+
+    /// Number of plugins currently registered. Mostly useful for
+    /// tests / debug output.
+    pub fn len(&self) -> usize {
+        self.plugins.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.plugins.is_empty()
+    }
+
+    /// Run the plugin pipeline against `app_config` and return the
+    /// resulting [`GenerateContext`]. Steps:
+    ///
+    /// 1. Build [`AppMeta`] + IR shells (or `None` per
+    ///    [`EnabledTargets`]).
+    /// 2. Reject any `app_config.plugins` entry whose key doesn't
+    ///    match a registered plugin's [`Plugin::name`] — a user
+    ///    declared a plugin that isn't installed.
+    /// 3. Topologically sort registered plugins by their `after()`
+    ///    / `before()` constraints; reject cycles.
+    /// 4. For each plugin: deserialize its user config (or use
+    ///    `Default` if absent), call `validate`, then `apply`.
+    /// 5. Walk the [`MutationJournal`] for `Set`/`Set` collisions
+    ///    on the same `(target, path)` and reject them. `Override`
+    ///    is the escape hatch.
+    pub fn compose(
+        &self,
+        app_config: &AppConfig,
+        enabled: EnabledTargets,
+    ) -> Result<GenerateContext> {
+        let mut ctx = build_initial_context(app_config, enabled);
+
+        check_no_unregistered_plugin_configs(app_config, &self.plugins)
+            .context("validate AppConfig.plugins against registered plugins")?;
+
+        let order = topo_sort(&self.plugins).context("topologically sort plugins")?;
+
+        for idx in order {
+            let plugin = &self.plugins[idx];
+            let name = plugin.name();
+            let user_cfg = app_config.plugins.get(name);
+            plugin
+                .run(&mut ctx, user_cfg)
+                .with_context(|| format!("plugin `{name}` failed"))?;
+        }
+
+        detect_conflicts(&ctx.journal).context("post-pipeline conflict check")?;
+
+        Ok(ctx)
+    }
+}
+
+// ============================================================================
+// Internal — type erasure
+// ============================================================================
+
+/// Erased [`Plugin`] surface. One blanket impl on every `P: Plugin`
+/// turns typed configs into JSON-keyed dispatch.
+pub(crate) trait DynPlugin {
+    fn name(&self) -> &'static str;
+    fn after(&self) -> &'static [&'static str];
+    fn before(&self) -> &'static [&'static str];
+    /// Run validate + apply with `user_config` (or the Config's
+    /// `Default` when `None`).
+    fn run(&self, ctx: &mut GenerateContext, user_config: Option<&Value>) -> Result<()>;
+}
+
+impl<P: Plugin> DynPlugin for P {
+    fn name(&self) -> &'static str {
+        Plugin::name(self)
+    }
+    fn after(&self) -> &'static [&'static str] {
+        Plugin::after(self)
+    }
+    fn before(&self) -> &'static [&'static str] {
+        Plugin::before(self)
+    }
+    fn run(&self, ctx: &mut GenerateContext, user_config: Option<&Value>) -> Result<()> {
+        let cfg: P::Config = match user_config {
+            Some(v) => serde_json::from_value(v.clone()).with_context(|| {
+                format!("decode user config for plugin `{}`", Plugin::name(self))
+            })?,
+            None => Default::default(),
+        };
+        Plugin::validate(self, &cfg)
+            .with_context(|| format!("`{}`::validate", Plugin::name(self)))?;
+        Plugin::apply(self, ctx, &cfg)
+            .with_context(|| format!("`{}`::apply", Plugin::name(self)))?;
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Internal — pipeline steps
+// ============================================================================
+
+fn build_initial_context(app_config: &AppConfig, enabled: EnabledTargets) -> GenerateContext {
+    let app_meta = AppMeta {
+        name: app_config.name.clone().unwrap_or_default(),
+        version: app_config.version.clone().unwrap_or_default(),
+        build_number: app_config.build_number.unwrap_or(1),
+        ios_bundle_id: if enabled.ios {
+            app_config
+                .ios
+                .bundle_id
+                .clone()
+                .or_else(|| app_config.bundle_id.clone())
+        } else {
+            None
+        },
+        android_application_id: if enabled.android {
+            app_config
+                .android
+                .application_id
+                .clone()
+                .or_else(|| app_config.bundle_id.clone())
+        } else {
+            None
+        },
+    };
+
+    GenerateContext {
+        app_meta,
+        ios: enabled.ios.then(IosProjectIr::default),
+        android: enabled.android.then(AndroidProjectIr::default),
+        journal: MutationJournal::default(),
+    }
+}
+
+fn check_no_unregistered_plugin_configs(
+    app_config: &AppConfig,
+    plugins: &[Box<dyn DynPlugin>],
+) -> Result<()> {
+    let registered: std::collections::HashSet<&str> = plugins.iter().map(|p| p.name()).collect();
+    let mut unknown: Vec<&String> = app_config
+        .plugins
+        .keys()
+        .filter(|k| !registered.contains(k.as_str()))
+        .collect();
+    if !unknown.is_empty() {
+        unknown.sort();
+        bail!(
+            "AppConfig declares plugin(s) not registered with the engine: {}. \
+             Either install the plugin crate or remove the `app.plugin::<{{Cfg}}>(…)` call.",
+            unknown
+                .iter()
+                .map(|s| format!("`{s}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// Kahn's algorithm with deterministic ordering: ties between
+/// candidates are broken alphabetically by plugin name so the same
+/// `(plugins, AppConfig)` pair always produces the same execution
+/// order. The fingerprint path downstream depends on this.
+fn topo_sort(plugins: &[Box<dyn DynPlugin>]) -> Result<Vec<usize>> {
+    // name → index, deterministic via BTreeMap iteration
+    let mut name_to_idx: BTreeMap<&'static str, usize> = BTreeMap::new();
+    for (i, p) in plugins.iter().enumerate() {
+        if name_to_idx.insert(p.name(), i).is_some() {
+            bail!("two plugins registered with the same name `{}`", p.name());
+        }
+    }
+
+    // Edges: predecessor → list of successors. `X.after(Y)` and
+    // `Y.before(X)` both produce the edge `Y → X`.
+    let mut succ: HashMap<usize, Vec<usize>> = HashMap::new();
+    let mut in_degree: Vec<usize> = vec![0; plugins.len()];
+
+    let resolve = |this_name: &str, target_name: &str, kind: &str| -> Result<usize> {
+        name_to_idx.get(target_name).copied().ok_or_else(|| {
+            anyhow!(
+                "plugin `{this_name}` declares {kind}(`{target_name}`), \
+                 but no plugin with that name is registered"
+            )
+        })
+    };
+
+    for (i, p) in plugins.iter().enumerate() {
+        for after_name in p.after() {
+            let j = resolve(p.name(), after_name, "after")?;
+            if j == i {
+                bail!("plugin `{}` lists itself in after()", p.name());
+            }
+            succ.entry(j).or_default().push(i);
+            in_degree[i] += 1;
+        }
+        for before_name in p.before() {
+            let j = resolve(p.name(), before_name, "before")?;
+            if j == i {
+                bail!("plugin `{}` lists itself in before()", p.name());
+            }
+            succ.entry(i).or_default().push(j);
+            in_degree[j] += 1;
+        }
+    }
+
+    // Seed queue from index order so registration order breaks
+    // ties — combined with the alphabetical name_to_idx walk above
+    // this is deterministic.
+    let mut queue: VecDeque<usize> = VecDeque::new();
+    let mut candidates: Vec<usize> = (0..plugins.len()).filter(|&i| in_degree[i] == 0).collect();
+    candidates.sort_by_key(|&i| plugins[i].name());
+    queue.extend(candidates);
+
+    let mut order = Vec::with_capacity(plugins.len());
+    while let Some(i) = queue.pop_front() {
+        order.push(i);
+        if let Some(succs) = succ.get(&i) {
+            let mut newly_ready: Vec<usize> = Vec::new();
+            for &j in succs {
+                in_degree[j] -= 1;
+                if in_degree[j] == 0 {
+                    newly_ready.push(j);
+                }
+            }
+            newly_ready.sort_by_key(|&j| plugins[j].name());
+            queue.extend(newly_ready);
+        }
+    }
+
+    if order.len() != plugins.len() {
+        let unfinished: Vec<&'static str> = (0..plugins.len())
+            .filter(|i| !order.contains(i))
+            .map(|i| plugins[i].name())
+            .collect();
+        bail!("plugin ordering cycle involving: {}", unfinished.join(", "));
+    }
+
+    Ok(order)
+}
+
+fn detect_conflicts(journal: &MutationJournal) -> Result<()> {
+    let mut last_writer: HashMap<(Target, &str), &MutationRecord> = HashMap::new();
+    for r in &journal.records {
+        match r.operation {
+            Operation::Set => {
+                let key = (r.target, r.path.as_str());
+                if let Some(prior) = last_writer.get(&key) {
+                    bail!(
+                        "plugin `{}` set `{:?}.{}` at sequence {}, but plugin `{}` \
+                         had already written it at sequence {}. \
+                         Order the plugins with `after()` / `before()` and have the \
+                         second writer use `Operation::Override` to acknowledge it \
+                         intends to replace the earlier value.",
+                        r.plugin,
+                        r.target,
+                        r.path,
+                        r.sequence_index,
+                        prior.plugin,
+                        prior.sequence_index,
+                    );
+                }
+                last_writer.insert(key, r);
+            }
+            Operation::Override => {
+                // Explicitly acknowledges the prior writer — no
+                // conflict either way. Still record so a subsequent
+                // `Set` against the same path errors.
+                last_writer.insert((r.target, r.path.as_str()), r);
+            }
+            Operation::ArrayPush { .. } => {
+                // Array fields are append-only; multiple plugins
+                // contributing entries is the whole point.
+            }
+        }
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use whisker_plugin::{PlistValue, PluginConfig};
+
+    // ----- Test plugins ----------------------------------------------------
+
+    #[derive(Default, Serialize, Deserialize)]
+    struct BundleIdCfg {
+        #[serde(default)]
+        suffix: String,
+    }
+    impl PluginConfig for BundleIdCfg {
+        const NAME: &'static str = "set-bundle-id";
+    }
+    struct BundleIdPlugin;
+    impl Plugin for BundleIdPlugin {
+        type Config = BundleIdCfg;
+        fn apply(&self, ctx: &mut GenerateContext, cfg: &BundleIdCfg) -> Result<()> {
+            let bundle_id = format!("{}{}", "rs.whisker.demo", cfg.suffix);
+            if let Some(ios) = ctx.ios.as_mut() {
+                ios.info_plist
+                    .insert("CFBundleIdentifier".into(), PlistValue::String(bundle_id));
+                ctx.journal.record(
+                    Self::Config::NAME,
+                    Target::Ios,
+                    "info_plist.CFBundleIdentifier",
+                    Operation::Set,
+                );
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Default, Serialize, Deserialize)]
+    struct PermissionsCfg {
+        #[serde(default)]
+        permissions: Vec<String>,
+    }
+    impl PluginConfig for PermissionsCfg {
+        const NAME: &'static str = "permissions";
+    }
+    struct PermissionsPlugin;
+    impl Plugin for PermissionsPlugin {
+        type Config = PermissionsCfg;
+        fn apply(&self, ctx: &mut GenerateContext, cfg: &PermissionsCfg) -> Result<()> {
+            if let Some(a) = ctx.android.as_mut() {
+                for p in &cfg.permissions {
+                    a.manifest.permissions.push(p.clone());
+                }
+                if !cfg.permissions.is_empty() {
+                    ctx.journal.record(
+                        Self::Config::NAME,
+                        Target::Android,
+                        "manifest.permissions",
+                        Operation::ArrayPush {
+                            count: cfg.permissions.len(),
+                        },
+                    );
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Conflicts with BundleIdPlugin if both `Set` the same key.
+    #[derive(Default, Serialize, Deserialize)]
+    struct AnotherBundleIdCfg {}
+    impl PluginConfig for AnotherBundleIdCfg {
+        const NAME: &'static str = "another-bundle-id";
+    }
+    struct AnotherBundleIdPlugin;
+    impl Plugin for AnotherBundleIdPlugin {
+        type Config = AnotherBundleIdCfg;
+        fn apply(&self, ctx: &mut GenerateContext, _cfg: &AnotherBundleIdCfg) -> Result<()> {
+            if let Some(ios) = ctx.ios.as_mut() {
+                ios.info_plist.insert(
+                    "CFBundleIdentifier".into(),
+                    PlistValue::String("rs.other".into()),
+                );
+                ctx.journal.record(
+                    Self::Config::NAME,
+                    Target::Ios,
+                    "info_plist.CFBundleIdentifier",
+                    Operation::Set,
+                );
+            }
+            Ok(())
+        }
+    }
+
+    /// Like AnotherBundleIdPlugin but uses Override.
+    #[derive(Default, Serialize, Deserialize)]
+    struct OverrideBundleIdCfg {}
+    impl PluginConfig for OverrideBundleIdCfg {
+        const NAME: &'static str = "override-bundle-id";
+    }
+    struct OverrideBundleIdPlugin;
+    impl Plugin for OverrideBundleIdPlugin {
+        type Config = OverrideBundleIdCfg;
+        fn after(&self) -> &'static [&'static str] {
+            &["set-bundle-id"]
+        }
+        fn apply(&self, ctx: &mut GenerateContext, _cfg: &OverrideBundleIdCfg) -> Result<()> {
+            if let Some(ios) = ctx.ios.as_mut() {
+                ios.info_plist.insert(
+                    "CFBundleIdentifier".into(),
+                    PlistValue::String("rs.overridden".into()),
+                );
+                ctx.journal.record(
+                    Self::Config::NAME,
+                    Target::Ios,
+                    "info_plist.CFBundleIdentifier",
+                    Operation::Override,
+                );
+            }
+            Ok(())
+        }
+    }
+
+    fn base_app_config() -> AppConfig {
+        let mut a = AppConfig::default();
+        a.name("Demo").bundle_id("rs.whisker.demo");
+        a
+    }
+
+    // ----- Happy paths -----------------------------------------------------
+
+    #[test]
+    fn empty_engine_yields_an_empty_context() {
+        let engine = Engine::new();
+        let ctx = engine
+            .compose(&base_app_config(), EnabledTargets::both())
+            .unwrap();
+        assert!(ctx.ios.is_some());
+        assert!(ctx.android.is_some());
+        assert!(ctx.journal.records.is_empty());
+    }
+
+    #[test]
+    fn enabled_targets_control_which_ir_is_populated() {
+        let engine = Engine::new();
+        let ios_only = engine
+            .compose(&base_app_config(), EnabledTargets::ios_only())
+            .unwrap();
+        assert!(ios_only.ios.is_some());
+        assert!(ios_only.android.is_none());
+        let android_only = engine
+            .compose(&base_app_config(), EnabledTargets::android_only())
+            .unwrap();
+        assert!(android_only.ios.is_none());
+        assert!(android_only.android.is_some());
+    }
+
+    #[test]
+    fn appmeta_is_populated_from_app_config() {
+        let engine = Engine::new();
+        let ctx = engine
+            .compose(&base_app_config(), EnabledTargets::both())
+            .unwrap();
+        assert_eq!(ctx.app_meta.name, "Demo");
+        assert_eq!(
+            ctx.app_meta.ios_bundle_id.as_deref(),
+            Some("rs.whisker.demo")
+        );
+        assert_eq!(
+            ctx.app_meta.android_application_id.as_deref(),
+            Some("rs.whisker.demo"),
+        );
+    }
+
+    #[test]
+    fn plugin_runs_with_user_config_when_declared_in_app_config() {
+        let mut engine = Engine::new();
+        engine.register(BundleIdPlugin);
+        let mut app = base_app_config();
+        app.plugin::<BundleIdCfg>(|c| {
+            c.suffix = ".staging".into();
+        });
+        let ctx = engine.compose(&app, EnabledTargets::ios_only()).unwrap();
+        let ios = ctx.ios.unwrap();
+        assert_eq!(
+            ios.info_plist.get("CFBundleIdentifier"),
+            Some(&PlistValue::String("rs.whisker.demo.staging".into())),
+        );
+    }
+
+    #[test]
+    fn plugin_falls_back_to_default_config_when_not_declared() {
+        // No app.plugin::<BundleIdCfg> call → engine still runs the
+        // registered plugin with BundleIdCfg::default().
+        let mut engine = Engine::new();
+        engine.register(BundleIdPlugin);
+        let ctx = engine
+            .compose(&base_app_config(), EnabledTargets::ios_only())
+            .unwrap();
+        let ios = ctx.ios.unwrap();
+        // suffix defaults to "" → no suffix appended.
+        assert_eq!(
+            ios.info_plist.get("CFBundleIdentifier"),
+            Some(&PlistValue::String("rs.whisker.demo".into())),
+        );
+    }
+
+    // ----- Ordering --------------------------------------------------------
+
+    #[test]
+    fn after_constraint_orders_dependent_plugin_later() {
+        let mut engine = Engine::new();
+        engine
+            .register(OverrideBundleIdPlugin)
+            .register(BundleIdPlugin);
+        let ctx = engine
+            .compose(&base_app_config(), EnabledTargets::ios_only())
+            .unwrap();
+        let ios = ctx.ios.unwrap();
+        assert_eq!(
+            ios.info_plist.get("CFBundleIdentifier"),
+            Some(&PlistValue::String("rs.overridden".into())),
+        );
+        // BundleIdPlugin ran first → set-bundle-id (Set) came before
+        // override-bundle-id (Override). Sequence indices reflect that.
+        let seqs: Vec<_> = ctx
+            .journal
+            .records
+            .iter()
+            .map(|r| r.plugin.as_str())
+            .collect();
+        assert_eq!(seqs, vec!["set-bundle-id", "override-bundle-id"]);
+    }
+
+    #[test]
+    fn cycle_in_after_constraints_is_rejected() {
+        // A.after(B) and B.after(A)
+        struct A;
+        struct B;
+        #[derive(Default, Serialize, Deserialize)]
+        struct CfgA;
+        impl PluginConfig for CfgA {
+            const NAME: &'static str = "a";
+        }
+        #[derive(Default, Serialize, Deserialize)]
+        struct CfgB;
+        impl PluginConfig for CfgB {
+            const NAME: &'static str = "b";
+        }
+        impl Plugin for A {
+            type Config = CfgA;
+            fn after(&self) -> &'static [&'static str] {
+                &["b"]
+            }
+            fn apply(&self, _: &mut GenerateContext, _: &CfgA) -> Result<()> {
+                Ok(())
+            }
+        }
+        impl Plugin for B {
+            type Config = CfgB;
+            fn after(&self) -> &'static [&'static str] {
+                &["a"]
+            }
+            fn apply(&self, _: &mut GenerateContext, _: &CfgB) -> Result<()> {
+                Ok(())
+            }
+        }
+        let mut engine = Engine::new();
+        engine.register(A).register(B);
+        let err = engine
+            .compose(&base_app_config(), EnabledTargets::both())
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("cycle"), "{msg}");
+    }
+
+    #[test]
+    fn after_referencing_an_unregistered_plugin_is_rejected() {
+        struct A;
+        #[derive(Default, Serialize, Deserialize)]
+        struct CfgA;
+        impl PluginConfig for CfgA {
+            const NAME: &'static str = "a";
+        }
+        impl Plugin for A {
+            type Config = CfgA;
+            fn after(&self) -> &'static [&'static str] {
+                &["non-existent"]
+            }
+            fn apply(&self, _: &mut GenerateContext, _: &CfgA) -> Result<()> {
+                Ok(())
+            }
+        }
+        let mut engine = Engine::new();
+        engine.register(A);
+        let err = engine
+            .compose(&base_app_config(), EnabledTargets::both())
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("non-existent"), "{msg}");
+    }
+
+    // ----- Validation ------------------------------------------------------
+
+    #[test]
+    fn declaring_an_unknown_plugin_in_app_config_is_rejected() {
+        // User wrote app.plugin::<X>(…) but no engine has X
+        // registered. Caught before any plugin runs.
+        let mut app = base_app_config();
+        app.plugins
+            .insert("ghost-plugin".to_string(), serde_json::json!({}));
+        let engine = Engine::new();
+        let err = engine.compose(&app, EnabledTargets::both()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("ghost-plugin"), "{msg}");
+    }
+
+    #[test]
+    fn duplicate_plugin_registration_is_rejected() {
+        let mut engine = Engine::new();
+        engine.register(BundleIdPlugin).register(BundleIdPlugin);
+        let err = engine
+            .compose(&base_app_config(), EnabledTargets::both())
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("set-bundle-id"), "{msg}");
+    }
+
+    #[test]
+    fn validate_failure_aborts_before_apply_runs() {
+        struct Picky;
+        #[derive(Default, Serialize, Deserialize)]
+        struct PickyCfg;
+        impl PluginConfig for PickyCfg {
+            const NAME: &'static str = "picky";
+        }
+        impl Plugin for Picky {
+            type Config = PickyCfg;
+            fn validate(&self, _: &PickyCfg) -> Result<()> {
+                bail!("nope")
+            }
+            fn apply(&self, _: &mut GenerateContext, _: &PickyCfg) -> Result<()> {
+                panic!("apply should not run when validate fails")
+            }
+        }
+        let mut engine = Engine::new();
+        engine.register(Picky);
+        let err = engine
+            .compose(&base_app_config(), EnabledTargets::both())
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("nope"));
+    }
+
+    // ----- Conflict detection ----------------------------------------------
+
+    #[test]
+    fn two_set_writes_to_same_path_is_a_conflict() {
+        let mut engine = Engine::new();
+        engine
+            .register(BundleIdPlugin)
+            .register(AnotherBundleIdPlugin);
+        let err = engine
+            .compose(&base_app_config(), EnabledTargets::ios_only())
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("CFBundleIdentifier"), "{msg}");
+        assert!(msg.contains("set-bundle-id"), "{msg}");
+        assert!(msg.contains("another-bundle-id"), "{msg}");
+    }
+
+    #[test]
+    fn override_resolves_what_would_otherwise_be_a_conflict() {
+        let mut engine = Engine::new();
+        engine
+            .register(BundleIdPlugin)
+            .register(OverrideBundleIdPlugin);
+        // Override-after-Set is the documented use case for Override.
+        engine
+            .compose(&base_app_config(), EnabledTargets::ios_only())
+            .expect("override should resolve the would-be conflict");
+    }
+
+    #[test]
+    fn array_push_never_conflicts_even_across_plugins() {
+        struct OneCam;
+        struct OneLoc;
+        #[derive(Default, Serialize, Deserialize)]
+        struct C1;
+        impl PluginConfig for C1 {
+            const NAME: &'static str = "one-cam";
+        }
+        #[derive(Default, Serialize, Deserialize)]
+        struct C2;
+        impl PluginConfig for C2 {
+            const NAME: &'static str = "one-loc";
+        }
+        impl Plugin for OneCam {
+            type Config = C1;
+            fn apply(&self, ctx: &mut GenerateContext, _: &C1) -> Result<()> {
+                if let Some(a) = ctx.android.as_mut() {
+                    a.manifest
+                        .permissions
+                        .push("android.permission.CAMERA".into());
+                    ctx.journal.record(
+                        Self::Config::NAME,
+                        Target::Android,
+                        "manifest.permissions",
+                        Operation::ArrayPush { count: 1 },
+                    );
+                }
+                Ok(())
+            }
+        }
+        impl Plugin for OneLoc {
+            type Config = C2;
+            fn apply(&self, ctx: &mut GenerateContext, _: &C2) -> Result<()> {
+                if let Some(a) = ctx.android.as_mut() {
+                    a.manifest
+                        .permissions
+                        .push("android.permission.LOCATION".into());
+                    ctx.journal.record(
+                        Self::Config::NAME,
+                        Target::Android,
+                        "manifest.permissions",
+                        Operation::ArrayPush { count: 1 },
+                    );
+                }
+                Ok(())
+            }
+        }
+        let mut engine = Engine::new();
+        engine.register(OneCam).register(OneLoc);
+        let ctx = engine
+            .compose(&base_app_config(), EnabledTargets::android_only())
+            .unwrap();
+        let perms = ctx.android.unwrap().manifest.permissions;
+        assert_eq!(perms.len(), 2);
+    }
+
+    // ----- Integration --------------------------------------------------
+
+    #[test]
+    fn config_decode_error_is_surfaced_with_plugin_name() {
+        // Plugin expects suffix: String but we hand it `{"suffix": 7}`.
+        let mut app = base_app_config();
+        app.plugins.insert(
+            BundleIdCfg::NAME.to_string(),
+            serde_json::json!({"suffix": 7}),
+        );
+        let mut engine = Engine::new();
+        engine.register(BundleIdPlugin);
+        let err = engine
+            .compose(&app, EnabledTargets::ios_only())
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("set-bundle-id"), "{msg}");
+        assert!(msg.contains("decode"), "{msg}");
+    }
+
+    #[test]
+    fn full_pipeline_with_permissions_and_bundle_id_succeeds() {
+        let mut app = base_app_config();
+        app.plugin::<BundleIdCfg>(|c| {
+            c.suffix = ".dev".into();
+        });
+        app.plugin::<PermissionsCfg>(|c| {
+            c.permissions.extend([
+                "android.permission.CAMERA".into(),
+                "android.permission.LOCATION".into(),
+            ]);
+        });
+
+        let mut engine = Engine::new();
+        engine.register(BundleIdPlugin).register(PermissionsPlugin);
+        let ctx = engine.compose(&app, EnabledTargets::both()).unwrap();
+
+        assert_eq!(
+            ctx.ios.as_ref().unwrap().info_plist["CFBundleIdentifier"],
+            PlistValue::String("rs.whisker.demo.dev".into()),
+        );
+        assert_eq!(ctx.android.as_ref().unwrap().manifest.permissions.len(), 2);
+        // 1 record from bundle id (Set) + 1 from permissions (ArrayPush)
+        assert_eq!(ctx.journal.records.len(), 2);
+    }
+}

--- a/crates/whisker-cng/src/lib.rs
+++ b/crates/whisker-cng/src/lib.rs
@@ -29,10 +29,12 @@
 //! makes it cheap to unit-test against tempdirs.
 
 pub mod android;
+pub mod compose;
 mod fingerprint;
 pub mod ios;
 mod render;
 
 pub use android::{sync as sync_android, AndroidInputs};
+pub use compose::{EnabledTargets, Engine};
 pub use ios::{sync as sync_ios, IosInputs};
 pub use whisker_app_config::AppConfig;

--- a/crates/whisker-plugin/src/lib.rs
+++ b/crates/whisker-plugin/src/lib.rs
@@ -432,7 +432,7 @@ pub struct FileEntry {
 // Mutation journal
 // ----------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum Target {
     Ios,


### PR DESCRIPTION
## Summary

Wires the third leg of RFC #164's plugin composition system: the engine that takes registered plugins + a user \`AppConfig\` and produces a \`GenerateContext\`. The CNG renderer (Phase 3) will consume that context to write \`gen/{android,ios}/\`.

**Scope (this PR)**: in-process execution only. 3rd-party subprocess spawning and Cargo-metadata-driven plugin discovery come in follow-up PRs (3b / 3c). Phase 2's built-in plugins land on top of this engine.

### New: \`whisker_cng::compose\`

- **\`EnabledTargets { ios, android }\`** — controls which IRs the pipeline materializes (\`ios_only()\` / \`android_only()\` / \`both()\`).
- **\`Engine\`** — registry that erases \`Plugin::Config\` so plugins of different Config types coexist. Public API: \`new()\`, \`register::<P: Plugin>(p)\`, \`compose(&AppConfig, EnabledTargets)\`.
- **Internal \`DynPlugin\`** trait — blanket impl on every \`P: Plugin\`. Handles typed-config dispatch (deserialize from \`AppConfig.plugins[NAME]\` or fall back to \`Cfg::default()\`).

### Pipeline (\`Engine::compose\`)

1. Build \`AppMeta\` from \`AppConfig\` + IR shells per \`EnabledTargets\`.
2. Reject \`AppConfig.plugins\` keys with no matching registered plugin.
3. Topo-sort plugins (deterministic, alphabetical tie-break).
4. Run each plugin via \`DynPlugin::run\` — decode/validate/apply errors carry plugin name in context.
5. Walk \`MutationJournal\` for \`Set\`/\`Set\` collisions on same \`(target, path)\`. \`Override\` is the escape hatch. \`ArrayPush\` never conflicts.

### Wire dependencies

- \`whisker-cng/Cargo.toml\` gains \`whisker-plugin\` dep.
- \`whisker-plugin/src/lib.rs::Target\` gains \`Hash\` derive (the conflict detector keys \`HashMap<(Target, &str)>\`).
- Re-exports \`Engine\` + \`EnabledTargets\` at \`whisker-cng\`'s crate root.

## What's intentionally NOT in this PR

- No 3rd-party plugin subprocess spawning (PR 3b).
- No Cargo-metadata-driven plugin discovery (PR 3c).
- No built-in plugins (Phase 2).
- No integration with the existing render path — the engine still ships parallel to \`sync_ios\` / \`sync_android\`. Phase 3 will swap them.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo fmt -p whisker-cng -p whisker-plugin\`
- [x] \`cargo clippy -p whisker-cng -p whisker-plugin --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-cng\` — **42 tests pass** (16 new + 26 existing)

New tests:

**Happy path** (5): empty engine, target-flag effects, \`AppMeta\` population, plugin-with-user-config, plugin-with-default-config.

**Ordering** (3): \`after()\` execution order, cycle rejection, missing-target rejection.

**Validation** (3): unknown plugin in AppConfig rejected, duplicate registration rejected, \`validate\` aborts before \`apply\`.

**Conflict detection** (3): two-Set conflict, Override escape hatch, ArrayPush never conflicts.

**Integration** (2): bad-typed config decode error, full pipeline (bundle-id + permissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)