### PR TITLE
fix(hot-reload): remount top-level set_root components on patch

### DIFF
--- a/crates/whisker-runtime/src/reactive/component.rs
+++ b/crates/whisker-runtime/src/reactive/component.rs
@@ -214,6 +214,11 @@ pub(crate) struct MountSite {
     /// was the first child of parent. Stable across remounts unless
     /// the anchor itself is removed by some other code path.
     pub anchor: Option<Element>,
+    /// True when this component's body_root was installed as the page
+    /// root via `view::set_root` (a top-level `#[whisker::main]`
+    /// component) rather than attached under a parent. Remount re-installs
+    /// it with `view::set_root` instead of inserting into a parent.
+    pub is_root: bool,
 }
 
 /// Called by `view::append_child` after every successful attach.
@@ -241,6 +246,28 @@ pub fn on_component_root_attached(parent: Element, child: Element) {
         if let Some(site) = rt.mount_sites.get_mut(&mount_id) {
             site.parent = Some(parent);
             site.anchor = anchor;
+        }
+    });
+}
+
+/// Called by `view::set_root` after the page root is installed.
+/// If a pending component mount's body_root matches `page`, this is a
+/// top-level component (`#[whisker::main] fn app() { render!{ Root } }`):
+/// mark its MountSite `is_root` so `remount_components_for` re-installs it
+/// via `set_root` on hot patch. No-op (and restores the pending entry) if
+/// nothing pending or the body_root doesn't match.
+pub fn on_component_root_set(page: Element) {
+    let pending = PENDING_MOUNT.with(|cell| cell.take());
+    let Some((mount_id, root)) = pending else {
+        return;
+    };
+    if root != page {
+        PENDING_MOUNT.with(|cell| cell.set(Some((mount_id, root))));
+        return;
+    }
+    super::with_runtime(|rt| {
+        if let Some(site) = rt.mount_sites.get_mut(&mount_id) {
+            site.is_root = true;
         }
     });
 }
@@ -306,6 +333,7 @@ where
                 body_root: Some(body_root),
                 parent: None,
                 anchor: None,
+                is_root: false,
             },
         );
         rt.fn_ptr_mounts.entry(fn_ptr).or_default().push(id);
@@ -387,6 +415,53 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
             })
             .collect()
     });
+
+    // Root sites (top-level components installed via `set_root`) have no
+    // parent in the child mirror, so the batched insert path can't handle
+    // them. Re-install each via `set_root` with a fresh owner + new body.
+    let (root_ids, ids): (Vec<MountId>, Vec<MountId>) = ids.into_iter().partition(|mid| {
+        with_runtime(|rt| rt.mount_sites.get(mid).map(|s| s.is_root).unwrap_or(false))
+    });
+    for mid in root_ids {
+        let Some((body, fn_ptr)) = with_runtime(|rt| {
+            let site = rt.mount_sites.get(&mid)?;
+            Some((site.body.clone(), site.fn_ptr))
+        }) else {
+            continue;
+        };
+        // Dispose the old owner (cascading reactive cleanup) before re-running.
+        let old_owner = with_runtime(|rt| {
+            let site = rt.mount_sites.get_mut(&mid)?;
+            site.body_root.take();
+            site.owner.take()
+        });
+        if let Some(o) = old_owner {
+            o.dispose();
+        }
+        let new_owner = Owner::new(None);
+        with_runtime(|rt| {
+            if let Some(o) = rt.owners.get_mut(new_owner) {
+                o.mount_fn = Some(fn_ptr);
+            }
+            rt.component_owners
+                .entry(fn_ptr)
+                .or_default()
+                .push(new_owner);
+        });
+        let new_body_root = untrack(|| new_owner.with(|| (*body)()));
+        // The body's nested `mount_component_remountable` calls leave a
+        // PENDING_MOUNT behind; drain it — we re-install via `set_root`,
+        // not the caller's `append_child`.
+        PENDING_MOUNT.with(|cell| cell.set(None));
+        crate::view::set_root(new_body_root);
+        with_runtime(|rt| {
+            if let Some(site) = rt.mount_sites.get_mut(&mid) {
+                site.owner = Some(new_owner);
+                site.body_root = Some(new_body_root);
+                // is_root stays true.
+            }
+        });
+    }
 
     if ids.is_empty() {
         return;

--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -55,7 +55,8 @@ pub use arc_signal::{arc_signal, ArcReadSignal, ArcRwSignal, ArcWriteSignal};
 pub use component::__reset_pending_mount_for_tests;
 pub use component::{
     flush_mounts, mount_component, mount_component_remountable, on_component_root_attached,
-    on_mount, owners_for_fn, remount_components_for, unmount_component, MountId,
+    on_component_root_set, on_mount, owners_for_fn, remount_components_for, unmount_component,
+    MountId,
 };
 pub use computed::computed;
 pub use context::{provide_context, use_context, with_context};

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -838,7 +838,8 @@ pub fn dispatch_event(target_sign: i32, event_name: &str, body: WhiskerValue) ->
 }
 
 pub fn set_root(page: Element) {
-    with_renderer(|r| r.set_root(page), ())
+    with_renderer(|r| r.set_root(page), ());
+    crate::reactive::on_component_root_set(page);
 }
 
 pub fn flush() {

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -159,6 +159,88 @@ fn install_returns_previous_renderer() {
     assert!(current_renderer_id().is_none());
 }
 
+// ----- Top-level (set_root) component remount -------------------------------
+
+/// A top-level `#[whisker::main]` component is installed via
+/// `view::set_root` (not `append_child`), so its `MountSite` has no
+/// recorded parent. Before the fix `remount_components_for` filtered it
+/// out and edits never hot-reloaded. This pins the `is_root` path:
+/// mounting + `set_root` marks the site root, and a subsequent
+/// `remount_components_for` re-runs the body and re-installs the new
+/// body_root via `set_root`.
+#[test]
+fn top_level_set_root_component_remounts() {
+    use crate::reactive::{mount_component_remountable, remount_components_for};
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    // Reset shared thread-local state so a reused worker thread starts clean.
+    crate::reactive::__reset_for_tests();
+    crate::reactive::__reset_pending_mount_for_tests();
+    crate::view::__reset_children_mirror_for_tests();
+
+    let (renderer, log) = RecordingRenderer::with_log();
+
+    let render_count = Rc::new(Cell::new(0_u32));
+    let render_count_body = render_count.clone();
+
+    let fn_ptr = 0x5151_0001 as *const ();
+
+    with_installed_renderer(Box::new(renderer), || {
+        let body = move || {
+            render_count_body.set(render_count_body.get() + 1);
+            create_element(ElementTag::View)
+        };
+        let body_root = mount_component_remountable(fn_ptr, body);
+        // Install it as the page root — this drains PENDING_MOUNT and
+        // marks the MountSite `is_root`.
+        set_root(body_root);
+
+        // Initial mount ran the body exactly once.
+        assert_eq!(render_count.get(), 1, "body ran once on initial mount");
+
+        let first_root_id = {
+            let ops = log.borrow();
+            let set_roots: Vec<u32> = ops
+                .iter()
+                .filter_map(|o| match o {
+                    Op::SetRoot { id } => Some(*id),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(set_roots.len(), 1, "one SetRoot from initial install");
+            assert_eq!(set_roots[0], body_root.id());
+            set_roots[0]
+        };
+
+        // Simulate a subsecond patch of the top-level component.
+        remount_components_for(&[fn_ptr]);
+
+        // Body re-ran.
+        assert_eq!(render_count.get(), 2, "body re-ran on remount");
+
+        // A second SetRoot landed with a *different* id (the new body_root
+        // installed as root).
+        let ops = log.borrow();
+        let set_roots: Vec<u32> = ops
+            .iter()
+            .filter_map(|o| match o {
+                Op::SetRoot { id } => Some(*id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            set_roots.len(),
+            2,
+            "second SetRoot from remount: {set_roots:?}"
+        );
+        assert_ne!(
+            set_roots[1], first_root_id,
+            "remount installs a fresh body_root as root: {set_roots:?}"
+        );
+    });
+}
+
 // ----- IntoView impls -------------------------------------------------------
 
 #[test]


### PR DESCRIPTION
## Root cause

A `#[component]` mounted at the **top level** via `view::set_root`
(`#[whisker::main] fn app() -> Element { render! { Root } }`) was never
hot-reloaded when edited. `remount_components_for` only processes mount
sites that have a recorded `parent`, and a `MountSite`'s `parent` is only
set by `on_component_root_attached`, which fires from `view::append_child`.
The top-level component's `body_root` is handed to `view::set_root` (never
`append_child`), so its `parent` stayed `None` and it was filtered out.
Only nested components remounted.

## Fix

- `MountSite` gains an `is_root` flag.
- New `on_component_root_set` handshake, called from `view::set_root` after
  the page root is installed: if the just-installed page matches the pending
  component mount's `body_root`, mark that `MountSite` `is_root`.
- `remount_components_for` partitions out root sites and re-installs each via
  `set_root` (fresh owner + new body, old owner disposed), leaving the
  existing batched parent-insert path for nested components.

## Test

Added `view::tests::top_level_set_root_component_remounts`: mounts a
top-level component via `mount_component_remountable` + `set_root`, asserts
the body ran once and one `SetRoot` op was recorded, then calls
`remount_components_for` and asserts the body re-ran (counter == 2) and a
second `SetRoot` op landed with a fresh body_root id.

`cargo test -p whisker-runtime`: 137 passed; 0 failed. clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)