### PR TITLE
fix(driver): keep host ticking while async tasks are outstanding (reactive resource + run_blocking hang)

### DIFF
--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -232,9 +232,20 @@ fn apply_pending_hot_patch() -> Vec<*const ()> {
 }
 
 /// Process one frame on demand. Returns `true` when the runtime is
-/// fully idle after this tick (no pending effects) so the host can
-/// pause its render loop until the next `request_frame` callback
-/// fires.
+/// fully idle after this tick so the host can pause its render loop
+/// until the next `request_frame` callback fires.
+///
+/// "Idle" requires BOTH that the dispatched frame completed AND that
+/// the async task pool has drained. An outstanding task — e.g. a
+/// `resource()` fetch parked on a `run_blocking` worker — keeps the
+/// runtime non-idle so the host keeps ticking until the fetch resumes.
+/// Without this, the host would pause its render loop the instant the
+/// fetch polled to `Pending`, and the worker's cross-thread unpause
+/// (`host_wake::wake_runtime`) races the end-of-frame pause: if the
+/// unpause is processed first, the pause clobbers it and the fetch is
+/// never re-polled — the resource hangs in `Loading`. See
+/// [`whisker_runtime::tasks::has_pending_tasks`] and the
+/// `cross_thread_wake` resource tests.
 pub fn tick(engine_raw: *mut c_void) -> bool {
     if engine_raw.is_null() {
         return true;
@@ -247,7 +258,8 @@ pub fn tick(engine_raw: *mut c_void) -> bool {
             std::ptr::null_mut(),
         )
     };
-    !PENDING.with(|p| p.get())
+    let dispatch_pending = PENDING.with(|p| p.get());
+    !dispatch_pending && !whisker_runtime::tasks::has_pending_tasks()
 }
 
 extern "C" fn tick_callback(_user_data: *mut c_void) {

--- a/crates/whisker-runtime/src/main_thread.rs
+++ b/crates/whisker-runtime/src/main_thread.rs
@@ -175,22 +175,33 @@ pub fn __reset_for_tests() {
     }
 }
 
+/// Shared serialisation lock for every test that touches the
+/// process-global host wiring (the main-thread dispatcher in this
+/// module and the frame-request callback in [`crate::host_wake`]).
+///
+/// These globals are reset/installed by tests across SEVERAL modules
+/// (`main_thread`, `tasks`, `reactive::tests_resource`). A per-module
+/// lock can't keep them from racing — module A could clear the
+/// dispatcher mid-fetch in module B, dropping the marshaled result.
+/// All such tests take THIS one lock instead.
+#[cfg(test)]
+pub(crate) fn host_test_lock<'a>() -> std::sync::MutexGuard<'a, ()> {
+    static HOST_TEST_LOCK: Mutex<()> = Mutex::new(());
+    HOST_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex, MutexGuard};
+    use std::sync::{Arc, MutexGuard};
 
-    /// Tests poke a shared global (the registered dispatcher), so they
-    /// must run one at a time. `cargo test` defaults to parallel test
-    /// threads — this lock serialises just the tests in this module.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
-
+    /// Tests poke process-global host state (the registered
+    /// dispatcher), so they must run one at a time AND not race tests
+    /// in sibling modules that touch the same globals — hence the
+    /// shared [`super::host_test_lock`].
     fn lock<'a>() -> MutexGuard<'a, ()> {
-        // Unwrap on poison: a poisoned lock means a previous test panicked
-        // mid-dispatch — re-running on top of that is fine because we
-        // reset state at the start of every test anyway.
-        TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+        super::host_test_lock()
     }
 
     /// Pretend-host dispatcher: invokes the callback synchronously on

--- a/crates/whisker-runtime/src/reactive/tests_resource.rs
+++ b/crates/whisker-runtime/src/reactive/tests_resource.rs
@@ -276,6 +276,323 @@ fn async_resource_returns_to_loading_during_refetch() {
     });
 }
 
+/// Regression repro for the field bug on 0.2.4: a **reactive resource
+/// whose fetcher reads a signal AND does blocking IO via `run_blocking`**
+/// hangs after the tracked signal changes — the re-fetch starts
+/// (`loading` flips true) but the result never lands.
+///
+/// ## Why this reproduces the device hang (and earlier attempts didn't)
+///
+/// On device the host render loop pauses whenever `whisker_tick`
+/// reports **idle**, and resumes only on a `request_frame` wake. A
+/// `run_blocking` fetch is resumed by a *cross-thread* wake fired from
+/// the worker (`host_wake::wake_runtime`). That wake races the host
+/// pausing its render loop at the end of the very frame that polled the
+/// fetch to `Pending`: on both iOS (`displayLink.isPaused`) and Android
+/// (`Choreographer` + `scheduled` `compareAndSet`) the end-of-frame
+/// pause can **clobber** the worker's concurrent unpause, and the wake
+/// is lost. The one-shot / single-write cases survive because their one
+/// async settle lands in a frame the host already had scheduled; the
+/// reactive **re-fetch** is a *second* settle that arrives after the
+/// host already idled once — the window where the clobber bites.
+///
+/// To model this deterministically the harness makes the worker's
+/// cross-thread wake **ineffective** (the frame-request callback is a
+/// no-op — i.e. the clobbered/lost wake). The ONLY thing that can drive
+/// a parked fetch to completion is then the runtime reporting **busy**
+/// while tasks are outstanding (`tasks::has_pending_tasks`, the fix),
+/// which keeps the host's loop ticking until the pool drains. With the
+/// fix the re-fetch completes; revert it (let `tick` go idle with tasks
+/// outstanding) and the loop pauses → the fetch is never re-polled →
+/// these tests hit the deadline (the field hang).
+mod cross_thread_wake {
+    use super::*;
+    use crate::main_thread::{set_main_thread_dispatcher, DispatchFn};
+    use crate::tasks::run_blocking;
+    use std::ffi::c_void;
+    use std::sync::MutexGuard;
+    use std::time::{Duration, Instant};
+
+    // These tests reach into process-global state (the main-thread
+    // dispatcher + frame-request callback). Use the shared host-test
+    // lock so sibling modules can't clear our dispatcher mid-fetch.
+    fn lock<'a>() -> MutexGuard<'a, ()> {
+        crate::main_thread::host_test_lock()
+    }
+
+    // The host's frame-request callback, modelled as a NO-OP: this is
+    // the *clobbered / lost* cross-thread wake. A robust runtime must
+    // NOT depend on it to finish an in-flight fetch.
+    extern "C" fn request_frame_noop(_: *mut c_void) {}
+
+    // Synchronous main-thread dispatcher: runs the marshaled closure
+    // inline (on whatever thread called run_on_main_thread, i.e. the
+    // worker). Matches the harness in `tasks::tests`.
+    extern "C" fn sync_invoke(
+        _engine: *mut c_void,
+        callback: extern "C" fn(*mut c_void),
+        user_data: *mut c_void,
+    ) -> bool {
+        callback(user_data);
+        true
+    }
+
+    fn install_host() {
+        set_main_thread_dispatcher(Some(sync_invoke as DispatchFn), std::ptr::null_mut());
+        crate::host_wake::set_request_frame_callback(
+            Some(request_frame_noop),
+            std::ptr::null_mut(),
+        );
+    }
+
+    fn reset_host() {
+        crate::main_thread::__reset_for_tests();
+        crate::host_wake::__reset_for_tests();
+    }
+
+    /// One "frame": exactly what the driver's `tick_frame` +
+    /// `tick`-idle-reporting do. Runs reactive flush, drains the task
+    /// pool, runs a SECOND reactive flush (to surface signal writes
+    /// made by tasks that resolved during the drain, e.g. a fetch
+    /// committing `state.set(Ready)`), and returns the runtime's
+    /// idle/busy verdict — `true` == idle == "host may pause".
+    ///
+    /// The idle verdict mirrors `whisker-driver`'s fixed `tick`: idle
+    /// requires the pool to be drained (`!has_pending_tasks()`).
+    fn tick() -> bool {
+        flush();
+        tasks::run_until_stalled();
+        flush();
+        !tasks::has_pending_tasks()
+    }
+
+    /// Drive the host loop until `done()` or the deadline.
+    ///
+    /// Models the real render loop: tick; if the runtime reports idle,
+    /// "pause" (stop ticking) — and because the worker's cross-thread
+    /// wake is the clobbered no-op above, the loop has NO way to resume
+    /// a parked fetch except the runtime continuing to report **busy**.
+    /// That busy signal is the fix (`has_pending_tasks`). Revert it and
+    /// `tick()` returns idle the instant the fetch parks → the loop
+    /// stops ticking → the re-poll never happens → deadline → hang.
+    fn drive_until(mut done: impl FnMut() -> bool) {
+        // 2s is ample margin over the worker sleeps (15–40ms) on the
+        // happy path; on a reverted fix the loop pauses and burns the
+        // full deadline (the hang).
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut idle = tick();
+        while !done() && Instant::now() < deadline {
+            if idle {
+                // Paused. The clobbered/no-op worker wake cannot resume
+                // us; a truly-idle runtime stays paused until the
+                // deadline (surfacing the hang on a reverted fix). We
+                // still loop so `done()` / the deadline are re-checked,
+                // but we do NOT tick.
+                std::thread::sleep(Duration::from_millis(2));
+            } else {
+                // Busy: keep ticking. This is the path the fix enables —
+                // `has_pending_tasks()` keeps `tick()` reporting busy
+                // until the in-flight fetch resumes and the pool drains.
+                idle = tick();
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+
+    #[test]
+    fn reactive_resource_reading_signal_with_run_blocking_completes_after_refetch() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let _g = lock();
+        __reset_for_tests();
+        tasks::__reset_for_tests();
+        install_host();
+
+        let runs = Rc::new(Cell::new(0u32));
+        let runs_for_fetcher = runs.clone();
+
+        let owner = Owner::new(None);
+        owner.with(|| {
+            let query = RwSignal::new(1_i32);
+            let r = resource::<i32, _, _>(move || {
+                runs_for_fetcher.set(runs_for_fetcher.get() + 1);
+                // Sync-prefix read of the tracked signal (the canonical
+                // "fetch keyed by a signal" pattern).
+                let q = query.get();
+                async move {
+                    // Blocking IO offloaded to a worker thread, result
+                    // marshaled back via run_on_main_thread. A small
+                    // sleep makes the worker outlive the spawning frame
+                    // so the cross-thread wake (not an inline poll) is
+                    // what resumes the fetch — as on device.
+                    let v = run_blocking(move || {
+                        std::thread::sleep(Duration::from_millis(15));
+                        q * 10
+                    })
+                    .await;
+                    Ok::<i32, String>(v)
+                }
+            });
+
+            // A consuming effect, as a component's render would have:
+            // it READS the resource state (subscribing to the state
+            // signal) so that each commit (`state.set`) schedules a
+            // re-run on the trailing flush — faithfully modelling the
+            // device, where the resource is rendered by `{expr}` text
+            // bindings.
+            let seen = Rc::new(Cell::new(0i32));
+            let seen_for_effect = seen.clone();
+            crate::reactive::effect::effect(move || {
+                if let ResourceState::Ready(v) = r.state() {
+                    seen_for_effect.set(v);
+                }
+            });
+
+            // Drive the INITIAL fetch to completion.
+            drive_until(|| !r.loading());
+            assert_eq!(
+                r.get(),
+                Some(10),
+                "initial reactive+run_blocking fetch must complete (query=1 → 10)"
+            );
+
+            // Change the tracked signal. On device the write's wake
+            // requests a frame; the host tick flushes the effect re-run
+            // (which spawns the new fetch). Do NOT flush inline — let
+            // the on-demand tick loop pick up the frame request, exactly
+            // as the host does.
+            query.set(7);
+
+            // Drive the RE-FETCH to completion. THIS is what hangs on
+            // 0.2.4: loading flips true but the result never arrives.
+            drive_until(|| matches!(r.state(), ResourceState::Ready(70)));
+            assert_eq!(
+                r.get(),
+                Some(70),
+                "reactive resource + run_blocking must finish the re-fetch \
+                 after the tracked signal changes (query=7 → 70), not stay Loading"
+            );
+            assert_eq!(
+                runs.get(),
+                2,
+                "fetcher must run exactly twice (initial + one re-fetch); a \
+                 spurious extra run would bump the generation and abandon the \
+                 in-flight fetch"
+            );
+            assert_eq!(seen.get(), 70, "consumer effect observed the final value");
+        });
+
+        owner.dispose();
+        reset_host();
+    }
+
+    /// Reporter's after-`.await` variant: the tracked signal is read
+    /// AFTER the `run_blocking().await` resumes — so the read happens
+    /// during a cross-thread-woken poll, inside `with_observer`. This
+    /// is the path the reporter's hypothesis points at (re-subscription
+    /// during the cross-thread-woken poll).
+    #[test]
+    fn reactive_resource_signal_read_after_run_blocking_await_refetches() {
+        let _g = lock();
+        __reset_for_tests();
+        tasks::__reset_for_tests();
+        install_host();
+
+        let owner = Owner::new(None);
+        owner.with(|| {
+            let multiplier = RwSignal::new(2_i32);
+            let r = resource::<i32, _, _>(move || async move {
+                // Blocking IO FIRST (a real cross-thread suspension),
+                // then read the tracked signal AFTER resuming.
+                let base = run_blocking(|| {
+                    std::thread::sleep(Duration::from_millis(15));
+                    10_i32
+                })
+                .await;
+                let m = multiplier.get();
+                Ok::<i32, String>(base * m)
+            });
+
+            drive_until(|| !r.loading());
+            assert_eq!(r.get(), Some(20), "initial: 10 * multiplier(2) = 20");
+
+            multiplier.set(5);
+            drive_until(|| matches!(r.state(), ResourceState::Ready(50)));
+            assert_eq!(
+                r.get(),
+                Some(50),
+                "after-await tracked read + run_blocking must re-fetch (10*5=50)"
+            );
+        });
+
+        owner.dispose();
+        reset_host();
+    }
+
+    /// Overlapping re-fetch: the tracked signal changes WHILE the first
+    /// fetch's worker is still in flight. This leaves a stale (gen-1)
+    /// ScopedFetch in the pool that must be abandoned, and a fresh
+    /// (gen-2) ScopedFetch that must run to completion. The bug: the
+    /// stale task's cross-thread wake (its worker finishes later) gets
+    /// tangled with the live task so the live result never lands.
+    #[test]
+    fn reactive_resource_overlapping_refetch_completes_latest() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let _g = lock();
+        __reset_for_tests();
+        tasks::__reset_for_tests();
+        install_host();
+
+        let owner = Owner::new(None);
+        owner.with(|| {
+            let query = RwSignal::new(1_i32);
+            let r = resource::<i32, _, _>(move || {
+                let q = query.get();
+                async move {
+                    let v = run_blocking(move || {
+                        // Long enough that the second change lands while
+                        // this worker is still asleep.
+                        std::thread::sleep(Duration::from_millis(40));
+                        q * 10
+                    })
+                    .await;
+                    Ok::<i32, String>(v)
+                }
+            });
+
+            let seen = Rc::new(Cell::new(0i32));
+            let seen_for_effect = seen.clone();
+            crate::reactive::effect::effect(move || {
+                if let ResourceState::Ready(v) = r.state() {
+                    seen_for_effect.set(v);
+                }
+            });
+
+            // Kick the first fetch (do NOT wait for it).
+            tick();
+            assert!(r.loading());
+
+            // Change the signal while the first worker is still asleep.
+            query.set(7);
+
+            // Drive to the LATEST result.
+            drive_until(|| matches!(r.state(), ResourceState::Ready(70)));
+            assert_eq!(
+                r.get(),
+                Some(70),
+                "overlapping re-fetch must settle on the latest query (7 → 70), \
+                 not hang in Loading"
+            );
+        });
+
+        owner.dispose();
+        reset_host();
+    }
+}
+
 #[test]
 fn resource_state_helpers_match_active_branch() {
     let loading: ResourceState<i32> = ResourceState::Loading;

--- a/crates/whisker-runtime/src/tasks.rs
+++ b/crates/whisker-runtime/src/tasks.rs
@@ -28,8 +28,10 @@
 //!
 //! [`resource`]: crate::reactive::resource
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use futures_executor::{LocalPool, LocalSpawner};
 use futures_util::task::LocalSpawnExt;
@@ -45,6 +47,69 @@ thread_local! {
     static SPAWNER: RefCell<LocalSpawner> = RefCell::new({
         POOL.with(|p| p.borrow().spawner())
     });
+
+    /// Count of spawned-but-not-yet-completed tasks. Incremented in
+    /// [`spawn_local`], decremented when a task's `TrackedTask` wrapper
+    /// is dropped (which happens exactly once: on completion OR on the
+    /// pool being torn down). Read by [`has_pending_tasks`] so the
+    /// driver's tick can report **not-idle** while async work is still
+    /// outstanding — see that function's docs for why this matters.
+    static OUTSTANDING: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Wrapper future that keeps the outstanding-task counter accurate.
+///
+/// `futures_executor::LocalPool` gives us no completion hook, so we
+/// can't decrement `OUTSTANDING` from inside the pool. Instead we wrap
+/// every spawned future: the wrapper's `Drop` runs once — when the task
+/// finishes and the pool drops it, or when the pool itself is reset —
+/// and decrements the counter then. Polling just forwards to the inner
+/// future.
+struct TrackedTask<F> {
+    inner: F,
+    counted: bool,
+}
+
+impl<F: Future<Output = ()>> Future for TrackedTask<F> {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        // SAFETY: standard pin-projection of a `!Unpin`-agnostic field;
+        // we never move `inner` out of the pinned wrapper.
+        let inner = unsafe { self.map_unchecked_mut(|s| &mut s.inner) };
+        inner.poll(cx)
+    }
+}
+
+impl<F> Drop for TrackedTask<F> {
+    fn drop(&mut self) {
+        if self.counted {
+            self.counted = false;
+            OUTSTANDING.with(|c| c.set(c.get().saturating_sub(1)));
+        }
+    }
+}
+
+/// Whether the task pool still has work that hasn't run to completion.
+///
+/// The driver's tick reports "idle" (letting the host pause its render
+/// loop) only when there's no reactive work pending. But a `resource()`
+/// fetch parked on a [`run_blocking`] worker is *outstanding* — it will
+/// be resumed by a cross-thread wake (the worker calling
+/// `run_on_main_thread`, which fires `host_wake::wake_runtime`). That
+/// wake races against the host pausing its render loop at the end of
+/// the very frame that polled the fetch to `Pending`: if the host
+/// processes the unpause *before* it processes the end-of-frame pause,
+/// the pause clobbers the unpause and the fetch is never re-polled —
+/// the resource stays `Loading` forever. (This is the field hang:
+/// reactive resource + `run_blocking`, re-fetch after a tracked signal
+/// change — see `reactive::tests_resource::cross_thread_wake`.)
+///
+/// Reporting not-idle while tasks are outstanding closes that race: the
+/// host keeps ticking frame-to-frame (as it does during an animation)
+/// until the pool drains, so the fetch is always re-polled regardless
+/// of how the cross-thread unpause interleaves.
+pub fn has_pending_tasks() -> bool {
+    OUTSTANDING.with(|c| c.get()) > 0
 }
 
 /// Queue `future` for execution on Whisker's task pool.
@@ -71,9 +136,18 @@ pub fn spawn_local<F>(future: F)
 where
     F: Future<Output = ()> + 'static,
 {
+    // Count this task as outstanding and wrap it so the count is
+    // decremented exactly once when the task completes (or the pool is
+    // reset). `has_pending_tasks` reads this so the driver keeps the
+    // host's render loop alive until async work drains — see that fn.
+    OUTSTANDING.with(|c| c.set(c.get() + 1));
+    let tracked = TrackedTask {
+        inner: future,
+        counted: true,
+    };
     SPAWNER.with(|s| {
         s.borrow()
-            .spawn_local(future)
+            .spawn_local(tracked)
             .expect("whisker tasks: local pool is shut down");
     });
     // Nudge the host so the next frame's tick callback actually
@@ -178,12 +252,16 @@ impl<T> Future for BlockingResult<T> {
 /// doesn't bleed across.
 #[doc(hidden)]
 pub fn __reset_for_tests() {
+    // Replacing the pool drops every queued `TrackedTask`, whose `Drop`
+    // decrements `OUTSTANDING`. Force it to 0 afterwards so the counter
+    // is exact even if a future was mid-poll / leaked.
     POOL.with(|p| *p.borrow_mut() = LocalPool::new());
     SPAWNER.with(|s| {
         POOL.with(|p| {
             *s.borrow_mut() = p.borrow().spawner();
         });
     });
+    OUTSTANDING.with(|c| c.set(0));
 }
 
 #[cfg(test)]
@@ -193,15 +271,14 @@ mod tests {
     use std::cell::Cell;
     use std::ffi::c_void;
     use std::rc::Rc;
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     /// Tests in this module reach into thread-local state (executor)
-    /// AND process-global state (dispatcher). Serialise them — the
-    /// global dispatcher would otherwise see installs from another
-    /// test mid-call.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    /// AND process-global state (dispatcher / frame callback). Use the
+    /// shared [`crate::main_thread::host_test_lock`] so they don't race
+    /// the host-global tests in sibling modules.
     fn lock<'a>() -> MutexGuard<'a, ()> {
-        TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+        crate::main_thread::host_test_lock()
     }
 
     fn reset_all() {
@@ -425,6 +502,66 @@ mod tests {
         assert!(
             flag.get(),
             "spawner must be re-bound to the new pool after reset"
+        );
+    }
+
+    /// `has_pending_tasks` must track the pool's outstanding work so the
+    /// driver's tick can report not-idle while a fetch is parked
+    /// (closing the cross-thread-wake clobber race). Drives the full
+    /// life-cycle: empty → spawned-and-parked → completed → empty.
+    #[test]
+    fn has_pending_tasks_tracks_outstanding_work() {
+        let _g = lock();
+        reset_all();
+        assert!(!has_pending_tasks(), "empty pool: no pending tasks");
+
+        // A task that parks on first poll (self-woken) then completes on
+        // the second — modelling a fetch parked on a cross-thread wake.
+        let phase = Rc::new(Cell::new(0));
+        let phase_for_task = phase.clone();
+        spawn_local(async move {
+            Yielder {
+                phase: phase_for_task,
+                polled_once: false,
+            }
+            .await;
+        });
+        assert!(
+            has_pending_tasks(),
+            "spawned-but-unrun task counts as pending"
+        );
+
+        // Yielder self-wakes, so a single run_until_stalled drives both
+        // polls to completion → pool drains → no longer pending.
+        run_until_stalled();
+        assert_eq!(phase.get(), 2, "task ran to completion");
+        assert!(
+            !has_pending_tasks(),
+            "completed task must be removed from the pending count"
+        );
+    }
+
+    /// A task that stays `Pending` (never woken) keeps the pool
+    /// outstanding — so the driver keeps the host alive until it
+    /// eventually completes (or its owner is reset).
+    #[test]
+    fn has_pending_tasks_stays_true_for_parked_task() {
+        use std::future;
+        let _g = lock();
+        reset_all();
+        spawn_local(async move {
+            future::pending::<()>().await;
+        });
+        run_until_stalled();
+        assert!(
+            has_pending_tasks(),
+            "a parked (Pending) task remains outstanding after a stalled drain"
+        );
+        // Reset drops the parked task; the count must zero out.
+        __reset_for_tests();
+        assert!(
+            !has_pending_tasks(),
+            "reset must clear the outstanding-task count"
         );
     }
 }


### PR DESCRIPTION
## Problem

A reactive `resource()` whose fetcher reads a signal **and** offloads blocking work via `run_blocking` hangs in `Loading` forever after the tracked signal changes — the re-fetch starts (`loading` flips true) but the result never lands. Field-reported on 0.2.4.

Disambiguating evidence: a one-shot resource that reads **no** signal but uses the same `run_blocking` HTTP completes fine; a hand-rolled `effect + spawn_local + run_blocking` completes fine; **only** the reactive resource that reads a signal hangs.

## Root cause — host idle-pause ↔ cross-thread-wake race

The driver's `tick` (`whisker-driver/src/lynx/bootstrap.rs`) reported idle (`!dispatch_pending`) the instant a fetch polled to `Pending`. The host render loop (iOS `CADisplayLink.isPaused`, Android `Choreographer`) pauses when `tick` reports idle, and resumes only on a `requestFrame` wake.

A `run_blocking` fetch resumes only via a **cross-thread** wake from the worker (`host_wake::wake_runtime` → `requestFrame`). That unpause races the end-of-frame pause. On a **re-fetch** — a *second* settle arriving after the host has already idled once — the pause can clobber the unpause, the wake is lost, and the parked fetch is never re-polled → stuck `Loading`. One-shot/hand-rolled paths survive because their single settle lands in a frame the host already had scheduled.

## Fix

Report idle only when the task pool has **also drained**. `tasks` now tracks outstanding spawned tasks via a `TrackedTask` wrapper (`Drop` decrements a counter exactly once) and exposes `has_pending_tasks()`. `tick` returns `!dispatch_pending && !has_pending_tasks()`.

While a fetch is in flight the runtime stays **busy**, so the host keeps ticking (exactly as during an animation) until the pool drains — no dependence on the racy cross-thread unpause. The waiting frames are **near-empty**: empty reactive flush, parked task not re-polled, empty renderer flush — no re-render, no layout, no paint. The only cost is the render heartbeat staying alive for the fetch's duration.

## Scope / follow-up

This is the immediate, **host-agnostic** correctness fix (Rust-only, no native shell changes). A follow-up will move the task executor onto the native **message loop** (Android `Looper` / iOS `CFRunLoop`), so async completions resume via a race-free main-loop post (the model React Native / Flutter use) and the host can **sleep during fetches** — at which point this busy-tick and its power cost are removed and vsync goes back to render-only.

## Tests

`reactive/tests_resource.rs` gains a `cross_thread_wake` module (real worker thread + sync main-thread dispatcher; the worker's wake is made a no-op to model the clobbered cross-thread wake, so the *only* thing that can complete a parked fetch is the runtime reporting busy via `has_pending_tasks()`). Three scenarios: sync-prefix read, after-`.await` read, overlapping re-fetch. **Passes with the fix; all three hang to the deadline when the fix is reverted** (faithful reproduction, not a tautology). Plus two unit tests in `tasks.rs`.

## Test plan
- [x] `cargo test -p whisker-runtime --lib` — 129 passed, 0 failed
- [x] `cargo test -p whisker-driver` — 17 passed, 0 failed
- [x] `cargo build --workspace`, `cargo clippy -p whisker-runtime -p whisker-driver` (no warnings), `cargo fmt --all --check` clean
- [x] Revert-verified: forcing `tick` idle with tasks outstanding reproduces the field hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)