### PR TITLE
feat(ios): resolve Lynx xcframeworks via remote SPM

### DIFF
--- a/crates/whisker-build/src/lynx.rs
+++ b/crates/whisker-build/src/lynx.rs
@@ -387,7 +387,15 @@ pub fn link_into_workspace(workspace_root: &Path, platform: LynxPlatform) -> Res
             )?;
         }
         LynxPlatform::Ios => {
-            relink(&target.join("lynx-ios"), &cache)?;
+            // No `target/lynx-ios` symlink anymore. The four xcframeworks
+            // are resolved by SPM via remote `binaryTarget(url:checksum:)`
+            // in `platforms/ios/Package.swift`, so xcodebuild gets them
+            // from the SPM cache without needing the workspace-relative
+            // path the old `binaryTarget(path:)` form required. The
+            // `lynx-headers` symlink below is still set up because
+            // `whisker-driver-sys`'s cargo build reads PrimJS C++
+            // headers out of the tarball cache — that consumer is in
+            // line for a follow-up that frees it from PrimJS entirely.
         }
     }
     let headers = cache.join("headers");

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -5,9 +5,17 @@ import PackageDescription
 // composes:
 //
 //   Lynx*.xcframework       — Lynx engine + PrimJS, dynamic frameworks
-//                             fetched at SPM resolve time from the
-//                             monorepo-local `target/lynx-ios/` cache
-//                             (`whisker-build` ensures it exists).
+//                             resolved by SPM via remote
+//                             `binaryTarget(url:checksum:)` against
+//                             whiskerrs/lynx's GitHub Releases. SPM
+//                             caches them under the Xcode-managed
+//                             SourcePackages dir; no local `target/`
+//                             pre-population is required for the
+//                             binaries themselves. The PrimJS public
+//                             headers are still staged out of the
+//                             tarball cache for `whisker-driver-sys`'s
+//                             cargo build until that consumer is
+//                             refactored.
 //   WhiskerCBridge          — header-only systemLibrary exposing the
 //                             Whisker C ABI declarations. The actual
 //                             implementation lives in
@@ -70,23 +78,44 @@ let package = Package(
         .library(name: "PrimJS", targets: ["PrimJS"]),
     ],
     targets: [
-        // Lynx engine + dependencies, as xcframeworks built from upstream
-        // CocoaPods source via `cargo xtask ios build-lynx-frameworks`.
+        // Lynx engine + dependencies, as xcframeworks built from the
+        // whiskerrs/lynx fork and published per release alongside the
+        // legacy tarball. Each archive's SwiftPM-format checksum lives
+        // in the matching release's `swiftpm-manifest-<ver>.txt`
+        // (https://github.com/whiskerrs/lynx/releases). Bumping the
+        // pinned tag means refreshing both the URL `<ver>` segment AND
+        // the corresponding `checksum:` here — keep them in lockstep.
+        //
+        // SPM resolves these during xcodebuild's package-resolution
+        // step (before any Build Phase runs), caches the unpacked
+        // xcframeworks under the user's per-Xcode-project SourcePackages
+        // dir, and shares them across every WhiskerRuntime consumer.
+        // The previous `binaryTarget(path:)` form required the cli to
+        // pre-populate `target/lynx-ios/*.xcframework` via
+        // `ensure_lynx_ios` + `link_lynx_into_workspace(Ios)` before
+        // xcodebuild started — that prerequisite no longer applies for
+        // the binaries themselves (PrimJS *headers* are still staged
+        // by `whisker-driver-sys`'s build.rs out of `target/lynx-headers`
+        // until the matching module-side refactor lands).
         .binaryTarget(
             name: "Lynx",
-            path: "../../target/lynx-ios/Lynx.xcframework"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/Lynx-3.8.0-whisker.6.xcframework.zip",
+            checksum: "a467fceb0bd6b0318c80fcc93fe9b14e26f268dc6b2b9e06bf0365f50cb76fc5"
         ),
         .binaryTarget(
             name: "LynxBase",
-            path: "../../target/lynx-ios/LynxBase.xcframework"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/LynxBase-3.8.0-whisker.6.xcframework.zip",
+            checksum: "309dd1e544a4cd035b71e1c786532e7344653c470d7206fbb28e1493b7f8e36e"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            path: "../../target/lynx-ios/LynxServiceAPI.xcframework"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/LynxServiceAPI-3.8.0-whisker.6.xcframework.zip",
+            checksum: "59bc9fcf07704d288de63b78ec1717fa81ade0af1cacea2f3712b57a220cb92f"
         ),
         .binaryTarget(
             name: "PrimJS",
-            path: "../../target/lynx-ios/PrimJS.xcframework"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/PrimJS-3.8.0-whisker.6.xcframework.zip",
+            checksum: "a7069cd487834f96af28a335da049220b61317b0448768f040c171224f891651"
         ),
 
         // Phase J — minimal module-author surface. Carved out of the


### PR DESCRIPTION
## Summary

iOS Lynx の依存解決を **ローカルキャッシュ参照 (`binaryTarget(path:)`) から remote SPM (`binaryTarget(url:checksum:)`)** に切り替えます。これで xcodebuild の package resolution が SPM 自身に Lynx の xcframework を download させるようになり、`whisker run ios` 経由でなくても Xcode から直接ビルドできる状態の足場が整います。

### 何が変わるか

- `platforms/ios/Package.swift` の 4 つの `binaryTarget(path:)` を `binaryTarget(url:checksum:)` に変更:
  - `Lynx` / `LynxBase` / `LynxServiceAPI` / `PrimJS`
  - URL は `https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/<name>-3.8.0-whisker.6.xcframework.zip`
  - checksum は同リリースの `swiftpm-manifest-3.8.0-whisker.6.txt` から
- `whisker_build::link_into_workspace`'s iOS ブランチから `target/lynx-ios` シンボリックリンク作成を削除 (xcframework binary 自体は SPM が SourcePackages 配下にキャッシュするので不要)
- `target/lynx-headers` シンボリックリンクは **そのまま残す** — `whisker-driver-sys`'s `compile_ios_module_sources` が PrimJS C++ ヘッダーを参照するため (これは別 PR で `Whisker module を PrimJS フリーに` 対応後に削除)

### Lynx fork 側の対応について

Lynx fork (`whiskerrs/lynx`) は **既に毎リリースで個別 xcframework.zip + SwiftPM-format checksum を publish しています** (`.whisker/ios/stage-swiftpm.sh`)。本 PR は consumer 側だけの変更で、upstream の coordination は不要です。

### 検証

`examples/podcast` でクリーン状態 (`platforms/ios/.build/`, `platforms/ios/.swiftpm/`, `examples/podcast/gen/ios/`, `target/lynx-ios` シンボリックリンクをすべて削除) から `whisker run ios` を実行:

```
✓ compile      plugins (whisker-audio-plugin) 79ms
✓ xcodebuild   Podcast                  27.1s   ← 初回は SPM の 4 xcframework download 込み
✓ boot         iPhone 17 Pro            83ms
✓ install      Podcast.app              461ms
✓ launch       rs.whisker.podcast       228ms
· initial done · 0 client(s) connected
RUNNING  iOS Simulator · rs.whisker.podcast
```

SPM は xcframework を `target/.whisker/ios-derived/podcast/SourcePackages/artifacts/ios/<name>/<name>.xcframework/` に展開していることを確認 (workspace の `target/lynx-ios/` には何も作られない)。

## Test plan

- [x] `cargo build -p whisker-cli -p whisker-build`
- [x] `cargo test -p whisker-cli -p whisker-build --lib`
- [x] `cargo clippy -p whisker-cli -p whisker-build --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `target/lynx-ios` を消した状態から `whisker run ios` が完走、アプリが simulator で立ち上がる
- [ ] `whisker build ios-sim` (本番 build) も完走するか — まだ未テスト、別途要確認
- [ ] バージョン bump 時の URL + checksum 更新手順を docs/internal-notes 等に追記 (follow-up)

## Follow-ups

- Whisker module を PrimJS フリーに → `target/lynx-headers` 経由のヘッダー staging も削除可能に
- Lynx バージョン bump 用の `cargo xtask` / cli 補助コマンド (swiftpm-manifest から Package.swift を自動更新)

🤖 Generated with [Claude Code](https://claude.com/claude-code)