### PR TITLE
feat(cng): cargo metadata plugin discovery (RFC #164 Phase 1 PR 3c)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ name = "whisker-cng"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "serde",
  "serde_json",
  "whisker-app-config",

--- a/crates/whisker-cng/Cargo.toml
+++ b/crates/whisker-cng/Cargo.toml
@@ -23,6 +23,12 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 whisker-app-config = { workspace = true }
+# Walks the user crate's dep graph to find dependencies that declare
+# `[package.metadata.whisker.plugins.<name>]` in their `Cargo.toml`.
+# Same crate `whisker-build` uses for module discovery — pinned at
+# the same major version so both subsystems agree on the dep-graph
+# shape.
+cargo_metadata = "0.18"
 # `Plugin` / `PluginConfig` trait + IR types the engine drives the
 # plugin pipeline against. The compose module turns each user-side
 # `AppConfig.plugins[name]` JSON entry back into the plugin's typed

--- a/crates/whisker-cng/src/discovery.rs
+++ b/crates/whisker-cng/src/discovery.rs
@@ -1,0 +1,340 @@
+//! Plugin discovery — walks a user crate's cargo dep graph and
+//! returns every dependency declaring a Whisker CNG plugin in its
+//! `Cargo.toml`'s `[package.metadata.whisker.plugins.<name>]` table.
+//!
+//! ## Schema
+//!
+//! A plugin crate's `Cargo.toml` opts in like this:
+//!
+//! ```toml
+//! [package.metadata.whisker.plugins.my-plugin]
+//! bin = "my-plugin-cng"          # the [[bin]] name in this crate
+//! after = ["whisker-info-plist"] # optional ordering hints
+//! before = []
+//! ```
+//!
+//! One crate may declare multiple plugins by adding more entries
+//! under `plugins.<name>`. The Whisker CLI consumes the resulting
+//! [`DiscoveredPlugin`] list, builds each plugin's `[[bin]]` target
+//! through `cargo build`, and registers a
+//! [`crate::SubprocessPlugin`] pointing at the resulting binary.
+//!
+//! ## Why discovery instead of explicit registration
+//!
+//! In Phase 2+ the user's `whisker.rs` will declare typed plugin
+//! Configs via `app.plugin::<MyCfg>(|c| ...)`. The Config type's
+//! `PluginConfig::NAME` matches the discovery table's key, so
+//! "what plugin runs" is decided entirely by what crates the app
+//! depends on plus how the user spelled `app.plugin::<…>(…)`. The
+//! CLI never needs an `Engine::register(...)` call site for
+//! 3rd-party plugins.
+//!
+//! ## Scope (Phase 1 PR 3c)
+//!
+//! This module is metadata-only: it discovers the *declarations*,
+//! not the binaries. Building each plugin's bin target + wiring it
+//! into [`crate::Engine`] happens in a downstream PR (likely as
+//! part of `whisker-build` once it gets a plugin-build step).
+//!
+//! Shared with [`whisker_build::modules::discover`] in spirit: both
+//! walk the same cargo metadata. Kept here rather than there to
+//! avoid a circular dep — `whisker-build` already depends on
+//! `whisker-cng` via the transitive sync calls.
+
+use anyhow::{anyhow, Context, Result};
+use cargo_metadata::MetadataCommand;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+/// A plugin declared by a dep of the user app, after the dep's
+/// `[package.metadata.whisker.plugins.<name>]` table has been
+/// resolved against the cargo dep graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredPlugin {
+    /// The plugin's stable name. Matches `Plugin::name()` /
+    /// `PluginConfig::NAME` and the `AppConfig.plugins` map key.
+    pub name: String,
+    /// The cargo package that declared this plugin. Used for
+    /// diagnostic messages and to anchor `bin_target_name` to a
+    /// specific `cargo build --bin <target> --package <source_crate>`
+    /// invocation.
+    pub source_crate: String,
+    /// The directory containing the source crate's `Cargo.toml`.
+    /// Mirrors `whisker_build::modules::ResolvedModule::manifest_dir`.
+    pub source_manifest_dir: PathBuf,
+    /// `[[bin]]` target name inside the source crate that, when
+    /// compiled, produces the plugin binary the engine spawns.
+    /// Resolution to an actual file path is the caller's job (it
+    /// needs cargo build + target-dir lookup).
+    pub bin_target_name: String,
+    pub after: Vec<String>,
+    pub before: Vec<String>,
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Walk the cargo dep graph rooted at `app_package` (resolved via
+/// `manifest_path`) and return every plugin declared in the
+/// transitive deps' `[package.metadata.whisker.plugins.<name>]`
+/// tables.
+///
+/// The order is a stable depth-first traversal of the resolution
+/// graph. Two plugins with the same `name` across different deps
+/// is a hard error — there's no way to disambiguate them at
+/// dispatch time.
+///
+/// Errors:
+/// - `cargo metadata` failure (workspace broken, manifest_path
+///   invalid).
+/// - Plugin metadata parse error (unknown / typoed field under
+///   `plugins.<name>`) — `deny_unknown_fields` is on for the
+///   per-plugin entry so typos surface immediately.
+/// - Duplicate plugin name across two crates.
+pub fn discover_plugins(manifest_path: &Path, app_package: &str) -> Result<Vec<DiscoveredPlugin>> {
+    let metadata = MetadataCommand::new()
+        .manifest_path(manifest_path)
+        .exec()
+        .with_context(|| {
+            format!(
+                "cargo metadata failed for {} (package: {app_package})",
+                manifest_path.display(),
+            )
+        })?;
+
+    let resolve = metadata
+        .resolve
+        .as_ref()
+        .ok_or_else(|| anyhow!("cargo metadata returned no resolve graph"))?;
+    let root_id = resolve
+        .root
+        .as_ref()
+        .filter(|id| {
+            metadata
+                .packages
+                .iter()
+                .any(|p| &p.id == *id && p.name == app_package)
+        })
+        .cloned()
+        .or_else(|| {
+            metadata
+                .packages
+                .iter()
+                .find(|p| p.name == app_package)
+                .map(|p| p.id.clone())
+        })
+        .ok_or_else(|| anyhow!("cargo package `{app_package}` not found in the workspace"))?;
+
+    // DFS the resolve graph collecting dep package ids. Skip the
+    // root app itself — a CNG plugin lives in a dep, not in the
+    // consuming app.
+    let mut visit: Vec<&cargo_metadata::PackageId> = vec![&root_id];
+    let mut seen: std::collections::HashSet<&cargo_metadata::PackageId> = Default::default();
+    let mut dep_ids: Vec<cargo_metadata::PackageId> = Vec::new();
+    while let Some(pkg_id) = visit.pop() {
+        if !seen.insert(pkg_id) {
+            continue;
+        }
+        if let Some(node) = resolve.nodes.iter().find(|n| &n.id == pkg_id) {
+            for d in &node.deps {
+                visit.push(&d.pkg);
+            }
+        }
+        if pkg_id != &root_id {
+            dep_ids.push(pkg_id.clone());
+        }
+    }
+
+    let mut discovered: Vec<DiscoveredPlugin> = Vec::new();
+    for id in dep_ids {
+        let pkg = metadata
+            .packages
+            .iter()
+            .find(|p| p.id == id)
+            .expect("dep id came from resolve.nodes, must exist in metadata.packages");
+
+        // The `whisker` table may also carry `[ios]` / `[android]`
+        // module sections that `whisker_build::modules::discover`
+        // consumes. We only care about the `plugins` sub-table here
+        // and read it as a serde_json::Value so the module schema
+        // can evolve independently.
+        let Some(whisker_meta) = pkg.metadata.get("whisker") else {
+            continue;
+        };
+        let Some(plugins_value) = whisker_meta.get("plugins") else {
+            continue;
+        };
+
+        let plugins_map: BTreeMap<String, PluginEntryRaw> =
+            serde_json::from_value(plugins_value.clone()).with_context(|| {
+                format!(
+                    "parse [package.metadata.whisker.plugins] in {}",
+                    pkg.manifest_path,
+                )
+            })?;
+
+        let manifest_dir = pkg
+            .manifest_path
+            .parent()
+            .map(|p| PathBuf::from(p.as_str()))
+            .ok_or_else(|| {
+                anyhow!(
+                    "dep `{}` manifest_path has no parent: {}",
+                    pkg.name,
+                    pkg.manifest_path,
+                )
+            })?;
+
+        for (name, entry) in plugins_map {
+            discovered.push(DiscoveredPlugin {
+                name,
+                source_crate: pkg.name.clone(),
+                source_manifest_dir: manifest_dir.clone(),
+                bin_target_name: entry.bin,
+                after: entry.after,
+                before: entry.before,
+            });
+        }
+    }
+
+    check_no_duplicate_names(&discovered)?;
+    Ok(discovered)
+}
+
+// ============================================================================
+// Internal
+// ============================================================================
+
+/// Shape of one `[package.metadata.whisker.plugins.<name>]` entry.
+/// `deny_unknown_fields` so a typoed key (e.g. `after`s plural
+/// confusion) surfaces immediately rather than getting silently
+/// dropped.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PluginEntryRaw {
+    bin: String,
+    #[serde(default)]
+    after: Vec<String>,
+    #[serde(default)]
+    before: Vec<String>,
+}
+
+fn check_no_duplicate_names(plugins: &[DiscoveredPlugin]) -> Result<()> {
+    let mut seen: BTreeMap<&str, &DiscoveredPlugin> = BTreeMap::new();
+    for p in plugins {
+        if let Some(prior) = seen.insert(p.name.as_str(), p) {
+            return Err(anyhow!(
+                "plugin name `{}` declared by both `{}` and `{}` — \
+                 plugin names must be globally unique across the dep graph. \
+                 Rename one of the `[package.metadata.whisker.plugins.<name>]` \
+                 entries.",
+                p.name,
+                prior.source_crate,
+                p.source_crate,
+            ));
+        }
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Most discovery testing happens end-to-end against a tempdir
+    // workspace fixture (`tests/discovery.rs`). The unit tests here
+    // cover the pure pieces — duplicate detection + the typed-shape
+    // deserializer.
+
+    fn p(
+        name: &str,
+        source_crate: &str,
+        bin: &str,
+        after: &[&str],
+        before: &[&str],
+    ) -> DiscoveredPlugin {
+        DiscoveredPlugin {
+            name: name.into(),
+            source_crate: source_crate.into(),
+            source_manifest_dir: PathBuf::from("/fake"),
+            bin_target_name: bin.into(),
+            after: after.iter().map(|s| s.to_string()).collect(),
+            before: before.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn duplicate_check_passes_with_distinct_names() {
+        let list = vec![
+            p("a", "crate-a", "bin-a", &[], &[]),
+            p("b", "crate-b", "bin-b", &[], &[]),
+        ];
+        check_no_duplicate_names(&list).unwrap();
+    }
+
+    #[test]
+    fn duplicate_check_fails_with_two_crates_claiming_the_same_name() {
+        let list = vec![
+            p("conflict", "crate-a", "bin-a", &[], &[]),
+            p("conflict", "crate-b", "bin-b", &[], &[]),
+        ];
+        let err = check_no_duplicate_names(&list).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("conflict"), "{msg}");
+        assert!(msg.contains("crate-a"), "{msg}");
+        assert!(msg.contains("crate-b"), "{msg}");
+    }
+
+    #[test]
+    fn entry_deserializes_with_only_bin() {
+        let v: PluginEntryRaw =
+            serde_json::from_value(serde_json::json!({"bin": "only-bin"})).unwrap();
+        assert_eq!(v.bin, "only-bin");
+        assert!(v.after.is_empty());
+        assert!(v.before.is_empty());
+    }
+
+    #[test]
+    fn entry_deserializes_with_all_fields() {
+        let v: PluginEntryRaw = serde_json::from_value(serde_json::json!({
+            "bin": "my-bin",
+            "after": ["a", "b"],
+            "before": ["c"],
+        }))
+        .unwrap();
+        assert_eq!(v.bin, "my-bin");
+        assert_eq!(v.after, vec!["a", "b"]);
+        assert_eq!(v.before, vec!["c"]);
+    }
+
+    #[test]
+    fn entry_rejects_unknown_fields() {
+        let err = serde_json::from_value::<PluginEntryRaw>(serde_json::json!({
+            "bin": "x",
+            "aftr": ["typo-of-after"],
+        }))
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("aftr"), "{msg}");
+    }
+
+    #[test]
+    fn entry_rejects_missing_bin() {
+        let err = serde_json::from_value::<PluginEntryRaw>(serde_json::json!({
+            "after": [],
+        }))
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("bin"), "{msg}");
+    }
+}

--- a/crates/whisker-cng/src/discovery.rs
+++ b/crates/whisker-cng/src/discovery.rs
@@ -85,10 +85,15 @@ pub struct DiscoveredPlugin {
 /// transitive deps' `[package.metadata.whisker.plugins.<name>]`
 /// tables.
 ///
-/// The order is a stable depth-first traversal of the resolution
-/// graph. Two plugins with the same `name` across different deps
-/// is a hard error — there's no way to disambiguate them at
-/// dispatch time.
+/// The iteration order is deterministic for a given dep tree
+/// (DFS over `cargo metadata`'s resolution graph + alphabetical
+/// within each crate's plugin table), but not part of the
+/// stability contract — downstream consumers that need a
+/// specific ordering should sort by `name` themselves.
+///
+/// Two plugins with the same `name` across different deps is a
+/// hard error — there's no way to disambiguate them at dispatch
+/// time.
 ///
 /// Errors:
 /// - `cargo metadata` failure (workspace broken, manifest_path

--- a/crates/whisker-cng/src/lib.rs
+++ b/crates/whisker-cng/src/lib.rs
@@ -30,11 +30,13 @@
 
 pub mod android;
 pub mod compose;
+pub mod discovery;
 mod fingerprint;
 pub mod ios;
 mod render;
 
 pub use android::{sync as sync_android, AndroidInputs};
 pub use compose::{EnabledTargets, Engine, SubprocessPlugin};
+pub use discovery::{discover_plugins, DiscoveredPlugin};
 pub use ios::{sync as sync_ios, IosInputs};
 pub use whisker_app_config::AppConfig;

--- a/crates/whisker-cng/tests/discovery.rs
+++ b/crates/whisker-cng/tests/discovery.rs
@@ -1,0 +1,223 @@
+//! End-to-end check on `discover_plugins`.
+//!
+//! Builds a throwaway 3-crate workspace under a tempdir (app +
+//! plugin + plugin-with-multiple-entries) and verifies cargo
+//! metadata + the parser produce the expected
+//! [`DiscoveredPlugin`] list.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use whisker_cng::discover_plugins;
+
+fn unique_tempdir() -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let p = std::env::temp_dir().join(format!("whisker-cng-discovery-test-{pid}-{n}"));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// Write a tiny path-deps workspace: one app crate consumes the
+/// plugin crate(s). Returns the path to the workspace root
+/// (which holds the workspace `Cargo.toml`).
+struct WorkspaceFixture {
+    root: PathBuf,
+}
+
+impl WorkspaceFixture {
+    fn new() -> Self {
+        let root = unique_tempdir();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            r#"
+                [workspace]
+                resolver = "2"
+                members = ["app", "plugin-a", "plugin-multi"]
+            "#,
+        )
+        .unwrap();
+        Self { root }
+    }
+
+    fn add_app(&self, deps: &[(&str, &str)]) {
+        let dir = self.root.join("app");
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        let deps_block = deps
+            .iter()
+            .map(|(name, path)| format!("{name} = {{ path = \"{path}\" }}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            format!(
+                r#"
+                    [package]
+                    name = "test-app"
+                    version = "0.0.1"
+                    edition = "2021"
+
+                    [dependencies]
+                    {deps_block}
+                "#
+            ),
+        )
+        .unwrap();
+        std::fs::write(dir.join("src/lib.rs"), "").unwrap();
+    }
+
+    fn add_plugin(&self, dir_name: &str, package_name: &str, plugins_toml: &str) {
+        let dir = self.root.join(dir_name);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            format!(
+                r#"
+                    [package]
+                    name = "{package_name}"
+                    version = "0.0.1"
+                    edition = "2021"
+
+                    {plugins_toml}
+                "#
+            ),
+        )
+        .unwrap();
+        std::fs::write(dir.join("src/lib.rs"), "").unwrap();
+    }
+
+    fn app_manifest(&self) -> PathBuf {
+        self.root.join("app/Cargo.toml")
+    }
+}
+
+#[test]
+fn discovers_a_single_plugin_in_a_dep_crate() {
+    let fx = WorkspaceFixture::new();
+    fx.add_app(&[
+        ("plugin-a", "../plugin-a"),
+        ("plugin-multi", "../plugin-multi"),
+    ]);
+    fx.add_plugin(
+        "plugin-a",
+        "plugin-a",
+        r#"
+            [package.metadata.whisker.plugins.alpha-plugin]
+            bin = "alpha-plugin-cng"
+        "#,
+    );
+    fx.add_plugin(
+        "plugin-multi",
+        "plugin-multi",
+        r#"
+            [package.metadata.whisker.plugins.beta-plugin]
+            bin = "beta-plugin-cng"
+            after = ["alpha-plugin"]
+
+            [package.metadata.whisker.plugins.gamma-plugin]
+            bin = "gamma-plugin-cng"
+            before = ["beta-plugin"]
+        "#,
+    );
+
+    let mut plugins = discover_plugins(&fx.app_manifest(), "test-app").unwrap();
+    plugins.sort_by(|a, b| a.name.cmp(&b.name));
+
+    assert_eq!(plugins.len(), 3);
+
+    assert_eq!(plugins[0].name, "alpha-plugin");
+    assert_eq!(plugins[0].source_crate, "plugin-a");
+    assert_eq!(plugins[0].bin_target_name, "alpha-plugin-cng");
+    assert!(plugins[0].after.is_empty());
+
+    assert_eq!(plugins[1].name, "beta-plugin");
+    assert_eq!(plugins[1].source_crate, "plugin-multi");
+    assert_eq!(plugins[1].bin_target_name, "beta-plugin-cng");
+    assert_eq!(plugins[1].after, vec!["alpha-plugin"]);
+
+    assert_eq!(plugins[2].name, "gamma-plugin");
+    assert_eq!(plugins[2].source_crate, "plugin-multi");
+    assert_eq!(plugins[2].bin_target_name, "gamma-plugin-cng");
+    assert_eq!(plugins[2].before, vec!["beta-plugin"]);
+}
+
+#[test]
+fn returns_empty_when_no_dep_declares_plugins() {
+    let fx = WorkspaceFixture::new();
+    fx.add_app(&[
+        ("plugin-a", "../plugin-a"),
+        ("plugin-multi", "../plugin-multi"),
+    ]);
+    fx.add_plugin("plugin-a", "plugin-a", "");
+    // Even an unrelated `[package.metadata.whisker.ios]` block (the
+    // module-discovery surface) should not be picked up as a
+    // plugin.
+    fx.add_plugin(
+        "plugin-multi",
+        "plugin-multi",
+        r#"
+            [package.metadata.whisker.ios]
+            swift_sources = []
+        "#,
+    );
+
+    let plugins = discover_plugins(&fx.app_manifest(), "test-app").unwrap();
+    assert!(plugins.is_empty(), "{plugins:?}");
+}
+
+#[test]
+fn duplicate_plugin_name_across_crates_is_rejected() {
+    let fx = WorkspaceFixture::new();
+    fx.add_app(&[
+        ("plugin-a", "../plugin-a"),
+        ("plugin-multi", "../plugin-multi"),
+    ]);
+    fx.add_plugin(
+        "plugin-a",
+        "plugin-a",
+        r#"
+            [package.metadata.whisker.plugins.collision]
+            bin = "from-plugin-a"
+        "#,
+    );
+    fx.add_plugin(
+        "plugin-multi",
+        "plugin-multi",
+        r#"
+            [package.metadata.whisker.plugins.collision]
+            bin = "from-plugin-multi"
+        "#,
+    );
+
+    let err = discover_plugins(&fx.app_manifest(), "test-app").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("collision"), "{msg}");
+    assert!(msg.contains("plugin-a"), "{msg}");
+    assert!(msg.contains("plugin-multi"), "{msg}");
+}
+
+#[test]
+fn typoed_plugin_entry_field_is_rejected_with_crate_path() {
+    let fx = WorkspaceFixture::new();
+    fx.add_app(&[
+        ("plugin-a", "../plugin-a"),
+        ("plugin-multi", "../plugin-multi"),
+    ]);
+    fx.add_plugin(
+        "plugin-a",
+        "plugin-a",
+        r#"
+            [package.metadata.whisker.plugins.bad]
+            bin = "ok-bin"
+            aftr = ["typo-of-after"]
+        "#,
+    );
+    fx.add_plugin("plugin-multi", "plugin-multi", "");
+
+    let err = discover_plugins(&fx.app_manifest(), "test-app").unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("aftr"), "{msg}");
+    // Crate-path attribution should be present so the user knows
+    // which Cargo.toml to fix.
+    assert!(msg.contains("plugin-a"), "{msg}");
+}


### PR DESCRIPTION
## Summary

Closes Phase 1 of RFC #164. Adds the discovery step that lets a user's \`whisker.rs\` consume 3rd-party plugins purely by adding a cargo dep — no explicit \`Engine::register_subprocess\` call site required.

### Schema

\`\`\`toml
[package.metadata.whisker.plugins.my-plugin]
bin = \"my-plugin-cng\"          # the [[bin]] target name
after = [\"whisker-info-plist\"] # optional ordering hints
before = []                    # optional ordering hints
\`\`\`

One crate may declare multiple plugins. Unknown fields per entry are rejected (\`#[serde(deny_unknown_fields)]\`) so typos like \`aftr = [...]\` surface against the crate's manifest path rather than silently dropping to default.

### New: \`whisker_cng::discovery\`

- **\`DiscoveredPlugin { name, source_crate, source_manifest_dir, bin_target_name, after, before }\`** — one entry per discovered plugin.
- **\`discover_plugins(manifest_path, app_package)\`** walks the cargo dep graph via \`cargo_metadata::MetadataCommand\` (same crate \`whisker-build\` uses for module discovery), picks out every dep with a \`whisker.plugins\` sub-table, returns the list.
- Conflict detection: two crates claiming the same plugin name is a hard error with both source-crate names in the message.

### Why discovery instead of explicit registration

The user's typed Config struct's \`PluginConfig::NAME\` matches the discovery table's key. So \"what plugin runs\" is decided entirely by what crates the app depends on plus how the user spelled \`app.plugin::<…>(…)\` — the CLI never needs an explicit registration call site for 3rd-party plugins.

### Cargo dep

\`cargo_metadata = \"0.18\"\` — pinned to the same version \`whisker-build\` uses.

## What's NOT in this PR

- **No build-side integration.** \`DiscoveredPlugin\` carries \`bin_target_name\`, not a resolved binary path. The downstream consumer (likely \`whisker-build\`) handles \`cargo build --bin <target> --package <source_crate>\` and the target-dir lookup, then constructs a \`SubprocessPlugin\`. Falls outside Phase 1's scope.
- **No engine auto-registration helper.** \`Engine::register\` / \`register_subprocess\` remain the only registration surface.
- **No module-schema change.** The discovery walk reads \`metadata.get(\"whisker\").get(\"plugins\")\` directly off the JSON value, so \`whisker_build::modules\`'s \`deny_unknown_fields\` strictness on \`[ios]\` / \`[android]\` stays intact.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo fmt -p whisker-cng\`
- [x] \`cargo clippy -p whisker-cng --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-cng\` — **61 tests pass** (54 unit + 4 discovery integration + 3 subprocess integration)

Unit (6 new): duplicate detection (pass/fail), \`PluginEntryRaw\` deserializer (only bin / all fields / unknown field / missing bin).

Integration (4 new, tempdir + path-deps workspace fixture): single + multi-entry discovery; empty when no plugins (unrelated \`[whisker.ios]\` not misread); duplicate-name across crates; typo rejected with crate-path attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)