### PR TITLE
chore(lynx): bump Lynx fork pin to v3.8.0-whisker.7 (lands #4 Bool fix)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,23 +74,23 @@ let package = Package(
         // `swiftpm-manifest-<ver>.txt` published alongside each release.
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/Lynx-3.8.0-whisker.6.xcframework.zip",
-            checksum: "a467fceb0bd6b0318c80fcc93fe9b14e26f268dc6b2b9e06bf0365f50cb76fc5"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.7/Lynx-3.8.0-whisker.7.xcframework.zip",
+            checksum: "56495235730cf22975060b27a378dc49e723e1d87d3417c648be6f5b7da4352b"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/LynxBase-3.8.0-whisker.6.xcframework.zip",
-            checksum: "309dd1e544a4cd035b71e1c786532e7344653c470d7206fbb28e1493b7f8e36e"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.7/LynxBase-3.8.0-whisker.7.xcframework.zip",
+            checksum: "85a401f3f1d6c313360f6c8e30ef405b2ee35131ddb2b02f9a73e9f73dfa3f4a"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/LynxServiceAPI-3.8.0-whisker.6.xcframework.zip",
-            checksum: "59bc9fcf07704d288de63b78ec1717fa81ade0af1cacea2f3712b57a220cb92f"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.7/LynxServiceAPI-3.8.0-whisker.7.xcframework.zip",
+            checksum: "e2955008fd71e73123f40faeb25c9d0a62bb3871d7b3da215d2ea76c3f68bc16"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/PrimJS-3.8.0-whisker.6.xcframework.zip",
-            checksum: "a7069cd487834f96af28a335da049220b61317b0448768f040c171224f891651"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.7/PrimJS-3.8.0-whisker.7.xcframework.zip",
+            checksum: "21fb987f606d7b9daa02e863891de3e86e587c72fcd1d80695e8ed716a430396"
         ),
 
         // Header-only mirror of `WhiskerDriver`'s public C ABI. Source

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -56,7 +56,7 @@ pub struct PlatformSync {
 ///
 /// 0.1.1 rolls forward the transitive Lynx pin baked into the SDK's
 /// POM from `v3.8.0-whisker.4` (initial SDK release) to
-/// `v3.8.0-whisker.6`. The newer Lynx exposes `lynx_capi_abi_version()`
+/// `v3.8.0-whisker.7`. The newer Lynx exposes `lynx_capi_abi_version()`
 /// which the Step-6 dlopen-based bridge requires; without this bump,
 /// downstream apps that pull `whisker-runtime-android:0.1.0`
 /// transitively get the older Lynx and the bridge loader aborts on

--- a/docs/ios-spm-distribution.md
+++ b/docs/ios-spm-distribution.md
@@ -96,4 +96,4 @@ Keep these aligned per release:
 
 | crates.io | iOS SwiftPM tag | Android SDK (Maven) | Gradle plugin | Lynx fork |
 |---|---|---|---|---|
-| `0.1.0` | `v0.1.0` | `0.1.1` | `0.4.0` | `3.8.0-whisker.6` |
+| `0.1.0` | `v0.1.0` | `0.1.1` | `0.4.0` | `3.8.0-whisker.7` |

--- a/docs/lynx-integration.md
+++ b/docs/lynx-integration.md
@@ -16,7 +16,7 @@ Audience: contributors bumping Lynx or debugging the C++ bridge build.
 ## How the dependency is wired
 
 The fork publishes pre-built Lynx artifacts per `v<ver>` tag (currently
-`v3.8.0-whisker.6`). Whisker consumes them per platform:
+`v3.8.0-whisker.7`). Whisker consumes them per platform:
 
 ### iOS — SwiftPM binary targets
 

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.6").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.7").removePrefix("v")
 
 dependencies {
     if (whiskerSdkRelease) {

--- a/platforms/android/whisker-runtime/build.gradle.kts
+++ b/platforms/android/whisker-runtime/build.gradle.kts
@@ -20,7 +20,7 @@
 // `whiskerSdkRelease` Gradle property toggles the dep form: unset
 // (default) → flatDir-friendly `:LynxAndroid@aar`; `true` → Maven
 // coords pinned to `lynxFork`. The CI publish workflow sets
-// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.6`; local CLI
+// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.7`; local CLI
 // flows leave both unset and use flatDir as before.
 
 plugins {
@@ -70,7 +70,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.6").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.7").removePrefix("v")
 
 dependencies {
     api(project(":module"))

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -99,23 +99,23 @@ let package = Package(
         // until the matching module-side refactor lands).
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/Lynx-3.8.0-whisker.6.xcframework.zip",
-            checksum: "a467fceb0bd6b0318c80fcc93fe9b14e26f268dc6b2b9e06bf0365f50cb76fc5"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.7/Lynx-3.8.0-whisker.7.xcframework.zip",
+            checksum: "56495235730cf22975060b27a378dc49e723e1d87d3417c648be6f5b7da4352b"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/LynxBase-3.8.0-whisker.6.xcframework.zip",
-            checksum: "309dd1e544a4cd035b71e1c786532e7344653c470d7206fbb28e1493b7f8e36e"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.7/LynxBase-3.8.0-whisker.7.xcframework.zip",
+            checksum: "85a401f3f1d6c313360f6c8e30ef405b2ee35131ddb2b02f9a73e9f73dfa3f4a"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/LynxServiceAPI-3.8.0-whisker.6.xcframework.zip",
-            checksum: "59bc9fcf07704d288de63b78ec1717fa81ade0af1cacea2f3712b57a220cb92f"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.7/LynxServiceAPI-3.8.0-whisker.7.xcframework.zip",
+            checksum: "e2955008fd71e73123f40faeb25c9d0a62bb3871d7b3da215d2ea76c3f68bc16"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.6/PrimJS-3.8.0-whisker.6.xcframework.zip",
-            checksum: "a7069cd487834f96af28a335da049220b61317b0448768f040c171224f891651"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.7/PrimJS-3.8.0-whisker.7.xcframework.zip",
+            checksum: "21fb987f606d7b9daa02e863891de3e86e587c72fcd1d80695e8ed716a430396"
         ),
 
         // Phase J — minimal module-author surface. Carved out of the


### PR DESCRIPTION
## Summary

評価フィードバック **#4（Bool ref-method 引数の round-trip 不可）**を着地させる Lynx fork ピン bump です。

### 背景
`WhiskerValue::Bool` を ref メソッド引数で渡すと Swift 側 `asBool == nil`（常に false）になっていた。真因は **upstream Lynx の iOS lepus→ObjC 変換** `convertLepusBoolToNSNumber` が `@(1)/@(0)`（整数リテラル, objCType `"q"`）でボックス化していたこと。fork `v3.8.0-whisker.7` で `+numberWithBool:`（objCType `"c"`）に修正（`v3.8.0-whisker.6` から最小 hotfix として cut）。

### 変更
- **iOS**: `Package.swift` / `platforms/ios/Package.swift` の4つの xcframework binaryTarget の URL＋SwiftPM checksum を更新（checksum は release の `swiftpm-manifest-3.8.0-whisker.7.txt` 由来）。
- **Android**: 両 `build.gradle.kts` の `lynxFork` 既定を bump（Maven AAR `rs.whisker:*:3.8.0-whisker.7`、fork の `build-whisker-tarballs` が gh-pages に公開済み）。
- docs / CLI コメントの参照を bump。

### 関連
- fork 修正コミット: whiskerrs/lynx `release/v3.8.0-whisker.7`（tag `v3.8.0-whisker.7`、build-whisker-tarballs success）。
- upstream `lynx-family/lynx` にも同バグが存在するため、別途 upstream PR を推奨。

## Test plan
- `cargo build -p whisker-cli` 通過（`platforms.rs` はコメントのみ変更）。
- ⚠️ SwiftPM checksum / xcframework 解決は実 iOS ビルドでのみ検証可能。次に podcast を whisker.7 で再ビルドして checksum 解決＋動作を smoke 確認予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)