### PR TITLE
chore(cli): pin gradle-plugin 0.4.1 in generated projects (closes #159)

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -84,7 +84,7 @@ const WHISKER_SDK_VERSION: &str = "0.1.1";
 ///     alone, plus places the staged `.so` into a nested
 ///     `<jniLibsDir>/<abi>/` subdir so AGP's `mergeJniLibFolders`
 ///     recognises the layout.
-const WHISKER_GRADLE_PLUGIN_VERSION: &str = "0.4.0";
+const WHISKER_GRADLE_PLUGIN_VERSION: &str = "0.4.1";
 const WHISKER_MAVEN_URL: &str = "https://whiskerrs.github.io/whisker/maven";
 const LYNX_MAVEN_URL: &str = "https://whiskerrs.github.io/lynx/maven";
 


### PR DESCRIPTION
## What

Bumps `WHISKER_GRADLE_PLUGIN_VERSION` `0.4.0` → `0.4.1` so generated `gen/android` projects resolve the freshly-published plugin.

## Release done

- `gradle-plugin-v0.4.1` tagged and published to the gh-pages Maven repo.
- Verified live: `https://whiskerrs.github.io/whisker/maven/rs/whisker/whisker-gradle-plugin/0.4.1/whisker-gradle-plugin-0.4.1.jar` → **200**, plus the `rs.whisker.gradle` / `rs.whisker` marker POMs.
- Staging smoke (`workflow_dispatch`) confirmed the 0.4.1 coordinates before the tag push.

## Effect

The shipped 0.4.1 plugin bundles the two source fixes that were stuck unpublished:
- **#267 / #260** — `WhiskerBuildTask` always runs (`outputs.upToDateWhen { false }`), so Android never ships a stale `.so`.
- **#156 / #159** — fail-fast with an install hint when the `whisker` CLI isn't on PATH.

Closes #159. The version string is an `AndroidInputs` input, so `gen/android` auto-regenerates on the next `whisker run` (no `template_version` bump needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)