### PR TITLE
feat(dev-runtime): capture device stdout/stderr over WebSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,6 +1933,7 @@ name = "whisker-dev-runtime"
 version = "0.1.0"
 dependencies = [
  "futures-util",
+ "libc",
  "serde",
  "serde_json",
  "subsecond-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,13 @@ subsecond-types = "0.7"
 # Dev-time WebSocket receiver — pulled in only via the `hot-reload`
 # feature, never present in release builds. Async stack kept minimal:
 # current-thread tokio + tungstenite over std TcpStream.
+#
+# `libc` is the POSIX syscall surface for `whisker-dev-runtime`'s
+# `log_capture` module (`dup2` over stdout/stderr → reader thread →
+# WS log frame). Every device target we support is POSIX (Android
+# NDK, iOS, macOS host, Linux host), so one workspace pin covers
+# the whole matrix.
+libc = "0.2"
 tokio = { version = "1", default-features = false }
 tokio-tungstenite = { version = "0.21", default-features = false }
 futures-util = { version = "0.3", default-features = false }

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -159,9 +159,10 @@ fn forward_event_to_ui(event: whisker_dev_server::Event) {
         ts_micros: _,
     } = event
     {
-        // Two-letter prefix keeps the column alignment compact next
-        // to `whisker-build::ui::info`'s own output. Future TUI can
-        // surface stream / timestamp / colour separately.
+        // Short `[device]` / `[device:err]` prefix keeps the column
+        // alignment compact next to `whisker-build::ui::info`'s own
+        // output. The Phase-2 TUI can surface stream / timestamp /
+        // colour separately.
         let tag = match stream.as_str() {
             "stderr" => "device:err",
             _ => "device",

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -141,7 +141,33 @@ pub fn run(args: Args) -> Result<()> {
         .enable_all()
         .build()
         .context("build tokio runtime")?;
-    rt.block_on(DevServer::new(config)?.run())
+    let server = DevServer::new(config)?.on_event(forward_event_to_ui);
+    rt.block_on(server.run())
+}
+
+/// Translate dev-server [`Event`]s into the existing line-based UI
+/// output. Phase 2 (ratatui TUI) will replace this with a routed
+/// dispatch into per-pane state; until then, the relevant signal we
+/// need to surface is the device's own stdout/stderr — everything else
+/// is already covered by `whisker_build::ui` calls inside the dev
+/// loop.
+fn forward_event_to_ui(event: whisker_dev_server::Event) {
+    use whisker_dev_server::Event;
+    if let Event::DeviceLog {
+        stream,
+        line,
+        ts_micros: _,
+    } = event
+    {
+        // Two-letter prefix keeps the column alignment compact next
+        // to `whisker-build::ui::info`'s own output. Future TUI can
+        // surface stream / timestamp / colour separately.
+        let tag = match stream.as_str() {
+            "stderr" => "device:err",
+            _ => "device",
+        };
+        whisker_build::ui::info(format!("[{tag}] {line}"));
+    }
 }
 
 /// Build [`AndroidParams`] from the resolved manifest. Returns an

--- a/crates/whisker-dev-runtime/Cargo.toml
+++ b/crates/whisker-dev-runtime/Cargo.toml
@@ -21,6 +21,7 @@ hot-reload = [
     "dep:serde_json",
     "dep:subsecond",
     "dep:subsecond-types",
+    "dep:libc",
 ]
 
 [dependencies]
@@ -34,3 +35,7 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 subsecond = { workspace = true, optional = true }
 subsecond-types = { workspace = true, optional = true }
+# `pipe(2)` / `dup2` / `read` / `STDOUT_FILENO` for `log_capture` —
+# every device target we support is POSIX (Android NDK, iOS, macOS host,
+# Linux host), so libc covers the whole matrix.
+libc = { workspace = true, optional = true }

--- a/crates/whisker-dev-runtime/src/hot_reload.rs
+++ b/crates/whisker-dev-runtime/src/hot_reload.rs
@@ -189,9 +189,29 @@ where
     ));
     ws.send(Message::Text(hello)).await?;
 
-    while let Some(msg) = ws.next().await {
-        let msg = msg?;
-        match msg {
+    loop {
+        tokio::select! {
+            // device → host: forward any captured stdout/stderr lines
+            // accumulated by `log_capture`. Drains in batches so a
+            // burst of `println!`s sends one frame per round-trip
+            // rather than one frame per line.
+            lines = crate::log_capture::drain_pending_logs() => {
+                for line in lines {
+                    let frame = serde_json::json!({
+                        "kind": "log",
+                        "stream": line.stream.as_wire(),
+                        "line": line.text,
+                        "ts_micros": line.ts_micros.to_string(),
+                    })
+                    .to_string();
+                    ws.send(Message::Text(frame)).await?;
+                }
+            }
+            // host → device: receive patches + close.
+            msg = ws.next() => {
+                let Some(msg) = msg else { return Ok(()); };
+                let msg = msg?;
+                match msg {
             Message::Binary(bytes) => {
                 devlog(&format!("patch frame received ({} bytes)", bytes.len()));
                 match parse_patch_frame(&bytes) {
@@ -228,9 +248,10 @@ where
             }
             Message::Close(_) => return Ok(()),
             _ => {} // ignore Text (no server→client text frames today) / Ping / Pong
+                }
+            }
         }
     }
-    Ok(())
 }
 
 /// Write the patch dylib payload to a local file under the app's

--- a/crates/whisker-dev-runtime/src/hot_reload.rs
+++ b/crates/whisker-dev-runtime/src/hot_reload.rs
@@ -210,48 +210,53 @@ where
             // host → device: receive patches + close.
             msg = ws.next() => {
                 let Some(msg) = msg else { return Ok(()); };
-                let msg = msg?;
-                match msg {
-            Message::Binary(bytes) => {
-                devlog(&format!("patch frame received ({} bytes)", bytes.len()));
-                match parse_patch_frame(&bytes) {
-                    Ok((mut table, dylib_bytes)) => {
-                        devlog(&format!(
-                            "frame parsed (map={} entries, dylib={} bytes)",
-                            table.map.len(),
-                            dylib_bytes.len(),
-                        ));
-                        match materialise_patch_dylib(dylib_bytes) {
-                            Ok(local) => {
-                                devlog(
-                                    &format!("patch dylib materialised at {}", local.display(),),
-                                );
-                                table.lib = local;
-                                if let Ok(mut p) = PENDING.lock() {
-                                    *p = Some(table);
-                                    devlog("patch queued");
-                                }
-                                // Wake the host so a frame is
-                                // scheduled — `take_pending_patch`
-                                // only runs inside `tick_callback`
-                                // and the TASM thread is idle when
-                                // nothing else is happening.
-                                whisker_runtime::host_wake::wake_runtime();
-                            }
-                            Err(e) => {
-                                devlog(&format!("could not materialise patch dylib: {e}"));
-                            }
-                        }
-                    }
-                    Err(e) => devlog(&format!("malformed patch frame: {e}")),
-                }
-            }
-            Message::Close(_) => return Ok(()),
-            _ => {} // ignore Text (no server→client text frames today) / Ping / Pong
+                match msg? {
+                    Message::Binary(bytes) => handle_patch_frame(&bytes),
+                    Message::Close(_) => return Ok(()),
+                    // Ignore Ping/Pong (auto-handled) and Text (no
+                    // server→client text frames defined today).
+                    _ => {}
                 }
             }
         }
     }
+}
+
+/// Decode one patch frame from the dev-server and park it in
+/// [`PENDING`] for the TASM thread to apply on the next tick. Pulled
+/// out so [`handle_session`]'s `select!` arm stays readable; the
+/// match-arm depth was 7 levels otherwise.
+fn handle_patch_frame(bytes: &[u8]) {
+    devlog(&format!("patch frame received ({} bytes)", bytes.len()));
+    let (mut table, dylib_bytes) = match parse_patch_frame(bytes) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            devlog(&format!("malformed patch frame: {e}"));
+            return;
+        }
+    };
+    devlog(&format!(
+        "frame parsed (map={} entries, dylib={} bytes)",
+        table.map.len(),
+        dylib_bytes.len(),
+    ));
+    let local = match materialise_patch_dylib(dylib_bytes) {
+        Ok(p) => p,
+        Err(e) => {
+            devlog(&format!("could not materialise patch dylib: {e}"));
+            return;
+        }
+    };
+    devlog(&format!("patch dylib materialised at {}", local.display()));
+    table.lib = local;
+    if let Ok(mut p) = PENDING.lock() {
+        *p = Some(table);
+        devlog("patch queued");
+    }
+    // Wake the host so a frame is scheduled — `take_pending_patch`
+    // only runs inside `tick_callback` and the TASM thread is idle
+    // when nothing else is happening.
+    whisker_runtime::host_wake::wake_runtime();
 }
 
 /// Write the patch dylib payload to a local file under the app's

--- a/crates/whisker-dev-runtime/src/lib.rs
+++ b/crates/whisker-dev-runtime/src/lib.rs
@@ -15,4 +15,10 @@
 pub mod hot_reload;
 
 #[cfg(feature = "hot-reload")]
+pub mod log_capture;
+
+#[cfg(feature = "hot-reload")]
 pub use hot_reload::{devlog, start_receiver, take_pending_patch};
+
+#[cfg(feature = "hot-reload")]
+pub use log_capture::start_log_capture;

--- a/crates/whisker-dev-runtime/src/log_capture.rs
+++ b/crates/whisker-dev-runtime/src/log_capture.rs
@@ -1,0 +1,440 @@
+//! Capture stdout/stderr from device-side Rust code and forward over
+//! the dev-server WebSocket.
+//!
+//! `whisker run` previously surfaced only its own dev-loop status —
+//! a `println!` from the user's app went to fd 1, which on Android is
+//! redirected to `/dev/null` by the Android runtime and on iOS is
+//! sunk into the simulator container with no host-side observability.
+//! Users had to attach a separate terminal (`adb logcat` / `simctl log
+//! stream`) to read their own code's output. This module fixes that:
+//! it installs a pipe over stdout/stderr at app bootstrap, reads the
+//! pipe on a background thread, and forwards each completed line over
+//! the dev-server WebSocket to `whisker-cli`.
+//!
+//! ## What gets captured
+//!
+//! Anything that eventually writes to fd 1 / fd 2:
+//!
+//! - `println!` / `eprintln!` / `dbg!`
+//! - `log` crate macros (`log::info!` etc.) with the standard backends —
+//!   `env_logger`, `simple_logger`, `pretty_env_logger` all emit to
+//!   stderr
+//! - `tracing` macros with the default `fmt::Subscriber` (writes to
+//!   stderr)
+//! - Rust's default panic hook (`set_hook` users may override this)
+//! - C FFI `printf` / `fprintf(stderr, …)` from third-party native libs
+//!
+//! Not captured:
+//!
+//! - Backends that bypass stdio and target the OS log directly
+//!   (`tracing-android` / `tracing-oslog` / `android_logger`,
+//!   `__android_log_write` / `os_log` called from FFI). Users who pick
+//!   those backends already opted into platform-log delivery; they
+//!   can read those with `adb logcat` / `simctl log stream`.
+//!
+//! ## Fan-out
+//!
+//! Each captured line is also written back to the original
+//! stdout/stderr fd (saved via `dup` before the redirect) and pushed
+//! to `__android_log_write` / `syslog`. That way `adb logcat -s
+//! whisker-stdout` / `simctl spawn booted log stream` still surface
+//! the same lines for users who prefer external tools, and the
+//! Xcode console attached to a simulator launch keeps working.
+//!
+//! ## Order
+//!
+//! [`start_log_capture`] must be called **before** any other code
+//! emits to stdout/stderr — calls that fire earlier go to the
+//! original (typically /dev/null on Android) destination. The
+//! canonical entry is `whisker_driver::lynx::bootstrap` right after
+//! the driver attach, before the first user component renders.
+
+use std::collections::VecDeque;
+use std::os::raw::c_int;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::Notify;
+
+/// Which stream a captured line came from. Carried over the wire so
+/// `whisker-cli` can colour-code stdout vs stderr.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stream {
+    Stdout,
+    Stderr,
+}
+
+impl Stream {
+    /// Stable on-wire string. Mirrored by the server-side parser.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+/// One captured line. The reader thread strips the trailing `\n`
+/// (and `\r\n` on macOS terminals) before pushing, so `text` is the
+/// payload only.
+#[derive(Debug, Clone)]
+pub struct LogLine {
+    pub stream: Stream,
+    pub text: String,
+    /// Microseconds since UNIX_EPOCH, stamped on the device at the
+    /// moment the line was completed. Useful for interleaving with
+    /// host-side events. `0` if the system clock is unavailable.
+    pub ts_micros: u128,
+}
+
+/// Bounded ring buffer shared between the reader threads and the WS
+/// session task. Drop-oldest on overflow: pre-connect buffering
+/// shouldn't crowd out fresh state when the buffer fills. `Notify`
+/// wakes the session task as soon as a line lands.
+struct LogBuffer {
+    inner: Mutex<VecDeque<LogLine>>,
+    notify: Notify,
+    capacity: usize,
+}
+
+impl LogBuffer {
+    fn push(&self, line: LogLine) {
+        let Ok(mut g) = self.inner.lock() else {
+            // Poisoned mutex — drop the line rather than propagating
+            // a panic out of the reader thread.
+            return;
+        };
+        if g.len() >= self.capacity {
+            g.pop_front();
+        }
+        g.push_back(line);
+        // `notify_one` is cheap and idempotent — extra wakeups are
+        // harmless because the drainer re-checks under lock.
+        self.notify.notify_one();
+    }
+
+    async fn drain(&self) -> Vec<LogLine> {
+        loop {
+            let drained: Vec<LogLine> = {
+                let Ok(mut g) = self.inner.lock() else {
+                    return Vec::new();
+                };
+                g.drain(..).collect()
+            };
+            if !drained.is_empty() {
+                return drained;
+            }
+            self.notify.notified().await;
+        }
+    }
+}
+
+static LOG_BUFFER: OnceLock<Arc<LogBuffer>> = OnceLock::new();
+
+/// ~1024 lines × typical short-string ~80 B ≈ 80 KB worst case.
+/// Bounded to backstop runaway log spam (panic loop, accidental
+/// `loop { println!() }`) before connect.
+const BUFFER_CAPACITY: usize = 1024;
+
+/// Install the stdout/stderr capture pipes. Idempotent — subsequent
+/// calls are no-ops. Returns `true` the first time, `false` on
+/// repeat calls.
+///
+/// Failures inside the install (pipe / dup / dup2 / thread spawn)
+/// are logged through [`super::hot_reload::devlog`] but never
+/// panic. A failed install leaves the original fds intact — the dev
+/// loop continues to function (just without device-side log capture).
+pub fn start_log_capture() -> bool {
+    static INITIALIZED: AtomicBool = AtomicBool::new(false);
+    if INITIALIZED.swap(true, Ordering::AcqRel) {
+        return false;
+    }
+
+    let buffer = Arc::new(LogBuffer {
+        inner: Mutex::new(VecDeque::with_capacity(BUFFER_CAPACITY)),
+        notify: Notify::new(),
+        capacity: BUFFER_CAPACITY,
+    });
+    // `OnceLock::set` only fails when the slot was already populated.
+    // The `INITIALIZED` swap above guarantees we're first, so the
+    // `is_err` branch is unreachable in practice; treat it as a
+    // defensive no-op.
+    let _ = LOG_BUFFER.set(Arc::clone(&buffer));
+
+    if let Err(e) = install_pipe(libc::STDOUT_FILENO, Stream::Stdout, Arc::clone(&buffer)) {
+        super::hot_reload::devlog(&format!("stdout capture install failed: {e}"));
+    }
+    if let Err(e) = install_pipe(libc::STDERR_FILENO, Stream::Stderr, Arc::clone(&buffer)) {
+        super::hot_reload::devlog(&format!("stderr capture install failed: {e}"));
+    }
+    true
+}
+
+/// Drain pending captured log lines, awaiting at least one if the
+/// buffer is currently empty. Used by the hot-reload WS session task
+/// to forward batched log frames to the server.
+///
+/// If [`start_log_capture`] wasn't called (capture disabled / install
+/// failed), this returns a future that never resolves — the session
+/// task's `select!` arm parks forever and the other arms keep
+/// running unchanged.
+pub(crate) async fn drain_pending_logs() -> Vec<LogLine> {
+    match LOG_BUFFER.get() {
+        Some(b) => b.drain().await,
+        None => futures_util::future::pending::<Vec<LogLine>>().await,
+    }
+}
+
+fn install_pipe(target_fd: c_int, stream: Stream, buffer: Arc<LogBuffer>) -> std::io::Result<()> {
+    // POSIX `pipe(2)` — two fds, [0] = read end, [1] = write end.
+    let mut fds: [c_int; 2] = [-1, -1];
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let read_fd = fds[0];
+    let write_fd = fds[1];
+
+    // Snapshot the original fd so the reader thread can fan-out the
+    // captured bytes back to whatever was wired up before us (Xcode
+    // console on iOS sim, /dev/null on Android, the host terminal on
+    // desktop). `dup` allocates a fresh fd pointing at the same open
+    // file description; the original target_fd then becomes safe to
+    // replace via `dup2`.
+    let original_fd = unsafe { libc::dup(target_fd) };
+    if original_fd == -1 {
+        let err = std::io::Error::last_os_error();
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+        }
+        return Err(err);
+    }
+
+    // Atomically replace target_fd with a duplicate of write_fd.
+    // `dup2` closes target_fd first if it's open. After this call,
+    // anything that writes to fd `target_fd` (STDOUT_FILENO /
+    // STDERR_FILENO) goes into our pipe.
+    if unsafe { libc::dup2(write_fd, target_fd) } == -1 {
+        let err = std::io::Error::last_os_error();
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+            libc::close(original_fd);
+        }
+        return Err(err);
+    }
+    // We have a duplicate at target_fd now; drop the original
+    // write_fd handle so we don't leak it.
+    unsafe {
+        libc::close(write_fd);
+    }
+
+    let thread_name = match stream {
+        Stream::Stdout => "whisker-log-stdout",
+        Stream::Stderr => "whisker-log-stderr",
+    };
+    std::thread::Builder::new()
+        .name(thread_name.to_string())
+        .spawn(move || reader_loop(read_fd, original_fd, stream, buffer))
+        .map(|_| ())?;
+    Ok(())
+}
+
+fn reader_loop(read_fd: c_int, original_fd: c_int, stream: Stream, buffer: Arc<LogBuffer>) {
+    let mut read_buf = [0u8; 4096];
+    // Bytes from a previous read that didn't end on a newline yet.
+    // Held across iterations so a `println!` that straddles a 4 KB
+    // boundary surfaces as one logical line, not two.
+    let mut partial: Vec<u8> = Vec::new();
+    loop {
+        let n = unsafe { libc::read(read_fd, read_buf.as_mut_ptr() as *mut _, read_buf.len()) };
+        if n <= 0 {
+            // EOF (n == 0) or error (n < 0). Either way the pipe is
+            // unusable; the thread exits and the original_fd /
+            // read_fd entries become caller-cleaned (process exit).
+            return;
+        }
+        let chunk = &read_buf[..n as usize];
+        // Fan out RAW bytes to the original fd FIRST so consumers of
+        // the original stdout/stderr (Xcode console attached to the
+        // sim launch, host terminal on a desktop dev build) see them
+        // exactly as the producer wrote them — no line-buffering
+        // delay, no partial-line withholding.
+        unsafe {
+            let _ = libc::write(original_fd, chunk.as_ptr() as *const _, chunk.len());
+        }
+
+        // Line-split for the WS frame stream. Partial-line carryover
+        // means each `println!` reaches the host as one line even if
+        // a large payload spans multiple `read` chunks.
+        partial.extend_from_slice(chunk);
+        while let Some(nl_pos) = partial.iter().position(|b| *b == b'\n') {
+            let mut line: Vec<u8> = partial.drain(..=nl_pos).collect();
+            // Trim trailing newline + any \r before it.
+            while matches!(line.last(), Some(b'\n') | Some(b'\r')) {
+                line.pop();
+            }
+            // Use `from_utf8_lossy` so a non-UTF-8 byte (raw bytes
+            // from a C lib, locale mismatch) shows up as U+FFFD
+            // rather than silently dropping the line.
+            let text = match String::from_utf8(line) {
+                Ok(s) => s,
+                Err(e) => String::from_utf8_lossy(&e.into_bytes()).into_owned(),
+            };
+            push_platform_log(stream, &text);
+            let ts_micros = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_micros())
+                .unwrap_or(0);
+            buffer.push(LogLine {
+                stream,
+                text,
+                ts_micros,
+            });
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+fn push_platform_log(stream: Stream, line: &str) {
+    // Fan out to logcat so external observers (`adb logcat -s
+    // whisker-stdout`) see the same lines. Tag chosen distinct from
+    // `whisker-dev` (the hot-reload runtime's own diagnostics) so
+    // users can filter cleanly.
+    unsafe extern "C" {
+        fn __android_log_write(
+            prio: std::os::raw::c_int,
+            tag: *const std::os::raw::c_char,
+            text: *const std::os::raw::c_char,
+        ) -> std::os::raw::c_int;
+    }
+    const ANDROID_LOG_INFO: std::os::raw::c_int = 4;
+    let tag: &[u8] = match stream {
+        Stream::Stdout => b"whisker-stdout\0",
+        Stream::Stderr => b"whisker-stderr\0",
+    };
+    let mut buf: Vec<u8> = Vec::with_capacity(line.len() + 1);
+    buf.extend_from_slice(line.as_bytes());
+    buf.push(0);
+    unsafe {
+        __android_log_write(
+            ANDROID_LOG_INFO,
+            tag.as_ptr() as *const _,
+            buf.as_ptr() as *const _,
+        );
+    }
+}
+
+#[cfg(target_os = "ios")]
+fn push_platform_log(stream: Stream, line: &str) {
+    // Fan out to syslog so `simctl spawn booted log stream` surfaces
+    // the same lines. Prefix mirrors the Android tag layout.
+    unsafe extern "C" {
+        fn syslog(priority: std::os::raw::c_int, fmt: *const std::os::raw::c_char, ...);
+    }
+    const LOG_INFO: std::os::raw::c_int = 6;
+    let prefix: &[u8] = match stream {
+        Stream::Stdout => b"[whisker-stdout] ",
+        Stream::Stderr => b"[whisker-stderr] ",
+    };
+    let mut buf: Vec<u8> = Vec::with_capacity(prefix.len() + line.len() + 1);
+    buf.extend_from_slice(prefix);
+    buf.extend_from_slice(line.as_bytes());
+    buf.push(0);
+    let fmt = b"%s\0";
+    unsafe {
+        syslog(LOG_INFO, fmt.as_ptr() as *const _, buf.as_ptr());
+    }
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn push_platform_log(_stream: Stream, _line: &str) {
+    // Host / Linux desktop: the `libc::write(original_fd, …)` above
+    // already lands lines on the user's terminal, which is the only
+    // sink that matters off-device. No additional platform log.
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{timeout, Duration};
+
+    /// Construct a fresh LogBuffer for direct testing — the global
+    /// `LOG_BUFFER` static can only be initialised once per process,
+    /// so unit tests build their own instance.
+    fn fresh_buffer(capacity: usize) -> Arc<LogBuffer> {
+        Arc::new(LogBuffer {
+            inner: Mutex::new(VecDeque::with_capacity(capacity)),
+            notify: Notify::new(),
+            capacity,
+        })
+    }
+
+    #[tokio::test]
+    async fn buffer_drains_what_was_pushed() {
+        let b = fresh_buffer(8);
+        b.push(LogLine {
+            stream: Stream::Stdout,
+            text: "hello".into(),
+            ts_micros: 1,
+        });
+        b.push(LogLine {
+            stream: Stream::Stderr,
+            text: "world".into(),
+            ts_micros: 2,
+        });
+        let drained = timeout(Duration::from_secs(1), b.drain()).await.unwrap();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].text, "hello");
+        assert_eq!(drained[0].stream, Stream::Stdout);
+        assert_eq!(drained[1].text, "world");
+        assert_eq!(drained[1].stream, Stream::Stderr);
+    }
+
+    #[tokio::test]
+    async fn buffer_drops_oldest_when_capacity_exceeded() {
+        let b = fresh_buffer(3);
+        for i in 0..5u32 {
+            b.push(LogLine {
+                stream: Stream::Stdout,
+                text: format!("line {i}"),
+                ts_micros: i as u128,
+            });
+        }
+        let drained = timeout(Duration::from_secs(1), b.drain()).await.unwrap();
+        // Capacity 3: lines 0 and 1 should have been dropped.
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].text, "line 2");
+        assert_eq!(drained[1].text, "line 3");
+        assert_eq!(drained[2].text, "line 4");
+    }
+
+    #[tokio::test]
+    async fn drain_blocks_until_pushed() {
+        let b = fresh_buffer(8);
+        // Spawn a producer that pushes after a delay.
+        let b_clone = Arc::clone(&b);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            b_clone.push(LogLine {
+                stream: Stream::Stdout,
+                text: "delayed".into(),
+                ts_micros: 0,
+            });
+        });
+        let drained = timeout(Duration::from_secs(2), b.drain()).await.unwrap();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].text, "delayed");
+    }
+
+    #[test]
+    fn stream_as_wire_is_stable() {
+        assert_eq!(Stream::Stdout.as_wire(), "stdout");
+        assert_eq!(Stream::Stderr.as_wire(), "stderr");
+    }
+}

--- a/crates/whisker-dev-runtime/src/log_capture.rs
+++ b/crates/whisker-dev-runtime/src/log_capture.rs
@@ -249,10 +249,23 @@ fn reader_loop(read_fd: c_int, original_fd: c_int, stream: Stream, buffer: Arc<L
     let mut partial: Vec<u8> = Vec::new();
     loop {
         let n = unsafe { libc::read(read_fd, read_buf.as_mut_ptr() as *mut _, read_buf.len()) };
-        if n <= 0 {
-            // EOF (n == 0) or error (n < 0). Either way the pipe is
-            // unusable; the thread exits and the original_fd /
-            // read_fd entries become caller-cleaned (process exit).
+        if n == -1 {
+            // EINTR = signal interrupted the syscall before any bytes
+            // were transferred. The POSIX idiom is to retry; without
+            // it a stray signal silently kills log capture for the
+            // rest of the session. Other errors (EBADF, EFAULT, …)
+            // mean the pipe is unrecoverably broken — exit.
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return;
+        }
+        if n == 0 {
+            // EOF: every write end of the pipe is closed. In normal
+            // operation this should never fire — the process keeps
+            // STDOUT_FILENO / STDERR_FILENO open for life — but
+            // returning cleanly is safer than spinning.
             return;
         }
         let chunk = &read_buf[..n as usize];

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -206,6 +206,22 @@ pub enum Event {
     ClientConnected,
     ClientDisconnected,
     PatchSent,
+    /// A line captured from the device-side app's stdout / stderr (via
+    /// the `whisker-dev-runtime::log_capture` `dup2` hook), forwarded
+    /// over the WS connection. `whisker-cli` surfaces these in the
+    /// dev-loop UI so users don't need a separate `adb logcat` /
+    /// `simctl log stream` terminal to read their own `println!`s.
+    DeviceLog {
+        /// `"stdout"` or `"stderr"` — kept as a string mirror of the
+        /// on-wire field so the variant stays trivially serialisable
+        /// without dragging a `LogStream` enum across crate
+        /// boundaries.
+        stream: String,
+        line: String,
+        /// Device-stamped microseconds since UNIX_EPOCH. `0` if the
+        /// device's clock was unavailable when the line was captured.
+        ts_micros: u128,
+    },
 }
 
 // ----- Server ---------------------------------------------------------------

--- a/crates/whisker-dev-server/src/server.rs
+++ b/crates/whisker-dev-server/src/server.rs
@@ -232,6 +232,14 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                             if let Ok(mut g) = state.aslr_reference.lock() {
                                 *g = Some(aslr);
                             }
+                        } else if let Some(log) = parse_client_log(&t) {
+                            if let Some(cb) = &state.on_event {
+                                cb(Event::DeviceLog {
+                                    stream: log.stream,
+                                    line: log.line,
+                                    ts_micros: log.ts_micros,
+                                });
+                            }
                         }
                     }
                     _ => {}
@@ -277,6 +285,49 @@ fn parse_client_aslr_reference(text: &str) -> Option<u64> {
     } else {
         None
     }
+}
+
+/// Decoded payload of a `{"kind":"log",…}` text frame emitted by the
+/// device-side `log_capture` module.
+struct ClientLog {
+    stream: String,
+    line: String,
+    ts_micros: u128,
+}
+
+/// Parse a client log envelope. Returns `None` for any other text
+/// frame so the caller can fall through to other handlers (the hello
+/// envelope is the only other text frame today).
+///
+/// `ts_micros` arrives as a string on the wire because `u128` doesn't
+/// round-trip through JSON's number type cleanly (>2^53 is lossy in
+/// most decoders). The device serializes via `to_string`; we decode
+/// with `parse`, defaulting to `0` on parse failure rather than
+/// rejecting the whole frame — the line itself is more valuable than
+/// a precise timestamp.
+fn parse_client_log(text: &str) -> Option<ClientLog> {
+    #[derive(serde::Deserialize)]
+    struct Log {
+        kind: String,
+        stream: String,
+        line: String,
+        #[serde(default)]
+        ts_micros: Option<String>,
+    }
+    let h: Log = serde_json::from_str(text).ok()?;
+    if h.kind != "log" {
+        return None;
+    }
+    let ts_micros = h
+        .ts_micros
+        .as_deref()
+        .and_then(|s| s.parse::<u128>().ok())
+        .unwrap_or(0);
+    Some(ClientLog {
+        stream: h.stream,
+        line: h.line,
+        ts_micros,
+    })
 }
 
 // ============================================================================
@@ -465,5 +516,81 @@ mod tests {
 
         // sender stays usable across the whole flow.
         assert_eq!(sender.client_count(), 0);
+    }
+
+    #[test]
+    fn parse_client_log_decodes_a_well_formed_frame() {
+        let log = parse_client_log(
+            r#"{"kind":"log","stream":"stdout","line":"hello world","ts_micros":"12345"}"#,
+        )
+        .expect("valid log envelope");
+        assert_eq!(log.stream, "stdout");
+        assert_eq!(log.line, "hello world");
+        assert_eq!(log.ts_micros, 12345);
+    }
+
+    #[test]
+    fn parse_client_log_falls_back_to_zero_ts_when_missing() {
+        let log =
+            parse_client_log(r#"{"kind":"log","stream":"stderr","line":"oops"}"#).expect("valid");
+        assert_eq!(log.stream, "stderr");
+        assert_eq!(log.line, "oops");
+        assert_eq!(log.ts_micros, 0);
+    }
+
+    #[test]
+    fn parse_client_log_rejects_other_kinds() {
+        assert!(parse_client_log(r#"{"kind":"hello","aslr_reference":42}"#,).is_none());
+    }
+
+    #[tokio::test]
+    async fn on_event_callback_fires_with_device_log_lines() {
+        use std::sync::Mutex;
+        let captured: Arc<Mutex<Vec<(String, String, u128)>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_clone = Arc::clone(&captured);
+        let on_event: Arc<dyn Fn(Event) + Send + Sync> = Arc::new(move |e| {
+            if let Event::DeviceLog {
+                stream,
+                line,
+                ts_micros,
+            } = e
+            {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((stream, line, ts_micros));
+            }
+        });
+
+        let (sender, addr) = spawn_test_server(Some(on_event)).await;
+        let mut client = connect(addr).await;
+        for _ in 0..100 {
+            if sender.client_count() > 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert_eq!(sender.client_count(), 1);
+
+        client
+            .send(tokio_tungstenite::tungstenite::Message::Text(
+                r#"{"kind":"log","stream":"stdout","line":"hi from device","ts_micros":"42"}"#
+                    .into(),
+            ))
+            .await
+            .expect("send log frame");
+
+        // Wait for the server to dispatch the callback.
+        for _ in 0..100 {
+            if !captured.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        let g = captured.lock().unwrap();
+        assert_eq!(g.len(), 1);
+        assert_eq!(g[0].0, "stdout");
+        assert_eq!(g[0].1, "hi from device");
+        assert_eq!(g[0].2, 42);
     }
 }

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -82,6 +82,11 @@ pub fn run<F>(
     if engine_raw.is_null() {
         return;
     }
+    // Install stdout/stderr capture BEFORE the user's `app_fn` runs so
+    // every `println!` / `log::*` / panic message from user code reaches
+    // `whisker run`. No-op in release builds (the hot-reload feature
+    // gates the module out entirely).
+    start_log_capture();
     // Boxed init context, handed across the C ABI via raw pointer.
     let ctx = Box::new(InitCtx {
         engine: engine_raw as *mut WhiskerEngine,
@@ -172,6 +177,14 @@ fn start_hot_reload_receiver() {
 
 #[cfg(not(feature = "hot-reload"))]
 fn start_hot_reload_receiver() {}
+
+#[cfg(feature = "hot-reload")]
+fn start_log_capture() {
+    whisker_dev_runtime::start_log_capture();
+}
+
+#[cfg(not(feature = "hot-reload"))]
+fn start_log_capture() {}
 
 /// Apply the next pending hot patch, if any. Returns `true` when a
 /// patch was successfully applied so the caller can force a flush


### PR DESCRIPTION
## Summary

\`whisker run\` previously surfaced only its own dev-loop status — a \`println!\` from the user's app went to fd 1, which on Android is redirected to /dev/null by the runtime and on iOS sinks into the simulator container with no host-side observability. Users had to attach a separate terminal (\`adb logcat\` / \`simctl log stream\`) to read their own code's output.

This is Phase 1 of the planned 3-part whisker-cli refresh (stdout capture → TUI → doctor/new). It plumbs the data layer through; TUI integration follows in a separate PR.

## Design

- **Device side** (\`whisker-dev-runtime/src/log_capture.rs\`): new module that calls \`pipe(2)\` → \`dup(target_fd)\` → \`dup2(write_fd, target_fd)\`, redirecting stdout/stderr to our pipe while preserving a handle to the original fd. A blocking reader thread per stream reads from the pipe, splits on newlines, fans the raw bytes back to the saved original fd (so Xcode console attached to a sim launch still works), pushes line records onto a bounded \`tokio::sync::Notify\`-coordinated ring buffer, and also calls \`__android_log_write\` (\`whisker-stdout\` / \`whisker-stderr\` tags) or \`syslog\` for external-tool fan-out.

- **Wire**: new text frame \`{\"kind\":\"log\",\"stream\":\"stdout|stderr\",\"line\":...,\"ts_micros\":...}\` client→server. \`ts_micros\` is on the wire as a string because u128 doesn't round-trip cleanly through JSON's number type.

- **Server** (\`whisker-dev-server/src/server.rs\`): parses the new frame, emits new \`Event::DeviceLog { stream, line, ts_micros }\`. Fully additive — no protocol break.

- **CLI** (\`whisker-cli/src/run.rs\`): attaches an event handler that renders \`Event::DeviceLog\` as \`[device]\` / \`[device:err]\` prefixed entries via the existing line-based \`whisker_build::ui::info\` path. Phase 2 (ratatui TUI) replaces this with per-pane routing.

## What gets captured

Anything that writes to fd 1 / fd 2:

- \`println!\` / \`eprintln!\` / \`dbg!\`
- \`log\` crate macros with the standard backends (\`env_logger\`, \`simple_logger\`, \`pretty_env_logger\`, \`tracing\` with the default \`fmt::Subscriber\`)
- Rust's default panic hook output
- C FFI \`printf\` / \`fprintf(stderr, ...)\` from third-party native libs

**Not** captured: backends that bypass stdio (\`tracing-android\`, \`android_logger\`, direct \`__android_log_write\` / \`os_log\` from FFI). Users who pick those already opted into platform-log delivery.

## Test plan

End-to-end verified by adding two lines to \`examples/podcast/src/lib.rs\`:

\`\`\`rust
println!(\"podcast: app() starting\");
eprintln!(\"podcast: stderr test\");
\`\`\`

- [x] **iOS Simulator** (Apple Silicon / iOS 26.3): both lines appear in \`whisker run\` output as \`[device] podcast: app() starting\` and \`[device:err] podcast: stderr test\`. Existing internal \`eprintln!\` warnings from \`whisker-reactive\` now also flow through (free coverage we previously couldn't see).
- [x] **Android** (Pixel 9 Pro / arm64-v8a): same end-to-end behaviour. \`adb logcat -s whisker-stdout whisker-stderr\` shows the fan-out.
- [x] \`cargo test -p whisker-dev-runtime -p whisker-dev-server --lib\` — new \`log_capture\` buffer tests + new \`parse_client_log\` / DeviceLog event tests, all green (162 passed total).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

## Notes for review

- The Android dev-loop already needs a gradle plugin republish (PR #179's \`WhiskerBuildTask\` change) before this lands in production — same rollout dependency, no new constraint.
- Lynx's C++ engine writes some GL initialisation chatter to stderr that now flows through too. This is real signal/noise the next phase (TUI) will filter; Phase 1 captures everything intentionally so we have data to tune against.
- The \`ts_micros\` field is exposed but \`whisker-cli\` ignores it for now — the field is wired in for Phase 2's interleaving-by-time use case.