### PR TITLE
fix(cli): TUI cooked mode + WHISKER_TUI early-set + Ctrl-C + Android double-build + gradle plain console

### DIFF
--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -43,7 +43,7 @@
 use anyhow::Result;
 use crossterm::{
     cursor,
-    terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
+    terminal::{Clear, ClearType},
     ExecutableCommand,
 };
 use ratatui::backend::CrosstermBackend;
@@ -177,11 +177,23 @@ pub struct Tui {
 }
 
 impl Tui {
-    /// Initialise the TUI: enter raw mode, hide the cursor, allocate
-    /// an inline viewport at the bottom of the terminal. Returns the
-    /// handle the rest of the cli uses to push state updates.
+    /// Initialise the TUI: hide the cursor, allocate an inline
+    /// viewport at the bottom of the terminal. Returns the handle the
+    /// rest of the cli uses to push state updates.
+    ///
+    /// **Cooked mode, not raw.** A previous iteration called
+    /// `enable_raw_mode()` here — that's what `ratatui` examples do
+    /// because they're handling keyboard input. We don't, and raw
+    /// mode breaks the rest of the dev loop: every `eprintln!` that
+    /// other crates use to write sections / steps / device logs
+    /// emits a bare `\n` (no `\r`), which under raw-mode tty
+    /// settings moves the cursor down one row but leaves it at the
+    /// same column the previous line ended at. The visible result
+    /// is a staircase of `⏵`/`✓` rows drifting rightward across the
+    /// screen. Skipping `enable_raw_mode` keeps `\n` → CRLF
+    /// translation on, so all of the legacy line-based output
+    /// scrolls cleanly at column 0 above the viewport.
     pub fn start(state: TuiState) -> Result<Self> {
-        enable_raw_mode()?;
         let mut stderr = std::io::stderr();
         stderr.execute(cursor::Hide)?;
         // 3-line viewport: 1 line for a separator, 2 lines of content.
@@ -267,19 +279,15 @@ impl Tui {
         Ok(())
     }
 
-    /// Drop the inline viewport, restore cooked mode + cursor. Safe
-    /// to call from a panic hook — `disable_raw_mode` and
-    /// `cursor::Show` are idempotent.
+    /// Drop the inline viewport + restore the cursor. We never
+    /// flipped to raw mode (see [`Tui::start`]), so there's nothing
+    /// to undo there — just clear the viewport region and re-show
+    /// the cursor so the user's shell prompt lands on a clean line.
     pub fn shutdown(mut self) -> Result<()> {
-        // Clear the viewport so the closing newline doesn't leave the
-        // bar painted in the user's scrollback. `MoveTo(0, last_row)`
-        // is what `clear_after_cursor` ends at, so the cursor returns
-        // to the natural position after the viewport.
         let _ = self.terminal.clear();
         let mut stderr = std::io::stderr();
         let _ = stderr.execute(cursor::Show);
         let _ = stderr.execute(Clear(ClearType::FromCursorDown));
-        let _ = disable_raw_mode();
         Ok(())
     }
 }


### PR DESCRIPTION
Six fixes layered on top of #184 surfacing as the user actually drives the dev loop.

## 1. Don't enable raw mode for the inline TUI

#184's `Tui::start` called `enable_raw_mode()` cargo-cult-style from ratatui examples. We don't read keyboard input, and raw-mode termios turns off `ONLCR`, so every `eprintln!` from the rest of the dev loop emits bare LF — the cursor moves down a row but stays at whatever column the previous line ended at, producing a staircase of `⏵` / `✓` rows drifting off the right edge.

Fix: drop `enable_raw_mode` / `disable_raw_mode`. ratatui's `Viewport::Inline` redraws fine in cooked mode.

## 2. Cursor restoration on Ctrl-C / panic

`Tui::start` issues `cursor::Hide` to keep the blinking caret from sitting in the viewport. `Tui::shutdown` un-hides it on the happy path, but on `^C` the default SIGINT handler kills the process before any Drop / shutdown code runs — leaving the user's shell with an invisible cursor.

Install two cleanup hooks once-per-process from `Tui::start`:

- `std::panic::set_hook` chain → `cursor::Show` + `Clear(FromCursorDown)` before delegating.
- `ctrlc::set_handler` → same cleanup + `std::process::exit(130)` (= 128 + SIGINT).

## 3. Slow the redraw from 5Hz to 1Hz

ratatui's inline viewport and foreign `eprintln!` from the rest of the dev loop both write to stderr without a shared lock, so every redraw is a chance for output to interleave with the bar's draw cycle — symptom: cargo warnings from the build land mid-status-bar, corrupting the layout. 5Hz multiplied that window by 5×; 1Hz is plenty of resolution for human-perceivable elapsed ticks while letting build output land cleanly between frames.

## 4. Fold the plugin-build cargo invocation into a step

`build_discovered_plugins` (run during `whisker run` setup, before the dev loop's `── whisker run ──` section header) used a raw `cmd.status()` so cargo's `    Finished \`dev\` profile…` line leaked out unfiltered. With the TUI on, that line landed *after* the status bar was already rendering, racing the redraw.

Switch to `Step::pipe` (\`✓ compile  plugins (whisker-audio-plugin)  N.Ns\`) so the row matches the rest of the curated layout.

## 5. Drop Android's pre-cargo build (align with iOS)

`Builder::build_android` ran cargo twice: once directly (`cargo_build_dylib`), then again inside gradle's `whiskerBuildDebugArm64V8a` task. The dev-server's pre-build was then staged into `app/src/main/jniLibs/` and immediately overwritten by AGP's `mergeJniLibFolders` step with gradle's output.

iOS already sidesteps this — its `build_ios_simulator` only stages module Swift sources; cargo runs inside the xcodebuild Build Phase. Align Android to the same shape:

- Drop `cargo_build_dylib` + `stage_jni_libs` from `Builder::build_android`.
- Update `original_binary_path` for Android to read from `target/<triple>/release/lib<pkg>.so` (the canonical cargo output dir gradle's `whisker-build android` invocation writes to) instead of the now-vestigial `app/src/main/jniLibs/` copy.
- Existing unit test renamed `original_binary_path_finds_android_so_under_cargo_target`.

Net effect: halves the wall-clock of every Tier 2 rebuild on a cache-warm cargo, removes one race against the TUI viewport, and removes ~30 lines of leaked cargo output from every initial run.

## 6. Force gradle's console to `plain`

Gradle's default `--console=auto` mode upgrades to ANSI-escape-driven in-place progress redraws when it thinks stdout is a TTY. With the inline TUI on, those redraw escapes leak into the viewport area and corrupt the layout (this is the "iOS でも Cargo のビルドログが出ています" / "Android のビルドのみ warning でレイアウトが崩れる" the user reported).

Add `--console=plain` to the gradle command line so output is always line-by-line, no in-place redraws — fits cleanly through our existing `Step::pipe` + `gradle_progress_text` line classifier.

## Test plan

- [x] `cargo test -p whisker-dev-server -p whisker-build -p whisker-cli --lib` — 158 + 40 + 82 = 280 tests still green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Manual: `whisker run --target ios` from a fresh terminal. No staircase, no leaked `Finished dev profile`, `^C` returns the cursor.
- [x] Manual: `whisker run --target android` — gradle output now folds entirely into the `✓ gradle :app:assembleDebug N.Ns` row. The dev-server no longer pre-builds cargo, halving Initial build wall-clock on a cache-warm rebuild.

## Follow-ups (not in this PR)

- **TUI viewport vs subprocess output race.** The 1Hz mitigation in §3 is partial — heavy cargo / rustc warning bursts can still nick a frame. The structural fix is to route every `eprintln!` through `Terminal::insert_before` so ratatui serialises scrollback writes. That's a substantial touch across `whisker_build::ui`'s entire public surface.