### PR TITLE
fix(gradle-plugin): always run WhiskerBuildTask so Android never ships a stale .so (#260)

### DIFF
--- a/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerProjectPlugin.kt
+++ b/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerProjectPlugin.kt
@@ -121,6 +121,12 @@ class WhiskerProjectPlugin : Plugin<Project> {
                     this.abi.set(abi)
                     this.jniLibsDir.set(jniLibsDir)
                     minSdk.set(minSdkProvider)
+                    // The Rust sources are `@Internal` (not declared inputs),
+                    // so Gradle can't tell when they change and would mark this
+                    // task UP-TO-DATE and skip the cargo recompile — shipping a
+                    // stale `.so` (#260). Always run; cargo is the single
+                    // authority and skips the actual rustc when nothing changed.
+                    outputs.upToDateWhen { false }
                 }
                 variant.sources.jniLibs?.addGeneratedSourceDirectory(
                     task,


### PR DESCRIPTION
## Problem (#260, trap #1)

`WhiskerBuildTask` (`whiskerBuild<Variant><Abi>`) cross-compiles the Rust crate and stages the `.so` into jniLibs. Its declared inputs are `packageName`/`profile`/`abi`/`minSdk` (stable across runs) and its output is the staged dir; the **Rust sources are `@Internal`** (not inputs). So after the first build, Gradle marks the task **UP-TO-DATE** and skips it — `whisker build-android` (cargo) never re-runs, the `.so` is never re-staged, and the APK ships **hours-old native code** even though the build *looks* like it rebuilt (no `compile <app> (aarch64-linux-android)` step, only `gradle :app:assembleDebug`).

The task's own comment already states the intent — "the task re-runs every time; cargo skips the actual compile when nothing changed" — but nothing enforced it.

## Fix (one line)

```kotlin
outputs.upToDateWhen { false }
```

Make **cargo the single authority** on incremental rebuilds: always run the task; cargo skips the actual `rustc` when nothing changed. This is more robust than declaring the Rust sources as Gradle inputs, which would duplicate change-detection and silently re-introduce staleness whenever the input set drifts from cargo's true inputs (e.g. `include_str!` of non-`.rs` files, build scripts).

Downstream `merge`/`strip`/`package` stay incremental: Gradle content-hashes the staged `.so`, so an unchanged `.so` keeps them UP-TO-DATE.

## Verification

Repro: edit a source file, then run `gradle :app:assembleDebug` against an already-built `gen/android` tree (no `rm`), and check the staged `.so` hash + the task state.

| | whiskerBuild task | staged `.so` sha256 |
|---|---|---|
| **before** | `UP-TO-DATE` | unchanged → **stale** |
| **after** | runs | changes → picks up the edit |

Tested locally by overriding the published plugin with `includeBuild(...)` and running the repro against `examples/tokio-smoke`.

## Note for release

`gen/android` resolves the plugin from the published Maven (`rs.whisker.gradle version "0.4.0"`), not from source — so this fix reaches users only after the gradle plugin is **re-published** and the cng `{{whisker_gradle_plugin_version}}` is bumped. The source fix here is the prerequisite.

Remaining #260 traps (watcher scope, CLI template embedding, `template_version` gating) are separate and out of scope for this one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)