### PR TITLE
feat(cng): extra_files → gen/{ios,android}/ (B-direction PR 3)

### DIFF
--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -28,10 +28,11 @@
 //! `rs/whisker/examples/helloworld/`.
 
 use anyhow::{anyhow, Context, Result};
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use whisker_app_config::AppConfig;
-use whisker_plugin::MetaDataEntry;
+use whisker_plugin::{FileEntry, MetaDataEntry};
 
 use crate::compose::{EnabledTargets, Engine};
 use crate::fingerprint;
@@ -128,6 +129,11 @@ pub struct AndroidInputs {
     /// `"implementation(\"com.google.firebase:firebase-analytics:21.5.0\")"`).
     #[serde(default)]
     pub extra_gradle_dependencies: Vec<String>,
+    /// Plugin-supplied additional files dropped into `gen/android/`.
+    /// Keys are relative paths (validated at write time); values
+    /// are [`FileEntry`]s — UTF-8 contents + optional POSIX mode.
+    #[serde(default)]
+    pub extra_files: BTreeMap<PathBuf, FileEntry>,
     /// Bumped whenever the template *shape* changes (added file,
     /// renamed placeholder, …). The fingerprint mixes this in so
     /// existing `gen/` trees regenerate after an upgrade.
@@ -378,6 +384,25 @@ fn write_files(out_dir: &Path, inputs: &AndroidInputs) -> Result<()> {
         false,
     )?;
 
+    // Plugin-supplied `extra_files`. Paths are validated to be
+    // relative and traversal-free; on Unix, `mode` is applied via
+    // the existing `write_file` executable flag (0o755 when set
+    // and `>= 0o100`, otherwise the default 0o644).
+    for (rel, entry) in &inputs.extra_files {
+        crate::render::validate_extra_file_path(rel).with_context(|| {
+            format!(
+                "extra_files entry `{}` (Android plugin contribution)",
+                rel.display(),
+            )
+        })?;
+        let abs = out_dir.join(rel);
+        // The Android renderer's `write_file` takes a `bool`
+        // executable flag (0o755 on Unix). Apply that for any
+        // mode that has the user-execute bit set.
+        let executable = entry.mode.map(|m| m & 0o100 != 0).unwrap_or(false);
+        write_file(&abs, entry.contents.as_bytes(), executable)?;
+    }
+
     Ok(())
 }
 
@@ -543,6 +568,7 @@ pub fn inputs_from(
     let extra_meta_data = android_ir.manifest.application_meta_data.clone();
     let extra_gradle_plugins = android_ir.gradle.apply_plugins.clone();
     let extra_gradle_dependencies = android_ir.gradle.dependencies.clone();
+    let extra_files = android_ir.extra_files.clone();
 
     Ok(AndroidInputs {
         app_name,
@@ -562,14 +588,11 @@ pub fn inputs_from(
         extra_meta_data,
         extra_gradle_plugins,
         extra_gradle_dependencies,
-        // Bumped 7 → 8 for the gradle-IR pass-through (RFC #164
-        // B-direction PR 2): `app/build.gradle.kts` gained
-        // `{{extra_gradle_plugins}}` and
-        // `{{extra_gradle_dependencies}}` placeholders. Existing
-        // `gen/android/` trees regenerate so the placeholders
-        // substitute correctly even before any plugin contributes
-        // content (they collapse to empty strings).
-        template_version: 8,
+        extra_files,
+        // Bumped 8 → 9 for `extra_files` write-through (RFC #164
+        // B-direction PR 3). The fingerprint shape grew an
+        // `extra_files` field; existing trees regenerate.
+        template_version: 9,
     })
 }
 
@@ -610,7 +633,8 @@ mod tests {
             extra_meta_data: Vec::new(),
             extra_gradle_plugins: Vec::new(),
             extra_gradle_dependencies: Vec::new(),
-            template_version: 8,
+            extra_files: BTreeMap::new(),
+            template_version: 9,
         }
     }
 

--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -28,8 +28,7 @@
 //! `rs/whisker/examples/helloworld/`.
 
 use anyhow::{anyhow, Context, Result};
-use std::collections::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use whisker_app_config::AppConfig;
 use whisker_plugin::{FileEntry, MetaDataEntry};
@@ -132,6 +131,16 @@ pub struct AndroidInputs {
     /// Plugin-supplied additional files dropped into `gen/android/`.
     /// Keys are relative paths (validated at write time); values
     /// are [`FileEntry`]s — UTF-8 contents + optional POSIX mode.
+    ///
+    /// Mode handling on Android is intentionally coarser than the
+    /// iOS renderer's: the existing `write_file` helper takes a
+    /// `bool` executable flag, so the renderer projects
+    /// `FileEntry::mode` onto "executable yes/no" (any mode with
+    /// the user-execute bit set → 0o755, otherwise 0o644). Plugins
+    /// that need finer-grained Android permissions today would have
+    /// to ship a wrapper script that `chmod`s at build time —
+    /// loosening this is a one-line `write_file` refactor when the
+    /// first consumer needs it.
     #[serde(default)]
     pub extra_files: BTreeMap<PathBuf, FileEntry>,
     /// Bumped whenever the template *shape* changes (added file,

--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -108,7 +108,9 @@ impl Engine {
             .register(crate::plugins::android_permissions::AndroidPermissionsPlugin)
             .register(crate::plugins::android_meta_data::AndroidMetaDataPlugin)
             .register(crate::plugins::android_gradle_plugins::GradlePluginsPlugin)
-            .register(crate::plugins::android_gradle_dependencies::GradleDependenciesPlugin);
+            .register(crate::plugins::android_gradle_dependencies::GradleDependenciesPlugin)
+            .register(crate::plugins::ios_extra_files::IosExtraFilesPlugin)
+            .register(crate::plugins::android_extra_files::AndroidExtraFilesPlugin);
         e
     }
 

--- a/crates/whisker-cng/src/ios.rs
+++ b/crates/whisker-cng/src/ios.rs
@@ -31,7 +31,7 @@ use anyhow::{anyhow, Context, Result};
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use whisker_app_config::AppConfig;
-use whisker_plugin::{GenerateContext, PlistValue};
+use whisker_plugin::{FileEntry, GenerateContext, PlistValue};
 
 use crate::compose::{EnabledTargets, Engine};
 use crate::fingerprint;
@@ -92,6 +92,12 @@ pub struct IosInputs {
     /// renderer change, not a wire-format break.
     #[serde(default)]
     pub extra_info_plist_kvs: BTreeMap<String, String>,
+    /// Plugin-supplied additional files dropped into `gen/ios/`.
+    /// Keys are relative paths (validated to be relative + free of
+    /// `..` traversal at write time); values are
+    /// [`FileEntry`]s — UTF-8 contents + optional POSIX mode.
+    #[serde(default)]
+    pub extra_files: BTreeMap<PathBuf, FileEntry>,
     pub template_version: u32,
 }
 
@@ -220,6 +226,46 @@ fn write_files(out_dir: &Path, inputs: &IosInputs) -> Result<()> {
         xcscheme.as_bytes(),
     )?;
 
+    // Plugin-supplied `extra_files`. Paths are validated to be
+    // relative + traversal-free; on Unix, `mode` is applied
+    // verbatim. iOS doesn't typically need the executable bit, but
+    // shipping the helper means a plugin can drop a code-signing
+    // script alongside the project.
+    for (rel, entry) in &inputs.extra_files {
+        crate::render::validate_extra_file_path(rel).with_context(|| {
+            format!(
+                "extra_files entry `{}` (iOS plugin contribution)",
+                rel.display(),
+            )
+        })?;
+        let abs = out_dir.join(rel);
+        write_file(&abs, entry.contents.as_bytes())?;
+        apply_mode(&abs, entry.mode)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn apply_mode(path: &Path, mode: Option<u32>) -> Result<()> {
+    if let Some(m) = mode {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path)
+            .with_context(|| format!("stat {} for chmod", path.display()))?
+            .permissions();
+        perms.set_mode(m);
+        std::fs::set_permissions(path, perms)
+            .with_context(|| format!("chmod {:o} on {}", m, path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn apply_mode(_path: &Path, _mode: Option<u32>) -> Result<()> {
+    // POSIX mode bits don't translate cleanly to Windows ACLs.
+    // The IR is platform-agnostic so we accept the field on every
+    // host and silently ignore it on Windows — matches how cargo
+    // and rustc handle the same situation in `[[bin]]` targets.
     Ok(())
 }
 
@@ -316,6 +362,7 @@ pub fn inputs_from(
         .unwrap_or_else(|| "13.0".to_string());
 
     let extra_info_plist_kvs = extract_info_plist_string_kvs(&ctx);
+    let extra_files = ios_ir.extra_files.clone();
 
     Ok(IosInputs {
         app_name,
@@ -329,14 +376,11 @@ pub fn inputs_from(
         workspace_root,
         user_package,
         extra_info_plist_kvs,
-        // Bumped 10 → 11 for the IR-canonical refactor (RFC #164
-        // B-direction PR 1): core fields now flow through the
-        // engine's IR rather than direct AppConfig reads. The
-        // rendered output is bit-identical for apps that don't
-        // override any core field via a plugin, but the
-        // fingerprint shape changed so existing `gen/ios/` trees
-        // regenerate once.
-        template_version: 11,
+        extra_files,
+        // Bumped 11 → 12 for `extra_files` write-through (RFC #164
+        // B-direction PR 3). The fingerprint shape grew an
+        // `extra_files` field; existing trees regenerate.
+        template_version: 12,
     })
 }
 
@@ -390,7 +434,8 @@ mod tests {
             workspace_root: PathBuf::from("/abs/workspace"),
             user_package: "hello-world".into(),
             extra_info_plist_kvs: BTreeMap::new(),
-            template_version: 11,
+            extra_files: BTreeMap::new(),
+            template_version: 12,
         }
     }
 

--- a/crates/whisker-cng/src/plugins/android_extra_files.rs
+++ b/crates/whisker-cng/src/plugins/android_extra_files.rs
@@ -1,0 +1,119 @@
+//! `whisker-android-extra-files` — drop arbitrary text files into
+//! the generated `gen/android/` tree.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! app.plugin::<AndroidExtraFilesCfg>(|c| c
+//!     .add("app/google-services.json", json_str)
+//!     .add("app/proguard-rules-extra.pro", proguard_text));
+//! ```
+//!
+//! Mirror of [`crate::plugins::ios_extra_files`] for Android.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use whisker_plugin::{FileEntry, GenerateContext, Operation, Plugin, PluginConfig, Target};
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct AndroidExtraFilesCfg {
+    /// Path → file. Path is relative to `gen/android/`.
+    #[serde(default)]
+    pub files: BTreeMap<PathBuf, FileEntry>,
+}
+
+impl AndroidExtraFilesCfg {
+    pub fn add(&mut self, path: impl Into<PathBuf>, contents: impl Into<String>) -> &mut Self {
+        self.files.insert(
+            path.into(),
+            FileEntry {
+                contents: contents.into(),
+                mode: None,
+            },
+        );
+        self
+    }
+    pub fn add_with_mode(
+        &mut self,
+        path: impl Into<PathBuf>,
+        contents: impl Into<String>,
+        mode: u32,
+    ) -> &mut Self {
+        self.files.insert(
+            path.into(),
+            FileEntry {
+                contents: contents.into(),
+                mode: Some(mode),
+            },
+        );
+        self
+    }
+}
+
+impl PluginConfig for AndroidExtraFilesCfg {
+    const NAME: &'static str = "whisker-android-extra-files";
+}
+
+pub struct AndroidExtraFilesPlugin;
+
+impl Plugin for AndroidExtraFilesPlugin {
+    type Config = AndroidExtraFilesCfg;
+    fn apply(&self, ctx: &mut GenerateContext, cfg: &AndroidExtraFilesCfg) -> anyhow::Result<()> {
+        let Some(android) = ctx.android.as_mut() else {
+            return Ok(());
+        };
+        if cfg.files.is_empty() {
+            return Ok(());
+        }
+        let count = cfg.files.len();
+        for (path, entry) in &cfg.files {
+            android.extra_files.insert(path.clone(), entry.clone());
+        }
+        ctx.journal.record(
+            AndroidExtraFilesCfg::NAME,
+            Target::Android,
+            "extra_files",
+            Operation::ArrayPush { count },
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::AndroidProjectIr;
+
+    fn ctx_with_android() -> GenerateContext {
+        GenerateContext {
+            android: Some(AndroidProjectIr::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_config_contributes_nothing() {
+        let mut ctx = ctx_with_android();
+        AndroidExtraFilesPlugin
+            .apply(&mut ctx, &AndroidExtraFilesCfg::default())
+            .unwrap();
+        assert!(ctx.android.unwrap().extra_files.is_empty());
+    }
+
+    #[test]
+    fn populated_config_writes_each_file_to_ir() {
+        let mut cfg = AndroidExtraFilesCfg::default();
+        cfg.add("app/google-services.json", "{\"foo\": 1}")
+            .add_with_mode("scripts/build.sh", "#!/bin/sh\n", 0o755);
+        let mut ctx = ctx_with_android();
+        AndroidExtraFilesPlugin.apply(&mut ctx, &cfg).unwrap();
+        let files = ctx.android.unwrap().extra_files;
+        assert_eq!(files.len(), 2);
+        assert_eq!(
+            files[&PathBuf::from("app/google-services.json")].contents,
+            "{\"foo\": 1}",
+        );
+        assert_eq!(files[&PathBuf::from("scripts/build.sh")].mode, Some(0o755),);
+    }
+}

--- a/crates/whisker-cng/src/plugins/ios_extra_files.rs
+++ b/crates/whisker-cng/src/plugins/ios_extra_files.rs
@@ -1,0 +1,154 @@
+//! `whisker-ios-extra-files` — drop arbitrary text files into the
+//! generated `gen/ios/` tree.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! app.plugin::<IosExtraFilesCfg>(|c| c
+//!     .add("Sources/Helper.swift", SWIFT_SRC)
+//!     .add("Resources/Config.json", json_str)
+//!     .add_with_mode("Scripts/run.sh", SCRIPT, 0o755));
+//! ```
+//!
+//! The plugin writes each `(relative_path, contents)` pair into
+//! `ctx.ios.extra_files`. The renderer copies them into
+//! `gen/ios/<relative_path>` after the template-driven files have
+//! been written. Paths are validated to be relative and free of
+//! `..` traversal — a plugin can't escape the gen tree.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use whisker_plugin::{FileEntry, GenerateContext, Operation, Plugin, PluginConfig, Target};
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct IosExtraFilesCfg {
+    /// Path → file. Path is relative to `gen/ios/`. `BTreeMap` for
+    /// deterministic iteration order — the fingerprint hashes the
+    /// IR and `HashMap` random ordering would break the skip path.
+    #[serde(default)]
+    pub files: BTreeMap<PathBuf, FileEntry>,
+}
+
+impl IosExtraFilesCfg {
+    /// Add (or replace) one file with default `0o644` permissions.
+    pub fn add(&mut self, path: impl Into<PathBuf>, contents: impl Into<String>) -> &mut Self {
+        self.files.insert(
+            path.into(),
+            FileEntry {
+                contents: contents.into(),
+                mode: None,
+            },
+        );
+        self
+    }
+    /// Add (or replace) one file with explicit POSIX mode bits
+    /// (e.g. `0o755` for an executable script).
+    pub fn add_with_mode(
+        &mut self,
+        path: impl Into<PathBuf>,
+        contents: impl Into<String>,
+        mode: u32,
+    ) -> &mut Self {
+        self.files.insert(
+            path.into(),
+            FileEntry {
+                contents: contents.into(),
+                mode: Some(mode),
+            },
+        );
+        self
+    }
+}
+
+impl PluginConfig for IosExtraFilesCfg {
+    const NAME: &'static str = "whisker-ios-extra-files";
+}
+
+pub struct IosExtraFilesPlugin;
+
+impl Plugin for IosExtraFilesPlugin {
+    type Config = IosExtraFilesCfg;
+    fn apply(&self, ctx: &mut GenerateContext, cfg: &IosExtraFilesCfg) -> anyhow::Result<()> {
+        let Some(ios) = ctx.ios.as_mut() else {
+            return Ok(());
+        };
+        if cfg.files.is_empty() {
+            return Ok(());
+        }
+        let count = cfg.files.len();
+        for (path, entry) in &cfg.files {
+            ios.extra_files.insert(path.clone(), entry.clone());
+        }
+        ctx.journal.record(
+            IosExtraFilesCfg::NAME,
+            Target::Ios,
+            "extra_files",
+            Operation::ArrayPush { count },
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::IosProjectIr;
+
+    fn ctx_with_ios() -> GenerateContext {
+        GenerateContext {
+            ios: Some(IosProjectIr::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_config_contributes_nothing() {
+        let mut ctx = ctx_with_ios();
+        IosExtraFilesPlugin
+            .apply(&mut ctx, &IosExtraFilesCfg::default())
+            .unwrap();
+        assert!(ctx.ios.unwrap().extra_files.is_empty());
+        assert!(ctx.journal.records.is_empty());
+    }
+
+    #[test]
+    fn populated_config_writes_each_file_to_ir() {
+        let mut cfg = IosExtraFilesCfg::default();
+        cfg.add("Sources/Helper.swift", "// helper").add_with_mode(
+            "Scripts/run.sh",
+            "#!/bin/sh\necho ok\n",
+            0o755,
+        );
+        let mut ctx = ctx_with_ios();
+        IosExtraFilesPlugin.apply(&mut ctx, &cfg).unwrap();
+        let files = ctx.ios.unwrap().extra_files;
+        assert_eq!(files.len(), 2);
+        let helper = &files[&PathBuf::from("Sources/Helper.swift")];
+        assert_eq!(helper.contents, "// helper");
+        assert!(helper.mode.is_none());
+        let script = &files[&PathBuf::from("Scripts/run.sh")];
+        assert_eq!(script.mode, Some(0o755));
+    }
+
+    #[test]
+    fn one_array_push_event_per_invocation() {
+        let mut cfg = IosExtraFilesCfg::default();
+        cfg.add("a.swift", "").add("b.swift", "").add("c.swift", "");
+        let mut ctx = ctx_with_ios();
+        IosExtraFilesPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert_eq!(ctx.journal.records.len(), 1);
+        let r = &ctx.journal.records[0];
+        assert_eq!(r.plugin, "whisker-ios-extra-files");
+        assert!(matches!(r.operation, Operation::ArrayPush { count: 3 }));
+    }
+
+    #[test]
+    fn no_ios_target_means_no_op() {
+        let mut cfg = IosExtraFilesCfg::default();
+        cfg.add("a.swift", "");
+        let mut ctx = GenerateContext::default();
+        IosExtraFilesPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert!(ctx.journal.records.is_empty());
+    }
+}

--- a/crates/whisker-cng/src/plugins/mod.rs
+++ b/crates/whisker-cng/src/plugins/mod.rs
@@ -34,8 +34,10 @@
 //! brief justification in this list and a registration line in
 //! [`crate::Engine::with_builtins`].
 
+pub mod android_extra_files;
 pub mod android_gradle_dependencies;
 pub mod android_gradle_plugins;
 pub mod android_meta_data;
 pub mod android_permissions;
 pub mod info_plist_extra;
+pub mod ios_extra_files;

--- a/crates/whisker-cng/src/render.rs
+++ b/crates/whisker-cng/src/render.rs
@@ -31,6 +31,31 @@ pub(crate) fn escape_xml(s: &str) -> String {
     out
 }
 
+/// Reject plugin-supplied `extra_files` paths that would escape
+/// the gen root: absolute paths, `..` traversal, and Windows
+/// drive prefixes (caught by `is_absolute` on Windows hosts).
+///
+/// Called by [`crate::ios`] / [`crate::android`] before writing
+/// any `extra_files` entry — a malicious or buggy plugin can't
+/// drop a file into the user's home dir / out of the workspace.
+pub(crate) fn validate_extra_file_path(path: &std::path::Path) -> anyhow::Result<()> {
+    if path.is_absolute() {
+        anyhow::bail!(
+            "extra_files path must be relative to the gen root: `{}`",
+            path.display(),
+        );
+    }
+    for component in path.components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            anyhow::bail!(
+                "extra_files path must not contain `..` (would escape gen root): `{}`",
+                path.display(),
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Replace every `{{key}}` in `template` with `vars[key]`. Returns
 /// `Err` if a placeholder doesn't have a corresponding entry — that
 /// almost always means a template was edited without updating the
@@ -102,5 +127,32 @@ mod tests {
     fn errors_on_unterminated_open_brace() {
         let err = render("hello {{name", &vars(&[("name", "x")])).unwrap_err();
         assert!(err.to_string().contains("unterminated"), "got: {err:#}");
+    }
+
+    use std::path::PathBuf;
+
+    #[test]
+    fn validate_extra_file_path_accepts_simple_relative_paths() {
+        validate_extra_file_path(&PathBuf::from("Sources/Helper.swift")).unwrap();
+        validate_extra_file_path(&PathBuf::from("app/google-services.json")).unwrap();
+        validate_extra_file_path(&PathBuf::from("file.txt")).unwrap();
+    }
+
+    #[test]
+    fn validate_extra_file_path_rejects_absolute_paths() {
+        let err = validate_extra_file_path(&PathBuf::from("/etc/passwd")).unwrap_err();
+        assert!(err.to_string().contains("must be relative"), "{err}");
+    }
+
+    #[test]
+    fn validate_extra_file_path_rejects_parent_dir_traversal() {
+        let err = validate_extra_file_path(&PathBuf::from("../../escape")).unwrap_err();
+        assert!(err.to_string().contains(".."), "{err}");
+    }
+
+    #[test]
+    fn validate_extra_file_path_rejects_middle_dot_dot() {
+        let err = validate_extra_file_path(&PathBuf::from("Sources/../escape")).unwrap_err();
+        assert!(err.to_string().contains(".."), "{err}");
     }
 }

--- a/crates/whisker-cng/tests/extra_files_e2e.rs
+++ b/crates/whisker-cng/tests/extra_files_e2e.rs
@@ -1,0 +1,258 @@
+//! End-to-end check on the `extra_files` IR pass-through (RFC #164
+//! B-direction PR 3): built-in plugin → engine → `inputs_from` →
+//! renderer drops the file into `gen/{ios,android}/`.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use whisker_app_config::AppConfig;
+use whisker_cng::plugins::android_extra_files::AndroidExtraFilesCfg;
+use whisker_cng::plugins::ios_extra_files::IosExtraFilesCfg;
+
+fn unique_tempdir() -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let p = std::env::temp_dir().join(format!("whisker-cng-extra-files-{pid}-{n}"));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn base_ios_app() -> AppConfig {
+    let mut a = AppConfig::default();
+    a.name("HelloWorld")
+        .bundle_id("rs.whisker.examples.helloWorld");
+    a
+}
+
+fn base_android_app() -> AppConfig {
+    let mut a = AppConfig::default();
+    a.name("HelloWorld").android(|x| {
+        x.application_id("rs.whisker.examples.helloworld");
+    });
+    a
+}
+
+fn sync_ios(app: &AppConfig) -> (PathBuf, PathBuf) {
+    let inputs = whisker_cng::ios::inputs_from(
+        app,
+        PathBuf::from("/abs/platforms/ios"),
+        PathBuf::from("/abs/gen/ios/whisker_modules"),
+        PathBuf::from("/abs/workspace"),
+        "hello-world".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/ios");
+    whisker_cng::ios::sync(&out, &inputs).unwrap();
+    (tmp, out)
+}
+
+fn sync_android(app: &AppConfig) -> (PathBuf, PathBuf) {
+    let inputs = whisker_cng::android::inputs_from(
+        app,
+        "hello_world".into(),
+        PathBuf::from("../.."),
+        "hello-world".into(),
+        "0.1.0".into(),
+        "0.1.0".into(),
+        "https://whiskerrs.github.io/whisker/maven".into(),
+        "https://whiskerrs.github.io/lynx/maven".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/android");
+    whisker_cng::android::sync(&out, &inputs).unwrap();
+    (tmp, out)
+}
+
+// ============================================================================
+// iOS
+// ============================================================================
+
+#[test]
+fn ios_extra_file_lands_at_the_declared_relative_path() {
+    let mut app = base_ios_app();
+    app.plugin::<IosExtraFilesCfg>(|c| {
+        c.add("Sources/Helper.swift", "// helper code\n");
+    });
+    let (tmp, out) = sync_ios(&app);
+    let helper = out.join("Sources/Helper.swift");
+    assert!(helper.is_file(), "missing: {}", helper.display());
+    assert_eq!(
+        std::fs::read_to_string(&helper).unwrap(),
+        "// helper code\n"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn ios_extra_file_creates_intermediate_directories() {
+    let mut app = base_ios_app();
+    app.plugin::<IosExtraFilesCfg>(|c| {
+        c.add(
+            "Resources/Config/Endpoints/prod.json",
+            "{\"api\": \"prod\"}",
+        );
+    });
+    let (tmp, out) = sync_ios(&app);
+    let path = out.join("Resources/Config/Endpoints/prod.json");
+    assert!(path.is_file(), "missing: {}", path.display());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[cfg(unix)]
+#[test]
+fn ios_extra_file_mode_is_applied_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+    let mut app = base_ios_app();
+    app.plugin::<IosExtraFilesCfg>(|c| {
+        c.add_with_mode("Scripts/run.sh", "#!/bin/sh\necho ok\n", 0o755);
+    });
+    let (tmp, out) = sync_ios(&app);
+    let script = out.join("Scripts/run.sh");
+    let mode = std::fs::metadata(&script).unwrap().permissions().mode();
+    assert_eq!(mode & 0o777, 0o755, "mode was {mode:o}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn ios_extra_file_with_absolute_path_is_rejected() {
+    let mut app = base_ios_app();
+    app.plugin::<IosExtraFilesCfg>(|c| {
+        c.add("/etc/passwd", "malicious");
+    });
+    let inputs = whisker_cng::ios::inputs_from(
+        &app,
+        PathBuf::from("/abs/platforms/ios"),
+        PathBuf::from("/abs/gen/ios/whisker_modules"),
+        PathBuf::from("/abs/workspace"),
+        "hello-world".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/ios");
+    let err = whisker_cng::ios::sync(&out, &inputs).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("must be relative"), "{msg}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn ios_extra_file_with_parent_dir_traversal_is_rejected() {
+    let mut app = base_ios_app();
+    app.plugin::<IosExtraFilesCfg>(|c| {
+        c.add("Sources/../escape.swift", "escape attempt");
+    });
+    let inputs = whisker_cng::ios::inputs_from(
+        &app,
+        PathBuf::from("/abs/platforms/ios"),
+        PathBuf::from("/abs/gen/ios/whisker_modules"),
+        PathBuf::from("/abs/workspace"),
+        "hello-world".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/ios");
+    let err = whisker_cng::ios::sync(&out, &inputs).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains(".."), "{msg}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn ios_no_plugin_means_no_extra_files_written() {
+    let app = base_ios_app();
+    let (tmp, out) = sync_ios(&app);
+    // No spurious files outside the known set.
+    assert!(out.join("Info.plist").exists());
+    assert!(!out.join("Sources/Helper.swift").exists());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ============================================================================
+// Android
+// ============================================================================
+
+#[test]
+fn android_extra_file_lands_at_the_declared_relative_path() {
+    let mut app = base_android_app();
+    app.plugin::<AndroidExtraFilesCfg>(|c| {
+        c.add("app/google-services.json", "{\"project\": \"demo\"}");
+    });
+    let (tmp, out) = sync_android(&app);
+    let gs = out.join("app/google-services.json");
+    assert!(gs.is_file(), "missing: {}", gs.display());
+    assert_eq!(
+        std::fs::read_to_string(&gs).unwrap(),
+        "{\"project\": \"demo\"}",
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[cfg(unix)]
+#[test]
+fn android_extra_file_mode_is_applied_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+    let mut app = base_android_app();
+    app.plugin::<AndroidExtraFilesCfg>(|c| {
+        c.add_with_mode("scripts/precheck.sh", "#!/bin/sh\n", 0o755);
+    });
+    let (tmp, out) = sync_android(&app);
+    let script = out.join("scripts/precheck.sh");
+    let mode = std::fs::metadata(&script).unwrap().permissions().mode();
+    assert_eq!(mode & 0o777, 0o755, "mode was {mode:o}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn android_extra_file_with_absolute_path_is_rejected() {
+    let mut app = base_android_app();
+    app.plugin::<AndroidExtraFilesCfg>(|c| {
+        c.add("/etc/passwd", "malicious");
+    });
+    let inputs = whisker_cng::android::inputs_from(
+        &app,
+        "hello_world".into(),
+        PathBuf::from("../.."),
+        "hello-world".into(),
+        "0.1.0".into(),
+        "0.1.0".into(),
+        "https://whiskerrs.github.io/whisker/maven".into(),
+        "https://whiskerrs.github.io/lynx/maven".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/android");
+    let err = whisker_cng::android::sync(&out, &inputs).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("must be relative"), "{msg}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ============================================================================
+// Realistic: Firebase google-services.json
+// ============================================================================
+
+#[test]
+fn android_firebase_google_services_json_drops_at_app_root() {
+    // What a real `whisker-firebase` plugin (Phase 4 dogfood)
+    // would do for Android — drop `google-services.json` next to
+    // the app's `build.gradle.kts`.
+    let mut app = base_android_app();
+    app.plugin::<AndroidExtraFilesCfg>(|c| {
+        c.add(
+            "app/google-services.json",
+            "{\"project_info\": {\"project_id\": \"demo\"}}",
+        );
+    });
+    let (tmp, out) = sync_android(&app);
+    let gs = out.join("app/google-services.json");
+    assert!(
+        gs.is_file(),
+        "google-services.json missing: {}",
+        gs.display()
+    );
+    let content = std::fs::read_to_string(&gs).unwrap();
+    assert!(content.contains("project_id"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}


### PR DESCRIPTION
## Summary

PR 3 in the \"fully plugin-driven\" series. \`IosProjectIr.extra_files\` and \`AndroidProjectIr.extra_files\` were visible to plugins but never reached disk. This PR copies them into \`gen/\`, gated by a strict path validator.

\`\`\`rust
// whisker.rs — Firebase google-services.json, no fork needed:
app.plugin::<AndroidExtraFilesCfg>(|c| c
    .add(\"app/google-services.json\", FIREBASE_CONFIG_JSON));

// iOS: drop a helper Swift file the user-level component imports
app.plugin::<IosExtraFilesCfg>(|c| c
    .add(\"Sources/Helper.swift\", SWIFT_SRC)
    .add_with_mode(\"Scripts/sign.sh\", SCRIPT, 0o755));
\`\`\`

## Built-in plugins (2 new)

| Plugin | Use case |
|---|---|
| **\`whisker-ios-extra-files\`** | Drop arbitrary text files into \`gen/ios/\` with optional POSIX mode |
| **\`whisker-android-extra-files\`** | Mirror for \`gen/android/\` |

Both opt-in.

## Renderer

- New \`render::validate_extra_file_path(rel)\` rejects \`is_absolute()\` paths and \`..\` components. Called before any write.
- \`IosInputs\` / \`AndroidInputs\` gain \`extra_files: BTreeMap<PathBuf, FileEntry>\`.
- \`{ios,android}::write_files\` iterates after the template-driven files.
- iOS: dedicated \`apply_mode\` helper applies POSIX mode on Unix (no-op on Windows, matching cargo's handling of \`[[bin]]\`).
- Android: reuses existing \`write_file(_, _, executable: bool)\`; \`0o100\` bit flips the flag.
- \`template_version\`: iOS 11 → 12, Android 8 → 9.

## Backwards compatibility

Apps without \`app.plugin::<…ExtraFilesCfg>(…)\` produce identical output.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo fmt -p whisker-cng\`
- [x] \`cargo clippy -p whisker-cng --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-cng\` — **119 tests pass** (81 unit + 10 extra-files-e2e + 10 gradle-e2e + 7 builtins-e2e + 7 core-override + 4 discovery + 3 subprocess). Zero regressions.

4 path-validator unit tests + 5 per-plugin tests + 10 e2e (relative path land, intermediate dirs, mode applied (#[cfg(unix)]), absolute path rejected, parent-dir traversal rejected, no-plugin = no-files, realistic Firebase scenario).

## What's NOT in this PR

- PR 4: \`pbxproj_ops\` applied to the iOS xcodeproj (heaviest of the remaining items).
- Eventually: renderer reads IR directly without the \`IosInputs\` / \`AndroidInputs\` intermediate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)