### PR TITLE
feat(whisker-fmt): preserve comments when formatting render!/css! bodies

### DIFF
--- a/crates/whisker-fmt/src/comments.rs
+++ b/crates/whisker-fmt/src/comments.rs
@@ -1,0 +1,233 @@
+//! Collect "grammar" comments from a `render!` / `css!` body.
+//!
+//! `syn` discards comments and `proc-macro2` exposes them only as
+//! inter-token whitespace, so to PRESERVE comments while pretty-printing
+//! we recover them straight from the body source text here, then reattach
+//! them during printing (see [`crate::printer`]).
+//!
+//! A *grammar* comment is one that lives in the macro grammar (between
+//! tags, kwargs, delimiters) — NOT inside an embedded Rust expr value.
+//! Comments inside an expr value are preserved by slicing / rustfmt-ing
+//! that expr's source, so they are deliberately excluded here (the
+//! caller masks each expr span before scanning).
+
+use crate::source_map::SourceMap;
+use proc_macro2::Span;
+
+/// A comment recovered verbatim from the macro body source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GrammarComment {
+    /// Byte offset of the comment start (the first `/`) in the body.
+    pub start: usize,
+    /// Exclusive end. For a `//` line comment this excludes the trailing
+    /// newline; for a `/* */` block it is just past the closing `*/`.
+    pub end: usize,
+    /// Verbatim comment text, right-trimmed (e.g. `// hi` or `/* x */`).
+    pub text: String,
+    /// `true` when only whitespace precedes `start` back to the previous
+    /// `\n` (or the body start) — i.e. the comment owns its line.
+    pub own_line: bool,
+}
+
+/// Scan `body` for `//` and `/* */` comments that live in the macro
+/// grammar (outside every embedded-expr span), returning them sorted by
+/// `start`.
+///
+/// String / char literals are skipped so a `//` or `/*` inside one is not
+/// mistaken for a comment. Block comments nest (Rust semantics). A comment
+/// whose `[start,end)` overlaps any expr span is dropped — those belong to
+/// the embedded expr and are handled by the expr path.
+pub(crate) fn collect_grammar_comments(
+    body: &str,
+    expr_spans: &[Span],
+    body_map: &SourceMap,
+) -> Vec<GrammarComment> {
+    // Byte ranges of the embedded exprs; a comment overlapping any of
+    // these is skipped.
+    let mut expr_ranges: Vec<(usize, usize)> = Vec::new();
+    for &span in expr_spans {
+        if let Some((s, e)) = body_map.byte_range(span) {
+            expr_ranges.push((s, e));
+        }
+    }
+    let in_expr = |start: usize, end: usize| {
+        expr_ranges
+            .iter()
+            .any(|&(s, e)| start < e && s < end.max(start + 1))
+    };
+
+    let bytes = body.as_bytes();
+    let mut out: Vec<GrammarComment> = Vec::new();
+    let mut i = 0usize;
+    let mut in_str: Option<u8> = None; // Some(quote_char)
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        match in_str {
+            Some(q) => {
+                if b == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if b == q {
+                    in_str = None;
+                }
+                i += 1;
+            }
+            None => {
+                if b == b'"' || b == b'\'' {
+                    in_str = Some(b);
+                    i += 1;
+                } else if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+                    // `//` line comment to end of line.
+                    let start = i;
+                    let mut j = i + 2;
+                    while j < bytes.len() && bytes[j] != b'\n' {
+                        j += 1;
+                    }
+                    // `end` excludes the newline; right-trim text.
+                    let text = body[start..j].trim_end().to_string();
+                    let end = start + text.len();
+                    if !in_expr(start, j) {
+                        out.push(GrammarComment {
+                            start,
+                            end,
+                            text,
+                            own_line: own_line(body, start),
+                        });
+                    }
+                    i = j;
+                } else if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+                    // `/* ... */` block comment — nests.
+                    let start = i;
+                    let mut j = i + 2;
+                    let mut depth = 1usize;
+                    while j < bytes.len() && depth > 0 {
+                        if j + 1 < bytes.len() && bytes[j] == b'/' && bytes[j + 1] == b'*' {
+                            depth += 1;
+                            j += 2;
+                        } else if j + 1 < bytes.len() && bytes[j] == b'*' && bytes[j + 1] == b'/' {
+                            depth -= 1;
+                            j += 2;
+                        } else {
+                            j += 1;
+                        }
+                    }
+                    let text = body[start..j].trim_end().to_string();
+                    let end = start + text.len();
+                    if !in_expr(start, j) {
+                        out.push(GrammarComment {
+                            start,
+                            end,
+                            text,
+                            own_line: own_line(body, start),
+                        });
+                    }
+                    i = j;
+                } else {
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    out.sort_by_key(|c| c.start);
+    out
+}
+
+/// `true` if only whitespace precedes byte `start` back to the previous
+/// `\n` (or the start of the body).
+fn own_line(body: &str, start: usize) -> bool {
+    let prefix = &body[..start];
+    let line_start = prefix.rfind('\n').map(|n| n + 1).unwrap_or(0);
+    body[line_start..start].chars().all(|c| c.is_whitespace())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collect(body: &str) -> Vec<GrammarComment> {
+        let map = SourceMap::new(body);
+        collect_grammar_comments(body, &[], &map)
+    }
+
+    #[test]
+    fn line_comment_own_line() {
+        let body = "view {\n    // hi\n    text\n}";
+        let cs = collect(body);
+        assert_eq!(cs.len(), 1);
+        assert_eq!(cs[0].text, "// hi");
+        assert!(cs[0].own_line);
+    }
+
+    #[test]
+    fn line_comment_trailing() {
+        let body = "view // tail\n";
+        let cs = collect(body);
+        assert_eq!(cs.len(), 1);
+        assert_eq!(cs[0].text, "// tail");
+        assert!(!cs[0].own_line);
+    }
+
+    #[test]
+    fn line_comment_right_trimmed() {
+        let body = "// hi   \n";
+        let cs = collect(body);
+        assert_eq!(cs[0].text, "// hi");
+        assert_eq!(cs[0].end, cs[0].start + "// hi".len());
+    }
+
+    #[test]
+    fn block_comment_single_line() {
+        let body = "/* x */ view";
+        let cs = collect(body);
+        assert_eq!(cs.len(), 1);
+        assert_eq!(cs[0].text, "/* x */");
+    }
+
+    #[test]
+    fn block_comment_nested() {
+        let body = "/* outer /* inner */ still */ view";
+        let cs = collect(body);
+        assert_eq!(cs.len(), 1);
+        assert_eq!(cs[0].text, "/* outer /* inner */ still */");
+    }
+
+    #[test]
+    fn block_comment_multiline_verbatim() {
+        let body = "/* line1\n   line2 */\nview";
+        let cs = collect(body);
+        assert_eq!(cs.len(), 1);
+        assert_eq!(cs[0].text, "/* line1\n   line2 */");
+    }
+
+    #[test]
+    fn slashes_in_string_not_comments() {
+        let body = "text(value: \"http://x // y\")";
+        let cs = collect(body);
+        assert!(cs.is_empty(), "got: {cs:?}");
+    }
+
+    #[test]
+    fn comment_inside_expr_span_excluded() {
+        // body has one comment inside an expr range and one outside.
+        let body = "a // outside\nb";
+        let map = SourceMap::new(body);
+        // Build a span covering byte 0..1 ("a"); easier: use no spans
+        // here and instead assert collection works; expr exclusion is
+        // covered via integration tests in lib.rs.
+        let cs = collect_grammar_comments(body, &[], &map);
+        assert_eq!(cs.len(), 1);
+        assert_eq!(cs[0].text, "// outside");
+    }
+
+    #[test]
+    fn two_consecutive_comments() {
+        let body = "// one\n// two\nview";
+        let cs = collect(body);
+        assert_eq!(cs.len(), 2);
+        assert_eq!(cs[0].text, "// one");
+        assert_eq!(cs[1].text, "// two");
+    }
+}

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -26,13 +26,24 @@
 //!
 //! # Comments inside macros
 //!
-//! `syn` drops comments, and `proc-macro2` exposes them only as
-//! whitespace between tokens. Full-fidelity comment preservation inside
-//! `render!` bodies is **not** implemented in this pass — see
-//! [`reformat_macros`] docs and the `comments_*` tests for the exact,
-//! documented limitation. Comments OUTSIDE macros are preserved by
-//! rustfmt as usual.
+//! `syn` drops comments and `proc-macro2` exposes them only as
+//! whitespace between tokens, so reprinting a `render!` / `css!` body
+//! from the parsed AST would lose them. To preserve them we recover the
+//! comments straight from the body source text ([`comments`]) and
+//! reattach them while pretty-printing ([`printer`]): own-line comments
+//! go on their own line at the block's indent, trailing comments are
+//! appended to the end of the preceding line. Comments INSIDE an embedded
+//! expr value are excluded from this pass — they ride along with the
+//! verbatim / rustfmt-formatted expr source instead.
+//!
+//! A **fail-safe** guards the result: after formatting, if any recovered
+//! comment would be dropped, or the output is not idempotent
+//! (`f(f(x)) != f(x)`), the body is left **untouched** (the original
+//! verbatim text) — so a comment can never be silently lost. See
+//! [`macro_body_edit`]. Comments OUTSIDE macros are preserved by rustfmt
+//! as usual.
 
+mod comments;
 mod expr_fmt;
 mod options;
 mod printer;
@@ -289,15 +300,14 @@ pub fn resolve_options(dir: &Path) -> FmtOptions {
 ///
 /// This is the testable core that does NOT need the rustfmt binary.
 ///
-/// ## Comment limitation
+/// ## Comments
 ///
-/// Comments *inside* a `render!` / `css!` body are dropped: `syn`
-/// discards them entirely, and recovering them from inter-token
-/// whitespace cannot be done reliably for an arbitrary nested grammar
-/// in this pass. Macro bodies that contain `//` or `/* */` comments are
-/// detected and left **untouched** (the original body text is kept
-/// verbatim) rather than silently losing the comments — see
-/// [`body_has_comments`]. This is the documented, tested limitation.
+/// Comments inside a `render!` / `css!` body ARE preserved: they're
+/// recovered from the body source ([`comments::collect_grammar_comments`])
+/// and reattached during pretty-printing. A fail-safe in
+/// [`macro_body_edit`] falls back to leaving the body untouched if any
+/// comment would be dropped or the result is not idempotent, so comments
+/// are never lost.
 pub fn reformat_macros(rust_src: &str, opts: &FmtOptions) -> Result<String> {
     // Public entry point: the rustfmt-FREE core. No `ExprFormatter`, so
     // every embedded expr is rendered verbatim (the printer's empty-map
@@ -442,27 +452,33 @@ fn macro_body_edit(
         .map_err(|e| anyhow!("whisker-fmt: could not lex {macro_name}! body: {e}"))?;
     let body_map = SourceMap::new(body_src);
 
+    let body_len = body_src.len();
+
     // Collect the embedded-expr spans up front: we need them both to
-    // batch-format the exprs AND to decide whether a comment in the body
-    // is inside an expr value (fine — preserved by slicing) or in the
-    // macro GRAMMAR (the documented limitation — bail).
-    let formatted = match macro_name {
+    // batch-format the exprs AND to mask out expr-internal comments when
+    // recovering the grammar comments to reattach. Comments INSIDE an
+    // expr value are kept by slicing / rustfmt-ing the expr source; only
+    // GRAMMAR comments are reattached here.
+    let (formatted, grammar_comments) = match macro_name {
         "render" => match whisker_macro_syntax::render::parse_root(body_ts.clone()) {
             Ok(root) => {
                 let mut spans = Vec::new();
                 collect_render_expr_spans(&root.node, &mut spans);
-                // Comment limitation: a comment OUTSIDE every embedded
-                // expr (i.e. in the render! grammar) still leaves the
-                // body untouched. A comment INSIDE an expr value is kept
-                // by slicing that value verbatim / formatting its source.
-                if body_has_grammar_comment(body_src, &spans, &body_map) {
-                    return Ok(None);
-                }
+                let comments = comments::collect_grammar_comments(body_src, &spans, &body_map);
                 // Batch-format every embedded expr with one rustfmt spawn.
                 // With no `exprfmt` (rustfmt-free core) the map stays
                 // empty and every expr renders verbatim.
                 let expr_map = build_expr_map(&spans, &body_map, exprfmt);
-                printer::print_render(&root, &body_map, opts, base_indent, &expr_map)
+                let s = printer::print_render(
+                    &root,
+                    &body_map,
+                    opts,
+                    base_indent,
+                    &expr_map,
+                    &comments,
+                    body_len,
+                );
+                (s, comments)
             }
             // Not a well-formed render! body (e.g. mid-edit) — leave it.
             Err(_) => return Ok(None),
@@ -478,11 +494,18 @@ fn macro_body_edit(
                         spans.push(span_of_expr(expr));
                     }
                 }
-                if body_has_grammar_comment(body_src, &spans, &body_map) {
-                    return Ok(None);
-                }
+                let comments = comments::collect_grammar_comments(body_src, &spans, &body_map);
                 let expr_map = build_expr_map(&spans, &body_map, exprfmt);
-                printer::print_css(&input, &body_map, opts, base_indent, &expr_map)
+                let s = printer::print_css(
+                    &input,
+                    &body_map,
+                    opts,
+                    base_indent,
+                    &expr_map,
+                    &comments,
+                    body_len,
+                );
+                (s, comments)
             }
             Err(_) => return Ok(None),
         },
@@ -507,11 +530,98 @@ fn macro_body_edit(
         return Ok(None);
     }
 
+    // ---- comment-preservation fail-safe ------------------------------
+    //
+    // If reattaching the comments could possibly have dropped one, or the
+    // result isn't a fixed point, leave the body UNTOUCHED (today's old
+    // behavior — no regression, no comment ever lost).
+    if !grammar_comments.is_empty() {
+        // (1) No comment lost: every recovered comment's text must appear
+        // in the formatted output, counting duplicates.
+        if !all_comments_present(&replacement, &grammar_comments) {
+            return Ok(None);
+        }
+        // (2) Idempotency: re-running the formatter on the produced body
+        // must be a fixed point. We re-run the SAME macro pass over a
+        // minimal synthetic wrapper containing the produced body and check
+        // the body comes back unchanged.
+        if !macro_replacement_is_fixed_point(macro_name, &replacement, base_indent, opts) {
+            return Ok(None);
+        }
+    }
+
     Ok(Some(MacroEdit {
         open_byte,
         close_byte,
         replacement,
     }))
+}
+
+// ---- comment-preservation fail-safe helpers -----------------------------
+
+/// Every recovered comment's (trimmed) text must appear in `output`,
+/// counting duplicates: if the body has two identical comments, both must
+/// survive. Uses a per-text occurrence count.
+fn all_comments_present(output: &str, comments: &[comments::GrammarComment]) -> bool {
+    use std::collections::HashMap;
+    // Required count per comment text.
+    let mut need: HashMap<&str, usize> = HashMap::new();
+    for c in comments {
+        *need.entry(c.text.trim()).or_insert(0) += 1;
+    }
+    for (text, count) in need {
+        if text.is_empty() {
+            continue;
+        }
+        if count_occurrences(output, text) < count {
+            return false;
+        }
+    }
+    true
+}
+
+/// Count non-overlapping occurrences of `needle` in `haystack`.
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    let mut n = 0;
+    let mut rest = haystack;
+    while let Some(pos) = rest.find(needle) {
+        n += 1;
+        rest = &rest[pos + needle.len()..];
+    }
+    n
+}
+
+/// Re-run the macro pass over the just-produced body and confirm it is a
+/// fixed point (`f(f(x)) == f(x)`). The `replacement` is the body text
+/// INCLUDING its leading/trailing newlines (i.e. exactly what sits between
+/// the macro delimiters). We splice it into a synthetic wrapper at the
+/// right `base_indent`, run the rustfmt-FREE macro pass, and check the
+/// macro body comes back identical.
+fn macro_replacement_is_fixed_point(
+    macro_name: &str,
+    replacement: &str,
+    base_indent: usize,
+    opts: &FmtOptions,
+) -> bool {
+    let indent = opts.indent_prefix(base_indent);
+    // Wrap in a trivial fn so the source is valid Rust. The macro sits at
+    // `base_indent` (the wrapper body is at base_indent, the fn at 0).
+    // To get `base_indent` levels of indent for the macro line we open
+    // (base_indent) nested-block-free wrapper: a single fn plus manual
+    // indent prefix on the macro line works because rustfmt isn't run.
+    let src = format!("fn _w() {{\n{indent}{macro_name}! {{{replacement}}}\n}}\n");
+    let once = match reformat_macros_inner(&src, opts, None) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let twice = match reformat_macros_inner(&once, opts, None) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    once == twice
 }
 
 // ---- embedded-expr collection + batched formatting ----------------------
@@ -575,75 +685,6 @@ fn build_expr_map(
         }
     }
     exprfmt.format_body(&exprs)
-}
-
-/// Like [`body_has_comments`], but ignores comments that live INSIDE an
-/// embedded expr value. Those are preserved by slicing / rustfmt-ing the
-/// expr source. Only a comment in the macro GRAMMAR (between tags,
-/// kwargs, delimiters) triggers the documented "leave-untouched"
-/// limitation.
-///
-/// Implementation: blank out each expr span's bytes (replacing with
-/// spaces, keeping length so the scan's string-awareness stays valid)
-/// then run the ordinary comment scan over what's left.
-fn body_has_grammar_comment(body: &str, expr_spans: &[Span], body_map: &SourceMap) -> bool {
-    // Fast path: no comment anywhere → definitely no grammar comment.
-    if !body_has_comments(body) {
-        return false;
-    }
-    let mut masked: Vec<u8> = body.as_bytes().to_vec();
-    for &span in expr_spans {
-        if let Some((s, e)) = body_map.byte_range(span) {
-            for b in &mut masked[s..e] {
-                // Preserve newlines so line structure (and any `//`
-                // single-line comment that ends at a newline) is intact
-                // outside the masked region; blank everything else.
-                if *b != b'\n' {
-                    *b = b' ';
-                }
-            }
-        }
-    }
-    // `masked` is still valid UTF-8 (we only replaced whole bytes of
-    // ASCII space within char boundaries… actually a multi-byte char
-    // could be partially masked, so rebuild lossily for safety).
-    let masked_str = String::from_utf8_lossy(&masked);
-    body_has_comments(&masked_str)
-}
-
-/// Detect `//` or `/* */` comments in a macro body. Uses a tiny
-/// string-aware scan so a `//` inside a string literal isn't a false
-/// positive.
-fn body_has_comments(body: &str) -> bool {
-    let bytes = body.as_bytes();
-    let mut i = 0;
-    let mut in_str: Option<u8> = None; // Some(quote_char)
-    while i < bytes.len() {
-        let b = bytes[i];
-        match in_str {
-            Some(q) => {
-                if b == b'\\' {
-                    i += 2;
-                    continue;
-                }
-                if b == q {
-                    in_str = None;
-                }
-            }
-            None => {
-                if b == b'"' || b == b'\'' {
-                    in_str = Some(b);
-                } else if b == b'/' && i + 1 < bytes.len() {
-                    let n = bytes[i + 1];
-                    if n == b'/' || n == b'*' {
-                        return true;
-                    }
-                }
-            }
-        }
-        i += 1;
-    }
-    false
 }
 
 /// Convert a line's leading-whitespace prefix into an indent level (in
@@ -751,12 +792,13 @@ mod tests {
     }
 
     #[test]
-    fn comments_in_body_left_untouched() {
-        // KNOWN LIMITATION: a macro body containing comments is left
-        // exactly as-is rather than dropping the comment.
+    fn trailing_block_comment_preserved_and_reflowed() {
+        // A trailing block comment after a node is now KEPT (reattached to
+        // the node's line) while the body is reflowed.
         let input = "fn ui() -> Element {\n    render! { view(style:\"x\") /* keep me */ }\n}\n";
         let out = reformat_macros(input, &opts(4, 100)).unwrap();
-        assert_eq!(out, input, "comment-bearing body must be untouched");
+        let expected = "fn ui() -> Element {\n    render! {\n        view(style: \"x\") /* keep me */\n    }\n}\n";
+        assert_eq!(out, expected, "got:\n{out}");
     }
 
     #[test]
@@ -909,5 +951,185 @@ mod tests {
         // rustfmt applied 2-space indent from the root config.
         assert!(out.contains("\n  let x = 1;"), "got:\n{out}");
         std::fs::remove_dir_all(&root).unwrap();
+    }
+}
+
+// ---- comment-preservation tests -----------------------------------------
+//
+// All feed already-rust-formatted input to `reformat_macros`, so they do
+// NOT need the rustfmt binary. They assert EXACT output to prove real
+// comment-preserving formatting happens (not just fallback).
+#[cfg(test)]
+mod comment_tests {
+    use super::*;
+
+    fn o() -> FmtOptions {
+        FmtOptions {
+            max_width: 100,
+            tab_spaces: 4,
+            hard_tabs: false,
+            edition: None,
+        }
+    }
+
+    fn fmt(input: &str) -> String {
+        reformat_macros(input, &o()).unwrap()
+    }
+
+    // 1. Own-line `//` before a top-level element (also reflows the body).
+    #[test]
+    fn own_line_before_top_element() {
+        let input = "fn d() -> Element {\n    render! {\n        // header\n        view(style: \"x\") { text(value: \"hi\") }\n    }\n}\n";
+        let expected = "fn d() -> Element {\n    render! {\n        // header\n        view(style: \"x\") {\n            text(value: \"hi\")\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), expected);
+    }
+
+    // 2. Own-line comment between two sibling children.
+    #[test]
+    fn own_line_between_siblings() {
+        let input = "fn d() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n            // mid\n            text(value: \"b\")\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 3. Own-line comment as the first child (right after `{`).
+    #[test]
+    fn own_line_first_child() {
+        let input = "fn d() -> Element {\n    render! {\n        view {\n            // first\n            text(value: \"a\")\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 4. Own-line comment after the last child, before `}` (inside block).
+    #[test]
+    fn own_line_after_last_child() {
+        let input = "fn d() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n            // last\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 5. Trailing `//` on the same line as a child.
+    #[test]
+    fn trailing_line_comment_on_child() {
+        let input = "fn d() -> Element {\n    render! {\n        view {\n            text(value: \"a\") // tail\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 6. Trailing comment after a `css!` field.
+    #[test]
+    fn trailing_comment_after_css_field() {
+        let input =
+            "fn s() -> Css {\n    css! {\n        color: red, // c\n        padding: px(8),\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 7. Own-line comment between two `css!` fields.
+    #[test]
+    fn own_line_between_css_fields() {
+        let input =
+            "fn s() -> Css {\n    css! {\n        color: red,\n        // gap\n        padding: px(8),\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 8. `/* block */` single-line comment.
+    #[test]
+    fn block_comment_single_line() {
+        let input = "fn d() -> Element {\n    render! {\n        /* b */\n        view(style: \"x\")\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 9. Multi-line `/* … */` block comment, kept verbatim.
+    #[test]
+    fn block_comment_multiline_verbatim() {
+        let input = "fn d() -> Element {\n    render! {\n        /* line1\n           line2 */\n        view(style: \"x\")\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 10. Two consecutive own-line comments.
+    #[test]
+    fn two_consecutive_comments() {
+        let input = "fn d() -> Element {\n    render! {\n        // one\n        // two\n        view(style: \"x\")\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 11. A comment INSIDE an embedded expr is not touched by
+    // reattachment and survives (handled by the expr path).
+    #[test]
+    fn comment_inside_embedded_expr_survives() {
+        let input = "fn d() -> Element {\n    render! {\n        view(on_tap: move |_| { /* keep */ go() })\n    }\n}\n";
+        let out = fmt(input);
+        assert!(out.contains("/* keep */"), "got:\n{out}");
+        // Not duplicated.
+        assert_eq!(out.matches("/* keep */").count(), 1, "got:\n{out}");
+    }
+
+    // 12. Deeply nested element: own-line comment before an inner child
+    // lands at the correct (deeper) indent.
+    #[test]
+    fn nested_inner_child_indent() {
+        let input = "fn d() -> Element {\n    render! {\n        view {\n            scroll_view {\n                // inner\n                text(value: \"a\")\n            }\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 13. Mixed leading + trailing comments in the same body.
+    #[test]
+    fn mixed_leading_and_trailing() {
+        let input = "fn d() -> Element {\n    render! {\n        // lead\n        view {\n            text(value: \"a\") // tail\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+    }
+
+    // 14. Idempotency over several comment-bearing inputs.
+    #[test]
+    fn idempotent_with_comments() {
+        let inputs = [
+            "fn d() -> Element {\n    render! {\n        // header\n        view(style: \"x\") { text(value: \"hi\") }\n    }\n}\n",
+            "fn d() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n            // mid\n            text(value: \"b\")\n        }\n    }\n}\n",
+            "fn s() -> Css {\n    css! {\n        color: red, // c\n        padding: px(8),\n    }\n}\n",
+            "fn d() -> Element {\n    render! {\n        /* line1\n           line2 */\n        view(style: \"x\")\n    }\n}\n",
+        ];
+        for input in inputs {
+            let once = fmt(input);
+            let twice = fmt(&once);
+            assert_eq!(once, twice, "not idempotent for:\n{input}\nonce:\n{once}");
+        }
+    }
+
+    // 15a. Fallback safety: directly exercise the `all_comments_present`
+    // guard — a dropped duplicate makes it report "not present".
+    #[test]
+    fn fallback_guard_detects_dropped_comment() {
+        let comments = vec![
+            crate::comments::GrammarComment {
+                start: 0,
+                end: 5,
+                text: "// hi".to_string(),
+                own_line: true,
+            },
+            crate::comments::GrammarComment {
+                start: 6,
+                end: 11,
+                text: "// hi".to_string(),
+                own_line: true,
+            },
+        ];
+        // Output with only ONE `// hi` must fail the duplicate-aware check.
+        assert!(!all_comments_present("only one // hi here", &comments));
+        // Output with BOTH passes.
+        assert!(all_comments_present("// hi and // hi", &comments));
+    }
+
+    // 15b. Fallback safety end-to-end: even a comment in an awkward spot
+    // (between a tag and its parens) is never lost — either reflowed or
+    // left untouched, but always present.
+    #[test]
+    fn fallback_keeps_comment_when_in_doubt() {
+        let input =
+            "fn d() -> Element {\n    render! {\n        view /* odd */ (style: \"x\")\n    }\n}\n";
+        let out = fmt(input);
+        assert!(out.contains("/* odd */"), "comment must survive:\n{out}");
+    }
+
+    // 16. Wallet-style section comments kept on their own lines.
+    #[test]
+    fn wallet_style_section_comments() {
+        let input = "fn d() -> Element {\n    render! {\n        view {\n            // \u{2500}\u{2500} Header \u{2500}\u{2500}\n            text(value: \"hi\")\n            // \u{2500}\u{2500} Body \u{2500}\u{2500}\n            text(value: \"yo\")\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
     }
 }

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -325,6 +325,19 @@ fn reformat_macros_inner(
     opts: &FmtOptions,
     exprfmt: Option<&ExprFormatter>,
 ) -> Result<String> {
+    reformat_macros_pass(rust_src, opts, exprfmt, true)
+}
+
+/// One macro-reformatting pass. `verify` enables the comment-preservation
+/// fail-safe (present-check + idempotency). The idempotency check re-runs
+/// this pass with `verify = false` so the guard does NOT recurse into
+/// itself (which would be unbounded for nested / large bodies).
+fn reformat_macros_pass(
+    rust_src: &str,
+    opts: &FmtOptions,
+    exprfmt: Option<&ExprFormatter>,
+    verify: bool,
+) -> Result<String> {
     // Parse the whole file just to confirm it is valid Rust; the actual
     // macro discovery walks the raw TokenStream (so we keep precise
     // span byte-offsets relative to `rust_src`).
@@ -341,7 +354,9 @@ fn reformat_macros_inner(
     // every macro, then splice from the end backwards so earlier
     // offsets stay valid.
     let mut edits: Vec<MacroEdit> = Vec::new();
-    collect_macro_edits(tokens, &file_map, rust_src, opts, exprfmt, &mut edits)?;
+    collect_macro_edits(
+        tokens, &file_map, rust_src, opts, exprfmt, verify, &mut edits,
+    )?;
 
     edits.sort_by_key(|e| e.open_byte);
     // Splice from the end so earlier byte offsets remain valid.
@@ -363,12 +378,14 @@ struct MacroEdit {
 /// Recursively walk a token stream, finding `render! { … }` /
 /// `css! { … }` (or `(…)` / `[…]`) invocations and queueing an edit for
 /// each body.
+#[allow(clippy::too_many_arguments)]
 fn collect_macro_edits(
     tokens: TokenStream,
     file_map: &SourceMap,
     rust_src: &str,
     opts: &FmtOptions,
     exprfmt: Option<&ExprFormatter>,
+    verify: bool,
     edits: &mut Vec<MacroEdit>,
 ) -> Result<()> {
     let trees: Vec<TokenTree> = tokens.into_iter().collect();
@@ -383,7 +400,7 @@ fn collect_macro_edits(
             {
                 if let TokenTree::Group(group) = &trees[i + 2] {
                     if let Some(edit) =
-                        macro_body_edit(&name, group, file_map, rust_src, opts, exprfmt)?
+                        macro_body_edit(&name, group, file_map, rust_src, opts, exprfmt, verify)?
                     {
                         edits.push(edit);
                     }
@@ -404,7 +421,15 @@ fn collect_macro_edits(
         }
         // Recurse into any group we didn't treat as a macro body.
         if let TokenTree::Group(group) = &trees[i] {
-            collect_macro_edits(group.stream(), file_map, rust_src, opts, exprfmt, edits)?;
+            collect_macro_edits(
+                group.stream(),
+                file_map,
+                rust_src,
+                opts,
+                exprfmt,
+                verify,
+                edits,
+            )?;
         }
         i += 1;
     }
@@ -414,6 +439,7 @@ fn collect_macro_edits(
 /// Build the splice edit for a single macro body group, or `None` if
 /// the body should be left untouched (empty, comment-bearing, or
 /// re-parse failure).
+#[allow(clippy::too_many_arguments)]
 fn macro_body_edit(
     macro_name: &str,
     group: &proc_macro2::Group,
@@ -421,6 +447,7 @@ fn macro_body_edit(
     rust_src: &str,
     opts: &FmtOptions,
     exprfmt: Option<&ExprFormatter>,
+    verify: bool,
 ) -> Result<Option<MacroEdit>> {
     let span = group.span();
     // Byte offsets of the WHOLE group (including delimiters).
@@ -535,7 +562,7 @@ fn macro_body_edit(
     // If reattaching the comments could possibly have dropped one, or the
     // result isn't a fixed point, leave the body UNTOUCHED (today's old
     // behavior — no regression, no comment ever lost).
-    if !grammar_comments.is_empty() {
+    if verify && !grammar_comments.is_empty() {
         // (1) No comment lost: every recovered comment's text must appear
         // in the formatted output, counting duplicates.
         if !all_comments_present(&replacement, &grammar_comments) {
@@ -613,11 +640,14 @@ fn macro_replacement_is_fixed_point(
     // (base_indent) nested-block-free wrapper: a single fn plus manual
     // indent prefix on the macro line works because rustfmt isn't run.
     let src = format!("fn _w() {{\n{indent}{macro_name}! {{{replacement}}}\n}}\n");
-    let once = match reformat_macros_inner(&src, opts, None) {
+    // Re-run WITHOUT the verify guard (`verify = false`) so this check does
+    // not recurse into itself — otherwise each fixed-point check would
+    // spawn another, blowing the stack on large / nested bodies.
+    let once = match reformat_macros_pass(&src, opts, None, false) {
         Ok(s) => s,
         Err(_) => return false,
     };
-    let twice = match reformat_macros_inner(&once, opts, None) {
+    let twice = match reformat_macros_pass(&once, opts, None, false) {
         Ok(s) => s,
         Err(_) => return false,
     };
@@ -1131,5 +1161,43 @@ mod comment_tests {
     fn wallet_style_section_comments() {
         let input = "fn d() -> Element {\n    render! {\n        view {\n            // \u{2500}\u{2500} Header \u{2500}\u{2500}\n            text(value: \"hi\")\n            // \u{2500}\u{2500} Body \u{2500}\u{2500}\n            text(value: \"yo\")\n        }\n    }\n}\n";
         assert_eq!(fmt(input), input);
+    }
+
+    // 17. Wallet-faithful reduction: a `render!` with section comments,
+    // irregular OVER-INDENTATION (page→view migration leftovers), and a
+    // user-component call whose closing `)` sits on its own line at a weird
+    // column. This is the exact shape that previously fell back (the body
+    // got NO formatting). It must now actually reflow — comments kept on
+    // their own lines at the corrected indent — AND be idempotent.
+    #[test]
+    fn wallet_faithful_reduction_formats_and_preserves_comments() {
+        let input = "fn d() -> Element {\n    render! {\n        view(style: css!(\n            flex_grow: 1.0,\n            background_color: BG,\n        )) {\n        view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false\n    )\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n        }\n        }\n    }\n}\n";
+        let expected = "fn d() -> Element {\n    render! {\n        view(\n            style: css!(\n                flex_grow: 1.0,\n                background_color: BG,\n            ),\n        ) {\n            view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false)\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n            }\n        }\n    }\n}\n";
+        let out = fmt(input);
+        // The body MUST be reformatted (not the fallback), with the section
+        // comment preserved at the right indent.
+        assert_ne!(out, input, "must not fall back:\n{out}");
+        assert_eq!(out, expected, "got:\n{out}");
+        // And it must be a fixed point.
+        assert_eq!(fmt(&out), out, "not idempotent");
+    }
+
+    // 18. Regression: a multi-line embedded-expr value (e.g. a wrapped
+    // `css!( … )` kwarg) must format idempotently via the rustfmt-free
+    // core — the verbatim slice is dedented before re-indenting so the
+    // continuation lines don't gain indentation on every pass. This is the
+    // bug that made the whole wallet body fail the idempotency fail-safe.
+    #[test]
+    fn multiline_expr_value_is_idempotent() {
+        let input = "fn s() -> Element {\n    render! {\n        view(style: css!(\n            flex_grow: 1.0,\n            background_color: BG,\n            display: Display::Flex,\n        ))\n    }\n}\n";
+        let once = fmt(input);
+        let twice = fmt(&once);
+        assert_eq!(
+            once, twice,
+            "not idempotent:\nonce:\n{once}\ntwice:\n{twice}"
+        );
+        // The css! values survive verbatim.
+        assert!(once.contains("flex_grow: 1.0,"), "got:\n{once}");
+        assert!(once.contains("background_color: BG,"), "got:\n{once}");
     }
 }

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -146,7 +146,13 @@ impl Printer<'_> {
         }
         if let Some(s) = self.map.slice(span) {
             // Trim surrounding whitespace; internal formatting is kept.
-            s.trim().to_string()
+            // For multi-line values, dedent continuation lines to column 0
+            // (matching the [`ExprMap`] contract) so the surrounding
+            // [`reindent`] call adds exactly the kwarg-column prefix and
+            // re-formatting is a fixed point. Without this, slicing an
+            // already-indented value and re-indenting it compounds the
+            // indentation on every pass (non-idempotent).
+            dedent_continuation(s.trim())
         } else {
             tokens.to_token_stream().to_string()
         }
@@ -475,6 +481,42 @@ fn brace_width(children: &[Node]) -> usize {
     }
 }
 
+/// Dedent the continuation (2nd..=Nth) lines of a multi-line fragment by
+/// their common leading-whitespace amount, so they sit at column 0
+/// relative to the first line. The first line is already at column 0 (the
+/// caller trimmed it). This makes the later [`reindent`] idempotent: a
+/// value re-sliced from already-formatted output has its kwarg-column
+/// indentation stripped back off before being re-indented.
+///
+/// Lines that are entirely whitespace are ignored when computing the
+/// common indent (and emitted empty) so they don't force the common
+/// dedent to zero.
+fn dedent_continuation(fragment: &str) -> String {
+    if !fragment.contains('\n') {
+        return fragment.to_string();
+    }
+    let mut lines = fragment.split('\n');
+    let first = lines.next().unwrap_or("");
+    let rest: Vec<&str> = lines.collect();
+    // Common leading-whitespace width across non-blank continuation lines.
+    let common = rest
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+    let mut out = String::from(first);
+    for line in rest {
+        out.push('\n');
+        if line.trim().is_empty() {
+            // keep blank lines blank
+        } else {
+            out.push_str(&line[common..]);
+        }
+    }
+    out
+}
+
 /// Re-indent the 2nd..=Nth lines of a (possibly multi-line) fragment so
 /// continuation lines sit under `prefix`. The first line is left as-is
 /// (the caller already emitted `prefix` before it).
@@ -500,4 +542,38 @@ fn reindent(fragment: &str, prefix: &str) -> String {
 fn span_of(expr: &syn::Expr) -> Span {
     use syn::spanned::Spanned;
     expr.span()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedent_single_line_unchanged() {
+        assert_eq!(dedent_continuation("foo"), "foo");
+    }
+
+    #[test]
+    fn dedent_strips_common_continuation_indent() {
+        let v = "css!(\n            a: 1,\n            b: 2,\n        )";
+        // First line at col 0; continuation lines share 8-space common
+        // indent (the `        )` closing line) — all stripped by 8.
+        let out = dedent_continuation(v);
+        assert_eq!(out, "css!(\n    a: 1,\n    b: 2,\n)");
+    }
+
+    #[test]
+    fn dedent_is_idempotent() {
+        let v = "css!(\n            a: 1,\n        )";
+        let once = dedent_continuation(v);
+        let twice = dedent_continuation(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn dedent_keeps_blank_lines_blank() {
+        let v = "a\n        b\n\n        c";
+        let out = dedent_continuation(v);
+        assert_eq!(out, "a\nb\n\nc");
+    }
 }

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -16,6 +16,15 @@
 //! 3. `proc_macro2` token printing when the span has no source position
 //!    (a rare, best-effort path).
 //!
+//! ## Comments
+//!
+//! `syn` drops comments, so they are recovered from the body source as
+//! [`GrammarComment`]s (see `comments.rs`) and reattached here. A cursor
+//! ([`Printer::next`]) tracks the next unconsumed comment; [`flush`] emits
+//! every pending comment whose `start` precedes a given byte bound, at the
+//! right indent. Own-line comments go on their own line; trailing comments
+//! are appended to the end of the preceding line.
+//!
 //! ## Layout
 //!
 //! A simple indent-and-wrap scheme (not full Wadler/Prettier): each
@@ -24,11 +33,13 @@
 //! indented lines. This matches the shallow, regular `render!` grammar
 //! and is easy to keep idempotent.
 
+use crate::comments::GrammarComment;
 use crate::expr_fmt::ExprMap;
 use crate::options::FmtOptions;
 use crate::source_map::SourceMap;
 use proc_macro2::Span;
 use quote::ToTokens;
+use std::cell::Cell;
 use whisker_macro_syntax::{CssInput, ElementNode, Kwarg, Node, Root, UserComponentNode};
 
 /// Pretty-print a parsed `render!` body.
@@ -41,20 +52,52 @@ use whisker_macro_syntax::{CssInput, ElementNode, Kwarg, Node, Root, UserCompone
 /// expressions, keyed by each expr's body-relative span. An EMPTY map
 /// means "render every expr verbatim" — that is the rustfmt-free path
 /// the [`crate::reformat_macros`] unit tests use.
+///
+/// `comments` are the grammar comments recovered from the body source,
+/// reattached during printing. `body_len` is the byte length of the body
+/// source (the top-level block's upper bound).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn print_render(
     root: &Root,
     map: &SourceMap,
     opts: &FmtOptions,
     base_indent: usize,
     expr_map: &ExprMap,
+    comments: &[GrammarComment],
+    body_len: usize,
 ) -> String {
     let p = Printer {
         map,
         opts,
         expr_map,
+        comments,
+        next: Cell::new(0),
     };
     let mut out = String::new();
+    // Leading comments before the root node.
+    if let Some(start) = p.node_start_byte(&root.node) {
+        p.flush(start, base_indent + 1, &mut out);
+    }
     p.node(&root.node, base_indent + 1, &mut out);
+    // A trailing comment on the root node's own last line attaches inline.
+    if let Some(start) = p.node_start_byte(&root.node) {
+        let (_, after) = p.map.node_extent(start);
+        if let Some(idx) = p.pending_trailing_on_line(after) {
+            let before = p.comments[idx].start + 1;
+            p.flush(before, base_indent + 1, &mut out);
+        }
+    }
+    // Any remaining (own-line) comments after the root node, on their own
+    // lines at the body indent.
+    let idx = p.next.get();
+    if idx < comments.len() {
+        let mut tail = String::new();
+        p.flush(body_len, base_indent + 1, &mut tail);
+        if !tail.is_empty() {
+            out.push('\n');
+            out.push_str(tail.trim_end_matches('\n'));
+        }
+    }
     out
 }
 
@@ -65,19 +108,26 @@ pub(crate) fn print_css(
     opts: &FmtOptions,
     base_indent: usize,
     expr_map: &ExprMap,
+    comments: &[GrammarComment],
+    body_len: usize,
 ) -> String {
     let p = Printer {
         map,
         opts,
         expr_map,
+        comments,
+        next: Cell::new(0),
     };
-    p.css(input, base_indent + 1)
+    p.css(input, base_indent + 1, body_len)
 }
 
 struct Printer<'a> {
     map: &'a SourceMap<'a>,
     opts: &'a FmtOptions,
     expr_map: &'a ExprMap,
+    comments: &'a [GrammarComment],
+    /// Index of the next unconsumed comment.
+    next: Cell<usize>,
 }
 
 impl Printer<'_> {
@@ -106,6 +156,76 @@ impl Printer<'_> {
         self.opts.indent_prefix(level)
     }
 
+    // ---- comment reattachment ------------------------------------------
+
+    /// Emit every not-yet-consumed comment whose `start < before`, at the
+    /// given indent `level`.
+    ///
+    /// Own-line comments are written on their own line: `{indent}{text}\n`
+    /// (possibly multi-line text is re-indented under `indent`). A
+    /// non-own-line (trailing) comment is appended to the END of `out`
+    /// (before the next `\n` the caller adds): ` {text}`.
+    fn flush(&self, before: usize, level: usize, out: &mut String) {
+        let indent = self.indent(level);
+        let mut idx = self.next.get();
+        while idx < self.comments.len() && self.comments[idx].start < before {
+            let c = &self.comments[idx];
+            if c.own_line {
+                out.push_str(&indent);
+                out.push_str(&reindent(&c.text, &indent));
+                out.push('\n');
+            } else {
+                // Trailing: append to the end of the current output. Strip
+                // a single trailing newline the caller may have already
+                // pushed, append ` text`, then restore the newline.
+                let had_nl = out.ends_with('\n');
+                if had_nl {
+                    out.pop();
+                }
+                out.push(' ');
+                out.push_str(&c.text);
+                if had_nl {
+                    out.push('\n');
+                }
+            }
+            idx += 1;
+        }
+        self.next.set(idx);
+    }
+
+    /// `true` if there is a pending trailing comment whose `start` falls
+    /// on the same source line as byte `line_end` (the end of the just-
+    /// emitted node). Used to attach trailing comments to a child.
+    fn pending_trailing_on_line(&self, line_end: usize) -> Option<usize> {
+        let idx = self.next.get();
+        let c = self.comments.get(idx)?;
+        if c.own_line {
+            return None;
+        }
+        // Same source line as `line_end` if no '\n' lies between them.
+        let (lo, hi) = if c.start < line_end {
+            (c.start, line_end)
+        } else {
+            (line_end, c.start)
+        };
+        let between = self.map.between_has_newline(lo, hi);
+        if between {
+            None
+        } else {
+            Some(idx)
+        }
+    }
+
+    /// First source byte of a node (its tag / alias ident).
+    fn node_start_byte(&self, node: &Node) -> Option<usize> {
+        let span = match node {
+            Node::Element(el) => el.tag.span(),
+            Node::UserComponent(uc) => uc.alias_ident.span(),
+            Node::ChildrenSlot { span } => *span,
+        };
+        self.map.byte_range(span).map(|(s, _)| s)
+    }
+
     // ---- render! -------------------------------------------------------
 
     fn node(&self, node: &Node, level: usize, out: &mut String) {
@@ -120,27 +240,41 @@ impl Printer<'_> {
     }
 
     fn element(&self, el: &ElementNode, level: usize, out: &mut String) {
-        self.tag_node(&el.tag.to_string(), &el.kwargs, &el.children, level, out);
+        let start = self.map.byte_range(el.tag.span()).map(|(s, _)| s);
+        self.tag_node(
+            &el.tag.to_string(),
+            &el.kwargs,
+            &el.children,
+            level,
+            start,
+            out,
+        );
     }
 
     fn user_component(&self, uc: &UserComponentNode, level: usize, out: &mut String) {
+        let start = self.map.byte_range(uc.alias_ident.span()).map(|(s, _)| s);
         self.tag_node(
             &uc.alias_ident.to_string(),
             &uc.kwargs,
             &uc.children,
             level,
+            start,
             out,
         );
     }
 
     /// The shared `tag(kwargs) { children }` rendering used by both
-    /// element and user-component nodes.
+    /// element and user-component nodes. `node_start` is the byte offset
+    /// of this node's tag in the body source (used to locate its block
+    /// via [`SourceMap::node_extent`] so comments land at the right
+    /// indent / side of the closing `}`).
     fn tag_node(
         &self,
         tag: &str,
         kwargs: &[Kwarg],
         children: &[Node],
         level: usize,
+        node_start: Option<usize>,
         out: &mut String,
     ) {
         let indent = self.indent(level);
@@ -179,11 +313,47 @@ impl Printer<'_> {
         }
 
         // ---- children ----
-        if !children.is_empty() {
+        // Resolve this node's block byte bounds so comments are placed
+        // relative to its `{ … }`.
+        let inner_close = node_start.and_then(|s| self.map.node_extent(s).0);
+
+        // If there are pending comments destined for this node's block
+        // (i.e. starting before its closing brace) we must render the
+        // multi-line block form even when `children` is empty, so those
+        // comments have somewhere to go.
+        let has_block_comments = inner_close
+            .map(|close| {
+                let idx = self.next.get();
+                self.comments
+                    .get(idx)
+                    .map(|c| c.start < close)
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false);
+
+        if !children.is_empty() || has_block_comments {
             out.push_str(" {\n");
+            let child_level = level + 1;
             for child in children {
-                self.node(child, level + 1, out);
+                let child_start = self.node_start_byte(child);
+                // Leading own-line comments before this child.
+                if let Some(cs) = child_start {
+                    self.flush(cs, child_level, out);
+                }
+                self.node(child, child_level, out);
+                // Trailing same-line comment on the child.
+                if let Some((_, child_end)) = child_extent(self, child) {
+                    if let Some(idx) = self.pending_trailing_on_line(child_end) {
+                        // Append trailing comment to the end of this line.
+                        let before = self.comments[idx].start + 1;
+                        self.flush(before, child_level, out);
+                    }
+                }
                 out.push('\n');
+            }
+            // Comments sitting before the closing `}`.
+            if let Some(close) = inner_close {
+                self.flush(close, child_level, out);
             }
             out.push_str(&indent);
             out.push('}');
@@ -203,44 +373,93 @@ impl Printer<'_> {
 
     // ---- css! ----------------------------------------------------------
 
-    fn css(&self, input: &CssInput, level: usize) -> String {
+    fn css(&self, input: &CssInput, level: usize, body_len: usize) -> String {
         if input.kwargs.is_empty() {
             return String::new();
         }
-        let parts: Vec<String> = input
-            .kwargs
-            .iter()
-            .map(|kw| {
-                let name = kw.name.to_string();
-                match &kw.value {
-                    Some(expr) => {
-                        let v = self.expr_src(span_of(expr), expr);
-                        format!("{name}: {v}")
-                    }
-                    None => name,
-                }
-            })
-            .collect();
 
-        // Try a single inline line first.
-        let inline = parts.join(", ");
-        let inline_width = self.opts.indent_width(level) + inline.len();
-        if !inline.contains('\n') && inline_width <= self.opts.max_width {
+        let has_comments = !self.comments.is_empty();
+
+        // Inline form only when there are NO comments to place (comments
+        // imply line breaks).
+        if !has_comments {
+            let parts: Vec<String> = input.kwargs.iter().map(|kw| self.css_kwarg(kw)).collect();
+            let inline = parts.join(", ");
+            let inline_width = self.opts.indent_width(level) + inline.len();
+            if !inline.contains('\n') && inline_width <= self.opts.max_width {
+                let indent = self.indent(level);
+                return format!("{indent}{inline}");
+            }
+            // Otherwise one kwarg per line, trailing comma.
             let indent = self.indent(level);
-            return format!("{indent}{inline}");
+            let mut out = String::new();
+            for part in &parts {
+                out.push_str(&indent);
+                out.push_str(&reindent(part, &indent));
+                out.push_str(",\n");
+            }
+            out.pop();
+            return out;
         }
-        // Otherwise one kwarg per line, trailing comma.
+
+        // Comment-bearing css! body: one field per line, flushing
+        // comments before each field and after the last.
         let indent = self.indent(level);
         let mut out = String::new();
-        for part in &parts {
+        for kw in &input.kwargs {
+            let start = self.map.byte_range(kw.name.span()).map(|(s, _)| s);
+            if let Some(s) = start {
+                self.flush(s, level, &mut out);
+            }
             out.push_str(&indent);
-            out.push_str(&reindent(part, &indent));
-            out.push_str(",\n");
+            out.push_str(&reindent(&self.css_kwarg(kw), &indent));
+            out.push(',');
+            // Trailing same-line comment after this field.
+            let field_end = self
+                .map
+                .byte_range(kw.name.span())
+                .map(|(_, e)| e)
+                .unwrap_or(0);
+            // Use the value's end if present for a tighter line bound.
+            let line_end = kw
+                .value
+                .as_ref()
+                .and_then(|e| self.map.byte_range(span_of(e)))
+                .map(|(_, e)| e)
+                .unwrap_or(field_end);
+            if let Some(idx) = self.pending_trailing_on_line(line_end) {
+                let before = self.comments[idx].start + 1;
+                self.flush(before, level, &mut out);
+            }
+            out.push('\n');
         }
+        // Any comments after the last field, before the body end.
+        self.flush(body_len, level, &mut out);
         // strip trailing newline (caller adds delimiters)
-        out.pop();
+        while out.ends_with('\n') {
+            out.pop();
+        }
         out
     }
+
+    fn css_kwarg(&self, kw: &whisker_macro_syntax::CssKwarg) -> String {
+        let name = kw.name.to_string();
+        match &kw.value {
+            Some(expr) => {
+                let v = self.expr_src(span_of(expr), expr);
+                format!("{name}: {v}")
+            }
+            None => name,
+        }
+    }
+}
+
+/// Byte extent `(start, end)` of a child node via its tag span +
+/// [`SourceMap::node_extent`]. `end` is the byte just past the node.
+fn child_extent(p: &Printer, child: &Node) -> Option<(usize, usize)> {
+    let start = p.node_start_byte(child)?;
+    let (_, after) = p.map.node_extent(start);
+    Some((start, after))
 }
 
 /// Width contribution of a ` { … }` children block when deciding

--- a/crates/whisker-fmt/src/source_map.rs
+++ b/crates/whisker-fmt/src/source_map.rs
@@ -67,6 +67,163 @@ impl<'a> SourceMap<'a> {
         Some((s, e))
     }
 
+    /// `true` if a `\n` lies in the byte range `[lo, hi)` of the source.
+    /// Used to decide whether a trailing comment is on the same source
+    /// line as a node it should attach to.
+    pub(crate) fn between_has_newline(&self, lo: usize, hi: usize) -> bool {
+        let lo = lo.min(self.src.len());
+        let hi = hi.min(self.src.len());
+        if hi <= lo {
+            return false;
+        }
+        self.src.as_bytes()[lo..hi].contains(&b'\n')
+    }
+
+    /// Locate a node's `tag(kwargs?) { children? }` extent starting at
+    /// byte `start` (the first byte of its tag ident).
+    ///
+    /// Returns `(inner_close, after)` where:
+    /// - `inner_close` is the byte offset of this node's closing `}` (the
+    ///   `}` itself), or `None` for a childless node (no `{ … }` block).
+    /// - `after` is the byte just past the whole node.
+    ///
+    /// The scan is balanced and string / char / comment aware so braces
+    /// inside literals or comments do not miscount. It skips: the ident,
+    /// an optional balanced `( … )`, then an optional balanced `{ … }`.
+    pub(crate) fn node_extent(&self, start: usize) -> (Option<usize>, usize) {
+        let bytes = self.src.as_bytes();
+        let len = bytes.len();
+        // Skip the ident: identifier chars (alnum / `_`).
+        let mut i = start;
+        while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+            i += 1;
+        }
+        // Skip whitespace + comments to the next significant byte.
+        i = self.skip_trivia(i);
+        // Optional `( … )`.
+        if i < len && bytes[i] == b'(' {
+            i = self.skip_balanced(i, b'(', b')');
+        }
+        let after_parens = i;
+        i = self.skip_trivia(i);
+        // Optional `{ … }`.
+        if i < len && bytes[i] == b'{' {
+            let close = self.skip_balanced(i, b'{', b'}');
+            // `close` is just past `}`; the `}` byte is `close - 1`.
+            return (Some(close - 1), close);
+        }
+        (None, after_parens)
+    }
+
+    /// Advance past whitespace and comments (line + nested block) from
+    /// `i`, returning the index of the next significant byte.
+    fn skip_trivia(&self, mut i: usize) -> usize {
+        let bytes = self.src.as_bytes();
+        let len = bytes.len();
+        loop {
+            // whitespace
+            while i < len && bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            if i + 1 < len && bytes[i] == b'/' && bytes[i + 1] == b'/' {
+                while i < len && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            if i + 1 < len && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+                let mut depth = 1usize;
+                i += 2;
+                while i < len && depth > 0 {
+                    if i + 1 < len && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+                        depth += 1;
+                        i += 2;
+                    } else if i + 1 < len && bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        depth -= 1;
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                continue;
+            }
+            break;
+        }
+        i
+    }
+
+    /// Skip a balanced `open … close` region starting at byte `i` (which
+    /// must be `open`), returning the index just past the matching
+    /// `close`. String / char literals and comments inside are skipped so
+    /// their delimiters don't affect the balance.
+    fn skip_balanced(&self, mut i: usize, open: u8, close: u8) -> usize {
+        let bytes = self.src.as_bytes();
+        let len = bytes.len();
+        let mut depth = 0usize;
+        while i < len {
+            let b = bytes[i];
+            if b == b'"' || b == b'\'' {
+                i = self.skip_string(i, b);
+                continue;
+            }
+            if i + 1 < len && b == b'/' && bytes[i + 1] == b'/' {
+                while i < len && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            if i + 1 < len && b == b'/' && bytes[i + 1] == b'*' {
+                let mut d = 1usize;
+                i += 2;
+                while i < len && d > 0 {
+                    if i + 1 < len && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+                        d += 1;
+                        i += 2;
+                    } else if i + 1 < len && bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        d -= 1;
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                continue;
+            }
+            if b == open {
+                depth += 1;
+            } else if b == close {
+                depth -= 1;
+                if depth == 0 {
+                    return i + 1;
+                }
+            }
+            i += 1;
+        }
+        i
+    }
+
+    /// Skip a string or char literal that opens with quote `q` at byte
+    /// `i`, returning the index just past the closing quote. Handles
+    /// backslash escapes. (Raw strings are uncommon in macro bodies; a
+    /// best-effort scan is acceptable here since the result only affects
+    /// comment placement, never correctness of the emitted Rust.)
+    fn skip_string(&self, mut i: usize, q: u8) -> usize {
+        let bytes = self.src.as_bytes();
+        let len = bytes.len();
+        i += 1; // past opening quote
+        while i < len {
+            let b = bytes[i];
+            if b == b'\\' {
+                i += 2;
+                continue;
+            }
+            if b == q {
+                return i + 1;
+            }
+            i += 1;
+        }
+        i
+    }
+
     /// The exact source substring covered by `span`, or `None` if the
     /// span's locations don't resolve (e.g. a synthesized span with no
     /// real source position).


### PR DESCRIPTION
## What

Make `whisker fmt` format `render!` / `css!` macro bodies **even when they contain comments**, preserving the comments. Previously any comment-containing body was detected and left entirely untouched (`syn` drops comments, so reprinting from the AST would lose them).

## Approach

- **Collect** (`src/comments.rs`): `collect_grammar_comments` recovers `//` and `/* */` comments straight from the body source with a string/char-aware, nesting-aware scanner. Comments inside an embedded-expr span are masked out (those ride along with the verbatim/rustfmt-formatted expr source). Returns `GrammarComment { start, end, text, own_line }` sorted by position.
- **Reattach** (`src/printer.rs`): the `Printer` threads the comment slice + a cursor. `flush(before, level, out)` emits every pending comment whose `start` precedes a byte bound — own-line comments on their own line at the block indent, trailing comments appended to the end of the preceding line. Block byte-bounds are computed by a balanced, string/comment-aware forward scan (`SourceMap::node_extent`) so comments land at the right indent and on the right side of a `}`.
- **Fail-safe** (`src/lib.rs`): the two blanket "comment → leave untouched" bails are removed; we always attempt to format. After producing the replacement, two guards run and fall back to the old leave-untouched behavior if either fails:
  1. **No comment lost** — every recovered comment's text appears in the output (duplicate-aware count).
  2. **Idempotency** — re-running the formatter on the produced body is a fixed point (`f(f(x)) == f(x)`).

So a comment can never be silently dropped: worst case the body is left exactly as today.

## Tests

16 new test cases in `comment_tests` (rustfmt-free core via `reformat_macros`, exact-output assertions) plus scanner unit tests in `comments.rs`: own-line before/between/first/last child, trailing line comments on a child and after a css field, own-line between css fields, single-line and multi-line block comments (verbatim), two consecutive comments, comment inside an embedded expr (untouched), deep nesting indent, mixed leading+trailing, idempotency over several inputs, the `all_comments_present` fallback guard, an awkward between-tag-parens comment, and the wallet-style section-comment case. The previous "comment-bearing body left untouched" test now asserts the new comment-preserving reflow.

All existing `whisker-fmt` tests stay green. `cargo clippy -p whisker-fmt --all-targets` is clean; `cargo fmt --all -- --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
