### PR TITLE
feat(cli): `whisker fmt` — rustfmt drop-in that formats render!/css! macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,6 +1679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2282,7 @@ dependencies = [
  "whisker-cng",
  "whisker-config",
  "whisker-dev-server",
+ "whisker-fmt",
 ]
 
 [[package]]
@@ -2362,6 +2369,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-fmt"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "similar",
+ "syn",
+ "whisker-macro-syntax",
+]
+
+[[package]]
 name = "whisker-icons"
 version = "0.3.0"
 dependencies = [
@@ -2409,6 +2428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-macro-syntax"
+version = "0.3.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "whisker-macros"
 version = "0.3.0"
 dependencies = [
@@ -2417,6 +2445,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "whisker-macro-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ members = [
     "crates/whisker-driver",
     "crates/whisker-driver-sys",
     "crates/whisker-macros",
+    "crates/whisker-macro-syntax",
+    "crates/whisker-fmt",
     "crates/whisker-css",
     "crates/whisker-plugin",
     "crates/whisker-runtime",
@@ -79,6 +81,8 @@ whisker-dev-server = { path = "crates/whisker-dev-server", version = "0.3.0" }
 whisker-driver = { path = "crates/whisker-driver", version = "0.3.0" }
 whisker-driver-sys = { path = "crates/whisker-driver-sys", version = "0.3.0" }
 whisker-macros = { path = "crates/whisker-macros", version = "0.3.0" }
+whisker-macro-syntax = { path = "crates/whisker-macro-syntax", version = "0.3.0" }
+whisker-fmt = { path = "crates/whisker-fmt", version = "0.3.0" }
 whisker-css = { path = "crates/whisker-css", version = "0.3.0" }
 whisker-plugin = { path = "crates/whisker-plugin", version = "0.3.0" }
 whisker-runtime = { path = "crates/whisker-runtime", version = "0.3.0" }

--- a/crates/whisker-cli/Cargo.toml
+++ b/crates/whisker-cli/Cargo.toml
@@ -49,6 +49,8 @@ indicatif = "0.17"
 # DevServer::run(); the heavy deps (tokio / axum / notify / object)
 # all live in whisker-dev-server.
 whisker-dev-server = { workspace = true }
+# `whisker fmt` — rustfmt drop-in that also formats render!/css! bodies.
+whisker-fmt = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 # `whisker run` reads the user's `whisker.rs` via a tiny probe build
 # and parses the resulting Config JSON. The dev-server does NOT

--- a/crates/whisker-cli/src/fmt.rs
+++ b/crates/whisker-cli/src/fmt.rs
@@ -1,0 +1,207 @@
+//! `whisker fmt` — a rustfmt drop-in that also formats Whisker's
+//! `render!` / `css!` macro bodies.
+//!
+//! Three modes:
+//!
+//! - `whisker fmt <files...>` — format each file in place (or print to
+//!   stdout with `--check`).
+//! - `whisker fmt --stdin` — read stdin, write formatted to stdout.
+//!   This is the rust-analyzer integration point:
+//!   `rust-analyzer.rustfmt.overrideCommand = ["whisker", "fmt", "--stdin"]`.
+//! - `whisker fmt --check <files...>` — don't write; print a unified
+//!   diff and exit non-zero if any file would change.
+//!
+//! There are NO whisker-specific formatting options: the layout values
+//! ([`whisker_fmt::FmtOptions`]) come from the nearest `rustfmt.toml`
+//! (resolved per file directory), and the base Rust pass shells out to
+//! the real rustfmt binary which reads `rustfmt.toml` itself.
+
+use anyhow::{bail, Context, Result};
+use clap::Args;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use whisker_fmt::FmtOptions;
+
+#[derive(Args, Debug)]
+pub struct FmtArgs {
+    /// Rust source files to format. Ignored when `--stdin` is set.
+    pub files: Vec<PathBuf>,
+
+    /// Read source from stdin and write the formatted result to stdout.
+    /// For `rust-analyzer.rustfmt.overrideCommand`.
+    #[arg(long)]
+    pub stdin: bool,
+
+    /// Don't write anything. Print a unified diff of what would change
+    /// and exit non-zero if any input is not already formatted.
+    #[arg(long)]
+    pub check: bool,
+}
+
+pub fn run(args: FmtArgs) -> Result<()> {
+    if args.stdin {
+        return run_stdin(&args);
+    }
+    if args.files.is_empty() {
+        bail!("whisker fmt: no input files (pass file paths, or use --stdin)");
+    }
+    run_files(&args)
+}
+
+/// stdin → stdout. `--check` on stdin prints the diff to stderr and
+/// exits non-zero if a change would be made.
+fn run_stdin(args: &FmtArgs) -> Result<()> {
+    let mut src = String::new();
+    std::io::stdin()
+        .read_to_string(&mut src)
+        .context("reading source from stdin")?;
+    // For stdin we resolve rustfmt.toml from the current directory.
+    let opts = resolve_options(&std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let formatted = whisker_fmt::format_source_in_dir(
+        &src,
+        &opts,
+        &std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+    )
+    .context("formatting stdin")?;
+
+    if args.check {
+        if formatted != src {
+            eprint!("{}", whisker_fmt::unified_diff(&src, &formatted));
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
+    let mut stdout = std::io::stdout().lock();
+    stdout
+        .write_all(formatted.as_bytes())
+        .context("writing formatted output to stdout")?;
+    Ok(())
+}
+
+fn run_files(args: &FmtArgs) -> Result<()> {
+    let mut any_changed = false;
+    let mut errored = false;
+
+    for file in &args.files {
+        match format_one_file(file, args.check) {
+            Ok(changed) => {
+                if changed {
+                    any_changed = true;
+                    if args.check {
+                        // Diff already printed by format_one_file.
+                    } else {
+                        eprintln!("formatted {}", file.display());
+                    }
+                }
+            }
+            Err(e) => {
+                errored = true;
+                eprintln!("error: {}: {e:#}", file.display());
+            }
+        }
+    }
+
+    if errored {
+        std::process::exit(1);
+    }
+    if args.check && any_changed {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Format a single file. Returns `Ok(true)` if the file's content would
+/// change. In `--check` mode prints a unified diff; otherwise writes the
+/// result back in place.
+fn format_one_file(path: &Path, check: bool) -> Result<bool> {
+    let src =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    // `Path::parent` of a bare filename is `Some("")` (empty), which is
+    // not a valid cwd to spawn rustfmt in — normalize it to `.`.
+    let dir = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => Path::new("."),
+    };
+    let opts = resolve_options(dir);
+
+    let formatted = whisker_fmt::format_source_in_dir(&src, &opts, dir)
+        .with_context(|| format!("formatting {}", path.display()))?;
+
+    if formatted == src {
+        return Ok(false);
+    }
+
+    if check {
+        println!("Diff in {}:", path.display());
+        print!("{}", whisker_fmt::unified_diff(&src, &formatted));
+    } else {
+        std::fs::write(path, &formatted).with_context(|| format!("writing {}", path.display()))?;
+    }
+    Ok(true)
+}
+
+/// Build [`FmtOptions`] from the nearest `rustfmt.toml` (searching from
+/// `dir` upward). Missing keys keep rustfmt's defaults. The base Rust
+/// pass re-reads the same file via rustfmt itself; here we only extract
+/// the few layout keys the macro-body printer needs.
+fn resolve_options(dir: &Path) -> FmtOptions {
+    if let Some(toml_path) = find_rustfmt_toml(dir) {
+        if let Ok(text) = std::fs::read_to_string(&toml_path) {
+            return FmtOptions::from_rustfmt_config(&text);
+        }
+    }
+    FmtOptions::default()
+}
+
+/// Walk upward from `dir` looking for `rustfmt.toml` or `.rustfmt.toml`.
+fn find_rustfmt_toml(dir: &Path) -> Option<PathBuf> {
+    let mut cur = Some(dir);
+    while let Some(d) = cur {
+        for name in ["rustfmt.toml", ".rustfmt.toml"] {
+            let candidate = d.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        cur = d.parent();
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_options_defaults_without_toml() {
+        // A directory with no rustfmt.toml anywhere up the chain falls
+        // back to rustfmt defaults. Use a tmp dir to avoid picking up a
+        // repo-level config.
+        let tmp = std::env::temp_dir().join(format!("whisker-fmt-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        let o = resolve_options(&tmp);
+        // No rustfmt.toml here, but a parent might have one in some
+        // environments — only assert the function returns a valid set.
+        assert!(o.tab_spaces >= 1);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_options_reads_local_toml() {
+        let tmp = std::env::temp_dir().join(format!(
+            "whisker-fmt-test-toml-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(tmp.join("rustfmt.toml"), "tab_spaces = 2\nmax_width = 80\n").unwrap();
+        let o = resolve_options(&tmp);
+        assert_eq!(o.tab_spaces, 2);
+        assert_eq!(o.max_width, 80);
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+}

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -37,6 +37,7 @@ use clap::{Parser, Subcommand};
 
 pub mod build_dispatch;
 pub mod doctor;
+pub mod fmt;
 pub mod linker_shim;
 pub mod manifest;
 pub mod new_app;
@@ -86,6 +87,13 @@ enum Command {
     /// `whisker run ios` from inside the new directory.
     New(new_app::NewAppArgs),
 
+    /// Format Rust source — a rustfmt drop-in that ALSO formats
+    /// Whisker's `render!` / `css!` macro bodies (which rustfmt leaves
+    /// untouched). Respects `rustfmt.toml` only; no whisker-specific
+    /// config. Use `--stdin` for the rust-analyzer integration
+    /// (`rustfmt.overrideCommand = ["whisker", "fmt", "--stdin"]`).
+    Fmt(fmt::FmtArgs),
+
     /// (internal) Cross-compile the user crate into
     /// `WhiskerDriver.framework`. Invoked by the generated Xcode
     /// project's Run Script Phase, not by users.
@@ -122,6 +130,7 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<()> {
         Command::Run(a) => run::run(a),
         Command::NewModule(a) => new_module::run(a),
         Command::New(a) => new_app::run(a),
+        Command::Fmt(a) => fmt::run(a),
         Command::BuildIos(a) => build_dispatch::run_ios(a),
         Command::BuildAndroid(a) => build_dispatch::run_android(a),
         Command::Modules(a) => build_dispatch::run_modules(a),
@@ -207,6 +216,32 @@ mod tests {
                 assert!(a.no_hot_patch);
             }
             other => panic!("expected Run, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_fmt_stdin() {
+        let cli = parse(["whisker", "fmt", "--stdin"]).unwrap();
+        match cli.command {
+            Command::Fmt(a) => {
+                assert!(a.stdin);
+                assert!(!a.check);
+                assert!(a.files.is_empty());
+            }
+            other => panic!("expected Fmt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_fmt_files_and_check() {
+        let cli = parse(["whisker", "fmt", "--check", "a.rs", "b.rs"]).unwrap();
+        match cli.command {
+            Command::Fmt(a) => {
+                assert!(a.check);
+                assert!(!a.stdin);
+                assert_eq!(a.files.len(), 2);
+            }
+            other => panic!("expected Fmt, got {other:?}"),
         }
     }
 

--- a/crates/whisker-fmt/Cargo.toml
+++ b/crates/whisker-fmt/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "whisker-fmt"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories = ["development-tools"]
+description = "rustfmt drop-in that additionally formats Whisker's `render!` / `css!` macro bodies. Respects rustfmt.toml only — no whisker-specific config."
+
+[dependencies]
+anyhow = { workspace = true }
+proc-macro2 = { version = "1", features = ["span-locations"] }
+quote = "1"
+syn = { version = "2", features = ["full", "visit", "extra-traits"] }
+whisker-macro-syntax = { workspace = true }
+# Unified diff for the `--check` path. No diff crate existed in the
+# workspace, so `similar` is added here (it's the de-facto standard,
+# pure-Rust, no transitive C deps).
+similar = "2"

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -1,0 +1,548 @@
+//! `whisker-fmt` — a rustfmt drop-in that also formats Whisker's
+//! `render!` and `css!` macro bodies.
+//!
+//! # Architecture (mirrors yew-fmt)
+//!
+//! rustfmt leaves macro *bodies* untouched. So we:
+//!
+//! 1. Shell out to the real **rustfmt binary** (`--emit stdout`),
+//!    letting it read the project's `rustfmt.toml` itself. This is the
+//!    base Rust formatting. ([`run_rustfmt`])
+//! 2. Parse that output with `syn` + `proc-macro2` (`span-locations`),
+//!    walk for `render!` / `css!` invocations, re-parse each body with
+//!    [`whisker_macro_syntax`], pretty-print it, and splice the result
+//!    back over the original body token range. ([`reformat_macros`])
+//!
+//! [`format_source`] runs the whole pipeline. [`reformat_macros`] is
+//! the macro-only pass and is independently testable WITHOUT the
+//! rustfmt binary (feed it already-rust-formatted input) — useful in
+//! CI environments where rustfmt may be absent.
+//!
+//! # Config
+//!
+//! There are NO whisker-specific options. [`FmtOptions`] mirrors only
+//! rustfmt keys (`max_width`, `tab_spaces`, `hard_tabs`, `edition`)
+//! and the base rustfmt pass reads `rustfmt.toml` directly.
+//!
+//! # Comments inside macros
+//!
+//! `syn` drops comments, and `proc-macro2` exposes them only as
+//! whitespace between tokens. Full-fidelity comment preservation inside
+//! `render!` bodies is **not** implemented in this pass — see
+//! [`reformat_macros`] docs and the `comments_*` tests for the exact,
+//! documented limitation. Comments OUTSIDE macros are preserved by
+//! rustfmt as usual.
+
+mod options;
+mod printer;
+mod source_map;
+
+pub use options::FmtOptions;
+
+use anyhow::{anyhow, Context, Result};
+use proc_macro2::{Delimiter, TokenStream, TokenTree};
+use source_map::SourceMap;
+use std::path::Path;
+use std::process::Command;
+
+/// Run the full pipeline: rustfmt the source, then reformat every
+/// `render!` / `css!` body found in the rustfmt output.
+///
+/// `opts` supplies the layout values the macro pretty-printer needs.
+/// The rustfmt binary independently reads `rustfmt.toml`; pass
+/// `opts.edition` through so both passes agree on the edition.
+pub fn format_source(src: &str, opts: &FmtOptions) -> Result<String> {
+    let base = run_rustfmt(src, opts, None)?;
+    reformat_macros(&base, opts)
+}
+
+/// Like [`format_source`] but tells rustfmt to resolve `rustfmt.toml`
+/// from `config_dir` (its `--config-path`). Used by the CLI so each
+/// file's nearest `rustfmt.toml` governs.
+pub fn format_source_in_dir(src: &str, opts: &FmtOptions, config_dir: &Path) -> Result<String> {
+    let base = run_rustfmt(src, opts, Some(config_dir))?;
+    reformat_macros(&base, opts)
+}
+
+/// `--check` helper: returns `Ok(None)` if the source is already
+/// formatted, or `Ok(Some(unified_diff))` describing what would change.
+pub fn check_source(src: &str, opts: &FmtOptions) -> Result<Option<String>> {
+    let formatted = format_source(src, opts)?;
+    if formatted == src {
+        Ok(None)
+    } else {
+        Ok(Some(unified_diff(src, &formatted)))
+    }
+}
+
+/// Render a unified diff between `before` and `after`.
+pub fn unified_diff(before: &str, after: &str) -> String {
+    use similar::{ChangeTag, TextDiff};
+    let diff = TextDiff::from_lines(before, after);
+    let mut out = String::new();
+    for group in diff.grouped_ops(3) {
+        for op in group {
+            for change in diff.iter_changes(&op) {
+                let sign = match change.tag() {
+                    ChangeTag::Delete => "-",
+                    ChangeTag::Insert => "+",
+                    ChangeTag::Equal => " ",
+                };
+                out.push_str(sign);
+                out.push_str(change.value());
+                if !change.value().ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+        }
+    }
+    out
+}
+
+// ---- rustfmt subprocess --------------------------------------------------
+
+/// Locate the rustfmt binary: `$RUSTFMT`, else `rustup which rustfmt`,
+/// else `rustfmt` on `PATH`.
+pub fn rustfmt_path() -> String {
+    if let Ok(p) = std::env::var("RUSTFMT") {
+        if !p.is_empty() {
+            return p;
+        }
+    }
+    if let Ok(out) = Command::new("rustup").args(["which", "rustfmt"]).output() {
+        if out.status.success() {
+            let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !p.is_empty() {
+                return p;
+            }
+        }
+    }
+    "rustfmt".to_string()
+}
+
+/// Returns `true` if a rustfmt binary appears to be invokable. Used to
+/// gate the integration tests.
+pub fn rustfmt_available() -> bool {
+    Command::new(rustfmt_path())
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Run the rustfmt binary over `src`, returning its stdout. rustfmt is
+/// run with cwd = `config_dir` (when given) so it resolves the right
+/// `rustfmt.toml`; otherwise it runs in the current dir.
+fn run_rustfmt(src: &str, opts: &FmtOptions, config_dir: Option<&Path>) -> Result<String> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut cmd = Command::new(rustfmt_path());
+    cmd.arg("--emit").arg("stdout");
+    if let Some(ed) = &opts.edition {
+        cmd.arg("--edition").arg(ed);
+    }
+    if let Some(dir) = config_dir {
+        // Run with cwd = the file's directory so rustfmt's own upward
+        // search finds the nearest `rustfmt.toml`. Only pass an explicit
+        // `--config-path` when a config actually exists at/above `dir`
+        // — pointing `--config-path` at a directory with no config is a
+        // hard error in rustfmt.
+        cmd.current_dir(dir);
+        if find_rustfmt_toml(dir).is_some() {
+            cmd.arg("--config-path").arg(dir);
+        }
+    }
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("failed to spawn rustfmt ({})", rustfmt_path()))?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("rustfmt stdin unavailable"))?
+        .write_all(src.as_bytes())
+        .context("writing source to rustfmt stdin")?;
+    let out = child
+        .wait_with_output()
+        .context("waiting for rustfmt to finish")?;
+    if !out.status.success() {
+        return Err(anyhow!(
+            "rustfmt failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    String::from_utf8(out.stdout).context("rustfmt produced non-UTF-8 output")
+}
+
+/// Walk upward from `dir` looking for `rustfmt.toml` / `.rustfmt.toml`.
+fn find_rustfmt_toml(dir: &Path) -> Option<std::path::PathBuf> {
+    let mut cur = Some(dir);
+    while let Some(d) = cur {
+        for name in ["rustfmt.toml", ".rustfmt.toml"] {
+            let candidate = d.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        cur = d.parent();
+    }
+    None
+}
+
+// ---- macro reformatting pass --------------------------------------------
+
+/// Reformat every `render!` / `css!` macro body found in `rust_src`
+/// (which must already be valid, rustfmt-formatted Rust).
+///
+/// This is the testable core that does NOT need the rustfmt binary.
+///
+/// ## Comment limitation
+///
+/// Comments *inside* a `render!` / `css!` body are dropped: `syn`
+/// discards them entirely, and recovering them from inter-token
+/// whitespace cannot be done reliably for an arbitrary nested grammar
+/// in this pass. Macro bodies that contain `//` or `/* */` comments are
+/// detected and left **untouched** (the original body text is kept
+/// verbatim) rather than silently losing the comments — see
+/// [`body_has_comments`]. This is the documented, tested limitation.
+pub fn reformat_macros(rust_src: &str, opts: &FmtOptions) -> Result<String> {
+    // Parse the whole file just to confirm it is valid Rust; the actual
+    // macro discovery walks the raw TokenStream (so we keep precise
+    // span byte-offsets relative to `rust_src`).
+    let _: syn::File = syn::parse_file(rust_src)
+        .context("whisker-fmt: rustfmt output did not re-parse as valid Rust")?;
+
+    let tokens: TokenStream = rust_src
+        .parse()
+        .map_err(|e| anyhow!("whisker-fmt: could not lex rustfmt output: {e}"))?;
+
+    let file_map = SourceMap::new(rust_src);
+
+    // Collect (body_open_offset, body_close_offset, replacement) for
+    // every macro, then splice from the end backwards so earlier
+    // offsets stay valid.
+    let mut edits: Vec<MacroEdit> = Vec::new();
+    collect_macro_edits(tokens, &file_map, rust_src, opts, &mut edits)?;
+
+    edits.sort_by_key(|e| e.open_byte);
+    // Splice from the end so earlier byte offsets remain valid.
+    let mut out = rust_src.to_string();
+    for edit in edits.into_iter().rev() {
+        out.replace_range(edit.open_byte..edit.close_byte, &edit.replacement);
+    }
+    Ok(out)
+}
+
+struct MacroEdit {
+    /// Byte offset just AFTER the opening delimiter.
+    open_byte: usize,
+    /// Byte offset of the closing delimiter.
+    close_byte: usize,
+    replacement: String,
+}
+
+/// Recursively walk a token stream, finding `render! { … }` /
+/// `css! { … }` (or `(…)` / `[…]`) invocations and queueing an edit for
+/// each body.
+fn collect_macro_edits(
+    tokens: TokenStream,
+    file_map: &SourceMap,
+    rust_src: &str,
+    opts: &FmtOptions,
+    edits: &mut Vec<MacroEdit>,
+) -> Result<()> {
+    let trees: Vec<TokenTree> = tokens.into_iter().collect();
+    let mut i = 0;
+    while i < trees.len() {
+        // Look for `IDENT ! GROUP` where IDENT is render/css.
+        if let TokenTree::Ident(ident) = &trees[i] {
+            let name = ident.to_string();
+            if (name == "render" || name == "css")
+                && i + 2 < trees.len()
+                && matches!(&trees[i + 1], TokenTree::Punct(p) if p.as_char() == '!')
+            {
+                if let TokenTree::Group(group) = &trees[i + 2] {
+                    if let Some(edit) = macro_body_edit(&name, group, file_map, rust_src, opts)? {
+                        edits.push(edit);
+                    }
+                    // Don't recurse into a macro body we've already
+                    // reformatted as a whole; but DO recurse if we
+                    // skipped it (comments etc.) so nested macros still
+                    // get a chance. Simplest correct choice: recurse
+                    // into the body always — the inner macro edits use
+                    // the same global byte offsets and the outer edit
+                    // (if any) reformats the body text from the AST,
+                    // which re-prints nested render!/css! via slicing.
+                    // To avoid double-editing the same bytes we only
+                    // recurse when no outer edit was produced.
+                    i += 3;
+                    continue;
+                }
+            }
+        }
+        // Recurse into any group we didn't treat as a macro body.
+        if let TokenTree::Group(group) = &trees[i] {
+            collect_macro_edits(group.stream(), file_map, rust_src, opts, edits)?;
+        }
+        i += 1;
+    }
+    Ok(())
+}
+
+/// Build the splice edit for a single macro body group, or `None` if
+/// the body should be left untouched (empty, comment-bearing, or
+/// re-parse failure).
+fn macro_body_edit(
+    macro_name: &str,
+    group: &proc_macro2::Group,
+    file_map: &SourceMap,
+    rust_src: &str,
+    opts: &FmtOptions,
+) -> Result<Option<MacroEdit>> {
+    let span = group.span();
+    // Byte offsets of the WHOLE group (including delimiters).
+    let Some((group_start, group_end)) = file_map.byte_range(span) else {
+        return Ok(None);
+    };
+    // The opening / closing delimiters are single chars; the body is
+    // between them.
+    let open_byte = group_start + 1;
+    let close_byte = group_end - 1;
+    if close_byte <= open_byte {
+        return Ok(None); // empty body
+    }
+    let body_src = &rust_src[open_byte..close_byte];
+
+    // Comment limitation: leave bodies with comments untouched.
+    if body_has_comments(body_src) {
+        return Ok(None);
+    }
+
+    // Base indent = the indent level of the line the macro sits on.
+    let line_start = rust_src[..group_start]
+        .rfind('\n')
+        .map(|n| n + 1)
+        .unwrap_or(0);
+    let line_prefix = &rust_src[line_start..group_start];
+    let base_indent = indent_level_of(line_prefix, opts);
+
+    // Re-parse the body with whisker-macro-syntax. The span locations
+    // inside `body_ts` are relative to `body_src`, so build a fresh
+    // SourceMap over exactly that substring.
+    let body_ts: TokenStream = body_src
+        .parse()
+        .map_err(|e| anyhow!("whisker-fmt: could not lex {macro_name}! body: {e}"))?;
+    let body_map = SourceMap::new(body_src);
+
+    let formatted = match macro_name {
+        "render" => match whisker_macro_syntax::render::parse_root(body_ts.clone()) {
+            Ok(root) => printer::print_render(&root, &body_map, opts, base_indent),
+            // Not a well-formed render! body (e.g. mid-edit) — leave it.
+            Err(_) => return Ok(None),
+        },
+        "css" => match whisker_macro_syntax::css::parse_input(body_ts.clone()) {
+            Ok(input) => {
+                if input.kwargs.is_empty() {
+                    return Ok(None);
+                }
+                printer::print_css(&input, &body_map, opts, base_indent)
+            }
+            Err(_) => return Ok(None),
+        },
+        _ => return Ok(None),
+    };
+
+    // Wrap with the delimiter-relative newlines: the printer emits the
+    // body already indented to `base_indent + 1`; surround with a
+    // leading newline and a trailing newline + closing-brace indent.
+    let closing_indent = opts.indent_prefix(base_indent);
+    let replacement = match group.delimiter() {
+        // `render! { … }` — the common form. Put body on its own lines.
+        Delimiter::Brace => format!("\n{formatted}\n{closing_indent}"),
+        // `css!( … )` / `css![ … ]` — also break onto lines for
+        // consistency with rustfmt's treatment of multi-item macros.
+        _ => format!("\n{formatted}\n{closing_indent}"),
+    };
+
+    // Idempotency guard: if the body already equals the replacement,
+    // skip (avoids spurious diffs and keeps format(format(x))==format(x)).
+    if body_src == replacement {
+        return Ok(None);
+    }
+
+    Ok(Some(MacroEdit {
+        open_byte,
+        close_byte,
+        replacement,
+    }))
+}
+
+/// Detect `//` or `/* */` comments in a macro body. Uses a tiny
+/// string-aware scan so a `//` inside a string literal isn't a false
+/// positive.
+fn body_has_comments(body: &str) -> bool {
+    let bytes = body.as_bytes();
+    let mut i = 0;
+    let mut in_str: Option<u8> = None; // Some(quote_char)
+    while i < bytes.len() {
+        let b = bytes[i];
+        match in_str {
+            Some(q) => {
+                if b == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if b == q {
+                    in_str = None;
+                }
+            }
+            None => {
+                if b == b'"' || b == b'\'' {
+                    in_str = Some(b);
+                } else if b == b'/' && i + 1 < bytes.len() {
+                    let n = bytes[i + 1];
+                    if n == b'/' || n == b'*' {
+                        return true;
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Convert a line's leading-whitespace prefix into an indent level (in
+/// tab-units). Tabs count as one level each; spaces are divided by
+/// `tab_spaces`.
+fn indent_level_of(line_prefix: &str, opts: &FmtOptions) -> usize {
+    let mut spaces = 0usize;
+    let mut tabs = 0usize;
+    for ch in line_prefix.chars() {
+        match ch {
+            ' ' => spaces += 1,
+            '\t' => tabs += 1,
+            _ => break,
+        }
+    }
+    let space_levels = spaces.checked_div(opts.tab_spaces).unwrap_or(0);
+    tabs + space_levels
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts(tab: usize, width: usize) -> FmtOptions {
+        FmtOptions {
+            max_width: width,
+            tab_spaces: tab,
+            hard_tabs: false,
+            edition: None,
+        }
+    }
+
+    // All tests below feed already-rust-formatted input to
+    // `reformat_macros`, so they DO NOT require the rustfmt binary.
+
+    #[test]
+    fn reformats_messy_render_body() {
+        let input = "fn ui() -> Element {\n    render! { view(style:\"x\",class:\"y\"){text(value:\"hi\")} }\n}\n";
+        let out = reformat_macros(input, &opts(4, 100)).unwrap();
+        let expected = "fn ui() -> Element {\n    render! {\n        view(style: \"x\", class: \"y\") {\n            text(value: \"hi\")\n        }\n    }\n}\n";
+        assert_eq!(out, expected, "got:\n{out}");
+    }
+
+    #[test]
+    fn idempotent() {
+        let input =
+            "fn ui() -> Element {\n    render! { view(style:\"x\"){text(value:\"hi\")} }\n}\n";
+        let once = reformat_macros(input, &opts(4, 100)).unwrap();
+        let twice = reformat_macros(&once, &opts(4, 100)).unwrap();
+        assert_eq!(
+            once, twice,
+            "not idempotent:\nonce:\n{once}\ntwice:\n{twice}"
+        );
+    }
+
+    #[test]
+    fn honors_tab_spaces_from_options() {
+        let input =
+            "fn ui() -> Element {\n    render! { view(style:\"x\"){text(value:\"hi\")} }\n}\n";
+        let four = reformat_macros(input, &opts(4, 100)).unwrap();
+        let two = reformat_macros(input, &opts(2, 100)).unwrap();
+        assert_ne!(four, two, "tab_spaces must change indentation");
+        // 4-space variant indents the inner text 12 cols; 2-space, 6.
+        assert!(
+            four.contains("            text(value: \"hi\")"),
+            "4-space:\n{four}"
+        );
+        assert!(two.contains("      text(value: \"hi\")"), "2-space:\n{two}");
+    }
+
+    #[test]
+    fn wraps_kwargs_over_max_width() {
+        // A node whose kwargs blow past a tiny max_width breaks each
+        // kwarg onto its own line with a trailing comma.
+        let input = "fn ui() -> Element {\n    render! { view(style: \"a-long-value\", class: \"another-long-value\") }\n}\n";
+        let out = reformat_macros(input, &opts(4, 40)).unwrap();
+        assert!(out.contains("view(\n"), "expected broken kwargs:\n{out}");
+        assert!(
+            out.contains("class: \"another-long-value\",\n"),
+            "trailing comma expected:\n{out}"
+        );
+    }
+
+    #[test]
+    fn preserves_user_expression_source() {
+        // The embedded closure expression should be kept verbatim
+        // (sliced), not re-printed from tokens.
+        let input =
+            "fn ui() -> Element {\n    render! { view(on_tap: move |_| do_thing(a, b)) }\n}\n";
+        let out = reformat_macros(input, &opts(4, 100)).unwrap();
+        assert!(
+            out.contains("on_tap: move |_| do_thing(a, b)"),
+            "expression must be preserved verbatim:\n{out}"
+        );
+    }
+
+    #[test]
+    fn formats_css_body() {
+        let input = "fn s() -> Css {\n    css! { color:red,padding:px(8) }\n}\n";
+        let out = reformat_macros(input, &opts(4, 100)).unwrap();
+        assert!(
+            out.contains("color: red, padding: px(8)"),
+            "css inline:\n{out}"
+        );
+    }
+
+    #[test]
+    fn comments_in_body_left_untouched() {
+        // KNOWN LIMITATION: a macro body containing comments is left
+        // exactly as-is rather than dropping the comment.
+        let input = "fn ui() -> Element {\n    render! { view(style:\"x\") /* keep me */ }\n}\n";
+        let out = reformat_macros(input, &opts(4, 100)).unwrap();
+        assert_eq!(out, input, "comment-bearing body must be untouched");
+    }
+
+    #[test]
+    fn children_slot_preserved() {
+        let input = "fn ui() -> Element {\n    render! { view(style:\"x\"){children()} }\n}\n";
+        let out = reformat_macros(input, &opts(4, 100)).unwrap();
+        assert!(
+            out.contains("children()"),
+            "children() slot must survive:\n{out}"
+        );
+    }
+
+    #[test]
+    fn non_render_macro_untouched() {
+        let input = "fn x() {\n    println!(\"hi {}\", v);\n}\n";
+        let out = reformat_macros(input, &opts(4, 100)).unwrap();
+        assert_eq!(out, input);
+    }
+}

--- a/crates/whisker-fmt/src/options.rs
+++ b/crates/whisker-fmt/src/options.rs
@@ -1,0 +1,164 @@
+//! Formatter options — derived ENTIRELY from rustfmt's own settings.
+//!
+//! There are deliberately NO whisker-specific knobs here. Every field
+//! mirrors a `rustfmt.toml` key, with rustfmt's documented default:
+//!
+//! | field        | rustfmt.toml key | default |
+//! |--------------|------------------|---------|
+//! | `max_width`  | `max_width`      | 100     |
+//! | `tab_spaces` | `tab_spaces`     | 4       |
+//! | `hard_tabs`  | `hard_tabs`      | false   |
+//! | `edition`    | (CLI `--edition`)| 2015    |
+//!
+//! `format_source` lets the rustfmt *binary* read `rustfmt.toml` for
+//! the base Rust pass (so any key rustfmt understands is honored). The
+//! subset captured here is exactly the subset the macro-body
+//! pretty-printer needs in order to match rustfmt's indentation /
+//! wrapping. We resolve those few keys from the same `rustfmt.toml`
+//! ([`FmtOptions::from_rustfmt_config`]) so the macro bodies line up
+//! with the surrounding code.
+
+/// Layout options for the macro-body pretty-printer. Mirrors the
+/// rustfmt keys that affect indentation and wrapping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FmtOptions {
+    /// `max_width` — the column past which the printer tries to wrap.
+    pub max_width: usize,
+    /// `tab_spaces` — spaces per indent level (when `hard_tabs` is
+    /// false). Also the width charged per `\t` when `hard_tabs` is on,
+    /// for column accounting.
+    pub tab_spaces: usize,
+    /// `hard_tabs` — emit a literal tab per indent level instead of
+    /// `tab_spaces` spaces.
+    pub hard_tabs: bool,
+    /// Rust edition to pass to the rustfmt binary (and to `syn` parse,
+    /// though `syn` is edition-agnostic for our purposes). `None` lets
+    /// rustfmt pick its own default.
+    pub edition: Option<String>,
+}
+
+impl Default for FmtOptions {
+    fn default() -> Self {
+        // rustfmt's documented defaults.
+        Self {
+            max_width: 100,
+            tab_spaces: 4,
+            hard_tabs: false,
+            edition: None,
+        }
+    }
+}
+
+impl FmtOptions {
+    /// Render one indent *level* as a string fragment.
+    pub(crate) fn indent_unit(&self) -> String {
+        if self.hard_tabs {
+            "\t".to_string()
+        } else {
+            " ".repeat(self.tab_spaces)
+        }
+    }
+
+    /// The display width charged for `levels` indent levels — used for
+    /// `max_width` accounting (a hard tab is charged `tab_spaces`).
+    pub(crate) fn indent_width(&self, levels: usize) -> usize {
+        levels * self.tab_spaces
+    }
+
+    /// Build an indent prefix of `levels` indent levels.
+    pub(crate) fn indent_prefix(&self, levels: usize) -> String {
+        self.indent_unit().repeat(levels)
+    }
+
+    /// Parse the handful of layout keys we care about out of a
+    /// `rustfmt.toml` text blob. Unknown keys are ignored (rustfmt
+    /// itself still sees them on the base pass). Missing keys keep
+    /// their default.
+    ///
+    /// This is a tiny hand-rolled `key = value` reader rather than a
+    /// full TOML parse so the crate doesn't take a `toml` dependency
+    /// just for four scalar keys.
+    pub fn from_rustfmt_config(toml_src: &str) -> Self {
+        let mut opts = FmtOptions::default();
+        for line in toml_src.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            let key = key.trim();
+            let value = value.trim().trim_matches('"').trim_matches('\'');
+            match key {
+                "max_width" => {
+                    if let Ok(v) = value.parse() {
+                        opts.max_width = v;
+                    }
+                }
+                "tab_spaces" => {
+                    if let Ok(v) = value.parse() {
+                        opts.tab_spaces = v;
+                    }
+                }
+                "hard_tabs" => {
+                    if let Ok(v) = value.parse() {
+                        opts.hard_tabs = v;
+                    }
+                }
+                "edition" => {
+                    opts.edition = Some(value.to_string());
+                }
+                _ => {}
+            }
+        }
+        opts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_rustfmt() {
+        let o = FmtOptions::default();
+        assert_eq!(o.max_width, 100);
+        assert_eq!(o.tab_spaces, 4);
+        assert!(!o.hard_tabs);
+        assert_eq!(o.edition, None);
+    }
+
+    #[test]
+    fn parses_rustfmt_toml_keys() {
+        let toml = "max_width = 80\ntab_spaces = 2\nhard_tabs = true\nedition = \"2021\"\n";
+        let o = FmtOptions::from_rustfmt_config(toml);
+        assert_eq!(o.max_width, 80);
+        assert_eq!(o.tab_spaces, 2);
+        assert!(o.hard_tabs);
+        assert_eq!(o.edition.as_deref(), Some("2021"));
+    }
+
+    #[test]
+    fn ignores_comments_and_unknown_keys() {
+        let toml = "# a comment\nimports_granularity = \"Crate\"\ntab_spaces = 2\n";
+        let o = FmtOptions::from_rustfmt_config(toml);
+        assert_eq!(o.tab_spaces, 2);
+        assert_eq!(o.max_width, 100); // default retained
+    }
+
+    #[test]
+    fn indent_unit_spaces_vs_tabs() {
+        let mut o = FmtOptions {
+            tab_spaces: 2,
+            ..FmtOptions::default()
+        };
+        assert_eq!(o.indent_unit(), "  ");
+        assert_eq!(o.indent_prefix(3), "      ");
+        o.hard_tabs = true;
+        assert_eq!(o.indent_unit(), "\t");
+        assert_eq!(o.indent_prefix(2), "\t\t");
+        // width accounting still charges tab_spaces per level
+        assert_eq!(o.indent_width(2), 4);
+    }
+}

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -1,0 +1,252 @@
+//! Width-aware pretty-printer for `render!` and `css!` bodies.
+//!
+//! ## Embedded Rust expressions
+//!
+//! Kwarg values, event-handler closures and any other embedded Rust
+//! are NOT re-printed from tokens. They are sliced verbatim out of the
+//! original macro-body source via [`SourceMap`] (see `source_map.rs`),
+//! so the user's own expression formatting is preserved exactly. We
+//! only fall back to `proc_macro2` token printing when the slice fails
+//! (e.g. a synthesized span with no source position) — a rare,
+//! best-effort path. This choice keeps the formatter from fighting
+//! rustfmt over expression internals.
+//!
+//! ## Layout
+//!
+//! A simple indent-and-wrap scheme (not full Wadler/Prettier): each
+//! node renders inline if it fits within `max_width` at its current
+//! indent, otherwise the kwargs and/or children break onto their own
+//! indented lines. This matches the shallow, regular `render!` grammar
+//! and is easy to keep idempotent.
+
+use crate::options::FmtOptions;
+use crate::source_map::SourceMap;
+use proc_macro2::Span;
+use quote::ToTokens;
+use whisker_macro_syntax::{CssInput, ElementNode, Kwarg, Node, Root, UserComponentNode};
+
+/// Pretty-print a parsed `render!` body.
+///
+/// `base_indent` is the indent level (in tab-units) at which the macro
+/// invocation sits in the rustfmt output; the body is indented one
+/// level deeper.
+pub(crate) fn print_render(
+    root: &Root,
+    map: &SourceMap,
+    opts: &FmtOptions,
+    base_indent: usize,
+) -> String {
+    let p = Printer { map, opts };
+    let mut out = String::new();
+    p.node(&root.node, base_indent + 1, &mut out);
+    out
+}
+
+/// Pretty-print a parsed `css!` body.
+pub(crate) fn print_css(
+    input: &CssInput,
+    map: &SourceMap,
+    opts: &FmtOptions,
+    base_indent: usize,
+) -> String {
+    let p = Printer { map, opts };
+    p.css(input, base_indent + 1)
+}
+
+struct Printer<'a> {
+    map: &'a SourceMap<'a>,
+    opts: &'a FmtOptions,
+}
+
+impl Printer<'_> {
+    /// Slice an embedded Rust expr verbatim from the source, falling
+    /// back to token printing if the span has no source position.
+    fn expr_src(&self, span: Span, tokens: &dyn ToTokens) -> String {
+        if let Some(s) = self.map.slice(span) {
+            // Trim surrounding whitespace; internal formatting is kept.
+            s.trim().to_string()
+        } else {
+            tokens.to_token_stream().to_string()
+        }
+    }
+
+    fn indent(&self, level: usize) -> String {
+        self.opts.indent_prefix(level)
+    }
+
+    // ---- render! -------------------------------------------------------
+
+    fn node(&self, node: &Node, level: usize, out: &mut String) {
+        match node {
+            Node::Element(el) => self.element(el, level, out),
+            Node::UserComponent(uc) => self.user_component(uc, level, out),
+            Node::ChildrenSlot { .. } => {
+                out.push_str(&self.indent(level));
+                out.push_str("children()");
+            }
+        }
+    }
+
+    fn element(&self, el: &ElementNode, level: usize, out: &mut String) {
+        self.tag_node(&el.tag.to_string(), &el.kwargs, &el.children, level, out);
+    }
+
+    fn user_component(&self, uc: &UserComponentNode, level: usize, out: &mut String) {
+        self.tag_node(
+            &uc.alias_ident.to_string(),
+            &uc.kwargs,
+            &uc.children,
+            level,
+            out,
+        );
+    }
+
+    /// The shared `tag(kwargs) { children }` rendering used by both
+    /// element and user-component nodes.
+    fn tag_node(
+        &self,
+        tag: &str,
+        kwargs: &[Kwarg],
+        children: &[Node],
+        level: usize,
+        out: &mut String,
+    ) {
+        let indent = self.indent(level);
+        out.push_str(&indent);
+        out.push_str(tag);
+
+        // ---- kwargs ----
+        if !kwargs.is_empty() {
+            let parts: Vec<String> = kwargs.iter().map(|kw| self.kwarg(kw)).collect();
+            let inline = format!("({})", parts.join(", "));
+            let inline_width =
+                self.opts.indent_width(level) + tag.len() + inline.len() + brace_width(children);
+            let single_line = !inline.contains('\n');
+            if single_line && inline_width <= self.opts.max_width {
+                out.push_str(&inline);
+            } else {
+                // Break each kwarg onto its own line.
+                out.push_str("(\n");
+                let inner = self.indent(level + 1);
+                for (i, part) in parts.iter().enumerate() {
+                    out.push_str(&inner);
+                    // Re-indent any internal newlines of a multi-line
+                    // kwarg value so it stays under the kwarg's column.
+                    out.push_str(&reindent(part, &inner));
+                    if i + 1 < parts.len() {
+                        out.push(',');
+                    } else {
+                        // trailing comma on the last kwarg
+                        out.push(',');
+                    }
+                    out.push('\n');
+                }
+                out.push_str(&indent);
+                out.push(')');
+            }
+        }
+
+        // ---- children ----
+        if !children.is_empty() {
+            out.push_str(" {\n");
+            for child in children {
+                self.node(child, level + 1, out);
+                out.push('\n');
+            }
+            out.push_str(&indent);
+            out.push('}');
+        }
+    }
+
+    fn kwarg(&self, kw: &Kwarg) -> String {
+        let name = kw.name.to_string();
+        if kw.partial {
+            // Partial kwarg: just the name (mid-typing). Preserve the
+            // author's `name` with no value.
+            return name;
+        }
+        let value = self.expr_src(span_of(&kw.value), &kw.value);
+        format!("{name}: {value}")
+    }
+
+    // ---- css! ----------------------------------------------------------
+
+    fn css(&self, input: &CssInput, level: usize) -> String {
+        if input.kwargs.is_empty() {
+            return String::new();
+        }
+        let parts: Vec<String> = input
+            .kwargs
+            .iter()
+            .map(|kw| {
+                let name = kw.name.to_string();
+                match &kw.value {
+                    Some(expr) => {
+                        let v = self.expr_src(span_of(expr), expr);
+                        format!("{name}: {v}")
+                    }
+                    None => name,
+                }
+            })
+            .collect();
+
+        // Try a single inline line first.
+        let inline = parts.join(", ");
+        let inline_width = self.opts.indent_width(level) + inline.len();
+        if !inline.contains('\n') && inline_width <= self.opts.max_width {
+            let indent = self.indent(level);
+            return format!("{indent}{inline}");
+        }
+        // Otherwise one kwarg per line, trailing comma.
+        let indent = self.indent(level);
+        let mut out = String::new();
+        for part in &parts {
+            out.push_str(&indent);
+            out.push_str(&reindent(part, &indent));
+            out.push_str(",\n");
+        }
+        // strip trailing newline (caller adds delimiters)
+        out.pop();
+        out
+    }
+}
+
+/// Width contribution of a ` { … }` children block when deciding
+/// whether a node's kwargs fit inline. A non-empty children block
+/// always forces a multi-line body, so we only need the ` {` opener's
+/// width to be honest about the first line; the closing brace and the
+/// children sit on later lines.
+fn brace_width(children: &[Node]) -> usize {
+    if children.is_empty() {
+        0
+    } else {
+        " {".len()
+    }
+}
+
+/// Re-indent the 2nd..=Nth lines of a (possibly multi-line) fragment so
+/// continuation lines sit under `prefix`. The first line is left as-is
+/// (the caller already emitted `prefix` before it).
+fn reindent(fragment: &str, prefix: &str) -> String {
+    if !fragment.contains('\n') {
+        return fragment.to_string();
+    }
+    let mut lines = fragment.lines();
+    let mut out = String::new();
+    if let Some(first) = lines.next() {
+        out.push_str(first);
+    }
+    for line in lines {
+        out.push('\n');
+        out.push_str(prefix);
+        out.push_str(line);
+    }
+    out
+}
+
+/// The `Span` covering an expression (start of first token to end of
+/// last), via `syn::spanned::Spanned`.
+fn span_of(expr: &syn::Expr) -> Span {
+    use syn::spanned::Spanned;
+    expr.span()
+}

--- a/crates/whisker-fmt/src/source_map.rs
+++ b/crates/whisker-fmt/src/source_map.rs
@@ -1,0 +1,138 @@
+//! Slice the original source text out of a `proc_macro2::Span`.
+//!
+//! When `proc-macro2`'s `span-locations` feature is on, `Span::start()`
+//! / `Span::end()` return `LineColumn` (1-based line, 0-based column)
+//! *relative to the token stream the span came from*. We re-parse each
+//! macro body as a standalone `TokenStream`, so the line/column are
+//! relative to that body's own text — which is exactly the substring we
+//! pass in here. That lets us recover the user's original expression
+//! text verbatim (preserving their internal formatting) rather than
+//! re-printing it from tokens (which would mangle spacing).
+
+use proc_macro2::Span;
+
+/// Maps `(line, column)` positions within a source blob to byte
+/// offsets, so a [`Span`] can be turned back into the exact source
+/// substring it covers.
+pub(crate) struct SourceMap<'a> {
+    src: &'a str,
+    /// Byte offset of the start of each line (1-based line → index
+    /// `line - 1`).
+    line_starts: Vec<usize>,
+}
+
+impl<'a> SourceMap<'a> {
+    pub(crate) fn new(src: &'a str) -> Self {
+        let mut line_starts = vec![0usize];
+        for (i, b) in src.bytes().enumerate() {
+            if b == b'\n' {
+                line_starts.push(i + 1);
+            }
+        }
+        SourceMap { src, line_starts }
+    }
+
+    /// Byte offset of a `(line, column)` location. `line` is 1-based,
+    /// `column` is a 0-based *char* offset within the line (matching
+    /// `proc_macro2::LineColumn`).
+    fn offset(&self, line: usize, column: usize) -> Option<usize> {
+        let line_start = *self.line_starts.get(line.checked_sub(1)?)?;
+        // `column` counts chars; walk that many chars from line_start.
+        let rest = &self.src[line_start..];
+        let mut byte = line_start;
+        let mut chars = column;
+        for ch in rest.chars() {
+            if chars == 0 {
+                break;
+            }
+            byte += ch.len_utf8();
+            chars -= 1;
+        }
+        Some(byte)
+    }
+
+    /// Byte range `(start, end)` covered by `span`, or `None` if the
+    /// span has no resolvable source location.
+    pub(crate) fn byte_range(&self, span: Span) -> Option<(usize, usize)> {
+        let start = span.start();
+        let end = span.end();
+        if start.line == 0 {
+            return None;
+        }
+        let s = self.offset(start.line, start.column)?;
+        let e = self.offset(end.line, end.column)?;
+        if e < s || e > self.src.len() {
+            return None;
+        }
+        Some((s, e))
+    }
+
+    /// The exact source substring covered by `span`, or `None` if the
+    /// span's locations don't resolve (e.g. a synthesized span with no
+    /// real source position).
+    pub(crate) fn slice(&self, span: Span) -> Option<&'a str> {
+        let start = span.start();
+        let end = span.end();
+        // A synthesized/`call_site` span reports (1,0)..(1,0); guard
+        // against that producing an empty (or bogus) slice.
+        if start.line == 0 {
+            return None;
+        }
+        let s = self.offset(start.line, start.column)?;
+        let e = self.offset(end.line, end.column)?;
+        if e < s || e > self.src.len() {
+            return None;
+        }
+        Some(&self.src[s..e])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proc_macro2::TokenStream;
+    use syn::spanned::Spanned;
+    use syn::Expr;
+
+    #[test]
+    fn slices_expr_from_its_own_token_stream() {
+        // Span locations are relative to the TokenStream the span came
+        // from, so re-parse the exact substring we map against.
+        let src = "a + b * c";
+        let ts: TokenStream = src.parse().unwrap();
+        let expr: Expr = syn::parse2(ts).unwrap();
+        let map = SourceMap::new(src);
+        assert_eq!(map.slice(expr.span()).unwrap(), "a + b * c");
+    }
+
+    #[test]
+    fn slices_nested_subexpr() {
+        let src = "foo(bar + 1)";
+        let ts: TokenStream = src.parse().unwrap();
+        let call: syn::ExprCall = syn::parse2(ts).unwrap();
+        let map = SourceMap::new(src);
+        // first (and only) argument is `bar + 1`
+        let arg = call.args.first().unwrap();
+        assert_eq!(map.slice(arg.span()).unwrap(), "bar + 1");
+    }
+
+    #[test]
+    fn offset_math_multiline() {
+        let src = "line one\nx = a +\n    b";
+        let map = SourceMap::new(src);
+        assert_eq!(map.offset(1, 0), Some(0));
+        assert_eq!(map.offset(2, 0), Some(9));
+        assert_eq!(map.offset(2, 4), Some(13));
+    }
+
+    #[test]
+    fn slices_multiline_expr_verbatim() {
+        // A user expression that spans lines should come back exactly
+        // as written (this is what preserves the user's formatting).
+        let src = "a\n    + b\n    + c";
+        let ts: TokenStream = src.parse().unwrap();
+        let expr: Expr = syn::parse2(ts).unwrap();
+        let map = SourceMap::new(src);
+        assert_eq!(map.slice(expr.span()).unwrap(), src);
+    }
+}

--- a/crates/whisker-fmt/tests/integration.rs
+++ b/crates/whisker-fmt/tests/integration.rs
@@ -1,0 +1,88 @@
+//! Integration tests that exercise the FULL pipeline, including the
+//! rustfmt subprocess. Gated on `rustfmt` being available so the suite
+//! still passes in environments without it (the macro-only unit tests
+//! in `src/lib.rs` cover the formatter logic without rustfmt).
+
+use whisker_fmt::{check_source, format_source, rustfmt_available, FmtOptions};
+
+fn opts(tab: usize, width: usize) -> FmtOptions {
+    FmtOptions {
+        max_width: width,
+        tab_spaces: tab,
+        hard_tabs: false,
+        edition: Some("2021".to_string()),
+    }
+}
+
+#[test]
+fn full_pipeline_formats_rust_and_macro() {
+    if !rustfmt_available() {
+        eprintln!("skipping: rustfmt binary not available");
+        return;
+    }
+    let messy =
+        "fn   ui()->Element{ render!{view(style:\"x\",class:\"y\"){text(value:\"hi\")}} }\n";
+    let out = format_source(messy, &opts(4, 100)).expect("format_source");
+
+    // rustfmt normalized the fn signature …
+    assert!(out.contains("fn ui() -> Element {"), "rust pass:\n{out}");
+    // … and the macro body got reformatted onto its own indented lines.
+    assert!(out.contains("    render! {"), "macro indent:\n{out}");
+    assert!(
+        out.contains("        view(style: \"x\", class: \"y\") {"),
+        "kwargs formatted:\n{out}"
+    );
+    assert!(
+        out.contains("            text(value: \"hi\")"),
+        "child indent:\n{out}"
+    );
+}
+
+#[test]
+fn full_pipeline_idempotent() {
+    if !rustfmt_available() {
+        return;
+    }
+    let messy = "fn ui()->Element{render!{view(style:\"x\"){text(value:\"hi\")}}}\n";
+    let once = format_source(messy, &opts(4, 100)).unwrap();
+    let twice = format_source(&once, &opts(4, 100)).unwrap();
+    assert_eq!(
+        once, twice,
+        "not idempotent:\n--once--\n{once}\n--twice--\n{twice}"
+    );
+}
+
+#[test]
+fn check_reports_diff_then_clean() {
+    if !rustfmt_available() {
+        return;
+    }
+    let messy = "fn ui()->Element{render!{view(style:\"x\")}}\n";
+    // First check: not formatted → Some(diff).
+    let diff = check_source(messy, &opts(4, 100)).unwrap();
+    assert!(diff.is_some(), "expected a diff for messy input");
+    // After formatting, check is clean.
+    let formatted = format_source(messy, &opts(4, 100)).unwrap();
+    let clean = check_source(&formatted, &opts(4, 100)).unwrap();
+    assert!(
+        clean.is_none(),
+        "formatted input should be clean, got:\n{clean:?}"
+    );
+}
+
+#[test]
+fn tab_spaces_option_changes_output() {
+    if !rustfmt_available() {
+        return;
+    }
+    // Proves the layout flows from FmtOptions, not a hardcoded value.
+    // NOTE: rustfmt itself defaults to 4-space indent for the *Rust*
+    // part regardless of `opts.tab_spaces` (it reads rustfmt.toml, not
+    // our opts), so we assert on the MACRO-BODY indentation, which the
+    // whisker pretty-printer controls via `opts.tab_spaces`.
+    let src =
+        "fn ui() -> Element {\n    render! { view(style: \"x\") { text(value: \"hi\") } }\n}\n";
+    let four = format_source(src, &opts(4, 100)).unwrap();
+    let two = format_source(src, &opts(2, 100)).unwrap();
+    assert_ne!(four, two, "tab_spaces must change macro indentation");
+}

--- a/crates/whisker-macro-syntax/Cargo.toml
+++ b/crates/whisker-macro-syntax/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "whisker-macro-syntax"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Shared parse AST for Whisker's `render!` and `css!` macros — consumed by whisker-macros (codegen) and whisker-fmt (formatting)."
+
+# NOTE: this is a plain library crate, NOT a proc-macro crate. It holds
+# only the `syn::parse::Parse` side of the DSLs so a non-proc-macro
+# consumer (the formatter) can re-parse macro bodies and pretty-print
+# them. Codegen (`to_tokens`) stays in `whisker-macros`.
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/crates/whisker-macro-syntax/src/css.rs
+++ b/crates/whisker-macro-syntax/src/css.rs
@@ -1,0 +1,72 @@
+//! Parse AST for the `css!` macro — `name: value` kwargs.
+//!
+//! The codegen (in `whisker-macros`) lowers a parsed [`CssInput`] to a
+//! `Css::new().name(value).…` method chain. This crate holds only the
+//! parse side so the formatter can re-parse and pretty-print `css!`
+//! bodies.
+
+use proc_macro2::TokenStream as TokenStream2;
+use syn::parse::{Parse, ParseStream, Result as SynResult};
+use syn::{Expr, Ident, Token};
+
+/// One `name: value` (or just `name`) pair from the macro input.
+pub struct CssKwarg {
+    pub name: Ident,
+    /// `None` when the user has typed an ident but not yet a `: value`.
+    /// Either the `:` was missing, or the value expression failed to
+    /// parse (e.g. cursor sentinel).
+    pub value: Option<Expr>,
+}
+
+/// A parsed `css!` body — a flat list of kwargs.
+pub struct CssInput {
+    pub kwargs: Vec<CssKwarg>,
+}
+
+impl Parse for CssInput {
+    fn parse(input: ParseStream) -> SynResult<Self> {
+        let mut kwargs = Vec::new();
+        while !input.is_empty() {
+            // Bail out if the next token isn't an ident — RA may
+            // inject other sentinels we don't want to chase. The
+            // already-collected kwargs still produce a useful
+            // expansion.
+            if !input.peek(Ident) {
+                break;
+            }
+            let name: Ident = input.parse()?;
+
+            let value = if input.peek(Token![:]) {
+                let _: Token![:] = input.parse()?;
+                // Try to parse the value expression. If the user is
+                // mid-typing and the parse fails, fall through with
+                // `None`; the emitter uses `()` so the method-call
+                // shape survives for RA's completion.
+                input.parse::<Expr>().ok()
+            } else {
+                // No `:` yet — cursor sits right after the ident.
+                None
+            };
+
+            kwargs.push(CssKwarg { name, value });
+
+            if input.peek(Token![,]) {
+                let _: Token![,] = input.parse()?;
+            } else {
+                // No comma, but the stream might still have trailing
+                // tokens (e.g. an unfinished partial after the last
+                // kwarg). Drain them so the macro doesn't error out.
+                while !input.is_empty() {
+                    let _: proc_macro2::TokenTree = input.parse()?;
+                }
+                break;
+            }
+        }
+        Ok(CssInput { kwargs })
+    }
+}
+
+/// Convenience: parse a `css!` body from a token stream.
+pub fn parse_input(tokens: TokenStream2) -> SynResult<CssInput> {
+    syn::parse2(tokens)
+}

--- a/crates/whisker-macro-syntax/src/lib.rs
+++ b/crates/whisker-macro-syntax/src/lib.rs
@@ -1,0 +1,26 @@
+//! Shared parse AST for Whisker's `render!` and `css!` macros.
+//!
+//! This crate holds ONLY the parse side (the AST structs/enums plus
+//! their [`syn::parse::Parse`] impls). It is deliberately NOT a
+//! proc-macro crate, so it can be linked into ordinary binaries — in
+//! particular `whisker-fmt`, which re-parses macro bodies in order to
+//! reformat them.
+//!
+//! The codegen side (the `to_tokens` lowering) lives in
+//! `whisker-macros`. Because these types are now defined here, the
+//! orphan rule forbids `whisker-macros` from adding *inherent* methods
+//! to them; the lowering is expressed there as free functions over
+//! `&Root` / `&Node` / … (see `whisker-macros/src/render.rs`).
+//!
+//! Spans are retained throughout the AST (every ident / expr carries
+//! its `proc_macro2::Span`) so the formatter can recover source slices
+//! and comment trivia.
+
+pub mod css;
+pub mod render;
+
+pub use css::{CssInput, CssKwarg};
+pub use render::{
+    is_builtin_tag, is_pascal_case, snake_to_pascal, ElementNode, Kwarg, Node, Root,
+    UserComponentNode,
+};

--- a/crates/whisker-macro-syntax/src/render.rs
+++ b/crates/whisker-macro-syntax/src/render.rs
@@ -1,0 +1,263 @@
+//! Parse AST for the `render!` macro — compose-style, kwarg-only DSL.
+//!
+//! ```text
+//! root      := node
+//! node      := IDENT ( '(' kwargs ')' )? ( '{' children '}' )?
+//! kwargs    := IDENT ':' expr ( ',' IDENT ':' expr )* ','?
+//!            | IDENT                           # partial (mid-typing)
+//! children  := node*
+//! ```
+//!
+//! Each `node` is classified by its leading ident:
+//!
+//! - Built-in tag (`view`, `page`, `text`, `raw_text`,
+//!   `scroll_view`) → [`Node::Element`].
+//! - `children()` (lowercase ident + empty parens, no block) →
+//!   [`Node::ChildrenSlot`].
+//! - Anything else → user `#[component]` invocation →
+//!   [`Node::UserComponent`].
+//!
+//! ## Children-block restriction
+//!
+//! Every item in a `{ … }` children block MUST be node-shaped
+//! (`IDENT(kwargs?) { … }?`). Bare string literals and bare
+//! `{expr}` blocks are rejected with a hard parser error (see the
+//! comment in [`Node`]'s `Parse` impl for why — it keeps the block on
+//! rust-analyzer's completion happy-path).
+
+use proc_macro2::TokenStream as TokenStream2;
+use syn::{
+    braced,
+    ext::IdentExt,
+    parenthesized,
+    parse::{Parse, ParseStream, Result},
+    token, Expr, Ident, LitStr, Token,
+};
+
+// ---- AST ----------------------------------------------------------------
+
+/// Root of a `render!` body — exactly one top-level [`Node`].
+pub struct Root {
+    pub node: Node,
+}
+
+impl Parse for Root {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            node: input.parse()?,
+        })
+    }
+}
+
+/// A single node in the `render!` tree.
+pub enum Node {
+    Element(ElementNode),
+    UserComponent(UserComponentNode),
+    /// `children()` — the lone special-cased ident in the children
+    /// grammar. Lowers (in `whisker-macros`) to
+    /// `::whisker::runtime::view::mount_children(&children)`.
+    ChildrenSlot {
+        span: proc_macro2::Span,
+    },
+}
+
+/// A built-in element (`view`, `text`, …).
+pub struct ElementNode {
+    pub tag: Ident,
+    pub kwargs: Vec<Kwarg>,
+    pub children: Vec<Node>,
+}
+
+/// A user `#[component]` invocation.
+pub struct UserComponentNode {
+    /// PascalCase ident the call site resolves to (the public
+    /// re-exported alias the `#[component]` macro emits). Derived from
+    /// whichever casing the author wrote.
+    pub alias_ident: Ident,
+    pub kwargs: Vec<Kwarg>,
+    pub children: Vec<Node>,
+}
+
+/// One `name: value` (or partial `name`) pair.
+pub struct Kwarg {
+    pub name: Ident,
+    pub value: Expr,
+    /// `true` when the user hasn't typed `:` + an expression yet
+    /// (cursor sits at the end of the kwarg name). `value` is then a
+    /// synthesized `()` placeholder.
+    pub partial: bool,
+}
+
+impl Parse for Node {
+    fn parse(input: ParseStream) -> Result<Self> {
+        // Every node starts with an ident. Reject anything else at
+        // this position with a targeted error message — that's the
+        // only way to give a useful hint when the user writes bare
+        // `"hi"` or `{ count }` as a child.
+        if input.peek(LitStr) {
+            let lit: LitStr = input.parse()?;
+            return Err(syn::Error::new(
+                lit.span(),
+                "bare string literals are not allowed in render!; \
+                 use `text(value: \"…\")` to render text content",
+            ));
+        }
+        if input.peek(token::Brace) {
+            // Take the span from the brace itself for a clean
+            // arrow in the diagnostic.
+            let body;
+            let _ = braced!(body in input);
+            let _ = body; // discard contents — we're erroring out
+            return Err(input.error(
+                "bare `{expr}` blocks are not allowed in render!; \
+                 use `text(value: <expr>)` to render dynamic text",
+            ));
+        }
+
+        let tag: Ident = input.parse()?;
+
+        // Special-case the `children()` slot before the regular
+        // kwarg path runs. Shape requirements:
+        //   - ident `children`
+        //   - immediately followed by an EMPTY paren group `()`
+        //   - no `{ … }` block after it
+        // Anything else (`children(arg)`, `children { … }`, bare
+        // `children`) falls through to the standard tag path.
+        if tag == "children" && input.peek(token::Paren) {
+            // Speculative parse of the paren body — we only commit
+            // to the slot interpretation if the body is empty AND
+            // no `{}` block follows.
+            let fork = input.fork();
+            let body;
+            parenthesized!(body in fork);
+            if body.is_empty() && !fork.peek(token::Brace) {
+                // Consume the same tokens off the real input cursor
+                // now that we've decided.
+                let consume;
+                parenthesized!(consume in input);
+                debug_assert!(consume.is_empty());
+                return Ok(Node::ChildrenSlot { span: tag.span() });
+            }
+            // Not a slot — fall through to the regular tag path.
+        }
+
+        let mut kwargs = Vec::new();
+        if input.peek(token::Paren) {
+            let body;
+            parenthesized!(body in input);
+            while !body.is_empty() {
+                // `Ident::peek_any` / `Ident::parse_any` admits
+                // raw-style identifiers AND Rust keywords (needed for
+                // the `ref:` kwarg).
+                if !body.peek(syn::Ident::peek_any) {
+                    return Err(body.error(
+                        "kwargs must be `name: expr` — positional arguments \
+                         not allowed",
+                    ));
+                }
+                let name: Ident = body.call(syn::Ident::parse_any)?;
+                let (value, partial) = if body.peek(Token![:]) {
+                    body.parse::<Token![:]>()?;
+                    (body.parse::<Expr>()?, false)
+                } else {
+                    // Partial — synthesize `()` as a placeholder so
+                    // the emitter can still place the method-name
+                    // token at the user's source span.
+                    let placeholder: Expr = syn::parse_quote_spanned!(name.span()=> ());
+                    (placeholder, true)
+                };
+                kwargs.push(Kwarg {
+                    name,
+                    value,
+                    partial,
+                });
+                if body.peek(Token![,]) {
+                    body.parse::<Token![,]>()?;
+                }
+            }
+        }
+
+        let mut children = Vec::new();
+        if input.peek(token::Brace) {
+            let body;
+            braced!(body in input);
+            while !body.is_empty() {
+                children.push(body.parse::<Node>()?);
+            }
+        }
+
+        let name = tag.to_string();
+        // Classification by casing + whitelist:
+        //
+        //   snake_case + in built-in whitelist  → Element (Lynx tag)
+        //   PascalCase (anything)                → UserComponent
+        //   snake_case + not in whitelist        → UserComponent
+        //                                          (back-compat path)
+        if is_builtin_tag(&name) {
+            Ok(Node::Element(ElementNode {
+                tag,
+                kwargs,
+                children,
+            }))
+        } else {
+            let span = tag.span();
+            let alias_str = if is_pascal_case(&name) {
+                name.clone()
+            } else {
+                snake_to_pascal(&name)
+            };
+            let alias_ident = Ident::new(&alias_str, span);
+            Ok(Node::UserComponent(UserComponentNode {
+                alias_ident,
+                kwargs,
+                children,
+            }))
+        }
+    }
+}
+
+// ---- Classification helpers (parse-time) --------------------------------
+
+/// `my_card` → `MyCard`. Snake-to-PascalCase for the back-compat
+/// snake_case path of user components in `render!`.
+pub fn snake_to_pascal(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut upper_next = true;
+    for c in name.chars() {
+        if c == '_' {
+            upper_next = true;
+            continue;
+        }
+        if upper_next {
+            for u in c.to_uppercase() {
+                out.push(u);
+            }
+            upper_next = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Lowercase identifiers that lower to `view::create_element` calls
+/// rather than user component invocations. Matches the `ElementTag`
+/// enum + the C bridge's `whisker_bridge_create_element` switch.
+pub fn is_builtin_tag(name: &str) -> bool {
+    matches!(
+        name,
+        "page" | "view" | "text" | "raw_text" | "scroll_view" | "list" | "fragment"
+    )
+}
+
+/// `true` if `name`'s first character is ASCII uppercase. Used to
+/// route PascalCase idents (user components / control flow) away
+/// from the snake_case-only Element path.
+pub fn is_pascal_case(name: &str) -> bool {
+    name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+}
+
+/// Convenience: parse a `render!` body from a token stream.
+pub fn parse_root(tokens: TokenStream2) -> Result<Root> {
+    syn::parse2(tokens)
+}

--- a/crates/whisker-macros/Cargo.toml
+++ b/crates/whisker-macros/Cargo.toml
@@ -18,6 +18,10 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
+# Shared parse AST for `render!` / `css!`. The codegen in
+# `render.rs` / `css.rs` consumes these types via free functions —
+# the orphan rule forbids inherent methods on the now-foreign types.
+whisker-macro-syntax = { workspace = true }
 
 # tests/ra_completion.rs drives rust-analyzer over LSP to verify
 # that `render! { view(sty|) }` and friends actually surface the

--- a/crates/whisker-macros/src/css.rs
+++ b/crates/whisker-macros/src/css.rs
@@ -1,81 +1,21 @@
-//! `css!` macro — builds a [`Css`] value from `name: value` kwargs.
+//! `css!` macro codegen — builds a [`Css`] value from `name: value`
+//! kwargs.
+//!
+//! The PARSE side (`CssInput` / `CssKwarg` + their `Parse` impl) lives
+//! in `whisker-macro-syntax`; this module holds only the lowering.
 //!
 //! Emitted as a proc macro (not `macro_rules!`) so partial input
 //! produced by rust-analyzer's completion engine still lowers to a
-//! well-formed method-call chain. The trick mirrors what `render!`
-//! does for partial element kwargs: every kwarg becomes
-//! `.<name>(<value>)` in the expansion, and when the value is
-//! missing (cursor sitting after `name` but before `:`), we emit
-//! `.<name>(())` so RA's method-name completion fires on the
-//! `.<name>` part. The unit value `()` is intentionally
-//! type-incorrect; the user is mid-typing, the program won't
-//! compile anyway, and RA discards expansions whose only error is
-//! at the cursor's sentinel.
+//! well-formed method-call chain. Every kwarg becomes `.<name>(<value>)`
+//! in the expansion, and when the value is missing (cursor sitting
+//! after `name` but before `:`), we emit `.<name>(())` so RA's
+//! method-name completion fires on the `.<name>` part.
 //!
 //! [`Css`]: whisker_css::Css
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
-use syn::parse::{Parse, ParseStream, Result as SynResult};
-use syn::{Expr, Ident, Token};
-
-/// One `name: value` (or just `name`) pair from the macro input.
-struct Kwarg {
-    name: Ident,
-    /// `None` when the user has typed an ident but not yet a `: value`.
-    /// Either the `:` was missing, or the value expression failed to
-    /// parse (e.g. cursor sentinel). The emitter substitutes `()`
-    /// so the expansion is still a method call.
-    value: Option<Expr>,
-}
-
-struct Input {
-    kwargs: Vec<Kwarg>,
-}
-
-impl Parse for Input {
-    fn parse(input: ParseStream) -> SynResult<Self> {
-        let mut kwargs = Vec::new();
-        while !input.is_empty() {
-            // Bail out if the next token isn't an ident — RA may
-            // inject other sentinels we don't want to chase. The
-            // already-collected kwargs still produce a useful
-            // expansion.
-            if !input.peek(Ident) {
-                break;
-            }
-            let name: Ident = input.parse()?;
-
-            let value = if input.peek(Token![:]) {
-                let _: Token![:] = input.parse()?;
-                // Try to parse the value expression. If the user is
-                // mid-typing and the parse fails, fall through with
-                // `None`; the emitter uses `()` so the method-call
-                // shape survives for RA's completion.
-                input.parse::<Expr>().ok()
-            } else {
-                // No `:` yet — cursor sits right after the ident.
-                None
-            };
-
-            kwargs.push(Kwarg { name, value });
-
-            if input.peek(Token![,]) {
-                let _: Token![,] = input.parse()?;
-            } else {
-                // No comma, but the stream might still have trailing
-                // tokens (e.g. an unfinished partial after the last
-                // kwarg). Drain them so the macro doesn't error out
-                // and RA still sees the completed-up-to-cursor part.
-                while !input.is_empty() {
-                    let _: proc_macro2::TokenTree = input.parse()?;
-                }
-                break;
-            }
-        }
-        Ok(Input { kwargs })
-    }
-}
+use whisker_macro_syntax::css::CssInput;
 
 /// Expand `css!(name: value, …)` into `Css::new().name(value).…`.
 ///
@@ -85,7 +25,7 @@ impl Parse for Input {
 /// from both `whisker` (umbrella) and `whisker-css` standalone
 /// without runtime-aware path detection.
 pub fn expand(input: TokenStream2) -> TokenStream2 {
-    let parsed: Input = match syn::parse2(input) {
+    let parsed: CssInput = match syn::parse2(input) {
         Ok(p) => p,
         // On total parse failure, still emit the root `Css::new()`
         // so the user sees a real type at the cursor instead of a

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -1,69 +1,30 @@
-//! `render!` macro — compose-style, kwarg-only DSL.
+//! `render!` macro codegen — compose-style, kwarg-only DSL.
 //!
-//! ```text
-//! root      := node
-//! node      := IDENT ( '(' kwargs ')' )? ( '{' children '}' )?
-//! kwargs    := IDENT ':' expr ( ',' IDENT ':' expr )* ','?
-//!            | IDENT                           # partial (mid-typing)
-//! children  := node*
-//! ```
+//! The PARSE side (AST + `syn::parse::Parse` impls + classification
+//! helpers) lives in the `whisker-macro-syntax` crate so both this
+//! codegen AND the `whisker-fmt` formatter can share it. This module
+//! holds only the lowering.
 //!
-//! Each `node` is classified by its leading ident:
+//! Because the AST types ([`Root`], [`Node`], …) are now defined in
+//! another crate, the orphan rule forbids adding *inherent* methods to
+//! them here. The lowering is therefore expressed as FREE FUNCTIONS
+//! over `&Root` / `&Node` / `&ElementNode` / `&UserComponentNode`
+//! (`root_to_tokens`, `node_to_tokens`, …). The emitted token streams
+//! are byte-for-byte identical to the previous inherent-method form, so
+//! all existing macro behavior and tests are preserved.
 //!
-//! - Built-in tag (`view`, `page`, `text`, `raw_text`,
-//!   `scroll_view`) → lowered to a builder chain
-//!   `::whisker::__tags::__<tag>_ctor().style(…).…__h()`.
-//! - `Show` / `For` → lowered to the matching `whisker::show` /
-//!   `whisker::for_each` helper.
-//! - `children()` (lowercase ident + empty parens, no block) → lowered
-//!   to `view::mount_children(&children)`. Mounts the surrounding
-//!   `#[component]`'s `children: Children` prop at this position.
-//!   Anywhere a regular node would go; can appear multiple times for
-//!   multi-projection. See `mount_children` in `whisker-runtime`.
-//! - Anything else → user `#[component]` invocation; lowered to
-//!   `name(<Name>Props::builder().k(v)…build())`.
-//!
-//! ## Children-block restriction
-//!
-//! Every item in a `{ … }` children block MUST be node-shaped
-//! (`IDENT(kwargs?) { … }?`). Bare string literals and bare
-//! `{expr}` blocks are rejected with a hard parser error.
-//!
-//! Why: RA experiments (kept as integration tests in
-//! `tests/ra_completion.rs`) showed that
-//! rust-analyzer's input fixup gives up on children blocks that
-//! contain anything other than `IDENT(name: value, …)` shapes at
-//! their top level. With a bare `"hi"` or `{count}` present, the
-//! sibling element's kwarg-position completion stops working — no
-//! emission-side workaround helped. The fix is to forbid those
-//! shapes at the DSL level so the block stays on RA's happy path.
-//!
-//! For text content, use a kwarg-styled element:
-//!
-//! ```ignore
-//! render! {
-//!     view(style: "...") {
-//!         text(value: "Hello")
-//!         text(value: format!("count: {}", c.get()))
-//!     }
-//! }
-//! ```
+//! See `whisker-macro-syntax/src/render.rs` for the grammar.
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, quote_spanned};
-use syn::{
-    braced,
-    ext::IdentExt,
-    parenthesized,
-    parse::{Parse, ParseStream, Result},
-    token, Expr, Ident, LitStr, Token,
-};
+use syn::LitStr;
+use whisker_macro_syntax::render::{ElementNode, Kwarg, Node, Root, UserComponentNode};
 
 pub fn expand(input: TokenStream) -> TokenStream {
     let tokens: TokenStream2 = input.into();
     match syn::parse2::<Root>(tokens) {
-        Ok(root) => root.to_tokens().into(),
+        Ok(root) => root_to_tokens(&root).into(),
         Err(err) => {
             // Pair the compile_error with a same-typed placeholder
             // so the surrounding code (`let h: Element = render!
@@ -88,469 +49,197 @@ pub fn expand(input: TokenStream) -> TokenStream {
 #[cfg(test)]
 fn expand_test(input: TokenStream2) -> TokenStream2 {
     let root: Root = syn::parse2(input).expect("test input must parse");
-    root.to_tokens()
-}
-
-// ---- AST ----------------------------------------------------------------
-
-struct Root {
-    node: Node,
-}
-
-impl Parse for Root {
-    fn parse(input: ParseStream) -> Result<Self> {
-        Ok(Self {
-            node: input.parse()?,
-        })
-    }
-}
-
-enum Node {
-    Element(ElementNode),
-    UserComponent(UserComponentNode),
-    /// `children()` — the lone special-cased ident in the children
-    /// grammar. Lowers to
-    /// `::whisker::runtime::view::mount_children(&children)` so the
-    /// surrounding `#[component]`'s `children: Children` prop gets
-    /// realised at this position. See `mount_children` in
-    /// `crates/whisker-runtime/src/view/into_view.rs` for the
-    /// phantom-mount mechanics.
-    ChildrenSlot {
-        span: proc_macro2::Span,
-    },
-}
-
-struct ElementNode {
-    tag: Ident,
-    kwargs: Vec<Kwarg>,
-    children: Vec<Node>,
-}
-
-struct UserComponentNode {
-    /// PascalCase ident the call site resolves to. `#[component]`
-    /// emits a `pub use __<name>_inner::<fn> as <PascalCase>;`
-    /// alias under this name; the snake_case fn itself lives
-    /// inside the inner module and isn't reachable from outer
-    /// scope, so the emission MUST go through this alias.
-    alias_ident: Ident,
-    kwargs: Vec<Kwarg>,
-    children: Vec<Node>,
-}
-
-struct Kwarg {
-    name: Ident,
-    value: Expr,
-    /// `true` when the user hasn't typed `:` + an expression yet
-    /// (cursor sits at the end of the kwarg name). The builder-
-    /// chain emitter routes these through `.#name(())` so RA's
-    /// method completion can fire on the partial prefix.
-    partial: bool,
-}
-
-impl Parse for Node {
-    fn parse(input: ParseStream) -> Result<Self> {
-        // Every node starts with an ident. Reject anything else at
-        // this position with a targeted error message — that's the
-        // only way to give a useful hint when the user writes bare
-        // `"hi"` or `{ count }` as a child.
-        if input.peek(LitStr) {
-            let lit: LitStr = input.parse()?;
-            return Err(syn::Error::new(
-                lit.span(),
-                "bare string literals are not allowed in render!; \
-                 use `text(value: \"…\")` to render text content",
-            ));
-        }
-        if input.peek(token::Brace) {
-            // Take the span from the brace itself for a clean
-            // arrow in the diagnostic.
-            let body;
-            let _ = braced!(body in input);
-            let _ = body; // discard contents — we're erroring out
-            return Err(input.error(
-                "bare `{expr}` blocks are not allowed in render!; \
-                 use `text(value: <expr>)` to render dynamic text",
-            ));
-        }
-
-        let tag: Ident = input.parse()?;
-
-        // Special-case the `children()` slot before the regular
-        // kwarg path runs. Shape requirements:
-        //   - ident `children`
-        //   - immediately followed by an EMPTY paren group `()`
-        //   - no `{ … }` block after it
-        // Anything else (`children(arg)`, `children { … }`, bare
-        // `children`) falls through to the standard tag path, so a
-        // user `#[component] fn children(…)` would still resolve
-        // correctly via the snake_case → PascalCase route. The
-        // empty-paren requirement keeps RA's "you typed `children` —
-        // suggest completions" behaviour usable; the `()` is the
-        // explicit signal "this is the slot, not an arbitrary ident".
-        if tag == "children" && input.peek(token::Paren) {
-            // Speculative parse of the paren body — we only commit
-            // to the slot interpretation if the body is empty AND
-            // no `{}` block follows.
-            let fork = input.fork();
-            let body;
-            parenthesized!(body in fork);
-            if body.is_empty() && !fork.peek(token::Brace) {
-                // Consume the same tokens off the real input cursor
-                // now that we've decided.
-                let consume;
-                parenthesized!(consume in input);
-                debug_assert!(consume.is_empty());
-                return Ok(Node::ChildrenSlot { span: tag.span() });
-            }
-            // Not a slot — fall through to the regular tag path.
-            // The paren tokens are still on `input` for the
-            // `parenthesized!` call below to consume.
-        }
-
-        let mut kwargs = Vec::new();
-        if input.peek(token::Paren) {
-            let body;
-            parenthesized!(body in input);
-            while !body.is_empty() {
-                // `Ident::peek_any` / `Ident::parse_any` admits
-                // raw-style identifiers AND Rust keywords. Required
-                // for the `ref:` kwarg (the most natural call-site
-                // name; `ref` itself is a Rust keyword). Plain
-                // `body.peek(Ident)` would reject `ref` outright;
-                // `peek_any` lets it through as an `Ident` whose text
-                // is `"ref"`, and the `name_str == "ref"` branch below
-                // routes it to the `.with_ref(...)` setter.
-                if !body.peek(syn::Ident::peek_any) {
-                    return Err(body.error(
-                        "kwargs must be `name: expr` — positional arguments \
-                         not allowed",
-                    ));
-                }
-                let name: Ident = body.call(syn::Ident::parse_any)?;
-                let (value, partial) = if body.peek(Token![:]) {
-                    body.parse::<Token![:]>()?;
-                    (body.parse::<Expr>()?, false)
-                } else {
-                    // Partial — synthesize `()` as a placeholder so
-                    // the emitter can still place the method-name
-                    // token at the user's source span.
-                    let placeholder: Expr = syn::parse_quote_spanned!(name.span()=> ());
-                    (placeholder, true)
-                };
-                kwargs.push(Kwarg {
-                    name,
-                    value,
-                    partial,
-                });
-                if body.peek(Token![,]) {
-                    body.parse::<Token![,]>()?;
-                }
-            }
-        }
-
-        let mut children = Vec::new();
-        if input.peek(token::Brace) {
-            let body;
-            braced!(body in input);
-            while !body.is_empty() {
-                children.push(body.parse::<Node>()?);
-            }
-        }
-
-        let name = tag.to_string();
-        // Classification by casing + whitelist:
-        //
-        //   snake_case + in built-in whitelist  → Element (Lynx tag)
-        //   PascalCase (anything)                → UserComponent
-        //                                          (preferred: PascalCase
-        //                                          alias from #[component])
-        //   snake_case + not in whitelist        → UserComponent
-        //                                          (back-compat path:
-        //                                          fn name as-is, Props
-        //                                          derived from snake_case)
-        //
-        // The PascalCase form is the canonical convention now (matches
-        // React / Leptos / Solid). Snake_case stays parseable so:
-        //   (1) mid-typing partials (`vie|`) don't blow up the macro
-        //       — RA needs the expansion to succeed for completion,
-        //   (2) older code calling snake_case names keeps compiling.
-        //
-        // Built-in control flow (`ForEach` / `Show`) is no longer
-        // special-cased: those are `#[component]` functions in the
-        // `whisker` crate (see `crates/whisker/src/control_flow.rs`)
-        // and resolve through the UserComponent path just like a
-        // user-implemented control flow.
-        if is_builtin_tag(&name) {
-            Ok(Node::Element(ElementNode {
-                tag,
-                kwargs,
-                children,
-            }))
-        } else {
-            // User component. Derive `alias_ident` (PascalCase —
-            // the public re-exported name) and `props_ident`
-            // (PascalCase + "Props") from whichever form the user
-            // wrote. The snake_case fn itself stays inside the
-            // inner module and we never reference it directly
-            // from the lowering.
-            let span = tag.span();
-            let alias_str = if is_pascal_case(&name) {
-                name.clone()
-            } else {
-                snake_to_pascal(&name)
-            };
-            let alias_ident = Ident::new(&alias_str, span);
-            Ok(Node::UserComponent(UserComponentNode {
-                alias_ident,
-                kwargs,
-                children,
-            }))
-        }
-    }
-}
-
-/// `my_card` → `MyCard`. Snake-to-PascalCase for the back-compat
-/// snake_case path of user components in `render!`.
-fn snake_to_pascal(name: &str) -> String {
-    let mut out = String::with_capacity(name.len());
-    let mut upper_next = true;
-    for c in name.chars() {
-        if c == '_' {
-            upper_next = true;
-            continue;
-        }
-        if upper_next {
-            for u in c.to_uppercase() {
-                out.push(u);
-            }
-            upper_next = false;
-        } else {
-            out.push(c);
-        }
-    }
-    out
-}
-
-/// Lowercase identifiers that lower to `view::create_element` calls
-/// rather than user component invocations. Matches the `ElementTag`
-/// enum + the C bridge's `whisker_bridge_create_element` switch.
-fn is_builtin_tag(name: &str) -> bool {
-    matches!(
-        name,
-        "page" | "view" | "text" | "raw_text" | "scroll_view" | "list" | "fragment"
-    )
-    // `list_item` is intentionally NOT exposed as a user-writable
-    // tag. The `list` render-props builder auto-wraps every
-    // `children(item)` result in a `<list-item>` for the Lynx
-    // platform UI layer's UIComponent contract — there's no path
-    // for user code to reach a list-item, so surfacing it would
-    // only invite confusion. The `__list_item_ctor` builder is
-    // kept in `__tags` as a `pub(crate)` runtime helper the list
-    // builder calls directly.
-}
-
-/// `true` if `name`'s first character is ASCII uppercase. Used to
-/// route PascalCase idents (user components / control flow) away
-/// from the snake_case-only Element path.
-fn is_pascal_case(name: &str) -> bool {
-    name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+    root_to_tokens(&root)
 }
 
 // ---- Codegen ------------------------------------------------------------
 
-impl Root {
-    fn to_tokens(&self) -> TokenStream2 {
-        self.node.to_tokens_returning_handle()
+fn root_to_tokens(root: &Root) -> TokenStream2 {
+    node_to_tokens_returning_handle(&root.node)
+}
+
+fn node_to_tokens_returning_handle(node: &Node) -> TokenStream2 {
+    match node {
+        Node::Element(el) => element_to_tokens(el),
+        Node::UserComponent(u) => user_component_to_tokens(u),
+        // `children()` resolves the surrounding `#[component]`'s
+        // `children: Children` prop by name. The body of a
+        // `#[component]` fn always destructures `children` into
+        // scope when the prop is declared, so this is a plain
+        // local-ident reference — no closure capture, no `move`,
+        // and (crucially) no `Rc::clone` either: `mount_children`
+        // takes `&Children` so the outer `FnMut` body can re-run
+        // (e.g. hot-reload remount) without `cannot move out`.
+        Node::ChildrenSlot { span } => quote_spanned! {*span=>
+            ::whisker::runtime::view::mount_children(&children)
+        },
     }
 }
 
-impl Node {
-    fn to_tokens_returning_handle(&self) -> TokenStream2 {
-        match self {
-            Node::Element(el) => el.to_tokens(),
-            Node::UserComponent(u) => u.to_tokens(),
-            // `children()` resolves the surrounding `#[component]`'s
-            // `children: Children` prop by name. The body of a
-            // `#[component]` fn always destructures `children` into
-            // scope when the prop is declared, so this is a plain
-            // local-ident reference — no closure capture, no `move`,
-            // and (crucially) no `Rc::clone` either: `mount_children`
-            // takes `&Children` so the outer `FnMut` body can re-run
-            // (e.g. hot-reload remount) without `cannot move out`.
-            Node::ChildrenSlot { span } => quote_spanned! {*span=>
-                ::whisker::runtime::view::mount_children(&children)
-            },
-        }
+/// Emit a `View`-shaped expression. Used by `Show` and `For`'s
+/// children-callback case; each child needs to be wrapped via
+/// `IntoView::into_view(…)` for the helper's signature.
+fn node_to_tokens_as_view(node: &Node) -> TokenStream2 {
+    let h = node_to_tokens_returning_handle(node);
+    quote! {
+        ::whisker::runtime::view::IntoView::into_view(#h)
+    }
+}
+
+/// Lower a built-in element to a builder chain on
+/// `::whisker::__tags::<tag>`. The inline-chain form
+/// (`__tags::__view_ctor().style(…).…__h()` with no intermediate
+/// `let __h = …; __h` binding) is load-bearing: a let-binding breaks
+/// RA's receiver-type threading and kills kwarg completion. See
+/// `tests/ra_completion.rs`.
+fn element_to_tokens(el: &ElementNode) -> TokenStream2 {
+    let tag_ident = &el.tag;
+    let tag_name = tag_ident.to_string();
+    let tag_span = tag_ident.span();
+    let ctor_ident = format_ident!("__{}_ctor", tag_ident, span = tag_span);
+    // Inline the full `::whisker::__tags::__<tag>_ctor()` path
+    // into the outer `quote!`s below. Storing it into an
+    // intermediate TokenStream and interpolating captures span /
+    // grouping info differently and breaks RA's kwarg completion.
+
+    // One `.kwarg(value)` token group per attr, span-anchored
+    // at the user's kwarg-name source position so RA's
+    // method-name completion lands on the right token.
+    let setter_calls: Vec<TokenStream2> = el
+        .kwargs
+        .iter()
+        .filter_map(|kw| element_kwarg_to_setter(el, kw))
+        .collect();
+
+    // Every partial kwarg routes through the setter chain as a
+    // method call — see the long comment in `element_kwarg_to_setter`.
+    let ident_refs: Vec<TokenStream2> = Vec::new();
+    let _ = tag_name;
+
+    // Children: each child becomes a `.child({ inner_chain })`
+    // method call on the builder.
+    let child_calls: Vec<TokenStream2> = el
+        .children
+        .iter()
+        .map(|c| {
+            let inner = node_to_tokens_returning_handle(c);
+            quote! { .child(#inner) }
+        })
+        .collect();
+
+    // No children AND no ident-refs → bare expression form.
+    // Keeps the chain on RA's happy path for partial-kwarg
+    // completion.
+    if child_calls.is_empty() && ident_refs.is_empty() {
+        return quote! {
+            {
+                use ::whisker::__tags::ElementBuilder as _;
+                ::whisker::__tags::#ctor_ident() #(#setter_calls)* .__h()
+            }
+        };
     }
 
-    /// Emit a `View`-shaped expression. Used by `Show` and
-    /// `For`'s children-callback case; each child needs to be
-    /// wrapped via `IntoView::into_view(…)` for the helper's
-    /// signature.
-    fn to_tokens_as_view(&self) -> TokenStream2 {
-        let h = self.to_tokens_returning_handle();
+    // Has children or ident-refs → still keep chain inline (no
+    // `let __h = … ; __h` binding around it), but add the
+    // ident-refs in a side block. The chain itself stays
+    // a single expression so RA can thread its receiver type.
+    let ident_refs_block = if ident_refs.is_empty() {
+        quote! {}
+    } else {
         quote! {
-            ::whisker::runtime::view::IntoView::into_view(#h)
+            #[allow(dead_code, unused_variables, path_statements)]
+            {
+                #(#ident_refs)*
+            }
+        }
+    };
+
+    if ident_refs.is_empty() {
+        quote! {
+            {
+                use ::whisker::__tags::ElementBuilder as _;
+                ::whisker::__tags::#ctor_ident() #(#setter_calls)* #(#child_calls)* .__h()
+            }
+        }
+    } else {
+        quote! {
+            {
+                use ::whisker::__tags::ElementBuilder as _;
+                #ident_refs_block
+                ::whisker::__tags::#ctor_ident() #(#setter_calls)* #(#child_calls)* .__h()
+            }
         }
     }
 }
 
-impl ElementNode {
-    /// Lower a built-in element to a builder chain on
-    /// `::whisker::__tags::<tag>`. The inline-chain form
-    /// (`__tags::__view_ctor().style(…).…__h()` with no intermediate
-    /// `let __h = …; __h` binding) is load-bearing: a let-binding
-    /// breaks RA's receiver-type threading and kills kwarg
-    /// completion. See `tests/ra_completion.rs`.
-    fn to_tokens(&self) -> TokenStream2 {
-        let tag_ident = &self.tag;
-        let tag_name = tag_ident.to_string();
-        let tag_span = tag_ident.span();
-        let ctor_ident = format_ident!("__{}_ctor", tag_ident, span = tag_span);
-        // Inline the full `::whisker::__tags::__<tag>_ctor()` path
-        // into the outer `quote!`s below. Storing it into an
-        // intermediate TokenStream and interpolating captures span /
-        // grouping info differently and breaks RA's kwarg completion.
+/// Lower one kwarg to a `.method(value)` token group, or `None` if this
+/// kwarg is partial-with-no-method-match (the emitter handles those via
+/// ident-refs instead).
+fn element_kwarg_to_setter(el: &ElementNode, kw: &Kwarg) -> Option<TokenStream2> {
+    let name = &kw.name;
+    let value = &kw.value;
+    let name_str = name.to_string();
+    let span = name.span();
+    let tag_name = el.tag.to_string();
 
-        // One `.kwarg(value)` token group per attr, span-anchored
-        // at the user's kwarg-name source position so RA's
-        // method-name completion lands on the right token.
-        let setter_calls: Vec<TokenStream2> = self
-            .kwargs
-            .iter()
-            .filter_map(|kw| self.kwarg_to_setter(kw))
-            .collect();
-
-        // Every partial kwarg routes through the setter chain as a
-        // method call — see the long comment in `kwarg_to_setter`.
-        let ident_refs: Vec<TokenStream2> = Vec::new();
-        let _ = tag_name;
-
-        // Children: each child becomes a `.child({ inner_chain })`
-        // method call on the builder.
-        let child_calls: Vec<TokenStream2> = self
-            .children
-            .iter()
-            .map(|c| {
-                let inner = c.to_tokens_returning_handle();
-                quote! { .child(#inner) }
-            })
-            .collect();
-
-        // No children AND no ident-refs → bare expression form.
-        // Keeps the chain on RA's happy path for partial-kwarg
-        // completion.
-        if child_calls.is_empty() && ident_refs.is_empty() {
-            return quote! {
-                {
-                    use ::whisker::__tags::ElementBuilder as _;
-                    ::whisker::__tags::#ctor_ident() #(#setter_calls)* .__h()
-                }
-            };
-        }
-
-        // Has children or ident-refs → still keep chain inline (no
-        // `let __h = … ; __h` binding around it), but add the
-        // ident-refs in a side block. The chain itself stays
-        // a single expression so RA can thread its receiver type.
-        let ident_refs_block = if ident_refs.is_empty() {
-            quote! {}
-        } else {
-            quote! {
-                #[allow(dead_code, unused_variables, path_statements)]
-                {
-                    #(#ident_refs)*
-                }
-            }
-        };
-
-        if ident_refs.is_empty() {
-            quote! {
-                {
-                    use ::whisker::__tags::ElementBuilder as _;
-                    ::whisker::__tags::#ctor_ident() #(#setter_calls)* #(#child_calls)* .__h()
-                }
-            }
-        } else {
-            quote! {
-                {
-                    use ::whisker::__tags::ElementBuilder as _;
-                    #ident_refs_block
-                    ::whisker::__tags::#ctor_ident() #(#setter_calls)* #(#child_calls)* .__h()
-                }
-            }
-        }
+    if name_str == "key" && tag_name != "list" {
+        // `key:` on a direct element is a no-op (reconciliation
+        // hint with no semantic effect outside keyed lists). The
+        // `list` builder has its own typed `key` setter for the
+        // keyed-list key extractor closure, so let it through.
+        return None;
     }
 
-    /// Lower one kwarg to a `.method(value)` token group, or
-    /// `None` if this kwarg is partial-with-no-method-match (the
-    /// emitter handles those via ident-refs instead).
-    fn kwarg_to_setter(&self, kw: &Kwarg) -> Option<TokenStream2> {
-        let name = &kw.name;
-        let value = &kw.value;
-        let name_str = name.to_string();
-        let span = name.span();
-        let tag_name = self.tag.to_string();
-
-        if name_str == "key" && tag_name != "list" {
-            // `key:` on a direct element is a no-op (reconciliation
-            // hint with no semantic effect outside keyed lists). The
-            // `list` builder has its own typed `key` setter for the
-            // keyed-list key extractor closure, so let it through.
-            return None;
-        }
-
-        if kw.partial {
-            // ALWAYS emit a method call for partial kwargs. RA
-            // injects a sentinel suffix at the cursor during its
-            // expansion-for-completion pass, so any prefix-match
-            // heuristic (e.g. "only emit `.sty(())` if some builder
-            // method starts with `sty`") sees the suffixed name and
-            // returns false, breaking method-name completion.
-            return Some(quote_spanned! {span=> .#name(()) });
-        }
-
-        let call = if is_known_attr_method(&tag_name, &name_str) {
-            // Named builder attribute method (`style`, `class`, the
-            // universal trait attrs, and per-tag ones like
-            // `scroll_view::bounces`, `text::text_maxline`). The method
-            // takes `impl Into<Signal<T>>` for its semantic `T` and
-            // handles Static / Dynamic dispatch internally; the value
-            // flows as-is and type inference picks the right `From`
-            // (`From<T>` static / `From<ReadSignal<T>>` reactive) — so
-            // `bounces: true` / `text_maxline: 3` /
-            // `mode: ImageMode::AspectFit` all just work.
-            quote_spanned! {span=> .#name(#value) }
-        } else if name_str == "ref" {
-            // `ref: <ElementRef>` on a built-in element → bind the ref
-            // to this element so its UI methods are invokable after
-            // mount. (`ref` is a keyword, so the builder method is
-            // `bind_ref`.)
-            quote_spanned! {span=> .bind_ref(#value) }
-        } else if is_known_event_method(&name_str) {
-            // Typed event helper on `ElementBuilder` — `.on_tap(f)`,
-            // `.on_longpress(f)`, … — where `f` receives a typed
-            // `TouchEvent` / `CustomEvent` / `AnimationEvent`. The
-            // closure flows through unchanged; the builder method
-            // fixes the event type.
-            quote_spanned! {span=> .#name(#value) }
-        } else if let Some(event) = strip_on_prefix(&name_str) {
-            // Unknown event name → raw `WhiskerValue` escape hatch
-            // (`.on("name", |e: WhiskerValue| …)`).
-            let event_lit = LitStr::new(&event, span);
-            quote_spanned! {span=> .on(#event_lit, #value) }
-        } else {
-            // Catch-all → `.attr("kebab-name", value)`. The builder's
-            // `.attr` accepts `impl Into<Signal<T>>` like the named
-            // attr methods; no closure wrapping here either.
-            let kebab = name_str.replace('_', "-");
-            let kebab_lit = LitStr::new(&kebab, span);
-            quote_spanned! {span=>
-                .attr(#kebab_lit, #value)
-            }
-        };
-        Some(call)
+    if kw.partial {
+        // ALWAYS emit a method call for partial kwargs. RA
+        // injects a sentinel suffix at the cursor during its
+        // expansion-for-completion pass, so any prefix-match
+        // heuristic (e.g. "only emit `.sty(())` if some builder
+        // method starts with `sty`") sees the suffixed name and
+        // returns false, breaking method-name completion.
+        return Some(quote_spanned! {span=> .#name(()) });
     }
+
+    let call = if is_known_attr_method(&tag_name, &name_str) {
+        // Named builder attribute method (`style`, `class`, the
+        // universal trait attrs, and per-tag ones like
+        // `scroll_view::bounces`, `text::text_maxline`). The method
+        // takes `impl Into<Signal<T>>` for its semantic `T` and
+        // handles Static / Dynamic dispatch internally; the value
+        // flows as-is and type inference picks the right `From`
+        // (`From<T>` static / `From<ReadSignal<T>>` reactive) — so
+        // `bounces: true` / `text_maxline: 3` /
+        // `mode: ImageMode::AspectFit` all just work.
+        quote_spanned! {span=> .#name(#value) }
+    } else if name_str == "ref" {
+        // `ref: <ElementRef>` on a built-in element → bind the ref
+        // to this element so its UI methods are invokable after
+        // mount. (`ref` is a keyword, so the builder method is
+        // `bind_ref`.)
+        quote_spanned! {span=> .bind_ref(#value) }
+    } else if is_known_event_method(&name_str) {
+        // Typed event helper on `ElementBuilder` — `.on_tap(f)`,
+        // `.on_longpress(f)`, … — where `f` receives a typed
+        // `TouchEvent` / `CustomEvent` / `AnimationEvent`. The
+        // closure flows through unchanged; the builder method
+        // fixes the event type.
+        quote_spanned! {span=> .#name(#value) }
+    } else if let Some(event) = strip_on_prefix(&name_str) {
+        // Unknown event name → raw `WhiskerValue` escape hatch
+        // (`.on("name", |e: WhiskerValue| …)`).
+        let event_lit = LitStr::new(&event, span);
+        quote_spanned! {span=> .on(#event_lit, #value) }
+    } else {
+        // Catch-all → `.attr("kebab-name", value)`. The builder's
+        // `.attr` accepts `impl Into<Signal<T>>` like the named
+        // attr methods; no closure wrapping here either.
+        let kebab = name_str.replace('_', "-");
+        let kebab_lit = LitStr::new(&kebab, span);
+        quote_spanned! {span=>
+            .attr(#kebab_lit, #value)
+        }
+    };
+    Some(call)
 }
 
 /// Kwargs that map to a **named** builder attribute method
@@ -703,77 +392,72 @@ fn is_known_event_method(name: &str) -> bool {
 
 // ---- User-component codegen ---------------------------------------------
 
-impl UserComponentNode {
-    fn to_tokens(&self) -> TokenStream2 {
-        let fn_ident = &self.alias_ident;
+fn user_component_to_tokens(uc: &UserComponentNode) -> TokenStream2 {
+    let fn_ident = &uc.alias_ident;
 
-        let setter_calls: Vec<TokenStream2> = self
-            .kwargs
-            .iter()
-            .map(|kw| {
-                let name = &kw.name;
-                let name_str = name.to_string();
-                let span = name.span();
-                if kw.partial {
-                    // Partial kwarg on a user component → emit
-                    // `.name(())` so typed-builder's per-field
-                    // setter shows up under RA's method completion.
-                    quote_spanned! {span=> .#name(()) }
-                } else if name_str == "ref" {
-                    // `ref:` is the canonical call-site name for the
-                    // implicit ElementRef prop. `ref` is a Rust
-                    // keyword so the setter is exposed as
-                    // `.with_ref(...)`; re-route here.
-                    let value = &kw.value;
-                    quote_spanned! {span=> .with_ref(#value) }
-                } else {
-                    let value = &kw.value;
-                    quote_spanned! {span=> .#name(#value) }
-                }
-            })
-            .collect();
-
-        // `key` flows as a regular Props field — control-flow
-        // components like `ForEach` are themselves `#[component]`s
-        // and read it directly off `XxxProps`.
-
-        let children_call = if self.children.is_empty() {
-            quote! {}
-        } else {
-            let child_views: Vec<TokenStream2> = self
-                .children
-                .iter()
-                .map(|c| c.to_tokens_as_view())
-                .collect();
-            let body = if child_views.len() == 1 {
-                let only = &child_views[0];
-                quote! { #only }
+    let setter_calls: Vec<TokenStream2> = uc
+        .kwargs
+        .iter()
+        .map(|kw| {
+            let name = &kw.name;
+            let name_str = name.to_string();
+            let span = name.span();
+            if kw.partial {
+                // Partial kwarg on a user component → emit
+                // `.name(())` so typed-builder's per-field
+                // setter shows up under RA's method completion.
+                quote_spanned! {span=> .#name(()) }
+            } else if name_str == "ref" {
+                // `ref:` is the canonical call-site name for the
+                // implicit ElementRef prop. `ref` is a Rust
+                // keyword so the setter is exposed as
+                // `.with_ref(...)`; re-route here.
+                let value = &kw.value;
+                quote_spanned! {span=> .with_ref(#value) }
             } else {
-                quote! {
-                    ::whisker::runtime::view::View::Fragment(
-                        ::std::vec![#(#child_views),*]
-                    )
-                }
-            };
+                let value = &kw.value;
+                quote_spanned! {span=> .#name(#value) }
+            }
+        })
+        .collect();
+
+    // `key` flows as a regular Props field — control-flow
+    // components like `ForEach` are themselves `#[component]`s
+    // and read it directly off `XxxProps`.
+
+    let children_call = if uc.children.is_empty() {
+        quote! {}
+    } else {
+        let child_views: Vec<TokenStream2> =
+            uc.children.iter().map(node_to_tokens_as_view).collect();
+        let body = if child_views.len() == 1 {
+            let only = &child_views[0];
+            quote! { #only }
+        } else {
             quote! {
-                .children(::std::rc::Rc::new(move || { #body }))
+                ::whisker::runtime::view::View::Fragment(
+                    ::std::vec![#(#child_views),*]
+                )
             }
         };
-
-        // `#fn_ident::builder()` (not `#props_ident::builder()`): the
-        // component name doubles as a TYPE alias to its Props struct (see
-        // `#[component]`), so a single `use crate::Icon` is enough — no
-        // separate `IconProps` import. The outer `#fn_ident(…)` resolves
-        // to the callable (value namespace), the inner `#fn_ident::` to
-        // the Props type (type namespace).
         quote! {
-            #fn_ident(
-                #fn_ident::builder()
-                    #(#setter_calls)*
-                    #children_call
-                    .build()
-            )
+            .children(::std::rc::Rc::new(move || { #body }))
         }
+    };
+
+    // `#fn_ident::builder()` (not `#props_ident::builder()`): the
+    // component name doubles as a TYPE alias to its Props struct (see
+    // `#[component]`), so a single `use crate::Icon` is enough — no
+    // separate `IconProps` import. The outer `#fn_ident(…)` resolves
+    // to the callable (value namespace), the inner `#fn_ident::` to
+    // the Props type (type namespace).
+    quote! {
+        #fn_ident(
+            #fn_ident::builder()
+                #(#setter_calls)*
+                #children_call
+                .build()
+        )
     }
 }
 
@@ -796,8 +480,9 @@ fn strip_on_prefix(name: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_builtin_tag, snake_to_pascal, strip_on_prefix};
+    use super::strip_on_prefix;
     use proc_macro2::TokenStream as TokenStream2;
+    use whisker_macro_syntax::render::{is_builtin_tag, snake_to_pascal, Root};
 
     #[test]
     fn strips_snake_case() {
@@ -921,7 +606,7 @@ mod tests {
     #[test]
     fn bare_string_literal_child_is_rejected() {
         let input: TokenStream2 = quote::quote! { view { "hi" } };
-        let result = syn::parse2::<super::Root>(input);
+        let result = syn::parse2::<Root>(input);
         match result {
             Err(e) => assert!(
                 e.to_string().contains("string literals are not allowed"),
@@ -934,7 +619,7 @@ mod tests {
     #[test]
     fn bare_brace_expr_child_is_rejected() {
         let input: TokenStream2 = quote::quote! { view { { count } } };
-        let result = syn::parse2::<super::Root>(input);
+        let result = syn::parse2::<Root>(input);
         match result {
             Err(e) => assert!(
                 e.to_string().contains("`{expr}` blocks are not allowed")
@@ -948,7 +633,7 @@ mod tests {
     #[test]
     fn positional_arg_is_rejected() {
         let input: TokenStream2 = quote::quote! { text("hi") };
-        let result = syn::parse2::<super::Root>(input);
+        let result = syn::parse2::<Root>(input);
         assert!(result.is_err(), "positional arg should be a parse error");
     }
 


### PR DESCRIPTION
## Summary

rustfmt はマクロ本体を整形しないため、`render!`/`css!` の DSL は永遠に未整形のままでした。`whisker fmt` を **rustfmt の drop-in**（yew-fmt 方式）として追加します: 通常の Rust 整形は**本物の rustfmt バイナリに委譲**し、rustfmt が飛ばしたマクロ本体だけを独自整形します。

**whisker 独自の整形設定は持ちません。`rustfmt.toml` のみを尊重**し、`max_width`/`tab_spaces`/`hard_tabs`/`edition` を rustfmt の設定そのまま使います。

### 構成
- **`whisker-macro-syntax`(新規)**: `render!`/`css!` の **parse 部（AST＋`syn::Parse`）を共有 lib 化**（pub・span 保持）。whisker-macros は free 関数 codegen でこれを消費（旧 inherent `to_tokens` を free fn 化＝orphan rule 対応）。**既存マクロテスト76件は不変**。フォーマッタが proc-macro と**同一文法**でパースするので文法ドリフトなし。
- **`whisker-fmt`(新規)**: `format_source(src, &FmtOptions)`。rustfmt バイナリへ委譲（`$RUSTFMT`→`rustup which rustfmt`→PATH、`--emit stdout`、rustfmt.toml があれば `--config-path`）→ `reformat_macros`（**rustfmt 非依存・単体テスト可能なコア**）が proc-macro2 span-locations で出力を走査し、各 `render!`/`css!` 本体を再パース→ pretty-print（`max_width`/`tab_spaces` 準拠の indent-and-wrap）→ 本体トークン範囲に splice。埋め込み式は source から verbatim slice。冪等。
- **`whisker fmt [files…] [--check] [--stdin]`**。`--stdin` は rust-analyzer `overrideCommand` 用、`--check` は差分表示＋非ゼロ終了。

### 既知の制限（ドキュメント済み・テスト済み）
- マクロ本体にコメントがある場合は本体を**そのまま温存**（`syn` がコメントを落とすため、消すより温存）。
- **埋め込み式は再整形しない**（verbatim 保持）。例: `format!("n: {}",c.get())` のカンマ後スペースは入らない。→ follow-up で prettyplease/rustfmt 個別適用（dioxus `prettier_please.rs` 方式）が可能。

### Before / After
```
fn app()->Element{render!{view(style:"flex:1;",class:"root"){text(value:"Hi")  text(value:format!("n: {}",c.get()))}}}
```
↓
```rust
fn app() -> Element {
    render! {
        view(style: "flex:1;", class: "root") {
            text(value: "Hi")
            text(value: format!("n: {}",c.get()))
        }
    }
}
```

## Test plan
- `cargo build --workspace` / `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` / `cargo test --workspace` / `cargo fmt --check` 全 pass。
- whisker-fmt: 17 lib テスト（rustfmt 非依存）＋4 integration（rustfmt 必要時のみ）。冪等性・`tab_spaces` 反映の proof テスト含む。whisker-macros 76件不変。
- 手元で `whisker fmt --stdin` の end-to-end 動作確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)