### PR TITLE
fix(whisker-dev-runtime): Android build broke on libc 0.2.186 (c_char buffer)

### DIFF
--- a/crates/whisker-dev-runtime/src/hot_reload.rs
+++ b/crates/whisker-dev-runtime/src/hot_reload.rs
@@ -204,8 +204,11 @@ fn dev_token() -> Option<String> {
 #[cfg(target_os = "android")]
 fn android_system_property(name: &str) -> Option<String> {
     let cname = std::ffi::CString::new(name).ok()?;
-    // PROP_VALUE_MAX = 92.
-    let mut buf = [0i8; 92];
+    // PROP_VALUE_MAX = 92. Use `c_char` for the buffer so its pointer matches
+    // bionic's `__system_property_get` signature regardless of `c_char`
+    // signedness (it is unsigned on Android — `libc` 0.2.186 made this a hard
+    // type mismatch against a plain `i8` buffer).
+    let mut buf = [0 as libc::c_char; 92];
     // SAFETY: `cname` is a valid NUL-terminated C string; `buf` is a
     // 92-byte buffer matching PROP_VALUE_MAX, which is the size bionic
     // writes into. The return value is the length written (excluding


### PR DESCRIPTION
## Problem

`whisker run android` (any app built with the `hot-reload` feature) fails to cross-compile:

```
error[E0308]: mismatched types
   --> crates/whisker-dev-runtime/src/hot_reload.rs:213
   expected raw pointer `*mut u8`, found `*mut i8`
```

`android_system_property` declared its `PROP_VALUE_MAX` buffer as `[0i8; 92]` and passed `buf.as_mut_ptr()` (`*mut i8`) to bionic's `__system_property_get`. Android's `c_char` is **unsigned**, and **libc 0.2.186** turned the long-standing signedness mismatch into a hard type error. Picked up automatically via the semver-compatible libc bump, so the break is latent on `main`.

## Fix

Declare the buffer as `[0 as libc::c_char; 92]` so its pointer matches the bionic signature regardless of `c_char` signedness. The function is `#[cfg(target_os = "android")]`, so host builds (where `c_char = i8`) are unaffected — `cargo check -p whisker-dev-runtime` on the host stays green.

Found while reproducing the Android custom-UI Input issue — the dev-runtime wouldn't even compile for `aarch64-linux-android` until this.