### PR TITLE
feat(reactive): make Signal<T> Copy (#8)

### DIFF
--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -614,7 +614,7 @@ fn prop_build_assignment(p: &Prop, tag_name: &str) -> TokenStream2 {
             }
         }
         // Style/Attr props are optional by default. `Signal<String>`
-        // defaults to `Signal::Static("")` when omitted, matching
+        // defaults to `Signal::Stored("")` when omitted, matching
         // what Lynx would see if the attribute wasn't declared.
         // Event handler props stay required because their `dyn Fn`
         // types don't have a sensible default and a missing callback

--- a/crates/whisker-runtime/src/reactive/prop.rs
+++ b/crates/whisker-runtime/src/reactive/prop.rs
@@ -15,8 +15,9 @@
 //!
 //! `Signal<T>` encodes this in two variants:
 //!
-//! - [`Signal::Static`] — a plain value the builder sets once and
-//!   forgets about.
+//! - [`Signal::Stored`] — a plain value the builder sets once and
+//!   forgets about, held in an owner-bound [`StoredValue<T>`] arena
+//!   slot so the whole enum stays `Copy`.
 //! - [`Signal::Dynamic`] — a [`ReadSignal<T>`] handle. The builder
 //!   wraps its read in an `effect`, so the underlying signal becomes
 //!   a dependency and changes propagate to the element automatically.
@@ -38,7 +39,7 @@
 //! // .value() does:
 //! fn value(self, v: impl Into<Signal<String>>) -> Self {
 //!     match v.into() {
-//!         Signal::Static(s) => set_attribute(h, "value", &s),
+//!         Signal::Stored(s) => set_attribute(h, "value", &s.get()),
 //!         Signal::Dynamic(sig) => {
 //!             effect(move || set_attribute(h, "value", &sig.get()));
 //!             //                                          ^^^^^^^
@@ -53,7 +54,7 @@
 //! ```
 //!
 //! Passing `my_signal.get()` instead — pre-reading the signal at the
-//! call site — produces a `Signal::Static`: the read happens once
+//! call site — produces a `Signal::Stored`: the read happens once
 //! before [`effect`] is even on the observer stack, so no
 //! subscription is registered, and the prop becomes a one-shot
 //! snapshot. This is the user-facing "static vs dynamic" distinction.
@@ -72,31 +73,41 @@
 //! [`Memo<T>`]: super::computed
 
 use super::signal::{ReadSignal, RwSignal};
+use super::stored::StoredValue;
 
 /// Prop value: either a static `T` or a reactive [`ReadSignal<T>`].
 ///
 /// Built-in tag builders / `#[component]` generated builders /
 /// `#[whisker::module_component]` generated builders all accept
 /// `impl Into<Signal<T>>`. The variant determines whether the
-/// builder sets the attribute once ([`Static`]) or wraps the read
+/// builder sets the attribute once ([`Stored`]) or wraps the read
 /// in an `effect` ([`Dynamic`]).
 ///
-/// [`Static`]: Signal::Static
+/// [`Stored`]: Signal::Stored
 /// [`Dynamic`]: Signal::Dynamic
 ///
-/// Cloneable when `T: Clone` — the `Static` arm clones the inner
-/// value, the `Dynamic` arm just `Copy`-clones the `ReadSignal`
-/// handle (which is internally a [`NodeId`]). Components routinely
-/// pass the same prop into multiple `computed` / `effect` closures,
-/// so cheap cloning is important.
+/// `Copy` (and `Clone`) regardless of whether `T: Clone` — the
+/// `Stored` arm holds an owner-bound [`StoredValue<T>`] (itself a
+/// `Copy` arena handle) rather than an inline `T`, and the `Dynamic`
+/// arm is a `Copy` [`ReadSignal`] handle (internally a [`NodeId`]).
+/// This is what lets `#[component]` bodies (`FnMut`) move a
+/// `Signal<T>` prop into several nested `move` closures without
+/// `.clone()` — see whisker issue #8.
 ///
 /// [`NodeId`]: super::NodeId
-#[derive(Clone)]
+//
+// NOTE: `Clone`/`Copy` are implemented by hand below rather than
+// `#[derive]`d. A derived impl would add a spurious `T: Copy` bound,
+// but both arms (`StoredValue<T>` / `ReadSignal<T>`) are `Copy` for
+// *any* `T: 'static` — they're arena handles, not inline values — so
+// `Signal<T>` must be `Copy` unconditionally (e.g. `Signal<String>`).
 pub enum Signal<T: 'static> {
-    /// Plain value. The builder method that consumes this calls
+    /// Plain value, held in an owner-bound [`StoredValue<T>`] arena
+    /// slot. The builder method that consumes this calls
     /// `set_attribute` / `set_inline_styles` / etc. exactly once
-    /// with the value. No reactive subscription is set up.
-    Static(T),
+    /// with the value. No reactive subscription is set up; reading
+    /// the `StoredValue` does not tick the dependency graph.
+    Stored(StoredValue<T>),
     /// Reactive handle. The builder wraps its read in
     /// [`super::effect`] — each read inside that effect registers
     /// the underlying signal as a dependency, so subsequent
@@ -108,10 +119,19 @@ pub enum Signal<T: 'static> {
     Dynamic(ReadSignal<T>),
 }
 
+// Hand-written so the bound is `T: 'static`, not `T: Copy` — see the
+// note on the enum. Both variants wrap `Copy` arena handles.
+impl<T: 'static> Clone for Signal<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T: 'static> Copy for Signal<T> {}
+
 impl<T: 'static + Clone> Signal<T> {
     /// Read the current value.
     ///
-    /// - For [`Signal::Static`]: returns a clone of the held value.
+    /// - For [`Signal::Stored`]: returns a clone of the held value.
     ///   No reactivity is involved.
     /// - For [`Signal::Dynamic`]: forwards to [`ReadSignal::get`],
     ///   which **registers the underlying signal as a dependency**
@@ -136,7 +156,7 @@ impl<T: 'static + Clone> Signal<T> {
     /// ```
     pub fn get(&self) -> T {
         match self {
-            Signal::Static(v) => v.clone(),
+            Signal::Stored(v) => v.get(),
             Signal::Dynamic(sig) => sig.get(),
         }
     }
@@ -152,18 +172,26 @@ impl<T: 'static + Clone> Signal<T> {
 
 impl<T: 'static> From<T> for Signal<T> {
     fn from(v: T) -> Self {
-        Signal::Static(v)
+        // NOTE: constructing a *static* `Signal` now allocates an
+        // owner-bound arena slot ([`StoredValue::new`]) rather than
+        // storing `v` inline — this is the cost of making `Signal<T>`
+        // `Copy`. Mirrors `StoredValue`'s detached-owner fallback: if
+        // there's no current reactive owner it logs a warning and
+        // parks the value in a detached scope (no panic). So a static
+        // `Signal` built entirely outside a reactive context still
+        // works, it just isn't tied to a disposable scope.
+        Signal::Stored(StoredValue::new(v))
     }
 }
 
-// `Signal<T: Default>::default() -> Signal::Static(T::default())`.
+// `Signal<T: Default>::default() -> Signal::Stored(T::default())`.
 // Used by `#[whisker::module_component]`'s builder: a prop the caller
 // omits falls back to `unwrap_or_default()`, which produces a
 // reasonable "attribute not set" value (`""` for `Signal<String>`,
 // `false` for `Signal<bool>`, etc.). Phase 7-Φ.H.2 follow-up.
 impl<T: 'static + Default> Default for Signal<T> {
     fn default() -> Self {
-        Signal::Static(T::default())
+        Signal::Stored(StoredValue::new(T::default()))
     }
 }
 
@@ -187,7 +215,7 @@ impl<T: 'static + Clone> From<RwSignal<T>> for Signal<T> {
 // `Into<Signal<&str>>` via the blanket `From<T> for Signal<T>`).
 impl From<&str> for Signal<String> {
     fn from(s: &str) -> Self {
-        Signal::Static(s.to_string())
+        Signal::Stored(StoredValue::new(s.to_string()))
     }
 }
 
@@ -202,8 +230,36 @@ mod tests {
     fn static_variant_returns_held_value() {
         __reset_for_tests();
         let s: Signal<&'static str> = "hello".into();
-        assert!(matches!(s, Signal::Static("hello")));
+        assert!(matches!(s, Signal::Stored(_)));
         assert_eq!(s.get(), "hello");
+    }
+
+    #[test]
+    fn signal_is_copy() {
+        // The whole point of issue #8: a non-Copy-`T` `Signal<T>` prop
+        // can be moved into multiple `move` closures without `.clone()`.
+        // This wouldn't even compile if `Signal<T>` weren't `Copy`.
+        __reset_for_tests();
+
+        fn assert_copy<C: Copy>(_: &C) {}
+
+        let s: Signal<String> = "abc".into();
+        assert_copy(&s);
+
+        // Move the *same* binding into two independent `move` closures.
+        let first = move || s.get();
+        let second = move || s.get();
+        assert_eq!(first(), "abc");
+        assert_eq!(second(), "abc");
+
+        // A dynamic Signal is Copy too.
+        let (count, _set) = signal(5_i32);
+        let d: Signal<i32> = count.into();
+        assert_copy(&d);
+        let a = move || d.get();
+        let b = move || d.get();
+        assert_eq!(a(), 5);
+        assert_eq!(b(), 5);
     }
 
     #[test]

--- a/crates/whisker-runtime/src/view/apply.rs
+++ b/crates/whisker-runtime/src/view/apply.rs
@@ -31,7 +31,7 @@ where
     T: ::std::string::ToString + ::std::clone::Clone + 'static,
 {
     match v.into() {
-        Signal::Static(t) => set_inline_styles(h, &t.to_string()),
+        Signal::Stored(sv) => sv.with(|t| set_inline_styles(h, &t.to_string())),
         Signal::Dynamic(sig) => {
             effect(move || set_inline_styles(h, &sig.get().to_string()));
         }
@@ -46,7 +46,7 @@ where
     T: ::std::string::ToString + ::std::clone::Clone + 'static,
 {
     match v.into() {
-        Signal::Static(t) => set_attribute(h, name, &t.to_string()),
+        Signal::Stored(sv) => sv.with(|t| set_attribute(h, name, &t.to_string())),
         Signal::Dynamic(sig) => {
             effect(move || set_attribute(h, name, &sig.get().to_string()));
         }
@@ -65,7 +65,7 @@ where
     V: ::std::convert::Into<Signal<i32>>,
 {
     match v.into() {
-        Signal::Static(t) => set_attribute_int(h, name, i64::from(t)),
+        Signal::Stored(sv) => sv.with(|t| set_attribute_int(h, name, i64::from(*t))),
         Signal::Dynamic(sig) => {
             effect(move || set_attribute_int(h, name, i64::from(sig.get())));
         }
@@ -77,7 +77,7 @@ where
     V: ::std::convert::Into<Signal<bool>>,
 {
     match v.into() {
-        Signal::Static(t) => set_attribute_bool(h, name, t),
+        Signal::Stored(sv) => sv.with(|t| set_attribute_bool(h, name, *t)),
         Signal::Dynamic(sig) => {
             effect(move || set_attribute_bool(h, name, sig.get()));
         }
@@ -89,7 +89,7 @@ where
     V: ::std::convert::Into<Signal<f64>>,
 {
     match v.into() {
-        Signal::Static(t) => set_attribute_double(h, name, t),
+        Signal::Stored(sv) => sv.with(|t| set_attribute_double(h, name, *t)),
         Signal::Dynamic(sig) => {
             effect(move || set_attribute_double(h, name, sig.get()));
         }
@@ -106,7 +106,7 @@ where
     T: ::std::string::ToString + ::std::clone::Clone + 'static,
 {
     match v.into() {
-        Signal::Static(t) => set_attribute(h, &name, &t.to_string()),
+        Signal::Stored(sv) => sv.with(|t| set_attribute(h, &name, &t.to_string())),
         Signal::Dynamic(sig) => {
             effect(move || set_attribute(h, &name, &sig.get().to_string()));
         }

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -131,16 +131,10 @@ fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
 /// inside a `computed` to drive a reactive `style` attribute.
 #[component]
 fn colored_tile(color: Signal<String>) -> Element {
-    // `color` is owned by the outer `__hot::call(move || …)` wrap
-    // the `#[component]` macro generates for hot-patch dispatch.
-    // Moving it into the `computed` closure would consume the
-    // outer FnMut's capture, hence the .clone() — cheap on a
-    // Dynamic Signal (Copy of the underlying ReadSignal NodeId)
-    // and a String clone on the Static arm.
-    let style = {
-        let color = color.clone();
-        computed(move || format!("background: {};", color.get()))
-    };
+    // `Signal<T>` is `Copy` (whisker #8), so `color` moves freely into
+    // the `computed` closure even though the `#[component]` body is the
+    // `FnMut` the macro wraps for hot-patch dispatch — no `.clone()`.
+    let style = computed(move || format!("background: {};", color.get()));
     render! {
         view(style: style)
     }

--- a/packages/whisker-icons/src/lib.rs
+++ b/packages/whisker-icons/src/lib.rs
@@ -69,28 +69,27 @@ use whisker_svg::Svg;
 ///   (`"1.5em"`, `"100%"`, `"24px"`) pass through unchanged.
 #[component]
 pub fn icon(svg: Signal<String>, color: Signal<String>, size: Signal<String>) -> Element {
-    let style = {
-        let size = size.clone();
-        computed(move || {
-            let raw = size.get();
-            let t = raw.trim();
-            // Common CSS length units pass through; bare numbers
-            // are treated as `px`.
-            let has_unit = ["px", "em", "rem", "%", "vw", "vh"]
-                .iter()
-                .any(|u| t.ends_with(u));
-            if has_unit {
-                format!("width: {t}; height: {t};")
-            } else {
-                format!("width: {t}px; height: {t}px;")
-            }
-        })
-    };
+    // `Signal<T>` is `Copy` (whisker #8), so `size`/`svg`/`color` move
+    // freely into the closure and builder below — no `.clone()`.
+    let style = computed(move || {
+        let raw = size.get();
+        let t = raw.trim();
+        // Common CSS length units pass through; bare numbers
+        // are treated as `px`.
+        let has_unit = ["px", "em", "rem", "%", "vw", "vh"]
+            .iter()
+            .any(|u| t.ends_with(u));
+        if has_unit {
+            format!("width: {t}; height: {t};")
+        } else {
+            format!("width: {t}px; height: {t}px;")
+        }
+    });
 
     render! {
         Svg(
-            content: svg.clone(),
-            color: color.clone(),
+            content: svg,
+            color: color,
             style: style,
         )
     }

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -548,7 +548,6 @@ pub fn input(
     // rather than moving them out of the `#[component]` re-invokable
     // body.
     let value_prop: Signal<String> = {
-        let value = value.clone();
         Signal::Dynamic(computed(move || {
             if let Some(t) = text {
                 t.get()
@@ -611,10 +610,10 @@ pub fn input(
     };
 
     // ----- Pass-through attrs (None → sensible default) ----------------
-    let placeholder_prop: Signal<String> = placeholder.clone().unwrap_or_default();
-    let caret_color_prop: Signal<String> = caret_color.clone().unwrap_or_default();
-    let placeholder_color_prop: Signal<String> = placeholder_color.clone().unwrap_or_default();
-    let selection_color_prop: Signal<String> = selection_color.clone().unwrap_or_default();
+    let placeholder_prop: Signal<String> = placeholder.unwrap_or_default();
+    let caret_color_prop: Signal<String> = caret_color.unwrap_or_default();
+    let placeholder_color_prop: Signal<String> = placeholder_color.unwrap_or_default();
+    let selection_color_prop: Signal<String> = selection_color.unwrap_or_default();
     let style_prop: Style = style.clone().unwrap_or_default();
 
     let multiline_attr = bool_attr(multiline);

--- a/packages/whisker-svg/src/lib.rs
+++ b/packages/whisker-svg/src/lib.rs
@@ -100,21 +100,15 @@ use whisker::Style;
 ///   `preserveAspectRatio="xMidYMid meet"` semantics.
 #[component]
 pub fn svg(content: Signal<String>, color: Signal<String>, style: Style) -> Element {
-    // Clone `content` before the move closure: `Signal` isn't `Copy`
-    // (the Static variant owns its T), and the `#[component]` body
-    // re-fires as a FnMut.
-    let display_list = {
-        let content = content.clone();
-        computed(move || encode(&content.get()))
-    };
+    // `Signal<T>` is `Copy`, so `content` is freely moved into the
+    // closure and `color` into the builder below even though the
+    // `#[component]` body re-fires as a `FnMut` (whisker #8).
+    let display_list = computed(move || encode(&content.get()));
 
-    // Same clone dance for pass-through props — `render!` internally
-    // re-applies via Fn closures, so a non-Copy `Signal` moved on
-    // first fire wouldn't be available on subsequent re-fires.
     render! {
         SvgRenderer(
             display_list: display_list,
-            color: color.clone(),
+            color: color,
             style: style.clone(),
         )
     }

--- a/packages/whisker-webview/src/lib.rs
+++ b/packages/whisker-webview/src/lib.rs
@@ -590,8 +590,8 @@ pub fn web_view(
     };
 
     // ----- Pass-through attrs (None → sensible default) ----------------
-    let html_prop: Signal<String> = html.clone().unwrap_or_default();
-    let user_agent_prop: Signal<String> = user_agent.clone().unwrap_or_default();
+    let html_prop: Signal<String> = html.unwrap_or_default();
+    let user_agent_prop: Signal<String> = user_agent.unwrap_or_default();
     let style_prop: Style = style.clone().unwrap_or_default();
 
     let javascript_enabled_attr = bool_attr(javascript_enabled);


### PR DESCRIPTION
## Summary

評価フィードバック #8。`#[component]` 本体は `FnMut` のため、非 Copy な `Signal<T>` prop を `computed(move || …)` 等のネストクロージャに move すると E0507 となり `.clone()` が必要だった。`RwSignal<T>` は Copy 済み。阻害要因は `Signal::Static(T)` がインラインの所有 `T` を保持していたこと。

### 変更
static 値を owner 紐付きの `StoredValue<T>`（Copy・非リアクティブな arena ハンドル）に格納し、両アームを Copy にして enum を Copy 化:

```rust
enum Signal<T> { Stored(StoredValue<T>), Dynamic(ReadSignal<T>) }
```

`Clone`/`Copy` は手書き（`T: 'static` 束縛、`T: Copy` ではない）。derive だと `T: Copy` が付き `Signal<String>` が Copy にならないため。

各 package の不要になった `.clone()`（whisker-icons / -svg / -input / -webview）も除去（Copy な Signal に `clippy::clone_on_copy` が `-D warnings` で発火するため）。`signal_is_copy` テストで `Signal<String>` を2つの `move` クロージャに `.clone()` 無しで move できることを検証。

### トレードオフ（要確認）
- **割り当て**: static `Signal` 構築（`From<T>`/`Default`/`From<&str>`）が、インライン保持ではなく owner 紐付き arena スロット1個を割り当てる（Copy の代償）。1 prop あたり小ヒープ1回で典型用途は無視可能。
- **セマンティクス変化**: static `Signal` が**値セマンティクス→owner スコープのハンドルセマンティクス**に。構築時の owner が dispose した後にコピーを読むと `StoredValue: disposed` で panic（旧来は値が複製され生存）。owner 外構築は detached scope に park（panic せず、微小リーク）。既存コードは「同一 builder 呼び出し内で構築・消費」のため影響なし（全 workspace test / clippy green で確認）。
  - これは memory の Arc→arena handle footgun と同類。docs への注意書き追加を推奨。

## Test plan
- `cargo build --workspace` clean。
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` 警告なし。
- `cargo test --workspace` 全 pass（`signal_is_copy` 含む）。
- `cargo fmt --check` clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)