### PR TITLE
feat(macros): module-component `style:` accepts `Css` directly (no to_css_string)

### DIFF
--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -341,9 +341,11 @@ struct Prop {
 }
 
 enum PropKind {
-    /// `style: Signal<String>` (or any `Signal<T>` / `T` whose name is
-    /// `style`) — routed through `apply_styles`.
-    Style { inner: Type },
+    /// `style: …` — the style prop. Always lowered to a
+    /// `::whisker::Style` field (ignoring the authored type) and
+    /// routed through `::whisker::apply_style`, exactly like a
+    /// built-in element's `style:`.
+    Style,
     /// Plain attribute — `Signal<T>` or `T`, name not in the special
     /// list. Routed through `apply_attr` with the kebab-cased name.
     Attr { inner: Type },
@@ -400,12 +402,11 @@ fn classify(ident: &Ident, ty: &Type) -> syn::Result<PropKind> {
         });
     }
 
-    // Style → SetRawInlineStyles. Inner type extraction is the same
-    // as for any attribute — strip `Signal<…>` if present.
+    // Style prop → `::whisker::Style`. The authored type is ignored
+    // (the macro always emits a `::whisker::Style` field + an
+    // `apply_style` call), so no inner-type extraction is needed.
     if name == "style" {
-        return Ok(PropKind::Style {
-            inner: signal_inner(ty).unwrap_or_else(|| ty.clone()),
-        });
+        return Ok(PropKind::Style);
     }
 
     // Otherwise: an attribute prop. Strip the `Signal<…>` wrapper if
@@ -444,7 +445,14 @@ fn is_unit_type(ty: &Type) -> bool {
 fn prop_struct_field(p: &Prop) -> TokenStream2 {
     let i = &p.ident;
     match &p.kind {
-        PropKind::Style { .. } | PropKind::Attr { .. } => {
+        // The style prop is ALWAYS typed `::whisker::Style` (the same
+        // wrapper built-in elements accept), regardless of the
+        // authored param type — so callers can pass a `Css` builder,
+        // a raw string, or a reactive signal of either directly.
+        PropKind::Style => {
+            quote! { pub #i: ::whisker::Style }
+        }
+        PropKind::Attr { .. } => {
             let t = &p.ty;
             quote! { pub #i: #t }
         }
@@ -463,7 +471,10 @@ fn prop_struct_field(p: &Prop) -> TokenStream2 {
 fn prop_builder_field(p: &Prop) -> TokenStream2 {
     let i = &p.ident;
     match &p.kind {
-        PropKind::Style { .. } | PropKind::Attr { .. } => {
+        PropKind::Style => {
+            quote! { #i: ::std::option::Option<::whisker::Style> }
+        }
+        PropKind::Attr { .. } => {
             let t = &p.ty;
             quote! { #i: ::std::option::Option<#t> }
         }
@@ -482,7 +493,19 @@ fn prop_builder_field(p: &Prop) -> TokenStream2 {
 fn prop_setter(p: &Prop) -> TokenStream2 {
     let i = &p.ident;
     match &p.kind {
-        PropKind::Style { .. } | PropKind::Attr { .. } => {
+        // Style setter accepts anything `Into<::whisker::Style>` —
+        // `Css`, `&Css`, `String`, `&str`, and reactive signals of
+        // either, exactly like a built-in element's `style(...)`.
+        PropKind::Style => {
+            quote! {
+                #[allow(unused_mut)]
+                pub fn #i(mut self, value: impl ::std::convert::Into<::whisker::Style>) -> Self {
+                    self.#i = ::std::option::Option::Some(value.into());
+                    self
+                }
+            }
+        }
+        PropKind::Attr { .. } => {
             let t = &p.ty;
             quote! {
                 #[allow(unused_mut)]
@@ -545,7 +568,7 @@ fn prop_build_assignment(p: &Prop, tag_name: &str) -> TokenStream2 {
         // Event handler props stay required because their `dyn Fn`
         // types don't have a sensible default and a missing callback
         // is almost always an author bug.
-        PropKind::Style { .. } | PropKind::Attr { .. } => {
+        PropKind::Style | PropKind::Attr { .. } => {
             quote! { #i: self.#i.unwrap_or_default() }
         }
         PropKind::EventNoPayload { .. } | PropKind::EventTyped { .. } => {
@@ -558,9 +581,12 @@ fn prop_apply_call(p: &Prop) -> TokenStream2 {
     let i = &p.ident;
     let name = i.to_string();
     match &p.kind {
-        PropKind::Style { inner } => {
+        PropKind::Style => {
+            // The style prop is a `::whisker::Style` value; route it
+            // through the same `apply_style` sink built-in elements
+            // use (Static → set-once, Dynamic → effect-wrapped).
             quote! {
-                ::whisker::runtime::view::apply_styles::<_, #inner>(__handle, props.#i);
+                ::whisker::apply_style(__handle, props.#i);
             }
         }
         PropKind::Attr { inner } => {

--- a/crates/whisker/src/style.rs
+++ b/crates/whisker/src/style.rs
@@ -18,6 +18,8 @@
 //! in `whisker-css`) so the `Css` crate stays `whisker-runtime`-free
 //! and reusable in standalone contexts.
 
+use std::rc::Rc;
+
 use whisker_css::{Css, ToCss};
 use whisker_runtime::reactive::{effect, ReadSignal, RwSignal};
 use whisker_runtime::view::set_inline_styles;
@@ -25,15 +27,30 @@ use whisker_runtime::view::Element;
 
 /// Value the `style:` builder method receives. One of the two
 /// variants below.
+///
+/// `Clone` is cheap: the `Dynamic` variant holds an [`Rc`], so a
+/// clone shares the same closure rather than re-boxing it. This lets
+/// the `#[component]` / `#[module_component]` macros store a `Style`
+/// prop and re-clone it on every re-invoke (hot-reload remount path).
+#[derive(Clone)]
 pub enum Style {
     /// CSS source the builder applies once, at element-construction
     /// time. Both [`Css`] builder values and raw strings collapse to
     /// this variant.
     Static(String),
-    /// CSS source produced by a reactive subscription. The boxed
+    /// CSS source produced by a reactive subscription. The shared
     /// closure is called inside an `effect` and re-fires whenever
     /// any signal it reads changes.
-    Dynamic(Box<dyn Fn() -> String + 'static>),
+    Dynamic(Rc<dyn Fn() -> String + 'static>),
+}
+
+impl Default for Style {
+    /// An empty static style — what an element would see if no
+    /// `style:` prop were declared. Lets the macros emit
+    /// `self.style.unwrap_or_default()` for an omitted style prop.
+    fn default() -> Self {
+        Style::Static(String::new())
+    }
 }
 
 // ---- Static sources --------------------------------------------------------
@@ -77,13 +94,13 @@ impl From<&String> for Style {
 
 impl From<ReadSignal<Css>> for Style {
     fn from(sig: ReadSignal<Css>) -> Self {
-        Style::Dynamic(Box::new(move || sig.get().to_css_string()))
+        Style::Dynamic(Rc::new(move || sig.get().to_css_string()))
     }
 }
 
 impl From<ReadSignal<String>> for Style {
     fn from(sig: ReadSignal<String>) -> Self {
-        Style::Dynamic(Box::new(move || sig.get()))
+        Style::Dynamic(Rc::new(move || sig.get()))
     }
 }
 

--- a/examples/podcast/crates/podcast-feature-detail/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-detail/src/lib.rs
@@ -157,7 +157,7 @@ fn detail_body(podcast: Podcast) -> Element {
                             height: px(220),
                             border_radius: theme::ARTWORK_RADIUS,
                             background_color: theme::SURFACE,
-                        ).raw("aspect-ratio", "1 / 1").to_css_string(),
+                        ).raw("aspect-ratio", "1 / 1"),
                         src: artwork_src,
                         mode: ImageMode::AspectFill,
                     )
@@ -275,7 +275,6 @@ fn top_bar(title: String) -> Element {
             flex_shrink: 0.0,
             background_color: theme::BG,
         )
-        .to_css_string()
     });
 
     render! {

--- a/examples/podcast/crates/podcast-ui-kit/src/featured_card.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/featured_card.rs
@@ -8,7 +8,7 @@
 
 use podcast_domain::Podcast;
 use podcast_theme as theme;
-use whisker::css::{Display, FlexDirection, FontWeight, TextOverflow, ToCss};
+use whisker::css::{Display, FlexDirection, FontWeight, TextOverflow};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_image::{Image, ImageMode};
@@ -49,8 +49,6 @@ pub fn featured_card(podcast: Podcast) -> Element {
                 ).raw("text-maxline", "2"),
                 value: title_text,
             )
-            // `Image` is a `module_component` — its `style` prop is
-            // `Signal<String>`, no `From<Css>` impl. Serialise here.
             Image(
                 style: css!(
                     width: theme::FEATURED_CARD_WIDTH,
@@ -58,7 +56,7 @@ pub fn featured_card(podcast: Podcast) -> Element {
                     border_radius: theme::ARTWORK_RADIUS,
                     margin_top: px(12),
                     background_color: theme::SURFACE,
-                ).to_css_string(),
+                ),
                 src: artwork_src,
                 mode: ImageMode::AspectFill,
             )

--- a/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
@@ -129,7 +129,7 @@ pub fn mini_player() -> Element {
                         height: px(40),
                         border_radius: px(6),
                         background_color: Color::rgba(255, 255, 255, 0.15),
-                    ).raw("aspect-ratio", "1 / 1").to_css_string(),
+                    ).raw("aspect-ratio", "1 / 1"),
                     src: artwork_src,
                     mode: ImageMode::AspectFill,
                 )

--- a/examples/podcast/crates/podcast-ui-kit/src/ranked_card.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/ranked_card.rs
@@ -7,7 +7,7 @@
 
 use podcast_domain::Podcast;
 use podcast_theme as theme;
-use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, TextOverflow, ToCss};
+use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, TextOverflow};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_image::{Image, ImageMode};
@@ -26,15 +26,12 @@ pub fn ranked_card(podcast: Podcast, rank: u32) -> Element {
             flex_direction: FlexDirection::Column,
         )) {
             Image(
-                // `Image` is a `module_component` — its `style` prop
-                // is `Signal<String>` with no `From<Css>` impl, so
-                // serialise here before handing it across.
                 style: css!(
                     width: theme::RANKED_CARD_SIDE,
                     height: theme::RANKED_CARD_SIDE,
                     border_radius: theme::ARTWORK_RADIUS,
                     background_color: theme::SURFACE,
-                ).to_css_string(),
+                ),
                 src: artwork_src,
                 mode: ImageMode::AspectFill,
             )

--- a/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
@@ -6,7 +6,7 @@
 //! shape). The menu glyph is `lucide::Menu` via `whisker-icons`.
 
 use podcast_theme as theme;
-use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, JustifyContent, ToCss};
+use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, JustifyContent};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_icons::{lucide, Icon};
@@ -38,7 +38,6 @@ pub fn top_nav(title: String, action_label: String) -> Element {
             flex_shrink: 0.0,
             background_color: theme::BG,
         )
-        .to_css_string()
     });
 
     render! {

--- a/packages/whisker-audio/example/src/lib.rs
+++ b/packages/whisker-audio/example/src/lib.rs
@@ -4,7 +4,7 @@
 //! the live playback position bound to a reactive signal, and
 //! renders Play / Pause / Stop / Seek tap targets.
 
-use whisker::css::{AlignItems, Color, Display, FlexDirection, FontWeight, JustifyContent, ToCss};
+use whisker::css::{AlignItems, Color, Display, FlexDirection, FontWeight, JustifyContent};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_audio::Player;
@@ -37,7 +37,7 @@ pub fn app() -> Element {
             padding_bottom: px(insets.get().bottom as f32 + 24.0),
             padding_left: px(24),
             padding_right: px(24),
-        ).to_css_string())) {
+        ))) {
             // Header
             view(style: css!(
                 width: percent(100),
@@ -120,7 +120,7 @@ pub fn app() -> Element {
     }
 }
 
-fn button_style() -> String {
+fn button_style() -> Css {
     css!(
         width: percent(100),
         max_width: px(280),
@@ -133,16 +133,14 @@ fn button_style() -> String {
         align_items: AlignItems::Center,
         justify_content: JustifyContent::Center,
     )
-    .to_css_string()
 }
 
-fn button_text_style() -> String {
+fn button_text_style() -> Css {
     css!(
         color: Color::hex(0xF0F0F3),
         font_size: px(15),
         font_weight: FontWeight::Numeric(600),
     )
-    .to_css_string()
 }
 
 fn fmt_bool(b: bool) -> String {

--- a/packages/whisker-icons/example/src/lib.rs
+++ b/packages/whisker-icons/example/src/lib.rs
@@ -20,7 +20,7 @@
 
 mod icons;
 
-use whisker::css::{FontWeight, TextAlign, ToCss};
+use whisker::css::{FontWeight, TextAlign};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_icons::Icon;
@@ -44,7 +44,7 @@ pub fn app() -> Element {
             flex_direction: FlexDirection::Column,
             padding_top: px(insets.get().top as f32 + 16.0),
             padding_bottom: px(insets.get().bottom as f32 + 16.0),
-        ).to_css_string())) {
+        ))) {
             // Wrap the header `text` in a `view` — a known Lynx
             // Android quirk collapses the first direct child of a
             // `<page>` to zero height when edge-to-edge is enabled

--- a/packages/whisker-image/src/lib.rs
+++ b/packages/whisker-image/src/lib.rs
@@ -115,7 +115,7 @@ impl std::fmt::Display for ImageMode {
 /// `onBorderRadiusUpdated` callback and feeds it to Coil's
 /// `RoundedCornersTransformation`).
 #[whisker::module_component("Image")]
-pub fn image(src: Signal<String>, mode: Signal<ImageMode>, style: Signal<String>) {}
+pub fn image(src: Signal<String>, mode: Signal<ImageMode>, style: whisker::Style) {}
 
 #[cfg(test)]
 mod tests {

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -146,7 +146,7 @@ use std::rc::Rc;
 
 use whisker::platform_module::WhiskerValue;
 use whisker::prelude::*;
-use whisker::{ElementRef, RefError, Signal};
+use whisker::{ElementRef, RefError, Signal, Style};
 
 // ---------------------------------------------------------------------------
 // Event payload
@@ -457,7 +457,7 @@ pub fn native_input(
     max_length: Signal<String>,
     keyboard_type: Signal<String>,
     return_key: Signal<String>,
-    style: Signal<String>,
+    style: Style,
     on_input: InputEvent,
     on_change: InputEvent,
     on_focus: InputEvent,
@@ -522,8 +522,10 @@ pub fn input(
     placeholder_color: Option<Signal<String>>,
     /// Selection-highlight color (CSS color string).
     selection_color: Option<Signal<String>>,
-    /// Standard Whisker CSS style string.
-    style: Option<Signal<String>>,
+    /// Standard Whisker style. Accepts a `Css` builder, a raw string,
+    /// or a reactive signal of either — same as a built-in element's
+    /// `style:`.
+    style: Option<Style>,
     /// Imperative handle ([`InputRef`]).
     input_ref: Option<InputRef>,
 ) -> Element {
@@ -613,7 +615,7 @@ pub fn input(
     let caret_color_prop: Signal<String> = caret_color.clone().unwrap_or_default();
     let placeholder_color_prop: Signal<String> = placeholder_color.clone().unwrap_or_default();
     let selection_color_prop: Signal<String> = selection_color.clone().unwrap_or_default();
-    let style_prop: Signal<String> = style.clone().unwrap_or_default();
+    let style_prop: Style = style.clone().unwrap_or_default();
 
     let multiline_attr = bool_attr(multiline);
     let secure_attr = bool_attr(secure);

--- a/packages/whisker-svg/src/lib.rs
+++ b/packages/whisker-svg/src/lib.rs
@@ -81,6 +81,7 @@ pub use replay::{replay, ReplayError, TraceVisitor, Visitor};
 use base64::Engine;
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
+use whisker::Style;
 
 /// `<Svg>` widget. Render arbitrary inline SVG inside the host
 /// element. Tracks `content` reactively — a content swap recompiles
@@ -98,7 +99,7 @@ use whisker::runtime::view::Element;
 ///   replayer scales the SVG's viewBox to fill these bounds with
 ///   `preserveAspectRatio="xMidYMid meet"` semantics.
 #[component]
-pub fn svg(content: Signal<String>, color: Signal<String>, style: Signal<String>) -> Element {
+pub fn svg(content: Signal<String>, color: Signal<String>, style: Style) -> Element {
     // Clone `content` before the move closure: `Signal` isn't `Copy`
     // (the Static variant owns its T), and the `#[component]` body
     // re-fires as a FnMut.
@@ -130,7 +131,7 @@ pub fn svg(content: Signal<String>, color: Signal<String>, style: Signal<String>
 /// (Whisker doesn't enforce visibility on Prop names yet — this
 /// is documentation-level.)
 #[whisker::module_component("Svg")]
-pub fn svg_renderer(display_list: Signal<String>, color: Signal<String>, style: Signal<String>) {}
+pub fn svg_renderer(display_list: Signal<String>, color: Signal<String>, style: Style) {}
 
 /// Compile `svg_xml` to a base64-cased display list. Returns empty
 /// string on parse failure (the replayer treats that as

--- a/packages/whisker-video/src/lib.rs
+++ b/packages/whisker-video/src/lib.rs
@@ -62,7 +62,7 @@ use whisker::{ElementRef, Signal};
 /// `Prop("src")` setter + `play` / `pause` / `seek` functions. `src`
 /// is the media URL; `style` is the standard layout-styling string.
 #[whisker::module_component("Video")]
-pub fn video(src: Signal<String>, style: Signal<String>) {}
+pub fn video(src: Signal<String>, style: whisker::Style) {}
 
 /// Typed imperative handle for a mounted `Video` element.
 ///

--- a/packages/whisker-webview/src/lib.rs
+++ b/packages/whisker-webview/src/lib.rs
@@ -155,7 +155,7 @@ use std::rc::Rc;
 
 use whisker::platform_module::WhiskerValue;
 use whisker::prelude::*;
-use whisker::{ElementRef, RefError, Signal};
+use whisker::{ElementRef, RefError, Signal, Style};
 
 // ---------------------------------------------------------------------------
 // Event payloads
@@ -466,7 +466,7 @@ pub fn native_webview(
     javascript_enabled: Signal<String>,
     scroll_enabled: Signal<String>,
     origin_whitelist: Signal<String>,
-    style: Signal<String>,
+    style: Style,
     on_message: MessageEvent,
     on_load_start: NavEvent,
     on_load: NavEvent,
@@ -516,8 +516,10 @@ pub fn web_view(
     on_progress: Option<Callback<f32>>,
     /// Navigation failed (url / code / description).
     on_error: Option<Callback<WebViewError>>,
-    /// Standard Whisker CSS style string.
-    style: Option<Signal<String>>,
+    /// Standard Whisker style. Accepts a `Css` builder, a raw string,
+    /// or a reactive signal of either — same as a built-in element's
+    /// `style:`.
+    style: Option<Style>,
     /// Imperative handle ([`WebViewRef`]).
     webview_ref: Option<WebViewRef>,
 ) -> Element {
@@ -590,7 +592,7 @@ pub fn web_view(
     // ----- Pass-through attrs (None → sensible default) ----------------
     let html_prop: Signal<String> = html.clone().unwrap_or_default();
     let user_agent_prop: Signal<String> = user_agent.clone().unwrap_or_default();
-    let style_prop: Signal<String> = style.clone().unwrap_or_default();
+    let style_prop: Style = style.clone().unwrap_or_default();
 
     let javascript_enabled_attr = bool_attr(javascript_enabled);
     let scroll_enabled_attr = bool_attr(scroll_enabled);


### PR DESCRIPTION
## Summary

Makes the `style:` prop on every `#[whisker::module_component]` native component — and its `#[component]` ergonomic wrapper — accept a `whisker_css::Css` builder value (and reactive `Css`/`String` signals) **directly**, exactly like built-in elements already do:

```rust
// before — module components required stringification
Input(style: Css::new().height(px(44)).to_css_string())

// after — same surface as `view(...)`
Input(style: Css::new().height(px(44)))
Svg(style: my_css_signal)                       // reactive
WebView(style: computed(move || css!(...)))     // reactive
```

Previously module-component style props were typed `Signal<String>`, so a `Css` had to be stringified with `.to_css_string()`. Built-in elements (`view`, `text`, …) never needed that because their `style(...)` setter accepts `impl Into<whisker::Style>`, and `Style` absorbs `Css`/`&Css`/`String`/`&str`/reactive `Css`/`String` signals.

## Approach

Route module-component style through the **same umbrella `Style` type + `apply_style` applier** that built-in elements use — one source of truth — instead of the stringly-typed `apply_styles` path. `apply_style` lowers to the same native `set_inline_styles` sink, so runtime behavior is unchanged; only the accepted input surface widens. Reactive sources (`ReadSignal<Css>` / `RwSignal<Css>` / `computed`) re-apply inside an `effect`, matching built-in semantics.

## Changes

- **`crates/whisker/src/style.rs`** — `Style` is now `Clone` + `Default` (the `Dynamic` variant holds `Rc` instead of `Box`), so component wrappers can `.clone()` / default it.
- **`crates/whisker-macros/src/module_component.rs`** — `PropKind::Style` split out from `PropKind::Attr`: it now emits a `::whisker::Style` field, an `impl Into<::whisker::Style>` setter, and a `::whisker::apply_style` call. The authored `style: Signal<String>` annotation becomes a name-keyed marker (the macro already classifies the style prop by name).
- **whisker-svg / -video / -image / -input / -webview** — `style` params retyped to `Style` / `Option<Style>`.
- **Sweep** — removed all now-gratuitous `.to_css_string()` calls that fed a component or built-in element `style:` prop (`whisker-audio`/`whisker-icons` examples, podcast demo). Left the low-level `whisker_runtime::view::apply_styles(...)` calls in `whisker-router` (a different, raw-element mechanism) untouched.

## Compatibility

Non-breaking: `Style` also has `From<String>` / `From<&str>` / `From<Signal-of-String>`, so existing callers passing strings or string signals keep working. The change only *adds* accepted types.

## Test plan
- [x] `cargo build --workspace` + `examples/podcast` workspace build clean
- [x] `cargo test --workspace` — 0 failures
- [x] `cargo clippy` (touched crates) — no warnings; `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)