### PR TITLE
feat!: signal() returns a single RwSignal instead of a (Read, Write) tuple

### DIFF
--- a/crates/whisker-cli/src/new_app.rs
+++ b/crates/whisker-cli/src/new_app.rs
@@ -202,9 +202,10 @@ fn app() -> Element {{
 /// just needs `flex_grow: 1.0` to fill it. Editing `Root` hot-reloads.
 #[component]
 fn root() -> Element {{
-    // `RwSignal` holds reactive state. Anything that reads it (like the
-    // `computed` below) re-runs and repaints when it changes.
-    let count = RwSignal::new(0);
+    // `signal` returns a reactive handle holding state. Anything that
+    // reads it (like the `computed` below) re-runs and repaints when it
+    // changes.
+    let count = signal(0);
 
     render! {{
         // Styles use the typed `css!` macro: field names map to CSS

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -222,7 +222,7 @@ pub fn css(input: TokenStream) -> TokenStream {
 ///
 /// #[component]
 /// fn counter(initial: i32) -> Element {
-///     let (count, set_count) = signal(initial);
+///     let count = signal(initial);
 ///     render! { /* ... */ }
 /// }
 ///

--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -83,11 +83,11 @@
 //! Same as user components and built-in tags. Inside `render!`:
 //!
 //! ```ignore
-//! let (text, set_text) = signal(String::new());
+//! let text = signal(String::new());
 //! render! {
 //!     XInput(
 //!         value: text,
-//!         on_input: move |new_value| set_text.set(new_value),
+//!         on_input: move |new_value| text.set(new_value),
 //!     )
 //! }
 //! ```

--- a/crates/whisker-runtime/src/reactive/arc_signal.rs
+++ b/crates/whisker-runtime/src/reactive/arc_signal.rs
@@ -333,20 +333,23 @@ impl<T: 'static> ArcWriteSignal<T> {
     }
 }
 
-/// Allocate a fresh Arc-backed signal and split into read/write
-/// halves. The Arc analog of [`signal`](super::signal::signal):
+/// Allocate a fresh Arc-backed signal as a combined [`ArcRwSignal`].
+/// The Arc analog of [`signal`](super::signal::signal):
 ///
 /// ```ignore
 /// use whisker_runtime::reactive::arc_signal;
 ///
-/// let (count, set_count) = arc_signal(0_i32);
-/// set_count.set(1);
+/// let count = arc_signal(0_i32);
+/// count.set(1);
 /// assert_eq!(count.get(), 1);
 /// ```
 ///
-/// The signal lives until both returned halves and any clone of
-/// them are dropped — process lifetime if either ends up in a
-/// `static` slot.
-pub fn arc_signal<T: 'static>(initial: T) -> (ArcReadSignal<T>, ArcWriteSignal<T>) {
-    ArcRwSignal::new(initial).split()
+/// For the split capability, call [`ArcRwSignal::split`] for the
+/// `(read, write)` pair, or [`ArcRwSignal::read_only`] /
+/// [`ArcRwSignal::write_only`] for one capability.
+///
+/// The signal lives until the returned handle and any clone of it
+/// are dropped — process lifetime if it ends up in a `static` slot.
+pub fn arc_signal<T: 'static>(initial: T) -> ArcRwSignal<T> {
+    ArcRwSignal::new(initial)
 }

--- a/crates/whisker-runtime/src/reactive/computed.rs
+++ b/crates/whisker-runtime/src/reactive/computed.rs
@@ -38,7 +38,7 @@ use super::{untrack, with_runtime};
 /// unchanged costs nothing downstream.
 ///
 /// ```ignore
-/// let (count, _set) = signal(0_i32);
+/// let count = signal(0_i32);
 /// let doubled: ReadSignal<i32> = computed(move || count.get() * 2);
 /// assert_eq!(doubled.get(), 0);
 /// ```

--- a/crates/whisker-runtime/src/reactive/prop.rs
+++ b/crates/whisker-runtime/src/reactive/prop.rs
@@ -253,7 +253,7 @@ mod tests {
         assert_eq!(second(), "abc");
 
         // A dynamic Signal is Copy too.
-        let (count, _set) = signal(5_i32);
+        let (count, _set) = signal(5_i32).split();
         let d: Signal<i32> = count.into();
         assert_copy(&d);
         let a = move || d.get();
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     fn read_signal_variant_returns_current_value() {
         __reset_for_tests();
-        let (count, set_count) = signal(0_i32);
+        let (count, set_count) = signal(0_i32).split();
         let s: Signal<i32> = count.into();
         assert!(matches!(s, Signal::Dynamic(_)));
         assert_eq!(s.get(), 0);
@@ -289,7 +289,7 @@ mod tests {
         // `Signal::Dynamic(...).get()` call inside an effect
         // produces a subscription that fires on .set.
         __reset_for_tests();
-        let (count, set_count) = signal(0_i32);
+        let (count, set_count) = signal(0_i32).split();
         let s: Signal<i32> = count.into();
         let log: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
         let log_clone = log.clone();
@@ -328,7 +328,7 @@ mod tests {
         // for Signal<T>` picks up. End-to-end: derivations flow as
         // dynamic props.
         __reset_for_tests();
-        let (count, set_count) = signal(0_i32);
+        let (count, set_count) = signal(0_i32).split();
         let doubled = computed(move || count.get() * 2);
         let s: Signal<i32> = doubled.into();
         assert!(matches!(s, Signal::Dynamic(_)));

--- a/crates/whisker-runtime/src/reactive/signal.rs
+++ b/crates/whisker-runtime/src/reactive/signal.rs
@@ -6,11 +6,14 @@
 //! `Rc<RefCell<dyn Any>>`. Cloning a handle is free; passing one into
 //! a `move ||` closure doesn't tie any lifetime.
 //!
-//! The Solid-style tuple form `let (count, set_count) = signal(0)`
-//! splits read and write capability into separate types, so a child
-//! component can be handed `count: ReadSignal<i32>` without the
-//! ability to write. The unified [`RwSignal`] is also provided for
-//! cases where the same code site needs both halves.
+//! `signal(0)` returns a combined [`RwSignal`] — the read+write handle
+//! you reach for most, and the one that threads cleanly through `move`
+//! closures and component props. When you want the Solid-style split
+//! capability, call [`RwSignal::split`] for the `(ReadSignal,
+//! WriteSignal)` pair, or [`RwSignal::read_only`] /
+//! [`RwSignal::write_only`] for a single narrowed capability — so a
+//! child component can be handed `count: ReadSignal<i32>` without the
+//! ability to write.
 
 use std::any::Any;
 use std::cell::RefCell;
@@ -21,26 +24,30 @@ use super::runtime::{NodeData, NodeId, ReactiveNode, Scope};
 use super::scheduler;
 use super::with_runtime;
 
-/// Allocate a fresh signal in the current owner. Returns a
-/// `(ReadSignal, WriteSignal)` pair — Solid-style separation.
+/// Allocate a fresh signal in the current owner. Returns a combined
+/// [`RwSignal`] — the read+write handle.
 ///
 /// ```ignore
-/// let (count, set_count) = signal(0);
+/// let count = signal(0);
+/// count.set(1);
+/// assert_eq!(count.get(), 1);
+/// ```
+///
+/// For the Solid-style split capability, call [`RwSignal::split`] for
+/// the `(ReadSignal, WriteSignal)` pair, or [`RwSignal::read_only`] /
+/// [`RwSignal::write_only`] for a single narrowed capability:
+///
+/// ```ignore
+/// let (count, set_count) = signal(0).split();
 /// set_count.set(1);
 /// assert_eq!(count.get(), 1);
 /// ```
-pub fn signal<T: 'static>(initial: T) -> (ReadSignal<T>, WriteSignal<T>) {
+pub fn signal<T: 'static>(initial: T) -> RwSignal<T> {
     let id = alloc_signal_node(initial);
-    (
-        ReadSignal {
-            id,
-            _ty: PhantomData,
-        },
-        WriteSignal {
-            id,
-            _ty: PhantomData,
-        },
-    )
+    RwSignal {
+        id,
+        _ty: PhantomData,
+    }
 }
 
 fn alloc_signal_node<T: 'static>(initial: T) -> NodeId {
@@ -184,8 +191,12 @@ impl<T: 'static> WriteSignal<T> {
     }
 }
 
-/// Combined read-write signal handle. Equivalent to holding both a
-/// `ReadSignal<T>` and `WriteSignal<T>` for the same underlying node.
+/// Combined read-write signal handle — what [`signal`] returns.
+/// Equivalent to holding both a `ReadSignal<T>` and `WriteSignal<T>`
+/// for the same underlying node. Use [`split`](RwSignal::split) for the
+/// `(read, write)` pair, or [`read_only`](RwSignal::read_only) /
+/// [`write_only`](RwSignal::write_only) to narrow to a single
+/// capability.
 pub struct RwSignal<T: 'static> {
     id: NodeId,
     _ty: PhantomData<fn(T) -> T>,
@@ -199,13 +210,10 @@ impl<T: 'static> Clone for RwSignal<T> {
 impl<T: 'static> Copy for RwSignal<T> {}
 
 impl<T: 'static> RwSignal<T> {
-    /// Allocate a new combined-handle signal.
+    /// Allocate a new combined-handle signal. Equivalent to
+    /// [`signal`].
     pub fn new(initial: T) -> Self {
-        let id = alloc_signal_node(initial);
-        Self {
-            id,
-            _ty: PhantomData,
-        }
+        signal(initial)
     }
 
     /// Project to a read-only handle pointing at the same underlying
@@ -215,6 +223,16 @@ impl<T: 'static> RwSignal<T> {
     /// `Signal::Dynamic` variant.
     pub fn read_only(self) -> ReadSignal<T> {
         ReadSignal {
+            id: self.id,
+            _ty: PhantomData,
+        }
+    }
+
+    /// Project to a write-only handle pointing at the same underlying
+    /// value. Mirror of [`read_only`](RwSignal::read_only); useful when
+    /// handing the signal to consumers that should only write.
+    pub fn write_only(self) -> WriteSignal<T> {
+        WriteSignal {
             id: self.id,
             _ty: PhantomData,
         }

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -17,14 +17,14 @@ fn fresh() {
 #[test]
 fn signal_returns_initial_value() {
     fresh();
-    let (read, _write) = signal(42_i32);
+    let (read, _write) = signal(42_i32).split();
     assert_eq!(read.get(), 42);
 }
 
 #[test]
 fn write_signal_updates_value() {
     fresh();
-    let (read, write) = signal(0_i32);
+    let (read, write) = signal(0_i32).split();
     write.set(7);
     assert_eq!(read.get(), 7);
 }
@@ -43,7 +43,7 @@ fn rw_signal_split_round_trip() {
 #[test]
 fn with_borrows_without_clone() {
     fresh();
-    let (read, write) = signal(vec![1, 2, 3]);
+    let (read, write) = signal(vec![1, 2, 3]).split();
     let sum = read.with(|v| v.iter().sum::<i32>());
     assert_eq!(sum, 6);
     write.update(|v| v.push(4));
@@ -53,7 +53,7 @@ fn with_borrows_without_clone() {
 #[test]
 fn signal_handles_are_copy_and_aliasable() {
     fresh();
-    let (read, _write) = signal(String::from("hello"));
+    let (read, _write) = signal(String::from("hello")).split();
     let a = read;
     let b = read;
     assert_eq!(a.get(), "hello");
@@ -74,7 +74,7 @@ fn effect_runs_once_immediately() {
 #[test]
 fn effect_reruns_on_dep_change() {
     fresh();
-    let (count, set_count) = signal(0_i32);
+    let (count, set_count) = signal(0_i32).split();
     let log: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
     let log_clone = log.clone();
     effect(move || {
@@ -91,7 +91,7 @@ fn effect_reruns_on_dep_change() {
 fn panicking_effect_does_not_latch_flushing_flag() {
     fresh();
     // An effect that panics on its second run (when the dep flips to 1).
-    let (count, set_count) = signal(0_i32);
+    let (count, set_count) = signal(0_i32).split();
     effect(move || {
         if count.get() == 1 {
             panic!("boom");
@@ -110,7 +110,7 @@ fn panicking_effect_does_not_latch_flushing_flag() {
     // stack restored).
     let ran = Rc::new(RefCell::new(0));
     let r = ran.clone();
-    let (dep, set_dep) = signal(0_i32);
+    let (dep, set_dep) = signal(0_i32).split();
     effect(move || {
         dep.get();
         *r.borrow_mut() += 1;
@@ -123,8 +123,8 @@ fn panicking_effect_does_not_latch_flushing_flag() {
 #[test]
 fn effect_only_reruns_for_tracked_deps() {
     fresh();
-    let (tracked, set_tracked) = signal(0_i32);
-    let (untracked, set_untracked) = signal(100_i32);
+    let (tracked, set_tracked) = signal(0_i32).split();
+    let (untracked, set_untracked) = signal(100_i32).split();
     let runs = Rc::new(RefCell::new(0));
     let runs_clone = runs.clone();
     effect(move || {
@@ -146,9 +146,9 @@ fn effect_only_reruns_for_tracked_deps() {
 #[test]
 fn effect_dynamic_deps_change_between_runs() {
     fresh();
-    let (toggle, set_toggle) = signal(false);
-    let (a, set_a) = signal(0_i32);
-    let (b, set_b) = signal(0_i32);
+    let (toggle, set_toggle) = signal(false).split();
+    let (a, set_a) = signal(0_i32).split();
+    let (b, set_b) = signal(0_i32).split();
     let runs = Rc::new(RefCell::new(0));
     let runs_clone = runs.clone();
     effect(move || {
@@ -190,8 +190,8 @@ fn effect_dynamic_deps_change_between_runs() {
 #[test]
 fn multiple_writes_coalesce_into_one_rerun() {
     fresh();
-    let (a, set_a) = signal(0_i32);
-    let (b, set_b) = signal(0_i32);
+    let (a, set_a) = signal(0_i32).split();
+    let (b, set_b) = signal(0_i32).split();
     let runs = Rc::new(RefCell::new(0));
     let runs_clone = runs.clone();
     effect(move || {
@@ -215,8 +215,8 @@ fn multiple_writes_coalesce_into_one_rerun() {
 #[test]
 fn signals_written_during_flush_propagate_in_same_flush() {
     fresh();
-    let (a, set_a) = signal(0_i32);
-    let (b, set_b) = signal(0_i32);
+    let (a, set_a) = signal(0_i32).split();
+    let (b, set_b) = signal(0_i32).split();
     let cascade_runs = Rc::new(RefCell::new(0));
     let cascade_clone = cascade_runs.clone();
 
@@ -249,7 +249,7 @@ fn signals_written_during_flush_propagate_in_same_flush() {
 fn dispose_owner_frees_nested_signals() {
     fresh();
     let owner = Owner::new(None);
-    let (read, _write) = owner.with(|| signal(123_i32));
+    let (read, _write) = owner.with(|| signal(123_i32)).split();
     // Signal works while owner is alive.
     assert_eq!(read.get(), 123);
     owner.dispose();
@@ -267,7 +267,7 @@ fn dispose_cascades_to_children() {
     let child = parent.with(|| {
         let c = Owner::new(None);
         c.with(|| {
-            let (r, _w) = signal(0_u32);
+            let (r, _w) = signal(0_u32).split();
             leaf_signals.push(r);
         });
         c
@@ -309,7 +309,7 @@ fn on_cleanup_fires_lifo() {
 fn disposing_owner_removes_its_effects_from_pending() {
     fresh();
     let owner = Owner::new(None);
-    let (count, set_count) = signal(0_i32);
+    let (count, set_count) = signal(0_i32).split();
     let runs = Rc::new(RefCell::new(0));
     let runs_clone = runs.clone();
 
@@ -380,7 +380,7 @@ fn stored_value_disposed_with_owner() {
 #[test]
 fn computed_caches_initial_value() {
     fresh();
-    let (count, _set) = signal(3_i32);
+    let (count, _set) = signal(3_i32).split();
     let doubled = computed(move || count.get() * 2);
     assert_eq!(doubled.get(), 6);
 }
@@ -388,7 +388,7 @@ fn computed_caches_initial_value() {
 #[test]
 fn computed_recomputes_on_source_change() {
     fresh();
-    let (count, set_count) = signal(0_i32);
+    let (count, set_count) = signal(0_i32).split();
     let doubled = computed(move || count.get() * 2);
     assert_eq!(doubled.get(), 0);
     set_count.set(5);
@@ -399,7 +399,7 @@ fn computed_recomputes_on_source_change() {
 #[test]
 fn computed_notifies_downstream_subscribers() {
     fresh();
-    let (count, set_count) = signal(0_i32);
+    let (count, set_count) = signal(0_i32).split();
     let doubled = computed(move || count.get() * 2);
     let observed: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
     let obs_clone = observed.clone();
@@ -425,8 +425,8 @@ fn on_mount_callback_inside_effect_does_not_leak_subscription_to_outer() {
     // upward regardless of the call-stack context.
     use super::component::{flush_mounts, on_mount};
     fresh();
-    let (effect_dep, set_effect_dep) = signal(0_i32);
-    let (mount_src, set_mount_src) = signal(0_i32);
+    let (effect_dep, set_effect_dep) = signal(0_i32).split();
+    let (mount_src, set_mount_src) = signal(0_i32).split();
     let outer_runs = Rc::new(RefCell::new(0));
     let outer_runs_clone = outer_runs.clone();
     effect(move || {
@@ -472,8 +472,8 @@ fn mount_component_body_inside_effect_does_not_leak_subscription_to_outer() {
     // calls, which establish their own tracker scope.
     use super::component::mount_component;
     fresh();
-    let (effect_dep, set_effect_dep) = signal(0_i32);
-    let (body_src, set_body_src) = signal(0_i32);
+    let (effect_dep, set_effect_dep) = signal(0_i32).split();
+    let (body_src, set_body_src) = signal(0_i32).split();
     let outer_runs = Rc::new(RefCell::new(0));
     let outer_runs_clone = outer_runs.clone();
     effect(move || {
@@ -515,8 +515,8 @@ fn computed_constructed_inside_effect_does_not_leak_subscription_to_outer() {
     // initial one + one for the explicit `effect_dep` change), not
     // two.
     fresh();
-    let (effect_dep, set_effect_dep) = signal(0_i32);
-    let (computed_src, set_computed_src) = signal(0_i32);
+    let (effect_dep, set_effect_dep) = signal(0_i32).split();
+    let (computed_src, set_computed_src) = signal(0_i32).split();
     let outer_runs = Rc::new(RefCell::new(0));
     let outer_runs_clone = outer_runs.clone();
     effect(move || {
@@ -546,7 +546,7 @@ fn computed_constructed_inside_effect_does_not_leak_subscription_to_outer() {
 #[test]
 fn computed_does_not_notify_when_value_unchanged() {
     fresh();
-    let (count, set_count) = signal(5_i32);
+    let (count, set_count) = signal(5_i32).split();
     // floor-div by 10 — different `count` values yield the same computed value
     let bucket = computed(move || count.get() / 10);
     let runs = Rc::new(RefCell::new(0));
@@ -591,7 +591,7 @@ fn with_context_closure_can_reenter_runtime() {
     let owner = Owner::new(None);
     owner.with(|| {
         provide_context(Theme("ctx"));
-        let (count, _set) = signal(7_i32);
+        let (count, _set) = signal(7_i32).split();
         // Read a signal AND do a nested context lookup from inside the
         // with_context closure — both re-enter the runtime.
         let combined = with_context::<Theme, _>(|theme| {
@@ -691,11 +691,11 @@ fn unmount_component_removes_registration_and_disposes() {
 fn mount_component_isolates_owner_state() {
     fresh();
     let (owner_a, sig_a) = mount_component(dummy_component_a as *const (), || {
-        let (r, _w) = signal(1_i32);
+        let (r, _w) = signal(1_i32).split();
         r
     });
     let (owner_b, sig_b) = mount_component(dummy_component_b as *const (), || {
-        let (r, _w) = signal(2_i32);
+        let (r, _w) = signal(2_i32).split();
         r
     });
     // Each signal lives in its own component owner.
@@ -761,7 +761,7 @@ fn flush_mounts_is_idempotent() {
 #[test]
 fn flush_breaks_self_feedback_loop_with_warning() {
     fresh();
-    let (count, set_count) = signal(0_i32);
+    let (count, set_count) = signal(0_i32).split();
     // An effect that reads AND writes the same signal — guaranteed
     // feedback loop. flush's iteration cap must break it.
     let runs = Rc::new(RefCell::new(0));
@@ -785,8 +785,8 @@ fn flush_breaks_self_feedback_loop_with_warning() {
 #[test]
 fn effect_reading_and_writing_unrelated_signals_terminates() {
     fresh();
-    let (a, _) = signal(0_i32);
-    let (_b, set_b) = signal(0_i32);
+    let (a, _) = signal(0_i32).split();
+    let (_b, set_b) = signal(0_i32).split();
     let runs = Rc::new(RefCell::new(0));
     let runs_clone = runs.clone();
 
@@ -1037,7 +1037,7 @@ fn computed_constructed_inside_computed_does_not_leak_subscription_to_outer_comp
     // legal — e.g. a derived value that itself wraps a computed)
     // must not leak.
     fresh();
-    let (src, set_src) = signal(0_i32);
+    let (src, set_src) = signal(0_i32).split();
     let outer_runs = Rc::new(RefCell::new(0));
     let outer_runs_clone = outer_runs.clone();
     let outer = computed(move || {
@@ -1117,7 +1117,7 @@ fn arc_signal_survives_caller_owner_disposal() {
 
     let owner = Owner::new(None);
     owner.with(|| {
-        let (r, w) = arc_signal(99_i32);
+        let (r, w) = arc_signal(99_i32).split();
         // Pretend `w` is the write half kept by a native module's
         // event callback; we don't need to keep it for this test.
         drop(w);
@@ -1316,7 +1316,7 @@ fn arc_to_rw_conversion_survives_caller_owner_disposal_via_arc() {
 #[test]
 fn arc_read_signal_to_read_signal_conversion_reads_correctly() {
     fresh();
-    let (r, w) = arc_signal(5_i32);
+    let (r, w) = arc_signal(5_i32).split();
     let owner = Owner::new(None);
     let copy: ReadSignal<i32> = owner.with(|| r.into());
     assert_eq!(copy.get(), 5);
@@ -1328,7 +1328,7 @@ fn arc_read_signal_to_read_signal_conversion_reads_correctly() {
 #[test]
 fn arc_write_signal_to_write_signal_conversion_writes_correctly() {
     fresh();
-    let (r, w) = arc_signal(0_i32);
+    let (r, w) = arc_signal(0_i32).split();
     let owner = Owner::new(None);
     let copy: WriteSignal<i32> = owner.with(|| w.into());
     copy.set(123);
@@ -1437,7 +1437,7 @@ fn arc_backed_arena_signal_under_detached_root_survives_sibling_dispose() {
 fn paused_owner_defers_effect_runs_until_resumed() {
     fresh();
     let runs = Rc::new(RefCell::new(0_u32));
-    let (read, write) = signal(0_i32);
+    let (read, write) = signal(0_i32).split();
 
     let owner = Owner::new(None);
     let runs_clone = runs.clone();
@@ -1475,7 +1475,7 @@ fn pause_cascades_to_descendants() {
     fresh();
     let parent_runs = Rc::new(RefCell::new(0_u32));
     let child_runs = Rc::new(RefCell::new(0_u32));
-    let (read, write) = signal(0_i32);
+    let (read, write) = signal(0_i32).split();
 
     let parent = Owner::new(None);
     let child = Owner::new(Some(parent));
@@ -1574,7 +1574,7 @@ fn pause_is_idempotent() {
 fn dispose_while_paused_drops_deferred_entries() {
     fresh();
     let runs = Rc::new(RefCell::new(0_u32));
-    let (read, write) = signal(0_i32);
+    let (read, write) = signal(0_i32).split();
 
     let owner = Owner::new(None);
     let runs_clone = runs.clone();
@@ -1602,7 +1602,7 @@ fn dispose_while_paused_drops_deferred_entries() {
 fn multiple_paused_signal_writes_collapse_to_one_run_on_resume() {
     fresh();
     let runs = Rc::new(RefCell::new(0_u32));
-    let (read, write) = signal(0_i32);
+    let (read, write) = signal(0_i32).split();
 
     let owner = Owner::new(None);
     let runs_clone = runs.clone();

--- a/crates/whisker-runtime/src/view/list_mount.rs
+++ b/crates/whisker-runtime/src/view/list_mount.rs
@@ -370,7 +370,7 @@ mod tests {
     fn changing_items_rebroadcasts_count() {
         with_capturing(|count, _installed| {
             let owner = Owner::new(None);
-            let (items_read, items_write) = crate::reactive::signal(vec![1_i32, 2, 3]);
+            let (items_read, items_write) = crate::reactive::signal(vec![1_i32, 2, 3]).split();
             owner.with(|| {
                 let handle = create_element_by_name("list");
                 list_mount(

--- a/crates/whisker/tests/component_macro.rs
+++ b/crates/whisker/tests/component_macro.rs
@@ -28,7 +28,7 @@ fn mount_component_runs_body_inside_owner() {
     let sink = Rc::new(RefCell::new(0));
     let sink_clone = sink.clone();
     let (_owner, returned) = mount_component(dummy_outer as *const (), move || {
-        let (count, _set_count) = signal(7_i32);
+        let (count, _set_count) = signal(7_i32).split();
         let v = count.get();
         *sink_clone.borrow_mut() = v;
         v

--- a/crates/whisker/tests/module_component.rs
+++ b/crates/whisker/tests/module_component.rs
@@ -182,7 +182,7 @@ fn style_prop_routes_through_set_inline_styles() {
 #[test]
 fn dynamic_style_re_runs_on_signal_change() {
     with_recorder_and_owner(|log| {
-        let (color, set_color) = signal("red".to_string());
+        let (color, set_color) = signal("red".to_string()).split();
         let css = computed(move || format!("background: {};", color.get()));
         let _h = render! {
             XStyled(style: css)
@@ -238,7 +238,7 @@ fn non_style_props_route_through_set_attribute_with_kebab_case() {
 #[test]
 fn read_signal_prop_tracks_underlying_signal() {
     with_recorder_and_owner(|log| {
-        let (value, set_value) = signal("alpha".to_string());
+        let (value, set_value) = signal("alpha".to_string()).split();
         let _h = render! {
             XInput(value: value, placeholder: "static")
         };
@@ -267,7 +267,7 @@ fn typed_signal_bool_serialises_via_to_string() {
     // `bool::to_string()` → "true" / "false". Verifies the macro's
     // turbofish picks the inner T correctly (not hardcoded String).
     with_recorder_and_owner(|log| {
-        let (checked, set_checked) = signal(false);
+        let (checked, set_checked) = signal(false).split();
         let _h = render! {
             XTypedCheckbox(checked: checked, count: 42_i32)
         };

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -200,10 +200,7 @@ fn context_inner_screen() -> Element {
     let state = use_context::<PreservedState>().unwrap();
     let local = signal(99_i32);
     let counter_label = computed(move || state.counter.get().to_string());
-    let local_label = {
-        let r = local.0;
-        computed(move || r.get().to_string())
-    };
+    let local_label = computed(move || local.get().to_string());
     render! {
         view {
             text(value: counter_label)

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -463,7 +463,7 @@ fn multiple_children_append_in_order() {
 #[test]
 fn dynamic_value_renders_initial_via_effect() {
     with_recorder_and_owner(|log| {
-        let (count, _set_count) = signal(0_i32);
+        let (count, _set_count) = signal(0_i32).split();
         // Phase 7-Φ.B: macro no longer auto-wraps kwargs. For
         // reactive numeric → string interpolation, derive a
         // `ReadSignal<String>` via `computed`. Passes through as
@@ -487,7 +487,7 @@ fn dynamic_value_renders_initial_via_effect() {
 #[test]
 fn dynamic_value_updates_on_signal_write() {
     with_recorder_and_owner(|log| {
-        let (count, set_count) = signal(0_i32);
+        let (count, set_count) = signal(0_i32).split();
         let label = computed(move || count.get().to_string());
         let _h = render! {
             text(value: label)
@@ -512,7 +512,7 @@ fn dynamic_value_updates_on_signal_write() {
 #[test]
 fn dynamic_style_re_runs_on_dep_change() {
     with_recorder_and_owner(|log| {
-        let (color, set_color) = signal("red".to_string());
+        let (color, set_color) = signal("red".to_string()).split();
         // `format!` expression captured inside `computed` so the
         // closure (and the underlying signal read) re-runs on
         // change.
@@ -538,7 +538,7 @@ fn dynamic_style_re_runs_on_dep_change() {
 #[test]
 fn dynamic_attribute_re_runs_on_dep_change() {
     with_recorder_and_owner(|log| {
-        let (src, set_src) = signal("a.png".to_string());
+        let (src, set_src) = signal("a.png".to_string()).split();
         // Already a `ReadSignal<String>` — pass the handle directly,
         // it converts to `Signal::Dynamic`.
         let _h = render! {
@@ -583,7 +583,7 @@ fn mixed_static_and_dynamic_children_via_raw_text() {
     // reading the signal. Same op-stream shape the legacy
     // `<text>"count=" {count.get()}</text>` produced.
     with_recorder_and_owner(|log| {
-        let (count, _set) = signal(7_i32);
+        let (count, _set) = signal(7_i32).split();
         let count_label = computed(move || count.get().to_string());
         let _h = render! {
             text {
@@ -606,8 +606,8 @@ fn mixed_static_and_dynamic_children_via_raw_text() {
 #[test]
 fn signal_only_updates_elements_that_read_it() {
     with_recorder_and_owner(|log| {
-        let (a, set_a) = signal(0_i32);
-        let (b, _set_b) = signal(100_i32);
+        let (a, set_a) = signal(0_i32).split();
+        let (b, _set_b) = signal(100_i32).split();
         let a_label = computed(move || a.get().to_string());
         let b_label = computed(move || b.get().to_string());
         let _h = render! {
@@ -637,7 +637,7 @@ fn signal_only_updates_elements_that_read_it() {
 #[test]
 fn show_renders_children_when_true() {
     with_recorder_and_owner(|log| {
-        let (cond, _set) = signal(true);
+        let (cond, _set) = signal(true).split();
         let _h = render! {
             view {
                 Show(when: move || cond.get()) {
@@ -660,7 +660,7 @@ fn show_renders_children_when_true() {
 #[test]
 fn show_renders_fallback_when_false() {
     with_recorder_and_owner(|log| {
-        let (cond, _set) = signal(false);
+        let (cond, _set) = signal(false).split();
         let _h = render! {
             view {
                 Show(
@@ -686,7 +686,7 @@ fn show_renders_fallback_when_false() {
 #[test]
 fn show_swaps_on_condition_flip() {
     with_recorder_and_owner(|log| {
-        let (cond, set_cond) = signal(true);
+        let (cond, set_cond) = signal(true).split();
         let _h = render! {
             view {
                 Show(
@@ -717,7 +717,7 @@ fn show_swaps_on_condition_flip() {
 #[test]
 fn show_without_fallback_renders_nothing_when_false() {
     with_recorder_and_owner(|log| {
-        let (cond, _set) = signal(false);
+        let (cond, _set) = signal(false).split();
         let _h = render! {
             view {
                 Show(when: move || cond.get()) {
@@ -752,7 +752,8 @@ fn for_renders_initial_items() {
             Item { id: 1, name: "a" },
             Item { id: 2, name: "b" },
             Item { id: 3, name: "c" },
-        ]);
+        ])
+        .split();
         let _h = render! {
             view {
                 ForEach(
@@ -781,7 +782,7 @@ fn for_renders_initial_items() {
 #[test]
 fn for_adds_new_items_on_update() {
     with_recorder_and_owner(|log| {
-        let (items, set_items) = signal(vec![1_u32, 2]);
+        let (items, set_items) = signal(vec![1_u32, 2]).split();
         let _h = render! {
             view {
                 ForEach(
@@ -822,7 +823,7 @@ fn for_adds_new_items_on_update() {
 #[test]
 fn for_reorders_existing_items_visually() {
     with_recorder_and_owner(|log| {
-        let (items, set_items) = signal(vec![1_u32, 2, 3]);
+        let (items, set_items) = signal(vec![1_u32, 2, 3]).split();
         let _h = render! {
             view {
                 ForEach(
@@ -852,7 +853,7 @@ fn for_reorders_existing_items_visually() {
 #[test]
 fn for_removes_items_on_update() {
     with_recorder_and_owner(|log| {
-        let (items, set_items) = signal(vec![1_u32, 2, 3]);
+        let (items, set_items) = signal(vec![1_u32, 2, 3]).split();
         let _h = render! {
             view {
                 ForEach(

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -163,7 +163,7 @@ fn static_string_prop_sets_attribute_once() {
 #[test]
 fn read_signal_prop_tracks_underlying_signal() {
     with_recorder_and_owner(|log| {
-        let (color, set_color) = signal("red".to_string());
+        let (color, set_color) = signal("red".to_string()).split();
         let _h = render! {
             ColoredTile(color: color)
         };
@@ -227,7 +227,7 @@ fn show_flips_when_signal_holding_option_transitions() {
     // Show + signal-read chain that the simpler `text(value: …)`
     // tests don't exercise.
     with_recorder_and_owner(|log| {
-        let (state, set_state) = signal::<Option<&'static str>>(None);
+        let (state, set_state) = signal::<Option<&'static str>>(None).split();
         let _h = render! {
             Show(
                 when: move || state.get().is_some(),
@@ -274,7 +274,7 @@ fn show_flips_when_signal_holding_option_transitions() {
 #[test]
 fn computed_prop_tracks_chain_of_signals() {
     with_recorder_and_owner(|log| {
-        let (count, set_count) = signal(0_i32);
+        let (count, set_count) = signal(0_i32).split();
         // Caller-side computed → ReadSignal<String> → flows into
         // ColoredTile as Signal::Dynamic. Updates to `count`
         // propagate end-to-end.

--- a/packages/whisker-input/example/src/lib.rs
+++ b/packages/whisker-input/example/src/lib.rs
@@ -71,14 +71,14 @@ fn two_way_demo() -> Element {
 /// writeback upper-cases each keystroke.
 #[component]
 fn controlled_demo() -> Element {
-    let (value, set_value) = signal(String::new());
+    let value = signal(String::new());
 
     render! {
         view(style: section_style()) {
             text(style: label_style(), value: "Controlled (UPPER-CASE)")
             Input(
                 value: value,
-                on_input: move |s: String| set_value.set(s.to_uppercase()),
+                on_input: move |s: String| value.set(s.to_uppercase()),
                 placeholder: "lowercase becomes UPPER",
                 placeholder_color: MUTED,
                 keyboard_type: KeyboardType::Email,

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -41,11 +41,11 @@
 //! and drive writeback yourself from `on_input`:
 //!
 //! ```ignore
-//! let (value, set_value) = signal(String::new());
+//! let value = signal(String::new());
 //! render! {
 //!     Input(
 //!         value: value,
-//!         on_input: move |s: String| set_value.set(s.to_uppercase()),
+//!         on_input: move |s: String| value.set(s.to_uppercase()),
 //!     )
 //! }
 //! ```


### PR DESCRIPTION
## What

`signal(v)` (and `arc_signal(v)`) now return a **combined `RwSignal<T>`** (`ArcRwSignal<T>`) instead of a `(ReadSignal<T>, WriteSignal<T>)` tuple. This is the handle people reach for most, and the one that threads cleanly through `move` closures and component props (it's `Copy`, so no destructuring dance to hand the same signal to a read site and a write site).

## Breaking change & migration

```rust
// before
let (count, set_count) = signal(0);
set_count.set(1);
assert_eq!(count.get(), 1);

// after — single combined handle (preferred)
let count = signal(0);
count.set(1);
assert_eq!(count.get(), 1);

// after — keep the old tuple when you genuinely need split capability
let (count, set_count) = signal(0).split();
```

- `.split()` gives back the `(ReadSignal, WriteSignal)` pair (behavior-identical, minimal-diff escape hatch).
- `.read_only()` / `.write_only()` narrow to a single capability — handy for capability-typed component props (e.g. handing a child `count: ReadSignal<i32>` with no write access).
- Same for `arc_signal` → `ArcRwSignal`, with `.split()` / `.read_only()` / `.write_only()`.

The `ReadSignal` / `WriteSignal` / `ArcReadSignal` / `ArcWriteSignal` types remain first-class.

## Changes

- **Runtime**: `signal()` → `RwSignal<T>`, `arc_signal()` → `ArcRwSignal<T>`. `RwSignal::new` now delegates to `signal()`. Added `RwSignal::write_only()` for symmetry with `read_only()`.
- **Scaffold** (`whisker new`): the generated counter now uses `let count = signal(0);`, promoting the single-handle idiom.
- **Sweep**: every call site migrated. User-facing code (examples, doctests, doc comments, scaffold, package examples) uses the single handle; runtime-internal code and library/crate tests use `.split()` as the behavior-identical fallback.

## Verify

- `cargo build --workspace` — clean
- `cargo test --workspace` — green (incl. `-p whisker -p whisker-runtime` + doctests)
- `cargo clippy --workspace --all-targets` — no new warnings
- `cargo fmt --all -- --check` — clean
- Generated a fresh scaffold against in-tree whisker — uses `signal(0)` and `cargo check`s clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)