### PR TITLE
fix(reactive): make `resource` fetcher reactive to the signals it reads

### DIFF
--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -149,6 +149,46 @@ pub(crate) fn untrack<R>(f: impl FnOnce() -> R) -> R {
     f()
 }
 
+/// Return the runtime's current reactive observer (`current_tracker`),
+/// if any. This is the node that signal reads register against right
+/// now — typically the effect / computed whose compute body is on the
+/// stack. Crate-internal; used by [`resource`](resource::resource) to
+/// capture its driving effect node so async-time reads can be
+/// re-attributed to it.
+pub(crate) fn current_tracker() -> Option<runtime::NodeId> {
+    with_runtime(|rt| rt.current_tracker)
+}
+
+/// Run `f` with the runtime's `current_tracker` temporarily set to
+/// `node`, then restore the previous tracker.
+///
+/// This is the inverse of [`untrack`]: where `untrack` clears the
+/// observer so reads register no dependencies, `with_observer`
+/// *installs* a specific observer so reads register as dependencies of
+/// `node`. The canonical use is re-installing a resource's driving
+/// effect node around each `poll` of its fetcher future, so that signal
+/// reads happening **after** an `.await` (i.e. outside any scheduler
+/// run) are still attributed to the resource — mirroring Leptos's
+/// per-poll observer restoration.
+///
+/// Like `untrack`, the restore runs from a `Drop` guard so a panic in
+/// `f` leaves the runtime's tracker in its prior state rather than
+/// dangling at `node`.
+pub(crate) fn with_observer<R>(node: runtime::NodeId, f: impl FnOnce() -> R) -> R {
+    use runtime::NodeId;
+
+    struct Restore(Option<NodeId>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            with_runtime(|rt| rt.current_tracker = self.0);
+        }
+    }
+
+    let prev = with_runtime(|rt| rt.current_tracker.replace(node));
+    let _guard = Restore(prev);
+    f()
+}
+
 /// (Test only) reset the thread-local runtime to an empty state. Used
 /// between unit tests to keep the arena clean.
 #[doc(hidden)]

--- a/crates/whisker-runtime/src/reactive/resource.rs
+++ b/crates/whisker-runtime/src/reactive/resource.rs
@@ -29,10 +29,15 @@
 //! pre-computed value, etc.) you can just write `async move { ... }`
 //! and skip the `run_blocking` step.
 
+use std::cell::Cell;
 use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll};
 
 use crate::tasks::spawn_local;
 
+use super::runtime::NodeId;
 use super::signal::RwSignal;
 
 /// Three-state machine the [`Resource`] cycles through. `Clone` so
@@ -124,14 +129,35 @@ impl<T: Clone + 'static> Resource<T> {
     }
 }
 
-/// Fire-and-forget async fetch. Drives `fetcher` (an `async fn` or
+/// Reactive async fetch. Drives `fetcher` (an `async fn` or
 /// `async move {…}` block) on Whisker's task pool and writes the
-/// resolved [`Result`] into the returned [`Resource`]'s signal.
+/// resolved [`Result`] into the returned [`Resource`]'s signal — then
+/// **re-runs the fetcher whenever any signal it read changes**.
 ///
-/// `fetcher` is called once on the TASM thread to obtain the
-/// `Future`, which is then spawned onto [`crate::tasks::spawn_local`]
-/// and polled by every tick. The future runs cooperatively — `await`
-/// points yield back to the runtime so the UI stays responsive.
+/// Reactivity: the fetcher is wrapped in a reactive [`effect`] and the
+/// spawned future re-installs that effect node as the current observer
+/// on every `poll`. As a result, signals read **anywhere** in the
+/// fetcher are tracked as dependencies of the resource — both in the
+/// synchronous prefix (before the first `.await`) and after any
+/// `.await` point. When any tracked signal changes, the fetcher runs
+/// again from scratch and the resource updates.
+///
+/// While a (re)fetch is in flight the resource returns to
+/// [`ResourceState::Loading`]. Only the latest run's result is
+/// committed: a monotonically-increasing generation counter guards the
+/// write, so if a newer run starts before an older in-flight fetch
+/// resolves, the stale result is discarded rather than clobbering the
+/// fresh state. In-flight stale fetches are abandoned *cooperatively*
+/// (the superseded future stops at its next `poll` boundary) — there is
+/// no hard cancellation, and any worker thread spawned via
+/// [`crate::tasks::run_blocking`] runs to completion with its result
+/// dropped.
+///
+/// Dynamic-dependency caveat: dependencies are rebuilt on every run, so
+/// a signal that is only read on *some* code path is only a dependency
+/// on the runs where that path actually executes. A signal read after
+/// an `.await` is only tracked once the future advances past that
+/// suspension point.
 ///
 /// For blocking sync work inside the fetcher (e.g. `ureq::get(...)`,
 /// `std::fs::read(...)`), wrap the call in
@@ -140,30 +166,118 @@ impl<T: Clone + 'static> Resource<T> {
 /// is back.
 ///
 /// Returns immediately with a `Resource<T>` in
-/// [`ResourceState::Loading`].
+/// [`ResourceState::Loading`]; the first fetch is spawned during the
+/// effect's synchronous initial run.
 ///
-/// Owner discipline: the underlying [`RwSignal`] is registered with
-/// whatever owner is current at call time. If that owner is disposed
-/// before the future completes, the eventual write is a no-op (the
-/// signal node is gone), so no stale write hits a re-mounted owner.
+/// Owner discipline: the underlying [`RwSignal`] and the driving effect
+/// are registered with whatever owner is current at call time. If that
+/// owner is disposed, the effect stops re-running and any eventual
+/// write is a no-op (the signal node is gone), so no stale write hits a
+/// re-mounted owner.
 ///
-/// For tests, prefer [`resource_sync`] — it runs the fetcher inline
-/// and doesn't depend on the executor having been ticked.
+/// For tests / already-in-memory values, prefer [`resource_sync`] — it
+/// runs the fetcher inline once, untracked, and doesn't depend on the
+/// executor having been ticked.
 pub fn resource<T, F, Fut>(fetcher: F) -> Resource<T>
 where
     T: Clone + 'static,
-    F: FnOnce() -> Fut + 'static,
+    F: Fn() -> Fut + 'static,
     Fut: Future<Output = Result<T, String>> + 'static,
 {
     let state = RwSignal::new(ResourceState::Loading);
-    spawn_local(async move {
-        let result = fetcher().await;
-        state.set(match result {
-            Ok(v) => ResourceState::Ready(v),
-            Err(e) => ResourceState::Error(e),
+    // Monotonic run counter. Each effect run bumps it and stamps its
+    // spawned future; the future only commits its result if the
+    // counter still matches at completion time (generation guard).
+    let generation = Rc::new(Cell::new(0u64));
+    let fetcher = Rc::new(fetcher);
+
+    super::effect::effect(move || {
+        // Inside an effect run the runtime's `current_tracker` IS this
+        // effect's node. Capture it so the spawned future can re-install
+        // it as the observer around each poll (so post-`.await` reads
+        // register as deps of this node too).
+        let node = super::current_tracker().expect("resource effect must run under a tracker");
+
+        let my_gen = generation.get().wrapping_add(1);
+        generation.set(my_gen);
+
+        // Build the future. The fetcher's SYNCHRONOUS prefix runs here,
+        // and because we're inside the effect run, its signal reads
+        // register as dependencies of `node`.
+        let fut = (fetcher)();
+
+        // Return to Loading on every (re)fetch. Write untracked so this
+        // never creates a dependency edge — the effect must not depend
+        // on `state` (the signal it writes) or it would re-trigger
+        // itself in an infinite loop.
+        state.update_untracked(|s| *s = ResourceState::Loading);
+
+        spawn_local(ScopedFetch {
+            node,
+            my_gen,
+            generation: generation.clone(),
+            state,
+            fut: Box::pin(fut),
         });
     });
+
     Resource { state }
+}
+
+/// A spawned fetch future that re-installs its resource's effect node
+/// as the current reactive observer on every `poll`, so signal reads
+/// after `.await` points are tracked as dependencies of the resource.
+/// A generation stamp lets a superseded run abandon itself
+/// cooperatively without clobbering a fresher result.
+struct ScopedFetch<T: Clone + 'static> {
+    /// The driving effect's node — re-installed as the observer per poll.
+    node: NodeId,
+    /// This run's generation stamp.
+    my_gen: u64,
+    /// Shared run counter; if it has moved past `my_gen` we're stale.
+    generation: Rc<Cell<u64>>,
+    /// Resource state slot to commit into.
+    state: RwSignal<ResourceState<T>>,
+    /// The fetcher's future (single-threaded / `!Send` is fine here).
+    fut: Pin<Box<dyn Future<Output = Result<T, String>>>>,
+}
+
+impl<T: Clone + 'static> Future for ScopedFetch<T> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        // Destructure through the pin so the borrow of `fut` inside the
+        // `with_observer` closure doesn't collide with reads of the
+        // other fields.
+        let this = self.get_mut();
+
+        // A newer run superseded us: abandon WITHOUT installing the
+        // observer (add no stale dependency edges) and WITHOUT writing
+        // state. The inner future is dropped with this `ScopedFetch`.
+        if this.generation.get() != this.my_gen {
+            return Poll::Ready(());
+        }
+
+        let node = this.node;
+        let fut = &mut this.fut;
+        // Re-install the resource's effect node as the current observer
+        // for THIS poll so reads after `.await` register as deps of it.
+        let poll = super::with_observer(node, || fut.as_mut().poll(cx));
+
+        match poll {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(result) => {
+                // Commit only if we're still the latest run.
+                if this.generation.get() == this.my_gen {
+                    this.state.set(match result {
+                        Ok(v) => ResourceState::Ready(v),
+                        Err(e) => ResourceState::Error(e),
+                    });
+                }
+                Poll::Ready(())
+            }
+        }
+    }
 }
 
 /// Synchronous-fetch variant. Runs `fetcher` inline on the calling

--- a/crates/whisker-runtime/src/reactive/tests_resource.rs
+++ b/crates/whisker-runtime/src/reactive/tests_resource.rs
@@ -7,7 +7,8 @@
 //! purely-async fetchers; `run_blocking`-using fetchers do require
 //! the dispatcher and are exercised in `tasks::tests`).
 
-use crate::reactive::{__reset_for_tests, resource, resource_sync, Owner, ResourceState};
+use crate::reactive::RwSignal;
+use crate::reactive::{__reset_for_tests, flush, resource, resource_sync, Owner, ResourceState};
 use crate::tasks;
 
 fn with_test_owner<R>(f: impl FnOnce() -> R) -> R {
@@ -126,6 +127,152 @@ fn async_resource_multi_step_future_completes_within_one_tick() {
         let r = resource::<i32, _, _>(|| OneYield(false));
         tasks::run_until_stalled();
         assert_eq!(r.get(), Some(123));
+    });
+}
+
+#[test]
+fn async_resource_tracks_signal_read_in_sync_prefix_and_refetches() {
+    // (a) Sync-prefix tracking: the fetcher reads `query` BEFORE its
+    // `.await`, deriving the fetched value from it. Changing `query`
+    // must re-run the fetcher and update the resource with the new
+    // value. This is the canonical search-box repro.
+    with_test_owner(|| {
+        let query = RwSignal::new(String::new());
+        let r = resource::<String, _, _>(move || {
+            // Synchronous read of `query` — registers as a dependency
+            // of the resource's driving effect.
+            let q = query.get();
+            async move {
+                if q.trim().is_empty() {
+                    Ok(String::new())
+                } else {
+                    // A trivial "fetch": echo the query back uppercased.
+                    Ok(q.to_uppercase())
+                }
+            }
+        });
+
+        // Initial fetch: empty query → empty result.
+        tasks::run_until_stalled();
+        assert_eq!(r.get().as_deref(), Some(""));
+
+        // Change the tracked signal → effect re-runs → fetcher re-fires.
+        query.set("Slime".to_string());
+        flush(); // drain the effect re-run (spawns the new fetch)
+        tasks::run_until_stalled(); // drive the new fetch to completion
+        assert_eq!(
+            r.get().as_deref(),
+            Some("SLIME"),
+            "resource must re-fetch with the new query after sync-prefix read changes"
+        );
+
+        // And again, to prove it keeps tracking across re-runs.
+        query.set("Goo".to_string());
+        flush();
+        tasks::run_until_stalled();
+        assert_eq!(r.get().as_deref(), Some("GOO"));
+    });
+}
+
+#[test]
+fn async_resource_tracks_signal_read_after_await_and_refetches() {
+    // (b) After-await tracking: the fetcher first `.await`s a future
+    // that is Pending on its first poll (a real suspension), and only
+    // AFTER resuming reads `multiplier`. The signal read therefore
+    // happens while the future is being polled outside the scheduler
+    // run — it is the per-poll `with_observer` re-install that makes it
+    // a tracked dependency. Changing `multiplier` must re-fetch.
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    // Ready-on-second-poll future, forcing a suspension before the read.
+    struct OneYield(bool);
+    impl std::future::Future for OneYield {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if !self.0 {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        }
+    }
+
+    with_test_owner(|| {
+        let multiplier = RwSignal::new(2_i32);
+        let r = resource::<i32, _, _>(move || async move {
+            // Suspend FIRST — the `multiplier` read below happens after
+            // a real `.await` point, outside any scheduler run.
+            OneYield(false).await;
+            let m = multiplier.get();
+            Ok(m * 10)
+        });
+
+        tasks::run_until_stalled();
+        assert_eq!(
+            r.get(),
+            Some(20),
+            "first fetch should suspend, resume, read multiplier=2 → 20"
+        );
+
+        // Change the post-await-tracked signal → must re-fetch.
+        multiplier.set(5);
+        flush();
+        tasks::run_until_stalled();
+        assert_eq!(
+            r.get(),
+            Some(50),
+            "resource must track a signal read AFTER an .await and re-fetch on change"
+        );
+    });
+}
+
+#[test]
+fn async_resource_returns_to_loading_during_refetch() {
+    // A re-fetch whose future suspends should leave the resource in
+    // Loading until the new run resolves (not stuck on the old value).
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    struct OneYield(bool);
+    impl std::future::Future for OneYield {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if !self.0 {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        }
+    }
+
+    with_test_owner(|| {
+        let n = RwSignal::new(1_i32);
+        let r = resource::<i32, _, _>(move || {
+            let v = n.get();
+            async move {
+                OneYield(false).await;
+                Ok(v)
+            }
+        });
+        tasks::run_until_stalled();
+        assert_eq!(r.get(), Some(1));
+
+        // Re-run the effect (spawns a new, suspending fetch) but do NOT
+        // drive the pool yet. The untracked Loading reset should be
+        // visible immediately after flush.
+        n.set(2);
+        flush();
+        assert!(
+            r.loading(),
+            "resource should be Loading during an in-flight re-fetch"
+        );
+        tasks::run_until_stalled();
+        assert_eq!(r.get(), Some(2));
     });
 }
 


### PR DESCRIPTION
## Problem

`resource(fetcher)` called the fetcher exactly **once** and never re-ran it. A fetcher that reads a signal therefore never re-fetched when that signal changed — it stayed stuck on the first result.

```rust
let committed = RwSignal::new(String::new());
let results = resource(move || {
    let q = committed.get();                 // reads a signal
    async move {
        if q.trim().is_empty() { return Ok(vec![]); }
        search_groups(q.trim()).await        // fetch depends on q
    }
});
// committed.set("Slime") → results did NOT re-fetch (bug): stuck on the initial empty Vec
```

## Fix

Make the fetcher **reactive**: signals read anywhere in it — both the synchronous prefix **and after `.await`** — are tracked, and any change re-runs the fetcher and updates the resource. This is the Leptos `LocalResource` / Solid `createResource` behavior.

### Mechanism (mirrors Leptos `LocalResource`)

- The fetch is driven by an `effect`; its synchronous run captures the effect node and builds + spawns the future.
- A `ScopedFetch` future wrapper **re-installs that effect node as the current reactive observer on every `poll`** (via a new internal `with_observer`). The async executor stays reactive-agnostic; the per-poll observer restore is what makes `signal.get()` calls *after* an `.await` register as dependencies.
- A monotonic **generation counter** guards stale results: a poll whose generation was superseded abandons cooperatively (no tracking, no write); only the latest run commits. `spawn_local` exposes no cancel handle, so this cooperative scheme stands in for hard cancellation (same as Leptos's version guard).
- The resource returns to `Loading` while a re-fetch is in flight.

### Per-poll overhead

The wrapper adds, per poll: 2× thread-local `RefCell` borrow + 2× `Option<NodeId>` (8-byte Copy) write + one generation compare — O(1), ~tens of ns, **no allocation, no graph walk, independent of dependency count**. Polls happen once per await-wakeup (not a hot loop), so it's dwarfed by the fetch work and the executor's own per-poll bookkeeping.

## API notes

- New internal primitives in `reactive/mod.rs`: `current_tracker()` and `with_observer(node, f)` (the value-setting twin of `untrack`).
- `resource_sync` unchanged (still one-shot, untracked).
- Fetcher bound widens `FnOnce` → `Fn` (called on every re-run). Both existing call sites already satisfy it.
- **Guidance:** for signal-derived *transforms* of already-fetched data (e.g. filtering a fetched list by a signal), prefer one-shot `resource` + `computed` rather than triggering a re-fetch.

## Tests

Added to `tests_resource.rs`:
- **sync-prefix tracking** — reads the signal before `.await`; re-fetches on change (the repro above).
- **after-await tracking** — suspends first, then reads the signal; still tracked and re-fetches.
- **loading-during-refetch** — returns to `Loading` while the new fetch is in flight.

## Test plan
- [x] `cargo test -p whisker-runtime` — 124 passed, 0 failed (incl. 3 new reactivity tests)
- [x] `cargo build --workspace` clean; `cargo clippy -p whisker-runtime` no warnings; `cargo fmt --all --check` clean
- [x] Existing one-shot/loading/error resource tests still pass (their fetchers read no signals → effect runs once)

🤖 Generated with [Claude Code](https://claude.com/claude-code)