### PR TITLE
chore: phase 5 cleanup — drop dead IR fields, rename cng→plugin in author surface

### DIFF
--- a/crates/whisker-plugin/src/lib.rs
+++ b/crates/whisker-plugin/src/lib.rs
@@ -60,20 +60,33 @@
 //! }
 //! ```
 //!
-//! ## What the IR covers — current scope (RFC #164 Phase 1)
+//! ## What the IR covers
 //!
-//! The IRs are intentionally minimal in this first cut. They expose
-//! the surfaces Phase 2's built-in plugins actually need —
-//! Info.plist key/value tree, AndroidManifest's
-//! permissions/intent-filter set, gradle plugin/dependency lists,
-//! and a free-form `extra_files` bag for everything else (resources,
-//! source files, etc.). Pbxproj structural edits are tracked as a
-//! deferred operation list; the engine replays them against the
-//! template renderer rather than the protocol carrying a full
-//! pbxproj object graph.
+//! [`IosProjectIr`] and [`AndroidProjectIr`] each carry two
+//! layers:
 //!
-//! Adding a new typed field to an IR is a non-breaking change if
-//! the field is `#[serde(default)]`: older plugin binaries simply
+//! 1. **Core fields** seeded from `AppConfig` by the engine before
+//!    any plugin runs — `app_name`, `version`, `bundle_id` /
+//!    `application_id`, `scheme`, `deployment_target`, `min_sdk`,
+//!    `target_sdk`. A plugin can read them to make decisions or
+//!    override them via `Operation::Override`.
+//! 2. **Plugin-additive fields** that plugins push into:
+//!    - `info_plist: BTreeMap<String, PlistValue>` (`String` /
+//!      `Boolean` / `Integer` / `Array<String>` rendered)
+//!    - `manifest.permissions: Vec<String>` (dedup'd at render)
+//!    - `manifest.application_meta_data: Vec<MetaDataEntry>`
+//!    - `gradle.apply_plugins: Vec<String>` /
+//!      `gradle.dependencies: Vec<String>` (raw Kotlin DSL lines
+//!      emitted into `app/build.gradle.kts`)
+//!    - `pbxproj_ops: Vec<PbxprojOp>` (`AddResource` / `AddSource` /
+//!      `SetBuildSetting` / `LinkSystemFramework` materialised
+//!      into the iOS xcodeproj)
+//!    - `extra_files: BTreeMap<PathBuf, FileEntry>` (arbitrary
+//!      files dropped into `gen/`, path-validated against `..`
+//!      traversal)
+//!
+//! Adding a new typed field is a non-breaking change when the
+//! field is `#[serde(default)]`: older plugin binaries simply
 //! don't touch it, the engine sees the default. Adding a *required*
 //! field is a wire-format break.
 //!
@@ -444,41 +457,12 @@ pub struct AndroidManifest {
     /// inside the `<application>` block.
     #[serde(default)]
     pub application_meta_data: Vec<MetaDataEntry>,
-
-    /// `<intent-filter>` entries added to the launcher activity.
-    /// Most plugins won't touch this — it exists for deep-link and
-    /// custom-scheme plugins.
-    #[serde(default)]
-    pub launcher_intent_filters: Vec<IntentFilter>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MetaDataEntry {
     pub name: String,
     pub value: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct IntentFilter {
-    #[serde(default)]
-    pub actions: Vec<String>,
-    #[serde(default)]
-    pub categories: Vec<String>,
-    /// `<data android:scheme="..." android:host="..." .../>` rows.
-    #[serde(default)]
-    pub data: Vec<IntentFilterData>,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
-pub struct IntentFilterData {
-    #[serde(default)]
-    pub scheme: Option<String>,
-    #[serde(default)]
-    pub host: Option<String>,
-    #[serde(default)]
-    pub path_prefix: Option<String>,
-    #[serde(default)]
-    pub mime_type: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/examples/podcast/whisker.rs
+++ b/examples/podcast/whisker.rs
@@ -29,17 +29,17 @@ pub fn configure(app: &mut whisker_app_config::AppConfig) {
             .deployment_target("13.0");
     });
 
-    // Whisker-audio CNG plugin — mirrors expo-audio's plugin
-    // surface. Exercise every option so the generated project
-    // shows we're contributing the right entries:
+    // Whisker-audio plugin — mirrors expo-audio's plugin surface.
+    // Exercise every option so the generated project shows we're
+    // contributing the right entries:
     //   - microphone_permission → Info.plist.NSMicrophoneUsageDescription
     //   - record_audio_android → AndroidManifest <uses-permission RECORD_AUDIO>
     //   - enable_background_{recording,playback} → Info.plist.UIBackgroundModes
     //
     // The probe pulls `whisker-audio` with `default-features = false`
-    // so only the `cng` module is built (no Lynx bridge / runtime
+    // so only the plugin module is built (no Lynx bridge / runtime
     // overhead) — see `crates/whisker-cli/src/probe.rs`.
-    app.plugin::<whisker_audio::cng::WhiskerAudio>(|c| {
+    app.plugin::<whisker_audio::WhiskerAudio>(|c| {
         c.microphone_permission("Record clips for podcast episodes.")
             .record_audio_android(true)
             .enable_background_playback(true);

--- a/packages/whisker-audio/Cargo.toml
+++ b/packages/whisker-audio/Cargo.toml
@@ -35,11 +35,11 @@ crate-type = ["rlib"]
 
 # Plugin registration — Whisker walks the consuming app's dep
 # tree, picks this entry up, builds the `whisker-audio-plugin`
-# binary below, and runs it during `whisker generate`. The user
-# opts into actual behaviour by calling
-# `app.plugin::<WhiskerAudio>(|c| …)` in their `whisker.rs`; with
-# no opt-in the plugin runs with `Config::default()` and
-# contributes nothing.
+# binary below, and runs it as part of every `whisker build` /
+# `whisker run` gen-tree sync. The user opts into actual
+# behaviour by calling `app.plugin::<WhiskerAudio>(|c| …)` in
+# their `whisker.rs`; with no opt-in the plugin runs with
+# `Config::default()` and contributes nothing.
 [package.metadata.whisker.plugins.whisker-audio]
 bin = "whisker-audio-plugin"
 

--- a/packages/whisker-audio/Cargo.toml
+++ b/packages/whisker-audio/Cargo.toml
@@ -16,7 +16,8 @@ include = [
     "Package.swift",
     "build.gradle.kts",
     "src/lib.rs",
-    "src/cng.rs",
+    "src/plugin.rs",
+    "src/runtime.rs",
     "bin/**/*.rs",
     "android/**/*.kt",
     "ios/**/*.swift",
@@ -32,17 +33,17 @@ crate-type = ["rlib"]
 # Android Gradle subproject + iOS SwiftPM package into the host build.
 [package.metadata.whisker]
 
-# CNG plugin registration — `whisker-cng::discovery` walks the
-# consuming app's dep tree, picks this entry up, builds the
-# `whisker-audio-plugin` binary below, and registers it as a
-# `SubprocessPlugin` with the engine. The user opts into actual
-# behaviour by calling `app.plugin::<WhiskerAudio>(|c| …)` in
-# their `whisker.rs`; with no opt-in the plugin runs with
-# `Config::default()` and contributes nothing.
+# Plugin registration — Whisker walks the consuming app's dep
+# tree, picks this entry up, builds the `whisker-audio-plugin`
+# binary below, and runs it during `whisker generate`. The user
+# opts into actual behaviour by calling
+# `app.plugin::<WhiskerAudio>(|c| …)` in their `whisker.rs`; with
+# no opt-in the plugin runs with `Config::default()` and
+# contributes nothing.
 [package.metadata.whisker.plugins.whisker-audio]
 bin = "whisker-audio-plugin"
 
-# Subprocess binary entry point the CNG engine spawns. Reads a
+# Subprocess binary entry point Whisker spawns. Reads a
 # `PluginRequest` JSON from stdin, mutates the IR via
 # `WhiskerAudio::apply`, writes a `PluginResponse` JSON to
 # stdout.
@@ -56,7 +57,7 @@ doc = false
 [dependencies]
 # `whisker` (the umbrella runtime crate) is gated behind the
 # `runtime` feature so the config probe — which only needs the
-# `cng` module — can pull this crate with
+# `plugin` module — can pull this crate with
 # `default-features = false` and avoid the multi-minute build of
 # the Lynx bridge + driver. The runtime feature is on by default
 # so user app crates that depend on `whisker-audio` for actual
@@ -64,7 +65,7 @@ doc = false
 # flag dance.
 whisker = { workspace = true, optional = true }
 
-# CNG plugin support — always on. Light deps (trait + IR types +
+# Plugin support — always on. Light deps (trait + IR types +
 # JSON envelope + subprocess runner) so the probe-build path stays
 # cheap when `runtime` is disabled.
 whisker-plugin = { workspace = true }

--- a/packages/whisker-audio/bin/whisker_audio_plugin.rs
+++ b/packages/whisker-audio/bin/whisker_audio_plugin.rs
@@ -1,13 +1,13 @@
 //! `whisker-audio-plugin` subprocess plugin binary.
 //!
-//! The CNG engine in `whisker-cng` discovers this binary via the
-//! `[package.metadata.whisker.plugins.whisker-audio]` table in this
-//! crate's `Cargo.toml`, builds it via `cargo build --bin
+//! The Whisker engine discovers this binary via the
+//! `[package.metadata.whisker.plugins.whisker-audio]` table in
+//! this crate's `Cargo.toml`, builds it via `cargo build --bin
 //! whisker-audio-plugin`, and spawns it with a `PluginRequest`
 //! JSON on stdin / `PluginResponse` JSON on stdout. The plugin
-//! logic lives in `whisker_audio::cng::WhiskerAudio`; this
-//! file is just the wrapper.
+//! logic lives in [`whisker_audio::WhiskerAudio`]; this file is
+//! just the wrapper.
 
 fn main() -> anyhow::Result<()> {
-    whisker_plugin::run_as_subprocess(whisker_audio::cng::WhiskerAudio)
+    whisker_plugin::run_as_subprocess(whisker_audio::WhiskerAudio)
 }

--- a/packages/whisker-audio/src/lib.rs
+++ b/packages/whisker-audio/src/lib.rs
@@ -69,20 +69,21 @@
 //! - iOS: `packages/whisker-audio/ios/Sources/WhiskerAudio/AudioModule.swift`
 //! - Android: `packages/whisker-audio/android/src/main/kotlin/rs/whisker/modules/audio/AudioModule.kt`
 
-/// Whisker CNG plugin — adds `Info.plist` / `AndroidManifest.xml`
+/// Whisker plugin — adds `Info.plist` / `AndroidManifest.xml`
 /// entries when the consuming app declares
 /// `app.plugin::<WhiskerAudio>(|c| …)` in `whisker.rs`. Always
-/// available — independent of the `runtime` feature so the config
-/// probe (which only pulls this crate with `default-features = false`)
-/// can still resolve `WhiskerAudio` from `whisker.rs`.
-pub mod cng;
+/// available — independent of the `runtime` feature so the
+/// `whisker.rs` config probe (which pulls this crate with
+/// `default-features = false`) can still resolve `WhiskerAudio`.
+mod plugin;
+pub use plugin::*;
 
 /// Player + reactive `PlaybackStatus` runtime. Gated behind the
 /// default-on `runtime` feature so the config probe build path can
 /// skip the heavyweight `whisker` umbrella crate (Lynx bridge,
 /// driver, render layer). Apps depending on `whisker-audio` for
 /// actual playback get this re-exported automatically; the probe
-/// only sees `cng`.
+/// only sees the plugin types.
 #[cfg(feature = "runtime")]
 mod runtime;
 #[cfg(feature = "runtime")]

--- a/packages/whisker-audio/src/plugin.rs
+++ b/packages/whisker-audio/src/plugin.rs
@@ -1,4 +1,4 @@
-//! Whisker CNG plugin for the audio module.
+//! Whisker plugin for the audio module.
 //!
 //! Mirrors the surface of `expo-audio`'s config plugin
 //! (<https://docs.expo.dev/versions/latest/sdk/audio/>) — apps that
@@ -9,7 +9,7 @@
 //! ## Usage in `whisker.rs`
 //!
 //! ```ignore
-//! use whisker_audio::cng::WhiskerAudio;
+//! use whisker_audio::WhiskerAudio;
 //!
 //! app.plugin::<WhiskerAudio>(|c| c
 //!     .microphone_permission("Record audio clips for podcasts.")
@@ -84,9 +84,9 @@ impl PluginConfig for WhiskerAudioConfig {
     const NAME: &'static str = "whisker-audio";
 }
 
-/// The plugin the CNG engine drives in-process (1st-party) or
-/// spawns as a subprocess (3rd-party path via the
-/// `whisker-audio-plugin` binary).
+/// The plugin the Whisker engine drives — either in-process or as
+/// a subprocess via the bundled `whisker-audio-plugin` binary,
+/// depending on the engine's plugin pipeline.
 pub struct WhiskerAudio;
 
 impl Plugin for WhiskerAudio {


### PR DESCRIPTION
## Summary

Two small cleanups bundled together.

### Phase 5 (closing RFC #164): drop unused IR fields

\`AndroidManifest.launcher_intent_filters\` + \`IntentFilter\` + \`IntentFilterData\` were declared but never populated by any plugin or read by any renderer. Pure dead code — removed. Bonus: rewrote \`whisker-plugin::lib.rs\`'s \"## What the IR covers\" section, which still claimed the IR was \"intentionally minimal in this first cut\" — accurate at Phase 1, no longer after the B-direction PRs.

When a real deep-link plugin lands it can reintroduce a fresh IR shape suited to its needs.

### Rename \`cng\` → \`plugin\` in whisker-audio's author surface

\`cng\` (Continuous Native Generation) is the engine's identity; plugin authors writing crates like \`whisker-audio\` should work in \"plugin\" terms.

- \`whisker-audio/src/cng.rs\` → \`whisker-audio/src/plugin.rs\`
- \`pub mod cng\` → \`mod plugin\` (file-private) + \`pub use plugin::*\` so types appear at the crate root.
- User-facing path: \`whisker_audio::WhiskerAudio\` (short form).
- \`bin/whisker_audio_plugin.rs\`, \`Cargo.toml\` comments, and \`examples/podcast/whisker.rs\` all updated.

The internal \`whisker-cng\` engine crate keeps its name — that's the engine itself, not a user-facing concept.

## Test plan

- [x] \`cargo check --workspace\`, \`cargo fmt --all\`, \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p whisker-cng -p whisker-audio -p whisker-plugin -p whisker-app-config\` — 134 + 9 + 8 + 6 tests pass
- [x] Fresh \`whisker build --target=ios-sim\` against podcast: Info.plist contains \`NSMicrophoneUsageDescription\` + \`UIBackgroundModes=[audio]\`
- [x] \`whisker build --target=android\`: APK builds, manifest contains \`RECORD_AUDIO\`
- [x] iPhone 17 Pro Simulator install + launch + screenshot: Podcasts UI renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)