### PR TITLE
refactor!: whisker owns the root page (remove user-facing `page`)

### DIFF
--- a/crates/whisker-cli/src/new_app.rs
+++ b/crates/whisker-cli/src/new_app.rs
@@ -183,10 +183,13 @@ use whisker::prelude::*;
 use whisker::runtime::view::Element;
 
 // `#[whisker::main]` is the app entry point. Keep it thin — it just
-// mounts the root component. Splitting your UI into `#[component]`s
-// (rather than writing everything here) is what lets `whisker run`
-// hot-reload your edits in well under a second: edit `Root` below, hit
-// save, and the running app updates live with its state preserved.
+// mounts the root component. Whisker provides the root `page` element
+// for you, so `app()` (and your components) just return a `view`.
+//
+// Splitting your UI into `#[component]`s (rather than writing everything
+// here) is what lets `whisker run` hot-reload your edits in well under a
+// second: edit `Root` below, hit save, and the running app updates live
+// with its state preserved.
 #[whisker::main]
 fn app() -> Element {{
     render! {{
@@ -194,7 +197,9 @@ fn app() -> Element {{
     }}
 }}
 
-/// The root of your app — put your state and layout here.
+/// The root of your app — put your state and layout here. Whisker wraps
+/// whatever `Root` returns in the full-screen root `page`, so this `view`
+/// just needs `flex_grow: 1.0` to fill it. Editing `Root` hot-reloads.
 #[component]
 fn root() -> Element {{
     // `RwSignal` holds reactive state. Anything that reads it (like the
@@ -206,7 +211,8 @@ fn root() -> Element {{
         // properties and values are checked at compile time. Reach for
         // `.raw("prop", "value")` for anything the typed builder doesn't
         // cover yet (here: `gap` and the gradient `background`).
-        page(style: css!(
+        view(style: css!(
+            flex_grow: 1.0,
             display: Display::Flex,
             flex_direction: FlexDirection::Column,
             justify_content: JustifyContent::Center,

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -47,10 +47,10 @@ use std::cell::Cell;
 use std::ffi::c_void;
 
 use whisker_driver_sys::{whisker_bridge_dispatch, WhiskerEngine};
+use whisker_runtime::element::ElementTag;
 use whisker_runtime::reactive::{
     flush as reactive_flush, flush_mounts as reactive_flush_mounts, remount_components_for,
 };
-use whisker_runtime::element::ElementTag;
 use whisker_runtime::view::{
     append_child, create_element, flush as renderer_flush, install_renderer, set_inline_styles,
     set_root, DynRenderer, Element,

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -50,8 +50,10 @@ use whisker_driver_sys::{whisker_bridge_dispatch, WhiskerEngine};
 use whisker_runtime::reactive::{
     flush as reactive_flush, flush_mounts as reactive_flush_mounts, remount_components_for,
 };
+use whisker_runtime::element::ElementTag;
 use whisker_runtime::view::{
-    flush as renderer_flush, install_renderer, set_root, DynRenderer, Element,
+    append_child, create_element, flush as renderer_flush, install_renderer, set_inline_styles,
+    set_root, DynRenderer, Element,
 };
 
 thread_local! {
@@ -185,10 +187,27 @@ extern "C" fn init_callback(user_data: *mut c_void) {
     // creates persist for the whole session.
     let root_owner = whisker_runtime::reactive::Owner::detached_root();
     root_owner.with(|| {
-        let root = app_fn();
+        // Whisker owns the root `page`. Lynx requires the shell's root to
+        // be a `page`-tagged element and keeps that element FIXED for the
+        // app's lifetime (it can't be swapped — see
+        // `whisker_bridge_set_root`). So rather than make the user declare
+        // it, we create one stable page here with a minimal, layout-only
+        // base style (full-size flex column) and mount the app's content
+        // as its child. Because the content is attached via
+        // `append_child`, a top-level `#[component]` lands with a real
+        // parent and hot-reloads through the normal child-remount path;
+        // the page itself never moves. Visual styling (background, safe
+        // area, padding) belongs on the user's root view, not here.
+        let page = create_element(ElementTag::Page);
+        set_inline_styles(
+            page,
+            "display:flex;flex-direction:column;flex-grow:1;flex-shrink:1;",
+        );
+        let content = app_fn();
+        append_child(page, content);
         // Commit the initial tree: mark the page as root and ask Lynx
         // to run the first layout+paint pass.
-        set_root(root);
+        set_root(page);
         renderer_flush();
         // Fire on_mount callbacks for everything that just mounted. Has
         // to happen after the renderer flush so user-side code that asks

--- a/crates/whisker-macro-syntax/src/render.rs
+++ b/crates/whisker-macro-syntax/src/render.rs
@@ -246,7 +246,7 @@ pub fn snake_to_pascal(name: &str) -> String {
 pub fn is_builtin_tag(name: &str) -> bool {
     matches!(
         name,
-        "page" | "view" | "text" | "raw_text" | "scroll_view" | "list" | "fragment"
+        "view" | "text" | "raw_text" | "scroll_view" | "list" | "fragment"
     )
 }
 

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -28,7 +28,7 @@ mod render;
 ///
 /// #[whisker::main]
 /// fn app() -> Element {
-///     render! { page { text(value: "Hello") } }
+///     render! { view(style: "flex-grow: 1;") { text(value: "Hello") } }
 /// }
 /// ```
 ///

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -502,7 +502,7 @@ mod tests {
 
     #[test]
     fn builtin_tags_recognised() {
-        for t in ["page", "view", "text", "raw_text", "scroll_view"] {
+        for t in ["view", "text", "raw_text", "scroll_view"] {
             assert!(is_builtin_tag(t));
         }
     }

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -10,12 +10,16 @@
 //! #[whisker::main]
 //! fn app() -> Element {
 //!     render! {
-//!         page(style: "background: white;") {
+//!         view(style: "flex-grow: 1; background: white;") {
 //!             text(value: "Hello, Whisker")
 //!         }
 //!     }
 //! }
 //! ```
+//!
+//! Whisker owns the root `page` element: it wraps whatever your app
+//! returns in a full-screen flex column, so app code just returns a
+//! `view` (give it `flex-grow: 1` to fill the screen).
 //!
 //! ## What's in this crate
 //!
@@ -36,7 +40,7 @@
 //!   Both are written as ordinary `#[component]` functions.
 //! - **CSS** — the [`css`] type-safe builder + the `css!` macro.
 //! - **Built-in elements** — `view`, `text`, `scroll_view`, `list`,
-//!   `page`, `raw_text`, `fragment`. The `render!` macro lowers each
+//!   `raw_text`, `fragment`. The `render!` macro lowers each
 //!   tag invocation into a builder chain on the corresponding struct in
 //!   [`__tags`]; the [`__tags::ElementBuilder`] trait provides the
 //!   shared `style` / `class` / `on_<event>` / … methods.
@@ -793,27 +797,15 @@ pub mod __tags {
     }
 
     /// `<page>` — top-level container Lynx mounts as the root of an
-    /// app. Holds the screen-level `style=` and a single content
-    /// subtree.
+    /// app. **Whisker-internal:** `page` is no longer a `render!`
+    /// built-in tag. The framework creates exactly one root `page`
+    /// during bootstrap (a full-screen flex column) and mounts whatever
+    /// your app returns as its child, so app code never writes `page` —
+    /// return a `view` (with `flex-grow: 1` to fill the screen) instead.
     ///
-    /// Use `page` as the outermost element returned from a
-    /// `#[whisker::main]` function. Lynx treats the page as the
-    /// viewport for layout, so screen-spanning styles
-    /// (`width: 100%`, `background`, …) belong here. There must be
-    /// exactly one `page` at the top of the tree.
-    ///
-    /// ```ignore
-    /// use whisker::prelude::*;
-    ///
-    /// #[whisker::main]
-    /// fn app() -> Element {
-    ///     render! {
-    ///         page(style: "background: white;") {
-    ///             text(value: "Hello")
-    ///         }
-    ///     }
-    /// }
-    /// ```
+    /// Lynx keeps this root `page` fixed for the app's lifetime; it
+    /// cannot be hot-reloaded, which is why whisker owns it rather than
+    /// the user.
     #[allow(non_camel_case_types)]
     pub struct page {
         handle: Element,

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -880,10 +880,10 @@ fn for_removes_items_on_update() {
 }
 
 #[test]
-fn page_view_scroll_view_tags_supported() {
+fn view_scroll_view_tags_supported() {
     with_recorder(|log| {
         let _ = render! {
-            page {
+            view {
                 scroll_view {
                     view()
                 }
@@ -899,7 +899,7 @@ fn page_view_scroll_view_tags_supported() {
             .collect();
         assert_eq!(
             creates,
-            vec![ElementTag::Page, ElementTag::ScrollView, ElementTag::View]
+            vec![ElementTag::View, ElementTag::ScrollView, ElementTag::View]
         );
     });
 }

--- a/examples/asset-demo/src/lib.rs
+++ b/examples/asset-demo/src/lib.rs
@@ -34,7 +34,8 @@ pub fn app() -> Element {
     let logo_src = asset!("images/logo.png");
 
     render! {
-        page(style: css!(
+        view(style: css!(
+            flex_grow: 1.0,
             background_color: Color::hex(0x101012),
             flex_direction: FlexDirection::Column,
             align_items: AlignItems::Center,

--- a/examples/podcast/src/lib.rs
+++ b/examples/podcast/src/lib.rs
@@ -133,7 +133,8 @@ fn app() -> Element {
         // mini-player to the page itself, so the bar floats above
         // *every* route — browse and detail alike — instead of
         // being scoped to one screen's layout.
-        page(style: css!(
+        view(style: css!(
+            flex_grow: 1.0,
             width: vw(100),
             height: vh(100),
             background_color: podcast_theme::BG,

--- a/packages/whisker-audio/example/src/lib.rs
+++ b/packages/whisker-audio/example/src/lib.rs
@@ -26,7 +26,7 @@ pub fn app() -> Element {
     let insets = safe_area_insets();
 
     render! {
-        page(style: computed(move || css!(
+        view(style: computed(move || css!(
             background_color: Color::hex(0x101012),
             flex_grow: 1.0,
             display: Display::Flex,

--- a/packages/whisker-icons/example/src/lib.rs
+++ b/packages/whisker-icons/example/src/lib.rs
@@ -36,7 +36,7 @@ pub fn app() -> Element {
     let insets = safe_area_insets();
 
     render! {
-        page(style: computed(move || css!(
+        view(style: computed(move || css!(
             background_color: Color::hex(0x101012),
             flex_grow: 1.0,
             flex_shrink: 1.0,
@@ -46,8 +46,8 @@ pub fn app() -> Element {
             padding_bottom: px(insets.get().bottom as f32 + 16.0),
         ))) {
             // Wrap the header `text` in a `view` — a known Lynx
-            // Android quirk collapses the first direct child of a
-            // `<page>` to zero height when edge-to-edge is enabled
+            // Android quirk collapses the first direct child of the
+            // root `<page>` to zero height when edge-to-edge is enabled
             // (`WhiskerActivity` flips `setDecorFitsSystemWindows(false)`).
             // Putting an intermediate flex container in between gives
             // the text a frame to lay out against. The wrapper is

--- a/packages/whisker-input/example/src/lib.rs
+++ b/packages/whisker-input/example/src/lib.rs
@@ -32,7 +32,7 @@ pub fn app() -> Element {
         format!("color: {FG}; font-size: 22px; font-weight: 700; margin-bottom: 20px;",);
 
     render! {
-        page(style: page_style) {
+        view(style: page_style) {
             text(style: header_style, value: "whisker-input demo")
 
             two_way_demo()

--- a/packages/whisker-router/example/src/lib.rs
+++ b/packages/whisker-router/example/src/lib.rs
@@ -114,8 +114,8 @@ fn render_stacked() -> Element {
     })
     .into();
     render! {
-        page(
-            style: "width: 100vw; height: 100vh; background-color: white; \
+        view(
+            style: "flex-grow: 1; width: 100vw; height: 100vh; background-color: white; \
                     display: flex; flex-direction: column;",
         ) {
             RouteProvider(stack: stack) {
@@ -130,8 +130,8 @@ fn render_stacked() -> Element {
 
 fn render_direct() -> Element {
     render! {
-        page(
-            style: "width: 100vw; height: 100vh; background-color: white; \
+        view(
+            style: "flex-grow: 1; width: 100vw; height: 100vh; background-color: white; \
                     display: flex; flex-direction: column;",
         ) {
             HomeScreen()

--- a/packages/whisker-svg/example/src/lib.rs
+++ b/packages/whisker-svg/example/src/lib.rs
@@ -84,7 +84,7 @@ pub fn app() -> Element {
         .to_string();
 
     render! {
-        page(style: page_style) {
+        view(style: page_style) {
             text(style: header_style, value: "whisker-svg gallery")
             view(style: grid_style) {
                 tile(label: "Rect (solid)",        svg: SVG_RECT,     color: FG)

--- a/packages/whisker-webview/example/src/lib.rs
+++ b/packages/whisker-webview/example/src/lib.rs
@@ -34,7 +34,7 @@ pub fn app() -> Element {
         format!("color: {FG}; font-size: 22px; font-weight: 700; margin-bottom: 20px;",);
 
     render! {
-        page(style: page_style) {
+        view(style: page_style) {
             text(style: header_style, value: "whisker-webview demo")
 
             url_demo()


### PR DESCRIPTION
## What & why

Lynx keeps the **root `page`** element fixed for the lifetime of an app — it is mounted once at bootstrap and **cannot be hot-reloaded**. Previously users wrote `page { ... }` as the outermost element of their app, which meant the one element that *can't* reload sat at the top of user code.

This change moves ownership of the root `page` to whisker. The driver bootstrap (prior commit on this branch) now creates a stable root `page` — a full-screen flex column (`display:flex; flex-direction:column; flex-grow:1; flex-shrink:1;`) — and mounts whatever the app returns as its child.

## New model

- `page` is **no longer a `render!` built-in tag**. Writing `page { ... }` now parses as a (PascalCase'd) user component `Page` and fails to resolve — an intentional guardrail.
- Apps return a `view` (or a `#[component]` returning a `view`). Give the root `view` `flex_grow: 1.0` (or `flex-grow: 1`) so it fills the auto-provided page.
- Because the top-level component is now ordinary user content, **it hot-reloads** — edit it and save, the running app updates with state preserved.
- `ElementTag::Page` and its renderer mapping are retained; only the macro's recognition of user-written `page` is removed.

## Migration (this is a breaking change)

All in-repo usages migrated: the former root-`page` styling moves onto a root `view` with `flex_grow: 1.0` (string-style pages that already carried `flex-grow: 1` / `100vw`/`100vh` keep their form). Safe-area insets, backgrounds, padding, and flex props are all preserved.

Migrated:
- `whisker new` scaffold (`crates/whisker-cli/src/new_app.rs`) — `Root` now returns a `view` with `flex_grow: 1.0`; docs explain whisker owns the root page and editing `Root` hot-reloads.
- Examples: `asset-demo`, `podcast`.
- Package examples: `whisker-icons` (safe-area), `whisker-audio` (safe-area), `whisker-router` (multiple screen-container pages), `whisker-input`, `whisker-svg`, `whisker-webview`.
- Tests: `crates/whisker/tests/render_macro.rs` (the `page`-builtin test now asserts `view`).
- Docs/doctests in `crates/whisker/src/lib.rs` and `crates/whisker-macros/src/lib.rs`.

## Verification

- `cargo build --workspace` — clean (any leftover `page` would fail to resolve `Page`).
- `cargo test -p whisker -p whisker-macros -p whisker-macro-syntax` — green.
- `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)