### PR TITLE
feat(cng): built-in plugins + engine as default render path (RFC #164 Phase 2+3)

### DIFF
--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -35,7 +35,7 @@ use whisker_plugin::MetaDataEntry;
 
 use crate::compose::{EnabledTargets, Engine};
 use crate::fingerprint;
-use crate::render::render;
+use crate::render::{escape_xml, render};
 
 // ---- Embedded templates ----------------------------------------------------
 //
@@ -220,21 +220,6 @@ fn render_extra_meta_data(entries: &[MetaDataEntry]) -> String {
     }
     if out.ends_with('\n') {
         out.pop();
-    }
-    out
-}
-
-fn escape_xml(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        match ch {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&apos;"),
-            c => out.push(c),
-        }
     }
     out
 }

--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -31,7 +31,9 @@ use anyhow::{anyhow, Context, Result};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use whisker_app_config::AppConfig;
+use whisker_plugin::MetaDataEntry;
 
+use crate::compose::{EnabledTargets, Engine};
 use crate::fingerprint;
 use crate::render::render;
 
@@ -100,6 +102,18 @@ pub struct AndroidInputs {
     /// gh-pages Maven URL hosting the Lynx fork AARs that
     /// `whisker-runtime-android` pulls transitively.
     pub lynx_maven_url: String,
+    /// `<uses-permission android:name="…"/>` rows from the engine's
+    /// post-pipeline IR. Emitted after the template's hardcoded
+    /// `INTERNET` permission. Dedup'd: the same permission
+    /// contributed by multiple plugins shows up once.
+    #[serde(default)]
+    pub extra_permissions: Vec<String>,
+    /// `<meta-data android:name="…" android:value="…"/>` rows from
+    /// the engine's post-pipeline IR. Emitted inside the
+    /// `<application>` block. Preserves insertion order — multiple
+    /// plugins contributing entries see deterministic output.
+    #[serde(default)]
+    pub extra_meta_data: Vec<MetaDataEntry>,
     /// Bumped whenever the template *shape* changes (added file,
     /// renamed placeholder, …). The fingerprint mixes this in so
     /// existing `gen/` trees regenerate after an upgrade.
@@ -158,7 +172,71 @@ pub(crate) fn template_vars(inputs: &AndroidInputs) -> HashMap<&'static str, Str
     );
     v.insert("whisker_maven_url", inputs.whisker_maven_url.clone());
     v.insert("lynx_maven_url", inputs.lynx_maven_url.clone());
+    v.insert(
+        "extra_uses_permissions",
+        render_extra_permissions(&inputs.extra_permissions),
+    );
+    v.insert(
+        "extra_application_meta_data",
+        render_extra_meta_data(&inputs.extra_meta_data),
+    );
     v
+}
+
+/// Render the engine-supplied permissions as `<uses-permission>`
+/// rows, dedup'd. Empty input → empty string so the template still
+/// parses when no plugin contributed.
+fn render_extra_permissions(perms: &[String]) -> String {
+    if perms.is_empty() {
+        return String::new();
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    let mut out = String::new();
+    for p in perms {
+        if seen.insert(p.as_str()) {
+            out.push_str(&format!(
+                "    <uses-permission android:name=\"{}\" />\n",
+                escape_xml(p),
+            ));
+        }
+    }
+    if out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+fn render_extra_meta_data(entries: &[MetaDataEntry]) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    for e in entries {
+        out.push_str(&format!(
+            "        <meta-data android:name=\"{}\" android:value=\"{}\" />\n",
+            escape_xml(&e.name),
+            escape_xml(&e.value),
+        ));
+    }
+    if out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+fn escape_xml(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 /// Application class. `HelloWorld` → `HelloWorldApplication`. Strips
@@ -400,6 +478,24 @@ pub fn inputs_from(
         ))?;
     let min_sdk = app_config.android.min_sdk.unwrap_or(24);
     let target_sdk = app_config.android.target_sdk.unwrap_or(34);
+
+    // Run the plugin pipeline with built-ins. Apps that never call
+    // `app.plugin::<…>(…)` get an empty IR back; the resulting
+    // `extra_permissions` / `extra_meta_data` are empty and the
+    // AndroidManifest render is bit-identical to the pre-Phase-3
+    // output (the placeholder substitutes into an empty string).
+    let ctx = Engine::with_builtins()
+        .compose(app_config, EnabledTargets::android_only())
+        .context("compose Whisker CNG plugin pipeline for Android")?;
+    let (extra_permissions, extra_meta_data) = if let Some(android) = ctx.android.as_ref() {
+        (
+            android.manifest.permissions.clone(),
+            android.manifest.application_meta_data.clone(),
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
     Ok(AndroidInputs {
         app_name,
         version,
@@ -414,11 +510,14 @@ pub fn inputs_from(
         whisker_gradle_plugin_version,
         whisker_maven_url,
         lynx_maven_url,
-        // Bumped 4 → 5 for Step 5-Android: templates switched from
-        // path-based composite-build + flatDir refs to Maven
-        // coordinates. Existing fingerprints invalidate so gen trees
-        // re-render their settings.gradle.kts + app/build.gradle.kts.
-        template_version: 5,
+        extra_permissions,
+        extra_meta_data,
+        // Bumped 5 → 6 for RFC #164 Phase 2/3: AndroidManifest.xml
+        // template gained `{{extra_uses_permissions}}` and
+        // `{{extra_application_meta_data}}` placeholders. Existing
+        // `gen/android/` trees regenerate so the placeholders
+        // substitute correctly even before any plugin contributes.
+        template_version: 6,
     })
 }
 
@@ -455,7 +554,9 @@ mod tests {
             whisker_gradle_plugin_version: "0.1.0".into(),
             whisker_maven_url: "https://whiskerrs.github.io/whisker/maven".into(),
             lynx_maven_url: "https://whiskerrs.github.io/lynx/maven".into(),
-            template_version: 5,
+            extra_permissions: Vec::new(),
+            extra_meta_data: Vec::new(),
+            template_version: 6,
         }
     }
 

--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -96,6 +96,20 @@ impl Engine {
         Self::default()
     }
 
+    /// Like [`Engine::new`] but pre-registers every built-in
+    /// plugin shipped under [`crate::plugins`]. The standard entry
+    /// point for `inputs_from` / `whisker generate` — built-ins
+    /// are opt-in (their `Cfg::default()` is empty), so apps that
+    /// never call `app.plugin::<…>(|c| …)` see the same output as
+    /// pre-engine `whisker-cng`.
+    pub fn with_builtins() -> Self {
+        let mut e = Self::new();
+        e.register(crate::plugins::info_plist_extra::InfoPlistExtraPlugin)
+            .register(crate::plugins::android_permissions::AndroidPermissionsPlugin)
+            .register(crate::plugins::android_meta_data::AndroidMetaDataPlugin);
+        e
+    }
+
     /// Register a typed [`Plugin`] with the engine. The engine
     /// retains ownership for the rest of its lifetime; plugins are
     /// run in topologically-sorted order on every `compose` call,

--- a/crates/whisker-cng/src/ios.rs
+++ b/crates/whisker-cng/src/ios.rs
@@ -28,10 +28,12 @@
 //! template via xcodegen once and re-templatize.
 
 use anyhow::{anyhow, Context, Result};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use whisker_app_config::AppConfig;
+use whisker_plugin::PlistValue;
 
+use crate::compose::{EnabledTargets, Engine};
 use crate::fingerprint;
 use crate::render::render;
 
@@ -77,6 +79,19 @@ pub struct IosInputs {
     /// Cargo package name (the user app crate) — the Rust side of
     /// `whisker-build ios --package=...`. Step 7.
     pub user_package: String,
+    /// `(key, string-value)` pairs sourced from the engine's
+    /// post-pipeline IR (`ctx.ios.info_plist`). Emitted into the
+    /// rendered `Info.plist` just before the closing `</dict>`. The
+    /// renderer XML-escapes values; keys are assumed safe because
+    /// they come from Rust string constants in plugin Configs.
+    ///
+    /// Only `PlistValue::String` entries surface here for now;
+    /// dict / array values are dropped because the Info.plist
+    /// template is hand-rolled XML rather than a real plist
+    /// serializer. Adding richer value support is a future
+    /// renderer change, not a wire-format break.
+    #[serde(default)]
+    pub extra_info_plist_kvs: BTreeMap<String, String>,
     pub template_version: u32,
 }
 
@@ -123,7 +138,53 @@ pub(crate) fn template_vars(inputs: &IosInputs) -> HashMap<&'static str, String>
         inputs.workspace_root.display().to_string(),
     );
     v.insert("whisker_user_package", inputs.user_package.clone());
+    v.insert(
+        "extra_info_plist_kvs",
+        render_extra_info_plist_kvs(&inputs.extra_info_plist_kvs),
+    );
     v
+}
+
+/// Render the engine-supplied `(key, string)` pairs as XML
+/// `<key>…</key><string>…</string>` rows ready to drop straight
+/// into the Info.plist template just before `</dict>`. Empty map
+/// → empty string (no whitespace) so the template still parses
+/// cleanly.
+fn render_extra_info_plist_kvs(entries: &BTreeMap<String, String>) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    // Indent matching the rest of the template (tab characters,
+    // matching the hand-rolled Info.plist's existing style).
+    let mut out = String::new();
+    for (key, value) in entries {
+        out.push_str(&format!(
+            "\t<key>{}</key>\n\t<string>{}</string>\n",
+            escape_xml(key),
+            escape_xml(value),
+        ));
+    }
+    // Strip the trailing newline so the template's own newline
+    // before `</dict>` isn't doubled up.
+    if out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+fn escape_xml(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 fn write_files(out_dir: &Path, inputs: &IosInputs) -> Result<()> {
@@ -262,6 +323,16 @@ pub fn inputs_from(
         .deployment_target
         .clone()
         .unwrap_or_else(|| "13.0".to_string());
+
+    // Run the plugin pipeline with built-ins. Apps that never call
+    // `app.plugin::<…>(…)` get an empty IR back; the resulting
+    // `extra_info_plist_kvs` is empty and the Info.plist render is
+    // bit-identical to the pre-Phase-3 output.
+    let ctx = Engine::with_builtins()
+        .compose(app_config, EnabledTargets::ios_only())
+        .context("compose Whisker CNG plugin pipeline for iOS")?;
+    let extra_info_plist_kvs = extract_info_plist_string_kvs(&ctx);
+
     Ok(IosInputs {
         app_name,
         version,
@@ -273,15 +344,35 @@ pub fn inputs_from(
         whisker_modules_path,
         workspace_root,
         user_package,
-        // Bumped 8 → 9 for RFC #164 Phase 0: the pbxproj template's
-        // Run Script Build Phase rename "Whisker Prebuild" →
-        // "Whisker Generate". Aligns with the RFC's "Generate"
-        // vocabulary (cng = Continuous Native Generation) and away
-        // from Expo's "Prebuild" loaner. Forces existing `gen/ios/`
-        // trees to regenerate so the Build Phase name in any open
-        // Xcode project window updates.
-        template_version: 9,
+        extra_info_plist_kvs,
+        // Bumped 9 → 10 for RFC #164 Phase 2/3: the Info.plist
+        // template gained the `{{extra_info_plist_kvs}}`
+        // placeholder. Existing `gen/ios/` trees regenerate so the
+        // placeholder substitutes correctly even before any
+        // plugin contributes content.
+        template_version: 10,
     })
+}
+
+/// Project the iOS info_plist BTreeMap (the IR layer) into the
+/// `(key, string-value)` shape the template renderer accepts.
+/// Non-string `PlistValue` variants are silently dropped — the
+/// template is hand-rolled XML and can't represent dicts / arrays
+/// safely. A future renderer that emits real plist XML can lift
+/// this restriction without changing the IR.
+fn extract_info_plist_string_kvs(
+    ctx: &whisker_plugin::GenerateContext,
+) -> BTreeMap<String, String> {
+    let Some(ios) = ctx.ios.as_ref() else {
+        return BTreeMap::new();
+    };
+    ios.info_plist
+        .iter()
+        .filter_map(|(k, v)| match v {
+            PlistValue::String(s) => Some((k.clone(), s.clone())),
+            _ => None,
+        })
+        .collect()
 }
 
 // ============================================================================
@@ -314,7 +405,8 @@ mod tests {
             whisker_modules_path: PathBuf::from("/abs/gen/ios/whisker_modules"),
             workspace_root: PathBuf::from("/abs/workspace"),
             user_package: "hello-world".into(),
-            template_version: 9,
+            extra_info_plist_kvs: BTreeMap::new(),
+            template_version: 10,
         }
     }
 

--- a/crates/whisker-cng/src/ios.rs
+++ b/crates/whisker-cng/src/ios.rs
@@ -31,11 +31,11 @@ use anyhow::{anyhow, Context, Result};
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use whisker_app_config::AppConfig;
-use whisker_plugin::PlistValue;
+use whisker_plugin::{GenerateContext, PlistValue};
 
 use crate::compose::{EnabledTargets, Engine};
 use crate::fingerprint;
-use crate::render::render;
+use crate::render::{escape_xml, render};
 
 const PBXPROJ: &str = include_str!("templates/ios/Project.xcodeproj/project.pbxproj");
 const XCWORKSPACEDATA: &str =
@@ -168,21 +168,6 @@ fn render_extra_info_plist_kvs(entries: &BTreeMap<String, String>) -> String {
     // before `</dict>` isn't doubled up.
     if out.ends_with('\n') {
         out.pop();
-    }
-    out
-}
-
-fn escape_xml(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        match ch {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&apos;"),
-            c => out.push(c),
-        }
     }
     out
 }
@@ -360,9 +345,7 @@ pub fn inputs_from(
 /// template is hand-rolled XML and can't represent dicts / arrays
 /// safely. A future renderer that emits real plist XML can lift
 /// this restriction without changing the IR.
-fn extract_info_plist_string_kvs(
-    ctx: &whisker_plugin::GenerateContext,
-) -> BTreeMap<String, String> {
+fn extract_info_plist_string_kvs(ctx: &GenerateContext) -> BTreeMap<String, String> {
     let Some(ios) = ctx.ios.as_ref() else {
         return BTreeMap::new();
     };

--- a/crates/whisker-cng/src/lib.rs
+++ b/crates/whisker-cng/src/lib.rs
@@ -33,6 +33,7 @@ pub mod compose;
 pub mod discovery;
 mod fingerprint;
 pub mod ios;
+pub mod plugins;
 mod render;
 
 pub use android::{sync as sync_android, AndroidInputs};

--- a/crates/whisker-cng/src/plugins/android_meta_data.rs
+++ b/crates/whisker-cng/src/plugins/android_meta_data.rs
@@ -1,0 +1,129 @@
+//! `whisker-android-meta-data` — append `<meta-data>` rows inside
+//! the generated `AndroidManifest.xml`'s `<application>` block.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! app.plugin::<AndroidMetaDataCfg>(|c| c
+//!     .add("com.google.firebase.messaging.default_notification_icon",
+//!          "@drawable/ic_notification")
+//!     .add("com.google.android.geo.API_KEY", "AIza..."));
+//! ```
+//!
+//! Required by Firebase, Google Maps, App Links host declarations
+//! and most other 1st-party Google SDKs that need to surface a
+//! manifest-time value to the runtime.
+
+use serde::{Deserialize, Serialize};
+use whisker_plugin::{GenerateContext, MetaDataEntry, Operation, Plugin, PluginConfig, Target};
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct AndroidMetaDataCfg {
+    /// `(name, value)` pairs the renderer emits as
+    /// `<meta-data android:name="…" android:value="…"/>` inside
+    /// `<application>`. Stored ordered so multiple plugins
+    /// contributing entries produce a deterministic manifest.
+    #[serde(default)]
+    pub entries: Vec<MetaDataEntry>,
+}
+
+impl AndroidMetaDataCfg {
+    pub fn add(&mut self, name: impl Into<String>, value: impl Into<String>) -> &mut Self {
+        self.entries.push(MetaDataEntry {
+            name: name.into(),
+            value: value.into(),
+        });
+        self
+    }
+}
+
+impl PluginConfig for AndroidMetaDataCfg {
+    const NAME: &'static str = "whisker-android-meta-data";
+}
+
+pub struct AndroidMetaDataPlugin;
+
+impl Plugin for AndroidMetaDataPlugin {
+    type Config = AndroidMetaDataCfg;
+
+    fn apply(&self, ctx: &mut GenerateContext, cfg: &AndroidMetaDataCfg) -> anyhow::Result<()> {
+        let Some(android) = ctx.android.as_mut() else {
+            return Ok(());
+        };
+        if cfg.entries.is_empty() {
+            return Ok(());
+        }
+        let count = cfg.entries.len();
+        android
+            .manifest
+            .application_meta_data
+            .extend(cfg.entries.clone());
+        ctx.journal.record(
+            AndroidMetaDataCfg::NAME,
+            Target::Android,
+            "manifest.application_meta_data",
+            Operation::ArrayPush { count },
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::AndroidProjectIr;
+
+    fn ctx_with_android() -> GenerateContext {
+        GenerateContext {
+            android: Some(AndroidProjectIr::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_config_contributes_nothing() {
+        let mut ctx = ctx_with_android();
+        AndroidMetaDataPlugin
+            .apply(&mut ctx, &AndroidMetaDataCfg::default())
+            .unwrap();
+        assert!(ctx
+            .android
+            .unwrap()
+            .manifest
+            .application_meta_data
+            .is_empty());
+        assert!(ctx.journal.records.is_empty());
+    }
+
+    #[test]
+    fn populated_config_appends_each_entry() {
+        let mut cfg = AndroidMetaDataCfg::default();
+        cfg.add(
+            "com.google.firebase.messaging.default_notification_icon",
+            "@drawable/ic_notification",
+        )
+        .add("com.google.android.geo.API_KEY", "AIza...");
+        let mut ctx = ctx_with_android();
+        AndroidMetaDataPlugin.apply(&mut ctx, &cfg).unwrap();
+        let entries = ctx.android.unwrap().manifest.application_meta_data;
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries[0].name,
+            "com.google.firebase.messaging.default_notification_icon",
+        );
+        assert_eq!(entries[1].name, "com.google.android.geo.API_KEY");
+        assert_eq!(entries[1].value, "AIza...");
+    }
+
+    #[test]
+    fn one_array_push_event_per_invocation() {
+        let mut cfg = AndroidMetaDataCfg::default();
+        cfg.add("a", "1").add("b", "2");
+        let mut ctx = ctx_with_android();
+        AndroidMetaDataPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert_eq!(ctx.journal.records.len(), 1);
+        let r = &ctx.journal.records[0];
+        assert_eq!(r.plugin, "whisker-android-meta-data");
+        assert!(matches!(r.operation, Operation::ArrayPush { count: 2 }));
+    }
+}

--- a/crates/whisker-cng/src/plugins/android_permissions.rs
+++ b/crates/whisker-cng/src/plugins/android_permissions.rs
@@ -1,0 +1,123 @@
+//! `whisker-android-permissions` — append `<uses-permission>` rows
+//! to the generated `AndroidManifest.xml`.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! app.plugin::<AndroidPermissionsCfg>(|c| c
+//!     .add("android.permission.CAMERA")
+//!     .add("android.permission.RECORD_AUDIO"));
+//! ```
+//!
+//! The plugin appends each permission to
+//! `ctx.android.manifest.permissions`. Duplicates within a single
+//! `add(...)` chain stay duplicated — the renderer dedups at write
+//! time so the manifest doesn't carry redundant entries even when
+//! several plugins contribute the same permission.
+
+use serde::{Deserialize, Serialize};
+use whisker_plugin::{GenerateContext, Operation, Plugin, PluginConfig, Target};
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct AndroidPermissionsCfg {
+    /// Permission strings exactly as they appear in
+    /// `android:name="…"`. e.g. `"android.permission.CAMERA"`.
+    #[serde(default)]
+    pub permissions: Vec<String>,
+}
+
+impl AndroidPermissionsCfg {
+    pub fn add(&mut self, name: impl Into<String>) -> &mut Self {
+        self.permissions.push(name.into());
+        self
+    }
+}
+
+impl PluginConfig for AndroidPermissionsCfg {
+    const NAME: &'static str = "whisker-android-permissions";
+}
+
+pub struct AndroidPermissionsPlugin;
+
+impl Plugin for AndroidPermissionsPlugin {
+    type Config = AndroidPermissionsCfg;
+
+    fn apply(&self, ctx: &mut GenerateContext, cfg: &AndroidPermissionsCfg) -> anyhow::Result<()> {
+        let Some(android) = ctx.android.as_mut() else {
+            return Ok(());
+        };
+        if cfg.permissions.is_empty() {
+            return Ok(());
+        }
+        let count = cfg.permissions.len();
+        android.manifest.permissions.extend(cfg.permissions.clone());
+        ctx.journal.record(
+            AndroidPermissionsCfg::NAME,
+            Target::Android,
+            "manifest.permissions",
+            Operation::ArrayPush { count },
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::AndroidProjectIr;
+
+    fn ctx_with_android() -> GenerateContext {
+        GenerateContext {
+            android: Some(AndroidProjectIr::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_config_contributes_nothing() {
+        let mut ctx = ctx_with_android();
+        AndroidPermissionsPlugin
+            .apply(&mut ctx, &AndroidPermissionsCfg::default())
+            .unwrap();
+        assert!(ctx.android.unwrap().manifest.permissions.is_empty());
+        assert!(ctx.journal.records.is_empty());
+    }
+
+    #[test]
+    fn populated_config_appends_each_permission() {
+        let mut cfg = AndroidPermissionsCfg::default();
+        cfg.add("android.permission.CAMERA")
+            .add("android.permission.RECORD_AUDIO");
+        let mut ctx = ctx_with_android();
+        AndroidPermissionsPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert_eq!(
+            ctx.android.unwrap().manifest.permissions,
+            vec![
+                "android.permission.CAMERA".to_string(),
+                "android.permission.RECORD_AUDIO".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn one_array_push_event_per_invocation() {
+        let mut cfg = AndroidPermissionsCfg::default();
+        cfg.add("a").add("b").add("c");
+        let mut ctx = ctx_with_android();
+        AndroidPermissionsPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert_eq!(ctx.journal.records.len(), 1);
+        let r = &ctx.journal.records[0];
+        assert_eq!(r.plugin, "whisker-android-permissions");
+        assert_eq!(r.target, Target::Android);
+        assert!(matches!(r.operation, Operation::ArrayPush { count: 3 }));
+    }
+
+    #[test]
+    fn no_android_target_means_no_op() {
+        let mut cfg = AndroidPermissionsCfg::default();
+        cfg.add("android.permission.CAMERA");
+        let mut ctx = GenerateContext::default();
+        AndroidPermissionsPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert!(ctx.journal.records.is_empty());
+    }
+}

--- a/crates/whisker-cng/src/plugins/info_plist_extra.rs
+++ b/crates/whisker-cng/src/plugins/info_plist_extra.rs
@@ -1,0 +1,141 @@
+//! `whisker-info-plist-extra` — append arbitrary `(key, string)`
+//! pairs to the iOS `Info.plist`.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! app.plugin::<InfoPlistExtraCfg>(|c| c
+//!     .add("NSCameraUsageDescription", "Take photos for posts.")
+//!     .add("LSApplicationQueriesSchemes", "comgooglemaps"));
+//! ```
+//!
+//! The plugin writes each `(key, value)` straight into
+//! `ctx.ios.info_plist` as a `PlistValue::String`. Two different
+//! plugins (built-in or 3rd-party) writing the same key surfaces as
+//! a conflict via the [`Operation::Set`] / mutation-journal path —
+//! this plugin is no different from a 3rd-party one in that
+//! respect.
+//!
+//! ## Why string-only
+//!
+//! 90%+ of Info.plist additions are either privacy strings or
+//! capability flags expressed as strings. Dict / array values
+//! exist but are rarer and not yet shipped — a future built-in
+//! (`whisker-info-plist-structured`) can extend the schema when
+//! the first real consumer asks.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use whisker_plugin::{GenerateContext, Operation, PlistValue, Plugin, PluginConfig, Target};
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct InfoPlistExtraCfg {
+    /// `(key, value)` pairs added to `Info.plist`. `BTreeMap` for
+    /// deterministic iteration order — the engine's fingerprint
+    /// hashes the IR, and `HashMap` random ordering would invalidate
+    /// the skip path.
+    #[serde(default)]
+    pub entries: BTreeMap<String, String>,
+}
+
+impl InfoPlistExtraCfg {
+    /// Add (or replace) one `(key, value)` pair. Returns `&mut Self`
+    /// for fluent chaining inside the `app.plugin::<…>(|c| …)`
+    /// closure.
+    pub fn add(&mut self, key: impl Into<String>, value: impl Into<String>) -> &mut Self {
+        self.entries.insert(key.into(), value.into());
+        self
+    }
+}
+
+impl PluginConfig for InfoPlistExtraCfg {
+    const NAME: &'static str = "whisker-info-plist-extra";
+}
+
+pub struct InfoPlistExtraPlugin;
+
+impl Plugin for InfoPlistExtraPlugin {
+    type Config = InfoPlistExtraCfg;
+
+    fn apply(&self, ctx: &mut GenerateContext, cfg: &InfoPlistExtraCfg) -> anyhow::Result<()> {
+        let Some(ios) = ctx.ios.as_mut() else {
+            // Target not enabled — nothing to do.
+            return Ok(());
+        };
+        for (key, value) in &cfg.entries {
+            ios.info_plist
+                .insert(key.clone(), PlistValue::String(value.clone()));
+            ctx.journal.record(
+                InfoPlistExtraCfg::NAME,
+                Target::Ios,
+                &format!("info_plist.{key}"),
+                Operation::Set,
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::IosProjectIr;
+
+    fn ctx_with_ios() -> GenerateContext {
+        GenerateContext {
+            ios: Some(IosProjectIr::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_config_contributes_nothing() {
+        let mut ctx = ctx_with_ios();
+        InfoPlistExtraPlugin
+            .apply(&mut ctx, &InfoPlistExtraCfg::default())
+            .unwrap();
+        assert!(ctx.ios.unwrap().info_plist.is_empty());
+        assert!(ctx.journal.records.is_empty());
+    }
+
+    #[test]
+    fn populated_config_writes_each_entry_to_info_plist() {
+        let mut cfg = InfoPlistExtraCfg::default();
+        cfg.add("NSCameraUsageDescription", "Take photos.")
+            .add("LSApplicationQueriesSchemes", "comgooglemaps");
+        let mut ctx = ctx_with_ios();
+        InfoPlistExtraPlugin.apply(&mut ctx, &cfg).unwrap();
+        let plist = ctx.ios.unwrap().info_plist;
+        assert_eq!(
+            plist["NSCameraUsageDescription"],
+            PlistValue::String("Take photos.".into()),
+        );
+        assert_eq!(
+            plist["LSApplicationQueriesSchemes"],
+            PlistValue::String("comgooglemaps".into()),
+        );
+    }
+
+    #[test]
+    fn each_entry_records_a_journal_event() {
+        let mut cfg = InfoPlistExtraCfg::default();
+        cfg.add("Key1", "v1").add("Key2", "v2");
+        let mut ctx = ctx_with_ios();
+        InfoPlistExtraPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert_eq!(ctx.journal.records.len(), 2);
+        for r in &ctx.journal.records {
+            assert_eq!(r.plugin, "whisker-info-plist-extra");
+            assert_eq!(r.target, Target::Ios);
+            assert!(matches!(r.operation, Operation::Set));
+        }
+    }
+
+    #[test]
+    fn no_ios_target_means_no_op() {
+        let mut cfg = InfoPlistExtraCfg::default();
+        cfg.add("k", "v");
+        let mut ctx = GenerateContext::default(); // ios = None
+        InfoPlistExtraPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert!(ctx.journal.records.is_empty());
+    }
+}

--- a/crates/whisker-cng/src/plugins/mod.rs
+++ b/crates/whisker-cng/src/plugins/mod.rs
@@ -1,0 +1,39 @@
+//! Built-in Whisker CNG plugins.
+//!
+//! Each module here implements one [`whisker_plugin::Plugin`] that
+//! the engine registers automatically via
+//! [`crate::Engine::with_builtins`]. Plugins are intentionally
+//! narrow — one IR field, one mutation, no cross-plugin
+//! coordination — so a 3rd-party plugin can rely on a stable set of
+//! upstream writers when expressing `after()` / `before()` hints.
+//!
+//! ## Opt-in semantics
+//!
+//! Every built-in is opt-in: the engine runs it on every
+//! `compose()` call, but it only writes IR entries when the user
+//! supplied a non-default Config via
+//! `app.plugin::<…Cfg>(|c| …)`. A built-in's `Cfg::default()`
+//! produces an empty contribution, so apps that don't declare any
+//! built-in see the legacy behavior bit-identical.
+//!
+//! ## Why these three
+//!
+//! - **[`info_plist_extra`]** — covers "I need an extra Info.plist
+//!   key I didn't expect" (privacy strings, capabilities, custom
+//!   URL schemes). The most common reason apps end up patching
+//!   Xcode-generated plists by hand.
+//! - **[`android_permissions`]** — covers the same shape for
+//!   Android's `<uses-permission>` list. Single most common manifest
+//!   edit.
+//! - **[`android_meta_data`]** — covers `<meta-data>` rows inside
+//!   `<application>`. Required by Firebase, Google Maps SDK keys,
+//!   App Links host declarations, and most other 1st-party Google
+//!   SDKs.
+//!
+//! Future built-ins land here additively. Each new entry needs a
+//! brief justification in this list and a registration line in
+//! [`crate::Engine::with_builtins`].
+
+pub mod android_meta_data;
+pub mod android_permissions;
+pub mod info_plist_extra;

--- a/crates/whisker-cng/src/render.rs
+++ b/crates/whisker-cng/src/render.rs
@@ -3,12 +3,33 @@
 //! Deliberately minimal — no conditionals, no escaping, no nested
 //! constructs. Templates are project scaffolding; if a value needs
 //! escaping (quote-heavy XML attributes, etc.) the renderer caller is
-//! responsible. Errors are returned for unknown placeholders so a
-//! typo'd `{{`-block fails loudly at sync time instead of writing a
-//! broken file the user has to debug.
+//! responsible — see [`escape_xml`]. Errors are returned for unknown
+//! placeholders so a typo'd `{{`-block fails loudly at sync time
+//! instead of writing a broken file the user has to debug.
 
 use anyhow::{bail, Result};
 use std::collections::HashMap;
+
+/// Escape the five XML special characters (`&`, `<`, `>`, `"`,
+/// `'`). Used by the per-platform `template_vars` builders when
+/// they emit plugin-supplied strings into hand-rolled XML
+/// (Info.plist, AndroidManifest.xml). Keys generally come from
+/// Rust string constants in plugin Configs and don't need
+/// escaping; values are user-supplied and do.
+pub(crate) fn escape_xml(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            c => out.push(c),
+        }
+    }
+    out
+}
 
 /// Replace every `{{key}}` in `template` with `vars[key]`. Returns
 /// `Err` if a placeholder doesn't have a corresponding entry — that

--- a/crates/whisker-cng/src/templates/android/app/src/main/AndroidManifest.xml
+++ b/crates/whisker-cng/src/templates/android/app/src/main/AndroidManifest.xml
@@ -6,12 +6,14 @@
          reverse` in non-emulator setups). Harmless in release builds
          since the dev-runtime is feature-gated out. -->
     <uses-permission android:name="android.permission.INTERNET" />
+{{extra_uses_permissions}}
 
     <application
         android:name=".{{android_application_class}}"
         android:label="{{app_name}}"
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.AppCompat.NoActionBar">
+{{extra_application_meta_data}}
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/crates/whisker-cng/src/templates/ios/Info.plist
+++ b/crates/whisker-cng/src/templates/ios/Info.plist
@@ -27,5 +27,6 @@
 	</dict>
 	<key>UILaunchScreen</key>
 	<dict/>
+{{extra_info_plist_kvs}}
 </dict>
 </plist>

--- a/crates/whisker-cng/tests/builtins_e2e.rs
+++ b/crates/whisker-cng/tests/builtins_e2e.rs
@@ -1,0 +1,270 @@
+//! End-to-end check on the Phase 2/3 wiring: built-in plugin →
+//! engine → `inputs_from` → template substitution → rendered file.
+//!
+//! Complements the per-plugin unit tests in
+//! `crates/whisker-cng/src/plugins/*` (which only check IR-level
+//! mutations) and the per-renderer tests in `src/ios.rs` /
+//! `src/android.rs` (which only check default-config rendering).
+//! Here we verify the whole pipeline writes the expected XML.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use whisker_app_config::AppConfig;
+use whisker_cng::plugins::android_meta_data::AndroidMetaDataCfg;
+use whisker_cng::plugins::android_permissions::AndroidPermissionsCfg;
+use whisker_cng::plugins::info_plist_extra::InfoPlistExtraCfg;
+
+fn unique_tempdir() -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let p = std::env::temp_dir().join(format!("whisker-cng-builtins-e2e-{pid}-{n}"));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn base_ios_app() -> AppConfig {
+    let mut a = AppConfig::default();
+    a.name("HelloWorld")
+        .bundle_id("rs.whisker.examples.helloWorld");
+    a
+}
+
+fn base_android_app() -> AppConfig {
+    let mut a = AppConfig::default();
+    a.name("HelloWorld").android(|x| {
+        x.application_id("rs.whisker.examples.helloworld");
+    });
+    a
+}
+
+// ============================================================================
+// iOS: InfoPlistExtra
+// ============================================================================
+
+#[test]
+fn ios_info_plist_extra_keys_reach_the_rendered_plist() {
+    let mut app = base_ios_app();
+    app.plugin::<InfoPlistExtraCfg>(|c| {
+        c.add("NSCameraUsageDescription", "Take photos.")
+            .add("LSApplicationQueriesSchemes", "comgooglemaps");
+    });
+
+    let inputs = whisker_cng::ios::inputs_from(
+        &app,
+        PathBuf::from("/abs/platforms/ios"),
+        PathBuf::from("/abs/gen/ios/whisker_modules"),
+        PathBuf::from("/abs/workspace"),
+        "hello-world".into(),
+    )
+    .unwrap();
+
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/ios");
+    whisker_cng::ios::sync(&out, &inputs).unwrap();
+
+    let plist = std::fs::read_to_string(out.join("Info.plist")).unwrap();
+    assert!(
+        plist.contains("<key>NSCameraUsageDescription</key>"),
+        "{plist}",
+    );
+    assert!(plist.contains("<string>Take photos.</string>"), "{plist}");
+    assert!(
+        plist.contains("<key>LSApplicationQueriesSchemes</key>"),
+        "{plist}",
+    );
+    assert!(plist.contains("<string>comgooglemaps</string>"), "{plist}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn ios_info_plist_extra_escapes_xml_in_values() {
+    let mut app = base_ios_app();
+    app.plugin::<InfoPlistExtraCfg>(|c| {
+        c.add("NSCameraUsageDescription", "Photos for <Foo & Bar>.");
+    });
+
+    let inputs = whisker_cng::ios::inputs_from(
+        &app,
+        PathBuf::from("/abs/platforms/ios"),
+        PathBuf::from("/abs/gen/ios/whisker_modules"),
+        PathBuf::from("/abs/workspace"),
+        "hello-world".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/ios");
+    whisker_cng::ios::sync(&out, &inputs).unwrap();
+
+    let plist = std::fs::read_to_string(out.join("Info.plist")).unwrap();
+    assert!(
+        plist.contains("Photos for &lt;Foo &amp; Bar&gt;."),
+        "{plist}",
+    );
+    // Raw `<` from the user value must not leak in.
+    assert!(
+        !plist.contains("Photos for <Foo & Bar>"),
+        "raw < should have been escaped: {plist}",
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn ios_no_plugin_declared_means_no_extra_keys_in_plist() {
+    let app = base_ios_app(); // no app.plugin::<…>(…)
+
+    let inputs = whisker_cng::ios::inputs_from(
+        &app,
+        PathBuf::from("/abs/platforms/ios"),
+        PathBuf::from("/abs/gen/ios/whisker_modules"),
+        PathBuf::from("/abs/workspace"),
+        "hello-world".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/ios");
+    whisker_cng::ios::sync(&out, &inputs).unwrap();
+
+    let plist = std::fs::read_to_string(out.join("Info.plist")).unwrap();
+    // Sanity: the rendered plist still has the baseline keys.
+    assert!(plist.contains("<key>CFBundleDisplayName</key>"));
+    // And nothing from any plugin's NAME landed.
+    assert!(!plist.contains("NSCameraUsageDescription"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ============================================================================
+// Android: Permissions + MetaData
+// ============================================================================
+
+#[test]
+fn android_extra_permissions_reach_the_rendered_manifest() {
+    let mut app = base_android_app();
+    app.plugin::<AndroidPermissionsCfg>(|c| {
+        c.add("android.permission.CAMERA")
+            .add("android.permission.RECORD_AUDIO");
+    });
+
+    let inputs = whisker_cng::android::inputs_from(
+        &app,
+        "hello_world".into(),
+        PathBuf::from("../.."),
+        "hello-world".into(),
+        "0.1.0".into(),
+        "0.1.0".into(),
+        "https://whiskerrs.github.io/whisker/maven".into(),
+        "https://whiskerrs.github.io/lynx/maven".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/android");
+    whisker_cng::android::sync(&out, &inputs).unwrap();
+
+    let manifest = std::fs::read_to_string(out.join("app/src/main/AndroidManifest.xml")).unwrap();
+    assert!(
+        manifest.contains("<uses-permission android:name=\"android.permission.INTERNET\""),
+        "{manifest}",
+    );
+    assert!(
+        manifest.contains("<uses-permission android:name=\"android.permission.CAMERA\""),
+        "{manifest}",
+    );
+    assert!(
+        manifest.contains("<uses-permission android:name=\"android.permission.RECORD_AUDIO\""),
+        "{manifest}",
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn android_duplicate_permissions_are_dedup_in_the_rendered_manifest() {
+    let mut app = base_android_app();
+    app.plugin::<AndroidPermissionsCfg>(|c| {
+        c.add("android.permission.CAMERA")
+            .add("android.permission.CAMERA");
+    });
+
+    let inputs = whisker_cng::android::inputs_from(
+        &app,
+        "hello_world".into(),
+        PathBuf::from("../.."),
+        "hello-world".into(),
+        "0.1.0".into(),
+        "0.1.0".into(),
+        "https://whiskerrs.github.io/whisker/maven".into(),
+        "https://whiskerrs.github.io/lynx/maven".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/android");
+    whisker_cng::android::sync(&out, &inputs).unwrap();
+
+    let manifest = std::fs::read_to_string(out.join("app/src/main/AndroidManifest.xml")).unwrap();
+    let count = manifest
+        .matches("<uses-permission android:name=\"android.permission.CAMERA\"")
+        .count();
+    assert_eq!(count, 1, "CAMERA appeared {count} times: {manifest}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn android_meta_data_reaches_the_rendered_manifest_inside_application() {
+    let mut app = base_android_app();
+    app.plugin::<AndroidMetaDataCfg>(|c| {
+        c.add("com.google.android.geo.API_KEY", "AIza-XYZ");
+    });
+
+    let inputs = whisker_cng::android::inputs_from(
+        &app,
+        "hello_world".into(),
+        PathBuf::from("../.."),
+        "hello-world".into(),
+        "0.1.0".into(),
+        "0.1.0".into(),
+        "https://whiskerrs.github.io/whisker/maven".into(),
+        "https://whiskerrs.github.io/lynx/maven".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/android");
+    whisker_cng::android::sync(&out, &inputs).unwrap();
+
+    let manifest = std::fs::read_to_string(out.join("app/src/main/AndroidManifest.xml")).unwrap();
+    assert!(manifest.contains("<application"), "{manifest}");
+    let app_open = manifest.find("<application").unwrap();
+    let app_close = manifest.find("</application>").unwrap();
+    let inside_application = &manifest[app_open..app_close];
+    assert!(
+        inside_application.contains("com.google.android.geo.API_KEY"),
+        "meta-data should be inside <application>: {manifest}",
+    );
+    assert!(inside_application.contains("AIza-XYZ"), "{manifest}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn android_no_plugin_declared_means_only_baseline_internet_permission() {
+    let app = base_android_app();
+    let inputs = whisker_cng::android::inputs_from(
+        &app,
+        "hello_world".into(),
+        PathBuf::from("../.."),
+        "hello-world".into(),
+        "0.1.0".into(),
+        "0.1.0".into(),
+        "https://whiskerrs.github.io/whisker/maven".into(),
+        "https://whiskerrs.github.io/lynx/maven".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/android");
+    whisker_cng::android::sync(&out, &inputs).unwrap();
+
+    let manifest = std::fs::read_to_string(out.join("app/src/main/AndroidManifest.xml")).unwrap();
+    // The hardcoded INTERNET permission must still be there.
+    assert!(manifest.contains("android.permission.INTERNET"));
+    // Nothing else.
+    assert!(!manifest.contains("android.permission.CAMERA"));
+    assert!(!manifest.contains("<meta-data"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}


### PR DESCRIPTION
## Summary

**Phase 2** ships three opt-in built-in plugins. **Phase 3** makes the engine the default code path inside \`inputs_from\` so user \`whisker.rs\` files can add Info.plist keys / Android permissions / manifest meta-data without touching the renderer.

Apps that never call \`app.plugin::<…>(…)\` see bit-identical output to pre-Phase-3 because every built-in's \`Cfg::default()\` is empty.

## Phase 2 — built-in plugins

| Plugin | Use case |
|---|---|
| **\`whisker-info-plist-extra\`** | Add Info.plist string keys (privacy descriptions, URL schemes) |
| **\`whisker-android-permissions\`** | Append \`<uses-permission>\` rows to AndroidManifest |
| **\`whisker-android-meta-data\`** | Append \`<meta-data>\` rows inside \`<application>\` (Firebase, Google Maps, App Links) |

\`\`\`rust
// User-facing whisker.rs:
app.plugin::<InfoPlistExtraCfg>(|c| c
    .add(\"NSCameraUsageDescription\", \"Take photos for posts.\")
    .add(\"LSApplicationQueriesSchemes\", \"comgooglemaps\"));

app.plugin::<AndroidPermissionsCfg>(|c| c
    .add(\"android.permission.CAMERA\"));

app.plugin::<AndroidMetaDataCfg>(|c| c
    .add(\"com.google.android.geo.API_KEY\", \"AIza...\"));
\`\`\`

## Phase 3 — engine as the default

- **\`Engine::with_builtins()\`** registers the three built-ins above.
- **\`ios::inputs_from\`** now runs the engine and reads back \`ctx.ios.info_plist\` string entries into \`IosInputs::extra_info_plist_kvs\`. Info.plist template gained \`{{extra_info_plist_kvs}}\` before \`</dict>\`; XML-escapes values.
- **\`android::inputs_from\`** runs the engine and reads \`ctx.android.manifest.{permissions, application_meta_data}\` into \`AndroidInputs::{extra_permissions, extra_meta_data}\`. \`AndroidManifest.xml\` template gained \`{{extra_uses_permissions}}\` (dedup'd) and \`{{extra_application_meta_data}}\` (inside \`<application>\`).
- **template_version bumps**: iOS 9 → 10, Android 5 → 6. Existing \`gen/\` trees regenerate on next sync so the new placeholder lines are present even when no plugin contributes.

## Backwards compatibility

- All pre-existing renderer tests pass unchanged. Apps without \`app.plugin::<…>\` calls produce identical XML modulo blank lines where empty placeholders substitute.
- Engine + built-ins always run; cost is one \`compose()\` per sync.

## What's NOT in this PR

- \`IosProjectIr::pbxproj_ops\` → pbxproj resource registration (future renderer pass).
- \`extra_files\` from IR copied into \`gen/\` (same reason).
- Legacy non-engine path removal — engine is purely additive. Phase 5 in RFC #164 retires the legacy.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo fmt -p whisker-cng\`
- [x] \`cargo clippy -p whisker-cng --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-cng\` — **79 tests pass** (65 unit + 7 e2e + 4 discovery + 3 subprocess), zero regressions

11 new unit tests (per-plugin); 7 new end-to-end tests verifying the engine → \`inputs_from\` → template substitution → rendered file pipeline including XML escaping and permission dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)