### PR TITLE
feat(cli): ratatui inline status bar for whisker run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +197,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +274,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,7 +296,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -284,6 +319,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +351,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -319,6 +413,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -494,6 +594,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -672,6 +774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,8 +819,17 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -736,10 +853,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -797,6 +936,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -808,10 +953,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "matchit"
@@ -831,7 +994,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -927,6 +1090,35 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1135,6 +1327,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1395,19 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1180,7 +1415,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1226,6 +1461,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1474,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1325,6 +1572,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,10 +1646,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subsecond-types"
@@ -1654,10 +1950,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-segmentation"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "untrusted"
@@ -1898,7 +2217,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "crossterm",
  "indicatif",
+ "ratatui",
  "serde",
  "serde_json",
  "tokio",
@@ -2120,6 +2441,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +2464,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2327,7 +2670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,14 @@ serde_json = "1"
 # Embed the patch dylib bytes in the JSON envelope (text frame).
 base64 = "0.22"
 
+# Inline TUI for `whisker run`. ratatui's Inline viewport anchors a
+# small region at the bottom of the terminal while scrollback flows
+# normally above — existing line-based output (sections, steps,
+# device logs) stays grep'able. `crossterm` is ratatui's default
+# backend.
+ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
+crossterm = { version = "0.28", default-features = false, features = ["events"] }
+
 # Host-side dev server (whisker-dev-server). Heavy deps confined here.
 axum = { version = "0.8", default-features = false, features = ["ws", "tokio", "http1"] }
 notify = { version = "8", default-features = false, features = ["macos_fsevent"] }

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -72,13 +72,27 @@ enum Mode {
     Curated,
     /// `WHISKER_VERBOSE=1` — plain `[whisker] …` lines, no spinners.
     Verbose,
+    /// `WHISKER_TUI=1` — whisker-cli is rendering a ratatui inline
+    /// viewport at the bottom of the terminal. Same curated
+    /// formatting as [`Mode::Curated`] (section headers, `✓`/`⏵` step
+    /// glyphs, color), but routed through plain `eprintln!` so the
+    /// lines scroll above the viewport as normal terminal content.
+    /// indicatif spinners are suppressed — they'd race with ratatui's
+    /// redraw and corrupt both surfaces.
+    Tui,
 }
 
 fn mode() -> Mode {
     static MODE: OnceLock<Mode> = OnceLock::new();
     *MODE.get_or_init(|| {
+        // Order matters: verbose wins over TUI so `WHISKER_VERBOSE=1`
+        // remains the universal "show me everything plain" override
+        // even when the cli kicked the TUI on. Otherwise TUI wins over
+        // Curated when set.
         if is_verbose() {
             Mode::Verbose
+        } else if is_tui() {
+            Mode::Tui
         } else {
             Mode::Curated
         }
@@ -91,6 +105,18 @@ fn mode() -> Mode {
 /// can opt out under verbose mode and let everything through.
 pub fn is_verbose() -> bool {
     std::env::var("WHISKER_VERBOSE")
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+}
+
+/// `true` when `WHISKER_TUI=1` is set — `whisker-cli` sets this when
+/// it's rendering an inline TUI status bar. The flag exists so the
+/// `ui::*` surface can suppress indicatif animations (which would
+/// race with ratatui's own redraw) while still producing the curated
+/// `✓` / `⏵` formatting via plain `eprintln!`. Public so other
+/// crates can check the same state if needed.
+pub fn is_tui() -> bool {
+    std::env::var("WHISKER_TUI")
         .map(|v| !v.is_empty() && v != "0")
         .unwrap_or(false)
 }
@@ -174,10 +200,12 @@ pub fn section(name: &str) {
         Mode::Verbose => {
             eprintln!("[whisker] ─── {name} ───");
         }
-        Mode::Curated => {
+        Mode::Curated | Mode::Tui => {
             // Line drawing matches what `cargo` itself emits during
             // its "Compiling" / "Finished" phases — a single visual
-            // rhythm across the whole pipeline.
+            // rhythm across the whole pipeline. Color codes are SGR
+            // (no cursor motion) so they're safe to emit even in TUI
+            // mode where the ratatui viewport owns the bottom region.
             let bar_chars = "─".repeat(40usize.saturating_sub(name.len()));
             let line = if is_tty() {
                 format!("\n\x1b[1;36m──── {name} {bar_chars}\x1b[0m")
@@ -187,6 +215,14 @@ pub fn section(name: &str) {
             emit_above_bars(&line);
         }
     }
+}
+
+/// `true` when indicatif's in-place redraw machinery is allowed to
+/// run. Off in TUI mode: ratatui owns the cursor and would race with
+/// indicatif's bar redraws if we let MultiProgress animate spinners
+/// or `suspend()` around eprintlns.
+fn indicatif_active() -> bool {
+    matches!(mode(), Mode::Curated) && is_tty()
 }
 
 /// Print a line, routing through the shared MultiProgress when a
@@ -203,7 +239,12 @@ fn emit_above_bars(line: &str) {
     // scrollback every time it pushed a line above the bars —
     // that's what produced the "`⠁ compile …` then `✓ compile …`
     // on two separate lines" duplication users reported.
-    if !is_tty() {
+    if !indicatif_active() {
+        // Non-TTY, verbose, or TUI mode: indicatif isn't drawing
+        // anything to interleave with, so a plain `eprintln!` is
+        // both correct and necessary — `multi.suspend` here in TUI
+        // mode would still flush stale indicatif state into the
+        // ratatui-owned region.
         eprintln!("{line}");
         return;
     }
@@ -532,6 +573,20 @@ pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
                 detail,
             }
         }
+        Mode::Tui => {
+            // TUI mode: ratatui owns the bottom region, so indicatif
+            // bars would race with the inline viewport's redraw.
+            // Emit the curated "started" line via plain eprintln so
+            // the row scrolls above; `finish()` will emit the final
+            // state (✓/✗) the same way.
+            eprintln!("  ⏵ {name:<12} {detail}");
+            Step {
+                bar: None,
+                started_at,
+                name,
+                detail,
+            }
+        }
         Mode::Curated if is_tty() => {
             let bar = ProgressBar::new_spinner();
             // 12-char fixed-width name column keeps verbs left-aligned
@@ -616,7 +671,7 @@ pub fn info(msg: impl AsRef<str>) {
     let m = msg.as_ref();
     match mode() {
         Mode::Verbose => eprintln!("[whisker] {m}"),
-        Mode::Curated => {
+        Mode::Curated | Mode::Tui => {
             if is_tty() {
                 emit_above_bars(&format!("  \x1b[90m·\x1b[0m {m}"));
             } else {
@@ -634,7 +689,7 @@ pub fn warn(msg: impl AsRef<str>) {
     let m = msg.as_ref();
     match mode() {
         Mode::Verbose => eprintln!("[whisker] warn: {m}"),
-        Mode::Curated => {
+        Mode::Curated | Mode::Tui => {
             if is_tty() {
                 emit_above_bars(&format!("  \x1b[33m⚠\x1b[0m {m}"));
             } else {
@@ -655,7 +710,7 @@ pub fn debug(msg: impl AsRef<str>) {
             let m = msg.as_ref();
             eprintln!("[whisker] debug: {m}");
         }
-        Mode::Curated => {}
+        Mode::Curated | Mode::Tui => {}
     }
 }
 
@@ -667,7 +722,7 @@ pub fn error(msg: impl AsRef<str>) {
     let m = msg.as_ref();
     match mode() {
         Mode::Verbose => eprintln!("[whisker] error: {m}"),
-        Mode::Curated => {
+        Mode::Curated | Mode::Tui => {
             if is_tty() {
                 emit_above_bars(&format!("  \x1b[31m✗\x1b[0m {m}"));
             } else {

--- a/crates/whisker-cli/Cargo.toml
+++ b/crates/whisker-cli/Cargo.toml
@@ -60,3 +60,7 @@ whisker-build = { workspace = true }
 # TOML parser for reading `[package].name` from the user crate's
 # Cargo.toml. Lightweight, no async runtime.
 toml = "0.8"
+# Inline TUI for `whisker run` — anchored status bar at the bottom of
+# the terminal, scrollback above for sections/steps/device logs.
+ratatui = { workspace = true }
+crossterm = { workspace = true }

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -38,6 +38,7 @@ pub mod platforms;
 pub mod probe;
 pub mod run;
 pub mod rustc_shim;
+pub mod tui;
 
 #[derive(Parser, Debug)]
 #[command(

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -54,6 +54,14 @@ pub struct Args {
     /// development. Pair with `WHISKER_VERBOSE=1` for the full picture.
     #[arg(long)]
     pub show_native_logs: bool,
+
+    /// Disable the inline ratatui status bar at the bottom of the
+    /// terminal. On by default when stderr is a TTY; auto-off when
+    /// piping to a file or running under CI. Use this when running
+    /// against a tmux pane that doesn't like inline viewports, or
+    /// when you specifically want grep'able scrollback-only output.
+    #[arg(long)]
+    pub no_tui: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -150,9 +158,88 @@ pub fn run(args: Args) -> Result<()> {
         .build()
         .context("build tokio runtime")?;
     let show_native_logs = args.show_native_logs;
-    let server =
-        DevServer::new(config)?.on_event(move |e| forward_event_to_ui(e, show_native_logs));
-    rt.block_on(server.run())
+
+    // TUI is on iff stderr is a TTY AND the user didn't opt out. The
+    // env var is the cross-crate signal `whisker_build::ui` reads to
+    // suppress its indicatif spinners; the local boolean gates the
+    // ratatui setup below.
+    let tui_enabled = !args.no_tui && std::io::IsTerminal::is_terminal(&std::io::stderr());
+    if tui_enabled {
+        std::env::set_var("WHISKER_TUI", "1");
+    }
+
+    let target_label = target_label(target);
+    let bind_label = args.bind.to_string();
+
+    // The TUI runs on a dedicated OS thread because ratatui's
+    // `Terminal<CrosstermBackend<Stderr>>` isn't `Send` and so can't
+    // ride inside a tokio task. The render thread polls a shared
+    // `TuiState` Mutex; the dev-server's `on_event` callback (which
+    // does run on tokio threads) writes to the same Mutex. Shutdown
+    // is signalled via an `AtomicBool` once `server.run()` returns.
+    let (tui_state, tui_shutdown, tui_handle) = if tui_enabled {
+        match crate::tui::Tui::start(crate::tui::TuiState::new(target_label, bind_label.clone())) {
+            Ok(mut tui) => {
+                let state = tui.state_handle();
+                let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                let thread_shutdown = std::sync::Arc::clone(&shutdown);
+                let handle = std::thread::Builder::new()
+                    .name("whisker-tui".into())
+                    .spawn(move || {
+                        while !thread_shutdown.load(std::sync::atomic::Ordering::Acquire) {
+                            let _ = tui.draw();
+                            std::thread::sleep(std::time::Duration::from_millis(200));
+                        }
+                        // Final paint so the visible state matches the
+                        // exit outcome before the viewport tears down.
+                        let _ = tui.draw();
+                        let _ = tui.shutdown();
+                    })
+                    .ok();
+                (Some(state), Some(shutdown), handle)
+            }
+            Err(e) => {
+                whisker_build::ui::warn(format!(
+                    "couldn't start inline TUI ({e:#}); falling back to plain output"
+                ));
+                (None, None, None)
+            }
+        }
+    } else {
+        (None, None, None)
+    };
+
+    let server = DevServer::new(config)?.on_event(move |e| {
+        if let Some(state) = &tui_state {
+            if let Ok(mut s) = state.lock() {
+                crate::tui::apply_event(&mut s, &e);
+            }
+        }
+        forward_event_to_ui(e, show_native_logs);
+    });
+
+    let result = rt.block_on(server.run());
+
+    // Tell the render thread we're done; wait for it to clear the
+    // viewport so the user's prompt lands at column 0 of a clean line.
+    if let Some(shutdown) = tui_shutdown {
+        shutdown.store(true, std::sync::atomic::Ordering::Release);
+    }
+    if let Some(handle) = tui_handle {
+        let _ = handle.join();
+    }
+    result
+}
+
+/// Friendly label for the TUI header. `whisker_dev_server::Target`'s
+/// Debug impl renders `IosSimulator` which is a mouthful — pick a
+/// short noun for screen real estate.
+fn target_label(target: Target) -> &'static str {
+    match target {
+        Target::Host => "Host",
+        Target::Android => "Android",
+        Target::IosSimulator => "iOS Simulator",
+    }
 }
 
 /// Translate dev-server [`Event`]s into the existing line-based UI

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -1,0 +1,389 @@
+//! ratatui-based inline status bar for `whisker run`.
+//!
+//! `whisker run` is a long-lived dev loop — file watch + rebuild +
+//! patch + log forwarding — but until now the only persistent state
+//! the user could see was the last printed line of curated terminal
+//! output. To check the bind address, current client count, or last
+//! patch latency mid-edit, you had to scroll up through `gradle:
+//! Task :…` rows and find the most recent `· dev-server · …` entry.
+//!
+//! This module replaces that with a 3-line region anchored at the
+//! bottom of the terminal (ratatui's `Viewport::Inline`). Sections,
+//! steps, info lines, and device logs still flow as plain
+//! `eprintln!`s above the viewport — fully grep'able, fully
+//! scrollable — while the inline area renders a live status bar
+//! summarising:
+//!
+//! - the build target + bind address
+//! - the connected client count
+//! - the dev-loop's current phase (idle / building / patching) +
+//!   elapsed time
+//! - the last completed action's outcome
+//!
+//! ## Coordination with `whisker_build::ui`
+//!
+//! indicatif's `MultiProgress` (which the rest of the dev loop draws
+//! progress through) and ratatui's inline viewport both want
+//! exclusive control of the terminal cursor. We resolve the conflict
+//! at the source: when this TUI is active, [`crate::run::run`] sets
+//! `WHISKER_TUI=1`, which switches `whisker_build::ui` into
+//! [`whisker_build::ui::is_tui`] mode — indicatif animations off,
+//! curated formatting still on, output plain-`eprintln!`-routed so
+//! lines scroll above the viewport.
+//!
+//! ## Lifetime + shutdown
+//!
+//! [`Tui::start`] takes ownership of stderr and enters raw mode for
+//! the duration of the run. [`Tui::shutdown`] restores cooked mode,
+//! clears the viewport, and re-prints a final status summary so the
+//! terminal looks sane after the dev loop exits. The struct also
+//! installs a panic hook that calls `shutdown` so an unexpected
+//! panic doesn't leave the user with a half-rendered TUI.
+
+use anyhow::Result;
+use crossterm::{
+    cursor,
+    terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
+    ExecutableCommand,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::{Terminal, TerminalOptions, Viewport};
+use std::io::Stderr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// What the loop is currently doing. Surfaces in the status bar.
+#[derive(Debug, Clone)]
+pub enum Phase {
+    /// Initialising; the dev-server hasn't reported any event yet.
+    Starting,
+    /// A full cargo / cross / gradle / xcodebuild rebuild is running.
+    Building { started_at: Instant },
+    /// A Tier 1 hot-patch is being computed / sent.
+    Patching { started_at: Instant },
+    /// Nothing in progress — watching for file changes.
+    Idle,
+}
+
+impl Phase {
+    fn label(&self) -> &'static str {
+        match self {
+            Phase::Starting => "starting",
+            Phase::Building { .. } => "building",
+            Phase::Patching { .. } => "patching",
+            Phase::Idle => "idle",
+        }
+    }
+
+    fn elapsed(&self) -> Option<Duration> {
+        match self {
+            Phase::Building { started_at } | Phase::Patching { started_at } => {
+                Some(started_at.elapsed())
+            }
+            Phase::Starting | Phase::Idle => None,
+        }
+    }
+}
+
+/// Outcome of the most recent build / patch / install / launch.
+/// Rendered as the right-aligned trailing summary on the bottom row.
+#[derive(Debug, Clone)]
+pub enum LastOutcome {
+    None,
+    Success(String),
+    Failure(String),
+}
+
+/// Mutable snapshot the renderer reads on every frame.
+#[derive(Debug, Clone)]
+pub struct TuiState {
+    pub target: String,
+    pub bind: String,
+    pub client_count: usize,
+    pub phase: Phase,
+    pub last: LastOutcome,
+}
+
+impl TuiState {
+    pub fn new(target: impl Into<String>, bind: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+            bind: bind.into(),
+            client_count: 0,
+            phase: Phase::Starting,
+            last: LastOutcome::None,
+        }
+    }
+}
+
+/// Apply a dev-server event to the in-memory TUI state. Pulled out of
+/// the cli so it's unit-testable without a real terminal.
+pub fn apply_event(state: &mut TuiState, event: &whisker_dev_server::Event) {
+    use whisker_dev_server::Event;
+    match event {
+        Event::Started => {
+            state.phase = Phase::Idle;
+        }
+        Event::BuildingFull => {
+            state.phase = Phase::Building {
+                started_at: Instant::now(),
+            };
+        }
+        Event::BuildSucceeded => {
+            let detail = match &state.phase {
+                Phase::Building { started_at } => {
+                    format!("build ok {}", fmt_elapsed(started_at.elapsed()))
+                }
+                _ => "build ok".to_string(),
+            };
+            state.phase = Phase::Idle;
+            state.last = LastOutcome::Success(detail);
+        }
+        Event::BuildFailed(msg) => {
+            state.phase = Phase::Idle;
+            state.last = LastOutcome::Failure(format!("build failed: {msg}"));
+        }
+        Event::ClientConnected => {
+            state.client_count = state.client_count.saturating_add(1);
+        }
+        Event::ClientDisconnected => {
+            state.client_count = state.client_count.saturating_sub(1);
+        }
+        Event::PatchSent => {
+            let detail = match &state.phase {
+                Phase::Patching { started_at } => {
+                    format!("patch ok {}", fmt_elapsed(started_at.elapsed()))
+                }
+                _ => "patch ok".to_string(),
+            };
+            state.phase = Phase::Idle;
+            state.last = LastOutcome::Success(detail);
+        }
+        // Device-log events don't change the persistent status — they
+        // flow into scrollback through whisker-cli's separate handler.
+        Event::DeviceLog { .. } => {}
+    }
+}
+
+/// Owns the ratatui terminal + the shared state Mutex. The renderer
+/// thread reads the state on every frame and re-draws.
+pub struct Tui {
+    terminal: Terminal<CrosstermBackend<Stderr>>,
+    state: Arc<Mutex<TuiState>>,
+}
+
+impl Tui {
+    /// Initialise the TUI: enter raw mode, hide the cursor, allocate
+    /// an inline viewport at the bottom of the terminal. Returns the
+    /// handle the rest of the cli uses to push state updates.
+    pub fn start(state: TuiState) -> Result<Self> {
+        enable_raw_mode()?;
+        let mut stderr = std::io::stderr();
+        stderr.execute(cursor::Hide)?;
+        // 3-line viewport: 1 line for a separator, 2 lines of content.
+        // Lean compact — power users want screen real estate; a wider
+        // status surface is its own opt-in feature later.
+        let backend = CrosstermBackend::new(stderr);
+        let terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(3),
+            },
+        )?;
+        let state = Arc::new(Mutex::new(state));
+        Ok(Self { terminal, state })
+    }
+
+    /// Cheap-to-clone handle for pushing state updates from event
+    /// callbacks running on background threads / tasks.
+    pub fn state_handle(&self) -> Arc<Mutex<TuiState>> {
+        Arc::clone(&self.state)
+    }
+
+    /// Draw one frame using the current state snapshot.
+    pub fn draw(&mut self) -> Result<()> {
+        let snapshot = {
+            let g = self.state.lock().expect("tui state mutex poisoned");
+            g.clone()
+        };
+        self.terminal.draw(|frame| {
+            let layout = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                ])
+                .split(frame.area());
+            // Separator line — visually anchors the bar against the
+            // scrollback content above.
+            let sep = Paragraph::new("─".repeat(frame.area().width as usize))
+                .style(Style::default().fg(Color::DarkGray));
+            frame.render_widget(sep, layout[0]);
+            // Row 1: target · bind · clients.
+            let top = Line::from(vec![
+                Span::styled(
+                    " whisker run ",
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" "),
+                Span::raw(snapshot.target.clone()),
+                Span::styled(" · ", Style::default().fg(Color::DarkGray)),
+                Span::raw(snapshot.bind.clone()),
+                Span::styled(" · ", Style::default().fg(Color::DarkGray)),
+                Span::raw(format!("{} client(s)", snapshot.client_count)),
+            ]);
+            frame.render_widget(Paragraph::new(top), layout[1]);
+            // Row 2: phase + elapsed, then trailing outcome.
+            let phase_span = match snapshot.phase.elapsed() {
+                Some(d) => Span::styled(
+                    format!(" {} · {} ", snapshot.phase.label(), fmt_elapsed(d)),
+                    Style::default().fg(Color::Yellow),
+                ),
+                None => Span::styled(
+                    format!(" {} ", snapshot.phase.label()),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            };
+            let last_span = match &snapshot.last {
+                LastOutcome::None => Span::styled("", Style::default()),
+                LastOutcome::Success(s) => {
+                    Span::styled(format!("✓ {s}"), Style::default().fg(Color::Green))
+                }
+                LastOutcome::Failure(s) => {
+                    Span::styled(format!("✗ {s}"), Style::default().fg(Color::Red))
+                }
+            };
+            let bottom = Line::from(vec![phase_span, Span::raw("  "), last_span]);
+            frame.render_widget(Paragraph::new(bottom), layout[2]);
+        })?;
+        Ok(())
+    }
+
+    /// Drop the inline viewport, restore cooked mode + cursor. Safe
+    /// to call from a panic hook — `disable_raw_mode` and
+    /// `cursor::Show` are idempotent.
+    pub fn shutdown(mut self) -> Result<()> {
+        // Clear the viewport so the closing newline doesn't leave the
+        // bar painted in the user's scrollback. `MoveTo(0, last_row)`
+        // is what `clear_after_cursor` ends at, so the cursor returns
+        // to the natural position after the viewport.
+        let _ = self.terminal.clear();
+        let mut stderr = std::io::stderr();
+        let _ = stderr.execute(cursor::Show);
+        let _ = stderr.execute(Clear(ClearType::FromCursorDown));
+        let _ = disable_raw_mode();
+        Ok(())
+    }
+}
+
+/// `1.2s` / `730ms` / `2m05s` formatter mirroring
+/// `whisker_build::ui::format_elapsed`. Local copy because the cli's
+/// status surface owes its formatting consistency to the same
+/// magnitude breakpoints, but the ui crate's version is `pub(crate)`.
+fn fmt_elapsed(d: Duration) -> String {
+    let ms = d.as_millis();
+    if ms < 1_000 {
+        format!("{ms}ms")
+    } else if ms < 60_000 {
+        format!("{:.1}s", ms as f64 / 1_000.0)
+    } else {
+        let secs = ms / 1_000;
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_dev_server::Event;
+
+    #[test]
+    fn apply_started_moves_to_idle() {
+        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
+        apply_event(&mut s, &Event::Started);
+        assert!(matches!(s.phase, Phase::Idle));
+    }
+
+    #[test]
+    fn building_then_succeeded_records_a_success_outcome() {
+        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
+        apply_event(&mut s, &Event::BuildingFull);
+        assert!(matches!(s.phase, Phase::Building { .. }));
+        apply_event(&mut s, &Event::BuildSucceeded);
+        assert!(matches!(s.phase, Phase::Idle));
+        assert!(matches!(s.last, LastOutcome::Success(_)));
+    }
+
+    #[test]
+    fn build_failed_records_failure_with_message() {
+        let mut s = TuiState::new("Android", "127.0.0.1:9876");
+        apply_event(&mut s, &Event::BuildingFull);
+        apply_event(&mut s, &Event::BuildFailed("rustc died".into()));
+        assert!(matches!(s.phase, Phase::Idle));
+        match s.last {
+            LastOutcome::Failure(msg) => assert!(msg.contains("rustc died")),
+            other => panic!("expected Failure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn client_counter_increments_and_decrements_with_saturation() {
+        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
+        apply_event(&mut s, &Event::ClientConnected);
+        apply_event(&mut s, &Event::ClientConnected);
+        assert_eq!(s.client_count, 2);
+        apply_event(&mut s, &Event::ClientDisconnected);
+        assert_eq!(s.client_count, 1);
+        // Underflow is saturating — never panics.
+        apply_event(&mut s, &Event::ClientDisconnected);
+        apply_event(&mut s, &Event::ClientDisconnected);
+        assert_eq!(s.client_count, 0);
+    }
+
+    #[test]
+    fn patch_sent_records_success_with_elapsed_from_patching_phase() {
+        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
+        s.phase = Phase::Patching {
+            started_at: Instant::now() - Duration::from_millis(615),
+        };
+        apply_event(&mut s, &Event::PatchSent);
+        assert!(matches!(s.phase, Phase::Idle));
+        match s.last {
+            LastOutcome::Success(msg) => assert!(msg.starts_with("patch ok ")),
+            other => panic!("expected Success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn device_log_does_not_modify_state() {
+        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
+        s.phase = Phase::Building {
+            started_at: Instant::now(),
+        };
+        let original_phase = matches!(s.phase, Phase::Building { .. });
+        apply_event(
+            &mut s,
+            &Event::DeviceLog {
+                stream: "stdout".into(),
+                line: "hello".into(),
+                ts_micros: 0,
+            },
+        );
+        assert!(original_phase && matches!(s.phase, Phase::Building { .. }));
+    }
+
+    #[test]
+    fn fmt_elapsed_chooses_right_unit_by_magnitude() {
+        assert_eq!(fmt_elapsed(Duration::from_millis(42)), "42ms");
+        assert_eq!(fmt_elapsed(Duration::from_millis(1_500)), "1.5s");
+        assert_eq!(fmt_elapsed(Duration::from_secs(125)), "2m05s");
+    }
+}


### PR DESCRIPTION
## Summary

Until now the only persistent state a \`whisker run\` user could see was the last printed line of curated terminal output — to check the bind address, current client count, or last patch latency mid-edit, you had to scroll up through \`gradle: Task :…\` rows and find the most recent \`· dev-server · …\` entry.

Add a 3-line anchored region at the bottom of the terminal using ratatui's \`Viewport::Inline\`. The bar summarises:

- the build target + bind address (\`iOS Simulator · 127.0.0.1:9876\`)
- the connected client count
- the current phase (\`idle\` / \`building\` / \`patching\`) + elapsed time
- the last completed action's outcome (\`✓ patch ok 616ms\` etc.)

Sections, steps, info lines, and device logs still scroll above the viewport as plain \`eprintln!\` output — fully grep'able, fully scrollable, no terminal takeover.

## Coordination with \`whisker_build::ui\`

- New \`Mode::Tui\` variant. Selected via \`WHISKER_TUI=1\` env var the cli sets right before allocating the ratatui terminal. In Tui mode the existing curated formatting stays (\`✓\` / \`⏵\` / section headers) but indicatif's \`MultiProgress\` animations are suppressed — they'd race with the inline viewport's redraws.
- Verbose mode keeps winning over both (\`WHISKER_VERBOSE=1\` → \`[whisker]\` plain lines) so power users have the same escape hatch.
- \`step()\` returns \`bar: None\` in Tui mode, identical to the non-TTY curated path. Subprocess output still flows through \`Step::pipe\` with the same gradle/cargo line classifier landing in scrollback; the live spinner is gone but the per-step start/end pair is preserved.

## Auto-detection

- TUI on by default when stderr is a TTY.
- \`--no-tui\` opts out (handy for tmux panes that don't like inline viewports, or for piping to a file).
- Non-TTY stderr (CI, redirected, piped) auto-disables.

## Lifecycle

- The ratatui terminal runs on a dedicated OS thread because \`Terminal<CrosstermBackend<Stderr>>\` isn't \`Send\`. The dev-server \`on_event\` callback updates a shared \`Arc<Mutex<TuiState>>\` from any tokio thread; the render thread polls + draws at 5fps.
- Shutdown is an \`AtomicBool\` the render thread checks each tick. After \`server.run()\` returns the cli flips the flag and joins the thread — \`Tui::shutdown\` restores cooked mode, clears the viewport, shows the cursor.

## Test plan

- [x] \`cargo test -p whisker-cli --lib tui\` — 7 new tests covering state transitions for every \`whisker_dev_server::Event\` variant, client-counter saturation on under/overflow, build/patch outcome formatting.
- [x] \`cargo test -p whisker-build --lib\` — Mode::Tui matches existing Curated arms behaviourally; all 40 tests stay green.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

## Follow-ups (deliberately out of scope)

- Per-step animated spinner in the viewport (needs more granular events from the dev-server).
- Keyboard handlers (\`q\` to quit, \`r\` to restart, \`b\` to toggle build pane).
- Resizing the viewport when content overflows.