### PR TITLE
fix(driver): run app() under a persistent root owner so app-level provide_context works

### DIFF
--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -173,19 +173,28 @@ extern "C" fn init_callback(user_data: *mut c_void) {
     let Some(app_fn) = ctx.app_fn.take() else {
         return;
     };
-    let root = app_fn();
 
-    // Commit the initial tree: mark the page as root and ask Lynx
-    // to run the first layout+paint pass.
-    set_root(root);
-    renderer_flush();
-
-    // Fire on_mount callbacks for everything that just mounted. Has
-    // to happen after the renderer flush so user-side code that asks
-    // "is my view in the tree?" (e.g. measure-after-layout) sees
-    // it. A callback that writes a signal schedules its work via the
-    // normal wake-up path; the next tick picks it up.
-    reactive_flush_mounts();
+    // Run the app under a persistent ROOT OWNER. `#[whisker::main]`'s
+    // body runs here, and `provide_context(...)` calls at that bare
+    // `app()` level need a current owner to attach to — without one they
+    // silently no-op, and any descendant that does
+    // `use_context::<T>().expect(...)` then panics across this `extern
+    // "C"` boundary (aborting on Android, blank-screening on iOS). The
+    // owner is a *detached root*: it lives for the process lifetime and
+    // is never disposed, so the contexts / signals / effects the app
+    // creates persist for the whole session.
+    let root_owner = whisker_runtime::reactive::Owner::detached_root();
+    root_owner.with(|| {
+        let root = app_fn();
+        // Commit the initial tree: mark the page as root and ask Lynx
+        // to run the first layout+paint pass.
+        set_root(root);
+        renderer_flush();
+        // Fire on_mount callbacks for everything that just mounted. Has
+        // to happen after the renderer flush so user-side code that asks
+        // "is my view in the tree?" sees it.
+        reactive_flush_mounts();
+    });
 
     start_hot_reload_receiver();
 }


### PR DESCRIPTION
## Summary

Fixes the **examples/podcast startup crash** (and a latent framework footgun): `provide_context(...)` called at the bare `#[whisker::main] app()` level was silently doing nothing, so a descendant's `use_context::<T>().expect(...)` panicked — aborting the process on Android and blank-screening on iOS.

## Root cause

`init_callback` ran the `app()` body with an **empty owner stack**. `provide_context` requires a *current owner* to attach to; with none it no-ops (only a debug `warn_no_owner`). So contexts provided at the top level were never stored. `MiniPlayer` (mounted in podcast's initial tree) then did:

```rust
let now_playing = use_context::<NowPlayingSignal>()
    .expect("mini_player requires NowPlayingSignal in context");  // ← panics
```

→ panic across the `extern "C"` `init_callback` boundary → **abort on Android, blank screen on iOS** (the asymmetry is just how a panic-unwind-across-FFI realizes per platform).

Reproduced on clean `0.2.4`. The `whisker-input` example (no app-level `provide_context`) was unaffected — which is why podcast was the only example that crashed.

## Fix

Run `app_fn()` (and the initial `set_root` / `renderer_flush` / `flush_mounts`) under a persistent **detached-root `Owner`**. Top-level `provide_context` now registers against it, and descendant `use_context` walks up to find it. The owner is a *detached root* (never disposed), so the app's contexts/signals/effects persist for the whole session — same persistence as the old detached-leak path, but contexts actually work now.

This removes a latent footgun: before, **any** bare-`app()` `provide_context` was silently useless.

## Device verification (Android)

With this fix, examples/podcast:
- renders the **Browse** screen (was: hard crash at launch), and
- the **reactive-search demo** (added in #207) re-fetches the iTunes API as the query signal changes — **"design" → design podcasts, "news" → news podcasts** — the on-device confirmation of the resource main-loop-drive fix (#207).

(Investigation note: the panic was only capturable after deleting the cached Android `.so` — `whisker run android` reuses a stale `.so` across rebuilds, so earlier driver-side diagnostics never took effect.)

## Test plan
- [x] `cargo build --workspace` clean; `cargo test -p whisker-driver` (17) / `-p whisker-runtime` (127) pass; `cargo clippy` / `cargo fmt --all --check` clean
- [x] Android device: podcast renders Browse + search re-fetches on keyword change (verified with screenshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)