### PR TITLE
chore(android): SDK v0.1.2 — roll Lynx fork .7 → .8 (capi ABI v2)

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -65,7 +65,14 @@ pub struct PlatformSync {
 /// downstream apps that pull `whisker-runtime-android:0.1.0`
 /// transitively get the older Lynx and the bridge loader aborts on
 /// "undefined symbol: lynx_capi_abi_version" at engine_attach time.
-const WHISKER_SDK_VERSION: &str = "0.1.1";
+///
+/// 0.1.2 rolls the SDK's transitive Lynx pin `v3.8.0-whisker.7` →
+/// `v3.8.0-whisker.8`, which raises the capi ABI to **v2** (list data
+/// source driven by real item-keys + per-item metadata; object-valued
+/// attributes for `item-snap`). The per-app WhiskerDriver bridge is now
+/// built for ABI v2, so it refuses to attach to the ABI v1 Lynx that
+/// `whisker-runtime-android:0.1.1` still pulls — apps must move to 0.1.2.
+const WHISKER_SDK_VERSION: &str = "0.1.2";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/docs/ios-spm-distribution.md
+++ b/docs/ios-spm-distribution.md
@@ -97,11 +97,20 @@ Keep these aligned per release:
 | crates.io | iOS SwiftPM tag | Android SDK (Maven) | Gradle plugin | Lynx fork |
 |---|---|---|---|---|
 | `0.1.0` | `v0.1.0` | `0.1.1` | `0.4.0` | `3.8.0-whisker.7` |
-| `0.1.1` | `v0.1.1` | _(unchanged)_ | _(unchanged)_ | `3.8.0-whisker.8` |
+| `0.1.1` | `v0.1.1` | `0.1.2` | `0.4.0` | `3.8.0-whisker.8` |
 
-`v0.1.1` bumps the Lynx fork to `3.8.0-whisker.8`, which raises the
-capi ABI to **v2** (list data source driven by real item-keys +
-per-item metadata; object-valued attributes for `item-snap`). Apps must
-rebuild against `v0.1.1` — a bridge built for ABI v2 refuses to attach
-to an ABI v1 Lynx (`whisker_bridge_engine_attach` returns NULL), and
-vice-versa.
+The `3.8.0-whisker.8` row bumps the Lynx fork on both platforms, raising
+the capi ABI to **v2** (list data source driven by real item-keys +
+per-item metadata; object-valued attributes for `item-snap`). The
+per-app WhiskerDriver bridge is built for ABI v2 and refuses to attach
+to an ABI v1 Lynx (`whisker_bridge_engine_attach` returns NULL), so apps
+must move to the new pins:
+
+- **iOS** — SwiftPM tag `v0.1.1` (`WHISKER_IOS_SPM_VERSION`).
+- **Android** — SDK `0.1.2` (`WHISKER_SDK_VERSION`), published by an
+  `sdk-v0.1.2` tag. Its POM rolls the transitive `lynx-android` pin
+  `3.8.0-whisker.7` → `.8` via the `lynxFork` default in
+  `platforms/android/{whisker-runtime,module}/build.gradle.kts`.
+
+The iOS SwiftPM tag and the Android `sdk-v*` tag are independent version
+streams (hence `v0.1.1` vs `0.1.2`), aligned here only by the Lynx fork.

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.7").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.8").removePrefix("v")
 
 dependencies {
     if (whiskerSdkRelease) {

--- a/platforms/android/whisker-runtime/build.gradle.kts
+++ b/platforms/android/whisker-runtime/build.gradle.kts
@@ -20,7 +20,7 @@
 // `whiskerSdkRelease` Gradle property toggles the dep form: unset
 // (default) → flatDir-friendly `:LynxAndroid@aar`; `true` → Maven
 // coords pinned to `lynxFork`. The CI publish workflow sets
-// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.7`; local CLI
+// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.8`; local CLI
 // flows leave both unset and use flatDir as before.
 
 plugins {
@@ -70,7 +70,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.7").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.8").removePrefix("v")
 
 dependencies {
     api(project(":module"))


### PR DESCRIPTION
Follow-up to #276. The Lynx fork bump to **v3.8.0-whisker.8 (capi ABI v2)** shipped for iOS (SwiftPM `v0.1.1`) but Android was left on ABI v1.

## Why
`#276` bumped `lynx_capi.h` to ABI v2 — that header compiles into the per-app `WhiskerDriver` bridge on **both** platforms. But the published `whisker-runtime-android:0.1.1` POM still pins `lynx-android:3.8.0-whisker.7` (ABI v1). So an Android app built from `main` now has an ABI v2 bridge attaching to an ABI v1 Lynx → `whisker_bridge_engine_attach` returns NULL → blank screen (the same failure iOS had before `v0.1.1`).

## Change
- `lynxFork` default `v3.8.0-whisker.7` → `.8` in `platforms/android/{whisker-runtime,module}/build.gradle.kts` (publish-sdk.yml builds with the gradle default — it doesn't pass `-PlynxFork`).
- `WHISKER_SDK_VERSION` `0.1.1` → `0.1.2` (0.1.1 is immutable / already on the gh-pages Maven).
- Compat-matrix update in `docs/ios-spm-distribution.md`.

## Release step (after merge)
```sh
git tag sdk-v0.1.2 <merge-commit> && git push origin sdk-v0.1.2
```
That triggers `publish-sdk.yml`, which publishes `whisker-runtime-android:0.1.2` (+ module + ksp) to the gh-pages Maven with the `lynx-android:3.8.0-whisker.8` transitive pin. The `.8` AAR is already published on the Lynx Maven (verified HTTP 200).

`cargo check -p whisker-cli` + `cargo fmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)