### PR TITLE
fix(cli): TUI mode caching + Ctrl-C cursor + Android single-build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +235,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -354,6 +369,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +427,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1035,6 +1073,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1116,21 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object"
@@ -2218,6 +2283,7 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm",
+ "ctrlc",
  "indicatif",
  "ratatui",
  "serde",

--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -548,6 +548,15 @@ pub fn run_gradle_assemble(
     let mut cmd = Command::new(&gradlew);
     cmd.arg(task)
         .arg("--no-daemon")
+        // `--console=plain` forces gradle to emit line-by-line output
+        // instead of its default `auto` heuristic, which on a TTY
+        // upgrades to ANSI-escape-driven in-place progress redraws.
+        // We pipe gradle through `Step::pipe` so the ANSI codes never
+        // reach a real terminal — but our line-based classifier
+        // doesn't know how to strip them, and the curated TUI's inline
+        // viewport gets corrupted by cursor-moving sequences leaking
+        // through. Plain console mode side-steps both.
+        .arg("--console=plain")
         .current_dir(gen_android)
         .env("JAVA_HOME", &java_home);
     if !features.is_empty() {

--- a/crates/whisker-cli/Cargo.toml
+++ b/crates/whisker-cli/Cargo.toml
@@ -64,3 +64,7 @@ toml = "0.8"
 # the terminal, scrollback above for sections/steps/device logs.
 ratatui = { workspace = true }
 crossterm = { workspace = true }
+# Ctrl-C handler so the TUI can restore cursor visibility before the
+# process exits — without it, the shell ends up with a hidden cursor
+# after `^C`. Tiny crate, no async runtime.
+ctrlc = "3"

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -209,7 +209,19 @@ fn build_engine_with_discovered_plugins(
 /// plugin's `[[bin]]` target. We use the workspace's existing
 /// `target/debug` so subsequent runs are no-op when the plugin
 /// crates haven't changed (cargo's own incremental cache).
+///
+/// Output streams through the curated `Step::pipe` machinery so the
+/// cargo progress (`    Compiling …` / `    Finished …` lines) folds
+/// into a single spinner row instead of leaking unfiltered ahead of
+/// the dev loop's `── whisker run ──` section header — and, with
+/// the TUI on, ahead of the inline status bar where stray
+/// `eprintln!`s race the viewport redraw.
 fn build_discovered_plugins(workspace_root: &Path, discovered: &[DiscoveredPlugin]) -> Result<()> {
+    let bins: Vec<&str> = discovered
+        .iter()
+        .map(|p| p.bin_target_name.as_str())
+        .collect();
+    let step = whisker_build::ui::step("compile", format!("plugins ({})", bins.join(", ")));
     let mut cmd = Command::new("cargo");
     cmd.arg("build").current_dir(workspace_root);
     for plugin in discovered {
@@ -218,16 +230,18 @@ fn build_discovered_plugins(workspace_root: &Path, discovered: &[DiscoveredPlugi
             .arg("--package")
             .arg(&plugin.source_crate);
     }
-    let status = cmd
-        .status()
+    let status = step
+        .pipe(&mut cmd)
         .with_context(|| "spawn `cargo build` for discovered Whisker CNG plugin binaries")?;
     if !status.success() {
+        step.fail(format!("{status}"));
         return Err(anyhow!(
             "`cargo build` for discovered Whisker CNG plugin binaries exited with {status}. \
              Re-run with `RUST_BACKTRACE=1 cargo build --bin <bin> --package <crate>` to see \
              the underlying compile error."
         ));
     }
+    step.done("");
     Ok(())
 }
 

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -82,6 +82,23 @@ impl From<CliTarget> for Target {
 }
 
 pub fn run(args: Args) -> Result<()> {
+    // Decide and announce the TUI mode BEFORE any `whisker_build::ui::*`
+    // call fires — that crate caches its `Mode` lookup in a `OnceLock`
+    // on the first call to `mode()`, so by the time
+    // `build_discovered_plugins` (run inside `sync_for_target` below)
+    // emits its first `ui::step`, the cache is locked. If we set
+    // `WHISKER_TUI=1` later the way the previous iteration of this
+    // file did, every subsequent `step()` keeps using indicatif's
+    // animated bar — which then leaks padded fixed-width rows next
+    // to the ratatui viewport once the TUI actually starts. Setting
+    // the env var here, before any other code path can touch the
+    // ui module, makes every `step()` go through the plain-line
+    // branch and lets the viewport own the bottom region cleanly.
+    let tui_enabled = !args.no_tui && std::io::IsTerminal::is_terminal(&std::io::stderr());
+    if tui_enabled {
+        std::env::set_var("WHISKER_TUI", "1");
+    }
+
     let m = manifest::resolve(args.manifest_path.as_deref())
         .context("resolve user-crate manifest (Cargo.toml + whisker.rs)")?;
 
@@ -159,14 +176,11 @@ pub fn run(args: Args) -> Result<()> {
         .context("build tokio runtime")?;
     let show_native_logs = args.show_native_logs;
 
-    // TUI is on iff stderr is a TTY AND the user didn't opt out. The
-    // env var is the cross-crate signal `whisker_build::ui` reads to
-    // suppress its indicatif spinners; the local boolean gates the
-    // ratatui setup below.
+    // `tui_enabled` was decided + the env var was set at the very top
+    // of this function so the early `ui::step` calls inside
+    // `sync_for_target` would see the right `Mode`. Reuse the same
+    // detection here so the ratatui setup matches.
     let tui_enabled = !args.no_tui && std::io::IsTerminal::is_terminal(&std::io::stderr());
-    if tui_enabled {
-        std::env::set_var("WHISKER_TUI", "1");
-    }
 
     let target_label = target_label(target);
     let bind_label = args.bind.to_string();
@@ -188,7 +202,18 @@ pub fn run(args: Args) -> Result<()> {
                     .spawn(move || {
                         while !thread_shutdown.load(std::sync::atomic::Ordering::Acquire) {
                             let _ = tui.draw();
-                            std::thread::sleep(std::time::Duration::from_millis(200));
+                            // 1Hz redraw. ratatui's inline viewport and
+                            // foreign `eprintln!` from the rest of the
+                            // dev loop both write to stderr without
+                            // a shared lock, so every frame is a chance
+                            // for output to interleave with the bar's
+                            // redraw. Polling at 5Hz (the original)
+                            // multiplied that race window by 5×; 1Hz
+                            // is plenty for human-perceivable elapsed
+                            // ticks while letting the bulk of the
+                            // build's stderr output land cleanly
+                            // between frames.
+                            std::thread::sleep(std::time::Duration::from_millis(1000));
                         }
                         // Final paint so the visible state matches the
                         // exit outcome before the viewport tears down.

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -207,6 +207,22 @@ impl Tui {
             },
         )?;
         let state = Arc::new(Mutex::new(state));
+
+        // Cleanup hooks for the two ways a `whisker run` can exit
+        // without our normal `Tui::shutdown` running:
+        //
+        // 1. **Panic** — `std::panic::set_hook` chains: our hook
+        //    restores cursor visibility + clears below it before
+        //    chaining to whatever was installed before us (typically
+        //    the default panic printer, which writes the message to
+        //    stderr — that lands in a clean terminal because we
+        //    cleaned up first).
+        // 2. **Ctrl-C** — the default SIGINT handler kills the
+        //    process before any Drop / shutdown code runs, leaving
+        //    the cursor hidden. `ctrlc::set_handler` installs an
+        //    OS-level handler that runs our cleanup then exits.
+        install_terminal_cleanup_once();
+
         Ok(Self { terminal, state })
     }
 
@@ -290,6 +306,39 @@ impl Tui {
         let _ = stderr.execute(Clear(ClearType::FromCursorDown));
         Ok(())
     }
+}
+
+/// Restore the cursor + clear anything below it. Used by both the
+/// panic hook and the Ctrl-C handler.
+fn emergency_terminal_reset() {
+    let mut stderr = std::io::stderr();
+    let _ = stderr.execute(cursor::Show);
+    let _ = stderr.execute(Clear(ClearType::FromCursorDown));
+}
+
+/// Install the panic hook + SIGINT handler. Idempotent — only the
+/// first `Tui::start` of the process installs anything; later calls
+/// are no-ops. The handlers stay registered for the rest of the
+/// process lifetime (no good way to unregister either), but that's
+/// fine: their cleanup is a no-op on already-cooked stderr.
+fn install_terminal_cleanup_once() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static INSTALLED: AtomicBool = AtomicBool::new(false);
+    if INSTALLED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        emergency_terminal_reset();
+        prev_hook(info);
+    }));
+    // `ctrlc::set_handler` errors if a handler is already registered.
+    // We treat that as benign — somebody else cared about the same
+    // cleanup, our reset would just run twice in the worst case.
+    let _ = ctrlc::set_handler(|| {
+        emergency_terminal_reset();
+        std::process::exit(130); // 128 + SIGINT
+    });
 }
 
 /// `1.2s` / `730ms` / `2m05s` formatter mirroring

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -103,11 +103,19 @@ impl Builder {
     }
 
     async fn build_android(&self) -> Result<()> {
-        // Dev loop uses a single ABI; the gen template's compileSdk
-        // can differ from the NDK API level — the NDK 24 default has
-        // worked across Whisker's supported devices.
-        let abi = "arm64-v8a".to_string();
-        let api: u32 = 24;
+        // Dev loop only stages module Kotlin sources, then drives
+        // gradle. Gradle's own `whiskerBuildDebugArm64V8a` task runs
+        // `whisker-build android` (which runs cargo + stages the .so +
+        // libc++_shared.so into the generated jniLibs source dir AGP
+        // mergeJniLibFolders picks up), so a *second* pre-cargo build
+        // here would just produce the same `.so` twice and leak its
+        // output across the curated dev-loop UI.
+        //
+        // Mirrors what iOS already does: cargo runs only inside
+        // xcodebuild's Build Phase; the dev-server's `build_ios_simulator`
+        // is module-source-staging only. Aligning Android to the same
+        // shape halves the wall-clock of every Tier 2 rebuild on a
+        // cache-warm cargo and removes one race against the TUI viewport.
         let ws = self.workspace_root.clone();
         let crate_dir = self.crate_dir.clone();
         let pkg = self.package.clone();
@@ -115,23 +123,12 @@ impl Builder {
         let capture = self.capture.clone();
 
         tokio::task::spawn_blocking(move || -> Result<()> {
-            let tc = whisker_build::android::resolve_toolchain(&abi, api)?;
-            let so =
-                whisker_build::android::cargo_build_dylib(&whisker_build::android::CargoBuild {
-                    workspace_root: &ws,
-                    package: &pkg,
-                    toolchain: &tc,
-                    profile: whisker_build::Profile::Debug,
-                    features: &features,
-                    capture: capture.as_ref(),
-                })?;
             let gen_android = crate_dir.join("gen/android");
             // Stage discovered Whisker modules' Android Kotlin
             // sources before gradle runs. Empty when no module
             // declares android.kotlin_sources.
             let modules = whisker_build::modules::discover(&ws.join("Cargo.toml"), &pkg)?;
             whisker_build::android::stage_module_kotlin_sources(&gen_android, &modules)?;
-            whisker_build::android::stage_jni_libs(&gen_android, &abi, &so, &tc)?;
             whisker_build::android::run_gradle_assemble(
                 &gen_android,
                 whisker_build::Profile::Debug,

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -692,18 +692,33 @@ fn original_binary_path(config: &Config) -> Result<PathBuf> {
     let crate_underscored = config.package.replace('-', "_");
     match config.target {
         Target::Android => {
+            // Read from cargo's workspace `target/<triple>/release/`
+            // dir, which is where `whisker-build android` (run inside
+            // gradle's `whiskerBuildDebugArm64V8a` task) deposits the
+            // freshly-cross-compiled .so. We deliberately don't reach
+            // into `gen/android/.../app/src/main/jniLibs/<abi>/` even
+            // though that path also exists after a successful gradle
+            // assemble — that file is a copy AGP made for jniLibs
+            // merging, and the symbol-loading order rustc uses pins
+            // its addresses to the canonical cargo output anyway.
             let android = config.android.as_ref().ok_or_else(|| {
                 anyhow::anyhow!(
                     "target=Android but Config.android is None — cli should have populated it from whisker.rs"
                 )
             })?;
-            // `whisker-build`'s NDK build drops the `lib<crate>.so`
-            // into the Gradle jniLibs tree before APK packaging.
+            let triple = match android.abi.as_str() {
+                "arm64-v8a" => "aarch64-linux-android",
+                "armeabi-v7a" => "armv7-linux-androideabi",
+                "x86_64" => "x86_64-linux-android",
+                "x86" => "i686-linux-android",
+                other => anyhow::bail!("unknown Android ABI: {other}"),
+            };
             let so_name = format!("lib{crate_underscored}.so");
-            let candidate = android
-                .project_dir
-                .join("app/src/main/jniLibs")
-                .join(&android.abi)
+            let candidate = config
+                .workspace_root
+                .join("target")
+                .join(triple)
+                .join("release")
                 .join(&so_name);
             if !candidate.is_file() {
                 anyhow::bail!(
@@ -927,19 +942,19 @@ mod tests {
     }
 
     #[test]
-    fn original_binary_path_finds_android_so_under_jni_libs() {
-        // Set up a fake Android project layout matching what the
-        // dev-server's `Config::android.project_dir` would point at.
+    fn original_binary_path_finds_android_so_under_cargo_target() {
+        // Reflects the post-#XXX layout: gradle's whiskerBuild*Android
+        // task drops the .so at `target/<triple>/release/` rather than
+        // the dev-server pre-staging into `app/src/main/jniLibs/`.
         use std::sync::atomic::{AtomicU64, Ordering};
         static SEQ: AtomicU64 = AtomicU64::new(0);
         let n = SEQ.fetch_add(1, Ordering::Relaxed);
         let pid = std::process::id();
         let ws = std::env::temp_dir().join(format!("whisker-dev-test-orig-{pid}-{n}"));
         let _ = std::fs::remove_dir_all(&ws);
-        // `mk_config` sets project_dir = ws/android — match that.
-        let abi_dir = ws.join("android/app/src/main/jniLibs/arm64-v8a");
-        std::fs::create_dir_all(&abi_dir).unwrap();
-        let so = abi_dir.join("libhello_world.so");
+        let release_dir = ws.join("target/aarch64-linux-android/release");
+        std::fs::create_dir_all(&release_dir).unwrap();
+        let so = release_dir.join("libhello_world.so");
         std::fs::write(&so, b"fake").unwrap();
 
         let cfg = mk_config(ws.clone(), Target::Android);


### PR DESCRIPTION
Follow-ups to #185 surfacing as I drove `whisker run` against a real Android device. Six fixes layered together — they share root causes (TUI coordination + Android orchestration redundancy).

## 1. Set `WHISKER_TUI=1` before any `whisker_build::ui::*` call

`whisker_build::ui::mode()` caches its `Mode` lookup in a `OnceLock` on the first call. #185 set `WHISKER_TUI=1` mid-`run()` — but `sync_for_target` calls `build_discovered_plugins` *before* that, and the resulting `ui::step` invocation locks `Mode::Curated` into the cache. From then on every `step()` keeps using indicatif's animated bar (padded fixed-width templates and all), even after the ratatui TUI starts.

Visible symptom: `✓ gradle :app:assembleDebug 6.1s` arrives padded with ~140 trailing spaces, and the next `adb` line concatenates onto the same row instead of landing on a fresh line.

Fix: detect TTY + `--no-tui` at the very top of `run()`, set `WHISKER_TUI=1` there. Every later `ui::*` call sees `Mode::Tui` from the start.

## 2. Cursor restoration on Ctrl-C / panic

`Tui::start` hides the cursor for the lifetime of the viewport. `Tui::shutdown` un-hides on the happy path, but `^C`'s default SIGINT handler kills the process before any Drop / shutdown runs — leaving the user's shell with an invisible cursor.

Install two cleanup hooks once-per-process from `Tui::start`: `std::panic::set_hook` chain + `ctrlc::set_handler`. Both run `cursor::Show` + `Clear(FromCursorDown)` before deferring to the default behaviour (panic printer / `exit(130)`).

## 3. Slow the redraw from 5Hz to 1Hz

ratatui's inline viewport and foreign `eprintln!` from the rest of the dev loop both write to stderr without a shared lock, so every redraw is a chance for output to interleave with the bar's draw cycle. 5Hz multiplied that window by 5×; 1Hz is plenty of resolution for human-perceivable elapsed ticks while letting build output land cleanly between frames.

## 4. Fold the plugin-build cargo invocation into a `Step::pipe`

`build_discovered_plugins` used a raw `cmd.status()` so cargo's `    Finished \`dev\` profile…` line leaked out unfiltered ahead of the TUI bar. Switch to `Step::pipe` (`✓ compile  plugins (whisker-audio-plugin)  N.Ns`) so the row matches the rest of the curated layout.

## 5. Drop Android's pre-cargo build (align with iOS)

`Builder::build_android` was running cargo twice: once directly (`cargo_build_dylib`), then again inside gradle's `whiskerBuildDebugArm64V8a` task. The dev-server's pre-build was then staged into `app/src/main/jniLibs/` and immediately overwritten by AGP's `mergeJniLibFolders` step with gradle's output. Pure waste.

iOS already sidesteps this — its `build_ios_simulator` only stages module Swift sources; cargo runs inside the xcodebuild Build Phase. Align Android to the same shape:

- Drop `cargo_build_dylib` + `stage_jni_libs` from `Builder::build_android`.
- Update `original_binary_path` for Android to read from `target/<triple>/release/lib<pkg>.so` (the canonical cargo output dir gradle's `whisker-build android` invocation writes to) instead of the now-vestigial `app/src/main/jniLibs/` copy.

Net effect: halves the wall-clock of every Tier 2 rebuild on a cache-warm cargo, removes one race against the TUI viewport, and cuts ~30 lines of leaked cargo output from every initial run.

## 6. Force gradle's console to `plain`

Gradle's default `--console=auto` mode upgrades to ANSI-escape-driven in-place progress redraws when it thinks stdout is a TTY. With the inline TUI on, those redraw escapes leak into the viewport area and corrupt the layout.

Add `--console=plain` to the gradle command line so output is always line-by-line — fits cleanly through our existing `Step::pipe` + `gradle_progress_text` line classifier.

## Test plan

- [x] `cargo test -p whisker-dev-server -p whisker-build -p whisker-cli --lib` — 158 + 40 + 82 = 280 tests green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

## Follow-ups (out of scope)

- **TUI viewport vs subprocess output race** (e.g. `✓ build ok 6.2sadb: failed to install …` on a single row). The 1Hz mitigation here is partial — heavy cargo / rustc warning bursts can still nick a frame. The structural fix is to route every `eprintln!` through `Terminal::insert_before` so ratatui serialises scrollback writes. That's a substantial touch across `whisker_build::ui`'s entire public surface.