### PR TITLE
fix(runtime): wake tasks driven from foreign threads (#7)

### DIFF
--- a/crates/whisker-runtime/src/tasks.rs
+++ b/crates/whisker-runtime/src/tasks.rs
@@ -30,9 +30,12 @@
 
 use std::cell::RefCell;
 use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use futures_executor::{LocalPool, LocalSpawner};
-use futures_util::task::LocalSpawnExt;
+use futures_util::task::{waker_ref, ArcWake, LocalSpawnExt};
 
 thread_local! {
     /// The per-thread executor. Holds queued + ready tasks. Polled
@@ -45,6 +48,126 @@ thread_local! {
     static SPAWNER: RefCell<LocalSpawner> = RefCell::new({
         POOL.with(|p| p.borrow().spawner())
     });
+}
+
+/// The "request a main-loop drive" hook invoked by a task's [`Waker`]
+/// when it is woken from ANY thread.
+///
+/// # Why this exists
+///
+/// `LocalPool`'s built-in waker, when woken, only re-queues the task
+/// into the pool's internal ready-queue — it does NOT poke the native
+/// main loop. The pool is re-polled only from the driver's
+/// `tick_frame` → [`run_until_stalled`], which fires on a host vsync
+/// `tick()` or on a `run_on_main_thread` DRIVE post. So a task awaiting
+/// a future that completes on a FOREIGN thread (e.g. a tokio runtime
+/// thread, or a `std::thread` worker) gets re-queued by the wake but
+/// never re-polled — it hangs forever while vsync is parked (issue #7).
+///
+/// We fix this by polling each spawned future through a [`DriveWaker`]
+/// that, on `wake`/`wake_by_ref`, forwards to the pool's inner waker
+/// (to re-queue the task) AND calls this hook (to poke the main loop).
+///
+/// In production the hook is [`request_main_loop_drive`], which routes
+/// through [`crate::main_thread::run_on_main_thread`] — documented as
+/// safe to call from any thread — so the registered DRIVE callback
+/// (`tick_frame` → `run_until_stalled`) runs and re-polls the pool.
+/// Tests can override it via [`set_drive_hook`] to observe wakes
+/// without a full main-loop harness.
+type DriveHook = fn();
+
+static DRIVE_HOOK: std::sync::Mutex<DriveHook> = std::sync::Mutex::new(request_main_loop_drive);
+
+/// Production drive hook: ask the host to run another drive of the
+/// runtime (which calls [`run_until_stalled`]).
+///
+/// Routed through `run_on_main_thread(|| {})`: posting an empty
+/// closure to the host's main-thread dispatcher makes the trampoline
+/// fire the registered DRIVE callback on the main thread, which runs
+/// `tick_frame` → `run_until_stalled` and re-polls the ready task.
+/// `run_on_main_thread` is any-thread-safe (it snapshots a global
+/// dispatcher behind a `Mutex`), so this is sound to call from a
+/// foreign thread's wake.
+///
+/// Re-entrancy: if the wake happens on the MAIN thread while a drive
+/// is already in progress (e.g. a task self-wakes during
+/// `run_until_stalled`), the trampoline consults
+/// `main_work_in_progress()` and defers to a vsync frame instead of
+/// re-entering `tick_frame`. The re-queued task is then picked up by
+/// the in-flight `run_until_stalled` loop (it drains to a stall) or by
+/// the next frame. See `main_thread::trampoline`.
+fn request_main_loop_drive() {
+    crate::main_thread::run_on_main_thread(|| {});
+}
+
+/// Install a custom drive hook. Returns the previous hook so callers
+/// (tests) can restore it.
+#[doc(hidden)]
+pub fn set_drive_hook(hook: DriveHook) -> DriveHook {
+    let mut guard = DRIVE_HOOK.lock().unwrap_or_else(|e| e.into_inner());
+    std::mem::replace(&mut *guard, hook)
+}
+
+fn invoke_drive_hook() {
+    let hook = *DRIVE_HOOK.lock().unwrap_or_else(|e| e.into_inner());
+    hook();
+}
+
+/// A `Waker` that bridges a foreign-thread wake to Whisker's main
+/// loop.
+///
+/// Holds the pool's own inner `Waker` for the task (so waking still
+/// re-queues the task into `LocalPool`'s ready-queue, preserving the
+/// stock same-thread / self-wake behavior). On `wake`, it:
+///
+/// 1. forwards to the inner waker → the task is marked ready; then
+/// 2. calls the drive hook → the main loop is poked so
+///    `run_until_stalled` actually re-polls.
+///
+/// Step 2 is the missing link the bare `LocalPool` lacked. It is safe
+/// from any thread: the inner waker is `Send + Sync` and the drive
+/// hook funnels through the any-thread-safe `run_on_main_thread`.
+struct DriveWaker {
+    inner: std::task::Waker,
+}
+
+impl ArcWake for DriveWaker {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        // (a) mark the task ready in the pool's ready-queue.
+        arc_self.inner.wake_by_ref();
+        // (b) ensure the main loop will re-poll the pool.
+        invoke_drive_hook();
+    }
+}
+
+/// Wraps a spawned future so that it is always polled with a
+/// [`DriveWaker`]-composed `Context`.
+///
+/// `LocalPool` polls this wrapper with ITS waker (`cx.waker()`). We
+/// build a `DriveWaker` around that inner waker and poll the user
+/// future with it, so whatever waker the user future stashes (and
+/// later wakes, possibly from a foreign thread) is the drive-bridging
+/// one — not the bare pool waker. The pool's own scheduling is
+/// preserved (the inner waker is still forwarded on every wake); we
+/// only ADD the main-loop poke.
+struct DriveBridged<F> {
+    future: F,
+}
+
+impl<F: Future<Output = ()>> Future for DriveBridged<F> {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        // SAFETY: standard pin-projection — we never move `future` out
+        // of `self`, and `DriveBridged` is `!Unpin`-agnostic: we only
+        // re-pin the field in place.
+        let future = unsafe { self.map_unchecked_mut(|s| &mut s.future) };
+        let drive_waker = Arc::new(DriveWaker {
+            inner: cx.waker().clone(),
+        });
+        let waker = waker_ref(&drive_waker);
+        let mut cx = Context::from_waker(&waker);
+        future.poll(&mut cx)
+    }
 }
 
 /// Queue `future` for execution on Whisker's task pool.
@@ -73,7 +196,12 @@ where
 {
     SPAWNER.with(|s| {
         s.borrow()
-            .spawn_local(future)
+            // Wrap so the future is polled with a `DriveWaker`-composed
+            // context: a wake from ANY thread re-queues the task in the
+            // pool AND pokes the main loop (see `DriveBridged` /
+            // `DRIVE_HOOK`). This is what lets a future awaited here
+            // resume when woken from a foreign (e.g. tokio) thread.
+            .spawn_local(DriveBridged { future })
             .expect("whisker tasks: local pool is shut down");
     });
     // Nudge the host so the next frame's tick callback actually
@@ -390,6 +518,109 @@ mod tests {
             "task body should NOT have completed without a dispatcher \
              (cancel-on-dispose semantics)"
         );
+    }
+
+    /// A future that parks on its first poll, stashing its `Waker` in a
+    /// shared slot, and resolves once an external (foreign-thread)
+    /// signal has been set. Models awaiting an I/O completion that is
+    /// resolved off the main thread (e.g. a tokio runtime thread).
+    struct ForeignSignal {
+        done: Arc<std::sync::atomic::AtomicBool>,
+        waker_slot: Arc<std::sync::Mutex<Option<std::task::Waker>>>,
+    }
+    impl Future for ForeignSignal {
+        type Output = ();
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<()> {
+            if self.done.load(std::sync::atomic::Ordering::SeqCst) {
+                std::task::Poll::Ready(())
+            } else {
+                // Stash the (drive-bridging) waker so a foreign thread
+                // can wake us later.
+                *self.waker_slot.lock().unwrap() = Some(cx.waker().clone());
+                std::task::Poll::Pending
+            }
+        }
+    }
+
+    #[test]
+    fn foreign_thread_wake_invokes_drive_hook_and_resumes_task() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        let _g = lock();
+        reset_all();
+
+        // Inject a test drive hook that records that it was poked. In
+        // production this hook routes through `run_on_main_thread`,
+        // poking the host main loop; here we just count the pokes and
+        // (crucially) re-poll the pool, the way the real DRIVE callback
+        // (`tick_frame` → `run_until_stalled`) would.
+        static DRIVE_POKES: AtomicUsize = AtomicUsize::new(0);
+        DRIVE_POKES.store(0, Ordering::SeqCst);
+        fn test_hook() {
+            DRIVE_POKES.fetch_add(1, Ordering::SeqCst);
+        }
+        let prev = set_drive_hook(test_hook);
+
+        let done = Arc::new(AtomicBool::new(false));
+        let waker_slot: Arc<std::sync::Mutex<Option<std::task::Waker>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        let completed = Rc::new(Cell::new(false));
+
+        let done_for_task = done.clone();
+        let slot_for_task = waker_slot.clone();
+        let completed_for_task = completed.clone();
+        spawn_local(async move {
+            ForeignSignal {
+                done: done_for_task,
+                waker_slot: slot_for_task,
+            }
+            .await;
+            completed_for_task.set(true);
+        });
+
+        // First drive: polls the task to Pending, stashing its waker.
+        run_until_stalled();
+        assert!(!completed.get(), "task should be parked awaiting signal");
+        assert!(
+            waker_slot.lock().unwrap().is_some(),
+            "task must have stashed its waker on the first poll"
+        );
+
+        // Now complete the future from a SEPARATE std::thread — exactly
+        // the foreign-thread wake the bug is about. The thread flips the
+        // done flag and wakes the stored (drive-bridging) waker.
+        let done_for_thread = done.clone();
+        let slot_for_thread = waker_slot.clone();
+        let handle = std::thread::spawn(move || {
+            done_for_thread.store(true, Ordering::SeqCst);
+            let waker = slot_for_thread.lock().unwrap().take().unwrap();
+            // Wake from the foreign thread. This must (a) re-queue the
+            // task in the pool and (b) invoke the drive hook so the main
+            // loop knows to re-poll.
+            waker.wake();
+        });
+        handle.join().unwrap();
+
+        // The drive hook MUST have been invoked by the foreign-thread
+        // wake — this is the link the bare LocalPool lacked.
+        assert!(
+            DRIVE_POKES.load(Ordering::SeqCst) >= 1,
+            "foreign-thread wake must invoke the drive hook so the main \
+             loop re-polls the pool (issue #7)"
+        );
+
+        // Simulate the DRIVE callback the hook would have triggered: a
+        // re-poll of the pool. The task is now ready and resolves.
+        run_until_stalled();
+        assert!(
+            completed.get(),
+            "task must resume and complete after the foreign-thread wake \
+             drove a re-poll"
+        );
+
+        set_drive_hook(prev);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

評価フィードバック #7 の修正。whisker のタスクプールから await した future が**外部スレッド（tokio ランタイムスレッド / `std::thread` ワーカー）から wake された場合に無言ハング**する問題を解消します。

### 原因
タスクプールは素の `futures_executor::LocalPool`。その標準 waker は wake されてもタスクを ready-queue に戻すだけで、**native main-loop を起こさない**。プールが再 poll されるのは driver の `tick_frame → run_until_stalled`（host vsync tick か `run_on_main_thread` の DRIVE post）のみ。vsync 停止中は再キューされたタスクが永遠に再 poll されない（パニックもログも無し）。`run_blocking` だけが手動で `run_on_main_thread` を叩くので動いていた。

### 修正（waker composition、LocalPool のスケジューリングは維持）
- `DriveBridged<F>` が spawn された future をラップし、プール自身の waker を包んだ `DriveWaker` で poll。user future が stash する waker が常にブリッジ版になる。
- `DriveWaker`（`ArcWake`）は wake 時に inner waker へ転送（再キュー＝stock 挙動維持）し、**drive hook を呼ぶ**。
- 本番 hook は `run_on_main_thread(|| {})`（any-thread-safe）経由で DRIVE callback → `tick_frame` → `run_until_stalled` を発火し、ready になったタスクを再 poll。main thread 上の self-wake は `main_work_in_progress()` で defer され、`MainWorkGuard` の再入保護は維持。
- hook は `Mutex<fn()>` で間接化しテストから観測可能。別 `std::thread` から wake してタスクが再開することを検証するテストを追加。

これにより `tokio::spawn(...).await` を含む外部 future の await が動くようになります。

## Test plan
- `cargo build -p whisker-runtime -p whisker-driver` 通過。
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` 警告なし。
- `cargo test -p whisker-runtime` **128 passed**（新規テスト1件含む）。
- 変更は `crates/whisker-runtime/src/tasks.rs` 1ファイルのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)