### PR TITLE
feat(whisker-secure-store): hardware-backed secure key-value module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2786,6 +2786,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-secure-store"
+version = "0.7.0"
+dependencies = [
+ "whisker",
+]
+
+[[package]]
+name = "whisker-secure-store-example"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+ "whisker-secure-store",
+]
+
+[[package]]
 name = "whisker-subsecond"
 version = "0.7.11"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ members = [
     "packages/whisker-router/example",
     "packages/whisker-router-macros",
     "packages/whisker-safe-area",
+    "packages/whisker-secure-store",
+    "packages/whisker-secure-store/example",
     "packages/whisker-svg",
     "packages/whisker-svg/example",
     "packages/whisker-video",

--- a/packages/whisker-secure-store/Cargo.toml
+++ b/packages/whisker-secure-store/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "whisker-secure-store"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Whisker platform module — hardware-backed secure key-value store. iOS Keychain (Security framework); Android Keystore-backed AES-256-GCM via Google Tink. For tokens, keys, and other secrets that must NOT sit in plaintext UserDefaults / SharedPreferences (use whisker-local-store for non-secrets)."
+
+# Explicit `include` list — mirrors `whisker-local-store`. `cargo
+# publish` ships the Kotlin + Swift platform sources alongside
+# `src/lib.rs`, but never the local Gradle / Xcode build artifacts.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "src/lib.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+# rlib only. The Whisker module system handles native-source
+# distribution out-of-band via the `android/` + `ios/` package dirs —
+# we don't ship a cdylib here. Sibling of `whisker-local-store`.
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker. The bare table identifies this cargo
+# crate as a Whisker module; `whisker-build` walks the consuming app's
+# dep tree, picks out every dep carrying it, and wires the Android
+# Gradle subproject + iOS SwiftPM package into the host build.
+[package.metadata.whisker]
+
+[dependencies]
+whisker = { workspace = true }

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -1,0 +1,40 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for the `whisker-secure-store` module package's iOS
+// half. See `whisker-local-store/Package.swift` for the architectural
+// rationale (env-injected whisker package path, codegen plugin, etc.).
+//
+// No external SwiftPM dependency: the Keychain APIs live in the system
+// `Security` framework, which `import Security` auto-links on Apple
+// platforms.
+
+import PackageDescription
+
+let package = Package(
+    name: "whisker-secure-store",
+    // macOS 13 is required because the SwiftPM build plugin
+    // (`WhiskerModuleCodegenPlugin`) is hosted by SwiftSyntax, which
+    // requires that floor at build time. Runtime artefacts only need
+    // iOS 13.
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerSecureStore",
+            dependencies: [
+                .product(name: "WhiskerModule", package: "whisker"),
+            ],
+            // Swift sources under the package's `ios/` directory
+            // (Expo-style layout), next to `android/` and `src/`.
+            path: "ios/Sources/WhiskerSecureStore",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "whisker"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-secure-store/README.md
+++ b/packages/whisker-secure-store/README.md
@@ -1,0 +1,37 @@
+# whisker-secure-store
+
+Hardware-backed secure key-value store for Whisker apps. For **secrets**
+— OAuth tokens, signing / DPoP private keys, API keys — that must never
+sit in plaintext. For non-secret app data use
+[`whisker-local-store`](../whisker-local-store) instead.
+
+```rust
+use whisker_secure_store::WhiskerSecureStore;
+
+WhiskerSecureStore::save("session".into(), session_json)?;
+let restored = WhiskerSecureStore::load("session".into())?; // Option<String>
+WhiskerSecureStore::remove("session".into())?;
+```
+
+## Backends
+
+| Platform | Storage | Key protection |
+|----------|---------|----------------|
+| **iOS** | Keychain (`kSecClassGenericPassword`) | Secure Enclave / device passcode; `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` (not iCloud-synced, not migrated to a new device) |
+| **Android** | AES-256-GCM via **Google Tink**, ciphertext in app-private `SharedPreferences` | Tink keyset envelope-encrypted by an **Android Keystore** master key (hardware-backed where available) |
+
+Android uses Tink rather than the now-deprecated
+`androidx.security:security-crypto` (`EncryptedSharedPreferences`):
+Tink — maintained by Google's security team — owns the payload crypto
+(consistent across OEMs, upgradeable), while Keystore only protects the
+keyset-wrapping key. `minSdk` is **23** (Keystore master key requirement).
+
+## API
+
+`save(key, value) -> Result<bool>`, `load(key) -> Result<Option<String>>`,
+`remove(key) -> Result<()>`. Keep values small — secrets, not blobs.
+
+Unlike `whisker-local-store`, a secure store can genuinely fail (a
+Keychain `OSStatus`, a Keystore exception, a Tink decrypt failure after
+a credential reset). Those surface as `Err(WhiskerModuleError)`; treat a
+`load` error like a miss that requires re-authentication.

--- a/packages/whisker-secure-store/android/src/main/kotlin/rs/whisker/modules/securestore/SecureStore.kt
+++ b/packages/whisker-secure-store/android/src/main/kotlin/rs/whisker/modules/securestore/SecureStore.kt
@@ -1,0 +1,106 @@
+// Secure string store backed by Google Tink AES-256-GCM, with the Tink
+// keyset envelope-encrypted by an Android Keystore master key
+// (hardware-backed where available). Ciphertext is held in an
+// app-private SharedPreferences. Persists across launches; never plain.
+//
+// Tink is Google's recommended replacement for the deprecated
+// androidx.security EncryptedSharedPreferences — it owns the payload
+// crypto (consistent across OEMs, upgradeable), while Keystore only
+// protects the keyset-wrapping key.
+//
+// Plain helper — no Whisker / Lynx types. The DSL module that exposes
+// it to Rust lives in `SecureStoreModule.kt`.
+
+package rs.whisker.modules.securestore
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.integration.android.AndroidKeysetManager
+import rs.whisker.runtime.WhiskerApplication
+
+internal object SecureStore {
+    /// App-private prefs file holding both the (wrapped) Tink keyset and
+    /// the per-key ciphertext entries.
+    private const val PREFS_NAME = "WhiskerSecureStore"
+
+    /// Pref key under which Tink stores its (Keystore-wrapped) keyset.
+    private const val KEYSET_NAME = "__whisker_secure_keyset__"
+
+    /// Android Keystore alias for the master key that envelope-encrypts
+    /// the Tink keyset. Tink creates it on first use.
+    private const val MASTER_KEY_URI = "android-keystore://whisker_secure_store_master_key"
+
+    @Volatile
+    private var cachedAead: Aead? = null
+
+    /**
+     * Resolve the app context. Lazy via `WhiskerApplication.appContext`,
+     * which the host app's `Application.onCreate()` installs before any
+     * module dispatch could reach here.
+     */
+    private fun context(): Context =
+        WhiskerApplication.appContext
+            ?: throw IllegalStateException(
+                "WhiskerSecureStore: WhiskerApplication.appContext not initialised — " +
+                    "ensure your Application extends WhiskerApplication and " +
+                    "super.onCreate() runs before any module dispatch",
+            )
+
+    private fun prefs(): SharedPreferences =
+        context().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * The AEAD primitive, built once and cached. `AndroidKeysetManager`
+     * loads the keyset if present or generates one on first run, wrapping
+     * it with the Keystore master key. Double-checked locking keeps the
+     * (mildly expensive, Keystore-touching) build single-shot and
+     * thread-safe — Tink also requires keyset reads/writes to be
+     * serialized.
+     */
+    private fun aead(): Aead {
+        cachedAead?.let { return it }
+        synchronized(this) {
+            cachedAead?.let { return it }
+            AeadConfig.register()
+            val keysetHandle = AndroidKeysetManager.Builder()
+                .withSharedPref(context(), KEYSET_NAME, PREFS_NAME)
+                .withKeyTemplate(KeyTemplates.get("AES256_GCM"))
+                .withMasterKeyUri(MASTER_KEY_URI)
+                .build()
+                .keysetHandle
+            return keysetHandle.getPrimitive(Aead::class.java).also { cachedAead = it }
+        }
+    }
+
+    /**
+     * Encrypt [value] and persist it under [key]. The key bytes are the
+     * AEAD associated data, binding each ciphertext to its key so an
+     * entry can't be swapped under another key. Returns the
+     * SharedPreferences commit result.
+     */
+    fun save(key: String, value: String): Boolean {
+        val ciphertext = aead().encrypt(
+            value.toByteArray(Charsets.UTF_8),
+            key.toByteArray(Charsets.UTF_8),
+        )
+        val encoded = Base64.encodeToString(ciphertext, Base64.NO_WRAP)
+        return prefs().edit().putString(key, encoded).commit()
+    }
+
+    /** Read + decrypt [key]; `null` on miss (→ `Option::None` in Rust). */
+    fun load(key: String): String? {
+        val encoded = prefs().getString(key, null) ?: return null
+        val ciphertext = Base64.decode(encoded, Base64.NO_WRAP)
+        val plaintext = aead().decrypt(ciphertext, key.toByteArray(Charsets.UTF_8))
+        return String(plaintext, Charsets.UTF_8)
+    }
+
+    /** Drop [key]'s entry. */
+    fun remove(key: String) {
+        prefs().edit().remove(key).apply()
+    }
+}

--- a/packages/whisker-secure-store/android/src/main/kotlin/rs/whisker/modules/securestore/SecureStoreModule.kt
+++ b/packages/whisker-secure-store/android/src/main/kotlin/rs/whisker/modules/securestore/SecureStoreModule.kt
@@ -1,0 +1,55 @@
+// `whisker-secure-store` ModuleDefinition (Android).
+//
+// A view-less DSL module: `definition()` has no `View(...)` block, just
+// module-level `Function`s. The KSP processor finds the `Module`
+// subclass and registers its functions with `WhiskerModuleRegistry`
+// under the `Name(...)`, so `whisker::platform_module::invoke(
+// "WhiskerSecureStore", ...)` from Rust routes into these handlers.
+//
+// Unlike `whisker-local-store`, the Tink / Keystore backend can throw
+// (keyset corruption, decrypt failure after a credential reset, …), so
+// each handler maps a caught `Throwable` to `WhiskerValue.Err(_)` —
+// which the Rust wrapper lifts into `Err(WhiskerModuleError)`.
+//
+// The storage logic lives in `SecureStore.kt`.
+
+package rs.whisker.modules.securestore
+
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerValue
+
+class SecureStoreModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("WhiskerSecureStore")
+
+        // save(key, value) -> Bool | Err
+        Function("save") { args ->
+            val key = args.getOrNull(0)?.asString() ?: ""
+            val value = args.getOrNull(1)?.asString() ?: ""
+            try {
+                WhiskerValue.Bool(SecureStore.save(key, value))
+            } catch (t: Throwable) {
+                WhiskerValue.Err("WhiskerSecureStore.save failed: ${t.message}")
+            }
+        }
+        // load(key) -> Str | Null | Err  (Rust lifts Null into Option::None)
+        Function("load") { args ->
+            try {
+                SecureStore.load(args.getOrNull(0)?.asString() ?: "")
+                    ?.let { WhiskerValue.Str(it) } ?: WhiskerValue.Null
+            } catch (t: Throwable) {
+                WhiskerValue.Err("WhiskerSecureStore.load failed: ${t.message}")
+            }
+        }
+        // remove(key) -> Null | Err
+        Function("remove") { args ->
+            try {
+                SecureStore.remove(args.getOrNull(0)?.asString() ?: "")
+                WhiskerValue.Null
+            } catch (t: Throwable) {
+                WhiskerValue.Err("WhiskerSecureStore.remove failed: ${t.message}")
+            }
+        }
+    }
+}

--- a/packages/whisker-secure-store/build.gradle.kts
+++ b/packages/whisker-secure-store/build.gradle.kts
@@ -1,0 +1,53 @@
+// Gradle build for the `whisker-secure-store` module's Android half.
+// See `whisker-local-store/build.gradle.kts` for the architectural
+// rationale.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.securestore"
+    compileSdk = 34
+
+    defaultConfig {
+        // Tink's Android Keystore master key (envelope-encrypting the
+        // keyset) requires API 23. Below that the keyset would be stored
+        // unwrapped, defeating the point — so this module floors at 23
+        // (vs. whisker-local-store's 21).
+        minSdk = 23
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    // build.gradle.kts sits at the package root (alongside Package.swift
+    // + Cargo.toml). Point the Kotlin source set at the package's
+    // `android/` subdir so AGP doesn't scan the Rust `src/`.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerSecureStore")
+    arg("whisker.crateName", "whisker-secure-store")
+}
+
+dependencies {
+    implementation("rs.whisker:whisker-module-android:0.1.0")
+    ksp("rs.whisker:ksp:0.1.0")
+
+    // Google Tink — AES-256-GCM payload crypto with an Android
+    // Keystore-wrapped keyset. Google's recommended replacement for the
+    // deprecated androidx.security EncryptedSharedPreferences.
+    implementation("com.google.crypto.tink:tink-android:1.13.0")
+}

--- a/packages/whisker-secure-store/example/Cargo.toml
+++ b/packages/whisker-secure-store/example/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "whisker-secure-store-example"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Example app for `whisker-secure-store`. On launch it runs a save → load → remove → load round-trip against the platform secure store (iOS Keychain / Android Tink+Keystore) and shows the result, so on-device verification of the module wiring happens in one place."
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+whisker = { workspace = true }
+whisker-secure-store = { path = ".." }

--- a/packages/whisker-secure-store/example/src/lib.rs
+++ b/packages/whisker-secure-store/example/src/lib.rs
@@ -1,0 +1,60 @@
+//! `whisker-secure-store` example app.
+//!
+//! On launch it runs a `save → load → remove → load` round-trip against
+//! the platform secure store (iOS Keychain / Android Tink + Keystore)
+//! and renders each step's result, so a `whisker run` on a real device
+//! verifies the native module wiring end-to-end.
+
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+use whisker_secure_store::WhiskerSecureStore;
+
+const BG: &str = "#101012";
+const FG: &str = "#f0f0f3";
+
+#[whisker::main]
+pub fn app() -> Element {
+    let log = RwSignal::new("running secure-store round-trip…".to_string());
+
+    on_mount(move || {
+        let key = "demo.session".to_string();
+        let secret = "tok_abc.dpop_xyz".to_string();
+        let mut out = String::new();
+
+        match WhiskerSecureStore::save(key.clone(), secret.clone()) {
+            Ok(true) => out.push_str("save: ok\n"),
+            Ok(false) => out.push_str("save: returned false\n"),
+            Err(e) => out.push_str(&format!("save: ERROR {e}\n")),
+        }
+        match WhiskerSecureStore::load(key.clone()) {
+            Ok(Some(v)) if v == secret => out.push_str("load: matches saved value\n"),
+            Ok(Some(v)) => out.push_str(&format!("load: MISMATCH {v}\n")),
+            Ok(None) => out.push_str("load: None (expected a value)\n"),
+            Err(e) => out.push_str(&format!("load: ERROR {e}\n")),
+        }
+        match WhiskerSecureStore::remove(key.clone()) {
+            Ok(()) => out.push_str("remove: ok\n"),
+            Err(e) => out.push_str(&format!("remove: ERROR {e}\n")),
+        }
+        match WhiskerSecureStore::load(key.clone()) {
+            Ok(None) => out.push_str("load after remove: None (correct)\n"),
+            Ok(Some(v)) => out.push_str(&format!("load after remove: STILL PRESENT {v}\n")),
+            Err(e) => out.push_str(&format!("load after remove: ERROR {e}\n")),
+        }
+        log.set(out);
+    });
+
+    let page = format!(
+        "background-color: {BG}; flex-grow: 1; display: flex; flex-direction: column; \
+         padding-top: 72px; padding-left: 20px; padding-right: 20px;"
+    );
+    let title = format!("color: {FG}; font-size: 22px; font-weight: 700; margin-bottom: 20px;");
+    let body = format!("color: {FG}; font-size: 16px; line-height: 28px;");
+
+    render! {
+        view(style: page) {
+            text(style: title, value: "whisker-secure-store")
+            text(style: body, value: computed(move || log.get()))
+        }
+    }
+}

--- a/packages/whisker-secure-store/example/whisker.rs
+++ b/packages/whisker-secure-store/example/whisker.rs
@@ -1,0 +1,25 @@
+// `whisker.rs` for the `whisker-secure-store` example.
+//
+// Tells `whisker run` how to install / launch / hot-patch this app.
+
+pub fn configure(app: &mut whisker_config::Config) {
+    app.name("WhiskerSecureStoreExample")
+        .bundle_id("rs.whisker.securestoreexample")
+        .version("0.1.0")
+        .build_number(1);
+
+    app.android(|a| {
+        a.package("rs.whisker.securestoreexample")
+            .application_id("rs.whisker.securestoreexample")
+            .launcher_activity(".MainActivity")
+            // whisker-secure-store floors at API 23 (Keystore master key).
+            .min_sdk(24)
+            .target_sdk(34);
+    });
+
+    app.ios(|i| {
+        i.bundle_id("rs.whisker.securestoreexample")
+            .scheme("WhiskerSecureStoreExample")
+            .deployment_target("13.0");
+    });
+}

--- a/packages/whisker-secure-store/ios/Sources/WhiskerSecureStore/SecureStore.swift
+++ b/packages/whisker-secure-store/ios/Sources/WhiskerSecureStore/SecureStore.swift
@@ -1,0 +1,102 @@
+// Keychain-backed secure string store. Persists across launches,
+// hardware-protected, not iCloud-synced, not migrated to a new device
+// or unencrypted backup.
+//
+// Plain helper — no Whisker / Lynx types. The DSL module that exposes
+// it to Rust lives in `SecureStoreModule.swift`.
+
+import Foundation
+import Security
+
+/// Carries a failure message out of `SecureStore`. `Result`'s `Failure`
+/// must conform to `Error`, and `String` doesn't — so we wrap it.
+struct SecureStoreError: Error {
+    let message: String
+}
+
+enum SecureStore {
+    /// Namespaces our items in the shared Keychain via `kSecAttrService`,
+    /// so keys can't collide with another component's generic passwords.
+    private static let service = "WhiskerSecureStore"
+
+    /// `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`: the value is
+    /// readable once the device has been unlocked at least once since
+    /// boot (so background refreshes work), never leaves this device
+    /// (no iCloud Keychain sync), and is excluded from encrypted
+    /// backups' device migration. A sensible default for auth tokens.
+    private static let accessible = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+    private static func fail(_ message: String) -> SecureStoreError {
+        SecureStoreError(message: message)
+    }
+
+    /// Encrypt + persist `value` under `key` (upsert). `.success(true)`
+    /// on success; `.failure` carries the `OSStatus`.
+    static func save(_ key: String, _ value: String) -> Result<Bool, SecureStoreError> {
+        guard let data = value.data(using: .utf8) else {
+            return .failure(fail("WhiskerSecureStore.save: value is not valid UTF-8"))
+        }
+        let match: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+        // Try to update an existing item first; if there's none, add.
+        let updateStatus = SecItemUpdate(
+            match as CFDictionary,
+            [kSecValueData as String: data] as CFDictionary
+        )
+        if updateStatus == errSecSuccess {
+            return .success(true)
+        }
+        if updateStatus == errSecItemNotFound {
+            var add = match
+            add[kSecValueData as String] = data
+            add[kSecAttrAccessible as String] = accessible
+            let addStatus = SecItemAdd(add as CFDictionary, nil)
+            if addStatus == errSecSuccess {
+                return .success(true)
+            }
+            return .failure(fail("WhiskerSecureStore.save: SecItemAdd failed (OSStatus \(addStatus))"))
+        }
+        return .failure(fail("WhiskerSecureStore.save: SecItemUpdate failed (OSStatus \(updateStatus))"))
+    }
+
+    /// Read + decrypt `key`. `.success(nil)` on miss (→ `Option::None`
+    /// on the Rust side); `.failure` on a real Keychain error.
+    static func load(_ key: String) -> Result<String?, SecureStoreError> {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound {
+            return .success(nil)
+        }
+        if status != errSecSuccess {
+            return .failure(fail("WhiskerSecureStore.load: SecItemCopyMatching failed (OSStatus \(status))"))
+        }
+        guard let data = item as? Data, let value = String(data: data, encoding: .utf8) else {
+            return .failure(fail("WhiskerSecureStore.load: stored value is not valid UTF-8"))
+        }
+        return .success(value)
+    }
+
+    /// Drop `key`'s entry. A missing item is success (idempotent).
+    static func remove(_ key: String) -> Result<Void, SecureStoreError> {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        if status == errSecSuccess || status == errSecItemNotFound {
+            return .success(())
+        }
+        return .failure(fail("WhiskerSecureStore.remove: SecItemDelete failed (OSStatus \(status))"))
+    }
+}

--- a/packages/whisker-secure-store/ios/Sources/WhiskerSecureStore/SecureStoreModule.swift
+++ b/packages/whisker-secure-store/ios/Sources/WhiskerSecureStore/SecureStoreModule.swift
@@ -1,0 +1,48 @@
+// `whisker-secure-store` ModuleDefinition (iOS).
+//
+// A view-less DSL module: `definition()` has no `View(...)` block, just
+// module-level `Function`s. The SwiftPM codegen plugin discovers the
+// `Module` subclass, emits a `@_cdecl` dispatch shim, and registers it
+// so `whisker::platform_module::invoke("WhiskerSecureStore", ...)` from
+// Rust routes into these handlers.
+//
+// Unlike `whisker-local-store`, the storage backend can fail, so each
+// handler maps a `.failure(message)` from `SecureStore` to
+// `WhiskerValue.error(_)` — which the Rust wrapper lifts into
+// `Err(WhiskerModuleError)`.
+//
+// The storage logic lives in `SecureStore.swift`.
+
+import WhiskerModule    // Module, ModuleDefinition, DSL
+
+public final class SecureStoreModule: Module {
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("WhiskerSecureStore")
+
+            // save(key, value) -> Bool | Error
+            Function("save") { (args: [WhiskerValue]) -> WhiskerValue in
+                let key = args.first?.asString ?? ""
+                let value = args.count > 1 ? (args[1].asString ?? "") : ""
+                switch SecureStore.save(key, value) {
+                case .success(let ok): return .bool(ok)
+                case .failure(let err): return .error(err.message)
+                }
+            }
+            // load(key) -> String | Null | Error  (Rust lifts Null into Option::None)
+            Function("load") { (args: [WhiskerValue]) -> WhiskerValue in
+                switch SecureStore.load(args.first?.asString ?? "") {
+                case .success(let value): return value.map { WhiskerValue.string($0) } ?? .null
+                case .failure(let err): return .error(err.message)
+                }
+            }
+            // remove(key) -> Null | Error
+            Function("remove") { (args: [WhiskerValue]) -> WhiskerValue in
+                switch SecureStore.remove(args.first?.asString ?? "") {
+                case .success: return .null
+                case .failure(let err): return .error(err.message)
+                }
+            }
+        }
+    }
+}

--- a/packages/whisker-secure-store/src/lib.rs
+++ b/packages/whisker-secure-store/src/lib.rs
@@ -1,0 +1,128 @@
+//! `whisker-secure-store` — hardware-backed secure key-value store.
+//!
+//! **API shape — 5 (Static methods).** See
+//! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
+//! §"Shape 5". Stateless one-shot operations, namespaced under the
+//! unit struct [`WhiskerSecureStore`] — `save` / `load` / `remove`,
+//! each returning a `Result`. The same shape as
+//! [`whisker-local-store`](https://docs.rs/whisker-local-store), but
+//! the value never touches plaintext storage.
+//!
+//! Backed by the platform's **secure credential storage**:
+//!   - **iOS**: Keychain (`kSecClassGenericPassword`), accessibility
+//!     `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — readable
+//!     after first unlock, not iCloud-synced, not migrated to a new
+//!     device / unencrypted backup.
+//!   - **Android**: AES-256-GCM via **Google Tink**, with the Tink
+//!     keyset wrapped (envelope-encrypted) by an Android-Keystore master
+//!     key — hardware-backed where the device has a secure element.
+//!     Ciphertext is stored in an app-private `SharedPreferences`.
+//!     (Tink is Google's recommended replacement for the now-deprecated
+//!     `EncryptedSharedPreferences`.)
+//!
+//! ## When to use this vs `whisker-local-store`
+//!
+//! Use **`whisker-secure-store`** for secrets: OAuth access / refresh
+//! tokens, DPoP / signing private keys, API keys, anything an attacker
+//! with filesystem access (rooted / jailbroken device, or an
+//! unencrypted backup) must not read. Use **`whisker-local-store`**
+//! (plaintext UserDefaults / SharedPreferences) for everything else —
+//! UI preferences, cached non-secret profile fields, feature flags.
+//!
+//! Keep values small (secrets, not blobs). Both backends are credential
+//! stores, not databases.
+//!
+//! ## Errors
+//!
+//! Unlike `whisker-local-store` (whose backends never fail), a secure
+//! store genuinely can: a Keychain `OSStatus`, a Keystore exception, or
+//! a Tink decrypt failure (e.g. the keyset was invalidated by a factory
+//! reset / credential change) all surface as
+//! `Err(WhiskerModuleError)`. Treat a `load` error the same as a miss
+//! that requires re-authentication rather than a fatal condition.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use whisker_secure_store::WhiskerSecureStore;
+//!
+//! WhiskerSecureStore::save("session".into(), session_json)?;
+//! let restored = WhiskerSecureStore::load("session".into())?; // Option<String>
+//! WhiskerSecureStore::remove("session".into())?;
+//! ```
+//!
+//! ## Native source
+//!
+//! Contributors: the matching platform module lives at
+//!
+//! - iOS: `packages/whisker-secure-store/ios/Sources/WhiskerSecureStore/SecureStoreModule.swift`
+//!   (storage: `SecureStore.swift`)
+//! - Android: `packages/whisker-secure-store/android/src/main/kotlin/rs/whisker/modules/securestore/SecureStoreModule.kt`
+//!   (storage: `SecureStore.kt`)
+
+use whisker::platform_module::{WhiskerModuleError, WhiskerValue};
+
+/// Typed Rust API for the `WhiskerSecureStore` platform module.
+///
+/// Hand-written wrapper over the framework primitive: each method
+/// builds the raw `Vec<WhiskerValue>` arg list, dispatches via
+/// `whisker::module!("WhiskerSecureStore").invoke(method, args)`, and
+/// lifts the returned `WhiskerValue` into the matching typed result.
+/// `module!` prepends this crate's name (→ `<crate>:WhiskerSecureStore`)
+/// so module names never collide across crates.
+pub struct WhiskerSecureStore;
+
+impl WhiskerSecureStore {
+    /// Encrypt and persist `value` under `key`. Returns `true` on
+    /// success.
+    ///
+    /// Overwrites any previously-stored value. A subsequent
+    /// [`load`](WhiskerSecureStore::load) with the same key resolves to
+    /// `Some(value)` across app launches. Returns
+    /// `Err(WhiskerModuleError)` if the platform secure store rejects
+    /// the write (Keychain `OSStatus` / Keystore / Tink failure).
+    pub fn save(key: String, value: String) -> Result<bool, WhiskerModuleError> {
+        let result = whisker::module!("WhiskerSecureStore").invoke(
+            "save",
+            vec![WhiskerValue::String(key), WhiskerValue::String(value)],
+        );
+        match result {
+            WhiskerValue::Bool(b) => Ok(b),
+            WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
+            other => Err(WhiskerModuleError(format!(
+                "WhiskerSecureStore::save expected Bool, got {other:?}"
+            ))),
+        }
+    }
+
+    /// Decrypt and read the value previously stored under `key`.
+    ///
+    /// Returns `None` when no entry exists. A decryption failure (e.g.
+    /// the keyset was invalidated) surfaces as `Err` — callers should
+    /// generally treat that like a miss and re-authenticate.
+    pub fn load(key: String) -> Result<Option<String>, WhiskerModuleError> {
+        let result =
+            whisker::module!("WhiskerSecureStore").invoke("load", vec![WhiskerValue::String(key)]);
+        match result {
+            WhiskerValue::Null => Ok(None),
+            WhiskerValue::String(s) => Ok(Some(s)),
+            WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
+            other => Err(WhiskerModuleError(format!(
+                "WhiskerSecureStore::load expected String or Null, got {other:?}"
+            ))),
+        }
+    }
+
+    /// Drop `key`'s entry (if any). No-op when the key isn't present.
+    pub fn remove(key: String) -> Result<(), WhiskerModuleError> {
+        let result = whisker::module!("WhiskerSecureStore")
+            .invoke("remove", vec![WhiskerValue::String(key)]);
+        match result {
+            WhiskerValue::Null => Ok(()),
+            WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
+            // Permissive: `remove` is documented side-effect-only
+            // (returns null), but a stale return shape shouldn't fail.
+            _ => Ok(()),
+        }
+    }
+}


### PR DESCRIPTION
## What

A new first-party Whisker platform module: a **hardware-backed secure key-value store** for secrets — OAuth tokens, DPoP / signing keys, API keys — that must never sit in plaintext. The secure counterpart to [`whisker-local-store`](../packages/whisker-local-store), with the same Shape-5 static API.

```rust
use whisker_secure_store::WhiskerSecureStore;
WhiskerSecureStore::save("session".into(), session_json)?;
let restored = WhiskerSecureStore::load("session".into())?; // Option<String>
WhiskerSecureStore::remove("session".into())?;
```

## Backends

| Platform | Storage | Key protection |
|----------|---------|----------------|
| **iOS** | Keychain (`kSecClassGenericPassword`) | `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — not iCloud-synced, not migrated to a new device. No SwiftPM dep (Security is a system framework). |
| **Android** | AES-256-GCM via **Google Tink**, ciphertext in app-private `SharedPreferences` | Tink keyset envelope-encrypted by an **Android Keystore** master key (hardware-backed where available). |

**Why Tink, not EncryptedSharedPreferences:** `androidx.security:security-crypto` was deprecated (2025-04, `1.1.0-alpha07`) over Keystore brittleness across OEMs. Google's recommended replacement is Tink, which owns the payload crypto while Keystore only protects the keyset-wrapping key. `minSdk` is **23** (Keystore master key requirement; local-store is 21).

## Error semantics

Unlike local-store (whose backends never fail), a secure store genuinely can — a Keychain `OSStatus`, a Keystore exception, a Tink decrypt failure after a credential reset. The native modules return `WhiskerValue.error` / `.Err`, lifted to `Err(WhiskerModuleError)` in the Rust wrapper. Treat a `load` error like a miss that requires re-authentication.

## Layout (clones the local-store module template)

```
packages/whisker-secure-store/
  Cargo.toml, src/lib.rs              # Rust wrapper + docs
  Package.swift, build.gradle.kts     # iOS / Android build wiring
  ios/.../{SecureStore,SecureStoreModule}.swift
  android/.../{SecureStore,SecureStoreModule}.kt
  README.md
  example/                            # save→load→remove round-trip smoke app
```

## Testing

- `cargo build` / `clippy` / `cargo fmt --check` — clean (module + example).
- The `example/` round-trip (`save → load → remove → load`) was run via `whisker run` and **passes on both** the **iOS Keychain** (simulator) and the **Android Tink/Keystore** (emulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)