### PR TITLE
feat(whisker-input): native text-input component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-input"
+version = "0.2.2"
+dependencies = [
+ "serde",
+ "whisker",
+]
+
+[[package]]
+name = "whisker-input-example"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+ "whisker-input",
+]
+
+[[package]]
 name = "whisker-local-store"
 version = "0.2.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ members = [
     "packages/whisker-icons",
     "packages/whisker-icons/example",
     "packages/whisker-image",
+    "packages/whisker-input",
+    "packages/whisker-input/example",
     "packages/whisker-local-store",
     "packages/whisker-router",
     "packages/whisker-router/example",

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
@@ -184,6 +184,19 @@ void InstallEventReporterIfNeeded(WhiskerEngine* engine, LynxView* view) {
         @try {
             NSMutableDictionary* body = [event generateEventBody];
             if (body != nil) {
+                // Custom events (`LynxCustomEvent` — input / change /
+                // focus / a module's `sendEvent`, …) carry their
+                // user-supplied payload under a `params` key, whereas
+                // every other event-body in Whisker (touch `detail`
+                // below, and the Android reporter which wraps custom
+                // params under `detail`) uses `detail`. Normalize
+                // `params` → `detail` here so the Rust typed event
+                // structs read ONE consistent key on both platforms.
+                // Only mirror when `detail` is absent so we never clobber
+                // a body that already carries it.
+                if (body[@"params"] != nil && body[@"detail"] == nil) {
+                    body[@"detail"] = body[@"params"];
+                }
                 // Step-6: avoid emitting an `_OBJC_CLASS_$_LynxTouchEvent`
                 // link-time reference. The class is registered with the
                 // Obj-C runtime by Lynx.framework at dyld load time, so a

--- a/packages/whisker-input/Cargo.toml
+++ b/packages/whisker-input/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "whisker-input"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Text-input component for Whisker — a native single-line / multiline field (UITextField / UITextView on iOS, EditText on Android) with Leptos-style two-way binding, placeholder / caret / selection colors, keyboard + return-key configuration, and an imperative focus / blur / clear / value handle."
+
+# Explicit `include` list — mirrors `whisker-image`. A `cargo publish`
+# ships the Kotlin + Swift platform sources alongside `src/lib.rs`,
+# but never the local Gradle / Xcode build artifacts that would
+# accidentally bloat the published crate if a stale build dir lingers.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "src/lib.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker. The bare table identifies this cargo
+# crate as a Whisker module; `whisker-build` walks the consuming app's
+# dep tree, picks out every dep carrying it, and wires the Android
+# Gradle subproject + iOS SwiftPM package into the host build.
+[package.metadata.whisker]
+
+[dependencies]
+whisker = { workspace = true }
+serde = { workspace = true }

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -1,0 +1,56 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for the `whisker-input` module package.
+//
+// Mirrors `whisker-safe-area`'s shape (WhiskerModule + WhiskerRuntime):
+// one library target with sources under `ios/Sources/WhiskerInput`, the
+// WhiskerModuleCodegenPlugin wired so `Module`-subclass registration
+// lands in `<Target>+Generated.swift` at build time.
+//
+// `WhiskerRuntime` is pulled in (same as `whisker-safe-area`) because
+// the view fires events via `WhiskerCustomEvent`, whose definition lives
+// in `WhiskerLynxAliases.swift` inside the `WhiskerModule` product;
+// the import chain also picks up `LynxContext` / `LynxCustomEvent` from
+// the re-exported Lynx framework.
+//
+// `whisker-build` injects the absolute location of Whisker's iOS
+// runtime + macros packages via env vars, so this module resolves them
+// no matter where the crate lives — in the monorepo, in a user's
+// whisker project, or unpacked from the cargo registry. No relative
+// fallback: a Whisker module is only ever built through `whisker run`
+// / `whisker build`, never standalone `swift build`.
+
+import PackageDescription
+
+// WhiskerRuntime + the WhiskerModuleCodegenPlugin resolve from the
+// remote `whisker` SwiftPM package (the repo-root Package.swift,
+// pinned by tag). No monorepo `platforms/ios` local path is required,
+// so this module builds for an app created outside the whisker repo.
+let package = Package(
+    name: "whisker-input",
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerInput",
+            dependencies: [
+                // WhiskerModule re-exports Lynx transitively (including
+                // LynxCustomEvent + LynxEventEmitter), which is what
+                // WhiskerCustomEvent.dispatch uses.
+                .product(name: "WhiskerModule", package: "whisker"),
+                // WhiskerRuntime pulls in WhiskerView and the
+                // WhiskerDriver symbols — mirroring whisker-safe-area.
+                .product(name: "WhiskerRuntime", package: "whisker"),
+            ],
+            path: "ios/Sources/WhiskerInput",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "whisker"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt
@@ -1,0 +1,117 @@
+// `whisker-input` ModuleDefinition (Android).
+//
+// KSP scans this module's sources for any concrete `Module` subclass
+// and emits the registration block into
+// `WhiskerInputBehaviors.registerAll()`.
+//
+// The `WhiskerInputView` Lynx UI subclass this references lives in
+// `WhiskerInputView.kt`. Matching iOS files live under
+// `packages/whisker-input/ios/Sources/WhiskerInput/`.
+
+package rs.whisker.elements.input
+
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerValue
+
+class InputModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("Input")
+        View(WhiskerInputView::class.java) {
+            // ---- text-content props ----------------------------------------
+
+            Prop("value") { view: WhiskerInputView, value ->
+                view.setValue(value.asString() ?: "")
+            }
+            Prop("placeholder") { view: WhiskerInputView, value ->
+                view.setPlaceholder(value.asString() ?: "")
+            }
+            Prop("placeholder-color") { view: WhiskerInputView, value ->
+                view.setPlaceholderColor(value.asString() ?: "")
+            }
+            Prop("caret-color") { view: WhiskerInputView, value ->
+                view.applyCaretColor(value.asString() ?: "")
+            }
+            Prop("selection-color") { view: WhiskerInputView, value ->
+                view.setSelectionColor(value.asString() ?: "")
+            }
+
+            // ---- behaviour props -------------------------------------------
+
+            Prop("multiline") { view: WhiskerInputView, value ->
+                view.setMultiline(value.asString() ?: "false")
+            }
+            Prop("lines") { view: WhiskerInputView, value ->
+                view.setLines(value.asString() ?: "0")
+            }
+            Prop("secure") { view: WhiskerInputView, value ->
+                view.setSecure(value.asString() ?: "false")
+            }
+            Prop("editable") { view: WhiskerInputView, value ->
+                view.setEditable(value.asString() ?: "true")
+            }
+            Prop("auto-focus") { view: WhiskerInputView, value ->
+                view.setAutoFocus(value.asString() ?: "false")
+            }
+            Prop("max-length") { view: WhiskerInputView, value ->
+                view.setMaxLength(value.asString() ?: "0")
+            }
+            Prop("keyboard-type") { view: WhiskerInputView, value ->
+                view.setKeyboardType(value.asString() ?: "default")
+            }
+            Prop("return-key") { view: WhiskerInputView, value ->
+                view.setReturnKey(value.asString() ?: "default")
+            }
+
+            // Declaration-only metadata (parity with the iOS module);
+            // actual dispatch is the imperative WhiskerCustomEvent path
+            // inside WhiskerInputView. Documents the emittable set.
+            Events("input", "change", "focus", "blur", "submit")
+
+            // ---- callable UI methods ---------------------------------------
+
+            // `focus` — request focus + show soft keyboard.
+            Function("focus") { view: WhiskerInputView, _ ->
+                view.focusField()
+                WhiskerValue.Null
+            }
+            // `blur` — clear focus + hide keyboard.
+            Function("blur") { view: WhiskerInputView, _ ->
+                view.blurField()
+                WhiskerValue.Null
+            }
+            // `clear` — empty the text and fire `input` so the bound
+            // signal sees the change as though the user typed it.
+            Function("clear") { view: WhiskerInputView, _ ->
+                view.clearField()
+                WhiskerValue.Null
+            }
+            // `setValue` — external text replacement. The view applies
+            // the cursor-diff guard and suppresses the resulting
+            // afterTextChanged event (not user-typed).
+            Function("setValue") { view: WhiskerInputView, args ->
+                // Args arrive packed as { "args": [map] } by the Lynx
+                // bridge. The map carries { "value": "<text>" }. Access
+                // via the first arg cast to a Map.
+                val map = (args.getOrNull(0) as? WhiskerValue.Map)?.value
+                val text = map?.get("value")?.asString() ?: ""
+                view.setValueExternal(text)
+                WhiskerValue.Null
+            }
+            // `getValue` — return the field's current text.
+            //
+            // NOTE (repo memory): Android result-returning custom element
+            // methods require the `invoke_async` bridge path wired through
+            // `lynx_native_renderer.cc`, which is iOS-only-compiled in
+            // Lynx 3.8.0-whisker.1. On an unforked Android runtime the
+            // Rust side receives a DispatchFailed error. Implement
+            // correctly here so the method is available once the fork
+            // wires the result-method plumbing on Android.
+            Function("getValue") { view: WhiskerInputView, _ ->
+                WhiskerValue.Map(
+                    mapOf("value" to WhiskerValue.Str(view.currentText()))
+                )
+            }
+        }
+    }
+}

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
@@ -1,0 +1,661 @@
+// Lynx UI subclass hosting a native EditText.
+// A plain `WhiskerUI` subclass — no Whisker annotations; registration
+// is driven by `InputModule`'s `definition()` (see `InputModule.kt`).
+//
+// ## Two-way binding + cursor-jump prevention
+//
+// The Rust side round-trips every `input` event value back down as a
+// new `value` prop. To avoid the cursor jumping to the end on every
+// keystroke, `setValue` is a no-op when the incoming string already
+// matches what the EditText displays. A boolean `programmaticWrite`
+// guard suppresses `afterTextChanged` during external writes so the
+// Rust signal doesn't double-fire.
+//
+// ## CSS text-style interception
+//
+// `color`, `font-size`, `font-weight`, and `text-align` arrive through
+// Lynx's CSS cascade. Whisker-registered custom UIs don't get an
+// APT-generated prop setter for CSS properties, so we intercept them
+// in `updatePropertiesInterval` via `StylesDiffMap.mBackingMap` — the
+// same pattern used by `WhiskerImageView` for `border-radius`.
+
+package rs.whisker.elements.input
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.Typeface
+import android.os.Build
+import android.text.Editable
+import android.text.InputFilter
+import android.text.InputType
+import android.text.TextWatcher
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import com.lynx.tasm.behavior.StylesDiffMap
+import rs.whisker.runtime.WhiskerContext
+import rs.whisker.runtime.WhiskerCustomEvent
+import rs.whisker.runtime.WhiskerUI
+
+open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.EditText>(context) {
+
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    /// True while we are programmatically writing to the EditText (e.g.
+    /// from an external `value` prop update or `setValue` / `clear` call).
+    /// While this flag is set, `afterTextChanged` does NOT emit an `input`
+    /// event so the two-way round-trip doesn't double-fire.
+    private var programmaticWrite: Boolean = false
+
+    /// True once the user has actually interacted with the field (a tap
+    /// or a hardware key press). Until then we suppress `input` emission.
+    ///
+    /// Android fires a storm of `afterTextChanged('')` callbacks at mount
+    /// / IME-attach time that are NOT user edits and NOT covered by
+    /// `programmaticWrite` (they come from the system clearing/restoring
+    /// the editor as the InputConnection is established). Without this
+    /// gate, those spurious empty events flow through the two-way
+    /// writeback and clobber the bound signal to "". A genuine edit can
+    /// only happen after the user taps to focus (or presses a key), so
+    /// gating on real interaction drops the spurious mount-time events
+    /// while still emitting every real keystroke.
+    private var userInteracted: Boolean = false
+
+    /// Pending `auto-focus` request. Stored until the view attaches to a
+    /// window (EditText must be attached before requesting focus works).
+    private var pendingAutoFocus: Boolean = false
+
+    /// Last-applied CSS `background-color` (ARGB int) and corner radius
+    /// (device px). We render these ourselves via a [GradientDrawable]
+    /// rather than relying on Lynx's `BackgroundDrawable` — see
+    /// [applyBackground] for why. `null` color means "transparent".
+    private var bgColor: Int = Color.TRANSPARENT
+    private var bgRadiusPx: Float = 0f
+
+    // -------------------------------------------------------------------------
+    // View creation
+    // -------------------------------------------------------------------------
+
+    override fun createView(context: Context): android.widget.EditText {
+        val et = android.widget.EditText(context)
+        // Replace the EditText's default underline background with a
+        // GradientDrawable WE own, so the CSS `background-color` /
+        // `border-radius` from the style cascade render here. We must NOT
+        // hard-null the background: a custom Lynx Android UI does not get
+        // its CSS background auto-drawn onto the wrapped view the way iOS
+        // does — Lynx only calls `view.setBackground(...)` once, in
+        // `LynxUI.didEnsureCreateView()`, and only if its own
+        // `BackgroundDrawable` already exists at that instant; later
+        // background-color / border-radius changes mutate that drawable
+        // in place without re-attaching it. Owning the drawable ourselves
+        // (fed from `updatePropertiesInterval`, the same channel as the
+        // text color) is deterministic. Starts transparent (no CSS
+        // background → no visible surface, matching iOS).
+        et.background = android.graphics.drawable.GradientDrawable()
+        // Single-line by default; `setMultiline("true")` switches to a
+        // multiline area.
+        et.isSingleLine = true
+        et.inputType = InputType.TYPE_CLASS_TEXT
+
+        // Deferred auto-focus: `setAutoFocus` may run before the EditText
+        // is attached to a window (a focus request has no effect then).
+        // We can't override `onAttachedToWindow` on this class — it's a
+        // LynxUI wrapper (`WhiskerUI`), not the View — so listen on the
+        // EditText itself.
+        et.addOnAttachStateChangeListener(
+            object : android.view.View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: android.view.View) {
+                    if (pendingAutoFocus) {
+                        pendingAutoFocus = false
+                        focusField()
+                    }
+                }
+
+                override fun onViewDetachedFromWindow(v: android.view.View) {}
+            },
+        )
+
+        // Mark genuine user interaction so the spurious mount/IME
+        // `afterTextChanged('')` storm doesn't get emitted as `input`.
+        // A tap (to focus) or a hardware key press both count. Neither
+        // listener consumes the event (returns false) — the EditText
+        // handles it normally.
+        et.setOnTouchListener { _, ev ->
+            if (ev.action == android.view.MotionEvent.ACTION_UP) {
+                userInteracted = true
+            }
+            false
+        }
+        et.setOnKeyListener { _, _, _ ->
+            userInteracted = true
+            false
+        }
+
+        // Wire text changes back to Rust.
+        et.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                // Suppress events that originated from our own programmatic
+                // write — only user typing should emit `input`.
+                if (programmaticWrite) return
+                // Suppress the spurious mount/IME-attach empty-text storm
+                // (see `userInteracted`): only emit once the user has
+                // actually touched/typed in the field.
+                if (!userInteracted) return
+                emitInput(s?.toString() ?: "")
+            }
+        })
+
+        // Focus change → `focus` / `blur` events.
+        et.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                emitEvent("focus", "")
+            } else {
+                emitEvent("change", et.text?.toString() ?: "")
+                emitEvent("blur", "")
+            }
+        }
+
+        // Done / Go / Search / Send action → `submit` event.
+        et.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
+                EditorInfo.IME_ACTION_DONE,
+                EditorInfo.IME_ACTION_GO,
+                EditorInfo.IME_ACTION_SEARCH,
+                EditorInfo.IME_ACTION_SEND -> {
+                    emitEvent("submit", et.text?.toString() ?: "")
+                    true
+                }
+                else -> false
+            }
+        }
+
+        return et
+    }
+
+    // -------------------------------------------------------------------------
+    // Props called from InputModule
+    // -------------------------------------------------------------------------
+
+    /** External `value` prop (from Lynx attribute pipeline). */
+    fun setValue(incoming: String) {
+        applyTextIfChanged(incoming)
+    }
+
+    /** `setValue` called from the callable UI method (same guard, same effect). */
+    fun setValueExternal(incoming: String) {
+        applyTextIfChanged(incoming)
+    }
+
+    fun setPlaceholder(text: String) {
+        view?.hint = text
+    }
+
+    fun setPlaceholderColor(color: String) {
+        val et = view ?: return
+        val parsed = parseColor(color) ?: return
+        et.setHintTextColor(parsed)
+    }
+
+    // Named `applyCaretColor` (not `setCaretColor`) on purpose: the
+    // LynxUI base class already declares `setCaretColor(String?)`, and a
+    // same-JVM-signature Kotlin `setCaretColor(String)` is an accidental
+    // override. We drive the EditText's cursor tint ourselves, so use a
+    // distinct name and call it from `InputModule`'s `caret-color` Prop.
+    fun applyCaretColor(color: String) {
+        val et = view ?: return
+        val parsed = parseColor(color) ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // API 29+: tint the cursor drawable directly.
+            et.textCursorDrawable?.setColorFilter(parsed, PorterDuff.Mode.SRC_IN)
+        } else {
+            // Pre-API-29: attempt reflection to reach mCursorDrawableRes.
+            // Best-effort — silently skip on failure.
+            try {
+                val field = android.widget.TextView::class.java
+                    .getDeclaredField("mCursorDrawableRes")
+                field.isAccessible = true
+                // Not possible to tint without the typed API; skip on older
+                // Android. Cursor color is a cosmetic enhancement only.
+            } catch (_: Throwable) { }
+        }
+    }
+
+    fun setSelectionColor(color: String) {
+        val et = view ?: return
+        val parsed = parseColor(color) ?: return
+        et.highlightColor = parsed
+    }
+
+    fun setMultiline(flag: String) {
+        val et = view ?: return
+        val multi = flag == "true"
+        if (multi) {
+            // Remove single-line constraint, allow multi-line input.
+            et.isSingleLine = false
+            et.inputType = et.inputType or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            // Top-align text in the multiline area (matches iOS behaviour).
+            et.gravity = Gravity.TOP or (et.gravity and Gravity.HORIZONTAL_GRAVITY_MASK)
+        } else {
+            et.isSingleLine = true
+            et.inputType = et.inputType and InputType.TYPE_TEXT_FLAG_MULTI_LINE.inv()
+            et.gravity = Gravity.CENTER_VERTICAL or (et.gravity and Gravity.HORIZONTAL_GRAVITY_MASK)
+        }
+    }
+
+    fun setLines(countStr: String) {
+        val et = view ?: return
+        val n = countStr.toIntOrNull() ?: 0
+        if (n > 0) {
+            // Authoritative height is CSS for v1; `setLines` is best-effort.
+            et.setLines(n)
+        }
+    }
+
+    fun setSecure(flag: String) {
+        val et = view ?: return
+        if (flag == "true") {
+            // Preserve current class (text vs number), replace variation.
+            val base = et.inputType and InputType.TYPE_MASK_CLASS
+            et.inputType = base or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        } else {
+            val base = et.inputType and InputType.TYPE_MASK_CLASS
+            et.inputType = base or InputType.TYPE_TEXT_VARIATION_NORMAL
+        }
+    }
+
+    fun setEditable(flag: String) {
+        val et = view ?: return
+        val enabled = flag != "false"
+        et.isEnabled = enabled
+        et.isFocusable = enabled
+        et.isFocusableInTouchMode = enabled
+    }
+
+    fun setAutoFocus(flag: String) {
+        if (flag != "true") return
+        val et = view ?: return
+        if (et.isAttachedToWindow) {
+            focusField()
+        } else {
+            // Defer until onAttachedToWindow fires.
+            pendingAutoFocus = true
+        }
+    }
+
+    fun setMaxLength(countStr: String) {
+        val et = view ?: return
+        val n = countStr.toIntOrNull() ?: 0
+        if (n > 0) {
+            et.filters = arrayOf(InputFilter.LengthFilter(n))
+        } else {
+            // Remove any previously applied length filter.
+            et.filters = emptyArray()
+        }
+    }
+
+    fun setKeyboardType(type: String) {
+        val et = view ?: return
+        // Preserve the variation flags (password, etc.) and replace
+        // only the class bits.
+        val variation = et.inputType and InputType.TYPE_MASK_VARIATION
+        et.inputType = when (type) {
+            "number" -> InputType.TYPE_CLASS_NUMBER or variation
+            "decimal" -> InputType.TYPE_CLASS_NUMBER or
+                InputType.TYPE_NUMBER_FLAG_DECIMAL or variation
+            "email" -> InputType.TYPE_CLASS_TEXT or
+                InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+            "phone" -> InputType.TYPE_CLASS_PHONE or variation
+            "url" -> InputType.TYPE_CLASS_TEXT or
+                InputType.TYPE_TEXT_VARIATION_URI
+            else -> InputType.TYPE_CLASS_TEXT or variation
+        }
+    }
+
+    fun setReturnKey(type: String) {
+        val et = view ?: return
+        et.imeOptions = when (type) {
+            "done" -> EditorInfo.IME_ACTION_DONE
+            "go" -> EditorInfo.IME_ACTION_GO
+            "next" -> EditorInfo.IME_ACTION_NEXT
+            "search" -> EditorInfo.IME_ACTION_SEARCH
+            "send" -> EditorInfo.IME_ACTION_SEND
+            else -> EditorInfo.IME_ACTION_UNSPECIFIED
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Callable UI methods (invoked from InputModule's Function blocks)
+    // -------------------------------------------------------------------------
+
+    fun focusField() {
+        val et = view ?: return
+        et.requestFocus()
+        val imm = et.context.getSystemService(Context.INPUT_METHOD_SERVICE)
+            as? InputMethodManager ?: return
+        imm.showSoftInput(et, InputMethodManager.SHOW_IMPLICIT)
+    }
+
+    fun blurField() {
+        val et = view ?: return
+        et.clearFocus()
+        val imm = et.context.getSystemService(Context.INPUT_METHOD_SERVICE)
+            as? InputMethodManager ?: return
+        imm.hideSoftInputFromWindow(et.windowToken, 0)
+    }
+
+    /** Clear the text and emit `input` so the bound signal updates. */
+    fun clearField() {
+        val et = view ?: return
+        // Do NOT set `programmaticWrite = true` here — we WANT the
+        // `input` event to fire so the Rust signal sees the empty value.
+        // `clear()` is an explicit, app-initiated content change, so let
+        // its emit through the `userInteracted` gate (and treat the field
+        // as active from here on).
+        userInteracted = true
+        et.setText("")
+        // Move the cursor to position 0 (end of empty string).
+        et.setSelection(0)
+    }
+
+    /** Return the EditText's current text — used by `getValue`. */
+    fun currentText(): String = view?.text?.toString() ?: ""
+
+    // -------------------------------------------------------------------------
+    // CSS text-style interception
+    // -------------------------------------------------------------------------
+
+    /// Intercept the CSS text-style cascade before the base implementation
+    /// runs. Custom UIs don't receive an APT-generated prop setter for CSS
+    /// properties, but the parsed values DO land in
+    /// `StylesDiffMap.mBackingMap` keyed by the CSS property name. We pull
+    /// `color`, `font-size`, `font-weight`, and `text-align` out of the
+    /// backing map and apply them to the EditText.
+    ///
+    /// `font-size` arrives as a 4-element `[px, unit, px, unit]` quartet
+    /// (PlatformLength) matching the border-radius shape in WhiskerImageView;
+    /// index 0 is the already-density-multiplied pixel value. We pass it to
+    /// `setTextSize(COMPLEX_UNIT_PX, px)` to avoid double-scaling.
+    ///
+    /// `color` and `font-weight` arrive as scalars (int and string/int).
+    /// `text-align` arrives as a string ("left", "center", "right").
+    override fun updatePropertiesInterval(props: StylesDiffMap?) {
+        super.updatePropertiesInterval(props)
+        val map = props?.mBackingMap ?: return
+        val et = view ?: return
+
+        // color — arrives as an ARGB int from Lynx's CSS engine.
+        if (map.hasKey("color")) {
+            runCatching {
+                val color = map.getInt("color")
+                et.setTextColor(color)
+            }
+        }
+
+        // font-size — PlatformLength quartet: [px, unit, px, unit].
+        // Index 0 is the pre-multiplied pixel value.
+        if (map.hasKey("font-size")) {
+            runCatching {
+                val arr = map.getArray("font-size")
+                if (arr != null && arr.size() >= 1) {
+                    val px = arr.getDouble(0).toFloat()
+                    et.setTextSize(TypedValue.COMPLEX_UNIT_PX, px)
+                }
+            }
+        }
+
+        // font-weight — may arrive as a number (400, 700) or a string
+        // ("bold", "normal"). Map to Typeface style.
+        if (map.hasKey("font-weight")) {
+            runCatching {
+                val weight = when {
+                    map.getDynamic("font-weight")?.type ==
+                        com.lynx.react.bridge.ReadableType.Number ->
+                        map.getInt("font-weight")
+                    map.getDynamic("font-weight")?.type ==
+                        com.lynx.react.bridge.ReadableType.String ->
+                        when (map.getString("font-weight")) {
+                            "bold" -> 700
+                            "normal" -> 400
+                            else -> map.getString("font-weight")?.toIntOrNull() ?: 400
+                        }
+                    else -> 400
+                }
+                val style = if (weight >= 600) Typeface.BOLD else Typeface.NORMAL
+                et.setTypeface(et.typeface, style)
+            }
+        }
+
+        // text-align — "left" / "center" / "right".
+        if (map.hasKey("text-align")) {
+            runCatching {
+                val align = map.getString("text-align")
+                val hGrav = when (align) {
+                    "center" -> Gravity.CENTER_HORIZONTAL
+                    "right" -> Gravity.END
+                    else -> Gravity.START
+                }
+                // Preserve the vertical gravity already set (e.g. TOP for
+                // multiline, CENTER_VERTICAL for single-line).
+                val vGrav = et.gravity and Gravity.VERTICAL_GRAVITY_MASK
+                et.gravity = vGrav or hGrav
+            }
+        }
+
+        // background-color + border-radius — see [applyBackground] for the
+        // rationale (Lynx doesn't auto-draw a custom UI's CSS background
+        // onto the wrapped Android view). Read both from the same backing
+        // map and rebuild our GradientDrawable when either changes.
+        var bgChanged = false
+
+        // `background-color` arrives as an ARGB int (same encoding as
+        // `color`, matching Lynx's `setBackgroundColor(int)` setter).
+        if (map.hasKey("background-color")) {
+            runCatching {
+                val c = map.getInt("background-color")
+                if (c != bgColor) {
+                    bgColor = c
+                    bgChanged = true
+                }
+            }
+        }
+
+        // `border-*-radius` arrive as PlatformLength quartets
+        // `[px, unit, px, unit]` (index 0 = density-multiplied px), the
+        // same shape WhiskerImageView reads. Lynx splits the shorthand
+        // into four per-corner keys; GradientDrawable's `cornerRadius`
+        // takes one uniform float, so we collapse to the largest corner.
+        var maxRadius = 0f
+        var sawRadius = false
+        for (k in CORNER_KEYS) {
+            if (!map.hasKey(k)) continue
+            runCatching {
+                val arr = map.getArray(k) ?: return@runCatching
+                if (arr.size() < 1) return@runCatching
+                sawRadius = true
+                val px = arr.getDouble(0).toFloat()
+                if (px > maxRadius) maxRadius = px
+            }
+        }
+        if (sawRadius && maxRadius != bgRadiusPx) {
+            bgRadiusPx = maxRadius
+            bgChanged = true
+        }
+
+        if (bgChanged) applyBackground()
+    }
+
+    /**
+     * Rebuild and apply the EditText's background [GradientDrawable] from
+     * the current [bgColor] + [bgRadiusPx].
+     *
+     * We draw the CSS background ourselves because a custom Lynx Android
+     * UI does NOT get its CSS `background-color` / `border-radius`
+     * auto-painted onto the wrapped view (the iOS path does this via the
+     * UITextField's layer; the Android `LynxUI` only sets the view
+     * background once in `didEnsureCreateView`, and only when its own
+     * `BackgroundDrawable` already exists — later mutations don't
+     * re-attach). The GradientDrawable also replaces the EditText's
+     * default underline, which is what we wanted gone anyway.
+     */
+    private fun applyBackground() {
+        val et = view ?: return
+        val bg = android.graphics.drawable.GradientDrawable().apply {
+            setColor(bgColor)
+            cornerRadius = bgRadiusPx
+        }
+        et.background = bg
+    }
+
+    // -------------------------------------------------------------------------
+    // CSS padding
+    // -------------------------------------------------------------------------
+
+    /// Lynx resolves the element's CSS `padding` / `padding-*` (shorthand,
+    /// units, %) during the layout pass and stores the result, in device
+    /// pixels, on the `LynxBaseUI` base via `mPaddingLeft` / `mPaddingTop`
+    /// / `mPaddingRight` / `mPaddingBottom` (exposed through
+    /// `getPaddingLeft()` etc.). `onLayoutUpdated` fires after every layout
+    /// pass with those values final, so it's the right hook to mirror them
+    /// onto the EditText — reading them in `updatePropertiesInterval` could
+    /// catch a pre-layout (stale/zero) value on first render.
+    ///
+    /// NOTE the name clash: `getPaddingLeft()` here resolves to LYNX's
+    /// computed padding (`LynxBaseUI.getPaddingLeft()`, returning
+    /// `mPaddingLeft`), NOT `android.view.View.getPaddingLeft()` — `this`
+    /// is the LynxUI wrapper, not the View.
+    override fun onLayoutUpdated() {
+        super.onLayoutUpdated()
+        applyPadding()
+    }
+
+    /**
+     * Mirror the Lynx-computed CSS padding (device px) onto the EditText,
+     * making CSS the single source of truth and overriding the EditText's
+     * built-in default internal padding (~4-6dp). With no CSS padding the
+     * computed values are 0 → the field sits flush, matching iOS's 0
+     * default. The EditText default must never leak through, so we set all
+     * four sides unconditionally.
+     */
+    private fun applyPadding() {
+        val et = view ?: return
+        // `getPaddingLeft()` / … are LynxBaseUI's computed-padding
+        // accessors (device px), not the EditText's own.
+        et.setPadding(
+            getPaddingLeft(),
+            getPaddingTop(),
+            getPaddingRight(),
+            getPaddingBottom(),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Set the EditText text to [incoming] only when it differs from what
+     * is currently displayed. When a write is needed, `programmaticWrite`
+     * is set to suppress the resulting `afterTextChanged` `input` event
+     * (it's not user-typed). Cursor is moved to the end after each write.
+     */
+    private fun applyTextIfChanged(incoming: String) {
+        val et = view ?: return
+        val current = et.text?.toString() ?: ""
+        if (current == incoming) return
+        programmaticWrite = true
+        try {
+            et.setText(incoming)
+            // Move cursor to end after an external value change.
+            et.setSelection(et.text?.length ?: 0)
+        } finally {
+            programmaticWrite = false
+        }
+    }
+
+    /**
+     * Build and dispatch a `{ detail: { value: "<text>" } }` custom
+     * event matching the shape [`InputEvent`] on the Rust side
+     * deserializes. The `detail` wrapper is the Lynx custom-event
+     * convention.
+     *
+     * For `focus` and `blur` the [text] is empty and the Rust handler
+     * ignores it (the event fires no value), but we keep the same
+     * payload shape for consistency.
+     *
+     * ## Deferred dispatch (reentrancy guard)
+     *
+     * The actual `WhiskerCustomEvent.dispatch` is deferred to the next
+     * main-loop tick via `View.post { ... }`. A synchronous dispatch
+     * inside a UI callback can reenter Rust while Rust holds the
+     * renderer borrow during a hot-reload remount / teardown — e.g.
+     * Lynx `remove_child` triggers a native focus-loss callback that
+     * fires `blur` / `change` synchronously, reentering
+     * `dispatch_event` and panicking with "RefCell already borrowed"
+     * (the event is dropped). Posting breaks the synchronous reentry.
+     *
+     * The suppression decision is made BEFORE we reach here: the
+     * caller (`afterTextChanged`) reads `programmaticWrite` and the
+     * text synchronously, so deferring only the dispatch doesn't
+     * weaken the `input`-echo guard. The two-way `input` round-trip
+     * arriving one tick late is absorbed by the cursor-diff guard in
+     * [applyTextIfChanged]. The `name` + `text` (hence `params`) are
+     * captured synchronously into the posted lambda.
+     */
+    private fun emitEvent(name: String, text: String) {
+        // Pass the payload directly as the params — do NOT wrap it in a
+        // `detail` key. The Android event reporter (WhiskerView's
+        // LynxEventReporter) already places the dispatched params UNDER a
+        // `detail` key in the event body (matching iOS's
+        // `generateEventBody`: `{ type, target, currentTarget, detail }`).
+        // The Rust `InputEvent { detail: { value } }` reads `body.detail`.
+        // Wrapping here too would double-nest and the value would never
+        // reach `on_input` (it would always deliver an empty string).
+        val params = mapOf("value" to text)
+        // `post` runs on the next UI-loop iteration on the main thread.
+        // No-op if the view is detached (post returns false; there's
+        // nothing to dispatch into anyway).
+        view?.post {
+            WhiskerCustomEvent.dispatch(
+                ui = this,
+                name = name,
+                params = params,
+            )
+        }
+    }
+
+    /** Convenience for the TextWatcher `afterTextChanged` path. */
+    private fun emitInput(text: String) = emitEvent("input", text)
+
+    /**
+     * Parse a CSS color string. Handles `#RGB`, `#RRGGBB`, and
+     * `#AARRGGBB`. Falls back to `null` for unrecognised strings so
+     * the caller can skip the assignment rather than throwing.
+     */
+    private fun parseColor(color: String): Int? {
+        if (color.isBlank()) return null
+        return try {
+            Color.parseColor(color)
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private companion object {
+        /// Lynx splits the CSS `border-radius` shorthand into these four
+        /// per-corner keys in `mBackingMap`. Same list WhiskerImageView
+        /// reads; each value is a `[px, unit, px, unit]` PlatformLength
+        /// quartet with the density-multiplied px at index 0.
+        val CORNER_KEYS = listOf(
+            "border-top-left-radius",
+            "border-top-right-radius",
+            "border-bottom-right-radius",
+            "border-bottom-left-radius",
+        )
+    }
+}

--- a/packages/whisker-input/build.gradle.kts
+++ b/packages/whisker-input/build.gradle.kts
@@ -1,0 +1,51 @@
+// Gradle build for `whisker-input`'s Android half.
+//
+// Mirrors `whisker-image`'s shape: one KSP-processed module subproject
+// with sources under `android/src/main/kotlin`, depending on Whisker's
+// runtime. No extra UI-library dependencies — the EditText we wrap is
+// part of the Android framework.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.input"
+    compileSdk = 34
+
+    defaultConfig {
+        // `textCursorDrawable` tint (API 29) is used best-effort for
+        // caret-color; the fallback path works on API 21+, which aligns
+        // with Whisker's baseline.
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    // Source set redirection so AGP only scans the `android/` subtree;
+    // Rust's `src/` next to this file stays out of the Kotlin
+    // compiler's view.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerInput")
+    arg("whisker.crateName", "whisker-input")
+}
+
+dependencies {
+    implementation("rs.whisker:whisker-module-android:0.1.0")
+    ksp("rs.whisker:ksp:0.1.0")
+}

--- a/packages/whisker-input/example/Cargo.toml
+++ b/packages/whisker-input/example/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "whisker-input-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Example app for `whisker-input`. Exercises a two-way bound field with a live preview, a controlled (upper-casing) field, a multiline notes field, and a secure password field so on-device verification of the UITextField / UITextView / EditText module wiring happens in one place."
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+whisker = { workspace = true }
+whisker-input = { path = ".." }

--- a/packages/whisker-input/example/src/lib.rs
+++ b/packages/whisker-input/example/src/lib.rs
@@ -1,0 +1,152 @@
+//! `whisker-input` example app.
+//!
+//! Exercises the four headline usage modes end-to-end on a real
+//! device so a `whisker run` round-trip verifies the native module
+//! wiring:
+//!
+//! * **Two-way** — an [`Input`] bound to an `RwSignal<String>`, with a
+//!   live `<text>` preview that updates on every keystroke.
+//! * **Controlled** — an [`Input`] driven by a `value:` signal whose
+//!   writeback upper-cases each keystroke (escape-hatch shape).
+//! * **Multiline** — a `lines: 4` notes area.
+//! * **Secure** — a masked password field.
+
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+use whisker_input::{Input, KeyboardType};
+
+const BG: &str = "#101012";
+const CARD_BG: &str = "#1c1c1f";
+const FG: &str = "#f0f0f3";
+const MUTED: &str = "#9a9aa2";
+const ACCENT: &str = "#ff5577";
+
+#[whisker::main]
+pub fn app() -> Element {
+    let page_style = format!(
+        "background-color: {BG}; flex-grow: 1; flex-shrink: 1; \
+         display: flex; flex-direction: column; \
+         padding-top: 56px; padding-left: 20px; padding-right: 20px;",
+    );
+    let header_style =
+        format!("color: {FG}; font-size: 22px; font-weight: 700; margin-bottom: 20px;",);
+
+    render! {
+        page(style: page_style) {
+            text(style: header_style, value: "whisker-input demo")
+
+            two_way_demo()
+            controlled_demo()
+            multiline_demo()
+            secure_demo()
+        }
+    }
+}
+
+/// Two-way bound field + a live preview of the bound signal.
+#[component]
+fn two_way_demo() -> Element {
+    let text = RwSignal::new(String::new());
+    let preview = format!("color: {MUTED}; font-size: 14px; margin-top: 6px;");
+
+    render! {
+        view(style: section_style()) {
+            text(style: label_style(), value: "Two-way binding")
+            Input(
+                text: text,
+                placeholder: "Type something…",
+                placeholder_color: MUTED,
+                caret_color: ACCENT,
+                style: field_style(),
+            )
+            text(
+                style: preview,
+                value: computed(move || format!("Bound value: {}", text.get())),
+            )
+        }
+    }
+}
+
+/// Controlled field — `value:` is the source of truth and the
+/// writeback upper-cases each keystroke.
+#[component]
+fn controlled_demo() -> Element {
+    let (value, set_value) = signal(String::new());
+
+    render! {
+        view(style: section_style()) {
+            text(style: label_style(), value: "Controlled (UPPER-CASE)")
+            Input(
+                value: value,
+                on_input: move |s: String| set_value.set(s.to_uppercase()),
+                placeholder: "lowercase becomes UPPER",
+                placeholder_color: MUTED,
+                keyboard_type: KeyboardType::Email,
+                style: field_style(),
+            )
+        }
+    }
+}
+
+/// Multiline notes area, fixed at 4 visible lines.
+#[component]
+fn multiline_demo() -> Element {
+    let notes = RwSignal::new(String::new());
+    let area_style = format!(
+        "background-color: {CARD_BG}; color: {FG}; \
+         font-size: 16px; border-radius: 10px; \
+         padding: 12px; min-height: 96px;",
+    );
+
+    render! {
+        view(style: section_style()) {
+            text(style: label_style(), value: "Multiline (4 lines)")
+            Input(
+                text: notes,
+                multiline: true,
+                lines: 4u32,
+                placeholder: "Notes…",
+                placeholder_color: MUTED,
+                style: area_style,
+            )
+        }
+    }
+}
+
+/// Secure (masked) password field.
+#[component]
+fn secure_demo() -> Element {
+    let password = RwSignal::new(String::new());
+
+    render! {
+        view(style: section_style()) {
+            text(style: label_style(), value: "Secure (password)")
+            Input(
+                text: password,
+                secure: true,
+                placeholder: "Password",
+                placeholder_color: MUTED,
+                return_key: whisker_input::ReturnKey::Done,
+                style: field_style(),
+            )
+        }
+    }
+}
+
+// ---- Shared styling --------------------------------------------------------
+
+fn section_style() -> String {
+    "display: flex; flex-direction: column; margin-bottom: 24px;".to_string()
+}
+
+fn label_style() -> String {
+    format!("color: {FG}; font-size: 13px; font-weight: 600; margin-bottom: 8px;")
+}
+
+fn field_style() -> String {
+    format!(
+        "background-color: {CARD_BG}; color: {FG}; \
+         font-size: 16px; height: 48px; border-radius: 10px; \
+         padding-left: 12px; padding-right: 12px;",
+    )
+}

--- a/packages/whisker-input/example/whisker.rs
+++ b/packages/whisker-input/example/whisker.rs
@@ -1,0 +1,24 @@
+// `whisker.rs` for the `whisker-input` example.
+//
+// Tells `whisker run` how to install / launch / hot-patch this app.
+
+pub fn configure(app: &mut whisker_config::Config) {
+    app.name("WhiskerInputExample")
+        .bundle_id("rs.whisker.inputexample")
+        .version("0.1.0")
+        .build_number(1);
+
+    app.android(|a| {
+        a.package("rs.whisker.inputexample")
+            .application_id("rs.whisker.inputexample")
+            .launcher_activity(".MainActivity")
+            .min_sdk(24)
+            .target_sdk(34);
+    });
+
+    app.ios(|i| {
+        i.bundle_id("rs.whisker.inputexample")
+            .scheme("WhiskerInputExample")
+            .deployment_target("13.0");
+    });
+}

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputModule.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputModule.swift
@@ -1,0 +1,177 @@
+// `whisker-input` ModuleDefinition (iOS).
+//
+// Mirrors `whisker-video`'s `VideoModule` shape for the `View(...)` +
+// `Prop(...)` + `Function(...)` + `Events(...)` DSL surface. The
+// codegen plugin discovers this `Module` subclass and emits a
+// registration block in `WhiskerInput+Generated.swift` that:
+//
+//   - Reads `definitionLazy.view!.viewClass` (== `WhiskerInputView`).
+//   - Calls `LynxComponentRegistry.registerUI(viewClass, withName:
+//     "whisker-input:Input")`.
+//   - Calls `module.registerWithLynx()` so all `Prop(...)` setters +
+//     `Function(...)` methods install via the Obj-C-runtime path.
+//
+// The `WhiskerInputView` Lynx UI subclass lives in `InputView.swift`.
+// Same split on Android (`InputModule.kt` + `WhiskerInputView.kt`).
+//
+// ## Events
+//
+// Events are declared inside the `View(...)` block per the DSL contract
+// (`Events(...)` is legal both at module-level and inside a view block).
+// The actual dispatch goes through `WhiskerCustomEvent.dispatch(from:
+// name:params:)` called by the view's delegate methods — see
+// `InputView.swift`. `Events(...)` here is declaration-only metadata.
+//
+// ## CSS text-style props
+//
+// `color`, `font-size`, `font-weight`, and `text-align` arrive from
+// Lynx's style cascade as explicit `Prop` entries rather than through
+// the base-class `LynxUI` inheritance chain. The base class handles
+// generic view props (background-color, border-radius, opacity), but
+// it does NOT forward text-style values into the backing UITextField /
+// UITextView — those live in the custom view layer and must be set
+// explicitly. This mirrors the same approach: each CSS text prop is
+// listed as a `Prop(...)` in the DSL definition and forwarded to the
+// corresponding setter on `WhiskerInputView`.
+
+import WhiskerModule
+
+public final class InputModule: Module {
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("Input")
+            View(WhiskerInputView.self) {
+
+                // ---- Value + placeholder ----------------------------------
+
+                Prop("value") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setValue(value.asString ?? "")
+                }
+                Prop("placeholder") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setPlaceholder(value.asString ?? "")
+                }
+                // Colour props arrive either as a parsed Lynx ARGB int
+                // (when set via the CSS cascade / `SetRawInlineStyles`) or
+                // as a raw CSS string (when set as a plain attribute). Pass
+                // the whole `WhiskerValue` through so the view can resolve
+                // both forms — see `WhiskerInputView.resolveColor(_:)`.
+                Prop("placeholder-color") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setPlaceholderColor(value)
+                }
+
+                // ---- Cursor / selection colours --------------------------
+
+                Prop("caret-color") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setCaretColor(value)
+                }
+                Prop("selection-color") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setSelectionColor(value)
+                }
+
+                // ---- Layout mode -----------------------------------------
+
+                Prop("multiline") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setMultiline(value.asString ?? "false")
+                }
+                Prop("lines") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setLines(value.asString ?? "0")
+                }
+
+                // ---- Input behaviour -------------------------------------
+
+                Prop("secure") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setSecure(value.asString ?? "false")
+                }
+                Prop("editable") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setEditable(value.asString ?? "true")
+                }
+                Prop("auto-focus") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setAutoFocus(value.asString ?? "false")
+                }
+                Prop("max-length") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setMaxLength(value.asString ?? "0")
+                }
+
+                // ---- Keyboard / return key -------------------------------
+
+                Prop("keyboard-type") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setKeyboardType(value.asString ?? "default")
+                }
+                Prop("return-key") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setReturnKey(value.asString ?? "default")
+                }
+
+                // ---- CSS text-style props --------------------------------
+                //
+                // `color`, `font-size`, `font-weight`, `text-align` flow
+                // through Lynx's style cascade and DO reach this custom UI's
+                // prop setters on iOS (Lynx dispatches the element's prop
+                // bundle through `LynxPropsProcessor.updateProp:withKey:forUI:`,
+                // which resolves our registered `set<Cap>:requestReset:`
+                // selectors via the Obj-C runtime — the same channel the
+                // base class's background/border setters use).
+                //
+                // CRITICAL: Lynx delivers these as ALREADY-PARSED values, not
+                // CSS strings — `color` is an ARGB int (NSNumber → `.int`),
+                // `font-size` a resolved point CGFloat (`.float`/`.int`),
+                // `font-weight` a `LynxFontWeightType` enum int, `text-align`
+                // a `LynxTextAlignType` enum int. We forward the whole
+                // `WhiskerValue` so the view can decode the numeric form
+                // (falling back to string parsing when set as a plain attr).
+                // The earlier `value.asString ?? ""` form silently dropped
+                // every numeric value → black text / default font (bug).
+
+                Prop("color") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setTextColor(value)
+                }
+                Prop("font-size") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setFontSize(value)
+                }
+                Prop("font-weight") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setFontWeight(value)
+                }
+                Prop("text-align") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setTextAlign(value)
+                }
+
+                // ---- Events ----------------------------------------------
+                //
+                // Declaration-only: dispatch goes through
+                // `WhiskerCustomEvent.dispatch(from:name:params:)` in
+                // `InputView.swift`. Listed here so the codegen / docs
+                // scanner knows the full event surface.
+
+                Events("input", "change", "focus", "blur", "submit")
+
+                // ---- Imperative methods ----------------------------------
+
+                Function("focus") { (view: WhiskerInputView, _: [WhiskerValue]) -> WhiskerValue in
+                    view.focusField()
+                    return .null
+                }
+                Function("blur") { (view: WhiskerInputView, _: [WhiskerValue]) -> WhiskerValue in
+                    view.blurField()
+                    return .null
+                }
+                Function("clear") { (view: WhiskerInputView, _: [WhiskerValue]) -> WhiskerValue in
+                    view.clearField()
+                    return .null
+                }
+                Function("setValue") { (view: WhiskerInputView, args: [WhiskerValue]) -> WhiskerValue in
+                    // Args arrive as `{ "args": [<WhiskerValue.map { "value": ... }>] }` via
+                    // `WhiskerValue.fromNSDictionary`; the first positional arg is the map
+                    // the Rust side sent as `WhiskerValue::map([("value", ...)])`.
+                    if case .map(let m) = args.first, let s = m["value"]?.asString {
+                        view.setValue(s)
+                    }
+                    return .null
+                }
+                Function("getValue") { (view: WhiskerInputView, _: [WhiskerValue]) -> WhiskerValue in
+                    // Returns `{ "value": "<current text>" }` — matches the
+                    // `GetValueResult` struct the Rust side deserializes into.
+                    return .map(["value": .string(view.currentText())])
+                }
+            }
+        }
+    }
+}

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
@@ -1,0 +1,946 @@
+// Lynx UI subclass hosting a UITextField (single-line) or UITextView
+// (multiline) behind a unified interface. Registration is driven by
+// `InputModule`'s `definition()` — no annotations required here.
+//
+// `@objc(WhiskerInputView)` pins the Obj-C class name so the codegen
+// plugin's `NSClassFromString` lookup can find it regardless of whether
+// the SwiftPM-target prefix (`whisker_input.WhiskerInputView`) or the
+// bare form is used.
+//
+// ## Single-line vs multiline
+//
+// The backing control is chosen lazily. `WhiskerUI<UIView>` hosts a
+// transparent `containerView` that holds either a `UITextField` or a
+// `UITextView` pinned to its bounds. The `multiline` prop (default
+// false) triggers a rebuild of the hosted control the first time it
+// changes; subsequent changes to `multiline` after the control is
+// built are treated as no-ops (matching native-input semantics: the
+// field type is set once at construction time). Consumers that need to
+// switch between single/multiline should remount the component.
+//
+// ## Event body shape
+//
+// All value-carrying events use `{ "detail": { "value": "<text>" } }`
+// so the Rust `InputEvent` struct's `#[serde(default)]` decode sees
+// the expected shape. Focus / blur emit `{ "detail": {} }`.
+//
+// ## Cursor-preservation diff
+//
+// `setValue(_:)` only calls `field.text = ...` / `textView.text = ...`
+// when the incoming string differs from what the control currently
+// displays. This avoids a cursor-jump on the two-way-binding round
+// trip (Rust sets `value`, view fires `input`, Rust sets `value` again
+// with the same text the view just reported — without the guard this
+// causes the insertion point to jump to the end on every keystroke).
+//
+// ## CSS text-style props
+//
+// `color`, `font-size`, `font-weight`, `text-align` are received as
+// `Prop(...)` callbacks from the `InputModule` definition. They are
+// applied immediately to whichever control is currently active and
+// cached so the next control swap re-applies them.
+
+import Foundation
+import UIKit
+import WhiskerModule
+
+@objc(WhiskerInputView)
+public final class WhiskerInputView: WhiskerUI<UIView> {
+
+    // MARK: - Hosted controls
+
+    /// Transparent container that fills the LynxUI frame; holds
+    /// either the `textField` or `textView` as a subview.
+    private lazy var containerView: UIView = {
+        let v = UIView()
+        v.backgroundColor = .clear
+        return v
+    }()
+
+    /// The live single-line field, when the current mode is single-line.
+    /// Mutually exclusive with `textView` — exactly one is non-nil once a
+    /// control has been built.
+    private var textField: UITextField?
+
+    /// The live multiline area, when the current mode is multiline.
+    /// Mutually exclusive with `textField`.
+    private var textView: UITextView?
+
+    /// Whether the view is currently in multiline mode. Determines which
+    /// control is hosted in `containerView`. `setMultiline` rebuilds the
+    /// control whenever the requested mode differs from this.
+    private var isMultiline: Bool = false
+
+    // MARK: - Cached prop state
+    //
+    // All mutable props are cached so they can be re-applied whenever the
+    // hosted control is (re)built — both on the initial build and when
+    // `setMultiline` switches between single-line and multiline. Props can
+    // arrive in any order relative to `multiline`, so we cache everything
+    // and `applyAllCachedProps()` reinstates the full state onto the new
+    // control after a switch.
+
+    private var cachedText: String = ""
+    private var cachedPlaceholder: String = ""
+    private var cachedPlaceholderColor: UIColor = UIColor(white: 0.6, alpha: 1)
+    private var cachedCaretColor: UIColor = UIColor.systemBlue  // tintColor default
+    private var cachedSelectionColor: UIColor? = nil    // nil = use caret color
+    private var cachedSecure: Bool = false
+    private var cachedEditable: Bool = true
+    private var cachedAutoFocus: Bool = false
+    private var cachedMaxLength: Int = 0                // 0 = unset
+    private var cachedKeyboardType: UIKeyboardType = .default
+    private var cachedReturnKeyType: UIReturnKeyType = .default
+    private var cachedTextColor: UIColor = .label
+    private var cachedFontSize: CGFloat = 17
+    private var cachedFontWeight: UIFont.Weight = .regular
+    private var cachedTextAlignment: NSTextAlignment = .natural
+
+    /// Computed CSS padding (left/top/right/bottom) read from the base
+    /// `LynxUI.padding`. Insets the text inside both controls so the text
+    /// doesn't sit flush against the element edges. Defaults to `.zero`
+    /// (flush) so a field with no CSS padding matches Android's 0 default.
+    private var cachedPadding: UIEdgeInsets = .zero
+
+    /// True once a control (UITextField or UITextView) has been built.
+    /// Distinguishes "no control yet" (initial build path) from "control
+    /// exists, possibly needs a mode switch" in `ensureControl`.
+    private var controlBuilt: Bool = false
+
+    // MARK: - LynxUI lifecycle
+
+    @objc public override func createView() -> UIView {
+        // The host container is created once; the inner control
+        // (`UITextField` or `UITextView`) is built lazily in
+        // `ensureControl()`. Default to single-line so the very first
+        // render shows a working text field even if `multiline` hasn't
+        // arrived yet.
+        ensureControl(multiline: false)
+        return containerView
+    }
+
+    @objc public override func frameDidChange() {
+        super.frameDidChange()
+        // `self.view()` is the `containerView` — Lynx already set its
+        // frame to the computed element bounds. Propagate that frame to
+        // the hosted UITextField / UITextView so they fill the element.
+        let bounds = self.view().bounds
+        textField?.frame = bounds
+        textView?.frame = bounds
+        // Padding is resolved during layout, so this hook (which fires
+        // after layout) is the authoritative point to read it.
+        syncPadding()
+    }
+
+    /// Fired by Lynx after a batch of prop / style updates has been
+    /// applied. We use it as a belt-and-braces fallback for `font-size`:
+    /// the base `LynxUI` exposes the computed `fontSize` (a resolved
+    /// point value) for ANY element, so even if the `font-size` prop
+    /// dispatch didn't reach our setter, we still pick up the cascaded
+    /// value here. `color` / `font-weight` / `text-align` have no
+    /// base-class computed accessor, so those rely on the `Prop` setters.
+    @objc public override func propsDidUpdate() {
+        super.propsDidUpdate()
+        let computed = self.fontSize
+        if computed > 0 && abs(computed - cachedFontSize) > 0.01 {
+            cachedFontSize = computed
+            applyFont()
+        }
+        // `padding` may be resolved by now on a props-only update too.
+        syncPadding()
+    }
+
+    /// Read the base `LynxUI.padding` (computed CSS padding — shorthand,
+    /// units, and per-side longhands all already resolved to point insets
+    /// by Lynx's layout) and apply it to the live control when it changed.
+    /// This is the single source of truth for the field's text inset.
+    private func syncPadding() {
+        let p = self.padding
+        if p != cachedPadding {
+            cachedPadding = p
+            applyPadding()
+        }
+    }
+
+    // MARK: - Control builder
+
+    /// Build the hosted control for `multiline`, or switch to it if a
+    /// control of the other mode is already live.
+    ///
+    /// `createView()` calls this once with the default single-line mode
+    /// so the element always shows a working field. `setMultiline(...)`
+    /// then calls it again once the real `multiline` value arrives (props
+    /// are applied after `createView`); if that differs from the current
+    /// mode we tear down the old control and rebuild as the other kind,
+    /// re-applying all cached props so no state (text / colours / font /
+    /// alignment / behaviour) is lost across the switch.
+    private func ensureControl(multiline: Bool) {
+        // Already in the requested mode → nothing to do.
+        if controlBuilt && isMultiline == multiline { return }
+
+        // Tear down the existing control (if any) before building the new
+        // one. Removing from the superview drops UIKit's strong ref; we
+        // also nil our own refs and clear the delegate / targets so a
+        // stale control can't deliver events after the switch.
+        if let tf = textField {
+            tf.delegate = nil
+            tf.removeTarget(self, action: nil, for: .allEvents)
+            tf.removeFromSuperview()
+            textField = nil
+        }
+        if let tv = textView {
+            tv.delegate = nil
+            tv.removeFromSuperview()
+            textView = nil
+        }
+
+        isMultiline = multiline
+        controlBuilt = true
+
+        if multiline {
+            buildTextView()
+        } else {
+            buildTextField()
+        }
+
+        // Pin the freshly-built control to the container's current bounds
+        // (frameDidChange may have already fired before this switch).
+        let bounds = containerView.bounds
+        textField?.frame = bounds
+        textView?.frame = bounds
+
+        applyAllCachedProps()
+    }
+
+    private func buildTextField() {
+        // `PaddedTextField` insets text / placeholder by `textInsets`;
+        // plain UITextField has no built-in inset, so a subclass is the
+        // only way to honor CSS padding on a single-line field.
+        let tf = PaddedTextField()
+        tf.borderStyle = .none
+        tf.backgroundColor = .clear
+        tf.autocorrectionType = .default
+        tf.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
+        tf.addTarget(self, action: #selector(textFieldDidEndOnExit(_:)), for: .editingDidEndOnExit)
+        tf.delegate = self
+        containerView.addSubview(tf)
+        textField = tf
+    }
+
+    private func buildTextView() {
+        let tv = UITextView()
+        tv.backgroundColor = .clear
+        // Start flush; `applyPadding()` sets the real CSS-padding inset.
+        // `lineFragmentPadding = 0` so horizontal padding equals exactly
+        // the CSS value (otherwise the container adds its own padding).
+        tv.textContainerInset = .zero
+        tv.textContainer.lineFragmentPadding = 0
+        // Top-align the text. A UITextView vertically centers its content
+        // whenever the content height is shorter than the bounds UNLESS
+        // scrolling is enabled (scroll-enabled views pin content to the
+        // top). Force scroll on, and disable the system content-inset
+        // adjustment so the safe-area / nav-bar doesn't push the first
+        // line down off the top edge.
+        tv.isScrollEnabled = true
+        tv.contentInsetAdjustmentBehavior = .never
+        // Default the keyboard's return key to insert a newline (the
+        // multiline contract); `setReturnKey` may override the label.
+        tv.returnKeyType = .default
+        tv.delegate = self
+        containerView.addSubview(tv)
+        textView = tv
+    }
+
+    // MARK: - Apply all cached props to the current active control
+
+    private func applyAllCachedProps() {
+        applyText(cachedText)
+        applyPlaceholder()
+        applyColors()
+        applyFont()
+        applyTextAlignment()
+        applyBehaviour()
+        applyPadding()
+    }
+
+    /// Inset the text by the computed CSS padding on whichever control is
+    /// live. UITextField routes through the `PaddedTextField` subclass's
+    /// `textInsets`; UITextView uses `textContainerInset` directly (with
+    /// `lineFragmentPadding = 0` already set so horizontal padding is
+    /// exact, not padding + the container's default fragment padding).
+    private func applyPadding() {
+        if let tf = textField as? PaddedTextField {
+            tf.textInsets = cachedPadding
+        }
+        if let tv = textView {
+            tv.textContainerInset = cachedPadding
+        }
+    }
+
+    /// Apply current text to whichever control is active, without
+    /// cursor-jump (no-op when text hasn't changed).
+    private func applyText(_ s: String) {
+        if let tf = textField {
+            if tf.text != s { tf.text = s }
+        } else if let tv = textView {
+            if tv.text != s { tv.text = s }
+        }
+    }
+
+    private func applyPlaceholder() {
+        if let tf = textField {
+            tf.attributedPlaceholder = NSAttributedString(
+                string: cachedPlaceholder,
+                attributes: [.foregroundColor: cachedPlaceholderColor]
+            )
+        }
+        // UITextView has no native placeholder; skip for v1
+        // (a label-overlay approach would be the follow-up).
+    }
+
+    private func applyColors() {
+        // iOS uses `tintColor` for both the cursor and selection highlight
+        // (UITextField / UITextView do not expose independent
+        // selection-color control via a public API). When `selection-color`
+        // is set it "wins" for that combined tint; otherwise fall back to
+        // `caret-color`. Both paths leave `caret-color` as the effective
+        // cursor color — best-effort, single tint shared across cursor and
+        // selection on this platform.
+        let tint = cachedSelectionColor ?? cachedCaretColor
+        if let tf = textField {
+            tf.textColor = cachedTextColor
+            tf.tintColor = tint
+        } else if let tv = textView {
+            tv.textColor = cachedTextColor
+            tv.tintColor = tint
+        }
+    }
+
+    private func applyFont() {
+        let font = UIFont.systemFont(ofSize: cachedFontSize, weight: cachedFontWeight)
+        textField?.font = font
+        textView?.font = font
+    }
+
+    private func applyTextAlignment() {
+        textField?.textAlignment = cachedTextAlignment
+        textView?.textAlignment = cachedTextAlignment
+    }
+
+    private func applyBehaviour() {
+        if let tf = textField {
+            tf.isSecureTextEntry = cachedSecure
+            tf.isEnabled = cachedEditable
+            tf.keyboardType = cachedKeyboardType
+            tf.returnKeyType = cachedReturnKeyType
+        }
+        if let tv = textView {
+            tv.isEditable = cachedEditable
+            tv.keyboardType = cachedKeyboardType
+            tv.returnKeyType = cachedReturnKeyType
+            // UITextView has no `isSecureTextEntry`; secure flag is a no-op
+            // for multiline (passwords are always single-line in practice).
+        }
+        if cachedAutoFocus {
+            // Defer to the next run-loop so the view has been attached to
+            // the window before we try to become first responder.
+            DispatchQueue.main.async { [weak self] in
+                self?.textField?.becomeFirstResponder()
+                self?.textView?.becomeFirstResponder()
+            }
+        }
+    }
+
+    // MARK: - Public setters (called by InputModule's Prop closures)
+
+    // ---- Value ----------------------------------------------------------
+
+    /// External value write (from Rust signal). Only re-sets the field's
+    /// displayed text when it differs from the current value — this is
+    /// the cursor-preservation diff guard described in the class comment.
+    public func setValue(_ s: String) {
+        cachedText = s
+        applyText(s)
+    }
+
+    // ---- Placeholder ----------------------------------------------------
+
+    public func setPlaceholder(_ s: String) {
+        cachedPlaceholder = s
+        applyPlaceholder()
+    }
+
+    public func setPlaceholderColor(_ value: WhiskerValue) {
+        cachedPlaceholderColor = Self.resolveColor(value) ?? UIColor(white: 0.6, alpha: 1)
+        applyPlaceholder()
+    }
+
+    // ---- Cursor / selection colours ------------------------------------
+
+    public func setCaretColor(_ value: WhiskerValue) {
+        cachedCaretColor = Self.resolveColor(value) ?? .systemBlue
+        applyColors()
+    }
+
+    public func setSelectionColor(_ value: WhiskerValue) {
+        // Empty string / null → unset → fall back to caret color.
+        if case .string(let s) = value, s.isEmpty {
+            cachedSelectionColor = nil
+        } else if case .null = value {
+            cachedSelectionColor = nil
+        } else {
+            cachedSelectionColor = Self.resolveColor(value)
+        }
+        applyColors()
+    }
+
+    // ---- Layout mode ---------------------------------------------------
+
+    public func setMultiline(_ s: String) {
+        let want = (s == "true")
+        // `multiline` is always sent by the Rust outer component, and it
+        // arrives AFTER `createView()` has built the default single-line
+        // field. `ensureControl` switches the control to a UITextView when
+        // `want` is true (and back to a UITextField if it ever flips),
+        // re-applying all cached props so the field lands in the right mode
+        // with its full state intact.
+        ensureControl(multiline: want)
+    }
+
+    public func setLines(_ s: String) {
+        // `lines` is a best-effort visible-line hint for multiline areas.
+        // CSS `height` / `min-height` from the Rust style prop is
+        // authoritative in v1; we store this for potential future use.
+        // (`UITextView` doesn't expose a "visible line count" API.)
+        _ = Int(s) ?? 0
+    }
+
+    // ---- Input behaviour -----------------------------------------------
+
+    public func setSecure(_ s: String) {
+        cachedSecure = (s == "true")
+        textField?.isSecureTextEntry = cachedSecure
+        // UITextView doesn't support secure entry.
+    }
+
+    public func setEditable(_ s: String) {
+        cachedEditable = (s != "false")
+        textField?.isEnabled = cachedEditable
+        textView?.isEditable = cachedEditable
+    }
+
+    public func setAutoFocus(_ s: String) {
+        cachedAutoFocus = (s == "true")
+        if cachedAutoFocus && controlBuilt {
+            DispatchQueue.main.async { [weak self] in
+                self?.textField?.becomeFirstResponder()
+                self?.textView?.becomeFirstResponder()
+            }
+        }
+    }
+
+    public func setMaxLength(_ s: String) {
+        cachedMaxLength = Int(s) ?? 0   // enforced in delegate callbacks
+    }
+
+    // ---- Keyboard / return key -----------------------------------------
+
+    public func setKeyboardType(_ s: String) {
+        cachedKeyboardType = Self.mapKeyboardType(s)
+        textField?.keyboardType = cachedKeyboardType
+        textView?.keyboardType = cachedKeyboardType
+    }
+
+    public func setReturnKey(_ s: String) {
+        cachedReturnKeyType = Self.mapReturnKeyType(s)
+        textField?.returnKeyType = cachedReturnKeyType
+        textView?.returnKeyType = cachedReturnKeyType
+    }
+
+    // ---- CSS text-style props ------------------------------------------
+    //
+    // These arrive from Lynx's CSS cascade ALREADY PARSED (not as CSS
+    // strings): `color` is an ARGB int, `font-size` a resolved point
+    // value, `font-weight` a `LynxFontWeightType` enum int, `text-align`
+    // a `LynxTextAlignType` enum int. Each setter decodes the numeric
+    // form first and falls back to string parsing so it still works if
+    // the value is ever delivered as a plain-string attribute.
+
+    public func setTextColor(_ value: WhiskerValue) {
+        cachedTextColor = Self.resolveColor(value) ?? .label
+        applyColors()
+    }
+
+    public func setFontSize(_ value: WhiskerValue) {
+        // Numeric form (Lynx cascade): a resolved point size — use as-is.
+        if let n = value.asDouble, n > 0 {
+            cachedFontSize = CGFloat(n)
+            applyFont()
+            return
+        }
+        // String form (plain attr): "16px", "16", "1.5em" → strip a
+        // trailing `px` and read the leading number. Unknown units leave
+        // the cached size unchanged rather than regressing the font.
+        if let s = value.asString {
+            let stripped = s.hasSuffix("px") ? String(s.dropLast(2)) : s
+            if let pt = Double(stripped.trimmingCharacters(in: .whitespaces)), pt > 0 {
+                cachedFontSize = CGFloat(pt)
+                applyFont()
+            }
+        }
+    }
+
+    public func setFontWeight(_ value: WhiskerValue) {
+        // Numeric form: `LynxFontWeightType` enum (Normal=0, Bold=1,
+        // 100=2 … 900=10). String form: a CSS keyword / numeric weight.
+        if let i = value.asInt {
+            cachedFontWeight = Self.mapLynxFontWeightEnum(Int(i))
+        } else if let s = value.asString {
+            cachedFontWeight = Self.mapFontWeight(s)
+        }
+        applyFont()
+    }
+
+    public func setTextAlign(_ value: WhiskerValue) {
+        // Numeric form: `LynxTextAlignType` enum (Left=0, Center=1,
+        // Right=2, Start=3, End=4, Justify=5). String form: CSS keyword.
+        if let i = value.asInt {
+            cachedTextAlignment = Self.mapLynxTextAlignEnum(Int(i))
+        } else if let s = value.asString {
+            cachedTextAlignment = Self.mapTextAlignment(s)
+        }
+        applyTextAlignment()
+    }
+
+    // MARK: - Imperative handle targets (called by InputModule's Function closures)
+
+    /// Focus the field and raise the keyboard.
+    public func focusField() {
+        textField?.becomeFirstResponder()
+        textView?.becomeFirstResponder()
+    }
+
+    /// Resign focus and dismiss the keyboard.
+    public func blurField() {
+        textField?.resignFirstResponder()
+        textView?.resignFirstResponder()
+    }
+
+    /// Clear the text to empty AND emit `input` so the bound signal
+    /// updates (the same outcome as the user deleting all characters).
+    public func clearField() {
+        applyText("")
+        cachedText = ""
+        emitInput("")
+    }
+
+    /// Synchronous read of the current text for `getValue`.
+    public func currentText() -> String {
+        return cachedText
+    }
+
+    // MARK: - Event emission helpers
+
+    /// The event params — `{ "value": "<text>" }`.
+    ///
+    /// IMPORTANT: do NOT wrap this in a `detail` key. Lynx's
+    /// `generateEventBody` (iOS) / the Android event reporter already
+    /// places the dispatched `params` UNDER a `detail` key in the event
+    /// body (`{ type, target, currentTarget, detail: <params> }`). The
+    /// Rust `InputEvent { detail: { value } }` then reads `body.detail`.
+    /// Wrapping here too would double-nest (`detail: { detail: { value }}`)
+    /// and the value would never reach the handler — every `on_input` /
+    /// `on_change` / `on_submit` would deliver an empty string.
+    private func detailPayload(_ text: String) -> [AnyHashable: Any] {
+        return ["value": text]
+    }
+
+    // NOTE: every `WhiskerCustomEvent.dispatch(...)` below is deferred to
+    // the next main-runloop tick via `DispatchQueue.main.async`. UIKit
+    // delegate callbacks (`textFieldDidEndEditing`, `textViewDidChange`,
+    // …) fire SYNCHRONOUSLY during Lynx's native teardown on a hot-reload
+    // remount, while `remove_child` still holds the `CURRENT_RENDERER`
+    // RefCell borrow. Dispatching synchronously reenters Rust's
+    // `dispatch_event` → a second `with_renderer` borrow → "RefCell
+    // already borrowed" panic (the event is dropped). Deferring one tick
+    // guarantees the dispatch lands at idle, never inside a render borrow.
+    //
+    // Safe for the two-way-binding `input` timing: the native field
+    // already shows the typed character immediately (native owns its
+    // text); the one-tick-later Rust `value` round-trip is absorbed by
+    // the cursor-preservation diff guard in `setValue(_:)`, so no jump.
+    // `self` is captured weakly and the text is snapshotted before the
+    // async block so a torn-down view never dispatches a dangling event.
+
+    private func emitInput(_ text: String) {
+        // `cachedText` is owned state — keep it immediate (synchronous) so
+        // `getValue` / the cursor-preservation diff stay correct even if
+        // the deferred dispatch hasn't fired yet.
+        cachedText = text
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            WhiskerCustomEvent.dispatch(from: self, name: "input", params: self.detailPayload(text))
+        }
+    }
+
+    private func emitChange(_ text: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            WhiskerCustomEvent.dispatch(from: self, name: "change", params: self.detailPayload(text))
+        }
+    }
+
+    private func emitFocus() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            WhiskerCustomEvent.dispatch(from: self, name: "focus", params: [:])
+        }
+    }
+
+    private func emitBlur() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            WhiskerCustomEvent.dispatch(from: self, name: "blur", params: [:])
+        }
+    }
+
+    private func emitSubmit(_ text: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            WhiskerCustomEvent.dispatch(from: self, name: "submit", params: self.detailPayload(text))
+        }
+    }
+
+    // MARK: - UITextField action targets
+
+    @objc private func textFieldDidChange(_ sender: UITextField) {
+        let text = sender.text ?? ""
+        emitInput(text)
+    }
+
+    @objc private func textFieldDidEndOnExit(_ sender: UITextField) {
+        // "Done" / return key on a UITextField. Emit both submit and change.
+        let text = sender.text ?? ""
+        emitSubmit(text)
+        emitChange(text)
+    }
+
+    // MARK: - Mapping helpers
+
+    private static func mapKeyboardType(_ s: String) -> UIKeyboardType {
+        switch s {
+        case "number":  return .numberPad
+        case "decimal": return .decimalPad
+        case "email":   return .emailAddress
+        case "phone":   return .phonePad
+        case "url":     return .URL
+        default:        return .default
+        }
+    }
+
+    private static func mapReturnKeyType(_ s: String) -> UIReturnKeyType {
+        switch s {
+        case "done":   return .done
+        case "go":     return .go
+        case "next":   return .next
+        case "search": return .search
+        case "send":   return .send
+        default:       return .default
+        }
+    }
+
+    private static func mapFontWeight(_ s: String) -> UIFont.Weight {
+        switch s.lowercased() {
+        case "100", "thin":        return .ultraLight
+        case "200", "extralight":  return .thin
+        case "300", "light":       return .light
+        case "400", "normal":      return .regular
+        case "500", "medium":      return .medium
+        case "600", "semibold":    return .semibold
+        case "700", "bold":        return .bold
+        case "800", "extrabold":   return .heavy
+        case "900", "black":       return .black
+        default:                   return .regular
+        }
+    }
+
+    private static func mapTextAlignment(_ s: String) -> NSTextAlignment {
+        switch s.lowercased() {
+        case "left":    return .left
+        case "right":   return .right
+        case "center":  return .center
+        case "justify": return .justified
+        default:        return .natural
+        }
+    }
+
+    /// `LynxTextAlignType` enum → `NSTextAlignment`. Values per
+    /// `LynxCSSType.h`: Left=0, Center=1, Right=2, Start=3, End=4,
+    /// Justify=5. Start/End map to `.natural` (UIKit resolves per the
+    /// writing direction).
+    private static func mapLynxTextAlignEnum(_ i: Int) -> NSTextAlignment {
+        switch i {
+        case 0:  return .left
+        case 1:  return .center
+        case 2:  return .right
+        case 5:  return .justified
+        default: return .natural   // Start(3) / End(4) / unknown
+        }
+    }
+
+    /// Numeric `font-weight` → `UIFont.Weight`. Lynx normally delivers
+    /// the `LynxFontWeightType` enum (Normal=0, Bold=1, 100=2 … 900=10,
+    /// per `LynxAutoGenCSSType.h`). As a belt-and-braces guard we also
+    /// accept a raw CSS weight number (100…900) since those ranges don't
+    /// overlap the 0…10 enum range — whichever form arrives resolves
+    /// correctly.
+    private static func mapLynxFontWeightEnum(_ i: Int) -> UIFont.Weight {
+        switch i {
+        // LynxFontWeightType enum indices.
+        case 0:   return .regular     // Normal
+        case 1:   return .bold        // Bold
+        case 2:   return .ultraLight  // 100
+        case 3:   return .thin        // 200
+        case 4:   return .light       // 300
+        case 5:   return .regular     // 400
+        case 6:   return .medium      // 500
+        case 7:   return .semibold    // 600
+        case 8:   return .bold        // 700
+        case 9:   return .heavy       // 800
+        case 10:  return .black       // 900
+        // Raw CSS numeric weights (in case Lynx forwards the literal).
+        case 100: return .ultraLight
+        case 200: return .thin
+        case 300: return .light
+        case 400: return .regular
+        case 500: return .medium
+        case 600: return .semibold
+        case 700: return .bold
+        case 800: return .heavy
+        case 900: return .black
+        default:  return .regular
+        }
+    }
+
+    /// Resolve a colour prop value to a `UIColor`. Lynx's CSS cascade
+    /// delivers a parsed colour as an ARGB integer (`0xAARRGGBB`,
+    /// arriving as `.int` after the NSNumber → WhiskerValue conversion);
+    /// a plain-string attribute delivers a CSS string. Returns `nil` on
+    /// an unrecognised / empty value so callers keep their default.
+    private static func resolveColor(_ value: WhiskerValue) -> UIColor? {
+        // Numeric ARGB (Lynx cascade). `.int`/`.float` both coerce via
+        // `asInt`. A literal 0 is fully-transparent black — a legitimate
+        // value, so we DON'T treat it as "unset" here.
+        if case .string(let s) = value {
+            return parseCssColor(s)
+        }
+        if let argb = value.asInt {
+            return colorFromARGB(UInt32(truncatingIfNeeded: argb))
+        }
+        return nil
+    }
+
+    /// Build a `UIColor` from a Lynx `0xAARRGGBB` packed integer.
+    private static func colorFromARGB(_ argb: UInt32) -> UIColor {
+        let a = CGFloat((argb >> 24) & 0xFF) / 255
+        let r = CGFloat((argb >> 16) & 0xFF) / 255
+        let g = CGFloat((argb >>  8) & 0xFF) / 255
+        let b = CGFloat(argb & 0xFF) / 255
+        return UIColor(red: r, green: g, blue: b, alpha: a)
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension WhiskerInputView: UITextFieldDelegate {
+
+    public func textFieldDidBeginEditing(_ textField: UITextField) {
+        emitFocus()
+    }
+
+    public func textFieldDidEndEditing(_ textField: UITextField) {
+        let text = textField.text ?? ""
+        emitBlur()
+        emitChange(text)
+    }
+
+    /// Enforce `max-length` on UITextField. The standard delegate
+    /// intercept: return `false` when adding `string` would push
+    /// the count over `cachedMaxLength`.
+    public func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        guard cachedMaxLength > 0 else { return true }
+        let current = (textField.text ?? "") as NSString
+        let proposed = current.replacingCharacters(in: range, with: string)
+        return proposed.count <= cachedMaxLength
+    }
+}
+
+// MARK: - UITextViewDelegate
+
+extension WhiskerInputView: UITextViewDelegate {
+
+    public func textViewDidBeginEditing(_ textView: UITextView) {
+        emitFocus()
+    }
+
+    public func textViewDidEndEditing(_ textView: UITextView) {
+        let text = textView.text ?? ""
+        emitBlur()
+        emitChange(text)
+    }
+
+    public func textViewDidChange(_ textView: UITextView) {
+        let text = textView.text ?? ""
+        emitInput(text)
+    }
+
+    /// Enforce `max-length` on UITextView.
+    ///
+    /// Return is a normal newline in a multiline area — we do NOT
+    /// intercept `\n` here. The field inserts the line break naturally,
+    /// and `submit` is a single-line-only concept (handled by the
+    /// UITextField `editingDidEndOnExit` path). Intercepting the newline
+    /// (the previous behaviour) both suppressed the line break the user
+    /// expected AND fired a spurious `submit` on every Return.
+    ///
+    /// `max-length` still counts newlines as characters, so a `\n` that
+    /// would exceed the limit is rejected like any other character.
+    public func textView(
+        _ textView: UITextView,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
+    ) -> Bool {
+        guard cachedMaxLength > 0 else { return true }
+        let current = (textView.text ?? "") as NSString
+        let proposed = current.replacingCharacters(in: range, with: text)
+        return proposed.count <= cachedMaxLength
+    }
+}
+
+// MARK: - CSS colour parser
+
+/// Best-effort CSS colour parser. Handles `#RGB`, `#RRGGBB`,
+/// `#RRGGBBAA`, `rgb(r, g, b)`, `rgba(r, g, b, a)`, and a handful of
+/// named colours. Returns `nil` on parse failure so callers can fall
+/// back to their cached default.
+///
+/// Mirrors `parseCssColor` from `whisker-svg/ios/Sources/WhiskerSvg/
+/// WhiskerSvgView.swift`, extended with `rgb()`/`rgba()` support for
+/// the colour-string inputs the Input view handles.
+private func parseCssColor(_ raw: String) -> UIColor? {
+    let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !s.isEmpty else { return nil }
+
+    // ---- Hex -----------------------------------------------------------
+    if s.hasPrefix("#") {
+        let hex = String(s.dropFirst())
+        switch hex.count {
+        case 3:
+            if let n = UInt32(hex, radix: 16) {
+                let r = (n >> 8) & 0xF
+                let g = (n >> 4) & 0xF
+                let b = n & 0xF
+                return UIColor(
+                    red:   CGFloat(r * 17) / 255,
+                    green: CGFloat(g * 17) / 255,
+                    blue:  CGFloat(b * 17) / 255,
+                    alpha: 1
+                )
+            }
+        case 6:
+            if let n = UInt32(hex, radix: 16) {
+                return UIColor(
+                    red:   CGFloat((n >> 16) & 0xFF) / 255,
+                    green: CGFloat((n >>  8) & 0xFF) / 255,
+                    blue:  CGFloat(n & 0xFF) / 255,
+                    alpha: 1
+                )
+            }
+        case 8:
+            if let n = UInt32(hex, radix: 16) {
+                return UIColor(
+                    red:   CGFloat((n >> 24) & 0xFF) / 255,
+                    green: CGFloat((n >> 16) & 0xFF) / 255,
+                    blue:  CGFloat((n >>  8) & 0xFF) / 255,
+                    alpha: CGFloat(n & 0xFF) / 255
+                )
+            }
+        default: break
+        }
+        return nil
+    }
+
+    // ---- rgb() / rgba() ------------------------------------------------
+    let lower = s.lowercased()
+    if lower.hasPrefix("rgb") {
+        // Grab the content inside the outer parens.
+        guard let open = s.firstIndex(of: "("),
+              let close = s.lastIndex(of: ")") else { return nil }
+        let inner = String(s[s.index(after: open)..<close])
+        let parts = inner.split(separator: ",").map {
+            $0.trimmingCharacters(in: .whitespaces)
+        }
+        guard parts.count >= 3,
+              let r = Double(parts[0]),
+              let g = Double(parts[1]),
+              let b = Double(parts[2]) else { return nil }
+        let a = parts.count >= 4 ? (Double(parts[3]) ?? 1.0) : 1.0
+        return UIColor(
+            red:   CGFloat(r) / 255,
+            green: CGFloat(g) / 255,
+            blue:  CGFloat(b) / 255,
+            alpha: CGFloat(a)
+        )
+    }
+
+    // ---- Named colours -------------------------------------------------
+    switch lower {
+    case "black":       return .black
+    case "white":       return .white
+    case "red":         return .red
+    case "green":       return UIColor(red: 0, green: 128.0/255, blue: 0, alpha: 1)
+    case "blue":        return .blue
+    case "gray", "grey":return .gray
+    case "transparent": return .clear
+    default:            return nil
+    }
+}
+
+// MARK: - Padded single-line field
+
+/// `UITextField` that insets its text, editing, and placeholder rects by
+/// `textInsets`. Plain `UITextField` has no built-in content inset, so a
+/// subclass overriding the three rect hooks is the only way to honor CSS
+/// padding on a single-line field — the multiline `UITextView` gets the
+/// same effect for free via `textContainerInset`.
+///
+/// `clearButtonRect` is intentionally left at the default so the clear
+/// button (when present) still tracks the right edge sensibly; the field
+/// doesn't enable a clear button today, so it's a non-issue in practice.
+private final class PaddedTextField: UITextField {
+
+    /// CSS padding (left/top/right/bottom). Setting it re-lays-out so the
+    /// new inset takes effect immediately.
+    var textInsets: UIEdgeInsets = .zero {
+        didSet {
+            guard textInsets != oldValue else { return }
+            setNeedsLayout()
+        }
+    }
+
+    override func textRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: textInsets)
+    }
+
+    override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: textInsets)
+    }
+
+    override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: textInsets)
+    }
+}

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -1,0 +1,738 @@
+//! `whisker-input` — native text-input component.
+//!
+//! **API shape — 2 (Component + ref-bound handle).** A native UI
+//! element ([`Input`]) backed by `UITextField` / `UITextView` on iOS
+//! and `EditText` on Android, with a Leptos-style **two-way binding**
+//! as the headline API plus a typed imperative handle ([`InputRef`])
+//! bound on mount via `ref:` for `focus` / `blur` / `clear` /
+//! `setValue` / `getValue`.
+//!
+//! The Lynx tag is `whisker-input:Input` (the crate name is
+//! auto-prepended by `#[whisker::module_component]`).
+//!
+//! ## Usage
+//!
+//! ### Two-way binding (headline)
+//!
+//! ```ignore
+//! use whisker::prelude::*;
+//! use whisker_input::Input;
+//!
+//! #[whisker::main]
+//! fn app() -> Element {
+//!     let text = RwSignal::new(String::new());
+//!     render! {
+//!         view(style: "flex-direction: column;") {
+//!             Input(
+//!                 text: text,
+//!                 placeholder: "Type something…",
+//!                 style: "height: 44px; font-size: 16px;",
+//!             )
+//!             // The bound signal updates on every keystroke.
+//!             text(value: move || format!("You typed: {}", text.get()))
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! ### Controlled (escape hatch)
+//!
+//! Pass `value:` (a read-only [`Signal<String>`]) instead of `text:`
+//! and drive writeback yourself from `on_input`:
+//!
+//! ```ignore
+//! let (value, set_value) = signal(String::new());
+//! render! {
+//!     Input(
+//!         value: value,
+//!         on_input: move |s: String| set_value.set(s.to_uppercase()),
+//!     )
+//! }
+//! ```
+//!
+//! ### Multiline
+//!
+//! ```ignore
+//! Input(text: notes, multiline: true, lines: 4,
+//!       placeholder: "Notes…",
+//!       style: "min-height: 96px;")
+//! ```
+//!
+//! ### Secure (password)
+//!
+//! ```ignore
+//! Input(text: password, secure: true, placeholder: "Password")
+//! ```
+//!
+//! ### Imperative handle
+//!
+//! ```ignore
+//! let field = InputRef::new();
+//! render! {
+//!     view(style: "flex-direction: row;") {
+//!         Input(text: text, input_ref: field.clone())
+//!         text(value: "Clear", on_tap: {
+//!             let field = field.clone();
+//!             move |_| field.clear()
+//!         })
+//!     }
+//! }
+//! ```
+//!
+//! ## Props
+//!
+//! | Prop               | Type                                  | Default       | Description |
+//! |--------------------|---------------------------------------|---------------|-------------|
+//! | `text`             | `RwSignal<String>`                    | —             | Two-way bound value. Updates on every keystroke. |
+//! | `value`            | `Signal<String>`                      | —             | Controlled read (escape hatch; ignored if `text` is set). |
+//! | `on_input`         | `Fn(String)`                          | —             | Fires every keystroke with the new full text. |
+//! | `on_change`        | `Fn(String)`                          | —             | Fires when editing ends / value committed. |
+//! | `on_focus`         | `Fn()`                                | —             | Field gained focus. |
+//! | `on_blur`          | `Fn()`                                | —             | Field lost focus. |
+//! | `on_submit`        | `Fn(String)`                          | —             | Return / done key pressed. |
+//! | `placeholder`      | `Signal<String>`                      | `""`          | Placeholder text shown when empty. |
+//! | `multiline`        | `bool`                                | `false`       | Single-line field vs multiline area. |
+//! | `lines`            | `u32`                                 | unset (`0`)   | Fixed visible line count (multiline only). |
+//! | `secure`           | `bool`                                | `false`       | Mask input (password entry). |
+//! | `editable`         | `bool`                                | `true`        | Allow editing. |
+//! | `auto_focus`       | `bool`                                | `false`       | Focus + raise keyboard on mount. |
+//! | `max_length`       | `u32`                                 | unset (`0`)   | Maximum character count. |
+//! | `keyboard_type`    | [`KeyboardType`]                      | `Default`     | On-screen keyboard layout. |
+//! | `return_key`       | [`ReturnKey`]                         | `Default`     | Return-key label / action. |
+//! | `caret_color`      | `Signal<String>`                      | `""`          | Cursor color (CSS color string). |
+//! | `placeholder_color`| `Signal<String>`                      | `""`          | Placeholder text color. |
+//! | `selection_color`  | `Signal<String>`                      | `""`          | Selection-highlight color. |
+//! | `style`            | `Signal<String>`                      | `""`          | Standard Whisker CSS style string. |
+//! | `input_ref`        | [`InputRef`]                          | —             | Imperative handle (see [Methods](#methods)). |
+//!
+//! ## Styling
+//!
+//! Box layout and **text** styling flow through the standard `style:`
+//! CSS cascade — `width` / `height` / `padding` / `border` /
+//! `background-color` / `border-radius`, plus the text properties the
+//! native field honors: `color`, `font-size`, `font-weight`,
+//! `text-align`.
+//!
+//! The cursor / placeholder / selection colors are **explicit props**
+//! ([`caret_color`](InputProps), [`placeholder_color`](InputProps),
+//! [`selection_color`](InputProps)) rather than CSS, because Lynx's CSS
+//! engine doesn't reach the internals of a custom UI element — the
+//! parsed style cascade only sets generic view properties, so these
+//! sub-element colors must be passed as attributes the native view
+//! reads directly.
+//!
+//! ## Methods
+//!
+//! Hold an [`InputRef`], pass `input_ref:` to the component, then:
+//!
+//! - [`InputRef::focus`] — focus the field + raise the keyboard.
+//! - [`InputRef::blur`] — resign focus + dismiss the keyboard.
+//! - [`InputRef::clear`] — clear the text to empty.
+//! - [`InputRef::set_value`] — replace the text imperatively.
+//! - [`InputRef::get_value`] — async read of the current text.
+//!   Reliable on iOS; Android result-returning element methods may
+//!   require a Lynx fork release (see the method docs).
+//!
+//! ## Native source
+//!
+//! Contributors: the matching platform module lives at
+//!
+//! - iOS: `packages/whisker-input/ios/Sources/WhiskerInput/InputModule.swift`
+//!   (view: `InputView.swift`)
+//! - Android: `packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt`
+//!   (view: `WhiskerInputView.kt`)
+
+use std::rc::Rc;
+
+use whisker::platform_module::WhiskerValue;
+use whisker::prelude::*;
+use whisker::{ElementRef, RefError, Signal};
+
+// ---------------------------------------------------------------------------
+// Event payload
+// ---------------------------------------------------------------------------
+
+/// Payload of an input event (`input` / `change` / `submit`).
+///
+/// The native view dispatches the event with the field's current text
+/// under `detail.value`. Both platforms deliver it under `detail`: the
+/// Android event reporter wraps a custom event's params there, and the
+/// iOS bridge normalizes `LynxCustomEvent`'s `params` key to `detail`
+/// (see `whisker_bridge_ios.mm`) so this struct reads one shape on both.
+/// Every field is `#[serde(default)]` so a partial / mismatched body
+/// degrades to an empty string rather than dropping the handler call
+/// (the "the event fired is the primary signal" philosophy `bind_typed`
+/// follows).
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[non_exhaustive]
+pub struct InputEvent {
+    /// The event body's `detail` dict.
+    #[serde(default)]
+    pub detail: InputDetail,
+}
+
+/// The `detail` of an [`InputEvent`] — carries the field's current
+/// text under the `value` key.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[non_exhaustive]
+pub struct InputDetail {
+    /// The field's current full text.
+    #[serde(default)]
+    pub value: String,
+}
+
+impl InputEvent {
+    /// The field's current text — shorthand for `self.detail.value`.
+    pub fn value(&self) -> &str {
+        &self.detail.value
+    }
+
+    /// Take ownership of the field's current text.
+    pub fn into_value(self) -> String {
+        self.detail.value
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Callback newtype
+// ---------------------------------------------------------------------------
+
+/// A cloneable user callback for an [`Input`] event prop.
+///
+/// Wraps `Rc<dyn Fn(A)>` so it's `Clone` (required: `#[component]`
+/// re-clones every prop for the hot-reload remount path) and so a
+/// bare closure coerces into it via `Into` at the call site
+/// (`on_input: move |s| …`). `A` is `String` for value-carrying
+/// events (`on_input` / `on_change` / `on_submit`) and `()` for the
+/// bare focus / blur events.
+///
+/// This is the one deviation from the original `Box<dyn Fn(..)>`
+/// design sketch: a `Box<dyn Fn>` is neither `Clone` (the macro needs
+/// it) nor `Into`-coercible from a closure through the generated
+/// `Optional` setter, so the newtype carries both properties.
+#[derive(Clone)]
+pub struct InputCallback<A>(Rc<dyn Fn(A) + 'static>);
+
+impl<A> InputCallback<A> {
+    /// Invoke the wrapped callback.
+    pub fn call(&self, arg: A) {
+        (self.0)(arg)
+    }
+}
+
+impl<A, F: Fn(A) + 'static> From<F> for InputCallback<A> {
+    fn from(f: F) -> Self {
+        InputCallback(Rc::new(f))
+    }
+}
+
+/// A cloneable no-argument user callback for an [`Input`] event prop
+/// (`on_focus` / `on_blur`). Same rationale as [`InputCallback`] — a
+/// `Clone`, `Into`-from-closure wrapper around `Rc<dyn Fn()>`.
+#[derive(Clone)]
+pub struct InputAction(Rc<dyn Fn() + 'static>);
+
+impl InputAction {
+    /// Invoke the wrapped callback.
+    pub fn call(&self) {
+        (self.0)()
+    }
+}
+
+impl<F: Fn() + 'static> From<F> for InputAction {
+    fn from(f: F) -> Self {
+        InputAction(Rc::new(f))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard / return-key enums
+// ---------------------------------------------------------------------------
+
+/// On-screen keyboard layout for an [`Input`]. Variant wire strings
+/// are locked against the native modules' string dispatch.
+///
+/// `#[non_exhaustive]` so a future keyboard type can be added without
+/// breaking exhaustive matches downstream.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum KeyboardType {
+    /// `"default"` — the standard full keyboard. The default.
+    #[default]
+    Default,
+    /// `"number"` — numeric keypad (integers).
+    Number,
+    /// `"decimal"` — numeric keypad with a decimal point.
+    Decimal,
+    /// `"email"` — keyboard tuned for email entry (`@`, `.`).
+    Email,
+    /// `"phone"` — telephone-style keypad.
+    Phone,
+    /// `"url"` — keyboard tuned for URL entry (`/`, `.com`).
+    Url,
+}
+
+impl KeyboardType {
+    /// Canonical wire string the native view dispatches on.
+    pub const fn as_attr(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Number => "number",
+            Self::Decimal => "decimal",
+            Self::Email => "email",
+            Self::Phone => "phone",
+            Self::Url => "url",
+        }
+    }
+}
+
+/// Return-key label / action for an [`Input`]. Variant wire strings
+/// are locked against the native modules' string dispatch.
+///
+/// `#[non_exhaustive]` so a future return-key type can be added
+/// without breaking exhaustive matches downstream.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum ReturnKey {
+    /// `"default"` — the platform's default return key. The default.
+    #[default]
+    Default,
+    /// `"done"` — a "Done" key.
+    Done,
+    /// `"go"` — a "Go" key.
+    Go,
+    /// `"next"` — a "Next" key (advance to the next field).
+    Next,
+    /// `"search"` — a "Search" key.
+    Search,
+    /// `"send"` — a "Send" key.
+    Send,
+}
+
+impl ReturnKey {
+    /// Canonical wire string the native view dispatches on.
+    pub const fn as_attr(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Done => "done",
+            Self::Go => "go",
+            Self::Next => "next",
+            Self::Search => "search",
+            Self::Send => "send",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Imperative handle
+// ---------------------------------------------------------------------------
+
+/// Typed imperative handle for a mounted [`Input`].
+///
+/// Wraps the framework-internal `ElementRef` bound on mount when
+/// passed as the component's `input_ref:` prop. Methods dispatch the
+/// matching platform UI method through `ElementRef::invoke` /
+/// `invoke_typed`. The fire-and-forget methods swallow "not mounted"
+/// / platform errors — these are UI controls; use [`InputRef::get_value`]
+/// (which returns a [`RefError`]) when you need to inspect failures.
+///
+/// `Clone` produces a shared handle (same backing arena slot), so the
+/// same handle can drive multiple event closures.
+#[derive(Clone)]
+pub struct InputRef {
+    r: ElementRef,
+}
+
+impl InputRef {
+    /// Allocate a fresh, unbound handle. Pass it to the component's
+    /// `input_ref:` prop in `render!` to bind it on mount.
+    pub fn new() -> Self {
+        Self {
+            r: ElementRef::new(),
+        }
+    }
+
+    /// The underlying `ElementRef`. Framework-internal — the [`input`]
+    /// component reads it to wire the element's `ref:`. App code holds
+    /// the `InputRef` and calls the methods below.
+    #[doc(hidden)]
+    pub fn r(&self) -> ElementRef {
+        self.r
+    }
+
+    /// Focus the field and raise the keyboard. No-op if the element
+    /// isn't mounted yet.
+    pub fn focus(&self) {
+        let _ = self.r.invoke("focus", WhiskerValue::Null);
+    }
+
+    /// Resign focus and dismiss the keyboard. No-op if the element
+    /// isn't mounted or isn't focused.
+    pub fn blur(&self) {
+        let _ = self.r.invoke("blur", WhiskerValue::Null);
+    }
+
+    /// Clear the text to empty. No-op if the element isn't mounted.
+    ///
+    /// Note: this does NOT write back through a bound `text` signal —
+    /// the native view clears its own text, and the resulting `input`
+    /// event (if the platform emits one) drives the signal update.
+    /// For a guaranteed signal update prefer `text.set(String::new())`.
+    pub fn clear(&self) {
+        let _ = self.r.invoke("clear", WhiskerValue::Null);
+    }
+
+    /// Replace the field's text imperatively. No-op if the element
+    /// isn't mounted.
+    ///
+    /// The native view treats this the same as an external `value`
+    /// change: it only re-sets its text when `v` differs from what it
+    /// currently shows, so the cursor doesn't jump on a no-op write.
+    pub fn set_value(&self, v: &str) {
+        let _ = self.r.invoke(
+            "setValue",
+            WhiskerValue::map([("value", WhiskerValue::String(v.to_string()))]),
+        );
+    }
+
+    /// Async read of the field's current text.
+    ///
+    /// **iOS:** reliable — the result arrives over Lynx's UI-method
+    /// callback. **Android:** result-returning custom element methods
+    /// may require a Lynx fork release (per repo notes — `componentAt`
+    /// / result-method plumbing is iOS-only-compiled upstream). On an
+    /// unforked Android runtime this resolves to
+    /// [`RefError::DispatchFailed`] or `NotBound`; prefer reading a
+    /// bound `text` signal there.
+    pub async fn get_value(&self) -> Result<String, RefError> {
+        self.r
+            .invoke_typed::<GetValueResult>("getValue", WhiskerValue::Null)
+            .await
+            .map(|r| r.value)
+    }
+}
+
+impl Default for InputRef {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Decode target for `getValue` — the native side returns
+/// `{ "value": "<text>" }`; [`InputRef::get_value`] unwraps it to the
+/// bare `String`.
+#[derive(Debug, Default, serde::Deserialize)]
+struct GetValueResult {
+    #[serde(default)]
+    value: String,
+}
+
+// ---------------------------------------------------------------------------
+// Inner native binding — the thin element.
+//
+// `value` / `placeholder` / `…color` are reactive `Signal<String>`
+// attrs (kebab-cased: `placeholder-color`, `caret-color`,
+// `selection-color`). The bool / number / enum props are passed as
+// pre-stringified `Signal<String>` attrs ("true" / "false", a decimal
+// string, the enum's `as_attr`) so the macro's `apply_attr`
+// stringifies them uniformly and the native view reads one stable
+// string form. `on_*: InputEvent` props are typed events wired via
+// `bind_typed`. Crate-internal — only the outer `input` component
+// uses it; not part of the public doc surface.
+// ---------------------------------------------------------------------------
+
+#[doc(hidden)]
+#[whisker::module_component("Input")]
+pub fn native_input(
+    value: Signal<String>,
+    placeholder: Signal<String>,
+    placeholder_color: Signal<String>,
+    caret_color: Signal<String>,
+    selection_color: Signal<String>,
+    multiline: Signal<String>,
+    lines: Signal<String>,
+    secure: Signal<String>,
+    editable: Signal<String>,
+    auto_focus: Signal<String>,
+    max_length: Signal<String>,
+    keyboard_type: Signal<String>,
+    return_key: Signal<String>,
+    style: Signal<String>,
+    on_input: InputEvent,
+    on_change: InputEvent,
+    on_focus: InputEvent,
+    on_blur: InputEvent,
+    on_submit: InputEvent,
+) {
+}
+
+// ---------------------------------------------------------------------------
+// Public ergonomic component.
+// ---------------------------------------------------------------------------
+
+/// `whisker-input:Input` — a native text field with Leptos-style
+/// two-way binding.
+///
+/// See the [crate docs](crate) for usage, the full prop table, and
+/// styling notes.
+#[allow(clippy::too_many_arguments)]
+#[component]
+pub fn input(
+    /// Two-way bound value (headline API). Updates on every keystroke.
+    text: Option<RwSignal<String>>,
+    /// Controlled read (escape hatch). Ignored when `text` is set.
+    value: Option<Signal<String>>,
+    /// Fires every keystroke with the new full text.
+    on_input: Option<InputCallback<String>>,
+    /// Fires when editing ends / the value is committed.
+    on_change: Option<InputCallback<String>>,
+    /// Field gained focus.
+    on_focus: Option<InputAction>,
+    /// Field lost focus.
+    on_blur: Option<InputAction>,
+    /// Return / done key pressed; carries the current text.
+    on_submit: Option<InputCallback<String>>,
+    /// Placeholder text shown when the field is empty.
+    placeholder: Option<Signal<String>>,
+    /// Multiline area vs single-line field.
+    #[prop(default = false)]
+    multiline: bool,
+    /// Fixed visible line count (multiline only).
+    lines: Option<u32>,
+    /// Mask input (password entry).
+    #[prop(default = false)]
+    secure: bool,
+    /// Allow editing.
+    #[prop(default = true)]
+    editable: bool,
+    /// Focus + raise the keyboard on mount.
+    #[prop(default = false)]
+    auto_focus: bool,
+    /// Maximum character count.
+    max_length: Option<u32>,
+    /// On-screen keyboard layout.
+    #[prop(default = KeyboardType::Default)]
+    keyboard_type: KeyboardType,
+    /// Return-key label / action.
+    #[prop(default = ReturnKey::Default)]
+    return_key: ReturnKey,
+    /// Cursor color (CSS color string).
+    caret_color: Option<Signal<String>>,
+    /// Placeholder text color (CSS color string).
+    placeholder_color: Option<Signal<String>>,
+    /// Selection-highlight color (CSS color string).
+    selection_color: Option<Signal<String>>,
+    /// Standard Whisker CSS style string.
+    style: Option<Signal<String>>,
+    /// Imperative handle ([`InputRef`]).
+    input_ref: Option<InputRef>,
+) -> Element {
+    // ----- Effective displayed value (reactive) ------------------------
+    //
+    // Priority: `text` (two-way) → `value` (controlled) → empty. Feed
+    // it down to `NativeInput`'s `value` prop as a `Signal::Dynamic`
+    // so an external `text.set(...)` / a controlled `value` change
+    // re-applies natively.
+    //
+    // We do NOT guard cursor-jump / echo here: the native view only
+    // re-sets its displayed text when the incoming `value` differs
+    // from what it currently shows, so feeding the round-tripped value
+    // straight back down is safe.
+    //
+    // `text` is `Option<RwSignal<String>>` — `RwSignal` is `Copy`, so
+    // the whole `Option` is `Copy` and freely usable in every closure
+    // below. The other props (`value`, the callbacks) are `Clone`
+    // (Rc-backed / signal handles), so we clone them into each closure
+    // rather than moving them out of the `#[component]` re-invokable
+    // body.
+    let value_prop: Signal<String> = {
+        let value = value.clone();
+        Signal::Dynamic(computed(move || {
+            if let Some(t) = text {
+                t.get()
+            } else if let Some(v) = &value {
+                v.get()
+            } else {
+                String::new()
+            }
+        }))
+    };
+
+    // ----- Event wiring -----------------------------------------------
+    //
+    // on_input: update the bound `text` signal FIRST (so reads inside
+    // the user callback already see the new value), then call the
+    // user's `on_input`.
+    let on_input_cb = {
+        let on_input = on_input.clone();
+        move |ev: InputEvent| {
+            let new = ev.into_value();
+            if let Some(t) = text {
+                t.set(new.clone());
+            }
+            if let Some(cb) = &on_input {
+                cb.call(new);
+            }
+        }
+    };
+    let on_change_cb = {
+        let on_change = on_change.clone();
+        move |ev: InputEvent| {
+            if let Some(cb) = &on_change {
+                cb.call(ev.into_value());
+            }
+        }
+    };
+    let on_focus_cb = {
+        let on_focus = on_focus.clone();
+        move |_ev: InputEvent| {
+            if let Some(cb) = &on_focus {
+                cb.call();
+            }
+        }
+    };
+    let on_blur_cb = {
+        let on_blur = on_blur.clone();
+        move |_ev: InputEvent| {
+            if let Some(cb) = &on_blur {
+                cb.call();
+            }
+        }
+    };
+    let on_submit_cb = {
+        let on_submit = on_submit.clone();
+        move |ev: InputEvent| {
+            if let Some(cb) = &on_submit {
+                cb.call(ev.into_value());
+            }
+        }
+    };
+
+    // ----- Pass-through attrs (None → sensible default) ----------------
+    let placeholder_prop: Signal<String> = placeholder.clone().unwrap_or_default();
+    let caret_color_prop: Signal<String> = caret_color.clone().unwrap_or_default();
+    let placeholder_color_prop: Signal<String> = placeholder_color.clone().unwrap_or_default();
+    let selection_color_prop: Signal<String> = selection_color.clone().unwrap_or_default();
+    let style_prop: Signal<String> = style.clone().unwrap_or_default();
+
+    let multiline_attr = bool_attr(multiline);
+    let secure_attr = bool_attr(secure);
+    let editable_attr = bool_attr(editable);
+    let auto_focus_attr = bool_attr(auto_focus);
+    // `0` is the "unset" sentinel for `lines` / `max_length`.
+    let lines_attr = lines.unwrap_or(0).to_string();
+    let max_length_attr = max_length.unwrap_or(0).to_string();
+    let keyboard_type_attr = keyboard_type.as_attr().to_string();
+    let return_key_attr = return_key.as_attr().to_string();
+
+    // ----- Imperative handle: forward its ElementRef as `ref:` ---------
+    let element_ref = input_ref.as_ref().map(|h| h.r());
+
+    let mut builder = NativeInput::builder()
+        .value(value_prop)
+        .placeholder(placeholder_prop)
+        .placeholder_color(placeholder_color_prop)
+        .caret_color(caret_color_prop)
+        .selection_color(selection_color_prop)
+        .multiline(multiline_attr)
+        .lines(lines_attr)
+        .secure(secure_attr)
+        .editable(editable_attr)
+        .auto_focus(auto_focus_attr)
+        .max_length(max_length_attr)
+        .keyboard_type(keyboard_type_attr)
+        .return_key(return_key_attr)
+        .style(style_prop)
+        .on_input(on_input_cb)
+        .on_change(on_change_cb)
+        .on_focus(on_focus_cb)
+        .on_blur(on_blur_cb)
+        .on_submit(on_submit_cb);
+
+    if let Some(r) = element_ref {
+        builder = builder.with_ref(r);
+    }
+
+    NativeInput(builder.build())
+}
+
+/// `true` / `false` wire string for a bool attr.
+fn bool_attr(b: bool) -> String {
+    if b { "true" } else { "false" }.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyboard_type_wire_strings() {
+        assert_eq!(KeyboardType::Default.as_attr(), "default");
+        assert_eq!(KeyboardType::Number.as_attr(), "number");
+        assert_eq!(KeyboardType::Decimal.as_attr(), "decimal");
+        assert_eq!(KeyboardType::Email.as_attr(), "email");
+        assert_eq!(KeyboardType::Phone.as_attr(), "phone");
+        assert_eq!(KeyboardType::Url.as_attr(), "url");
+    }
+
+    #[test]
+    fn return_key_wire_strings() {
+        assert_eq!(ReturnKey::Default.as_attr(), "default");
+        assert_eq!(ReturnKey::Done.as_attr(), "done");
+        assert_eq!(ReturnKey::Go.as_attr(), "go");
+        assert_eq!(ReturnKey::Next.as_attr(), "next");
+        assert_eq!(ReturnKey::Search.as_attr(), "search");
+        assert_eq!(ReturnKey::Send.as_attr(), "send");
+    }
+
+    #[test]
+    fn enum_defaults() {
+        assert_eq!(KeyboardType::default(), KeyboardType::Default);
+        assert_eq!(ReturnKey::default(), ReturnKey::Default);
+    }
+
+    #[test]
+    fn bool_attr_strings() {
+        assert_eq!(bool_attr(true), "true");
+        assert_eq!(bool_attr(false), "false");
+    }
+
+    #[test]
+    fn input_event_deserializes_detail_value() {
+        // Mirrors the native event body: { detail: { value: "<text>" } }.
+        let v = WhiskerValue::map([(
+            "detail",
+            WhiskerValue::map([("value", WhiskerValue::String("hello".into()))]),
+        )]);
+        let ev: InputEvent = v.deserialize_into().expect("deserialize InputEvent");
+        assert_eq!(ev.value(), "hello");
+        assert_eq!(ev.into_value(), "hello");
+    }
+
+    #[test]
+    fn input_event_empty_body_defaults_to_empty() {
+        // focus / blur carry no value: the native side emits an empty
+        // (or `detail`-less) body. An empty map deserializes cleanly to
+        // an empty value via the `#[serde(default)]` on `detail`.
+        let empty: [(&str, WhiskerValue); 0] = [];
+        let ev: InputEvent = WhiskerValue::map(empty)
+            .deserialize_into()
+            .expect("empty map defaults");
+        assert_eq!(ev.value(), "");
+    }
+
+    #[test]
+    fn input_event_default_is_empty() {
+        // serde refuses to build a struct from a bare `null`, so for a
+        // truly null body `bind_typed` falls back to `E::default()` —
+        // which must be the empty-value event.
+        assert_eq!(InputEvent::default().value(), "");
+    }
+
+    #[test]
+    fn get_value_result_unwraps_value() {
+        let v = WhiskerValue::map([("value", WhiskerValue::String("abc".into()))]);
+        let r: GetValueResult = v.deserialize_into().expect("deserialize getValue");
+        assert_eq!(r.value, "abc");
+    }
+}


### PR DESCRIPTION
A new `whisker-input` package — a native text field shipped as a Whisker module — plus one framework-level bridge fix it surfaced.

## What's in it

A `#[whisker::module_component("Input")]` component backed by `UITextField`/`UITextView` (iOS) and `EditText` (Android):

- **Leptos-style two-way binding** as the headline API (`Input(text: my_rw_signal)`), with a **controlled** escape hatch (`value:` + `on_input:`, e.g. upper-casing).
- **Single-line / multiline** in one component (`multiline: true`, `lines:`) — no separate textarea.
- **Imperative handle** `InputRef` (focus / blur / clear / set_value / get_value via `ElementRef`).
- **Props**: placeholder, secure, editable, auto_focus, max_length, keyboard_type, return_key, and the Lynx-CSS-unreachable colors (`caret_color` / `placeholder_color` / `selection_color`).
- **CSS-driven layout & text style**: color, font-size/weight, text-align, `padding`, background-color, border-radius all flow through the standard `style:` cascade and are applied natively on both platforms (read from each platform's resolved-style channel).
- **Events**: on_input / on_change / on_focus / on_blur / on_submit.
- An **example app** exercising two-way, controlled (UPPER-CASE), multiline, and secure.

## Bridge fix (separate commit)

`fix(driver): normalize iOS custom-event params → detail` — on iOS, `LynxCustomEvent.generateEventBody` puts a custom event's payload under `params`, while the universal Whisker convention (and the Android reporter) uses `detail`. The Rust typed event structs read `detail`, so on iOS the payload of any custom **element** event silently arrived empty. The iOS reporter now mirrors `params` → `detail` when `detail` is absent. Additive and safe (touch events have no `params`; bodies already carrying `detail` are untouched; nothing reads `params`; module `sendEvent` uses a separate channel). This also fixes any built-in custom element event (scroll/list/…) whose iOS `detail` was previously empty.

## On-device verification

Built and verified end-to-end on the **iOS Simulator (iPhone 17 Pro)** and **Android emulator (Pixel 9 Pro)** — rendering, all styling props, two-way binding, controlled transform, multiline (3-line top-aligned + newline), secure, events round-trip (real typing), background, and CSS padding match across both platforms. Several native-specific issues were found and fixed in the process: async event dispatch (renderer-borrow reentrancy on teardown), the Android IME mount-time empty-event storm (user-interaction gate), the multiline mode switch, ARGB-int CSS color decoding, and CSS background/padding application.

## Tests / checks

`whisker-input` unit tests pass; `cargo fmt` / `cargo clippy -D warnings` clean; workspace + example build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)