### PR TITLE
chore: wire release-plz for PR-based crates.io releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,93 @@
+# Release-plz — PR-based crates.io releases.
+#
+# How it works:
+#   1. Every push to `main` runs the `release-plz-pr` job. It scans
+#      git history for conventional-commit-bumping changes since the
+#      last release, decides the next version per crate (semver rules
+#      based on `feat:` / `fix:` / `!` breaking marker), updates
+#      `Cargo.toml` versions + per-crate `CHANGELOG.md`, and opens or
+#      updates a single PR titled `chore: release` on a
+#      `release-plz/main` branch. The PR is idempotent — subsequent
+#      pushes amend it rather than stacking new ones.
+#   2. Merging that release PR runs the `release-plz-release` job on
+#      the resulting tip-of-main. It picks up each crate whose version
+#      changed in the merge, runs `cargo publish` in topological order
+#      (respecting workspace dep edges), then creates per-crate git
+#      tags + GitHub releases populated from the per-crate changelog.
+#
+# Required repository secrets (set under Settings → Secrets and
+# variables → Actions):
+#   CARGO_REGISTRY_TOKEN  — a crates.io API token with publish scope
+#                           covering all whisker* crates. Mint at
+#                           https://crates.io/me with the
+#                           "publish-update" scope.
+#
+# Optional but recommended:
+#   - Replace the `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` lines
+#     with a fine-grained personal access token (PAT). The default
+#     `GITHUB_TOKEN` cannot trigger downstream workflows, so CI does
+#     NOT automatically run on the release PR that this workflow
+#     opens — a reviewer has to push a no-op commit to wake the
+#     ci.yml workflow. A PAT (named e.g. `RELEASE_PLZ_TOKEN`) avoids
+#     that footgun. The PAT needs `Contents: write` +
+#     `Pull requests: write` on this repo.
+#
+# Concurrency:
+#   The PR job is locked so two rapid `main` pushes don't race on the
+#   release branch. The release job stays parallel-friendly because
+#   it's keyed to the merge commit, not the branch.
+name: release-plz
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  release-plz-release:
+    # cargo publish + git tags + GitHub releases. No-ops when the
+    # commit that triggered this run isn't a release PR merge.
+    name: release-plz / release (publish + tag)
+    runs-on: ubuntu-latest
+    # Skip on forks — only the canonical repo can publish.
+    if: github.repository_owner == 'whiskerrs'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so release-plz can read changelogs back to
+          # the previous release tag.
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    # Opens / updates the `chore: release` PR.
+    name: release-plz / open release PR
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'whiskerrs'
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run release-plz release-pr
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,27 @@
+# release-plz workspace-wide configuration.
+#
+# Defaults handle most of what we want — this file only overrides
+# behaviour that needs to diverge for Whisker. See
+# https://release-plz.dev/docs/config for the full schema.
+
+[workspace]
+# Single source of truth for the next version: when release-plz bumps
+# `[workspace.package] version` in the root `Cargo.toml`, every crate
+# that uses `version.workspace = true` (i.e. all of `crates/*` except
+# `whisker-subsecond`, plus all of `packages/*`) follows along. The
+# fork crate `whisker-subsecond` pins its own `version = "0.7.x"` and
+# is bumped independently when commits touch `crates/whisker-subsecond/`.
+dependencies_update = true
+# Generate `CHANGELOG.md` per crate from conventional-commit history.
+# git-cliff defaults map: `feat:` → minor, `fix:`/`refactor:`/`perf:` →
+# patch, trailing `!` or `BREAKING CHANGE:` footer → major.
+changelog_update = true
+# Don't open an empty release PR when nothing has landed since the
+# last release — keeps the "PR appears when there's something to
+# release" signal honest.
+release_always = false
+# Per-crate git tag (`<crate>-v<version>`) + GitHub release populated
+# from the changelog. Useful for browsing release history per crate
+# on the GitHub UI.
+git_tag_enable = true
+git_release_enable = true


### PR DESCRIPTION
## Summary

Automates 0.1.1+ crates.io releases via [release-plz](https://release-plz.dev), in the PR-based pattern:

1. **Push to main** → `release-plz-pr` job opens / updates a single `chore: release` PR.
   - Bumps `[workspace.package] version` (every crate using `version.workspace = true` follows — 22/23 in this repo).
   - Bumps `whisker-subsecond` independently when commits touch its dir (kept on its own `0.7.x` line because it's a dioxus fork).
   - Regenerates per-crate `CHANGELOG.md` from conventional-commit history (git-cliff defaults).
   - Idempotent — subsequent pushes amend, no PR pileup.
2. **Merge the release PR** → `release-plz-release` job:
   - `cargo publish` in topological order across all 23 crates.
   - Per-crate `<crate>-v<version>` git tag + GitHub release with changelog body.

This replaces the manual 1-by-1 drip publish run we just did for 0.1.0 (which took ~2.5h purely waiting on the crates.io new-crate rate limit — that ceiling is gone now that all 23 names are claimed).

## Files

- `.github/workflows/release-plz.yml` — two jobs (`release-pr`, `release`), both gated on `github.repository_owner == 'whiskerrs'` so forks don't try to publish.
- `release-plz.toml` — workspace-wide config. Minimal overrides; defaults handle most behaviour.

## After merge — required setup

1. **Repo secret**: `CARGO_REGISTRY_TOKEN`
   - https://crates.io/me → "API Tokens" → New Token with `publish-update` scope covering `whisker*` crates
   - Settings → Secrets and variables → Actions → New repository secret

2. **Optional but recommended**: replace the default `GITHUB_TOKEN` in `release-plz.yml` with a fine-grained PAT (e.g. `RELEASE_PLZ_TOKEN`) so CI runs automatically on the release PRs this workflow opens. The default `GITHUB_TOKEN` cannot trigger downstream workflows — without a PAT, reviewers need to push a no-op commit (or use the "re-run CI" button) to make ci.yml run on the release PR.
   - PAT scopes: `Contents: write` + `Pull requests: write` on this repo.

## How releases will feel after this lands

- Land any conventional-commit work on main (`feat: …`, `fix: …`, `refactor: …`).
- release-plz-pr opens (or updates) the release PR. Review it like any other PR — CHANGELOG entries are inline.
- Merge → publish + tag + GitHub release happens automatically. ~5–10 minutes wall time.

## Test plan

- [x] `yaml.safe_load` on the workflow + `tomllib.load` on the config — both parse clean.
- [ ] CI passes on this PR (no Rust code changes, so this is just YAML/TOML lint via existing checks; no new gates added).
- [ ] After merge, the first push to main (or this very merge) should trigger the `release-plz-pr` job. Expected first behaviour: **no release PR opens** because every crate is already at 0.1.0 / 0.7.9 with no bump-worthy commits since publish. The next conventional-commit landing will trigger the first real release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)