### PR TITLE
chore: migrate to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ exclude = [
 
 [workspace.package]
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/whiskerrs/whisker"

--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -27,12 +27,12 @@
 //! the `capture` field on [`CargoBuild`] — dev-server's Tier 2
 //! cold rebuild passes `Some(&shims)`; gradle-plugin and direct gradle invocations pass `None`.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::capture::{capture_env_vars, CaptureShims};
 use crate::Profile;
+use crate::capture::{CaptureShims, capture_env_vars};
 
 // ----- NDK toolchain resolution --------------------------------------------
 

--- a/crates/whisker-build/src/child_guard.rs
+++ b/crates/whisker-build/src/child_guard.rs
@@ -91,8 +91,8 @@ mod tests {
         let g = track(999_999_002);
         std::mem::forget(g);
         kill_all(); // ESRCH ignored; no panic.
-                    // Clean up the leaked registration so other tests see a clean
-                    // registry.
+        // Clean up the leaked registration so other tests see a clean
+        // registry.
         if let Ok(mut t) = TRACKED.lock() {
             t.retain(|&p| p != 999_999_002);
         }

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -34,7 +34,7 @@
 //! `whisker build-ios` subprocess, and finally cargo. Direct `xcodebuild`
 //! sets no env so the build runs without capture.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -51,7 +51,7 @@ use std::process::Command;
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
 pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.0";
 
-use crate::capture::{capture_env_vars_for_triple, CaptureShims};
+use crate::capture::{CaptureShims, capture_env_vars_for_triple};
 
 const FRAMEWORK_NAME: &str = "WhiskerDriver";
 

--- a/crates/whisker-build/src/lib.rs
+++ b/crates/whisker-build/src/lib.rs
@@ -38,8 +38,8 @@ pub mod modules;
 pub mod ui;
 
 pub use capture::{
-    capture_env_vars, capture_env_vars_for_triple, target_linker_env_var, target_rustflags_env_var,
-    CaptureShims,
+    CaptureShims, capture_env_vars, capture_env_vars_for_triple, target_linker_env_var,
+    target_rustflags_env_var,
 };
 
 /// Build profile. Maps to `cargo --release` and to the

--- a/crates/whisker-build/src/modules.rs
+++ b/crates/whisker-build/src/modules.rs
@@ -52,7 +52,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use cargo_metadata::MetadataCommand;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -814,7 +814,8 @@ mod tests {
         // Force the non-TTY branch (plain output) so the assertion
         // doesn't depend on `is_tty()` returning false at test time
         // — which it does under cargo test, but explicit is better.
-        std::env::set_var("WHISKER_VERBOSE", "");
+        // FIXME: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("WHISKER_VERBOSE", "") };
         let line = if is_tty() {
             // Test fixture: derive the non-color version even when
             // running interactively. We can't easily mock is_tty()

--- a/crates/whisker-cli/src/build_dispatch.rs
+++ b/crates/whisker-cli/src/build_dispatch.rs
@@ -26,7 +26,7 @@
 //! whisker modules --workspace="$WS" --package="$PKG"
 //! ```
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use clap::Args;
 use std::path::PathBuf;
 use whisker_build::Profile;

--- a/crates/whisker-cli/src/fmt.rs
+++ b/crates/whisker-cli/src/fmt.rs
@@ -16,7 +16,7 @@
 //! (resolved per file directory), and the base Rust pass shells out to
 //! the real rustfmt binary which reads `rustfmt.toml` itself.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Args;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -123,7 +123,8 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<()> {
     // the env var means any subprocess we spawn (dev-server, shim
     // binaries) sees the same mode without further plumbing.
     if cli.verbose {
-        std::env::set_var("WHISKER_VERBOSE", "1");
+        // FIXME: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("WHISKER_VERBOSE", "1") };
     }
     match cli.command {
         Command::Doctor(a) => doctor::run(a),

--- a/crates/whisker-cli/src/manifest.rs
+++ b/crates/whisker-cli/src/manifest.rs
@@ -19,7 +19,7 @@
 //! config source. Missing `whisker.rs` is an error: the dev-server
 //! needs bundle id, application id, etc. that the file supplies.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::path::{Path, PathBuf};
 use whisker_config::Config;
 

--- a/crates/whisker-cli/src/new_app.rs
+++ b/crates/whisker-cli/src/new_app.rs
@@ -29,7 +29,7 @@
 //!   where `<ns>` is `_`-joined snake_case. Override with
 //!   `--bundle-id`.
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::Args;
 use std::path::{Path, PathBuf};
 
@@ -148,7 +148,7 @@ resolver = "2"
 [package]
 name = "{name}"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/whisker-cli/src/new_module.rs
+++ b/crates/whisker-cli/src/new_module.rs
@@ -28,7 +28,7 @@
 //! `whisker new-module` subcommand can grow later without breaking
 //! the contract documented at <https://whisker.rs/docs/authoring-a-module>.
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::Args;
 use std::path::{Path, PathBuf};
 
@@ -220,7 +220,7 @@ fn cargo_toml(v: &Vars) -> String {
         r#"[package]
 name = "{name}"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Whisker module — short tagline shown on crates.io."
 

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -16,10 +16,10 @@
 //! `build` subcommands call this before kicking off the rest of the
 //! build pipeline.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use whisker_cng::{discover_plugins, DiscoveredPlugin, Engine, SubprocessPlugin};
+use whisker_cng::{DiscoveredPlugin, Engine, SubprocessPlugin, discover_plugins};
 use whisker_config::Config;
 use whisker_dev_server::Target;
 

--- a/crates/whisker-cli/src/probe.rs
+++ b/crates/whisker-cli/src/probe.rs
@@ -33,7 +33,7 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use whisker_cng::{discover_plugins, DiscoveredPlugin};
+use whisker_cng::{DiscoveredPlugin, discover_plugins};
 use whisker_config::Config;
 
 /// Run the probe and return the parsed config. Caches via mtime so
@@ -114,7 +114,7 @@ fn write_probe_project(
 [package]
 name = "{probe_crate_name}"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -10,7 +10,7 @@
 //! notebook front-end, …) can reuse the same loop without a
 //! whisker-config dependency.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use whisker_dev_server::{AndroidParams, Config, DevServer, HotPatchMode, IosParams, Target};
@@ -88,7 +88,8 @@ pub fn run(args: Args) -> Result<()> {
     // unstick a `Curated` cache.
     let tui_enabled = !args.no_tui && std::io::IsTerminal::is_terminal(&std::io::stderr());
     if tui_enabled {
-        std::env::set_var("WHISKER_TUI", "1");
+        // FIXME: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("WHISKER_TUI", "1") };
     }
 
     // Resolve the user-facing manifest before doing anything UI-y so

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -61,10 +61,9 @@
 
 use anyhow::{Context, Result};
 use crossterm::{
-    cursor,
-    event::{poll, read, Event as CtEvent, KeyCode, KeyEventKind, KeyModifiers},
+    ExecutableCommand, cursor,
+    event::{Event as CtEvent, KeyCode, KeyEventKind, KeyModifiers, poll, read},
     terminal::{disable_raw_mode, enable_raw_mode},
-    ExecutableCommand,
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::buffer::Buffer;
@@ -75,7 +74,7 @@ use ratatui::widgets::{Paragraph, Widget, Wrap};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use std::io::Write;
 use std::os::raw::c_int;
-use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
+use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 

--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -27,7 +27,7 @@
 //! converted to slashes: `rs.whisker.examples.helloworld` →
 //! `rs/whisker/examples/helloworld/`.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use whisker_config::Config;

--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -29,7 +29,7 @@
 //! invites trying to instantiate a plugin without registering it
 //! with the engine, which loses the topo-sort / conflict checks.
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::io::Write;

--- a/crates/whisker-cng/src/discovery.rs
+++ b/crates/whisker-cng/src/discovery.rs
@@ -41,7 +41,7 @@
 //! avoid a circular dep — `whisker-build` already depends on
 //! `whisker-cng` via the transitive sync calls.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use cargo_metadata::MetadataCommand;
 use serde::Deserialize;
 use std::collections::BTreeMap;

--- a/crates/whisker-cng/src/ios.rs
+++ b/crates/whisker-cng/src/ios.rs
@@ -27,7 +27,7 @@
 //! if Xcode N+1 demands a new objectVersion, regenerate the
 //! template via xcodegen once and re-templatize.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use whisker_config::Config;
@@ -848,17 +848,23 @@ mod tests {
             "folder ref must use lastKnownFileType = folder: {}",
             rendered.file_reference_entries,
         );
-        assert!(rendered
-            .file_reference_entries
-            .contains("path = \"whisker_assets\""));
+        assert!(
+            rendered
+                .file_reference_entries
+                .contains("path = \"whisker_assets\"")
+        );
         // Lands in the Resources phase + navigator group, not Sources.
-        assert!(rendered
-            .resources_phase_files
-            .contains("whisker_assets in Resources"));
+        assert!(
+            rendered
+                .resources_phase_files
+                .contains("whisker_assets in Resources")
+        );
         assert!(rendered.sources_phase_files.is_empty());
-        assert!(rendered
-            .plugin_files_group_children
-            .contains("whisker_assets"));
+        assert!(
+            rendered
+                .plugin_files_group_children
+                .contains("whisker_assets")
+        );
     }
 
     #[test]

--- a/crates/whisker-cng/src/lib.rs
+++ b/crates/whisker-cng/src/lib.rs
@@ -36,8 +36,8 @@ pub mod ios;
 pub mod plugins;
 mod render;
 
-pub use android::{sync as sync_android, AndroidInputs};
+pub use android::{AndroidInputs, sync as sync_android};
 pub use compose::{EnabledTargets, Engine, SubprocessPlugin};
-pub use discovery::{discover_plugins, DiscoveredPlugin};
-pub use ios::{sync as sync_ios, IosInputs};
+pub use discovery::{DiscoveredPlugin, discover_plugins};
+pub use ios::{IosInputs, sync as sync_ios};
 pub use whisker_config::Config;

--- a/crates/whisker-cng/src/plugins/android_meta_data.rs
+++ b/crates/whisker-cng/src/plugins/android_meta_data.rs
@@ -86,12 +86,13 @@ mod tests {
         AndroidMetaData
             .apply(&mut ctx, &AndroidMetaDataConfig::default())
             .unwrap();
-        assert!(ctx
-            .android
-            .unwrap()
-            .manifest
-            .application_meta_data
-            .is_empty());
+        assert!(
+            ctx.android
+                .unwrap()
+                .manifest
+                .application_meta_data
+                .is_empty()
+        );
         assert!(ctx.journal.records.is_empty());
     }
 

--- a/crates/whisker-cng/src/render.rs
+++ b/crates/whisker-cng/src/render.rs
@@ -7,7 +7,7 @@
 //! placeholders so a typo'd `{{`-block fails loudly at sync time
 //! instead of writing a broken file the user has to debug.
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use std::collections::HashMap;
 
 /// Escape the five XML special characters (`&`, `<`, `>`, `"`,

--- a/crates/whisker-css/src/data_type/angle.rs
+++ b/crates/whisker-css/src/data_type/angle.rs
@@ -14,7 +14,7 @@
 
 use core::fmt;
 
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 /// A CSS `<angle>` value.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/crates/whisker-css/src/data_type/color.rs
+++ b/crates/whisker-css/src/data_type/color.rs
@@ -16,7 +16,7 @@
 
 use core::fmt;
 
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 use super::Angle;
 

--- a/crates/whisker-css/src/data_type/length.rs
+++ b/crates/whisker-css/src/data_type/length.rs
@@ -21,7 +21,7 @@
 
 use core::fmt;
 
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 /// A CSS `<length>` value.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/crates/whisker-css/src/data_type/length_percentage.rs
+++ b/crates/whisker-css/src/data_type/length_percentage.rs
@@ -18,7 +18,7 @@
 
 use core::fmt;
 
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 use super::{Length, Percentage};
 

--- a/crates/whisker-css/src/data_type/number.rs
+++ b/crates/whisker-css/src/data_type/number.rs
@@ -11,7 +11,7 @@
 
 use core::fmt;
 
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 /// A CSS `<number>` value.
 ///

--- a/crates/whisker-css/src/data_type/percentage.rs
+++ b/crates/whisker-css/src/data_type/percentage.rs
@@ -11,7 +11,7 @@
 
 use core::fmt;
 
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 /// A CSS `<percentage>` value.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/crates/whisker-css/src/data_type/time.rs
+++ b/crates/whisker-css/src/data_type/time.rs
@@ -15,7 +15,7 @@
 
 use core::fmt;
 
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 /// A CSS `<time>` value.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/crates/whisker-css/src/data_type_ext/easing.rs
+++ b/crates/whisker-css/src/data_type_ext/easing.rs
@@ -9,7 +9,7 @@
 
 use core::fmt;
 
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 /// A CSS `<easing-function>` value.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/crates/whisker-css/src/keyword/animation.rs
+++ b/crates/whisker-css/src/keyword/animation.rs
@@ -10,7 +10,7 @@
 use core::fmt;
 
 use crate::data_type::CssString;
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 /// The `animation-direction` keyword.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/whisker-css/src/keyword/text.rs
+++ b/crates/whisker-css/src/keyword/text.rs
@@ -254,7 +254,7 @@ mod tests {
     use super::*;
 
     macro_rules! assert_keyword_set {
-        ($cases:expr) => {
+        ($cases:expr_2021) => {
             for (k, expected) in $cases {
                 assert_eq!(k.to_css_string(), expected);
             }

--- a/crates/whisker-css/src/prop/animation.rs
+++ b/crates/whisker-css/src/prop/animation.rs
@@ -60,10 +60,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type_ext::EasingFunction;
     use crate::ext::*;
     use crate::keyword::*;
-    use crate::Css;
 
     #[test]
     fn animation_full_set() {

--- a/crates/whisker-css/src/prop/background.rs
+++ b/crates/whisker-css/src/prop/background.rs
@@ -79,13 +79,13 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type::{Color, CssString, Gradient, NamedColor};
     use crate::data_type::{ColorStop, Percentage};
     use crate::data_type_ext::{Position, PositionKeyword};
     use crate::ext::*;
     use crate::keyword::*;
     use crate::value::ImageRef;
-    use crate::Css;
 
     #[test]
     fn background_color() {

--- a/crates/whisker-css/src/prop/border.rs
+++ b/crates/whisker-css/src/prop/border.rs
@@ -132,10 +132,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type::Color;
     use crate::ext::*;
     use crate::keyword::BorderStyle;
-    use crate::Css;
 
     #[test]
     fn border_width_per_side() {

--- a/crates/whisker-css/src/prop/box_model.rs
+++ b/crates/whisker-css/src/prop/box_model.rs
@@ -138,11 +138,11 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type::{FitContent, MaxContent};
     use crate::ext::*;
     use crate::keyword::BoxSizing;
     use crate::value::Size;
-    use crate::Css;
 
     #[test]
     fn width_height_basic() {

--- a/crates/whisker-css/src/prop/display.rs
+++ b/crates/whisker-css/src/prop/display.rs
@@ -44,8 +44,8 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
-    use crate::keyword::{Direction, Display};
     use crate::Css;
+    use crate::keyword::{Direction, Display};
 
     #[test]
     fn display_keyword() {

--- a/crates/whisker-css/src/prop/effects.rs
+++ b/crates/whisker-css/src/prop/effects.rs
@@ -191,10 +191,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type::Color;
     use crate::ext::*;
     use crate::keyword::*;
-    use crate::Css;
 
     #[test]
     fn opacity_full_range() {

--- a/crates/whisker-css/src/prop/flex.rs
+++ b/crates/whisker-css/src/prop/flex.rs
@@ -72,10 +72,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::ext::*;
     use crate::keyword::*;
     use crate::value::FlexBasis;
-    use crate::Css;
 
     #[test]
     fn flex_direction_and_wrap() {

--- a/crates/whisker-css/src/prop/grid.rs
+++ b/crates/whisker-css/src/prop/grid.rs
@@ -75,10 +75,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::ext::*;
     use crate::keyword::GridAutoFlow;
     use crate::value::{GridLine, GridTemplate};
-    use crate::Css;
 
     #[test]
     fn template_rows_and_columns() {

--- a/crates/whisker-css/src/prop/linear.rs
+++ b/crates/whisker-css/src/prop/linear.rs
@@ -51,8 +51,8 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
-    use crate::keyword::*;
     use crate::Css;
+    use crate::keyword::*;
 
     #[test]
     fn linear_orientation_and_direction() {

--- a/crates/whisker-css/src/prop/position.rs
+++ b/crates/whisker-css/src/prop/position.rs
@@ -59,9 +59,9 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::ext::*;
     use crate::keyword::PositionKind;
-    use crate::Css;
 
     #[test]
     fn position_absolute_with_offsets() {

--- a/crates/whisker-css/src/prop/text.rs
+++ b/crates/whisker-css/src/prop/text.rs
@@ -108,10 +108,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type::{Color, NamedColor};
     use crate::ext::*;
     use crate::keyword::*;
-    use crate::Css;
 
     #[test]
     fn text_align_keywords() {

--- a/crates/whisker-css/src/prop/transform.rs
+++ b/crates/whisker-css/src/prop/transform.rs
@@ -45,10 +45,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type_ext::{Position, PositionKeyword};
     use crate::ext::*;
     use crate::keyword::*;
-    use crate::Css;
 
     #[test]
     fn transform_origin_keywords() {

--- a/crates/whisker-css/src/prop/transition.rs
+++ b/crates/whisker-css/src/prop/transition.rs
@@ -34,10 +34,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type_ext::EasingFunction;
     use crate::ext::*;
     use crate::keyword::TransitionPropertyKind;
-    use crate::Css;
 
     #[test]
     fn transition_set() {

--- a/crates/whisker-css/src/prop/typography.rs
+++ b/crates/whisker-css/src/prop/typography.rs
@@ -56,10 +56,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::ext::*;
     use crate::keyword::*;
     use crate::value::LineHeight;
-    use crate::Css;
 
     #[test]
     fn font_family_quotes_the_value() {

--- a/crates/whisker-css/src/shorthand/animation.rs
+++ b/crates/whisker-css/src/shorthand/animation.rs
@@ -150,10 +150,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type_ext::EasingFunction;
     use crate::ext::*;
     use crate::keyword::*;
-    use crate::Css;
 
     use super::*;
 

--- a/crates/whisker-css/src/shorthand/background.rs
+++ b/crates/whisker-css/src/shorthand/background.rs
@@ -182,11 +182,11 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type::{Color, ColorStop, CssString, Gradient, NamedColor};
     use crate::data_type_ext::{Position, PositionKeyword};
     use crate::keyword::*;
     use crate::value::ImageRef;
-    use crate::Css;
 
     use super::*;
 

--- a/crates/whisker-css/src/shorthand/border.rs
+++ b/crates/whisker-css/src/shorthand/border.rs
@@ -134,10 +134,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type::Color;
     use crate::ext::*;
     use crate::keyword::BorderStyle;
-    use crate::Css;
 
     use super::*;
 

--- a/crates/whisker-css/src/shorthand/flex.rs
+++ b/crates/whisker-css/src/shorthand/flex.rs
@@ -63,9 +63,9 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::ext::*;
     use crate::value::FlexBasis;
-    use crate::Css;
 
     use super::*;
 

--- a/crates/whisker-css/src/shorthand/padding_margin.rs
+++ b/crates/whisker-css/src/shorthand/padding_margin.rs
@@ -200,9 +200,9 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::ext::*;
     use crate::shorthand::padding_margin::MarginValue;
-    use crate::Css;
 
     #[test]
     fn padding_single_value_expands_to_four() {

--- a/crates/whisker-css/src/shorthand/transform.rs
+++ b/crates/whisker-css/src/shorthand/transform.rs
@@ -4,7 +4,7 @@ use core::fmt;
 
 use crate::css::Css;
 use crate::data_type::{Angle, Length, LengthPercentage};
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 /// One CSS transform function. Lynx supports the 2-D and 3-D
 /// transform families except `rotate3d()` and `scale3d()`.
@@ -200,8 +200,8 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
-    use crate::ext::*;
     use crate::Css;
+    use crate::ext::*;
 
     use super::*;
 

--- a/crates/whisker-css/src/shorthand/transition.rs
+++ b/crates/whisker-css/src/shorthand/transition.rs
@@ -94,10 +94,10 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
+    use crate::Css;
     use crate::data_type_ext::EasingFunction;
     use crate::ext::*;
     use crate::keyword::TransitionPropertyKind;
-    use crate::Css;
 
     use super::*;
 

--- a/crates/whisker-css/src/value.rs
+++ b/crates/whisker-css/src/value.rs
@@ -11,7 +11,7 @@
 use core::fmt;
 
 use crate::data_type::{CssString, FitContent, Length, LengthPercentage, MaxContent, Percentage};
-use crate::to_css::{write_number, ToCss};
+use crate::to_css::{ToCss, write_number};
 
 // ---------- Size (width / height / min-/max-) ----------
 

--- a/crates/whisker-css/tests/css_macro.rs
+++ b/crates/whisker-css/tests/css_macro.rs
@@ -2,8 +2,8 @@
 
 use whisker_css::ext::*;
 use whisker_css::{
-    css, AnimationDirection, Border, BorderStyle, Color, Css, FlexDirection, JustifyContent,
-    NamedColor, PositionKind, ToCss, TransformFn,
+    AnimationDirection, Border, BorderStyle, Color, Css, FlexDirection, JustifyContent, NamedColor,
+    PositionKind, ToCss, TransformFn, css,
 };
 
 #[test]

--- a/crates/whisker-dev-runtime/src/log_capture.rs
+++ b/crates/whisker-dev-runtime/src/log_capture.rs
@@ -375,7 +375,7 @@ fn push_platform_log(_stream: Stream, _line: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::time::{timeout, Duration};
+    use tokio::time::{Duration, timeout};
 
     /// Construct a fresh LogBuffer for direct testing — the global
     /// `LOG_BUFFER` static can only be initialised once per process,

--- a/crates/whisker-dev-server/src/hotpatch/cache.rs
+++ b/crates/whisker-dev-server/src/hotpatch/cache.rs
@@ -33,7 +33,7 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
-use super::symbol_table::{parse_symbol_table_from_bytes, SymbolTable};
+use super::symbol_table::{SymbolTable, parse_symbol_table_from_bytes};
 
 /// Pre-parsed snapshot of the original (== "fat") binary. Built once
 /// per dev-server run; subsequent JumpTable construction reads from

--- a/crates/whisker-dev-server/src/hotpatch/jump_table.rs
+++ b/crates/whisker-dev-server/src/hotpatch/jump_table.rs
@@ -220,10 +220,12 @@ mod tests {
     fn data_symbols_are_skipped() {
         let old = t(vec![("g", data(0x4000, 8))]);
         let new = t(vec![("g", data(0x4100, 8))]);
-        assert!(build_jump_table(&old, &new, lib(), 0, 0)
-            .table
-            .map
-            .is_empty());
+        assert!(
+            build_jump_table(&old, &new, lib(), 0, 0)
+                .table
+                .map
+                .is_empty()
+        );
     }
 
     #[test]
@@ -242,10 +244,12 @@ mod tests {
         // a size-0 entry is a PLT stub or compiler marker — skip.
         let old = t(vec![("plt_stub", text(0x1000, 0))]);
         let new = t(vec![("plt_stub", text(0x1100, 0))]);
-        assert!(build_jump_table(&old, &new, lib(), 0, 0)
-            .table
-            .map
-            .is_empty());
+        assert!(
+            build_jump_table(&old, &new, lib(), 0, 0)
+                .table
+                .map
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/whisker-dev-server/src/hotpatch/link_plan.rs
+++ b/crates/whisker-dev-server/src/hotpatch/link_plan.rs
@@ -223,11 +223,7 @@ fn xcrun_sdk_path(kind: &str) -> Option<String> {
         return None;
     }
     let path = String::from_utf8(out.stdout).ok()?.trim().to_string();
-    if path.is_empty() {
-        None
-    } else {
-        Some(path)
-    }
+    if path.is_empty() { None } else { Some(path) }
 }
 
 /// Pick the [`LinkerOs`] that matches the host we're building on.

--- a/crates/whisker-dev-server/src/hotpatch/mod.rs
+++ b/crates/whisker-dev-server/src/hotpatch/mod.rs
@@ -24,20 +24,20 @@ pub mod validate;
 pub mod wrapper;
 
 pub use cache::HotpatchModuleCache;
-pub use jump_table::{build_jump_table, DiffReport, PatchPlan};
-pub use link_plan::{build_link_plan, linker_os_for_host, LinkPlan, LinkerOs};
+pub use jump_table::{DiffReport, PatchPlan, build_jump_table};
+pub use link_plan::{LinkPlan, LinkerOs, build_link_plan, linker_os_for_host};
 pub use patcher::Patcher;
 pub use runner::{run_link_plan, run_obj_plan, thin_rebuild_obj};
-pub use shim_paths::{expected_shim_paths, resolve_shim_paths, ShimPaths};
+pub use shim_paths::{ShimPaths, expected_shim_paths, resolve_shim_paths};
 pub use stub_object::{
     build_stub_for_needed, compute_needed_symbols, compute_needed_symbols_multi,
     create_undefined_symbol_stub,
 };
-pub use symbol_table::{parse_symbol_table, SymbolInfo, SymbolTable};
-pub use thin_build::{build_obj_plan, library_filename, object_filename, ObjBuildPlan};
+pub use symbol_table::{SymbolInfo, SymbolTable, parse_symbol_table};
+pub use thin_build::{ObjBuildPlan, build_obj_plan, library_filename, object_filename};
 pub use validate::{ensure_target_supported, extract_target_triple, validate_environment};
 pub use wrapper::{
-    default_cache_dir, default_linker_cache_dir, load_captured_args, load_captured_linker_args,
-    resolve_host_linker, run_fat_build, CapturedLinkerInvocation, CapturedRustcInvocation,
-    LinkerCaptureConfig,
+    CapturedLinkerInvocation, CapturedRustcInvocation, LinkerCaptureConfig, default_cache_dir,
+    default_linker_cache_dir, load_captured_args, load_captured_linker_args, resolve_host_linker,
+    run_fat_build,
 };

--- a/crates/whisker-dev-server/src/hotpatch/patcher.rs
+++ b/crates/whisker-dev-server/src/hotpatch/patcher.rs
@@ -25,9 +25,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use super::{
+    CapturedLinkerInvocation, CapturedRustcInvocation, HotpatchModuleCache, LinkerOs, PatchPlan,
     build_jump_table, build_link_plan, load_captured_args, load_captured_linker_args,
     parse_symbol_table, run_link_plan, run_obj_plan, thin_build, validate_environment,
-    CapturedLinkerInvocation, CapturedRustcInvocation, HotpatchModuleCache, LinkerOs, PatchPlan,
 };
 
 /// Single-slot in-session cache of the stub `.o` we synthesize for the

--- a/crates/whisker-dev-server/src/hotpatch/runner.rs
+++ b/crates/whisker-dev-server/src/hotpatch/runner.rs
@@ -18,8 +18,8 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
-use super::link_plan::{build_link_plan, LinkPlan, LinkerOs};
-use super::thin_build::{build_obj_plan, ObjBuildPlan};
+use super::link_plan::{LinkPlan, LinkerOs, build_link_plan};
+use super::thin_build::{ObjBuildPlan, build_obj_plan};
 use super::wrapper::CapturedRustcInvocation;
 
 /// Spawn rustc with `plan.args` from `cwd`. On success, returns

--- a/crates/whisker-dev-server/src/hotpatch/shim_paths.rs
+++ b/crates/whisker-dev-server/src/hotpatch/shim_paths.rs
@@ -209,11 +209,14 @@ mod tests {
         // Use CARGO_TARGET_DIR so we don't depend on the workspace
         // layout the tests run from.
         let prev = std::env::var_os("CARGO_TARGET_DIR");
-        std::env::set_var("CARGO_TARGET_DIR", &target);
+        // FIXME: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("CARGO_TARGET_DIR", &target) };
         let result = resolve_shim_paths(&dir);
         match prev {
-            Some(p) => std::env::set_var("CARGO_TARGET_DIR", p),
-            None => std::env::remove_var("CARGO_TARGET_DIR"),
+            // FIXME: Audit that the environment access only happens in single-threaded code.
+            Some(p) => unsafe { std::env::set_var("CARGO_TARGET_DIR", p) },
+            // FIXME: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var("CARGO_TARGET_DIR") },
         }
 
         let paths = result.expect("resolve");

--- a/crates/whisker-dev-server/src/hotpatch/stub_object.rs
+++ b/crates/whisker-dev-server/src/hotpatch/stub_object.rs
@@ -38,7 +38,7 @@
 //!   our hot-patches reference data symbols in the host so far; the
 //!   tests in B-4 confirm this).
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use object::write::{Object, StandardSection, Symbol, SymbolSection};
 use object::{
     Architecture, BinaryFormat, Endianness, Object as _, ObjectSymbol, SymbolFlags, SymbolKind,
@@ -47,8 +47,8 @@ use object::{
 use std::collections::HashSet;
 use std::path::Path;
 
-use crate::hotpatch::cache::HotpatchModuleCache;
 use crate::hotpatch::LinkerOs;
+use crate::hotpatch::cache::HotpatchModuleCache;
 
 /// Build a stub `.o` (bytes ready to write to disk) that satisfies
 /// every undefined symbol in `patch_obj` whose name is also present

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -60,7 +60,7 @@ pub use installer::Installer;
 pub use server::{Patch, PatchSender};
 pub use watcher::{Change, ChangeKind};
 pub use whisker_build::CaptureShims;
-pub use workspace::{discover_path_deps, identify_crate_for_paths, PathDepCrate};
+pub use workspace::{PathDepCrate, discover_path_deps, identify_crate_for_paths};
 
 // ----- Config & enums --------------------------------------------------------
 

--- a/crates/whisker-dev-server/src/server.rs
+++ b/crates/whisker-dev-server/src/server.rs
@@ -34,11 +34,11 @@
 //! buffer, not replayed.
 
 use anyhow::Result;
-use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::Router;
 use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::Response;
 use axum::routing::get;
-use axum::Router;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
@@ -83,8 +83,8 @@ enum PatchHeader<'a> {
 /// shared crate) because the type is tiny and the duplication
 /// burden is one ~30-line module.
 pub mod wire_jump_table {
-    use serde::ser::SerializeStruct;
     use serde::Serializer;
+    use serde::ser::SerializeStruct;
     use subsecond_types::JumpTable;
 
     pub fn serialize<S: Serializer>(t: &JumpTable, s: S) -> Result<S::Ok, S::Error> {

--- a/crates/whisker-dev-server/tests/fixtures/thin-build-fixture/Cargo.toml
+++ b/crates/whisker-dev-server/tests/fixtures/thin-build-fixture/Cargo.toml
@@ -8,7 +8,7 @@
 [package]
 name = "thin-build-fixture"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/crates/whisker-dev-server/tests/fixtures/thin-build-fixture/src/lib.rs
+++ b/crates/whisker-dev-server/tests/fixtures/thin-build-fixture/src/lib.rs
@@ -16,12 +16,12 @@
 //!   check that Tier 1 hot-patch is even possible for ordinary
 //!   Rust functions.
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn answer() -> i32 {
     42
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn other_function() -> i32 {
     99
 }
@@ -37,13 +37,13 @@ pub fn calculate(x: i32) -> i32 {
 // Mach-O. The real Whisker `#[whisker::main]` macro generates these;
 // fixtures don't go through the macro, so we define them by hand to
 // keep the integration-test link happy.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn whisker_aslr_anchor() -> i32 {
     0
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn whisker_app_main() {}
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn whisker_tick() -> bool {
     false
 }

--- a/crates/whisker-dev-server/tests/patcher.rs
+++ b/crates/whisker-dev-server/tests/patcher.rs
@@ -35,9 +35,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use whisker_dev_server::hotpatch::{
+    CapturedLinkerInvocation, CapturedRustcInvocation, HotpatchModuleCache, LinkerOs, Patcher,
     build_link_plan, build_obj_plan, library_filename, linker_os_for_host, parse_symbol_table,
-    run_link_plan, run_obj_plan, CapturedLinkerInvocation, CapturedRustcInvocation,
-    HotpatchModuleCache, LinkerOs, Patcher,
+    run_link_plan, run_obj_plan,
 };
 
 const FIXTURE_CRATE_NAME: &str = "thin_build_fixture";

--- a/crates/whisker-dev-server/tests/thin_rebuild_obj.rs
+++ b/crates/whisker-dev-server/tests/thin_rebuild_obj.rs
@@ -21,8 +21,8 @@
 use std::path::{Path, PathBuf};
 
 use whisker_dev_server::hotpatch::{
-    build_link_plan, build_obj_plan, library_filename, linker_os_for_host, parse_symbol_table,
-    run_link_plan, run_obj_plan, CapturedRustcInvocation,
+    CapturedRustcInvocation, build_link_plan, build_obj_plan, library_filename, linker_os_for_host,
+    parse_symbol_table, run_link_plan, run_obj_plan,
 };
 
 const FIXTURE_CRATE_NAME: &str = "thin_build_fixture";

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -224,7 +224,7 @@ pub type WhiskerModuleDispatchFn = extern "C" fn(
     arg_count: usize,
 ) -> WhiskerValueRaw;
 
-extern "C" {
+unsafe extern "C" {
     pub fn whisker_bridge_engine_attach(lynx_view_ptr: *mut c_void) -> *mut WhiskerEngine;
     pub fn whisker_bridge_engine_release(engine: *mut WhiskerEngine);
 

--- a/crates/whisker-driver/src/element_ref.rs
+++ b/crates/whisker-driver/src/element_ref.rs
@@ -32,9 +32,9 @@
 //! code sees [`ElementHandle`], [`ScrollViewHandle`], [`TextHandle`],
 //! and similar typed handles — never `ElementRef` directly.
 
-use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use whisker_runtime::reactive::{computed, RwSignal, Signal};
+use serde::de::DeserializeOwned;
+use whisker_runtime::reactive::{RwSignal, Signal, computed};
 use whisker_runtime::view::Element;
 
 use crate::module::WhiskerValue;

--- a/crates/whisker-driver/src/lib.rs
+++ b/crates/whisker-driver/src/lib.rs
@@ -30,13 +30,13 @@ pub use element_ref::{
 pub use lynx::bootstrap;
 pub use lynx::renderer::BridgeRenderer;
 
-use std::ffi::{c_void, CString};
+use std::ffi::{CString, c_void};
 
 use whisker_driver_sys as ffi;
 use whisker_driver_sys::WhiskerElement;
-use whisker_runtime::view::{module_component_ptr, Element};
+use whisker_runtime::view::{Element, module_component_ptr};
 
-use crate::module::{async_trampoline, from_raw, RawBuilder, WhiskerValue};
+use crate::module::{RawBuilder, WhiskerValue, async_trampoline, from_raw};
 
 /// Synchronously invoke `method` on the platform component identified
 /// by `handle`, with `args` passed positionally through Lynx's

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -46,14 +46,14 @@ use super::renderer::BridgeRenderer;
 use std::cell::Cell;
 use std::ffi::c_void;
 
-use whisker_driver_sys::{whisker_bridge_dispatch, WhiskerEngine};
+use whisker_driver_sys::{WhiskerEngine, whisker_bridge_dispatch};
 use whisker_runtime::element::ElementTag;
 use whisker_runtime::reactive::{
     flush as reactive_flush, flush_mounts as reactive_flush_mounts, remount_components_for,
 };
 use whisker_runtime::view::{
-    append_child, create_element, flush as renderer_flush, install_renderer, set_inline_styles,
-    set_root, DynRenderer, Element,
+    DynRenderer, Element, append_child, create_element, flush as renderer_flush, install_renderer,
+    set_inline_styles, set_root,
 };
 
 thread_local! {

--- a/crates/whisker-driver/src/lynx/list_provider.rs
+++ b/crates/whisker-driver/src/lynx/list_provider.rs
@@ -29,13 +29,13 @@
 //! after the version bump.
 
 use std::os::raw::{c_int, c_void};
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use whisker_driver_sys::{
     self as ffi, LynxListComponentAtIndexFn, LynxListEnqueueComponentFn, LynxUserDataFreeFn,
 };
-use whisker_runtime::view::list_provider::NativeItemProvider;
 use whisker_runtime::view::Element;
+use whisker_runtime::view::list_provider::NativeItemProvider;
 
 use crate::lynx::renderer::BridgeRenderer;
 

--- a/crates/whisker-driver/src/module.rs
+++ b/crates/whisker-driver/src/module.rs
@@ -526,63 +526,73 @@ fn empty_raw(ty: ffi::WhiskerValueType) -> ffi::WhiskerValueRaw {
 /// `invoke_module*` invocation or another bridge-produced
 /// `WhiskerValueRaw`.
 pub unsafe fn from_raw(raw: &ffi::WhiskerValueRaw) -> WhiskerValue {
-    match raw.type_ {
-        x if x == ffi::WhiskerValueType::Null as u8 => WhiskerValue::Null,
-        x if x == ffi::WhiskerValueType::Bool as u8 => WhiskerValue::Bool(raw.v.b),
-        x if x == ffi::WhiskerValueType::Int as u8 => WhiskerValue::Int(raw.v.i),
-        x if x == ffi::WhiskerValueType::Float as u8 => WhiskerValue::Float(raw.v.f),
-        x if x == ffi::WhiskerValueType::String as u8 => WhiskerValue::String(read_string(raw.v.s)),
-        x if x == ffi::WhiskerValueType::Bytes as u8 => {
-            WhiskerValue::Bytes(read_bytes(raw.v.bytes))
-        }
-        x if x == ffi::WhiskerValueType::Array as u8 => {
-            let arr = raw.v.array;
-            let mut out = Vec::with_capacity(arr.count);
-            for i in 0..arr.count {
-                let item = &*arr.items.add(i);
-                out.push(from_raw(item));
+    unsafe {
+        match raw.type_ {
+            x if x == ffi::WhiskerValueType::Null as u8 => WhiskerValue::Null,
+            x if x == ffi::WhiskerValueType::Bool as u8 => WhiskerValue::Bool(raw.v.b),
+            x if x == ffi::WhiskerValueType::Int as u8 => WhiskerValue::Int(raw.v.i),
+            x if x == ffi::WhiskerValueType::Float as u8 => WhiskerValue::Float(raw.v.f),
+            x if x == ffi::WhiskerValueType::String as u8 => {
+                WhiskerValue::String(read_string(raw.v.s))
             }
-            WhiskerValue::Array(out)
-        }
-        x if x == ffi::WhiskerValueType::Map as u8 => {
-            let m = raw.v.map;
-            let mut out = BTreeMap::new();
-            for i in 0..m.count {
-                let entry = &*m.entries.add(i);
-                let key = read_string(entry.key);
-                let value = from_raw(&entry.value);
-                out.insert(key, value);
+            x if x == ffi::WhiskerValueType::Bytes as u8 => {
+                WhiskerValue::Bytes(read_bytes(raw.v.bytes))
             }
-            WhiskerValue::Map(out)
+            x if x == ffi::WhiskerValueType::Array as u8 => {
+                let arr = raw.v.array;
+                let mut out = Vec::with_capacity(arr.count);
+                for i in 0..arr.count {
+                    let item = &*arr.items.add(i);
+                    out.push(from_raw(item));
+                }
+                WhiskerValue::Array(out)
+            }
+            x if x == ffi::WhiskerValueType::Map as u8 => {
+                let m = raw.v.map;
+                let mut out = BTreeMap::new();
+                for i in 0..m.count {
+                    let entry = &*m.entries.add(i);
+                    let key = read_string(entry.key);
+                    let value = from_raw(&entry.value);
+                    out.insert(key, value);
+                }
+                WhiskerValue::Map(out)
+            }
+            x if x == ffi::WhiskerValueType::Error as u8 => {
+                WhiskerValue::Error(read_string(raw.v.s))
+            }
+            // Bridge produced an unknown discriminant — surface as
+            // an error rather than panicking. Indicates the bridge
+            // and the Rust mirror have drifted out of sync.
+            other => WhiskerValue::Error(format!(
+                "WhiskerValueRaw carries unknown type discriminant {other}"
+            )),
         }
-        x if x == ffi::WhiskerValueType::Error as u8 => WhiskerValue::Error(read_string(raw.v.s)),
-        // Bridge produced an unknown discriminant — surface as
-        // an error rather than panicking. Indicates the bridge
-        // and the Rust mirror have drifted out of sync.
-        other => WhiskerValue::Error(format!(
-            "WhiskerValueRaw carries unknown type discriminant {other}"
-        )),
     }
 }
 
 unsafe fn read_string(r: ffi::WhiskerStringRef) -> String {
-    if r.ptr.is_null() || r.len == 0 {
-        return String::new();
+    unsafe {
+        if r.ptr.is_null() || r.len == 0 {
+            return String::new();
+        }
+        // Don't assume NUL-termination — `len` is authoritative.
+        let bytes = std::slice::from_raw_parts(r.ptr as *const u8, r.len);
+        std::str::from_utf8(bytes)
+            .map(|s| s.to_string())
+            // If the bridge produced non-UTF8, fall through to a
+            // lossy conversion so we never panic at the FFI seam.
+            .unwrap_or_else(|_| String::from_utf8_lossy(bytes).into_owned())
     }
-    // Don't assume NUL-termination — `len` is authoritative.
-    let bytes = std::slice::from_raw_parts(r.ptr as *const u8, r.len);
-    std::str::from_utf8(bytes)
-        .map(|s| s.to_string())
-        // If the bridge produced non-UTF8, fall through to a
-        // lossy conversion so we never panic at the FFI seam.
-        .unwrap_or_else(|_| String::from_utf8_lossy(bytes).into_owned())
 }
 
 unsafe fn read_bytes(r: ffi::WhiskerBytesRef) -> Vec<u8> {
-    if r.ptr.is_null() || r.len == 0 {
-        return Vec::new();
+    unsafe {
+        if r.ptr.is_null() || r.len == 0 {
+            return Vec::new();
+        }
+        std::slice::from_raw_parts(r.ptr, r.len).to_vec()
     }
-    std::slice::from_raw_parts(r.ptr, r.len).to_vec()
 }
 
 // ----- Tests --------------------------------------------------------------

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -51,7 +51,7 @@ mod source_map;
 
 pub use options::FmtOptions;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use expr_fmt::{ExprFormatter, ExprMap};
 use proc_macro2::{Delimiter, Span, TokenStream, TokenTree};
 use source_map::SourceMap;
@@ -1045,16 +1045,14 @@ mod comment_tests {
     // 6. Trailing comment after a `css!` field.
     #[test]
     fn trailing_comment_after_css_field() {
-        let input =
-            "fn s() -> Css {\n    css! {\n        color: red, // c\n        padding: px(8),\n    }\n}\n";
+        let input = "fn s() -> Css {\n    css! {\n        color: red, // c\n        padding: px(8),\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
     // 7. Own-line comment between two `css!` fields.
     #[test]
     fn own_line_between_css_fields() {
-        let input =
-            "fn s() -> Css {\n    css! {\n        color: red,\n        // gap\n        padding: px(8),\n    }\n}\n";
+        let input = "fn s() -> Css {\n    css! {\n        color: red,\n        // gap\n        padding: px(8),\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -215,11 +215,7 @@ impl Printer<'_> {
             (line_end, c.start)
         };
         let between = self.map.between_has_newline(lo, hi);
-        if between {
-            None
-        } else {
-            Some(idx)
-        }
+        if between { None } else { Some(idx) }
     }
 
     /// First source byte of a node (its tag / alias ident).
@@ -474,11 +470,7 @@ fn child_extent(p: &Printer, child: &Node) -> Option<(usize, usize)> {
 /// width to be honest about the first line; the closing brace and the
 /// children sit on later lines.
 fn brace_width(children: &[Node]) -> usize {
-    if children.is_empty() {
-        0
-    } else {
-        " {".len()
-    }
+    if children.is_empty() { 0 } else { " {".len() }
 }
 
 /// Dedent the continuation (2nd..=Nth) lines of a multi-line fragment by

--- a/crates/whisker-fmt/src/source_map.rs
+++ b/crates/whisker-fmt/src/source_map.rs
@@ -248,8 +248,8 @@ impl<'a> SourceMap<'a> {
 mod tests {
     use super::*;
     use proc_macro2::TokenStream;
-    use syn::spanned::Spanned;
     use syn::Expr;
+    use syn::spanned::Spanned;
 
     #[test]
     fn slices_expr_from_its_own_token_stream() {

--- a/crates/whisker-fmt/tests/integration.rs
+++ b/crates/whisker-fmt/tests/integration.rs
@@ -3,7 +3,7 @@
 //! still passes in environments without it (the macro-only unit tests
 //! in `src/lib.rs` cover the formatter logic without rustfmt).
 
-use whisker_fmt::{check_source, format_source, rustfmt_available, FmtOptions};
+use whisker_fmt::{FmtOptions, check_source, format_source, rustfmt_available};
 
 fn opts(tab: usize, width: usize) -> FmtOptions {
     FmtOptions {

--- a/crates/whisker-macro-syntax/src/lib.rs
+++ b/crates/whisker-macro-syntax/src/lib.rs
@@ -21,6 +21,6 @@ pub mod render;
 
 pub use css::{CssInput, CssKwarg};
 pub use render::{
-    is_builtin_tag, is_pascal_case, snake_to_pascal, ElementNode, Kwarg, Node, Root,
-    UserComponentNode,
+    ElementNode, Kwarg, Node, Root, UserComponentNode, is_builtin_tag, is_pascal_case,
+    snake_to_pascal,
 };

--- a/crates/whisker-macro-syntax/src/render.rs
+++ b/crates/whisker-macro-syntax/src/render.rs
@@ -27,11 +27,11 @@
 
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{
-    braced,
+    Expr, Ident, LitStr, Token, braced,
     ext::IdentExt,
     parenthesized,
     parse::{Parse, ParseStream, Result},
-    token, Expr, Ident, LitStr, Token,
+    token,
 };
 
 // ---- AST ----------------------------------------------------------------

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -36,7 +36,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::spanned::Spanned;
-use syn::{parse2, Expr, FnArg, GenericParam, Ident, ItemFn, Pat, Type};
+use syn::{Expr, FnArg, GenericParam, Ident, ItemFn, Pat, Type, parse2};
 
 pub fn expand(item: TokenStream2) -> TokenStream2 {
     let input: ItemFn = match parse2(item) {

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -13,7 +13,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, ItemFn};
+use syn::{ItemFn, parse_macro_input};
 
 mod component;
 mod css;
@@ -37,7 +37,7 @@ mod render;
 /// ```ignore
 /// fn app() -> Element { /* user body */ }
 ///
-/// #[no_mangle]
+/// #[unsafe(no_mangle)]
 /// pub extern "C" fn whisker_app_main(
 ///     engine: *mut std::ffi::c_void,
 ///     request_frame: Option<extern "C" fn(*mut std::ffi::c_void)>,
@@ -46,7 +46,7 @@ mod render;
 ///     ::whisker::__main_runtime::run(engine, request_frame, request_frame_data, app);
 /// }
 ///
-/// #[no_mangle]
+/// #[unsafe(no_mangle)]
 /// pub extern "C" fn whisker_tick(engine: *mut std::ffi::c_void) -> bool {
 ///     ::whisker::__main_runtime::tick(engine)
 /// }
@@ -80,7 +80,13 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
             ::whisker::__main_runtime::call_user_app(#fn_name)
         }
 
-        #[no_mangle]
+        // `#[unsafe(no_mangle)]` (not bare `#[no_mangle]`): in edition
+        // 2024 a bare `#[no_mangle]` is a hard error, and this macro
+        // expands in the USER crate's edition. The `#[unsafe(...)]`
+        // attribute spelling was stabilized in Rust 1.82 — below the
+        // workspace MSRV of 1.85 — so it compiles cleanly in both 2021
+        // and 2024 user crates.
+        #[unsafe(no_mangle)]
         pub extern "C" fn whisker_app_main(
             engine: *mut ::std::ffi::c_void,
             request_frame: ::std::option::Option<
@@ -96,7 +102,7 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
             );
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn whisker_tick(engine: *mut ::std::ffi::c_void) -> bool {
             ::whisker::__main_runtime::tick(engine)
         }
@@ -121,7 +127,7 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         // The stub never runs — Whisker is JNI-loaded, never executed
         // as a process entry point. It only needs to exist in the
         // export list at a known static address.
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn whisker_aslr_anchor() -> ::std::ffi::c_int { 0 }
     };
 

--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -96,8 +96,8 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::spanned::Spanned;
 use syn::{
-    parse2, FnArg, GenericArgument, Ident, ItemFn, LitStr, Pat, PathArguments, Type, TypePath,
-    TypeTuple,
+    FnArg, GenericArgument, Ident, ItemFn, LitStr, Pat, PathArguments, Type, TypePath, TypeTuple,
+    parse2,
 };
 
 pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -482,7 +482,7 @@ fn strip_on_prefix(name: &str) -> Option<String> {
 mod tests {
     use super::strip_on_prefix;
     use proc_macro2::TokenStream as TokenStream2;
-    use whisker_macro_syntax::render::{is_builtin_tag, snake_to_pascal, Root};
+    use whisker_macro_syntax::render::{Root, is_builtin_tag, snake_to_pascal};
 
     #[test]
     fn strips_snake_case() {

--- a/crates/whisker-macros/tests/ra_completion.rs
+++ b/crates/whisker-macros/tests/ra_completion.rs
@@ -42,12 +42,12 @@
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::{Duration, Instant};
 
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Pinned rust-analyzer release tag. Bump to update.
 ///

--- a/crates/whisker-runtime/src/event.rs
+++ b/crates/whisker-runtime/src/event.rs
@@ -27,11 +27,11 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use serde::de::{self, DeserializeOwned, Deserializer, MapAccess, Visitor};
 use serde::Deserialize;
+use serde::de::{self, DeserializeOwned, Deserializer, MapAccess, Visitor};
 
 use crate::value::WhiskerValue;
-use crate::view::{set_event_listener, Element};
+use crate::view::{Element, set_event_listener};
 
 /// Re-export so `event::BindType` sits next to `event::bind_typed` /
 /// `event::bind_unit` — the propagation type these take. Canonical

--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -50,12 +50,12 @@ mod tests_loop_wedge;
 #[cfg(test)]
 mod tests_resource;
 
-pub use arc_signal::{arc_signal, ArcReadSignal, ArcRwSignal, ArcWriteSignal};
+pub use arc_signal::{ArcReadSignal, ArcRwSignal, ArcWriteSignal, arc_signal};
 #[doc(hidden)]
 pub use component::__reset_pending_mount_for_tests;
 pub use component::{
-    flush_mounts, mount_component, mount_component_remountable, on_component_root_attached,
-    on_mount, owners_for_fn, remount_components_for, unmount_component, MountId,
+    MountId, flush_mounts, mount_component, mount_component_remountable,
+    on_component_root_attached, on_mount, owners_for_fn, remount_components_for, unmount_component,
 };
 pub use computed::computed;
 pub use context::{provide_context, use_context, with_context};
@@ -67,10 +67,10 @@ pub use effect::effect;
 // `whisker::owner::Owner::new(None)` / `owner.with(...)` / etc.
 pub use owner::on_cleanup;
 pub use prop::Signal;
-pub use resource::{resource, resource_sync, Resource, ResourceState};
+pub use resource::{Resource, ResourceState, resource, resource_sync};
 pub use runtime::{NodeId, Owner};
 pub use scheduler::{flush, has_pending_work};
-pub use signal::{signal, ReadSignal, RwSignal, WriteSignal};
+pub use signal::{ReadSignal, RwSignal, WriteSignal, signal};
 pub use stored::StoredValue;
 
 use std::cell::RefCell;

--- a/crates/whisker-runtime/src/reactive/prop.rs
+++ b/crates/whisker-runtime/src/reactive/prop.rs
@@ -222,7 +222,7 @@ impl From<&str> for Signal<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reactive::{__reset_for_tests, computed, effect, flush, signal, RwSignal};
+    use crate::reactive::{__reset_for_tests, RwSignal, computed, effect, flush, signal};
     use std::cell::RefCell;
     use std::rc::Rc;
 

--- a/crates/whisker-runtime/src/reactive/runtime.rs
+++ b/crates/whisker-runtime/src/reactive/runtime.rs
@@ -22,7 +22,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
-use slotmap::{new_key_type, SlotMap};
+use slotmap::{SlotMap, new_key_type};
 
 new_key_type! {
     /// Identifier for an [`Owner`] slot in the runtime's owner map.

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -881,7 +881,7 @@ fn untrack_is_nestable_without_breaking_outer_restore() {
 
 #[test]
 fn untrack_restores_tracker_when_f_panics() {
-    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::panic::{AssertUnwindSafe, catch_unwind};
     fresh();
     let restored = Rc::new(RefCell::new(None));
     let restored_clone = restored.clone();

--- a/crates/whisker-runtime/src/reactive/tests_loop_wedge.rs
+++ b/crates/whisker-runtime/src/reactive/tests_loop_wedge.rs
@@ -34,7 +34,7 @@ use std::rc::Rc;
 use std::sync::MutexGuard;
 
 use crate::reactive::effect::effect;
-use crate::reactive::{__reset_for_tests, flush, has_pending_work, Owner, RwSignal};
+use crate::reactive::{__reset_for_tests, Owner, RwSignal, flush, has_pending_work};
 use crate::tasks;
 
 // These tests reach into process-global host state (the request-frame

--- a/crates/whisker-runtime/src/reactive/tests_resource.rs
+++ b/crates/whisker-runtime/src/reactive/tests_resource.rs
@@ -8,7 +8,7 @@
 //! the dispatcher and are exercised in `tasks::tests`).
 
 use crate::reactive::RwSignal;
-use crate::reactive::{__reset_for_tests, flush, resource, resource_sync, Owner, ResourceState};
+use crate::reactive::{__reset_for_tests, Owner, ResourceState, flush, resource, resource_sync};
 use crate::tasks;
 
 fn with_test_owner<R>(f: impl FnOnce() -> R) -> R {
@@ -319,7 +319,7 @@ fn async_resource_returns_to_loading_during_refetch() {
 /// never re-polled → these tests hit the deadline (the field hang).
 mod cross_thread_wake {
     use super::*;
-    use crate::main_thread::{set_drive_callback, set_main_thread_dispatcher, DispatchFn};
+    use crate::main_thread::{DispatchFn, set_drive_callback, set_main_thread_dispatcher};
     use crate::tasks::run_blocking;
     use std::ffi::c_void;
     use std::sync::{Mutex, MutexGuard};

--- a/crates/whisker-runtime/src/tasks.rs
+++ b/crates/whisker-runtime/src/tasks.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures_executor::{LocalPool, LocalSpawner};
-use futures_util::task::{waker_ref, ArcWake, LocalSpawnExt};
+use futures_util::task::{ArcWake, LocalSpawnExt, waker_ref};
 
 thread_local! {
     /// The per-thread executor. Holds queued + ready tasks. Polled
@@ -318,7 +318,7 @@ pub fn __reset_for_tests() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::main_thread::{set_main_thread_dispatcher, DispatchFn};
+    use crate::main_thread::{DispatchFn, set_main_thread_dispatcher};
     use std::cell::Cell;
     use std::ffi::c_void;
     use std::rc::Rc;

--- a/crates/whisker-runtime/src/value.rs
+++ b/crates/whisker-runtime/src/value.rs
@@ -33,8 +33,8 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use serde::de::{DeserializeOwned, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::Deserialize;
+use serde::de::{DeserializeOwned, Deserializer, MapAccess, SeqAccess, Visitor};
 
 /// Tagged-union variant set passed between Rust and the platform
 /// side — module args/returns and event payloads alike.

--- a/crates/whisker-runtime/src/view/apply.rs
+++ b/crates/whisker-runtime/src/view/apply.rs
@@ -14,7 +14,7 @@
 //! the read in `effect(...)` so the value re-applies whenever the
 //! signal source changes.
 
-use crate::reactive::{effect, Signal};
+use crate::reactive::{Signal, effect};
 use crate::view::handle::Element;
 use crate::view::renderer::{
     set_attribute, set_attribute_bool, set_attribute_double, set_attribute_int, set_inline_styles,

--- a/crates/whisker-runtime/src/view/list_mount.rs
+++ b/crates/whisker-runtime/src/view/list_mount.rs
@@ -47,10 +47,10 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
 
-use crate::reactive::{effect, on_cleanup, Owner};
+use crate::reactive::{Owner, effect, on_cleanup};
 
 use super::handle::Element;
-use super::list_provider::{NativeItemProvider, INVALID_ITEM_INDEX};
+use super::list_provider::{INVALID_ITEM_INDEX, NativeItemProvider};
 use super::renderer::{element_sign, install_list_native_item_provider, set_update_list_info};
 
 /// One live item — its FiberElement (`element`) and the reactive
@@ -159,8 +159,8 @@ mod tests {
     use super::*;
     use crate::element::ElementTag;
     use crate::reactive::flush;
-    use crate::view::renderer::{install_renderer, uninstall_renderer, DynRenderer};
-    use crate::view::{create_element_by_name, BindType};
+    use crate::view::renderer::{DynRenderer, install_renderer, uninstall_renderer};
+    use crate::view::{BindType, create_element_by_name};
 
     /// Minimal recording renderer that captures the calls
     /// `list_mount` makes — `set_update_list_info(count)` and

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -38,10 +38,10 @@ pub use apply::{
 };
 pub use handle::Element;
 pub use into_view::{
-    mount_children, Children, EachFn, Fallback, IntoView, ItemFn, KeyFn, View, WhenFn,
+    Children, EachFn, Fallback, IntoView, ItemFn, KeyFn, View, WhenFn, mount_children,
 };
 pub use list_mount::list_mount;
-pub use list_provider::{NativeItemProvider, INVALID_ITEM_INDEX};
+pub use list_provider::{INVALID_ITEM_INDEX, NativeItemProvider};
 #[doc(hidden)]
 pub use renderer::__reset_children_mirror_for_tests;
 
@@ -49,10 +49,10 @@ pub use renderer::__reset_children_mirror_for_tests;
 // against and that framework-extension authors (custom control flow,
 // platform-component module crates) legitimately reach for.
 pub use renderer::{
-    append_child, child_index, children_of, create_element, create_element_by_name,
+    BindType, append_child, child_index, children_of, create_element, create_element_by_name,
     create_phantom_element, dispatch_event, flush, insert_child_at,
     install_list_native_item_provider, is_phantom, previous_sibling, release_element, remove_child,
-    set_attribute, set_event_listener, set_inline_styles, set_root, set_update_list_info, BindType,
+    set_attribute, set_event_listener, set_inline_styles, set_root, set_update_list_info,
 };
 
 // Renderer-wiring internals. Public because `whisker-driver` (and test
@@ -63,6 +63,6 @@ pub use renderer::{
 // cross-crate references.
 #[doc(hidden)]
 pub use renderer::{
-    current_renderer_id, element_sign, install_renderer, module_component_ptr, uninstall_renderer,
-    with_installed_renderer, DynRenderer, EventDispatchPlan, PHANTOM_BASE,
+    DynRenderer, EventDispatchPlan, PHANTOM_BASE, current_renderer_id, element_sign,
+    install_renderer, module_component_ptr, uninstall_renderer, with_installed_renderer,
 };

--- a/crates/whisker-subsecond/src/lib.rs
+++ b/crates/whisker-subsecond/src/lib.rs
@@ -235,7 +235,7 @@ use std::{
     backtrace,
     mem::transmute,
     panic::AssertUnwindSafe,
-    sync::{atomic::AtomicPtr, Arc, Mutex},
+    sync::{Arc, Mutex, atomic::AtomicPtr},
 };
 
 /// Call a given function with hot-reloading enabled. If the function's code changes, `call` will use
@@ -505,225 +505,228 @@ impl<A, M, F: HotFunction<A, M>> HotFn<A, M, F> {
 /// this list to find live component owners whose body is now stale and re-mount
 /// them.
 pub unsafe fn apply_patch(mut table: JumpTable) -> Result<Vec<*const ()>, PatchError> {
-    // On non-wasm platforms we can just use libloading and the known aslr offsets to load the library
-    #[cfg(any(unix, windows))]
-    {
-        // on android we try to circumvent permissions issues by copying the library to a memmap and then libloading that
-        #[cfg(target_os = "android")]
-        let lib = Box::leak(Box::new(android_memmap_dlopen(&table.lib)?));
+    unsafe {
+        // On non-wasm platforms we can just use libloading and the known aslr offsets to load the library
+        #[cfg(any(unix, windows))]
+        {
+            // on android we try to circumvent permissions issues by copying the library to a memmap and then libloading that
+            #[cfg(target_os = "android")]
+            let lib = Box::leak(Box::new(android_memmap_dlopen(&table.lib)?));
 
-        #[cfg(not(target_os = "android"))]
-        let lib = Box::leak(Box::new({
-            match libloading::Library::new(&table.lib) {
-                Ok(lib) => lib,
-                Err(err) => return Err(PatchError::Dlopen(err.to_string())),
-            }
-        }));
+            #[cfg(not(target_os = "android"))]
+            let lib = Box::leak(Box::new({
+                match libloading::Library::new(&table.lib) {
+                    Ok(lib) => lib,
+                    Err(err) => return Err(PatchError::Dlopen(err.to_string())),
+                }
+            }));
 
-        // Whisker fork: anchor on `whisker_aslr_anchor` rather than `main`.
-        //
-        // Upstream uses `main` as the cross-library ASLR anchor. That works
-        // for Dioxus, where `main` is the PIE process entry and unique in
-        // the linker namespace. Whisker ships the user crate as a `dylib`
-        // loaded via Android `System.loadLibrary`, where the namespace can
-        // contain several `main` symbols (`app_process64`'s, stale patch
-        // memfds', etc.) — `dlsym(RTLD_DEFAULT, "main")` then returns the
-        // wrong one and the computed ASLR slide is garbage.
-        //
-        // `whisker_aslr_anchor` is synthesised by `#[whisker::main]` and
-        // is unique to the user's `.so`, so the dlsym lookup is
-        // unambiguous regardless of namespace order.
-        let old_offset = aslr_reference() - table.aslr_reference as usize;
-
-        let new_offset = unsafe {
-            // Leak the library. dlopen is basically a no-op on many platforms and if we even try to drop it,
-            // some code might be called (ie drop) that results in really bad crashes (restart your computer...)
+            // Whisker fork: anchor on `whisker_aslr_anchor` rather than `main`.
             //
-            // The CLI (whisker-dev-server) coordinates by ensuring
-            // `whisker_aslr_anchor` is in the export list of every patch.
-            lib.get::<*const ()>(b"whisker_aslr_anchor")
-                .ok()
-                .unwrap()
-                .try_as_raw_ptr()
-                .unwrap()
-                .wrapping_byte_sub(table.new_base_address as usize) as usize
+            // Upstream uses `main` as the cross-library ASLR anchor. That works
+            // for Dioxus, where `main` is the PIE process entry and unique in
+            // the linker namespace. Whisker ships the user crate as a `dylib`
+            // loaded via Android `System.loadLibrary`, where the namespace can
+            // contain several `main` symbols (`app_process64`'s, stale patch
+            // memfds', etc.) — `dlsym(RTLD_DEFAULT, "main")` then returns the
+            // wrong one and the computed ASLR slide is garbage.
+            //
+            // `whisker_aslr_anchor` is synthesised by `#[whisker::main]` and
+            // is unique to the user's `.so`, so the dlsym lookup is
+            // unambiguous regardless of namespace order.
+            let old_offset = aslr_reference() - table.aslr_reference as usize;
+
+            let new_offset = {
+                // Leak the library. dlopen is basically a no-op on many platforms and if we even try to drop it,
+                // some code might be called (ie drop) that results in really bad crashes (restart your computer...)
+                //
+                // The CLI (whisker-dev-server) coordinates by ensuring
+                // `whisker_aslr_anchor` is in the export list of every patch.
+                lib.get::<*const ()>(b"whisker_aslr_anchor")
+                    .ok()
+                    .unwrap()
+                    .try_as_raw_ptr()
+                    .unwrap()
+                    .wrapping_byte_sub(table.new_base_address as usize) as usize
+            };
+
+            // Modify the jump table to be relative to the base address of the loaded library
+            table.map = table
+                .map
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        (*k as usize + old_offset) as u64,
+                        (*v as usize + new_offset) as u64,
+                    )
+                })
+                .collect();
+
+            // Snapshot the host-side (post-slide) function pointers BEFORE
+            // committing the patch — `commit_patch` consumes `table`. Whisker's
+            // remount logic compares these against `fn as *const ()` values
+            // stashed in its component-owner registry.
+            let patched: Vec<*const ()> = table.map.keys().map(|k| *k as *const ()).collect();
+
+            commit_patch(table);
+            return Ok(patched);
         };
 
-        // Modify the jump table to be relative to the base address of the loaded library
-        table.map = table
-            .map
-            .iter()
-            .map(|(k, v)| {
-                (
-                    (*k as usize + old_offset) as u64,
-                    (*v as usize + new_offset) as u64,
-                )
-            })
-            .collect();
-
-        // Snapshot the host-side (post-slide) function pointers BEFORE
-        // committing the patch — `commit_patch` consumes `table`. Whisker's
-        // remount logic compares these against `fn as *const ()` values
-        // stashed in its component-owner registry.
-        let patched: Vec<*const ()> = table.map.keys().map(|k| *k as *const ()).collect();
-
-        commit_patch(table);
-        return Ok(patched);
-    };
-
-    // The non-wasm path above returns inside the block; for wasm we drop
-    // through to the wasm-specific code below which never returns Ok with
-    // a list (patches are async-applied). Surface an empty list in that
-    // case rather than restructuring the existing wasm flow.
-    #[allow(unreachable_code)]
-    {
-        let _unused: Vec<*const ()> = Vec::new();
-    }
-
-    // On wasm, we need to download the module, compile it, and then run it.
-    #[cfg(target_arch = "wasm32")]
-    wasm_bindgen_futures::spawn_local(async move {
-        use js_sys::{
-            ArrayBuffer, Object, Reflect,
-            WebAssembly::{self, Instance, Memory, Module, Table},
-        };
-        use wasm_bindgen::prelude::*;
-        use wasm_bindgen::JsValue;
-        use wasm_bindgen::UnwrapThrowExt;
-        use wasm_bindgen_futures::JsFuture;
-
-        let funcs: Table = wasm_bindgen::function_table().unchecked_into();
-        let memory: Memory = wasm_bindgen::memory().unchecked_into();
-        let exports: Object = wasm_bindgen::exports().unchecked_into();
-
-        let path = table.lib.to_str().unwrap();
-        if !path.ends_with(".wasm") {
-            return;
+        // The non-wasm path above returns inside the block; for wasm we drop
+        // through to the wasm-specific code below which never returns Ok with
+        // a list (patches are async-applied). Surface an empty list in that
+        // case rather than restructuring the existing wasm flow.
+        #[allow(unreachable_code)]
+        {
+            let _unused: Vec<*const ()> = Vec::new();
         }
 
-        // Fetch + decode the patch wasm. Both awaits are pure I/O — they
-        // touch no shared state, so the future is safe to drop here.
-        let response: web_sys::Response =
-            JsFuture::from(web_sys::window().unwrap_throw().fetch_with_str(&path))
+        // On wasm, we need to download the module, compile it, and then run it.
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(async move {
+            use js_sys::{
+                ArrayBuffer, Object, Reflect,
+                WebAssembly::{self, Instance, Memory, Module, Table},
+            };
+            use wasm_bindgen::JsValue;
+            use wasm_bindgen::UnwrapThrowExt;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen_futures::JsFuture;
+
+            let funcs: Table = wasm_bindgen::function_table().unchecked_into();
+            let memory: Memory = wasm_bindgen::memory().unchecked_into();
+            let exports: Object = wasm_bindgen::exports().unchecked_into();
+
+            let path = table.lib.to_str().unwrap();
+            if !path.ends_with(".wasm") {
+                return;
+            }
+
+            // Fetch + decode the patch wasm. Both awaits are pure I/O — they
+            // touch no shared state, so the future is safe to drop here.
+            let response: web_sys::Response =
+                JsFuture::from(web_sys::window().unwrap_throw().fetch_with_str(&path))
+                    .await
+                    .unwrap()
+                    .unchecked_into();
+            if !response.ok() {
+                panic!(
+                    "Failed to patch wasm module at {} - response failed with: {}",
+                    path,
+                    response.status_text()
+                );
+            }
+            let dl_bytes: ArrayBuffer = JsFuture::from(response.array_buffer().unwrap())
                 .await
                 .unwrap()
                 .unchecked_into();
-        if !response.ok() {
-            panic!(
-                "Failed to patch wasm module at {} - response failed with: {}",
-                path,
-                response.status_text()
-            );
-        }
-        let dl_bytes: ArrayBuffer = JsFuture::from(response.array_buffer().unwrap())
-            .await
-            .unwrap()
-            .unchecked_into();
 
-        // Pre-compile. This is the slow part — V8 hands it to a worker —
-        // and yields the longest. The result is a Module with no side
-        // effects on host JS state, so cancelling here is also safe.
-        let module: Module = JsFuture::from(WebAssembly::compile(dl_bytes.unchecked_ref()))
-            .await
-            .unwrap()
-            .unchecked_into();
+            // Pre-compile. This is the slow part — V8 hands it to a worker —
+            // and yields the longest. The result is a Module with no side
+            // effects on host JS state, so cancelling here is also safe.
+            let module: Module = JsFuture::from(WebAssembly::compile(dl_bytes.unchecked_ref()))
+                .await
+                .unwrap()
+                .unchecked_into();
 
-        // ── HOST-STATE-MUTATING SECTION ───────────────────────────────
-        //
-        // Below we grow shared linear memory and the indirect function
-        // table, then async-instantiate the patch into them and commit
-        // the new jump table. There IS one `.await` for the instantiate
-        // (we can't avoid it: Chrome disallows synchronous
-        // `new WebAssembly.Instance` on the main thread for modules
-        // larger than 8MB, and patches routinely cross that), but it's
-        // safe — the original race we fixed wasn't about yielding here:
-        //
-        //  * `memory.grow` and `funcs.grow` each return their PRIOR
-        //    length atomically. Concurrent `apply_patch` tasks therefore
-        //    each get a unique, non-overlapping `memory_base` /
-        //    `table_base`, so two patches can't land on the same region.
-        //  * Host code can't observe the half-instantiated patch: the
-        //    new memory pages are zero, the new table slots are null,
-        //    and the jump table isn't committed until the very end of
-        //    this block, so nothing redirects through the new slots.
-        //  * The original bug — using `memory.buffer().byteLength()`
-        //    captured before the awaits, which returned 0 if the buffer
-        //    had been detached by a concurrent grow — is gone because
-        //    we derive `memory_base` from `memory.grow()`'s return
-        //    value instead.
-        //  * Cancellation between grow and `commit_patch` leaks memory
-        //    pages and table slots, but doesn't corrupt anything.
-        const PAGE_SIZE: u32 = 64 * 1024;
-        let patch_pages = (dl_bytes.byte_length() as f64 / PAGE_SIZE as f64).ceil() as u32 + 1;
+            // ── HOST-STATE-MUTATING SECTION ───────────────────────────────
+            //
+            // Below we grow shared linear memory and the indirect function
+            // table, then async-instantiate the patch into them and commit
+            // the new jump table. There IS one `.await` for the instantiate
+            // (we can't avoid it: Chrome disallows synchronous
+            // `new WebAssembly.Instance` on the main thread for modules
+            // larger than 8MB, and patches routinely cross that), but it's
+            // safe — the original race we fixed wasn't about yielding here:
+            //
+            //  * `memory.grow` and `funcs.grow` each return their PRIOR
+            //    length atomically. Concurrent `apply_patch` tasks therefore
+            //    each get a unique, non-overlapping `memory_base` /
+            //    `table_base`, so two patches can't land on the same region.
+            //  * Host code can't observe the half-instantiated patch: the
+            //    new memory pages are zero, the new table slots are null,
+            //    and the jump table isn't committed until the very end of
+            //    this block, so nothing redirects through the new slots.
+            //  * The original bug — using `memory.buffer().byteLength()`
+            //    captured before the awaits, which returned 0 if the buffer
+            //    had been detached by a concurrent grow — is gone because
+            //    we derive `memory_base` from `memory.grow()`'s return
+            //    value instead.
+            //  * Cancellation between grow and `commit_patch` leaks memory
+            //    pages and table slots, but doesn't corrupt anything.
+            const PAGE_SIZE: u32 = 64 * 1024;
+            let patch_pages = (dl_bytes.byte_length() as f64 / PAGE_SIZE as f64).ceil() as u32 + 1;
 
-        // Use grow's return value (the prior page count) to derive
-        // memory_base. Atomic w.r.t. concurrent grows, unlike reading
-        // memory.buffer().byteLength().
-        let prev_pages = memory.grow(patch_pages);
-        let memory_base = (prev_pages + 1) * PAGE_SIZE;
+            // Use grow's return value (the prior page count) to derive
+            // memory_base. Atomic w.r.t. concurrent grows, unlike reading
+            // memory.buffer().byteLength().
+            let prev_pages = memory.grow(patch_pages);
+            let memory_base = (prev_pages + 1) * PAGE_SIZE;
 
-        // grow returns the prior table length, which is __table_base.
-        let table_base = funcs.grow(table.ifunc_count as u32).unwrap();
+            // grow returns the prior table length, which is __table_base.
+            let table_base = funcs.grow(table.ifunc_count as u32).unwrap();
 
-        // Rebase the jump table entries onto the patch's table slot range.
-        for v in table.map.values_mut() {
-            *v += table_base as u64;
-        }
+            // Rebase the jump table entries onto the patch's table slot range.
+            for v in table.map.values_mut() {
+                *v += table_base as u64;
+            }
 
-        // Build the env import object: copy every host export through and
-        // add __memory_base / __table_base globals so the patch's PIC
-        // code resolves correctly.
-        let env = Object::new();
-        for key in Object::keys(&exports) {
-            Reflect::set(&env, &key, &Reflect::get(&exports, &key).unwrap()).unwrap();
-        }
-        for (name, value) in [("__table_base", table_base), ("__memory_base", memory_base)] {
-            let descriptor = Object::new();
-            Reflect::set(&descriptor, &"value".into(), &"i32".into()).unwrap();
-            Reflect::set(&descriptor, &"mutable".into(), &false.into()).unwrap();
-            let global = WebAssembly::Global::new(&descriptor, &value.into()).unwrap();
-            Reflect::set(&env, &name.into(), &global.into()).unwrap();
-        }
-        let imports = Object::new();
-        Reflect::set(&imports, &"env".into(), &env).unwrap();
+            // Build the env import object: copy every host export through and
+            // add __memory_base / __table_base globals so the patch's PIC
+            // code resolves correctly.
+            let env = Object::new();
+            for key in Object::keys(&exports) {
+                Reflect::set(&env, &key, &Reflect::get(&exports, &key).unwrap()).unwrap();
+            }
+            for (name, value) in [("__table_base", table_base), ("__memory_base", memory_base)] {
+                let descriptor = Object::new();
+                Reflect::set(&descriptor, &"value".into(), &"i32".into()).unwrap();
+                Reflect::set(&descriptor, &"mutable".into(), &false.into()).unwrap();
+                let global = WebAssembly::Global::new(&descriptor, &value.into()).unwrap();
+                Reflect::set(&env, &name.into(), &global.into()).unwrap();
+            }
+            let imports = Object::new();
+            Reflect::set(&imports, &"env".into(), &env).unwrap();
 
-        // Async instantiation of the precompiled module. We use the
-        // (Module, imports) form of `WebAssembly.instantiate`, which
-        // resolves directly to an `Instance` (not `{module, instance}`).
-        // This is the no-size-limit path; the synchronous
-        // `new WebAssembly.Instance` constructor is capped at 8MB on
-        // Chrome's main thread.
-        let instance: Instance = JsFuture::from(WebAssembly::instantiate_module(&module, &imports))
-            .await
-            .unwrap()
-            .unchecked_into();
-        let inst_exports: Object = instance.exports();
+            // Async instantiation of the precompiled module. We use the
+            // (Module, imports) form of `WebAssembly.instantiate`, which
+            // resolves directly to an `Instance` (not `{module, instance}`).
+            // This is the no-size-limit path; the synchronous
+            // `new WebAssembly.Instance` constructor is capped at 8MB on
+            // Chrome's main thread.
+            let instance: Instance =
+                JsFuture::from(WebAssembly::instantiate_module(&module, &imports))
+                    .await
+                    .unwrap()
+                    .unchecked_into();
+            let inst_exports: Object = instance.exports();
 
-        // Run the patch's relocation thunks and constructors. Order
-        // matters: data relocs first (write memory_base- and table_base-
-        // relative pointers into the patch's data segment), then global
-        // relocs (adjust GOT.func.internal globals by __table_base —
-        // wasm-ld synthesizes those as element-segment-relative offsets),
-        // then ctors. `dyn_into` instead of `unchecked_into` so missing
-        // exports just no-op rather than throwing.
-        for func_name in [
-            "__wasm_apply_data_relocs",
-            "__wasm_apply_global_relocs",
-            "__wasm_call_ctors",
-        ] {
-            if let Ok(val) = Reflect::get(&inst_exports, &func_name.into()) {
-                if let Ok(func) = val.dyn_into::<js_sys::Function>() {
-                    _ = func.call0(&JsValue::undefined());
+            // Run the patch's relocation thunks and constructors. Order
+            // matters: data relocs first (write memory_base- and table_base-
+            // relative pointers into the patch's data segment), then global
+            // relocs (adjust GOT.func.internal globals by __table_base —
+            // wasm-ld synthesizes those as element-segment-relative offsets),
+            // then ctors. `dyn_into` instead of `unchecked_into` so missing
+            // exports just no-op rather than throwing.
+            for func_name in [
+                "__wasm_apply_data_relocs",
+                "__wasm_apply_global_relocs",
+                "__wasm_call_ctors",
+            ] {
+                if let Ok(val) = Reflect::get(&inst_exports, &func_name.into()) {
+                    if let Ok(func) = val.dyn_into::<js_sys::Function>() {
+                        _ = func.call0(&JsValue::undefined());
+                    }
                 }
             }
-        }
 
-        unsafe { commit_patch(table) };
-    });
+            unsafe { commit_patch(table) };
+        });
 
-    // wasm path applies the patch asynchronously inside the spawned
-    // future. We have no synchronous patched-pointer list to return.
-    Ok(Vec::new())
+        // wasm path applies the patch asynchronously inside the spawned
+        // future. We have no synchronous patched-pointer list to return.
+        Ok(Vec::new())
+    }
 }
 
 #[derive(Debug, PartialEq, thiserror::Error)]
@@ -756,11 +759,16 @@ pub fn aslr_reference() -> usize {
     #[cfg(not(target_family = "wasm"))]
     unsafe {
         use std::ffi::c_void;
+        use std::sync::atomic::{AtomicPtr, Ordering};
 
-        // The first call to this function should occur in the
-        static mut MAIN_PTR: *mut c_void = std::ptr::null_mut();
+        // Cache the resolved anchor address. Edition 2024 makes a
+        // reference to a `static mut` a hard error (`static_mut_refs`);
+        // an `AtomicPtr` is the clean equivalent and keeps the
+        // self-initializing-on-first-call behavior intact.
+        static MAIN_PTR: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
 
-        if MAIN_PTR.is_null() {
+        let mut ptr = MAIN_PTR.load(Ordering::Relaxed);
+        if ptr.is_null() {
             // Whisker fork: anchor on `whisker_aslr_anchor` rather than
             // `main` so the dlsym/GetProcAddress lookup cannot collide
             // with system binaries' `main` (e.g. Android's
@@ -769,12 +777,12 @@ pub fn aslr_reference() -> usize {
             // `#[whisker::main]` and is unique to the user's `.so`.
             #[cfg(unix)]
             {
-                MAIN_PTR = libc::dlsym(libc::RTLD_DEFAULT, c"whisker_aslr_anchor".as_ptr() as _);
+                ptr = libc::dlsym(libc::RTLD_DEFAULT, c"whisker_aslr_anchor".as_ptr() as _);
             }
 
             #[cfg(windows)]
             {
-                extern "system" {
+                unsafe extern "system" {
                     fn GetModuleHandleA(lpModuleName: *const i8) -> *mut std::ffi::c_void;
                     fn GetProcAddress(
                         hModule: *mut std::ffi::c_void,
@@ -782,14 +790,16 @@ pub fn aslr_reference() -> usize {
                     ) -> *mut std::ffi::c_void;
                 }
 
-                MAIN_PTR = GetProcAddress(
+                ptr = GetProcAddress(
                     GetModuleHandleA(std::ptr::null()),
                     c"whisker_aslr_anchor".as_ptr() as _,
                 ) as _;
             }
+
+            MAIN_PTR.store(ptr, Ordering::Relaxed);
         }
 
-        MAIN_PTR as usize
+        ptr as usize
     }
 }
 
@@ -807,7 +817,7 @@ pub fn aslr_reference() -> usize {
 /// - https://developer.android.com/ndk/reference/structandroid/dlextinfo
 #[cfg(target_os = "android")]
 unsafe fn android_memmap_dlopen(file: &std::path::Path) -> Result<libloading::Library, PatchError> {
-    use std::ffi::{c_void, CStr, CString};
+    use std::ffi::{CStr, CString, c_void};
     use std::os::fd::{AsRawFd, BorrowedFd};
     use std::ptr;
 
@@ -822,7 +832,7 @@ unsafe fn android_memmap_dlopen(file: &std::path::Path) -> Result<libloading::Li
         library_namespace: *const c_void,
     }
 
-    extern "C" {
+    unsafe extern "C" {
         fn android_dlopen_ext(
             filename: *const libc::c_char,
             flags: libc::c_int,

--- a/crates/whisker/src/control_flow.rs
+++ b/crates/whisker/src/control_flow.rs
@@ -44,10 +44,10 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
 
-use whisker_runtime::reactive::{effect, Owner};
+use whisker_runtime::reactive::{Owner, effect};
 use whisker_runtime::view::{
-    append_child, create_phantom_element, remove_child, Children, EachFn, Element, Fallback,
-    ItemFn, KeyFn, WhenFn,
+    Children, EachFn, Element, Fallback, ItemFn, KeyFn, WhenFn, append_child,
+    create_phantom_element, remove_child,
 };
 
 use crate::component;

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -79,9 +79,9 @@ pub use whisker_runtime::view::Element;
 pub use whisker_macros::{component, main, module_component, render};
 
 pub use whisker_driver::{
-    animate_cancel, animate_start, invoke_element_animate, AnimateOp, AnimateOptions,
-    BoundingClientRect, ElementHandle, ElementRef, RefError, ScrollInfo, ScrollViewHandle,
-    TextBoundingRect, TextHandle, UiInfo,
+    AnimateOp, AnimateOptions, BoundingClientRect, ElementHandle, ElementRef, RefError, ScrollInfo,
+    ScrollViewHandle, TextBoundingRect, TextHandle, UiInfo, animate_cancel, animate_start,
+    invoke_element_animate,
 };
 
 pub use whisker_driver::module::PlatformModule;
@@ -125,9 +125,9 @@ macro_rules! module {
 }
 
 pub use whisker_runtime::reactive::{
-    arc_signal, computed, effect, flush, on_cleanup, on_mount, provide_context, resource,
-    resource_sync, signal, use_context, with_context, ArcReadSignal, ArcRwSignal, ArcWriteSignal,
-    ReadSignal, Resource, ResourceState, RwSignal, Signal, StoredValue, WriteSignal,
+    ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, Resource, ResourceState, RwSignal,
+    Signal, StoredValue, WriteSignal, arc_signal, computed, effect, flush, on_cleanup, on_mount,
+    provide_context, resource, resource_sync, signal, use_context, with_context,
 };
 // Component mount/unmount + mount-queue machinery. Driven by the
 // `#[component]` expansion and the hot-reload remount path, not by app
@@ -140,8 +140,8 @@ pub use whisker_runtime::reactive::{flush_mounts, mount_component, unmount_compo
 // extension code (custom control-flow, custom routers, advanced
 // tests) reaches into this module to create and dispose reactive
 // scopes manually.
-pub use whisker_runtime::reactive::owner;
 pub use whisker_runtime::reactive::Owner;
+pub use whisker_runtime::reactive::owner;
 pub use whisker_runtime::tasks::{run_blocking, spawn_local};
 // Frame-driving internal used by the host tick loop, not app code.
 #[doc(hidden)]
@@ -151,7 +151,7 @@ mod style;
 
 pub mod attrs;
 
-pub use style::{apply_style, Style};
+pub use style::{Style, apply_style};
 
 pub use control_flow::{ForEach, ForEachProps, Show, ShowProps};
 pub use whisker_runtime::view::Children;
@@ -180,16 +180,15 @@ pub use whisker_runtime::view::{EachFn, Fallback, ItemFn, KeyFn, WhenFn};
 pub mod __tags {
     use crate::ElementTag;
     use whisker_runtime::event::{
-        bind_typed, AnimationEvent, CustomEvent, ScrollEvent, SelectionChangeEvent,
-        TextLayoutEvent, TouchEvent,
+        AnimationEvent, CustomEvent, ScrollEvent, SelectionChangeEvent, TextLayoutEvent,
+        TouchEvent, bind_typed,
     };
     use whisker_runtime::reactive::Signal;
     use whisker_runtime::value::WhiskerValue;
     use whisker_runtime::view::{
-        append_child, apply_attr, apply_attr_bool, apply_attr_int, apply_attr_owned,
-        create_element, create_element_by_name, create_phantom_element,
-        install_list_native_item_provider, set_event_listener, set_update_list_info, BindType,
-        Element,
+        BindType, Element, append_child, apply_attr, apply_attr_bool, apply_attr_int,
+        apply_attr_owned, create_element, create_element_by_name, create_phantom_element,
+        install_list_native_item_provider, set_event_listener, set_update_list_info,
     };
 
     // Why a trait (and not `macro_rules!`): RA's method-completion
@@ -1609,7 +1608,7 @@ pub use whisker_runtime::main_thread::run_on_main_thread;
 /// module directly only when you need the raw [`WhiskerValue`] enum.
 pub mod platform_module {
     pub use whisker_driver::module::{
-        from_raw, invoke, invoke_async, WhiskerModuleError, WhiskerValue,
+        WhiskerModuleError, WhiskerValue, from_raw, invoke, invoke_async,
     };
 }
 
@@ -1734,19 +1733,18 @@ pub mod __hot {
 /// that bootstrap reactive scopes) reaches past the prelude into
 /// [`crate::runtime`] / [`crate::owner`] / [`crate::platform_module`].
 pub mod prelude {
+    pub use crate::Children;
     pub use crate::css::ext::*;
     pub use crate::css::{
         AlignItems, Border, Color, Css, Display, Flex, FlexDirection, FlexWrap, JustifyContent,
         Length, NamedColor, ToCss,
     };
-    pub use crate::Children;
     pub use crate::{
-        arc_signal, computed, effect, on_cleanup, on_mount, provide_context, resource,
-        resource_sync, run_blocking, run_on_main_thread, signal, spawn_local, use_context,
-        with_context, ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, Resource,
-        ResourceState, RwSignal, Signal, StoredValue, WriteSignal,
+        ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, Resource, ResourceState, RwSignal,
+        Signal, StoredValue, WriteSignal, arc_signal, computed, effect, on_cleanup, on_mount,
+        provide_context, resource, resource_sync, run_blocking, run_on_main_thread, signal,
+        spawn_local, use_context, with_context,
     };
-    pub use crate::{component, main, render};
     pub use crate::{
         BoundingClientRect, ElementHandle, ElementRef, RefError, ScrollInfo, ScrollViewHandle,
         TextBoundingRect, TextHandle,
@@ -1754,6 +1752,7 @@ pub mod prelude {
     pub use crate::{EachFn, Fallback, ItemFn, KeyFn, WhenFn};
     pub use crate::{Element, ElementTag};
     pub use crate::{ForEach, ForEachProps, Show, ShowProps};
+    pub use crate::{component, main, render};
     // The `css!` macro coexists with the `crate::css` module
     // re-export above because the macro and module namespaces are
     // disjoint.

--- a/crates/whisker/src/style.rs
+++ b/crates/whisker/src/style.rs
@@ -21,9 +21,9 @@
 use std::rc::Rc;
 
 use whisker_css::{Css, ToCss};
-use whisker_runtime::reactive::{effect, ReadSignal, RwSignal};
-use whisker_runtime::view::set_inline_styles;
+use whisker_runtime::reactive::{ReadSignal, RwSignal, effect};
 use whisker_runtime::view::Element;
+use whisker_runtime::view::set_inline_styles;
 
 /// Value the `style:` builder method receives. One of the two
 /// variants below.

--- a/crates/whisker/tests/children_slot.rs
+++ b/crates/whisker/tests/children_slot.rs
@@ -20,10 +20,10 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use whisker::Owner;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, __reset_pending_mount_for_tests};
-use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
-use whisker::Owner;
+use whisker::runtime::view::{DynRenderer, Element, install_renderer, uninstall_renderer};
 
 // ----- Recording renderer ----------------------------------------------------
 //

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -16,10 +16,10 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use whisker::Owner;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, __reset_pending_mount_for_tests};
-use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element, View};
-use whisker::Owner;
+use whisker::runtime::view::{DynRenderer, Element, View, install_renderer, uninstall_renderer};
 
 // ----- Recording renderer ----------------------------------------------------
 

--- a/crates/whisker/tests/element_ref.rs
+++ b/crates/whisker/tests/element_ref.rs
@@ -20,10 +20,10 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use whisker::Owner;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, effect, flush};
-use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
-use whisker::Owner;
+use whisker::runtime::view::{DynRenderer, Element, install_renderer, uninstall_renderer};
 
 // ---- Minimal renderer ------------------------------------------------------
 

--- a/crates/whisker/tests/module_component.rs
+++ b/crates/whisker/tests/module_component.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 use whisker::flush;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
-use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
+use whisker::runtime::view::{DynRenderer, Element, install_renderer, uninstall_renderer};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -18,12 +18,12 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use whisker::prelude::*;
 use whisker::runtime::reactive::__reset_pending_mount_for_tests;
-use whisker::runtime::reactive::{__reset_for_tests, owners_for_fn, remount_components_for, Owner};
+use whisker::runtime::reactive::{__reset_for_tests, Owner, owners_for_fn, remount_components_for};
 use whisker::runtime::view::{
-    __reset_children_mirror_for_tests, append_child, create_element, install_renderer,
-    uninstall_renderer, DynRenderer, Element,
+    __reset_children_mirror_for_tests, DynRenderer, Element, append_child, create_element,
+    install_renderer, uninstall_renderer,
 };
-use whisker::{flush, ElementTag};
+use whisker::{ElementTag, flush};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -13,7 +13,7 @@ use whisker::flush;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
 use whisker::runtime::view::{
-    install_renderer, uninstall_renderer, BindType, DynRenderer, Element,
+    BindType, DynRenderer, Element, install_renderer, uninstall_renderer,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -429,9 +429,10 @@ fn camel_case_event_handler_lowercased() {
             view(onTap: |_| {})
         };
         let ops = log.borrow();
-        assert!(ops
-            .iter()
-            .any(|op| matches!(op, Op::Event { name, .. } if name == "tap")));
+        assert!(
+            ops.iter()
+                .any(|op| matches!(op, Op::Event { name, .. } if name == "tap"))
+        );
     });
 }
 

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use whisker::flush;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
-use whisker::runtime::view::{install_renderer, uninstall_renderer, DynRenderer, Element};
+use whisker::runtime::view::{DynRenderer, Element, install_renderer, uninstall_renderer};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {

--- a/examples/asset-demo/Cargo.toml
+++ b/examples/asset-demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "asset-demo"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Example app for `whisker-asset`. Bundles a PNG under `assets/` and displays it via `Image(src: asset!(\"images/logo.png\"))` so on-device verification of the Phase 3 native base wiring (iOS bundle dir / Android packaged assets) happens in one place."
 

--- a/examples/aurora-wallet/Cargo.toml
+++ b/examples/aurora-wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aurora-wallet"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "A polished single-file Whisker demo: a finance / wallet dashboard (balance card, segmented control, spending chart, transactions) built entirely in one `src/lib.rs`. Designed to show off the hot-reload dev loop — tweak a colour, label, or number and watch the running app update in under a second with its state intact."
 

--- a/examples/aurora-wallet/src/lib.rs
+++ b/examples/aurora-wallet/src/lib.rs
@@ -16,7 +16,7 @@
 use whisker::css::{AlignItems, Color, Display, FlexDirection, FontWeight, JustifyContent, ToCss};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_icons::{lucide, Icon};
+use whisker_icons::{Icon, lucide};
 
 // ── Tweak me (great hot-reload targets) ──────────────────────────────
 const ACCENT: Color = Color::hex(0x7C5CFF); // brand / interactive accent

--- a/examples/podcast/Cargo.toml
+++ b/examples/podcast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "podcast"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Production-grade podcast browser example. Demonstrates a layered Whisker app: theme tokens, pure domain types, iTunes Search API data layer, reusable UI kit, and a Browse feature crate composed at the app's main entry."
 

--- a/examples/podcast/crates/podcast-data/Cargo.toml
+++ b/examples/podcast/crates/podcast-data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "podcast-data"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "iTunes Search API client + repositories for the podcast example. Hides the iTunes Search wire shape behind a domain-typed `Repository` so the UI layer never sees DTOs or HTTP errors directly."
 

--- a/examples/podcast/crates/podcast-data/src/lib.rs
+++ b/examples/podcast/crates/podcast-data/src/lib.rs
@@ -20,6 +20,6 @@ mod itunes;
 mod repository;
 
 pub use itunes::{
-    fetch_episodes_blocking as fetch_episodes, search_blocking as search, FetchError, SearchQuery,
+    FetchError, SearchQuery, fetch_episodes_blocking as fetch_episodes, search_blocking as search,
 };
 pub use repository::fetch_browse_screen;

--- a/examples/podcast/crates/podcast-domain/Cargo.toml
+++ b/examples/podcast/crates/podcast-domain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "podcast-domain"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Pure value types for the podcast example. No I/O, no UI, no whisker dependency — consumed by both the data layer (deserialise) and the UI layer (render) without dragging either side into the other's transitive deps."
 

--- a/examples/podcast/crates/podcast-feature-browse/Cargo.toml
+++ b/examples/podcast/crates/podcast-feature-browse/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "podcast-feature-browse"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Browse-screen feature crate. Composes podcast-ui-kit widgets against podcast-data results, manages the load state, and exposes a single `browse_screen()` component the app's main entry mounts."
 

--- a/examples/podcast/crates/podcast-feature-detail/Cargo.toml
+++ b/examples/podcast/crates/podcast-feature-detail/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "podcast-feature-detail"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Podcast detail screen — shows artwork, title, artist, genre, episode-count, and an episode-list placeholder. Reads the podcast from a shared `RwSignal<HashMap<u64, Podcast>>` registry the browse feature populates on load — keeps the route URL-friendly (`/podcast/:id`) without forcing a re-fetch on every tap. Playback is a future PR; this crate is rendering-only."
 

--- a/examples/podcast/crates/podcast-feature-detail/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-detail/src/lib.rs
@@ -50,15 +50,15 @@ use podcast_data::fetch_episodes;
 use podcast_domain::{Episode, NowPlaying, Podcast};
 use podcast_routing::Navigator;
 use podcast_theme as theme;
+use whisker::ArcRwSignal;
 use whisker::css::{
     AlignItems, Display, FlexDirection, FontWeight, JustifyContent, TextAlign, TextOverflow,
 };
 use whisker::prelude::*;
 use whisker::runtime::tasks::run_blocking;
 use whisker::runtime::view::Element;
-use whisker::ArcRwSignal;
 use whisker_audio::Player;
-use whisker_icons::{lucide, Icon};
+use whisker_icons::{Icon, lucide};
 use whisker_image::{Image, ImageMode};
 use whisker_safe_area::safe_area_insets;
 

--- a/examples/podcast/crates/podcast-feature-search/Cargo.toml
+++ b/examples/podcast/crates/podcast-feature-search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "podcast-feature-search"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Search screen — reactive resource re-fetches iTunes on every query-signal change, demonstrating resource-reactivity with whisker-input."
 

--- a/examples/podcast/crates/podcast-feature-search/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-search/src/lib.rs
@@ -33,7 +33,7 @@
 //!   +---------------------------+
 //! ```
 
-use podcast_data::{search, FetchError, SearchQuery};
+use podcast_data::{FetchError, SearchQuery, search};
 use podcast_domain::Podcast;
 use podcast_routing::Navigator;
 use podcast_theme as theme;
@@ -41,7 +41,7 @@ use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, JustifyConten
 use whisker::prelude::*;
 use whisker::runtime::tasks::run_blocking;
 use whisker::runtime::view::Element;
-use whisker_icons::{lucide, Icon};
+use whisker_icons::{Icon, lucide};
 use whisker_image::{Image, ImageMode};
 use whisker_input::{Input, ReturnKey};
 use whisker_safe_area::safe_area_insets;

--- a/examples/podcast/crates/podcast-routing/Cargo.toml
+++ b/examples/podcast/crates/podcast-routing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "podcast-routing"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Routing surface for the podcast example: the `AppRoute` enum (the typed enum the StackLayout dispatches on) and the `Navigator` struct (a thin push/pop facade the feature crates read from context). Defined here, in a crate both `podcast-feature-browse` and `podcast-feature-detail` depend on, so the two features share the same Rust types when they look the values up via `use_context` — distinct structurally-identical types in each feature crate match on different `TypeId`s and the lookup returns `None`."
 

--- a/examples/podcast/crates/podcast-theme/Cargo.toml
+++ b/examples/podcast/crates/podcast-theme/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "podcast-theme"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Design tokens for the podcast example: colors, type scale, spacing. Pure const `Color` / `Length` values from `whisker-css`'s data-type layer so consumers can drop them straight into `css!(color: theme::TEXT_PRIMARY, font_size: theme::T_HERO)`."
 

--- a/examples/podcast/crates/podcast-ui-kit/Cargo.toml
+++ b/examples/podcast/crates/podcast-ui-kit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "podcast-ui-kit"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Reusable atomic widgets for the podcast example: top nav, section header, featured / ranked artwork cards, mini player. Depends only on whisker + theme + domain — features compose these into screens."
 

--- a/examples/podcast/crates/podcast-ui-kit/src/horizontal_row.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/horizontal_row.rs
@@ -6,10 +6,10 @@
 //! their own intrinsic widths.
 
 use podcast_theme as theme;
+use whisker::Children;
 use whisker::css::{AlignItems, Display, FlexDirection};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker::Children;
 
 #[component]
 pub fn horizontal_row(children: Children) -> Element {

--- a/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
@@ -26,15 +26,15 @@
 
 use podcast_domain::NowPlaying;
 use podcast_theme as theme;
+use whisker::ArcRwSignal;
 use whisker::css::{
     AlignItems, Color, Display, FlexDirection, FontWeight, JustifyContent, PositionKind,
     TextOverflow,
 };
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker::ArcRwSignal;
 use whisker_audio::Player;
-use whisker_icons::{lucide, Icon};
+use whisker_icons::{Icon, lucide};
 use whisker_image::{Image, ImageMode};
 
 /// Mirror of the shell-side alias. Same TypeId across crates

--- a/examples/podcast/crates/podcast-ui-kit/src/section_header.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/section_header.rs
@@ -10,7 +10,7 @@ use podcast_theme as theme;
 use whisker::css::{Display, FlexDirection, FontWeight};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_icons::{lucide, Icon};
+use whisker_icons::{Icon, lucide};
 
 #[component]
 pub fn section_header(title: String, #[prop(default = false)] show_chevron: bool) -> Element {

--- a/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/top_nav.rs
@@ -11,7 +11,7 @@ use podcast_theme as theme;
 use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, JustifyContent};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker_icons::{lucide, Icon};
+use whisker_icons::{Icon, lucide};
 use whisker_safe_area::safe_area_insets;
 
 /// Title shown centred in the bar. Action label shown trailing.

--- a/examples/podcast/src/lib.rs
+++ b/examples/podcast/src/lib.rs
@@ -43,12 +43,12 @@ use podcast_feature_detail::DetailScreen;
 use podcast_feature_search::SearchScreen;
 use podcast_routing::{AppRoute, Navigator};
 use podcast_ui_kit::MiniPlayer;
+use whisker::ArcRwSignal;
 use whisker::css::{Display, FlexDirection, PositionKind};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker::ArcRwSignal;
 use whisker_audio::Player;
-use whisker_router::stack::{route_stack, RouteStack};
+use whisker_router::stack::{RouteStack, route_stack};
 use whisker_router::{
     AndroidPredictiveBack, IosSwipeBack, RouteProvider, RouteRenderFn, StackLayout,
 };

--- a/packages/whisker-asset-macros/src/lib.rs
+++ b/packages/whisker-asset-macros/src/lib.rs
@@ -32,7 +32,7 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use std::path::{Component, Path, PathBuf};
-use syn::{parse_macro_input, LitStr};
+use syn::{LitStr, parse_macro_input};
 
 /// Validate the logical path and return the absolute on-disk path of the
 /// asset (`${CARGO_MANIFEST_DIR}/assets/<rel>`), or a `syn::Error` with a

--- a/packages/whisker-asset/src/lib.rs
+++ b/packages/whisker-asset/src/lib.rs
@@ -165,7 +165,7 @@ pub fn resolve(rel: &str) -> String {
 /// `ptr` must point to at least `len` valid, initialized bytes for the
 /// duration of the call (or `len` must be 0). The bytes must be valid
 /// UTF-8; invalid input is ignored (the base is left unchanged).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn whisker_asset_set_ios_base(ptr: *const u8, len: usize) {
     if ptr.is_null() && len != 0 {
         return;
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn whisker_asset_set_ios_base(ptr: *const u8, len: usize) 
 ///
 /// Takes no arguments — the Android resolution prefix is fixed
 /// (`file:///android_asset/whisker/`).
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn whisker_asset_set_android() {
     set_base(AssetBase::AndroidAssets);
 }
@@ -248,7 +248,7 @@ mod android_init {
     /// explicit `.init_array` section is what the linker scans for
     /// constructor function pointers.
     #[used]
-    #[link_section = ".init_array"]
+    #[unsafe(link_section = ".init_array")]
     static INIT_ANDROID_BASE: extern "C" fn() = ctor;
 }
 

--- a/packages/whisker-asset/src/plugin.rs
+++ b/packages/whisker-asset/src/plugin.rs
@@ -500,18 +500,20 @@ mod tests {
         WhiskerAsset.apply(&mut ctx, &cfg).unwrap();
 
         // Bundles under basename, not the source subpath.
-        assert!(ctx
-            .ios
-            .as_ref()
-            .unwrap()
-            .extra_files
-            .contains_key(&PathBuf::from("whisker_assets/logo.png")));
-        assert!(ctx
-            .android
-            .as_ref()
-            .unwrap()
-            .extra_files
-            .contains_key(&PathBuf::from("app/src/main/assets/whisker/logo.png")));
+        assert!(
+            ctx.ios
+                .as_ref()
+                .unwrap()
+                .extra_files
+                .contains_key(&PathBuf::from("whisker_assets/logo.png"))
+        );
+        assert!(
+            ctx.android
+                .as_ref()
+                .unwrap()
+                .extra_files
+                .contains_key(&PathBuf::from("app/src/main/assets/whisker/logo.png"))
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/packages/whisker-asset/tests/plugin_e2e.rs
+++ b/packages/whisker-asset/tests/plugin_e2e.rs
@@ -71,21 +71,21 @@ fn ios_generation_lands_assets_and_folder_reference() {
     )
     .unwrap();
 
-    let gen = unique_tempdir("ios-gen").join("gen/ios");
-    whisker_cng::ios::sync(&gen, &inputs).unwrap();
+    let r#gen = unique_tempdir("ios-gen").join("gen/ios");
+    whisker_cng::ios::sync(&r#gen, &inputs).unwrap();
 
     // Assets written under whisker_assets/<rel>, bytes intact.
-    let logo = gen.join("whisker_assets/images/logo.png");
+    let logo = r#gen.join("whisker_assets/images/logo.png");
     assert!(logo.exists(), "logo not written to {}", logo.display());
     assert_eq!(
         std::fs::read(&logo).unwrap(),
         vec![0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a],
     );
-    assert!(gen.join("whisker_assets/data/config.json").exists());
+    assert!(r#gen.join("whisker_assets/data/config.json").exists());
 
     // pbxproj carries the folder reference so the bundle keeps subdirs.
     let pbxproj =
-        std::fs::read_to_string(gen.join(format!("{}.xcodeproj/project.pbxproj", inputs.scheme)))
+        std::fs::read_to_string(r#gen.join(format!("{}.xcodeproj/project.pbxproj", inputs.scheme)))
             .unwrap();
     assert!(
         pbxproj.contains("lastKnownFileType = folder;")
@@ -96,7 +96,7 @@ fn ios_generation_lands_assets_and_folder_reference() {
     assert!(!pbxproj.contains("{{"), "unsubstituted placeholder");
 
     let _ = std::fs::remove_dir_all(&crate_dir);
-    let _ = std::fs::remove_dir_all(gen.parent().unwrap());
+    let _ = std::fs::remove_dir_all(r#gen.parent().unwrap());
 }
 
 #[test]
@@ -119,17 +119,17 @@ fn android_generation_lands_assets_under_whisker_namespace() {
     )
     .unwrap();
 
-    let gen = unique_tempdir("android-gen").join("gen/android");
-    whisker_cng::android::sync(&gen, &inputs).unwrap();
+    let r#gen = unique_tempdir("android-gen").join("gen/android");
+    whisker_cng::android::sync(&r#gen, &inputs).unwrap();
 
     // AGP source set: app/src/main/assets/whisker/<rel>
-    let logo = gen.join("app/src/main/assets/whisker/images/logo.png");
+    let logo = r#gen.join("app/src/main/assets/whisker/images/logo.png");
     assert!(logo.exists(), "logo not written to {}", logo.display());
     assert_eq!(std::fs::read(&logo).unwrap(), vec![0x00, 0xff, 0x10]);
-    assert!(gen.join("app/src/main/assets/whisker/sound.bin").exists());
+    assert!(r#gen.join("app/src/main/assets/whisker/sound.bin").exists());
 
     let _ = std::fs::remove_dir_all(&crate_dir);
-    let _ = std::fs::remove_dir_all(gen.parent().unwrap());
+    let _ = std::fs::remove_dir_all(r#gen.parent().unwrap());
 }
 
 #[test]

--- a/packages/whisker-audio/example/Cargo.toml
+++ b/packages/whisker-audio/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whisker-audio-example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Example app for `whisker-audio`. Plays a short MP3 with play / pause / stop / seek controls so on-device verification of the ExoPlayer / AVPlayer module wiring happens in one place."
 

--- a/packages/whisker-audio/example/src/lib.rs
+++ b/packages/whisker-audio/example/src/lib.rs
@@ -144,11 +144,7 @@ fn button_text_style() -> Css {
 }
 
 fn fmt_bool(b: bool) -> String {
-    if b {
-        "true".into()
-    } else {
-        "false".into()
-    }
+    if b { "true".into() } else { "false".into() }
 }
 
 /// One labelled row in the status card. Two `<text>` siblings — the

--- a/packages/whisker-audio/src/runtime.rs
+++ b/packages/whisker-audio/src/runtime.rs
@@ -1,11 +1,11 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use whisker::platform_module::WhiskerValue;
-use whisker::{module, ArcReadSignal, ArcRwSignal, ReadSignal};
+use whisker::{ArcReadSignal, ArcRwSignal, ReadSignal, module};
 
 /// Current playback state. Updated by the native side and read
 /// through the reactive signal returned by [`Player::status`].

--- a/packages/whisker-icons/example/Cargo.toml
+++ b/packages/whisker-icons/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whisker-icons-example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Example app for `whisker-icons`. Renders the entire Lucide-icon set in a virtualised list so on-device verification of the codegen + display-list pipeline happens against every icon at once."
 

--- a/packages/whisker-input/example/Cargo.toml
+++ b/packages/whisker-input/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whisker-input-example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Example app for `whisker-input`. Exercises a two-way bound field with a live preview, a controlled (upper-casing) field, a multiline notes field, and a secure password field so on-device verification of the UITextField / UITextView / EditText module wiring happens in one place."
 

--- a/packages/whisker-router-macros/src/lib.rs
+++ b/packages/whisker-router-macros/src/lib.rs
@@ -59,7 +59,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Data, DeriveInput, Fields, LitStr, Variant};
+use syn::{Data, DeriveInput, Fields, LitStr, Variant, parse_macro_input};
 
 /// `#[route]` attribute on an enum — generates
 /// `impl whisker_router::route::Route for Enum`.

--- a/packages/whisker-router/example/Cargo.toml
+++ b/packages/whisker-router/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whisker-router-example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Minimal repro for the `StackLayout` crash that surfaces when its render closure mounts cross-crate components. Wires two feature crates (`-feature-home` and `-feature-detail`) through `StackLayout` exactly the way the podcast example does, so a fix can be validated here without dragging the whole podcast app along."
 

--- a/packages/whisker-router/example/crates/router-example-feature-detail/Cargo.toml
+++ b/packages/whisker-router/example/crates/router-example-feature-detail/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "router-example-feature-detail"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Detail screen for the `whisker-router` cross-crate StackLayout repro. Symmetric to `-feature-home`; the only point is to make the shell route between two screens that come from different crates."
 

--- a/packages/whisker-router/example/crates/router-example-feature-home/Cargo.toml
+++ b/packages/whisker-router/example/crates/router-example-feature-home/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "router-example-feature-home"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Home screen for the `whisker-router` cross-crate StackLayout repro. Lives in its own crate so the shell mounts it across a crate boundary — that's the configuration that crashes."
 

--- a/packages/whisker-router/example/src/lib.rs
+++ b/packages/whisker-router/example/src/lib.rs
@@ -80,8 +80,8 @@ use router_example_feature_home::HomeScreen;
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_router::{
-    route, route_stack, AndroidPredictiveBack, IosSwipeBack, RouteProvider, RouteRenderFn,
-    StackLayout,
+    AndroidPredictiveBack, IosSwipeBack, RouteProvider, RouteRenderFn, StackLayout, route,
+    route_stack,
 };
 
 /// Flip to `false` to mount `HomeScreen` directly under `page`

--- a/packages/whisker-router/src/gestures/ios_swipe_back.rs
+++ b/packages/whisker-router/src/gestures/ios_swipe_back.rs
@@ -27,10 +27,10 @@ use whisker::css::ToCss;
 use whisker::event::TouchEvent;
 use whisker::runtime::event::bind_typed;
 use whisker::runtime::reactive::on_mount;
-use whisker::runtime::view::{set_inline_styles, BindType, Element};
-use whisker::{animate_start, component, render, use_context, AnimateOptions, Style};
+use whisker::runtime::view::{BindType, Element, set_inline_styles};
+use whisker::{AnimateOptions, Style, animate_start, component, render, use_context};
 
-use crate::layouts::stack::{clear_stack_animations, slot_css, StackLayoutHandle};
+use crate::layouts::stack::{StackLayoutHandle, clear_stack_animations, slot_css};
 use crate::transitions::ios_slide;
 use crate::transitions::{Direction, Side, StackTransitionBox};
 

--- a/packages/whisker-router/src/layouts/modal.rs
+++ b/packages/whisker-router/src/layouts/modal.rs
@@ -25,8 +25,8 @@ use whisker::css::{AlignItems, Color, Css, PositionKind, ToCss};
 use whisker::runtime::element::ElementTag;
 use whisker::runtime::reactive::on_mount;
 use whisker::runtime::view::apply::apply_styles;
-use whisker::runtime::view::{append_child, create_element, Element};
-use whisker::{animate_start, component, AnimateOptions};
+use whisker::runtime::view::{Element, append_child, create_element};
+use whisker::{AnimateOptions, animate_start, component};
 
 use crate::route::Route;
 

--- a/packages/whisker-router/src/layouts/pane.rs
+++ b/packages/whisker-router/src/layouts/pane.rs
@@ -28,7 +28,7 @@
 use whisker::css::ext::*;
 use whisker::css::{Css, Display, FlexDirection, ToCss};
 use whisker::runtime::view::Element;
-use whisker::{component, computed, Children, WhenFn};
+use whisker::{Children, WhenFn, component, computed};
 
 /// Container that toggles between `display: flex` (children visible)
 /// and `display: none` (children hidden but still mounted).

--- a/packages/whisker-router/src/layouts/stack.rs
+++ b/packages/whisker-router/src/layouts/stack.rs
@@ -58,14 +58,14 @@ use whisker::animate_cancel;
 use whisker::css::ext::*;
 use whisker::css::{Css, FlexDirection, Overflow, PositionKind, ToCss};
 use whisker::runtime::element::ElementTag;
-use whisker::runtime::reactive::{effect, on_mount, Owner};
+use whisker::runtime::reactive::{Owner, effect, on_mount};
 use whisker::runtime::view::apply::apply_styles;
 use whisker::runtime::view::{
-    append_child, create_element, insert_child_at, remove_child, set_inline_styles, Element,
+    Element, append_child, create_element, insert_child_at, remove_child, set_inline_styles,
 };
-use whisker::{component, provide_context, Children, Style};
+use whisker::{Children, Style, component, provide_context};
 
-use crate::outlet::{router, RouteRenderFn};
+use crate::outlet::{RouteRenderFn, router};
 use crate::route::Route;
 use crate::stack::EntryId;
 use crate::transitions::{Direction, Side, StackTransitionBox};
@@ -769,13 +769,13 @@ mod tests {
     use crate::outlet::RouteRenderFn;
     use crate::route::{Route, RouteError};
     use crate::stack::{EntryId, EntryState, RouteEntry};
+    use whisker::RwSignal;
     use whisker::runtime::element::ElementTag;
     use whisker::runtime::reactive::Owner;
     use whisker::runtime::value::WhiskerValue;
     use whisker::runtime::view::{
-        create_element, install_renderer, uninstall_renderer, BindType, DynRenderer, Element,
+        BindType, DynRenderer, Element, create_element, install_renderer, uninstall_renderer,
     };
-    use whisker::RwSignal;
 
     #[derive(Clone, Debug, PartialEq)]
     enum TestRoute {

--- a/packages/whisker-router/src/layouts/tabs.rs
+++ b/packages/whisker-router/src/layouts/tabs.rs
@@ -46,7 +46,7 @@ use whisker::css::ext::*;
 use whisker::css::{Css, Display, FlexDirection, ToCss};
 use whisker::runtime::element::ElementTag;
 use whisker::runtime::view::apply::apply_styles;
-use whisker::runtime::view::{append_child, create_element, Element};
+use whisker::runtime::view::{Element, append_child, create_element};
 use whisker::{component, computed};
 
 use crate::outlet::router;

--- a/packages/whisker-router/src/lib.rs
+++ b/packages/whisker-router/src/lib.rs
@@ -109,7 +109,7 @@ pub mod transitions;
 /// ```
 pub use whisker_router_macros::route;
 
-pub use crate::back_handler::{on_back, BackHandlerGuard};
+pub use crate::back_handler::{BackHandlerGuard, on_back};
 pub use crate::gestures::{
     AndroidPredictiveBack, AndroidPredictiveBackProps, IosSwipeBack, IosSwipeBackProps,
 };
@@ -118,11 +118,11 @@ pub use crate::layouts::pane::{Pane, PaneProps};
 pub use crate::layouts::stack::{StackLayout, StackLayoutHandle, StackLayoutProps};
 pub use crate::layouts::tabs::{TabSpec, TabsLayout, TabsLayoutProps};
 pub use crate::outlet::{
-    router, Outlet, OutletProps, RouteProvider, RouteProviderProps, RouteRenderFn,
+    Outlet, OutletProps, RouteProvider, RouteProviderProps, RouteRenderFn, router,
 };
 pub use crate::route::{Route, RouteError};
-pub use crate::stack::{route_stack, EntryId, EntryState, RouteEntry, RouteStack};
+pub use crate::stack::{EntryId, EntryState, RouteEntry, RouteStack, route_stack};
 pub use crate::transitions::{
-    Direction, Fade, Instant, IosSlide, Side, StackTransition, StackTransitionBox, VerticalSlide,
-    IOS_PARALLAX_PCT,
+    Direction, Fade, IOS_PARALLAX_PCT, Instant, IosSlide, Side, StackTransition,
+    StackTransitionBox, VerticalSlide,
 };

--- a/packages/whisker-router/src/outlet.rs
+++ b/packages/whisker-router/src/outlet.rs
@@ -20,9 +20,9 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use whisker::runtime::reactive::{effect, Owner};
-use whisker::runtime::view::{append_child, create_phantom_element, remove_child, Element};
-use whisker::{component, provide_context, use_context, Children};
+use whisker::runtime::reactive::{Owner, effect};
+use whisker::runtime::view::{Element, append_child, create_phantom_element, remove_child};
+use whisker::{Children, component, provide_context, use_context};
 
 use crate::route::Route;
 use crate::stack::RouteStack;

--- a/packages/whisker-router/src/stack.rs
+++ b/packages/whisker-router/src/stack.rs
@@ -20,7 +20,7 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use whisker::{computed, Owner, ReadSignal, RwSignal};
+use whisker::{Owner, ReadSignal, RwSignal, computed};
 
 use crate::route::Route;
 

--- a/packages/whisker-router/src/transitions/fade.rs
+++ b/packages/whisker-router/src/transitions/fade.rs
@@ -1,7 +1,7 @@
 //! [`Fade`] — opacity cross-fade between two stack entries.
 
 use whisker::runtime::view::Element;
-use whisker::{animate_start, AnimateOptions};
+use whisker::{AnimateOptions, animate_start};
 
 use super::{Direction, Side, StackTransition};
 

--- a/packages/whisker-router/src/transitions/ios_slide.rs
+++ b/packages/whisker-router/src/transitions/ios_slide.rs
@@ -12,7 +12,7 @@
 //! and gestures freely.
 
 use whisker::runtime::view::Element;
-use whisker::{animate_start, AnimateOptions, Style};
+use whisker::{AnimateOptions, Style, animate_start};
 
 use super::{Direction, Side, StackTransition};
 

--- a/packages/whisker-router/src/transitions/mod.rs
+++ b/packages/whisker-router/src/transitions/mod.rs
@@ -53,8 +53,8 @@
 
 use std::rc::Rc;
 
-use whisker::runtime::view::Element;
 use whisker::Style;
+use whisker::runtime::view::Element;
 
 pub mod fade;
 pub mod instant;
@@ -63,7 +63,7 @@ pub mod vertical_slide;
 
 pub use fade::Fade;
 pub use instant::Instant;
-pub use ios_slide::{IosSlide, IOS_PARALLAX_PCT};
+pub use ios_slide::{IOS_PARALLAX_PCT, IosSlide};
 pub use vertical_slide::VerticalSlide;
 
 /// Direction of the current navigation — derived by

--- a/packages/whisker-router/src/transitions/vertical_slide.rs
+++ b/packages/whisker-router/src/transitions/vertical_slide.rs
@@ -2,7 +2,7 @@
 //! [`super::IosSlide`] for stack-driven modal-style presentations.
 
 use whisker::runtime::view::Element;
-use whisker::{animate_start, AnimateOptions};
+use whisker::{AnimateOptions, animate_start};
 
 use super::{Direction, Side, StackTransition};
 

--- a/packages/whisker-svg/example/Cargo.toml
+++ b/packages/whisker-svg/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whisker-svg-example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Example app for `whisker-svg`. Renders a small gallery of SVGs (solid fills, strokes, currentColor tinting) so visual + on-device verification of the display-list replayer happens in one place. The iOS / Android test targets defined in the parent `whisker-svg` package's `Package.swift` / `build.gradle.kts` are reachable through this example's gen/ project — `cd gen/android && ./gradlew :whisker-svg:testDebugUnitTest`, `cd gen/ios && xcodebuild -scheme WhiskerSvg test`."
 

--- a/packages/whisker-svg/src/lib.rs
+++ b/packages/whisker-svg/src/lib.rs
@@ -71,17 +71,17 @@ pub mod path_parse;
 #[doc(hidden)]
 pub mod replay;
 
-pub use compile::{compile, CompileError, Compiled};
+pub use compile::{CompileError, Compiled, compile};
 
 #[doc(hidden)]
 pub use builder::{Color, DisplayListBuilder, Transform};
 #[doc(hidden)]
-pub use replay::{replay, ReplayError, TraceVisitor, Visitor};
+pub use replay::{ReplayError, TraceVisitor, Visitor, replay};
 
 use base64::Engine;
+use whisker::Style;
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
-use whisker::Style;
 
 /// `<Svg>` widget. Render arbitrary inline SVG inside the host
 /// element. Tracks `content` reactively — a content swap recompiles

--- a/packages/whisker-svg/src/path_parse.rs
+++ b/packages/whisker-svg/src/path_parse.rs
@@ -227,11 +227,7 @@ pub fn parse(d: &str) -> Vec<PathCommand> {
 
 #[inline]
 fn resolve(x: f32, y: f32, abs: bool, cx: f32, cy: f32) -> (f32, f32) {
-    if abs {
-        (x, y)
-    } else {
-        (cx + x, cy + y)
-    }
+    if abs { (x, y) } else { (cx + x, cy + y) }
 }
 
 /// Convert an SVG arc endpoint to one or more cubic Béziers using

--- a/packages/whisker-svg/tests/fixtures_test.rs
+++ b/packages/whisker-svg/tests/fixtures_test.rs
@@ -17,7 +17,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use whisker_svg::{compile, replay, TraceVisitor};
+use whisker_svg::{TraceVisitor, compile, replay};
 
 fn fixtures_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/packages/whisker-svg/tests/path_parse_test.rs
+++ b/packages/whisker-svg/tests/path_parse_test.rs
@@ -4,7 +4,7 @@
 //! rather than as a subtle rendering glitch in the integration
 //! tests.
 
-use whisker_svg::path_parse::{parse, PathCommand};
+use whisker_svg::path_parse::{PathCommand, parse};
 
 #[test]
 fn absolute_move_line_close() {

--- a/packages/whisker-svg/tests/root_paint_cascade_test.rs
+++ b/packages/whisker-svg/tests/root_paint_cascade_test.rs
@@ -9,7 +9,7 @@
 //! as a black silhouette instead of an outline. See compile.rs's
 //! `update_paint(&root, …)` call.
 
-use whisker_svg::{compile, replay, TraceVisitor};
+use whisker_svg::{TraceVisitor, compile, replay};
 
 const LUCIDE_LIKE: &str = r#"<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>"#;
 

--- a/packages/whisker-svg/tests/round_trip_test.rs
+++ b/packages/whisker-svg/tests/round_trip_test.rs
@@ -3,10 +3,10 @@
 //! every opcode encoded → decoded back to its arguments, error
 //! surfaces).
 
+use whisker_svg::DisplayListBuilder;
 use whisker_svg::builder::{Color, Transform};
 use whisker_svg::format::*;
-use whisker_svg::replay::{replay, ReplayError, Visitor};
-use whisker_svg::DisplayListBuilder;
+use whisker_svg::replay::{ReplayError, Visitor, replay};
 
 /// Capture every visitor call as a tagged event so we can
 /// match-assert the sequence and arguments precisely.

--- a/packages/whisker-webview/example/Cargo.toml
+++ b/packages/whisker-webview/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "whisker-webview-example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 description = "Example app for `whisker-webview`. Exercises a URL-loading web view driven by a reactive signal with reload / back / forward buttons over a WebViewRef, a JS bridge round-trip (on_message + post_message + evaluate_javascript), and a second view rendering inline HTML that posts back to Rust — so on-device verification of the WKWebView / android.webkit.WebView module wiring happens in one place."
 


### PR DESCRIPTION
## Summary

Bumps the workspace (and the `whisker new` / `whisker new-module` scaffolds) from edition **2021 → 2024**. This is an **edition-only** change:

- **MSRV is unchanged** — `rust-version` stays `1.85`, which is exactly what edition 2024 requires. No new toolchain floor.
- **Not breaking for downstream users** — editions don't propagate to dependents. A 2021 user crate keeps compiling against whisker; a 2024 user crate now works too.

## What `cargo fix --edition` did automatically
Standard 2024-compat rewrites across the tree:
- `unsafe fn` bodies wrapped in `unsafe { … }` (no longer implicitly unsafe).
- `unsafe extern "C" { … }` on the active-cfg `whisker-driver-sys` block.
- `#[unsafe(no_mangle)]` on `whisker-asset`'s exported FFI fns.
- `std::env::set_var/remove_var` calls wrapped in `unsafe { … }` (now unsafe in 2024).
- `gen` → `r#gen` (reserved keyword in 2024) in `whisker-asset` tests.
- `expr` → `expr_2021` macro fragment specifier in a `whisker-css` test macro.

## Manual FFI / `static_mut_refs` fixes (cfg-gated code `cargo fix` couldn't see on macOS)
- **`static mut` → `AtomicPtr`** in `crates/whisker-subsecond/src/lib.rs` (`aslr_reference`). The cached anchor pointer was a `static mut`; replaced with a function-local `AtomicPtr<c_void>` (`load`/`store`, `Relaxed`), preserving the self-initializing-on-first-call behavior. Removes the `static mut` entirely so no `static_mut_refs` exposure even if a `&` is added later.
- **`unsafe extern` on cfg-gated blocks** `cargo fix` skipped on macOS: the `#[cfg(windows)]` `extern "system"` block and the `#[cfg(target_os = "android")]` `extern "C"` block in `whisker-subsecond`.
- **`#[unsafe(link_section = ".init_array")]`** on the `#[cfg(target_os = "android")]` `.init_array` ctor static in `whisker-asset`.
- Dropped a now-redundant nested `unsafe { }` in `apply_patch` (would have been an `unused_unsafe` error under `-D warnings`).

## Macro output kept edition-agnostic (the load-bearing bit)
`#[whisker::main]` expands in the **user crate's** edition. Its FFI exports used bare `#[no_mangle]`, which is a hard error in a 2024 user crate. Switched the macro's three emitted `#[no_mangle]` to **`#[unsafe(no_mangle)]`** — that spelling was stabilized in Rust 1.82 (below MSRV 1.85), so it compiles cleanly in **both** 2021 and 2024 user crates. Verified by scaffolding a fresh app and `cargo check`ing it on both editions.

## Scaffolds
- `whisker new` (`new_app.rs`) and `whisker new-module` (`new_module.rs`) templates emit `edition = "2024"`.
- The internal config-probe crate template (`probe.rs`) bumped for consistency.

## Verification
- `cargo build --workspace --all-targets` — clean.
- `cargo test --workspace` — green (0 failures).
- `cargo clippy --workspace --all-targets` — no warnings.
- `cargo fmt --all -- --check` — clean. Note: with no `rustfmt.toml`, rustfmt's `style_edition` follows the crate edition, so the 2024 style edition reformatted imports / `assert!` wrapping / comment indentation across the tree. This churn is mechanical and semantics-preserving, and is required for CI's `fmt --check`.
- Scaffold smoke test: `whisker new smoke` emits `edition = "2024"`; repointed to a path dep on this branch's `crates/whisker` and `cargo check` passes (and also passes when flipped to a 2021 user crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)