### PR TITLE
feat(whisker-router): RouteTree + RouteState core (new router, phase 1)

### DIFF
--- a/packages/whisker-router/src/core/mod.rs
+++ b/packages/whisker-router/src/core/mod.rs
@@ -1,0 +1,56 @@
+//! # New router core — `RouteTree` + `RouteState` (phase 1)
+//!
+//! This module is the **pure-logic** model of the redesigned router
+//! described in [`docs/router-design.md`]. It is deliberately free of
+//! the macro, of rendering (`Outlet` / `Stack` components), of signals
+//! and `Element` wiring, and of any device/gesture concern. It is just
+//! the in-memory navigation graph and the operations over it, so the
+//! model can be exhaustively unit-tested without a reactive runtime.
+//!
+//! The old `whisker-router` files (the signal-backed stack) are
+//! untouched and still compile; this `core` module is the new system
+//! and will grow the macro / rendering / device layers in later phases.
+//!
+//! ## The two graphs
+//!
+//! - [`RouteTree`] — the **static** structure: a tree of [`RouteTree`]
+//!   nodes ([`RouteTree::Route`] leaves, [`RouteTree::Stack`] ordered
+//!   containers, [`RouteTree::Switch`] parallel containers). It
+//!   determines URLs and the set of legal targets. Built by hand here
+//!   via the constructor helpers ([`RouteTree::route`],
+//!   [`RouteTree::stack`], [`RouteTree::switch`]) since there is no
+//!   `routes!` macro yet.
+//! - [`RouteState`] — the **dynamic** state: the tree *instantiated*
+//!   with `Stack.history` and `Switch.selected`. The shown screen
+//!   ([`RouteState::current`]) is **derived** by walking the tree — it
+//!   is never stored, so there is no marker that can drift.
+//!
+//! ## Addressing
+//!
+//! Every node has a stable [`NodeId`] (assigned in a pre-order walk at
+//! [`CompiledTree`] build time) and can be addressed positionally by a
+//! [`NodePath`] (the child-index chain from the root). Resolution and
+//! `current` both speak `NodePath`.
+//!
+//! ## Operations
+//!
+//! The five verbs ([`navigate`], [`back`], [`replace`], [`pop_to`],
+//! [`reset`]) live on [`Navigator`], a thin handle wrapping
+//! `&mut RouteState` + `&CompiledTree`.
+//!
+//! [`navigate`]: Navigator::navigate
+//! [`back`]: Navigator::back
+//! [`replace`]: Navigator::replace
+//! [`pop_to`]: Navigator::pop_to
+//! [`reset`]: Navigator::reset
+//! [`docs/router-design.md`]: https://github.com/whiskerrs/whisker/blob/main/docs/router-design.md
+
+pub mod nav;
+pub mod resolve;
+pub mod state;
+pub mod tree;
+
+pub use nav::{NavError, Navigator};
+pub use resolve::{Scope, Target, resolve, resolve_within};
+pub use state::{RouteInstance, RouteState, StackEntry, StackState, SwitchState};
+pub use tree::{CompiledTree, NodeId, NodeInfo, NodePath, RouteDef, RouteTree, SwitchDef};

--- a/packages/whisker-router/src/core/nav.rs
+++ b/packages/whisker-router/src/core/nav.rs
@@ -1,0 +1,432 @@
+//! The [`Navigator`] — the five operations over a [`RouteState`].
+//!
+//! A `Navigator` is a thin handle wrapping `&mut RouteState` +
+//! `&CompiledTree`. Each operation is a mutation of `history` /
+//! `selected`; [`RouteState::current`] recomputes afterward.
+//!
+//! | Op | Effect |
+//! | --- | --- |
+//! | [`navigate`](Navigator::navigate) | resolve target; along root→target select `Switch` branches and **always push** the toward-target `Stack` child; reveal a buried intermediate container by popping entries above it |
+//! | [`back`](Navigator::back) | pop the top of the **deepest non-trivial `Stack`** (history > 1) on the active path; `Switch` selection is never popped; tab-root with nothing to pop → no-op |
+//! | [`replace`](Navigator::replace) | swap the **top** of the current stack with the target; same stack only (else [`NavError::CrossStack`]) |
+//! | [`pop_to`](Navigator::pop_to) | pop the current stack until the target is the top; same stack only |
+//! | [`reset`](Navigator::reset) | replace the **entire** current stack with `[target]` |
+
+use super::resolve::{self, Scope, Target};
+use super::state::{RouteInstance, RouteState, StackEntry, StackState};
+use super::tree::{CompiledTree, NodePath};
+
+/// An error from an operation that cannot be expressed as a clean
+/// mutation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NavError {
+    /// The target id/url matched no node in the tree.
+    NoSuchTarget,
+    /// `replace` / `pop_to` resolved to a node that is **not in the
+    /// current stack**. These operations are same-stack only; crossing a
+    /// `Switch` has no clean meaning, so it is a hard error (use
+    /// `navigate` to cross branches).
+    CrossStack,
+    /// `pop_to` target is not present anywhere in the current stack's
+    /// history.
+    NotInStack,
+}
+
+/// A handle bundling the static tree with the mutable state, exposing
+/// the five navigation verbs.
+pub struct Navigator<'a> {
+    tree: &'a CompiledTree,
+    state: &'a mut RouteState,
+}
+
+impl<'a> Navigator<'a> {
+    /// Wrap a tree + mutable state.
+    pub fn new(tree: &'a CompiledTree, state: &'a mut RouteState) -> Self {
+        Navigator { tree, state }
+    }
+
+    /// The current (shown) leaf instance.
+    pub fn current(&self) -> &RouteInstance {
+        self.state.current()
+    }
+
+    /// The [`NodePath`] of the current leaf.
+    pub fn current_path(&self) -> NodePath {
+        self.state.current().path.clone()
+    }
+
+    // ----- navigate -------------------------------------------------
+
+    /// Navigate to `target` (relative resolution), with no params.
+    pub fn navigate(&mut self, target: &Target) -> Result<(), NavError> {
+        self.navigate_with(target, RouteInstance::new(NodePath::root()))
+    }
+
+    /// Navigate to `target`, attaching the param values from `instance`
+    /// (its `path` is ignored — resolution decides the path).
+    pub fn navigate_with(
+        &mut self,
+        target: &Target,
+        instance: RouteInstance,
+    ) -> Result<(), NavError> {
+        let current = self.current_path();
+        let dest =
+            resolve::resolve(self.tree, target, Some(&current)).ok_or(NavError::NoSuchTarget)?;
+        self.navigate_to_path(&dest, instance.params);
+        Ok(())
+    }
+
+    /// Navigate to `target` within an explicit [`Scope`] (the deferred
+    /// `within` hook). See [`Scope`].
+    pub fn navigate_within(&mut self, target: &Target, scope: &Scope) -> Result<(), NavError> {
+        let current = self.current_path();
+        let dest = resolve::resolve_within(self.tree, target, Some(&current), scope)
+            .ok_or(NavError::NoSuchTarget)?;
+        self.navigate_to_path(&dest, Default::default());
+        Ok(())
+    }
+
+    /// The mechanical part of `navigate`: walk root→`dest`, selecting
+    /// `Switch` branches and pushing `Stack` children, revealing buried
+    /// intermediate containers.
+    fn navigate_to_path(
+        &mut self,
+        dest: &NodePath,
+        params: std::collections::BTreeMap<String, String>,
+    ) {
+        let tree = self.tree;
+        walk_navigate(tree, self.state, dest, 0, &params);
+    }
+
+    // ----- select ---------------------------------------------------
+
+    /// Select the `Switch` branch that leads toward `target`, **without
+    /// pushing** anything onto any `Stack`.
+    ///
+    /// This is the tab-switch primitive (`select_tab` in the design
+    /// doc's `Layout` example): switching tabs is a pure `Switch.selected`
+    /// change that preserves every tab's retained history — unlike
+    /// [`navigate`](Navigator::navigate), which always advances a stack
+    /// by one. `target` is resolved relative to the current position
+    /// (so a `select` to a shared route stays in the most relevant
+    /// branch). Returns the resolved [`NodePath`].
+    ///
+    /// Only `Switch` selections along the path to `target` are changed;
+    /// `Stack` histories are left exactly as they are (the target tab's
+    /// own current screen is whatever it was last left at).
+    pub fn select(&mut self, target: &Target) -> Result<NodePath, NavError> {
+        let current = self.current_path();
+        let dest =
+            resolve::resolve(self.tree, target, Some(&current)).ok_or(NavError::NoSuchTarget)?;
+        select_toward(self.state, &dest, 0);
+        Ok(dest)
+    }
+
+    // ----- back -----------------------------------------------------
+
+    /// Pop the top of the deepest non-trivial `Stack` on the active
+    /// path. Returns `true` if something was popped, `false` for a
+    /// no-op (nothing poppable — e.g. at a tab root).
+    pub fn back(&mut self) -> bool {
+        back_at(self.state)
+    }
+
+    // ----- replace --------------------------------------------------
+
+    /// Swap the **top** of the current stack with `target`. Same stack
+    /// only: if `target` resolves outside the current stack,
+    /// [`NavError::CrossStack`] is returned and the state is unchanged.
+    pub fn replace(&mut self, target: &Target) -> Result<(), NavError> {
+        self.replace_with(target, Default::default())
+    }
+
+    /// Like [`replace`](Navigator::replace) with explicit params.
+    pub fn replace_with(
+        &mut self,
+        target: &Target,
+        params: std::collections::BTreeMap<String, String>,
+    ) -> Result<(), NavError> {
+        let current = self.current_path();
+        let dest =
+            resolve::resolve(self.tree, target, Some(&current)).ok_or(NavError::NoSuchTarget)?;
+
+        let stack_path = deepest_active_stack_path(self.state).ok_or(NavError::CrossStack)?;
+        // The destination must be a *direct child* of the current stack
+        // (same stack only).
+        if !is_child_of(&stack_path, &dest) {
+            return Err(NavError::CrossStack);
+        }
+        let stack = active_stack_mut(self.state).expect("stack exists");
+        let entry = make_entry(self.tree, &dest, params);
+        let top = stack.history.len() - 1;
+        stack.history[top] = entry;
+        Ok(())
+    }
+
+    // ----- pop_to ---------------------------------------------------
+
+    /// Pop the current stack until `target` is the top. Same stack
+    /// only. Errors with [`NavError::CrossStack`] if the target is not a
+    /// child of the current stack, or [`NavError::NotInStack`] if no
+    /// matching entry exists in its history.
+    pub fn pop_to(&mut self, target: &Target) -> Result<(), NavError> {
+        let current = self.current_path();
+        let dest =
+            resolve::resolve(self.tree, target, Some(&current)).ok_or(NavError::NoSuchTarget)?;
+        let stack_path = deepest_active_stack_path(self.state).ok_or(NavError::CrossStack)?;
+        if !is_child_of(&stack_path, &dest) {
+            return Err(NavError::CrossStack);
+        }
+        let stack = active_stack_mut(self.state).expect("stack exists");
+        // Find the deepest (top-most) entry whose child == dest.
+        let idx = stack
+            .history
+            .iter()
+            .rposition(|e| e.child == dest)
+            .ok_or(NavError::NotInStack)?;
+        stack.history.truncate(idx + 1);
+        Ok(())
+    }
+
+    // ----- reset ----------------------------------------------------
+
+    /// Replace the **entire** current stack's history with `[target]`
+    /// (the logout / clear-back-stack case). Same stack only.
+    pub fn reset(&mut self, target: &Target) -> Result<(), NavError> {
+        self.reset_with(target, Default::default())
+    }
+
+    /// Like [`reset`](Navigator::reset) with explicit params.
+    pub fn reset_with(
+        &mut self,
+        target: &Target,
+        params: std::collections::BTreeMap<String, String>,
+    ) -> Result<(), NavError> {
+        let current = self.current_path();
+        let dest =
+            resolve::resolve(self.tree, target, Some(&current)).ok_or(NavError::NoSuchTarget)?;
+        let stack_path = deepest_active_stack_path(self.state).ok_or(NavError::CrossStack)?;
+        if !is_child_of(&stack_path, &dest) {
+            return Err(NavError::CrossStack);
+        }
+        let entry = make_entry(self.tree, &dest, params);
+        let stack = active_stack_mut(self.state).expect("stack exists");
+        stack.history = vec![entry];
+        Ok(())
+    }
+}
+
+// ===================================================================
+// navigate machinery
+// ===================================================================
+
+/// Recursively drive `state` toward `dest`, starting at child-index
+/// `depth` of `dest`.
+///
+/// At each level, `dest.0[depth]` names the child to move toward.
+fn walk_navigate(
+    tree: &CompiledTree,
+    state: &mut RouteState,
+    dest: &NodePath,
+    depth: usize,
+    params: &std::collections::BTreeMap<String, String>,
+) {
+    if depth == dest.0.len() {
+        // `state` is the destination node itself. If it is a leaf, set
+        // its params; if it is a container we've already arrived (the
+        // caller having pushed/selected us here) — nothing more to do.
+        if let RouteState::Route(r) = state {
+            r.params = params.clone();
+        }
+        return;
+    }
+
+    let toward = dest.0[depth];
+    match state {
+        RouteState::Switch(s) => {
+            // Select the branch toward dest, then descend into it.
+            s.selected = toward;
+            walk_navigate(tree, &mut s.branches[toward], dest, depth + 1, params);
+        }
+        RouteState::Stack(s) => {
+            let child_path = s.path.child(toward);
+            // The remaining destination beyond this stack's child.
+            let arrives_at_leaf = depth + 1 == dest.0.len();
+
+            if arrives_at_leaf {
+                // Always push a fresh leaf instance.
+                let mut state_child = RouteState::initial_at(tree, &child_path);
+                if let RouteState::Route(r) = &mut state_child {
+                    r.params = params.clone();
+                }
+                s.history.push(StackEntry {
+                    child: child_path,
+                    state: state_child,
+                });
+            } else {
+                // The destination passes *through* a container child of
+                // this stack. Reveal a buried instance of that container
+                // if present (pop entries above it), preserving its
+                // retained `selected`/`history`; otherwise push a fresh
+                // one. Then descend.
+                let i = reveal_or_push(tree, s, &child_path);
+                walk_navigate(tree, &mut s.history[i].state, dest, depth + 1, params);
+            }
+        }
+        RouteState::Route(_) => {
+            // Shouldn't be reachable: a Route is a leaf, dest passes
+            // through it only as the final element (handled above).
+        }
+    }
+}
+
+/// Drive only the `Switch` selections along the path to `dest`,
+/// touching no `Stack` history. Used by [`Navigator::select`].
+///
+/// At a `Stack` we follow the **currently active** entry if it leads
+/// toward `dest` (a buried container is *not* revealed and nothing is
+/// pushed — `select` is non-destructive); if the active entry does not
+/// lead toward `dest`, the descent simply stops (the relevant Switch
+/// selections above it have already been set).
+fn select_toward(state: &mut RouteState, dest: &NodePath, depth: usize) {
+    if depth == dest.0.len() {
+        return;
+    }
+    let toward = dest.0[depth];
+    match state {
+        RouteState::Switch(s) => {
+            s.selected = toward;
+            select_toward(&mut s.branches[toward], dest, depth + 1);
+        }
+        RouteState::Stack(s) => {
+            // Follow the active top only if it already leads toward dest.
+            let top = s.history.len() - 1;
+            if s.history[top].child.0.last() == Some(&toward) {
+                select_toward(&mut s.history[top].state, dest, depth + 1);
+            }
+        }
+        RouteState::Route(_) => {}
+    }
+}
+
+/// Reveal a buried container instance of `child_path` in `stack`, or
+/// push a fresh one. Returns the history index to descend into.
+///
+/// "Reveal" = if an existing entry for this exact container child is in
+/// the history, pop everything above it (so it becomes the active top)
+/// and keep its retained nested state. This is the buried-tabs case:
+/// `navigate` to a tab route from an outside route reveals the tabs
+/// `Switch` rather than minting a second one.
+fn reveal_or_push(tree: &CompiledTree, stack: &mut StackState, child_path: &NodePath) -> usize {
+    if let Some(i) = stack.history.iter().position(|e| e.child == *child_path) {
+        // Reveal: drop everything above the existing container entry.
+        stack.history.truncate(i + 1);
+        i
+    } else {
+        let state_child = RouteState::initial_at(tree, child_path);
+        stack.history.push(StackEntry {
+            child: child_path.clone(),
+            state: state_child,
+        });
+        stack.history.len() - 1
+    }
+}
+
+/// Build a [`StackEntry`] for a leaf or container `dest` with `params`.
+fn make_entry(
+    tree: &CompiledTree,
+    dest: &NodePath,
+    params: std::collections::BTreeMap<String, String>,
+) -> StackEntry {
+    let mut state = RouteState::initial_at(tree, dest);
+    if let RouteState::Route(r) = &mut state {
+        r.params = params;
+    }
+    StackEntry {
+        child: dest.clone(),
+        state,
+    }
+}
+
+// ===================================================================
+// back machinery
+// ===================================================================
+
+/// Pop the deepest non-trivial `Stack` (history > 1) on the active
+/// path. Returns whether anything was popped.
+///
+/// We recurse to the bottom of the active chain first, so the
+/// **deepest** poppable stack wins; a higher stack only pops if no
+/// deeper one could.
+fn back_at(state: &mut RouteState) -> bool {
+    match state {
+        RouteState::Route(_) => false,
+        RouteState::Switch(s) => {
+            let sel = s.selected;
+            back_at(&mut s.branches[sel])
+        }
+        RouteState::Stack(s) => {
+            let top = s.history.len() - 1;
+            // Try to pop deeper first.
+            if back_at(&mut s.history[top].state) {
+                return true;
+            }
+            // Otherwise pop this stack if non-trivial.
+            if s.history.len() > 1 {
+                s.history.pop();
+                true
+            } else {
+                false
+            }
+        }
+    }
+}
+
+// ===================================================================
+// active-stack helpers (for replace / pop_to / reset)
+// ===================================================================
+
+/// The path of the deepest `Stack` on the active path (the stack whose
+/// top is/leads to the current leaf). `None` if there is no stack on the
+/// active path at all.
+fn deepest_active_stack_path(state: &RouteState) -> Option<NodePath> {
+    let mut found: Option<NodePath> = None;
+    for node in state.active_chain() {
+        if let RouteState::Stack(s) = node {
+            found = Some(s.path.clone());
+        }
+    }
+    found
+}
+
+/// A mutable reference to the deepest `Stack` on the active path.
+fn active_stack_mut(state: &mut RouteState) -> Option<&mut StackState> {
+    // Walk down the active path, remembering the deepest stack via raw
+    // recursion that returns the deepest one.
+    fn go(state: &mut RouteState) -> Option<&mut StackState> {
+        match state {
+            RouteState::Route(_) => None,
+            RouteState::Switch(s) => {
+                let sel = s.selected;
+                go(&mut s.branches[sel])
+            }
+            RouteState::Stack(s) => {
+                let top = s.history.len() - 1;
+                // Prefer a deeper stack if one exists on the active path.
+                let has_deeper = deepest_active_stack_path(&s.history[top].state).is_some();
+                if has_deeper {
+                    go(&mut s.history[top].state)
+                } else {
+                    Some(s)
+                }
+            }
+        }
+    }
+    go(state)
+}
+
+/// Whether `child` is a direct child of `parent` (parent path + one
+/// index).
+fn is_child_of(parent: &NodePath, child: &NodePath) -> bool {
+    child.0.len() == parent.0.len() + 1 && child.0[..parent.0.len()] == parent.0[..]
+}

--- a/packages/whisker-router/src/core/resolve.rs
+++ b/packages/whisker-router/src/core/resolve.rs
@@ -1,0 +1,138 @@
+//! Relative resolution: which **instance** of an (often shared) target
+//! does a [`navigate`](super::nav::Navigator::navigate) hit?
+//!
+//! > Among nodes matching the target, pick the one whose path shares the
+//! > **deepest common ancestor with the current position**. Break ties
+//! > by **declaration order** (first defined wins).
+//!
+//! Operationally ([`resolve`]): walk up from the current leaf to the
+//! root; the first (deepest) ancestor whose subtree contains a match
+//! resolves it; within that subtree, declaration (pre-order) order
+//! breaks ties. Cold start (no current) resolves from the root, i.e.
+//! pure declaration order.
+
+use super::tree::{CompiledTree, NodePath};
+
+/// A target to resolve: either a nav-target id ([`RouteDef::id`]) or a
+/// full URL.
+///
+/// [`RouteDef::id`]: super::tree::RouteDef::id
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Target {
+    /// Match by nav-target identity (the deduped shared-route case).
+    Id(String),
+    /// Match by derived full URL.
+    Url(String),
+}
+
+impl Target {
+    /// A target by nav-target id.
+    pub fn id(id: impl Into<String>) -> Self {
+        Target::Id(id.into())
+    }
+
+    /// A target by URL.
+    pub fn url(url: impl Into<String>) -> Self {
+        Target::Url(url.into())
+    }
+}
+
+/// An explicit resolution-scope override hook (`within(scope)`).
+///
+/// This is the rare cross-branch case (`route::post(42).within(
+/// scope::search)`). The **API surface is provided** so callers can be
+/// written against it, but full behaviour is deferred to a later phase
+/// per the design doc's open items; [`resolve_within`] currently
+/// restricts the candidate set to the scope subtree and then applies the
+/// ordinary deepest-common-ancestor rule within it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Scope {
+    /// The subtree to resolve within (a container node's path).
+    pub root: NodePath,
+}
+
+impl Scope {
+    /// A scope rooted at `path`.
+    pub fn at(path: NodePath) -> Self {
+        Scope { root: path }
+    }
+}
+
+/// All static paths matching `target`, in declaration order.
+fn candidates(tree: &CompiledTree, target: &Target) -> Vec<NodePath> {
+    match target {
+        Target::Id(id) => tree.paths_with_route_id(id),
+        Target::Url(url) => tree.paths_with_url(url),
+    }
+}
+
+/// Resolve `target` relative to `current` (the path of the current
+/// leaf, or `None` for cold start).
+///
+/// Returns the chosen candidate's [`NodePath`], or `None` if nothing
+/// matches.
+pub fn resolve(
+    tree: &CompiledTree,
+    target: &Target,
+    current: Option<&NodePath>,
+) -> Option<NodePath> {
+    let cands = candidates(tree, target);
+    if cands.is_empty() {
+        return None;
+    }
+
+    match current {
+        // Cold start: resolve from the root ⇒ pure declaration order.
+        None => Some(cands[0].clone()),
+        Some(cur) => {
+            // Walk up from the current leaf's ancestors (deepest first):
+            // current itself, then its parent, ... up to the root.
+            // The first ancestor whose subtree contains a candidate
+            // wins; declaration order (candidates are pre-ordered)
+            // breaks ties within it.
+            for depth in (0..=cur.len()).rev() {
+                let ancestor = NodePath(cur.0[..depth].to_vec());
+                if let Some(found) = cands.iter().find(|c| ancestor.is_ancestor_of(c)) {
+                    return Some(found.clone());
+                }
+            }
+            // Unreachable in a well-formed tree (root is an ancestor of
+            // everything), but stay total.
+            Some(cands[0].clone())
+        }
+    }
+}
+
+/// Resolve `target` restricted to `scope`'s subtree, then by the
+/// ordinary relative rule within it. See [`Scope`] (deferred behaviour).
+pub fn resolve_within(
+    tree: &CompiledTree,
+    target: &Target,
+    current: Option<&NodePath>,
+    scope: &Scope,
+) -> Option<NodePath> {
+    let cands: Vec<NodePath> = candidates(tree, target)
+        .into_iter()
+        .filter(|c| scope.root.is_ancestor_of(c))
+        .collect();
+    if cands.is_empty() {
+        return None;
+    }
+    // Prefer a candidate sharing the deepest ancestor with current,
+    // falling back to declaration order within the scope.
+    match current {
+        None => Some(cands[0].clone()),
+        Some(cur) => {
+            for depth in (0..=cur.len()).rev() {
+                let ancestor = NodePath(cur.0[..depth].to_vec());
+                if !scope.root.is_ancestor_of(&ancestor) && ancestor != scope.root {
+                    continue;
+                }
+                if let Some(found) = cands.iter().find(|c| ancestor.is_ancestor_of(c)) {
+                    return Some(found.clone());
+                }
+            }
+            Some(cands[0].clone())
+        }
+    }
+}

--- a/packages/whisker-router/src/core/state.rs
+++ b/packages/whisker-router/src/core/state.rs
@@ -1,0 +1,195 @@
+//! The dynamic [`RouteState`] — the [`CompiledTree`] *instantiated*
+//! with runtime navigation state.
+//!
+//! The state tree mirrors the static tree's shape, carrying exactly two
+//! kinds of mutable state:
+//!
+//! - [`StackState`] (for a `Stack` node): a `history` of [`StackEntry`]s.
+//!   Each entry is a child *instance* — a `Route` instance carries its
+//!   concrete param values; a container entry carries the nested
+//!   [`RouteState`] of that whole subtree.
+//! - [`SwitchState`] (for a `Switch` node): a `selected` branch index,
+//!   plus the (lazily built) nested state of every branch so each branch
+//!   keeps its own history while buried.
+//!
+//! There is **no stored `current`**. [`RouteState::current`] derives the
+//! active leaf every time by walking `history.top` / `selected`.
+
+use std::collections::BTreeMap;
+
+use super::tree::{CompiledTree, NodePath, RouteTree, SwitchDef};
+
+/// The runtime state of one node, mirroring the static tree's shape.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RouteState {
+    /// A leaf instance carrying its concrete param values (segment
+    /// name → value). A bare route has an empty map.
+    Route(RouteInstance),
+    /// An ordered container's history.
+    Stack(StackState),
+    /// A parallel container's selection + per-branch nested state.
+    Switch(SwitchState),
+}
+
+/// A concrete `Route` instance: which static node it is + its param
+/// values.
+///
+/// `post(1)` and `post(2)` are two distinct instances of the same
+/// static `Route` node, differing only in [`params`](RouteInstance::params).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RouteInstance {
+    /// The static node this instantiates.
+    pub path: NodePath,
+    /// Concrete param values, keyed by segment name (e.g. `id` → `42`).
+    pub params: BTreeMap<String, String>,
+}
+
+impl RouteInstance {
+    /// A bare route instance with no params.
+    pub fn new(path: NodePath) -> Self {
+        RouteInstance {
+            path,
+            params: BTreeMap::new(),
+        }
+    }
+
+    /// A route instance with one param.
+    pub fn with_param(path: NodePath, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let mut params = BTreeMap::new();
+        params.insert(key.into(), value.into());
+        RouteInstance { path, params }
+    }
+}
+
+/// One entry in a [`StackState`]'s history: a child instance.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StackEntry {
+    /// The static child this entry instantiates (a child index of the
+    /// owning `Stack`, expressed as a full [`NodePath`]).
+    pub child: NodePath,
+    /// The nested runtime state of that child subtree.
+    pub state: RouteState,
+}
+
+/// A `Stack` node's runtime state: its non-empty history.
+///
+/// The **top** of `history` is the active child.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StackState {
+    /// The static node this instantiates.
+    pub path: NodePath,
+    /// The entered children, oldest first; the last is the active one.
+    /// Invariant: never empty after [`RouteState::initial`].
+    pub history: Vec<StackEntry>,
+}
+
+/// A `Switch` node's runtime state: which branch is selected + every
+/// branch's nested state.
+///
+/// All branches are kept alive (the parallel-container property), so a
+/// buried tab retains its own history.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SwitchState {
+    /// The static node this instantiates.
+    pub path: NodePath,
+    /// The selected branch index.
+    pub selected: usize,
+    /// Nested state for every branch, by branch index.
+    pub branches: Vec<RouteState>,
+}
+
+impl RouteState {
+    /// Build the **initial** state for a whole [`CompiledTree`]: every
+    /// `Stack` seeded with its first child, every `Switch` set to its
+    /// declared default branch (else `0`), recursively.
+    pub fn initial(tree: &CompiledTree) -> RouteState {
+        Self::initial_at(tree, &NodePath::root())
+    }
+
+    /// Build the initial state for the subtree rooted at `path`.
+    pub fn initial_at(tree: &CompiledTree, path: &NodePath) -> RouteState {
+        let node = tree
+            .node_at(path)
+            .expect("initial_at: path must address a node in the tree");
+        match node {
+            RouteTree::Route(_) => RouteState::Route(RouteInstance::new(path.clone())),
+            RouteTree::Stack(children) => {
+                assert!(!children.is_empty(), "a Stack must have at least one child");
+                let child_path = path.child(0);
+                RouteState::Stack(StackState {
+                    path: path.clone(),
+                    history: vec![StackEntry {
+                        child: child_path.clone(),
+                        state: Self::initial_at(tree, &child_path),
+                    }],
+                })
+            }
+            RouteTree::Switch(def, branches) => {
+                assert!(
+                    !branches.is_empty(),
+                    "a Switch must have at least one branch"
+                );
+                let selected = clamp_default(def, branches.len());
+                let branch_states = (0..branches.len())
+                    .map(|i| Self::initial_at(tree, &path.child(i)))
+                    .collect();
+                RouteState::Switch(SwitchState {
+                    path: path.clone(),
+                    selected,
+                    branches: branch_states,
+                })
+            }
+        }
+    }
+
+    /// The [`NodePath`] of the static node this state instantiates.
+    pub fn path(&self) -> &NodePath {
+        match self {
+            RouteState::Route(r) => &r.path,
+            RouteState::Stack(s) => &s.path,
+            RouteState::Switch(s) => &s.path,
+        }
+    }
+
+    /// Derive the **current** (shown) leaf: walk root → (Stack:
+    /// history.top, Switch: selected) → leaf.
+    ///
+    /// `current` is computed, never stored — there is no marker field
+    /// anywhere in [`RouteState`].
+    pub fn current(&self) -> &RouteInstance {
+        match self {
+            RouteState::Route(r) => r,
+            RouteState::Stack(s) => s
+                .history
+                .last()
+                .expect("Stack history is never empty")
+                .state
+                .current(),
+            RouteState::Switch(s) => s.branches[s.selected].current(),
+        }
+    }
+
+    /// The active path from this node down to the current leaf, as the
+    /// sequence of [`RouteState`] nodes visited (this node first, the
+    /// leaf last).
+    pub fn active_chain(&self) -> Vec<&RouteState> {
+        let mut chain = vec![self];
+        let mut node = self;
+        loop {
+            let next = match node {
+                RouteState::Route(_) => break,
+                RouteState::Stack(s) => &s.history.last().expect("non-empty").state,
+                RouteState::Switch(s) => &s.branches[s.selected],
+            };
+            chain.push(next);
+            node = next;
+        }
+        chain
+    }
+}
+
+/// Clamp a `Switch`'s declared default to a legal branch index.
+fn clamp_default(def: &SwitchDef, branch_count: usize) -> usize {
+    let d = def.default_branch();
+    if d < branch_count { d } else { 0 }
+}

--- a/packages/whisker-router/src/core/tree.rs
+++ b/packages/whisker-router/src/core/tree.rs
@@ -1,0 +1,355 @@
+//! The static [`RouteTree`] and its compiled, addressable form
+//! [`CompiledTree`].
+//!
+//! A [`RouteTree`] is the hand-written description of the app's screen
+//! structure. Because there is no `routes!` macro yet, trees are built
+//! with the constructor helpers ([`RouteTree::route`],
+//! [`RouteTree::stack`], [`RouteTree::switch`]).
+//!
+//! [`CompiledTree`] wraps a `RouteTree` and pre-computes, in a
+//! pre-order walk, a flat table of node metadata keyed by [`NodeId`],
+//! plus parent links and full URLs — everything resolution and URL
+//! derivation need without re-walking the tree each time.
+
+use std::collections::BTreeMap;
+
+/// A stable identity for a node, assigned in pre-order at
+/// [`CompiledTree`] build time.
+///
+/// Two *different* nodes always get different `NodeId`s. Logical
+/// **nav-target identity** (the "shared route deduped to one target"
+/// case) is expressed separately by [`RouteDef::id`], not by `NodeId`:
+/// the same `post/:id` route spread into several tabs is several
+/// distinct `NodeId`s that share one [`RouteDef::id`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeId(pub usize);
+
+/// A positional address: the chain of child indices from the root to a
+/// node.
+///
+/// The root is `NodePath(vec![])`. A `Switch`'s third branch reached
+/// through the root stack's first entry is `NodePath(vec![0, 2])`.
+/// `NodePath` is what [`RouteState::current`](crate::core::RouteState::current)
+/// returns and what resolution produces.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct NodePath(pub Vec<usize>);
+
+impl NodePath {
+    /// The root path (empty).
+    pub fn root() -> Self {
+        NodePath(Vec::new())
+    }
+
+    /// A child path: `self` extended by `index`.
+    pub fn child(&self, index: usize) -> Self {
+        let mut v = self.0.clone();
+        v.push(index);
+        NodePath(v)
+    }
+
+    /// Depth (number of edges from the root).
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether this is the root path.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Whether `self` is an ancestor of (or equal to) `other`.
+    pub fn is_ancestor_of(&self, other: &NodePath) -> bool {
+        other.0.len() >= self.0.len() && other.0[..self.0.len()] == self.0[..]
+    }
+}
+
+/// The param spec + identity of a leaf screen.
+///
+/// For this phase, params are just the **names** of the dynamic
+/// segments (e.g. `["id"]` for `post/:id`); typed params are the
+/// macro's job in a later phase.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RouteDef {
+    /// The path segment as written, e.g. `""`, `"search"`,
+    /// `"post/:id"`. May contain multiple `/`-joined parts and any
+    /// number of `:name` dynamic segments.
+    pub segment: String,
+    /// The nav-target identity. The same logical route spread into
+    /// several stacks shares one `id` (dedupe), even though each
+    /// placement is a distinct [`NodeId`].
+    pub id: String,
+    /// The names of the dynamic (`:name`) segments, in order.
+    pub params: Vec<String>,
+}
+
+impl RouteDef {
+    /// Build a [`RouteDef`] from a segment and an id, extracting the
+    /// `:name` param names from the segment automatically.
+    pub fn new(segment: impl Into<String>, id: impl Into<String>) -> Self {
+        let segment = segment.into();
+        let params = segment
+            .split('/')
+            .filter_map(|p| p.strip_prefix(':').map(str::to_string))
+            .collect();
+        RouteDef {
+            segment,
+            id: id.into(),
+            params,
+        }
+    }
+}
+
+/// Optional configuration for a [`RouteTree::Switch`].
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct SwitchDef {
+    /// An optional identifier (for debugging / `within(scope)` targeting).
+    pub id: Option<String>,
+    /// The branch selected on cold start (when `selected` is otherwise
+    /// undefined). `None` falls back to branch `0` (declaration order).
+    pub default: Option<usize>,
+}
+
+impl SwitchDef {
+    /// A switch with a named id and an explicit default branch.
+    pub fn new(id: impl Into<String>, default: usize) -> Self {
+        SwitchDef {
+            id: Some(id.into()),
+            default: Some(default),
+        }
+    }
+
+    /// The default branch index (the declared default, else `0`).
+    pub fn default_branch(&self) -> usize {
+        self.default.unwrap_or(0)
+    }
+}
+
+/// The static route structure: a tree of three node kinds.
+///
+/// Built by hand here with [`RouteTree::route`], [`RouteTree::stack`]
+/// and [`RouteTree::switch`]. Wrap in a [`CompiledTree`] to address and
+/// query it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RouteTree {
+    /// A leaf screen with a path segment + param spec.
+    Route(RouteDef),
+    /// An **ordered** container: push/pop, has history.
+    Stack(Vec<RouteTree>),
+    /// A **parallel** container: keeps all branches alive, selects one,
+    /// no history.
+    Switch(SwitchDef, Vec<RouteTree>),
+}
+
+impl RouteTree {
+    /// A leaf [`RouteTree::Route`] from a segment + id.
+    pub fn route(segment: impl Into<String>, id: impl Into<String>) -> Self {
+        RouteTree::Route(RouteDef::new(segment, id))
+    }
+
+    /// A [`RouteTree::Stack`] from its ordered children.
+    pub fn stack(children: Vec<RouteTree>) -> Self {
+        RouteTree::Stack(children)
+    }
+
+    /// A [`RouteTree::Switch`] from a [`SwitchDef`] and its branches.
+    pub fn switch(def: SwitchDef, branches: Vec<RouteTree>) -> Self {
+        RouteTree::Switch(def, branches)
+    }
+
+    /// The children of a container node (empty for a `Route`).
+    pub fn children(&self) -> &[RouteTree] {
+        match self {
+            RouteTree::Route(_) => &[],
+            RouteTree::Stack(c) => c,
+            RouteTree::Switch(_, c) => c,
+        }
+    }
+}
+
+/// Per-node metadata pre-computed by [`CompiledTree`].
+#[derive(Clone, Debug)]
+pub struct NodeInfo {
+    /// Stable identity (pre-order index).
+    pub id: NodeId,
+    /// Positional address.
+    pub path: NodePath,
+    /// Path of the parent (`None` for the root).
+    pub parent: Option<NodePath>,
+    /// The [`RouteDef::id`] if this is a `Route`, else `None`.
+    pub route_id: Option<String>,
+    /// The full URL of this node if it is a `Route`, else `None`.
+    pub url: Option<String>,
+}
+
+/// A [`RouteTree`] wrapped with a pre-computed, addressable metadata
+/// table.
+///
+/// Build with [`CompiledTree::new`]. Lookups by [`NodePath`] are
+/// `O(depth)`; lookups by [`NodeId`] are `O(log n)`.
+#[derive(Clone, Debug)]
+pub struct CompiledTree {
+    root: RouteTree,
+    // NodePath → info, keyed by the path vec for ordered iteration.
+    by_path: BTreeMap<Vec<usize>, NodeInfo>,
+    by_id: BTreeMap<usize, NodePath>,
+}
+
+impl CompiledTree {
+    /// Compile a [`RouteTree`], assigning [`NodeId`]s in pre-order and
+    /// pre-computing parents + URLs.
+    pub fn new(root: RouteTree) -> Self {
+        let mut by_path = BTreeMap::new();
+        let mut by_id = BTreeMap::new();
+        let mut counter = 0usize;
+        Self::walk(
+            &root,
+            NodePath::root(),
+            None,
+            String::new(),
+            &mut counter,
+            &mut by_path,
+            &mut by_id,
+        );
+        CompiledTree {
+            root,
+            by_path,
+            by_id,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn walk(
+        node: &RouteTree,
+        path: NodePath,
+        parent: Option<NodePath>,
+        url_so_far: String,
+        counter: &mut usize,
+        by_path: &mut BTreeMap<Vec<usize>, NodeInfo>,
+        by_id: &mut BTreeMap<usize, NodePath>,
+    ) {
+        let id = NodeId(*counter);
+        *counter += 1;
+
+        let (route_id, this_url, child_url_base) = match node {
+            RouteTree::Route(def) => {
+                let url = join_url(&url_so_far, &def.segment);
+                (Some(def.id.clone()), Some(url.clone()), url)
+            }
+            // Containers are pathless: they contribute nothing to the URL.
+            RouteTree::Stack(_) | RouteTree::Switch(_, _) => (None, None, url_so_far.clone()),
+        };
+
+        by_path.insert(
+            path.0.clone(),
+            NodeInfo {
+                id,
+                path: path.clone(),
+                parent,
+                route_id,
+                url: this_url,
+            },
+        );
+        by_id.insert(id.0, path.clone());
+
+        for (i, child) in node.children().iter().enumerate() {
+            Self::walk(
+                child,
+                path.child(i),
+                Some(path.clone()),
+                child_url_base.clone(),
+                counter,
+                by_path,
+                by_id,
+            );
+        }
+    }
+
+    /// The root node.
+    pub fn root(&self) -> &RouteTree {
+        &self.root
+    }
+
+    /// The node at `path`, if any.
+    pub fn node_at(&self, path: &NodePath) -> Option<&RouteTree> {
+        let mut node = &self.root;
+        for &idx in &path.0 {
+            node = node.children().get(idx)?;
+        }
+        Some(node)
+    }
+
+    /// Metadata for the node at `path`.
+    pub fn info_at(&self, path: &NodePath) -> Option<&NodeInfo> {
+        self.by_path.get(&path.0)
+    }
+
+    /// The [`NodePath`] of a node addressed by [`NodeId`].
+    pub fn path_of_id(&self, id: NodeId) -> Option<&NodePath> {
+        self.by_id.get(&id.0)
+    }
+
+    /// The full URL of the route at `path` (pathless containers → `None`).
+    ///
+    /// This is the segment-concatenation derivation: walk from the root,
+    /// joining each `Route`'s static segment parts; containers
+    /// contribute nothing.
+    pub fn url_of(&self, path: &NodePath) -> Option<String> {
+        self.info_at(path).and_then(|i| i.url.clone())
+    }
+
+    /// All [`NodePath`]s whose `Route` has the given [`RouteDef::id`],
+    /// in **declaration order** (pre-order).
+    pub fn paths_with_route_id(&self, route_id: &str) -> Vec<NodePath> {
+        self.by_path
+            .values()
+            .filter(|i| i.route_id.as_deref() == Some(route_id))
+            .map(|i| i.path.clone())
+            .collect()
+    }
+
+    /// All [`NodePath`]s whose `Route` derives the given full URL, in
+    /// declaration order. (Two different ids may share a URL — the
+    /// resolvable-ambiguity case.)
+    pub fn paths_with_url(&self, url: &str) -> Vec<NodePath> {
+        self.by_path
+            .values()
+            .filter(|i| i.url.as_deref() == Some(url))
+            .map(|i| i.path.clone())
+            .collect()
+    }
+
+    /// Iterate every node's metadata in declaration (pre-order) order.
+    pub fn iter_infos(&self) -> impl Iterator<Item = &NodeInfo> {
+        self.by_path.values()
+    }
+}
+
+/// Join the static parts of a route segment onto an accumulated URL.
+///
+/// `:name` dynamic parts are kept as `:name` placeholders in the URL so
+/// `post/:id` derives `/post/:id`. A pathless / empty segment leaves the
+/// base unchanged (apart from ensuring a leading `/` at the root).
+fn join_url(base: &str, segment: &str) -> String {
+    // Build from the segment's own parts, preserving order and :params.
+    let seg_parts: Vec<&str> = segment.split('/').filter(|p| !p.is_empty()).collect();
+
+    if seg_parts.is_empty() {
+        // Pathless route (e.g. the "" home route). Its URL is the base,
+        // normalised to "/" at the root.
+        if base.is_empty() {
+            return "/".to_string();
+        }
+        return base.to_string();
+    }
+
+    let mut url = if base.is_empty() || base == "/" {
+        String::new()
+    } else {
+        base.to_string()
+    };
+    for part in seg_parts {
+        url.push('/');
+        url.push_str(part);
+    }
+    url
+}

--- a/packages/whisker-router/src/lib.rs
+++ b/packages/whisker-router/src/lib.rs
@@ -78,6 +78,7 @@
 #![warn(missing_docs)]
 
 pub mod back_handler;
+pub mod core;
 pub mod gestures;
 pub mod layouts;
 pub mod linking;

--- a/packages/whisker-router/tests/core_router.rs
+++ b/packages/whisker-router/tests/core_router.rs
@@ -1,0 +1,758 @@
+//! Exhaustive unit tests for the new router core (`whisker_router::core`).
+//!
+//! These build the Twitter-style tree from `docs/router-design.md` by
+//! hand and assert URL derivation, `current` derivation, the five
+//! operations, relative resolution, the buried-container reveal, and the
+//! no-stored-marker invariant. The 14 numbered behaviours from the phase
+//! brief are tagged in the test names / comments.
+
+use std::collections::BTreeMap;
+
+use whisker_router::core::{
+    CompiledTree, NavError, Navigator, NodePath, RouteState, RouteTree, Scope, SwitchDef, Target,
+};
+
+// ===================================================================
+// The Twitter-style tree (built by hand — no macro yet)
+// ===================================================================
+//
+// The root node has the empty NodePath [], so its children start at [0]:
+//
+//  root Stack                         []
+//   ├ Switch (tabs, default = 0)       [0]
+//   │   ├ Stack timeline               [0,0]
+//   │   │   ├ Route ""        timeline [0,0,0]
+//   │   │   ├ Route "post/:id"  post   [0,0,1]   (shared, id "post")
+//   │   │   └ Route "profile/:id" prof [0,0,2]   (shared, id "profile")
+//   │   ├ Stack search                 [0,1]
+//   │   │   ├ Route "search"  search   [0,1,0]
+//   │   │   ├ Route "post/:id"  post   [0,1,1]
+//   │   │   └ Route "profile/:id" prof [0,1,2]
+//   │   ├ Stack notifications          [0,2]
+//   │   │   ├ Route "notifications" .. [0,2,0]
+//   │   │   ├ Route "post/:id"         [0,2,1]
+//   │   │   └ Route "profile/:id"      [0,2,2]
+//   │   └ Stack mypage                 [0,3]
+//   │       ├ Route "mypage"           [0,3,0]
+//   │       ├ Route "post/:id"         [0,3,1]
+//   │       └ Route "profile/:id"      [0,3,2]
+//   ├ Route "video/:id" video          [1]
+//   └ Route "login"     login          [2]
+
+fn shared_routes() -> Vec<RouteTree> {
+    vec![
+        RouteTree::route("post/:id", "post"),
+        RouteTree::route("profile/:id", "profile"),
+    ]
+}
+
+fn tab(root_segment: &str, root_id: &str) -> RouteTree {
+    let mut children = vec![RouteTree::route(root_segment, root_id)];
+    children.extend(shared_routes());
+    RouteTree::stack(children)
+}
+
+fn twitter_tree() -> CompiledTree {
+    let tabs = RouteTree::switch(
+        SwitchDef::new("tabs", 0),
+        vec![
+            tab("", "timeline"),
+            tab("search", "search"),
+            tab("notifications", "notifications"),
+            tab("mypage", "mypage"),
+        ],
+    );
+    let root = RouteTree::stack(vec![
+        tabs,
+        RouteTree::route("video/:id", "video"),
+        RouteTree::route("login", "login"),
+    ]);
+    CompiledTree::new(root)
+}
+
+fn p(indices: &[usize]) -> NodePath {
+    NodePath(indices.to_vec())
+}
+
+fn one_param(k: &str, v: &str) -> BTreeMap<String, String> {
+    let mut m = BTreeMap::new();
+    m.insert(k.to_string(), v.to_string());
+    m
+}
+
+// ===================================================================
+// 1. URL derivation
+// ===================================================================
+
+#[test]
+fn url_derivation_named_segments_concatenate() {
+    let t = twitter_tree();
+    assert_eq!(t.url_of(&p(&[0, 0, 0])).as_deref(), Some("/")); // timeline home
+    assert_eq!(t.url_of(&p(&[0, 1, 0])).as_deref(), Some("/search"));
+    assert_eq!(t.url_of(&p(&[0, 2, 0])).as_deref(), Some("/notifications"));
+    assert_eq!(t.url_of(&p(&[0, 3, 0])).as_deref(), Some("/mypage"));
+    assert_eq!(t.url_of(&p(&[1])).as_deref(), Some("/video/:id"));
+    assert_eq!(t.url_of(&p(&[2])).as_deref(), Some("/login"));
+    // shared post in each tab derives the same URL
+    assert_eq!(t.url_of(&p(&[0, 0, 1])).as_deref(), Some("/post/:id"));
+    assert_eq!(t.url_of(&p(&[0, 1, 1])).as_deref(), Some("/post/:id"));
+    assert_eq!(t.url_of(&p(&[0, 3, 1])).as_deref(), Some("/post/:id"));
+}
+
+#[test]
+fn url_pathless_containers_contribute_nothing() {
+    let t = twitter_tree();
+    // root Stack and the tabs Switch are pathless ⇒ no URL.
+    assert_eq!(t.url_of(&p(&[])), None); // root Stack
+    assert_eq!(t.url_of(&p(&[0])), None); // tabs Switch
+}
+
+#[test]
+fn url_shared_post_dedupes_to_one_url_and_one_nav_id() {
+    let t = twitter_tree();
+    // Four placements of post, but ONE url and ONE nav-target id.
+    let post_paths = t.paths_with_route_id("post");
+    assert_eq!(post_paths.len(), 4, "four physical placements");
+    let urls: std::collections::BTreeSet<_> =
+        post_paths.iter().map(|pp| t.url_of(pp).unwrap()).collect();
+    assert_eq!(urls.len(), 1, "all share /post/:id");
+    assert!(urls.contains("/post/:id"));
+    // And all four resolve by the single id "post".
+    assert_eq!(t.paths_with_url("/post/:id").len(), 4);
+}
+
+// ===================================================================
+// 2. current derivation after construction (defaults)
+// ===================================================================
+
+#[test]
+fn initial_current_honours_switch_default_and_stack_first() {
+    let t = twitter_tree();
+    let st = RouteState::initial(&t);
+    // root stack → first child (the Switch); Switch default 0 → timeline
+    // stack → its first route "" (timeline home).
+    assert_eq!(st.current().path, p(&[0, 0, 0]));
+}
+
+#[test]
+fn initial_current_respects_nonzero_switch_default() {
+    // A tiny tree with a Switch defaulting to branch 1.
+    let tree = CompiledTree::new(RouteTree::stack(vec![RouteTree::switch(
+        SwitchDef::new("s", 1),
+        vec![
+            RouteTree::stack(vec![RouteTree::route("a", "a")]),
+            RouteTree::stack(vec![RouteTree::route("b", "b")]),
+        ],
+    )]));
+    let st = RouteState::initial(&tree);
+    assert_eq!(st.current().path, p(&[0, 1, 0])); // branch 1, route "b"
+}
+
+// ===================================================================
+// 3. navigate within same tab (timeline → post) stays in timeline
+// ===================================================================
+
+#[test]
+fn navigate_within_same_tab_lands_in_that_tabs_stack() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+        .unwrap();
+    // timeline tab still selected; post is in timeline's stack.
+    assert_eq!(nav.current().path, p(&[0, 0, 1]));
+    assert_eq!(
+        nav.current().params.get("id").map(String::as_str),
+        Some("1")
+    );
+}
+
+// ===================================================================
+// 4. navigate to a shared route from a different tab → current tab
+// ===================================================================
+
+#[test]
+fn navigate_shared_route_resolves_within_current_tab() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    // Move to the search tab first.
+    nav.navigate(&Target::id("search")).unwrap();
+    assert_eq!(nav.current().path, p(&[0, 1, 0]));
+    // Now go to a profile: must resolve inside the SEARCH tab's subtree.
+    nav.navigate(&Target::id("profile")).unwrap();
+    assert_eq!(nav.current().path, p(&[0, 1, 2]));
+}
+
+// ===================================================================
+// 5. navigate to a shared route from OUTSIDE the tabs (video)
+//    → declaration-order first instance; selects that tab
+// ===================================================================
+
+#[test]
+fn navigate_shared_route_from_outside_uses_declaration_order() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    // Push video (outside the tabs, on the root stack).
+    nav.navigate_with(&Target::id("video"), one_param_inst("id", "9"))
+        .unwrap();
+    assert_eq!(nav.current().path, p(&[1]));
+    // From video, go to post. Common ancestor is the root stack ⇒ the
+    // first-declared post = timeline tab's post [0,0,0,1].
+    nav.navigate_with(&Target::id("post"), one_param_inst("id", "7"))
+        .unwrap();
+    assert_eq!(nav.current().path, p(&[0, 0, 1]));
+    // And the tabs Switch is now selected on timeline (branch 0).
+    if let RouteState::Stack(root) = &st {
+        if let RouteState::Switch(sw) = &root.history[0].state {
+            assert_eq!(sw.selected, 0);
+        } else {
+            panic!("first root entry should be the Switch");
+        }
+    } else {
+        panic!("root is a stack");
+    }
+}
+
+// ===================================================================
+// 6. navigate ALWAYS pushes (post(1), post(2) → two entries; even an
+//    identical instance pushes again)
+// ===================================================================
+
+#[test]
+fn navigate_always_pushes_distinct_instances() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+            .unwrap();
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "2"))
+            .unwrap();
+        assert_eq!(nav.current().params.get("id").unwrap(), "2");
+    }
+    // timeline stack now: [ "", post(1), post(2) ]
+    let hist = timeline_history(&st);
+    assert_eq!(hist.len(), 3);
+    assert_eq!(hist[1].state.current().params.get("id").unwrap(), "1");
+    assert_eq!(hist[2].state.current().params.get("id").unwrap(), "2");
+}
+
+#[test]
+fn navigate_always_pushes_even_identical_instance() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+        .unwrap();
+    nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+        .unwrap();
+    let hist = timeline_history(&st);
+    // Two post entries even though params are identical ("always push").
+    assert_eq!(hist.len(), 3);
+    assert_eq!(hist[1].state.current().params.get("id").unwrap(), "1");
+    assert_eq!(hist[2].state.current().params.get("id").unwrap(), "1");
+}
+
+// ===================================================================
+// 7. buried-container reveal: from video, navigate to a tab post → pops
+//    video, selects tab, pushes post; path goes back through the Switch
+// ===================================================================
+
+#[test]
+fn navigate_reveals_buried_tabs_switch() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        // Drive the search tab into a post first so we can check the
+        // Switch's retained selection survives being buried.
+        nav.navigate(&Target::id("search")).unwrap();
+        // Now push video over the tabs.
+        nav.navigate_with(&Target::id("video"), one_param_inst("id", "1"))
+            .unwrap();
+        assert_eq!(nav.current().path, p(&[1]));
+    }
+    // root stack history: [ Switch, video ]
+    assert_eq!(root_history_len(&st), 2);
+
+    // Navigate to post. The first-declared post is timeline's, so the
+    // buried Switch is revealed (video popped) AND its branch flips to
+    // timeline. Current path passes through the Switch again.
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "5"))
+            .unwrap();
+        assert_eq!(nav.current().path, p(&[0, 0, 1]));
+    }
+    // video was popped → root stack back to length 1 (just the Switch).
+    assert_eq!(root_history_len(&st), 1);
+    // The active chain goes root-stack → Switch → timeline-stack → post,
+    // i.e. the Switch is on the path (tabs "visible").
+    let chain_kinds = active_chain_kinds(&st);
+    assert_eq!(chain_kinds, vec!["Stack", "Switch", "Stack", "Route"]);
+}
+
+// ===================================================================
+// 8. back: deepest non-trivial stack; reveals buried; no-op at tab root;
+//    Switch never popped
+// ===================================================================
+
+#[test]
+fn back_pops_deepest_nontrivial_stack() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+        .unwrap();
+    assert_eq!(nav.current().path, p(&[0, 0, 1])); // timeline post
+    assert!(nav.back());
+    // Back to timeline home.
+    assert_eq!(nav.current().path, p(&[0, 0, 0]));
+}
+
+#[test]
+fn back_from_outside_reveals_tab_screen() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    // timeline → post, then push video over the tabs.
+    nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+        .unwrap();
+    nav.navigate_with(&Target::id("video"), one_param_inst("id", "2"))
+        .unwrap();
+    assert_eq!(nav.current().path, p(&[1]));
+    // back pops video off the ROOT stack (the deepest non-trivial stack
+    // on the active path is the root: the tabs Switch hides the inner
+    // post, but `video` lives directly on root).
+    assert!(nav.back());
+    // Reveals the timeline post that the Switch retained.
+    assert_eq!(nav.current().path, p(&[0, 0, 1]));
+}
+
+#[test]
+fn back_at_tab_root_is_noop() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let before = st.clone();
+    let mut nav = Navigator::new(&t, &mut st);
+    // At the timeline home with nothing pushed anywhere → no-op.
+    assert!(!nav.back());
+    assert_eq!(st, before);
+}
+
+#[test]
+fn back_never_pops_switch_selection() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    // Select search (a pure Switch change), no stack pushes.
+    nav.select(&Target::id("search")).unwrap();
+    assert_eq!(nav.current().path, p(&[0, 1, 0]));
+    // back has nothing to pop (search stack is trivial, root is trivial)
+    // and must NOT revert the Switch selection.
+    assert!(!nav.back());
+    assert_eq!(nav.current().path, p(&[0, 1, 0]));
+}
+
+// ===================================================================
+// 9. replace: swaps top of current stack; cross-switch replace errors
+// ===================================================================
+
+#[test]
+fn replace_swaps_top_of_current_stack() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+        .unwrap();
+    // Replace the top post with a profile (same timeline stack).
+    nav.replace_with(&Target::id("profile"), one_param("id", "9"))
+        .unwrap();
+    assert_eq!(nav.current().path, p(&[0, 0, 2]));
+    assert_eq!(nav.current().params.get("id").unwrap(), "9");
+    // History length unchanged: [ "", profile(9) ].
+    assert_eq!(timeline_history(&st).len(), 2);
+}
+
+#[test]
+fn replace_cross_switch_errors() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    // The current stack is the timeline tab's stack. `video` lives on the
+    // ROOT stack (a different stack), so replacing to it must error.
+    let err = nav.replace(&Target::id("video")).unwrap_err();
+    assert_eq!(err, NavError::CrossStack);
+    // State unchanged.
+    assert_eq!(nav.current().path, p(&[0, 0, 0]));
+}
+
+// ===================================================================
+// 10. pop_to: unwinds the current stack to a target
+// ===================================================================
+
+#[test]
+fn pop_to_unwinds_current_stack() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+            .unwrap();
+        nav.navigate_with(&Target::id("profile"), one_param_inst("id", "2"))
+            .unwrap();
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "3"))
+            .unwrap();
+    }
+    // timeline: [ "", post(1), profile(2), post(3) ]
+    assert_eq!(timeline_history(&st).len(), 4);
+    // pop_to the timeline home route "" (id "timeline").
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.pop_to(&Target::id("timeline")).unwrap();
+        assert_eq!(nav.current().path, p(&[0, 0, 0]));
+    }
+    assert_eq!(timeline_history(&st).len(), 1);
+}
+
+#[test]
+fn pop_to_missing_target_errors() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+        .unwrap();
+    // profile is a child of this stack but no profile entry is present.
+    let err = nav.pop_to(&Target::id("profile")).unwrap_err();
+    assert_eq!(err, NavError::NotInStack);
+}
+
+// ===================================================================
+// 11. reset: clears the current stack to [target] (logout case)
+// ===================================================================
+
+#[test]
+fn reset_clears_current_stack_to_single_entry() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+            .unwrap();
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "2"))
+            .unwrap();
+    }
+    assert_eq!(timeline_history(&st).len(), 3);
+    // Reset the timeline stack to its home.
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.reset(&Target::id("timeline")).unwrap();
+        assert_eq!(nav.current().path, p(&[0, 0, 0]));
+    }
+    assert_eq!(timeline_history(&st).len(), 1);
+}
+
+#[test]
+fn reset_logout_clears_root_back_stack() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    // Push video so the ROOT stack is non-trivial, and make login the
+    // current stack's target. To reset the ROOT stack we navigate to a
+    // root-level route first so the deepest active stack IS the root.
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate_with(&Target::id("video"), one_param_inst("id", "1"))
+            .unwrap();
+    }
+    assert_eq!(root_history_len(&st), 2);
+    // current stack is the root stack (video is a leaf directly on root).
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.reset(&Target::id("login")).unwrap();
+        assert_eq!(nav.current().path, p(&[2]));
+    }
+    assert_eq!(root_history_len(&st), 1);
+}
+
+// ===================================================================
+// 12. cold-start resolution → declaration order; Switch(default) honored
+// ===================================================================
+
+#[test]
+fn cold_start_resolution_uses_declaration_order() {
+    let t = twitter_tree();
+    // No current position (cold deep-link): resolve directly with
+    // `current = None`. Must pick the first-declared post (timeline's).
+    let dest = whisker_router::core::resolve(&t, &Target::id("post"), None).unwrap();
+    assert_eq!(dest, p(&[0, 0, 1]));
+    // And profile cold-start → first-declared profile too.
+    let prof = whisker_router::core::resolve(&t, &Target::id("profile"), None).unwrap();
+    assert_eq!(prof, p(&[0, 0, 2]));
+}
+
+#[test]
+fn switch_default_honored_for_return_branch() {
+    // A Switch defaulting to branch 2 is honored on initial state even
+    // though it was never explicitly visited.
+    let tree = CompiledTree::new(RouteTree::stack(vec![RouteTree::switch(
+        SwitchDef::new("s", 2),
+        vec![
+            RouteTree::stack(vec![RouteTree::route("a", "a")]),
+            RouteTree::stack(vec![RouteTree::route("b", "b")]),
+            RouteTree::stack(vec![RouteTree::route("c", "c")]),
+        ],
+    )]));
+    let st = RouteState::initial(&tree);
+    assert_eq!(st.current().path, p(&[0, 2, 0])); // branch 2, route "c"
+}
+
+// ===================================================================
+// 13. No-marker invariant: current() is always the walked leaf, and the
+//     type has no stored current field. Property-ish over an op sequence.
+// ===================================================================
+
+#[test]
+fn no_marker_current_is_always_the_walked_leaf() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+
+    // A scripted op sequence; after each step assert current() equals an
+    // INDEPENDENT manual walk of history-tops / selecteds.
+    type Op = Box<dyn Fn(&mut Navigator)>;
+    let ops: Vec<Op> = vec![
+        Box::new(|n| {
+            n.navigate(&Target::id("search")).unwrap();
+        }),
+        Box::new(|n| {
+            n.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+                .unwrap();
+        }),
+        Box::new(|n| {
+            n.navigate_with(&Target::id("video"), one_param_inst("id", "2"))
+                .unwrap();
+        }),
+        Box::new(|n| {
+            n.navigate_with(&Target::id("post"), one_param_inst("id", "3"))
+                .unwrap();
+        }),
+        Box::new(|n| {
+            n.back();
+        }),
+        Box::new(|n| {
+            n.back();
+        }),
+        Box::new(|n| {
+            n.navigate(&Target::id("mypage")).unwrap();
+        }),
+    ];
+
+    for op in ops {
+        {
+            let mut nav = Navigator::new(&t, &mut st);
+            op(&mut nav);
+        }
+        let derived = st.current().path.clone();
+        let manual = manual_walk(&st);
+        assert_eq!(
+            derived, manual,
+            "current() must equal an independent history-top/selected walk"
+        );
+    }
+}
+
+/// Independent re-derivation of the current leaf, used to prove there is
+/// no stored marker that could drift from the walk.
+fn manual_walk(state: &RouteState) -> NodePath {
+    match state {
+        RouteState::Route(r) => r.path.clone(),
+        RouteState::Stack(s) => manual_walk(&s.history.last().unwrap().state),
+        RouteState::Switch(s) => manual_walk(&s.branches[s.selected]),
+    }
+}
+
+// ===================================================================
+// 14. each tab keeps an independent stack
+// ===================================================================
+
+#[test]
+fn tabs_keep_independent_stacks() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+
+    // Drive timeline into a post.
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "11"))
+            .unwrap();
+        assert_eq!(nav.current().path, p(&[0, 0, 1]));
+    }
+    // Switch to search (a pure `select`) and drive it into a profile.
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.select(&Target::id("search")).unwrap();
+        nav.navigate_with(&Target::id("profile"), one_param_inst("id", "22"))
+            .unwrap();
+        assert_eq!(nav.current().path, p(&[0, 1, 2]));
+    }
+    // Timeline stack untouched: still [ "", post(11) ].
+    assert_eq!(timeline_history(&st).len(), 2);
+    assert_eq!(
+        timeline_history(&st)[1]
+            .state
+            .current()
+            .params
+            .get("id")
+            .unwrap(),
+        "11"
+    );
+    // Switch back to timeline via `select`: its post is preserved exactly
+    // (no fresh home pushed — that is the whole point of `select` vs
+    // `navigate`).
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.select(&Target::id("timeline")).unwrap();
+        assert_eq!(nav.current().path, p(&[0, 0, 1])); // back on the post
+    }
+    assert_eq!(timeline_history(&st).len(), 2);
+    // search stack still has its profile, untouched by timeline.
+    assert_eq!(search_history(&st).len(), 2);
+    assert_eq!(
+        search_history(&st)[1]
+            .state
+            .current()
+            .params
+            .get("id")
+            .unwrap(),
+        "22"
+    );
+}
+
+#[test]
+fn switching_tabs_preserves_each_stack_via_select() {
+    // Use the `select` primitive and confirm the OTHER tab's stack is
+    // preserved across the switch.
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+            .unwrap(); // timeline: ["", post]
+    }
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.select(&Target::id("search")).unwrap(); // select search
+    }
+    // timeline preserved its 2-entry stack while search is active.
+    assert_eq!(timeline_history(&st).len(), 2);
+    // back in search (trivial) is a no-op and doesn't touch timeline.
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        assert!(!nav.back());
+    }
+    assert_eq!(timeline_history(&st).len(), 2);
+}
+
+#[test]
+fn select_is_nondestructive_and_returns_to_retained_screen() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    // Drive timeline deep: ["", post(1), post(2)].
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "1"))
+            .unwrap();
+        nav.navigate_with(&Target::id("post"), one_param_inst("id", "2"))
+            .unwrap();
+    }
+    // select away to search, then back to timeline.
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.select(&Target::id("search")).unwrap();
+        assert_eq!(nav.current().path, p(&[0, 1, 0])); // search home
+        nav.select(&Target::id("timeline")).unwrap();
+        // Returns to timeline's RETAINED top (post(2)) — nothing pushed.
+        assert_eq!(nav.current().path, p(&[0, 0, 1]));
+        assert_eq!(nav.current().params.get("id").unwrap(), "2");
+    }
+    // timeline history untouched (still 3 deep).
+    assert_eq!(timeline_history(&st).len(), 3);
+}
+
+// ===================================================================
+// within(scope) API-surface smoke (deferred behaviour)
+// ===================================================================
+
+#[test]
+fn within_scope_restricts_resolution_to_branch() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    // From timeline, target post but scope it to the search tab subtree.
+    let search_scope = Scope::at(p(&[0, 1]));
+    nav.navigate_within(&Target::id("post"), &search_scope)
+        .unwrap();
+    // Resolves inside the search tab → its post.
+    assert_eq!(nav.current().path, p(&[0, 1, 1]));
+}
+
+// ===================================================================
+// Error: unknown target
+// ===================================================================
+
+#[test]
+fn navigate_unknown_target_errors() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    let err = nav.navigate(&Target::id("nope")).unwrap_err();
+    assert_eq!(err, NavError::NoSuchTarget);
+}
+
+// ===================================================================
+// helpers that reach into the state tree for assertions
+// ===================================================================
+
+fn one_param_inst(k: &str, v: &str) -> whisker_router::core::RouteInstance {
+    whisker_router::core::RouteInstance::with_param(NodePath::root(), k, v)
+}
+
+fn root_history_len(st: &RouteState) -> usize {
+    match st {
+        RouteState::Stack(s) => s.history.len(),
+        _ => panic!("root is a stack"),
+    }
+}
+
+fn timeline_history(st: &RouteState) -> &[whisker_router::core::StackEntry] {
+    tab_history(st, 0)
+}
+
+fn search_history(st: &RouteState) -> &[whisker_router::core::StackEntry] {
+    tab_history(st, 1)
+}
+
+fn tab_history(st: &RouteState, branch: usize) -> &[whisker_router::core::StackEntry] {
+    if let RouteState::Stack(root) = st {
+        // The Switch is always root entry 0 (it's never popped; even when
+        // revealed it stays at index 0).
+        if let RouteState::Switch(sw) = &root.history[0].state {
+            if let RouteState::Stack(tab) = &sw.branches[branch] {
+                return &tab.history;
+            }
+        }
+    }
+    panic!("could not reach tab {branch} history");
+}
+
+fn active_chain_kinds(st: &RouteState) -> Vec<&'static str> {
+    st.active_chain()
+        .into_iter()
+        .map(|n| match n {
+            RouteState::Route(_) => "Route",
+            RouteState::Stack(_) => "Stack",
+            RouteState::Switch(_) => "Switch",
+        })
+        .collect()
+}


### PR DESCRIPTION
## Phase 1 of the new whisker-router: the pure-logic `RouteTree` + `RouteState` core

Implements exactly the model in `docs/router-design.md` — the two-graph navigation domain — as plain, runtime-free Rust. **No macro, no rendering (`Outlet`/`Stack`), no signals/Element wiring, no gestures/animations.** The old signal-backed router files are untouched and still build; the new system lives under `packages/whisker-router/src/core/` and is exported as `whisker_router::core`.

### The model

**Static — `RouteTree`** (`core/tree.rs`)
- Three node kinds: `Route(RouteDef)` leaf, `Stack(Vec<RouteTree>)` ordered container, `Switch(SwitchDef, Vec<RouteTree>)` parallel container.
- `RouteDef` = `segment` + nav-target `id` + auto-extracted `:param` names. Same `id` in several stacks = the spread/shared-route case (deduped to one nav target).
- Built by hand via `RouteTree::route/stack/switch` (no macro yet).
- `CompiledTree::new` does one pre-order walk, assigning `NodeId`s and pre-computing parent links + full URLs. **URL derivation** concatenates named segments from the root; pathless containers contribute nothing (`/`, `/search`, `/post/:id`, `/video/:id`, `/login`).

**Dynamic — `RouteState`** (`core/state.rs`)
- Mirrors the tree shape: `StackState { history: Vec<StackEntry> }`, `SwitchState { selected, branches }`, `RouteInstance { path, params }`.
- A `StackEntry` references a child subtree **plus its own nested `RouteState`**, so "push a screen outside the tabs" is just the tabs `Switch` occupying one history slot with an outside `Route` above it — no special case.
- **`current` is derived, never stored** (`RouteState::current` walks history-tops/selecteds). There is no marker field by construction.

### Addressing
- `NodeId(usize)` — stable pre-order identity (dedupe of nav-target identity is via `RouteDef::id`, separate from `NodeId`).
- `NodePath(Vec<usize>)` — positional child-index chain from the root (root = `[]`). Resolution and `current` both speak `NodePath`.

### Resolution algorithm (`core/resolve.rs`)
Relative resolution: collect candidate paths for the target (by `id` or by `url`) in declaration order; walk **up** from the current leaf (deepest ancestor first); the first ancestor whose subtree contains a candidate resolves it; declaration order breaks ties within it. Cold start (`current = None`) → root → pure declaration order. `within(scope)` API surface is present (restricts candidates to a subtree) with full cross-branch behaviour deferred per the doc's open items.

### Operations (`core/nav.rs`, on `Navigator`)
- `navigate` — resolve, then walk root→target: `Switch` selects toward target, `Stack` **always pushes** a fresh instance; a buried intermediate container is **revealed** (entries above popped, its retained state kept).
- `select` — the tab-switch primitive: a pure `Switch.selected` change toward the target, **pushing nothing** (the doc's `select_tab`). Added because `navigate` always-push would otherwise duplicate a tab's home route on every tab change.
- `back` — pop the deepest non-trivial `Stack` on the active path; `Switch` selection is never popped; no-op at a tab root.
- `replace` / `pop_to` / `reset` — same-stack only.

### `replace` cross-switch decision: **error**
`replace`/`pop_to`/`reset` to a node that is not a direct child of the current stack returns `NavError::CrossStack` and leaves state unchanged (the doc calls cross-`Switch` replace meaningless). `pop_to` to an absent-but-same-stack target returns `NavError::NotInStack`.

### Tests — `tests/core_router.rs` (29 tests, all green)
Builds the Twitter-style tree by hand and covers all 14 brief behaviours: URL derivation + pathless containers + shared-route dedup (1); initial `current` defaults incl. non-zero `Switch` default (2); same-tab navigate (3); shared-route relative resolution from another tab (4) and from outside → declaration order + tab selected (5); always-push incl. identical instance (6); buried-tabs reveal with active-chain assertion (7); back deepest-stack / reveal-from-outside / tab-root no-op / never-pops-Switch (8); replace swap + cross-switch error (9); pop_to unwind + NotInStack (10); reset stack + root logout (11); cold-start declaration order + honored `Switch` default (12); **no-marker invariant** via an independent history-top/selected re-walk after each op in a scripted sequence (13); independent per-tab stacks via `select` (14); plus `select` non-destructive return, `within`-scope smoke, and unknown-target error.

### Verify
- `cargo test -p whisker-router` — green (44 lib + 29 new core + 8 existing integration).
- `cargo build --workspace` — clean.
- `cargo clippy -p whisker-router --all-targets` — no warnings.
- `cargo fmt --all -- --check` — clean.

### Design-doc ambiguities & decisions
- **Tab switching primitive.** The doc's `navigate` is "always push", but its `Layout` example switches tabs via `select_tab`. I added an explicit `select` (pure `Switch.selected` change, no push) as the tab primitive; `navigate` to a tab root still pushes per the literal rule.
- **`back` from an outside route.** With a post in a tab and `video` pushed over the tabs, `back` pops `video` off the root stack (the deepest *non-trivial* stack on the active path is the root, since the tabs `Switch` hides the inner post), revealing the retained tab post. Matches the doc's example.
- **Reveal scope.** "Reveal a buried intermediate container" is implemented as: when navigate passes through a container child already present in a stack's history, truncate everything above it and reuse its retained nested state; otherwise push a fresh one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
