### PR TITLE
feat(whisker-run): surface build staleness — compile relinked/up-to-date + gen reused/regenerated (#260)

### DIFF
--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -233,15 +233,11 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
         }
     }
 
-    let cargo_step = crate::ui::step("compile", format!("{} ({triple})", b.package));
-    let status = cargo_step
-        .pipe(&mut cmd)
-        .with_context(|| format!("spawn cargo for {triple}"))?;
-    cargo_step.done("");
-    if !status.success() {
-        return Err(anyhow!("cargo build failed ({status}) for {triple}"));
-    }
-
+    // Resolve the output `.so` up-front and snapshot its mtime, so the step
+    // summary can report whether cargo actually relinked a fresh lib or
+    // no-op'd (`up-to-date`). This is the "did my change reach native code?"
+    // signal the dev loop was missing: a stale `.so` (#260) shows as
+    // `up-to-date` exactly when you expected a rebuild. mtime-only, so it's free.
     let lib_name = format!("lib{}.so", b.package.replace('-', "_"));
     let so_path = b
         .workspace_root
@@ -249,6 +245,24 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
         .join(triple)
         .join(b.profile.dir_name())
         .join(&lib_name);
+    let so_mtime = |p: &std::path::Path| std::fs::metadata(p).and_then(|m| m.modified()).ok();
+    let before = so_mtime(&so_path);
+
+    let cargo_step = crate::ui::step("compile", format!("{} ({triple})", b.package));
+    let status = cargo_step
+        .pipe(&mut cmd)
+        .with_context(|| format!("spawn cargo for {triple}"))?;
+    if !status.success() {
+        cargo_step.done("failed");
+        return Err(anyhow!("cargo build failed ({status}) for {triple}"));
+    }
+    cargo_step.done(match (before, so_mtime(&so_path)) {
+        (None, Some(_)) => "linked",
+        (Some(b), Some(a)) if a > b => "relinked",
+        (_, Some(_)) => "up-to-date",
+        (_, None) => "",
+    });
+
     if !so_path.is_file() {
         return Err(anyhow!(
             "cargo finished but {} is missing",

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -48,6 +48,10 @@ pub struct PlatformSync {
     /// `true` if the renderer rewrote files this pass, `false` if the
     /// fingerprint matched and the existing tree was reused.
     pub regenerated: bool,
+    /// cng template version that drives `gen/` regeneration (Android only;
+    /// `None` for iOS). Surfaced in the run log so a "reused cached gen/"
+    /// line tells the user which template generation is on disk.
+    pub template_version: Option<u32>,
 }
 
 /// SDK version pinned into the cng-generated
@@ -111,10 +115,12 @@ fn sync_android(
         LYNX_MAVEN_URL.to_string(),
     )?;
     let gen_dir = crate_dir.join("gen/android");
+    let template_version = inputs.template_version;
     let regenerated = whisker_cng::sync_android(&gen_dir, &inputs).context("render gen/android")?;
     Ok(PlatformSync {
         gen_dir,
         regenerated,
+        template_version: Some(template_version),
     })
 }
 
@@ -149,6 +155,7 @@ fn sync_ios(
     Ok(PlatformSync {
         gen_dir,
         regenerated,
+        template_version: None,
     })
 }
 

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -207,9 +207,21 @@ fn run_inner(
         &m.package,
     )
     .context("sync native project (gen/{android,ios}/)")?;
+    // Always say which path was taken — a silent "reused" is exactly the
+    // staleness trap (#260): a template/source edit that didn't bump the cng
+    // `template_version` leaves the old gen/ tree on disk and nothing told you.
+    let tv = sync
+        .template_version
+        .map(|v| format!(" (template_version {v})"))
+        .unwrap_or_default();
     if sync.regenerated {
         eprintln!(
-            "[whisker run] native project regenerated at {}",
+            "[whisker run] regenerated gen/ at {}{tv}",
+            sync.gen_dir.display(),
+        );
+    } else {
+        eprintln!(
+            "[whisker run] reused cached gen/ at {}{tv}",
             sync.gen_dir.display(),
         );
     }


### PR DESCRIPTION
## Why

Every #260 trap presents identically — **"my change had no effect"** — which sends you debugging your code when the code never ran. The cheapest mitigation is to make the run loop **say what it actually did**, so a stale build is visible instead of silent.

## Changes (two free signals)

### 1. Android compile: `relinked` vs `up-to-date`
The cargo step now reports whether cargo actually relinked a fresh `.so` or no-op'd, from the target `.so`'s mtime (no hashing, ~2 stats):

```
✓ compile foo (aarch64-linux-android) relinked    6.0s
✓ compile foo (aarch64-linux-android) up-to-date   88ms
```

So you can see at a glance whether a source edit reached native code. (`up-to-date` right when you expected a rebuild = the #260 smell.)

### 2. `whisker run`: gen/ `reused` vs `regenerated`
It used to print **only** on regeneration — a silent "reused" is exactly the stale-template trap (#260 trap #4: an edit that didn't bump the cng `template_version` leaves the old `gen/` tree on disk and nothing tells you). Now both directions log, with the template version:

```
[whisker run] reused cached gen/ at .../gen/android (template_version 10)
[whisker run] regenerated gen/ at  .../gen/android (template_version 10)
```

`PlatformSync` carries `template_version` (Android; `None` for iOS) for the log.

## Verification

- `whisker build-android` run twice on `tokio-smoke`: shows `relinked` (6.0s) then `up-to-date` (88ms).
- `whisker run android`: shows `reused cached gen/ … (template_version 10)`.
- `cargo fmt --check` / `clippy` clean; `whisker-build` (25) + `whisker-cli` (82) tests pass.

## Scope

Cross-cutting visibility only — no behavior change. Complements #267 (the actual `.so`-staleness fix). Both appear in the TUI (compile via the live step rows; the gen line as run-loop scrollback) and in `--no-tui` plain mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)