### PR TITLE
fix(module): scaffold builds out of the box + reject reserved Lynx event names

### DIFF
--- a/crates/whisker-cli/src/new_module.rs
+++ b/crates/whisker-cli/src/new_module.rs
@@ -26,7 +26,7 @@
 //! templates and substitutes a handful of variables. For a richer
 //! template story (multiple module types, custom dirs, …) the
 //! `whisker new-module` subcommand can grow later without breaking
-//! the contract documented in `docs/module-author-guide.md`.
+//! the contract documented at <https://whisker.rs/docs/authoring-a-module>.
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Args;
@@ -160,7 +160,7 @@ pub fn run(args: NewModuleArgs) -> Result<()> {
          1. cd {}\n  \
          2. Implement the platform-side logic in ios/ and android/.\n  \
          3. From your Whisker app: `cargo add --path {}` (or publish to crates.io).\n  \
-         4. See docs/module-author-guide.md for the full reference.",
+         4. See https://whisker.rs/docs/authoring-a-module for the full reference.",
         target_dir.display(),
         target_dir.display(),
         target_dir.display(),
@@ -201,6 +201,20 @@ fn write(root: &Path, rel: &str, content: &str) -> Result<()> {
     Ok(())
 }
 
+/// The `MAJOR.MINOR` version requirement the scaffolded crate should
+/// pin `whisker` to. Derived from whisker-cli's own (workspace-shared)
+/// version so a freshly-scaffolded module unifies with the toolchain
+/// that generated it — e.g. cli `0.2.5` → `"0.2"`. An app on `0.2.x`
+/// can't unify a module that asks for `^0.1`, so a hardcoded `"0.1"`
+/// would break every scaffold after the 0.2 bump.
+fn whisker_dep_version() -> String {
+    let v = env!("CARGO_PKG_VERSION");
+    let mut parts = v.split('.');
+    let major = parts.next().unwrap_or("0");
+    let minor = parts.next().unwrap_or("0");
+    format!("{major}.{minor}")
+}
+
 fn cargo_toml(v: &Vars) -> String {
     format!(
         r#"[package]
@@ -232,9 +246,10 @@ crate-type = ["rlib"]
 # The umbrella `whisker` crate. The proc macros' emit paths
 # (::whisker::ElementRef, ::whisker::platform_module::WhiskerValue, ...)
 # resolve under the `whisker` name — the same dep app crates use.
-whisker = "0.1"
+whisker = "{dep_version}"
 "#,
         name = v.crate_name,
+        dep_version = whisker_dep_version(),
     )
 }
 
@@ -249,7 +264,7 @@ and exposes `{tag}` for use in Whisker app `render!` trees.
 
 ```toml
 [dependencies]
-{name} = "0.1"
+{name} = "{dep_version}"
 ```
 
 ```rust
@@ -264,12 +279,13 @@ fn app() -> Element {{
 }}
 ```
 
-See [the Whisker Module Author Guide](https://github.com/whiskerrs/whisker/blob/main/docs/module-author-guide.md)
+See [the Whisker Module Author Guide](https://whisker.rs/docs/authoring-a-module)
 for the full reference.
 "#,
         name = v.crate_name,
         tag = v.tag,
         ident = v.ident,
+        dep_version = whisker_dep_version(),
     )
 }
 
@@ -284,22 +300,15 @@ fn package_swift(v: &Vars) -> String {
 // Package.swift lives at the package root (SwiftPM requires it
 // there); the Swift sources live under the `ios/` subdir alongside
 // `android/` + `src/`.
+//
+// The module resolves Whisker's iOS runtime + macros via the published
+// `whisker` SwiftPM package (the same remote-git dependency every
+// first-party module uses) — `WhiskerModule` re-exports Lynx, and
+// `WhiskerRuntime` pulls in the `WhiskerView` / driver symbols. The
+// `WhiskerModuleCodegenPlugin` build-tool plugin walks `Module`
+// subclasses at build time and emits the Lynx registration.
 
 import PackageDescription
-
-// whisker-build injects the absolute location of Whisker's iOS
-// runtime + macros packages via these env vars, so this module
-// resolves them wherever it lives — in a whisker project, or unpacked
-// from the cargo registry. A Whisker module is only ever built through
-// `whisker run` (which set these), never standalone.
-guard let whiskerRuntimePath = Context.environment["WHISKER_IOS_RUNTIME"],
-      let whiskerMacrosPath = Context.environment["WHISKER_IOS_MACROS"]
-else {{
-    fatalError("""
-        WHISKER_IOS_RUNTIME / WHISKER_IOS_MACROS not set. Build this Whisker \
-        module through `whisker run`, which inject these paths.
-        """)
-}}
 
 let package = Package(
     name: "{name}",
@@ -308,18 +317,18 @@ let package = Package(
         .library(name: "{spm}", targets: ["{spm}"]),
     ],
     dependencies: [
-        .package(name: "macros", path: whiskerMacrosPath),
-        .package(name: "WhiskerRuntime", path: whiskerRuntimePath),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "{ios_tag}"),
     ],
     targets: [
         .target(
             name: "{spm}",
             dependencies: [
-                .product(name: "WhiskerModule", package: "WhiskerRuntime"),
+                .product(name: "WhiskerModule", package: "whisker"),
+                .product(name: "WhiskerRuntime", package: "whisker"),
             ],
             path: "ios/Sources/{spm}",
             plugins: [
-                .plugin(name: "WhiskerModuleCodegenPlugin", package: "macros"),
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "whisker"),
             ]
         ),
     ]
@@ -327,8 +336,16 @@ let package = Package(
 "#,
         name = v.crate_name,
         spm = v.spm,
+        ios_tag = WHISKER_IOS_SPM_TAG,
     )
 }
+
+/// The exact iOS SwiftPM tag the scaffolded `Package.swift` pins for
+/// the `whisker` git dependency. This is the iOS SPM release tag, which
+/// is versioned independently from the cargo crate version — it must
+/// match whatever the first-party modules pin (see
+/// `packages/whisker-webview/Package.swift`, currently `exact: "0.1.0"`).
+const WHISKER_IOS_SPM_TAG: &str = "0.1.0";
 
 fn build_gradle(v: &Vars) -> String {
     format!(
@@ -372,19 +389,30 @@ ksp {{
 }}
 
 dependencies {{
-    // Single Whisker runtime dep. ksp(rs.whisker:ksp) stays
-    // separate because it's a build-time processor, not on the
-    // runtime classpath. The KSP processor discovers Module
-    // subclasses by inheritance (no marker annotation needed).
-    implementation(project(":module"))
-    ksp("rs.whisker:ksp")
+    // Published Whisker runtime + KSP processor — the same Maven
+    // coordinates every first-party module uses. ksp(rs.whisker:ksp)
+    // stays separate because it's a build-time processor, not on the
+    // runtime classpath. The KSP processor discovers Module subclasses
+    // by inheritance (no marker annotation needed). The `{android_tag}`
+    // tag is the Android (Maven) release, versioned independently from
+    // the cargo crate.
+    implementation("rs.whisker:whisker-module-android:{android_tag}")
+    ksp("rs.whisker:ksp:{android_tag}")
 }}
 "#,
         name = v.crate_name,
         ns = v.ns,
         spm = v.spm,
+        android_tag = WHISKER_ANDROID_MAVEN_TAG,
     )
 }
+
+/// The Maven release tag the scaffolded `build.gradle.kts` pins for the
+/// Whisker Android runtime + KSP processor. Like the iOS SPM tag, the
+/// Android Maven release is versioned independently from the cargo
+/// crate — must match first-party (see
+/// `packages/whisker-webview/build.gradle.kts`, currently `0.1.0`).
+const WHISKER_ANDROID_MAVEN_TAG: &str = "0.1.0";
 
 fn lib_rs_view(v: &Vars) -> String {
     format!(

--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -368,6 +368,44 @@ enum PropKind {
     EventTyped { event: String, payload: Type },
 }
 
+/// Event names Lynx's native gesture / animation pipeline claims for
+/// itself. A `#[whisker::module_component]` that dispatches a custom
+/// event under one of these names is **silently swallowed** — Lynx's
+/// built-in gesture recognition consumes the name before it reaches the
+/// custom-event path, so the `on_<event>` handler never fires (no
+/// error, no log). It cost an evaluation project hours to find, so the
+/// macro now rejects it at compile time.
+///
+/// The list mirrors Lynx's touch + animation event families (see
+/// `whisker_runtime::event` and <https://lynxjs.org/api/lynx-api/event/event.html>).
+/// Both the canonical spelling (`longpress`) and the snake_case form an
+/// `on_<event>` prop would naturally produce (`long_press`) are
+/// reserved, since authors hit the collision either way. Component-level
+/// custom events Lynx does NOT intercept (`scroll`, `change`, …) are
+/// fine — only the gesture/animation names below collide.
+const RESERVED_EVENT_NAMES: &[&str] = &[
+    // TouchEvent family (canonical + snake_case variants).
+    "tap",
+    "click",
+    "longpress",
+    "long_press",
+    "touchstart",
+    "touch_start",
+    "touchmove",
+    "touch_move",
+    "touchend",
+    "touch_end",
+    "touchcancel",
+    "touch_cancel",
+    // AnimationEvent family (canonical + snake_case variants).
+    "animationstart",
+    "animation_start",
+    "animationend",
+    "animation_end",
+    "transitionend",
+    "transition_end",
+];
+
 fn classify(ident: &Ident, ty: &Type) -> syn::Result<PropKind> {
     let name = ident.to_string();
 
@@ -385,10 +423,23 @@ fn classify(ident: &Ident, ty: &Type) -> syn::Result<PropKind> {
             return Err(syn::Error::new(
                 ident.span(),
                 "#[whisker::module_component]: event prop name `on_` is empty; \
-                 use e.g. `on_tap: ()` or `on_input: TouchEvent`",
+                 use e.g. `on_press: ()` or `on_input: TouchEvent`",
             ));
         }
         let event = event.to_string();
+        if RESERVED_EVENT_NAMES.contains(&event.as_str()) {
+            return Err(syn::Error::new(
+                ident.span(),
+                format!(
+                    "#[whisker::module_component]: event name `{event}` collides with a \
+                     Lynx built-in gesture/animation event and would be silently swallowed \
+                     (the native gesture pipeline consumes it before your custom event \
+                     fires, so `{ident}` would never be called). Rename it to a \
+                     non-reserved, module-specific name — e.g. `on_{event}_gesture`, \
+                     `on_press`, `on_page_changed`, or `on_activate`.",
+                ),
+            ));
+        }
         if is_unit_type(ty) {
             return Ok(PropKind::EventNoPayload { event });
         }

--- a/crates/whisker/tests/module_component.rs
+++ b/crates/whisker/tests/module_component.rs
@@ -123,7 +123,7 @@ pub fn x_input(value: Signal<String>, placeholder: Signal<String>) {}
 pub fn x_typed_checkbox(checked: Signal<bool>, count: Signal<i32>) {}
 
 #[whisker::module_component("x-button")]
-pub fn x_button(label: Signal<String>, on_tap: ()) {}
+pub fn x_button(label: Signal<String>, on_press: ()) {}
 
 #[whisker::module_component("x-input-payload")]
 pub fn x_input_payload(value: Signal<String>, on_input: ::whisker::WhiskerValue) {}
@@ -292,11 +292,12 @@ fn typed_signal_bool_serialises_via_to_string() {
 
 #[test]
 fn no_payload_event_handler_registers_listener() {
-    // `on_tap: ()` → builder takes `Fn() + 'static`, body wires through
-    // `set_event_listener`. The Recorder logs as `Op::Event`.
+    // `on_press: ()` → builder takes `Fn() + 'static`, body wires through
+    // `set_event_listener`. The Recorder logs as `Op::Event`. (`on_press`,
+    // not `on_tap`: `tap` is a reserved Lynx gesture name the macro rejects.)
     with_recorder_and_owner(|log| {
         let _h = render! {
-            XButton(label: "Click me", on_tap: || {})
+            XButton(label: "Click me", on_press: || {})
         };
         let events: Vec<_> = log
             .borrow()
@@ -306,7 +307,7 @@ fn no_payload_event_handler_registers_listener() {
                 _ => None,
             })
             .collect();
-        assert_eq!(events, vec!["tap".to_string()]);
+        assert_eq!(events, vec!["press".to_string()]);
     });
 }
 


### PR DESCRIPTION
## Summary

評価プロジェクト（giga-whisker）のフィードバックで判明した、モジュール作成 DX の2つの罠を修正します。

### `whisker new-module` の scaffold が素でビルドできない（P1 #2/#5）
`whisker new-module` 直後に `whisker run` するとビルド不能だった:
- **iOS `Package.swift`**: 注入されない env-var（`WHISKER_IOS_RUNTIME`/`WHISKER_IOS_MACROS`）を `guard ... else fatalError` で要求 → first-party と同じ remote-git-URL 方式（`.package(url: whisker.git, exact:"0.1.0")` + `WhiskerModule`/`WhiskerRuntime` + codegen plugin）へ。
- **Android `build.gradle.kts`**: 同種の壊れた依存（`project(":module")` / unversioned `ksp`）→ first-party の Maven 座標（`rs.whisker:whisker-module-android:0.1.0` / `ksp:0.1.0`）へ。
- **`Cargo.toml`**: `whisker = "0.1"`（app が 0.2.x だと unify 不可）→ whisker-cli の `CARGO_PKG_VERSION` から `MAJOR.MINOR` を導出。
- 存在しない `docs/module-author-guide.md` への dead link 3箇所 → `https://whisker.rs/docs/authoring-a-module`。

### 予約イベント名の silent failure を compile-time で拒否（P1 #1）
`#[module_component]` が Lynx 組込ジェスチャー名（`tap`/`longpress`/`click`/`animationend` …）でカスタムイベントを dispatch すると、Lynx の gesture pipeline に奪われ **`on_<event>` が無言で発火しない**（エラーもログもなし。評価で数時間を溶かした最大のハマり）。`classify()` で予約名（TouchEvent + AnimationEvent ファミリ、canonical と snake_case 両方）を検出し `syn::Error` で落とすように。`scroll`/`change` 等の component-level custom event と、built-in 要素の `text(on_tap:)`（Lynx template 経路）は影響なし。

## Test plan
- `cargo build -p whisker-cli` / `-p whisker-macros` / `-p whisker-input` 通過、`cargo test -p whisker-macros` 通過。
- scaffold を tmp に生成して `Package.swift`/`Cargo.toml`/`build.gradle.kts` の出力を確認（first-party と一致）。
- 既存の first-party モジュール・examples に予約名 `on_<gesture>` prop は無く、ビルド非破壊を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)