### PR TITLE
feat(whisker-driver): tokio feature — reqwest/spawn_blocking just work in resource()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,8 +624,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -635,9 +637,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -726,6 +730,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -734,13 +755,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -918,6 +947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1061,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
@@ -1344,6 +1385,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1544,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1600,12 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1514,6 +1654,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1614,6 +1755,18 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -1790,6 +1943,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1853,6 +2009,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +2048,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-smoke"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "tokio",
+ "whisker",
 ]
 
 [[package]]
@@ -1960,6 +2150,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2178,31 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -2113,6 +2346,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2388,6 +2630,7 @@ version = "0.6.0"
 dependencies = [
  "futures-channel",
  "serde",
+ "tokio",
  "whisker-dev-runtime",
  "whisker-driver-sys",
  "whisker-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "examples/asset-demo",
     "examples/aurora-wallet",
     "examples/podcast",
+    "examples/tokio-smoke",
     "packages/whisker-icons",
     "packages/whisker-icons/example",
     "packages/whisker-image",

--- a/crates/whisker-driver/Cargo.toml
+++ b/crates/whisker-driver/Cargo.toml
@@ -27,10 +27,24 @@ hot-reload = [
     "dep:whisker-dev-runtime",
     "whisker-dev-runtime/hot-reload",
 ]
+# Hosts a multi-thread tokio runtime at bootstrap and keeps its context
+# `enter()`ed on the TASM thread for the process lifetime. With this on,
+# tokio-based libraries (reqwest, sqlx, tokio::time, spawn_blocking) work
+# directly inside `resource()` / `spawn_local()` futures: those futures
+# are still polled on the TASM thread (no `Send` required, signals stay
+# reachable), while tokio's reactor/timer run on its own background
+# threads. Off by default — tokio drops out of release builds entirely.
+tokio = ["dep:tokio"]
 
 [dependencies]
 whisker-runtime = { workspace = true }
 whisker-driver-sys = { workspace = true }
+# `tokio` feature only. `rt-multi-thread` is mandatory: a current-thread
+# runtime only drives its reactor inside `block_on`, but Whisker polls
+# futures via its own `run_until_stalled`, so a current-thread reactor
+# would never advance the IO our futures register. Multi-thread drives
+# IO/timer on tokio's own background threads regardless of who polls.
+tokio = { workspace = true, optional = true, features = ["rt-multi-thread", "time", "net", "io-util"] }
 # `module::invoke_async` bridges the Whisker bridge's C callback
 # (`whisker_bridge_invoke_module_async`) into a Rust `Future` via a
 # oneshot channel. Pulled directly rather than full `futures` to

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -151,6 +151,14 @@ extern "C" fn init_callback(user_data: *mut c_void) {
     // ticking, and no race against a paused CADisplayLink/Choreographer.
     whisker_runtime::main_thread::set_drive_callback(Some(drive));
 
+    // Stand up the tokio runtime (feature-gated) and `enter()` its
+    // context on THIS (TASM) thread before any user code runs. We're on
+    // the same thread that `tick_frame` later polls the task pool on, so
+    // keeping the context entered here means every future poll can find
+    // tokio's reactor — making `reqwest` / `spawn_blocking` / `tokio::time`
+    // work directly inside `resource()` fetchers. No-op without the feature.
+    init_tokio_runtime();
+
     // Route the platform reporter's events through Whisker's Rust-side
     // propagation reconstruction (capture/bubble/catch over the
     // driver's own element tree). The bridge calls this dispatcher
@@ -225,6 +233,30 @@ fn start_hot_reload_receiver() {
 
 #[cfg(not(feature = "hot-reload"))]
 fn start_hot_reload_receiver() {}
+
+// Build a multi-thread tokio runtime and keep its context entered on the
+// TASM thread for the whole process. Must be multi-thread: a
+// current-thread runtime only drives its reactor inside `block_on`, but
+// Whisker polls futures via `run_until_stalled`, so a current-thread
+// reactor would never advance the IO our futures register.
+#[cfg(feature = "tokio")]
+fn init_tokio_runtime() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all() // IO (mio: epoll on Android / kqueue on iOS) + timer
+        .worker_threads(2) // conservative for mobile; tune later if needed
+        .thread_name("whisker-tokio")
+        .build()
+        .expect("whisker: build tokio runtime");
+    // Leak the runtime to `'static`, then `forget` the EnterGuard so its
+    // Drop never runs — the context stays entered on this thread (which
+    // lives for the process lifetime) and tokio's background threads keep
+    // driving the reactor regardless of who polls the futures.
+    let rt: &'static tokio::runtime::Runtime = Box::leak(Box::new(rt));
+    std::mem::forget(rt.enter());
+}
+
+#[cfg(not(feature = "tokio"))]
+fn init_tokio_runtime() {}
 
 #[cfg(feature = "hot-reload")]
 fn start_log_capture() {

--- a/crates/whisker/Cargo.toml
+++ b/crates/whisker/Cargo.toml
@@ -23,6 +23,10 @@ default = []
 # both sides — otherwise subsecond can't dispatch to the patched
 # version.
 hot-reload = ["whisker-driver/hot-reload", "dep:subsecond"]
+# Forwarded to `whisker-driver` — hosts a tokio runtime so tokio-based
+# async libraries (reqwest, etc.) work inside `resource()`/`spawn_local()`.
+# Off by default; tokio drops out of release builds when unused.
+tokio = ["whisker-driver/tokio"]
 
 [dependencies]
 whisker-runtime = { workspace = true }

--- a/examples/tokio-smoke/Cargo.toml
+++ b/examples/tokio-smoke/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tokio-smoke"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Smoke test for whisker's `tokio` feature: a `resource()` fetcher that does an HTTP GET with reqwest (tokio reactor) and a CPU offload with tokio::task::spawn_blocking, both driven on the TASM thread without freezing the UI. If the byte count renders, the runtime is entered correctly."
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+# `tokio` feature on: whisker-driver builds + enters a multi-thread tokio
+# runtime at bootstrap, so the reqwest / spawn_blocking calls below find a
+# reactor instead of panicking.
+whisker = { workspace = true, features = ["tokio"] }
+# rustls (not native-tls/openssl) so the TLS stack cross-compiles cleanly
+# to iOS/Android — same choice the podcast example makes with ureq.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+# Pulled in directly for `tokio::task::spawn_blocking`. `rt` carries the
+# task API; the actual runtime is owned by whisker-driver, and cargo
+# feature unification makes it the same tokio crate.
+tokio = { version = "1", default-features = false, features = ["rt"] }

--- a/examples/tokio-smoke/src/lib.rs
+++ b/examples/tokio-smoke/src/lib.rs
@@ -1,0 +1,104 @@
+//! Smoke test for whisker's `tokio` feature.
+//!
+//! The app runs one [`resource()`] fetcher that combines the two things
+//! the feature is meant to unlock:
+//!
+//! 1. **I/O on tokio's reactor** — `reqwest::get(...).await`. reqwest
+//!    registers its socket with `Handle::current()`; without an entered
+//!    runtime this panics. With the `tokio` feature, whisker-driver has
+//!    entered a multi-thread runtime on the TASM thread at bootstrap, so
+//!    it resolves and the request progresses (reactor on tokio's bg
+//!    threads, future polled on the TASM thread → no `Send` needed).
+//! 2. **CPU offload** — `tokio::task::spawn_blocking(...)`. Moves work to
+//!    tokio's blocking pool so the UI thread never stalls, then `.await`s
+//!    the result back.
+//!
+//! If the screen shows `OK · N bytes`, the whole chain worked: runtime
+//! entered → reqwest serviced → spawn_blocking joined → result marshalled
+//! back to the TASM thread and rendered. The `resource` state is read
+//! reactively in a `move ||` text binding, so Loading → Ready/Error
+//! transitions repaint on their own.
+
+use whisker::css::{AlignItems, FlexDirection, FontWeight, JustifyContent};
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+
+/// A public, auth-free AppView endpoint — no setup or credentials needed,
+/// which keeps this smoke test runnable anywhere.
+const ENDPOINT: &str =
+    "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=bsky.app&limit=1";
+
+#[whisker::main]
+pub fn app() -> Element {
+    let body_len = resource(fetch_body_len);
+
+    // Derive the status line reactively from the resource state. `computed`
+    // yields a `ReadSignal<String>` (which `text`'s `value:` accepts), and
+    // re-runs on every Loading → Ready/Error transition so the text repaints
+    // without any manual wiring.
+    let status = computed(move || {
+        if let Some(n) = body_len.get() {
+            format!("OK · {n} bytes")
+        } else if let Some(err) = body_len.error() {
+            format!("error: {err}")
+        } else {
+            "loading…".to_string()
+        }
+    });
+
+    render! {
+        view(style: css!(
+            flex_grow: 1.0,
+            background_color: Color::hex(0x101012),
+            flex_direction: FlexDirection::Column,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            padding: px(24),
+        )) {
+            text(
+                style: css!(
+                    color: Color::hex(0xF5F5F7),
+                    font_size: px(18),
+                    font_weight: FontWeight::Bold,
+                    margin_bottom: px(12),
+                ),
+                value: "tokio feature smoke",
+            )
+            text(
+                style: css!(
+                    color: Color::hex(0x9AA0AA),
+                    font_size: px(14),
+                    margin_bottom: px(20),
+                ),
+                value: "reqwest (I/O) + spawn_blocking (CPU offload)",
+            )
+            text(
+                style: css!(
+                    color: Color::hex(0x4ADE80),
+                    font_size: px(16),
+                    font_weight: FontWeight::Bold,
+                ),
+                value: status,
+            )
+        }
+    }
+}
+
+/// `resource()` fetcher: fetch the endpoint over HTTPS, then count the
+/// bytes off the TASM thread. Errors are stringified at this boundary to
+/// match `resource`'s `Result<T, String>` contract.
+async fn fetch_body_len() -> Result<usize, String> {
+    // ① reqwest drives the request on tokio's reactor.
+    let body = reqwest::get(ENDPOINT)
+        .await
+        .map_err(|e| e.to_string())?
+        .text()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // ② Hand the (trivial here, but stand-in for real work) computation to
+    //    tokio's blocking pool so the UI thread isn't the one doing it.
+    tokio::task::spawn_blocking(move || body.len())
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/examples/tokio-smoke/whisker.rs
+++ b/examples/tokio-smoke/whisker.rs
@@ -1,0 +1,26 @@
+// `whisker.rs` for the `tokio-smoke` example.
+//
+// No build plugins — this app only exercises the `tokio` feature's
+// runtime, which whisker-driver stands up at bootstrap. The config below
+// is just enough metadata for `whisker run` to generate the native shells.
+
+pub fn configure(app: &mut whisker_config::Config) {
+    app.name("WhiskerTokioSmoke")
+        .bundle_id("rs.whisker.tokiosmoke")
+        .version("0.1.0")
+        .build_number(1);
+
+    app.android(|a| {
+        a.package("rs.whisker.tokiosmoke")
+            .application_id("rs.whisker.tokiosmoke")
+            .launcher_activity(".MainActivity")
+            .min_sdk(24)
+            .target_sdk(34);
+    });
+
+    app.ios(|i| {
+        i.bundle_id("rs.whisker.tokiosmoke")
+            .scheme("WhiskerTokioSmoke")
+            .deployment_target("13.0");
+    });
+}


### PR DESCRIPTION
## What

Adds an optional **`tokio` feature** (off by default) that lets tokio-based async libraries — `reqwest`, `sqlx`, `tokio::time`, `tokio::task::spawn_blocking` — work directly inside `resource()` / `spawn_local()` futures.

```rust
let posts = resource(|| async {
    let body = reqwest::get(url).await?.text().await?;        // I/O on tokio's reactor
    let n = tokio::task::spawn_blocking(move || body.len())   // CPU offload, UI stays live
        .await?;
    Ok(n)
});
```

## How

The model mirrors Dioxus's native integration:

> **futures are polled on the TASM thread** by Whisker's own `LocalPool` (no `Send` required, signals stay reachable), **while tokio's reactor/timer run on its own background threads**.

"Running under tokio" really means *a tokio reactor is `enter()`ed on the thread where the future's IO registers* — `reqwest` calls `Handle::current()` internally and panics without one. Whisker already had the polling half (`LocalPool` + `run_until_stalled` driven by `tick_frame`, plus `DriveWaker`, whose wake path is explicitly built to resume a future woken from a foreign/tokio thread). The only missing piece was entering a runtime context — `init_tokio_runtime()` in `bootstrap.rs` now builds a runtime and keeps its `enter()` guard alive on the TASM thread for the process lifetime.

**The runtime must be multi-thread.** A current-thread runtime only drives its reactor inside `block_on`, but Whisker polls via `run_until_stalled`, so a current-thread reactor would never advance the IO our futures register. Multi-thread drives IO/timer on tokio's own background threads regardless of who polls.

Feature wiring mirrors the existing `hot-reload` feature: an optional `tokio` dep threaded `whisker` → `whisker-driver`, **default off** so release builds carry zero tokio.

## Changes

- `crates/whisker-driver/Cargo.toml` — `tokio` feature + optional dep (`rt-multi-thread`, `time`, `net`, `io-util`)
- `crates/whisker/Cargo.toml` — feature passthrough `tokio = ["whisker-driver/tokio"]`
- `crates/whisker-driver/src/lynx/bootstrap.rs` — `init_tokio_runtime()` (multi-thread runtime + persistent `enter()` on the TASM thread; cfg pair is a no-op when off)
- `examples/tokio-smoke/` — PoC app (reqwest + spawn_blocking inside `resource()`)

## Verification

| Check | Result |
|---|---|
| host build (feature off) | ✅ |
| host build (feature on, example) | ✅ |
| iOS-sim cross-compile (tokio / mio / reqwest-rustls) | ✅ `aarch64-apple-ios-sim` |
| `cargo fmt --check` / `clippy` | ✅ clean |
| feature **off** drops tokio from the dep graph | ✅ `cargo tree` confirmed |
| **iOS simulator, live run** | ✅ renders `OK · 4317 bytes` |

The live run proves the full chain on-device: runtime entered (no `Handle::current()` panic) → reqwest fetched the public Bluesky AppView endpoint over HTTPS/rustls → `spawn_blocking` joined → result marshalled back to the TASM thread and repainted reactively (Loading → Ready).

## Notes / scope

- Role split (unchanged by this PR): tokio = I/O concurrency + offload, **not** CPU speedup. A CPU loop with no `.await` inside a UI-thread-polled future still blocks the UI — use `spawn_blocking` (pooled) or the existing `run_blocking` (single-shot, no tokio) to offload, and `rayon` for multi-core speedup.
- Out of scope: firehose/Jetstream websocket streaming; a `whisker::spawn` ergonomic re-export; configurable worker-thread count.
- This is the networking foundation for an upcoming Bluesky AT Protocol client example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)