### PR TITLE
feat(cng): subprocess plugin spawner (RFC #164 Phase 1 PR 3b)

### DIFF
--- a/crates/whisker-cng/Cargo.toml
+++ b/crates/whisker-cng/Cargo.toml
@@ -28,3 +28,15 @@ whisker-app-config = { workspace = true }
 # `AppConfig.plugins[name]` JSON entry back into the plugin's typed
 # Config via this crate's helpers.
 whisker-plugin = { workspace = true }
+
+# Tiny stdin/stdout echo-style plugin binary the subprocess
+# integration test in `tests/subprocess.rs` spawns. Declared here
+# so it gets a `CARGO_BIN_EXE_whisker-cng-fixture-echo-plugin` env
+# var available inside the integration test. Not intended for end
+# users; safe to ignore in any `cargo install` flow (pre-alpha).
+[[bin]]
+name = "whisker-cng-fixture-echo-plugin"
+path = "tests/fixtures/echo_plugin.rs"
+test = false
+bench = false
+doc = false

--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -519,8 +519,13 @@ fn spawn_and_exchange(
             .write_all(&json)
             .with_context(|| format!("write PluginRequest to plugin `{plugin_name}`"))?;
     }
-    // Drop stdin so the child sees EOF and proceeds to write
-    // its response. `wait_with_output` re-takes ownership.
+    // No explicit `child.stdin.take()` here — `wait_with_output`
+    // does it internally before reading stdout, which is what
+    // signals EOF to the child. If we closed stdin first AND the
+    // child wrote a stdout response larger than the pipe buffer,
+    // we'd deadlock (parent waiting on child exit, child waiting
+    // on parent to drain stdout). The wait_with_output path
+    // serialises them safely.
 
     let output = child
         .wait_with_output()

--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -32,10 +32,13 @@
 use anyhow::{anyhow, bail, Context, Result};
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use whisker_app_config::AppConfig;
 use whisker_plugin::{
     AndroidProjectIr, AppMeta, GenerateContext, IosProjectIr, MutationJournal, MutationRecord,
-    Operation, Plugin, Target,
+    Operation, Plugin, PluginRequest, PluginResponse, Target,
 };
 
 // ============================================================================
@@ -159,25 +162,32 @@ impl Engine {
 // ============================================================================
 
 /// Erased [`Plugin`] surface. One blanket impl on every `P: Plugin`
-/// turns typed configs into JSON-keyed dispatch.
+/// for in-process plugins; an explicit impl on [`SubprocessPlugin`]
+/// for 3rd-party binaries.
+///
+/// Return shapes are owned-string-ish (`&str`, `Vec<&str>`) rather
+/// than `&'static`-pinned: subprocess plugins read their name and
+/// ordering hints at runtime (from Cargo metadata in PR 3c), so the
+/// trait has to accept dynamic strings as well as the
+/// `&'static`-clean shape `Plugin` exposes.
 pub(crate) trait DynPlugin {
-    fn name(&self) -> &'static str;
-    fn after(&self) -> &'static [&'static str];
-    fn before(&self) -> &'static [&'static str];
+    fn name(&self) -> &str;
+    fn after(&self) -> Vec<&str>;
+    fn before(&self) -> Vec<&str>;
     /// Run validate + apply with `user_config` (or the Config's
     /// `Default` when `None`).
     fn run(&self, ctx: &mut GenerateContext, user_config: Option<&Value>) -> Result<()>;
 }
 
 impl<P: Plugin> DynPlugin for P {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &str {
         Plugin::name(self)
     }
-    fn after(&self) -> &'static [&'static str] {
-        Plugin::after(self)
+    fn after(&self) -> Vec<&str> {
+        Plugin::after(self).to_vec()
     }
-    fn before(&self) -> &'static [&'static str] {
-        Plugin::before(self)
+    fn before(&self) -> Vec<&str> {
+        Plugin::before(self).to_vec()
     }
     fn run(&self, ctx: &mut GenerateContext, user_config: Option<&Value>) -> Result<()> {
         let cfg: P::Config = match user_config {
@@ -264,7 +274,11 @@ fn topo_sort(plugins: &[Box<dyn DynPlugin>]) -> Result<Vec<usize>> {
     // name → index. Only used for `after()` / `before()` lookups;
     // determinism of the final order comes from sort_by_key on the
     // ready-queue below, not from iteration of this map.
-    let mut name_to_idx: BTreeMap<&'static str, usize> = BTreeMap::new();
+    //
+    // Keys are borrowed-from-plugin (`&str`), since subprocess
+    // plugins' names live in a `String` field rather than a
+    // `&'static str` constant.
+    let mut name_to_idx: BTreeMap<&str, usize> = BTreeMap::new();
     for (i, p) in plugins.iter().enumerate() {
         if name_to_idx.insert(p.name(), i).is_some() {
             bail!("two plugins registered with the same name `{}`", p.name());
@@ -329,7 +343,7 @@ fn topo_sort(plugins: &[Box<dyn DynPlugin>]) -> Result<Vec<usize>> {
     }
 
     if order.len() != plugins.len() {
-        let unfinished: Vec<&'static str> = (0..plugins.len())
+        let unfinished: Vec<&str> = (0..plugins.len())
             .filter(|i| !order.contains(i))
             .map(|i| plugins[i].name())
             .collect();
@@ -375,6 +389,167 @@ fn detect_conflicts(journal: &MutationJournal) -> Result<()> {
         }
     }
     Ok(())
+}
+
+// ============================================================================
+// Subprocess plugins
+// ============================================================================
+
+/// 3rd-party plugin shipped as a standalone binary, driven by JSON
+/// over stdin/stdout. The corresponding author-side helper is
+/// `whisker_plugin::run_as_subprocess`.
+///
+/// From [`Engine`]'s perspective a subprocess plugin behaves
+/// exactly like an in-process one: same `name` / `after` / `before`
+/// surface, same dispatch into [`DynPlugin::run`]. The difference
+/// is what `run` does — spawn a child process, write a
+/// [`PluginRequest`] to its stdin, parse a [`PluginResponse`] back
+/// from its stdout, swap the response's context into the engine's
+/// running context.
+///
+/// ## Journal continuity
+///
+/// The engine hands the subprocess the full running
+/// [`GenerateContext`], including the [`MutationJournal`] entries
+/// previous plugins already wrote. The subprocess's
+/// `whisker_plugin::run_as_subprocess` helper preserves those
+/// records and appends new ones via `MutationJournal::record`,
+/// which keeps sequence indices monotonic across the in-process /
+/// subprocess boundary.
+///
+/// A malicious or buggy subprocess could drop existing journal
+/// entries. PR 3c (discovery) is the right place to surface that
+/// guarantee as a hard check; for now we trust the response.
+pub struct SubprocessPlugin {
+    name: String,
+    binary: PathBuf,
+    after: Vec<String>,
+    before: Vec<String>,
+}
+
+impl SubprocessPlugin {
+    pub fn new(name: impl Into<String>, binary: impl Into<PathBuf>) -> Self {
+        Self {
+            name: name.into(),
+            binary: binary.into(),
+            after: Vec::new(),
+            before: Vec::new(),
+        }
+    }
+
+    pub fn after(mut self, names: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.after = names.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn before(mut self, names: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.before = names.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+impl DynPlugin for SubprocessPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn after(&self) -> Vec<&str> {
+        self.after.iter().map(String::as_str).collect()
+    }
+    fn before(&self) -> Vec<&str> {
+        self.before.iter().map(String::as_str).collect()
+    }
+    fn run(&self, ctx: &mut GenerateContext, user_config: Option<&Value>) -> Result<()> {
+        let request = build_request(self.name.clone(), user_config, ctx);
+        let response = spawn_and_exchange(&self.binary, &self.name, &request)
+            .with_context(|| format!("subprocess plugin `{}` failed", self.name))?;
+        merge_response(ctx, response);
+        Ok(())
+    }
+}
+
+impl Engine {
+    /// Register a subprocess plugin. The engine spawns
+    /// `plugin.binary` on every [`Engine::compose`] call that
+    /// dispatches to it.
+    pub fn register_subprocess(&mut self, plugin: SubprocessPlugin) -> &mut Self {
+        self.plugins.push(Box::new(plugin));
+        self
+    }
+}
+
+fn build_request(
+    name: String,
+    user_config: Option<&Value>,
+    ctx: &GenerateContext,
+) -> PluginRequest {
+    PluginRequest {
+        name,
+        config: user_config.cloned().unwrap_or(Value::Null),
+        context: ctx.clone(),
+    }
+}
+
+fn merge_response(ctx: &mut GenerateContext, response: PluginResponse) {
+    *ctx = response.context;
+}
+
+/// Spawn the plugin binary, pipe JSON, parse the response. stderr
+/// is inherited so plugin diagnostics reach the user during
+/// `whisker generate --verbose`.
+fn spawn_and_exchange(
+    binary: &Path,
+    plugin_name: &str,
+    request: &PluginRequest,
+) -> Result<PluginResponse> {
+    let mut child = Command::new(binary)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("spawn plugin `{plugin_name}` binary `{}`", binary.display(),))?;
+
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| anyhow!("plugin `{plugin_name}` stdin pipe missing"))?;
+        let json = serde_json::to_vec(request)
+            .with_context(|| format!("encode PluginRequest for plugin `{plugin_name}`"))?;
+        stdin
+            .write_all(&json)
+            .with_context(|| format!("write PluginRequest to plugin `{plugin_name}`"))?;
+    }
+    // Drop stdin so the child sees EOF and proceeds to write
+    // its response. `wait_with_output` re-takes ownership.
+
+    let output = child
+        .wait_with_output()
+        .with_context(|| format!("wait for plugin `{plugin_name}`"))?;
+
+    check_exit_status(plugin_name, output.status)?;
+    decode_response_bytes(plugin_name, &output.stdout)
+}
+
+fn check_exit_status(plugin_name: &str, status: std::process::ExitStatus) -> Result<()> {
+    if !status.success() {
+        bail!(
+            "plugin `{plugin_name}` exited with non-zero status ({status}). \
+             Check its stderr for the error message."
+        );
+    }
+    Ok(())
+}
+
+fn decode_response_bytes(plugin_name: &str, bytes: &[u8]) -> Result<PluginResponse> {
+    if bytes.is_empty() {
+        bail!(
+            "plugin `{plugin_name}` produced empty stdout. \
+             A 3rd-party plugin binary should write exactly one \
+             PluginResponse JSON envelope and exit 0."
+        );
+    }
+    serde_json::from_slice(bytes)
+        .with_context(|| format!("decode PluginResponse JSON from plugin `{plugin_name}`'s stdout"))
 }
 
 // ============================================================================
@@ -862,5 +1037,81 @@ mod tests {
         assert_eq!(ctx.android.as_ref().unwrap().manifest.permissions.len(), 2);
         // 1 record from bundle id (Set) + 1 from permissions (ArrayPush)
         assert_eq!(ctx.journal.records.len(), 2);
+    }
+
+    // ----- Subprocess plumbing (pure helpers) --------------------------
+
+    #[test]
+    fn build_request_carries_name_config_and_full_context() {
+        let mut ctx = GenerateContext::default();
+        ctx.app_meta.name = "Demo".into();
+        ctx.journal.record(
+            "earlier-plugin",
+            Target::Ios,
+            "info_plist.X",
+            Operation::Set,
+        );
+        let req = build_request(
+            "my-plugin".into(),
+            Some(&serde_json::json!({"opt": true})),
+            &ctx,
+        );
+        assert_eq!(req.name, "my-plugin");
+        assert_eq!(req.config["opt"], true);
+        // The journal entry already in the engine context must be
+        // visible to the subprocess so its sequence counter continues
+        // monotonically — `next_sequence_index` will be 1 there.
+        assert_eq!(req.context.journal.next_sequence_index, 1);
+        assert_eq!(req.context.app_meta.name, "Demo");
+    }
+
+    #[test]
+    fn build_request_uses_null_for_missing_user_config() {
+        let ctx = GenerateContext::default();
+        let req = build_request("my-plugin".into(), None, &ctx);
+        assert!(req.config.is_null());
+    }
+
+    #[test]
+    fn merge_response_replaces_the_engine_context() {
+        let mut ctx = GenerateContext::default();
+        ctx.app_meta.name = "Old".into();
+        let mut new_ctx = GenerateContext::default();
+        new_ctx.app_meta.name = "New".into();
+        new_ctx.journal.record(
+            "subprocess-plugin",
+            Target::Android,
+            "manifest.permissions",
+            Operation::ArrayPush { count: 1 },
+        );
+        merge_response(&mut ctx, PluginResponse { context: new_ctx });
+        assert_eq!(ctx.app_meta.name, "New");
+        assert_eq!(ctx.journal.records.len(), 1);
+    }
+
+    #[test]
+    fn decode_response_bytes_handles_empty_stdout() {
+        let err = decode_response_bytes("p", b"").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("empty"), "{msg}");
+        assert!(msg.contains("`p`"), "{msg}");
+    }
+
+    #[test]
+    fn decode_response_bytes_surfaces_invalid_json_with_plugin_name() {
+        let err = decode_response_bytes("p", b"not json").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("`p`"), "{msg}");
+        assert!(msg.contains("decode"), "{msg}");
+    }
+
+    #[test]
+    fn decode_response_bytes_accepts_a_valid_envelope() {
+        let envelope = serde_json::to_vec(&PluginResponse {
+            context: GenerateContext::default(),
+        })
+        .unwrap();
+        let resp = decode_response_bytes("p", &envelope).unwrap();
+        assert_eq!(resp.context.journal.records.len(), 0);
     }
 }

--- a/crates/whisker-cng/src/lib.rs
+++ b/crates/whisker-cng/src/lib.rs
@@ -35,6 +35,6 @@ pub mod ios;
 mod render;
 
 pub use android::{sync as sync_android, AndroidInputs};
-pub use compose::{EnabledTargets, Engine};
+pub use compose::{EnabledTargets, Engine, SubprocessPlugin};
 pub use ios::{sync as sync_ios, IosInputs};
 pub use whisker_app_config::AppConfig;

--- a/crates/whisker-cng/tests/fixtures/echo_plugin.rs
+++ b/crates/whisker-cng/tests/fixtures/echo_plugin.rs
@@ -1,0 +1,45 @@
+//! Fixture binary for `tests/subprocess.rs`.
+//!
+//! A minimal 3rd-party-shaped Whisker CNG plugin that pushes its
+//! `permission` config string into the Android manifest's
+//! permissions list. The test crafts a `PluginRequest` envelope and
+//! spawns this binary via `Engine::register_subprocess` to verify
+//! the spawn / pipe / merge wiring end-to-end.
+
+use serde::{Deserialize, Serialize};
+use whisker_plugin::{GenerateContext, MutationJournal, Operation, Plugin, PluginConfig, Target};
+
+#[derive(Default, Serialize, Deserialize)]
+struct EchoCfg {
+    #[serde(default)]
+    permission: String,
+}
+
+impl PluginConfig for EchoCfg {
+    const NAME: &'static str = "fixture-echo-plugin";
+}
+
+struct EchoPlugin;
+
+impl Plugin for EchoPlugin {
+    type Config = EchoCfg;
+    fn apply(&self, ctx: &mut GenerateContext, cfg: &EchoCfg) -> anyhow::Result<()> {
+        if let Some(android) = ctx.android.as_mut() {
+            if !cfg.permission.is_empty() {
+                android.manifest.permissions.push(cfg.permission.clone());
+                <MutationJournal>::record(
+                    &mut ctx.journal,
+                    EchoCfg::NAME,
+                    Target::Android,
+                    "manifest.permissions",
+                    Operation::ArrayPush { count: 1 },
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    whisker_plugin::run_as_subprocess(EchoPlugin)
+}

--- a/crates/whisker-cng/tests/fixtures/echo_plugin.rs
+++ b/crates/whisker-cng/tests/fixtures/echo_plugin.rs
@@ -7,7 +7,7 @@
 //! the spawn / pipe / merge wiring end-to-end.
 
 use serde::{Deserialize, Serialize};
-use whisker_plugin::{GenerateContext, MutationJournal, Operation, Plugin, PluginConfig, Target};
+use whisker_plugin::{GenerateContext, Operation, Plugin, PluginConfig, Target};
 
 #[derive(Default, Serialize, Deserialize)]
 struct EchoCfg {
@@ -27,8 +27,7 @@ impl Plugin for EchoPlugin {
         if let Some(android) = ctx.android.as_mut() {
             if !cfg.permission.is_empty() {
                 android.manifest.permissions.push(cfg.permission.clone());
-                <MutationJournal>::record(
-                    &mut ctx.journal,
+                ctx.journal.record(
                     EchoCfg::NAME,
                     Target::Android,
                     "manifest.permissions",

--- a/crates/whisker-cng/tests/subprocess.rs
+++ b/crates/whisker-cng/tests/subprocess.rs
@@ -1,0 +1,87 @@
+//! End-to-end check on `Engine::register_subprocess`.
+//!
+//! Spawns the `whisker-cng-fixture-echo-plugin` binary (declared as
+//! `[[bin]]` in this crate's Cargo.toml) and verifies the
+//! request → spawn → response → context-merge round-trip works.
+//! Unit tests in `compose.rs` cover the pure pieces; this test is
+//! the only place we actually fork() a real process.
+
+use std::path::PathBuf;
+use whisker_app_config::AppConfig;
+use whisker_cng::{EnabledTargets, Engine, SubprocessPlugin};
+
+fn fixture_binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_whisker-cng-fixture-echo-plugin"))
+}
+
+#[test]
+fn subprocess_plugin_pushes_permission_through_a_real_spawn() {
+    let plugin = SubprocessPlugin::new("fixture-echo-plugin", fixture_binary_path());
+
+    let mut engine = Engine::new();
+    engine.register_subprocess(plugin);
+
+    // User-side config: simulate what `app.plugin::<EchoCfg>(|c| ...)`
+    // would have stored into AppConfig.plugins.
+    let mut app = AppConfig::default();
+    app.name("Demo");
+    app.plugins.insert(
+        "fixture-echo-plugin".into(),
+        serde_json::json!({"permission": "android.permission.CAMERA"}),
+    );
+
+    let ctx = engine
+        .compose(&app, EnabledTargets::android_only())
+        .expect("subprocess plugin should run cleanly");
+
+    let android = ctx.android.expect("android IR should be populated");
+    assert_eq!(
+        android.manifest.permissions,
+        vec!["android.permission.CAMERA".to_string()],
+    );
+    assert_eq!(ctx.journal.records.len(), 1);
+    let r = &ctx.journal.records[0];
+    assert_eq!(r.plugin, "fixture-echo-plugin");
+    assert_eq!(r.path, "manifest.permissions");
+}
+
+#[test]
+fn subprocess_plugin_runs_with_default_config_when_user_omitted_declaration() {
+    // No app.plugins entry → engine sends a Null config; the
+    // fixture's EchoCfg::default() has an empty permission, so
+    // nothing should be added to the Android manifest.
+    let plugin = SubprocessPlugin::new("fixture-echo-plugin", fixture_binary_path());
+    let mut engine = Engine::new();
+    engine.register_subprocess(plugin);
+
+    let mut app = AppConfig::default();
+    app.name("Demo");
+
+    let ctx = engine
+        .compose(&app, EnabledTargets::android_only())
+        .expect("subprocess plugin should still run when undeclared");
+
+    assert!(ctx.android.unwrap().manifest.permissions.is_empty());
+    assert!(ctx.journal.records.is_empty());
+}
+
+#[test]
+fn subprocess_plugin_with_a_bad_binary_path_surfaces_spawn_error() {
+    let plugin = SubprocessPlugin::new(
+        "fixture-echo-plugin",
+        // Path that definitely does not exist anywhere on PATH.
+        PathBuf::from("/does/not/exist/whisker-fixture-no-such-binary"),
+    );
+    let mut engine = Engine::new();
+    engine.register_subprocess(plugin);
+
+    let mut app = AppConfig::default();
+    app.name("Demo");
+
+    let err = engine
+        .compose(&app, EnabledTargets::android_only())
+        .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("fixture-echo-plugin"), "{msg}");
+    assert!(msg.contains("spawn"), "{msg}");
+}

--- a/crates/whisker-plugin/src/lib.rs
+++ b/crates/whisker-plugin/src/lib.rs
@@ -571,8 +571,18 @@ pub fn run_as_subprocess<P: Plugin>(plugin: P) -> anyhow::Result<()> {
         ));
     }
 
-    let config: P::Config = serde_json::from_value(request.config)
-        .map_err(|e| anyhow::anyhow!("decode plugin config for `{}`: {e}", plugin.name()))?;
+    // `null` config arrives when the user didn't declare the plugin
+    // in `whisker.rs` at all — the engine's wire protocol uses Null
+    // to mean "use the Config's `Default`". This matches the
+    // in-process path's `Option::is_none` → `Default::default()`
+    // fallback, keeping the same semantics regardless of which
+    // execution mode a plugin runs in.
+    let config: P::Config = if request.config.is_null() {
+        Default::default()
+    } else {
+        serde_json::from_value(request.config)
+            .map_err(|e| anyhow::anyhow!("decode plugin config for `{}`: {e}", plugin.name()))?
+    };
 
     plugin
         .validate(&config)


### PR DESCRIPTION
## Summary

Wires the 3rd-party plugin execution mode that complements PR 3a's in-process path. Plugins shipped as standalone binaries can now register with the same \`Engine\`, taking part in topo-sort and conflict detection alongside in-process plugins.

### \`SubprocessPlugin\` + \`Engine::register_subprocess\`

\`\`\`rust
let plugin = SubprocessPlugin::new(\"my-plugin\", \"/path/to/binary\")
    .after([\"some-other-plugin\"]);
let mut engine = Engine::new();
engine.register_subprocess(plugin);
let ctx = engine.compose(&app_config, EnabledTargets::both())?;
\`\`\`

The subprocess receives the full running \`GenerateContext\` (including the in-progress \`MutationJournal\`) as JSON, mutates it via its \`Plugin::apply\`, and writes the response back. The engine swaps the response into its running context. Sequence indices stay monotonic across in-process ↔ subprocess boundaries.

### Auxiliary changes

- **\`DynPlugin\` relaxed** — \`after()\` / \`before()\` now return \`Vec<&str>\` instead of \`&'static [&'static str]\`. Needed because subprocess plugins read ordering hints at runtime (Cargo metadata in PR 3c). Typed-plugin blanket impl just \`.to_vec()\`s the slice; no behaviour change.
- **\`run_as_subprocess\` Null-config semantics** — \`PluginRequest.config == null\` now means \"use \`Config::default()\`\", mirroring the in-process path's \`Option::is_none → Default\` fallback. Plugin semantics are identical regardless of execution mode.
- **Pure spawn helpers factored out** — \`build_request\` / \`merge_response\` / \`check_exit_status\` / \`decode_response_bytes\`. Unit-tested directly.

### Test fixture

\`[[bin]] whisker-cng-fixture-echo-plugin\` declared in this crate's \`Cargo.toml\`, sourced from \`tests/fixtures/echo_plugin.rs\`. Trivial plugin that pushes a \`permission\` string into the Android manifest. \`test = false, bench = false, doc = false\` for hygiene. Integration test locates it via \`env!(\"CARGO_BIN_EXE_…\")\`.

## What's NOT in this PR

- No Cargo-metadata-driven plugin discovery (PR 3c).
- No sanity check on subprocess preserving prior journal entries (defer to PR 3c).
- No built-in plugins (Phase 2).

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo fmt -p whisker-cng -p whisker-plugin\`
- [x] \`cargo clippy -p whisker-cng -p whisker-plugin --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-cng -p whisker-plugin\` — **59 tests pass** (48 cng-unit + 3 cng-integration + 8 plugin-unit)
  - Unit (6 new): build_request shape, build_request Null fallback, merge_response replacement, decode rejects empty / invalid / valid
  - Integration (3 new): real spawn + permission push, real spawn with Default config, bad-binary-path spawn error

🤖 Generated with [Claude Code](https://claude.com/claude-code)