### PR TITLE
feat(whisker-cli): warn when the running CLI is older than crates/whisker-cng (#260)

### DIFF
--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -199,6 +199,12 @@ fn run_inner(
     // the SDK pom. Neither path needs the workspace `target/lynx-*`
     // tree the cli used to stage here.
 
+    // cng templates are `include_str!`-baked into this binary, so a CLI that
+    // predates an edit under `crates/whisker-cng/src` renders stale gen/ files
+    // (#260 trap #3). Read-only mtime check; only fires inside a whisker repo
+    // checkout (where those sources exist), never for installed users.
+    warn_if_cli_older_than_cng(&workspace_root);
+
     let sync = crate::platforms::sync_for_target(
         target,
         &m.config,
@@ -521,6 +527,59 @@ fn find_workspace_root(start: &Path) -> Option<PathBuf> {
             return None;
         }
     }
+}
+
+/// Warn if the running `whisker` binary predates the cng template/renderer
+/// sources, i.e. its `include_str!`-baked templates are stale relative to the
+/// repo (#260 trap #3). No-op unless `crates/whisker-cng/src` exists under
+/// `workspace_root` — installed users (no whisker sources) never see this.
+/// Read-only: compares file mtimes and prints a warning, nothing else.
+fn warn_if_cli_older_than_cng(workspace_root: &Path) {
+    let cng_src = workspace_root.join("crates/whisker-cng/src");
+    if !cng_src.is_dir() {
+        return; // not a whisker repo checkout
+    }
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let Ok(cli_mtime) = std::fs::metadata(&exe).and_then(|m| m.modified()) else {
+        return;
+    };
+    let Some(cng_mtime) = newest_mtime_under(&cng_src) else {
+        return;
+    };
+    if cng_mtime > cli_mtime {
+        whisker_build::ui::warn(format!(
+            "running `whisker` ({}) is older than crates/whisker-cng/src — its \
+             embedded templates may be stale and gen/ could be generated from old \
+             templates. Rebuild and use the workspace CLI \
+             (e.g. `cargo run -p whisker-cli -- run …`).",
+            exe.display(),
+        ));
+    }
+}
+
+/// Newest file mtime anywhere under `dir` (recursive). `None` if the tree is
+/// unreadable or empty. Best-effort: unreadable entries are skipped.
+fn newest_mtime_under(dir: &Path) -> Option<std::time::SystemTime> {
+    let mut newest: Option<std::time::SystemTime> = None;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+            if is_dir {
+                stack.push(entry.path());
+                continue;
+            }
+            if let Ok(mtime) = entry.metadata().and_then(|m| m.modified()) {
+                newest = Some(newest.map_or(mtime, |n| n.max(mtime)));
+            }
+        }
+    }
+    newest
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem (#260 trap #3)

cng templates are `include_str!`-baked into the `whisker` binary. So a CLI that **predates** an edit under `crates/whisker-cng/src` renders **stale `gen/` files** — you edit a template, run an old (e.g. globally-`cargo install`ed) `whisker`, and the change silently vanishes. We hit this with the predictive-back `enableOnBackInvokedCallback` manifest attribute; the symptom ("my change had no effect") is identical to every other #260 trap.

## Fix (warn, read-only)

`whisker run` now compares the running binary's mtime against the newest file under `crates/whisker-cng/src` and warns if the CLI is older:

```
! running `whisker` (.../target/debug/whisker) is older than crates/whisker-cng/src —
  its embedded templates may be stale and gen/ could be generated from old templates.
  Rebuild and use the workspace CLI (e.g. `cargo run -p whisker-cli -- run …`).
```

- **Read-only**: an mtime stat + a `ui::warn`. No behavior change, no rebuild, no git/file mutation.
- **Scoped**: only fires inside a whisker repo checkout (where `crates/whisker-cng/src` exists). Installed users with no whisker sources never see it.
- **Precise**: a freshly-built/`cargo run` CLI is always newer than the sources → silent. Only an actually-stale binary warns.

## Verification

- Freshly-built CLI → no warning (just the normal sync line).
- `touch crates/whisker-cng/src/android.rs`, then re-run the **same** binary → the warning prints.
- `cargo fmt --check` / `clippy` clean; `whisker-cli` tests (82) pass.

## Scope

Addresses the "silent stale templates" half of trap #3. The complementary "make gradle's `whisker build-android` use the same CLI binary as `whisker run`" (forward the CLI path via env) is a possible follow-up but needs a plugin republish; left out here. Part of the #260 dev-loop-trust work (cf. #267, #268).

🤖 Generated with [Claude Code](https://claude.com/claude-code)