### PR TITLE
fix(view): re-entrancy-safe renderer dispatch (#3)

### DIFF
--- a/crates/whisker-driver/src/lynx/list_provider.rs
+++ b/crates/whisker-driver/src/lynx/list_provider.rs
@@ -124,7 +124,7 @@ impl BridgeRenderer {
     /// the element (e.g. it was already released) — in that case the
     /// provider is dropped immediately.
     pub(crate) fn install_list_native_item_provider(
-        &mut self,
+        &self,
         list_element: Element,
         provider: NativeItemProvider,
     ) -> bool {

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -13,6 +13,7 @@
 //! we don't currently reuse them (cheap; can be revisited if
 //! per-frame churn ever matters).
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::CString;
 use std::ptr::NonNull;
@@ -30,12 +31,31 @@ use super::propagation;
 /// list and the closure can run after the renderer borrow is released.
 type Listener = (BindType, Rc<dyn Fn(WhiskerValue) + 'static>);
 
+/// The bridge-backed [`DynRenderer`]. All mutating methods take
+/// `&self` (see the trait docs) — the three mutable fields therefore
+/// live behind **per-field** `RefCell`s rather than `&mut self`.
+///
+/// ## Re-entrancy contract (whisker #3)
+///
+/// A native event can fire *synchronously* from inside an FFI call
+/// that this renderer makes — e.g. `whisker_bridge_remove_child`
+/// triggers Lynx teardown → a UIKit callback → a custom event →
+/// [`whisker_runtime::view::dispatch_event`] → back into *this*
+/// renderer's [`plan_event_dispatch`](Self::plan_event_dispatch),
+/// which reads `parent_sign` (chain reconstruction) and `listeners`.
+///
+/// Therefore **no field borrow may span a re-entrant FFI call.** Each
+/// mutating method that calls a Lynx C API capable of dispatching an
+/// event must: read/compute everything it needs under a *short*
+/// borrow, **drop** the borrow, make the FFI call, then re-borrow if
+/// it must mutate afterwards. Per-field `RefCell`s (not one big lock)
+/// also keep independent fields from false-conflicting.
 pub struct BridgeRenderer {
     engine: NonNull<WhiskerEngine>,
     /// Index → raw C element pointer. `None` means the slot has been
     /// released. Index assigned at `create_element` time, returned in
     /// the public `Element`.
-    elements: Vec<Option<NonNull<WhiskerElement>>>,
+    elements: RefCell<Vec<Option<NonNull<WhiskerElement>>>>,
     /// Child Lynx-sign → parent Lynx-sign, mirroring the attached
     /// tree. Populated in [`append_child`](Self::append_child),
     /// cleared in [`remove_child`](Self::remove_child) /
@@ -43,7 +63,7 @@ pub struct BridgeRenderer {
     /// chain walk (`target → root`) follows these links — Lynx's
     /// reporter only hands us the target, so we reconstruct the
     /// ancestor chain ourselves.
-    parent_sign: HashMap<i32, i32>,
+    parent_sign: RefCell<HashMap<i32, i32>>,
     /// `(element sign, event name)` → listeners registered for it.
     /// Keyed by Lynx sign so the reporter's target sign (and the
     /// ancestor signs we walk to) look up directly. A given
@@ -51,7 +71,7 @@ pub struct BridgeRenderer {
     /// and bubble handlers are both registered (mirrors Lynx storing a
     /// handler per type).
     #[allow(clippy::type_complexity)]
-    listeners: HashMap<(i32, String), Vec<Listener>>,
+    listeners: RefCell<HashMap<(i32, String), Vec<Listener>>>,
 }
 
 impl BridgeRenderer {
@@ -63,9 +83,9 @@ impl BridgeRenderer {
     pub unsafe fn from_raw(engine: *mut WhiskerEngine) -> Option<Self> {
         NonNull::new(engine).map(|engine| Self {
             engine,
-            elements: Vec::new(),
-            parent_sign: HashMap::new(),
-            listeners: HashMap::new(),
+            elements: RefCell::new(Vec::new()),
+            parent_sign: RefCell::new(HashMap::new()),
+            listeners: RefCell::new(HashMap::new()),
         })
     }
 
@@ -73,8 +93,13 @@ impl BridgeRenderer {
         self.engine.as_ptr()
     }
 
+    /// Resolve `handle` to its raw C pointer. Copies the pointer out
+    /// from under a short borrow of `elements` so the returned value
+    /// never keeps the borrow alive — callers are free to make FFI
+    /// calls (which may re-enter and re-borrow `elements`) with it.
     pub(crate) fn lookup(&self, handle: Element) -> Option<NonNull<WhiskerElement>> {
         self.elements
+            .borrow()
             .get(handle.id() as usize)
             .and_then(|slot| *slot)
     }
@@ -82,6 +107,11 @@ impl BridgeRenderer {
     /// The Lynx element sign for `handle`, or `None` if the handle is
     /// unknown / released. Routes through the bridge (the sign is
     /// `lynx_element_id` of the underlying FiberElement).
+    ///
+    /// `lookup`'s `elements` borrow is dropped before the FFI call (it
+    /// only returns a copied pointer), so this never holds a borrow
+    /// across `whisker_bridge_element_sign` — a pure getter that does
+    /// not tear down views or dispatch events.
     fn sign_of(&self, handle: Element) -> Option<i32> {
         let ptr = self.lookup(handle)?;
         let sign = unsafe { ffi::whisker_bridge_element_sign(ptr.as_ptr()) };
@@ -102,18 +132,23 @@ fn map_tag(tag: ElementTag) -> WhiskerElementTag {
 }
 
 impl DynRenderer for BridgeRenderer {
-    fn create_element(&mut self, tag: ElementTag) -> Element {
+    fn create_element(&self, tag: ElementTag) -> Element {
+        // FFI first, with NO `elements` borrow held — then borrow only
+        // to register the new pointer. Element creation can't dispatch
+        // an event, but keeping the borrow off the FFI call obeys the
+        // renderer's uniform re-entrancy contract.
         let raw = unsafe { ffi::whisker_bridge_create_element(self.engine_ptr(), map_tag(tag)) };
         let ptr = match NonNull::new(raw) {
             Some(p) => p,
             None => return Element::from_raw(u32::MAX),
         };
-        let id = self.elements.len() as u32;
-        self.elements.push(Some(ptr));
+        let mut elements = self.elements.borrow_mut();
+        let id = elements.len() as u32;
+        elements.push(Some(ptr));
         Element::from_raw(id)
     }
 
-    fn create_element_by_name(&mut self, tag_name: &str) -> Element {
+    fn create_element_by_name(&self, tag_name: &str) -> Element {
         let Ok(c) = CString::new(tag_name) else {
             return Element::from_raw(u32::MAX);
         };
@@ -123,8 +158,9 @@ impl DynRenderer for BridgeRenderer {
             Some(p) => p,
             None => return Element::from_raw(u32::MAX),
         };
-        let id = self.elements.len() as u32;
-        self.elements.push(Some(ptr));
+        let mut elements = self.elements.borrow_mut();
+        let id = elements.len() as u32;
+        elements.push(Some(ptr));
         Element::from_raw(id)
     }
 
@@ -135,23 +171,30 @@ impl DynRenderer for BridgeRenderer {
         self.sign_of(handle).unwrap_or(0)
     }
 
-    fn release_element(&mut self, handle: Element) {
-        // Resolve the sign before releasing so we can drop the element's
-        // listeners + parent link. After release the underlying pointer
-        // is gone, so `sign_of` would fail.
+    fn release_element(&self, handle: Element) {
+        // RE-ENTRANT FFI: `whisker_bridge_release_element` tears down
+        // the native view, which can synchronously dispatch an event
+        // that re-enters `plan_event_dispatch` (reads `parent_sign` +
+        // `listeners`). So: resolve the sign and take the pointer out
+        // of `elements` under SHORT borrows, DROP them, then make the
+        // FFI call, then re-borrow `parent_sign`/`listeners` to clean
+        // up. No field borrow spans the release call.
         let sign = self.sign_of(handle);
-        if let Some(slot) = self.elements.get_mut(handle.id() as usize) {
-            if let Some(ptr) = slot.take() {
-                unsafe { ffi::whisker_bridge_release_element(ptr.as_ptr()) };
-            }
+        let ptr = self
+            .elements
+            .borrow_mut()
+            .get_mut(handle.id() as usize)
+            .and_then(|slot| slot.take());
+        if let Some(ptr) = ptr {
+            unsafe { ffi::whisker_bridge_release_element(ptr.as_ptr()) };
         }
         if let Some(sign) = sign {
-            self.parent_sign.remove(&sign);
-            self.listeners.retain(|(s, _), _| *s != sign);
+            self.parent_sign.borrow_mut().remove(&sign);
+            self.listeners.borrow_mut().retain(|(s, _), _| *s != sign);
         }
     }
 
-    fn set_attribute(&mut self, handle: Element, key: &str, value: &str) {
+    fn set_attribute(&self, handle: Element, key: &str, value: &str) {
         let Some(ptr) = self.lookup(handle) else {
             return;
         };
@@ -164,7 +207,7 @@ impl DynRenderer for BridgeRenderer {
         };
     }
 
-    fn set_attribute_int(&mut self, handle: Element, key: &str, value: i64) {
+    fn set_attribute_int(&self, handle: Element, key: &str, value: i64) {
         let Some(ptr) = self.lookup(handle) else {
             return;
         };
@@ -172,7 +215,7 @@ impl DynRenderer for BridgeRenderer {
         unsafe { ffi::whisker_bridge_set_attribute_int(ptr.as_ptr(), key_c.as_ptr(), value) };
     }
 
-    fn set_attribute_bool(&mut self, handle: Element, key: &str, value: bool) {
+    fn set_attribute_bool(&self, handle: Element, key: &str, value: bool) {
         let Some(ptr) = self.lookup(handle) else {
             return;
         };
@@ -180,7 +223,7 @@ impl DynRenderer for BridgeRenderer {
         unsafe { ffi::whisker_bridge_set_attribute_bool(ptr.as_ptr(), key_c.as_ptr(), value) };
     }
 
-    fn set_attribute_double(&mut self, handle: Element, key: &str, value: f64) {
+    fn set_attribute_double(&self, handle: Element, key: &str, value: f64) {
         let Some(ptr) = self.lookup(handle) else {
             return;
         };
@@ -188,7 +231,7 @@ impl DynRenderer for BridgeRenderer {
         unsafe { ffi::whisker_bridge_set_attribute_double(ptr.as_ptr(), key_c.as_ptr(), value) };
     }
 
-    fn set_inline_styles(&mut self, handle: Element, css: &str) {
+    fn set_inline_styles(&self, handle: Element, css: &str) {
         let Some(ptr) = self.lookup(handle) else {
             return;
         };
@@ -196,7 +239,7 @@ impl DynRenderer for BridgeRenderer {
         unsafe { ffi::whisker_bridge_set_inline_styles(ptr.as_ptr(), css_c.as_ptr()) };
     }
 
-    fn set_update_list_info(&mut self, handle: Element, count: i32) {
+    fn set_update_list_info(&self, handle: Element, count: i32) {
         let Some(ptr) = self.lookup(handle) else {
             return;
         };
@@ -204,7 +247,7 @@ impl DynRenderer for BridgeRenderer {
     }
 
     fn install_list_native_item_provider(
-        &mut self,
+        &self,
         handle: Element,
         provider: whisker_runtime::view::list_provider::NativeItemProvider,
     ) -> bool {
@@ -214,29 +257,43 @@ impl DynRenderer for BridgeRenderer {
         BridgeRenderer::install_list_native_item_provider(self, handle, provider)
     }
 
-    fn append_child(&mut self, parent: Element, child: Element) {
+    fn append_child(&self, parent: Element, child: Element) {
+        // `lookup` returns copied pointers (its `elements` borrow is
+        // already dropped). The FFI append can synchronously dispatch
+        // an event, so we must NOT hold a `parent_sign` borrow across
+        // it: do the FFI first, then borrow `parent_sign` to record
+        // the edge.
         let Some(p) = self.lookup(parent) else { return };
         let Some(c) = self.lookup(child) else { return };
         unsafe { ffi::whisker_bridge_append_child(p.as_ptr(), c.as_ptr()) };
         // Mirror the attachment in sign space for the event chain walk.
         // (`insert_child_at` is built on append/remove, so it flows
-        // through here too.)
+        // through here too.) `sign_of` holds no `parent_sign` borrow,
+        // so computing the signs first and inserting after is safe.
         if let (Some(cs), Some(ps)) = (self.sign_of(child), self.sign_of(parent)) {
-            self.parent_sign.insert(cs, ps);
+            self.parent_sign.borrow_mut().insert(cs, ps);
         }
     }
 
-    fn remove_child(&mut self, parent: Element, child: Element) {
+    fn remove_child(&self, parent: Element, child: Element) {
+        // RE-ENTRANT FFI: `whisker_bridge_remove_child` tears down the
+        // native subtree, which can synchronously dispatch an event
+        // that re-enters `plan_event_dispatch` (walks `parent_sign`,
+        // reads `listeners`). We resolve the child's sign BEFORE the
+        // FFI (the pointer is still live then), hold NO field borrow
+        // across the FFI call, and only borrow `parent_sign` to drop
+        // the edge AFTER it returns.
         let Some(p) = self.lookup(parent) else { return };
         let Some(c) = self.lookup(child) else { return };
+        let child_sign = self.sign_of(child);
         unsafe { ffi::whisker_bridge_remove_child(p.as_ptr(), c.as_ptr()) };
-        if let Some(cs) = self.sign_of(child) {
-            self.parent_sign.remove(&cs);
+        if let Some(cs) = child_sign {
+            self.parent_sign.borrow_mut().remove(&cs);
         }
     }
 
     fn set_event_listener(
-        &mut self,
+        &self,
         handle: Element,
         event_name: &str,
         bind_type: BindType,
@@ -260,6 +317,9 @@ impl DynRenderer for BridgeRenderer {
         // the gesture pipeline to the reporter regardless — so we only
         // register a native handler for the non-gesture events, both to
         // unblock their emission and to avoid any double-fire on touch.
+        // The native-handler registration FFI runs with NO `listeners`
+        // borrow held — it only enables emission and cannot dispatch.
+        // We borrow `listeners` afterwards to record the closure.
         if !is_gesture_event(event_name) {
             if let Ok(name_c) = CString::new(event_name) {
                 unsafe {
@@ -267,10 +327,8 @@ impl DynRenderer for BridgeRenderer {
                 };
             }
         }
-        let entry = self
-            .listeners
-            .entry((sign, event_name.to_string()))
-            .or_default();
+        let mut listeners = self.listeners.borrow_mut();
+        let entry = listeners.entry((sign, event_name.to_string())).or_default();
         // Replace any handler of the SAME bind/catch/capture type for
         // this (element, event) — mirrors Lynx's per-type handler slot.
         // A different type (e.g. capture + bubble on one element) is
@@ -287,22 +345,35 @@ impl DynRenderer for BridgeRenderer {
     ) -> EventDispatchPlan {
         // Reconstruct the response chain (target → root) from the
         // parent mirror — Lynx's reporter only hands us the target.
-        let mut chain = vec![target_sign];
-        let mut cur = target_sign;
-        let mut guard = 0usize;
-        while let Some(&parent) = self.parent_sign.get(&cur) {
-            chain.push(parent);
-            cur = parent;
-            guard += 1;
-            // Defensive: a malformed tree shouldn't spin forever.
-            if guard > 4096 {
-                break;
+        // The `parent_sign` borrow is scoped to the walk and dropped
+        // before we touch `listeners`; planning makes no FFI call, so
+        // these read-only borrows can't span a re-entrant op.
+        let chain = {
+            let parent_sign = self.parent_sign.borrow();
+            let mut chain = vec![target_sign];
+            let mut cur = target_sign;
+            let mut guard = 0usize;
+            while let Some(&parent) = parent_sign.get(&cur) {
+                chain.push(parent);
+                cur = parent;
+                guard += 1;
+                // Defensive: a malformed tree shouldn't spin forever.
+                if guard > 4096 {
+                    break;
+                }
             }
-        }
+            chain
+        };
 
+        // Hold a single shared borrow of `listeners` across the plan.
+        // `propagation::plan` only reads (no FFI), so this borrow can't
+        // conflict with a re-entrant op; releasing it after planning
+        // means the listeners then fire (in `dispatch_event`) with no
+        // renderer-field borrow held at all.
         let empty: Vec<Listener> = Vec::new();
+        let listeners = self.listeners.borrow();
         let (consumed, ordered) = propagation::plan(&chain, |sign| {
-            self.listeners
+            listeners
                 .get(&(sign, event_name.to_string()))
                 .map(Vec::as_slice)
                 .unwrap_or(&empty)
@@ -319,12 +390,18 @@ impl DynRenderer for BridgeRenderer {
         EventDispatchPlan { consumed, firings }
     }
 
-    fn set_root(&mut self, page: Element) {
+    fn set_root(&self, page: Element) {
+        // `lookup`'s `elements` borrow is dropped before the FFI call
+        // (it returns a copied pointer), so even if attaching the root
+        // dispatches an event, no field borrow spans the call.
         let Some(ptr) = self.lookup(page) else { return };
         unsafe { ffi::whisker_bridge_set_root(self.engine_ptr(), ptr.as_ptr()) };
     }
 
-    fn flush(&mut self) {
+    fn flush(&self) {
+        // No field borrow held; if flush triggers native layout that
+        // dispatches an event, the re-entrant op sees no outstanding
+        // borrow of any renderer field.
         unsafe { ffi::whisker_bridge_flush(self.engine_ptr()) };
     }
 

--- a/crates/whisker-runtime/src/view/list_mount.rs
+++ b/crates/whisker-runtime/src/view/list_mount.rs
@@ -169,23 +169,29 @@ mod tests {
     /// list and exercise the callbacks.
     #[derive(Default)]
     struct CapturingRenderer {
-        next_id: u32,
+        // `Cell` for interior mutability — `DynRenderer` methods take
+        // `&self` (the re-entrancy fix).
+        next_id: std::cell::Cell<u32>,
         last_count: Rc<RefCell<Option<i32>>>,
         installed: Rc<RefCell<Option<NativeItemProvider>>>,
     }
 
+    impl CapturingRenderer {
+        fn alloc_id(&self) -> u32 {
+            let id = self.next_id.get();
+            self.next_id.set(id + 1);
+            id
+        }
+    }
+
     impl DynRenderer for CapturingRenderer {
-        fn create_element(&mut self, _tag: ElementTag) -> Element {
-            let id = self.next_id;
-            self.next_id += 1;
-            Element::from_raw(id)
+        fn create_element(&self, _tag: ElementTag) -> Element {
+            Element::from_raw(self.alloc_id())
         }
-        fn create_element_by_name(&mut self, _tag: &str) -> Element {
-            let id = self.next_id;
-            self.next_id += 1;
-            Element::from_raw(id)
+        fn create_element_by_name(&self, _tag: &str) -> Element {
+            Element::from_raw(self.alloc_id())
         }
-        fn release_element(&mut self, _h: Element) {}
+        fn release_element(&self, _h: Element) {}
         // Model the Lynx sign as the element's own id so signs are
         // distinct per element (a real renderer returns the bridge
         // `impl_id`). Without this the trait default returns 0 for
@@ -193,31 +199,31 @@ mod tests {
         fn element_sign(&self, handle: Element) -> i32 {
             handle.id() as i32
         }
-        fn set_attribute(&mut self, _h: Element, _k: &str, _v: &str) {}
-        fn set_inline_styles(&mut self, _h: Element, _css: &str) {}
-        fn set_update_list_info(&mut self, _h: Element, count: i32) {
+        fn set_attribute(&self, _h: Element, _k: &str, _v: &str) {}
+        fn set_inline_styles(&self, _h: Element, _css: &str) {}
+        fn set_update_list_info(&self, _h: Element, count: i32) {
             *self.last_count.borrow_mut() = Some(count);
         }
         fn install_list_native_item_provider(
-            &mut self,
+            &self,
             _h: Element,
             provider: NativeItemProvider,
         ) -> bool {
             *self.installed.borrow_mut() = Some(provider);
             true
         }
-        fn append_child(&mut self, _p: Element, _c: Element) {}
-        fn remove_child(&mut self, _p: Element, _c: Element) {}
+        fn append_child(&self, _p: Element, _c: Element) {}
+        fn remove_child(&self, _p: Element, _c: Element) {}
         fn set_event_listener(
-            &mut self,
+            &self,
             _h: Element,
             _n: &str,
             _bt: BindType,
             _cb: Box<dyn Fn(crate::value::WhiskerValue) + 'static>,
         ) {
         }
-        fn set_root(&mut self, _p: Element) {}
-        fn flush(&mut self) {}
+        fn set_root(&self, _p: Element) {}
+        fn flush(&self) {}
     }
 
     fn with_capturing<R>(

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -79,16 +79,27 @@ pub struct EventDispatchPlan {
 /// type-erased — the handle type is always [`Element`]. Existing
 /// `R: Renderer` implementations bridge into here via a small adapter
 /// that maintains its own `Element → R::Element` map.
+/// All mutating methods take `&self`, not `&mut self`. This is the
+/// core of the re-entrancy fix for whisker issue #3: a native event
+/// can fire *synchronously* during a renderer operation (e.g. Lynx
+/// teardown inside [`remove_child`](Self::remove_child) triggering a
+/// UIKit callback that dispatches a custom event), which re-enters the
+/// renderer through [`dispatch_event`]. With `&self` methods the
+/// thread-local [`CURRENT_RENDERER`] is held by a *shared* borrow in
+/// [`with_renderer`], so a re-entrant call (also shared) is permitted
+/// rather than panicking with "RefCell already borrowed". Renderers
+/// own their mutable state behind per-field `RefCell`s and must scope
+/// each field borrow so it does **not** span a re-entrant FFI call.
 pub trait DynRenderer {
-    fn create_element(&mut self, tag: ElementTag) -> Element;
+    fn create_element(&self, tag: ElementTag) -> Element;
     /// Phase 7: tag-by-name dispatch for custom / xelement-style
     /// tags ("x-input", etc.) not in the built-in [`ElementTag`]
     /// enum. Returns [`Element::INVALID`] when the tag is unknown
     /// to Lynx's behaviour registry.
-    fn create_element_by_name(&mut self, tag_name: &str) -> Element;
-    fn release_element(&mut self, handle: Element);
+    fn create_element_by_name(&self, tag_name: &str) -> Element;
+    fn release_element(&self, handle: Element);
 
-    fn set_attribute(&mut self, handle: Element, key: &str, value: &str);
+    fn set_attribute(&self, handle: Element, key: &str, value: &str);
     /// Typed-attr variants. Lynx's prop dispatch on many UIs
     /// (`<list>`, `<scroll-view>`, …) gates branches on
     /// `value.IsNumber()` / `value.IsBool()` against the underlying
@@ -98,16 +109,16 @@ pub trait DynRenderer {
     /// reads the value as anything other than a string. Default
     /// impls forward to the string path (good enough for test
     /// renderers that don't model the underlying type discrimination).
-    fn set_attribute_int(&mut self, handle: Element, key: &str, value: i64) {
+    fn set_attribute_int(&self, handle: Element, key: &str, value: i64) {
         self.set_attribute(handle, key, &value.to_string());
     }
-    fn set_attribute_bool(&mut self, handle: Element, key: &str, value: bool) {
+    fn set_attribute_bool(&self, handle: Element, key: &str, value: bool) {
         self.set_attribute(handle, key, if value { "true" } else { "false" });
     }
-    fn set_attribute_double(&mut self, handle: Element, key: &str, value: f64) {
+    fn set_attribute_double(&self, handle: Element, key: &str, value: f64) {
         self.set_attribute(handle, key, &value.to_string());
     }
-    fn set_inline_styles(&mut self, handle: Element, css: &str);
+    fn set_inline_styles(&self, handle: Element, css: &str);
 
     /// Underlying Lynx sign (`impl_id`) for `handle`, or 0 if the
     /// renderer doesn't model signs (test renderers) or the handle
@@ -124,7 +135,7 @@ pub trait DynRenderer {
     /// Lynx's decoupled native list reads its items from. The `list`
     /// builder calls this once at `__h()` finalize. Default no-op for
     /// test renderers that don't model list virtualisation.
-    fn set_update_list_info(&mut self, _handle: Element, _count: i32) {}
+    fn set_update_list_info(&self, _handle: Element, _count: i32) {}
 
     /// Install a native item provider on a `<list>` element. The
     /// `provider`'s callbacks are invoked by Lynx's list machinery to
@@ -135,7 +146,7 @@ pub trait DynRenderer {
     /// The default drops `provider` so test code doesn't leak boxed
     /// closures.
     fn install_list_native_item_provider(
-        &mut self,
+        &self,
         _handle: Element,
         provider: super::list_provider::NativeItemProvider,
     ) -> bool {
@@ -143,8 +154,8 @@ pub trait DynRenderer {
         false
     }
 
-    fn append_child(&mut self, parent: Element, child: Element);
-    fn remove_child(&mut self, parent: Element, child: Element);
+    fn append_child(&self, parent: Element, child: Element);
+    fn remove_child(&self, parent: Element, child: Element);
 
     /// Register `callback` for `event_name` on `handle`.
     ///
@@ -156,7 +167,7 @@ pub trait DynRenderer {
     /// shape, deserializing the payload as needed. An event with no
     /// body fires the callback with [`WhiskerValue::Null`].
     fn set_event_listener(
-        &mut self,
+        &self,
         handle: Element,
         event_name: &str,
         bind_type: BindType,
@@ -189,8 +200,8 @@ pub trait DynRenderer {
         EventDispatchPlan::default()
     }
 
-    fn set_root(&mut self, page: Element);
-    fn flush(&mut self);
+    fn set_root(&self, page: Element);
+    fn flush(&self);
 
     /// Opaque platform pointer the C bridge associates with this
     /// `Element` handle (cast from `*mut WhiskerElement` for the
@@ -309,9 +320,24 @@ pub fn current_renderer_id() -> Option<&'static str> {
     CURRENT_RENDERER.with_borrow(|slot| slot.as_ref().map(|_| "installed"))
 }
 
-fn with_renderer<R>(f: impl FnOnce(&mut dyn DynRenderer) -> R, default: R) -> R {
-    CURRENT_RENDERER.with_borrow_mut(|slot| match slot.as_mut() {
-        Some(r) => f(r.as_mut()),
+/// Run `f` against the installed renderer under a **shared** borrow of
+/// the [`CURRENT_RENDERER`] slot.
+///
+/// The shared borrow is the re-entrancy fix: `RefCell` permits any
+/// number of simultaneous shared borrows, so if `f` (e.g. a
+/// `remove_child` that synchronously tears down native views) causes a
+/// native callback to re-enter Whisker through [`dispatch_event`] →
+/// another `with_renderer`, that nested shared borrow is granted
+/// instead of aborting with "already borrowed". This works because
+/// every [`DynRenderer`] method now takes `&self` and owns its mutable
+/// state behind interior `RefCell`s.
+///
+/// Slot *swapping* ([`install_renderer`] / [`uninstall_renderer`])
+/// still uses `with_borrow_mut`; those are never called during
+/// dispatch, so they can't conflict with an outstanding shared borrow.
+fn with_renderer<R>(f: impl FnOnce(&dyn DynRenderer) -> R, default: R) -> R {
+    CURRENT_RENDERER.with_borrow(|slot| match slot.as_ref() {
+        Some(r) => f(r.as_ref()),
         None => {
             #[cfg(debug_assertions)]
             eprintln!("whisker-view: renderer call outside any installed renderer; ignored");

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -22,7 +22,10 @@ enum Op {
 
 #[derive(Default)]
 struct RecordingRenderer {
-    next_id: u32,
+    // `Cell` because `DynRenderer` methods take `&self` now (the
+    // re-entrancy fix): the renderer owns its mutable state behind
+    // interior mutability instead of `&mut self`.
+    next_id: std::cell::Cell<u32>,
     ops: std::rc::Rc<std::cell::RefCell<Vec<Op>>>,
 }
 
@@ -32,54 +35,58 @@ impl RecordingRenderer {
         let log = renderer.ops.clone();
         (renderer, log)
     }
+
+    fn alloc_id(&self) -> u32 {
+        let id = self.next_id.get();
+        self.next_id.set(id + 1);
+        id
+    }
 }
 
 impl DynRenderer for RecordingRenderer {
-    fn create_element(&mut self, tag: ElementTag) -> Element {
-        let id = self.next_id;
-        self.next_id += 1;
+    fn create_element(&self, tag: ElementTag) -> Element {
+        let id = self.alloc_id();
         self.ops.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
-    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
-        let id = self.next_id;
-        self.next_id += 1;
+    fn create_element_by_name(&self, _tag_name: &str) -> Element {
+        let id = self.alloc_id();
         self.ops.borrow_mut().push(Op::Create {
             id,
             tag: ElementTag::View,
         });
         Element::from_raw(id)
     }
-    fn release_element(&mut self, h: Element) {
+    fn release_element(&self, h: Element) {
         self.ops.borrow_mut().push(Op::Release { id: h.id() });
     }
-    fn set_attribute(&mut self, h: Element, key: &str, value: &str) {
+    fn set_attribute(&self, h: Element, key: &str, value: &str) {
         self.ops.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: key.into(),
             value: value.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: Element, css: &str) {
+    fn set_inline_styles(&self, h: Element, css: &str) {
         self.ops.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, parent: Element, child: Element) {
+    fn append_child(&self, parent: Element, child: Element) {
         self.ops.borrow_mut().push(Op::Append {
             parent: parent.id(),
             child: child.id(),
         });
     }
-    fn remove_child(&mut self, parent: Element, child: Element) {
+    fn remove_child(&self, parent: Element, child: Element) {
         self.ops.borrow_mut().push(Op::Remove {
             parent: parent.id(),
             child: child.id(),
         });
     }
     fn set_event_listener(
-        &mut self,
+        &self,
         h: Element,
         name: &str,
         _bind_type: super::BindType,
@@ -90,10 +97,10 @@ impl DynRenderer for RecordingRenderer {
             name: name.into(),
         });
     }
-    fn set_root(&mut self, page: Element) {
+    fn set_root(&self, page: Element) {
         self.ops.borrow_mut().push(Op::SetRoot { id: page.id() });
     }
-    fn flush(&mut self) {
+    fn flush(&self) {
         self.ops.borrow_mut().push(Op::Flush);
     }
 }
@@ -235,4 +242,354 @@ fn view_attach_appends_each_leaf() {
         .filter(|o| matches!(o, Op::Append { .. }))
         .collect();
     assert_eq!(appends.len(), 3, "Empty fragments must be skipped");
+}
+
+// ===========================================================================
+// Re-entrancy (whisker #3) — these tests pin the root-cause fix: a native
+// event that fires *synchronously during* a renderer operation must be able
+// to re-enter the dispatch path without aborting on "RefCell already
+// borrowed". The fix is: `DynRenderer` methods take `&self`, renderers own
+// their state behind interior `RefCell`s with FFI-scoped borrows, and
+// `with_renderer` takes a *shared* borrow of the renderer slot.
+// ===========================================================================
+mod reentrancy {
+    use super::*;
+    use crate::value::WhiskerValue;
+    use std::cell::{Cell, RefCell};
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    /// A test renderer that mirrors the *shape* of the real
+    /// `BridgeRenderer`: it keeps `parent_sign` and `listeners` behind
+    /// per-field `RefCell`s and plans event dispatch from them. Its
+    /// `remove_child` runs a caller-supplied **re-entrancy hook**
+    /// *while simulating native teardown* — standing in for Lynx
+    /// synchronously dispatching a UIKit event during `remove_child`.
+    ///
+    /// Crucially `remove_child` holds **no field borrow** across the
+    /// hook (mirroring the FFI-scoping rule), so the hook is free to
+    /// re-enter any `view::*` op, including `dispatch_event`, which
+    /// reads `parent_sign` + `listeners`.
+    #[derive(Default)]
+    struct ReentrantRenderer {
+        next_id: Cell<u32>,
+        /// `element id` → its mirror parent id (used as the "sign" —
+        /// the test models sign == element id for simplicity).
+        parent_sign: RefCell<HashMap<i32, i32>>,
+        /// `(sign, event)` → listener closures.
+        #[allow(clippy::type_complexity)]
+        listeners: RefCell<HashMap<(i32, String), Vec<Rc<dyn Fn(WhiskerValue)>>>>,
+        /// Ordered side-effect log so tests can assert *sync* delivery
+        /// order (outer op effects interleaved with inner re-entrant
+        /// effects).
+        log: Rc<RefCell<Vec<String>>>,
+        /// Fired once, from inside `remove_child`, with no field borrow
+        /// held — the simulated synchronous native callback.
+        #[allow(clippy::type_complexity)]
+        on_remove_hook: RefCell<Option<Box<dyn Fn()>>>,
+    }
+
+    impl ReentrantRenderer {
+        fn new() -> (Self, Rc<RefCell<Vec<String>>>) {
+            let r = Self::default();
+            let log = r.log.clone();
+            (r, log)
+        }
+        fn alloc_id(&self) -> u32 {
+            let id = self.next_id.get();
+            self.next_id.set(id + 1);
+            id
+        }
+    }
+
+    impl DynRenderer for ReentrantRenderer {
+        fn create_element(&self, _tag: ElementTag) -> Element {
+            Element::from_raw(self.alloc_id())
+        }
+        fn create_element_by_name(&self, _tag: &str) -> Element {
+            Element::from_raw(self.alloc_id())
+        }
+        fn release_element(&self, _h: Element) {}
+        fn element_sign(&self, h: Element) -> i32 {
+            h.id() as i32
+        }
+        fn set_attribute(&self, h: Element, key: &str, value: &str) {
+            self.log
+                .borrow_mut()
+                .push(format!("set_attr {} {}={}", h.id(), key, value));
+        }
+        fn set_inline_styles(&self, _h: Element, _css: &str) {}
+        fn append_child(&self, parent: Element, child: Element) {
+            // Scope the `parent_sign` borrow — never spanning anything
+            // re-entrant (matches the renderer contract).
+            self.parent_sign
+                .borrow_mut()
+                .insert(child.id() as i32, parent.id() as i32);
+            self.log
+                .borrow_mut()
+                .push(format!("append {} -> {}", child.id(), parent.id()));
+        }
+        fn remove_child(&self, parent: Element, child: Element) {
+            // Simulate native teardown: FIRST mutate `parent_sign`
+            // under a short, scoped borrow that is fully released…
+            {
+                let mut ps = self.parent_sign.borrow_mut();
+                ps.remove(&(child.id() as i32));
+            }
+            // …THEN run the synchronous "native callback" with NO field
+            // borrow held. This is exactly the spot where Lynx would
+            // re-enter Whisker during teardown. If any field borrow
+            // leaked into here, the re-entrant op below would panic.
+            self.log
+                .borrow_mut()
+                .push(format!("remove {} from {}", child.id(), parent.id()));
+            let hook = self.on_remove_hook.borrow_mut().take();
+            if let Some(hook) = hook {
+                hook();
+            }
+        }
+        fn set_event_listener(
+            &self,
+            h: Element,
+            event_name: &str,
+            _bind_type: BindType,
+            callback: Box<dyn Fn(WhiskerValue) + 'static>,
+        ) {
+            self.listeners
+                .borrow_mut()
+                .entry((h.id() as i32, event_name.to_string()))
+                .or_default()
+                .push(Rc::from(callback));
+        }
+        fn plan_event_dispatch(
+            &self,
+            target_sign: i32,
+            event_name: &str,
+            body: &WhiskerValue,
+        ) -> EventDispatchPlan {
+            // Reconstruct the chain under a scoped `parent_sign` borrow,
+            // then drop it before touching `listeners` — mirroring the
+            // real renderer. Both borrows are read-only and span no
+            // re-entrant op.
+            let chain = {
+                let ps = self.parent_sign.borrow();
+                let mut chain = vec![target_sign];
+                let mut cur = target_sign;
+                while let Some(&p) = ps.get(&cur) {
+                    chain.push(p);
+                    cur = p;
+                }
+                chain
+            };
+            let listeners = self.listeners.borrow();
+            let mut firings: Vec<super::super::renderer::EventFiring> = Vec::new();
+            // Bubble: target → root.
+            for sign in &chain {
+                if let Some(ls) = listeners.get(&(*sign, event_name.to_string())) {
+                    for l in ls {
+                        firings.push((l.clone(), body.clone()));
+                    }
+                }
+            }
+            EventDispatchPlan {
+                consumed: !firings.is_empty(),
+                firings,
+            }
+        }
+        fn set_root(&self, _p: Element) {}
+        fn flush(&self) {}
+    }
+
+    /// Re-entrant *renderer op* during a renderer op does not panic.
+    /// `remove_child` synchronously calls back into `set_attribute`
+    /// (another `with_renderer` shared borrow). Pre-fix this aborted
+    /// with "already borrowed".
+    #[test]
+    fn reentrant_renderer_op_during_remove_does_not_panic() {
+        let (renderer, log) = ReentrantRenderer::new();
+        // Install a hook that re-enters the public dispatch path.
+        *renderer.on_remove_hook.borrow_mut() = Some(Box::new(|| {
+            // This goes through `with_renderer` again — a NESTED shared
+            // borrow of CURRENT_RENDERER. Must be granted, not aborted.
+            set_attribute(Element::from_raw(99), "reentrant", "1");
+        }));
+
+        with_installed_renderer(Box::new(renderer), || {
+            let parent = create_element(ElementTag::View); // 0
+            let child = create_element(ElementTag::View); // 1
+            append_child(parent, child);
+            // Triggers the hook mid-`remove_child`.
+            remove_child(parent, child);
+        });
+
+        let log = log.borrow();
+        assert!(
+            log.iter().any(|l| l == "remove 1 from 0"),
+            "outer remove ran: {log:?}"
+        );
+        assert!(
+            log.iter().any(|l| l == "set_attr 99 reentrant=1"),
+            "re-entrant set_attribute ran synchronously: {log:?}"
+        );
+        // The re-entrant op was observed AFTER the outer remove began —
+        // synchronous, in-order, no deferral.
+        let remove_pos = log.iter().position(|l| l == "remove 1 from 0").unwrap();
+        let reentrant_pos = log
+            .iter()
+            .position(|l| l == "set_attr 99 reentrant=1")
+            .unwrap();
+        assert!(
+            reentrant_pos > remove_pos,
+            "re-entrant effect must come after the op that triggered it: {log:?}"
+        );
+    }
+
+    /// Re-entrant *event dispatch* during a renderer op runs
+    /// synchronously and in order. `remove_child` synchronously
+    /// dispatches an event whose listener performs another renderer op
+    /// — both the outer op and the inner listener's effect are observed
+    /// in order. This proves there is no one-tick deferral (the #3
+    /// `DispatchQueue.main.async` workaround is no longer needed).
+    #[test]
+    fn reentrant_event_dispatch_runs_synchronously_in_order() {
+        let (renderer, log) = ReentrantRenderer::new();
+        *renderer.on_remove_hook.borrow_mut() = Some(Box::new(|| {
+            // Simulate the native reporter forwarding a custom event
+            // during teardown.
+            dispatch_event(7, "custominput", WhiskerValue::Null);
+        }));
+
+        with_installed_renderer(Box::new(renderer), || {
+            let parent = create_element(ElementTag::View); // 0
+            let child = create_element(ElementTag::View); // 1
+            append_child(parent, child);
+
+            // Register a listener on sign 7 that, WHEN FIRED, performs a
+            // renderer op (set_attribute). Sign 7 is modeled as element
+            // id 7.
+            set_event_listener(
+                Element::from_raw(7),
+                "custominput",
+                BindType::Bind,
+                Box::new(|_v| {
+                    set_attribute(Element::from_raw(42), "from-listener", "fired");
+                }),
+            );
+
+            remove_child(parent, child);
+        });
+
+        let log = log.borrow();
+        let remove_pos = log.iter().position(|l| l == "remove 1 from 0");
+        let listener_pos = log
+            .iter()
+            .position(|l| l == "set_attr 42 from-listener=fired");
+        assert!(remove_pos.is_some(), "outer remove ran: {log:?}");
+        assert!(
+            listener_pos.is_some(),
+            "re-entrant event listener fired synchronously: {log:?}"
+        );
+        assert!(
+            listener_pos.unwrap() > remove_pos.unwrap(),
+            "listener effect must follow the triggering op, in order: {log:?}"
+        );
+    }
+
+    /// Field-borrow scoping: the outer op is mid-mutation of the SAME
+    /// field (`parent_sign`) that the re-entrant op reads/writes.
+    /// `remove_child` mutates `parent_sign` (scoped + dropped) and then,
+    /// in the hook, the re-entrant `dispatch_event` walks `parent_sign`
+    /// AND a re-entrant `append_child` writes it. No panic; final state
+    /// is correct. This guards against re-introducing a spanning borrow.
+    #[test]
+    fn field_borrow_scoping_same_field_reentrant() {
+        let (renderer, log) = ReentrantRenderer::new();
+        *renderer.on_remove_hook.borrow_mut() = Some(Box::new(|| {
+            // READ parent_sign (chain walk) …
+            dispatch_event(5, "tap", WhiskerValue::Null);
+            // … and WRITE parent_sign (new edge), all re-entrantly while
+            // the outer remove_child is on the stack.
+            append_child(Element::from_raw(10), Element::from_raw(11));
+        }));
+
+        with_installed_renderer(Box::new(renderer), || {
+            let p = create_element(ElementTag::View); // 0
+            let a = create_element(ElementTag::View); // 1
+            let b = create_element(ElementTag::View); // 2
+            append_child(p, a);
+            append_child(a, b); // parent_sign: 1->0, 2->1
+            remove_child(a, b); // mutates parent_sign (removes 2->1), then hooks
+        });
+
+        let log = log.borrow();
+        // Re-entrant append must have landed in parent_sign without a
+        // borrow conflict.
+        assert!(
+            log.iter().any(|l| l == "append 11 -> 10"),
+            "re-entrant append while outer remove on stack: {log:?}"
+        );
+        assert!(log.iter().any(|l| l == "remove 2 from 1"));
+    }
+
+    /// Nested `with_renderer` (shared borrow) is allowed, but a mut
+    /// swap of the renderer slot *during* an outstanding shared borrow
+    /// is still rejected — sanity that we didn't accidentally make the
+    /// slot permissive to concurrent shared+exclusive access.
+    #[test]
+    fn mut_swap_during_dispatch_is_rejected() {
+        let (renderer, _log) = ReentrantRenderer::new();
+        // The hook attempts to swap the renderer slot (an exclusive
+        // borrow) while the outer op holds a shared borrow → must
+        // panic. We catch it so the test asserts on the rejection
+        // rather than aborting.
+        *renderer.on_remove_hook.borrow_mut() = Some(Box::new(|| {
+            let result = std::panic::catch_unwind(|| {
+                // `install_renderer` uses `with_borrow_mut`.
+                let _ = install_renderer(Box::new(RecordingRenderer::default()));
+            });
+            assert!(
+                result.is_err(),
+                "swapping the renderer slot during a shared borrow must be rejected"
+            );
+        }));
+
+        with_installed_renderer(Box::new(renderer), || {
+            let parent = create_element(ElementTag::View);
+            let child = create_element(ElementTag::View);
+            append_child(parent, child);
+            remove_child(parent, child);
+        });
+    }
+
+    /// Nested shared `with_renderer` borrows stack arbitrarily deep
+    /// without panicking — drives the re-entrant path two levels deep.
+    #[test]
+    fn deeply_nested_shared_borrows_do_not_panic() {
+        let (renderer, log) = ReentrantRenderer::new();
+        // Hook fires a renderer op which itself triggers another
+        // renderer op via a listener → 3 stacked shared borrows.
+        *renderer.on_remove_hook.borrow_mut() = Some(Box::new(|| {
+            set_attribute(Element::from_raw(100), "level", "2");
+            dispatch_event(8, "deep", WhiskerValue::Null);
+        }));
+
+        with_installed_renderer(Box::new(renderer), || {
+            set_event_listener(
+                Element::from_raw(8),
+                "deep",
+                BindType::Bind,
+                Box::new(|_v| {
+                    set_attribute(Element::from_raw(101), "level", "3");
+                }),
+            );
+            let parent = create_element(ElementTag::View);
+            let child = create_element(ElementTag::View);
+            append_child(parent, child);
+            remove_child(parent, child);
+        });
+
+        let log = log.borrow();
+        assert!(log.iter().any(|l| l == "set_attr 100 level=2"));
+        assert!(log.iter().any(|l| l == "set_attr 101 level=3"));
+    }
 }

--- a/crates/whisker/tests/children_slot.rs
+++ b/crates/whisker/tests/children_slot.rs
@@ -40,52 +40,52 @@ enum Op {
 
 #[derive(Default)]
 struct Recorder {
-    next: u32,
+    next: ::std::cell::Cell<u32>,
     log: Rc<RefCell<Vec<Op>>>,
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element(&self, tag: ElementTag) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
-    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element_by_name(&self, _tag_name: &str) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create {
             id,
             tag: ElementTag::View,
         });
         Element::from_raw(id)
     }
-    fn release_element(&mut self, _h: Element) {}
-    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
+    fn release_element(&self, _h: Element) {}
+    fn set_attribute(&self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, _h: Element, _css: &str) {}
-    fn append_child(&mut self, p: Element, c: Element) {
+    fn set_inline_styles(&self, _h: Element, _css: &str) {}
+    fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn remove_child(&self, _p: Element, _c: Element) {}
     fn set_event_listener(
-        &mut self,
+        &self,
         _h: Element,
         _name: &str,
         _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
     }
-    fn set_root(&mut self, _p: Element) {}
-    fn flush(&mut self) {}
+    fn set_root(&self, _p: Element) {}
+    fn flush(&self) {}
 }
 
 fn fresh() {

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -33,57 +33,57 @@ enum Op {
 
 #[derive(Default)]
 struct Recorder {
-    next: u32,
+    next: ::std::cell::Cell<u32>,
     log: Rc<RefCell<Vec<Op>>>,
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element(&self, tag: ElementTag) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
-    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element_by_name(&self, _tag_name: &str) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create {
             id,
             tag: ElementTag::View,
         });
         Element::from_raw(id)
     }
-    fn release_element(&mut self, _h: Element) {}
-    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
+    fn release_element(&self, _h: Element) {}
+    fn set_attribute(&self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: Element, css: &str) {
+    fn set_inline_styles(&self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: Element, c: Element) {
+    fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn remove_child(&self, _p: Element, _c: Element) {}
     fn set_event_listener(
-        &mut self,
+        &self,
         _h: Element,
         _name: &str,
         _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
     }
-    fn set_root(&mut self, _p: Element) {}
-    fn flush(&mut self) {}
+    fn set_root(&self, _p: Element) {}
+    fn flush(&self) {}
 }
 
 fn fresh() {

--- a/crates/whisker/tests/element_ref.rs
+++ b/crates/whisker/tests/element_ref.rs
@@ -29,7 +29,7 @@ use whisker::Owner;
 
 #[derive(Default)]
 struct Recorder {
-    next: u32,
+    next: ::std::cell::Cell<u32>,
     last_tag: Rc<RefCell<Option<String>>>,
 }
 
@@ -42,32 +42,32 @@ impl Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, _tag: ElementTag) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element(&self, _tag: ElementTag) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         Element::from_raw(id)
     }
-    fn create_element_by_name(&mut self, tag_name: &str) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element_by_name(&self, tag_name: &str) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         *self.last_tag.borrow_mut() = Some(tag_name.to_string());
         Element::from_raw(id)
     }
-    fn release_element(&mut self, _h: Element) {}
-    fn set_attribute(&mut self, _h: Element, _k: &str, _v: &str) {}
-    fn set_inline_styles(&mut self, _h: Element, _css: &str) {}
-    fn append_child(&mut self, _p: Element, _c: Element) {}
-    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn release_element(&self, _h: Element) {}
+    fn set_attribute(&self, _h: Element, _k: &str, _v: &str) {}
+    fn set_inline_styles(&self, _h: Element, _css: &str) {}
+    fn append_child(&self, _p: Element, _c: Element) {}
+    fn remove_child(&self, _p: Element, _c: Element) {}
     fn set_event_listener(
-        &mut self,
+        &self,
         _h: Element,
         _n: &str,
         _bind_type: whisker::runtime::view::BindType,
         _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
     ) {
     }
-    fn set_root(&mut self, _p: Element) {}
-    fn flush(&mut self) {}
+    fn set_root(&self, _p: Element) {}
+    fn flush(&self) {}
 }
 
 fn with_test_env<R>(f: impl FnOnce() -> R) -> R {

--- a/crates/whisker/tests/module_component.rs
+++ b/crates/whisker/tests/module_component.rs
@@ -30,7 +30,7 @@ enum Op {
 
 #[derive(Default)]
 struct Recorder {
-    next: u32,
+    next: ::std::cell::Cell<u32>,
     log: Rc<RefCell<Vec<Op>>>,
 }
 
@@ -43,44 +43,44 @@ impl Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element(&self, tag: ElementTag) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
-    fn create_element_by_name(&mut self, tag_name: &str) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element_by_name(&self, tag_name: &str) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::CreateByName {
             id,
             tag_name: tag_name.into(),
         });
         Element::from_raw(id)
     }
-    fn release_element(&mut self, _h: Element) {}
-    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
+    fn release_element(&self, _h: Element) {}
+    fn set_attribute(&self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: Element, css: &str) {
+    fn set_inline_styles(&self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: Element, c: Element) {
+    fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn remove_child(&self, _p: Element, _c: Element) {}
     fn set_event_listener(
-        &mut self,
+        &self,
         h: Element,
         name: &str,
         _bind_type: whisker::runtime::view::BindType,
@@ -91,8 +91,8 @@ impl DynRenderer for Recorder {
             name: name.into(),
         });
     }
-    fn set_root(&mut self, _p: Element) {}
-    fn flush(&mut self) {}
+    fn set_root(&self, _p: Element) {}
+    fn flush(&self) {}
 }
 
 fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -38,7 +38,7 @@ enum Op {
 
 #[derive(Default)]
 struct Recorder {
-    next: u32,
+    next: ::std::cell::Cell<u32>,
     log: Rc<RefCell<Vec<Op>>>,
 }
 
@@ -51,51 +51,51 @@ impl Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element(&self, tag: ElementTag) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
-    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element_by_name(&self, _tag_name: &str) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create {
             id,
             tag: ElementTag::View,
         });
         Element::from_raw(id)
     }
-    fn release_element(&mut self, h: Element) {
+    fn release_element(&self, h: Element) {
         self.log.borrow_mut().push(Op::Release { id: h.id() });
     }
-    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
+    fn set_attribute(&self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: Element, css: &str) {
+    fn set_inline_styles(&self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: Element, c: Element) {
+    fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, p: Element, c: Element) {
+    fn remove_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Remove {
             parent: p.id(),
             child: c.id(),
         });
     }
     fn set_event_listener(
-        &mut self,
+        &self,
         h: Element,
         name: &str,
         _bind_type: whisker::runtime::view::BindType,
@@ -106,8 +106,8 @@ impl DynRenderer for Recorder {
             name: name.into(),
         });
     }
-    fn set_root(&mut self, _p: Element) {}
-    fn flush(&mut self) {}
+    fn set_root(&self, _p: Element) {}
+    fn flush(&self) {}
 }
 
 /// Reset every thread-local the per-component remount machinery

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -44,7 +44,7 @@ enum Op {
 
 #[derive(Default)]
 struct Recorder {
-    next: u32,
+    next: ::std::cell::Cell<u32>,
     log: Rc<RefCell<Vec<Op>>>,
 }
 
@@ -57,44 +57,44 @@ impl Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element(&self, tag: ElementTag) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
-    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element_by_name(&self, _tag_name: &str) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create {
             id,
             tag: ElementTag::View,
         });
         Element::from_raw(id)
     }
-    fn release_element(&mut self, _h: Element) {}
-    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
+    fn release_element(&self, _h: Element) {}
+    fn set_attribute(&self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: Element, css: &str) {
+    fn set_inline_styles(&self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: Element, c: Element) {
+    fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, _p: Element, _c: Element) {}
+    fn remove_child(&self, _p: Element, _c: Element) {}
     fn set_event_listener(
-        &mut self,
+        &self,
         h: Element,
         name: &str,
         bind_type: BindType,
@@ -106,8 +106,8 @@ impl DynRenderer for Recorder {
             bind_type,
         });
     }
-    fn set_root(&mut self, _p: Element) {}
-    fn flush(&mut self) {}
+    fn set_root(&self, _p: Element) {}
+    fn flush(&self) {}
 }
 
 fn with_recorder<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -38,7 +38,7 @@ enum Op {
 
 #[derive(Default)]
 struct Recorder {
-    next: u32,
+    next: ::std::cell::Cell<u32>,
     log: Rc<RefCell<Vec<Op>>>,
 }
 
@@ -51,51 +51,51 @@ impl Recorder {
 }
 
 impl DynRenderer for Recorder {
-    fn create_element(&mut self, tag: ElementTag) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element(&self, tag: ElementTag) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create { id, tag });
         Element::from_raw(id)
     }
-    fn create_element_by_name(&mut self, _tag_name: &str) -> Element {
-        let id = self.next;
-        self.next += 1;
+    fn create_element_by_name(&self, _tag_name: &str) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
         self.log.borrow_mut().push(Op::Create {
             id,
             tag: ElementTag::View,
         });
         Element::from_raw(id)
     }
-    fn release_element(&mut self, h: Element) {
+    fn release_element(&self, h: Element) {
         self.log.borrow_mut().push(Op::Release { id: h.id() });
     }
-    fn set_attribute(&mut self, h: Element, k: &str, v: &str) {
+    fn set_attribute(&self, h: Element, k: &str, v: &str) {
         self.log.borrow_mut().push(Op::SetAttr {
             id: h.id(),
             key: k.into(),
             value: v.into(),
         });
     }
-    fn set_inline_styles(&mut self, h: Element, css: &str) {
+    fn set_inline_styles(&self, h: Element, css: &str) {
         self.log.borrow_mut().push(Op::SetStyles {
             id: h.id(),
             css: css.into(),
         });
     }
-    fn append_child(&mut self, p: Element, c: Element) {
+    fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),
             child: c.id(),
         });
     }
-    fn remove_child(&mut self, p: Element, c: Element) {
+    fn remove_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Remove {
             parent: p.id(),
             child: c.id(),
         });
     }
     fn set_event_listener(
-        &mut self,
+        &self,
         h: Element,
         name: &str,
         _bind_type: whisker::runtime::view::BindType,
@@ -106,10 +106,10 @@ impl DynRenderer for Recorder {
             name: name.into(),
         });
     }
-    fn set_root(&mut self, p: Element) {
+    fn set_root(&self, p: Element) {
         self.log.borrow_mut().push(Op::SetRoot { id: p.id() });
     }
-    fn flush(&mut self) {
+    fn flush(&self) {
         self.log.borrow_mut().push(Op::Flush);
     }
 }

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
@@ -555,60 +555,47 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
         return ["value": text]
     }
 
-    // NOTE: every `WhiskerCustomEvent.dispatch(...)` below is deferred to
-    // the next main-runloop tick via `DispatchQueue.main.async`. UIKit
-    // delegate callbacks (`textFieldDidEndEditing`, `textViewDidChange`,
-    // …) fire SYNCHRONOUSLY during Lynx's native teardown on a hot-reload
-    // remount, while `remove_child` still holds the `CURRENT_RENDERER`
-    // RefCell borrow. Dispatching synchronously reenters Rust's
-    // `dispatch_event` → a second `with_renderer` borrow → "RefCell
-    // already borrowed" panic (the event is dropped). Deferring one tick
-    // guarantees the dispatch lands at idle, never inside a render borrow.
+    // These dispatch SYNCHRONOUSLY. UIKit delegate callbacks
+    // (`textFieldDidEndEditing`, `textViewDidChange`, …) can fire during
+    // Lynx's native teardown on a hot-reload remount, *while*
+    // `remove_child` is on the stack inside Rust's renderer. Previously
+    // that re-entered `dispatch_event` → a second `with_renderer` borrow
+    // → "RefCell already borrowed" panic, so we deferred a runloop tick
+    // (`DispatchQueue.main.async`) to dodge it — which is exactly the
+    // one-tick-late delivery of whisker #3.
     //
-    // Safe for the two-way-binding `input` timing: the native field
-    // already shows the typed character immediately (native owns its
-    // text); the one-tick-later Rust `value` round-trip is absorbed by
-    // the cursor-preservation diff guard in `setValue(_:)`, so no jump.
-    // `self` is captured weakly and the text is snapshotted before the
-    // async block so a torn-down view never dispatches a dangling event.
+    // The Rust renderer is now re-entrancy-safe: `DynRenderer` methods
+    // take `&self`, `BridgeRenderer` holds its state behind per-field
+    // `RefCell`s with FFI-scoped borrows, and `with_renderer` takes a
+    // SHARED borrow — so a synchronous re-entrant `dispatch_event` during
+    // teardown is granted instead of aborting. See
+    // `crates/whisker-runtime/src/view/renderer.rs` (`with_renderer`) and
+    // `crates/whisker-driver/src/lynx/renderer.rs` (BridgeRenderer). With
+    // that fix the deferral is no longer needed, and removing it collapses
+    // the one-tick delay: `on_input` / `on_change` / `on_submit` now
+    // deliver on the same tick the user interacts.
 
     private func emitInput(_ text: String) {
-        // `cachedText` is owned state — keep it immediate (synchronous) so
-        // `getValue` / the cursor-preservation diff stay correct even if
-        // the deferred dispatch hasn't fired yet.
+        // `cachedText` is owned state — keep it correct before dispatch so
+        // `getValue` / the cursor-preservation diff stay consistent.
         cachedText = text
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "input", params: self.detailPayload(text))
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "input", params: detailPayload(text))
     }
 
     private func emitChange(_ text: String) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "change", params: self.detailPayload(text))
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "change", params: detailPayload(text))
     }
 
     private func emitFocus() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "focus", params: [:])
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "focus", params: [:])
     }
 
     private func emitBlur() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "blur", params: [:])
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "blur", params: [:])
     }
 
     private func emitSubmit(_ text: String) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "submit", params: self.detailPayload(text))
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "submit", params: detailPayload(text))
     }
 
     // MARK: - UITextField action targets

--- a/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
+++ b/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
@@ -30,15 +30,16 @@
 //
 // ## Event dispatch
 //
-// Every `WhiskerCustomEvent.dispatch(...)` is deferred one main-runloop
-// tick via `DispatchQueue.main.async { [weak self] in guard let self else
-// { return } ... }`. Navigation-delegate / KVO / script-message callbacks
-// can fire during Lynx teardown while the renderer RefCell borrow is held
-// — dispatching synchronously from there reenters Rust's `dispatch_event`
-// which takes a second borrow → "RefCell already borrowed" abort. Deferring
-// one tick guarantees dispatch always lands at idle, never inside a render
-// borrow. The view is captured weakly so a deallocated view never fires a
-// dangling event.
+// Every `WhiskerCustomEvent.dispatch(...)` fires SYNCHRONOUSLY. These
+// callbacks (navigation-delegate / KVO / script-message) can fire during
+// Lynx teardown while a renderer op is on the Rust stack; that used to
+// re-enter `dispatch_event` → a second renderer borrow → "RefCell already
+// borrowed" abort, so dispatch was deferred a runloop tick — the one-tick
+// delay of whisker #3. The Rust renderer is now re-entrancy-safe (shared
+// `with_renderer` borrow + `&self` `DynRenderer` methods + FFI-scoped
+// per-field `RefCell`s in `BridgeRenderer`), so synchronous re-entrant
+// dispatch is safe and the deferral was removed. See the emission helpers
+// below.
 //
 // ## Event payload shape
 //
@@ -379,58 +380,50 @@ public final class WhiskerWebViewView: WhiskerUI<UIView> {
 
     // MARK: - Event emission helpers
 
-    // NOTE: every dispatch below is deferred one main-runloop tick via
-    // `DispatchQueue.main.async` with `[weak self]`. Navigation-delegate /
-    // KVO / script-message callbacks fire synchronously during Lynx teardown
-    // while the renderer RefCell borrow is held. Dispatching synchronously
-    // reenters `dispatch_event` → second borrow → "RefCell already borrowed"
-    // panic. One-tick deferral guarantees dispatch lands at idle.
-    // `self` is captured weakly; a deallocated view silently drops the event.
+    // These dispatch SYNCHRONOUSLY. Navigation-delegate / KVO /
+    // script-message callbacks can fire during Lynx teardown while a
+    // renderer op (`remove_child`) is on the Rust stack. Previously that
+    // re-entered `dispatch_event` → a second `with_renderer` borrow →
+    // "RefCell already borrowed" abort, so we deferred one main-runloop
+    // tick (`DispatchQueue.main.async`) to dodge it — the one-tick-late
+    // delivery of whisker #3.
+    //
+    // The Rust renderer is now re-entrancy-safe: `DynRenderer` methods
+    // take `&self`, `BridgeRenderer` keeps its state behind per-field
+    // `RefCell`s with FFI-scoped borrows, and `with_renderer` takes a
+    // SHARED borrow, so a synchronous re-entrant dispatch during teardown
+    // is granted rather than aborting. See
+    // `crates/whisker-runtime/src/view/renderer.rs` and
+    // `crates/whisker-driver/src/lynx/renderer.rs`. The deferral is no
+    // longer needed; removing it collapses the one-tick delay so webview
+    // events (`load`, `navigation`, `message`, …) deliver on the same tick.
 
     private func emitLoadStart(_ urlString: String) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "load_start", params: ["url": urlString])
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "load_start", params: ["url": urlString])
     }
 
     private func emitLoad(_ urlString: String) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "load", params: ["url": urlString])
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "load", params: ["url": urlString])
     }
 
     private func emitError(urlString: String, code: Int, description: String) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "error", params: [
-                "url": urlString,
-                "code": code,
-                "description": description,
-            ])
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "error", params: [
+            "url": urlString,
+            "code": code,
+            "description": description,
+        ])
     }
 
     private func emitNavigation(_ urlString: String) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "navigation", params: ["url": urlString])
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "navigation", params: ["url": urlString])
     }
 
     private func emitProgress(_ progress: Double) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "progress", params: ["progress": progress])
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "progress", params: ["progress": progress])
     }
 
     private func emitMessage(_ data: String) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            WhiskerCustomEvent.dispatch(from: self, name: "message", params: ["data": data])
-        }
+        WhiskerCustomEvent.dispatch(from: self, name: "message", params: ["data": data])
     }
 
     // MARK: - Origin-whitelist matching


### PR DESCRIPTION
## Summary

評価フィードバック #3 の root-cause 修正。ネイティブイベントがレンダラ操作中に**同期発火**（例: `remove_child` 内の Lynx teardown → UIKit callback → `WhiskerCustomEvent.dispatch` → `dispatch_event` → レンダラ再入）すると `RefCell already borrowed` で abort する問題を解消。これまで各 module は `DispatchQueue.main.async` で1 runloop tick 遅延させて回避しており、それが #3 の「イベント1タップ遅延」でした。

### 修正（遅延なしの再入安全化）
- **`DynRenderer` メソッドを `&self` 化**。`with_renderer` を `CURRENT_RENDERER` の**共有借用**に変更。RefCell は共有借用を何重にも許すため、再入した `with_renderer`（同じく共有）は panic せず許可される。slot 入れ替え（install/uninstall）は `with_borrow_mut` のままだが dispatch 中には呼ばれない。
- **`BridgeRenderer` の3可変フィールド（`elements`/`parent_sign`/`listeners`）を per-field `RefCell` 化**し、**どのフィールド借用も再入しうる FFI をまたがない**ようスコープ:
  - `remove_child`: `child_sign` を**FFI 前**に解決し、`parent_sign` は FFI 後のみ借用。
  - `release_element`: pointer を take→借用 drop→release FFI→後始末。
  - `append_child`/`set_event_listener`: FFI 後にのみ借用。
  - `plan_event_dispatch`: `parent_sign` walk の借用を `listeners` を触る前に drop。

### テスト
`ReentrantRenderer` による再入テスト5件: `remove_child` 内から再入した「レンダラ操作 / イベント dispatch / 同一フィールド read+write」が panic せず同期順序で走る、共有借用3段ネスト可、再入 mut slot-swap は依然 reject。既存テストレンダラも `&self`＋内部可変へ更新。

### Swift（要実機検証）
`whisker-input` / `whisker-webview` の iOS から不要になった `DispatchQueue.main.async` を除去し同期 dispatch に。**teardown 再入経路はユニットテスト不可のため実機/シミュレータ検証が必要**。Android の `View.post` は同理由で今回は据え置き。

## Test plan
- `cargo build --workspace` / `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` clean。
- `cargo test -p whisker-runtime -p whisker` 全 pass（whisker-runtime 134、再入テスト5件含む）。
- ⚠️ iOS の同期 dispatch 化は on-device 検証が残課題。

🤖 Generated with [Claude Code](https://claude.com/claude-code)