### PR TITLE
feat(list): core-originated <list> events (scroll / scrolltolower / snap / layoutcomplete) now reach whisker

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,23 +74,23 @@ let package = Package(
         // `swiftpm-manifest-<ver>.txt` published alongside each release.
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.8/Lynx-3.8.0-whisker.8.xcframework.zip",
-            checksum: "e1c93ac66f6eb565737c52eb1d7ab28f62c9eea566c0a83ccb13d7686ffaeab9"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/Lynx-3.8.0-whisker.9.xcframework.zip",
+            checksum: "98f29de0577960f52f13b895de7c36714afb947ba8719df35a7ce605f1262d13"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.8/LynxBase-3.8.0-whisker.8.xcframework.zip",
-            checksum: "ee623643504b1a561d18b40b2ba4bb24346071169d3e131329159713b0320cf0"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/LynxBase-3.8.0-whisker.9.xcframework.zip",
+            checksum: "44e22f9d39199fd6ebbd84f851e5186a6900f1953362f878c039a472d2b8e268"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.8/LynxServiceAPI-3.8.0-whisker.8.xcframework.zip",
-            checksum: "ff5dbe812919dadabad4b60b24878b2c5599eda5357ca9b3aee28cb8f300dd17"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/LynxServiceAPI-3.8.0-whisker.9.xcframework.zip",
+            checksum: "f65968b15c40484d864ba776aac42f94c032fcdb62d113a488b8f29062581774"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.8/PrimJS-3.8.0-whisker.8.xcframework.zip",
-            checksum: "4749b6b2e7237904204218628797dd010a94aad803fd0366e0f92decbbef4fbe"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/PrimJS-3.8.0-whisker.9.xcframework.zip",
+            checksum: "bd4000889b4337889e143056edf0a7a441d43fade5915b72d7701d7c9688bfa9"
         ),
 
         // Header-only mirror of `WhiskerDriver`'s public C ABI. Source

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -72,7 +72,15 @@ pub struct PlatformSync {
 /// attributes for `item-snap`). The per-app WhiskerDriver bridge is now
 /// built for ABI v2, so it refuses to attach to the ABI v1 Lynx that
 /// `whisker-runtime-android:0.1.1` still pulls — apps must move to 0.1.2.
-const WHISKER_SDK_VERSION: &str = "0.1.2";
+///
+/// 0.1.3 rolls the SDK's transitive Lynx pin `v3.8.0-whisker.8` →
+/// `v3.8.0-whisker.9`, which adds `lynx_shell_set_custom_event_callback`
+/// (tail addition, ABI stays v2) — the channel that routes core-
+/// originated `<list>` events (`scroll` / `scrolltolower` / `snap` /
+/// `layoutcomplete`) to whisker. Non-breaking: the bridge feature-
+/// detects the symbol, so 0.1.2's Lynx still attaches — list events
+/// just stay dark until the app moves to 0.1.3.
+const WHISKER_SDK_VERSION: &str = "0.1.3";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/crates/whisker-driver-sys/bridge/include/lynx_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_capi.h
@@ -230,6 +230,20 @@ typedef int32_t (*lynx_element_animate_fn)(
     const lynx_ui_method_value_t* keyframes,
     const lynx_ui_method_value_t* options);
 
+// Core-originated custom events (the `<list>` family + `<frame>`).
+// `params` is the event payload (`detail`), valid only for the
+// duration of the call. Return true to consume (skip the JS-path
+// forward). Embedder passes it INTO Lynx → direct function pointer.
+typedef bool (*lynx_custom_event_callback_t)(
+    void* user_data,
+    int32_t element_id,
+    const char* event_name,
+    const lynx_ui_method_value_t* params);
+typedef void (*lynx_shell_set_custom_event_callback_fn)(
+    lynx_shell_t* shell,
+    lynx_custom_event_callback_t callback,
+    void* user_data);
+
 // ----- Dispatch table -------------------------------------------------------
 //
 // Populated by `whisker_bridge_load_lynx()`. Field order is purely
@@ -278,6 +292,11 @@ typedef struct WhiskerLynxCapi {
 
   // Element-level animation.
   lynx_element_animate_fn element_animate;
+
+  // Core-originated custom events. OPTIONAL: bound tail-additively —
+  // NULL when the loaded Lynx predates the symbol (feature-detect at
+  // the call site; list events simply stay dark on old engines).
+  lynx_shell_set_custom_event_callback_fn shell_set_custom_event_callback;
 } WhiskerLynxCapi;
 
 // ----- Loader API -----------------------------------------------------------

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -308,6 +308,27 @@ typedef bool (*WhiskerEventDispatcher)(int32_t target_sign,
 WHISKER_BRIDGE_EXPORT void whisker_bridge_register_event_dispatcher(
     WhiskerEventDispatcher dispatcher);
 
+// Register (or clear, with NULL) the Rust dispatcher for CORE-originated
+// custom events (the `<list>` family, `<frame>` events). Same shape as
+// `WhiskerEventDispatcher`, but a SEPARATE channel: these events fire
+// from inside Lynx's engine pipeline (mid-scroll, mid-layout), so the
+// Rust side must queue them and dispatch on the next frame tick rather
+// than running user handlers synchronously. The body handed to the
+// dispatcher is `{type, target, currentTarget, detail}`, matching the
+// platform reporter's shape; borrowed for the call.
+WHISKER_BRIDGE_EXPORT void whisker_bridge_register_custom_event_dispatcher(
+    WhiskerEventDispatcher dispatcher);
+
+// Point Lynx's core custom-event callback at the bridge, so core-
+// originated events flow to the dispatcher registered above. Requires
+// the Lynx fork's `lynx_shell_set_custom_event_callback` capi (tail-
+// added after ABI v2); returns false — and list events stay dark, as
+// they were before the feature — when the loaded Lynx predates it.
+// Must be called on the TASM thread after fiber-arch init (i.e. from
+// inside a `whisker_bridge_dispatch` callback).
+WHISKER_BRIDGE_EXPORT bool whisker_bridge_install_custom_event_reporter(
+    WhiskerEngine* engine);
+
 // The Lynx element sign (impl id) for `element` — the same identifier
 // the reporter reports as the event target, and the key the driver
 // uses for its tree + listener maps. Returns 0 for a null element.

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -100,6 +100,13 @@ WhiskerEventDispatcher& EventDispatcher() {
     return dispatcher;
 }
 
+// Separate channel for CORE-originated custom events (see the header
+// commentary on `whisker_bridge_register_custom_event_dispatcher`).
+WhiskerEventDispatcher& CustomEventDispatcher() {
+    static WhiskerEventDispatcher dispatcher = nullptr;
+    return dispatcher;
+}
+
 }  // namespace
 
 // ----------------------------------------------------------------------------
@@ -375,6 +382,11 @@ extern "C" void whisker_bridge_set_event_listener_with_value(
 extern "C" void whisker_bridge_register_event_dispatcher(
     WhiskerEventDispatcher dispatcher) {
     EventDispatcher() = dispatcher;
+}
+
+extern "C" void whisker_bridge_register_custom_event_dispatcher(
+    WhiskerEventDispatcher dispatcher) {
+    CustomEventDispatcher() = dispatcher;
 }
 
 extern "C" int32_t whisker_bridge_element_sign(WhiskerElement* element) {
@@ -1109,6 +1121,88 @@ void FailElementMethodAsync(WhiskerModuleCallback callback, void* user_data,
     whisker_bridge_value_release(&err);
 }
 }  // namespace
+
+// ----------------------------------------------------------------------------
+// Core-originated custom events (`<list>` scroll family, `<frame>`)
+// ----------------------------------------------------------------------------
+
+namespace {
+
+// malloc-duplicate a C string into a `WhiskerStringRef`, matching
+// `whisker_bridge_value_release`'s free pattern (not NUL-terminated;
+// len==0 still owns a 1-byte allocation).
+WhiskerStringRef DupWhiskerString(const char* s) {
+    const char* src = s != nullptr ? s : "";
+    size_t len = std::strlen(src);
+    char* buf = static_cast<char*>(std::malloc(len == 0 ? 1 : len));
+    if (len > 0) std::memcpy(buf, src, len);
+    WhiskerStringRef out;
+    out.ptr = buf;
+    out.len = len;
+    return out;
+}
+
+// The C callback handed to `lynx_shell_set_custom_event_callback`.
+// Fires synchronously on the TASM thread from INSIDE Lynx's engine
+// pipeline (mid-scroll, mid-layout) — which is exactly why it must not
+// run user handlers inline: the dispatcher on the Rust side queues the
+// event and drains it on the next frame tick. Builds the same
+// `{type, target, currentTarget, detail}` body shape the platform
+// reporter produces so the Rust deserialization path is shared.
+bool CustomEventReporterThunk(void* /*user_data*/,
+                              int32_t element_id,
+                              const char* event_name,
+                              const lynx_ui_method_value_t* params) {
+    WhiskerEventDispatcher dispatcher = CustomEventDispatcher();
+    if (dispatcher == nullptr || event_name == nullptr) return false;
+
+    WhiskerValueRaw body;
+    std::memset(&body, 0, sizeof(body));
+    body.type = WHISKER_VALUE_MAP;
+    body.v.map.count = 4;
+    body.v.map.entries = static_cast<WhiskerKeyValueRaw*>(
+        std::malloc(sizeof(WhiskerKeyValueRaw) * 4));
+
+    WhiskerKeyValueRaw* e = body.v.map.entries;
+    std::memset(e, 0, sizeof(WhiskerKeyValueRaw) * 4);
+
+    e[0].key = DupWhiskerString("type");
+    e[0].value.type = WHISKER_VALUE_STRING;
+    e[0].value.v.s = DupWhiskerString(event_name);
+
+    e[1].key = DupWhiskerString("target");
+    e[1].value.type = WHISKER_VALUE_INT;
+    e[1].value.v.i = element_id;
+
+    e[2].key = DupWhiskerString("currentTarget");
+    e[2].value.type = WHISKER_VALUE_INT;
+    e[2].value.v.i = element_id;
+
+    e[3].key = DupWhiskerString("detail");
+    e[3].value = CapiValueToWhisker(params);
+
+    bool consumed = dispatcher(element_id, event_name, &body);
+    whisker_bridge_value_release(&body);
+    return consumed;
+}
+
+}  // namespace
+
+extern "C" bool whisker_bridge_install_custom_event_reporter(
+    WhiskerEngine* engine) {
+    if (engine == nullptr || engine->shell == nullptr) return false;
+    const WhiskerLynxCapi* capi = whisker_lynx_capi();
+    // Feature-detect: the symbol is tail-added after ABI v2, so it is
+    // NULL when the loaded Lynx predates it — list events then simply
+    // stay dark, exactly as before the feature existed.
+    if (capi == nullptr || capi->shell_set_custom_event_callback == nullptr) {
+        return false;
+    }
+    capi->shell_set_custom_event_callback(engine->shell,
+                                          CustomEventReporterThunk,
+                                          nullptr);
+    return true;
+}
 
 extern "C" bool whisker_bridge_invoke_element_method_async(
     WhiskerElement* element,

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
@@ -177,6 +177,15 @@ int DoLoad() {
     // Animation.
     BindSymbol(handle, "lynx_element_animate", &g_capi.element_animate, &ok);
 
+    // Core-originated custom events — OPTIONAL (tail-added after ABI v2).
+    // A missing symbol is not an error: the field stays NULL and the
+    // bridge feature-detects at the install site (list events simply
+    // don't fire on an older Lynx, same as before the feature existed).
+    (void)dlerror();
+    g_capi.shell_set_custom_event_callback =
+        reinterpret_cast<lynx_shell_set_custom_event_callback_fn>(
+            dlsym(handle, "lynx_shell_set_custom_event_callback"));
+
     if (!ok) return WHISKER_BRIDGE_LYNX_LOAD_ERR_MISSING_SYMBOL;
     return WHISKER_BRIDGE_LYNX_LOAD_OK;
 }

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -319,6 +319,19 @@ unsafe extern "C" {
     /// [`WhiskerEventDispatcher`].
     pub fn whisker_bridge_register_event_dispatcher(dispatcher: WhiskerEventDispatcher);
 
+    /// Register the Rust dispatcher for CORE-originated custom events
+    /// (the `<list>` scroll family, `<frame>` events). Separate channel
+    /// from the reporter path: these fire from inside Lynx's engine
+    /// pipeline, so the dispatcher must queue and defer to the next
+    /// frame tick instead of running user handlers inline.
+    pub fn whisker_bridge_register_custom_event_dispatcher(dispatcher: WhiskerEventDispatcher);
+
+    /// Point Lynx's core custom-event callback at the bridge. Requires
+    /// the fork capi tail-added after ABI v2; returns `false` (list
+    /// events stay dark, as before the feature) on an older Lynx. Call
+    /// on the TASM thread after fiber-arch init.
+    pub fn whisker_bridge_install_custom_event_reporter(engine: *mut WhiskerEngine) -> bool;
+
     /// The Lynx element sign for `element` — same id the reporter
     /// reports as the event target, used as the key for the driver's
     /// tree + listener maps. Returns 0 for a null element.

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -165,6 +165,19 @@ extern "C" fn init_callback(user_data: *mut c_void) {
     // whenever its reporter hook fires.
     super::renderer::register_event_dispatcher();
 
+    // Route CORE-originated custom events (the `<list>` scroll family)
+    // through the queue-and-drain channel — they fire from inside
+    // Lynx's engine pipeline, so they can't dispatch inline like
+    // reporter events. Requires the fork capi tail-added after ABI v2;
+    // on an older Lynx this returns false and list events stay dark
+    // (exactly the pre-feature behaviour), so no hard failure here.
+    if !super::renderer::register_custom_event_dispatcher(ctx.engine) {
+        eprintln!(
+            "whisker: Lynx build lacks lynx_shell_set_custom_event_callback; \
+             <list> scroll/snap/layoutcomplete events will not fire"
+        );
+    }
+
     // Install the bridge renderer into the thread-local before
     // running user code. The `render!` macro's `view::*` calls
     // route through whatever is installed here.
@@ -423,6 +436,10 @@ fn tick_frame() {
         // survives.
         remount_components_for(&patched);
     }
+    // Dispatch core-originated events (`<list>` scroll family) queued
+    // since the last frame — before the reactive flush, so handler
+    // signal writes render in this same frame.
+    super::renderer::drain_custom_events();
     // Advance the continuous animation engine (whisker-animation) by
     // one frame *before* the reactive flush, so any progress signal it
     // writes is drained and painted in this same frame. `step` feeds a

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -545,3 +545,93 @@ extern "C" fn whisker_event_dispatch_entry(
 pub(crate) fn register_event_dispatcher() {
     unsafe { ffi::whisker_bridge_register_event_dispatcher(whisker_event_dispatch_entry) };
 }
+
+// ----- Core-originated custom events -----------------------------------------
+//
+// The `<list>` scroll family (`scroll` / `scrolltoupper` / `scrolltolower`
+// / `snap` / `layoutcomplete` / impression events) is generated inside
+// Lynx's C++ core, not by the platform UI layer, so it never reaches the
+// platform reporter. The bridge routes those events here through the
+// fork's `lynx_shell_set_custom_event_callback` capi instead.
+//
+// Unlike reporter events (which arrive from the platform event stack,
+// outside any engine call), these fire synchronously from INSIDE Lynx's
+// scroll/layout pipeline — often while the renderer `RefCell` is
+// borrowed (`renderer_flush` → Lynx layout → `layoutcomplete`). Running
+// user handlers inline would re-enter the borrow and panic, so the
+// entry queues the event and [`drain_custom_events`] dispatches the
+// backlog at the top of the next frame tick.
+
+thread_local! {
+    /// Pending core-originated events, drained by `tick_frame`. TASM
+    /// (main) thread only — both the enqueue (Lynx pipeline) and the
+    /// drain (frame tick) run there.
+    static CUSTOM_EVENT_QUEUE: std::cell::RefCell<Vec<(i32, String, WhiskerValue)>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// C entry point for core-originated custom events (registered via
+/// `whisker_bridge_register_custom_event_dispatcher`). Copies the event
+/// out, queues it, and asks the host for a frame. Always reports
+/// "consumed" — Whisker owns event delivery; there is no JS runtime for
+/// the engine to forward to.
+extern "C" fn whisker_custom_event_entry(
+    target_sign: i32,
+    event_name: *const std::os::raw::c_char,
+    body: *const ffi::WhiskerValueRaw,
+) -> bool {
+    if event_name.is_null() {
+        return false;
+    }
+    // SAFETY: the bridge passes a valid NUL-terminated event name for
+    // the duration of the call.
+    let name = match unsafe { std::ffi::CStr::from_ptr(event_name) }.to_str() {
+        Ok(s) => s.to_owned(),
+        Err(_) => return false,
+    };
+    let value = if body.is_null() {
+        WhiskerValue::Null
+    } else {
+        // SAFETY: `body` points to a valid `WhiskerValueRaw` owned by
+        // the bridge, valid for this call. `from_raw` copies it out.
+        unsafe { crate::module::from_raw(&*body) }
+    };
+    CUSTOM_EVENT_QUEUE.with(|q| q.borrow_mut().push((target_sign, name, value)));
+    // Schedule a frame so the backlog drains promptly even when the
+    // render loop is idle (no signal writes pending).
+    whisker_runtime::host_wake::wake_runtime();
+    true
+}
+
+/// Dispatch every queued core-originated event through the same
+/// propagation path reporter events take. Called at the top of each
+/// frame tick, before the reactive flush, so handler signal writes
+/// render in the same frame. Events queued *during* this drain (e.g. a
+/// `layoutcomplete` fired by a flush a handler triggered) wait for the
+/// next frame — single pass, no loop-until-empty.
+pub(crate) fn drain_custom_events() {
+    let backlog = CUSTOM_EVENT_QUEUE.with(|q| std::mem::take(&mut *q.borrow_mut()));
+    for (target_sign, name, value) in backlog {
+        // Contain handler panics per-event (same contract as
+        // `whisker_event_dispatch_entry`).
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            whisker_runtime::view::dispatch_event(target_sign, &name, value)
+        }))
+        .is_err()
+        {
+            eprintln!("whisker: panic in event handler for `{name}`; event dropped");
+        }
+    }
+}
+
+/// Register [`whisker_custom_event_entry`] and point Lynx's core
+/// custom-event callback at the bridge. `engine` must be inside a
+/// `whisker_bridge_dispatch` callback (TASM thread, fiber-arch
+/// initialized). Returns whether the loaded Lynx supports the capi
+/// (`false` on an older fork — list events stay dark, as before).
+pub(crate) fn register_custom_event_dispatcher(engine: *mut ffi::WhiskerEngine) -> bool {
+    unsafe {
+        ffi::whisker_bridge_register_custom_event_dispatcher(whisker_custom_event_entry);
+        ffi::whisker_bridge_install_custom_event_reporter(engine)
+    }
+}

--- a/examples/list-smoke/src/lib.rs
+++ b/examples/list-smoke/src/lib.rs
@@ -6,6 +6,7 @@
 //! - **Rotate / Prepend** buttons mutate the data order — verifies bug ①
 //!   (stable item-key reorders correctly instead of appending at the tail).
 
+use whisker::ListHandle;
 use whisker::css::{AlignItems, FlexDirection, FontWeight, JustifyContent};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
@@ -34,6 +35,13 @@ fn body_text(n: u32) -> String {
 pub fn app() -> Element {
     let ids = signal((1u32..=30).collect::<Vec<u32>>());
     let next = signal(100u32);
+    // Scroll-event smoke: on the FIRST layoutcomplete, smooth-scroll to
+    // the bottom. A programmatic smooth scroll drives the same native
+    // UIScrollView path a finger does, so `scroll` + `scrolltolower`
+    // fire without needing a human drag (synthetic touches don't reach
+    // Lynx's scroll pipeline on the simulator).
+    let list_handle = ListHandle::new();
+    let auto_scrolled = signal(false);
 
     let rotate = move |_| {
         let mut v = ids.get();
@@ -52,7 +60,8 @@ pub fn app() -> Element {
     // Rotate on scroll-to-bottom too — a data update triggerable by a
     // synthetic drag (taps don't reach Lynx's on_tap on the simulator), so
     // the reorder path can be verified without a device.
-    let rotate_on_scroll = move |_| {
+    let rotate_on_scroll = move |e| {
+        eprintln!("[SMOKE] scrolltolower fired: {e:?}");
         let mut v = ids.get();
         if !v.is_empty() {
             v.rotate_left(1);
@@ -94,6 +103,19 @@ pub fn app() -> Element {
                 style: css!(flex_grow: 1.0, width: percent(100)),
                 lower_threshold_item_count: 2,
                 on_scrolltolower: rotate_on_scroll,
+                // Event-pipeline smoke signals: `layoutcomplete` fires on
+                // first layout (no interaction needed), `scroll` on every
+                // scroll frame. Both are core-originated — they only fire
+                // when the capi custom-event channel works end-to-end.
+                ref: list_handle.r(),
+                on_layoutcomplete: move |e| {
+                    eprintln!("[SMOKE] layoutcomplete fired: {e:?}");
+                    if !auto_scrolled.get() {
+                        auto_scrolled.set(true);
+                        list_handle.scroll_to_position(30, true);
+                    }
+                },
+                on_scroll: |e| eprintln!("[SMOKE] scroll fired: {e:?}"),
                 each: move || {
                     let mut rows = vec![Row::Header];
                     rows.extend(ids.get().into_iter().map(Row::Item));

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.8").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.9").removePrefix("v")
 
 dependencies {
     if (whiskerSdkRelease) {

--- a/platforms/android/whisker-runtime/build.gradle.kts
+++ b/platforms/android/whisker-runtime/build.gradle.kts
@@ -20,7 +20,7 @@
 // `whiskerSdkRelease` Gradle property toggles the dep form: unset
 // (default) → flatDir-friendly `:LynxAndroid@aar`; `true` → Maven
 // coords pinned to `lynxFork`. The CI publish workflow sets
-// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.8`; local CLI
+// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.9`; local CLI
 // flows leave both unset and use flatDir as before.
 
 plugins {
@@ -70,7 +70,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.8").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.9").removePrefix("v")
 
 dependencies {
     api(project(":module"))

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -99,23 +99,23 @@ let package = Package(
         // until the matching module-side refactor lands).
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.8/Lynx-3.8.0-whisker.8.xcframework.zip",
-            checksum: "e1c93ac66f6eb565737c52eb1d7ab28f62c9eea566c0a83ccb13d7686ffaeab9"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/Lynx-3.8.0-whisker.9.xcframework.zip",
+            checksum: "98f29de0577960f52f13b895de7c36714afb947ba8719df35a7ce605f1262d13"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.8/LynxBase-3.8.0-whisker.8.xcframework.zip",
-            checksum: "ee623643504b1a561d18b40b2ba4bb24346071169d3e131329159713b0320cf0"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/LynxBase-3.8.0-whisker.9.xcframework.zip",
+            checksum: "44e22f9d39199fd6ebbd84f851e5186a6900f1953362f878c039a472d2b8e268"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.8/LynxServiceAPI-3.8.0-whisker.8.xcframework.zip",
-            checksum: "ff5dbe812919dadabad4b60b24878b2c5599eda5357ca9b3aee28cb8f300dd17"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/LynxServiceAPI-3.8.0-whisker.9.xcframework.zip",
+            checksum: "f65968b15c40484d864ba776aac42f94c032fcdb62d113a488b8f29062581774"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.8/PrimJS-3.8.0-whisker.8.xcframework.zip",
-            checksum: "4749b6b2e7237904204218628797dd010a94aad803fd0366e0f92decbbef4fbe"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/PrimJS-3.8.0-whisker.9.xcframework.zip",
+            checksum: "bd4000889b4337889e143056edf0a7a441d43fade5915b72d7701d7c9688bfa9"
         ),
 
         // Phase J — minimal module-author surface. Carved out of the


### PR DESCRIPTION
## Summary

Fixes the last missing piece of the `<list>` binding: **core-originated events never fired**. Lynx generates the `<list>` event family (`scroll` / `scrolltoupper` / `scrolltolower` / `snap` / `layoutcomplete` / impression) inside the C++ core and dispatches it to the JS event system only — whisker's platform event-reporter hook is not on that path, so `on_scrolltolower` (infinite scroll), `on_snap` and `on_layoutcomplete` were structurally unreachable. Root cause analysis: runtime instrumentation showed the fork emitting with `hasBound=1` while whisker's dispatch entry received zero events.

## Design

Fork **v3.8.0-whisker.9** (whiskerrs/lynx#25) adds `lynx_shell_set_custom_event_callback` — an `ElementManager`-level observer at the head of `SendNativeCustomEvent`, the single funnel all core-originated custom events flow through. Pure capi tail addition; **ABI stays v2**.

Whisker side (this PR):

- **loader**: binds the new symbol *optionally* — on an older Lynx the field is NULL, the install site feature-detects, and list events simply stay dark (pre-feature behaviour) instead of failing the ABI handshake.
- **bridge**: `whisker_bridge_install_custom_event_reporter` points Lynx's core callback at a thunk that builds the same `{type, target, currentTarget, detail}` body the platform reporter produces (payload deep-copied via the existing `CapiValueToWhisker`), keeping the Rust deserialization path shared.
- **driver**: these events fire synchronously from *inside* Lynx's scroll/layout pipeline — often while the renderer `RefCell` is borrowed (`renderer_flush` → layout → `layoutcomplete`). Dispatching inline would re-enter the borrow, so the entry **queues** the event and `tick_frame` drains the backlog at the top of the next frame, before the reactive flush, so handler signal writes render in the same frame.
- Platform-originated events (touch/gesture, `<scroll-view>` scroll) are untouched; there is no double delivery (list events are core-generated only).

Also rolls the Lynx pins `.8` → `.9` (root + platforms/ios `Package.swift` with released checksums, gradle `lynxFork`, `WHISKER_SDK_VERSION` 0.1.3 — publish via `sdk-v0.1.3` tag after merge).

## Testing

- `cargo test -p whisker-driver` (17 passed), clippy + fmt clean; bridge C++ compiles for host stub + `aarch64-apple-ios-sim`.
- **iOS simulator E2E** with `list-smoke`, first against a local instrumented fork build, then re-verified against the **released `.9` xcframeworks** (SPM checksum-verified, device+sim slices): `layoutcomplete` fires on first layout with no interaction; a programmatic smooth scroll (synthetic touches don't reach Lynx's scroll pipeline on the simulator — `list-smoke` now self-drives via `ListHandle::scroll_to_position` on first `layoutcomplete`) fires `scroll` + `scrolltolower` with correctly-deserialized typed `detail`; the `scrolltolower` handler's rotate triggers relayout + a second `layoutcomplete`; zero panics / RefCell re-entrancy.
- Android: pins prepared; runtime verification pending the `sdk-v0.1.3` publish (non-breaking either way — feature-detected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)