### PR TITLE
fix: router hit-test, render! alias ergonomics, safe-area owner crash

### DIFF
--- a/crates/whisker-cli/src/new_app.rs
+++ b/crates/whisker-cli/src/new_app.rs
@@ -152,10 +152,23 @@ edition = "2021"
 crate-type = ["rlib"]
 
 [dependencies]
-whisker = "0.1"
+whisker = "{whisker_version}"
 "#,
         name = v.crate_name,
+        whisker_version = whisker_dep_version(),
     )
+}
+
+/// The `whisker` version a freshly-scaffolded app should depend on: the
+/// CLI's own `major.minor`. release-plz bumps every workspace crate in
+/// lockstep, so the CLI version always matches the published `whisker`
+/// crate — this keeps `whisker new` from pinning a stale version (e.g. a
+/// `0.1` scaffold while crates.io is already on `0.2`).
+fn whisker_dep_version() -> String {
+    let mut parts = env!("CARGO_PKG_VERSION").split('.');
+    let major = parts.next().unwrap_or("0");
+    let minor = parts.next().unwrap_or("1");
+    format!("{major}.{minor}")
 }
 
 fn lib_rs(v: &Vars) -> String {
@@ -453,7 +466,9 @@ mod tests {
         let cargo = std::fs::read_to_string(root.join("Cargo.toml")).unwrap();
         assert!(cargo.contains("name = \"demo-app\""));
         assert!(cargo.contains("[workspace]"));
-        assert!(cargo.contains("whisker = \"0.1\""));
+        // Tracks the CLI's own major.minor (release-plz bumps in lockstep),
+        // so this stays correct across version bumps.
+        assert!(cargo.contains(&format!("whisker = \"{}\"", super::whisker_dep_version())));
 
         let whisker_rs = std::fs::read_to_string(root.join("whisker.rs")).unwrap();
         // Default display name + bundle id are derived.

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -324,16 +324,29 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
     // inside fn bodies) — both because `pub use` only works at
     // module level and because components benefit from being
     // visible to their crate's `render!` callers.
+    // Alongside the callable alias (value namespace), expose the same
+    // PascalCase name as a TYPE alias to the Props struct (type
+    // namespace). The two coexist because Rust keeps separate value and
+    // type namespaces, and a single `use crate::Icon` imports the name
+    // from *both* — so `render!` can lower a call to
+    // `Icon(Icon::builder()…build())` using only the component name, and
+    // users never have to import `IconProps` separately.
     let pascal_alias = if alias_str == fn_name_str {
         quote! {
             #[doc(hidden)]
             #vis use #inner_mod::#fn_name;
+            #[doc(hidden)]
+            #[allow(non_camel_case_types, type_alias_bounds)]
+            #vis type #fn_name #impl_generics = #props_name #ty_generics;
         }
     } else {
         let alias_ident = format_ident!("{}", alias_str);
         quote! {
             #[allow(non_snake_case)]
             #vis use #inner_mod::#fn_name as #alias_ident;
+            #[doc(hidden)]
+            #[allow(type_alias_bounds)]
+            #vis type #alias_ident #impl_generics = #props_name #ty_generics;
         }
     };
 

--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -206,15 +206,26 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
     // PascalCase alias — same scheme as `#[component]`.
     let pascal_alias_ident = format_ident!("{}", to_pascal_case(&fn_name.to_string()));
     let fn_name_str = fn_name.to_string();
+    // Alongside the value-namespace `pub use` we emit a type alias of
+    // the same name pointing at the Props struct. Rust keeps value and
+    // type namespaces separate, so `XZeroProps` resolves to the fn in
+    // call position and to `XZeroPropsProps` in type position — letting
+    // `render!` write `Alias::builder()` with only the alias imported,
+    // no separate `…Props` import. See `#[component]` for the twin.
     let alias_emission = if pascal_alias_ident == fn_name_str.as_str() {
         quote! {
             #[doc(hidden)]
             #vis use #inner_mod::#fn_name;
+            #[doc(hidden)]
+            #[allow(non_camel_case_types)]
+            #vis type #fn_name = #props_name;
         }
     } else {
         quote! {
             #[allow(non_snake_case)]
             #vis use #inner_mod::#fn_name as #pascal_alias_ident;
+            #[doc(hidden)]
+            #vis type #pascal_alias_ident = #props_name;
         }
     };
 

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -133,9 +133,6 @@ struct UserComponentNode {
     /// inside the inner module and isn't reachable from outer
     /// scope, so the emission MUST go through this alias.
     alias_ident: Ident,
-    /// PascalCase Props struct ident (`<name>Props`). Same span
-    /// as the render! token so RA's go-to-definition lands here.
-    props_ident: Ident,
     kwargs: Vec<Kwarg>,
     children: Vec<Node>,
 }
@@ -297,18 +294,14 @@ impl Parse for Node {
             // inner module and we never reference it directly
             // from the lowering.
             let span = tag.span();
-            let (alias_str, props_str) = if is_pascal_case(&name) {
-                (name.clone(), format!("{name}Props"))
+            let alias_str = if is_pascal_case(&name) {
+                name.clone()
             } else {
-                let pascal = snake_to_pascal(&name);
-                let props = format!("{pascal}Props");
-                (pascal, props)
+                snake_to_pascal(&name)
             };
             let alias_ident = Ident::new(&alias_str, span);
-            let props_ident = Ident::new(&props_str, span);
             Ok(Node::UserComponent(UserComponentNode {
                 alias_ident,
-                props_ident,
                 kwargs,
                 children,
             }))
@@ -713,7 +706,6 @@ fn is_known_event_method(name: &str) -> bool {
 impl UserComponentNode {
     fn to_tokens(&self) -> TokenStream2 {
         let fn_ident = &self.alias_ident;
-        let props_ident = &self.props_ident;
 
         let setter_calls: Vec<TokenStream2> = self
             .kwargs
@@ -768,9 +760,15 @@ impl UserComponentNode {
             }
         };
 
+        // `#fn_ident::builder()` (not `#props_ident::builder()`): the
+        // component name doubles as a TYPE alias to its Props struct (see
+        // `#[component]`), so a single `use crate::Icon` is enough — no
+        // separate `IconProps` import. The outer `#fn_ident(…)` resolves
+        // to the callable (value namespace), the inner `#fn_ident::` to
+        // the Props type (type namespace).
         quote! {
             #fn_ident(
-                #props_ident::builder()
+                #fn_ident::builder()
                     #(#setter_calls)*
                     #children_call
                     .build()
@@ -978,12 +976,16 @@ mod tests {
              output was: {output}"
         );
         // Emission goes through the PascalCase alias the `#[component]`
-        // macro emits — that's how we keep snake_case `my_card` hidden
-        // in the inner module from user-call-site completion.
+        // macro emits — both the value-namespace fn AND the
+        // type-namespace `type MyCard = MyCardProps` alias share that
+        // name, so `MyCard::builder()` resolves without a separate
+        // `MyCardProps` import (issue #1). The `…Props` name must NOT
+        // appear in the emission.
         assert!(
-            output.contains("MyCard") && output.contains("MyCardProps"),
-            "user component must lower to `MyCard(MyCardProps::builder()…)` \
-             — the PascalCase alias is the public call surface; \
+            output.contains("MyCard (MyCard :: builder ()") && !output.contains("MyCardProps"),
+            "user component must lower to `MyCard(MyCard::builder()…)` \
+             — the PascalCase alias is the public call surface and the \
+             `…Props` name should not leak into the call site; \
              output was: {output}",
         );
     }
@@ -996,7 +998,7 @@ mod tests {
         let input: TokenStream2 = quote::quote! { my_card(title: "x") };
         let output = super::expand_test(input).to_string();
         assert!(
-            output.contains("MyCard") && output.contains("MyCardProps"),
+            output.contains("MyCard (MyCard :: builder ()") && !output.contains("MyCardProps"),
             "snake_case input should lower to the PascalCase alias call site; \
              output was: {output}",
         );
@@ -1115,9 +1117,9 @@ mod tests {
         };
         let output = super::expand_test(input).to_string();
         assert!(
-            output.contains("ChildrenProps"),
+            output.contains("Children (Children :: builder ()"),
             "children(arg: x) should route through the user-component \
-             path → ChildrenProps::builder(); output was: {output}"
+             path → Children::builder(); output was: {output}"
         );
         assert!(
             !output.contains("mount_children"),

--- a/crates/whisker-runtime/src/reactive/owner.rs
+++ b/crates/whisker-runtime/src/reactive/owner.rs
@@ -59,6 +59,31 @@ impl Owner {
         })
     }
 
+    /// Create a parentless **root** owner, ignoring whatever owner is
+    /// currently on the stack.
+    ///
+    /// Unlike [`Owner::new(None)`](Owner::new) — which adopts the
+    /// current top-of-stack owner as parent — this always produces a
+    /// detached root. Use it for **process-global singletons** whose
+    /// lifetime must not be tied to the (possibly short-lived) owner
+    /// that happens to be active when the singleton is first touched.
+    ///
+    /// The canonical case is a module that lazily mints an
+    /// arena-backed handle on first access (e.g.
+    /// `whisker-safe-area`): if that first access lands inside a
+    /// per-route / per-component owner, minting under `new(None)` would
+    /// free the handle when that scope disposes, and a later read would
+    /// hit a disposed node. Minting under a `detached_root()` (then
+    /// never disposing it) keeps the handle alive for the whole
+    /// process — the intended semantics for a singleton.
+    ///
+    /// The returned owner is never auto-disposed; the caller is
+    /// expected to leak it (i.e. drop the handle without calling
+    /// [`dispose`](Owner::dispose)) for genuine process-lifetime data.
+    pub fn detached_root() -> Owner {
+        with_runtime(|rt| rt.owners.insert(Scope::new(None)))
+    }
+
     /// Push `self` as the current scope, run `f`, pop back.
     /// Reactive primitives (`signal()`, `effect()`, `computed()`,
     /// view elements created via `render!`) allocated inside `f`

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -1383,6 +1383,54 @@ fn arc_signal_inside_oncelock_outlives_caller_owner() {
     assert_eq!(*observed.borrow(), Some(99));
 }
 
+#[test]
+#[should_panic(expected = "signal disposed")]
+fn reading_arc_backed_arena_signal_after_owner_dispose_panics() {
+    // The mechanism behind the StackLayout crash: `safe_area_insets()`
+    // mints a fresh arena ReadSignal in *whatever owner is current*
+    // (`.into()`), backed by a process-global arc. If that owner is a
+    // per-route owner that later disposes, the arena node is freed —
+    // but a captured `insets` handle still points at the freed NodeId.
+    // Reading it (e.g. a surviving computed/effect, or a late native
+    // event re-run) hits `fetch_value`'s `expect("…disposed…")` and,
+    // across the FFI tick boundary, aborts as `panic_cannot_unwind`.
+    fresh();
+    let global_arc = ArcRwSignal::new(0_i32);
+    let route_owner = Owner::new(None);
+    let insets: ReadSignal<i32> = route_owner.with(|| global_arc.read_only().into());
+    route_owner.dispose();
+    // The global arc still lives (process-global), but the arena
+    // handle minted under the route owner is gone.
+    let _ = insets.get();
+}
+
+#[test]
+fn arc_backed_arena_signal_under_detached_root_survives_sibling_dispose() {
+    // The fix: mint the shared arena handle under `Owner::detached_root`
+    // (a never-disposed root, ignoring the current owner stack). It
+    // then outlives any per-route / per-component owner that comes and
+    // goes — `safe_area_insets()` relies on exactly this.
+    fresh();
+    let global_arc = ArcRwSignal::new(1_i32);
+
+    // Mint under a detached root *while a per-route owner is current*,
+    // proving detached_root does NOT adopt it as parent.
+    let route_owner = Owner::new(None);
+    let insets: ReadSignal<i32> = route_owner.with(|| {
+        let root = Owner::detached_root();
+        root.with(|| global_arc.read_only().into())
+    });
+
+    // Disposing the per-route owner must not free the detached-root
+    // handle.
+    route_owner.dispose();
+    assert_eq!(insets.get(), 1, "handle survives sibling owner disposal");
+
+    // And it still tracks updates from the global arc.
+    global_arc.set(42);
+    assert_eq!(insets.get(), 42);
+}
+
 // ----- Owner pause / resume -------------------------------------------------
 
 #[test]

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -114,7 +114,7 @@ fn captures() -> Vec<String> {
     PROP_CAPTURES.with(|c| c.borrow().clone())
 }
 
-fn push_capture(s: impl Into<String>) {
+pub(crate) fn push_capture(s: impl Into<String>) {
     PROP_CAPTURES.with(|c| c.borrow_mut().push(s.into()));
 }
 
@@ -500,4 +500,37 @@ fn view_module_exposes_children_alias() {
     fn _accepts(_: whisker::Children) {}
     let c: whisker::Children = ::std::rc::Rc::new(|| View::Empty);
     _accepts(c);
+}
+
+// A component defined in its own module exporting ONLY its
+// PascalCase alias (its `…Props` struct stays unimported). The
+// `#[component]` macro emits a same-named type alias in the type
+// namespace alongside the value-namespace fn, so `render!` can
+// lower `Card(...)` to `Card::builder()` without a separate
+// `CardProps` import. This is the ergonomics fix for issue #1.
+mod alias_only {
+    use whisker::prelude::*;
+    use whisker::runtime::view::Element;
+
+    use crate::push_capture;
+
+    #[component]
+    pub fn card(title: String) -> Element {
+        push_capture(format!("card:title={title}"));
+        render! { view() }
+    }
+}
+
+#[test]
+fn component_usable_in_render_with_only_pascal_alias_imported() {
+    // Import the component by its PascalCase name only — crucially
+    // NOT `alias_only::CardProps`. If the macro failed to emit the
+    // type-namespace alias, `Card::builder()` inside `render!` would
+    // not resolve and this file would not compile.
+    use alias_only::Card;
+
+    with_test_env(|_log| {
+        let _h = render! { Card(title: "boxed") };
+        assert_eq!(captures(), vec!["card:title=boxed"]);
+    });
 }

--- a/examples/podcast/crates/podcast-feature-browse/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-browse/src/lib.rs
@@ -43,10 +43,7 @@ use podcast_data::fetch_browse_screen;
 use podcast_domain::{ChartSection, Podcast, SectionLayout};
 use podcast_routing::Navigator;
 use podcast_theme as theme;
-use podcast_ui_kit::{
-    FeaturedCard, FeaturedCardProps, HorizontalRow, HorizontalRowProps, RankedCard,
-    RankedCardProps, SectionHeader, SectionHeaderProps, TopNav, TopNavProps,
-};
+use podcast_ui_kit::{FeaturedCard, HorizontalRow, RankedCard, SectionHeader, TopNav};
 use whisker::css::{AlignItems, Display, FlexDirection, JustifyContent, PositionKind};
 use whisker::prelude::*;
 use whisker::runtime::tasks::run_blocking;

--- a/examples/podcast/crates/podcast-feature-detail/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-detail/src/lib.rs
@@ -58,8 +58,8 @@ use whisker::runtime::tasks::run_blocking;
 use whisker::runtime::view::Element;
 use whisker::ArcRwSignal;
 use whisker_audio::Player;
-use whisker_icons::{lucide, Icon, IconProps};
-use whisker_image::{Image, ImageMode, ImageProps};
+use whisker_icons::{lucide, Icon};
+use whisker_image::{Image, ImageMode};
 use whisker_safe_area::safe_area_insets;
 
 /// `Rc<RefCell<HashMap<u64, Podcast>>>` — same alias the top-level

--- a/examples/podcast/crates/podcast-ui-kit/src/featured_card.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/featured_card.rs
@@ -11,7 +11,7 @@ use podcast_theme as theme;
 use whisker::css::{Display, FlexDirection, FontWeight, TextOverflow, ToCss};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_image::{Image, ImageMode, ImageProps};
+use whisker_image::{Image, ImageMode};
 
 #[component]
 pub fn featured_card(podcast: Podcast) -> Element {

--- a/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
@@ -34,8 +34,8 @@ use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker::ArcRwSignal;
 use whisker_audio::Player;
-use whisker_icons::{lucide, Icon, IconProps};
-use whisker_image::{Image, ImageMode, ImageProps};
+use whisker_icons::{lucide, Icon};
+use whisker_image::{Image, ImageMode};
 
 /// Mirror of the shell-side alias. Same TypeId across crates
 /// because the resolver matches on `Rc`/`ArcRwSignal` instantiation,

--- a/examples/podcast/crates/podcast-ui-kit/src/ranked_card.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/ranked_card.rs
@@ -10,7 +10,7 @@ use podcast_theme as theme;
 use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, TextOverflow, ToCss};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_image::{Image, ImageMode, ImageProps};
+use whisker_image::{Image, ImageMode};
 
 #[component]
 pub fn ranked_card(podcast: Podcast, rank: u32) -> Element {

--- a/examples/podcast/crates/podcast-ui-kit/src/section_header.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/section_header.rs
@@ -10,7 +10,7 @@ use podcast_theme as theme;
 use whisker::css::{Display, FlexDirection, FontWeight};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_icons::{lucide, Icon, IconProps};
+use whisker_icons::{lucide, Icon};
 
 #[component]
 pub fn section_header(title: String, #[prop(default = false)] show_chevron: bool) -> Element {

--- a/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
@@ -9,7 +9,7 @@ use podcast_theme as theme;
 use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, JustifyContent, ToCss};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_icons::{lucide, Icon, IconProps};
+use whisker_icons::{lucide, Icon};
 use whisker_safe_area::safe_area_insets;
 
 /// Title shown centred in the bar. Action label shown trailing.

--- a/examples/podcast/src/lib.rs
+++ b/examples/podcast/src/lib.rs
@@ -38,10 +38,10 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use podcast_domain::{NowPlaying, Podcast};
-use podcast_feature_browse::{BrowseScreen, BrowseScreenProps};
-use podcast_feature_detail::{DetailScreen, DetailScreenProps};
+use podcast_feature_browse::BrowseScreen;
+use podcast_feature_detail::DetailScreen;
 use podcast_routing::{AppRoute, Navigator};
-use podcast_ui_kit::{MiniPlayer, MiniPlayerProps};
+use podcast_ui_kit::MiniPlayer;
 use whisker::css::{Display, FlexDirection, PositionKind};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
@@ -49,8 +49,7 @@ use whisker::ArcRwSignal;
 use whisker_audio::Player;
 use whisker_router::stack::{route_stack, RouteStack};
 use whisker_router::{
-    AndroidPredictiveBack, AndroidPredictiveBackProps, IosSwipeBack, IosSwipeBackProps,
-    RouteProvider, RouteProviderProps, RouteRenderFn, StackLayout, StackLayoutProps,
+    AndroidPredictiveBack, IosSwipeBack, RouteProvider, RouteRenderFn, StackLayout,
 };
 
 /// Process-wide table mapping a podcast `id` to its full [`Podcast`]

--- a/packages/whisker-icons/example/src/lib.rs
+++ b/packages/whisker-icons/example/src/lib.rs
@@ -23,7 +23,7 @@ mod icons;
 use whisker::css::{FontWeight, TextAlign, ToCss};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_icons::{Icon, IconProps};
+use whisker_icons::Icon;
 use whisker_safe_area::safe_area_insets;
 
 #[whisker::main]

--- a/packages/whisker-icons/src/lib.rs
+++ b/packages/whisker-icons/src/lib.rs
@@ -51,7 +51,7 @@
 
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_svg::{Svg, SvgProps};
+use whisker_svg::Svg;
 
 /// One Lucide-style icon at a square `size × size` box.
 ///

--- a/packages/whisker-router/example/src/lib.rs
+++ b/packages/whisker-router/example/src/lib.rs
@@ -75,14 +75,13 @@
 //! safe-area + computed pattern that triggers the bug; reducing
 //! that body to plain text makes both modes work.
 
-use router_example_feature_detail::{DetailScreen, DetailScreenProps};
-use router_example_feature_home::{HomeScreen, HomeScreenProps};
+use router_example_feature_detail::DetailScreen;
+use router_example_feature_home::HomeScreen;
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_router::{
-    route, route_stack, AndroidPredictiveBack, AndroidPredictiveBackProps, IosSwipeBack,
-    IosSwipeBackProps, RouteProvider, RouteProviderProps, RouteRenderFn, StackLayout,
-    StackLayoutProps,
+    route, route_stack, AndroidPredictiveBack, IosSwipeBack, RouteProvider, RouteRenderFn,
+    StackLayout,
 };
 
 /// Flip to `false` to mount `HomeScreen` directly under `page`

--- a/packages/whisker-router/example/src/lib.rs
+++ b/packages/whisker-router/example/src/lib.rs
@@ -36,28 +36,36 @@
 //! log) — we narrowed the trigger by bisection rather than by
 //! reading the panic text.
 //!
-//! ## Likely cause (hypothesis to verify)
+//! ## Root cause (confirmed June 2026) + fix
 //!
-//! `safe_area_insets()` allocates a process-global signal lazily on
-//! first call (`OnceLock::get_or_init`). When that first call lands
-//! inside `StackLayout`'s `Owner::new(None).with(|| …)`
-//! body, the signal becomes owned by the per-route owner. The
-//! Android side of the module fires `OnStartObserving` synchronously
-//! and `sendEvent("insetsChanged", …)` lands during the same tick
-//! — the resulting `WriteSignal::set` interacts badly with the
-//! still-mounting `computed` whose `f()` is about to register a
-//! subscription on the same signal under a different owner.
+//! Not the `computed` timing — the **handle ownership**.
+//! `safe_area_insets()` used to convert its process-global
+//! `ArcReadSignal` into an arena `ReadSignal` (`.into()`) **on every
+//! call**, minting a fresh arena entry in *whichever owner was current
+//! at call time*. Under `StackLayout` that owner is the per-route /
+//! per-component scope. When a later read of that handle outlives the
+//! scope — a surviving `computed`/effect, or a native `insetsChanged`
+//! event after the scope disposed — `ReadSignal`'s `fetch_value` hits
+//! `expect("signal disposed …")`, and the panic aborts as
+//! `panic_cannot_unwind` at the `tick_callback` FFI boundary. The
+//! `computed(insets.get())` row in the table is just the smallest body
+//! that retains a handle long enough to be read after disposal; plain
+//! `safe_area_insets()` with no read never trips it. The direct mount
+//! never disposes its owner, so it never trips it either.
 //!
-//! Two reasonable fixes to try (work for both):
+//! The mechanism is pinned by two whisker-runtime unit tests:
+//! `reading_arc_backed_arena_signal_after_owner_dispose_panics`
+//! (reproduces the abort) and
+//! `arc_backed_arena_signal_under_detached_root_survives_sibling_dispose`
+//! (proves the fix).
 //!
-//! 1. Allocate the safe-area signal at app startup (in the engine's
-//!    bootstrap before the first `tick_callback`), so the signal's
-//!    owner is the root and the per-route owner never gets a fresh
-//!    allocation tied to a soon-to-be-disposed scope.
-//! 2. Have `computed(...)` defer its first `f()` call to the
-//!    scheduler's next batch instead of running it inline at
-//!    construction time, so the initial read happens under
-//!    consistent owner / tracker state.
+//! **Fix (shipped).** `safe_area_insets()` now mints its arena handle
+//! **once**, under a never-disposed [`whisker::Owner::detached_root`],
+//! and caches it — every call returns the same `Copy` handle, pinned
+//! to a process-lifetime root instead of a transient scope. See
+//! `packages/whisker-safe-area/src/lib.rs`. This repro is kept as a
+//! living regression: with the fix, `MOUNT_VIA_STACK_LAYOUT = true`
+//! renders without aborting.
 //!
 //! ## Switching the repro
 //!

--- a/packages/whisker-router/src/gestures/ios_swipe_back.rs
+++ b/packages/whisker-router/src/gestures/ios_swipe_back.rs
@@ -279,7 +279,11 @@ fn apply_pose(
     progress: f32,
 ) {
     clear_natural_animations(element);
-    let mut style = slot_css().to_css_string();
+    // Incoming == the screen being revealed (the new top once the
+    // swipe commits) → `relative` so its children stay hit-testable;
+    // the outgoing screen sliding out stays `absolute`. Matches the
+    // top/non-top split in `StackLayout`'s `slot_css`.
+    let mut style = slot_css(matches!(side, Side::Incoming)).to_css_string();
     let decoration = match transition.slot_style(side, direction) {
         Style::Static(s) => s,
         Style::Dynamic(_) => String::new(),

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -372,11 +372,23 @@ fn run_navigation_effect<R: Route>(
         if let Some(inc) = incoming {
             // Incoming == the new top → `relative` so its children
             // hit-test.
-            apply_wrapper_style(inc.wrapper, transition.0.as_ref(), Side::Incoming, dir, true);
+            apply_wrapper_style(
+                inc.wrapper,
+                transition.0.as_ref(),
+                Side::Incoming,
+                dir,
+                true,
+            );
         }
         if let Some(out) = outgoing {
             // Outgoing == the old top → back to `absolute`.
-            apply_wrapper_style(out.wrapper, transition.0.as_ref(), Side::Outgoing, dir, false);
+            apply_wrapper_style(
+                out.wrapper,
+                transition.0.as_ref(),
+                Side::Outgoing,
+                dir,
+                false,
+            );
         }
 
         // Reorder for z-stacking from the transition's foreground

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -333,6 +333,9 @@ fn run_navigation_effect<R: Route>(
             transition.0.as_ref(),
             Side::Outgoing,
             Direction::Forward,
+            // Suspended-pose mount — not the interactive top. The top
+            // transition step below re-styles the new top as `is_top`.
+            false,
         );
         // DOM order matches stack order — root at index 0, top at
         // the last index — so the top entry paints on top naturally.
@@ -367,10 +370,13 @@ fn run_navigation_effect<R: Route>(
         let outgoing = old_top.and_then(|id| state.mounted.borrow().get(&id).copied());
 
         if let Some(inc) = incoming {
-            apply_wrapper_style(inc.wrapper, transition.0.as_ref(), Side::Incoming, dir);
+            // Incoming == the new top → `relative` so its children
+            // hit-test.
+            apply_wrapper_style(inc.wrapper, transition.0.as_ref(), Side::Incoming, dir, true);
         }
         if let Some(out) = outgoing {
-            apply_wrapper_style(out.wrapper, transition.0.as_ref(), Side::Outgoing, dir);
+            // Outgoing == the old top → back to `absolute`.
+            apply_wrapper_style(out.wrapper, transition.0.as_ref(), Side::Outgoing, dir, false);
         }
 
         // Reorder for z-stacking from the transition's foreground
@@ -411,6 +417,8 @@ fn run_navigation_effect<R: Route>(
                 transition.0.as_ref(),
                 Side::Incoming,
                 Direction::None,
+                // First mount / replace_all top → the interactive slot.
+                true,
             );
         }
     }
@@ -538,8 +546,9 @@ pub(crate) fn apply_wrapper_style(
     transition: &dyn crate::transitions::StackTransition,
     side: Side,
     direction: Direction,
+    is_top: bool,
 ) {
-    let base = slot_css().to_css_string();
+    let base = slot_css(is_top).to_css_string();
     match transition.slot_style(side, direction) {
         Style::Static(extra) => {
             let combined = if extra.is_empty() {
@@ -563,11 +572,26 @@ pub(crate) fn apply_wrapper_style(
     }
 }
 
-pub(crate) fn slot_css() -> Css {
+pub(crate) fn slot_css(is_top: bool) -> Css {
+    // The interactive top slot must be `relative`. Lynx's hit-testing
+    // does *not* descend into the children of a `position: absolute`
+    // element — it stops at the absolute wrapper as the event target.
+    // Whisker then replays propagation from that target, so the
+    // wrapper's `on_tap` still bubbles but the children's `on_tap`s
+    // silently never fire. Making the front (interactive) slot
+    // `relative` (in flow, filling the container) lets the hit-test
+    // descend to its children. Covered / back-stack / mid-transition
+    // slots stay `absolute` so they overlay out of flow; exactly one
+    // slot — the current top — is `relative` at any time.
+    //
     // See container_css: `overflow: visible` keeps IosSlide's
     // leading-edge shadow visible.
     Css::new()
-        .position(PositionKind::Absolute)
+        .position(if is_top {
+            PositionKind::Relative
+        } else {
+            PositionKind::Absolute
+        })
         .top(0.px())
         .left(0.px())
         .width(100.percent())

--- a/packages/whisker-safe-area/src/lib.rs
+++ b/packages/whisker-safe-area/src/lib.rs
@@ -73,7 +73,7 @@
 use std::sync::OnceLock;
 
 use whisker::module;
-use whisker::{ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, WhiskerValue};
+use whisker::{ArcRwSignal, ArcWriteSignal, Owner, ReadSignal, WhiskerValue};
 
 /// Safe-area inset amounts in **points (iOS) / dp (Android)** — the
 /// same density-independent units that the rest of Whisker's CSS
@@ -101,33 +101,34 @@ pub struct SafeAreaInsets {
 /// `SafeAreaInsets::default()` and updates as soon as the native side
 /// can push the host view's current values.
 ///
-/// The returned handle is a `Copy` [`ReadSignal`] — the conversion
-/// from the underlying [`ArcReadSignal`] happens inside this function
-/// so callers get the same ergonomics as a component-local
-/// `signal()`. The arena entry minted by the conversion lives in
-/// whichever owner is current at call time; when that owner disposes,
-/// only the entry is freed, the underlying value stays alive because
-/// the `OnceLock` keeps the Arc strong count up.
+/// The returned handle is a `Copy` [`ReadSignal`]. Crucially it is
+/// minted **once**, under a process-lifetime
+/// [`Owner::detached_root`], and cached in [`SLOT`] — every call hands
+/// back the *same* arena entry. An earlier design converted the
+/// underlying `ArcReadSignal` on every call, minting a fresh arena
+/// entry in *whichever owner was current*; when that owner was a
+/// short-lived per-route / per-component scope (e.g. under
+/// `whisker_router::StackLayout`), disposing it freed the entry, and a
+/// surviving reader (a `computed`/effect, or a late native event)
+/// would then read a disposed node and panic — aborting at the FFI
+/// tick boundary. Pinning the entry to a never-disposed root removes
+/// that footgun entirely.
 ///
 /// **Must be called from the main thread.** The underlying reactive
 /// runtime is thread-local.
 pub fn safe_area_insets() -> ReadSignal<SafeAreaInsets> {
     install();
-    SLOT.get()
-        .expect("install() ran above")
-        .read
-        .inner
-        .clone()
-        .into()
+    SLOT.get().expect("install() ran above").read.inner
 }
 
 // ---- Internals -------------------------------------------------------------
 
-// Slot contents — both halves of the global Arc signal. The read
-// half is what `safe_area_insets()` hands out; the write half stays
-// here so the native event callback can `set()` through it.
+// Slot contents. `read` is the cached `Copy` arena handle minted
+// once under a detached root owner (see `install`) — what
+// `safe_area_insets()` hands out. The write half stays here so the
+// native event callback can `set()` through it.
 struct Slot {
-    read: MainThreadOnly<ArcReadSignal<SafeAreaInsets>>,
+    read: MainThreadOnly<ReadSignal<SafeAreaInsets>>,
     // Kept reachable from the on-event closure; never read here.
     #[allow(dead_code)]
     write: MainThreadOnly<ArcWriteSignal<SafeAreaInsets>>,
@@ -140,6 +141,14 @@ struct Slot {
 /// governed by [`SLOT`]'s Arc strong count rather than the caller's
 /// owner; the owner that triggered the first call can come and go
 /// without affecting subsequent reads.
+///
+/// The `Copy` arena handle that callers receive is also minted here,
+/// **once**, under an [`Owner::detached_root`] that we deliberately
+/// leak (never dispose). Pinning it to a process-lifetime root — not
+/// the owner that happens to be current on first call — is what keeps
+/// `safe_area_insets()` from handing out a handle that a transient
+/// scope can free out from under a surviving reader. See the
+/// `safe_area_insets` doc for the failure mode this avoids.
 fn install() {
     SLOT.get_or_init(|| {
         let (read, write) = ArcRwSignal::new(SafeAreaInsets::default()).split();
@@ -151,8 +160,12 @@ fn install() {
         subscribe_to_native(MainThreadOnly {
             inner: write.clone(),
         });
+        // Mint the shared arena handle under a never-disposed root so
+        // it outlives every per-route / per-component owner.
+        let root = Owner::detached_root();
+        let read_handle: ReadSignal<SafeAreaInsets> = root.with(|| read.into());
         Slot {
-            read: MainThreadOnly { inner: read },
+            read: MainThreadOnly { inner: read_handle },
             write: MainThreadOnly { inner: write },
         }
     });

--- a/packages/whisker-svg/example/src/lib.rs
+++ b/packages/whisker-svg/example/src/lib.rs
@@ -17,7 +17,7 @@
 
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_svg::{Svg, SvgProps};
+use whisker_svg::Svg;
 
 const BG: &str = "#101012";
 const CARD_BG: &str = "#1c1c1f";


### PR DESCRIPTION
Four fixes from the recent evaluation-report pass. Each is an isolated commit.

## fix(router): top StackLayout slot stays `relative` so children hit-test
`StackLayout` mounted every route wrapper as `position: absolute`, leaving the **top** screen's children outside Lynx's hit-test pass — taps on the active route silently did nothing. `slot_css` now takes an `is_top` flag: the interactive top slot renders `relative`, non-top slots stay `absolute` for stacking. `IosSwipeBack` applies the same split to its drag poses.

## feat(macros): `XxxProps` import no longer needed in `render!` (#1)
Call sites had to import both the component **and** its generated `XxxProps` struct because `render!` lowered `Foo(..)` to `FooProps::builder()`. Exploiting Rust's separate value/type namespaces, `#[component]` and `#[whisker::module_component]` now emit a type-namespace alias `type Foo = FooProps` next to the value-namespace fn, and `render!` lowers to `Foo::builder()`. Callers need only `use module::Foo;`. Direct `FooProps::builder()` still works (the struct is still re-exported).

## fix(safe-area): pin the insets handle to a detached root owner (#6)
`safe_area_insets()` converted its process-global `ArcReadSignal` into an arena `ReadSignal` (`.into()`) on **every call**, minting a fresh node in whatever owner was current. Under `StackLayout` that's a short-lived per-route/per-component scope; once disposed, a surviving reader (a `computed`/effect, or a late `insetsChanged` event) read a freed node, hit `fetch_value`'s `expect("signal disposed")`, and aborted as `panic_cannot_unwind` at the `tick_callback` FFI boundary. This is the StackLayout crash the router example documents — `computed(insets.get())` was just the smallest body that retained the handle past disposal.

Fix: add `Owner::detached_root()` (a true parentless root that ignores the current owner stack) and mint the insets handle **once** under it, cached in the module SLOT, living for the whole process.

## fix(cli): scaffold tracks the CLI's whisker major.minor
`whisker new` hard-coded `whisker = "0.1"`, pinning a stale dep when scaffolding with a 0.2 CLI. Now derived from `CARGO_PKG_VERSION` (release-plz bumps the workspace in lockstep).

## Tests
- New integration test: component used in `render!` with **only** the PascalCase alias imported.
- Two new runtime tests: one reproduces the disposed-node abort, one proves the detached-root handle survives sibling owner disposal.
- Macro unit tests updated to the new emission; router example doc records the #6 root cause + fix.

All green: `whisker` / `whisker-macros` / `whisker-runtime` test suites, clippy clean on touched crates, workspace + router-example build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)