### PR TITLE
fix(hot-reload): dispatch pointer-sized component closures via call_it

### DIFF
--- a/crates/whisker-build/src/capture.rs
+++ b/crates/whisker-build/src/capture.rs
@@ -123,8 +123,9 @@ pub fn capture_env_vars_for_triple(
     // without this, subsecond compiles to `self.inner.call_it(args)`
     // and skips the JumpTable entirely (apply_patch becomes a no-op
     // from the caller's perspective). Tier 1 dev builds want the
-    // JumpTable lookup but otherwise keep release-level optimization;
-    // this flag flips the cfg without dropping to the dev profile.
+    // JumpTable lookup; this flag flips the cfg without dropping to the
+    // dev profile. (We also force `-Copt-level=0` below so the host's
+    // per-component dispatch closures match the patch's — see there.)
     //
     // Pick the export-dynamic flag spelling for the *target* triple,
     // not the host — Apple linkers take `-export_dynamic`; GNU / lld
@@ -134,7 +135,18 @@ pub fn capture_env_vars_for_triple(
         Some(t) if t.contains("apple") => "-Clink-arg=-Wl,-export_dynamic",
         _ => "-Clink-arg=-Wl,--export-dynamic",
     };
-    let save_temps = format!("-Csave-temps=y -Cdebug-assertions=on {export_dynamic}");
+    // `-Copt-level=0` matches the thin patch's opt-level (the patch
+    // forces 0 via `hotpatch::thin_build::override_opt_level`). This is
+    // load-bearing for hot reload: at -O3 the host *inlines* each
+    // `#[component]`'s `__hot::call(move ||{…})` dispatch closure into
+    // its parent fn, so the standalone `HotFunction::call_it` /
+    // `call_as_ptr` symbol subsecond keys its JumpTable on either isn't
+    // emitted or gets a different mangling hash than the -O0 patch's.
+    // The lookup then misses and a remounted component body dispatches to
+    // the OLD (inlined) code — "patch applied" but the screen never
+    // updates. Forcing -O0 on the captured (host) build keeps both sides'
+    // dispatch closures symbol-identical so patches actually take effect.
+    let save_temps = format!("-Csave-temps=y -Cdebug-assertions=on -Copt-level=0 {export_dynamic}");
     let save_temps = save_temps.as_str();
     match triple_override {
         Some(triple) => {

--- a/crates/whisker-subsecond/src/lib.rs
+++ b/crates/whisker-subsecond/src/lib.rs
@@ -960,6 +960,30 @@ macro_rules! impl_hot_function {
                             // No nibble on 32-bit platforms, but we still need to assume u64 since the host always writes 64-bit addresses
                             #[cfg(target_pointer_width = "32")] let real = real as u64;
 
+                            // Whisker fix for pointer-sized *capturing* closures.
+                            //
+                            // The `size_of::<F>() == size_of::<fn()>()` gate in
+                            // `try_call` routes any closure that is coincidentally
+                            // pointer-sized through this `call_as_ptr` path — which
+                            // assumes `F` is a bare function pointer and recovers its
+                            // address via `transmute_copy`. But a `#[component]` body
+                            // closure that captures exactly one 8-byte value (the
+                            // common case: a single signal / `NodeId`) is *also*
+                            // pointer-sized, and `transmute_copy` then yields the
+                            // captured VALUE (e.g. a slotmap key like `0x1_0000_0001`),
+                            // not a code address. The lookup misses and the stale
+                            // pre-patch body runs — "patch applied" but no visual
+                            // change.
+                            //
+                            // When the transmute-recovered key isn't in the table,
+                            // fall back to the closure's own `call_it`
+                            // monomorphisation address — a real code symbol that the
+                            // JumpTable carries (the same key the non-pointer-sized
+                            // `try_call` path uses). For a genuine fn pointer the
+                            // first lookup already hits, so this only adds a fallback.
+                            // Genuine bare fn pointer: `real` is its code
+                            // address and is in the table. Call it as
+                            // `Self::Real` (a plain `fn(args)`, no `self`).
                             if let Some(ptr) = jump_table.map.get(&real).cloned() {
                                 // Re-apply the nibble - though this might not be required (we aren't calling malloc for a new pointer)
                                 #[cfg(all(target_pointer_width = "64", target_os = "android"))] let ptr: u64 = ptr | nibble;
@@ -978,6 +1002,25 @@ macro_rules! impl_hot_function {
                                 type PtrWidth = u32;
 
                                 return std::mem::transmute::<PtrWidth, Self::Real>(ptr)($($arg),*);
+                            }
+
+                            // Whisker fix: `real` missed because this is a
+                            // pointer-sized *capturing* closure, not a bare fn
+                            // pointer — `transmute_copy` yielded the captured
+                            // value (e.g. a single signal's `NodeId`), not a code
+                            // address. Dispatch on the closure's own `call_it`
+                            // monomorphisation address instead — a real symbol the
+                            // JumpTable carries — calling it WITH `&mut self` since
+                            // `call_it` takes `self`.
+                            let call_it_key =
+                                <Self as HotFunction<($($arg,)*), $marker>>::call_it
+                                    as *const () as u64;
+                            if let Some(ptr) = jump_table.map.get(&call_it_key).cloned() {
+                                let patched = std::mem::transmute::<
+                                    *const (),
+                                    fn(&mut Self, ($($arg,)*)) -> Self::Return,
+                                >(ptr as *const ());
+                                return patched(self, args);
                             }
                         }
 


### PR DESCRIPTION
## 症状

`#[component]` の body closure が **ちょうどポインタサイズ(8バイト)のキャプチャ**を持つとき(典型: **signal を1個だけキャプチャ** — `RwSignal`/`ReadSignal`/`WriteSignal` はいずれも 8バイトの `NodeId`)、**Tier 1 ホットリロードが画面に反映されない**。dev-server は `✓ patch tier 1` と表示し、パッチは実際に受信・適用(N個の fn ポインタ書き換え)され、コンポーネントも remount されているのに、画面は編集前のまま。0個 or 16バイト以上のキャプチャでは正常に効くため、間欠的に見えていた。

## 根本原因(二段)

**① opt-level skew**
Tier 1 の host(fat)ビルドは `--release`(`-O3`)、thin patch は `-O0`。`-O3` は `#[component]` の `__hot::call(move ||{…})` ディスパッチ closure を親関数にインライン化し、subsecond が JumpTable のキーに使う **`HotFunction::call_it` シンボルを host から消す** → 対応表に載らない。
→ capture の RUSTFLAGS に **`-Copt-level=0`** を追加し、host/patch で closure の monomorphization を一致させる。`-O0` は dev ビルドとして一般的で、かつ **hot-reload(capture)経路にのみ**適用されるため、非 capture / `--no-hot-patch` ビルドには影響しない。

**② `call_as_ptr` の誤ディスパッチ(本命)**
subsecond は「closure のサイズ == ポインタサイズ」の closure を「生の関数ポインタ」と仮定して `call_as_ptr`(`transmute_copy` でアドレス復元)へ回す。**8バイトのキャプチャ closure**(signal 1個)もここに入ってしまい、`transmute_copy` が**キャプチャした値**(例: slotmap キー `0x1_0000_0001`)を関数アドレスとして読む → lookup MISS → 旧 body を実行。
→ このキーが MISS したら、**closure 自身の `call_it` モノモーフ化アドレス**(JumpTable にある実コードシンボル)で引き直し、`call_it` は `self` を取るので **`&mut self` 付きで**呼ぶフォールバックを追加。生の fn ポインタは最初の lookup で当たるので純粋な追加保険。

## 検証

iOS Simulator で**キャプチャサイズ・マトリクス**(0 / 8=signal / 8=i64 / 16=signal×2 / 16=&str)を用意して A/B 実機検証:
- **修正OFF**: 8バイト(signal)コンポーネントだけ編集が反映されない、他は反映。
- **修正ON**: 全コンポーネントがホットリロード、クラッシュなし、1パッチで一括反映。

## 注記

- 変更は Rust のディスパッチ層で**プラットフォーム非依存**。フォールバックは clean な `call_it` アドレスを使い Android の MTE nibble 経路を通らないため、Android 固有のリスクは無いと判断。**Android 実機/エミュ検証は推奨 follow-up**。
- `-O0` 化のトレードオフ(dev アプリが最適化なしで動く / 依存を一度 -O0 で再ビルド)は dev では許容。最適化された dev ビルドが必要なら `--no-hot-patch`(Tier 2)を使う、というオプトイン設計。
- 関連: 既知メモ「subsecond::call closures must be `move`(stack-shaped key で lookup が miss)」と同根の、ポインタサイズ closure 一般の修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)