### PR TITLE
fix(ios): bump whisker-secure-store SwiftPM pin 0.1.0 → 0.1.1

### DIFF
--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.0"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
`whisker-secure-store` landed via #275 in parallel with the #276 version bump, so its `Package.swift` kept `exact: "0.1.0"` while every other `packages/*/Package.swift` moved to `0.1.1`.

Any iOS app depending on **secure-store + at least one other whisker module** now fails SwiftPM resolution:

```
Dependencies could not be resolved because 'whisker-secure-store' depends on
'whisker' 0.1.0 and root depends on 'whisker' 0.1.1.
```

Surfaced while building the Bluesky example (uses secure-store for session persistence + several other modules). One-line pin bump to restore consistency across all 10 module manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)