### PR TITLE
feat(whisker-animation): continuous signal-based animation engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,12 +2240,21 @@ dependencies = [
 name = "whisker"
 version = "0.6.0"
 dependencies = [
+ "whisker-animation",
  "whisker-config",
  "whisker-css",
  "whisker-driver",
  "whisker-macros",
  "whisker-runtime",
  "whisker-subsecond",
+]
+
+[[package]]
+name = "whisker-animation"
+version = "0.6.0"
+dependencies = [
+ "whisker-css",
+ "whisker-runtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/whisker",
+    "crates/whisker-animation",
     "crates/whisker-config",
     "crates/whisker-build",
     "crates/whisker-cli",
@@ -77,6 +78,7 @@ categories = ["gui"]
 
 [workspace.dependencies]
 whisker = { path = "crates/whisker", version = "0.6.0" }
+whisker-animation = { path = "crates/whisker-animation", version = "0.6.0" }
 whisker-config = { path = "crates/whisker-config", version = "0.6.0" }
 whisker-build = { path = "crates/whisker-build", version = "0.6.0" }
 whisker-cng = { path = "crates/whisker-cng", version = "0.6.0" }

--- a/crates/whisker-animation/Cargo.toml
+++ b/crates/whisker-animation/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "whisker-animation"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Continuous, signal-based animation engine for Whisker (Flutter-style AnimationController + Tween, no Lynx animator)."
+
+[dependencies]
+whisker-runtime = { workspace = true }
+whisker-css = { workspace = true }

--- a/crates/whisker-animation/src/animatable.rs
+++ b/crates/whisker-animation/src/animatable.rs
@@ -1,0 +1,132 @@
+//! The [`Animatable`] trait: linear interpolation for animatable types.
+//!
+//! A [`Tween<T>`](crate::Tween) maps a controller's `0..1` progress to a
+//! value of type `T` by calling `T::lerp(from, to, t)`. Any type that
+//! can be smoothly interpolated implements [`Animatable`]; the engine
+//! ships impls for `f32` and `whisker_css::Color`, with more to follow.
+
+use whisker_css::data_type::{Angle, Color};
+
+/// A type whose values can be linearly interpolated. The fundamental
+/// operation a [`Tween`](crate::Tween) needs.
+pub trait Animatable: Clone + 'static {
+    /// Interpolate from `from` (at `t == 0.0`) to `to` (at `t == 1.0`).
+    /// `t` is the eased progress; implementations should treat the
+    /// endpoints as exact (`t == 0` ⇒ `from`, `t == 1` ⇒ `to`).
+    fn lerp(from: &Self, to: &Self, t: f32) -> Self;
+}
+
+impl Animatable for f32 {
+    fn lerp(from: &Self, to: &Self, t: f32) -> Self {
+        from + (to - from) * t
+    }
+}
+
+/// Linearly interpolate a `u8` channel, rounding to the nearest value.
+fn lerp_u8(from: u8, to: u8, t: f32) -> u8 {
+    let v = from as f32 + (to as f32 - from as f32) * t;
+    v.round().clamp(0.0, 255.0) as u8
+}
+
+impl Animatable for Color {
+    /// Interpolate two colors.
+    ///
+    /// - Two `Hsla` colors interpolate in HSL space (hue / saturation /
+    ///   lightness / alpha each lerped) — natural for hue sweeps.
+    /// - Any pair reducible to concrete RGBA channels (`Rgba`,
+    ///   `Transparent`, or an `Hsla`/`Rgba` mix) interpolates per
+    ///   channel.
+    /// - A [`Color::Named`] endpoint has no resolvable channels here
+    ///   (the named-color table lives in Lynx, not in this crate), so a
+    ///   pair involving a named color **snaps** at the midpoint rather
+    ///   than producing a wrong RGBA. Use explicit `Color::rgb(..)` /
+    ///   `Color::hsl(..)` endpoints when you need a smooth color tween.
+    fn lerp(from: &Self, to: &Self, t: f32) -> Self {
+        // Same-space HSL interpolation keeps hue sweeps natural.
+        if let (
+            Color::Hsla {
+                h: h0,
+                s: s0,
+                l: l0,
+                a: a0,
+            },
+            Color::Hsla {
+                h: h1,
+                s: s1,
+                l: l1,
+                a: a1,
+            },
+        ) = (from, to)
+        {
+            return Color::Hsla {
+                h: Angle::Deg(f32::lerp(&angle_deg(*h0), &angle_deg(*h1), t)),
+                s: f32::lerp(s0, s1, t),
+                l: f32::lerp(l0, l1, t),
+                a: f32::lerp(a0, a1, t),
+            };
+        }
+
+        match (rgba_channels(from), rgba_channels(to)) {
+            (Some((r0, g0, b0, a0)), Some((r1, g1, b1, a1))) => Color::Rgba(
+                lerp_u8(r0, r1, t),
+                lerp_u8(g0, g1, t),
+                lerp_u8(b0, b1, t),
+                f32::lerp(&a0, &a1, t),
+            ),
+            // A named endpoint can't be resolved to channels here;
+            // snap at the midpoint rather than guess.
+            _ => {
+                if t < 0.5 {
+                    *from
+                } else {
+                    *to
+                }
+            }
+        }
+    }
+}
+
+/// Resolve a [`Color`] to concrete `(r, g, b, a)` channels, or `None`
+/// for a [`Color::Named`] (whose RGB table lives in Lynx, not here).
+fn rgba_channels(c: &Color) -> Option<(u8, u8, u8, f32)> {
+    match c {
+        Color::Rgba(r, g, b, a) => Some((*r, *g, *b, *a)),
+        Color::Transparent => Some((0, 0, 0, 0.0)),
+        Color::Hsla { h, s, l, a } => {
+            let (r, g, b) = hsl_to_rgb(angle_deg(*h), *s / 100.0, *l / 100.0);
+            Some((r, g, b, *a))
+        }
+        Color::Named(_) => None,
+    }
+}
+
+/// Degrees value of an [`Angle`], for interpolation.
+fn angle_deg(a: Angle) -> f32 {
+    match a {
+        Angle::Deg(d) => d,
+        Angle::Rad(r) => r.to_degrees(),
+        Angle::Turn(t) => t * 360.0,
+    }
+}
+
+/// Convert HSL (hue in degrees, saturation/lightness in `0..1`) to
+/// 8-bit RGB.
+fn hsl_to_rgb(h: f32, s: f32, l: f32) -> (u8, u8, u8) {
+    let h = h.rem_euclid(360.0);
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let x = c * (1.0 - ((h / 60.0) % 2.0 - 1.0).abs());
+    let m = l - c / 2.0;
+    let (r1, g1, b1) = match h {
+        _ if h < 60.0 => (c, x, 0.0),
+        _ if h < 120.0 => (x, c, 0.0),
+        _ if h < 180.0 => (0.0, c, x),
+        _ if h < 240.0 => (0.0, x, c),
+        _ if h < 300.0 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    (
+        ((r1 + m) * 255.0).round().clamp(0.0, 255.0) as u8,
+        ((g1 + m) * 255.0).round().clamp(0.0, 255.0) as u8,
+        ((b1 + m) * 255.0).round().clamp(0.0, 255.0) as u8,
+    )
+}

--- a/crates/whisker-animation/src/config.rs
+++ b/crates/whisker-animation/src/config.rs
@@ -1,0 +1,68 @@
+//! [`AnimConfig`] — duration + easing for an [`AnimationController`].
+//!
+//! [`AnimationController`]: crate::AnimationController
+
+use crate::curve::Curve;
+
+/// Configuration for a time-driven animation: how long it runs and how
+/// progress is shaped over that time.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AnimConfig {
+    /// Total duration, in milliseconds, for a full `0.0 → 1.0` sweep.
+    /// A `reverse()` / partial run scales proportionally (the time to
+    /// cover the remaining distance at the same rate).
+    pub duration_ms: f32,
+    /// Easing curve applied to the linear time fraction.
+    pub curve: Curve,
+}
+
+impl AnimConfig {
+    /// A linear animation over `duration_ms` milliseconds.
+    pub fn linear(duration_ms: u32) -> Self {
+        Self {
+            duration_ms: duration_ms as f32,
+            curve: Curve::Linear,
+        }
+    }
+
+    /// An ease-in (accelerate) animation.
+    pub fn ease_in(duration_ms: u32) -> Self {
+        Self {
+            duration_ms: duration_ms as f32,
+            curve: Curve::EaseIn,
+        }
+    }
+
+    /// An ease-out (decelerate) animation.
+    pub fn ease_out(duration_ms: u32) -> Self {
+        Self {
+            duration_ms: duration_ms as f32,
+            curve: Curve::EaseOut,
+        }
+    }
+
+    /// An ease-in-out animation.
+    pub fn ease_in_out(duration_ms: u32) -> Self {
+        Self {
+            duration_ms: duration_ms as f32,
+            curve: Curve::EaseInOut,
+        }
+    }
+
+    /// A custom cubic-Bézier easing `(x1, y1, x2, y2)` (CSS
+    /// `cubic-bezier()` model) over `duration_ms`.
+    pub fn cubic_bezier(duration_ms: u32, x1: f32, y1: f32, x2: f32, y2: f32) -> Self {
+        Self {
+            duration_ms: duration_ms as f32,
+            curve: Curve::CubicBezier(x1, y1, x2, y2),
+        }
+    }
+
+    /// Build with an explicit [`Curve`].
+    pub fn new(duration_ms: u32, curve: Curve) -> Self {
+        Self {
+            duration_ms: duration_ms as f32,
+            curve,
+        }
+    }
+}

--- a/crates/whisker-animation/src/controller.rs
+++ b/crates/whisker-animation/src/controller.rs
@@ -1,0 +1,431 @@
+//! [`AnimationController`] + the per-thread [`AnimationScheduler`].
+//!
+//! The controller is a state machine driving a `0..1` **progress**
+//! signal. It is *idle when not driving*: `forward` / `reverse` /
+//! `animate_to` / `repeat` register it with the scheduler (which keeps
+//! the host ticking and advances it each frame); reaching the target,
+//! `stop`, or owner-dispose deregisters it. `set_value` writes the
+//! progress once without registering.
+//!
+//! See `docs/animation-design.md` for the model.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use whisker_runtime::anim_hook;
+use whisker_runtime::reactive::{ReadSignal, RwSignal, on_cleanup, signal};
+
+use crate::config::AnimConfig;
+
+/// How a running controller continues once it reaches its target.
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum Repeat {
+    /// Stop at the target (the default).
+    Once,
+    /// Jump back to the start and run forward again, indefinitely.
+    Loop,
+    /// Ping-pong: on reaching a bound, flip direction and continue.
+    Reverse,
+}
+
+/// Direction a controller is currently driving.
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum Dir {
+    Forward,
+    Backward,
+}
+
+/// Mutable controller state, shared between the [`AnimationController`]
+/// handle, the scheduler's active list, and the registered cleanup.
+struct ControllerState {
+    cfg: AnimConfig,
+    /// The progress signal (`0.0..=1.0`) consumers read.
+    value: RwSignal<f32>,
+    /// Whether this controller is currently self-driving.
+    active: bool,
+    /// Target progress the current run drives toward.
+    target: f32,
+    /// Progress at the moment the current run started.
+    start_value: f32,
+    /// Scheduler timestamp (ms) at which the current run started.
+    start_ms: f64,
+    /// Direction of the current run (for ping-pong bookkeeping).
+    dir: Dir,
+    repeat: Repeat,
+    /// Callbacks fired when a (non-repeating) run reaches its target.
+    on_finish: Vec<Box<dyn FnMut()>>,
+}
+
+impl ControllerState {
+    /// Distance-proportional duration (ms) for the current run: a half
+    /// sweep takes half the configured time, so `set_value` then
+    /// `forward` settles at a consistent rate. Guards a zero/positive
+    /// duration so a degenerate config finishes immediately.
+    fn run_duration_ms(&self) -> f64 {
+        let span = (self.target - self.start_value).abs();
+        (self.cfg.duration_ms as f64) * span as f64
+    }
+
+    /// Advance to time `now_ms`. Returns `true` if still animating.
+    fn advance(&mut self, now_ms: f64) -> bool {
+        if !self.active {
+            return false;
+        }
+        let dur = self.run_duration_ms();
+        // A tiny epsilon (in ms) absorbs the f32→f64 rounding in
+        // `run_duration_ms` (e.g. a 0.6 span yields dur ≈ 60.0000023,
+        // so a frame at exactly 60ms would otherwise read t = 0.99999996
+        // and never finish). Treat "within a hundredth of a ms of done"
+        // as done.
+        let finished = dur <= 0.0 || (now_ms - self.start_ms) >= dur - 1e-2;
+        let raw_t = if finished {
+            1.0
+        } else {
+            ((now_ms - self.start_ms) / dur).clamp(0.0, 1.0) as f32
+        };
+        let eased = self.cfg.curve.ease(raw_t);
+        let progress = self.start_value + (self.target - self.start_value) * eased;
+        self.value.set(progress);
+
+        if !finished {
+            return true;
+        }
+
+        // Reached the target.
+        self.value.set(self.target);
+        match self.repeat {
+            Repeat::Once => {
+                self.active = false;
+                let mut cbs = std::mem::take(&mut self.on_finish);
+                for cb in cbs.iter_mut() {
+                    cb();
+                }
+                self.on_finish = cbs;
+                false
+            }
+            Repeat::Loop => {
+                // Restart from the opposite bound in the same direction.
+                let (from, to) = match self.dir {
+                    Dir::Forward => (0.0, 1.0),
+                    Dir::Backward => (1.0, 0.0),
+                };
+                self.value.set(from);
+                self.start_value = from;
+                self.target = to;
+                self.start_ms = now_ms;
+                true
+            }
+            Repeat::Reverse => {
+                // Flip direction and continue from this bound.
+                self.dir = match self.dir {
+                    Dir::Forward => Dir::Backward,
+                    Dir::Backward => Dir::Forward,
+                };
+                self.start_value = self.target;
+                self.target = match self.dir {
+                    Dir::Forward => 1.0,
+                    Dir::Backward => 0.0,
+                };
+                self.start_ms = now_ms;
+                true
+            }
+        }
+    }
+}
+
+thread_local! {
+    static SCHEDULER: RefCell<AnimationScheduler> =
+        RefCell::new(AnimationScheduler::new());
+}
+
+/// One per runtime thread: holds the set of active controllers and
+/// advances them each frame. Registered with the runtime's
+/// [`anim_hook`] the first time any controller is created on this
+/// thread, so the driver's `tick_frame` drives it.
+struct AnimationScheduler {
+    active: Vec<Rc<RefCell<ControllerState>>>,
+    /// Most recent timestamp seen from `step` — used as the start time
+    /// for a `forward`/`reverse` issued between frames.
+    last_ms: f64,
+    /// Whether the per-frame callback has been registered with the
+    /// runtime's `anim_hook` for this thread.
+    hook_installed: bool,
+}
+
+impl AnimationScheduler {
+    fn new() -> Self {
+        Self {
+            active: Vec::new(),
+            last_ms: 0.0,
+            hook_installed: false,
+        }
+    }
+}
+
+/// Ensure the scheduler's per-frame step callback is registered with
+/// the runtime, so `tick_frame` advances animations on this thread.
+fn ensure_hook_installed() {
+    let already = SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        let was = s.hook_installed;
+        s.hook_installed = true;
+        was
+    });
+    if !already {
+        anim_hook::set_step_callback(Box::new(step));
+    }
+}
+
+/// Advance every active controller by one frame at `now_ms`. Returns
+/// `true` if any controller is still animating afterward. This is the
+/// callback the runtime's `anim_hook` invokes each `tick_frame`.
+fn step(now_ms: f64) -> bool {
+    // Snapshot the active list outside the scheduler borrow: a
+    // controller's `advance` writes its value signal, which schedules
+    // reactive subscribers — none of which re-enter the scheduler, but
+    // keeping the borrow window tight matches the runtime's discipline.
+    let snapshot: Vec<Rc<RefCell<ControllerState>>> = SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        s.last_ms = now_ms;
+        s.active.clone()
+    });
+
+    let mut finished: Vec<*const RefCell<ControllerState>> = Vec::new();
+    for st in &snapshot {
+        let still = st.borrow_mut().advance(now_ms);
+        if !still {
+            finished.push(Rc::as_ptr(st));
+        }
+    }
+
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        if !finished.is_empty() {
+            s.active.retain(|st| !finished.contains(&Rc::as_ptr(st)));
+        }
+        let any = !s.active.is_empty();
+        anim_hook::mark_animating(any);
+        any
+    })
+}
+
+/// Register `state` as active (idempotent) and wake the host so a frame
+/// runs. Records the run's start time from the scheduler's last-seen
+/// timestamp.
+fn register(state: &Rc<RefCell<ControllerState>>) {
+    let already = SCHEDULER.with(|s| {
+        let s = s.borrow();
+        s.active.iter().any(|a| Rc::ptr_eq(a, state))
+    });
+    let last_ms = SCHEDULER.with(|s| s.borrow().last_ms);
+    state.borrow_mut().start_ms = last_ms;
+    if !already {
+        SCHEDULER.with(|s| s.borrow_mut().active.push(state.clone()));
+    }
+    // Report busy immediately (before the next `step`) and nudge the
+    // host to schedule a frame.
+    anim_hook::mark_animating(true);
+    whisker_runtime::host_wake::wake_runtime();
+}
+
+/// Deregister `state` from the active list (no-op if absent).
+fn deregister(state: &Rc<RefCell<ControllerState>>) {
+    SCHEDULER.with(|s| {
+        let mut s = s.borrow_mut();
+        s.active.retain(|a| !Rc::ptr_eq(a, state));
+        if s.active.is_empty() {
+            anim_hook::mark_animating(false);
+        }
+    });
+}
+
+/// (Test only) number of currently-active controllers on this thread.
+#[doc(hidden)]
+pub fn __active_count() -> usize {
+    SCHEDULER.with(|s| s.borrow().active.len())
+}
+
+/// (Test only) drive one animation frame at monotonic time `now_ms`
+/// (milliseconds) without a real clock. Mirrors what the driver's
+/// `tick_frame` does, then flushes the reactive queue so tween
+/// `computed`s recompute.
+///
+/// Returns `true` if any controller is still animating.
+#[doc(hidden)]
+pub fn __step_for_tests(now_ms: f64) -> bool {
+    let still = step(now_ms);
+    whisker_runtime::reactive::flush();
+    still
+}
+
+/// (Test only) reset the scheduler thread-local. Pairs with the
+/// runtime's `__reset_for_tests`.
+#[doc(hidden)]
+pub fn __reset_for_tests() {
+    SCHEDULER.with(|s| *s.borrow_mut() = AnimationScheduler::new());
+    anim_hook::__reset_for_tests();
+}
+
+/// Drives a `0..1` progress signal as an explicit state machine.
+///
+/// Construct with [`AnimationController::new`], then drive it with
+/// [`forward`](Self::forward) / [`reverse`](Self::reverse) /
+/// [`stop`](Self::stop) / [`animate_to`](Self::animate_to) /
+/// [`set_value`](Self::set_value). Read the live progress via
+/// [`value`](Self::value) — a `ReadSignal<f32>` consumable anywhere in
+/// the reactive graph (e.g. by a [`Tween`](crate::Tween)).
+///
+/// **No auto-play**: a freshly-constructed controller sits at `0.0` and
+/// requests no frames until you drive it. **Idle is free**: when no
+/// controller is driving, the engine adds no per-frame work.
+///
+/// The controller is owned by the current reactive owner: when that
+/// owner disposes, the controller deregisters from the scheduler — no
+/// leaked frame requests.
+#[derive(Clone)]
+pub struct AnimationController {
+    state: Rc<RefCell<ControllerState>>,
+}
+
+impl AnimationController {
+    /// Create a controller for `cfg`, sitting idle at progress `0.0`.
+    pub fn new(cfg: AnimConfig) -> Self {
+        ensure_hook_installed();
+        let value = signal(0.0_f32);
+        let state = Rc::new(RefCell::new(ControllerState {
+            cfg,
+            value,
+            active: false,
+            target: 0.0,
+            start_value: 0.0,
+            start_ms: 0.0,
+            dir: Dir::Forward,
+            repeat: Repeat::Once,
+            on_finish: Vec::new(),
+        }));
+
+        // Deregister on owner dispose so a controller created inside a
+        // component never leaves a dangling frame request behind.
+        let weak = Rc::downgrade(&state);
+        on_cleanup(move || {
+            if let Some(st) = weak.upgrade() {
+                deregister(&st);
+            }
+        });
+
+        Self { state }
+    }
+
+    /// The live progress as a read-only signal (`0.0..=1.0`).
+    pub fn value(&self) -> ReadSignal<f32> {
+        self.state.borrow().value.read_only()
+    }
+
+    /// Drive from the current value toward `1.0`.
+    pub fn forward(&self) {
+        self.animate_to(1.0);
+    }
+
+    /// Drive from the current value back toward `0.0`.
+    pub fn reverse(&self) {
+        self.animate_to(0.0);
+    }
+
+    /// Drive from the current value toward an arbitrary `target`
+    /// (clamped to `0.0..=1.0`). If already at the target, finishes
+    /// immediately (fires `on_finish`) without registering a frame.
+    pub fn animate_to(&self, target: f32) {
+        let target = target.clamp(0.0, 1.0);
+        let start_value = self.state.borrow().value.get_untracked();
+        {
+            let mut st = self.state.borrow_mut();
+            st.repeat = Repeat::Once;
+            st.target = target;
+            st.start_value = start_value;
+            st.dir = if target >= start_value {
+                Dir::Forward
+            } else {
+                Dir::Backward
+            };
+            st.active = true;
+        }
+        if (target - start_value).abs() <= f32::EPSILON {
+            // Already there: settle synchronously, fire on_finish, and
+            // don't register (nothing to animate).
+            let mut st = self.state.borrow_mut();
+            st.value.set(target);
+            st.active = false;
+            let mut cbs = std::mem::take(&mut st.on_finish);
+            drop(st);
+            for cb in cbs.iter_mut() {
+                cb();
+            }
+            self.state.borrow_mut().on_finish = cbs;
+            return;
+        }
+        register(&self.state);
+    }
+
+    /// Halt at the current value. Deregisters from the scheduler; the
+    /// value signal holds its last progress. Does not fire `on_finish`.
+    pub fn stop(&self) {
+        self.state.borrow_mut().active = false;
+        deregister(&self.state);
+    }
+
+    /// Set the progress to `v` (clamped `0.0..=1.0`) **once**, without
+    /// self-driving. The canonical finger-driven path: one update per
+    /// gesture frame. Deregisters any in-flight run so the manual value
+    /// isn't immediately overwritten by the scheduler.
+    pub fn set_value(&self, v: f32) {
+        let v = v.clamp(0.0, 1.0);
+        {
+            let mut st = self.state.borrow_mut();
+            st.active = false;
+            st.value.set(v);
+        }
+        deregister(&self.state);
+    }
+
+    /// Register a callback fired each time a non-repeating run reaches
+    /// its target (via `forward` / `reverse` / `animate_to`). Multiple
+    /// callbacks accumulate.
+    pub fn on_finish(&self, cb: impl FnMut() + 'static) {
+        self.state.borrow_mut().on_finish.push(Box::new(cb));
+    }
+
+    /// Run forward to `1.0`, then restart from `0.0` and run forward
+    /// again, indefinitely. Registers the controller.
+    pub fn repeat(&self) {
+        let start_value = self.state.borrow().value.get_untracked();
+        {
+            let mut st = self.state.borrow_mut();
+            st.repeat = Repeat::Loop;
+            st.dir = Dir::Forward;
+            st.start_value = start_value;
+            st.target = 1.0;
+            st.active = true;
+        }
+        register(&self.state);
+    }
+
+    /// Ping-pong forever: forward to `1.0`, reverse to `0.0`, repeat.
+    /// Registers the controller.
+    pub fn repeat_reverse(&self) {
+        let start_value = self.state.borrow().value.get_untracked();
+        {
+            let mut st = self.state.borrow_mut();
+            st.repeat = Repeat::Reverse;
+            st.dir = Dir::Forward;
+            st.start_value = start_value;
+            st.target = 1.0;
+            st.active = true;
+        }
+        register(&self.state);
+    }
+
+    /// Whether this controller is currently self-driving.
+    pub fn is_animating(&self) -> bool {
+        self.state.borrow().active
+    }
+}

--- a/crates/whisker-animation/src/curve.rs
+++ b/crates/whisker-animation/src/curve.rs
@@ -1,0 +1,104 @@
+//! Easing curves: pure `f32 -> f32` mappings over the unit interval.
+//!
+//! A [`Curve`] takes a linear time fraction `t ∈ [0, 1]` (elapsed /
+//! duration) and returns an eased progress in `[0, 1]`. Every curve
+//! satisfies `f(0) == 0` and `f(1) == 1`; intermediate shaping is what
+//! distinguishes them.
+
+/// An easing curve. Cheap to copy; pure (no state).
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Curve {
+    /// No easing — progress equals time.
+    Linear,
+    /// Cubic accelerate-from-zero (`t³`).
+    EaseIn,
+    /// Cubic decelerate-to-one (`1 - (1-t)³`).
+    EaseOut,
+    /// Cubic ease-in then ease-out, symmetric about `t = 0.5`.
+    EaseInOut,
+    /// Arbitrary cubic Bézier `(x1, y1, x2, y2)` with implicit
+    /// endpoints `(0,0)` and `(1,1)` — the CSS `cubic-bezier()` model.
+    CubicBezier(f32, f32, f32, f32),
+}
+
+impl Curve {
+    /// Evaluate the curve at time fraction `t`. `t` is clamped to
+    /// `[0, 1]` first, so callers needn't pre-clamp.
+    pub fn ease(self, t: f32) -> f32 {
+        let t = t.clamp(0.0, 1.0);
+        match self {
+            Curve::Linear => t,
+            Curve::EaseIn => t * t * t,
+            Curve::EaseOut => {
+                let u = 1.0 - t;
+                1.0 - u * u * u
+            }
+            Curve::EaseInOut => {
+                if t < 0.5 {
+                    4.0 * t * t * t
+                } else {
+                    let u = -2.0 * t + 2.0;
+                    1.0 - (u * u * u) / 2.0
+                }
+            }
+            Curve::CubicBezier(x1, y1, x2, y2) => cubic_bezier(x1, y1, x2, y2, t),
+        }
+    }
+}
+
+/// Evaluate a CSS-style cubic Bézier easing with control points
+/// `(x1, y1)` and `(x2, y2)` (endpoints fixed at `(0,0)` and `(1,1)`).
+///
+/// The curve is parametric in `s`: `x(s)` and `y(s)` are cubic Béziers.
+/// We solve `x(s) = t` for the parameter `s` (Newton's method, with a
+/// bisection fallback for robustness), then return `y(s)`.
+fn cubic_bezier(x1: f32, y1: f32, x2: f32, y2: f32, t: f32) -> f32 {
+    // Bézier basis for endpoints (0,0)..(1,1): the cubic in `s` reduces
+    // to `3(1-s)²s·c1 + 3(1-s)s²·c2 + s³` for a control coordinate `c`.
+    fn bezier(c1: f32, c2: f32, s: f32) -> f32 {
+        let u = 1.0 - s;
+        3.0 * u * u * s * c1 + 3.0 * u * s * s * c2 + s * s * s
+    }
+    fn bezier_deriv(c1: f32, c2: f32, s: f32) -> f32 {
+        let u = 1.0 - s;
+        3.0 * u * u * c1 + 6.0 * u * s * (c2 - c1) + 3.0 * s * s * (1.0 - c2)
+    }
+
+    if t <= 0.0 {
+        return 0.0;
+    }
+    if t >= 1.0 {
+        return 1.0;
+    }
+
+    // Newton-Raphson to invert x(s) = t.
+    let mut s = t;
+    for _ in 0..8 {
+        let x = bezier(x1, x2, s) - t;
+        if x.abs() < 1e-6 {
+            return bezier(y1, y2, s);
+        }
+        let dx = bezier_deriv(x1, x2, s);
+        if dx.abs() < 1e-6 {
+            break;
+        }
+        s -= x / dx;
+    }
+
+    // Bisection fallback if Newton stalled or shot out of range.
+    let (mut lo, mut hi) = (0.0_f32, 1.0_f32);
+    let mut s = t.clamp(lo, hi);
+    for _ in 0..32 {
+        let x = bezier(x1, x2, s);
+        if (x - t).abs() < 1e-6 {
+            break;
+        }
+        if x < t {
+            lo = s;
+        } else {
+            hi = s;
+        }
+        s = (lo + hi) / 2.0;
+    }
+    bezier(y1, y2, s)
+}

--- a/crates/whisker-animation/src/lib.rs
+++ b/crates/whisker-animation/src/lib.rs
@@ -1,0 +1,60 @@
+//! Whisker's **continuous, signal-based animation engine**.
+//!
+//! This is the second of Whisker's two animation systems (see
+//! `docs/animation-design.md`). Unlike Lynx's discrete CSS-keyframe
+//! animator, this engine lives entirely in Rust and drives a `0..1`
+//! **progress** signal that the reactive runtime advances each frame —
+//! so an animated value is just a [`ReadSignal`] you can read anywhere
+//! in the signal graph, with full control over forward / reverse /
+//! stop / scrub.
+//!
+//! ## Model: Controller + Tween (Flutter's split)
+//!
+//! - [`AnimationController`] drives a `0..1` progress as an explicit
+//!   state machine. **No auto-play** — it sits idle until you call
+//!   [`forward`](AnimationController::forward) /
+//!   [`reverse`](AnimationController::reverse) /
+//!   [`animate_to`](AnimationController::animate_to) /
+//!   [`set_value`](AnimationController::set_value). **Idle is free**:
+//!   when nothing is driving, the engine requests no frames.
+//! - [`Tween<T>`] is a pure `0..1 → T` mapping. One controller can
+//!   drive several tweens.
+//! - [`animated`] builds a `(value_signal, controller)` pair for the
+//!   common single-value case.
+//!
+//! ```ignore
+//! use whisker_animation::{animated, AnimConfig};
+//!
+//! let (x, ctrl) = animated(0.0_f32, 100.0, AnimConfig::ease_out(300));
+//! ctrl.forward();                 // explicit — you decide when it runs
+//! // read `x.get()` in a css!/computed; it tracks progress each frame
+//! ```
+//!
+//! ## Frame driving
+//!
+//! The engine keeps the runtime's level-triggered render loop ticking
+//! only while a controller is active: registering wakes the host and
+//! marks the runtime busy; reaching the target (or `stop`, or
+//! owner-dispose) deregisters and releases vsync. The per-frame advance
+//! is invoked from the driver's `tick_frame` via the runtime's
+//! `anim_hook`; progress is derived from a monotonic millisecond
+//! timestamp, which tests inject directly through
+//! [`__step_for_tests`](controller::__step_for_tests).
+
+mod animatable;
+mod config;
+mod controller;
+mod curve;
+mod tween;
+
+pub use animatable::Animatable;
+pub use config::AnimConfig;
+pub use controller::AnimationController;
+pub use curve::Curve;
+pub use tween::{Tween, animated};
+
+#[doc(hidden)]
+pub use controller::{__active_count, __reset_for_tests, __step_for_tests};
+
+#[cfg(test)]
+mod tests;

--- a/crates/whisker-animation/src/tests.rs
+++ b/crates/whisker-animation/src/tests.rs
@@ -1,0 +1,428 @@
+//! Unit tests for the continuous animation engine.
+//!
+//! Every test resets both the reactive runtime and the animation
+//! scheduler first (cargo reuses worker threads, so thread-locals must
+//! be cleared between runs), and drives frames through the injectable
+//! virtual clock [`__step_for_tests`] so results are exact and no real
+//! time passes.
+
+use super::*;
+use whisker_css::data_type::Color;
+use whisker_runtime::reactive::{Owner, ReadSignal, flush};
+
+/// Reset thread-local runtime + animation scheduler.
+fn fresh() {
+    whisker_runtime::reactive::__reset_for_tests();
+    __reset_for_tests();
+}
+
+/// Approximate float equality for progress/value assertions.
+fn approx(a: f32, b: f32) -> bool {
+    (a - b).abs() < 1e-3
+}
+
+// ----- 1. Animatable::lerp -------------------------------------------------
+
+#[test]
+fn lerp_f32_endpoints_and_midpoint() {
+    fresh();
+    assert!(approx(f32::lerp(&0.0, &100.0, 0.0), 0.0));
+    assert!(approx(f32::lerp(&0.0, &100.0, 1.0), 100.0));
+    assert!(approx(f32::lerp(&0.0, &100.0, 0.5), 50.0));
+    assert!(approx(f32::lerp(&20.0, &-20.0, 0.5), 0.0));
+}
+
+#[test]
+fn lerp_color_rgba_endpoints_and_midpoint() {
+    fresh();
+    let from = Color::rgb(0, 0, 0);
+    let to = Color::rgb(255, 100, 50);
+    assert_eq!(Color::lerp(&from, &to, 0.0), from);
+    assert_eq!(Color::lerp(&from, &to, 1.0), to);
+    // Midpoint: each channel halves (with rounding).
+    match Color::lerp(&from, &to, 0.5) {
+        Color::Rgba(r, g, b, a) => {
+            assert_eq!((r, g, b), (128, 50, 25));
+            assert!(approx(a, 1.0));
+        }
+        other => panic!("expected Rgba, got {other:?}"),
+    }
+}
+
+#[test]
+fn lerp_color_alpha_interpolates() {
+    fresh();
+    let from = Color::rgba(255, 0, 0, 0.0);
+    let to = Color::rgba(255, 0, 0, 1.0);
+    match Color::lerp(&from, &to, 0.25) {
+        Color::Rgba(_, _, _, a) => assert!(approx(a, 0.25)),
+        other => panic!("expected Rgba, got {other:?}"),
+    }
+}
+
+// ----- 2. Curves -----------------------------------------------------------
+
+#[test]
+fn curves_pin_endpoints() {
+    for c in [
+        Curve::Linear,
+        Curve::EaseIn,
+        Curve::EaseOut,
+        Curve::EaseInOut,
+        Curve::CubicBezier(0.42, 0.0, 0.58, 1.0),
+    ] {
+        assert!(approx(c.ease(0.0), 0.0), "{c:?} f(0) != 0");
+        assert!(approx(c.ease(1.0), 1.0), "{c:?} f(1) != 1");
+    }
+}
+
+#[test]
+fn curves_are_monotonic() {
+    for c in [
+        Curve::Linear,
+        Curve::EaseIn,
+        Curve::EaseOut,
+        Curve::EaseInOut,
+        Curve::CubicBezier(0.25, 0.1, 0.25, 1.0),
+    ] {
+        let mut prev = c.ease(0.0);
+        let mut t = 0.0;
+        while t <= 1.0 {
+            let v = c.ease(t);
+            assert!(
+                v + 1e-4 >= prev,
+                "{c:?} not monotonic at t={t}: {v} < {prev}"
+            );
+            prev = v;
+            t += 0.02;
+        }
+    }
+}
+
+#[test]
+fn ease_out_vs_ease_in_asymmetry() {
+    // ease_out is ahead of linear at the midpoint; ease_in is behind.
+    let mid_in = Curve::EaseIn.ease(0.5);
+    let mid_out = Curve::EaseOut.ease(0.5);
+    assert!(mid_in < 0.5, "ease_in mid {mid_in} should be < 0.5");
+    assert!(mid_out > 0.5, "ease_out mid {mid_out} should be > 0.5");
+    // Symmetric about 0.5 for cubic in/out.
+    assert!(approx(mid_in, 1.0 - mid_out));
+}
+
+#[test]
+fn curve_clamps_out_of_range() {
+    assert!(approx(Curve::Linear.ease(-1.0), 0.0));
+    assert!(approx(Curve::Linear.ease(2.0), 1.0));
+}
+
+// ----- 3. forward / reverse ------------------------------------------------
+
+#[test]
+fn forward_reaches_one_then_reverse_returns_to_zero() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    let v = ctrl.value();
+    assert!(approx(v.get_untracked(), 0.0));
+
+    ctrl.forward();
+    // Step in 25ms increments; t=0 at first registered start (last_ms=0).
+    __step_for_tests(0.0);
+    __step_for_tests(50.0);
+    assert!(
+        v.get_untracked() > 0.4 && v.get_untracked() < 0.6,
+        "mid {}",
+        v.get_untracked()
+    );
+    __step_for_tests(100.0);
+    assert!(approx(v.get_untracked(), 1.0), "end {}", v.get_untracked());
+    // Finished → deregistered.
+    assert_eq!(__active_count(), 0);
+
+    ctrl.reverse();
+    __step_for_tests(100.0); // run start re-anchored to last seen 100
+    __step_for_tests(150.0);
+    assert!(
+        v.get_untracked() < 0.6,
+        "reversing mid {}",
+        v.get_untracked()
+    );
+    __step_for_tests(200.0);
+    assert!(
+        approx(v.get_untracked(), 0.0),
+        "reverse end {}",
+        v.get_untracked()
+    );
+    assert_eq!(__active_count(), 0);
+}
+
+// ----- 4. idle when stopped ------------------------------------------------
+
+#[test]
+fn idle_when_no_controllers_active() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    // Constructed but not driven: nothing active, not animating.
+    assert_eq!(__active_count(), 0);
+    assert!(!whisker_runtime::anim_hook::is_animating());
+
+    ctrl.forward();
+    assert_eq!(__active_count(), 1);
+    assert!(whisker_runtime::anim_hook::is_animating());
+
+    // Run to completion; it must deregister and report idle.
+    __step_for_tests(0.0);
+    __step_for_tests(100.0);
+    assert_eq!(__active_count(), 0);
+    assert!(!whisker_runtime::anim_hook::is_animating());
+    // has_pending_work must no longer be kept busy by animation.
+    assert!(!whisker_runtime::reactive::has_pending_work());
+}
+
+#[test]
+fn stop_deregisters_at_current_value() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    let v = ctrl.value();
+    ctrl.forward();
+    __step_for_tests(0.0);
+    __step_for_tests(40.0);
+    let held = v.get_untracked();
+    ctrl.stop();
+    assert_eq!(__active_count(), 0);
+    // Further frames don't move it.
+    __step_for_tests(200.0);
+    assert!(approx(v.get_untracked(), held), "stop should hold value");
+}
+
+// ----- 5. set_value is one-shot --------------------------------------------
+
+#[test]
+fn set_value_does_not_self_drive() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    let v = ctrl.value();
+    ctrl.set_value(0.42);
+    assert!(approx(v.get_untracked(), 0.42));
+    assert_eq!(__active_count(), 0);
+    assert!(!whisker_runtime::anim_hook::is_animating());
+    // Next frame must not change it.
+    __step_for_tests(16.0);
+    __step_for_tests(32.0);
+    assert!(
+        approx(v.get_untracked(), 0.42),
+        "set_value drifted to {}",
+        v.get_untracked()
+    );
+}
+
+// ----- 6. one controller drives multiple tweens ----------------------------
+
+#[test]
+fn one_controller_drives_f32_and_color_tweens() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    let x: ReadSignal<f32> = Tween::new(0.0_f32, 200.0).animate(&ctrl);
+    let col: ReadSignal<Color> =
+        Tween::new(Color::rgb(0, 0, 0), Color::rgb(100, 100, 100)).animate(&ctrl);
+
+    ctrl.forward();
+    __step_for_tests(0.0);
+    __step_for_tests(50.0); // half-way (linear)
+    flush();
+    assert!(
+        approx(x.get_untracked(), 100.0),
+        "x mid {}",
+        x.get_untracked()
+    );
+    match col.get_untracked() {
+        Color::Rgba(r, g, b, _) => assert_eq!((r, g, b), (50, 50, 50)),
+        other => panic!("expected Rgba, got {other:?}"),
+    }
+
+    __step_for_tests(100.0);
+    flush();
+    assert!(approx(x.get_untracked(), 200.0));
+    match col.get_untracked() {
+        Color::Rgba(r, g, b, _) => assert_eq!((r, g, b), (100, 100, 100)),
+        other => panic!("expected Rgba, got {other:?}"),
+    }
+}
+
+// ----- 7. interactive: scrub then settle -----------------------------------
+
+#[test]
+fn interactive_scrub_then_commit_settles_to_one() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    let v = ctrl.value();
+    // Finger drags across several frames.
+    for p in [0.1_f32, 0.25, 0.4, 0.55] {
+        ctrl.set_value(p);
+        __step_for_tests(0.0); // a frame in which nothing self-drives
+        assert!(approx(v.get_untracked(), p));
+        assert_eq!(__active_count(), 0);
+    }
+    // Release → commit: drive to 1.0.
+    ctrl.forward();
+    __step_for_tests(0.0);
+    // Remaining span is 0.45 → 0.45*100ms = 45ms to finish.
+    __step_for_tests(45.0);
+    assert!(
+        approx(v.get_untracked(), 1.0),
+        "commit end {}",
+        v.get_untracked()
+    );
+    assert_eq!(__active_count(), 0);
+}
+
+#[test]
+fn interactive_scrub_then_cancel_settles_to_zero() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    let v = ctrl.value();
+    ctrl.set_value(0.6);
+    __step_for_tests(0.0);
+    ctrl.reverse();
+    __step_for_tests(0.0);
+    __step_for_tests(60.0); // 0.6 span → 60ms
+    assert!(
+        approx(v.get_untracked(), 0.0),
+        "cancel end {}",
+        v.get_untracked()
+    );
+    assert_eq!(__active_count(), 0);
+}
+
+// ----- 8. cleanup deregisters on owner dispose -----------------------------
+
+#[test]
+fn controller_deregisters_on_owner_dispose() {
+    fresh();
+    let owner = Owner::new(None);
+    let ctrl = owner.with(|| {
+        let c = AnimationController::new(AnimConfig::linear(100));
+        c.forward();
+        c
+    });
+    // Mid-flight: active.
+    __step_for_tests(0.0);
+    __step_for_tests(20.0);
+    assert_eq!(__active_count(), 1);
+
+    // Dispose the owner: the controller's on_cleanup must deregister.
+    owner.dispose();
+    assert_eq!(__active_count(), 0, "controller leaked after owner dispose");
+    assert!(!whisker_runtime::anim_hook::is_animating());
+    drop(ctrl);
+}
+
+// ----- 9. determinism: exact progress at exact frames ----------------------
+
+#[test]
+fn deterministic_linear_progress_values() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    let v = ctrl.value();
+    ctrl.forward();
+    // Anchor the run at t=0.
+    __step_for_tests(0.0);
+    // Linear, 100ms duration: progress == elapsed/100.
+    __step_for_tests(10.0);
+    assert!(
+        approx(v.get_untracked(), 0.10),
+        "t=10 -> {}",
+        v.get_untracked()
+    );
+    __step_for_tests(33.0);
+    assert!(
+        approx(v.get_untracked(), 0.33),
+        "t=33 -> {}",
+        v.get_untracked()
+    );
+    __step_for_tests(75.0);
+    assert!(
+        approx(v.get_untracked(), 0.75),
+        "t=75 -> {}",
+        v.get_untracked()
+    );
+    __step_for_tests(100.0);
+    assert!(approx(v.get_untracked(), 1.0));
+}
+
+#[test]
+fn deterministic_ease_in_progress_values() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::ease_in(100));
+    let v = ctrl.value();
+    ctrl.forward();
+    __step_for_tests(0.0);
+    // ease_in = t^3. At elapsed 50ms, raw t=0.5 -> 0.125.
+    __step_for_tests(50.0);
+    assert!(
+        approx(v.get_untracked(), 0.125),
+        "ease_in t=50 -> {}",
+        v.get_untracked()
+    );
+    __step_for_tests(100.0);
+    assert!(approx(v.get_untracked(), 1.0));
+}
+
+// ----- on_finish + animated() sugar ----------------------------------------
+
+#[test]
+fn on_finish_fires_once_at_target() {
+    fresh();
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    let count = Rc::new(RefCell::new(0));
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    let c = count.clone();
+    ctrl.on_finish(move || *c.borrow_mut() += 1);
+    ctrl.forward();
+    __step_for_tests(0.0);
+    __step_for_tests(100.0);
+    assert_eq!(*count.borrow(), 1);
+    // No extra frames re-fire it.
+    __step_for_tests(200.0);
+    assert_eq!(*count.borrow(), 1);
+}
+
+#[test]
+fn animated_sugar_no_autoplay() {
+    fresh();
+    let (x, ctrl) = animated(0.0_f32, 100.0, AnimConfig::linear(100));
+    // No autoplay: stays at `from` with no frames requested.
+    __step_for_tests(0.0);
+    __step_for_tests(50.0);
+    flush();
+    assert!(
+        approx(x.get_untracked(), 0.0),
+        "autoplayed to {}",
+        x.get_untracked()
+    );
+    assert_eq!(__active_count(), 0);
+
+    // Explicit forward drives it. The run anchors at the scheduler's
+    // last-seen time (50ms), so a full 100ms sweep finishes at 150ms.
+    ctrl.forward();
+    __step_for_tests(50.0);
+    __step_for_tests(150.0);
+    flush();
+    assert!(
+        approx(x.get_untracked(), 100.0),
+        "forward end {}",
+        x.get_untracked()
+    );
+}
+
+#[test]
+fn animate_to_already_at_target_finishes_without_registering() {
+    fresh();
+    let ctrl = AnimationController::new(AnimConfig::linear(100));
+    let v = ctrl.value();
+    // Already at 0.0; reverse() targets 0.0 → immediate finish.
+    ctrl.reverse();
+    assert_eq!(__active_count(), 0);
+    assert!(approx(v.get_untracked(), 0.0));
+}

--- a/crates/whisker-animation/src/tween.rs
+++ b/crates/whisker-animation/src/tween.rs
@@ -1,0 +1,61 @@
+//! [`Tween<T>`] — a pure, reusable `0..1 → T` mapping, and the
+//! [`animated`] convenience constructor.
+
+use whisker_runtime::reactive::{ReadSignal, computed};
+
+use crate::animatable::Animatable;
+use crate::config::AnimConfig;
+use crate::controller::AnimationController;
+
+/// A stateless interpolation definition: maps a controller's `0..1`
+/// progress to a value of type `T`. Reusable — one `Tween` can be
+/// `animate`d against different controllers, and one controller can
+/// drive several tweens.
+#[derive(Clone)]
+pub struct Tween<T: Animatable> {
+    from: T,
+    to: T,
+}
+
+impl<T: Animatable + PartialEq> Tween<T> {
+    /// Define a tween from `from` (progress `0.0`) to `to` (progress
+    /// `1.0`).
+    pub fn new(from: T, to: T) -> Self {
+        Self { from, to }
+    }
+
+    /// Tie this tween to `ctrl`, returning a [`ReadSignal<T>`] that
+    /// tracks `T::lerp(from, to, ctrl.value())` — recomputed each time
+    /// the controller's progress changes. The value is consumable
+    /// anywhere in the reactive graph.
+    pub fn animate(&self, ctrl: &AnimationController) -> ReadSignal<T> {
+        let from = self.from.clone();
+        let to = self.to.clone();
+        let progress = ctrl.value();
+        computed(move || T::lerp(&from, &to, progress.get()))
+    }
+}
+
+/// Build a single-value animated signal and its controller together.
+///
+/// Sugar for the common case: `animated(from, to, cfg)` constructs a
+/// [`Tween`] from `from` to `to`, a fresh [`AnimationController`] for
+/// `cfg`, and returns `(value_signal, controller)`.
+///
+/// **No auto-play** — nothing moves until you drive the controller
+/// (`ctrl.forward()` / `ctrl.reverse()` / …). This is the only
+/// `animated` form; the auto-playing variant is deliberately omitted.
+///
+/// ```ignore
+/// let (x, ctrl) = animated(0.0_f32, 100.0, AnimConfig::ease_out(300));
+/// ctrl.forward(); // you decide when it runs
+/// ```
+pub fn animated<T: Animatable + PartialEq>(
+    from: T,
+    to: T,
+    cfg: AnimConfig,
+) -> (ReadSignal<T>, AnimationController) {
+    let ctrl = AnimationController::new(cfg);
+    let value = Tween::new(from, to).animate(&ctrl);
+    (value, ctrl)
+}

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -391,6 +391,15 @@ fn tick_frame() {
         // survives.
         remount_components_for(&patched);
     }
+    // Advance the continuous animation engine (whisker-animation) by
+    // one frame *before* the reactive flush, so any progress signal it
+    // writes is drained and painted in this same frame. `step` feeds a
+    // monotonic millisecond timestamp; the engine derives each
+    // controller's progress from elapsed time, sets its value signal,
+    // and reports (via `anim_hook::is_animating`, ORed into
+    // `has_pending_work`) whether the host should schedule another
+    // frame. No-op when no controller is active — idle costs nothing.
+    whisker_runtime::anim_hook::step(monotonic_millis());
     reactive_flush();
     // Drive any async tasks (resource() fetchers, user-spawned
     // futures) until they stall. Tasks that resolve here may write
@@ -420,6 +429,19 @@ fn tick_frame() {
         reactive_flush_mounts();
         renderer_flush();
     }
+}
+
+/// Monotonic wall-clock time in milliseconds, measured from a fixed
+/// process-start anchor. Feeds the animation engine's per-frame
+/// `step` so progress advances by real elapsed time. Uses `Instant`
+/// (monotonic, never goes backwards) rather than `SystemTime` so a
+/// clock adjustment can't jump or stall an animation.
+fn monotonic_millis() -> f64 {
+    use std::sync::OnceLock;
+    use std::time::Instant;
+    static ANCHOR: OnceLock<Instant> = OnceLock::new();
+    let anchor = ANCHOR.get_or_init(Instant::now);
+    anchor.elapsed().as_secs_f64() * 1000.0
 }
 
 #[cfg(feature = "hot-reload")]

--- a/crates/whisker-runtime/src/anim_hook.rs
+++ b/crates/whisker-runtime/src/anim_hook.rs
@@ -1,0 +1,96 @@
+//! Frame-driving hook for the continuous animation engine.
+//!
+//! The animation engine (`whisker-animation`) is a *separate* crate
+//! that depends on this one — so this runtime crate cannot name its
+//! `AnimationScheduler` directly (that would be a dependency cycle).
+//! Instead the runtime exposes a tiny inversion-of-control surface:
+//!
+//! - The engine registers a **per-frame step callback** via
+//!   [`set_step_callback`]. The callback advances every active
+//!   controller by the elapsed wall-clock time and returns whether
+//!   *any* controller is still animating.
+//! - Each frame, the driver's `tick_frame` calls [`step`], which
+//!   invokes the registered callback and latches its "still animating"
+//!   result into a thread-local flag.
+//! - [`is_animating`] reports that flag. The reactive scheduler's
+//!   [`has_pending_work`](crate::reactive::has_pending_work) ORs it in,
+//!   so the host keeps its vsync loop running while an animation is in
+//!   flight and releases it the moment the last controller finishes —
+//!   matching the runtime's level-triggered idle model.
+//!
+//! This keeps the runtime ignorant of *how* animation works (curves,
+//! tweens, springs) while still owning the one thing only it can own:
+//! the decision to keep ticking. Engine logic, types, and tests all
+//! live in `whisker-animation`.
+//!
+//! Single-threaded, like the rest of the reactive runtime: everything
+//! here lives in a `thread_local!` and runs on the TASM thread.
+
+use std::cell::Cell;
+use std::cell::RefCell;
+
+/// Signature of the engine's per-frame advance callback.
+///
+/// Receives the current monotonic timestamp in **milliseconds**
+/// (injectable for tests; the driver feeds it a real monotonic clock).
+/// Returns `true` if at least one controller is still animating after
+/// this step — i.e. the host should schedule another frame.
+pub type StepCallback = Box<dyn FnMut(f64) -> bool>;
+
+thread_local! {
+    /// The engine's registered step callback, if any.
+    static STEP: RefCell<Option<StepCallback>> = const { RefCell::new(None) };
+    /// Latched "is anything animating right now" flag. Written by
+    /// [`step`], read by [`is_animating`].
+    static ANIMATING: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Register the engine's per-frame step callback. Called once by
+/// `whisker-animation` when its scheduler is first touched on this
+/// thread. Passing a new callback replaces any previous one.
+pub fn set_step_callback(cb: StepCallback) {
+    STEP.with(|s| *s.borrow_mut() = Some(cb));
+}
+
+/// Advance the animation engine by one frame at monotonic time
+/// `now_ms` (milliseconds). Invokes the registered step callback (if
+/// any) and latches whether anything is still animating.
+///
+/// Called once per frame from the driver's `tick_frame`. A no-op (and
+/// clears the animating flag) when no engine is registered.
+pub fn step(now_ms: f64) {
+    // Take the callback out of the cell so the engine body — which may
+    // re-enter the runtime to write signals — never runs while we hold
+    // the `STEP` borrow. Mirrors the scheduler's compute-Rc pattern.
+    let cb = STEP.with(|s| s.borrow_mut().take());
+    let Some(mut cb) = cb else {
+        ANIMATING.with(|a| a.set(false));
+        return;
+    };
+    let still = cb(now_ms);
+    STEP.with(|s| *s.borrow_mut() = Some(cb));
+    ANIMATING.with(|a| a.set(still));
+}
+
+/// Whether any controller was still animating as of the last [`step`].
+///
+/// `has_pending_work()` ORs this in so the host keeps ticking while an
+/// animation is in flight.
+pub fn is_animating() -> bool {
+    ANIMATING.with(|a| a.get())
+}
+
+/// Directly set the animating flag. The engine calls this when a
+/// controller is registered *between* frames (e.g. `forward()` from an
+/// event handler) so `has_pending_work()` reports busy immediately —
+/// before the next `step` has run — and the host wakes for a frame.
+pub fn mark_animating(active: bool) {
+    ANIMATING.with(|a| a.set(active));
+}
+
+/// (Test only) clear the registered callback and animating flag.
+#[doc(hidden)]
+pub fn __reset_for_tests() {
+    STEP.with(|s| *s.borrow_mut() = None);
+    ANIMATING.with(|a| a.set(false));
+}

--- a/crates/whisker-runtime/src/lib.rs
+++ b/crates/whisker-runtime/src/lib.rs
@@ -20,6 +20,7 @@
 //! pipeline; that retired when the macro switched to emitting
 //! imperative `view::*` calls driven by reactive effects.
 
+pub mod anim_hook;
 pub mod element;
 pub mod event;
 pub mod host_wake;

--- a/crates/whisker-runtime/src/reactive/scheduler.rs
+++ b/crates/whisker-runtime/src/reactive/scheduler.rs
@@ -61,6 +61,7 @@ pub(crate) fn schedule(node: NodeId) {
 /// resume via the main-loop drive, not vsync).
 pub fn has_pending_work() -> bool {
     with_runtime(|rt| !rt.pending.is_empty() || !rt.pending_mounts.is_empty())
+        || crate::anim_hook::is_animating()
 }
 
 /// Drain the pending queue, re-running effects and computeds in the order

--- a/crates/whisker/Cargo.toml
+++ b/crates/whisker/Cargo.toml
@@ -26,6 +26,7 @@ hot-reload = ["whisker-driver/hot-reload", "dep:subsecond"]
 
 [dependencies]
 whisker-runtime = { workspace = true }
+whisker-animation = { workspace = true }
 whisker-macros = { workspace = true }
 whisker-driver = { workspace = true }
 whisker-config = { workspace = true }

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -66,6 +66,14 @@ pub use whisker_runtime as runtime;
 
 pub use whisker_css as css;
 
+// Continuous, signal-based animation engine (Flutter-style
+// AnimationController + Tween). See `docs/animation-design.md`. The
+// public surface is also re-exported flat into the prelude below so
+// `whisker::{animated, AnimationController, Tween, AnimConfig,
+// Animatable, Curve}` work directly.
+pub use whisker_animation as animation;
+pub use whisker_animation::{AnimConfig, Animatable, AnimationController, Curve, Tween, animated};
+
 // The macro expansions reference this through `::whisker::ElementTag`;
 // the C bridge keys element creation off the same enum.
 pub use whisker_runtime::element::ElementTag;


### PR DESCRIPTION
## Summary

Implements **phase 1** of the continuous animation engine described in `docs/animation-design.md`: a Flutter-style `AnimationController` + `Tween` that lives entirely in Rust (no Lynx animator). An animated value is just a `ReadSignal<T>` the reactive runtime advances each frame, with explicit `forward`/`reverse`/`stop`/`set_value` control and **no auto-play**. Idle costs nothing — when no controller is driving, the engine requests no frames.

New crate `crates/whisker-animation` (workspace member + `[workspace.dependencies]` at `0.6.0`), re-exported through the `whisker` prelude.

## Public API

- `Animatable` trait — `lerp(from, to, t)`; impls for `f32` and `whisker_css::Color` (RGBA per-channel; HSL-in-HSL; named-color endpoints snap at the midpoint, since the named→RGB table lives in Lynx, not this crate).
- `Curve` + `AnimConfig` — `linear` / `ease_in` / `ease_out` / `ease_in_out` (cubic) / `cubic_bezier(x1,y1,x2,y2)` (Newton + bisection inversion). Pure `f32 → f32` over `0..1`.
- `AnimationController` — `new(cfg)`, `forward`, `reverse`, `stop`, `animate_to(t)`, `set_value(v)` (one-shot, no self-drive), `value() -> ReadSignal<f32>`, plus `on_finish`, `repeat`, `repeat_reverse`. Distance-proportional duration so scrub→settle runs at a consistent rate. Deregisters on owner dispose via `on_cleanup`.
- `Tween<T>` — `new(from, to)`, `.animate(&ctrl) -> ReadSignal<T>` (= `computed(|| T::lerp(from, to, ctrl.value().get()))`). One controller drives many tweens.
- `animated(from, to, cfg) -> (ReadSignal<T>, AnimationController)` — the single, non-auto-playing convenience form.

## Runtime hook (the frame-driving integration)

The runtime is level-triggered: the host ticks while `has_pending_work()` is true. The engine crate can't be named by the runtime/driver (dependency cycle), so I added a tiny inversion-of-control surface in `whisker-runtime`:

- **New module `whisker_runtime::anim_hook`** — holds a thread-local per-frame `step` callback + a latched `is_animating` flag. The engine registers its scheduler's step fn on first controller creation.
- **`reactive::has_pending_work()`** now ORs in `anim_hook::is_animating()`, so the host keeps its vsync loop running while an animation is in flight and releases it the moment the last controller finishes.
- **`whisker-driver`'s `tick_frame`** calls `anim_hook::step(monotonic_millis())` once per frame, before the reactive flush, so the progress signal it writes is drained and painted the same frame. `monotonic_millis()` is `Instant`-based (monotonic anchor at process start).

This keeps the runtime ignorant of *how* animation works while owning the one thing only it can: the decision to keep ticking.

## Time source (testable)

Progress is derived from a millisecond timestamp passed into `step`. The driver feeds a real monotonic clock; tests inject exact timestamps via `__step_for_tests(now_ms)` (which steps the scheduler then flushes), so frame-stepping is deterministic with no real time passing. Controllers anchor a run's start to the scheduler's last-seen timestamp, so a `forward()` between frames settles correctly.

## Tests

`cargo test -p whisker-animation` — **20 passed**. Covers: `lerp` (f32 + Color endpoints/midpoint/alpha); each curve (endpoints, monotonicity, ease-in/out asymmetry + symmetry, clamping); forward→1.0 / reverse→0.0; idle-when-stopped (active count + `is_animating` + `has_pending_work` all go false on finish); `set_value` one-shot (next frame doesn't move it); one controller driving an f32 + Color tween together; interactive scrub→commit / scrub→cancel; **owner-dispose deregistration** (no leak); deterministic progress at exact frames (linear + ease-in); `on_finish` fires once; `animated()` no-autoplay.

## Verification

- `cargo test -p whisker-animation` — 20 passed; `cargo test -p whisker-runtime` — 136 passed (hook change).
- `cargo build --workspace` — clean.
- `cargo clippy --workspace --all-targets` — 0 warnings.
- `cargo fmt --all -- --check` — clean.

## Design-doc refinements worth noting (possible follow-up)

- The doc's `request_frame`/`set_inline_styles` framing assumes the engine pokes vsync directly. The real runtime is level-triggered through `has_pending_work()` + `tick_frame`, so the cleaner integration is the `anim_hook` IoC surface rather than the engine calling `request_frame` itself.
- `Animatable for Color` can't resolve `Color::Named` to channels (the 147-entry table lives in Lynx). Named endpoints snap at the midpoint; use `Color::rgb(..)` / `Color::hsl(..)` for smooth color tweens. Worth calling out in the "Animatable coverage" open item.
- Springs are listed in the doc but not in this phase (curves first, as instructed); `Curve` is the extension point.

Not wired into the router or any device path — phase 1 is the engine + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)