### PR TITLE
fix(whisker-router)!: reset/replace/swipe-back fixes + global reset + leaf URL resolution

### DIFF
--- a/packages/whisker-router/example/src/lib.rs
+++ b/packages/whisker-router/example/src/lib.rs
@@ -255,14 +255,13 @@ fn detail() -> Element {
                 text(value: "Reset → Detail #5", style: button_label_style())
             }
 
-            // Reset to the Home tab. Use the canonical "/(home)" URL (the
-            // home route is "" under the "(home)" group, so its URL is
-            // "/(home)"); a bare "/" resolves relative to the current tab.
+            // Reset to the Home tab. "/" resolves to the home index screen
+            // (the "" route inside the "(home)" group), even from another tab.
             view(
                 style: button_style(),
                 on_tap: {
                     let nav = nav.clone();
-                    move |_| { let _ = nav.reset("/(home)"); }
+                    move |_| { let _ = nav.reset("/"); }
                 },
             ) {
                 text(value: "Reset → Home", style: button_label_style())

--- a/packages/whisker-router/example/src/lib.rs
+++ b/packages/whisker-router/example/src/lib.rs
@@ -242,9 +242,9 @@ fn detail() -> Element {
                 text(value: format!("Replace → Detail #{next}"), style: button_label_style())
             }
 
-            // Reset (#264): collapse the whole stack to a single entry whose
-            // route differs from the bottom (Home). Must show Detail #5
-            // cleanly — pre-fix it kept the stale bottom screen.
+            // Reset to a NEW route (not in the back stack): global reset
+            // collapses every stack to `[detail/5]`. Direction would be a
+            // push once reset animates.
             view(
                 style: button_style(),
                 on_tap: {
@@ -253,6 +253,19 @@ fn detail() -> Element {
                 },
             ) {
                 text(value: "Reset → Detail #5", style: button_label_style())
+            }
+
+            // Reset to the Home tab. Use the canonical "/(home)" URL (the
+            // home route is "" under the "(home)" group, so its URL is
+            // "/(home)"); a bare "/" resolves relative to the current tab.
+            view(
+                style: button_style(),
+                on_tap: {
+                    let nav = nav.clone();
+                    move |_| { let _ = nav.reset("/(home)"); }
+                },
+            ) {
+                text(value: "Reset → Home", style: button_label_style())
             }
 
             view(

--- a/packages/whisker-router/example/src/lib.rs
+++ b/packages/whisker-router/example/src/lib.rs
@@ -208,18 +208,60 @@ fn detail() -> Element {
     // Read this route's `:id` param from context — the macro-free analogue
     // of `routes! { Route("detail/:id", Detail) }` + `use_param`.
     let id = use_param("id");
-    let label = format!("Detail #{}", id.get().unwrap_or_default());
+    let cur = id.get().and_then(|s| s.parse::<u32>().ok()).unwrap_or(0);
+    let next = cur + 1;
     render! {
         view(style: screen_style(0x1A1422)) {
-            text(value: label, style: title_style())
-            text(value: "Swipe from the left edge, or tap Back.", style: subtitle_style())
+            text(value: format!("Detail #{cur}"), style: title_style())
+            text(
+                value: "Try the stack ops below. Push/Back are the baseline; \
+                        Replace and Reset are what #265 / #264 fixed.",
+                style: subtitle_style(),
+            )
+
+            // Push (baseline): grows the stack — slides in.
+            view(
+                style: button_style(),
+                on_tap: {
+                    let nav = nav.clone();
+                    move |_| { let _ = nav.navigate(&format!("/detail/{next}")); }
+                },
+            ) {
+                text(value: format!("Push → Detail #{next}"), style: button_label_style())
+            }
+
+            // Replace (#265): swaps the top in place. Must SLIDE the new
+            // screen in like a push, not snap instantly.
+            view(
+                style: button_style(),
+                on_tap: {
+                    let nav = nav.clone();
+                    move |_| { let _ = nav.replace(&format!("/detail/{next}")); }
+                },
+            ) {
+                text(value: format!("Replace → Detail #{next}"), style: button_label_style())
+            }
+
+            // Reset (#264): collapse the whole stack to a single entry whose
+            // route differs from the bottom (Home). Must show Detail #5
+            // cleanly — pre-fix it kept the stale bottom screen.
+            view(
+                style: button_style(),
+                on_tap: {
+                    let nav = nav.clone();
+                    move |_| { let _ = nav.reset("/detail/5"); }
+                },
+            ) {
+                text(value: "Reset → Detail #5", style: button_label_style())
+            }
+
             view(
                 style: button_style(),
                 on_tap: move |_| {
                     let _ = nav.back();
                 },
             ) {
-                text(value: "Back", style: button_label_style())
+                text(value: "Back (or swipe from the left edge)", style: button_label_style())
             }
         }
     }

--- a/packages/whisker-router/src/core/nav.rs
+++ b/packages/whisker-router/src/core/nav.rs
@@ -402,7 +402,22 @@ fn active_stack_mut(state: &mut RouteState) -> Option<&mut StackState> {
     // recursion that returns the deepest one.
     fn go(state: &mut RouteState) -> Option<&mut StackState> {
         match state {
-            RouteState::Route(_) => None,
+            RouteState::Route(r) => {
+                // A *leaf* Route has no stack below it. A layout/group Route
+                // (`Route(component:) { … }` / a pathless `(group)`) wraps a
+                // Switch/Stack/Route child — we must descend into it, exactly
+                // as `active_chain`/`deepest_active_stack_path` do. Without
+                // this the two disagreed (path found, but no `&mut` stack)
+                // and `replace`/`reset`/`pop_to` panicked on `expect`.
+                if r.children.is_empty() {
+                    return None;
+                }
+                let idx = r
+                    .children
+                    .iter()
+                    .position(|c| !matches!(c, RouteState::Route(ri) if ri.children.is_empty()))?;
+                go(&mut r.children[idx])
+            }
             RouteState::Switch(s) => {
                 let sel = s.selected;
                 go(&mut s.branches[sel])

--- a/packages/whisker-router/src/core/nav.rs
+++ b/packages/whisker-router/src/core/nav.rs
@@ -10,7 +10,7 @@
 //! | [`back`](Navigator::back) | pop the top of the **deepest non-trivial `Stack`** (history > 1) on the active path; `Switch` selection is never popped; tab-root with nothing to pop → no-op |
 //! | [`replace`](Navigator::replace) | swap the **top** of the current stack with the target; same stack only (else [`NavError::CrossStack`]) |
 //! | [`pop_to`](Navigator::pop_to) | pop the current stack until the target is the top; same stack only |
-//! | [`reset`](Navigator::reset) | replace the **entire** current stack with `[target]` |
+//! | [`reset`](Navigator::reset) | *global*: rebuild the whole state onto one clean path to `target` — select `Switch`es toward it and collapse **every** `Stack` to a single entry (no back history anywhere) |
 
 use super::resolve::{self, Scope};
 use super::state::{RouteInstance, RouteState, StackEntry, StackState};
@@ -181,21 +181,19 @@ impl<'a> Navigator<'a> {
 
     // ----- reset ----------------------------------------------------
 
-    /// Replace the **entire** current stack's history with the route
-    /// matched by `url` (the logout / clear-back-stack case). Same stack
-    /// only.
+    /// **Reset the whole navigation state** onto a single clean path to the
+    /// route matched by `url` (the logout / clear-everything case). Unlike
+    /// the other verbs this is *global*, not same-stack: `url` is resolved
+    /// across the entire tree (like `navigate`), every `Switch` is selected
+    /// toward the target, and **every `Stack` collapses to a single entry**
+    /// so no back history survives anywhere — on the path to the target or in
+    /// any other branch. Errors only with [`NavError::NoSuchTarget`].
     pub fn reset(&mut self, url: &str) -> Result<(), NavError> {
         let current = self.current_path();
         let params = self.tree.match_url(url).map(|(_, p)| p).unwrap_or_default();
         let dest =
             resolve::resolve(self.tree, url, Some(&current)).ok_or(NavError::NoSuchTarget)?;
-        let stack_path = deepest_active_stack_path(self.state).ok_or(NavError::CrossStack)?;
-        if !is_child_of(&stack_path, &dest) {
-            return Err(NavError::CrossStack);
-        }
-        let entry = make_entry(self.tree, &dest, params);
-        let stack = active_stack_mut(self.state).expect("stack exists");
-        stack.history = vec![entry];
+        *self.state = RouteState::focused_at(self.tree, &dest, params);
         Ok(())
     }
 }

--- a/packages/whisker-router/src/core/resolve.rs
+++ b/packages/whisker-router/src/core/resolve.rs
@@ -43,11 +43,29 @@ impl Scope {
 /// Returns the chosen candidate's [`NodePath`], or `None` if nothing
 /// matches.
 pub fn resolve(tree: &CompiledTree, url: &str, current: Option<&NodePath>) -> Option<NodePath> {
-    let cands = tree.paths_matching_url(url);
+    // Prefer a leaf **screen** matching the URL.
+    if let Some(found) = pick_relative(&tree.paths_matching_url(url), current) {
+        return Some(found);
+    }
+    // Fallback: the URL named a **container** (e.g. a bare `/(group)` whose
+    // group has no index `""` screen) — resolve to the index leaf inside the
+    // chosen container so it is still a navigable destination.
+    let container = pick_relative(&tree.container_paths_matching_url(url), current)?;
+    Some(
+        super::state::RouteState::initial_at(tree, &container)
+            .current()
+            .path
+            .clone(),
+    )
+}
+
+/// Pick from `cands` by the deepest-common-ancestor-with-`current` rule
+/// (declaration order breaks ties); cold start (no current) takes the first.
+/// `None` when `cands` is empty.
+fn pick_relative(cands: &[NodePath], current: Option<&NodePath>) -> Option<NodePath> {
     if cands.is_empty() {
         return None;
     }
-
     match current {
         None => Some(cands[0].clone()),
         Some(cur) => {

--- a/packages/whisker-router/src/core/state.rs
+++ b/packages/whisker-router/src/core/state.rs
@@ -163,6 +163,82 @@ impl RouteState {
         }
     }
 
+    /// Build a fresh state for the whole tree **collapsed onto the single
+    /// path that leads to `dest`** — the global `reset` shape. Every `Stack`
+    /// holds exactly one entry (the child toward `dest`, or its first child
+    /// when `dest` is off this branch), so no back history survives anywhere;
+    /// every `Switch` selects the branch toward `dest` (else its default);
+    /// off-path subtrees are at their plain initial state. The `dest` Route
+    /// carries `params`.
+    pub fn focused_at(
+        tree: &CompiledTree,
+        dest: &NodePath,
+        params: BTreeMap<String, String>,
+    ) -> RouteState {
+        Self::focused_inner(tree, &NodePath::root(), dest, &params)
+    }
+
+    fn focused_inner(
+        tree: &CompiledTree,
+        path: &NodePath,
+        dest: &NodePath,
+        params: &BTreeMap<String, String>,
+    ) -> RouteState {
+        let node = tree
+            .node_at(path)
+            .expect("focused_at: path must address a node in the tree");
+        // The child index whose subtree contains `dest`, if any.
+        let toward =
+            |n: usize| -> Option<usize> { (0..n).find(|&i| dest.0.starts_with(&path.child(i).0)) };
+        match node {
+            RouteTree::Route(_, children) => {
+                let child_states = children
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| Self::focused_inner(tree, &path.child(i), dest, params))
+                    .collect();
+                RouteState::Route(RouteInstance {
+                    path: path.clone(),
+                    params: if path == dest {
+                        params.clone()
+                    } else {
+                        BTreeMap::new()
+                    },
+                    children: child_states,
+                })
+            }
+            RouteTree::Stack(children) => {
+                assert!(!children.is_empty(), "a Stack must have at least one child");
+                // Collapse to a single entry: the child toward `dest`, else
+                // the first child (an off-path stack reset to its root).
+                let child_path = path.child(toward(children.len()).unwrap_or(0));
+                RouteState::Stack(StackState {
+                    path: path.clone(),
+                    history: vec![StackEntry {
+                        child: child_path.clone(),
+                        state: Self::focused_inner(tree, &child_path, dest, params),
+                    }],
+                })
+            }
+            RouteTree::Switch(def, branches) => {
+                assert!(
+                    !branches.is_empty(),
+                    "a Switch must have at least one branch"
+                );
+                let selected =
+                    toward(branches.len()).unwrap_or_else(|| clamp_default(def, branches.len()));
+                let branch_states = (0..branches.len())
+                    .map(|i| Self::focused_inner(tree, &path.child(i), dest, params))
+                    .collect();
+                RouteState::Switch(SwitchState {
+                    path: path.clone(),
+                    selected,
+                    branches: branch_states,
+                })
+            }
+        }
+    }
+
     /// The [`NodePath`] of the static node this state instantiates.
     pub fn path(&self) -> &NodePath {
         match self {

--- a/packages/whisker-router/src/core/tree.rs
+++ b/packages/whisker-router/src/core/tree.rs
@@ -435,6 +435,15 @@ impl CompiledTree {
         self.by_path
             .values()
             .filter(|i| {
+                // A destination is a navigable **leaf** screen, never a
+                // container Route (a `(group)` / layout with children). A
+                // group's URL equals its index child's, so without this a bare
+                // `/` (or `/(group)`) matches the container too and — being a
+                // nearer common ancestor of the current position — gets picked
+                // over the index screen inside it.
+                if !self.is_leaf_route(&i.path) {
+                    return false;
+                }
                 let Some(pattern) = i.url.as_deref() else {
                     return false;
                 };
@@ -443,6 +452,12 @@ impl CompiledTree {
             })
             .map(|i| i.path.clone())
             .collect()
+    }
+
+    /// Whether `path` addresses a leaf `Route` (a screen) — a `Route` with no
+    /// children, as opposed to a `Stack` / `Switch` / `(group)` container.
+    fn is_leaf_route(&self, path: &NodePath) -> bool {
+        matches!(self.node_at(path), Some(RouteTree::Route(_, kids)) if kids.is_empty())
     }
 
     /// All [`NodePath`]s whose `Route` derives the given full URL

--- a/packages/whisker-router/src/core/tree.rs
+++ b/packages/whisker-router/src/core/tree.rs
@@ -460,6 +460,28 @@ impl CompiledTree {
         matches!(self.node_at(path), Some(RouteTree::Route(_, kids)) if kids.is_empty())
     }
 
+    /// **Container** Routes (a `(group)` / layout with children) whose URL
+    /// matches `url`. The fallback for a URL that names no leaf screen — e.g.
+    /// a bare `/(group)` whose group has no index `""` child; the caller
+    /// descends the chosen container to its index leaf.
+    pub fn container_paths_matching_url(&self, url: &str) -> Vec<NodePath> {
+        let input: Vec<&str> = url.split('/').filter(|s| !s.is_empty()).collect();
+        self.by_path
+            .values()
+            .filter(|i| {
+                if self.is_leaf_route(&i.path) {
+                    return false;
+                }
+                let Some(pattern) = i.url.as_deref() else {
+                    return false;
+                };
+                let pat: Vec<&str> = pattern.split('/').filter(|s| !s.is_empty()).collect();
+                match_segments(&pat, &input).is_some()
+            })
+            .map(|i| i.path.clone())
+            .collect()
+    }
+
     /// All [`NodePath`]s whose `Route` derives the given full URL
     /// (exact match, no group-optional logic), in declaration order.
     pub fn paths_with_url(&self, url: &str) -> Vec<NodePath> {

--- a/packages/whisker-router/src/render/gesture.rs
+++ b/packages/whisker-router/src/render/gesture.rs
@@ -214,6 +214,13 @@ pub(crate) fn begin(nav: &RouterHandle, edge: SwipeEdge) -> Option<StackBridge> 
     if let (Some(ctrl), Some(top), Some(under)) =
         (&bridge.top_ctrl, &bridge.top_pose, &bridge.under_pose)
     {
+        // The under may be a paused buried entry (after a `replace` the
+        // settle freezes it); resume it so its pose effect runs and follows
+        // the finger through the scrub. Without this the under stays frozen
+        // and only snaps at the end of the gesture.
+        if let Some(under_owner) = bridge.under_owner {
+            under_owner.resume();
+        }
         point(top, ctrl, Role::Top, mode.clone());
         point(under, ctrl, Role::Under, mode);
         // The Material backdrop dim is Android-only; the iOS slide carries

--- a/packages/whisker-router/src/render/handle.rs
+++ b/packages/whisker-router/src/render/handle.rs
@@ -71,6 +71,12 @@ pub(crate) struct StackBridge {
     pub top_pose: Option<PoseBinding>,
     /// The revealed-under wrapper's pose binding, if any.
     pub under_pose: Option<PoseBinding>,
+    /// The revealed-under wrapper's owner. A gesture re-points the under's
+    /// pose bindings but must also `resume()` it: a buried under is paused
+    /// (no effects run), so without this its pose effect would not follow
+    /// the finger during an interactive back. `run_pop` resumes the survivor
+    /// itself; the gesture path has only the bridge, hence this handle.
+    pub under_owner: Option<Owner>,
     /// The stack's backdrop-dim **drive**: when `Some(ctrl)`, the dim
     /// opacity reactively follows `(1 - ctrl.value()) * PB_MAX_DIM`, so it
     /// darkens during the drag AND animates in lockstep with the settle

--- a/packages/whisker-router/src/render/node.rs
+++ b/packages/whisker-router/src/render/node.rs
@@ -476,13 +476,17 @@ fn reconcile_stack(
                 drive.set_value(1.0);
                 dispose_wrapper(slot, old);
             } else {
-                // Tear the old top down ONLY when the slide finishes (mirrors
-                // `run_pop`), never mid-animation.
+                // Tear the old top down on the slide's first completion —
+                // whether it finished or was cancelled by a follow-up nav
+                // (e.g. an immediate Back, which `reverse()`s this same
+                // controller and fires `on_finish(false)`). The old top is
+                // logically gone the moment the replace starts, so it must
+                // never linger and cover the revealed screen.
                 let old_wrapper = old.wrapper;
                 let old_owner = old.owner;
                 let done = Rc::new(RefCell::new(false));
-                drive.on_finish(move |finished| {
-                    if !finished || *done.borrow() {
+                drive.on_finish(move |_finished| {
+                    if *done.borrow() {
                         return;
                     }
                     *done.borrow_mut() = true;

--- a/packages/whisker-router/src/render/node.rs
+++ b/packages/whisker-router/src/render/node.rs
@@ -561,6 +561,7 @@ fn reconcile_stack(
         top_ctrl: top_w.map(|w| w.ctrl.clone()),
         top_pose: top_w.map(pose_of),
         under_pose: under_w.map(pose_of),
+        under_owner: under_w.map(|w| w.owner),
         dim_drive: Some(dim_drive),
         can_back: l.len() > 1,
     };

--- a/packages/whisker-router/src/render/node.rs
+++ b/packages/whisker-router/src/render/node.rs
@@ -399,26 +399,57 @@ fn reconcile_stack(
         }
     }
 
-    // ----- Shrink: a pop / reset.
+    // ----- Shrink: a pop or a reset.
     if new_len < old_len {
-        let popped: Vec<StackWrapper> = {
-            let mut l = live.borrow_mut();
-            l.split_off(new_len)
+        // A genuine pop leaves the revealed survivor unchanged, so we animate
+        // the removed top out over it. A `reset` (full-history replacement)
+        // can instead leave a *different* route at the new top index — the
+        // surviving wrapper is stale. Wrappers are keyed by index, so a naive
+        // shrink would keep that stale screen mounted (showing the wrong
+        // screen and leaking its native views). Check the survivor: if it no
+        // longer matches the history, this is a reset — swap it in place
+        // (disposing the stale wrapper) with no pop animation.
+        let survivor_matches = new_len == 0 || {
+            let l = live.borrow();
+            let w = &l[new_len - 1];
+            let entry = &stack.history[new_len - 1];
+            w.child == entry.child && w.fingerprint == entry.state
         };
-        // The deepest-removed (the visible top) animates out coordinated
-        // with the newly-revealed survivor; any extra removed entries
-        // (multi-pop / reset) just vanish.
-        let mut popped = popped.into_iter();
-        if let Some(top_popped) = popped.next() {
-            run_pop(slot, live, top_popped);
-        }
-        for w in popped {
-            dispose_wrapper(slot, w);
+        let popped: Vec<StackWrapper> = live.borrow_mut().split_off(new_len);
+        if survivor_matches {
+            // The deepest-removed (the visible top) animates out coordinated
+            // with the newly-revealed survivor; any extra removed entries
+            // (multi-pop) just vanish.
+            let mut popped = popped.into_iter();
+            if let Some(top_popped) = popped.next() {
+                run_pop(slot, live, top_popped);
+            }
+            for w in popped {
+                dispose_wrapper(slot, w);
+            }
+        } else {
+            // Reset: dispose every removed wrapper (no pop animation), then
+            // replace the stale survivor top with the route the history now
+            // wants there. Disposing the old wrapper tears down its native
+            // views, so nothing from the cleared screens lingers.
+            for w in popped {
+                dispose_wrapper(slot, w);
+            }
+            let top_idx = new_len - 1;
+            let old = live.borrow_mut().remove(top_idx);
+            dispose_wrapper(slot, old);
+            let entry = &stack.history[top_idx];
+            let w = mount_wrapper(handle, slot, top_idx, entry);
+            w.ctrl.set_value(1.0);
+            set_pose(&w, &w.ctrl.clone(), Role::Top, Direction::Push);
+            live.borrow_mut().insert(top_idx, w);
         }
     }
 
-    // ----- Same length but the top changed = `replace`. Swap in place,
-    // no animation (the new top is already present).
+    // ----- Same length but the top changed = `replace`. Swap the top in
+    // place and slide the new screen in (drive its controller 0 → 1) using
+    // its route transition, instead of snapping to the final pose. The entry
+    // beneath (if any) stays put — a replace swaps only the top. (#265)
     if new_len == old_len && new_len > 0 {
         let top_idx = new_len - 1;
         let entry = &stack.history[top_idx];
@@ -431,8 +462,14 @@ fn reconcile_stack(
             let old = live.borrow_mut().remove(top_idx);
             dispose_wrapper(slot, old);
             let w = mount_wrapper(handle, slot, top_idx, entry);
-            w.ctrl.set_value(1.0);
-            set_pose(&w, &w.ctrl.clone(), Role::Top, Direction::Push);
+            let drive = w.ctrl.clone();
+            w.ctrl.set_value(0.0);
+            set_pose(&w, &drive, Role::Top, Direction::Push);
+            if w.transition.is_instant() {
+                drive.set_value(1.0);
+            } else {
+                drive.forward();
+            }
             live.borrow_mut().insert(top_idx, w);
         }
     }

--- a/packages/whisker-router/src/render/node.rs
+++ b/packages/whisker-router/src/render/node.rs
@@ -446,10 +446,12 @@ fn reconcile_stack(
         }
     }
 
-    // ----- Same length but the top changed = `replace`. Swap the top in
-    // place and slide the new screen in (drive its controller 0 → 1) using
-    // its route transition, instead of snapping to the final pose. The entry
-    // beneath (if any) stays put — a replace swaps only the top. (#265)
+    // ----- Same length but the top changed = `replace`. Animate it like a
+    // push: the new screen slides in OVER the old top (kept mounted as a
+    // transient `Under`), and the old wrapper is disposed when the slide
+    // finishes. The entry *below* the old top is left untouched (it stays
+    // covered), so the lower screen never flashes into view behind the
+    // incoming one. (#265)
     if new_len == old_len && new_len > 0 {
         let top_idx = new_len - 1;
         let entry = &stack.history[top_idx];
@@ -459,18 +461,36 @@ fn reconcile_stack(
             w.child != entry.child || w.fingerprint != entry.state
         };
         if needs_swap {
+            // Detach the old top from `live` but keep it mounted — it is the
+            // incoming screen's `Under` for the duration of the slide.
             let old = live.borrow_mut().remove(top_idx);
-            dispose_wrapper(slot, old);
             let w = mount_wrapper(handle, slot, top_idx, entry);
             let drive = w.ctrl.clone();
+            let instant = w.transition.is_instant();
             w.ctrl.set_value(0.0);
             set_pose(&w, &drive, Role::Top, Direction::Push);
-            if w.transition.is_instant() {
+            set_pose(&old, &drive, Role::Under, Direction::Push);
+            live.borrow_mut().insert(top_idx, w);
+
+            if instant {
                 drive.set_value(1.0);
+                dispose_wrapper(slot, old);
             } else {
+                // Tear the old top down ONLY when the slide finishes (mirrors
+                // `run_pop`), never mid-animation.
+                let old_wrapper = old.wrapper;
+                let old_owner = old.owner;
+                let done = Rc::new(RefCell::new(false));
+                drive.on_finish(move |finished| {
+                    if !finished || *done.borrow() {
+                        return;
+                    }
+                    *done.borrow_mut() = true;
+                    remove_child(slot, old_wrapper);
+                    old_owner.dispose();
+                });
                 drive.forward();
             }
-            live.borrow_mut().insert(top_idx, w);
         }
     }
 

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -336,6 +336,70 @@ fn navigate_mounts_new_leaf_exactly_once() {
     });
 }
 
+/// A single root Stack with mount-counting leaves (`home` at `""`, `detail`
+/// at `detail/:id`).
+fn counting_simple_handle(counts: Counts) -> RouterHandle {
+    let tree = CompiledTree::new(RouteTree::stack(vec![
+        RouteTree::route("", "home"),
+        RouteTree::route("detail/:id", "detail"),
+    ]));
+    let mk = |id: &'static str, counts: Counts| {
+        move |_: &RouteInstance| {
+            *counts.borrow_mut().entry(id).or_insert(0) += 1;
+            whisker::runtime::view::create_phantom_element()
+        }
+    };
+    let registry = RouteRegistry::new()
+        .route("home", mk("home", counts.clone()))
+        .route_with(
+            "detail",
+            RouteTransition::none(),
+            mk("detail", counts.clone()),
+        );
+    RouterHandle::new((tree, registry))
+}
+
+/// Regression for #264. When `reset` replaces the whole history with a route
+/// that differs from the surviving index-0 wrapper, the reconcile must dispose
+/// the stale survivor and mount the new route — not re-show the old screen.
+/// (Wrappers are keyed by history index; a naive shrink kept the stale
+/// survivor, so the cleared screen reappeared and its native views leaked.)
+#[test]
+fn reset_to_different_route_reinstantiates_revealed_top() {
+    with_runtime(|| {
+        let counts: Counts = Rc::new(RefCell::new(HashMap::new()));
+        let h = counting_simple_handle(counts.clone());
+        let _slot = mount_node(&h, NodePath::root());
+        flush();
+        assert_eq!(counts.borrow().get("home").copied(), Some(1));
+
+        // Push detail → history [home, detail/1].
+        h.navigate("/detail/1").unwrap();
+        flush();
+        assert_eq!(counts.borrow().get("detail").copied(), Some(1));
+
+        // Reset to a route DIFFERENT from index 0 (home) → history [detail/2].
+        // The shrink reveals the index-0 survivor (home), which no longer
+        // matches the history (detail/2), so it must be swapped.
+        h.reset("/detail/2").unwrap();
+        flush();
+
+        let RouteState::Stack(s) = h.state().get() else {
+            panic!("root is a stack")
+        };
+        assert_eq!(s.history.len(), 1, "reset collapses to a single entry");
+
+        // The revealed top is a NEW detail leaf (mounted for /2), so detail
+        // mounted twice total. Pre-fix this stayed at 1 — the stale `home`
+        // wrapper was kept and `detail/2` never mounted.
+        assert_eq!(
+            counts.borrow().get("detail").copied(),
+            Some(2),
+            "reset must re-instantiate the revealed top when its route changed"
+        );
+    });
+}
+
 // ----- coordinated pop: survivor returns to the active (0%) pose -------
 
 /// A single-stack handle with Slide routes so a push/pop runs a real
@@ -436,6 +500,59 @@ fn push_settles_top_to_full_progress() {
             detail_ctrl.value().get_untracked(),
             1.0,
             "top settles at progress 1.0 after push"
+        );
+    });
+    owner.dispose();
+}
+
+/// Regression for #265. `replace` used to snap the new top to its final pose
+/// (`ctrl.set_value(1.0)`); it must instead slide the new screen in (drive
+/// 0 → 1) using the route transition.
+#[test]
+fn replace_animates_the_new_top_in() {
+    whisker::runtime::reactive::__reset_for_tests();
+    whisker_animation::__reset_for_tests();
+    let owner = Owner::new(None);
+    owner.with(|| {
+        let h = slide_stack_handle();
+        let _slot = mount_node(&h, NodePath::root());
+        flush();
+
+        // Push detail/1 and let it settle (top at progress 1.0).
+        h.navigate("/detail/1").unwrap();
+        flush();
+        settle_animations();
+
+        // Replace the top (detail/1 → detail/2, same depth).
+        h.replace("/detail/2").unwrap();
+        flush();
+        let top_ctrl = h
+            .active_stack_bridge_for_test(&NodePath::root())
+            .and_then(|b| b.top_ctrl)
+            .expect("new top ctrl");
+
+        // Step a few frames WITHOUT settling: the new top's progress must
+        // traverse intermediate values (a visible slide-in), not be pinned at
+        // 1.0 from the first frame (the pre-fix instant-swap bug).
+        let mut t = 1000.0;
+        let mut traj = Vec::new();
+        for _ in 0..6 {
+            whisker_animation::__step_for_tests(t);
+            flush();
+            traj.push(top_ctrl.value().get_untracked());
+            t += 16.0;
+        }
+        assert!(
+            traj.iter().any(|&p| p > 0.05 && p < 0.95),
+            "replace should animate the new top in, not snap; traj={traj:?}"
+        );
+
+        // …and it must still settle fully present.
+        settle_animations();
+        assert_eq!(
+            top_ctrl.value().get_untracked(),
+            1.0,
+            "replaced top settles at progress 1.0"
         );
     });
     owner.dispose();

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -475,6 +475,27 @@ fn slide_stack_handle() -> RouterHandle {
     RouterHandle::new((tree, registry))
 }
 
+/// `Route(layout) { Stack { home(slide), detail/:id(slide) } }` — the same
+/// layout-Route-above-a-stack shape as the tabbed example, with slide
+/// transitions so animation is observable.
+fn layout_slide_handle() -> RouterHandle {
+    let tree = CompiledTree::new(RouteTree::route_with(
+        RouteDef::new("", "layout"),
+        vec![RouteTree::stack(vec![
+            RouteTree::route("", "home"),
+            RouteTree::route("detail/:id", "detail"),
+        ])],
+    ));
+    let registry = RouteRegistry::new()
+        .route_with("home", RouteTransition::slide(), |_: &RouteInstance| {
+            whisker::runtime::view::create_phantom_element()
+        })
+        .route_with("detail", RouteTransition::slide(), |_: &RouteInstance| {
+            whisker::runtime::view::create_phantom_element()
+        });
+    RouterHandle::new((tree, registry))
+}
+
 /// Advance animation frames + flush until nothing is animating (or a
 /// budget is hit), driving any in-flight push/pop/settle to completion.
 fn settle_animations() {
@@ -609,6 +630,96 @@ fn replace_animates_the_new_top_in() {
             top_ctrl.value().get_untracked(),
             1.0,
             "replaced top settles at progress 1.0"
+        );
+    });
+    owner.dispose();
+}
+
+/// After a `replace`, a `back` must still animate the revealed survivor (the
+/// screen below) sliding in from covered → rest — not snap it in. Regression
+/// for the "Home doesn't animate on back after replace" report.
+#[test]
+fn back_after_replace_animates_the_revealed_survivor() {
+    whisker::runtime::reactive::__reset_for_tests();
+    whisker_animation::__reset_for_tests();
+    let owner = Owner::new(None);
+    owner.with(|| {
+        let h = slide_stack_handle();
+        let _slot = mount_node(&h, NodePath::root());
+        flush();
+
+        h.navigate("/detail/1").unwrap();
+        flush();
+        settle_animations();
+
+        h.replace("/detail/2").unwrap();
+        flush();
+        settle_animations();
+
+        // The survivor (home) below the replaced top.
+        let under = h
+            .active_stack_bridge_for_test(&NodePath::root())
+            .and_then(|b| b.under_pose)
+            .expect("home is the under after replace");
+
+        // Back: the survivor must be coupled to the leaving controller and
+        // slide in through intermediate frames.
+        assert!(h.back().is_ok());
+        flush();
+        let mut t = 1000.0;
+        let mut traj = Vec::new();
+        for _ in 0..6 {
+            whisker_animation::__step_for_tests(t);
+            flush();
+            traj.push(under.ctrl.get().value().get_untracked());
+            t += 16.0;
+        }
+        assert!(
+            traj.iter().any(|&p| p > 0.05 && p < 0.95),
+            "the revealed survivor must animate in on back-after-replace; traj={traj:?}"
+        );
+    });
+    owner.dispose();
+}
+
+/// Same as above but with a layout Route above the stack (the tabbed example's
+/// shape). Reproduces the "Home doesn't animate on back after replace" report.
+#[test]
+fn back_after_replace_animates_under_a_layout_route() {
+    whisker::runtime::reactive::__reset_for_tests();
+    whisker_animation::__reset_for_tests();
+    let owner = Owner::new(None);
+    owner.with(|| {
+        let h = layout_slide_handle();
+        let _slot = mount_node(&h, NodePath::root());
+        flush();
+
+        h.navigate("/detail/1").unwrap();
+        flush();
+        settle_animations();
+
+        h.replace("/detail/2").unwrap();
+        flush();
+        settle_animations();
+
+        let under = h
+            .active_stack_bridge()
+            .and_then(|b| b.under_pose)
+            .expect("home is the under after replace");
+
+        assert!(h.back().is_ok());
+        flush();
+        let mut t = 1000.0;
+        let mut traj = Vec::new();
+        for _ in 0..6 {
+            whisker_animation::__step_for_tests(t);
+            flush();
+            traj.push(under.ctrl.get().value().get_untracked());
+            t += 16.0;
+        }
+        assert!(
+            traj.iter().any(|&p| p > 0.05 && p < 0.95),
+            "survivor must animate in on back-after-replace under a layout route; traj={traj:?}"
         );
     });
     owner.dispose();

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -725,6 +725,53 @@ fn back_after_replace_animates_under_a_layout_route() {
     owner.dispose();
 }
 
+/// After a `replace`, the revealed under is a paused buried entry (the settle
+/// freezes it because its pose controller is idle — unlike a push, whose under
+/// is mid-animation and so stays live). An interactive swipe-back must resume
+/// it so its pose effect follows the finger through the scrub; the gesture can
+/// only re-point the bridge's pose bindings, so the bridge carries the under's
+/// owner for exactly this. Regression for "SwipeBack intermediate animation
+/// doesn't work after replace".
+#[test]
+fn swipe_back_resumes_the_paused_under_after_replace() {
+    whisker::runtime::reactive::__reset_for_tests();
+    whisker_animation::__reset_for_tests();
+    let owner = Owner::new(None);
+    owner.with(|| {
+        let h = layout_slide_handle();
+        let _slot = mount_node(&h, NodePath::root());
+        flush();
+
+        h.navigate("/detail/1").unwrap();
+        flush();
+        settle_animations();
+
+        h.replace("/detail/2").unwrap();
+        flush();
+        settle_animations();
+
+        let under_owner = h
+            .active_stack_bridge()
+            .and_then(|b| b.under_owner)
+            .expect("under owner present after replace");
+
+        // The replace settle freezes (pauses) the buried under.
+        assert!(
+            under_owner.is_paused(),
+            "precondition: the under is paused after a replace"
+        );
+
+        // Starting a swipe-back must resume it so the scrub animates it.
+        crate::render::gesture::begin(&h, crate::render::transition::SwipeEdge::Left)
+            .expect("swipe-back begins (stack can pop)");
+        assert!(
+            !under_owner.is_paused(),
+            "swipe-back must resume the under so it follows the finger"
+        );
+    });
+    owner.dispose();
+}
+
 #[test]
 fn pop_animates_outgoing_top_through_intermediate_frames() {
     whisker::runtime::reactive::__reset_for_tests();

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -13,7 +13,9 @@ use std::rc::Rc;
 
 use whisker::runtime::reactive::Owner;
 
-use crate::core::{CompiledTree, NodePath, RouteInstance, RouteState, RouteTree, SwitchDef};
+use crate::core::{
+    CompiledTree, NodePath, RouteDef, RouteInstance, RouteState, RouteTree, SwitchDef,
+};
 use crate::render::handle::{RouterHandle, state_at};
 use crate::render::node::mount_node;
 use crate::render::registry::RouteRegistry;
@@ -173,6 +175,60 @@ fn reset_clears_stack_to_target() {
         };
         assert_eq!(s.history.len(), 1);
         assert_eq!(h.current().get().path, NodePath(vec![0]));
+    });
+}
+
+/// `Route(layout) { Stack { home, detail/:id } }` — a layout Route (a
+/// `Route` with children, like `routes! { Route(component: X) { … } }`) above
+/// the active stack.
+fn layout_wrapped_handle() -> RouterHandle {
+    let tree = CompiledTree::new(RouteTree::route_with(
+        RouteDef::new("", "layout"),
+        vec![RouteTree::stack(vec![
+            RouteTree::route("", "home"),
+            RouteTree::route("detail/:id", "detail"),
+        ])],
+    ));
+    RouterHandle::new((tree, registry()))
+}
+
+fn layout_stack_history_len(h: &RouterHandle) -> usize {
+    let RouteState::Route(r) = h.state().get() else {
+        panic!("root is a layout route")
+    };
+    let RouteState::Stack(s) = &r.children[0] else {
+        panic!("layout child is a stack")
+    };
+    s.history.len()
+}
+
+/// Regression: `replace` / `reset` (and `pop_to`) must work when a layout
+/// Route sits above the active stack. `active_stack_mut` returned `None` for
+/// any `Route`, so it disagreed with `deepest_active_stack_path` and the
+/// `.expect("stack exists")` panicked — surfaced by the tabbed router example
+/// (tap Replace / Reset → "panic in event handler for `tap`; event dropped").
+#[test]
+fn stack_ops_work_under_a_layout_route() {
+    with_runtime(|| {
+        let h = layout_wrapped_handle();
+        h.navigate("/detail/1").unwrap();
+        flush();
+
+        // replace: swaps the top in place (no panic), depth unchanged.
+        h.replace("/detail/2").unwrap();
+        assert_eq!(
+            h.current().get().params.get("id").map(String::as_str),
+            Some("2"),
+        );
+        assert_eq!(layout_stack_history_len(&h), 2, "replace keeps depth");
+
+        // reset: collapses the stack to a single entry (no panic).
+        h.reset("/detail/5").unwrap();
+        assert_eq!(
+            h.current().get().params.get("id").map(String::as_str),
+            Some("5"),
+        );
+        assert_eq!(layout_stack_history_len(&h), 1, "reset collapses to one");
     });
 }
 

--- a/packages/whisker-router/tests/core_router.rs
+++ b/packages/whisker-router/tests/core_router.rs
@@ -74,6 +74,22 @@ fn reset_to_home_tab_from_another_tab() {
     }
 }
 
+#[test]
+fn bare_group_url_resolves_to_its_first_screen() {
+    // The "(search)" group has no index "" child. A bare "/(search)" (e.g. a
+    // tab-bar `select("/(search)")`) must still resolve — to the group's first
+    // screen (list) — so the tab stays selectable.
+    let t = grouped_tabs_tree();
+    let mut st = RouteState::initial(&t);
+    let mut nav = Navigator::new(&t, &mut st);
+    nav.select("/(search)").unwrap();
+    assert_eq!(
+        nav.current().path,
+        NodePath(vec![0, 1, 0, 0]),
+        "select(\"/(search)\") lands on the search tab's first screen (list)"
+    );
+}
+
 // ===================================================================
 // The Twitter-style tree (built by hand — no macro yet)
 // ===================================================================

--- a/packages/whisker-router/tests/core_router.rs
+++ b/packages/whisker-router/tests/core_router.rs
@@ -7,8 +7,63 @@
 //! brief are tagged in the test names / comments.
 
 use whisker_router::core::{
-    CompiledTree, NavError, Navigator, NodePath, RouteState, RouteTree, Scope, SwitchDef,
+    CompiledTree, NavError, Navigator, NodePath, RouteDef, RouteState, RouteTree, Scope, SwitchDef,
 };
+
+/// Mirror the router example: a layout `Route` over a `Switch` whose branches
+/// are `(group) → Stack` tabs (home tab + search tab).
+fn grouped_tabs_tree() -> CompiledTree {
+    CompiledTree::new(RouteTree::route_with(
+        RouteDef::new("", "layout"),
+        vec![RouteTree::switch(
+            SwitchDef::new("tabs", 0),
+            vec![
+                RouteTree::route_with(
+                    RouteDef::new("(home)", "home_grp"),
+                    vec![RouteTree::stack(vec![
+                        RouteTree::route("", "home"),
+                        RouteTree::route("detail/:id", "detail"),
+                    ])],
+                ),
+                RouteTree::route_with(
+                    RouteDef::new("(search)", "search_grp"),
+                    vec![RouteTree::stack(vec![
+                        RouteTree::route("list", "list"),
+                        RouteTree::route("detail/:id", "detail"),
+                    ])],
+                ),
+            ],
+        )],
+    ))
+}
+
+#[test]
+fn reset_to_home_tab_from_another_tab() {
+    let t = grouped_tabs_tree();
+    let mut st = RouteState::initial(&t);
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.select("/list").unwrap(); // switch to the search tab
+        nav.navigate("/detail/1").unwrap(); // list → detail
+        assert_eq!(
+            nav.current().path,
+            NodePath(vec![0, 1, 0, 1]),
+            "in search/detail"
+        );
+    }
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        // The home route is "" under the "(home)" group, so its canonical URL
+        // is "/(home)". A bare "/" matches no route here and resolves relative
+        // to the current tab — use the explicit group URL to target Home.
+        nav.reset("/(home)").unwrap();
+        assert_eq!(
+            nav.current().path,
+            NodePath(vec![0, 0, 0, 0]),
+            "reset(\"/(home)\") from the search tab lands on the Home tab"
+        );
+    }
+}
 
 // ===================================================================
 // The Twitter-style tree (built by hand — no macro yet)

--- a/packages/whisker-router/tests/core_router.rs
+++ b/packages/whisker-router/tests/core_router.rs
@@ -447,6 +447,55 @@ fn reset_logout_clears_root_back_stack() {
     assert_eq!(root_history_len(&st), 1);
 }
 
+#[test]
+fn reset_is_global_clears_every_stack_and_branch() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    // Deepen the timeline stack, switch to the search tab, deepen that too.
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate("/post/1").unwrap();
+        nav.navigate("/post/2").unwrap(); // timeline depth 3
+        nav.select("/search").unwrap();
+        nav.navigate("/post/9").unwrap(); // search depth 2
+    }
+    assert_eq!(timeline_history(&st).len(), 3);
+    assert_eq!(search_history(&st).len(), 2);
+
+    // A global reset to the timeline home must collapse EVERYTHING — the
+    // target branch, the other branch, and the root stack — to one entry.
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.reset("/").unwrap();
+        assert_eq!(nav.current().path, p(&[0, 0, 0]), "current = timeline home");
+    }
+    assert_eq!(root_history_len(&st), 1, "root stack collapsed");
+    assert_eq!(timeline_history(&st).len(), 1, "target branch collapsed");
+    assert_eq!(
+        search_history(&st).len(),
+        1,
+        "the OTHER branch (search) is cleared to its root too"
+    );
+    assert_eq!(switch_selected(&st), 0, "switch selects the target branch");
+}
+
+#[test]
+fn reset_crosses_into_another_branch() {
+    let t = twitter_tree();
+    let mut st = RouteState::initial(&t);
+    {
+        let mut nav = Navigator::new(&t, &mut st);
+        nav.navigate("/post/1").unwrap(); // timeline depth 2, switch on timeline
+        // Reset straight into the search tab (a different Switch branch) —
+        // the old same-stack `reset` would have errored CrossStack.
+        nav.reset("/search").unwrap();
+        assert_eq!(nav.current().path, p(&[0, 1, 0]), "current = search home");
+    }
+    assert_eq!(switch_selected(&st), 1, "switch moved to search");
+    assert_eq!(timeline_history(&st).len(), 1, "timeline cleared");
+    assert_eq!(search_history(&st).len(), 1);
+}
+
 // ===================================================================
 // 12. cold-start resolution → declaration order; Switch(default) honored
 // ===================================================================
@@ -690,6 +739,15 @@ fn timeline_history(st: &RouteState) -> &[whisker_router::core::StackEntry] {
 
 fn search_history(st: &RouteState) -> &[whisker_router::core::StackEntry] {
     tab_history(st, 1)
+}
+
+fn switch_selected(st: &RouteState) -> usize {
+    if let RouteState::Stack(root) = st {
+        if let RouteState::Switch(sw) = &root.history[0].state {
+            return sw.selected;
+        }
+    }
+    panic!("could not reach the tabs switch");
 }
 
 fn tab_history(st: &RouteState, branch: usize) -> &[whisker_router::core::StackEntry] {

--- a/packages/whisker-router/tests/core_router.rs
+++ b/packages/whisker-router/tests/core_router.rs
@@ -53,15 +53,24 @@ fn reset_to_home_tab_from_another_tab() {
     }
     {
         let mut nav = Navigator::new(&t, &mut st);
-        // The home route is "" under the "(home)" group, so its canonical URL
-        // is "/(home)". A bare "/" matches no route here and resolves relative
-        // to the current tab — use the explicit group URL to target Home.
-        nav.reset("/(home)").unwrap();
+        // The home is the index "" route under the "(home)" group. "/" must
+        // resolve to that leaf screen — not the group container (which shares
+        // the URL) — so reset("/") from the search tab lands on the Home tab.
+        nav.reset("/").unwrap();
         assert_eq!(
             nav.current().path,
             NodePath(vec![0, 0, 0, 0]),
-            "reset(\"/(home)\") from the search tab lands on the Home tab"
+            "reset(\"/\") from the search tab lands on the Home tab"
         );
+    }
+    // The explicit group URL works identically.
+    {
+        let mut st2 = RouteState::initial(&t);
+        let mut nav = Navigator::new(&t, &mut st2);
+        nav.select("/list").unwrap();
+        nav.navigate("/detail/1").unwrap();
+        nav.reset("/(home)").unwrap();
+        assert_eq!(nav.current().path, NodePath(vec![0, 0, 0, 0]));
     }
 }
 


### PR DESCRIPTION
A series of `whisker-router` correctness + interaction fixes, surfaced by exercising reset/replace/swipe-back on the example. **Contains a breaking change** to `reset` semantics (see below).

**Closes #264. Closes #265.**

## Reconcile / animation
- **#264 — `reset` left a stale lower wrapper mounted.** Wrappers are keyed by history index, so a shrink that lands a *different* route at the surviving index kept the wrong screen mounted (and leaked its native views). The shrink branch now checks the survivor and swaps it when it no longer matches.
- **#265 — `replace` snapped instead of animating.** It now slides the new screen in **over** the old top (kept as a transient `Under`), disposing the old wrapper when the slide finishes — and **even if `Back` interrupts** the slide (the old top is logically gone the moment the replace starts, so it never lingers and covers the revealed screen).
- **`replace`/`reset`/`pop_to` panicked under a layout `Route`.** `active_stack_mut` returned `None` for any `Route`, disagreeing with `active_chain`/`deepest_active_stack_path`, so `.expect("stack exists")` panicked when a `Route(component:){…}` / `(group)` sat above the active stack (the tabbed example). It now descends into the Route's container child.
- **Swipe-back didn't animate the under after a `replace`.** A `replace` settles the under paused; the gesture only had the bridge's pose bindings, so it could re-point but not `resume()` the under — it stayed frozen and snapped at the end. The bridge now carries the under's owner and `gesture::begin` resumes it.

## `reset` is now **global** (BREAKING)
`reset(url)` was same-stack only (`CrossStack` otherwise). It now resolves `url` across the whole tree like `navigate`, selects every `Switch` toward the target, and **collapses every `Stack` to a single entry** — no back history survives anywhere, on the target path or in any other branch. This is the true "clear everything / clean slate" semantics (cf. React Navigation `reset({routes})`, Flutter `pushAndRemoveUntil(_, (_) => false)`). Implemented via a new `RouteState::focused_at(tree, dest, params)`.

## URL resolution targets **screens**, not containers
- A navigation destination is a **leaf** `Route` (a screen) — never a `Stack`/`Switch`/`(group)` container. A group's URL equals its index child's, so previously a bare `/` matched the group container and (being a nearer common ancestor) was picked over the index screen inside it — `reset("/")` from another tab stayed on the wrong tab.
- `/` now resolves to the home index screen even from another tab.
- **Fallback:** a bare `/(group)` whose group has no index `""` screen resolves to the group's first screen (so a tab bar's `select("/(group)")` keeps working).

## Example
The router example's Detail screen gains Push / Replace / Reset → Detail / Reset → Home buttons to exercise these paths on device. Verified on the iOS simulator.

## Not included (follow-up)
The **directional reset *animation*** (pop/push depending on back-stack membership, incl. cross-tab) is deferred — it needs a top-level transition layer. `reset` is correct today; a same-branch reset onto an existing lower entry already animates as a pop, while reset-to-a-new-route is instant.

## Tests
Reconcile-level regressions (reset re-instantiation, replace slide-in, back-after-replace survivor, swipe-back resume, layout-route ops) + core resolution/reset tests (global collapse, cross-branch reset, `/` → home index, bare `/(group)` → first screen). `cargo fmt --all --check` / `clippy -D warnings` clean; whisker-router render (40) + core (33) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)