### PR TITLE
feat(cng): pbxproj_ops via template placeholders (B-direction PR 4)

### DIFF
--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -110,7 +110,8 @@ impl Engine {
             .register(crate::plugins::android_gradle_plugins::GradlePluginsPlugin)
             .register(crate::plugins::android_gradle_dependencies::GradleDependenciesPlugin)
             .register(crate::plugins::ios_extra_files::IosExtraFilesPlugin)
-            .register(crate::plugins::android_extra_files::AndroidExtraFilesPlugin);
+            .register(crate::plugins::android_extra_files::AndroidExtraFilesPlugin)
+            .register(crate::plugins::ios_pbxproj_ops::IosPbxprojOpsPlugin);
         e
     }
 

--- a/crates/whisker-cng/src/ios.rs
+++ b/crates/whisker-cng/src/ios.rs
@@ -31,7 +31,7 @@ use anyhow::{anyhow, Context, Result};
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use whisker_app_config::AppConfig;
-use whisker_plugin::{FileEntry, GenerateContext, PlistValue};
+use whisker_plugin::{FileEntry, GenerateContext, PbxprojOp, PlistValue};
 
 use crate::compose::{EnabledTargets, Engine};
 use crate::fingerprint;
@@ -98,6 +98,16 @@ pub struct IosInputs {
     /// [`FileEntry`]s — UTF-8 contents + optional POSIX mode.
     #[serde(default)]
     pub extra_files: BTreeMap<PathBuf, FileEntry>,
+    /// Plugin-supplied structural mutations against the Xcode
+    /// `project.pbxproj`. Each variant maps to a small set of
+    /// generated entries in the rendered pbxproj — see
+    /// [`PbxprojOp`] for the supported ops and
+    /// [`render_pbxproj_op_placeholders`] for the renderer's
+    /// behaviour. Deterministic UUIDs (FNV-1a over each op's
+    /// content) keep the rendered file byte-identical across
+    /// rebuilds.
+    #[serde(default)]
+    pub pbxproj_ops: Vec<PbxprojOp>,
     pub template_version: u32,
 }
 
@@ -148,7 +158,190 @@ pub(crate) fn template_vars(inputs: &IosInputs) -> HashMap<&'static str, String>
         "extra_info_plist_kvs",
         render_extra_info_plist_kvs(&inputs.extra_info_plist_kvs),
     );
+    let pbx = render_pbxproj_op_placeholders(&inputs.pbxproj_ops);
+    v.insert("extra_pbxproj_build_file_entries", pbx.build_file_entries);
+    v.insert(
+        "extra_pbxproj_file_reference_entries",
+        pbx.file_reference_entries,
+    );
+    v.insert("extra_pbxproj_sources_phase_files", pbx.sources_phase_files);
+    v.insert(
+        "extra_pbxproj_resources_phase_files",
+        pbx.resources_phase_files,
+    );
+    v.insert(
+        "extra_pbxproj_frameworks_phase_files",
+        pbx.frameworks_phase_files,
+    );
+    v.insert(
+        "extra_pbxproj_plugin_files_group_children",
+        pbx.plugin_files_group_children,
+    );
+    v.insert(
+        "extra_pbxproj_target_build_settings",
+        pbx.target_build_settings,
+    );
     v
+}
+
+/// Bundled output of [`render_pbxproj_op_placeholders`] — one
+/// field per pbxproj-template placeholder so adding a new
+/// op-derived section stays a single-line change here + a
+/// matching `{{…}}` in the template.
+struct PbxprojRendered {
+    build_file_entries: String,
+    file_reference_entries: String,
+    sources_phase_files: String,
+    resources_phase_files: String,
+    frameworks_phase_files: String,
+    plugin_files_group_children: String,
+    target_build_settings: String,
+}
+
+/// Translate the engine's `Vec<PbxprojOp>` into the seven
+/// pbxproj-template placeholder strings the renderer needs. Empty
+/// inputs → empty strings for every placeholder so the template
+/// stays valid pbxproj even with no plugin contributions.
+///
+/// UUIDs are deterministic ([`pbxproj_uuid`]). A given
+/// `(op variant, payload)` pair produces the same UUID across
+/// every render, which keeps the rendered file byte-identical
+/// across rebuilds and lets the fingerprint cache skip path do
+/// its job.
+fn render_pbxproj_op_placeholders(ops: &[PbxprojOp]) -> PbxprojRendered {
+    let mut build_file_entries = String::new();
+    let mut file_reference_entries = String::new();
+    let mut sources_phase_files = String::new();
+    let mut resources_phase_files = String::new();
+    let mut frameworks_phase_files = String::new();
+    let mut plugin_files_group_children = String::new();
+    let mut target_build_settings = String::new();
+
+    for op in ops {
+        match op {
+            PbxprojOp::AddResource { path } => {
+                let path_str = path.display().to_string();
+                let fileref_uuid = pbxproj_uuid(&format!("PBXFileReference:{path_str}"));
+                let buildfile_uuid = pbxproj_uuid(&format!("PBXBuildFile:Resources:{path_str}"));
+                let file_type = last_known_file_type(path);
+                build_file_entries.push_str(&format!(
+                    "\t\t{buildfile_uuid} /* {path_str} in Resources */ = \
+                     {{isa = PBXBuildFile; fileRef = {fileref_uuid} /* {path_str} */; }};\n",
+                ));
+                file_reference_entries.push_str(&format!(
+                    "\t\t{fileref_uuid} /* {path_str} */ = \
+                     {{isa = PBXFileReference; lastKnownFileType = {file_type}; \
+                     path = \"{path_str}\"; sourceTree = \"<group>\"; }};\n",
+                ));
+                resources_phase_files.push_str(&format!(
+                    "\t\t\t\t{buildfile_uuid} /* {path_str} in Resources */,\n",
+                ));
+                plugin_files_group_children
+                    .push_str(&format!("\t\t\t\t{fileref_uuid} /* {path_str} */,\n",));
+            }
+            PbxprojOp::AddSource { path } => {
+                let path_str = path.display().to_string();
+                let fileref_uuid = pbxproj_uuid(&format!("PBXFileReference:{path_str}"));
+                let buildfile_uuid = pbxproj_uuid(&format!("PBXBuildFile:Sources:{path_str}"));
+                let file_type = last_known_file_type(path);
+                build_file_entries.push_str(&format!(
+                    "\t\t{buildfile_uuid} /* {path_str} in Sources */ = \
+                     {{isa = PBXBuildFile; fileRef = {fileref_uuid} /* {path_str} */; }};\n",
+                ));
+                file_reference_entries.push_str(&format!(
+                    "\t\t{fileref_uuid} /* {path_str} */ = \
+                     {{isa = PBXFileReference; lastKnownFileType = {file_type}; \
+                     path = \"{path_str}\"; sourceTree = \"<group>\"; }};\n",
+                ));
+                sources_phase_files.push_str(&format!(
+                    "\t\t\t\t{buildfile_uuid} /* {path_str} in Sources */,\n",
+                ));
+                plugin_files_group_children
+                    .push_str(&format!("\t\t\t\t{fileref_uuid} /* {path_str} */,\n",));
+            }
+            PbxprojOp::LinkSystemFramework { name } => {
+                let fileref_uuid = pbxproj_uuid(&format!("PBXFileReference:Framework:{name}"));
+                let buildfile_uuid = pbxproj_uuid(&format!("PBXBuildFile:Frameworks:{name}"));
+                build_file_entries.push_str(&format!(
+                    "\t\t{buildfile_uuid} /* {name} in Frameworks */ = \
+                     {{isa = PBXBuildFile; fileRef = {fileref_uuid} /* {name} */; }};\n",
+                ));
+                file_reference_entries.push_str(&format!(
+                    "\t\t{fileref_uuid} /* {name} */ = \
+                     {{isa = PBXFileReference; lastKnownFileType = wrapper.framework; \
+                     name = \"{name}\"; path = \"System/Library/Frameworks/{name}\"; \
+                     sourceTree = SDKROOT; }};\n",
+                ));
+                frameworks_phase_files.push_str(&format!(
+                    "\t\t\t\t{buildfile_uuid} /* {name} in Frameworks */,\n",
+                ));
+                plugin_files_group_children
+                    .push_str(&format!("\t\t\t\t{fileref_uuid} /* {name} */,\n",));
+            }
+            PbxprojOp::SetBuildSetting { key, value } => {
+                target_build_settings.push_str(&format!("\t\t\t\t\t{key} = \"{value}\";\n"));
+            }
+        }
+    }
+
+    // Trim trailing newlines so the surrounding template's own
+    // newlines aren't doubled up. Empty strings stay empty.
+    fn trim(s: &mut String) {
+        if s.ends_with('\n') {
+            s.pop();
+        }
+    }
+    trim(&mut build_file_entries);
+    trim(&mut file_reference_entries);
+    trim(&mut sources_phase_files);
+    trim(&mut resources_phase_files);
+    trim(&mut frameworks_phase_files);
+    trim(&mut plugin_files_group_children);
+    trim(&mut target_build_settings);
+
+    PbxprojRendered {
+        build_file_entries,
+        file_reference_entries,
+        sources_phase_files,
+        resources_phase_files,
+        frameworks_phase_files,
+        plugin_files_group_children,
+        target_build_settings,
+    }
+}
+
+/// Pick a `lastKnownFileType` for a file path, by extension. Falls
+/// back to `text` for anything unknown — Xcode tolerates a wrong
+/// guess; it just affects the navigator icon.
+fn last_known_file_type(path: &Path) -> &'static str {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("swift") => "sourcecode.swift",
+        Some("m") => "sourcecode.c.objc",
+        Some("mm") => "sourcecode.cpp.objcpp",
+        Some("h") => "sourcecode.c.h",
+        Some("plist") => "text.plist.xml",
+        Some("json") => "text.json",
+        Some("png") => "image.png",
+        Some("jpg") | Some("jpeg") => "image.jpeg",
+        Some("xcassets") => "folder.assetcatalog",
+        Some("storyboard") => "file.storyboard",
+        Some("xib") => "file.xib",
+        _ => "text",
+    }
+}
+
+/// Deterministic 24-hex-char UUID for a stable string seed.
+/// Pbxproj refs are 24-char hex strings (96-bit). We splice two
+/// FNV-1a hashes (16 hex each, salted differently) and take the
+/// first 24 chars so the output stays in the canonical shape Xcode
+/// produces. Determinism is what matters — collision risk across
+/// `seed` strings within a single sync is negligible at this
+/// length and the rendered pbxproj would fail to parse on
+/// collision anyway, surfacing the bug immediately.
+fn pbxproj_uuid(seed: &str) -> String {
+    let a = crate::fingerprint::fingerprint(seed.as_bytes());
+    let b = crate::fingerprint::fingerprint(format!("{seed}-salt").as_bytes());
+    format!("{a}{}", &b[..8]).to_uppercase()
 }
 
 /// Render the engine-supplied `(key, string)` pairs as XML
@@ -363,6 +556,7 @@ pub fn inputs_from(
 
     let extra_info_plist_kvs = extract_info_plist_string_kvs(&ctx);
     let extra_files = ios_ir.extra_files.clone();
+    let pbxproj_ops = ios_ir.pbxproj_ops.clone();
 
     Ok(IosInputs {
         app_name,
@@ -377,10 +571,14 @@ pub fn inputs_from(
         user_package,
         extra_info_plist_kvs,
         extra_files,
-        // Bumped 11 → 12 for `extra_files` write-through (RFC #164
-        // B-direction PR 3). The fingerprint shape grew an
-        // `extra_files` field; existing trees regenerate.
-        template_version: 12,
+        pbxproj_ops,
+        // Bumped 12 → 13 for `pbxproj_ops` template-injection
+        // (RFC #164 B-direction PR 4). The pbxproj template grew
+        // seven new placeholders + a PBXResourcesBuildPhase
+        // section + a "Whisker Plugin Files" group; existing
+        // `gen/ios/` trees regenerate so the new sections render
+        // correctly even before any plugin contributes content.
+        template_version: 13,
     })
 }
 
@@ -435,7 +633,8 @@ mod tests {
             user_package: "hello-world".into(),
             extra_info_plist_kvs: BTreeMap::new(),
             extra_files: BTreeMap::new(),
-            template_version: 12,
+            pbxproj_ops: Vec::new(),
+            template_version: 13,
         }
     }
 

--- a/crates/whisker-cng/src/ios.rs
+++ b/crates/whisker-cng/src/ios.rs
@@ -279,7 +279,10 @@ fn render_pbxproj_op_placeholders(ops: &[PbxprojOp]) -> PbxprojRendered {
                     .push_str(&format!("\t\t\t\t{fileref_uuid} /* {name} */,\n",));
             }
             PbxprojOp::SetBuildSetting { key, value } => {
-                target_build_settings.push_str(&format!("\t\t\t\t\t{key} = \"{value}\";\n"));
+                target_build_settings.push_str(&format!(
+                    "\t\t\t\t\t{key} = \"{}\";\n",
+                    escape_pbxproj_string(value),
+                ));
             }
         }
     }
@@ -308,6 +311,22 @@ fn render_pbxproj_op_placeholders(ops: &[PbxprojOp]) -> PbxprojRendered {
         plugin_files_group_children,
         target_build_settings,
     }
+}
+
+/// Escape a string for inclusion inside a pbxproj double-quoted
+/// literal. The pbxproj "OpenStep plist" lexer treats `"` and `\`
+/// as the only chars that need backslash-escape inside `"…"`;
+/// everything else (whitespace, `$`, `(`, `)`, etc.) is fine.
+fn escape_pbxproj_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 /// Pick a `lastKnownFileType` for a file path, by extension. Falls

--- a/crates/whisker-cng/src/plugins/ios_pbxproj_ops.rs
+++ b/crates/whisker-cng/src/plugins/ios_pbxproj_ops.rs
@@ -1,0 +1,158 @@
+//! `whisker-ios-pbxproj-ops` — request structural mutations
+//! against the generated Xcode `project.pbxproj`.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! app.plugin::<IosPbxprojOpsCfg>(|c| c
+//!     .add_resource("GoogleService-Info.plist")
+//!     .link_system_framework("AVFoundation.framework")
+//!     .set_build_setting("OTHER_LDFLAGS", "-ObjC"));
+//! ```
+//!
+//! Each op is appended to `ctx.ios.pbxproj_ops`; the renderer
+//! produces the matching pbxproj entries (PBXFileReference,
+//! PBXBuildFile, PBXGroup membership, build-phase files list,
+//! buildSettings dict) at sync time. The plugin doesn't touch the
+//! pbxproj text directly — that work happens in
+//! `crate::ios::template_vars`.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use whisker_plugin::{GenerateContext, Operation, PbxprojOp, Plugin, PluginConfig, Target};
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct IosPbxprojOpsCfg {
+    #[serde(default)]
+    pub ops: Vec<PbxprojOp>,
+}
+
+impl IosPbxprojOpsCfg {
+    /// Register a file as a Resource (bundled into the `.app`).
+    /// Use for `GoogleService-Info.plist` etc. The file itself
+    /// should already exist on disk — drop it via
+    /// `whisker-ios-extra-files` first.
+    pub fn add_resource(&mut self, path: impl Into<PathBuf>) -> &mut Self {
+        self.ops.push(PbxprojOp::AddResource { path: path.into() });
+        self
+    }
+    /// Add a `.swift` / `.m` / `.mm` to the app target's Sources
+    /// compile phase.
+    pub fn add_source(&mut self, path: impl Into<PathBuf>) -> &mut Self {
+        self.ops.push(PbxprojOp::AddSource { path: path.into() });
+        self
+    }
+    /// Append `KEY = VALUE;` to both Debug and Release target
+    /// build settings.
+    pub fn set_build_setting(
+        &mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> &mut Self {
+        self.ops.push(PbxprojOp::SetBuildSetting {
+            key: key.into(),
+            value: value.into(),
+        });
+        self
+    }
+    /// Add a system framework (e.g. `"AVFoundation.framework"`)
+    /// to the app target's Frameworks link phase.
+    pub fn link_system_framework(&mut self, name: impl Into<String>) -> &mut Self {
+        self.ops
+            .push(PbxprojOp::LinkSystemFramework { name: name.into() });
+        self
+    }
+}
+
+impl PluginConfig for IosPbxprojOpsCfg {
+    const NAME: &'static str = "whisker-ios-pbxproj-ops";
+}
+
+pub struct IosPbxprojOpsPlugin;
+
+impl Plugin for IosPbxprojOpsPlugin {
+    type Config = IosPbxprojOpsCfg;
+    fn apply(&self, ctx: &mut GenerateContext, cfg: &IosPbxprojOpsCfg) -> anyhow::Result<()> {
+        let Some(ios) = ctx.ios.as_mut() else {
+            return Ok(());
+        };
+        if cfg.ops.is_empty() {
+            return Ok(());
+        }
+        let count = cfg.ops.len();
+        ios.pbxproj_ops.extend(cfg.ops.clone());
+        ctx.journal.record(
+            IosPbxprojOpsCfg::NAME,
+            Target::Ios,
+            "pbxproj_ops",
+            Operation::ArrayPush { count },
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::IosProjectIr;
+
+    fn ctx_with_ios() -> GenerateContext {
+        GenerateContext {
+            ios: Some(IosProjectIr::default()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_config_contributes_nothing() {
+        let mut ctx = ctx_with_ios();
+        IosPbxprojOpsPlugin
+            .apply(&mut ctx, &IosPbxprojOpsCfg::default())
+            .unwrap();
+        assert!(ctx.ios.unwrap().pbxproj_ops.is_empty());
+        assert!(ctx.journal.records.is_empty());
+    }
+
+    #[test]
+    fn populated_config_appends_each_op_preserving_order() {
+        let mut cfg = IosPbxprojOpsCfg::default();
+        cfg.add_resource("GoogleService-Info.plist")
+            .link_system_framework("AVFoundation.framework")
+            .set_build_setting("OTHER_LDFLAGS", "-ObjC");
+        let mut ctx = ctx_with_ios();
+        IosPbxprojOpsPlugin.apply(&mut ctx, &cfg).unwrap();
+        let ops = ctx.ios.unwrap().pbxproj_ops;
+        assert_eq!(ops.len(), 3);
+        match &ops[0] {
+            PbxprojOp::AddResource { path } => {
+                assert_eq!(path, &PathBuf::from("GoogleService-Info.plist"));
+            }
+            other => panic!("unexpected op: {other:?}"),
+        }
+        match &ops[1] {
+            PbxprojOp::LinkSystemFramework { name } => {
+                assert_eq!(name, "AVFoundation.framework");
+            }
+            other => panic!("unexpected op: {other:?}"),
+        }
+        match &ops[2] {
+            PbxprojOp::SetBuildSetting { key, value } => {
+                assert_eq!(key, "OTHER_LDFLAGS");
+                assert_eq!(value, "-ObjC");
+            }
+            other => panic!("unexpected op: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn one_array_push_event_per_invocation() {
+        let mut cfg = IosPbxprojOpsCfg::default();
+        cfg.add_resource("a").add_source("b.swift");
+        let mut ctx = ctx_with_ios();
+        IosPbxprojOpsPlugin.apply(&mut ctx, &cfg).unwrap();
+        assert_eq!(ctx.journal.records.len(), 1);
+        let r = &ctx.journal.records[0];
+        assert_eq!(r.plugin, "whisker-ios-pbxproj-ops");
+        assert!(matches!(r.operation, Operation::ArrayPush { count: 2 }));
+    }
+}

--- a/crates/whisker-cng/src/plugins/mod.rs
+++ b/crates/whisker-cng/src/plugins/mod.rs
@@ -41,3 +41,4 @@ pub mod android_meta_data;
 pub mod android_permissions;
 pub mod info_plist_extra;
 pub mod ios_extra_files;
+pub mod ios_pbxproj_ops;

--- a/crates/whisker-cng/src/templates/ios/Project.xcodeproj/project.pbxproj
+++ b/crates/whisker-cng/src/templates/ios/Project.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		46E97003F6597438A0AC93C0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEF20C6F91CCD1A10D66BCE /* AppDelegate.swift */; };
 		E5C85D1F07153227204F81D6 /* WhiskerRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = F920EEBD91D9E8039DA5A3F9 /* WhiskerRuntime */; };
 		8B41E0C2B6A95E8F70D2A38B /* WhiskerModules in Frameworks */ = {isa = PBXBuildFile; productRef = A4F2BE0925D17CE83AB061F7 /* WhiskerModules */; };
+{{extra_pbxproj_build_file_entries}}
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		35D466DB8920E7A52C599EBC /* {{ios_scheme}}.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "{{ios_scheme}}.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BEF20C6F91CCD1A10D66BCE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D3F08A1D5C9B6E7A2F104B59 /* whisker_modules */ = {isa = PBXFileReference; lastKnownFileType = folder; name = whisker_modules; path = "{{whisker_modules_ios_path}}"; sourceTree = "<absolute>"; };
+{{extra_pbxproj_file_reference_entries}}
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -25,6 +27,7 @@
 			files = (
 				E5C85D1F07153227204F81D6 /* WhiskerRuntime in Frameworks */,
 				8B41E0C2B6A95E8F70D2A38B /* WhiskerModules in Frameworks */,
+{{extra_pbxproj_frameworks_phase_files}}
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -52,6 +55,7 @@
 			children = (
 				E8E7FE2E076C1851BADE1012 /* Packages */,
 				2AFB6256646F5C748E027F5E /* Sources */,
+				F1F2F3F4F5F6F7F8F9FAFBFC /* Whisker Plugin Files */,
 				00961668E9C919BF4554CF95 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -64,6 +68,14 @@
 			name = Packages;
 			sourceTree = "<group>";
 		};
+		F1F2F3F4F5F6F7F8F9FAFBFC /* Whisker Plugin Files */ = {
+			isa = PBXGroup;
+			children = (
+{{extra_pbxproj_plugin_files_group_children}}
+			);
+			name = "Whisker Plugin Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -73,6 +85,7 @@
 			buildPhases = (
 				7E2B91D0F46A1C73B5A5DE91 /* Whisker Generate */,
 				4A590CB0D847DB4C38DDCDFC /* Sources */,
+				A1A2A3A4A5A6A7A8A9AAAB00 /* Resources */,
 				D4C57884A372C8EC69F16CAD /* Frameworks */,
 				3F69E4C8A2D75B6E81C094BB /* Whisker Embed Framework */,
 			);
@@ -167,12 +180,24 @@
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		A1A2A3A4A5A6A7A8A9AAAB00 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+{{extra_pbxproj_resources_phase_files}}
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		4A590CB0D847DB4C38DDCDFC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				46E97003F6597438A0AC93C0 /* AppDelegate.swift in Sources */,
+{{extra_pbxproj_sources_phase_files}}
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -258,6 +283,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "{{ios_bundle_id}}";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+{{extra_pbxproj_target_build_settings}}
 			};
 			name = Debug;
 		};
@@ -274,6 +300,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "{{ios_bundle_id}}";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+{{extra_pbxproj_target_build_settings}}
 			};
 			name = Release;
 		};

--- a/crates/whisker-cng/tests/pbxproj_ops_e2e.rs
+++ b/crates/whisker-cng/tests/pbxproj_ops_e2e.rs
@@ -1,0 +1,268 @@
+//! End-to-end check on `IosProjectIr.pbxproj_ops` → rendered
+//! `project.pbxproj` (RFC #164 B-direction PR 4).
+//!
+//! The renderer uses template injection — no pbxproj parsing.
+//! Plugin-contributed ops produce additions to:
+//!   - PBXBuildFile + PBXFileReference sections (file declared)
+//!   - PBXSourcesBuildPhase / PBXResourcesBuildPhase /
+//!     PBXFrameworksBuildPhase files lists (built into target)
+//!   - "Whisker Plugin Files" PBXGroup (visible in navigator)
+//!   - target Debug + Release XCBuildConfiguration buildSettings
+//!     (SetBuildSetting)
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use whisker_app_config::AppConfig;
+use whisker_cng::plugins::ios_pbxproj_ops::IosPbxprojOpsCfg;
+
+fn unique_tempdir() -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let p = std::env::temp_dir().join(format!("whisker-cng-pbxproj-e2e-{pid}-{n}"));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn base_app() -> AppConfig {
+    let mut a = AppConfig::default();
+    a.name("HelloWorld")
+        .bundle_id("rs.whisker.examples.helloWorld");
+    a
+}
+
+fn sync_and_read_pbxproj(app: &AppConfig) -> (PathBuf, String) {
+    let inputs = whisker_cng::ios::inputs_from(
+        app,
+        PathBuf::from("/abs/platforms/ios"),
+        PathBuf::from("/abs/gen/ios/whisker_modules"),
+        PathBuf::from("/abs/workspace"),
+        "hello-world".into(),
+    )
+    .unwrap();
+    let tmp = unique_tempdir();
+    let out = tmp.join("gen/ios");
+    whisker_cng::ios::sync(&out, &inputs).unwrap();
+    let pbxproj =
+        std::fs::read_to_string(out.join(format!("{}.xcodeproj/project.pbxproj", inputs.scheme)))
+            .unwrap();
+    (tmp, pbxproj)
+}
+
+// ============================================================================
+// AddResource — the Firebase GoogleService-Info.plist case
+// ============================================================================
+
+#[test]
+fn add_resource_emits_pbx_build_file_and_file_reference() {
+    let mut app = base_app();
+    app.plugin::<IosPbxprojOpsCfg>(|c| {
+        c.add_resource("GoogleService-Info.plist");
+    });
+    let (tmp, pbxproj) = sync_and_read_pbxproj(&app);
+    assert!(
+        pbxproj.contains("/* GoogleService-Info.plist in Resources */"),
+        "PBXBuildFile entry missing",
+    );
+    assert!(
+        pbxproj.contains("isa = PBXFileReference; lastKnownFileType = text.plist.xml")
+            && pbxproj.contains("path = \"GoogleService-Info.plist\""),
+        "PBXFileReference entry missing",
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn add_resource_appears_in_resources_build_phase_files_list() {
+    let mut app = base_app();
+    app.plugin::<IosPbxprojOpsCfg>(|c| {
+        c.add_resource("GoogleService-Info.plist");
+    });
+    let (tmp, pbxproj) = sync_and_read_pbxproj(&app);
+    let phase_open = pbxproj
+        .find("isa = PBXResourcesBuildPhase;")
+        .expect("PBXResourcesBuildPhase block");
+    let phase_close = pbxproj[phase_open..]
+        .find("\n\t\t};")
+        .map(|i| phase_open + i)
+        .unwrap();
+    let inside_phase = &pbxproj[phase_open..phase_close];
+    assert!(
+        inside_phase.contains("GoogleService-Info.plist in Resources"),
+        "Resources phase missing the file: {inside_phase}",
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn add_resource_appears_in_whisker_plugin_files_group() {
+    let mut app = base_app();
+    app.plugin::<IosPbxprojOpsCfg>(|c| {
+        c.add_resource("GoogleService-Info.plist");
+    });
+    let (tmp, pbxproj) = sync_and_read_pbxproj(&app);
+    let group_open = pbxproj.find("name = \"Whisker Plugin Files\"").unwrap();
+    // Walk backwards to children = (
+    let children_marker = pbxproj[..group_open].rfind("children = (").unwrap();
+    let group_section = &pbxproj[children_marker..group_open];
+    assert!(
+        group_section.contains("GoogleService-Info.plist"),
+        "navigator group missing the file: {group_section}",
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ============================================================================
+// AddSource
+// ============================================================================
+
+#[test]
+fn add_source_lands_in_sources_build_phase() {
+    let mut app = base_app();
+    app.plugin::<IosPbxprojOpsCfg>(|c| {
+        c.add_source("Sources/PluginContrib.swift");
+    });
+    let (tmp, pbxproj) = sync_and_read_pbxproj(&app);
+    let sources_open = pbxproj
+        .find("isa = PBXSourcesBuildPhase;")
+        .expect("PBXSourcesBuildPhase block");
+    let sources_close = pbxproj[sources_open..]
+        .find("\n\t\t};")
+        .map(|i| sources_open + i)
+        .unwrap();
+    let inside = &pbxproj[sources_open..sources_close];
+    assert!(
+        inside.contains("Sources/PluginContrib.swift in Sources"),
+        "Sources phase missing the file: {inside}",
+    );
+    // PBXFileReference's lastKnownFileType correctly identified.
+    assert!(pbxproj.contains("lastKnownFileType = sourcecode.swift"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ============================================================================
+// LinkSystemFramework
+// ============================================================================
+
+#[test]
+fn link_system_framework_emits_sdkroot_file_ref_and_appears_in_frameworks_phase() {
+    let mut app = base_app();
+    app.plugin::<IosPbxprojOpsCfg>(|c| {
+        c.link_system_framework("AVFoundation.framework");
+    });
+    let (tmp, pbxproj) = sync_and_read_pbxproj(&app);
+    // File reference uses sourceTree = SDKROOT and the canonical
+    // System/Library/Frameworks path.
+    assert!(
+        pbxproj.contains("path = \"System/Library/Frameworks/AVFoundation.framework\"")
+            && pbxproj.contains("sourceTree = SDKROOT"),
+        "framework file ref shape wrong",
+    );
+    // Frameworks phase carries the new entry.
+    let frameworks_open = pbxproj.find("isa = PBXFrameworksBuildPhase;").unwrap();
+    let frameworks_close = pbxproj[frameworks_open..]
+        .find("\n\t\t};")
+        .map(|i| frameworks_open + i)
+        .unwrap();
+    let inside = &pbxproj[frameworks_open..frameworks_close];
+    assert!(
+        inside.contains("AVFoundation.framework in Frameworks"),
+        "Frameworks phase missing: {inside}",
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ============================================================================
+// SetBuildSetting
+// ============================================================================
+
+#[test]
+fn set_build_setting_appears_in_both_debug_and_release_target_configs() {
+    let mut app = base_app();
+    app.plugin::<IosPbxprojOpsCfg>(|c| {
+        c.set_build_setting("OTHER_LDFLAGS", "$(inherited) -ObjC");
+    });
+    let (tmp, pbxproj) = sync_and_read_pbxproj(&app);
+    // Each target config block's buildSettings should now end with
+    // the new entry. We look for it appearing twice — once Debug,
+    // once Release.
+    let occurrences = pbxproj
+        .matches("OTHER_LDFLAGS = \"$(inherited) -ObjC\"")
+        .count();
+    assert_eq!(
+        occurrences, 2,
+        "expected the build setting in both Debug + Release, found {occurrences}",
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ============================================================================
+// Determinism — same input → same UUIDs across renders
+// ============================================================================
+
+#[test]
+fn rendering_twice_with_same_input_yields_byte_identical_pbxproj() {
+    let mut app = base_app();
+    app.plugin::<IosPbxprojOpsCfg>(|c| {
+        c.add_resource("GoogleService-Info.plist")
+            .link_system_framework("AVFoundation.framework");
+    });
+    let (tmp_a, pbxproj_a) = sync_and_read_pbxproj(&app);
+    let (tmp_b, pbxproj_b) = sync_and_read_pbxproj(&app);
+    assert_eq!(pbxproj_a, pbxproj_b);
+    let _ = std::fs::remove_dir_all(&tmp_a);
+    let _ = std::fs::remove_dir_all(&tmp_b);
+}
+
+// ============================================================================
+// No-op when no plugin contributes
+// ============================================================================
+
+#[test]
+fn baseline_pbxproj_is_intact_when_no_plugin_declared() {
+    let app = base_app();
+    let (tmp, pbxproj) = sync_and_read_pbxproj(&app);
+    // Baseline still present.
+    assert!(pbxproj.contains("PRODUCT_BUNDLE_IDENTIFIER = \"rs.whisker.examples.helloWorld\""));
+    assert!(pbxproj.contains("AppDelegate.swift"));
+    // PBXResourcesBuildPhase exists (it's always emitted), but
+    // its files list is empty.
+    let resources_open = pbxproj.find("isa = PBXResourcesBuildPhase;").unwrap();
+    let resources_close = pbxproj[resources_open..]
+        .find("\n\t\t};")
+        .map(|i| resources_open + i)
+        .unwrap();
+    let inside = &pbxproj[resources_open..resources_close];
+    // No entries beyond the empty files = () marker.
+    assert!(!inside.contains("in Resources */,"), "{inside}");
+    // No SetBuildSetting noise either.
+    assert!(!pbxproj.contains("/* extra-pbxproj */"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ============================================================================
+// Realistic: Firebase iOS scenario
+// ============================================================================
+
+#[test]
+fn firebase_ios_scenario_emits_resource_registration_and_objc_flag() {
+    // A `whisker-firebase` plugin (Phase 4 dogfood) would:
+    //   1. Drop GoogleService-Info.plist via extra_files
+    //   2. Register it as a resource so Xcode bundles it
+    //   3. Some Firebase SDKs require -ObjC linker flag for
+    //      categories on NSObject subclasses
+    let mut app = base_app();
+    app.plugin::<IosPbxprojOpsCfg>(|c| {
+        c.add_resource("GoogleService-Info.plist")
+            .set_build_setting("OTHER_LDFLAGS", "$(inherited) -ObjC");
+    });
+    let (tmp, pbxproj) = sync_and_read_pbxproj(&app);
+    assert!(pbxproj.contains("GoogleService-Info.plist in Resources"));
+    assert!(
+        pbxproj
+            .matches("OTHER_LDFLAGS = \"$(inherited) -ObjC\"")
+            .count()
+            == 2,
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/crates/whisker-cng/tests/pbxproj_ops_e2e.rs
+++ b/crates/whisker-cng/tests/pbxproj_ops_e2e.rs
@@ -196,6 +196,28 @@ fn set_build_setting_appears_in_both_debug_and_release_target_configs() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
+#[test]
+fn set_build_setting_escapes_quotes_in_value() {
+    // Some compiler defines need quotes inside the value, e.g.
+    // `-DFOO="bar"` becomes `-DFOO=\"bar\"` in the pbxproj.
+    // Without escaping, the plain `"` would terminate the
+    // surrounding OpenStep plist string and break the parser.
+    let mut app = base_app();
+    app.plugin::<IosPbxprojOpsCfg>(|c| {
+        c.set_build_setting(
+            "GCC_PREPROCESSOR_DEFINITIONS",
+            "FOO=\"bar baz\"",
+        );
+    });
+    let (tmp, pbxproj) = sync_and_read_pbxproj(&app);
+    // The escaped form ends up inside the quoted literal.
+    assert!(
+        pbxproj.contains("GCC_PREPROCESSOR_DEFINITIONS = \"FOO=\\\"bar baz\\\"\""),
+        "value not escaped: {pbxproj}",
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
 // ============================================================================
 // Determinism — same input → same UUIDs across renders
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes the B-direction \"fully plugin-driven\" series. \`IosProjectIr.pbxproj_ops\` was decorative until now. This PR wires all 4 \`PbxprojOp\` variants (AddResource, AddSource, LinkSystemFramework, SetBuildSetting) into the rendered Xcode project via **template placeholder injection** — no pbxproj parser, no XML-format edits, just compose fragments from the IR and substitute.

\`\`\`rust
// whisker.rs — Firebase iOS, no fork needed:
app.plugin::<IosExtraFilesCfg>(|c| c
    .add(\"GoogleService-Info.plist\", FIREBASE_PLIST));
app.plugin::<IosPbxprojOpsCfg>(|c| c
    .add_resource(\"GoogleService-Info.plist\")
    .set_build_setting(\"OTHER_LDFLAGS\", \"\$(inherited) -ObjC\"));
\`\`\`

## Built-in plugin

**\`whisker-ios-pbxproj-ops\`** — \`add_resource\`, \`add_source\`, \`link_system_framework\`, \`set_build_setting\` builder methods. Opt-in.

## Renderer wiring

- \`pbxproj_uuid(seed)\` — deterministic 24-hex UUIDs via two spliced FNV-1a hashes. Same op → same UUID every render.
- \`last_known_file_type(path)\` — covers common iOS extensions (.swift / .m / .mm / .plist / .json / .png / .xcassets / .storyboard etc.). Unknowns fall back to \`text\`.
- 7 new template placeholders for PBXBuildFile / PBXFileReference / 3× build-phase files lists / plugin-files group / target build settings.
- Template gained: a new always-emitted PBXResourcesBuildPhase section, a new \"Whisker Plugin Files\" PBXGroup, and a Resources reference in PBXNativeTarget.buildPhases.
- \`template_version\` 12 → 13.

## Backwards compatibility

Apps without \`app.plugin::<IosPbxprojOpsCfg>(…)\` render an unchanged pbxproj modulo always-emitted (but empty) Resources phase + plugin-files group. Both are inert in Xcode.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo fmt -p whisker-cng\`
- [x] \`cargo clippy -p whisker-cng --all-targets -- -D warnings\`
- [x] \`cargo test -p whisker-cng\` — **134 tests pass** (84 unit + 9 pbxproj-e2e + 10 extra-files-e2e + 10 gradle-e2e + 7 builtins-e2e + 7 core-override + 4 discovery + 3 subprocess). Zero regressions.

9 new E2E tests covering each variant's pbxproj-section placement, SDKROOT framework path, target Debug + Release build settings, byte-identical rendering across runs, no-plugin baseline regression, and the realistic Firebase iOS scenario.

## Status of \"fully plugin-driven\"

After this PR, **every previously-decorative IR field is consumed** by the renderer. 3rd-party plugins can express common Firebase / Crashlytics / Google Maps integrations without forking \`whisker-cng\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)