### PR TITLE
feat(cli): inline-viewport TUI for whisker run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,6 +2285,7 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "indicatif",
+ "libc",
  "ratatui",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,8 +108,11 @@ base64 = "0.22"
 # small region at the bottom of the terminal while scrollback flows
 # normally above — existing line-based output (sections, steps,
 # device logs) stays grep'able. `crossterm` is ratatui's default
-# backend.
-ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
+# backend. `scrolling-regions` enables the DECSTBM-based fast path
+# for `Terminal::insert_before`, the API the `whisker run` TUI uses
+# to commit captured cargo/gradle stderr into the terminal's normal
+# scrollback while the live region redraws at the bottom.
+ratatui = { version = "0.29", default-features = false, features = ["crossterm", "scrolling-regions"] }
 crossterm = { version = "0.28", default-features = false, features = ["events"] }
 
 # Host-side dev server (whisker-dev-server). Heavy deps confined here.

--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -559,6 +559,21 @@ pub fn run_gradle_assemble(
         .arg("--console=plain")
         .current_dir(gen_android)
         .env("JAVA_HOME", &java_home);
+    // Forward the TUI-mode + verbose env vars down to `whisker-build
+    // android`, which gradle invokes inside `WhiskerBuildTask` via
+    // `execOperations.exec`. `Command` *does* inherit env by default
+    // — but the gradle Plugin sits behind a published Maven artifact,
+    // so older plugin versions whose `exec {}` block doesn't
+    // explicitly forward env names won't propagate them to grandchild
+    // processes on every gradle version. Setting the vars on the
+    // outermost gradle invocation keeps the dev-loop UI consistent
+    // regardless of which plugin version a given gen tree pins.
+    if crate::ui::is_tui() {
+        cmd.env("WHISKER_TUI", "1");
+    }
+    if crate::ui::is_verbose() {
+        cmd.env("WHISKER_VERBOSE", "1");
+    }
     if !features.is_empty() {
         cmd.env("WHISKER_FEATURES", features.join(" "));
     }

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -162,6 +162,11 @@ static LAST_STATUS: Mutex<Option<String>> = Mutex::new(None);
 /// in `whisker-dev-server` use it as a sentinel that says "you're
 /// allowed to call `set_status` after this point".
 pub fn ensure_status(_label: impl Into<String>) {
+    if matches!(mode(), Mode::Tui) {
+        // Live region carries the same data — no-op the legacy
+        // status surface to avoid double-displaying it.
+        return;
+    }
     if let Ok(mut guard) = LAST_STATUS.lock() {
         *guard = Some(String::new());
     }
@@ -171,7 +176,17 @@ pub fn ensure_status(_label: impl Into<String>) {
 /// emission so back-to-back `set_status("X")` calls don't double-
 /// print the same content. The line goes through `info()` so it
 /// shares the `· <msg>` visual style with other one-shot lines.
+///
+/// In TUI mode this is a no-op: `whisker-cli`'s live region at the
+/// bottom of the terminal already renders the ws addr and the
+/// client count (via the dev-server's `Event::ClientConnected /
+/// Disconnected` stream), so emitting the legacy `· dev-server · …`
+/// line just duplicates the same information one row above the
+/// pinned status panel.
 pub fn set_status(msg: impl Into<String>) {
+    if matches!(mode(), Mode::Tui) {
+        return;
+    }
     let m = msg.into();
     let m_for_dedupe = m.clone();
     if let Ok(mut guard) = LAST_STATUS.lock() {
@@ -185,8 +200,12 @@ pub fn set_status(msg: impl Into<String>) {
 
 /// Emit a final dev-server status line on shutdown. Same code path
 /// as `set_status` minus the dedupe (we want the goodbye visible
-/// even if it matches the previous status).
+/// even if it matches the previous status). Also no-ops in TUI
+/// mode — the live region disappearing IS the goodbye.
 pub fn finish_status(final_msg: impl Into<String>) {
+    if matches!(mode(), Mode::Tui) {
+        return;
+    }
     info(format!("dev-server · {}", final_msg.into()));
 }
 

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -574,12 +574,15 @@ pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
             }
         }
         Mode::Tui => {
-            // TUI mode: ratatui owns the bottom region, so indicatif
-            // bars would race with the inline viewport's redraw.
-            // Emit the curated "started" line via plain eprintln so
-            // the row scrolls above; `finish()` will emit the final
-            // state (✓/✗) the same way.
-            eprintln!("  ⏵ {name:<12} {detail}");
+            // TUI mode: the inline ratatui viewport captures stderr
+            // and `insert_before`s each captured line into scrollback.
+            // Emitting a "⏵ started" line here would just be
+            // immediately followed by the "✓ done" line from
+            // `finish()`, doubling the row count — there's no
+            // overwrite mechanism for already-committed scrollback
+            // lines (unlike indicatif's spinner in Curated mode).
+            // Defer all output to `finish()` so each step occupies
+            // exactly one row.
             Step {
                 bar: None,
                 started_at,

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -417,11 +417,12 @@ fn stream_through_bar<R: std::io::Read + Send + 'static>(
                 eprintln!("[whisker] {line}");
             }
         } else if !line.is_empty() {
-            // In curated mode, drop known-noise advisory lines that
-            // the user can't act on. Verbose mode keeps everything
-            // so the user has a chance to diagnose the filter
-            // itself if a real diagnostic ever gets misclassified.
-            if matches!(mode(), Mode::Curated) && is_subprocess_noise(&line) {
+            // Drop known-noise advisory lines that the user can't
+            // act on (gradle daemon JVM banner, etc.). Both curated
+            // and TUI modes filter — Verbose keeps everything so
+            // the user has a chance to diagnose the filter itself
+            // if a real diagnostic ever gets misclassified.
+            if matches!(mode(), Mode::Curated | Mode::Tui) && is_subprocess_noise(&line) {
                 continue;
             }
             // Diagnostics / errors / unrecognised tool output:

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -357,10 +357,28 @@ impl Step {
             );
             bar.finish_with_message(line);
         } else {
+            // Tui + non-TTY Curated both fall through here. In TUI
+            // mode, also emit the matching END marker so the cli
+            // clears the live-region's `current_step` field — see
+            // the START marker emitted in `step()` above.
+            if matches!(mode(), Mode::Tui) {
+                eprintln!("{TUI_STEP_END_MARKER}");
+            }
             eprintln!("{line}");
         }
     }
 }
+
+/// Marker prefix the cli's capture thread looks for to learn that a
+/// step has *started*. Followed by `\x1e<name>\x1e<detail>` and a
+/// newline — i.e. one line per START. The `\x1e` (ASCII RS, "record
+/// separator") is deliberately non-printable so it can't collide
+/// with legitimate user output. See
+/// `whisker_cli::tui::capture_reader_loop`.
+pub const TUI_STEP_START_MARKER: &str = "\x1eWHISKER-TUI-STEP-START";
+/// Marker the cli's capture thread looks for to learn that the
+/// active step has *finished*. One token per line, no payload.
+pub const TUI_STEP_END_MARKER: &str = "\x1eWHISKER-TUI-STEP-END";
 
 /// Read `stream` line-by-line, classifying each line into one of
 /// three buckets:
@@ -600,8 +618,18 @@ pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
             // `finish()`, doubling the row count — there's no
             // overwrite mechanism for already-committed scrollback
             // lines (unlike indicatif's spinner in Curated mode).
-            // Defer all output to `finish()` so each step occupies
-            // exactly one row.
+            //
+            // Instead, emit a structured marker on stderr that
+            // whisker-cli's capture thread recognises and routes
+            // into the live region's `current_step` field, so the
+            // user sees an animated spinner during long steps
+            // (`xcodebuild`, `gradle :app:assembleDebug`, etc.)
+            // without that label entering scrollback. `finish()`
+            // emits a matching END marker plus the regular
+            // `✓ <name> <detail> <elapsed>` line that DOES enter
+            // scrollback. See `whisker_cli::tui::capture_reader_loop`
+            // for the consuming side.
+            eprintln!("{TUI_STEP_START_MARKER}\x1e{name}\x1e{detail}");
             Step {
                 bar: None,
                 started_at,

--- a/crates/whisker-cli/Cargo.toml
+++ b/crates/whisker-cli/Cargo.toml
@@ -68,3 +68,8 @@ crossterm = { workspace = true }
 # process exits — without it, the shell ends up with a hidden cursor
 # after `^C`. Tiny crate, no async runtime.
 ctrlc = "3"
+# POSIX `pipe(2)` / `dup` / `dup2` / `read` for the TUI's stderr
+# capture (`dup2` STDERR_FILENO over a pipe so every `eprintln!` from
+# `whisker_build::ui` and child subprocesses flows into the Logs
+# pane instead of corrupting the alternate-screen viewport).
+libc = { workspace = true }

--- a/crates/whisker-cli/src/build.rs
+++ b/crates/whisker-cli/src/build.rs
@@ -36,8 +36,10 @@ pub struct Args {
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 
-    /// Where to package for.
-    #[arg(long, value_enum)]
+    /// Where to package for. Positional so the common case
+    /// (`whisker build android` / `whisker build ios-sim`) reads
+    /// naturally without a `--target=` prefix.
+    #[arg(value_enum)]
     pub target: BuildTarget,
 
     /// Override the workspace root. Defaults to walking up from the
@@ -75,9 +77,9 @@ pub fn run(args: Args) -> Result<()> {
         BuildTarget::Android => build_android_apk(&m, &workspace_root),
         BuildTarget::IosSim => build_ios_app(&m, &workspace_root, IosFlavour::Simulator),
         BuildTarget::IosDevice => Err(anyhow!(
-            "`whisker build --target ios-device` is not yet implemented. \
+            "`whisker build ios-device` is not yet implemented. \
              Codesigning + provisioning + `xcodebuild archive` are coming \
-             in a follow-up. Use `whisker build --target ios-sim` for a \
+             in a follow-up. Use `whisker build ios-sim` for a \
              Simulator-installable .app today."
         )),
     }

--- a/crates/whisker-cli/src/doctor.rs
+++ b/crates/whisker-cli/src/doctor.rs
@@ -15,7 +15,7 @@
 
 use anyhow::Result;
 use indicatif::{ProgressBar, ProgressStyle};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
 
@@ -27,9 +27,6 @@ pub struct Args {
     /// Skip the Android section.
     #[arg(long)]
     pub no_android: bool,
-    /// Skip the Lynx-artifact section.
-    #[arg(long)]
-    pub no_lynx: bool,
 }
 
 pub fn run(args: Args) -> Result<()> {
@@ -45,9 +42,15 @@ pub fn run(args: Args) -> Result<()> {
     if !args.no_ios {
         report.add_section("iOS", check_ios);
     }
-    if !args.no_lynx {
-        report.add_section("Lynx artifacts", check_lynx);
-    }
+
+    // No Lynx section: Android pulls the Lynx aar from gradle's
+    // `whiskerrs.github.io/lynx/maven` repository (no local cache
+    // ever touched by the doctor), and iOS auto-downloads the
+    // xcframeworks into `~/.cache/whisker/lynx/<version>/ios` the
+    // first time `whisker run ios` / `whisker build ios-sim` needs
+    // them. Pre-checking either was busywork — the cache is a
+    // build-time concern, not a "is this dev machine ready"
+    // concern.
 
     report.print_summary();
     if report.has_errors() {
@@ -398,138 +401,6 @@ fn check_ios() -> Vec<Check> {
     out
 }
 
-// ----- Lynx artifacts (user-cache) -------------------------------------------
-
-fn check_lynx() -> Vec<Check> {
-    let mut out = Vec::new();
-
-    // Pinned version + source.
-    out.push(Check::ok(
-        "Pinned Lynx fork",
-        format!("{} (from whiskerrs/lynx)", whisker_build::LYNX_FORK_TAG,),
-    ));
-
-    // Override status.
-    if let Some(dir) = std::env::var_os("WHISKER_LYNX_DIR") {
-        let p = PathBuf::from(&dir);
-        out.push(Check::ok("WHISKER_LYNX_DIR override", short_path(&p)));
-    }
-
-    // Per-platform cache state.
-    for (label, platform, sentinel) in [
-        (
-            "Android cache",
-            whisker_build::LynxPlatform::Android,
-            "LynxAndroid.aar",
-        ),
-        (
-            "iOS cache",
-            whisker_build::LynxPlatform::Ios,
-            "Lynx.xcframework",
-        ),
-    ] {
-        match whisker_build::lynx_cache_dir(platform) {
-            Ok(dir) if dir.join(sentinel).exists() => {
-                out.push(Check::ok(label, format!("cached at {}", short_path(&dir))));
-            }
-            Ok(dir) => {
-                out.push(Check::warn(
-                    label,
-                    format!(
-                        "not cached — will be downloaded on next `whisker run/build` (would land at {})",
-                        short_path(&dir),
-                    ),
-                ));
-            }
-            Err(e) => {
-                out.push(Check::warn(
-                    label,
-                    format!("cache path unresolvable: {e:#}"),
-                ));
-            }
-        }
-    }
-
-    // Workspace symlinks (created by ensure_lynx_for_target). Useful
-    // sanity check for "did my last whisker run / build sync the
-    // symlinks?" — if they're stale, the next invocation rebuilds.
-    if let Some(ws) = workspace_root() {
-        let target = ws.join("target");
-        for (label, name) in [
-            ("Android jniLibs symlink", "lynx-android-unpacked"),
-            ("Android AAR symlink", "lynx-android"),
-            ("iOS xcframeworks symlink", "lynx-ios"),
-            ("Lynx headers symlink", "lynx-headers"),
-        ] {
-            let path = target.join(name);
-            match std::fs::symlink_metadata(&path) {
-                Ok(meta) if meta.file_type().is_symlink() => match std::fs::read_link(&path) {
-                    Ok(dest) => out.push(Check::ok(label, format!("→ {}", short_path(&dest)))),
-                    Err(_) => out.push(Check::warn(label, "broken symlink".to_string())),
-                },
-                Ok(_) => {
-                    out.push(Check::warn(
-                        label,
-                        format!(
-                            "{} exists but isn't a symlink — `rm -rf` it to let \
-                             `whisker run/build` recreate the link",
-                            short_path(&path),
-                        ),
-                    ));
-                }
-                Err(_) => {
-                    // Missing is fine pre-first-run; whisker run/build creates it.
-                }
-            }
-        }
-    }
-
-    out
-}
-
-fn short_path(p: &Path) -> String {
-    let home = std::env::var_os("HOME").map(PathBuf::from);
-    short_path_with_home(p, home.as_deref())
-}
-
-/// Pure-function core of [`short_path`]: replace a leading `home` prefix
-/// with `~`. Factored out so unit tests don't have to mutate `$HOME`.
-fn short_path_with_home(p: &Path, home: Option<&Path>) -> String {
-    if let Some(home) = home {
-        if let Ok(rest) = p.strip_prefix(home) {
-            return format!("~/{}", rest.display());
-        }
-    }
-    p.display().to_string()
-}
-
-/// Best-effort workspace root: walk up from CWD looking for a Cargo.toml
-/// whose `[workspace]` table mentions whisker-driver-sys (cheap heuristic).
-fn workspace_root() -> Option<PathBuf> {
-    let cwd = std::env::current_dir().ok()?;
-    workspace_root_from(&cwd)
-}
-
-/// Pure-function core of [`workspace_root`]: start the upward walk from
-/// the supplied directory rather than the process CWD. Factored out so
-/// unit tests can drive it with a tempdir.
-fn workspace_root_from(start: &Path) -> Option<PathBuf> {
-    let mut cur = start.to_path_buf();
-    loop {
-        let cargo = cur.join("Cargo.toml");
-        if cargo.is_file() {
-            if let Ok(txt) = std::fs::read_to_string(&cargo) {
-                if txt.contains("[workspace]") && txt.contains("whisker-driver-sys") {
-                    return Some(cur);
-                }
-            }
-        }
-        if !cur.pop() {
-            return None;
-        }
-    }
-}
-
 // ----- Tiny helpers ----------------------------------------------------------
 
 fn run_capture(cmd: &str, args: &[&str]) -> Result<String> {
@@ -558,7 +429,6 @@ fn which(cmd: &str) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
 
     // ----- parse_rustc_version ------------------------------------------------
 
@@ -660,108 +530,5 @@ mod tests {
         assert!(!r.has_errors(), "warnings alone don't constitute errors");
         r.err = 1;
         assert!(r.has_errors());
-    }
-
-    // ----- short_path_with_home -----------------------------------------------
-
-    #[test]
-    fn short_path_with_home_substitutes_tilde() {
-        let home = PathBuf::from("/home/itome");
-        assert_eq!(
-            short_path_with_home(Path::new("/home/itome/projects/whisker"), Some(&home),),
-            "~/projects/whisker",
-        );
-    }
-
-    #[test]
-    fn short_path_with_home_leaves_unrelated_paths_alone() {
-        let home = PathBuf::from("/home/itome");
-        assert_eq!(
-            short_path_with_home(Path::new("/etc/hosts"), Some(&home)),
-            "/etc/hosts",
-        );
-    }
-
-    #[test]
-    fn short_path_with_home_none_returns_full_path() {
-        assert_eq!(short_path_with_home(Path::new("/tmp/x"), None), "/tmp/x",);
-    }
-
-    #[test]
-    fn short_path_with_home_does_not_match_overlapping_prefix() {
-        // `/home/itome2` must not get its `/home/itome` prefix stripped.
-        let home = PathBuf::from("/home/itome");
-        assert_eq!(
-            short_path_with_home(Path::new("/home/itome2/work"), Some(&home)),
-            "/home/itome2/work",
-        );
-    }
-
-    // ----- workspace_root_from ------------------------------------------------
-
-    fn write_workspace_marker(dir: &Path) {
-        fs::write(
-            dir.join("Cargo.toml"),
-            "[workspace]\nmembers = [\"crates/whisker-driver-sys\"]\n",
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn workspace_root_from_finds_root_at_start_dir() {
-        let tmp = tempdir();
-        write_workspace_marker(tmp.path());
-        assert_eq!(workspace_root_from(tmp.path()).as_deref(), Some(tmp.path()),);
-    }
-
-    #[test]
-    fn workspace_root_from_walks_up_to_find_root() {
-        let tmp = tempdir();
-        write_workspace_marker(tmp.path());
-        let nested = tmp.path().join("crates/whisker-cli/src");
-        fs::create_dir_all(&nested).unwrap();
-        assert_eq!(workspace_root_from(&nested).as_deref(), Some(tmp.path()),);
-    }
-
-    #[test]
-    fn workspace_root_from_ignores_unrelated_cargo_tomls() {
-        // A non-workspace Cargo.toml in the start dir must NOT match —
-        // we only want the one with `[workspace]` + whisker-driver-sys.
-        let tmp = tempdir();
-        fs::write(tmp.path().join("Cargo.toml"), "[package]\nname = \"foo\"\n").unwrap();
-        assert_eq!(workspace_root_from(tmp.path()), None);
-    }
-
-    #[test]
-    fn workspace_root_from_returns_none_when_no_root_above() {
-        // Bare tempdir, no Cargo.toml anywhere on the path.
-        let tmp = tempdir();
-        assert_eq!(workspace_root_from(tmp.path()), None);
-    }
-
-    // ----- tempdir helper -----------------------------------------------------
-    //
-    // The test suite is too small to justify pulling in the `tempfile`
-    // crate as a dev-dependency; this hand-rolled helper is enough.
-
-    struct TempDir(PathBuf);
-    impl TempDir {
-        fn path(&self) -> &Path {
-            &self.0
-        }
-    }
-    impl Drop for TempDir {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.0);
-        }
-    }
-    fn tempdir() -> TempDir {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static SEQ: AtomicU64 = AtomicU64::new(0);
-        let n = SEQ.fetch_add(1, Ordering::Relaxed);
-        let pid = std::process::id();
-        let p = std::env::temp_dir().join(format!("whisker-cli-test-{pid}-{n}"));
-        fs::create_dir_all(&p).unwrap();
-        TempDir(p)
     }
 }

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -79,8 +79,8 @@ enum Command {
     /// Scaffold a new Whisker app — single-crate workspace with
     /// `Cargo.toml`, a `#[whisker::main]` `src/lib.rs`, the
     /// `whisker.rs` `AppConfig` probe, `.gitignore`, and `README.md`.
-    /// The result compiles standalone; run `whisker run host` from
-    /// inside the new directory.
+    /// The result compiles standalone; run `whisker run android` or
+    /// `whisker run ios` from inside the new directory.
     New(new_app::NewAppArgs),
 }
 
@@ -133,12 +133,15 @@ mod tests {
     }
 
     #[test]
-    fn parses_run_with_defaults() {
-        let cli = parse(["whisker", "run"]).unwrap();
+    fn parses_run_with_only_target() {
+        // `target` is now required (no default), so the bare
+        // `whisker run` form is gone — supply a positional target
+        // and assert the rest of the args adopt their defaults.
+        let cli = parse(["whisker", "run", "android"]).unwrap();
         match cli.command {
             Command::Run(a) => {
                 assert!(a.manifest_path.is_none());
-                assert_eq!(a.target, run::CliTarget::Host);
+                assert_eq!(a.target, run::CliTarget::Android);
                 assert_eq!(a.bind.port(), 9876);
                 // Hot-patch is the dev default — opt out with --no-hot-patch.
                 assert!(!a.no_hot_patch);
@@ -146,6 +149,14 @@ mod tests {
             }
             other => panic!("expected Run, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_run_without_target_fails() {
+        // `whisker run` with no positional target is now an error
+        // (Host was the previous default and has been removed).
+        let res = parse(["whisker", "run"]);
+        assert!(res.is_err(), "expected clap error, got {res:?}");
     }
 
     #[test]

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -126,7 +126,6 @@ mod tests {
             Command::Doctor(a) => {
                 assert!(!a.no_ios);
                 assert!(!a.no_android);
-                assert!(!a.no_lynx);
             }
             other => panic!("expected Doctor, got {other:?}"),
         }
@@ -192,12 +191,11 @@ mod tests {
 
     #[test]
     fn parses_doctor_skip_flags() {
-        let cli = parse(["whisker", "doctor", "--no-ios", "--no-lynx"]).unwrap();
+        let cli = parse(["whisker", "doctor", "--no-ios", "--no-android"]).unwrap();
         match cli.command {
             Command::Doctor(a) => {
                 assert!(a.no_ios);
-                assert!(!a.no_android);
-                assert!(a.no_lynx);
+                assert!(a.no_android);
             }
             other => panic!("expected Doctor, got {other:?}"),
         }

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -79,8 +79,8 @@ enum Command {
     /// Scaffold a new Whisker app — single-crate workspace with
     /// `Cargo.toml`, a `#[whisker::main]` `src/lib.rs`, the
     /// `whisker.rs` `AppConfig` probe, `.gitignore`, and `README.md`.
-    /// The result compiles standalone; run `whisker run --target
-    /// host` from inside the new directory.
+    /// The result compiles standalone; run `whisker run host` from
+    /// inside the new directory.
     New(new_app::NewAppArgs),
 }
 
@@ -150,12 +150,15 @@ mod tests {
 
     #[test]
     fn parses_run_with_explicit_target_and_flags() {
+        // `target` moved from `--target <value>` to a positional
+        // argument (`whisker run android`) — clap accepts it in any
+        // position relative to the named flags, so the test mixes
+        // them deliberately.
         let cli = parse([
             "whisker",
             "run",
             "--manifest-path",
             "/tmp/my-app/Cargo.toml",
-            "--target",
             "android",
             "--bind",
             "0.0.0.0:1234",

--- a/crates/whisker-cli/src/new_app.rs
+++ b/crates/whisker-cli/src/new_app.rs
@@ -98,9 +98,8 @@ pub fn run(args: NewAppArgs) -> Result<()> {
          \n\
          Next steps:\n  \
          1. cd {}\n  \
-         2. whisker run host     # fastest iteration; no device needed\n  \
-         3. whisker run ios      # requires Xcode + iOS simulator\n  \
-         4. whisker run android  # requires Android SDK + emulator\n  \
+         2. whisker run ios      # requires Xcode + iOS simulator\n  \
+         3. whisker run android  # requires Android SDK + emulator\n  \
          \n\
          Run `whisker doctor` first to verify your toolchain.",
         target_dir.display(),
@@ -257,9 +256,6 @@ A [Whisker](https://github.com/whiskerrs/whisker) app.
 ## Develop
 
 ```sh
-# Fastest iteration — no emulator / simulator required.
-whisker run host
-
 # On an iOS Simulator (macOS only).
 whisker run ios
 

--- a/crates/whisker-cli/src/new_app.rs
+++ b/crates/whisker-cli/src/new_app.rs
@@ -233,18 +233,40 @@ pub fn configure(app: &mut whisker_app_config::AppConfig) {{
 }
 
 const GITIGNORE: &str = "\
-# Cargo + Whisker build artifacts.
+# Cargo build artifacts.
 target/
-Cargo.lock
 
-# Whisker-generated host projects (refreshed on every `whisker run` / `whisker build`).
+# rustfmt backup files (older toolchains left these behind on a failed
+# format pass; harmless to keep ignored).
+**/*.rs.bk
+
+# Whisker-generated host projects — refreshed on every `whisker run` /
+# `whisker build`. Includes gradle's `.gradle/` + `build/` caches and
+# xcodebuild's `xcuserdata/` / `*.xcuserstate` under here, so no need
+# to list those separately.
 gen/
 
-# IDE / OS noise.
-.DS_Store
+# Environment / secrets. Copy the pattern (e.g. `.env.example`) when
+# you need to share a template across the team without committing the
+# real values.
+.env
+.env.local
+.env.*.local
+
+# IDE / editor noise.
 .idea/
 .vscode/
 *.iml
+.vs/
+
+# OS noise.
+.DS_Store
+Thumbs.db
+
+# NOTE: `Cargo.lock` is deliberately NOT ignored. A Whisker user crate
+# is shaped like an application (compiled into the device-side dylib),
+# so the lock file is what guarantees every CI / teammate / production
+# build resolves to the same dependency tree. Commit it.
 ";
 
 fn readme(v: &Vars) -> String {
@@ -426,6 +448,22 @@ mod tests {
         // Default display name + bundle id are derived.
         assert!(whisker_rs.contains("Demo App"));
         assert!(whisker_rs.contains("rs.example.demo_app"));
+
+        let gitignore = std::fs::read_to_string(root.join(".gitignore")).unwrap();
+        // Sanity-check the load-bearing entries — losing either of
+        // these would surface as committed `target/` artifacts or a
+        // committed `gen/` tree on the user's first push.
+        assert!(
+            gitignore.contains("target/"),
+            "missing target/ in .gitignore",
+        );
+        assert!(gitignore.contains("gen/"), "missing gen/ in .gitignore");
+        // `Cargo.lock` must NOT be ignored — a Whisker app's lock
+        // file pins the dep tree the CI / production build resolves.
+        assert!(
+            !gitignore.lines().any(|l| l.trim() == "Cargo.lock"),
+            ".gitignore must NOT exclude Cargo.lock",
+        );
 
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/crates/whisker-cli/src/new_app.rs
+++ b/crates/whisker-cli/src/new_app.rs
@@ -98,9 +98,9 @@ pub fn run(args: NewAppArgs) -> Result<()> {
          \n\
          Next steps:\n  \
          1. cd {}\n  \
-         2. whisker run --target host     # fastest iteration; no device needed\n  \
-         3. whisker run --target ios      # requires Xcode + iOS simulator\n  \
-         4. whisker run --target android  # requires Android SDK + emulator\n  \
+         2. whisker run host     # fastest iteration; no device needed\n  \
+         3. whisker run ios      # requires Xcode + iOS simulator\n  \
+         4. whisker run android  # requires Android SDK + emulator\n  \
          \n\
          Run `whisker doctor` first to verify your toolchain.",
         target_dir.display(),
@@ -258,13 +258,13 @@ A [Whisker](https://github.com/whiskerrs/whisker) app.
 
 ```sh
 # Fastest iteration — no emulator / simulator required.
-whisker run --target host
+whisker run host
 
 # On an iOS Simulator (macOS only).
-whisker run --target ios
+whisker run ios
 
 # On an Android device or emulator.
-whisker run --target android
+whisker run android
 ```
 
 Run `whisker doctor` first to verify your toolchain is set up for each
@@ -284,8 +284,8 @@ project.
 ## Build for release
 
 ```sh
-whisker build --target ios-sim   # .app for the simulator
-whisker build --target android   # release .apk
+whisker build ios-sim   # .app for the simulator
+whisker build android   # release .apk
 ```
 "##,
         display = v.display_name,

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -36,10 +36,6 @@ pub fn sync_for_target(
     match target {
         Target::Android => sync_android(app_config, crate_dir, workspace_root, package),
         Target::IosSimulator => sync_ios(app_config, crate_dir, workspace_root, package),
-        Target::Host => Ok(PlatformSync {
-            gen_dir: crate_dir.to_path_buf(),
-            regenerated: false,
-        }),
     }
 }
 
@@ -47,8 +43,7 @@ pub fn sync_for_target(
 #[derive(Debug, Clone)]
 pub struct PlatformSync {
     /// Where the generated project tree lives — `gen/android/` or
-    /// `gen/ios/` under `crate_dir`. For `Target::Host` this is just
-    /// `crate_dir` (no native project to generate).
+    /// `gen/ios/` under `crate_dir`.
     pub gen_dir: PathBuf,
     /// `true` if the renderer rewrote files this pass, `false` if the
     /// fingerprint matched and the existing tree was reused.
@@ -243,19 +238,4 @@ fn build_discovered_plugins(workspace_root: &Path, discovered: &[DiscoveredPlugi
     }
     step.done("");
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn host_target_returns_crate_dir_without_regenerating() {
-        let cfg = AppConfig::default();
-        let crate_dir = PathBuf::from("/tmp/crate");
-        let ws = PathBuf::from("/tmp/ws");
-        let sync = sync_for_target(Target::Host, &cfg, &crate_dir, &ws, "pkg").unwrap();
-        assert_eq!(sync.gen_dir, crate_dir);
-        assert!(!sync.regenerated);
-    }
 }

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -265,9 +265,18 @@ fn run_inner(
 
     let server = DevServer::new(config)?.on_event(move |e| {
         if let Some(h) = &tui_for_events {
+            // TUI mode: the handle's `apply_event` already pushes
+            // `Event::DeviceLog` into scrollback via `insert_before`
+            // as a `[device]` / `[device:err]` row. Routing the
+            // same event through `forward_event_to_ui` would
+            // double-print every device log line (once raw, once
+            // wrapped in `whisker_build::ui::info`'s `· ` prefix
+            // and captured back through stderr). Skip the legacy
+            // path entirely when the TUI is on.
             h.apply_event(&e);
+        } else {
+            forward_event_to_ui(e, show_native_logs);
         }
-        forward_event_to_ui(e, show_native_logs);
     });
 
     rt.block_on(server.run())

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -27,11 +27,8 @@ pub struct Args {
 
     /// Where to deploy the rebuilt artifact. Positional so the
     /// common case (`whisker run android` / `whisker run ios`) reads
-    /// naturally without a `--target=` prefix. Defaults to `host`,
-    /// which compiles the user crate for the dev machine — useful
-    /// for unit-test-style iteration without an emulator/simulator
-    /// up.
-    #[arg(value_enum, default_value_t = CliTarget::Host)]
+    /// naturally without a `--target=` prefix.
+    #[arg(value_enum)]
     pub target: CliTarget,
 
     /// WebSocket bind address. The Whisker app on the device dials this
@@ -71,7 +68,6 @@ pub struct Args {
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CliTarget {
-    Host,
     Android,
     Ios,
 }
@@ -79,7 +75,6 @@ pub enum CliTarget {
 impl From<CliTarget> for Target {
     fn from(t: CliTarget) -> Self {
         match t {
-            CliTarget::Host => Target::Host,
             CliTarget::Android => Target::Android,
             CliTarget::Ios => Target::IosSimulator,
         }
@@ -292,7 +287,6 @@ fn run_inner(
 /// short noun for screen real estate.
 fn target_label(target: Target) -> &'static str {
     match target {
-        Target::Host => "Host",
         Target::Android => "Android",
         Target::IosSimulator => "iOS Simulator",
     }
@@ -505,7 +499,6 @@ mod tests {
 
     #[test]
     fn cli_target_maps_to_dev_server_target() {
-        assert_eq!(Target::from(CliTarget::Host), Target::Host);
         assert_eq!(Target::from(CliTarget::Android), Target::Android);
         assert_eq!(Target::from(CliTarget::Ios), Target::IosSimulator);
     }

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -25,8 +25,13 @@ pub struct Args {
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 
-    /// Where to deploy the rebuilt artifact.
-    #[arg(long, value_enum, default_value_t = CliTarget::Host)]
+    /// Where to deploy the rebuilt artifact. Positional so the
+    /// common case (`whisker run android` / `whisker run ios`) reads
+    /// naturally without a `--target=` prefix. Defaults to `host`,
+    /// which compiles the user crate for the dev machine — useful
+    /// for unit-test-style iteration without an emulator/simulator
+    /// up.
+    #[arg(value_enum, default_value_t = CliTarget::Host)]
     pub target: CliTarget,
 
     /// WebSocket bind address. The Whisker app on the device dials this
@@ -421,7 +426,7 @@ fn android_params_from(
         .or_else(|| m.config.bundle_id.clone())
         .ok_or_else(|| {
             anyhow!(
-                "whisker.rs: app.android(|a| a.application_id(\"…\")) is required for --target android"
+                "whisker.rs: app.android(|a| a.application_id(\"…\")) is required for the android target"
             )
         })?;
     let launcher_activity = a
@@ -448,7 +453,7 @@ fn ios_params_from(m: &manifest::ResolvedManifest, project_dir: &Path) -> Result
         .or_else(|| m.config.bundle_id.clone())
         .ok_or_else(|| {
             anyhow!(
-                "whisker.rs: app.ios(|i| i.bundle_id(\"…\")) or app.bundle_id(\"…\") is required for --target ios"
+                "whisker.rs: app.ios(|i| i.bundle_id(\"…\")) or app.bundle_id(\"…\") is required for the ios target"
             )
         })?;
     let scheme = i
@@ -457,7 +462,7 @@ fn ios_params_from(m: &manifest::ResolvedManifest, project_dir: &Path) -> Result
         .or_else(|| m.config.name.clone())
         .ok_or_else(|| {
             anyhow!(
-                "whisker.rs: app.ios(|i| i.scheme(\"…\")) or app.name(\"…\") is required for --target ios"
+                "whisker.rs: app.ios(|i| i.scheme(\"…\")) or app.name(\"…\") is required for the ios target"
             )
         })?;
     Ok(IosParams {

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -82,28 +82,22 @@ impl From<CliTarget> for Target {
 }
 
 pub fn run(args: Args) -> Result<()> {
-    // Decide and announce the TUI mode BEFORE any `whisker_build::ui::*`
-    // call fires — that crate caches its `Mode` lookup in a `OnceLock`
-    // on the first call to `mode()`, so by the time
-    // `build_discovered_plugins` (run inside `sync_for_target` below)
-    // emits its first `ui::step`, the cache is locked. If we set
-    // `WHISKER_TUI=1` later the way the previous iteration of this
-    // file did, every subsequent `step()` keeps using indicatif's
-    // animated bar — which then leaks padded fixed-width rows next
-    // to the ratatui viewport once the TUI actually starts. Setting
-    // the env var here, before any other code path can touch the
-    // ui module, makes every `step()` go through the plain-line
-    // branch and lets the viewport own the bottom region cleanly.
+    // Set the cross-crate TUI signal before any `whisker_build::ui::*`
+    // call fires — `whisker_build::ui::mode()` caches its lookup in a
+    // `OnceLock` on the first call, so flipping this env later doesn't
+    // unstick a `Curated` cache.
     let tui_enabled = !args.no_tui && std::io::IsTerminal::is_terminal(&std::io::stderr());
     if tui_enabled {
         std::env::set_var("WHISKER_TUI", "1");
     }
 
+    // Resolve the user-facing manifest before doing anything UI-y so
+    // that the TUI header can display the bundle id from the moment
+    // it first paints.
     let m = manifest::resolve(args.manifest_path.as_deref())
         .context("resolve user-crate manifest (Cargo.toml + whisker.rs)")?;
-
-    let workspace_root = match args.workspace_root {
-        Some(p) => p,
+    let workspace_root = match &args.workspace_root {
+        Some(p) => p.clone(),
         None => find_workspace_root(&m.crate_dir).ok_or_else(|| {
             anyhow!(
                 "no [workspace] Cargo.toml at or above {}",
@@ -111,20 +105,74 @@ pub fn run(args: Args) -> Result<()> {
             )
         })?,
     };
-
     let target: Target = args.target.into();
+    let target_label = target_label(target);
+    let bundle = m
+        .config
+        .bundle_id
+        .clone()
+        .unwrap_or_else(|| m.package.clone());
 
-    // Ensure Lynx artifacts for the target platform are cached and
-    // linked into `target/lynx-*` (where gradle's flatDir, SPM's
-    // binaryTarget paths, and whisker-driver-sys/build.rs all expect
-    // to find them). On cache hit this is a few stat() syscalls.
-    ensure_lynx_for_target(target, &workspace_root)?;
+    // Start the TUI as the very first user-visible action so the
+    // long setup steps (sync, plugin build, initial build, install)
+    // render with a proper progress indicator instead of leaking
+    // ahead of an inline status bar.
+    let tui_pieces = if tui_enabled {
+        match crate::tui::Tui::start(crate::tui::TuiState::new(target_label, bundle.clone())) {
+            Ok(tui) => {
+                let handle = tui.handle();
+                handle.set_phase(crate::tui::AppPhase::Setup);
+                let render_handle = std::thread::Builder::new()
+                    .name("whisker-tui-render".into())
+                    .spawn(move || run_tui_render_loop(tui))
+                    .ok();
+                Some((handle, render_handle))
+            }
+            Err(e) => {
+                eprintln!("couldn't start TUI ({e:#}); falling back to plain output");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let tui_handle = tui_pieces.as_ref().map(|(h, _)| h.clone());
 
+    // Run the rest of the cli pipeline. Each phase pushes its progress
+    // through `tui_handle`. If the TUI isn't running, every step is
+    // a no-op + the existing `whisker_build::ui::*` lines fall back
+    // to scrollback.
+    let result = run_inner(args, m, workspace_root, target, tui_handle.as_ref());
+
+    // Stop the render thread + restore the terminal. Use should_quit
+    // as the signal so the render thread exits cleanly.
+    if let Some((handle, render_thread)) = tui_pieces {
+        handle.request_quit();
+        if let Some(t) = render_thread {
+            let _ = t.join();
+        }
+    }
+    result
+}
+
+fn run_tui_render_loop(mut tui: crate::tui::Tui) {
+    let _ = tui.render_until_quit();
+    let _ = tui.shutdown();
+}
+
+fn run_inner(
+    args: Args,
+    m: manifest::ResolvedManifest,
+    workspace_root: PathBuf,
+    target: Target,
+    tui: Option<&crate::tui::TuiHandle>,
+) -> Result<()> {
     // Sync the native host project (gen/{android,ios}/) before doing
-    // anything else. Fast-path on fingerprint match — typical run is
-    // a single file read. Errors here (missing whisker.rs fields,
-    // missing native runtime) are fatal: there's no point starting
-    // the dev loop if we can't build the app it would deploy.
+    // anything else. The cargo-side `build_discovered_plugins` step
+    // happens inside `sync_for_target` and is the long pole here.
+    if let Some(t) = tui {
+        t.set_phase(crate::tui::AppPhase::Setup);
+    }
     let sync = crate::platforms::sync_for_target(
         target,
         &m.config,
@@ -156,11 +204,8 @@ pub fn run(args: Args) -> Result<()> {
         crate_dir: m.crate_dir,
         package: m.package,
         target,
-        watch_paths,
+        watch_paths: watch_paths.clone(),
         bind_addr: args.bind,
-        // Tier 1 is the dev-loop default — `--no-hot-patch` is the
-        // emergency-exit when subsecond is misbehaving and you just
-        // need a working cold-rebuild loop.
         hot_patch_mode: if args.no_hot_patch {
             HotPatchMode::Tier2ColdRebuild
         } else {
@@ -170,90 +215,30 @@ pub fn run(args: Args) -> Result<()> {
         ios,
     };
 
+    let watching_paths: Vec<String> = watch_paths
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect();
+    if let Some(t) = tui {
+        t.set_dev_server(config.bind_addr.to_string(), watching_paths);
+        t.set_phase(crate::tui::AppPhase::Initializing);
+    }
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .context("build tokio runtime")?;
     let show_native_logs = args.show_native_logs;
-
-    // `tui_enabled` was decided + the env var was set at the very top
-    // of this function so the early `ui::step` calls inside
-    // `sync_for_target` would see the right `Mode`. Reuse the same
-    // detection here so the ratatui setup matches.
-    let tui_enabled = !args.no_tui && std::io::IsTerminal::is_terminal(&std::io::stderr());
-
-    let target_label = target_label(target);
-    let bind_label = args.bind.to_string();
-
-    // The TUI runs on a dedicated OS thread because ratatui's
-    // `Terminal<CrosstermBackend<Stderr>>` isn't `Send` and so can't
-    // ride inside a tokio task. The render thread polls a shared
-    // `TuiState` Mutex; the dev-server's `on_event` callback (which
-    // does run on tokio threads) writes to the same Mutex. Shutdown
-    // is signalled via an `AtomicBool` once `server.run()` returns.
-    let (tui_state, tui_shutdown, tui_handle) = if tui_enabled {
-        match crate::tui::Tui::start(crate::tui::TuiState::new(target_label, bind_label.clone())) {
-            Ok(mut tui) => {
-                let state = tui.state_handle();
-                let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-                let thread_shutdown = std::sync::Arc::clone(&shutdown);
-                let handle = std::thread::Builder::new()
-                    .name("whisker-tui".into())
-                    .spawn(move || {
-                        while !thread_shutdown.load(std::sync::atomic::Ordering::Acquire) {
-                            let _ = tui.draw();
-                            // 1Hz redraw. ratatui's inline viewport and
-                            // foreign `eprintln!` from the rest of the
-                            // dev loop both write to stderr without
-                            // a shared lock, so every frame is a chance
-                            // for output to interleave with the bar's
-                            // redraw. Polling at 5Hz (the original)
-                            // multiplied that race window by 5×; 1Hz
-                            // is plenty for human-perceivable elapsed
-                            // ticks while letting the bulk of the
-                            // build's stderr output land cleanly
-                            // between frames.
-                            std::thread::sleep(std::time::Duration::from_millis(1000));
-                        }
-                        // Final paint so the visible state matches the
-                        // exit outcome before the viewport tears down.
-                        let _ = tui.draw();
-                        let _ = tui.shutdown();
-                    })
-                    .ok();
-                (Some(state), Some(shutdown), handle)
-            }
-            Err(e) => {
-                whisker_build::ui::warn(format!(
-                    "couldn't start inline TUI ({e:#}); falling back to plain output"
-                ));
-                (None, None, None)
-            }
-        }
-    } else {
-        (None, None, None)
-    };
+    let tui_for_events = tui.cloned();
 
     let server = DevServer::new(config)?.on_event(move |e| {
-        if let Some(state) = &tui_state {
-            if let Ok(mut s) = state.lock() {
-                crate::tui::apply_event(&mut s, &e);
-            }
+        if let Some(h) = &tui_for_events {
+            h.apply_event(&e);
         }
         forward_event_to_ui(e, show_native_logs);
     });
 
-    let result = rt.block_on(server.run());
-
-    // Tell the render thread we're done; wait for it to clear the
-    // viewport so the user's prompt lands at column 0 of a clean line.
-    if let Some(shutdown) = tui_shutdown {
-        shutdown.store(true, std::sync::atomic::Ordering::Release);
-    }
-    if let Some(handle) = tui_handle {
-        let _ = handle.join();
-    }
-    result
+    rt.block_on(server.run())
 }
 
 /// Friendly label for the TUI header. `whisker_dev_server::Target`'s
@@ -440,27 +425,6 @@ fn ios_params_from(m: &manifest::ResolvedManifest, project_dir: &Path) -> Result
         bundle_id,
         device_override: std::env::var("WHISKER_IOS_SIMULATOR").ok(),
     })
-}
-
-/// Populate the Lynx artifact cache for `target` and (re)create the
-/// workspace symlinks downstream consumers read from. No-op for
-/// `Target::Host`. Duplicated in `build.rs::ensure_lynx_for_target`;
-/// if a third consumer shows up, factor into a helper module.
-fn ensure_lynx_for_target(target: Target, workspace_root: &Path) -> Result<()> {
-    use whisker_build::LynxPlatform;
-    match target {
-        Target::Host => Ok(()),
-        Target::Android => {
-            whisker_build::ensure_lynx_android()?;
-            whisker_build::link_lynx_into_workspace(workspace_root, LynxPlatform::Android)?;
-            Ok(())
-        }
-        Target::IosSimulator => {
-            whisker_build::ensure_lynx_ios()?;
-            whisker_build::link_lynx_into_workspace(workspace_root, LynxPlatform::Ios)?;
-            Ok(())
-        }
-    }
 }
 
 /// Walk up from `start` looking for a `Cargo.toml` containing a

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -184,6 +184,27 @@ fn run_inner(
     // `set_phase(Setup)` already fired from `run()` before we got
     // here, so re-issuing it would duplicate the "▶ Setup" entry in
     // scrollback.
+    // iOS only: populate `target/lynx-ios/` with the Lynx SDK
+    // download and create the workspace-relative symlinks the
+    // cng-generated SPM `Package.swift` points its `binaryTarget`s
+    // at. Without this, xcodebuild's package-resolution step (which
+    // runs *before* any Run Script Build Phase) fails with
+    //
+    //     local binary target 'Lynx' at '…/target/lynx-ios/Lynx.xcframework'
+    //     does not contain a binary artifact.
+    //
+    // Android skips this entirely because gradle pulls the Lynx aar
+    // from the `whiskerrs.github.io/lynx/maven` repo transitively
+    // via the SDK pom; nothing in the workspace tree references a
+    // local Lynx artifact for Android. Host has no Lynx dependency
+    // at all (the driver dlopens it lazily).
+    if matches!(target, Target::IosSimulator) {
+        whisker_build::ensure_lynx_ios()
+            .context("populate target/lynx-ios with Lynx SDK XCFrameworks")?;
+        whisker_build::link_lynx_into_workspace(&workspace_root, whisker_build::LynxPlatform::Ios)
+            .context("link Lynx XCFrameworks into the workspace")?;
+    }
+
     let sync = crate::platforms::sync_for_target(
         target,
         &m.config,

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -118,9 +118,8 @@ pub fn run(args: Args) -> Result<()> {
     // render with a proper progress indicator instead of leaking
     // ahead of an inline status bar.
     let tui_pieces = if tui_enabled {
-        match crate::tui::Tui::start(crate::tui::TuiState::new(target_label, bundle.clone())) {
-            Ok(tui) => {
-                let handle = tui.handle();
+        match crate::tui::Tui::start(target_label.to_string(), bundle.clone()) {
+            Ok((tui, handle)) => {
                 handle.set_phase(crate::tui::AppPhase::Setup);
                 let render_handle = std::thread::Builder::new()
                     .name("whisker-tui-render".into())
@@ -157,7 +156,19 @@ pub fn run(args: Args) -> Result<()> {
 
 fn run_tui_render_loop(mut tui: crate::tui::Tui) {
     let _ = tui.render_until_quit();
+    let user_quit = tui.was_user_quit();
     let _ = tui.shutdown();
+    if user_quit {
+        // The dev-server runs to completion (i.e. forever) inside
+        // `rt.block_on(server.run())` on the cli thread, so simply
+        // tearing the TUI down here would leave a headless `whisker
+        // run` process alive after `q`. Hard-exit with a normal
+        // status; tokio sockets / file watchers get reaped by the
+        // kernel. cli-initiated shutdowns (build failed, etc.) take
+        // the other branch and let `run()`'s normal return path
+        // surface the error.
+        std::process::exit(0);
+    }
 }
 
 fn run_inner(
@@ -170,9 +181,9 @@ fn run_inner(
     // Sync the native host project (gen/{android,ios}/) before doing
     // anything else. The cargo-side `build_discovered_plugins` step
     // happens inside `sync_for_target` and is the long pole here.
-    if let Some(t) = tui {
-        t.set_phase(crate::tui::AppPhase::Setup);
-    }
+    // `set_phase(Setup)` already fired from `run()` before we got
+    // here, so re-issuing it would duplicate the "▶ Setup" entry in
+    // scrollback.
     let sync = crate::platforms::sync_for_target(
         target,
         &m.config,

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -304,14 +304,22 @@ pub fn apply_event(
         Event::ClientDisconnected => {
             state.client_count = state.client_count.saturating_sub(1);
         }
+        Event::PatchBuilding => {
+            // Flip into Patching the moment the dev-server starts
+            // assembling the hot patch (cargo + symbol-table diff
+            // + ASLR rebase, the wall-clock-heavy bit of the loop).
+            // `Event::PatchSent` flips back to Idle on completion;
+            // `Event::BuildingFull` covers the Tier 2 fallback case
+            // where Tier 1 errored out mid-build and the loop fell
+            // through to a cold rebuild — that event resets phase
+            // to Building, overriding this Patching state.
+            state.phase = AppPhase::Patching {
+                started_at: Instant::now(),
+            };
+        }
         Event::PatchSent => {
             if let AppPhase::Patching { started_at } = &state.phase {
                 let elapsed = started_at.elapsed();
-                history.push(HistoryItem::PhaseDone {
-                    label: "Hot patch".into(),
-                    status: StepStatus::Done,
-                    elapsed,
-                });
                 state.last_patch = Some(fmt_elapsed(elapsed));
             }
             state.phase = AppPhase::Idle;
@@ -1189,7 +1197,23 @@ mod tests {
         let h = drain(&mut st, &Event::PatchSent);
         assert!(matches!(st.phase, AppPhase::Idle));
         assert!(st.last_patch.is_some());
-        assert!(h.iter().any(|i| matches!(i, HistoryItem::PhaseDone { .. })));
+        // PhaseDone is no longer emitted on PatchSent — the dev-server
+        // already emits `✓ patch tier 1 …` via `ui::step` and a
+        // duplicate "Hot patch" summary row would just clutter
+        // scrollback.
+        assert!(h.is_empty());
+    }
+
+    #[test]
+    fn patch_building_transitions_phase_to_patching() {
+        let mut st = s();
+        st.phase = AppPhase::Idle;
+        let h = drain(&mut st, &Event::PatchBuilding);
+        assert!(
+            matches!(st.phase, AppPhase::Patching { .. }),
+            "phase should be Patching after PatchBuilding"
+        );
+        assert!(h.is_empty(), "PatchBuilding shouldn't emit history rows");
     }
 
     #[test]

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -1,81 +1,119 @@
-//! Full-screen ratatui TUI for `whisker run`.
+//! Inline-viewport TUI for `whisker run`.
 //!
-//! Replaces the inline status bar in #184/#185 with an alternate-screen
-//! UI that owns the entire terminal. Reasons:
+//! ## Design (vs. the alternate-screen design in #187)
 //!
-//! - Inline mode raced against every `eprintln!` from `whisker_build::ui`
-//!   and Step::pipe-driven subprocess output, corrupting the viewport on
-//!   any heavy log burst.
-//! - Sub-step granularity (Sync → Build → Install → Launch) can't fit
-//!   in 3 inline rows.
-//! - Full-screen lets us own stderr — we `dup2` it through a pipe, read
-//!   captured lines on a background thread, and render them in a Logs
-//!   pane below the steps. Every output channel funnels through ratatui;
-//!   there's nothing to race with.
+//! Full-screen ratatui owned the terminal and erased scrollback;
+//! cargo / gradle / xcodebuild log bursts during a build no longer
+//! fit in any reasonable pane and the user couldn't scroll back
+//! through them. The codex-rs TUI solves this by anchoring a small
+//! "live region" at the bottom and pushing everything else into the
+//! terminal's *normal* scrollback via ANSI scroll-region tricks. We
+//! get the same shape for free out of ratatui 0.29's
+//! [`Viewport::Inline`] + [`Terminal::insert_before`] (with the
+//! `scrolling-regions` feature enabled so we land on the DECSTBM
+//! fast path).
+//!
+//! Layout while the cli is running:
+//!
+//! ```text
+//! ── terminal scrollback (mouse-wheel scrollable) ──────────────────
+//!   …earlier shell output…
+//!   ▶ Setup
+//!   ✓ Sync gen/ios            124ms
+//!   ▶ Initial build
+//!   warning: unused import: `Foo`   ← captured cargo stderr
+//!   ✓ Initial build           6.2s
+//!   ▶ Install + launch
+//!   …
+//! ── live region (LIVE_HEIGHT rows, redraws ~10Hz) ─────────────────
+//!    whisker run · iOS Simulator · rs.example.bar · building · 4.1s
+//!    ⠋ xcodebuild …
+//!
+//!    q  quit
+//! ──────────────────────────────────────────────────────────────────
+//! ```
+//!
+//! ## Subprocess output → scrollback
+//!
+//! cargo / gradle / xcodebuild and every `whisker_build::ui::*` call
+//! write to stderr. We `dup2` `STDERR_FILENO` to a pipe whose read
+//! end a dedicated thread drains line-by-line, strips ANSI escapes
+//! from, and sends through an mpsc channel. The render thread drains
+//! that channel each frame and calls
+//! [`Terminal::insert_before`] per line, so captured output lands
+//! above the live region — which the terminal's scrollback keeps for
+//! us. ratatui's backend is wired to the *saved* original stderr fd
+//! so its own draw escapes don't self-loop into the pipe.
+//!
+//! Because stderr is no longer a TTY once we `dup2` it, cargo /
+//! gradle / xcodebuild automatically fall back to line-based output
+//! (no in-place progress bars), which is exactly what we want for
+//! scrollback.
 //!
 //! ## State machine
 //!
-//! [`AppPhase`] tracks where the dev loop is. Transitions are driven by
-//! a combination of explicit cli calls (`Setup`, `Initializing` —
-//! before dev-server events fire) and `whisker_dev_server::Event`s
-//! (`Building`, `Idle`, `Patching`, …) routed through [`apply_event`].
-//!
-//! ## Lifetime
-//!
-//! [`Tui::start`] enters the alternate screen, hides the cursor, and
-//! `dup2`s `STDERR_FILENO` to a pipe whose read end a dedicated thread
-//! drains into the log buffer. [`Tui::shutdown`] reverses each step in
-//! the opposite order. Both a panic hook and a `ctrlc::set_handler`
-//! emergency-reset stderr + cursor visibility so a hard exit doesn't
-//! leave the user's shell hosed.
+//! [`AppPhase`] tracks where the dev loop is. The cli calls
+//! [`TuiHandle::set_phase`] for phases it drives directly
+//! (`Setup`, `Initializing`); dev-server events drive the rest via
+//! [`TuiHandle::apply_event`]. Each transition emits a one-line
+//! "▶ <phase>" / "✓ <phase>  Xs" history entry plus updates the live
+//! header.
 
 use anyhow::{Context, Result};
 use crossterm::{
     cursor,
-    event::{poll, read, Event as CtEvent, KeyCode, KeyEventKind},
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    event::{poll, read, Event as CtEvent, KeyCode, KeyEventKind, KeyModifiers},
+    terminal::{disable_raw_mode, enable_raw_mode},
     ExecutableCommand,
 };
 use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
-use ratatui::Terminal;
-use std::collections::VecDeque;
+use ratatui::widgets::{Paragraph, Widget, Wrap};
+use ratatui::{Terminal, TerminalOptions, Viewport};
 use std::io::Write;
 use std::os::raw::c_int;
+use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+/// Height of the live region in rows. The header, current step,
+/// dev-server info and key hint together comfortably fit in 6 rows;
+/// taller cuts scrollback density and saves nothing.
+const LIVE_HEIGHT: u16 = 6;
+
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 // ============================================================================
 // Public state model
 // ============================================================================
 
 /// Which phase of the dev loop the user is currently watching. Drives
-/// the steps pane's content and the header's right-hand badge.
+/// the live-region header label + spinner color.
 #[derive(Debug, Clone)]
 pub enum AppPhase {
     /// Pre-dev-server cli work: `sync_for_target` (gen tree + plugin
     /// build). Driven by explicit `TuiHandle::set_phase` calls.
     Setup,
     /// dev-server's setup (WS bind, watcher, capture shim resolve).
-    /// Brief; usually flips to `Building` within a hundred ms once
+    /// Brief; usually flips to `Building` within ~100ms once
     /// `Event::BuildingFull` arrives.
     Initializing,
-    /// `cargo` + `gradle`/`xcodebuild` in flight.
+    /// `cargo` + `gradle` / `xcodebuild` in flight.
     Building {
         started_at: Instant,
         kind: BuildKind,
     },
     /// dev-server bound, initial build succeeded, watching for source
-    /// changes. The header shows ws addr + client count + last
-    /// build/patch summaries.
+    /// changes.
     Idle,
     /// Tier 1 hot-patch in flight. Phase exit is signalled by
     /// `Event::PatchSent` or a Tier 2 fallback's `Event::BuildingFull`.
     Patching { started_at: Instant },
-    /// Build failed. Surfaces the cause in the steps pane.
+    /// Build failed. The live region surfaces the cause and the cli
+    /// is about to exit non-zero.
     Failed { phase: String, reason: String },
 }
 
@@ -85,115 +123,108 @@ pub enum BuildKind {
     Rebuild,
 }
 
-/// Outcome of a completed step (a single row in the steps pane).
+/// Outcome of a completed step. Pushed to scrollback by
+/// [`TuiHandle::finish_step`]; never rendered in the live region.
 #[derive(Debug, Clone, Copy)]
 pub enum StepStatus {
-    Pending,
-    InProgress,
     Done,
     Failed,
     Skipped,
 }
 
-/// One row in the steps pane.
+/// Snapshot the render thread reads on every frame to draw the live
+/// region. Mutated under a `Mutex` from the cli thread; everything
+/// that needs to *enter scrollback* goes through the history channel
+/// instead so the render thread can call `insert_before` from the
+/// thread that owns the ratatui terminal.
 #[derive(Debug, Clone)]
-pub struct Step {
-    pub label: String,
-    pub status: StepStatus,
-    pub elapsed_ms: Option<u64>,
-}
-
-/// Bounded ring of captured stderr lines for the Logs pane.
-#[derive(Debug, Clone)]
-pub struct LogBuffer {
-    pub lines: VecDeque<String>,
-    pub capacity: usize,
-}
-
-impl LogBuffer {
-    fn new(capacity: usize) -> Self {
-        Self {
-            lines: VecDeque::with_capacity(capacity),
-            capacity,
-        }
-    }
-    pub fn push(&mut self, line: String) {
-        if self.lines.len() >= self.capacity {
-            self.lines.pop_front();
-        }
-        self.lines.push_back(line);
-    }
-}
-
-/// Snapshot the render thread reads on every frame.
-#[derive(Debug, Clone)]
-pub struct TuiState {
+pub struct LiveState {
     pub target: String,
     pub bundle: String,
+    pub phase: AppPhase,
+    /// Label of the in-progress step (e.g. "xcodebuild …"). Cleared
+    /// when the step finishes.
+    pub current_step: Option<String>,
     pub ws_addr: Option<String>,
     pub watching: Vec<String>,
     pub client_count: usize,
-    pub phase: AppPhase,
-    pub steps: Vec<Step>,
     pub last_build: Option<String>,
     pub last_patch: Option<String>,
-    pub logs: LogBuffer,
     pub should_quit: bool,
+    /// `true` when the quit was triggered by a user keypress
+    /// (`q` / Esc / Ctrl-C), `false` when the cli called
+    /// `TuiHandle::request_quit` after its own work finished or
+    /// failed. The render thread uses this to decide whether to
+    /// force-exit the process after shutdown — the dev-server
+    /// `rt.block_on(server.run())` call in the main thread otherwise
+    /// blocks forever, so without a hard exit `q` would tear down the
+    /// TUI but leave the process running.
+    pub user_initiated_quit: bool,
 }
 
-impl TuiState {
+impl LiveState {
     pub fn new(target: impl Into<String>, bundle: impl Into<String>) -> Self {
         Self {
             target: target.into(),
             bundle: bundle.into(),
+            phase: AppPhase::Setup,
+            current_step: None,
             ws_addr: None,
             watching: Vec::new(),
             client_count: 0,
-            phase: AppPhase::Setup,
-            steps: Vec::new(),
             last_build: None,
             last_patch: None,
-            logs: LogBuffer::new(500),
             should_quit: false,
+            user_initiated_quit: false,
         }
     }
 }
 
-// ============================================================================
-// Step helpers
-// ============================================================================
-
-pub fn start_step(state: &mut TuiState, label: impl Into<String>) -> usize {
-    state.steps.push(Step {
-        label: label.into(),
-        status: StepStatus::InProgress,
-        elapsed_ms: None,
-    });
-    state.steps.len() - 1
-}
-
-pub fn finish_step_at(state: &mut TuiState, idx: usize, status: StepStatus, elapsed_ms: u64) {
-    if let Some(step) = state.steps.get_mut(idx) {
-        step.status = status;
-        step.elapsed_ms = Some(elapsed_ms);
-    }
-}
-
-pub fn reset_steps(state: &mut TuiState) {
-    state.steps.clear();
+/// One entry the render thread will push into the terminal's
+/// scrollback via [`Terminal::insert_before`].
+#[derive(Debug, Clone)]
+pub enum HistoryItem {
+    /// Phase-transition heading: "▶ Initial build".
+    PhaseEnter(String),
+    /// Phase-completion summary: "✓ Initial build  6.2s".
+    PhaseDone {
+        label: String,
+        status: StepStatus,
+        elapsed: Duration,
+    },
+    /// A completed step: "✓ Sync gen/ios       124ms".
+    Step {
+        label: String,
+        status: StepStatus,
+        elapsed: Duration,
+    },
+    /// One line captured from the dup2'd stderr pipe (with ANSI
+    /// escapes already stripped).
+    CapturedStderr(String),
+    /// Device log forwarded from the dev-server.
+    DeviceLog { stream: String, line: String },
+    /// One-shot failure description for the scrollback.
+    Failure(String),
 }
 
 // ============================================================================
 // Event → state machine
 // ============================================================================
 
-/// Apply a dev-server event to the in-memory TUI state.
-pub fn apply_event(state: &mut TuiState, event: &whisker_dev_server::Event) {
+/// Apply a dev-server event to the live state and emit any history
+/// entries the transition implies. Pure — the test suite exercises
+/// it without any terminal io.
+pub fn apply_event(
+    state: &mut LiveState,
+    event: &whisker_dev_server::Event,
+    history: &mut Vec<HistoryItem>,
+) {
     use whisker_dev_server::Event;
     match event {
         Event::Started => {
-            // dev-server is up. Phase transition is driven by the
-            // cli's explicit `set_phase` calls — respect that ordering.
+            // dev-server is up. The cli's explicit `set_phase` calls
+            // own the transition out of Initializing — respect that
+            // ordering so we don't race the "▶ Initial build" entry.
         }
         Event::BuildingFull => {
             let kind = match state.phase {
@@ -204,24 +235,52 @@ pub fn apply_event(state: &mut TuiState, event: &whisker_dev_server::Event) {
                 started_at: Instant::now(),
                 kind,
             };
-            reset_steps(state);
+            // Phase entry markers come from `whisker_build::ui::section`
+            // ("──── Initial build ────"), which lands in scrollback
+            // via the stderr capture. Emitting a second "▶ Initial
+            // build" line here would just duplicate it. Phase *exit*
+            // (the `✓ Initial build  6.2s` summary) is unique to our
+            // TUI and is emitted on `BuildSucceeded`.
+            state.current_step = None;
         }
         Event::BuildSucceeded => {
             if let AppPhase::Building { started_at, kind } = &state.phase {
                 let elapsed = started_at.elapsed();
                 let label = match kind {
-                    BuildKind::Initial => "initial",
-                    BuildKind::Rebuild => "rebuild",
+                    BuildKind::Initial => "Initial build",
+                    BuildKind::Rebuild => "Rebuild",
                 };
-                state.last_build = Some(format!("{label} · {}", fmt_elapsed(elapsed)));
+                history.push(HistoryItem::PhaseDone {
+                    label: label.into(),
+                    status: StepStatus::Done,
+                    elapsed,
+                });
+                state.last_build = Some(format!(
+                    "{} · {}",
+                    if matches!(kind, BuildKind::Initial) {
+                        "initial"
+                    } else {
+                        "rebuild"
+                    },
+                    fmt_elapsed(elapsed)
+                ));
             }
             state.phase = AppPhase::Idle;
+            state.current_step = None;
         }
         Event::BuildFailed(msg) => {
+            let phase = "build".to_string();
+            history.push(HistoryItem::PhaseDone {
+                label: phase.clone(),
+                status: StepStatus::Failed,
+                elapsed: Duration::ZERO,
+            });
+            history.push(HistoryItem::Failure(msg.clone()));
             state.phase = AppPhase::Failed {
-                phase: "build".into(),
+                phase,
                 reason: msg.clone(),
             };
+            state.current_step = None;
         }
         Event::ClientConnected => {
             state.client_count = state.client_count.saturating_add(1);
@@ -232,27 +291,127 @@ pub fn apply_event(state: &mut TuiState, event: &whisker_dev_server::Event) {
         Event::PatchSent => {
             if let AppPhase::Patching { started_at } = &state.phase {
                 let elapsed = started_at.elapsed();
+                history.push(HistoryItem::PhaseDone {
+                    label: "Hot patch".into(),
+                    status: StepStatus::Done,
+                    elapsed,
+                });
                 state.last_patch = Some(fmt_elapsed(elapsed));
             }
             state.phase = AppPhase::Idle;
+            state.current_step = None;
         }
         Event::DeviceLog { stream, line, .. } => {
-            let tag = match stream.as_str() {
-                "stderr" => "[device:err]",
-                _ => "[device]",
-            };
-            state.logs.push(format!("{tag} {line}"));
+            history.push(HistoryItem::DeviceLog {
+                stream: stream.clone(),
+                line: line.clone(),
+            });
         }
     }
 }
 
 // ============================================================================
-// Tui: alternate-screen + stderr capture + render loop
+// TuiHandle: cli-side facade
 // ============================================================================
 
-/// Writer for ratatui's backend — writes directly to the saved
-/// (pre-`dup2`) stderr fd so its escape codes don't get folded into
-/// the captured log.
+/// Cheap-to-clone handle the cli code passes around to update the
+/// live region and to commit lines to scrollback. Thread-safe;
+/// non-blocking on send (a slow render thread can't stall the
+/// build).
+#[derive(Clone)]
+pub struct TuiHandle {
+    live: Arc<Mutex<LiveState>>,
+    tx: Sender<HistoryItem>,
+}
+
+impl TuiHandle {
+    fn with<F: FnOnce(&mut LiveState)>(&self, f: F) {
+        if let Ok(mut g) = self.live.lock() {
+            f(&mut g);
+        }
+    }
+    fn send(&self, item: HistoryItem) {
+        // Disconnected receiver is harmless — we just stop emitting.
+        let _ = self.tx.send(item);
+    }
+
+    /// Enter `phase`. Updates the live region's phase label/spinner
+    /// color and clears any in-progress step display. Does NOT push
+    /// a scrollback entry — `whisker_build::ui::section` already
+    /// prints labeled phase boundaries that flow into scrollback via
+    /// the stderr capture, so a duplicate "▶ <label>" line would
+    /// just be noise. Event-driven phase completions (build
+    /// finished, patch sent) still emit `HistoryItem::PhaseDone`
+    /// via [`apply_event`] — those carry elapsed-time data that
+    /// `whisker_build::ui` doesn't.
+    pub fn set_phase(&self, phase: AppPhase) {
+        self.with(|s| {
+            s.phase = phase;
+            s.current_step = None;
+        });
+    }
+
+    /// Begin a step. Updates `current_step` in the live region; on
+    /// `finish_step` the row gets committed to scrollback.
+    pub fn start_step(&self, label: impl Into<String>) {
+        let label = label.into();
+        self.with(|s| {
+            s.current_step = Some(label);
+        });
+    }
+
+    /// Finish the currently-displayed step. The row is pushed to
+    /// scrollback as "✓ <label>  <elapsed>"; the live region clears
+    /// `current_step`.
+    pub fn finish_step(&self, label: impl Into<String>, status: StepStatus, elapsed: Duration) {
+        let label = label.into();
+        self.with(|s| s.current_step = None);
+        self.send(HistoryItem::Step {
+            label,
+            status,
+            elapsed,
+        });
+    }
+
+    pub fn apply_event(&self, event: &whisker_dev_server::Event) {
+        let mut history: Vec<HistoryItem> = Vec::new();
+        self.with(|s| apply_event(s, event, &mut history));
+        for h in history {
+            self.send(h);
+        }
+    }
+
+    pub fn set_dev_server(&self, ws_addr: impl Into<String>, watching: Vec<String>) {
+        let ws_addr = ws_addr.into();
+        self.with(|s| {
+            s.ws_addr = Some(ws_addr);
+            s.watching = watching;
+        });
+    }
+
+    pub fn should_quit(&self) -> bool {
+        self.live.lock().map(|s| s.should_quit).unwrap_or(false)
+    }
+
+    pub fn request_quit(&self) {
+        self.with(|s| s.should_quit = true);
+    }
+
+    /// Test-only: pull a snapshot of the live state. Avoid in
+    /// production code — render is the only legitimate reader.
+    #[cfg(test)]
+    pub fn snapshot(&self) -> LiveState {
+        self.live.lock().unwrap().clone()
+    }
+}
+
+// ============================================================================
+// Tui: terminal owner + render loop
+// ============================================================================
+
+/// Writer for ratatui's crossterm backend. Writes to the *saved*
+/// (pre-dup2) stderr fd so the terminal's draw escapes don't loop
+/// back into the capture pipe.
 struct OriginalStderr(c_int);
 
 impl Write for OriginalStderr {
@@ -269,83 +428,109 @@ impl Write for OriginalStderr {
     }
 }
 
-/// Owns the ratatui terminal + state mutex + the saved stderr fd.
 pub struct Tui {
     terminal: Terminal<CrosstermBackend<OriginalStderr>>,
-    state: Arc<Mutex<TuiState>>,
+    live: Arc<Mutex<LiveState>>,
+    rx: Receiver<HistoryItem>,
     saved_stderr_fd: c_int,
+    spinner_idx: usize,
 }
 
 impl Tui {
-    pub fn start(state: TuiState) -> Result<Self> {
+    /// Set up the inline TUI, install the stderr capture, and hand
+    /// back a `(Tui, TuiHandle)` pair. The cli keeps `TuiHandle` and
+    /// passes `Tui` to a dedicated OS thread that runs the render
+    /// loop (ratatui's `Terminal` isn't `Send` once it has a backend
+    /// holding raw fds — keep it pinned to one thread).
+    pub fn start(target: String, bundle: String) -> Result<(Self, TuiHandle)> {
         let (saved_stderr_fd, capture_read_fd) =
             install_stderr_capture().context("install stderr capture")?;
         install_terminal_cleanup_once(saved_stderr_fd);
 
         enable_raw_mode().context("enable raw mode")?;
         let mut original = OriginalStderr(saved_stderr_fd);
-        original
-            .execute(EnterAlternateScreen)
-            .context("enter alternate screen")?;
         original.execute(cursor::Hide).context("hide cursor")?;
 
         let backend = CrosstermBackend::new(original);
-        let terminal = Terminal::new(backend).context("create ratatui terminal")?;
+        let terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(LIVE_HEIGHT),
+            },
+        )
+        .context("create ratatui terminal (inline viewport)")?;
 
-        let state = Arc::new(Mutex::new(state));
-        let state_for_reader = Arc::clone(&state);
-        std::thread::Builder::new()
-            .name("whisker-tui-capture".into())
-            .spawn(move || capture_reader_loop(capture_read_fd, state_for_reader))
-            .context("spawn capture reader")?;
+        let live = Arc::new(Mutex::new(LiveState::new(target, bundle)));
+        let (tx, rx) = channel::<HistoryItem>();
 
-        Ok(Self {
-            terminal,
-            state,
-            saved_stderr_fd,
-        })
-    }
-
-    pub fn handle(&self) -> TuiHandle {
-        TuiHandle {
-            state: Arc::clone(&self.state),
+        {
+            // stderr capture → channel. Each captured line becomes
+            // a `HistoryItem::CapturedStderr` once we've stripped
+            // ANSI escape sequences.
+            let tx = tx.clone();
+            std::thread::Builder::new()
+                .name("whisker-tui-stderr-capture".into())
+                .spawn(move || capture_reader_loop(capture_read_fd, tx))
+                .context("spawn stderr capture reader")?;
         }
+
+        let handle = TuiHandle {
+            live: Arc::clone(&live),
+            tx,
+        };
+
+        Ok((
+            Self {
+                terminal,
+                live,
+                rx,
+                saved_stderr_fd,
+                spinner_idx: 0,
+            },
+            handle,
+        ))
     }
 
-    /// Drive the render loop until either the user presses `q` or
-    /// `should_quit` is flipped externally.
+    /// Drive the render loop until `should_quit` flips (either via
+    /// `q` / Esc / Ctrl-C in the terminal or via `TuiHandle::request_quit`
+    /// from the cli when its work finishes).
     pub fn render_until_quit(&mut self) -> Result<()> {
         let frame_interval = Duration::from_millis(100);
         let mut last_draw = Instant::now() - frame_interval;
         loop {
-            if poll(Duration::from_millis(10))? {
+            self.drain_history_into_scrollback()?;
+
+            if last_draw.elapsed() >= frame_interval {
+                self.spinner_idx = self.spinner_idx.wrapping_add(1);
+                let snapshot = self.live.lock().ok().map(|g| g.clone());
+                if let Some(s) = snapshot {
+                    let spinner_idx = self.spinner_idx;
+                    self.terminal
+                        .draw(|f| render_live(f, &s, spinner_idx))
+                        .context("draw live region")?;
+                }
+                last_draw = Instant::now();
+            }
+
+            // Short key poll — must be tight enough that pressing
+            // `q` feels responsive but not so tight it pegs a core.
+            // 50ms is the same budget the previous full-screen TUI
+            // used; works fine.
+            if poll(Duration::from_millis(50))? {
                 if let CtEvent::Key(key) = read()? {
                     if matches!(key.kind, KeyEventKind::Press) {
                         match key.code {
-                            KeyCode::Char('q') | KeyCode::Esc => {
-                                if let Ok(mut s) = self.state.lock() {
-                                    s.should_quit = true;
-                                }
-                            }
-                            KeyCode::Char('c')
-                                if key
-                                    .modifiers
-                                    .contains(crossterm::event::KeyModifiers::CONTROL) =>
-                            {
-                                if let Ok(mut s) = self.state.lock() {
-                                    s.should_quit = true;
-                                }
+                            KeyCode::Char('q') | KeyCode::Esc => self.user_quit(),
+                            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                                self.user_quit()
                             }
                             _ => {}
                         }
                     }
                 }
             }
-            if last_draw.elapsed() >= frame_interval {
-                self.draw()?;
-                last_draw = Instant::now();
-            }
-            if let Ok(s) = self.state.lock() {
+
+            if let Ok(s) = self.live.lock() {
                 if s.should_quit {
                     break;
                 }
@@ -354,71 +539,83 @@ impl Tui {
         Ok(())
     }
 
-    fn draw(&mut self) -> Result<()> {
-        let snapshot = match self.state.lock() {
-            Ok(g) => g.clone(),
-            Err(_) => return Ok(()),
-        };
-        self.terminal.draw(|frame| render(frame, &snapshot))?;
+    fn drain_history_into_scrollback(&mut self) -> Result<()> {
+        loop {
+            match self.rx.try_recv() {
+                Ok(item) => {
+                    let lines = render_history_item(&item);
+                    let height = lines.len().min(u16::MAX as usize) as u16;
+                    if height == 0 {
+                        continue;
+                    }
+                    // Move `lines` into the closure — ratatui's `Buffer`
+                    // borrows the cells we copy from `Line`s.
+                    self.terminal
+                        .insert_before(height, move |buf| {
+                            write_lines_to_buffer(buf, &lines);
+                        })
+                        .context("insert history line into scrollback")?;
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
         Ok(())
     }
 
+    /// User-initiated quit (q / Esc / Ctrl-C from the TUI).
+    /// Distinguished from a cli-initiated quit (`TuiHandle::request_quit`)
+    /// so `run_until_quit`'s caller can decide to force-exit the
+    /// process — the dev-server's `rt.block_on` would otherwise keep
+    /// running after the TUI tears down.
+    fn user_quit(&self) {
+        if let Ok(mut s) = self.live.lock() {
+            s.should_quit = true;
+            s.user_initiated_quit = true;
+        }
+    }
+
+    /// Whether the most recent quit signal came from a user keypress
+    /// rather than a `TuiHandle::request_quit` call. Callers use this
+    /// after `render_until_quit` returns to decide whether to
+    /// `process::exit` (user quit while the dev-server was running) or
+    /// to fall through and let the cli's own return path run (cli
+    /// finished its work).
+    pub fn was_user_quit(&self) -> bool {
+        self.live
+            .lock()
+            .map(|s| s.user_initiated_quit)
+            .unwrap_or(false)
+    }
+
     pub fn shutdown(mut self) -> Result<()> {
+        // One last drain so any final phase/Step/Failure entry the
+        // cli emitted between the last render and quit lands in
+        // scrollback before the live region disappears.
+        let _ = self.drain_history_into_scrollback();
+        // ratatui clears its viewport rows on `clear`; on Inline
+        // mode this leaves the scrollback intact and just blanks
+        // the LIVE_HEIGHT rows at the cursor. Then we restore the
+        // cursor via `Terminal::show_cursor` (not a bare crossterm
+        // `cursor::Show` against the saved fd) — going through the
+        // terminal clears its internal `hidden_cursor` flag, which
+        // otherwise causes ratatui's `Drop` impl to try the same
+        // call later when the fd is already closed and we'd see
+        // `Failed to show the cursor: Bad file descriptor` printed
+        // to the shell.
         let _ = self.terminal.clear();
-        let mut original = OriginalStderr(self.saved_stderr_fd);
-        let _ = original.execute(cursor::Show);
-        let _ = original.execute(LeaveAlternateScreen);
+        let _ = self.terminal.show_cursor();
         let _ = disable_raw_mode();
+        // Restore STDERR_FILENO to the saved fd so callers can
+        // continue to `eprintln!` after the TUI is gone; close the
+        // duplicated saved fd afterward. `Tui`'s drop order then
+        // unwinds the ratatui Terminal cleanly (hidden_cursor is
+        // already false, so Drop is a no-op).
         unsafe {
             libc::dup2(self.saved_stderr_fd, libc::STDERR_FILENO);
             libc::close(self.saved_stderr_fd);
         }
         Ok(())
-    }
-}
-
-#[derive(Clone)]
-pub struct TuiHandle {
-    state: Arc<Mutex<TuiState>>,
-}
-
-impl TuiHandle {
-    pub fn with<F: FnOnce(&mut TuiState)>(&self, f: F) {
-        if let Ok(mut g) = self.state.lock() {
-            f(&mut g);
-        }
-    }
-    pub fn set_phase(&self, phase: AppPhase) {
-        self.with(|s| {
-            s.phase = phase;
-            reset_steps(s);
-        });
-    }
-    pub fn start_step(&self, label: impl Into<String>) -> usize {
-        let label = label.into();
-        let mut idx = 0;
-        self.with(|s| {
-            idx = start_step(s, label);
-        });
-        idx
-    }
-    pub fn finish_step(&self, idx: usize, status: StepStatus, elapsed_ms: u64) {
-        self.with(|s| finish_step_at(s, idx, status, elapsed_ms));
-    }
-    pub fn apply_event(&self, event: &whisker_dev_server::Event) {
-        self.with(|s| apply_event(s, event));
-    }
-    pub fn set_dev_server(&self, ws_addr: impl Into<String>, watching: Vec<String>) {
-        self.with(|s| {
-            s.ws_addr = Some(ws_addr.into());
-            s.watching = watching;
-        });
-    }
-    pub fn should_quit(&self) -> bool {
-        self.state.lock().map(|s| s.should_quit).unwrap_or(false)
-    }
-    pub fn request_quit(&self) {
-        self.with(|s| s.should_quit = true);
     }
 }
 
@@ -458,7 +655,7 @@ fn install_stderr_capture() -> Result<(c_int, c_int)> {
     Ok((saved_fd, read_fd))
 }
 
-fn capture_reader_loop(read_fd: c_int, state: Arc<Mutex<TuiState>>) {
+fn capture_reader_loop(read_fd: c_int, tx: Sender<HistoryItem>) {
     let mut buf = [0u8; 4096];
     let mut partial: Vec<u8> = Vec::new();
     loop {
@@ -483,13 +680,68 @@ fn capture_reader_loop(read_fd: c_int, state: Arc<Mutex<TuiState>>) {
                 Ok(s) => s,
                 Err(e) => String::from_utf8_lossy(&e.into_bytes()).into_owned(),
             };
-            if !text.is_empty() {
-                if let Ok(mut g) = state.lock() {
-                    g.logs.push(text);
-                }
+            let text = strip_ansi(&text);
+            if !text.is_empty() && tx.send(HistoryItem::CapturedStderr(text)).is_err() {
+                return;
             }
         }
     }
+}
+
+/// Strip ECMA-48 CSI (`\x1b[…<final>`) and OSC (`\x1b]…\x07` or
+/// `\x1b]…\x1b\\`) escapes from `s`. cargo / gradle write colored
+/// output via SGR (CSI ending in `m`); without this, the captured
+/// line would render as visible `^[[33mwarning…^[[0m` in the
+/// scrollback. Iterates over `chars()` so multi-byte UTF-8
+/// sequences (`whisker_build::ui` decorations like `▶ ✓ ·`) survive
+/// intact.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut iter = s.chars().peekable();
+    while let Some(c) = iter.next() {
+        if c == '\x1b' {
+            match iter.peek().copied() {
+                Some('[') => {
+                    iter.next();
+                    // Consume CSI parameter bytes until a final
+                    // byte in the 0x40..=0x7e range (the SGR
+                    // terminator `m` lives here).
+                    for ch in iter.by_ref() {
+                        if matches!(ch as u32, 0x40..=0x7e) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    iter.next();
+                    // Consume the OSC string until BEL (`\x07`) or
+                    // ST (`ESC \`).
+                    while let Some(ch) = iter.next() {
+                        if ch == '\x07' {
+                            break;
+                        }
+                        if ch == '\x1b' {
+                            if matches!(iter.peek(), Some('\\')) {
+                                iter.next();
+                            }
+                            break;
+                        }
+                    }
+                }
+                _ => {
+                    // Lone ESC or unknown introducer — drop it.
+                }
+            }
+            continue;
+        }
+        // Drop other C0 control characters except tab. Multi-byte
+        // UTF-8 characters have a `u32` value ≥ 0x80, so they pass
+        // the `>= 0x20` check unconditionally.
+        if c == '\t' || (c as u32) >= 0x20 {
+            out.push(c);
+        }
+    }
+    out
 }
 
 // ============================================================================
@@ -499,7 +751,6 @@ fn capture_reader_loop(read_fd: c_int, state: Arc<Mutex<TuiState>>) {
 fn emergency_terminal_reset(original_stderr_fd: c_int) {
     let mut o = OriginalStderr(original_stderr_fd);
     let _ = o.execute(cursor::Show);
-    let _ = o.execute(LeaveAlternateScreen);
     let _ = disable_raw_mode();
 }
 
@@ -526,26 +777,18 @@ fn install_terminal_cleanup_once(original_stderr_fd: c_int) {
 // Rendering
 // ============================================================================
 
-fn render(frame: &mut ratatui::Frame, state: &TuiState) {
+fn render_live(frame: &mut ratatui::Frame, state: &LiveState, spinner_idx: usize) {
     let area = frame.area();
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(3),      // header
-            Constraint::Min(8),         // mid pane (steps OR status)
-            Constraint::Percentage(40), // logs
-            Constraint::Length(1),      // footer
-        ])
-        .split(area);
-
-    render_header(frame, chunks[0], state);
-    render_middle(frame, chunks[1], state);
-    render_logs(frame, chunks[2], state);
-    render_footer(frame, chunks[3], state);
+    let lines = build_live_lines(state, spinner_idx);
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
 }
 
-fn render_header(frame: &mut ratatui::Frame, area: Rect, state: &TuiState) {
-    let line = Line::from(vec![
+fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Header line: ` whisker run · target · bundle · phase ` with
+    // phase-elapsed when the phase is wall-clock-meaningful.
+    let mut header: Vec<Span<'static>> = vec![
         Span::styled(
             " whisker run ",
             Style::default()
@@ -567,148 +810,193 @@ fn render_header(frame: &mut ratatui::Frame, area: Rect, state: &TuiState) {
                 .fg(phase_color(&state.phase))
                 .add_modifier(Modifier::BOLD),
         ),
-    ]);
-    let block = Block::default()
-        .borders(Borders::BOTTOM)
-        .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(Paragraph::new(line).block(block), area);
-}
-
-fn render_middle(frame: &mut ratatui::Frame, area: Rect, state: &TuiState) {
-    let mut lines: Vec<Line> = Vec::new();
-    match &state.phase {
-        AppPhase::Idle => {
-            lines.push(Line::from(Span::styled(
-                "Status",
-                Style::default().add_modifier(Modifier::BOLD),
-            )));
-            lines.push(Line::from(""));
-            if let Some(addr) = &state.ws_addr {
-                lines.push(kv_line("Dev server", addr));
-            }
-            lines.push(kv_line(
-                "Clients",
-                &format!("{} connected", state.client_count),
-            ));
-            if !state.watching.is_empty() {
-                lines.push(kv_line(
-                    "Watching",
-                    &format!("{} path(s)", state.watching.len()),
-                ));
-            }
-            if let Some(b) = &state.last_build {
-                lines.push(kv_line("Last build", b));
-            }
-            if let Some(p) = &state.last_patch {
-                lines.push(kv_line("Last patch", p));
-            }
-        }
-        AppPhase::Failed { phase, reason } => {
-            lines.push(Line::from(Span::styled(
-                format!("{phase} failed"),
-                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-            )));
-            lines.push(Line::from(""));
-            lines.push(Line::from(reason.clone()));
-        }
-        _ => {
-            lines.push(Line::from(Span::styled(
-                phase_section_title(&state.phase),
-                Style::default().add_modifier(Modifier::BOLD),
-            )));
-            lines.push(Line::from(""));
-            for step in &state.steps {
-                lines.push(render_step_row(step));
-            }
-        }
-    }
-    let block = Block::default()
-        .borders(Borders::BOTTOM)
-        .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(
-        Paragraph::new(lines)
-            .block(block)
-            .wrap(Wrap { trim: false }),
-        area,
-    );
-}
-
-fn render_logs(frame: &mut ratatui::Frame, area: Rect, state: &TuiState) {
-    let visible_rows = area.height.saturating_sub(2) as usize;
-    let total = state.logs.lines.len();
-    let start = total.saturating_sub(visible_rows);
-    let lines: Vec<Line> = state
-        .logs
-        .lines
-        .iter()
-        .skip(start)
-        .map(|l| Line::from(l.clone()))
-        .collect();
-    let title = format!(" Logs ({}/{}) ", lines.len(), total);
-    let block = Block::default()
-        .borders(Borders::TOP)
-        .title(title)
-        .style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(Paragraph::new(lines).block(block), area);
-}
-
-fn render_footer(frame: &mut ratatui::Frame, area: Rect, _state: &TuiState) {
-    let hint = Line::from(vec![
-        Span::styled(" q ", Style::default().fg(Color::Black).bg(Color::DarkGray)),
-        Span::raw(" quit"),
-    ]);
-    frame.render_widget(Paragraph::new(hint), area);
-}
-
-fn render_step_row(step: &Step) -> Line<'static> {
-    let glyph = match step.status {
-        StepStatus::Pending => Span::styled("·", Style::default().fg(Color::DarkGray)),
-        StepStatus::InProgress => Span::styled("⠋", Style::default().fg(Color::Yellow)),
-        StepStatus::Done => Span::styled("✓", Style::default().fg(Color::Green)),
-        StepStatus::Failed => Span::styled("✗", Style::default().fg(Color::Red)),
-        StepStatus::Skipped => Span::styled("○", Style::default().fg(Color::DarkGray)),
-    };
-    let label_style = match step.status {
-        StepStatus::Pending | StepStatus::Skipped => Style::default().fg(Color::DarkGray),
-        StepStatus::InProgress | StepStatus::Done => Style::default(),
-        StepStatus::Failed => Style::default().fg(Color::Red),
-    };
-    let mut spans = vec![
-        Span::raw("  "),
-        glyph,
-        Span::raw("  "),
-        Span::styled(step.label.clone(), label_style),
     ];
-    if let Some(elapsed) = step.elapsed_ms {
-        spans.push(Span::raw("  "));
-        spans.push(Span::styled(
-            fmt_elapsed(Duration::from_millis(elapsed)),
-            Style::default().fg(Color::DarkGray),
-        ));
+    if let Some(extra) = phase_elapsed(&state.phase) {
+        header.push(Span::styled(" · ", Style::default().fg(Color::DarkGray)));
+        header.push(Span::styled(extra, Style::default().fg(Color::DarkGray)));
     }
-    Line::from(spans)
+    lines.push(Line::from(header));
+
+    // Current step line (spinner + label) OR phase-specific info.
+    match (&state.current_step, &state.phase) {
+        (Some(label), _) => {
+            let spinner = SPINNER_FRAMES[spinner_idx % SPINNER_FRAMES.len()];
+            lines.push(Line::from(vec![
+                Span::raw(" "),
+                Span::styled(
+                    spinner.to_string(),
+                    Style::default().fg(phase_color(&state.phase)),
+                ),
+                Span::raw("  "),
+                Span::raw(label.clone()),
+            ]));
+        }
+        (None, AppPhase::Failed { reason, .. }) => {
+            lines.push(Line::from(vec![
+                Span::raw(" "),
+                Span::styled(reason.clone(), Style::default().fg(Color::Red)),
+            ]));
+        }
+        (None, _) => {
+            lines.push(Line::from(""));
+        }
+    }
+
+    // Dev-server / clients info — shown once dev-server is bound,
+    // regardless of phase.
+    if let Some(addr) = &state.ws_addr {
+        lines.push(Line::from(vec![
+            Span::raw(" "),
+            Span::styled("dev server  ", Style::default().fg(Color::DarkGray)),
+            Span::raw(format!("ws://{addr}")),
+        ]));
+        let clients = format!("{} connected", state.client_count);
+        let mut watching = vec![
+            Span::raw(" "),
+            Span::styled("clients     ", Style::default().fg(Color::DarkGray)),
+            Span::raw(clients),
+        ];
+        if !state.watching.is_empty() {
+            watching.push(Span::styled(
+                "   ·   ",
+                Style::default().fg(Color::DarkGray),
+            ));
+            watching.push(Span::styled(
+                format!("watching {} path(s)", state.watching.len()),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        lines.push(Line::from(watching));
+    } else {
+        // Reserve one row so the layout doesn't jiggle when the
+        // dev-server comes online mid-build.
+        lines.push(Line::from(""));
+    }
+
+    // Spacer + footer hint.
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::raw(" "),
+        Span::styled(
+            " q ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  quit", Style::default().fg(Color::DarkGray)),
+    ]));
+
+    // Truncate / pad to LIVE_HEIGHT so the viewport renders cleanly.
+    lines.truncate(LIVE_HEIGHT as usize);
+    while lines.len() < LIVE_HEIGHT as usize {
+        lines.push(Line::from(""));
+    }
+    lines
 }
 
-fn kv_line(key: &str, value: &str) -> Line<'static> {
-    Line::from(vec![
-        Span::raw("  "),
-        Span::styled(format!("{key:<12}"), Style::default().fg(Color::DarkGray)),
-        Span::raw(value.to_string()),
-    ])
+fn render_history_item(item: &HistoryItem) -> Vec<Line<'static>> {
+    match item {
+        HistoryItem::PhaseEnter(label) => vec![Line::from(vec![
+            Span::styled("▶ ", Style::default().fg(Color::Cyan)),
+            Span::styled(label.clone(), Style::default().add_modifier(Modifier::BOLD)),
+        ])],
+        HistoryItem::PhaseDone {
+            label,
+            status,
+            elapsed,
+        } => {
+            let (glyph, color) = match status {
+                StepStatus::Done => ("✓ ", Color::Green),
+                StepStatus::Failed => ("✗ ", Color::Red),
+                StepStatus::Skipped => ("○ ", Color::DarkGray),
+            };
+            vec![Line::from(vec![
+                Span::styled(glyph, Style::default().fg(color)),
+                Span::styled(label.clone(), Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw("  "),
+                Span::styled(fmt_elapsed(*elapsed), Style::default().fg(Color::DarkGray)),
+            ])]
+        }
+        HistoryItem::Step {
+            label,
+            status,
+            elapsed,
+        } => {
+            let (glyph, color) = match status {
+                StepStatus::Done => ("✓", Color::Green),
+                StepStatus::Failed => ("✗", Color::Red),
+                StepStatus::Skipped => ("○", Color::DarkGray),
+            };
+            vec![Line::from(vec![
+                Span::raw("  "),
+                Span::styled(glyph, Style::default().fg(color)),
+                Span::raw("  "),
+                Span::raw(label.clone()),
+                Span::raw("  "),
+                Span::styled(fmt_elapsed(*elapsed), Style::default().fg(Color::DarkGray)),
+            ])]
+        }
+        HistoryItem::CapturedStderr(text) => {
+            vec![Line::from(Span::raw(text.clone()))]
+        }
+        HistoryItem::DeviceLog { stream, line } => {
+            let tag = match stream.as_str() {
+                "stderr" => "[device:err]",
+                _ => "[device]",
+            };
+            vec![Line::from(vec![
+                Span::styled(tag, Style::default().fg(Color::Magenta)),
+                Span::raw(" "),
+                Span::raw(line.clone()),
+            ])]
+        }
+        HistoryItem::Failure(reason) => vec![Line::from(vec![
+            Span::styled(
+                "✗ ",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(reason.clone(), Style::default().fg(Color::Red)),
+        ])],
+    }
+}
+
+/// Paint `lines` into `buf` starting at the buffer's top-left.
+/// Used by `insert_before`'s draw_fn, which gives us a buffer that
+/// is exactly the height we asked for and the terminal's full
+/// width.
+fn write_lines_to_buffer(buf: &mut Buffer, lines: &[Line<'static>]) {
+    for (i, line) in lines.iter().enumerate() {
+        let area = Rect {
+            x: buf.area.x,
+            y: buf.area.y + i as u16,
+            width: buf.area.width,
+            height: 1,
+        };
+        if area.y >= buf.area.bottom() {
+            break;
+        }
+        Paragraph::new(line.clone()).render(area, buf);
+    }
 }
 
 fn phase_label(phase: &AppPhase) -> String {
     match phase {
         AppPhase::Setup => "setup".into(),
         AppPhase::Initializing => "initializing".into(),
-        AppPhase::Building { started_at, .. } => {
-            format!("building · {}", fmt_elapsed(started_at.elapsed()))
-        }
+        AppPhase::Building { .. } => "building".into(),
         AppPhase::Idle => "idle".into(),
-        AppPhase::Patching { started_at } => {
-            format!("patching · {}", fmt_elapsed(started_at.elapsed()))
-        }
+        AppPhase::Patching { .. } => "patching".into(),
         AppPhase::Failed { phase, .. } => format!("{phase} failed"),
+    }
+}
+
+fn phase_elapsed(phase: &AppPhase) -> Option<String> {
+    match phase {
+        AppPhase::Building { started_at, .. } | AppPhase::Patching { started_at } => {
+            Some(fmt_elapsed(started_at.elapsed()))
+        }
+        _ => None,
     }
 }
 
@@ -718,20 +1006,6 @@ fn phase_color(phase: &AppPhase) -> Color {
         AppPhase::Building { .. } | AppPhase::Patching { .. } => Color::Yellow,
         AppPhase::Idle => Color::Green,
         AppPhase::Failed { .. } => Color::Red,
-    }
-}
-
-fn phase_section_title(phase: &AppPhase) -> &'static str {
-    match phase {
-        AppPhase::Setup => "Setup",
-        AppPhase::Initializing => "Initializing dev server",
-        AppPhase::Building { kind, .. } => match kind {
-            BuildKind::Initial => "Initial build",
-            BuildKind::Rebuild => "Rebuild",
-        },
-        AppPhase::Idle => "Status",
-        AppPhase::Patching { .. } => "Patch (tier 1)",
-        AppPhase::Failed { .. } => "Failed",
     }
 }
 
@@ -756,36 +1030,47 @@ mod tests {
     use super::*;
     use whisker_dev_server::Event;
 
-    fn s() -> TuiState {
-        TuiState::new("iOS Simulator", "rs.whisker.podcast")
+    fn s() -> LiveState {
+        LiveState::new("iOS Simulator", "rs.whisker.podcast")
+    }
+
+    fn drain(state: &mut LiveState, e: &Event) -> Vec<HistoryItem> {
+        let mut h = Vec::new();
+        apply_event(state, e, &mut h);
+        h
     }
 
     #[test]
     fn build_lifecycle_records_outcome() {
         let mut st = s();
-        apply_event(&mut st, &Event::BuildingFull);
+        let started = drain(&mut st, &Event::BuildingFull);
         assert!(matches!(st.phase, AppPhase::Building { .. }));
-        apply_event(&mut st, &Event::BuildSucceeded);
+        // BuildingFull no longer emits a PhaseEnter — that's
+        // delegated to `whisker_build::ui::section` which lands in
+        // scrollback via stderr capture.
+        assert!(started.is_empty());
+        let done = drain(&mut st, &Event::BuildSucceeded);
         assert!(matches!(st.phase, AppPhase::Idle));
         assert!(st.last_build.is_some());
+        assert!(matches!(done[0], HistoryItem::PhaseDone { .. }));
     }
 
     #[test]
     fn client_counter_saturates() {
         let mut st = s();
-        apply_event(&mut st, &Event::ClientConnected);
-        apply_event(&mut st, &Event::ClientConnected);
+        drain(&mut st, &Event::ClientConnected);
+        drain(&mut st, &Event::ClientConnected);
         assert_eq!(st.client_count, 2);
-        apply_event(&mut st, &Event::ClientDisconnected);
-        apply_event(&mut st, &Event::ClientDisconnected);
-        apply_event(&mut st, &Event::ClientDisconnected);
+        drain(&mut st, &Event::ClientDisconnected);
+        drain(&mut st, &Event::ClientDisconnected);
+        drain(&mut st, &Event::ClientDisconnected);
         assert_eq!(st.client_count, 0);
     }
 
     #[test]
-    fn device_log_goes_into_log_buffer_with_tag() {
+    fn device_log_becomes_history_item() {
         let mut st = s();
-        apply_event(
+        let h = drain(
             &mut st,
             &Event::DeviceLog {
                 stream: "stdout".into(),
@@ -793,30 +1078,14 @@ mod tests {
                 ts_micros: 0,
             },
         );
-        assert_eq!(st.logs.lines.len(), 1);
-        assert!(st.logs.lines[0].contains("[device]"));
-        assert!(st.logs.lines[0].contains("hello"));
-    }
-
-    #[test]
-    fn log_buffer_drops_oldest_at_capacity() {
-        let mut b = LogBuffer::new(3);
-        for i in 0..5 {
-            b.push(format!("line {i}"));
+        assert_eq!(h.len(), 1);
+        match &h[0] {
+            HistoryItem::DeviceLog { stream, line } => {
+                assert_eq!(stream, "stdout");
+                assert_eq!(line, "hello");
+            }
+            other => panic!("expected DeviceLog, got {other:?}"),
         }
-        assert_eq!(b.lines.len(), 3);
-        assert_eq!(b.lines.front().unwrap(), "line 2");
-        assert_eq!(b.lines.back().unwrap(), "line 4");
-    }
-
-    #[test]
-    fn start_finish_step_round_trips() {
-        let mut st = s();
-        let i = start_step(&mut st, "Sync gen/ios");
-        assert_eq!(st.steps.len(), 1);
-        finish_step_at(&mut st, i, StepStatus::Done, 124);
-        assert!(matches!(st.steps[0].status, StepStatus::Done));
-        assert_eq!(st.steps[0].elapsed_ms, Some(124));
     }
 
     #[test]
@@ -825,8 +1094,71 @@ mod tests {
         st.phase = AppPhase::Patching {
             started_at: Instant::now() - Duration::from_millis(615),
         };
-        apply_event(&mut st, &Event::PatchSent);
+        let h = drain(&mut st, &Event::PatchSent);
         assert!(matches!(st.phase, AppPhase::Idle));
         assert!(st.last_patch.is_some());
+        assert!(h.iter().any(|i| matches!(i, HistoryItem::PhaseDone { .. })));
+    }
+
+    #[test]
+    fn build_failed_emits_failure_history() {
+        let mut st = s();
+        drain(&mut st, &Event::BuildingFull);
+        let h = drain(&mut st, &Event::BuildFailed("link error".into()));
+        assert!(matches!(st.phase, AppPhase::Failed { .. }));
+        assert!(h.iter().any(|i| matches!(i, HistoryItem::Failure(_))));
+    }
+
+    #[test]
+    fn strip_ansi_removes_csi_sgr() {
+        let s = "\x1b[33mwarning\x1b[0m: \x1b[1munused\x1b[0m";
+        assert_eq!(strip_ansi(s), "warning: unused");
+    }
+
+    #[test]
+    fn strip_ansi_preserves_utf8_glyphs() {
+        let s = "\x1b[32m✓\x1b[0m Sync gen/ios";
+        assert_eq!(strip_ansi(s), "✓ Sync gen/ios");
+    }
+
+    #[test]
+    fn strip_ansi_drops_osc_titles() {
+        let s = "\x1b]0;title\x07hello";
+        assert_eq!(strip_ansi(s), "hello");
+    }
+
+    #[test]
+    fn build_live_lines_has_fixed_height() {
+        let st = s();
+        let lines = build_live_lines(&st, 0);
+        assert_eq!(lines.len(), LIVE_HEIGHT as usize);
+    }
+
+    #[test]
+    fn build_live_lines_shows_current_step() {
+        let mut st = s();
+        st.current_step = Some("xcodebuild WhiskerDriver-Debug".into());
+        let lines = build_live_lines(&st, 0);
+        let rendered = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|sp| sp.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(rendered.contains("xcodebuild"));
+    }
+
+    #[test]
+    fn build_live_lines_shows_dev_server_when_set() {
+        let mut st = s();
+        st.ws_addr = Some("127.0.0.1:9090".into());
+        st.client_count = 1;
+        let lines = build_live_lines(&st, 0);
+        let rendered = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|sp| sp.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(rendered.contains("127.0.0.1:9090"));
+        assert!(rendered.contains("1 connected"));
     }
 }

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -849,14 +849,18 @@ fn render_live(frame: &mut ratatui::Frame, state: &LiveState, spinner_idx: usize
 fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
 
-    // Header line: ` whisker run · target · bundle · phase ` with
-    // phase-elapsed when the phase is wall-clock-meaningful.
+    // Header line: ` <STATUS>  <target> · <bundle> [· <elapsed>] `.
+    // The leading chip used to be a static ` whisker run ` brand
+    // mark; it now doubles as the phase indicator. Background color
+    // + label change with the dev loop's state, so the user reads
+    // the run's situation without parsing the trailing word.
+    let (chip_label, chip_bg, chip_fg) = status_chip(state);
     let mut header: Vec<Span<'static>> = vec![
         Span::styled(
-            " whisker run ",
+            format!(" {chip_label} "),
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::Cyan)
+                .fg(chip_fg)
+                .bg(chip_bg)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" "),
@@ -866,29 +870,6 @@ fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Line<'static>>
         ),
         Span::styled(" · ", Style::default().fg(Color::DarkGray)),
         Span::raw(state.bundle.clone()),
-        Span::styled(" · ", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            // When a step is in flight (e.g. `xcodebuild` inside
-            // `installer.install_and_launch`, which fires after
-            // `Event::BuildSucceeded` has already moved the phase to
-            // `Idle`), show "running" instead of the underlying
-            // phase so the header doesn't say "idle" while a
-            // spinner is plainly active.
-            if state.current_step.is_some() && matches!(state.phase, AppPhase::Idle) {
-                "running".to_string()
-            } else {
-                phase_label(&state.phase)
-            },
-            Style::default()
-                .fg(
-                    if state.current_step.is_some() && matches!(state.phase, AppPhase::Idle) {
-                        Color::Yellow
-                    } else {
-                        phase_color(&state.phase)
-                    },
-                )
-                .add_modifier(Modifier::BOLD),
-        ),
     ];
     if let Some(extra) = phase_elapsed(&state.phase) {
         header.push(Span::styled(" · ", Style::default().fg(Color::DarkGray)));
@@ -900,12 +881,15 @@ fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Line<'static>>
     match (&state.current_step, &state.phase) {
         (Some(label), _) => {
             let spinner = SPINNER_FRAMES[spinner_idx % SPINNER_FRAMES.len()];
+            // Spinner colour = chip background so the eye reads the
+            // header + step row as one indicator. `chip_bg` is the
+            // RUNNING-or-BUILDING-or-PATCHING colour and is already
+            // computed for the header above; recompute here so the
+            // helper stays self-contained.
+            let (_, chip_bg, _) = status_chip(state);
             lines.push(Line::from(vec![
                 Span::raw(" "),
-                Span::styled(
-                    spinner.to_string(),
-                    Style::default().fg(phase_color(&state.phase)),
-                ),
+                Span::styled(spinner.to_string(), Style::default().fg(chip_bg)),
                 Span::raw("  "),
                 Span::raw(label.clone()),
             ]));
@@ -1068,15 +1052,40 @@ fn write_lines_to_buffer(buf: &mut Buffer, lines: &[Line<'static>]) {
     }
 }
 
-fn phase_label(phase: &AppPhase) -> String {
-    match phase {
-        AppPhase::Setup => "setup".into(),
-        AppPhase::Initializing => "initializing".into(),
-        AppPhase::Building { .. } => "building".into(),
-        AppPhase::Idle => "idle".into(),
-        AppPhase::Patching { .. } => "patching".into(),
-        AppPhase::Failed { phase, .. } => format!("{phase} failed"),
+/// Picks the leading status chip's (label, background, foreground)
+/// triple for the current live state. Combines `LiveState::phase`
+/// with `LiveState::current_step` so a long-running step that fires
+/// AFTER `Event::BuildSucceeded` (e.g. `xcodebuild` inside
+/// `installer.install_and_launch` — which runs while the phase is
+/// already `Idle`) still surfaces as `BUILDING`. Once the launch
+/// step finishes and `current_step` clears, the chip flips to
+/// `RUNNING`. Order of checks is significant: `Failed` outranks
+/// everything; `Patching` outranks both Building and Idle; in-flight
+/// step outranks bare Idle.
+fn status_chip(state: &LiveState) -> (&'static str, Color, Color) {
+    if matches!(state.phase, AppPhase::Failed { .. }) {
+        return ("FAILED", Color::Red, Color::White);
     }
+    if matches!(state.phase, AppPhase::Patching { .. }) {
+        return ("PATCHING", Color::Magenta, Color::Black);
+    }
+    if matches!(state.phase, AppPhase::Building { .. }) {
+        return ("BUILDING", Color::Yellow, Color::Black);
+    }
+    // Idle: distinguish "actively doing install / launch work" (a
+    // step is in flight, even though the phase-machine has moved on
+    // from Building) from "truly settled and the app is live on the
+    // device".
+    if matches!(state.phase, AppPhase::Idle) {
+        if state.current_step.is_some() {
+            return ("BUILDING", Color::Yellow, Color::Black);
+        }
+        return ("RUNNING", Color::Green, Color::Black);
+    }
+    // Setup / Initializing — the very brief pre-build phases. Render
+    // as a neutral chip so the user knows the loop is alive but not
+    // doing anything heavy yet.
+    ("STARTING", Color::DarkGray, Color::White)
 }
 
 fn phase_elapsed(phase: &AppPhase) -> Option<String> {
@@ -1085,15 +1094,6 @@ fn phase_elapsed(phase: &AppPhase) -> Option<String> {
             Some(fmt_elapsed(started_at.elapsed()))
         }
         _ => None,
-    }
-}
-
-fn phase_color(phase: &AppPhase) -> Color {
-    match phase {
-        AppPhase::Setup | AppPhase::Initializing => Color::DarkGray,
-        AppPhase::Building { .. } | AppPhase::Patching { .. } => Color::Yellow,
-        AppPhase::Idle => Color::Green,
-        AppPhase::Failed { .. } => Color::Red,
     }
 }
 

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -873,14 +873,18 @@ fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Line<'static>>
         lines.push(Line::from(""));
     }
 
-    // Spacer + footer hint.
+    // Spacer + footer hint. The key chip uses `White` (not `Black`)
+    // on the dark-gray background so it stays legible in
+    // dark-themed terminals where ANSI color 0 (`Color::Black`)
+    // resolves to the terminal's *background* hue and visually
+    // disappears against the chip's fill.
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::raw(" "),
         Span::styled(
             " q ",
             Style::default()
-                .fg(Color::Black)
+                .fg(Color::White)
                 .bg(Color::DarkGray)
                 .add_modifier(Modifier::BOLD),
         ),

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -180,8 +180,12 @@ impl LiveState {
     }
 }
 
-/// One entry the render thread will push into the terminal's
-/// scrollback via [`Terminal::insert_before`].
+/// One message the render thread receives from upstream producers
+/// (cli code, dev-server events, and the stderr capture thread).
+/// Most variants paint a row into the terminal's scrollback via
+/// [`Terminal::insert_before`]; the `SetCurrentStep` variant is the
+/// exception — it only mutates [`LiveState::current_step`] so the
+/// inline live region can show a spinner during the next frame.
 #[derive(Debug, Clone)]
 pub enum HistoryItem {
     /// Phase-transition heading: "▶ Initial build".
@@ -205,6 +209,15 @@ pub enum HistoryItem {
     DeviceLog { stream: String, line: String },
     /// One-shot failure description for the scrollback.
     Failure(String),
+    /// Update the live region's `current_step` field. `Some(label)`
+    /// makes the spinner visible with the given label; `None`
+    /// hides it. Synthesised by the stderr capture thread when it
+    /// sees `whisker_build::ui::TUI_STEP_START_MARKER` /
+    /// `TUI_STEP_END_MARKER` — those markers let the dev-server's
+    /// `ui::step` calls drive the live spinner without committing
+    /// a "⏵ started" row that would later double-up with the
+    /// matching "✓ done" row in scrollback.
+    SetCurrentStep(Option<String>),
 }
 
 // ============================================================================
@@ -246,15 +259,18 @@ pub fn apply_event(
         Event::BuildSucceeded => {
             if let AppPhase::Building { started_at, kind } = &state.phase {
                 let elapsed = started_at.elapsed();
-                let label = match kind {
-                    BuildKind::Initial => "Initial build",
-                    BuildKind::Rebuild => "Rebuild",
-                };
-                history.push(HistoryItem::PhaseDone {
-                    label: label.into(),
-                    status: StepStatus::Done,
-                    elapsed,
-                });
+                // Don't emit a `HistoryItem::PhaseDone` summary for
+                // builds. On iOS the `Event::BuildSucceeded` fires
+                // after `builder.build()` (= staging Swift sources,
+                // ~100ms); the *actual* cargo + xcodebuild work
+                // happens later inside `installer.install_and_launch`
+                // and gets its own `✓ xcodebuild Podcast … XX.Xs`
+                // row via `whisker_build::ui::step`. The Build
+                // section is already delimited by
+                // `──── Initial build ────` plus the in-line step
+                // rows, so an aggregate "✓ Initial build XXms"
+                // line either misleads (iOS) or duplicates the
+                // section header (Android / Host).
                 state.last_build = Some(format!(
                     "{} · {}",
                     if matches!(kind, BuildKind::Initial) {
@@ -542,6 +558,14 @@ impl Tui {
     fn drain_history_into_scrollback(&mut self) -> Result<()> {
         loop {
             match self.rx.try_recv() {
+                Ok(HistoryItem::SetCurrentStep(label)) => {
+                    // Live-region-only update: don't `insert_before`,
+                    // just mutate the shared `LiveState` so the next
+                    // frame picks up the new spinner label.
+                    if let Ok(mut s) = self.live.lock() {
+                        s.current_step = label;
+                    }
+                }
                 Ok(item) => {
                     let lines = render_history_item(&item);
                     let height = lines.len().min(u16::MAX as usize) as u16;
@@ -694,6 +718,26 @@ fn capture_reader_loop(read_fd: c_int, tx: Sender<HistoryItem>) {
                 Ok(s) => s,
                 Err(e) => String::from_utf8_lossy(&e.into_bytes()).into_owned(),
             };
+            // Step markers are detected *before* `strip_ansi`, which
+            // drops C0 control bytes including the `\x1e` (RS) that
+            // frames our markers. The marker prefix is identical to
+            // `whisker_build::ui::TUI_STEP_*_MARKER`; we duplicate
+            // the constants as literals here to avoid pulling the
+            // `whisker-build` crate into a tighter ABI contract over
+            // an internal protocol.
+            if let Some(rest) = text.strip_prefix("\x1eWHISKER-TUI-STEP-START\x1e") {
+                let label = rest.replace('\x1e', " ").trim().to_string();
+                if !label.is_empty() && tx.send(HistoryItem::SetCurrentStep(Some(label))).is_err() {
+                    return;
+                }
+                continue;
+            }
+            if text == "\x1eWHISKER-TUI-STEP-END" {
+                if tx.send(HistoryItem::SetCurrentStep(None)).is_err() {
+                    return;
+                }
+                continue;
+            }
             let text = strip_ansi(&text);
             if !text.is_empty() && tx.send(HistoryItem::CapturedStderr(text)).is_err() {
                 return;
@@ -824,9 +868,25 @@ fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Line<'static>>
         Span::raw(state.bundle.clone()),
         Span::styled(" · ", Style::default().fg(Color::DarkGray)),
         Span::styled(
-            phase_label(&state.phase),
+            // When a step is in flight (e.g. `xcodebuild` inside
+            // `installer.install_and_launch`, which fires after
+            // `Event::BuildSucceeded` has already moved the phase to
+            // `Idle`), show "running" instead of the underlying
+            // phase so the header doesn't say "idle" while a
+            // spinner is plainly active.
+            if state.current_step.is_some() && matches!(state.phase, AppPhase::Idle) {
+                "running".to_string()
+            } else {
+                phase_label(&state.phase)
+            },
             Style::default()
-                .fg(phase_color(&state.phase))
+                .fg(
+                    if state.current_step.is_some() && matches!(state.phase, AppPhase::Idle) {
+                        Color::Yellow
+                    } else {
+                        phase_color(&state.phase)
+                    },
+                )
                 .add_modifier(Modifier::BOLD),
         ),
     ];
@@ -981,6 +1041,11 @@ fn render_history_item(item: &HistoryItem) -> Vec<Line<'static>> {
             ),
             Span::styled(reason.clone(), Style::default().fg(Color::Red)),
         ])],
+        HistoryItem::SetCurrentStep(_) => {
+            // Live-region-only; consumed by
+            // `drain_history_into_scrollback` before reaching here.
+            Vec::new()
+        }
     }
 }
 
@@ -1075,7 +1140,11 @@ mod tests {
         let done = drain(&mut st, &Event::BuildSucceeded);
         assert!(matches!(st.phase, AppPhase::Idle));
         assert!(st.last_build.is_some());
-        assert!(matches!(done[0], HistoryItem::PhaseDone { .. }));
+        // BuildSucceeded no longer emits a `PhaseDone` summary —
+        // the section header + per-step rows in scrollback are
+        // enough. `last_build` is the only state mutation we care
+        // about here, plus the phase transition above.
+        assert!(done.is_empty());
     }
 
     #[test]

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -1,151 +1,227 @@
-//! ratatui-based inline status bar for `whisker run`.
+//! Full-screen ratatui TUI for `whisker run`.
 //!
-//! `whisker run` is a long-lived dev loop — file watch + rebuild +
-//! patch + log forwarding — but until now the only persistent state
-//! the user could see was the last printed line of curated terminal
-//! output. To check the bind address, current client count, or last
-//! patch latency mid-edit, you had to scroll up through `gradle:
-//! Task :…` rows and find the most recent `· dev-server · …` entry.
+//! Replaces the inline status bar in #184/#185 with an alternate-screen
+//! UI that owns the entire terminal. Reasons:
 //!
-//! This module replaces that with a 3-line region anchored at the
-//! bottom of the terminal (ratatui's `Viewport::Inline`). Sections,
-//! steps, info lines, and device logs still flow as plain
-//! `eprintln!`s above the viewport — fully grep'able, fully
-//! scrollable — while the inline area renders a live status bar
-//! summarising:
+//! - Inline mode raced against every `eprintln!` from `whisker_build::ui`
+//!   and Step::pipe-driven subprocess output, corrupting the viewport on
+//!   any heavy log burst.
+//! - Sub-step granularity (Sync → Build → Install → Launch) can't fit
+//!   in 3 inline rows.
+//! - Full-screen lets us own stderr — we `dup2` it through a pipe, read
+//!   captured lines on a background thread, and render them in a Logs
+//!   pane below the steps. Every output channel funnels through ratatui;
+//!   there's nothing to race with.
 //!
-//! - the build target + bind address
-//! - the connected client count
-//! - the dev-loop's current phase (idle / building / patching) +
-//!   elapsed time
-//! - the last completed action's outcome
+//! ## State machine
 //!
-//! ## Coordination with `whisker_build::ui`
+//! [`AppPhase`] tracks where the dev loop is. Transitions are driven by
+//! a combination of explicit cli calls (`Setup`, `Initializing` —
+//! before dev-server events fire) and `whisker_dev_server::Event`s
+//! (`Building`, `Idle`, `Patching`, …) routed through [`apply_event`].
 //!
-//! indicatif's `MultiProgress` (which the rest of the dev loop draws
-//! progress through) and ratatui's inline viewport both want
-//! exclusive control of the terminal cursor. We resolve the conflict
-//! at the source: when this TUI is active, [`crate::run::run`] sets
-//! `WHISKER_TUI=1`, which switches `whisker_build::ui` into
-//! [`whisker_build::ui::is_tui`] mode — indicatif animations off,
-//! curated formatting still on, output plain-`eprintln!`-routed so
-//! lines scroll above the viewport.
+//! ## Lifetime
 //!
-//! ## Lifetime + shutdown
-//!
-//! [`Tui::start`] takes ownership of stderr and enters raw mode for
-//! the duration of the run. [`Tui::shutdown`] restores cooked mode,
-//! clears the viewport, and re-prints a final status summary so the
-//! terminal looks sane after the dev loop exits. The struct also
-//! installs a panic hook that calls `shutdown` so an unexpected
-//! panic doesn't leave the user with a half-rendered TUI.
+//! [`Tui::start`] enters the alternate screen, hides the cursor, and
+//! `dup2`s `STDERR_FILENO` to a pipe whose read end a dedicated thread
+//! drains into the log buffer. [`Tui::shutdown`] reverses each step in
+//! the opposite order. Both a panic hook and a `ctrlc::set_handler`
+//! emergency-reset stderr + cursor visibility so a hard exit doesn't
+//! leave the user's shell hosed.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossterm::{
     cursor,
-    terminal::{Clear, ClearType},
+    event::{poll, read, Event as CtEvent, KeyCode, KeyEventKind},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
 use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::Paragraph;
-use ratatui::{Terminal, TerminalOptions, Viewport};
-use std::io::Stderr;
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::Terminal;
+use std::collections::VecDeque;
+use std::io::Write;
+use std::os::raw::c_int;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-/// What the loop is currently doing. Surfaces in the status bar.
+// ============================================================================
+// Public state model
+// ============================================================================
+
+/// Which phase of the dev loop the user is currently watching. Drives
+/// the steps pane's content and the header's right-hand badge.
 #[derive(Debug, Clone)]
-pub enum Phase {
-    /// Initialising; the dev-server hasn't reported any event yet.
-    Starting,
-    /// A full cargo / cross / gradle / xcodebuild rebuild is running.
-    Building { started_at: Instant },
-    /// A Tier 1 hot-patch is being computed / sent.
-    Patching { started_at: Instant },
-    /// Nothing in progress — watching for file changes.
+pub enum AppPhase {
+    /// Pre-dev-server cli work: `sync_for_target` (gen tree + plugin
+    /// build). Driven by explicit `TuiHandle::set_phase` calls.
+    Setup,
+    /// dev-server's setup (WS bind, watcher, capture shim resolve).
+    /// Brief; usually flips to `Building` within a hundred ms once
+    /// `Event::BuildingFull` arrives.
+    Initializing,
+    /// `cargo` + `gradle`/`xcodebuild` in flight.
+    Building {
+        started_at: Instant,
+        kind: BuildKind,
+    },
+    /// dev-server bound, initial build succeeded, watching for source
+    /// changes. The header shows ws addr + client count + last
+    /// build/patch summaries.
     Idle,
+    /// Tier 1 hot-patch in flight. Phase exit is signalled by
+    /// `Event::PatchSent` or a Tier 2 fallback's `Event::BuildingFull`.
+    Patching { started_at: Instant },
+    /// Build failed. Surfaces the cause in the steps pane.
+    Failed { phase: String, reason: String },
 }
 
-impl Phase {
-    fn label(&self) -> &'static str {
-        match self {
-            Phase::Starting => "starting",
-            Phase::Building { .. } => "building",
-            Phase::Patching { .. } => "patching",
-            Phase::Idle => "idle",
-        }
-    }
-
-    fn elapsed(&self) -> Option<Duration> {
-        match self {
-            Phase::Building { started_at } | Phase::Patching { started_at } => {
-                Some(started_at.elapsed())
-            }
-            Phase::Starting | Phase::Idle => None,
-        }
-    }
+#[derive(Debug, Clone, Copy)]
+pub enum BuildKind {
+    Initial,
+    Rebuild,
 }
 
-/// Outcome of the most recent build / patch / install / launch.
-/// Rendered as the right-aligned trailing summary on the bottom row.
+/// Outcome of a completed step (a single row in the steps pane).
+#[derive(Debug, Clone, Copy)]
+pub enum StepStatus {
+    Pending,
+    InProgress,
+    Done,
+    Failed,
+    Skipped,
+}
+
+/// One row in the steps pane.
 #[derive(Debug, Clone)]
-pub enum LastOutcome {
-    None,
-    Success(String),
-    Failure(String),
+pub struct Step {
+    pub label: String,
+    pub status: StepStatus,
+    pub elapsed_ms: Option<u64>,
 }
 
-/// Mutable snapshot the renderer reads on every frame.
+/// Bounded ring of captured stderr lines for the Logs pane.
+#[derive(Debug, Clone)]
+pub struct LogBuffer {
+    pub lines: VecDeque<String>,
+    pub capacity: usize,
+}
+
+impl LogBuffer {
+    fn new(capacity: usize) -> Self {
+        Self {
+            lines: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+    pub fn push(&mut self, line: String) {
+        if self.lines.len() >= self.capacity {
+            self.lines.pop_front();
+        }
+        self.lines.push_back(line);
+    }
+}
+
+/// Snapshot the render thread reads on every frame.
 #[derive(Debug, Clone)]
 pub struct TuiState {
     pub target: String,
-    pub bind: String,
+    pub bundle: String,
+    pub ws_addr: Option<String>,
+    pub watching: Vec<String>,
     pub client_count: usize,
-    pub phase: Phase,
-    pub last: LastOutcome,
+    pub phase: AppPhase,
+    pub steps: Vec<Step>,
+    pub last_build: Option<String>,
+    pub last_patch: Option<String>,
+    pub logs: LogBuffer,
+    pub should_quit: bool,
 }
 
 impl TuiState {
-    pub fn new(target: impl Into<String>, bind: impl Into<String>) -> Self {
+    pub fn new(target: impl Into<String>, bundle: impl Into<String>) -> Self {
         Self {
             target: target.into(),
-            bind: bind.into(),
+            bundle: bundle.into(),
+            ws_addr: None,
+            watching: Vec::new(),
             client_count: 0,
-            phase: Phase::Starting,
-            last: LastOutcome::None,
+            phase: AppPhase::Setup,
+            steps: Vec::new(),
+            last_build: None,
+            last_patch: None,
+            logs: LogBuffer::new(500),
+            should_quit: false,
         }
     }
 }
 
-/// Apply a dev-server event to the in-memory TUI state. Pulled out of
-/// the cli so it's unit-testable without a real terminal.
+// ============================================================================
+// Step helpers
+// ============================================================================
+
+pub fn start_step(state: &mut TuiState, label: impl Into<String>) -> usize {
+    state.steps.push(Step {
+        label: label.into(),
+        status: StepStatus::InProgress,
+        elapsed_ms: None,
+    });
+    state.steps.len() - 1
+}
+
+pub fn finish_step_at(state: &mut TuiState, idx: usize, status: StepStatus, elapsed_ms: u64) {
+    if let Some(step) = state.steps.get_mut(idx) {
+        step.status = status;
+        step.elapsed_ms = Some(elapsed_ms);
+    }
+}
+
+pub fn reset_steps(state: &mut TuiState) {
+    state.steps.clear();
+}
+
+// ============================================================================
+// Event → state machine
+// ============================================================================
+
+/// Apply a dev-server event to the in-memory TUI state.
 pub fn apply_event(state: &mut TuiState, event: &whisker_dev_server::Event) {
     use whisker_dev_server::Event;
     match event {
         Event::Started => {
-            state.phase = Phase::Idle;
+            // dev-server is up. Phase transition is driven by the
+            // cli's explicit `set_phase` calls — respect that ordering.
         }
         Event::BuildingFull => {
-            state.phase = Phase::Building {
-                started_at: Instant::now(),
+            let kind = match state.phase {
+                AppPhase::Setup | AppPhase::Initializing => BuildKind::Initial,
+                _ => BuildKind::Rebuild,
             };
+            state.phase = AppPhase::Building {
+                started_at: Instant::now(),
+                kind,
+            };
+            reset_steps(state);
         }
         Event::BuildSucceeded => {
-            let detail = match &state.phase {
-                Phase::Building { started_at } => {
-                    format!("build ok {}", fmt_elapsed(started_at.elapsed()))
-                }
-                _ => "build ok".to_string(),
-            };
-            state.phase = Phase::Idle;
-            state.last = LastOutcome::Success(detail);
+            if let AppPhase::Building { started_at, kind } = &state.phase {
+                let elapsed = started_at.elapsed();
+                let label = match kind {
+                    BuildKind::Initial => "initial",
+                    BuildKind::Rebuild => "rebuild",
+                };
+                state.last_build = Some(format!("{label} · {}", fmt_elapsed(elapsed)));
+            }
+            state.phase = AppPhase::Idle;
         }
         Event::BuildFailed(msg) => {
-            state.phase = Phase::Idle;
-            state.last = LastOutcome::Failure(format!("build failed: {msg}"));
+            state.phase = AppPhase::Failed {
+                phase: "build".into(),
+                reason: msg.clone(),
+            };
         }
         Event::ClientConnected => {
             state.client_count = state.client_count.saturating_add(1);
@@ -154,197 +230,511 @@ pub fn apply_event(state: &mut TuiState, event: &whisker_dev_server::Event) {
             state.client_count = state.client_count.saturating_sub(1);
         }
         Event::PatchSent => {
-            let detail = match &state.phase {
-                Phase::Patching { started_at } => {
-                    format!("patch ok {}", fmt_elapsed(started_at.elapsed()))
-                }
-                _ => "patch ok".to_string(),
-            };
-            state.phase = Phase::Idle;
-            state.last = LastOutcome::Success(detail);
+            if let AppPhase::Patching { started_at } = &state.phase {
+                let elapsed = started_at.elapsed();
+                state.last_patch = Some(fmt_elapsed(elapsed));
+            }
+            state.phase = AppPhase::Idle;
         }
-        // Device-log events don't change the persistent status — they
-        // flow into scrollback through whisker-cli's separate handler.
-        Event::DeviceLog { .. } => {}
+        Event::DeviceLog { stream, line, .. } => {
+            let tag = match stream.as_str() {
+                "stderr" => "[device:err]",
+                _ => "[device]",
+            };
+            state.logs.push(format!("{tag} {line}"));
+        }
     }
 }
 
-/// Owns the ratatui terminal + the shared state Mutex. The renderer
-/// thread reads the state on every frame and re-draws.
+// ============================================================================
+// Tui: alternate-screen + stderr capture + render loop
+// ============================================================================
+
+/// Writer for ratatui's backend — writes directly to the saved
+/// (pre-`dup2`) stderr fd so its escape codes don't get folded into
+/// the captured log.
+struct OriginalStderr(c_int);
+
+impl Write for OriginalStderr {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = unsafe { libc::write(self.0, buf.as_ptr() as *const _, buf.len()) };
+        if n < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(n as usize)
+        }
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Owns the ratatui terminal + state mutex + the saved stderr fd.
 pub struct Tui {
-    terminal: Terminal<CrosstermBackend<Stderr>>,
+    terminal: Terminal<CrosstermBackend<OriginalStderr>>,
     state: Arc<Mutex<TuiState>>,
+    saved_stderr_fd: c_int,
 }
 
 impl Tui {
-    /// Initialise the TUI: hide the cursor, allocate an inline
-    /// viewport at the bottom of the terminal. Returns the handle the
-    /// rest of the cli uses to push state updates.
-    ///
-    /// **Cooked mode, not raw.** A previous iteration called
-    /// `enable_raw_mode()` here — that's what `ratatui` examples do
-    /// because they're handling keyboard input. We don't, and raw
-    /// mode breaks the rest of the dev loop: every `eprintln!` that
-    /// other crates use to write sections / steps / device logs
-    /// emits a bare `\n` (no `\r`), which under raw-mode tty
-    /// settings moves the cursor down one row but leaves it at the
-    /// same column the previous line ended at. The visible result
-    /// is a staircase of `⏵`/`✓` rows drifting rightward across the
-    /// screen. Skipping `enable_raw_mode` keeps `\n` → CRLF
-    /// translation on, so all of the legacy line-based output
-    /// scrolls cleanly at column 0 above the viewport.
     pub fn start(state: TuiState) -> Result<Self> {
-        let mut stderr = std::io::stderr();
-        stderr.execute(cursor::Hide)?;
-        // 3-line viewport: 1 line for a separator, 2 lines of content.
-        // Lean compact — power users want screen real estate; a wider
-        // status surface is its own opt-in feature later.
-        let backend = CrosstermBackend::new(stderr);
-        let terminal = Terminal::with_options(
-            backend,
-            TerminalOptions {
-                viewport: Viewport::Inline(3),
-            },
-        )?;
+        let (saved_stderr_fd, capture_read_fd) =
+            install_stderr_capture().context("install stderr capture")?;
+        install_terminal_cleanup_once(saved_stderr_fd);
+
+        enable_raw_mode().context("enable raw mode")?;
+        let mut original = OriginalStderr(saved_stderr_fd);
+        original
+            .execute(EnterAlternateScreen)
+            .context("enter alternate screen")?;
+        original.execute(cursor::Hide).context("hide cursor")?;
+
+        let backend = CrosstermBackend::new(original);
+        let terminal = Terminal::new(backend).context("create ratatui terminal")?;
+
         let state = Arc::new(Mutex::new(state));
+        let state_for_reader = Arc::clone(&state);
+        std::thread::Builder::new()
+            .name("whisker-tui-capture".into())
+            .spawn(move || capture_reader_loop(capture_read_fd, state_for_reader))
+            .context("spawn capture reader")?;
 
-        // Cleanup hooks for the two ways a `whisker run` can exit
-        // without our normal `Tui::shutdown` running:
-        //
-        // 1. **Panic** — `std::panic::set_hook` chains: our hook
-        //    restores cursor visibility + clears below it before
-        //    chaining to whatever was installed before us (typically
-        //    the default panic printer, which writes the message to
-        //    stderr — that lands in a clean terminal because we
-        //    cleaned up first).
-        // 2. **Ctrl-C** — the default SIGINT handler kills the
-        //    process before any Drop / shutdown code runs, leaving
-        //    the cursor hidden. `ctrlc::set_handler` installs an
-        //    OS-level handler that runs our cleanup then exits.
-        install_terminal_cleanup_once();
-
-        Ok(Self { terminal, state })
+        Ok(Self {
+            terminal,
+            state,
+            saved_stderr_fd,
+        })
     }
 
-    /// Cheap-to-clone handle for pushing state updates from event
-    /// callbacks running on background threads / tasks.
-    pub fn state_handle(&self) -> Arc<Mutex<TuiState>> {
-        Arc::clone(&self.state)
+    pub fn handle(&self) -> TuiHandle {
+        TuiHandle {
+            state: Arc::clone(&self.state),
+        }
     }
 
-    /// Draw one frame using the current state snapshot.
-    pub fn draw(&mut self) -> Result<()> {
-        let snapshot = {
-            let g = self.state.lock().expect("tui state mutex poisoned");
-            g.clone()
-        };
-        self.terminal.draw(|frame| {
-            let layout = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(1),
-                    Constraint::Length(1),
-                    Constraint::Length(1),
-                ])
-                .split(frame.area());
-            // Separator line — visually anchors the bar against the
-            // scrollback content above.
-            let sep = Paragraph::new("─".repeat(frame.area().width as usize))
-                .style(Style::default().fg(Color::DarkGray));
-            frame.render_widget(sep, layout[0]);
-            // Row 1: target · bind · clients.
-            let top = Line::from(vec![
-                Span::styled(
-                    " whisker run ",
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::raw(" "),
-                Span::raw(snapshot.target.clone()),
-                Span::styled(" · ", Style::default().fg(Color::DarkGray)),
-                Span::raw(snapshot.bind.clone()),
-                Span::styled(" · ", Style::default().fg(Color::DarkGray)),
-                Span::raw(format!("{} client(s)", snapshot.client_count)),
-            ]);
-            frame.render_widget(Paragraph::new(top), layout[1]);
-            // Row 2: phase + elapsed, then trailing outcome.
-            let phase_span = match snapshot.phase.elapsed() {
-                Some(d) => Span::styled(
-                    format!(" {} · {} ", snapshot.phase.label(), fmt_elapsed(d)),
-                    Style::default().fg(Color::Yellow),
-                ),
-                None => Span::styled(
-                    format!(" {} ", snapshot.phase.label()),
-                    Style::default().fg(Color::DarkGray),
-                ),
-            };
-            let last_span = match &snapshot.last {
-                LastOutcome::None => Span::styled("", Style::default()),
-                LastOutcome::Success(s) => {
-                    Span::styled(format!("✓ {s}"), Style::default().fg(Color::Green))
+    /// Drive the render loop until either the user presses `q` or
+    /// `should_quit` is flipped externally.
+    pub fn render_until_quit(&mut self) -> Result<()> {
+        let frame_interval = Duration::from_millis(100);
+        let mut last_draw = Instant::now() - frame_interval;
+        loop {
+            if poll(Duration::from_millis(10))? {
+                if let CtEvent::Key(key) = read()? {
+                    if matches!(key.kind, KeyEventKind::Press) {
+                        match key.code {
+                            KeyCode::Char('q') | KeyCode::Esc => {
+                                if let Ok(mut s) = self.state.lock() {
+                                    s.should_quit = true;
+                                }
+                            }
+                            KeyCode::Char('c')
+                                if key
+                                    .modifiers
+                                    .contains(crossterm::event::KeyModifiers::CONTROL) =>
+                            {
+                                if let Ok(mut s) = self.state.lock() {
+                                    s.should_quit = true;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
                 }
-                LastOutcome::Failure(s) => {
-                    Span::styled(format!("✗ {s}"), Style::default().fg(Color::Red))
+            }
+            if last_draw.elapsed() >= frame_interval {
+                self.draw()?;
+                last_draw = Instant::now();
+            }
+            if let Ok(s) = self.state.lock() {
+                if s.should_quit {
+                    break;
                 }
-            };
-            let bottom = Line::from(vec![phase_span, Span::raw("  "), last_span]);
-            frame.render_widget(Paragraph::new(bottom), layout[2]);
-        })?;
+            }
+        }
         Ok(())
     }
 
-    /// Drop the inline viewport + restore the cursor. We never
-    /// flipped to raw mode (see [`Tui::start`]), so there's nothing
-    /// to undo there — just clear the viewport region and re-show
-    /// the cursor so the user's shell prompt lands on a clean line.
+    fn draw(&mut self) -> Result<()> {
+        let snapshot = match self.state.lock() {
+            Ok(g) => g.clone(),
+            Err(_) => return Ok(()),
+        };
+        self.terminal.draw(|frame| render(frame, &snapshot))?;
+        Ok(())
+    }
+
     pub fn shutdown(mut self) -> Result<()> {
         let _ = self.terminal.clear();
-        let mut stderr = std::io::stderr();
-        let _ = stderr.execute(cursor::Show);
-        let _ = stderr.execute(Clear(ClearType::FromCursorDown));
+        let mut original = OriginalStderr(self.saved_stderr_fd);
+        let _ = original.execute(cursor::Show);
+        let _ = original.execute(LeaveAlternateScreen);
+        let _ = disable_raw_mode();
+        unsafe {
+            libc::dup2(self.saved_stderr_fd, libc::STDERR_FILENO);
+            libc::close(self.saved_stderr_fd);
+        }
         Ok(())
     }
 }
 
-/// Restore the cursor + clear anything below it. Used by both the
-/// panic hook and the Ctrl-C handler.
-fn emergency_terminal_reset() {
-    let mut stderr = std::io::stderr();
-    let _ = stderr.execute(cursor::Show);
-    let _ = stderr.execute(Clear(ClearType::FromCursorDown));
+#[derive(Clone)]
+pub struct TuiHandle {
+    state: Arc<Mutex<TuiState>>,
 }
 
-/// Install the panic hook + SIGINT handler. Idempotent — only the
-/// first `Tui::start` of the process installs anything; later calls
-/// are no-ops. The handlers stay registered for the rest of the
-/// process lifetime (no good way to unregister either), but that's
-/// fine: their cleanup is a no-op on already-cooked stderr.
-fn install_terminal_cleanup_once() {
-    use std::sync::atomic::{AtomicBool, Ordering};
+impl TuiHandle {
+    pub fn with<F: FnOnce(&mut TuiState)>(&self, f: F) {
+        if let Ok(mut g) = self.state.lock() {
+            f(&mut g);
+        }
+    }
+    pub fn set_phase(&self, phase: AppPhase) {
+        self.with(|s| {
+            s.phase = phase;
+            reset_steps(s);
+        });
+    }
+    pub fn start_step(&self, label: impl Into<String>) -> usize {
+        let label = label.into();
+        let mut idx = 0;
+        self.with(|s| {
+            idx = start_step(s, label);
+        });
+        idx
+    }
+    pub fn finish_step(&self, idx: usize, status: StepStatus, elapsed_ms: u64) {
+        self.with(|s| finish_step_at(s, idx, status, elapsed_ms));
+    }
+    pub fn apply_event(&self, event: &whisker_dev_server::Event) {
+        self.with(|s| apply_event(s, event));
+    }
+    pub fn set_dev_server(&self, ws_addr: impl Into<String>, watching: Vec<String>) {
+        self.with(|s| {
+            s.ws_addr = Some(ws_addr.into());
+            s.watching = watching;
+        });
+    }
+    pub fn should_quit(&self) -> bool {
+        self.state.lock().map(|s| s.should_quit).unwrap_or(false)
+    }
+    pub fn request_quit(&self) {
+        self.with(|s| s.should_quit = true);
+    }
+}
+
+// ============================================================================
+// Stderr capture
+// ============================================================================
+
+fn install_stderr_capture() -> Result<(c_int, c_int)> {
+    let mut fds: [c_int; 2] = [-1, -1];
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error()).context("pipe(2)");
+    }
+    let read_fd = fds[0];
+    let write_fd = fds[1];
+    let saved_fd = unsafe { libc::dup(libc::STDERR_FILENO) };
+    if saved_fd == -1 {
+        let e = std::io::Error::last_os_error();
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+        }
+        return Err(e).context("dup STDERR_FILENO");
+    }
+    if unsafe { libc::dup2(write_fd, libc::STDERR_FILENO) } == -1 {
+        let e = std::io::Error::last_os_error();
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+            libc::close(saved_fd);
+        }
+        return Err(e).context("dup2 over STDERR_FILENO");
+    }
+    unsafe {
+        libc::close(write_fd);
+    }
+    Ok((saved_fd, read_fd))
+}
+
+fn capture_reader_loop(read_fd: c_int, state: Arc<Mutex<TuiState>>) {
+    let mut buf = [0u8; 4096];
+    let mut partial: Vec<u8> = Vec::new();
+    loop {
+        let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut _, buf.len()) };
+        if n == -1 {
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return;
+        }
+        if n == 0 {
+            return;
+        }
+        let chunk = &buf[..n as usize];
+        partial.extend_from_slice(chunk);
+        while let Some(nl_pos) = partial.iter().position(|b| *b == b'\n') {
+            let mut line: Vec<u8> = partial.drain(..=nl_pos).collect();
+            while matches!(line.last(), Some(b'\n') | Some(b'\r')) {
+                line.pop();
+            }
+            let text = match String::from_utf8(line) {
+                Ok(s) => s,
+                Err(e) => String::from_utf8_lossy(&e.into_bytes()).into_owned(),
+            };
+            if !text.is_empty() {
+                if let Ok(mut g) = state.lock() {
+                    g.logs.push(text);
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Cleanup hooks
+// ============================================================================
+
+fn emergency_terminal_reset(original_stderr_fd: c_int) {
+    let mut o = OriginalStderr(original_stderr_fd);
+    let _ = o.execute(cursor::Show);
+    let _ = o.execute(LeaveAlternateScreen);
+    let _ = disable_raw_mode();
+}
+
+fn install_terminal_cleanup_once(original_stderr_fd: c_int) {
+    use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
     static INSTALLED: AtomicBool = AtomicBool::new(false);
+    static SAVED_FD: AtomicI32 = AtomicI32::new(-1);
+    SAVED_FD.store(original_stderr_fd, Ordering::Release);
     if INSTALLED.swap(true, Ordering::AcqRel) {
         return;
     }
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        emergency_terminal_reset();
+        emergency_terminal_reset(SAVED_FD.load(Ordering::Acquire));
         prev_hook(info);
     }));
-    // `ctrlc::set_handler` errors if a handler is already registered.
-    // We treat that as benign — somebody else cared about the same
-    // cleanup, our reset would just run twice in the worst case.
     let _ = ctrlc::set_handler(|| {
-        emergency_terminal_reset();
-        std::process::exit(130); // 128 + SIGINT
+        emergency_terminal_reset(SAVED_FD.load(Ordering::Acquire));
+        std::process::exit(130);
     });
 }
 
-/// `1.2s` / `730ms` / `2m05s` formatter mirroring
-/// `whisker_build::ui::format_elapsed`. Local copy because the cli's
-/// status surface owes its formatting consistency to the same
-/// magnitude breakpoints, but the ui crate's version is `pub(crate)`.
+// ============================================================================
+// Rendering
+// ============================================================================
+
+fn render(frame: &mut ratatui::Frame, state: &TuiState) {
+    let area = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),      // header
+            Constraint::Min(8),         // mid pane (steps OR status)
+            Constraint::Percentage(40), // logs
+            Constraint::Length(1),      // footer
+        ])
+        .split(area);
+
+    render_header(frame, chunks[0], state);
+    render_middle(frame, chunks[1], state);
+    render_logs(frame, chunks[2], state);
+    render_footer(frame, chunks[3], state);
+}
+
+fn render_header(frame: &mut ratatui::Frame, area: Rect, state: &TuiState) {
+    let line = Line::from(vec![
+        Span::styled(
+            " whisker run ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            state.target.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" · ", Style::default().fg(Color::DarkGray)),
+        Span::raw(state.bundle.clone()),
+        Span::styled(" · ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            phase_label(&state.phase),
+            Style::default()
+                .fg(phase_color(&state.phase))
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]);
+    let block = Block::default()
+        .borders(Borders::BOTTOM)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(Paragraph::new(line).block(block), area);
+}
+
+fn render_middle(frame: &mut ratatui::Frame, area: Rect, state: &TuiState) {
+    let mut lines: Vec<Line> = Vec::new();
+    match &state.phase {
+        AppPhase::Idle => {
+            lines.push(Line::from(Span::styled(
+                "Status",
+                Style::default().add_modifier(Modifier::BOLD),
+            )));
+            lines.push(Line::from(""));
+            if let Some(addr) = &state.ws_addr {
+                lines.push(kv_line("Dev server", addr));
+            }
+            lines.push(kv_line(
+                "Clients",
+                &format!("{} connected", state.client_count),
+            ));
+            if !state.watching.is_empty() {
+                lines.push(kv_line(
+                    "Watching",
+                    &format!("{} path(s)", state.watching.len()),
+                ));
+            }
+            if let Some(b) = &state.last_build {
+                lines.push(kv_line("Last build", b));
+            }
+            if let Some(p) = &state.last_patch {
+                lines.push(kv_line("Last patch", p));
+            }
+        }
+        AppPhase::Failed { phase, reason } => {
+            lines.push(Line::from(Span::styled(
+                format!("{phase} failed"),
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            )));
+            lines.push(Line::from(""));
+            lines.push(Line::from(reason.clone()));
+        }
+        _ => {
+            lines.push(Line::from(Span::styled(
+                phase_section_title(&state.phase),
+                Style::default().add_modifier(Modifier::BOLD),
+            )));
+            lines.push(Line::from(""));
+            for step in &state.steps {
+                lines.push(render_step_row(step));
+            }
+        }
+    }
+    let block = Block::default()
+        .borders(Borders::BOTTOM)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn render_logs(frame: &mut ratatui::Frame, area: Rect, state: &TuiState) {
+    let visible_rows = area.height.saturating_sub(2) as usize;
+    let total = state.logs.lines.len();
+    let start = total.saturating_sub(visible_rows);
+    let lines: Vec<Line> = state
+        .logs
+        .lines
+        .iter()
+        .skip(start)
+        .map(|l| Line::from(l.clone()))
+        .collect();
+    let title = format!(" Logs ({}/{}) ", lines.len(), total);
+    let block = Block::default()
+        .borders(Borders::TOP)
+        .title(title)
+        .style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_footer(frame: &mut ratatui::Frame, area: Rect, _state: &TuiState) {
+    let hint = Line::from(vec![
+        Span::styled(" q ", Style::default().fg(Color::Black).bg(Color::DarkGray)),
+        Span::raw(" quit"),
+    ]);
+    frame.render_widget(Paragraph::new(hint), area);
+}
+
+fn render_step_row(step: &Step) -> Line<'static> {
+    let glyph = match step.status {
+        StepStatus::Pending => Span::styled("·", Style::default().fg(Color::DarkGray)),
+        StepStatus::InProgress => Span::styled("⠋", Style::default().fg(Color::Yellow)),
+        StepStatus::Done => Span::styled("✓", Style::default().fg(Color::Green)),
+        StepStatus::Failed => Span::styled("✗", Style::default().fg(Color::Red)),
+        StepStatus::Skipped => Span::styled("○", Style::default().fg(Color::DarkGray)),
+    };
+    let label_style = match step.status {
+        StepStatus::Pending | StepStatus::Skipped => Style::default().fg(Color::DarkGray),
+        StepStatus::InProgress | StepStatus::Done => Style::default(),
+        StepStatus::Failed => Style::default().fg(Color::Red),
+    };
+    let mut spans = vec![
+        Span::raw("  "),
+        glyph,
+        Span::raw("  "),
+        Span::styled(step.label.clone(), label_style),
+    ];
+    if let Some(elapsed) = step.elapsed_ms {
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(
+            fmt_elapsed(Duration::from_millis(elapsed)),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    Line::from(spans)
+}
+
+fn kv_line(key: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(format!("{key:<12}"), Style::default().fg(Color::DarkGray)),
+        Span::raw(value.to_string()),
+    ])
+}
+
+fn phase_label(phase: &AppPhase) -> String {
+    match phase {
+        AppPhase::Setup => "setup".into(),
+        AppPhase::Initializing => "initializing".into(),
+        AppPhase::Building { started_at, .. } => {
+            format!("building · {}", fmt_elapsed(started_at.elapsed()))
+        }
+        AppPhase::Idle => "idle".into(),
+        AppPhase::Patching { started_at } => {
+            format!("patching · {}", fmt_elapsed(started_at.elapsed()))
+        }
+        AppPhase::Failed { phase, .. } => format!("{phase} failed"),
+    }
+}
+
+fn phase_color(phase: &AppPhase) -> Color {
+    match phase {
+        AppPhase::Setup | AppPhase::Initializing => Color::DarkGray,
+        AppPhase::Building { .. } | AppPhase::Patching { .. } => Color::Yellow,
+        AppPhase::Idle => Color::Green,
+        AppPhase::Failed { .. } => Color::Red,
+    }
+}
+
+fn phase_section_title(phase: &AppPhase) -> &'static str {
+    match phase {
+        AppPhase::Setup => "Setup",
+        AppPhase::Initializing => "Initializing dev server",
+        AppPhase::Building { kind, .. } => match kind {
+            BuildKind::Initial => "Initial build",
+            BuildKind::Rebuild => "Rebuild",
+        },
+        AppPhase::Idle => "Status",
+        AppPhase::Patching { .. } => "Patch (tier 1)",
+        AppPhase::Failed { .. } => "Failed",
+    }
+}
+
 fn fmt_elapsed(d: Duration) -> String {
     let ms = d.as_millis();
     if ms < 1_000 {
@@ -357,90 +747,86 @@ fn fmt_elapsed(d: Duration) -> String {
     }
 }
 
+// ============================================================================
+// Tests
+// ============================================================================
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use whisker_dev_server::Event;
 
-    #[test]
-    fn apply_started_moves_to_idle() {
-        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
-        apply_event(&mut s, &Event::Started);
-        assert!(matches!(s.phase, Phase::Idle));
+    fn s() -> TuiState {
+        TuiState::new("iOS Simulator", "rs.whisker.podcast")
     }
 
     #[test]
-    fn building_then_succeeded_records_a_success_outcome() {
-        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
-        apply_event(&mut s, &Event::BuildingFull);
-        assert!(matches!(s.phase, Phase::Building { .. }));
-        apply_event(&mut s, &Event::BuildSucceeded);
-        assert!(matches!(s.phase, Phase::Idle));
-        assert!(matches!(s.last, LastOutcome::Success(_)));
+    fn build_lifecycle_records_outcome() {
+        let mut st = s();
+        apply_event(&mut st, &Event::BuildingFull);
+        assert!(matches!(st.phase, AppPhase::Building { .. }));
+        apply_event(&mut st, &Event::BuildSucceeded);
+        assert!(matches!(st.phase, AppPhase::Idle));
+        assert!(st.last_build.is_some());
     }
 
     #[test]
-    fn build_failed_records_failure_with_message() {
-        let mut s = TuiState::new("Android", "127.0.0.1:9876");
-        apply_event(&mut s, &Event::BuildingFull);
-        apply_event(&mut s, &Event::BuildFailed("rustc died".into()));
-        assert!(matches!(s.phase, Phase::Idle));
-        match s.last {
-            LastOutcome::Failure(msg) => assert!(msg.contains("rustc died")),
-            other => panic!("expected Failure, got {other:?}"),
-        }
+    fn client_counter_saturates() {
+        let mut st = s();
+        apply_event(&mut st, &Event::ClientConnected);
+        apply_event(&mut st, &Event::ClientConnected);
+        assert_eq!(st.client_count, 2);
+        apply_event(&mut st, &Event::ClientDisconnected);
+        apply_event(&mut st, &Event::ClientDisconnected);
+        apply_event(&mut st, &Event::ClientDisconnected);
+        assert_eq!(st.client_count, 0);
     }
 
     #[test]
-    fn client_counter_increments_and_decrements_with_saturation() {
-        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
-        apply_event(&mut s, &Event::ClientConnected);
-        apply_event(&mut s, &Event::ClientConnected);
-        assert_eq!(s.client_count, 2);
-        apply_event(&mut s, &Event::ClientDisconnected);
-        assert_eq!(s.client_count, 1);
-        // Underflow is saturating — never panics.
-        apply_event(&mut s, &Event::ClientDisconnected);
-        apply_event(&mut s, &Event::ClientDisconnected);
-        assert_eq!(s.client_count, 0);
-    }
-
-    #[test]
-    fn patch_sent_records_success_with_elapsed_from_patching_phase() {
-        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
-        s.phase = Phase::Patching {
-            started_at: Instant::now() - Duration::from_millis(615),
-        };
-        apply_event(&mut s, &Event::PatchSent);
-        assert!(matches!(s.phase, Phase::Idle));
-        match s.last {
-            LastOutcome::Success(msg) => assert!(msg.starts_with("patch ok ")),
-            other => panic!("expected Success, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn device_log_does_not_modify_state() {
-        let mut s = TuiState::new("iOS", "127.0.0.1:9876");
-        s.phase = Phase::Building {
-            started_at: Instant::now(),
-        };
-        let original_phase = matches!(s.phase, Phase::Building { .. });
+    fn device_log_goes_into_log_buffer_with_tag() {
+        let mut st = s();
         apply_event(
-            &mut s,
+            &mut st,
             &Event::DeviceLog {
                 stream: "stdout".into(),
                 line: "hello".into(),
                 ts_micros: 0,
             },
         );
-        assert!(original_phase && matches!(s.phase, Phase::Building { .. }));
+        assert_eq!(st.logs.lines.len(), 1);
+        assert!(st.logs.lines[0].contains("[device]"));
+        assert!(st.logs.lines[0].contains("hello"));
     }
 
     #[test]
-    fn fmt_elapsed_chooses_right_unit_by_magnitude() {
-        assert_eq!(fmt_elapsed(Duration::from_millis(42)), "42ms");
-        assert_eq!(fmt_elapsed(Duration::from_millis(1_500)), "1.5s");
-        assert_eq!(fmt_elapsed(Duration::from_secs(125)), "2m05s");
+    fn log_buffer_drops_oldest_at_capacity() {
+        let mut b = LogBuffer::new(3);
+        for i in 0..5 {
+            b.push(format!("line {i}"));
+        }
+        assert_eq!(b.lines.len(), 3);
+        assert_eq!(b.lines.front().unwrap(), "line 2");
+        assert_eq!(b.lines.back().unwrap(), "line 4");
+    }
+
+    #[test]
+    fn start_finish_step_round_trips() {
+        let mut st = s();
+        let i = start_step(&mut st, "Sync gen/ios");
+        assert_eq!(st.steps.len(), 1);
+        finish_step_at(&mut st, i, StepStatus::Done, 124);
+        assert!(matches!(st.steps[0].status, StepStatus::Done));
+        assert_eq!(st.steps[0].elapsed_ms, Some(124));
+    }
+
+    #[test]
+    fn patch_sent_records_elapsed_and_resets_phase() {
+        let mut st = s();
+        st.phase = AppPhase::Patching {
+            started_at: Instant::now() - Duration::from_millis(615),
+        };
+        apply_event(&mut st, &Event::PatchSent);
+        assert!(matches!(st.phase, AppPhase::Idle));
+        assert!(st.last_patch.is_some());
     }
 }

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -605,6 +605,20 @@ impl Tui {
         // to the shell.
         let _ = self.terminal.clear();
         let _ = self.terminal.show_cursor();
+        // Force the cursor to column 0 of a fresh row before we
+        // hand the terminal back. `terminal.clear()` *should* leave
+        // the cursor at the viewport's top-left, but if the user
+        // hit `Ctrl-C` and the libc signal beat our `KeyEvent`
+        // handler to the punch, the in-flight render's last
+        // `\x1b[<row>;<col>H` is the position the shell's PS1
+        // inherits — and the visible symptom is a prompt that
+        // starts at column ~113 instead of 0. `\r` re-aligns,
+        // `\n` drops the prompt onto a brand-new row below the
+        // (now-blank) live region. Both bytes go through the saved
+        // stderr fd so they reach the real terminal even while
+        // STDERR_FILENO is still pointing at the capture pipe.
+        let mut original = OriginalStderr(self.saved_stderr_fd);
+        let _ = original.write_all(b"\r\n");
         let _ = disable_raw_mode();
         // Restore STDERR_FILENO to the saved fd so callers can
         // continue to `eprintln!` after the TUI is gone; close the
@@ -751,6 +765,11 @@ fn strip_ansi(s: &str) -> String {
 fn emergency_terminal_reset(original_stderr_fd: c_int) {
     let mut o = OriginalStderr(original_stderr_fd);
     let _ = o.execute(cursor::Show);
+    // Mirror `Tui::shutdown`'s cursor reset (see the comment
+    // there): without `\r\n` after `cursor::Show`, the shell
+    // prompt that takes over on `process::exit(130)` starts at
+    // whatever column the last live-region draw left the cursor.
+    let _ = o.write_all(b"\r\n");
     let _ = disable_raw_mode();
 }
 

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -7,9 +7,8 @@
 //! doubles as a **fat build** that fills the rustc + linker capture
 //! caches the Tier 1 hot-patch pipeline replays later.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use std::path::PathBuf;
-use tokio::process::Command;
 
 use crate::Target;
 use whisker_build::CaptureShims;
@@ -75,7 +74,6 @@ impl Builder {
     /// Run the build for the current target. Inherits stdout/stderr.
     pub async fn build(&self) -> Result<()> {
         match self.target {
-            Target::Host => self.build_host().await,
             Target::Android => self.build_android().await,
             Target::IosSimulator => self.build_ios_simulator().await,
         }
@@ -87,20 +85,6 @@ impl Builder {
     }
 
     // ----- per-target build paths ------------------------------------------
-
-    async fn build_host(&self) -> Result<()> {
-        let mut cmd = Command::new("cargo");
-        cmd.args(["build", "-p", &self.package]);
-        for f in &self.features {
-            cmd.args(["--features", f]);
-        }
-        cmd.current_dir(&self.workspace_root);
-        let s = cmd.status().await.context("spawn cargo")?;
-        if !s.success() {
-            return Err(anyhow!("cargo build failed ({s})"));
-        }
-        Ok(())
-    }
 
     async fn build_android(&self) -> Result<()> {
         // Dev loop only stages module Kotlin sources, then drives
@@ -195,7 +179,7 @@ mod tests {
 
     #[test]
     fn builder_can_be_constructed_for_each_target() {
-        for t in [Target::Host, Target::Android, Target::IosSimulator] {
+        for t in [Target::Android, Target::IosSimulator] {
             let b = Builder::new(
                 PathBuf::from("/tmp/ws"),
                 PathBuf::from("/tmp/ws/examples/x"),
@@ -213,7 +197,7 @@ mod tests {
             PathBuf::from("/tmp/ws"),
             PathBuf::from("/tmp/ws/examples/x"),
             "x".into(),
-            Target::Host,
+            Target::Android,
         )
         .with_features(vec!["whisker/hot-reload".into(), "extra".into()]);
         assert_eq!(b.features, vec!["whisker/hot-reload", "extra"]);

--- a/crates/whisker-dev-server/src/hotpatch/wrapper.rs
+++ b/crates/whisker-dev-server/src/hotpatch/wrapper.rs
@@ -589,7 +589,7 @@ mod tests {
         let res = run_fat_build(
             &bad_workspace,
             "no-such-package",
-            Target::Host,
+            Target::Android,
             Path::new("/bin/true"),
             &cache,
             None,
@@ -618,7 +618,7 @@ mod tests {
         let res = run_fat_build(
             &bad_workspace,
             "no-such-package",
-            Target::Host,
+            Target::Android,
             Path::new("/bin/true"),
             &rustc_cache,
             Some(&lc),

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -258,6 +258,14 @@ enum SimctlNoise {
     /// preamble lines, and the post-build "xcframework written"
     /// confirmation all belong here.
     Xcodebuild,
+    /// `adb install -r` — stdout banners "Performing Streamed
+    /// Install" and "Success" duplicate the `install_step.done()`
+    /// row our UI already prints.
+    AdbInstall,
+    /// `adb shell am start` — stdout banner `Starting: Intent
+    /// { cmp=... }` duplicates what the launch step's label
+    /// already says.
+    AdbAmStart,
 }
 
 impl SimctlNoise {
@@ -276,6 +284,7 @@ impl SimctlNoise {
             }
             SimctlNoise::Other => false,
             SimctlNoise::Xcodebuild => is_benign_xcodebuild_line(line),
+            SimctlNoise::AdbInstall | SimctlNoise::AdbAmStart => false,
         }
     }
 
@@ -292,6 +301,13 @@ impl SimctlNoise {
             // success; it duplicates info our `step.done(...)`
             // already covers.
             SimctlNoise::Other => line.contains(": ") && line.chars().any(|c| c.is_ascii_digit()),
+            // `adb install -r`: two stdout lines on success — both
+            // are subsumed by the `install` step's ✓ row.
+            SimctlNoise::AdbInstall => line == "Performing Streamed Install" || line == "Success",
+            // `adb shell am start -n <component>`: the one stdout
+            // line "Starting: Intent { cmp=… }" duplicates the
+            // launch step's label.
+            SimctlNoise::AdbAmStart => line.starts_with("Starting: Intent {"),
             _ => false,
         }
     }
@@ -309,37 +325,51 @@ async fn android_install_and_launch(p: &AndroidParams) -> Result<()> {
     // on-device dev-runtime can reach our WebSocket without knowing
     // the emulator-gateway IP (10.0.2.2). Best-effort: it might
     // already be set from a previous run, or the device might be a
-    // non-emulator that doesn't need it.
-    let _ = Command::new("adb")
-        .args(["reverse", "tcp:9876", "tcp:9876"])
-        .status()
-        .await;
+    // non-emulator that doesn't need it. Routed through
+    // `run_filtered` rather than `.status()` so its stdio doesn't
+    // bypass the TUI's stderr-capture pipe and overlay the live
+    // region — same reason every other adb call below now uses it.
+    let mut reverse_cmd = Command::new("adb");
+    reverse_cmd.args(["reverse", "tcp:9876", "tcp:9876"]);
+    let _ = run_filtered(reverse_cmd, SimctlNoise::Other).await;
 
-    let install = Command::new("adb")
-        .args(["install", "-r"])
-        .arg(&apk)
-        .status()
+    let install_step = whisker_build::ui::step(
+        "install",
+        apk.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "app-debug.apk".into()),
+    );
+    let mut install_cmd = Command::new("adb");
+    install_cmd.args(["install", "-r"]).arg(&apk);
+    let install = run_filtered(install_cmd, SimctlNoise::AdbInstall)
         .await
         .context("spawn adb install")?;
     if !install.success() {
+        install_step.fail(format!("{install}"));
         anyhow::bail!("adb install -r {} failed ({install})", apk.display());
     }
+    install_step.done("");
 
-    // adb shell am force-stop  (so the relaunch actually re-bootstraps)
-    let _ = Command::new("adb")
-        .args(["shell", "am", "force-stop", &p.application_id])
-        .status()
-        .await;
+    // adb shell am force-stop  (so the relaunch actually re-bootstraps).
+    // `force-stop` is silent on success; route through `run_filtered`
+    // anyway so any error preamble lands in scrollback rather than on
+    // top of the live region.
+    let mut stop_cmd = Command::new("adb");
+    stop_cmd.args(["shell", "am", "force-stop", &p.application_id]);
+    let _ = run_filtered(stop_cmd, SimctlNoise::Other).await;
 
     let component = format!("{}/{}", p.application_id, p.launcher_activity);
-    let launch = Command::new("adb")
-        .args(["shell", "am", "start", "-n", &component])
-        .status()
+    let launch_step = whisker_build::ui::step("launch", component.clone());
+    let mut launch_cmd = Command::new("adb");
+    launch_cmd.args(["shell", "am", "start", "-n", &component]);
+    let launch = run_filtered(launch_cmd, SimctlNoise::AdbAmStart)
         .await
         .context("spawn adb am start")?;
     if !launch.success() {
+        launch_step.fail(format!("{launch}"));
         anyhow::bail!("adb am start {component} failed ({launch})");
     }
+    launch_step.done("");
     Ok(())
 }
 

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -247,12 +247,12 @@ enum SimctlNoise {
     /// fires when the sim is already up, which is the normal case
     /// after the first `whisker run`.
     Boot,
-    /// `xcrun simctl terminate` — "found nothing to terminate" fires
-    /// on the very first run before the app exists in the sim.
-    Terminate,
     /// `xcrun simctl install` / `launch` — generally low-noise but
     /// can emit POSIX prefixes; treat anything matching the known
-    /// boilerplate as suppressed.
+    /// boilerplate as suppressed. `simctl launch
+    /// --terminate-running-process` is also routed through here
+    /// (the previous separate `simctl terminate` step was rolled
+    /// into the launch flag — see `ios_install_and_launch`).
     Other,
     /// `xcodebuild` — `[MT] IDERunDestination`, the date-time
     /// preamble lines, and the post-build "xcframework written"
@@ -273,18 +273,6 @@ impl SimctlNoise {
             SimctlNoise::Boot => {
                 line.contains("Unable to boot device in current state: Booted")
                     || line.starts_with("(code=405)")
-            }
-            SimctlNoise::Terminate => {
-                line.contains("found nothing to terminate")
-                    || line.contains("(domain=NSPOSIXErrorDomain, code=3)")
-                    // Fires on every first launch — the dev loop
-                    // terminates the previous run before relaunching
-                    // so the runtime re-bootstraps, but on a cold
-                    // start the previous run never existed and
-                    // simctl emits this benign warning. Filtered
-                    // here instead of upstream so a real "couldn't
-                    // kill a stuck process" is still surfaced.
-                    || line.contains("Simulator device failed to terminate")
             }
             SimctlNoise::Other => false,
             SimctlNoise::Xcodebuild => is_benign_xcodebuild_line(line),
@@ -469,19 +457,29 @@ async fn ios_install_and_launch(
     }
     install_step.done("");
 
-    // Force the previous run to die so the relaunch re-bootstraps the
-    // runtime + reconnects the dev WebSocket. Errors here are benign
-    // (first launch — nothing running yet).
-    let mut term_cmd = Command::new("xcrun");
-    term_cmd.args(["simctl", "terminate", "booted", &p.bundle_id]);
-    let _ = run_filtered(term_cmd, SimctlNoise::Terminate).await;
-
     // `SIMCTL_CHILD_<NAME>` shows up as `<NAME>` inside the launched
     // app's env — that's how the dev-runtime finds us.
+    //
+    // `--terminate-running-process` makes simctl atomically kill the
+    // previous instance (so the runtime re-bootstraps + reconnects
+    // the dev WebSocket) and immediately launch the fresh build. We
+    // used to do this as two steps — `simctl terminate` followed by
+    // `simctl launch` — but the terminate call emits
+    // `Simulator device failed to terminate <bundle>.` to stderr
+    // whenever the app exists on the simulator but isn't actually
+    // running (which is every cold start, and also the "user
+    // backgrounded the app between rebuilds" case). The flag bundles
+    // both operations and handles the not-running case silently.
     let launch_step = whisker_build::ui::step("launch", p.bundle_id.clone());
     let mut launch_cmd = Command::new("xcrun");
     launch_cmd
-        .args(["simctl", "launch", "booted", &p.bundle_id])
+        .args([
+            "simctl",
+            "launch",
+            "--terminate-running-process",
+            "booted",
+            &p.bundle_id,
+        ])
         .env("SIMCTL_CHILD_WHISKER_DEV_ADDR", "127.0.0.1:9876");
     let launch = run_filtered(launch_cmd, SimctlNoise::Other)
         .await

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -3,8 +3,7 @@
 //! After a successful cold-rebuild, the freshly-built artifact has to
 //! land on the target and start (re-bootstrapping the dev-runtime so
 //! it dials the dev-server back). For Android we shell out to `adb`;
-//! for iOS Simulator to `xcrun simctl`; for `Host` we no-op (the user
-//! runs the host binary themselves).
+//! for iOS Simulator to `xcrun simctl`.
 //!
 //! Application identity (bundle id, applicationId, launcher activity,
 //! scheme, …) is **not** baked in here. The cli passes those as
@@ -68,7 +67,6 @@ impl Installer {
 
     pub async fn install_and_launch(&self) -> Result<()> {
         match self.target {
-            Target::Host => self.host_skip(),
             Target::Android => {
                 let p = self.android.as_ref().context(
                     "target=Android but no AndroidParams — cli must populate Config.android",
@@ -89,13 +87,6 @@ impl Installer {
                 .await
             }
         }
-    }
-
-    fn host_skip(&self) -> Result<()> {
-        whisker_build::ui::info(
-            "host target: install/launch is the user's job — run the binary manually",
-        );
-        Ok(())
     }
 }
 
@@ -563,26 +554,6 @@ mod tests {
             launcher_activity: ".MainActivity".into(),
             abi: "arm64-v8a".into(),
         }
-    }
-
-    #[test]
-    fn installer_for_host_doesnt_need_android_or_ios() {
-        let inst = Installer::new(
-            Target::Host,
-            None,
-            None,
-            PathBuf::new(),
-            "x".into(),
-            None,
-            Vec::new(),
-        );
-        // Just exercise the `host_skip` branch via the public API —
-        // it doesn't await anything async so we can run it on the
-        // current thread without a runtime.
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .unwrap();
-        rt.block_on(async { inst.install_and_launch().await.unwrap() });
     }
 
     #[test]

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -277,6 +277,14 @@ impl SimctlNoise {
             SimctlNoise::Terminate => {
                 line.contains("found nothing to terminate")
                     || line.contains("(domain=NSPOSIXErrorDomain, code=3)")
+                    // Fires on every first launch — the dev loop
+                    // terminates the previous run before relaunching
+                    // so the runtime re-bootstraps, but on a cold
+                    // start the previous run never existed and
+                    // simctl emits this benign warning. Filtered
+                    // here instead of upstream so a real "couldn't
+                    // kill a stuck process" is still surfaced.
+                    || line.contains("Simulator device failed to terminate")
             }
             SimctlNoise::Other => false,
             SimctlNoise::Xcodebuild => is_benign_xcodebuild_line(line),

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -742,42 +742,46 @@ fn original_binary_path(config: &Config) -> Result<PathBuf> {
     let crate_underscored = config.package.replace('-', "_");
     match config.target {
         Target::Android => {
-            // Read from cargo's workspace `target/<triple>/debug/`
-            // dir, which is where `whisker-build android` (run inside
-            // gradle's `whiskerBuildDebugArm64V8a` task) deposits the
-            // freshly-cross-compiled .so during the dev loop. The
-            // dev-loop's `Builder` is hard-coded to `Profile::Debug`
-            // (`crates/whisker-dev-server/src/builder.rs`), so the
-            // patcher's expectation must match that — earlier code
-            // here used `release/` and silently fell back to Tier 2.
-            // We deliberately don't reach into
-            // `gen/android/.../app/src/main/jniLibs/<abi>/` even
-            // though that path also exists after a successful gradle
-            // assemble — that file is a copy AGP made for jniLibs
-            // merging, and the symbol-loading order rustc uses pins
-            // its addresses to the canonical cargo output anyway.
+            // Read from the *gradle plugin's* output directory rather
+            // than from `<workspace>/target/<triple>/debug/`. Why:
+            // gradle's `WhiskerBuildTask` declares its `jniLibsDir`
+            // as an `@OutputDirectory` but the cargo target dir as
+            // `@Internal` (see
+            // `platforms/android/gradle-plugin/whisker-gradle-plugin/
+            // src/main/kotlin/rs/whisker/gradle/WhiskerBuildTask.kt`),
+            // which means gradle treats the jniLibs path as the
+            // ground-truth output it must guarantee, but happily
+            // skips the task when only the cargo target dir is
+            // missing. If the user runs `cargo clean` (or anything
+            // that nukes `target/<triple>/debug/`) between sessions
+            // gradle still reports UP-TO-DATE and the dev-server
+            // sees nothing under the workspace's target dir.
+            //
+            // Stage location: `whisker_build::android::stage_so_files`
+            // copies the freshly-built `.so` into the abi subdir of
+            // gradle's `@OutputDirectory`. The directory layout is
+            // `gen/android/app/build/generated/jniLibs/
+            //  whiskerBuild<Variant><AbiCamel>/<abi>/lib<pkg>.so`,
+            // where `<AbiCamel>` is the abi name with each `-`/`_`
+            // segment titlecased (`arm64-v8a` → `Arm64V8a`,
+            // `x86_64` → `X8664`) and `<Variant>` is the AGP build
+            // type ("Debug" for the dev loop).
             let android = config.android.as_ref().ok_or_else(|| {
                 anyhow::anyhow!(
                     "target=Android but Config.android is None — cli should have populated it from whisker.rs"
                 )
             })?;
-            let triple = match android.abi.as_str() {
-                "arm64-v8a" => "aarch64-linux-android",
-                "armeabi-v7a" => "armv7-linux-androideabi",
-                "x86_64" => "x86_64-linux-android",
-                "x86" => "i686-linux-android",
-                other => anyhow::bail!("unknown Android ABI: {other}"),
-            };
             let so_name = format!("lib{crate_underscored}.so");
+            let abi_camel = android_abi_to_camel(&android.abi);
             let candidate = config
-                .workspace_root
-                .join("target")
-                .join(triple)
-                .join("debug")
+                .crate_dir
+                .join("gen/android/app/build/generated/jniLibs")
+                .join(format!("whiskerBuildDebug{abi_camel}"))
+                .join(&android.abi)
                 .join(&so_name);
             if !candidate.is_file() {
                 anyhow::bail!(
-                    "no Android cdylib at {} — initial build didn't drop the artifact where the dev loop expects it",
+                    "no Android cdylib at {} — gradle's whiskerBuildDebug{abi_camel} task didn't produce its output (run `whisker run --target android` first)",
                     candidate.display(),
                 );
             }
@@ -836,6 +840,25 @@ fn original_binary_path(config: &Config) -> Result<PathBuf> {
             Ok(dylib)
         }
     }
+}
+
+/// Map an Android ABI name to the camel-cased form gradle's
+/// `WhiskerProjectPlugin` uses when synthesising
+/// `whiskerBuild<Variant><AbiCamel>` task names. Each `-` or `_`
+/// segment is titlecased and the parts are concatenated:
+/// `arm64-v8a` → `Arm64V8a`, `armeabi-v7a` → `ArmeabiV7a`,
+/// `x86_64` → `X8664`, `x86` → `X86`. Mirrors `String.toCamelCase()`
+/// in `WhiskerProjectPlugin.kt`.
+fn android_abi_to_camel(abi: &str) -> String {
+    abi.split(['-', '_'])
+        .map(|seg| {
+            let mut chars = seg.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().chain(chars).collect::<String>(),
+                None => String::new(),
+            }
+        })
+        .collect()
 }
 
 fn target_os_for(target: Target) -> hotpatch::LinkerOs {
@@ -1002,20 +1025,27 @@ mod tests {
     }
 
     #[test]
-    fn original_binary_path_finds_android_so_under_cargo_target() {
-        // Reflects the post-#XXX layout: gradle's whiskerBuild*Android
-        // task drops the .so at `target/<triple>/debug/` (the dev loop
-        // builds with `Profile::Debug`) rather than the dev-server
-        // pre-staging into `app/src/main/jniLibs/`.
+    fn original_binary_path_finds_android_so_under_gradle_output() {
+        // Reads from the gradle plugin's `@OutputDirectory`, not from
+        // `target/<triple>/debug/` — the latter can be cleaned out by
+        // `cargo clean` while gradle still reports its task as
+        // UP-TO-DATE (the cargo target dir is `@Internal`, not an
+        // input). See `original_binary_path` for the rationale.
         use std::sync::atomic::{AtomicU64, Ordering};
         static SEQ: AtomicU64 = AtomicU64::new(0);
         let n = SEQ.fetch_add(1, Ordering::Relaxed);
         let pid = std::process::id();
         let ws = std::env::temp_dir().join(format!("whisker-dev-test-orig-{pid}-{n}"));
         let _ = std::fs::remove_dir_all(&ws);
-        let debug_dir = ws.join("target/aarch64-linux-android/debug");
-        std::fs::create_dir_all(&debug_dir).unwrap();
-        let so = debug_dir.join("libhello_world.so");
+        // `mk_config` sets `crate_dir = ws` for Android, so the path
+        // the patcher checks is `<ws>/gen/android/app/build/generated/
+        // jniLibs/whiskerBuildDebug<AbiCamel>/<abi>/lib<pkg>.so`.
+        let gradle_out_dir = ws
+            .join("gen/android/app/build/generated/jniLibs")
+            .join("whiskerBuildDebugArm64V8a")
+            .join("arm64-v8a");
+        std::fs::create_dir_all(&gradle_out_dir).unwrap();
+        let so = gradle_out_dir.join("libhello_world.so");
         std::fs::write(&so, b"fake").unwrap();
 
         let cfg = mk_config(ws.clone(), Target::Android);
@@ -1023,6 +1053,17 @@ mod tests {
         assert_eq!(resolved, so);
 
         let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn android_abi_to_camel_matches_gradle_plugin_naming() {
+        // Mirrors `WhiskerProjectPlugin.kt::String.toCamelCase`. The
+        // patcher's task-name suffix has to match exactly or the
+        // gradle output path won't resolve.
+        assert_eq!(android_abi_to_camel("arm64-v8a"), "Arm64V8a");
+        assert_eq!(android_abi_to_camel("armeabi-v7a"), "ArmeabiV7a");
+        assert_eq!(android_abi_to_camel("x86_64"), "X8664");
+        assert_eq!(android_abi_to_camel("x86"), "X86");
     }
 
     #[test]

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -347,7 +347,15 @@ impl DevServer {
 
         // Now bind the WS so `install_and_launch` (next) has
         // somewhere for the device's `whisker-dev-runtime` to dial.
-        whisker_build::ui::section("dev server");
+        // `whisker_build::ui::section("dev server")` used to live
+        // here as a visual divider between the cargo build and the
+        // device install/launch. The TUI's live region already
+        // surfaces the ws addr + client count, so the section
+        // header was a redundant row of dashes. `ensure_status` /
+        // `set_status` are no-ops in TUI mode (see
+        // `whisker_build::ui::set_status`); we keep them for the
+        // `--no-tui` and CI paths where the legacy status surface
+        // is still the only signal.
         whisker_build::ui::ensure_status("dev-server");
         let (sender, bound, _server_handle) =
             server::serve(self.config.bind_addr, self.on_event.clone()).await?;

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -323,22 +323,27 @@ impl DevServer {
         // deferred until *after* the WS is bound, because the device
         // app spins up its `whisker-dev-runtime` socket as soon as it
         // launches and would race a not-yet-bound dev-server.
-        // A build failure isn't fatal: the loop still enters so
-        // fixing the source and saving recovers.
+        //
+        // A build failure here is fatal: there's nothing actionable
+        // the dev-loop can do (no app to patch, no install to
+        // recover from a source-edit save), so we surface the error
+        // and exit. The previous behaviour of "enter the loop anyway
+        // and recover on next save" was misleading — users routinely
+        // missed the warn line and assumed the build had succeeded.
         whisker_build::ui::section("Initial build");
         emit(&self.on_event, Event::BuildingFull);
-        let initial_build_ok = match builder.build().await {
-            Ok(()) => {
-                emit(&self.on_event, Event::BuildSucceeded);
-                true
-            }
-            Err(e) => {
-                let msg = format!("{e:#}");
-                whisker_build::ui::error(format!("initial build failed: {msg}"));
-                emit(&self.on_event, Event::BuildFailed(msg));
-                false
-            }
-        };
+        if let Err(e) = builder.build().await {
+            let msg = format!("{e:#}");
+            emit(&self.on_event, Event::BuildFailed(msg.clone()));
+            // cli main prints the bail message via `ui::error` (it
+            // formats `e.root_cause()`), so emitting our own
+            // `ui::error` here would double-print every install /
+            // build failure to the user. Keep the bail message
+            // user-actionable; the verbose chain is still reachable
+            // via `WHISKER_VERBOSE=1`.
+            anyhow::bail!("initial build failed: {msg}");
+        }
+        emit(&self.on_event, Event::BuildSucceeded);
 
         // Now bind the WS so `install_and_launch` (next) has
         // somewhere for the device's `whisker-dev-runtime` to dial.
@@ -395,19 +400,23 @@ impl DevServer {
         }
         emit(&self.on_event, Event::Started);
 
-        // Install + launch the freshly-built artifact. Skipped when
-        // the build failed — the loop's first save will retry via
-        // the rebuild path. `run_build_cycle` reuses this codepath
-        // for rebuilds inside the loop (where WS is already bound).
-        if initial_build_ok {
-            if let Err(e) = installer.install_and_launch().await {
-                whisker_build::ui::error(format!("initial install failed: {e}"));
-            }
-            whisker_build::ui::info(format!(
-                "initial done · {} client(s) connected",
-                sender.client_count()
-            ));
+        // Install + launch the freshly-built artifact. A failure
+        // here is fatal for the same reason a build failure is —
+        // there's nothing to dev-loop against if the app never made
+        // it onto the device (no `INSTALL_FAILED_INSUFFICIENT_STORAGE`
+        // recovery story over file watching). `run_build_cycle`
+        // reuses the build + install codepath for rebuilds inside
+        // the loop (where WS is already bound and a failure there
+        // does fall through — the user can then save again to retry).
+        if let Err(e) = installer.install_and_launch().await {
+            // See the `initial build failed` arm above for why we
+            // bail instead of `ui::error`-ing here.
+            anyhow::bail!("initial install failed: {e:#}");
         }
+        whisker_build::ui::info(format!(
+            "initial done · {} client(s) connected",
+            sender.client_count()
+        ));
 
         // After the fat build has happened, Patcher::initialize can
         // read the now-populated caches. Failure here is non-fatal
@@ -725,11 +734,16 @@ fn original_binary_path(config: &Config) -> Result<PathBuf> {
     let crate_underscored = config.package.replace('-', "_");
     match config.target {
         Target::Android => {
-            // Read from cargo's workspace `target/<triple>/release/`
+            // Read from cargo's workspace `target/<triple>/debug/`
             // dir, which is where `whisker-build android` (run inside
             // gradle's `whiskerBuildDebugArm64V8a` task) deposits the
-            // freshly-cross-compiled .so. We deliberately don't reach
-            // into `gen/android/.../app/src/main/jniLibs/<abi>/` even
+            // freshly-cross-compiled .so during the dev loop. The
+            // dev-loop's `Builder` is hard-coded to `Profile::Debug`
+            // (`crates/whisker-dev-server/src/builder.rs`), so the
+            // patcher's expectation must match that — earlier code
+            // here used `release/` and silently fell back to Tier 2.
+            // We deliberately don't reach into
+            // `gen/android/.../app/src/main/jniLibs/<abi>/` even
             // though that path also exists after a successful gradle
             // assemble — that file is a copy AGP made for jniLibs
             // merging, and the symbol-loading order rustc uses pins
@@ -751,11 +765,11 @@ fn original_binary_path(config: &Config) -> Result<PathBuf> {
                 .workspace_root
                 .join("target")
                 .join(triple)
-                .join("release")
+                .join("debug")
                 .join(&so_name);
             if !candidate.is_file() {
                 anyhow::bail!(
-                    "no Android cdylib at {} — run `whisker build --target android` first",
+                    "no Android cdylib at {} — initial build didn't drop the artifact where the dev loop expects it",
                     candidate.display(),
                 );
             }
@@ -791,18 +805,23 @@ fn original_binary_path(config: &Config) -> Result<PathBuf> {
                 "x86_64" => "x86_64-apple-ios",
                 arch => anyhow::bail!("unsupported host arch {arch} for iOS Simulator target"),
             };
+            // The dev-loop's `Builder` is hard-coded to
+            // `Profile::Debug`, and xcodebuild's Build Phase Run
+            // Script (`whisker-build ios`) invokes cargo with the
+            // same debug profile, so the dylib lands in
+            // `target/<triple>/debug/`. Previously we read from
+            // `release/` and the patcher init silently fell back to
+            // Tier 2 on every run.
             let dylib = config
                 .workspace_root
                 .join("target")
                 .join(triple)
-                .join("release")
+                .join("debug")
                 .join(&dylib_name);
             if !dylib.is_file() {
                 anyhow::bail!(
                     "no iOS Simulator dylib at {} — \
-                     `whisker run --target ios` would have built it; \
-                     reaching this branch means the initial build was \
-                     skipped or failed",
+                     initial xcodebuild didn't drop the artifact where the dev loop expects it",
                     dylib.display(),
                 );
             }
@@ -955,9 +974,9 @@ mod tests {
             "x86_64" => "x86_64-apple-ios",
             other => panic!("unsupported test host arch {other}"),
         };
-        let release_dir = ws.join("target").join(triple).join("release");
-        std::fs::create_dir_all(&release_dir).unwrap();
-        let dylib = release_dir.join("libhello_world.dylib");
+        let debug_dir = ws.join("target").join(triple).join("debug");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        let dylib = debug_dir.join("libhello_world.dylib");
         std::fs::write(&dylib, b"fake-macho").unwrap();
 
         let cfg = mk_config(ws.clone(), Target::IosSimulator);
@@ -977,17 +996,18 @@ mod tests {
     #[test]
     fn original_binary_path_finds_android_so_under_cargo_target() {
         // Reflects the post-#XXX layout: gradle's whiskerBuild*Android
-        // task drops the .so at `target/<triple>/release/` rather than
-        // the dev-server pre-staging into `app/src/main/jniLibs/`.
+        // task drops the .so at `target/<triple>/debug/` (the dev loop
+        // builds with `Profile::Debug`) rather than the dev-server
+        // pre-staging into `app/src/main/jniLibs/`.
         use std::sync::atomic::{AtomicU64, Ordering};
         static SEQ: AtomicU64 = AtomicU64::new(0);
         let n = SEQ.fetch_add(1, Ordering::Relaxed);
         let pid = std::process::id();
         let ws = std::env::temp_dir().join(format!("whisker-dev-test-orig-{pid}-{n}"));
         let _ = std::fs::remove_dir_all(&ws);
-        let release_dir = ws.join("target/aarch64-linux-android/release");
-        std::fs::create_dir_all(&release_dir).unwrap();
-        let so = release_dir.join("libhello_world.so");
+        let debug_dir = ws.join("target/aarch64-linux-android/debug");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        let so = debug_dir.join("libhello_world.so");
         std::fs::write(&so, b"fake").unwrap();
 
         let cfg = mk_config(ws.clone(), Target::Android);

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -805,18 +805,18 @@ fn original_binary_path(config: &Config) -> Result<PathBuf> {
                 "x86_64" => "x86_64-apple-ios",
                 arch => anyhow::bail!("unsupported host arch {arch} for iOS Simulator target"),
             };
-            // The dev-loop's `Builder` is hard-coded to
-            // `Profile::Debug`, and xcodebuild's Build Phase Run
-            // Script (`whisker-build ios`) invokes cargo with the
-            // same debug profile, so the dylib lands in
-            // `target/<triple>/debug/`. Previously we read from
-            // `release/` and the patcher init silently fell back to
-            // Tier 2 on every run.
+            // xcodebuild's Build Phase Run Script (`whisker-build
+            // ios`) invokes cargo with `--release` (see
+            // `crates/whisker-build/src/ios.rs::cargo_build_ios_dylib`:
+            // the comment there spells out that iOS dev wants the
+            // same optimised codegen prod ships, so debug profile is
+            // deliberately not used). Android uses Debug; the two
+            // platforms can't share this path.
             let dylib = config
                 .workspace_root
                 .join("target")
                 .join(triple)
-                .join("debug")
+                .join("release")
                 .join(&dylib_name);
             if !dylib.is_file() {
                 anyhow::bail!(
@@ -974,9 +974,9 @@ mod tests {
             "x86_64" => "x86_64-apple-ios",
             other => panic!("unsupported test host arch {other}"),
         };
-        let debug_dir = ws.join("target").join(triple).join("debug");
-        std::fs::create_dir_all(&debug_dir).unwrap();
-        let dylib = debug_dir.join("libhello_world.dylib");
+        let release_dir = ws.join("target").join(triple).join("release");
+        std::fs::create_dir_all(&release_dir).unwrap();
+        let dylib = release_dir.join("libhello_world.dylib");
         std::fs::write(&dylib, b"fake-macho").unwrap();
 
         let cfg = mk_config(ws.clone(), Target::IosSimulator);

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -170,9 +170,6 @@ pub struct IosParams {
 /// What kind of binary the dev server is rebuilding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Target {
-    /// Plain host binary — no Lynx, no device, mostly for runtime
-    /// experiments (the `subsecond-poc` sort of thing).
-    Host,
     /// Android cdylib + APK + adb install + launch.
     Android,
     /// iOS Simulator app + xcrun simctl install + launch.
@@ -720,7 +717,6 @@ fn target_triple_for(config: &Config) -> Option<String> {
             };
             Some(triple.to_string())
         }
-        Target::Host => None,
     }
 }
 
@@ -744,7 +740,7 @@ fn resolve_linker_for(config: &Config) -> Result<PathBuf> {
             hotpatch::android_ndk::android_clang_for(abi, api)
                 .with_context(|| format!("resolve NDK clang for ABI {abi} API {api}"))
         }
-        Target::Host | Target::IosSimulator => Ok(hotpatch::wrapper::resolve_host_linker()),
+        Target::IosSimulator => Ok(hotpatch::wrapper::resolve_host_linker()),
     }
 }
 
@@ -765,12 +761,9 @@ fn init_patcher_for(config: &Config, prep: &Tier1Prep) -> Result<hotpatch::Patch
 }
 
 /// Locate the device-loadable original binary for the configured
-/// target. Tier 1 only supports targets that produce a
-/// `.so`/`.dylib` we can mmap and diff against; `Host` (which
-/// produces just an `.rlib` today) returns `Err` so the caller
-/// falls back to Tier 2.
-///
-/// Reads paths from `Config::android` / `Config::ios` rather than
+/// target. Both [`Target::Android`] and [`Target::IosSimulator`]
+/// produce a `.so` / `.dylib` we can mmap and diff against; reads
+/// the paths from `Config::android` / `Config::ios` rather than
 /// guessing — the cli populates these from the user's
 /// `whisker.rs::configure` output.
 fn original_binary_path(config: &Config) -> Result<PathBuf> {
@@ -821,12 +814,6 @@ fn original_binary_path(config: &Config) -> Result<PathBuf> {
                 );
             }
             Ok(candidate)
-        }
-        Target::Host => {
-            anyhow::bail!(
-                "Tier 1 not supported for Host target yet \
-                 (the user crate is rlib-only — no patchable shared library)"
-            );
         }
         Target::IosSimulator => {
             // Use the single-arch dylib that cargo dropped directly,
@@ -900,7 +887,6 @@ fn target_os_for(target: Target) -> hotpatch::LinkerOs {
     match target {
         Target::Android => hotpatch::LinkerOs::Linux,
         Target::IosSimulator => hotpatch::LinkerOs::Macos,
-        Target::Host => hotpatch::linker_os_for_host(),
     }
 }
 
@@ -960,11 +946,11 @@ mod tests {
         let cfg = Config::defaults_for(
             PathBuf::from("/tmp/ws"),
             "hello-world".to_string(),
-            Target::Host,
+            Target::Android,
         );
         assert_eq!(cfg.workspace_root, Path::new("/tmp/ws"));
         assert_eq!(cfg.package, "hello-world");
-        assert_eq!(cfg.target, Target::Host);
+        assert_eq!(cfg.target, Target::Android);
         assert_eq!(cfg.bind_addr.port(), 9876);
         assert!(cfg.bind_addr.ip().is_loopback());
         assert_eq!(cfg.hot_patch_mode, HotPatchMode::Tier2ColdRebuild);
@@ -988,7 +974,7 @@ mod tests {
         let cfg = Config::defaults_for(
             PathBuf::from("/tmp/ws"),
             "hello-world".to_string(),
-            Target::Host,
+            Target::Android,
         );
         assert!(DevServer::new(cfg).is_ok());
     }
@@ -1015,16 +1001,8 @@ mod tests {
                     device_override: None,
                 });
             }
-            Target::Host => {}
         }
         cfg
-    }
-
-    #[test]
-    fn original_binary_path_errors_for_host_target() {
-        let cfg = mk_config(PathBuf::from("/tmp/ws"), Target::Host);
-        let err = original_binary_path(&cfg).unwrap_err();
-        assert!(format!("{err:#}").contains("Host"), "got: {err:#}");
     }
 
     #[test]

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -270,11 +270,80 @@ impl DevServer {
         ));
         whisker_build::ui::debug(format!("mode={:?}", self.config.hot_patch_mode));
 
-        // Dev-server status flows through `set_status`; deduped so
-        // back-to-back transitions (startup → bound → first
-        // connect) don't stack lines.
-        whisker_build::ui::ensure_status("dev-server");
+        // Configure the initial build first. The Builder + Installer
+        // pair doesn't need the WS server, so we wire them up before
+        // touching the socket — this lets the user see a clean
+        // "Initial build" section open immediately after the
+        // top-level "whisker run" section, with no intervening
+        // dev-server chatter. Once the cargo step (the long pole)
+        // succeeds we bind the WS, then `install_and_launch` so the
+        // device app has somewhere to connect to.
+        //
+        // For Tier 1 mode this build doubles as the fat build that
+        // fills the rustc / linker capture caches; the shims are
+        // resolved (built if missing) and installed into the builder
+        // *before* the spawn. The same Builder is reused for Tier 2
+        // fallback rebuilds inside the change loop.
+        let mut builder = Builder::new(
+            self.config.workspace_root.clone(),
+            self.config.crate_dir.clone(),
+            self.config.package.clone(),
+            self.config.target,
+        )
+        .with_features(vec!["whisker/hot-reload".into()]);
 
+        let tier1_init = if self.config.hot_patch_mode == HotPatchMode::Tier1Subsecond {
+            match prepare_tier1_capture(&self.config) {
+                Ok(prep) => {
+                    builder = builder.with_capture(prep.capture.clone());
+                    Some(prep)
+                }
+                Err(e) => {
+                    whisker_build::ui::warn(format!(
+                        "Tier 1 capture setup failed ({e:#}); falling back to Tier 2 cold rebuilds",
+                    ));
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let installer = Installer::new(
+            self.config.target,
+            self.config.android.clone(),
+            self.config.ios.clone(),
+            self.config.workspace_root.clone(),
+            self.config.package.clone(),
+            tier1_init.as_ref().map(|p| p.capture.clone()),
+            builder.features().to_vec(),
+        );
+
+        // Initial build — cargo only. `install_and_launch` is
+        // deferred until *after* the WS is bound, because the device
+        // app spins up its `whisker-dev-runtime` socket as soon as it
+        // launches and would race a not-yet-bound dev-server.
+        // A build failure isn't fatal: the loop still enters so
+        // fixing the source and saving recovers.
+        whisker_build::ui::section("Initial build");
+        emit(&self.on_event, Event::BuildingFull);
+        let initial_build_ok = match builder.build().await {
+            Ok(()) => {
+                emit(&self.on_event, Event::BuildSucceeded);
+                true
+            }
+            Err(e) => {
+                let msg = format!("{e:#}");
+                whisker_build::ui::error(format!("initial build failed: {msg}"));
+                emit(&self.on_event, Event::BuildFailed(msg));
+                false
+            }
+        };
+
+        // Now bind the WS so `install_and_launch` (next) has
+        // somewhere for the device's `whisker-dev-runtime` to dial.
+        whisker_build::ui::section("dev server");
+        whisker_build::ui::ensure_status("dev-server");
         let (sender, bound, _server_handle) =
             server::serve(self.config.bind_addr, self.on_event.clone()).await?;
         whisker_build::ui::set_status(format!("ws://{bound} · 0 client(s)"));
@@ -326,55 +395,19 @@ impl DevServer {
         }
         emit(&self.on_event, Event::Started);
 
-        // Configure the initial build. For Tier 1 it doubles as the
-        // fat build that fills the rustc / linker capture caches —
-        // the shims are resolved (built if missing) and installed
-        // into the builder *before* the spawn. The same Builder
-        // object is then reused for Tier 2 fallback rebuilds, which
-        // just inherit the capture env (harmless if the patcher
-        // never reads the new captures).
-        let mut builder = Builder::new(
-            self.config.workspace_root.clone(),
-            self.config.crate_dir.clone(),
-            self.config.package.clone(),
-            self.config.target,
-        )
-        .with_features(vec!["whisker/hot-reload".into()]);
-
-        let tier1_init = if self.config.hot_patch_mode == HotPatchMode::Tier1Subsecond {
-            match prepare_tier1_capture(&self.config) {
-                Ok(prep) => {
-                    builder = builder.with_capture(prep.capture.clone());
-                    Some(prep)
-                }
-                Err(e) => {
-                    whisker_build::ui::warn(format!(
-                        "Tier 1 capture setup failed ({e:#}); falling back to Tier 2 cold rebuilds",
-                    ));
-                    None
-                }
+        // Install + launch the freshly-built artifact. Skipped when
+        // the build failed — the loop's first save will retry via
+        // the rebuild path. `run_build_cycle` reuses this codepath
+        // for rebuilds inside the loop (where WS is already bound).
+        if initial_build_ok {
+            if let Err(e) = installer.install_and_launch().await {
+                whisker_build::ui::error(format!("initial install failed: {e}"));
             }
-        } else {
-            None
-        };
-
-        let installer = Installer::new(
-            self.config.target,
-            self.config.android.clone(),
-            self.config.ios.clone(),
-            self.config.workspace_root.clone(),
-            self.config.package.clone(),
-            tier1_init.as_ref().map(|p| p.capture.clone()),
-            builder.features().to_vec(),
-        );
-
-        // Initial build + install + launch. Without this the dev
-        // server would just sit there until the user touched a file —
-        // unfriendly when you've started an emulator and want the app
-        // up immediately. A failure here doesn't abort: the loop
-        // still enters, so fixing the source and saving recovers.
-        whisker_build::ui::section("Initial build");
-        run_build_cycle(&builder, &installer, &self.on_event, &sender, "initial").await;
+            whisker_build::ui::info(format!(
+                "initial done · {} client(s) connected",
+                sender.client_count()
+            ));
+        }
 
         // After the fat build has happened, Patcher::initialize can
         // read the now-populated caches. Failure here is non-fatal

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -263,11 +263,20 @@ impl DevServer {
     /// `ChangeKind::RustCode` events. Patcher initialisation or
     /// `build_patch` failure falls back to Tier 2 silently.
     pub async fn run(self) -> Result<()> {
-        whisker_build::ui::section("whisker run");
-        whisker_build::ui::info(format!(
-            "{} · {:?}",
-            self.config.package, self.config.target,
-        ));
+        // In TUI mode the live region's header already shows the
+        // package + target + phase; the `──── whisker run ────` +
+        // `· podcast · Android` rows above just duplicated that
+        // information. The `mode={:?}` debug line is debug-only
+        // anyway, so it never made it to scrollback in the
+        // production curated path. Non-TUI runs (CI, `--no-tui`)
+        // still get the intro section + info line.
+        if !whisker_build::ui::is_tui() {
+            whisker_build::ui::section("whisker run");
+            whisker_build::ui::info(format!(
+                "{} · {:?}",
+                self.config.package, self.config.target,
+            ));
+        }
         whisker_build::ui::debug(format!("mode={:?}", self.config.hot_patch_mode));
 
         // Configure the initial build first. The Builder + Installer
@@ -330,7 +339,16 @@ impl DevServer {
         // and exit. The previous behaviour of "enter the loop anyway
         // and recover on next save" was misleading — users routinely
         // missed the warn line and assumed the build had succeeded.
-        whisker_build::ui::section("Initial build");
+        //
+        // The `──── Initial build ────` section header is only
+        // emitted in non-TUI mode. In TUI mode the live region's
+        // phase indicator (`building`) + spinner already make it
+        // obvious that the build started; the section divider
+        // becomes pure noise above the in-line cargo/gradle/
+        // xcodebuild step rows.
+        if !whisker_build::ui::is_tui() {
+            whisker_build::ui::section("Initial build");
+        }
         emit(&self.on_event, Event::BuildingFull);
         if let Err(e) = builder.build().await {
             let msg = format!("{e:#}");
@@ -452,7 +470,12 @@ impl DevServer {
         // the dev loop from being killed by a transient build
         // glitch.
         while let Some(change) = rx.recv().await {
-            whisker_build::ui::section("Change");
+            // `──── Change ────` only in non-TUI mode (live
+            // region's phase flip to `building` / `patching`
+            // already announces a save has been picked up).
+            if !whisker_build::ui::is_tui() {
+                whisker_build::ui::section("Change");
+            }
             whisker_build::ui::debug(format!(
                 "{:?} — {} path(s)",
                 change.kind,

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -205,6 +205,13 @@ pub enum Event {
     BuildFailed(String),
     ClientConnected,
     ClientDisconnected,
+    /// A Tier 1 hot patch build kicked off. Fires *before* the
+    /// `Patcher::build_patch` call so consumers (the cli TUI) can
+    /// flip into "patching" state while the patch is still being
+    /// compiled — without this paired event, `PatchSent` is the
+    /// only signal and arrives so close to its own completion that
+    /// any UI keying off it never shows a patch-in-flight indicator.
+    PatchBuilding,
     PatchSent,
     /// A line captured from the device-side app's stdout / stderr (via
     /// the `whisker-dev-runtime::log_capture` `dup2` hook), forwarded
@@ -493,6 +500,11 @@ impl DevServer {
                     // wire-up so the user sees a single elapsed
                     // duration for "edit → app updated".
                     let patch_step = whisker_build::ui::step("patch", "tier 1");
+                    // Tell the cli to flip into "patching" right now —
+                    // the patcher work that follows (`build_patch` +
+                    // dylib read + send) is the wall-clock-heavy bit,
+                    // and the matching `PatchSent` flips back to Idle.
+                    emit(&self.on_event, Event::PatchBuilding);
                     // Map the changed file paths to the owning crate.
                     // None = batch spans multiple crates, or a path
                     // outside every known src dir — fall back to a

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -816,7 +816,7 @@ fn original_binary_path(config: &Config) -> Result<PathBuf> {
                 .join(&so_name);
             if !candidate.is_file() {
                 anyhow::bail!(
-                    "no Android cdylib at {} — gradle's whiskerBuildDebug{abi_camel} task didn't produce its output (run `whisker run --target android` first)",
+                    "no Android cdylib at {} — gradle's whiskerBuildDebug{abi_camel} task didn't produce its output (run `whisker run android` first)",
                     candidate.display(),
                 );
             }

--- a/docs/module-author-guide.md
+++ b/docs/module-author-guide.md
@@ -338,9 +338,9 @@ fn app() -> Element {
 ```
 
 No separate `Podfile`, `Package.swift`, `build.gradle` change required
-in the consuming app. `whisker run --target ios` / `--target android`
-picks up the new dep automatically through cargo metadata + the
-host-project staging step.
+in the consuming app. `whisker run ios` / `whisker run android` picks
+up the new dep automatically through cargo metadata + the host-project
+staging step.
 
 ## Directory layout reference
 

--- a/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerBuildTask.kt
+++ b/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerBuildTask.kt
@@ -119,6 +119,21 @@ abstract class WhiskerBuildTask : DefaultTask() {
                     "--min-sdk=${minSdk.get()}",
                 ) + featureArgs,
             )
+            // Forward the dev-loop UI mode env vars to the child.
+            // `exec {}` inherits the gradle daemon's env by default,
+            // but the daemon's env is captured at fork-time and may
+            // predate the `whisker run` cli setting `WHISKER_TUI=1`
+            // (especially with `--daemon` reuse across sessions).
+            // Without these explicit forwards, `whisker-build android`
+            // calls `whisker_build::ui::step` in non-TUI mode and
+            // emits the `⏵ …` row that the whisker-cli capture
+            // thread treats as plain scrollback output, then
+            // immediately follows with the `✓ …` row from
+            // `Step::finish` — doubling the row count for every
+            // step the child runs.
+            for (name in listOf("WHISKER_TUI", "WHISKER_VERBOSE")) {
+                System.getenv(name)?.let { value -> environment(name, value) }
+            }
         }
     }
 

--- a/platforms/android/gradle-plugin/whisker-settings-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerPlugin.kt
+++ b/platforms/android/gradle-plugin/whisker-settings-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerPlugin.kt
@@ -67,7 +67,7 @@ class WhiskerPlugin : Plugin<Settings> {
                     "rs.whisker: workspace path baked into settings.gradle.kts no longer " +
                         "exists: $workspace. The project was likely moved or renamed " +
                         "after \\`whisker build\\` first generated gen/android. Re-run " +
-                        "\\`whisker build --target=android\\` from the (new) workspace root " +
+                        "\\`whisker build android\\` from the (new) workspace root " +
                         "to refresh the gen tree.",
                 )
             }


### PR DESCRIPTION
## Summary

`whisker run` の TUI を **alternate-screen full-screen から inline viewport へ**作り直しました。
codex-rs の手法 (`ratatui::Viewport::Inline` + `Terminal::insert_before`、`scrolling-regions` feature による DECSTBM 高速パス) を採用しています。

### 解決した問題

- **#187 の full-screen 版**では cargo / gradle / xcodebuild のログバーストがビルドペインで流れ去り、ターミナルの mouse-wheel scrollback も消えるので追跡不能だった
- **inline 版**ではログがターミナルの**通常の scrollback** に積まれるので、マウスホイール / トラックパッドで普通にスクロールバックできる

### アーキテクチャ

- stderr を `dup2` で pipe に向け、専用スレッドが ANSI escape を strip しつつ mpsc channel に転送
- render スレッドが各フレームで channel を drain、`Terminal::insert_before` で 1 行ずつ scrollback に push
- live region (6 行固定) は phase / current step / dev-server info / `q  quit` ヒント
- `whisker_build::ui::section` が phase 入口マーカー (`──── Initial build ────`) を担当、新 TUI は phase 出口サマリ (`✓ Initial build  6.2s`) のみ emit。二重表示しない
- `Tui::shutdown` は `terminal.show_cursor()` を呼んで ratatui の `hidden_cursor` フラグを下ろす → `Drop` impl が fd 閉鎖後に再試行して `Failed to show the cursor` を eprintln する問題を回避
- `q` / Esc / Ctrl-C による user-initiated quit は `LiveState::user_initiated_quit` を立て、TUI 終了後に `process::exit(0)` で dev-server (`rt.block_on(server.run())`) を強制終了。cli 起因の quit (build failed 等) はこの分岐を取らず通常のエラー return パスを通る

### 動作確認

`examples/podcast` で `whisker run --target host` を tmux 上で実行 → 通常の cargo Compiling ログが scrollback に流れ、bottom の live region が phase 遷移に追従、`q` で即座に終了 (exit code 0、エラー出力なし)。

捕捉した scrollback の例:
```
──── whisker run ─────────────────────────────
  · podcast · Host
  · dev-server · ws://127.0.0.1:9876 · 0 client(s)
──── Initial build ───────────────────────────
   Compiling whisker-plugin v0.1.0 ...
   ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.08s
✓ Initial build  19.1s
  · host target: install/launch is the user's job — run the binary manually
  · initial done · 1 client(s) connected
 whisker run  Host · rs.whisker.podcast · idle

 dev server  ws://127.0.0.1:9876
 clients     1 connected   ·   watching 2 path(s)

  q   quit
```

## Test plan
- [x] `cargo build -p whisker-cli`
- [x] `cargo test -p whisker-cli --lib` (86 passed)
- [x] `cargo clippy -p whisker-cli --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] tmux 上で `whisker run --target host` → scrollback OK、live region OK、`q` で exit 0
- [ ] `whisker run --target ios` を実機で試して scroll back / 終了挙動を確認
- [ ] `whisker run --target android` で gradle ログが scrollback に流れることを確認
- [ ] hot-patch (`PatchSent`) が `✓ Hot patch  Xms` として scrollback に積まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)