### PR TITLE
feat(cng): gradle IR pass-through to app/build.gradle.kts (B-direction PR 2)

### DIFF
--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -206,16 +206,23 @@ pub(crate) fn template_vars(inputs: &AndroidInputs) -> HashMap<&'static str, Str
 }
 
 /// Render `apply_plugins` entries as Kotlin DSL lines inside the
-/// `plugins { … }` block. Bare ids → `id("…")`; lines that already
-/// start with `id(` pass through verbatim (callers attach
-/// `version "…"` / `apply false` qualifiers themselves).
+/// `plugins { … }` block. Two shapes:
+///
+///   - Bare gradle plugin id (e.g. `"com.google.gms.google-services"`)
+///     → wrapped in `id("…")`.
+///   - Anything containing a `(` character (e.g. `id("…") version "X"`,
+///     `alias(libs.plugins.foo)`, `kotlin("jvm")`) → emitted
+///     verbatim. The Kotlin DSL's plugin block accepts every
+///     callable that returns a `PluginDependencySpec`, and bare
+///     gradle plugin ids never contain `(`, so this is a safe
+///     discriminator.
 fn render_extra_gradle_plugins(entries: &[String]) -> String {
     if entries.is_empty() {
         return String::new();
     }
     let mut out = String::new();
     for entry in entries {
-        if entry.starts_with("id(") {
+        if entry.contains('(') {
             out.push_str(&format!("    {entry}\n"));
         } else {
             out.push_str(&format!("    id(\"{entry}\")\n"));

--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -114,6 +114,20 @@ pub struct AndroidInputs {
     /// plugins contributing entries see deterministic output.
     #[serde(default)]
     pub extra_meta_data: Vec<MetaDataEntry>,
+    /// Extra entries the renderer drops into the app module's
+    /// `plugins { … }` block, just after the baseline Whisker /
+    /// AGP / Kotlin plugin ids. Bare ids (e.g.
+    /// `"com.google.gms.google-services"`) get wrapped in
+    /// `id("…")`; raw `id(...)` lines pass through verbatim so
+    /// users can attach `version "…"` / `apply false` qualifiers.
+    #[serde(default)]
+    pub extra_gradle_plugins: Vec<String>,
+    /// Extra raw lines the renderer drops into the app module's
+    /// `dependencies { … }` block. Each entry is emitted verbatim
+    /// (e.g.
+    /// `"implementation(\"com.google.firebase:firebase-analytics:21.5.0\")"`).
+    #[serde(default)]
+    pub extra_gradle_dependencies: Vec<String>,
     /// Bumped whenever the template *shape* changes (added file,
     /// renamed placeholder, …). The fingerprint mixes this in so
     /// existing `gen/` trees regenerate after an upgrade.
@@ -180,7 +194,51 @@ pub(crate) fn template_vars(inputs: &AndroidInputs) -> HashMap<&'static str, Str
         "extra_application_meta_data",
         render_extra_meta_data(&inputs.extra_meta_data),
     );
+    v.insert(
+        "extra_gradle_plugins",
+        render_extra_gradle_plugins(&inputs.extra_gradle_plugins),
+    );
+    v.insert(
+        "extra_gradle_dependencies",
+        render_extra_gradle_dependencies(&inputs.extra_gradle_dependencies),
+    );
     v
+}
+
+/// Render `apply_plugins` entries as Kotlin DSL lines inside the
+/// `plugins { … }` block. Bare ids → `id("…")`; lines that already
+/// start with `id(` pass through verbatim (callers attach
+/// `version "…"` / `apply false` qualifiers themselves).
+fn render_extra_gradle_plugins(entries: &[String]) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    for entry in entries {
+        if entry.starts_with("id(") {
+            out.push_str(&format!("    {entry}\n"));
+        } else {
+            out.push_str(&format!("    id(\"{entry}\")\n"));
+        }
+    }
+    if out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+fn render_extra_gradle_dependencies(entries: &[String]) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    for entry in entries {
+        out.push_str(&format!("    {entry}\n"));
+    }
+    if out.ends_with('\n') {
+        out.pop();
+    }
+    out
 }
 
 /// Render the engine-supplied permissions as `<uses-permission>`
@@ -476,6 +534,8 @@ pub fn inputs_from(
 
     let extra_permissions = android_ir.manifest.permissions.clone();
     let extra_meta_data = android_ir.manifest.application_meta_data.clone();
+    let extra_gradle_plugins = android_ir.gradle.apply_plugins.clone();
+    let extra_gradle_dependencies = android_ir.gradle.dependencies.clone();
 
     Ok(AndroidInputs {
         app_name,
@@ -493,14 +553,16 @@ pub fn inputs_from(
         lynx_maven_url,
         extra_permissions,
         extra_meta_data,
-        // Bumped 6 → 7 for the IR-canonical refactor (RFC #164
-        // B-direction PR 1): core fields (application_id, sdk
-        // versions, etc.) now flow through the engine's IR rather
-        // than direct AppConfig reads. The rendered output is
-        // bit-identical for apps that don't override anything; the
-        // fingerprint shape changed so existing `gen/android/`
-        // trees regenerate once.
-        template_version: 7,
+        extra_gradle_plugins,
+        extra_gradle_dependencies,
+        // Bumped 7 → 8 for the gradle-IR pass-through (RFC #164
+        // B-direction PR 2): `app/build.gradle.kts` gained
+        // `{{extra_gradle_plugins}}` and
+        // `{{extra_gradle_dependencies}}` placeholders. Existing
+        // `gen/android/` trees regenerate so the placeholders
+        // substitute correctly even before any plugin contributes
+        // content (they collapse to empty strings).
+        template_version: 8,
     })
 }
 
@@ -539,7 +601,9 @@ mod tests {
             lynx_maven_url: "https://whiskerrs.github.io/lynx/maven".into(),
             extra_permissions: Vec::new(),
             extra_meta_data: Vec::new(),
-            template_version: 7,
+            extra_gradle_plugins: Vec::new(),
+            extra_gradle_dependencies: Vec::new(),
+            template_version: 8,
         }
     }
 

--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -106,7 +106,9 @@ impl Engine {
         let mut e = Self::new();
         e.register(crate::plugins::info_plist_extra::InfoPlistExtraPlugin)
             .register(crate::plugins::android_permissions::AndroidPermissionsPlugin)
-            .register(crate::plugins::android_meta_data::AndroidMetaDataPlugin);
+            .register(crate::plugins::android_meta_data::AndroidMetaDataPlugin)
+            .register(crate::plugins::android_gradle_plugins::GradlePluginsPlugin)
+            .register(crate::plugins::android_gradle_dependencies::GradleDependenciesPlugin);
         e
     }
 

--- a/crates/whisker-cng/src/plugins/android_gradle_dependencies.rs
+++ b/crates/whisker-cng/src/plugins/android_gradle_dependencies.rs
@@ -1,0 +1,111 @@
+//! `whisker-gradle-dependencies` — append raw Gradle dependency
+//! lines to `app/build.gradle.kts`'s `dependencies { }` block.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! app.plugin::<GradleDependenciesCfg>(|c| c
+//!     .add("implementation(\"com.google.firebase:firebase-analytics:21.5.0\")")
+//!     .add("kapt(\"androidx.room:room-compiler:2.6.0\")"));
+//! ```
+//!
+//! Each entry is a raw DSL line. The renderer emits it verbatim
+//! inside `dependencies { }`. Letting users pass the full line
+//! keeps `implementation` / `api` / `kapt` / `runtimeOnly` / etc.
+//! distinctions expressible without modelling Gradle's full
+//! configuration grammar.
+
+use serde::{Deserialize, Serialize};
+use whisker_plugin::{GenerateContext, Operation, Plugin, PluginConfig, Target};
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct GradleDependenciesCfg {
+    /// Raw `<configuration>("coordinate")` lines, e.g.
+    /// `"implementation(\"com.google.firebase:firebase-analytics:21.5.0\")"`.
+    /// Renderer emits each verbatim inside `dependencies { }`.
+    #[serde(default)]
+    pub entries: Vec<String>,
+}
+
+impl GradleDependenciesCfg {
+    pub fn add(&mut self, line: impl Into<String>) -> &mut Self {
+        self.entries.push(line.into());
+        self
+    }
+}
+
+impl PluginConfig for GradleDependenciesCfg {
+    const NAME: &'static str = "whisker-gradle-dependencies";
+}
+
+pub struct GradleDependenciesPlugin;
+
+impl Plugin for GradleDependenciesPlugin {
+    type Config = GradleDependenciesCfg;
+    fn apply(&self, ctx: &mut GenerateContext, cfg: &GradleDependenciesCfg) -> anyhow::Result<()> {
+        let Some(android) = ctx.android.as_mut() else {
+            return Ok(());
+        };
+        if cfg.entries.is_empty() {
+            return Ok(());
+        }
+        let count = cfg.entries.len();
+        android.gradle.dependencies.extend(cfg.entries.clone());
+        ctx.journal.record(
+            GradleDependenciesCfg::NAME,
+            Target::Android,
+            "gradle.dependencies",
+            Operation::ArrayPush { count },
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::AndroidProjectIr;
+
+    fn ctx_with_android() -> GenerateContext {
+        GenerateContext {
+            android: Some(AndroidProjectIr::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_config_contributes_nothing() {
+        let mut ctx = ctx_with_android();
+        GradleDependenciesPlugin
+            .apply(&mut ctx, &GradleDependenciesCfg::default())
+            .unwrap();
+        assert!(ctx.android.unwrap().gradle.dependencies.is_empty());
+        assert!(ctx.journal.records.is_empty());
+    }
+
+    #[test]
+    fn populated_config_appends_each_entry_preserving_order() {
+        let mut cfg = GradleDependenciesCfg::default();
+        cfg.add("implementation(\"com.google.firebase:firebase-analytics:21.5.0\")")
+            .add("kapt(\"androidx.room:room-compiler:2.6.0\")");
+        let mut ctx = ctx_with_android();
+        GradleDependenciesPlugin.apply(&mut ctx, &cfg).unwrap();
+        let deps = ctx.android.unwrap().gradle.dependencies;
+        assert_eq!(deps.len(), 2);
+        assert!(deps[0].starts_with("implementation("));
+        assert!(deps[1].starts_with("kapt("));
+    }
+
+    #[test]
+    fn one_array_push_event_per_invocation() {
+        let mut cfg = GradleDependenciesCfg::default();
+        cfg.add("implementation(\"a:b:1\")")
+            .add("implementation(\"c:d:1\")");
+        let mut ctx = ctx_with_android();
+        GradleDependenciesPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert_eq!(ctx.journal.records.len(), 1);
+        let r = &ctx.journal.records[0];
+        assert_eq!(r.plugin, "whisker-gradle-dependencies");
+        assert!(matches!(r.operation, Operation::ArrayPush { count: 2 }));
+    }
+}

--- a/crates/whisker-cng/src/plugins/android_gradle_plugins.rs
+++ b/crates/whisker-cng/src/plugins/android_gradle_plugins.rs
@@ -1,0 +1,121 @@
+//! `whisker-gradle-plugins` — append Gradle `plugins { id(...) }`
+//! entries to the generated `app/build.gradle.kts`.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! app.plugin::<GradlePluginsCfg>(|c| c
+//!     .add("com.google.gms.google-services")
+//!     .add_raw("id(\"com.android.dynamic-feature\") version \"8.5.0\""));
+//! ```
+//!
+//! The plugin appends each entry to `ctx.android.gradle.apply_plugins`.
+//! The renderer wraps simple `id`-only strings in `id("...")`; raw
+//! `id(...)` lines pass through verbatim so users can attach
+//! `version "X"` / `apply false` / etc.
+
+use serde::{Deserialize, Serialize};
+use whisker_plugin::{GenerateContext, Operation, Plugin, PluginConfig, Target};
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct GradlePluginsCfg {
+    /// Plugin identifiers to apply. Each entry is either:
+    ///   - a bare gradle plugin id (e.g. `"com.google.gms.google-services"`),
+    ///     which the renderer wraps in `id("…")`
+    ///   - a raw `id(...)` DSL line (starts with `id(`), which the
+    ///     renderer emits verbatim. Use this for `version "…"` /
+    ///     `apply false` qualifiers.
+    #[serde(default)]
+    pub entries: Vec<String>,
+}
+
+impl GradlePluginsCfg {
+    /// Bare plugin id. Renderer wraps it in `id("…")`.
+    pub fn add(&mut self, id: impl Into<String>) -> &mut Self {
+        self.entries.push(id.into());
+        self
+    }
+    /// Raw `id(...)` line. Renderer emits verbatim.
+    pub fn add_raw(&mut self, line: impl Into<String>) -> &mut Self {
+        self.entries.push(line.into());
+        self
+    }
+}
+
+impl PluginConfig for GradlePluginsCfg {
+    const NAME: &'static str = "whisker-gradle-plugins";
+}
+
+pub struct GradlePluginsPlugin;
+
+impl Plugin for GradlePluginsPlugin {
+    type Config = GradlePluginsCfg;
+    fn apply(&self, ctx: &mut GenerateContext, cfg: &GradlePluginsCfg) -> anyhow::Result<()> {
+        let Some(android) = ctx.android.as_mut() else {
+            return Ok(());
+        };
+        if cfg.entries.is_empty() {
+            return Ok(());
+        }
+        let count = cfg.entries.len();
+        android.gradle.apply_plugins.extend(cfg.entries.clone());
+        ctx.journal.record(
+            GradlePluginsCfg::NAME,
+            Target::Android,
+            "gradle.apply_plugins",
+            Operation::ArrayPush { count },
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::AndroidProjectIr;
+
+    fn ctx_with_android() -> GenerateContext {
+        GenerateContext {
+            android: Some(AndroidProjectIr::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_config_contributes_nothing() {
+        let mut ctx = ctx_with_android();
+        GradlePluginsPlugin
+            .apply(&mut ctx, &GradlePluginsCfg::default())
+            .unwrap();
+        assert!(ctx.android.unwrap().gradle.apply_plugins.is_empty());
+        assert!(ctx.journal.records.is_empty());
+    }
+
+    #[test]
+    fn populated_config_appends_each_entry_preserving_order() {
+        let mut cfg = GradlePluginsCfg::default();
+        cfg.add("com.google.gms.google-services")
+            .add_raw("id(\"com.android.dynamic-feature\") version \"8.5.0\"");
+        let mut ctx = ctx_with_android();
+        GradlePluginsPlugin.apply(&mut ctx, &cfg).unwrap();
+        let plugins = ctx.android.unwrap().gradle.apply_plugins;
+        assert_eq!(plugins.len(), 2);
+        assert_eq!(plugins[0], "com.google.gms.google-services");
+        assert_eq!(
+            plugins[1],
+            "id(\"com.android.dynamic-feature\") version \"8.5.0\"",
+        );
+    }
+
+    #[test]
+    fn one_array_push_event_per_invocation() {
+        let mut cfg = GradlePluginsCfg::default();
+        cfg.add("a").add("b").add("c");
+        let mut ctx = ctx_with_android();
+        GradlePluginsPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert_eq!(ctx.journal.records.len(), 1);
+        let r = &ctx.journal.records[0];
+        assert_eq!(r.plugin, "whisker-gradle-plugins");
+        assert!(matches!(r.operation, Operation::ArrayPush { count: 3 }));
+    }
+}

--- a/crates/whisker-cng/src/plugins/mod.rs
+++ b/crates/whisker-cng/src/plugins/mod.rs
@@ -34,6 +34,8 @@
 //! brief justification in this list and a registration line in
 //! [`crate::Engine::with_builtins`].
 
+pub mod android_gradle_dependencies;
+pub mod android_gradle_plugins;
 pub mod android_meta_data;
 pub mod android_permissions;
 pub mod info_plist_extra;

--- a/crates/whisker-cng/src/templates/android/app/build.gradle.kts
+++ b/crates/whisker-cng/src/templates/android/app/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
     // into AGP's source sets. Version is inherited from the
     // `pluginManagement.plugins` block in settings.gradle.kts.
     id("rs.whisker.gradle")
+{{extra_gradle_plugins}}
 }
 
 android {
@@ -67,4 +68,5 @@ dependencies {
     implementation("rs.whisker:whisker-runtime-android:{{whisker_sdk_version}}")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.core:core-ktx:1.13.1")
+{{extra_gradle_dependencies}}
 }

--- a/crates/whisker-cng/tests/gradle_e2e.rs
+++ b/crates/whisker-cng/tests/gradle_e2e.rs
@@ -88,6 +88,27 @@ fn gradle_raw_id_line_passes_through_verbatim() {
 }
 
 #[test]
+fn gradle_version_catalog_alias_passes_through_verbatim() {
+    // Version catalog form — the renderer recognises `(` as a
+    // "this is already DSL" marker and doesn't double-wrap.
+    let mut app = base_android_app();
+    app.plugin::<GradlePluginsCfg>(|c| {
+        c.add_raw("alias(libs.plugins.kotlin.android)");
+    });
+    let gradle = sync_and_read_gradle(&app);
+    assert!(
+        gradle.contains("alias(libs.plugins.kotlin.android)"),
+        "{gradle}",
+    );
+    // Specifically, the renderer must NOT have wrapped it as
+    // `id("alias(libs.plugins.kotlin.android)")`.
+    assert!(
+        !gradle.contains("id(\"alias("),
+        "renderer wrapped a DSL call: {gradle}",
+    );
+}
+
+#[test]
 fn gradle_plugin_entry_lands_inside_the_plugins_block() {
     let mut app = base_android_app();
     app.plugin::<GradlePluginsCfg>(|c| {

--- a/crates/whisker-cng/tests/gradle_e2e.rs
+++ b/crates/whisker-cng/tests/gradle_e2e.rs
@@ -1,0 +1,207 @@
+//! End-to-end check on the gradle IR pass-through (RFC #164
+//! B-direction PR 2): built-in plugin → engine → `inputs_from` →
+//! template substitution → rendered `app/build.gradle.kts`.
+//!
+//! Complements:
+//!   - `crates/whisker-cng/src/plugins/android_gradle_*.rs`
+//!     unit tests, which only check IR-level mutations
+//!   - `tests/builtins_e2e.rs` which covers Info.plist /
+//!     permissions / meta-data — those land in the manifest, not
+//!     gradle
+//!
+//! Together with PR 1's IR-canonical refactor, this means
+//! Firebase / Google Maps / Crashlytics integration is now
+//! expressible as a single `app.plugin::<…>(|c| …)` block without
+//! forking `whisker-cng`.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use whisker_app_config::AppConfig;
+use whisker_cng::plugins::android_gradle_dependencies::GradleDependenciesCfg;
+use whisker_cng::plugins::android_gradle_plugins::GradlePluginsCfg;
+
+fn unique_tempdir() -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let p = std::env::temp_dir().join(format!("whisker-cng-gradle-e2e-{pid}-{n}"));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn base_android_app() -> AppConfig {
+    let mut a = AppConfig::default();
+    a.name("HelloWorld").android(|x| {
+        x.application_id("rs.whisker.examples.helloworld");
+    });
+    a
+}
+
+fn sync_and_read_gradle(app: &AppConfig) -> String {
+    let inputs = whisker_cng::android::inputs_from(
+        app,
+        "hello_world".into(),
+        PathBuf::from("../.."),
+        "hello-world".into(),
+        "0.1.0".into(),
+        "0.1.0".into(),
+        "https://whiskerrs.github.io/whisker/maven".into(),
+        "https://whiskerrs.github.io/lynx/maven".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/android");
+    whisker_cng::android::sync(&out, &inputs).unwrap();
+    let gradle = std::fs::read_to_string(out.join("app/build.gradle.kts")).unwrap();
+    let _ = std::fs::remove_dir_all(&tmp);
+    gradle
+}
+
+// ============================================================================
+// Gradle plugins block
+// ============================================================================
+
+#[test]
+fn gradle_bare_plugin_id_is_wrapped_in_id_call() {
+    let mut app = base_android_app();
+    app.plugin::<GradlePluginsCfg>(|c| {
+        c.add("com.google.gms.google-services");
+    });
+    let gradle = sync_and_read_gradle(&app);
+    assert!(
+        gradle.contains("id(\"com.google.gms.google-services\")"),
+        "{gradle}",
+    );
+}
+
+#[test]
+fn gradle_raw_id_line_passes_through_verbatim() {
+    let mut app = base_android_app();
+    app.plugin::<GradlePluginsCfg>(|c| {
+        c.add_raw("id(\"com.android.dynamic-feature\") version \"8.5.0\"");
+    });
+    let gradle = sync_and_read_gradle(&app);
+    assert!(
+        gradle.contains("id(\"com.android.dynamic-feature\") version \"8.5.0\""),
+        "{gradle}",
+    );
+}
+
+#[test]
+fn gradle_plugin_entry_lands_inside_the_plugins_block() {
+    let mut app = base_android_app();
+    app.plugin::<GradlePluginsCfg>(|c| {
+        c.add("com.google.gms.google-services");
+    });
+    let gradle = sync_and_read_gradle(&app);
+    // Find the plugins { } block and check our entry is inside.
+    let plugins_open = gradle.find("plugins {").unwrap();
+    let plugins_close = gradle[plugins_open..].find("\n}").unwrap() + plugins_open;
+    let inside_plugins = &gradle[plugins_open..plugins_close];
+    assert!(
+        inside_plugins.contains("com.google.gms.google-services"),
+        "must be inside plugins block: {inside_plugins}",
+    );
+}
+
+// ============================================================================
+// Gradle dependencies block
+// ============================================================================
+
+#[test]
+fn gradle_dependency_line_emitted_verbatim() {
+    let mut app = base_android_app();
+    app.plugin::<GradleDependenciesCfg>(|c| {
+        c.add("implementation(\"com.google.firebase:firebase-analytics:21.5.0\")");
+    });
+    let gradle = sync_and_read_gradle(&app);
+    assert!(
+        gradle.contains("implementation(\"com.google.firebase:firebase-analytics:21.5.0\")"),
+        "{gradle}",
+    );
+}
+
+#[test]
+fn gradle_dependencies_land_inside_the_dependencies_block() {
+    let mut app = base_android_app();
+    app.plugin::<GradleDependenciesCfg>(|c| {
+        c.add("implementation(\"com.example:lib:1.0\")");
+    });
+    let gradle = sync_and_read_gradle(&app);
+    let deps_open = gradle.find("dependencies {").unwrap();
+    let deps_close = gradle[deps_open..].find("\n}").unwrap() + deps_open;
+    let inside_deps = &gradle[deps_open..deps_close];
+    assert!(
+        inside_deps.contains("com.example:lib:1.0"),
+        "must be inside dependencies block: {inside_deps}",
+    );
+}
+
+#[test]
+fn gradle_dependencies_preserve_insertion_order() {
+    let mut app = base_android_app();
+    app.plugin::<GradleDependenciesCfg>(|c| {
+        c.add("implementation(\"com.example:a:1.0\")")
+            .add("implementation(\"com.example:b:1.0\")")
+            .add("implementation(\"com.example:c:1.0\")");
+    });
+    let gradle = sync_and_read_gradle(&app);
+    let a = gradle.find("com.example:a").unwrap();
+    let b = gradle.find("com.example:b").unwrap();
+    let c = gradle.find("com.example:c").unwrap();
+    assert!(a < b && b < c, "ordering broken: {a} {b} {c}");
+}
+
+#[test]
+fn gradle_supports_non_implementation_configurations() {
+    // Real-world: Firebase needs kapt + classpath stuff in
+    // various configurations. The raw-line approach must let
+    // users emit any of them.
+    let mut app = base_android_app();
+    app.plugin::<GradleDependenciesCfg>(|c| {
+        c.add("kapt(\"androidx.room:room-compiler:2.6.0\")")
+            .add("runtimeOnly(\"com.example:plugin:1.0\")");
+    });
+    let gradle = sync_and_read_gradle(&app);
+    assert!(gradle.contains("kapt(\"androidx.room:room-compiler:2.6.0\")"));
+    assert!(gradle.contains("runtimeOnly(\"com.example:plugin:1.0\")"));
+}
+
+// ============================================================================
+// No-op when no plugin declared
+// ============================================================================
+
+#[test]
+fn gradle_baseline_unchanged_when_no_plugin_declared() {
+    let app = base_android_app();
+    let gradle = sync_and_read_gradle(&app);
+    // Baseline plugins / deps must still be there.
+    assert!(gradle.contains("id(\"com.android.application\")"));
+    assert!(gradle.contains("id(\"rs.whisker.gradle\")"));
+    assert!(gradle.contains("implementation(\"rs.whisker:whisker-runtime-android:"));
+    // Nothing from any plugin.
+    assert!(!gradle.contains("com.google.gms.google-services"));
+    assert!(!gradle.contains("firebase-analytics"));
+}
+
+// ============================================================================
+// Realistic scenario: Firebase
+// ============================================================================
+
+#[test]
+fn gradle_firebase_scenario_reaches_the_rendered_file() {
+    // Recreate the exact pattern a `whisker-firebase` plugin
+    // (Phase 4 dogfood) would produce.
+    let mut app = base_android_app();
+    app.plugin::<GradlePluginsCfg>(|c| {
+        c.add("com.google.gms.google-services");
+    });
+    app.plugin::<GradleDependenciesCfg>(|c| {
+        c.add("implementation(platform(\"com.google.firebase:firebase-bom:33.1.0\"))")
+            .add("implementation(\"com.google.firebase:firebase-analytics\")");
+    });
+    let gradle = sync_and_read_gradle(&app);
+    assert!(gradle.contains("id(\"com.google.gms.google-services\")"));
+    assert!(gradle.contains("platform(\"com.google.firebase:firebase-bom:33.1.0\")"));
+    assert!(gradle.contains("implementation(\"com.google.firebase:firebase-analytics\")"));
+}


### PR DESCRIPTION
## Summary

PR 2 in the \"make cng fully plugin-driven\" series. Until now, \`AndroidProjectIr::gradle.{apply_plugins, dependencies}\` was visible to plugins but never reached the rendered \`build.gradle.kts\`. This PR wires it end-to-end.

\`\`\`rust
// whisker.rs — Firebase integration, no fork needed:
app.plugin::<GradlePluginsCfg>(|c| c
    .add(\"com.google.gms.google-services\"));
app.plugin::<GradleDependenciesCfg>(|c| c
    .add(\"implementation(platform(\\\"com.google.firebase:firebase-bom:33.1.0\\\"))\")
    .add(\"implementation(\\\"com.google.firebase:firebase-analytics\\\")\"));
\`\`\`

## Built-in plugins (2 new)

| Plugin | Use case |
|---|---|
| **\`whisker-gradle-plugins\`** | \`plugins { id(\"…\") }\` entries (bare ids wrapped, raw \`id(...)\` lines pass through) |
| **\`whisker-gradle-dependencies\`** | Raw lines in \`dependencies { }\` — \`implementation\` / \`api\` / \`kapt\` / \`runtimeOnly\` / \`platform(...)\` / \`classpath(...)\` all expressible |

Both opt-in (\`Cfg::default()\` is empty).

## Renderer

- \`AndroidInputs\` gains \`extra_gradle_plugins\` + \`extra_gradle_dependencies\`.
- \`app/build.gradle.kts\` template gains \`{{extra_gradle_plugins}}\` (after \`id(\"rs.whisker.gradle\")\`) and \`{{extra_gradle_dependencies}}\` (after the baseline deps).
- \`android::inputs_from\` reads from \`android_ir.gradle.{apply_plugins, dependencies}\`.
- \`template_version\` 7 → 8.

## Backwards compatibility

Apps without \`app.plugin::<Gradle…Cfg>(…)\` render an unchanged \`build.gradle.kts\` modulo empty-placeholder blank lines.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo fmt -p whisker-cng\`
- [x] \`cargo clippy -p whisker-cng --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-cng\` — **101 tests pass** (71 unit + 7 builtins-e2e + 7 core-override + 9 gradle-e2e + 4 discovery + 3 subprocess). Zero regressions.

Unit (6 new); E2E (9 new) including bare id wrapping, raw line passthrough, block placement, insertion order preservation, non-\`implementation\` configurations, baseline regression, full Firebase scenario.

## What's NOT in this PR

- PR 3: \`pbxproj_ops\` applied to iOS xcodeproj
- PR 4: \`extra_files\` copied into \`gen/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)