### PR TITLE
feat(bluesky): timeline infinite scroll via on_scrolltolower

### DIFF
--- a/examples/bluesky/crates/bsky-auth/src/lib.rs
+++ b/examples/bluesky/crates/bsky-auth/src/lib.rs
@@ -303,8 +303,14 @@ pub fn is_authenticated() -> bool {
     AGENT.lock().unwrap().is_some()
 }
 
-/// Fetch the home timeline as domain types. Errors if not logged in.
-pub async fn fetch_timeline(limit: u8) -> Result<bsky_domain::Timeline, String> {
+/// Fetch a page of the home timeline as domain types. Pass `cursor:
+/// None` for the first page, then the previous page's
+/// [`Timeline::cursor`](bsky_domain::Timeline) to load the next page
+/// (infinite scroll). Errors if not logged in.
+pub async fn fetch_timeline(
+    limit: u8,
+    cursor: Option<String>,
+) -> Result<bsky_domain::Timeline, String> {
     let agent = AGENT.lock().unwrap().clone().ok_or("not authenticated")?;
     let output = agent
         .api
@@ -314,7 +320,7 @@ pub async fn fetch_timeline(limit: u8) -> Result<bsky_domain::Timeline, String> 
         .get_timeline(
             get_timeline::ParametersData {
                 algorithm: None,
-                cursor: None,
+                cursor,
                 limit: limit.try_into().ok(),
             }
             .into(),

--- a/examples/bluesky/src/lib.rs
+++ b/examples/bluesky/src/lib.rs
@@ -1813,15 +1813,53 @@ fn timeline_screen() -> Element {
     // prefix makes the feed re-run the moment auth flips true — so a fresh
     // login lands on a populated timeline without remounting the shell.
     let AuthState(authed) = use_context::<AuthState>().expect("AuthState provided at root");
+    // Initial page (auth-gated, re-runs when auth flips). `more` accumulates
+    // subsequent pages appended by infinite scroll; `next_cursor` tracks the
+    // cursor to fetch from once we've paged past the first page (`seeded`).
     let feed = resource(move || {
         let ready = authed.get();
         async move {
             if !ready {
                 return Err(String::new());
             }
-            bsky_auth::fetch_timeline(50).await
+            bsky_auth::fetch_timeline(50, None).await
         }
     });
+    let more = RwSignal::new(Vec::<bsky_domain::FeedPost>::new());
+    let next_cursor = RwSignal::new(None::<String>);
+    let seeded = RwSignal::new(false);
+    let loading_more = RwSignal::new(false);
+
+    // on_scrolltolower fires a few rows before the end (lower_threshold_item_count).
+    // Fetch the next page from the current cursor and append it. Guards against
+    // re-entrancy (loading_more) and the end of the feed (cursor == None).
+    let load_more = move |_| {
+        if loading_more.get() {
+            return;
+        }
+        let cursor = if seeded.get() {
+            next_cursor.get()
+        } else {
+            feed.get().and_then(|t| t.cursor)
+        };
+        let Some(cursor) = cursor else {
+            return; // no more pages
+        };
+        loading_more.set(true);
+        spawn_local(async move {
+            match bsky_auth::fetch_timeline(50, Some(cursor)).await {
+                Ok(page) => {
+                    let mut acc = more.get();
+                    acc.extend(page.posts);
+                    more.set(acc);
+                    next_cursor.set(page.cursor);
+                    seeded.set(true);
+                }
+                Err(e) => eprintln!("bluesky: timeline load-more failed: {e}"),
+            }
+            loading_more.set(false);
+        });
+    };
 
     // Inset the feed by the safe-area: top keeps the first post clear of the
     // status bar / notch, bottom keeps the last clear of the home indicator.
@@ -1853,7 +1891,22 @@ fn timeline_screen() -> Element {
                     )
                 },
             ) {
-                post_list(posts: feed.get().map(|t| t.posts).unwrap_or_default())
+                list(
+                    style: css!(flex_grow: 1.0, flex_shrink: 1.0, width: percent(100)),
+                    lower_threshold_item_count: 3,
+                    on_scrolltolower: load_more,
+                    each: move || {
+                        let mut all = feed.get().map(|t| t.posts).unwrap_or_default();
+                        all.extend(more.get());
+                        all
+                    },
+                    key: |p: &bsky_domain::FeedPost| p.uri.clone(),
+                    children: |p: bsky_domain::FeedPost| render! {
+                        list_item(reuse_identifier: "post", estimated_size: 140) {
+                            PostRow(post: p)
+                        }
+                    },
+                )
             }
             ComposeFab {}
         }


### PR DESCRIPTION
## Summary

Pages the home timeline with the AT Protocol cursor:

- `bsky_auth::fetch_timeline` gains a `cursor` param and returns the page cursor.
- `timeline_screen` fetches the first page via the existing `resource`; `on_scrolltolower` (fires `lower_threshold_item_count: 3` rows before the end) fetches the next page and appends it to a `more` accumulator. Re-entrancy guarded (`loading_more`); end-of-feed detected (`cursor == None`).
- Timeline rows are `list_item(reuse_identifier, estimated_size)` like the other `<list>` consumers.

Requires the core-originated `<list>` event channel (#279 / Lynx fork v3.8.0-whisker.9) — without it `on_scrolltolower` never fires.

## Verified (iOS simulator)

Login → timeline → scroll to bottom → `on_scrolltolower` → next page fetched and appended, repeatedly (4+ pages), with the re-entrancy guard holding.

## Known framework-side issues (NOT addressed here)

Verification surfaced three `<list>` framework bugs, all rooted in whisker sending every data update as a **full replace** (`removeAction` for all prior positions + `insertAction` for all current) — Lynx's `ListAnchorManager` then treats every on-screen child as removed and cannot hold the scroll position:

1. **Scroll resets to top when a page is appended** (makes infinite scroll janky).
2. Initial viewport doesn't fill until the first scroll when the data arrives after mount.
3. Item 0 fails to re-materialize after being recycled off-screen.

Root-cause investigation + diff-based `update-list-info` fix (fork capi + whisker virtualizer) is the follow-up work item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)