### PR TITLE
fix(android): dispatch module events synchronously (#3 follow-up)

### DIFF
--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
@@ -588,24 +588,19 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
      * ignores it (the event fires no value), but we keep the same
      * payload shape for consistency.
      *
-     * ## Deferred dispatch (reentrancy guard)
+     * ## Synchronous dispatch
      *
-     * The actual `WhiskerCustomEvent.dispatch` is deferred to the next
-     * main-loop tick via `View.post { ... }`. A synchronous dispatch
-     * inside a UI callback can reenter Rust while Rust holds the
-     * renderer borrow during a hot-reload remount / teardown — e.g.
-     * Lynx `remove_child` triggers a native focus-loss callback that
-     * fires `blur` / `change` synchronously, reentering
-     * `dispatch_event` and panicking with "RefCell already borrowed"
-     * (the event is dropped). Posting breaks the synchronous reentry.
-     *
-     * The suppression decision is made BEFORE we reach here: the
-     * caller (`afterTextChanged`) reads `programmaticWrite` and the
-     * text synchronously, so deferring only the dispatch doesn't
-     * weaken the `input`-echo guard. The two-way `input` round-trip
-     * arriving one tick late is absorbed by the cursor-diff guard in
-     * [applyTextIfChanged]. The `name` + `text` (hence `params`) are
-     * captured synchronously into the posted lambda.
+     * `WhiskerCustomEvent.dispatch` is called synchronously. The Rust
+     * renderer is re-entrancy-safe (whisker #3: `with_renderer` takes a
+     * shared borrow and every renderer field borrow is scoped so it
+     * never spans a re-entrant FFI call), so a UI callback that reenters
+     * Rust during a hot-reload remount / teardown — e.g. Lynx
+     * `remove_child` triggering a native focus-loss callback that fires
+     * `blur` / `change` — no longer panics with "RefCell already
+     * borrowed". This used to be deferred a main-loop tick via
+     * `View.post { ... }`; dispatching synchronously removes that
+     * one-tick lag (whisker #3). All callers (`afterTextChanged`, focus
+     * listeners) already run on the UI thread.
      */
     private fun emitEvent(name: String, text: String) {
         // Pass the payload directly as the params — do NOT wrap it in a
@@ -617,16 +612,11 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
         // Wrapping here too would double-nest and the value would never
         // reach `on_input` (it would always deliver an empty string).
         val params = mapOf("value" to text)
-        // `post` runs on the next UI-loop iteration on the main thread.
-        // No-op if the view is detached (post returns false; there's
-        // nothing to dispatch into anyway).
-        view?.post {
-            WhiskerCustomEvent.dispatch(
-                ui = this,
-                name = name,
-                params = params,
-            )
-        }
+        WhiskerCustomEvent.dispatch(
+            ui = this,
+            name = name,
+            params = params,
+        )
     }
 
     /** Convenience for the TextWatcher `afterTextChanged` path. */

--- a/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WhiskerWebView.kt
+++ b/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WhiskerWebView.kt
@@ -24,17 +24,20 @@
 //
 // ## Event dispatch
 //
-// ALL WhiskerCustomEvent.dispatch calls are wrapped in `view?.post { … }`
-// to hop onto the UI-thread's next message-loop tick. This is required
-// for two orthogonal reasons:
-//   1. WebViewClient / WebChromeClient callbacks fire on the UI thread
-//      but can arrive while Lynx holds the renderer borrow (during
-//      teardown / hot-reload remount). A synchronous dispatch re-enters
-//      Rust's RefCell and panics. Posting breaks the synchronous
-//      reentry.
-//   2. @JavascriptInterface methods fire on JavaBridge (a background
-//      thread). view.post() hops back to the UI thread before touching
-//      any Android View APIs or Lynx emitter state.
+// WebViewClient / WebChromeClient callbacks fire on the UI thread and
+// dispatch SYNCHRONOUSLY. They can arrive while Lynx is mid-teardown /
+// hot-reload remount, but the Rust renderer is now re-entrancy-safe
+// (whisker #3: `with_renderer` takes a shared borrow and every renderer
+// field borrow is scoped so it never spans a re-entrant FFI call), so a
+// re-entrant dispatch no longer panics with "RefCell already borrowed".
+// This used to be deferred a main-loop tick via `view?.post { … }`;
+// dispatching synchronously removes that one-tick lag (whisker #3).
+//
+// The ONE exception is `@JavascriptInterface` (window.whisker.postMessage
+// → emitMessage), which fires on JavaBridge (a background thread). That
+// path still hops to the UI thread via `view?.post { … }` before touching
+// any Android View / Lynx emitter state — a real thread transition, not a
+// reentrancy guard, so it is kept.
 //
 // ## Teardown
 //
@@ -186,24 +189,20 @@ open class WhiskerWebView(context: WhiskerContext) :
                     view.evaluateJavascript(JS_SHIM, null)
                 }
                 val safeUrl = url ?: ""
-                view.post {
-                    WhiskerCustomEvent.dispatch(
-                        ui = this@WhiskerWebView,
-                        name = "load_start",
-                        params = mapOf("url" to safeUrl),
-                    )
-                }
+                WhiskerCustomEvent.dispatch(
+                    ui = this@WhiskerWebView,
+                    name = "load_start",
+                    params = mapOf("url" to safeUrl),
+                )
             }
 
             override fun onPageFinished(view: android.webkit.WebView, url: String?) {
                 val safeUrl = url ?: ""
-                view.post {
-                    WhiskerCustomEvent.dispatch(
-                        ui = this@WhiskerWebView,
-                        name = "load",
-                        params = mapOf("url" to safeUrl),
-                    )
-                }
+                WhiskerCustomEvent.dispatch(
+                    ui = this@WhiskerWebView,
+                    name = "load",
+                    params = mapOf("url" to safeUrl),
+                )
             }
 
             override fun onReceivedError(
@@ -227,17 +226,15 @@ open class WhiskerWebView(context: WhiskerContext) :
                 } else {
                     ""
                 }
-                view.post {
-                    WhiskerCustomEvent.dispatch(
-                        ui = this@WhiskerWebView,
-                        name = "error",
-                        params = mapOf(
-                            "url" to url,
-                            "code" to code,
-                            "description" to description,
-                        ),
-                    )
-                }
+                WhiskerCustomEvent.dispatch(
+                    ui = this@WhiskerWebView,
+                    name = "error",
+                    params = mapOf(
+                        "url" to url,
+                        "code" to code,
+                        "description" to description,
+                    ),
+                )
             }
 
             override fun shouldOverrideUrlLoading(
@@ -274,13 +271,11 @@ open class WhiskerWebView(context: WhiskerContext) :
                     originWhitelist.any { pattern -> matchesGlob(pattern, url) }
                 if (!allowed) return true // block
                 // Allowed — let WebView load it and inform Rust.
-                view.post {
-                    WhiskerCustomEvent.dispatch(
-                        ui = this@WhiskerWebView,
-                        name = "navigation",
-                        params = mapOf("url" to url),
-                    )
-                }
+                WhiskerCustomEvent.dispatch(
+                    ui = this@WhiskerWebView,
+                    name = "navigation",
+                    params = mapOf("url" to url),
+                )
                 return false // proceed with load
             }
         }
@@ -288,13 +283,11 @@ open class WhiskerWebView(context: WhiskerContext) :
         wv.webChromeClient = object : WebChromeClient() {
             override fun onProgressChanged(view: android.webkit.WebView, newProgress: Int) {
                 val fraction = newProgress / 100.0
-                view.post {
-                    WhiskerCustomEvent.dispatch(
-                        ui = this@WhiskerWebView,
-                        name = "progress",
-                        params = mapOf("progress" to fraction),
-                    )
-                }
+                WhiskerCustomEvent.dispatch(
+                    ui = this@WhiskerWebView,
+                    name = "progress",
+                    params = mapOf("progress" to fraction),
+                )
             }
         }
 


### PR DESCRIPTION
## Summary

#214（再入安全レンダラ）の Android 側 follow-up。Rust レンダラが再入安全になったため、first-party Android module view が teardown / hot-reload remount 中の `RefCell already borrowed` abort を避けるために行っていた `view.post { … }` の1 tick 遅延が不要になりました。同期 dispatch に変更し、Android でも #3 の「イベント1タップ遅延」を解消します（iOS は #214 で対応済み）。

### 変更
- **whisker-input** `WhiskerInputView.emitEvent`: 同期 dispatch（呼び出し元の `afterTextChanged`・focus listener はすべて UI スレッド）。
- **whisker-webview**: 5つの WebViewClient/WebChromeClient コールバック（load_start / load / error / navigation / progress、いずれも UI スレッド）を同期 dispatch に。
  - **`@JavascriptInterface postMessage` は `view.post { … }` を保持** — JavaBridge（バックグラウンドスレッド）で発火するため、UI スレッドへの hop は再入ガードではなく**正当なスレッド遷移**。

## Test plan
- ⚠️ Kotlin は cargo CI でコンパイルされない。Android エミュレータで compile＋動作（input の同期配送・webview イベント・teardown でクラッシュしない）を検証予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)