### PR TITLE
feat(whisker-fmt): format embedded Rust exprs in macro bodies via rustfmt

### DIFF
--- a/crates/whisker-fmt/src/expr_fmt.rs
+++ b/crates/whisker-fmt/src/expr_fmt.rs
@@ -1,0 +1,317 @@
+//! Real-rustfmt formatting for the embedded Rust expressions inside
+//! `render!` / `css!` bodies (kwarg values, event-handler closures).
+//!
+//! # Why
+//!
+//! The pretty-printer ([`crate::printer`]) lays out the macro *grammar*
+//! (tags, kwargs, children) but treats each embedded expression as an
+//! opaque slice. By default it keeps that slice verbatim. This module
+//! upgrades the embedded exprs to *real* rustfmt formatting so e.g.
+//! `format!("count: {}",c.get())` becomes `format!("count: {}", c.get())`
+//! and long values wrap at `max_width`.
+//!
+//! # Approach (matches dioxus-fmt / yew-fmt)
+//!
+//! We format each expr's **source text** (not its AST — so comments and
+//! the author's intent survive) by wrapping every expr of one macro body
+//! into a single synthetic source:
+//!
+//! ```text
+//! fn __wsk_e0() {
+//! <expr0 source>
+//! }
+//! fn __wsk_e1() {
+//! <expr1 source>
+//! }
+//! ```
+//!
+//! That source is run through the SAME rustfmt binary / `rustfmt.toml` /
+//! edition as the base pass — exactly ONCE per macro body (one spawn,
+//! not one per expr). We then re-parse rustfmt's output, find each
+//! `__wsk_eN` fn, slice its body text, strip the `fn __wsk_eN() {` / `}`
+//! wrapper lines and dedent the body by one indent level. The result is
+//! the formatted expr at column 0, ready for the printer to splice in
+//! and re-indent to the kwarg's column.
+//!
+//! # Column-shift limitation (MVP)
+//!
+//! rustfmt wraps each expr against the synthetic wrapper's SHALLOW
+//! indent (one level), not against the expr's true, possibly-deeper
+//! column in the macro. So a value that lands at, say, column 24 in the
+//! final output may wrap a few columns later than a from-scratch rustfmt
+//! run would. dioxus-fmt and yew-fmt have the same limitation. A future
+//! refinement could compute a per-expr `max_width` adjusted by the
+//! expr's target column and run a wrapper per width-bucket — deliberately
+//! NOT done in this pass.
+//!
+//! # Fallbacks
+//!
+//! Every step degrades gracefully to the verbatim slice (the prior
+//! behavior): no rustfmt binary, a wrapper that fails to format, or an
+//! individual `__wsk_eN` body that can't be re-extracted all leave that
+//! expr (or all exprs of the body) verbatim. A formatting hiccup in one
+//! expr never errors the whole file.
+
+use crate::options::FmtOptions;
+use proc_macro2::{LineColumn, Span};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// A map from an embedded expr's body-relative span to its
+/// rustfmt-formatted text (dedented to column 0).
+///
+/// The key is the `(start, end)` [`LineColumn`] pair of the expr's span.
+/// Because the macro body is re-parsed as its own standalone
+/// `TokenStream`, these line/column positions are body-relative and
+/// unique per expr within that body — a stable key the printer can look
+/// up by `Span` alone.
+#[derive(Default)]
+pub(crate) struct ExprMap {
+    inner: HashMap<SpanKey, String>,
+}
+
+impl ExprMap {
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Look up the formatted text for an expr by its span.
+    pub(crate) fn get(&self, span: Span) -> Option<&str> {
+        self.inner.get(&SpanKey::from(span)).map(String::as_str)
+    }
+
+    fn insert(&mut self, span: Span, formatted: String) {
+        self.inner.insert(SpanKey::from(span), formatted);
+    }
+}
+
+/// Hashable, comparable key derived from a span's start/end position.
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+struct SpanKey {
+    start_line: usize,
+    start_col: usize,
+    end_line: usize,
+    end_col: usize,
+}
+
+impl From<Span> for SpanKey {
+    fn from(span: Span) -> Self {
+        let LineColumn {
+            line: start_line,
+            column: start_col,
+        } = span.start();
+        let LineColumn {
+            line: end_line,
+            column: end_col,
+        } = span.end();
+        SpanKey {
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+        }
+    }
+}
+
+/// Holds the rustfmt configuration so a batch of expr slices from one
+/// macro body can be formatted with the SAME settings as the base pass.
+pub(crate) struct ExprFormatter {
+    opts: FmtOptions,
+    config_dir: Option<PathBuf>,
+}
+
+impl ExprFormatter {
+    /// Build a formatter that mirrors `format_source` (no explicit
+    /// config dir — rustfmt resolves `rustfmt.toml` from cwd).
+    pub(crate) fn new(opts: &FmtOptions) -> Self {
+        Self {
+            opts: opts.clone(),
+            config_dir: None,
+        }
+    }
+
+    /// Build a formatter that mirrors `format_source_in_dir`, threading
+    /// the same `config_dir` through so the embedded exprs honor the
+    /// same nearest `rustfmt.toml` as the base pass.
+    pub(crate) fn new_in_dir(opts: &FmtOptions, config_dir: &Path) -> Self {
+        Self {
+            opts: opts.clone(),
+            config_dir: Some(config_dir.to_path_buf()),
+        }
+    }
+
+    /// Format every expr (given as `(span, source_slice)` pairs) of ONE
+    /// macro body with a single rustfmt spawn, returning a map from span
+    /// to formatted text. Exprs that fail to format are simply absent
+    /// from the map (the printer then falls back to verbatim).
+    ///
+    /// `exprs` carries the body-relative span of each expr (for keying)
+    /// alongside its verbatim source slice (the text we format).
+    pub(crate) fn format_body(&self, exprs: &[(Span, String)]) -> ExprMap {
+        let mut map = ExprMap::default();
+        if exprs.is_empty() {
+            return map;
+        }
+
+        // ---- build the batched synthetic source ----
+        let mut synthetic = String::new();
+        for (i, (_, src)) in exprs.iter().enumerate() {
+            synthetic.push_str(&format!("fn __wsk_e{i}() {{\n"));
+            synthetic.push_str(src);
+            // Guarantee the body ends on its own line so the closing
+            // brace is on a fresh line (slicing relies on this).
+            if !src.ends_with('\n') {
+                synthetic.push('\n');
+            }
+            synthetic.push_str("}\n");
+        }
+
+        // ---- one rustfmt spawn for the whole batch ----
+        let formatted_file =
+            match crate::run_rustfmt(&synthetic, &self.opts, self.config_dir.as_deref()) {
+                Ok(s) => s,
+                // No rustfmt, or the batch failed to parse/format as a whole
+                // → leave every expr verbatim.
+                Err(_) => return map,
+            };
+
+        // ---- extract each __wsk_eN body ----
+        let bodies = match extract_bodies(&formatted_file, exprs.len()) {
+            Some(b) => b,
+            None => return map,
+        };
+
+        let unit = self.opts.indent_unit();
+        for (i, (span, _)) in exprs.iter().enumerate() {
+            if let Some(body) = bodies.get(i).and_then(|b| b.as_deref()) {
+                let dedented = dedent_one_level(body, &unit);
+                map.insert(*span, dedented);
+            }
+        }
+        map
+    }
+}
+
+/// Re-parse the rustfmt output, locate every `__wsk_eN` fn (in order),
+/// and return its raw body text (between the `{` and `}` braces, newline
+/// boundaries trimmed). Returns `None` if the output can't be parsed or
+/// any wrapper fn is missing — so the caller falls back wholesale.
+fn extract_bodies(formatted_file: &str, count: usize) -> Option<Vec<Option<String>>> {
+    let parsed: syn::File = syn::parse_file(formatted_file).ok()?;
+    let map = crate::source_map::SourceMap::new(formatted_file);
+
+    // index -> body text
+    let mut found: HashMap<usize, String> = HashMap::new();
+    for item in &parsed.items {
+        let syn::Item::Fn(f) = item else { continue };
+        let name = f.sig.ident.to_string();
+        let Some(idx) = name
+            .strip_prefix("__wsk_e")
+            .and_then(|n| n.parse::<usize>().ok())
+        else {
+            continue;
+        };
+        // The block's brace span covers `{ … }`. Slice the inside.
+        let brace = f.block.brace_token.span;
+        // `Span::join` of the open/close delimiters gives the full
+        // `{ … }` range; use the group span directly.
+        let span: Span = brace.join();
+        let Some((open, close)) = map.byte_range(span) else {
+            continue;
+        };
+        // Strip the outer braces: byte `open` is `{`, `close-1` is `}`.
+        if close <= open + 1 {
+            // Empty body — keep as empty string.
+            found.insert(idx, String::new());
+            continue;
+        }
+        let inner = &formatted_file[open + 1..close - 1];
+        // Trim a single leading / trailing newline introduced by the
+        // braces being on their own lines; keep internal indentation so
+        // `dedent_one_level` can strip exactly one level.
+        let inner = inner.strip_prefix('\n').unwrap_or(inner);
+        let inner = inner.strip_suffix('\n').unwrap_or(inner);
+        found.insert(idx, inner.to_string());
+    }
+
+    // Require every expected wrapper to be present.
+    let mut bodies = Vec::with_capacity(count);
+    for i in 0..count {
+        match found.remove(&i) {
+            Some(b) => bodies.push(Some(b)),
+            None => return None,
+        }
+    }
+    Some(bodies)
+}
+
+/// Strip exactly one indentation level (`unit`) from the front of every
+/// non-blank line, leaving the expr at column 0. Lines that don't start
+/// with the full unit (shouldn't happen for rustfmt output, but be
+/// defensive) are left as-is. Blank lines stay blank.
+fn dedent_one_level(body: &str, unit: &str) -> String {
+    let mut out = String::new();
+    let mut first = true;
+    for line in body.split('\n') {
+        if !first {
+            out.push('\n');
+        }
+        first = false;
+        if line.is_empty() {
+            continue;
+        }
+        match line.strip_prefix(unit) {
+            Some(rest) => out.push_str(rest),
+            None => out.push_str(line),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> FmtOptions {
+        FmtOptions {
+            max_width: 100,
+            tab_spaces: 4,
+            hard_tabs: false,
+            edition: Some("2021".to_string()),
+        }
+    }
+
+    #[test]
+    fn dedent_strips_one_level() {
+        let body = "    foo(a, b)\n    + bar";
+        assert_eq!(dedent_one_level(body, "    "), "foo(a, b)\n+ bar");
+    }
+
+    #[test]
+    fn dedent_keeps_blank_lines() {
+        let body = "    a\n\n    b";
+        assert_eq!(dedent_one_level(body, "    "), "a\n\nb");
+    }
+
+    #[test]
+    fn extract_single_body() {
+        let file = "fn __wsk_e0() {\n    foo(a, b)\n}\n";
+        let bodies = extract_bodies(file, 1).unwrap();
+        assert_eq!(bodies[0].as_deref(), Some("    foo(a, b)"));
+    }
+
+    #[test]
+    fn extract_requires_all() {
+        let file = "fn __wsk_e0() {\n    a\n}\n";
+        // Asking for 2 but only 1 present → None.
+        assert!(extract_bodies(file, 2).is_none());
+    }
+
+    #[test]
+    fn format_body_empty_is_empty_map() {
+        let f = ExprFormatter::new(&opts());
+        let m = f.format_body(&[]);
+        assert!(m.is_empty());
+    }
+}

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -33,6 +33,7 @@
 //! documented limitation. Comments OUTSIDE macros are preserved by
 //! rustfmt as usual.
 
+mod expr_fmt;
 mod options;
 mod printer;
 mod source_map;
@@ -40,7 +41,8 @@ mod source_map;
 pub use options::FmtOptions;
 
 use anyhow::{anyhow, Context, Result};
-use proc_macro2::{Delimiter, TokenStream, TokenTree};
+use expr_fmt::{ExprFormatter, ExprMap};
+use proc_macro2::{Delimiter, Span, TokenStream, TokenTree};
 use source_map::SourceMap;
 use std::path::Path;
 use std::process::Command;
@@ -53,7 +55,8 @@ use std::process::Command;
 /// `opts.edition` through so both passes agree on the edition.
 pub fn format_source(src: &str, opts: &FmtOptions) -> Result<String> {
     let base = run_rustfmt(src, opts, None)?;
-    reformat_macros(&base, opts)
+    let exprfmt = ExprFormatter::new(opts);
+    reformat_macros_inner(&base, opts, Some(&exprfmt))
 }
 
 /// Like [`format_source`] but tells rustfmt to resolve `rustfmt.toml`
@@ -61,7 +64,8 @@ pub fn format_source(src: &str, opts: &FmtOptions) -> Result<String> {
 /// file's nearest `rustfmt.toml` governs.
 pub fn format_source_in_dir(src: &str, opts: &FmtOptions, config_dir: &Path) -> Result<String> {
     let base = run_rustfmt(src, opts, Some(config_dir))?;
-    reformat_macros(&base, opts)
+    let exprfmt = ExprFormatter::new_in_dir(opts, config_dir);
+    reformat_macros_inner(&base, opts, Some(&exprfmt))
 }
 
 /// `--check` helper: returns `Ok(None)` if the source is already
@@ -210,6 +214,22 @@ fn find_rustfmt_toml(dir: &Path) -> Option<std::path::PathBuf> {
 /// verbatim) rather than silently losing the comments — see
 /// [`body_has_comments`]. This is the documented, tested limitation.
 pub fn reformat_macros(rust_src: &str, opts: &FmtOptions) -> Result<String> {
+    // Public entry point: the rustfmt-FREE core. No `ExprFormatter`, so
+    // every embedded expr is rendered verbatim (the printer's empty-map
+    // path). This is what keeps the 17 unit tests in this file passing
+    // without a rustfmt binary.
+    reformat_macros_inner(rust_src, opts, None)
+}
+
+/// The shared implementation behind [`reformat_macros`] and the full
+/// pipeline. When `exprfmt` is `Some`, embedded exprs are formatted by
+/// the real rustfmt (batched per macro body); when `None`, they are kept
+/// verbatim.
+fn reformat_macros_inner(
+    rust_src: &str,
+    opts: &FmtOptions,
+    exprfmt: Option<&ExprFormatter>,
+) -> Result<String> {
     // Parse the whole file just to confirm it is valid Rust; the actual
     // macro discovery walks the raw TokenStream (so we keep precise
     // span byte-offsets relative to `rust_src`).
@@ -226,7 +246,7 @@ pub fn reformat_macros(rust_src: &str, opts: &FmtOptions) -> Result<String> {
     // every macro, then splice from the end backwards so earlier
     // offsets stay valid.
     let mut edits: Vec<MacroEdit> = Vec::new();
-    collect_macro_edits(tokens, &file_map, rust_src, opts, &mut edits)?;
+    collect_macro_edits(tokens, &file_map, rust_src, opts, exprfmt, &mut edits)?;
 
     edits.sort_by_key(|e| e.open_byte);
     // Splice from the end so earlier byte offsets remain valid.
@@ -253,6 +273,7 @@ fn collect_macro_edits(
     file_map: &SourceMap,
     rust_src: &str,
     opts: &FmtOptions,
+    exprfmt: Option<&ExprFormatter>,
     edits: &mut Vec<MacroEdit>,
 ) -> Result<()> {
     let trees: Vec<TokenTree> = tokens.into_iter().collect();
@@ -266,7 +287,9 @@ fn collect_macro_edits(
                 && matches!(&trees[i + 1], TokenTree::Punct(p) if p.as_char() == '!')
             {
                 if let TokenTree::Group(group) = &trees[i + 2] {
-                    if let Some(edit) = macro_body_edit(&name, group, file_map, rust_src, opts)? {
+                    if let Some(edit) =
+                        macro_body_edit(&name, group, file_map, rust_src, opts, exprfmt)?
+                    {
                         edits.push(edit);
                     }
                     // Don't recurse into a macro body we've already
@@ -286,7 +309,7 @@ fn collect_macro_edits(
         }
         // Recurse into any group we didn't treat as a macro body.
         if let TokenTree::Group(group) = &trees[i] {
-            collect_macro_edits(group.stream(), file_map, rust_src, opts, edits)?;
+            collect_macro_edits(group.stream(), file_map, rust_src, opts, exprfmt, edits)?;
         }
         i += 1;
     }
@@ -302,6 +325,7 @@ fn macro_body_edit(
     file_map: &SourceMap,
     rust_src: &str,
     opts: &FmtOptions,
+    exprfmt: Option<&ExprFormatter>,
 ) -> Result<Option<MacroEdit>> {
     let span = group.span();
     // Byte offsets of the WHOLE group (including delimiters).
@@ -316,11 +340,6 @@ fn macro_body_edit(
         return Ok(None); // empty body
     }
     let body_src = &rust_src[open_byte..close_byte];
-
-    // Comment limitation: leave bodies with comments untouched.
-    if body_has_comments(body_src) {
-        return Ok(None);
-    }
 
     // Base indent = the indent level of the line the macro sits on.
     let line_start = rust_src[..group_start]
@@ -338,9 +357,28 @@ fn macro_body_edit(
         .map_err(|e| anyhow!("whisker-fmt: could not lex {macro_name}! body: {e}"))?;
     let body_map = SourceMap::new(body_src);
 
+    // Collect the embedded-expr spans up front: we need them both to
+    // batch-format the exprs AND to decide whether a comment in the body
+    // is inside an expr value (fine — preserved by slicing) or in the
+    // macro GRAMMAR (the documented limitation — bail).
     let formatted = match macro_name {
         "render" => match whisker_macro_syntax::render::parse_root(body_ts.clone()) {
-            Ok(root) => printer::print_render(&root, &body_map, opts, base_indent),
+            Ok(root) => {
+                let mut spans = Vec::new();
+                collect_render_expr_spans(&root.node, &mut spans);
+                // Comment limitation: a comment OUTSIDE every embedded
+                // expr (i.e. in the render! grammar) still leaves the
+                // body untouched. A comment INSIDE an expr value is kept
+                // by slicing that value verbatim / formatting its source.
+                if body_has_grammar_comment(body_src, &spans, &body_map) {
+                    return Ok(None);
+                }
+                // Batch-format every embedded expr with one rustfmt spawn.
+                // With no `exprfmt` (rustfmt-free core) the map stays
+                // empty and every expr renders verbatim.
+                let expr_map = build_expr_map(&spans, &body_map, exprfmt);
+                printer::print_render(&root, &body_map, opts, base_indent, &expr_map)
+            }
             // Not a well-formed render! body (e.g. mid-edit) — leave it.
             Err(_) => return Ok(None),
         },
@@ -349,7 +387,17 @@ fn macro_body_edit(
                 if input.kwargs.is_empty() {
                     return Ok(None);
                 }
-                printer::print_css(&input, &body_map, opts, base_indent)
+                let mut spans = Vec::new();
+                for kw in &input.kwargs {
+                    if let Some(expr) = &kw.value {
+                        spans.push(span_of_expr(expr));
+                    }
+                }
+                if body_has_grammar_comment(body_src, &spans, &body_map) {
+                    return Ok(None);
+                }
+                let expr_map = build_expr_map(&spans, &body_map, exprfmt);
+                printer::print_css(&input, &body_map, opts, base_indent, &expr_map)
             }
             Err(_) => return Ok(None),
         },
@@ -379,6 +427,103 @@ fn macro_body_edit(
         close_byte,
         replacement,
     }))
+}
+
+// ---- embedded-expr collection + batched formatting ----------------------
+
+/// The `Span` covering an `Expr` (start of first token to end of last).
+fn span_of_expr(expr: &syn::Expr) -> Span {
+    use syn::spanned::Spanned;
+    expr.span()
+}
+
+/// Walk a parsed `render!` node tree collecting the span of every
+/// embedded expr (kwarg values). `partial` kwargs hold a synthesized
+/// placeholder with no real source span, so they're skipped. `css!`
+/// kwargs are collected separately at the call site (different type).
+fn collect_render_expr_spans(node: &whisker_macro_syntax::Node, out: &mut Vec<Span>) {
+    use whisker_macro_syntax::Node;
+    match node {
+        Node::Element(el) => {
+            for kw in &el.kwargs {
+                if !kw.partial {
+                    out.push(span_of_expr(&kw.value));
+                }
+            }
+            for child in &el.children {
+                collect_render_expr_spans(child, out);
+            }
+        }
+        Node::UserComponent(uc) => {
+            for kw in &uc.kwargs {
+                if !kw.partial {
+                    out.push(span_of_expr(&kw.value));
+                }
+            }
+            for child in &uc.children {
+                collect_render_expr_spans(child, out);
+            }
+        }
+        Node::ChildrenSlot { .. } => {}
+    }
+}
+
+/// Slice each expr's verbatim source from `body_map` and batch-format
+/// the whole set with one rustfmt spawn (via `exprfmt`). Returns an
+/// [`ExprMap`] keyed by span. When `exprfmt` is `None` (rustfmt-free
+/// core) the returned map is empty, so the printer renders verbatim.
+///
+/// Spans whose source slice fails to resolve are skipped (they'll hit
+/// the printer's verbatim / token fallback anyway).
+fn build_expr_map(
+    spans: &[Span],
+    body_map: &SourceMap,
+    exprfmt: Option<&ExprFormatter>,
+) -> ExprMap {
+    let Some(exprfmt) = exprfmt else {
+        return ExprMap::default();
+    };
+    let mut exprs: Vec<(Span, String)> = Vec::with_capacity(spans.len());
+    for &span in spans {
+        if let Some(slice) = body_map.slice(span) {
+            exprs.push((span, slice.trim().to_string()));
+        }
+    }
+    exprfmt.format_body(&exprs)
+}
+
+/// Like [`body_has_comments`], but ignores comments that live INSIDE an
+/// embedded expr value. Those are preserved by slicing / rustfmt-ing the
+/// expr source. Only a comment in the macro GRAMMAR (between tags,
+/// kwargs, delimiters) triggers the documented "leave-untouched"
+/// limitation.
+///
+/// Implementation: blank out each expr span's bytes (replacing with
+/// spaces, keeping length so the scan's string-awareness stays valid)
+/// then run the ordinary comment scan over what's left.
+fn body_has_grammar_comment(body: &str, expr_spans: &[Span], body_map: &SourceMap) -> bool {
+    // Fast path: no comment anywhere → definitely no grammar comment.
+    if !body_has_comments(body) {
+        return false;
+    }
+    let mut masked: Vec<u8> = body.as_bytes().to_vec();
+    for &span in expr_spans {
+        if let Some((s, e)) = body_map.byte_range(span) {
+            for b in &mut masked[s..e] {
+                // Preserve newlines so line structure (and any `//`
+                // single-line comment that ends at a newline) is intact
+                // outside the masked region; blank everything else.
+                if *b != b'\n' {
+                    *b = b' ';
+                }
+            }
+        }
+    }
+    // `masked` is still valid UTF-8 (we only replaced whole bytes of
+    // ASCII space within char boundaries… actually a multi-byte char
+    // could be partially masked, so rebuild lossily for safety).
+    let masked_str = String::from_utf8_lossy(&masked);
+    body_has_comments(&masked_str)
 }
 
 /// Detect `//` or `/* */` comments in a macro body. Uses a tiny

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -3,13 +3,18 @@
 //! ## Embedded Rust expressions
 //!
 //! Kwarg values, event-handler closures and any other embedded Rust
-//! are NOT re-printed from tokens. They are sliced verbatim out of the
-//! original macro-body source via [`SourceMap`] (see `source_map.rs`),
-//! so the user's own expression formatting is preserved exactly. We
-//! only fall back to `proc_macro2` token printing when the slice fails
-//! (e.g. a synthesized span with no source position) — a rare,
-//! best-effort path. This choice keeps the formatter from fighting
-//! rustfmt over expression internals.
+//! are rendered through [`Printer::expr_src`], which resolves in this
+//! order:
+//!
+//! 1. A rustfmt-formatted entry in the [`ExprMap`] built by the full
+//!    pipeline (see `expr_fmt.rs`). The text is stored dedented to
+//!    column 0; the surrounding [`reindent`] calls push its continuation
+//!    lines under the kwarg column.
+//! 2. The verbatim source slice from [`SourceMap`] (see
+//!    `source_map.rs`). This is the rustfmt-free path the unit tests
+//!    use, and the fallback when rustfmt produced no entry for an expr.
+//! 3. `proc_macro2` token printing when the span has no source position
+//!    (a rare, best-effort path).
 //!
 //! ## Layout
 //!
@@ -19,6 +24,7 @@
 //! indented lines. This matches the shallow, regular `render!` grammar
 //! and is easy to keep idempotent.
 
+use crate::expr_fmt::ExprMap;
 use crate::options::FmtOptions;
 use crate::source_map::SourceMap;
 use proc_macro2::Span;
@@ -30,13 +36,23 @@ use whisker_macro_syntax::{CssInput, ElementNode, Kwarg, Node, Root, UserCompone
 /// `base_indent` is the indent level (in tab-units) at which the macro
 /// invocation sits in the rustfmt output; the body is indented one
 /// level deeper.
+///
+/// `expr_map` supplies rustfmt-formatted text for the embedded
+/// expressions, keyed by each expr's body-relative span. An EMPTY map
+/// means "render every expr verbatim" — that is the rustfmt-free path
+/// the [`crate::reformat_macros`] unit tests use.
 pub(crate) fn print_render(
     root: &Root,
     map: &SourceMap,
     opts: &FmtOptions,
     base_indent: usize,
+    expr_map: &ExprMap,
 ) -> String {
-    let p = Printer { map, opts };
+    let p = Printer {
+        map,
+        opts,
+        expr_map,
+    };
     let mut out = String::new();
     p.node(&root.node, base_indent + 1, &mut out);
     out
@@ -48,20 +64,36 @@ pub(crate) fn print_css(
     map: &SourceMap,
     opts: &FmtOptions,
     base_indent: usize,
+    expr_map: &ExprMap,
 ) -> String {
-    let p = Printer { map, opts };
+    let p = Printer {
+        map,
+        opts,
+        expr_map,
+    };
     p.css(input, base_indent + 1)
 }
 
 struct Printer<'a> {
     map: &'a SourceMap<'a>,
     opts: &'a FmtOptions,
+    expr_map: &'a ExprMap,
 }
 
 impl Printer<'_> {
-    /// Slice an embedded Rust expr verbatim from the source, falling
-    /// back to token printing if the span has no source position.
+    /// Render an embedded Rust expr. Resolution order:
+    ///
+    /// 1. A rustfmt-formatted entry in [`ExprMap`] (keyed by the expr's
+    ///    body-relative span), stored dedented to column 0. Continuation
+    ///    lines are re-indented to the kwarg column by the [`reindent`]
+    ///    calls at the call sites, so nothing extra is needed here.
+    /// 2. The verbatim source slice (rustfmt-free core / fallback).
+    /// 3. `proc_macro2` token printing when the span has no source
+    ///    position.
     fn expr_src(&self, span: Span, tokens: &dyn ToTokens) -> String {
+        if let Some(formatted) = self.expr_map.get(span) {
+            return formatted.to_string();
+        }
         if let Some(s) = self.map.slice(span) {
             // Trim surrounding whitespace; internal formatting is kept.
             s.trim().to_string()

--- a/crates/whisker-fmt/tests/integration.rs
+++ b/crates/whisker-fmt/tests/integration.rs
@@ -70,6 +70,91 @@ fn check_reports_diff_then_clean() {
     );
 }
 
+// ---- embedded-expr rustfmt formatting -----------------------------------
+
+#[test]
+fn formats_embedded_format_macro_expr() {
+    if !rustfmt_available() {
+        return;
+    }
+    // The kwarg value is a `format!` call with a missing comma-space:
+    // rustfmt should normalize it.
+    let src =
+        "fn ui() -> Element {\n    render! { text(value: format!(\"count: {}\",c.get())) }\n}\n";
+    let out = format_source(src, &opts(4, 100)).unwrap();
+    assert!(
+        out.contains("format!(\"count: {}\", c.get())"),
+        "embedded format! should be rustfmt-normalized:\n{out}"
+    );
+}
+
+#[test]
+fn long_kwarg_value_wraps_at_max_width() {
+    if !rustfmt_available() {
+        return;
+    }
+    // A long call expression as a kwarg value should be wrapped by
+    // rustfmt onto multiple lines.
+    let long = "some_function_with_a_fairly_long_name(argument_one, argument_two, argument_three, argument_four)";
+    let src = format!("fn ui() -> Element {{\n    render! {{ text(value: {long}) }}\n}}\n");
+    let narrow = format_source(&src, &opts(4, 40)).unwrap();
+    let wide = format_source(&src, &opts(4, 200)).unwrap();
+    // Narrow max_width forces the expr to wrap (more body lines); wide
+    // keeps it on one line — proving rustfmt.toml/max_width flows in.
+    assert!(
+        narrow.matches('\n').count() > wide.matches('\n').count(),
+        "narrow max_width should wrap the embedded expr more than wide:\n--narrow--\n{narrow}\n--wide--\n{wide}"
+    );
+}
+
+#[test]
+fn multi_statement_closure_handler_reindented() {
+    if !rustfmt_available() {
+        return;
+    }
+    // A multi-statement closure handler should be rustfmt-formatted and
+    // re-indented under the kwarg column in the macro body.
+    let src = "fn ui() -> Element {\n    render! { view(on_tap: move |_| { let x=1;do_thing(x); }) }\n}\n";
+    let out = format_source(src, &opts(4, 100)).unwrap();
+    // rustfmt splits the two statements onto their own lines …
+    assert!(out.contains("let x = 1;"), "statement formatted:\n{out}");
+    assert!(out.contains("do_thing(x);"), "statement formatted:\n{out}");
+    // … and they sit indented inside the macro body (not at col 0).
+    assert!(
+        out.contains("\n            let x = 1;") || out.contains("\n                let x = 1;"),
+        "closure body re-indented into the macro:\n{out}"
+    );
+}
+
+#[test]
+fn comment_inside_expr_preserved() {
+    if !rustfmt_available() {
+        return;
+    }
+    // A block comment INSIDE the expr must survive — proving we format
+    // the SOURCE SLICE, not the (comment-stripped) AST.
+    let src = "fn ui() -> Element {\n    render! { text(value: foo(/* keep me */ x)) }\n}\n";
+    let out = format_source(src, &opts(4, 100)).unwrap();
+    assert!(
+        out.contains("/* keep me */"),
+        "comment inside expr must be preserved:\n{out}"
+    );
+}
+
+#[test]
+fn full_pipeline_idempotent_with_exprs() {
+    if !rustfmt_available() {
+        return;
+    }
+    let src = "fn ui() -> Element {\n    render! { view(on_tap: move |_| { let x=1;do_thing(x); }, style: \"flex:1;\") { text(value: format!(\"count: {}\",c.get())) } }\n}\n";
+    let once = format_source(src, &opts(4, 100)).unwrap();
+    let twice = format_source(&once, &opts(4, 100)).unwrap();
+    assert_eq!(
+        once, twice,
+        "expr formatting must be idempotent:\n--once--\n{once}\n--twice--\n{twice}"
+    );
+}
+
 #[test]
 fn tab_spaces_option_changes_output() {
     if !rustfmt_available() {


### PR DESCRIPTION
## Summary

`whisker fmt` のフォローアップ。これまで `render!`/`css!` 本体内の埋め込み式は **verbatim 温存**（rustfmt はマクロ本体を見ない）でしたが、各式を**本物の rustfmt にかける**ようにしました。これでマクロ DSL も周囲のコードと同じ rustfmt 品質に揃います（カンマ後スペース、`max_width` での折返し、複数行クロージャ等）。

### 方式（Approach B: 本物の rustfmt・バッチ・グレースフルフォールバック）
- **`expr_fmt.rs`(新規)**: マクロ本体の全埋め込み式のソースを集め、1つの合成ソース（`fn __wsk_eN() { <式> }`）に包んで **本体あたり rustfmt を1回**実行（`run_rustfmt` を同じ opts/edition/rustfmt.toml で再利用）→ 出力を再パースして各 fn 本体を切り出し、ラッパを剥がして column 0 へデデント。**ソースを包む（AST でない）ので式内コメントも保持**。
- `printer.rs` の `expr_src` が `ExprMap`（式の span line/col キー）を参照し、継続行を kwarg カラムへ再インデント。失敗時（rustfmt 無し／整形不能／抽出失敗）は **verbatim にフォールバック**。
- rustfmt 非依存の `reformat_macros` コアは不変（空 ExprMap → verbatim）で、既存17ユニットテストは rustfmt 無しでも pass。
- コメントガード改良: マクロ**文法**中のコメントは従来通り本体 verbatim にするが、**式値の中のコメントは本体整形を妨げない**（slice ベース整形で保持）。

**設定は rustfmt.toml のみ尊重**（`max_width`/`tab_spaces`/`edition` が式パスにも流れる）。MVP は単一 max_width（式はラッパの浅いインデントで折返すため最終カラムと数桁ずれうる＝dioxus/yew-fmt と同じ既知の限界。式ごと調整 max_width は将来課題）。

### Before / After
```
fn ui()->Element{render!{view(on_tap:move |e|{let n=count.get();count.set(n+1);log(e);},style:"flex:1;"){text(value:format!("count: {}",count.get()))}}}
```
↓
```rust
fn ui() -> Element {
    render! {
        view(
            on_tap: move |e| {
                let n = count.get();
                count.set(n + 1);
                log(e);
            },
            style: "flex:1;",
        ) {
            text(value: format!("count: {}", count.get()))
        }
    }
}
```

## Test plan
- 全4ゲート green（build / clippy -D warnings / test / fmt --check）。
- whisker-fmt: 22 lib/unit ＋ 9 integration（既存17 rustfmt 非依存＋新規5: カンマ後スペース・max_width 折返し・複数文クロージャ再インデント・式内コメント保持・冪等性）。
- 手元で `whisker fmt --stdin` の end-to-end＋冪等性を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)