### PR TITLE
feat(whisker-input): auto_capitalize / autocorrect / spell_check text-input traits

### DIFF
--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt
@@ -62,6 +62,15 @@ class InputModule : Module() {
             Prop("return-key") { view: WhiskerInputView, value ->
                 view.setReturnKey(value.asString() ?: "default")
             }
+            Prop("auto-capitalize") { view: WhiskerInputView, value ->
+                view.setAutoCapitalize(value.asString() ?: "sentences")
+            }
+            Prop("autocorrect") { view: WhiskerInputView, value ->
+                view.setAutocorrect(value.asString() ?: "true")
+            }
+            Prop("spell-check") { view: WhiskerInputView, value ->
+                view.setSpellCheck(value.asString() ?: "true")
+            }
 
             // Declaration-only metadata (parity with the iOS module);
             // actual dispatch is the imperative WhiskerCustomEvent path

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
@@ -69,6 +69,34 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
     /// window (EditText must be attached before requesting focus works).
     private var pendingAutoFocus: Boolean = false
 
+    /// Selected auto-capitalization flag bit (one of the
+    /// `InputType.TYPE_TEXT_FLAG_CAP_*` flags, or `0` for "none").
+    ///
+    /// On Android, autocapitalization is NOT a standalone property like
+    /// iOS's `autocapitalizationType`; it's a few flag bits packed into
+    /// the same `inputType` Int that also carries the class / variation /
+    /// multiline / password bits. So `setKeyboardType`, `setSecure`, and
+    /// `setMultiline` — which all rebuild `inputType` — would wipe this
+    /// flag. We cache it here and reapply via [applyTextFlags] after every
+    /// such rebuild, so the cap setting survives regardless of prop order.
+    ///
+    /// Default `TYPE_TEXT_FLAG_CAP_SENTENCES` matches iOS UIKit's
+    /// `.sentences` default, keeping the two platforms consistent (the
+    /// Rust component always sends an explicit `auto-capitalize` attr,
+    /// defaulting to `"sentences"`).
+    private var capFlag: Int = InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
+
+    /// `auto-capitalize`'s siblings: the autocorrect and "no suggestions"
+    /// flag bits. Like [capFlag] these live in the shared `inputType` and
+    /// are reinstated by [applyTextFlags] after any inputType rebuild.
+    ///
+    /// `autoCorrectFlag` defaults to `TYPE_TEXT_FLAG_AUTO_CORRECT` (ON) to
+    /// match iOS's `.default` autocorrect, per the platform-alignment
+    /// decision. `noSuggestionsFlag` defaults to `0` (suggestions shown),
+    /// matching both Android's native default and iOS spell-check on.
+    private var autoCorrectFlag: Int = InputType.TYPE_TEXT_FLAG_AUTO_CORRECT
+    private var noSuggestionsFlag: Int = 0
+
     /// Last-applied CSS `background-color` (ARGB int) and corner radius
     /// (device px). We render these ourselves via a [GradientDrawable]
     /// rather than relying on Lynx's `BackgroundDrawable` — see
@@ -246,6 +274,9 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
             et.inputType = et.inputType and InputType.TYPE_TEXT_FLAG_MULTI_LINE.inv()
             et.gravity = Gravity.CENTER_VERTICAL or (et.gravity and Gravity.HORIZONTAL_GRAVITY_MASK)
         }
+        // `isSingleLine` / the MULTI_LINE flag toggle can reset inputType
+        // bits; reinstate the cached cap flag.
+        applyTextFlags()
     }
 
     fun setLines(countStr: String) {
@@ -267,6 +298,8 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
             val base = et.inputType and InputType.TYPE_MASK_CLASS
             et.inputType = base or InputType.TYPE_TEXT_VARIATION_NORMAL
         }
+        // The masked rebuild above drops the cap flags; reinstate them.
+        applyTextFlags()
     }
 
     fun setEditable(flag: String) {
@@ -315,6 +348,8 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
                 InputType.TYPE_TEXT_VARIATION_URI
             else -> InputType.TYPE_CLASS_TEXT or variation
         }
+        // Rebuilding `inputType` from scratch drops the cap flags; reinstate.
+        applyTextFlags()
     }
 
     fun setReturnKey(type: String) {
@@ -327,6 +362,52 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
             "send" -> EditorInfo.IME_ACTION_SEND
             else -> EditorInfo.IME_ACTION_UNSPECIFIED
         }
+    }
+
+    fun setAutoCapitalize(mode: String) {
+        capFlag = when (mode) {
+            "none" -> 0
+            "words" -> InputType.TYPE_TEXT_FLAG_CAP_WORDS
+            "characters" -> InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS
+            else -> InputType.TYPE_TEXT_FLAG_CAP_SENTENCES // "sentences"
+        }
+        applyTextFlags()
+    }
+
+    fun setAutocorrect(flag: String) {
+        autoCorrectFlag = if (flag == "false") 0 else InputType.TYPE_TEXT_FLAG_AUTO_CORRECT
+        applyTextFlags()
+    }
+
+    fun setSpellCheck(flag: String) {
+        // `spell_check` is the inverse of the `NO_SUGGESTIONS` flag:
+        // spell-check OFF → set NO_SUGGESTIONS to hide the suggestion strip.
+        noSuggestionsFlag = if (flag == "false") InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS else 0
+        applyTextFlags()
+    }
+
+    /**
+     * Reapply the cached text-behaviour flag bits ([capFlag],
+     * [autoCorrectFlag], [noSuggestionsFlag]) onto the EditText's current
+     * `inputType`, clearing the managed bits first. Called from each
+     * behaviour setter and after every setter that rebuilds `inputType`
+     * ([setKeyboardType], [setSecure], [setMultiline]) so these settings
+     * survive a rebuild regardless of prop-arrival order — they all share
+     * the single `inputType` Int (unlike iOS's orthogonal traits).
+     *
+     * These flags only have an effect under `TYPE_CLASS_TEXT`; for
+     * number / phone classes (or email / URI variations) Android ignores
+     * them, so ORing unconditionally is harmless.
+     */
+    private fun applyTextFlags() {
+        val et = view ?: return
+        val managed = InputType.TYPE_TEXT_FLAG_CAP_SENTENCES or
+            InputType.TYPE_TEXT_FLAG_CAP_WORDS or
+            InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS or
+            InputType.TYPE_TEXT_FLAG_AUTO_CORRECT or
+            InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+        et.inputType = (et.inputType and managed.inv()) or
+            capFlag or autoCorrectFlag or noSuggestionsFlag
     }
 
     // -------------------------------------------------------------------------

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputModule.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputModule.swift
@@ -100,6 +100,15 @@ public final class InputModule: Module {
                 Prop("return-key") { (view: WhiskerInputView, value: WhiskerValue) in
                     view.setReturnKey(value.asString ?? "default")
                 }
+                Prop("auto-capitalize") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setAutoCapitalize(value.asString ?? "sentences")
+                }
+                Prop("autocorrect") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setAutocorrect(value.asString ?? "true")
+                }
+                Prop("spell-check") { (view: WhiskerInputView, value: WhiskerValue) in
+                    view.setSpellCheck(value.asString ?? "true")
+                }
 
                 // ---- CSS text-style props --------------------------------
                 //

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
@@ -91,6 +91,15 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
     private var cachedMaxLength: Int = 0                // 0 = unset
     private var cachedKeyboardType: UIKeyboardType = .default
     private var cachedReturnKeyType: UIReturnKeyType = .default
+    // Default `.sentences` matches UIKit's own UITextField/UITextView
+    // default, so a field that never sets `auto-capitalize` behaves
+    // exactly as before this prop existed.
+    private var cachedAutoCapitalize: UITextAutocapitalizationType = .sentences
+    // `.default` (not `.yes`) for the enabled case so UIKit keeps its
+    // contextual behaviour — e.g. it already disables autocorrect on URL
+    // / email keyboards. `false` forces `.no`.
+    private var cachedAutocorrect: UITextAutocorrectionType = .default
+    private var cachedSpellCheck: UITextSpellCheckingType = .default
     private var cachedTextColor: UIColor = .label
     private var cachedFontSize: CGFloat = 17
     private var cachedFontWeight: UIFont.Weight = .regular
@@ -219,7 +228,9 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
         let tf = PaddedTextField()
         tf.borderStyle = .none
         tf.backgroundColor = .clear
-        tf.autocorrectionType = .default
+        // `autocorrectionType` / `spellCheckingType` are applied from the
+        // cached prop state in `applyBehaviour` (called via
+        // `applyAllCachedProps` right after this build).
         tf.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
         tf.addTarget(self, action: #selector(textFieldDidEndOnExit(_:)), for: .editingDidEndOnExit)
         tf.delegate = self
@@ -333,11 +344,17 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
             tf.isEnabled = cachedEditable
             tf.keyboardType = cachedKeyboardType
             tf.returnKeyType = cachedReturnKeyType
+            tf.autocapitalizationType = cachedAutoCapitalize
+            tf.autocorrectionType = cachedAutocorrect
+            tf.spellCheckingType = cachedSpellCheck
         }
         if let tv = textView {
             tv.isEditable = cachedEditable
             tv.keyboardType = cachedKeyboardType
             tv.returnKeyType = cachedReturnKeyType
+            tv.autocapitalizationType = cachedAutoCapitalize
+            tv.autocorrectionType = cachedAutocorrect
+            tv.spellCheckingType = cachedSpellCheck
             // UITextView has no `isSecureTextEntry`; secure flag is a no-op
             // for multiline (passwords are always single-line in practice).
         }
@@ -455,6 +472,35 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
         cachedReturnKeyType = Self.mapReturnKeyType(s)
         textField?.returnKeyType = cachedReturnKeyType
         textView?.returnKeyType = cachedReturnKeyType
+    }
+
+    public func setAutoCapitalize(_ s: String) {
+        cachedAutoCapitalize = Self.mapAutoCapitalize(s)
+        textField?.autocapitalizationType = cachedAutoCapitalize
+        textView?.autocapitalizationType = cachedAutoCapitalize
+        // Changing the autocapitalization type while the keyboard is up
+        // only takes effect on the next keyboard presentation; UIKit
+        // exposes `reloadInputViews()` to apply it live.
+        if textField?.isFirstResponder == true { textField?.reloadInputViews() }
+        if textView?.isFirstResponder == true { textView?.reloadInputViews() }
+    }
+
+    public func setAutocorrect(_ s: String) {
+        // `.default` (not `.yes`) for the enabled case — see the cached
+        // property's declaration.
+        cachedAutocorrect = (s == "false") ? .no : .default
+        textField?.autocorrectionType = cachedAutocorrect
+        textView?.autocorrectionType = cachedAutocorrect
+        if textField?.isFirstResponder == true { textField?.reloadInputViews() }
+        if textView?.isFirstResponder == true { textView?.reloadInputViews() }
+    }
+
+    public func setSpellCheck(_ s: String) {
+        cachedSpellCheck = (s == "false") ? .no : .default
+        textField?.spellCheckingType = cachedSpellCheck
+        textView?.spellCheckingType = cachedSpellCheck
+        if textField?.isFirstResponder == true { textField?.reloadInputViews() }
+        if textView?.isFirstResponder == true { textView?.reloadInputViews() }
     }
 
     // ---- CSS text-style props ------------------------------------------
@@ -633,6 +679,15 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
         case "search": return .search
         case "send":   return .send
         default:       return .default
+        }
+    }
+
+    private static func mapAutoCapitalize(_ s: String) -> UITextAutocapitalizationType {
+        switch s {
+        case "none":       return .none
+        case "words":      return .words
+        case "characters": return .allCharacters
+        default:           return .sentences
         }
     }
 

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -99,6 +99,9 @@
 //! | `max_length`       | `u32`                                 | unset (`0`)   | Maximum character count. |
 //! | `keyboard_type`    | [`KeyboardType`]                      | `Default`     | On-screen keyboard layout. |
 //! | `return_key`       | [`ReturnKey`]                         | `Default`     | Return-key label / action. |
+//! | `auto_capitalize`  | [`AutoCapitalize`]                    | `Sentences`   | Keyboard auto-capitalization (`None` for handles / emails). |
+//! | `autocorrect`      | `bool`                                | `true`        | Automatic typo replacement (`false` for identifiers). |
+//! | `spell_check`      | `bool`                                | `true`        | Spell-check underline / suggestion strip (`false` for identifiers). |
 //! | `caret_color`      | `Signal<String>`                      | `""`          | Cursor color (CSS color string). |
 //! | `placeholder_color`| `Signal<String>`                      | `""`          | Placeholder text color. |
 //! | `selection_color`  | `Signal<String>`                      | `""`          | Selection-highlight color. |
@@ -323,6 +326,45 @@ impl ReturnKey {
     }
 }
 
+/// Auto-capitalization behaviour for an [`Input`]. Controls whether the
+/// on-screen keyboard auto-shifts to uppercase as the user types.
+///
+/// The default is [`Sentences`](Self::Sentences) — the platform-typical
+/// "capitalize the first letter of each sentence" behaviour. Identifier
+/// fields (handles, emails, URLs, usernames) should set
+/// [`None`](Self::None) so the very first character isn't forced upper.
+///
+/// Variant wire strings are locked against the native modules' string
+/// dispatch. `#[non_exhaustive]` so a future mode can be added without
+/// breaking exhaustive matches downstream.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum AutoCapitalize {
+    /// `"sentences"` — capitalize the first letter of each sentence.
+    /// The default; matches the platform standard for prose entry.
+    #[default]
+    Sentences,
+    /// `"none"` — never auto-capitalize. Use for handles / emails /
+    /// URLs / any case-sensitive identifier.
+    None,
+    /// `"words"` — capitalize the first letter of every word.
+    Words,
+    /// `"characters"` — capitalize every character (all-caps).
+    Characters,
+}
+
+impl AutoCapitalize {
+    /// Canonical wire string the native view dispatches on.
+    pub const fn as_attr(self) -> &'static str {
+        match self {
+            Self::Sentences => "sentences",
+            Self::None => "none",
+            Self::Words => "words",
+            Self::Characters => "characters",
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Imperative handle
 // ---------------------------------------------------------------------------
@@ -457,6 +499,9 @@ pub fn native_input(
     max_length: Signal<String>,
     keyboard_type: Signal<String>,
     return_key: Signal<String>,
+    auto_capitalize: Signal<String>,
+    autocorrect: Signal<String>,
+    spell_check: Signal<String>,
     style: Style,
     on_input: InputEvent,
     on_change: InputEvent,
@@ -516,6 +561,29 @@ pub fn input(
     /// Return-key label / action.
     #[prop(default = ReturnKey::Default)]
     return_key: ReturnKey,
+    /// Keyboard auto-capitalization. Defaults to
+    /// [`Sentences`](AutoCapitalize::Sentences); set
+    /// [`None`](AutoCapitalize::None) for handles / emails / URLs.
+    #[prop(default = AutoCapitalize::Sentences)]
+    auto_capitalize: AutoCapitalize,
+    /// Automatic typo replacement as the user types. Defaults to `true`
+    /// (the platform standard for prose); set `false` for handles /
+    /// emails / URLs / any case- or spelling-sensitive identifier.
+    ///
+    /// iOS maps this to `UITextField.autocorrectionType` (`true` →
+    /// `.default`, `false` → `.no`); Android to the `inputType`
+    /// `TYPE_TEXT_FLAG_AUTO_CORRECT` flag.
+    #[prop(default = true)]
+    autocorrect: bool,
+    /// Spelling / suggestion assistance — the iOS red-underline spell
+    /// check and the Android keyboard suggestion strip. Defaults to
+    /// `true`; set `false` to suppress both for identifier fields.
+    ///
+    /// iOS maps this to `UITextField.spellCheckingType` (`true` →
+    /// `.default`, `false` → `.no`); Android to the *inverse* of the
+    /// `inputType` `TYPE_TEXT_FLAG_NO_SUGGESTIONS` flag.
+    #[prop(default = true)]
+    spell_check: bool,
     /// Cursor color (CSS color string).
     caret_color: Option<Signal<String>>,
     /// Placeholder text color (CSS color string).
@@ -625,6 +693,9 @@ pub fn input(
     let max_length_attr = max_length.unwrap_or(0).to_string();
     let keyboard_type_attr = keyboard_type.as_attr().to_string();
     let return_key_attr = return_key.as_attr().to_string();
+    let auto_capitalize_attr = auto_capitalize.as_attr().to_string();
+    let autocorrect_attr = bool_attr(autocorrect);
+    let spell_check_attr = bool_attr(spell_check);
 
     // ----- Imperative handle: forward its ElementRef as `ref:` ---------
     let element_ref = input_ref.as_ref().map(|h| h.r());
@@ -643,6 +714,9 @@ pub fn input(
         .max_length(max_length_attr)
         .keyboard_type(keyboard_type_attr)
         .return_key(return_key_attr)
+        .auto_capitalize(auto_capitalize_attr)
+        .autocorrect(autocorrect_attr)
+        .spell_check(spell_check_attr)
         .style(style_prop)
         .on_input(on_input_cb)
         .on_change(on_change_cb)
@@ -687,9 +761,20 @@ mod tests {
     }
 
     #[test]
+    fn auto_capitalize_wire_strings() {
+        assert_eq!(AutoCapitalize::Sentences.as_attr(), "sentences");
+        assert_eq!(AutoCapitalize::None.as_attr(), "none");
+        assert_eq!(AutoCapitalize::Words.as_attr(), "words");
+        assert_eq!(AutoCapitalize::Characters.as_attr(), "characters");
+    }
+
+    #[test]
     fn enum_defaults() {
         assert_eq!(KeyboardType::default(), KeyboardType::Default);
         assert_eq!(ReturnKey::default(), ReturnKey::Default);
+        // Default matches iOS UIKit's `.sentences` so existing iOS behaviour
+        // is preserved; Android honours the same default explicitly.
+        assert_eq!(AutoCapitalize::default(), AutoCapitalize::Sentences);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds three `Input` props for per-field control over the keyboard's text assistance:

| prop | type | default | iOS | Android |
|---|---|---|---|---|
| `auto_capitalize` | `AutoCapitalize` (`none`/`sentences`/`words`/`characters`) | `Sentences` | `autocapitalizationType` | `inputType` `TYPE_TEXT_FLAG_CAP_*` |
| `autocorrect` | `bool` | `true` | `autocorrectionType` (`true`→`.default`, `false`→`.no`) | `TYPE_TEXT_FLAG_AUTO_CORRECT` |
| `spell_check` | `bool` | `true` | `spellCheckingType` | inverse of `TYPE_TEXT_FLAG_NO_SUGGESTIONS` |

Naming/value sets mirror React Native (`autoCapitalize` / `autoCorrect`), which is the convention the existing `keyboard_type` / `return_key` props already follow.

## Why

Identifier fields (handles, emails, URLs) need to opt out of first-letter capitalization and typo replacement. Before this, neither was controllable, and the defaults were **inconsistent across platforms**: iOS `UITextField` auto-capitalizes/auto-corrects by default while a plain Android `EditText` does not. Defaults here preserve the prior iOS behaviour, and Android now honours the same defaults explicitly — so both platforms behave identically.

## Platform-design note (the non-obvious part)

iOS models these as **independent `UITextInputTraits`** — `autocapitalizationType` / `autocorrectionType` / `spellCheckingType` are orthogonal properties.

Android packs them as **flag bits inside the single `inputType` Int** that also carries class / variation / multiline / password. So `setKeyboardType` / `setSecure` / `setMultiline` — which rebuild `inputType` — would wipe the trait flags. The Android view caches the three managed flags and reinstates them via `applyTextFlags()` after every inputType-rebuilding setter, so they survive regardless of prop-arrival order.

## Layers touched

- **Rust** (`src/lib.rs`): `AutoCapitalize` enum + `autocorrect`/`spell_check` bool props + builder wiring + doc table + wire-string test.
- **iOS** (`InputView.swift` + `InputModule.swift`): cached traits, `setAutoCapitalize`/`setAutocorrect`/`setSpellCheck`, applied in `applyBehaviour`, `Prop` registrations.
- **Android** (`WhiskerInputView.kt` + `InputModule.kt`): cached flags, the three setters, generalized `applyTextFlags()`, `Prop` registrations.

## Testing

- `cargo test -p whisker-input` (9 pass), `cargo clippy`, `cargo fmt --check` — all clean.
- Built & launched the Bluesky example on the iOS simulator with these changes (Swift module compiles, app runs). The Bluesky login field's use of these props rides on PR #266 (the example), which stacks on top of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)