### PR TITLE
feat(list): minimal-diff data-source updates — scroll position holds across appends

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,23 +74,23 @@ let package = Package(
         // `swiftpm-manifest-<ver>.txt` published alongside each release.
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/Lynx-3.8.0-whisker.9.xcframework.zip",
-            checksum: "98f29de0577960f52f13b895de7c36714afb947ba8719df35a7ce605f1262d13"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/Lynx-3.8.0-whisker.10.xcframework.zip",
+            checksum: "b0e2e3f2a1f0b828222b529ffa25c69a06c0b5f16ca5b8d7762ab91a5981757d"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/LynxBase-3.8.0-whisker.9.xcframework.zip",
-            checksum: "44e22f9d39199fd6ebbd84f851e5186a6900f1953362f878c039a472d2b8e268"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/LynxBase-3.8.0-whisker.10.xcframework.zip",
+            checksum: "4ca0bde69e6f65b4023e12ae45e6cabcb64640c5c4c86966a2a161f70c439d9f"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/LynxServiceAPI-3.8.0-whisker.9.xcframework.zip",
-            checksum: "f65968b15c40484d864ba776aac42f94c032fcdb62d113a488b8f29062581774"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/LynxServiceAPI-3.8.0-whisker.10.xcframework.zip",
+            checksum: "905a192eb633611e2892f20fc874b24bbed691255f1946d88bcd46605198c37c"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/PrimJS-3.8.0-whisker.9.xcframework.zip",
-            checksum: "bd4000889b4337889e143056edf0a7a441d43fade5915b72d7701d7c9688bfa9"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/PrimJS-3.8.0-whisker.10.xcframework.zip",
+            checksum: "f5077dee5ba24d33895e35d027e67f72e5f82158f8fd346aa3edbe0f07d356b4"
         ),
 
         // Header-only mirror of `WhiskerDriver`'s public C ABI. Source

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -80,7 +80,15 @@ pub struct PlatformSync {
 /// `layoutcomplete`) to whisker. Non-breaking: the bridge feature-
 /// detects the symbol, so 0.1.2's Lynx still attaches — list events
 /// just stay dark until the app moves to 0.1.3.
-const WHISKER_SDK_VERSION: &str = "0.1.3";
+///
+/// 0.1.4 rolls the SDK's transitive Lynx pin `v3.8.0-whisker.9` →
+/// `v3.8.0-whisker.10`, which adds `lynx_element_update_list_actions`
+/// (tail addition, ABI stays v2) — explicit minimal diff actions for
+/// `<list>` data updates, so the scroll position holds across appends
+/// (infinite scroll) instead of resetting to the top. Non-breaking:
+/// feature-detected; on 0.1.3's Lynx whisker falls back to the
+/// full-replace update (the pre-fix behaviour).
+const WHISKER_SDK_VERSION: &str = "0.1.4";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/crates/whisker-driver-sys/bridge/include/lynx_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_capi.h
@@ -179,6 +179,17 @@ typedef void (*lynx_element_set_update_list_info_fn)(lynx_fiber_element_t* eleme
                                                       const uint8_t* sticky_bottom,
                                                       const uint8_t* recyclable,
                                                       int32_t count);
+// Explicit diff actions for the decoupled `<list>` data source —
+// minimal-action alternative to `lynx_element_set_update_list_info`.
+// Removals: ascending pre-update indices, applied first. Inserts:
+// ascending splice points into the post-removal list.
+typedef void (*lynx_element_update_list_actions_fn)(
+    lynx_fiber_element_t* element,
+    const int32_t* remove_indices,
+    int32_t remove_count,
+    const int32_t* insert_positions,
+    const char* const* insert_keys,
+    int32_t insert_count);
 typedef void (*lynx_element_set_event_handler_fn)(lynx_fiber_element_t* element,
                                                     const char* event_name);
 typedef void (*lynx_element_append_child_fn)(lynx_fiber_element_t* parent,
@@ -297,6 +308,12 @@ typedef struct WhiskerLynxCapi {
   // NULL when the loaded Lynx predates the symbol (feature-detect at
   // the call site; list events simply stay dark on old engines).
   lynx_shell_set_custom_event_callback_fn shell_set_custom_event_callback;
+
+  // Explicit list diff actions. OPTIONAL (tail-added after ABI v2) —
+  // NULL on an older Lynx; the caller falls back to the full-replace
+  // `element_set_update_list_info` (pre-feature behaviour: scroll
+  // position resets on data updates, but nothing breaks).
+  lynx_element_update_list_actions_fn element_update_list_actions;
 } WhiskerLynxCapi;
 
 // ----- Loader API -----------------------------------------------------------

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -125,6 +125,21 @@ WHISKER_BRIDGE_EXPORT void whisker_bridge_list_set_item_count(
     WhiskerElement* element, int32_t prev_count, const char* const* item_keys,
     int32_t count);
 
+// Explicit `<list>` diff actions — the minimal-action alternative to
+// `whisker_bridge_list_set_item_count`'s full replace. Items mentioned
+// in neither action keep their native ItemHolder identity, which is
+// what lets the list hold its scroll position across an append.
+// Removals: ascending pre-update indices (applied first). Inserts:
+// `insert_positions`/`insert_keys` parallel arrays, ascending splice
+// points into the post-removal list.
+//
+// Returns false when the loaded Lynx predates the capi (tail-added
+// after ABI v2) — the caller then falls back to the full replace.
+WHISKER_BRIDGE_EXPORT bool whisker_bridge_list_update_actions(
+    WhiskerElement* element, const int32_t* remove_indices,
+    int32_t remove_count, const int32_t* insert_positions,
+    const char* const* insert_keys, int32_t insert_count);
+
 // Object-valued attribute (`{obj_keys[i]: obj_values[i]}` of doubles),
 // e.g. `<list>` `item-snap` {factor, offset}.
 WHISKER_BRIDGE_EXPORT void whisker_bridge_set_attribute_object(

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -309,6 +309,23 @@ extern "C" void whisker_bridge_list_set_item_count(WhiskerElement* element,
         /*sticky_bottom=*/nullptr, /*recyclable=*/nullptr, count);
 }
 
+extern "C" bool whisker_bridge_list_update_actions(
+    WhiskerElement* element, const int32_t* remove_indices,
+    int32_t remove_count, const int32_t* insert_positions,
+    const char* const* insert_keys, int32_t insert_count) {
+    if (element == nullptr || element->handle == nullptr) return false;
+    const WhiskerLynxCapi* capi = whisker_lynx_capi();
+    // Feature-detect: tail-added after ABI v2 — NULL on an older Lynx.
+    // The caller falls back to the full-replace update.
+    if (capi == nullptr || capi->element_update_list_actions == nullptr) {
+        return false;
+    }
+    capi->element_update_list_actions(element->handle, remove_indices,
+                                      remove_count, insert_positions,
+                                      insert_keys, insert_count);
+    return true;
+}
+
 // Install a native item provider on a `<list>` element so Whisker can
 // drive Lynx's list virtualisation directly. On both platforms this
 // resolves to Lynx's `lynx_list_set_native_item_provider` (Android:

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
@@ -186,6 +186,14 @@ int DoLoad() {
         reinterpret_cast<lynx_shell_set_custom_event_callback_fn>(
             dlsym(handle, "lynx_shell_set_custom_event_callback"));
 
+    // Explicit list diff actions — OPTIONAL (tail-added after ABI v2).
+    // NULL on an older Lynx; the bridge falls back to the full-replace
+    // update (scroll position resets on data updates, as before).
+    (void)dlerror();
+    g_capi.element_update_list_actions =
+        reinterpret_cast<lynx_element_update_list_actions_fn>(
+            dlsym(handle, "lynx_element_update_list_actions"));
+
     if (!ok) return WHISKER_BRIDGE_LYNX_LOAD_ERR_MISSING_SYMBOL;
     return WHISKER_BRIDGE_LYNX_LOAD_OK;
 }

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -285,6 +285,19 @@ unsafe extern "C" {
         count: i32,
     );
 
+    /// Explicit `<list>` diff actions (minimal-action alternative to
+    /// the full replace above). Returns `false` when the loaded Lynx
+    /// predates the capi — fall back to
+    /// [`whisker_bridge_list_set_item_count`].
+    pub fn whisker_bridge_list_update_actions(
+        element: *mut WhiskerElement,
+        remove_indices: *const i32,
+        remove_count: i32,
+        insert_positions: *const i32,
+        insert_keys: *const *const c_char,
+        insert_count: i32,
+    ) -> bool;
+
     pub fn whisker_bridge_list_set_native_item_provider(
         element: *mut WhiskerElement,
         component_at_index: LynxListComponentAtIndexFn,

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -368,7 +368,16 @@ pub fn tick(engine_raw: *mut c_void) -> bool {
     // has run (the bridge dispatch above completes synchronously on the
     // TASM==main thread), so it observes any node a commit-time re-entry
     // left in the queue.
-    !dispatch_pending && !whisker_runtime::reactive::has_pending_work()
+    //
+    // The custom-event queue is part of the same level-triggered idle
+    // test: a core-originated event (list `layoutcomplete` / `scroll`)
+    // queued DURING this tick's own `renderer_flush` already had its
+    // `wake_runtime()` edge consumed by the tick in progress, so
+    // reporting idle here would pause the vsync loop with the event
+    // stranded in the queue.
+    !dispatch_pending
+        && !whisker_runtime::reactive::has_pending_work()
+        && !super::renderer::has_pending_custom_events()
 }
 
 extern "C" fn tick_callback(_user_data: *mut c_void) {
@@ -478,6 +487,10 @@ fn tick_frame() {
         reactive_flush_mounts();
         renderer_flush();
     }
+    // (A core-originated event queued DURING this tick — e.g. a
+    // `layoutcomplete` fired by this tick's own renderer_flush — is kept
+    // alive by `tick()`'s level-triggered idle test, which reports busy
+    // while the custom-event queue is non-empty.)
 }
 
 /// Monotonic wall-clock time in milliseconds, measured from a fixed

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -262,6 +262,36 @@ impl DynRenderer for BridgeRenderer {
         };
     }
 
+    fn update_list_actions(
+        &self,
+        handle: Element,
+        removals: &[i32],
+        inserts: &[(i32, String)],
+    ) -> bool {
+        let Some(ptr) = self.lookup(handle) else {
+            return false;
+        };
+        // Own the C strings for the duration of the call; no renderer
+        // field borrow spans the FFI.
+        let c_keys: Vec<std::ffi::CString> = inserts
+            .iter()
+            .map(|(_, k)| std::ffi::CString::new(k.as_str()).unwrap_or_default())
+            .collect();
+        let key_ptrs: Vec<*const std::os::raw::c_char> =
+            c_keys.iter().map(|c| c.as_ptr()).collect();
+        let positions: Vec<i32> = inserts.iter().map(|(p, _)| *p).collect();
+        unsafe {
+            ffi::whisker_bridge_list_update_actions(
+                ptr.as_ptr(),
+                removals.as_ptr(),
+                removals.len() as i32,
+                positions.as_ptr(),
+                key_ptrs.as_ptr(),
+                inserts.len() as i32,
+            )
+        }
+    }
+
     fn set_attribute_object(&self, handle: Element, key: &str, obj: &[(String, f64)]) {
         let Some(ptr) = self.lookup(handle) else {
             return;
@@ -601,6 +631,16 @@ extern "C" fn whisker_custom_event_entry(
     // render loop is idle (no signal writes pending).
     whisker_runtime::host_wake::wake_runtime();
     true
+}
+
+/// Whether core-originated events are queued and waiting for a drain.
+/// `tick_frame` checks this at the END of a frame: an event queued
+/// mid-tick (a `layoutcomplete` fired by this tick's own
+/// `renderer_flush`) has already had its `wake_runtime()` edge consumed
+/// by the tick in progress, so without a re-wake it would sit in the
+/// queue until some unrelated frame happened to run.
+pub(crate) fn has_pending_custom_events() -> bool {
+    CUSTOM_EVENT_QUEUE.with(|q| !q.borrow().is_empty())
 }
 
 /// Dispatch every queued core-originated event through the same

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -137,7 +137,32 @@ pub trait DynRenderer {
     /// the previous call's item count (for the remove+insert diff). The
     /// `list` virtualizer calls this on every data update. Default no-op
     /// for test renderers that don't model list virtualisation.
+    ///
+    /// This is the FULL-REPLACE form — it severs every native item's
+    /// identity, so the list cannot hold its scroll position across the
+    /// update. The virtualizer prefers [`update_list_actions`]
+    /// (Self::update_list_actions) and only falls back here.
     fn set_update_list_info(&self, _handle: Element, _item_keys: &[String], _prev_count: usize) {}
+
+    /// Explicit `<list>` diff actions — the minimal-action form.
+    /// `removals` are ascending indices into the PRE-update item-key
+    /// list (applied first); `inserts` are `(position, item_key)`
+    /// pairs with ascending splice points into the post-removal list.
+    /// Items mentioned in neither action keep their native identity,
+    /// which lets the list hold its scroll position across appends.
+    ///
+    /// Returns whether the renderer delivered the actions — `false`
+    /// (the default, also reported when the loaded Lynx predates the
+    /// capi) tells the virtualizer to fall back to the full-replace
+    /// [`set_update_list_info`](Self::set_update_list_info).
+    fn update_list_actions(
+        &self,
+        _handle: Element,
+        _removals: &[i32],
+        _inserts: &[(i32, String)],
+    ) -> bool {
+        false
+    }
 
     /// Set an object-valued attribute (`{obj[i].0: obj[i].1}` of doubles)
     /// — e.g. `<list>` `item-snap` {factor, offset}. Default no-op.
@@ -592,6 +617,13 @@ pub fn set_update_list_info(handle: Element, item_keys: &[String], prev_count: u
         |r| r.set_update_list_info(handle, item_keys, prev_count),
         (),
     )
+}
+
+pub fn update_list_actions(handle: Element, removals: &[i32], inserts: &[(i32, String)]) -> bool {
+    if is_phantom(handle) {
+        return false;
+    }
+    with_renderer(|r| r.update_list_actions(handle, removals, inserts), false)
 }
 
 pub fn set_attribute_object(handle: Element, key: &str, obj: &[(String, f64)]) {

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -593,13 +593,16 @@ mod tests {
         );
     }
 
+    /// One recorded `update_list_actions` call: `(removals, inserts)`.
+    type RecordedActions = (Vec<i32>, Vec<(i32, String)>);
+
     /// Renderer that accepts explicit actions (like the real bridge on a
     /// new-enough Lynx) — the virtualizer must prefer them and NOT fall
     /// back to the full replace.
     #[derive(Default)]
     struct ActionsRenderer {
         next_id: std::cell::Cell<u32>,
-        actions: Rc<RefCell<Vec<(Vec<i32>, Vec<(i32, String)>)>>>,
+        actions: Rc<RefCell<Vec<RecordedActions>>>,
         full_replace_calls: Rc<RefCell<u32>>,
     }
 

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -54,8 +54,64 @@ use super::handle::Element;
 use super::list_provider::{INVALID_ITEM_INDEX, NativeItemProvider};
 use super::renderer::{
     append_child, element_sign, install_list_native_item_provider, remove_child, set_attribute_int,
-    set_update_list_info,
+    set_update_list_info, update_list_actions,
 };
+
+/// Send a data-source update as the MINIMAL action set against the
+/// previous key list: the longest common prefix and suffix survive
+/// untouched (keeping their native `ItemHolder` identity — which is
+/// what lets the list hold its scroll position across an append), and
+/// only the middle window is expressed as remove+insert.
+///
+/// Index contract (what Lynx's `AdapterHelper` expects, matching
+/// ReactLynx's `ListUpdateInfoRecording` output): removals are
+/// ascending indices into the PRE-update list and apply first; insert
+/// positions are ascending splice points into the post-removal list.
+///
+/// A reorder that survives neither prefix nor suffix degrades to a
+/// full-window remove+insert — same identity loss as the legacy full
+/// replace, no worse. When the renderer can't deliver explicit actions
+/// (a Lynx build predating the capi, or a test renderer), falls back
+/// to the full-replace [`set_update_list_info`].
+fn send_data_source_update(handle: Element, prev: &[String], keys: &[String]) {
+    let (removals, inserts) = splice_diff(prev, keys);
+    if removals.is_empty() && inserts.is_empty() {
+        // Identical key list — nothing structural to update.
+        return;
+    }
+    if !update_list_actions(handle, &removals, &inserts) {
+        set_update_list_info(handle, keys, prev.len());
+    }
+}
+
+/// The common-prefix/suffix splice between two key lists, as
+/// `(removals, inserts)` in `AdapterHelper`'s index spaces (removals:
+/// ascending pre-update indices; inserts: ascending `(position, key)`
+/// splice points into the post-removal list).
+fn splice_diff(prev: &[String], keys: &[String]) -> (Vec<i32>, Vec<(i32, String)>) {
+    let p = prev
+        .iter()
+        .zip(keys.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    // The zip over the two post-prefix slices yields at most
+    // `min(prev.len(), keys.len()) - p` pairs, so the suffix can never
+    // overlap the prefix.
+    let s = prev[p..]
+        .iter()
+        .rev()
+        .zip(keys[p..].iter().rev())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let removals: Vec<i32> = (p..prev.len() - s).map(|i| i as i32).collect();
+    let inserts: Vec<(i32, String)> = keys[p..keys.len() - s]
+        .iter()
+        .enumerate()
+        .map(|(k, key)| ((p + k) as i32, key.clone()))
+        .collect();
+    (removals, inserts)
+}
 
 /// Drive `handle`'s native item provider on demand.
 ///
@@ -97,9 +153,11 @@ pub fn virtualize<T, K, ItemsFn, KeyFn, BuildFn>(
     let key_ids: Rc<RefCell<HashMap<K, u64>>> = Rc::new(RefCell::new(HashMap::new()));
     let next_id: Rc<Cell<u64>> = Rc::new(Cell::new(0));
     let layout_id: Rc<Cell<i64>> = Rc::new(Cell::new(0));
-    // Item count from the previous `set_update_list_info` — the native diff
-    // is a full replace (remove `prev` positions, insert the current keys).
-    let prev_count: Rc<Cell<usize>> = Rc::new(Cell::new(0));
+    // Item-key list from the previous data-source update — the minimal
+    // diff (common prefix/suffix splice) is computed against it, so
+    // untouched items keep their native identity and the list can hold
+    // its scroll position across appends.
+    let prev_keys: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
     let key = Rc::new(key);
     let build = Rc::new(build);
     // Anchor slot owners to the owner active at SETUP (the list component's
@@ -128,7 +186,7 @@ pub fn virtualize<T, K, ItemsFn, KeyFn, BuildFn>(
     {
         let current_items = current_items.clone();
         let layout_id = layout_id.clone();
-        let prev_count = prev_count.clone();
+        let prev_keys = prev_keys.clone();
         let key_ids = key_ids.clone();
         let next_id = next_id.clone();
         let key = key.clone();
@@ -159,13 +217,12 @@ pub fn virtualize<T, K, ItemsFn, KeyFn, BuildFn>(
                     })
                     .collect()
             };
-            let count = new_items.len();
             *current_items.borrow_mut() = new_items;
             let lid = layout_id.get();
             layout_id.set(lid + 1);
             set_attribute_int(handle, "layout-id", lid);
-            set_update_list_info(handle, &keys, prev_count.get());
-            prev_count.set(count);
+            send_data_source_update(handle, &prev_keys.borrow(), &keys);
+            *prev_keys.borrow_mut() = keys;
         });
     }
 
@@ -476,5 +533,159 @@ mod tests {
             );
             owner.dispose();
         });
+    }
+
+    fn ks(keys: &[&str]) -> Vec<String> {
+        keys.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn splice_diff_append_is_insert_only() {
+        let (removals, inserts) = splice_diff(&ks(&["a", "b"]), &ks(&["a", "b", "c", "d"]));
+        assert!(removals.is_empty());
+        assert_eq!(inserts, vec![(2, "c".to_string()), (3, "d".to_string())]);
+    }
+
+    #[test]
+    fn splice_diff_prepend_is_insert_at_zero() {
+        let (removals, inserts) = splice_diff(&ks(&["a", "b"]), &ks(&["x", "a", "b"]));
+        assert!(removals.is_empty());
+        assert_eq!(inserts, vec![(0, "x".to_string())]);
+    }
+
+    #[test]
+    fn splice_diff_mid_replace_touches_only_the_window() {
+        // [a b c d e] -> [a b X Y e]: remove old 2,3; insert X@2, Y@3.
+        let (removals, inserts) = splice_diff(
+            &ks(&["a", "b", "c", "d", "e"]),
+            &ks(&["a", "b", "X", "Y", "e"]),
+        );
+        assert_eq!(removals, vec![2, 3]);
+        assert_eq!(inserts, vec![(2, "X".to_string()), (3, "Y".to_string())]);
+    }
+
+    #[test]
+    fn splice_diff_removal_only() {
+        let (removals, inserts) = splice_diff(&ks(&["a", "b", "c"]), &ks(&["a", "c"]));
+        assert_eq!(removals, vec![1]);
+        assert!(inserts.is_empty());
+    }
+
+    #[test]
+    fn splice_diff_identical_is_empty() {
+        let (removals, inserts) = splice_diff(&ks(&["a", "b"]), &ks(&["a", "b"]));
+        assert!(removals.is_empty());
+        assert!(inserts.is_empty());
+    }
+
+    #[test]
+    fn splice_diff_reorder_degrades_to_full_window() {
+        // No common prefix/suffix survives a rotate — remove all, insert all.
+        let (removals, inserts) = splice_diff(&ks(&["a", "b", "c"]), &ks(&["b", "c", "a"]));
+        assert_eq!(removals, vec![0, 1, 2]);
+        assert_eq!(
+            inserts,
+            vec![
+                (0, "b".to_string()),
+                (1, "c".to_string()),
+                (2, "a".to_string())
+            ]
+        );
+    }
+
+    /// Renderer that accepts explicit actions (like the real bridge on a
+    /// new-enough Lynx) — the virtualizer must prefer them and NOT fall
+    /// back to the full replace.
+    #[derive(Default)]
+    struct ActionsRenderer {
+        next_id: std::cell::Cell<u32>,
+        actions: Rc<RefCell<Vec<(Vec<i32>, Vec<(i32, String)>)>>>,
+        full_replace_calls: Rc<RefCell<u32>>,
+    }
+
+    impl DynRenderer for ActionsRenderer {
+        fn create_element(&self, _tag: ElementTag) -> Element {
+            let id = self.next_id.get();
+            self.next_id.set(id + 1);
+            Element::from_raw(id)
+        }
+        fn create_element_by_name(&self, _tag: &str) -> Element {
+            self.create_element(ElementTag::View)
+        }
+        fn release_element(&self, _h: Element) {}
+        fn set_attribute(&self, _h: Element, _k: &str, _v: &str) {}
+        fn set_inline_styles(&self, _h: Element, _css: &str) {}
+        fn set_update_list_info(&self, _h: Element, _keys: &[String], _prev: usize) {
+            *self.full_replace_calls.borrow_mut() += 1;
+        }
+        fn update_list_actions(
+            &self,
+            _h: Element,
+            removals: &[i32],
+            inserts: &[(i32, String)],
+        ) -> bool {
+            self.actions
+                .borrow_mut()
+                .push((removals.to_vec(), inserts.to_vec()));
+            true
+        }
+        fn install_list_native_item_provider(&self, _h: Element, _p: NativeItemProvider) -> bool {
+            true
+        }
+        fn append_child(&self, _p: Element, _c: Element) {}
+        fn remove_child(&self, _p: Element, _c: Element) {}
+        fn set_event_listener(
+            &self,
+            _h: Element,
+            _n: &str,
+            _bt: BindType,
+            _cb: Box<dyn Fn(crate::value::WhiskerValue) + 'static>,
+        ) {
+        }
+        fn set_root(&self, _p: Element) {}
+        fn flush(&self) {}
+    }
+
+    #[test]
+    fn append_sends_insert_only_actions_and_skips_full_replace() {
+        crate::reactive::__reset_for_tests();
+        let recorder = ActionsRenderer::default();
+        let actions = recorder.actions.clone();
+        let full_replace = recorder.full_replace_calls.clone();
+        let prev = install_renderer(Box::new(recorder));
+
+        let owner = Owner::new(None);
+        let (items, set_items) = crate::reactive::signal(vec![1_i32, 2]).split();
+        owner.with(|| {
+            let handle = create_element_by_name("list");
+            virtualize(
+                handle,
+                move || items.get(),
+                |x| *x,
+                |_x| create_element_by_name("list-item"),
+            );
+        });
+        flush();
+        // Initial population: pure insert of both keys.
+        assert_eq!(actions.borrow().len(), 1);
+        assert_eq!(actions.borrow()[0].0, Vec::<i32>::new());
+        assert_eq!(actions.borrow()[0].1.len(), 2);
+
+        // Append: insert-only at the tail, untouched items unmentioned.
+        set_items.set(vec![1_i32, 2, 3]);
+        flush();
+        assert_eq!(actions.borrow().len(), 2);
+        let (removals, inserts) = actions.borrow()[1].clone();
+        assert!(removals.is_empty());
+        assert_eq!(inserts, vec![(2, "w_2".to_string())]);
+
+        // Identical re-run: nothing sent.
+        set_items.set(vec![1_i32, 2, 3]);
+        flush();
+        assert_eq!(actions.borrow().len(), 2);
+
+        assert_eq!(*full_replace.borrow(), 0, "must not fall back");
+        owner.dispose();
+        uninstall_renderer(prev);
     }
 }

--- a/examples/list-smoke/src/lib.rs
+++ b/examples/list-smoke/src/lib.rs
@@ -33,15 +33,20 @@ fn body_text(n: u32) -> String {
 
 #[whisker::main]
 pub fn app() -> Element {
-    let ids = signal((1u32..=30).collect::<Vec<u32>>());
+    // Start EMPTY and populate in `on_mount` — the data then arrives
+    // AFTER the first layout, exercising the "late data source" fill
+    // path (a data-only update must still tick the list's viewport
+    // fill; regression: items only materialized on the first scroll).
+    let ids = signal(Vec::<u32>::new());
     let next = signal(100u32);
+    on_mount(move || ids.set((1u32..=30).collect::<Vec<u32>>()));
     // Scroll-event smoke: on the FIRST layoutcomplete, smooth-scroll to
     // the bottom. A programmatic smooth scroll drives the same native
     // UIScrollView path a finger does, so `scroll` + `scrolltolower`
     // fire without needing a human drag (synthetic touches don't reach
     // Lynx's scroll pipeline on the simulator).
     let list_handle = ListHandle::new();
-    let auto_scrolled = signal(false);
+    let lc_seen = signal(0u32);
 
     let rotate = move |_| {
         let mut v = ids.get();
@@ -57,16 +62,43 @@ pub fn app() -> Element {
         v.insert(0, n);
         ids.set(v);
     };
-    // Rotate on scroll-to-bottom too — a data update triggerable by a
-    // synthetic drag (taps don't reach Lynx's on_tap on the simulator), so
-    // the reorder path can be verified without a device.
-    let rotate_on_scroll = move |e| {
+    // Append a page on scroll-to-bottom — the infinite-scroll pattern.
+    // With diff-based data updates the append is insert-only, so the
+    // scroll position must HOLD at the bottom (regression: the full
+    // replace reset it to the top on every append). At the cap, scroll
+    // back to the top once — the first row must re-materialize after
+    // having been recycled off-screen.
+    let back_to_top_done = signal(false);
+    let chase_bottom = signal(false);
+    let append_on_scroll = move |e: whisker::event::ScrollEvent| {
         eprintln!("[SMOKE] scrolltolower fired: {e:?}");
-        let mut v = ids.get();
-        if !v.is_empty() {
-            v.rotate_left(1);
+        if e.detail.scroll_height < 500.0 {
+            // The pre-data (header-only, 160px) list is trivially "at
+            // the bottom" — ignore that spurious trigger. Gate on the
+            // EVENT's own content height: the signal may already hold
+            // the real data by the time this drains.
+            return;
         }
+        let mut v = ids.get();
+        if v.len() >= 60 {
+            if !back_to_top_done.get() {
+                back_to_top_done.set(true);
+                eprintln!("[SMOKE] cap reached — scrolling back to top");
+                list_handle.scroll_to_position(0, true);
+            }
+            return;
+        }
+        let n = next.get();
+        next.set(n + 10);
+        v.extend(n..n + 10);
         ids.set(v);
+        // Chase the new bottom ON THE NEXT layoutcomplete (scrolling now
+        // would target an index the NATIVE list doesn't have yet — the
+        // append flushes later this tick). The chase keeps the smoke
+        // paging until the cap: the position HOLD after an append means
+        // we drift out of the lower threshold, which is correct UX but
+        // would stall the run.
+        chase_bottom.set(true);
     };
 
     render! {
@@ -102,7 +134,7 @@ pub fn app() -> Element {
             list(
                 style: css!(flex_grow: 1.0, width: percent(100)),
                 lower_threshold_item_count: 2,
-                on_scrolltolower: rotate_on_scroll,
+                on_scrolltolower: append_on_scroll,
                 // Event-pipeline smoke signals: `layoutcomplete` fires on
                 // first layout (no interaction needed), `scroll` on every
                 // scroll frame. Both are core-originated — they only fire
@@ -110,9 +142,26 @@ pub fn app() -> Element {
                 ref: list_handle.r(),
                 on_layoutcomplete: move |e| {
                     eprintln!("[SMOKE] layoutcomplete fired: {e:?}");
-                    if !auto_scrolled.get() {
-                        auto_scrolled.set(true);
-                        list_handle.scroll_to_position(30, true);
+                    // `SIMCTL_CHILD_SMOKE_NO_AUTOSCROLL=1` (simctl launch env)
+                    // disables the auto-scroll so the "late data fills the
+                    // viewport WITHOUT any scroll" state can be observed.
+                    // Trigger on the SECOND layoutcomplete: the first is the
+                    // pre-data (header-only) layout — the signal already
+                    // holds 30 ids then, but the NATIVE list doesn't yet, so
+                    // scrolling on it would target an out-of-range index.
+                    let seen = lc_seen.get() + 1;
+                    lc_seen.set(seen);
+                    if seen == 2 && std::env::var("SMOKE_NO_AUTOSCROLL").is_err() {
+                        list_handle.scroll_to_position(ids.get().len() as i32, true);
+                    }
+                    // An append's layout completed — scroll back to the TOP:
+                    // the first row was recycled off-screen during the trip
+                    // to the bottom, so this exercises re-materialization of
+                    // item 0 (regression: it stayed blank).
+                    if chase_bottom.get() {
+                        chase_bottom.set(false);
+                        eprintln!("[SMOKE] append landed — scrolling back to top");
+                        list_handle.scroll_to_position(0, true);
                     }
                 },
                 on_scroll: |e| eprintln!("[SMOKE] scroll fired: {e:?}"),

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.9").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.10").removePrefix("v")
 
 dependencies {
     if (whiskerSdkRelease) {

--- a/platforms/android/whisker-runtime/build.gradle.kts
+++ b/platforms/android/whisker-runtime/build.gradle.kts
@@ -20,7 +20,7 @@
 // `whiskerSdkRelease` Gradle property toggles the dep form: unset
 // (default) → flatDir-friendly `:LynxAndroid@aar`; `true` → Maven
 // coords pinned to `lynxFork`. The CI publish workflow sets
-// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.9`; local CLI
+// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.10`; local CLI
 // flows leave both unset and use flatDir as before.
 
 plugins {
@@ -70,7 +70,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.9").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.10").removePrefix("v")
 
 dependencies {
     api(project(":module"))

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -99,23 +99,23 @@ let package = Package(
         // until the matching module-side refactor lands).
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/Lynx-3.8.0-whisker.9.xcframework.zip",
-            checksum: "98f29de0577960f52f13b895de7c36714afb947ba8719df35a7ce605f1262d13"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/Lynx-3.8.0-whisker.10.xcframework.zip",
+            checksum: "b0e2e3f2a1f0b828222b529ffa25c69a06c0b5f16ca5b8d7762ab91a5981757d"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/LynxBase-3.8.0-whisker.9.xcframework.zip",
-            checksum: "44e22f9d39199fd6ebbd84f851e5186a6900f1953362f878c039a472d2b8e268"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/LynxBase-3.8.0-whisker.10.xcframework.zip",
+            checksum: "4ca0bde69e6f65b4023e12ae45e6cabcb64640c5c4c86966a2a161f70c439d9f"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/LynxServiceAPI-3.8.0-whisker.9.xcframework.zip",
-            checksum: "f65968b15c40484d864ba776aac42f94c032fcdb62d113a488b8f29062581774"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/LynxServiceAPI-3.8.0-whisker.10.xcframework.zip",
+            checksum: "905a192eb633611e2892f20fc874b24bbed691255f1946d88bcd46605198c37c"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.9/PrimJS-3.8.0-whisker.9.xcframework.zip",
-            checksum: "bd4000889b4337889e143056edf0a7a441d43fade5915b72d7701d7c9688bfa9"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/PrimJS-3.8.0-whisker.10.xcframework.zip",
+            checksum: "f5077dee5ba24d33895e35d027e67f72e5f82158f8fd346aa3edbe0f07d356b4"
         ),
 
         // Phase J — minimal module-author surface. Carved out of the


### PR DESCRIPTION
## Summary

Fixes the three `<list>` bugs surfaced by the Bluesky timeline verification (#280): **scroll position reset to the top on every append**, the initial viewport not filling when data arrived after mount, and the first row failing to re-materialize after being recycled.

## Root causes (two, not three)

1. **Full-replace data updates.** whisker sent every update as `removeAction` for all prior positions + `insertAction` for every current item. Lynx's adapter recycles elements by item-key, but the remove severs every `ItemHolder`'s identity — the anchor manager (`UpdateAnchorRefItem`) then has no surviving on-screen sibling to re-anchor to and the offset collapses to the top. ReactLynx (`ListUpdateInfoRecording`) instead emits minimal actions where untouched items appear in NO action — the contract the anchor logic is designed around.
2. **A tick-idle wedge for core-originated events.** An event queued DURING a tick (a `layoutcomplete` fired by that tick's own `renderer_flush`) has its `wake_runtime()` edge consumed by the tick in progress; `tick()` then reported idle and the vsync loop paused with the event stranded. This is what made post-mount data updates look unfilled until a scroll (the scroll resumed vsync).

## Changes

- **virtualizer**: keeps the previous item-key list and sends the common-prefix/suffix splice via the fork's new `lynx_element_update_list_actions` (v3.8.0-whisker.10, tail addition, ABI stays v2). Append = insert-only; identical key list = nothing sent; a reorder degrades to a full-window remove+insert (no worse than before). `splice_diff` is a pure function with unit tests. Falls back to the full-replace `set_update_list_info` on an older Lynx (optional dlsym bind).
- **tick()**: the level-triggered idle test now also reports busy while core-originated events sit in the drain queue — same treatment as the reactive queue's wedge fix.
- **list-smoke**: self-verifying run — late data fills the viewport with no interaction, a programmatic scroll-to-bottom appends a page with the position HELD, and a scroll back to the top re-materializes row 1.
- Pins: root + platforms/ios `Package.swift` → `.10` (released checksums), gradle `lynxFork` → `.10`, `WHISKER_SDK_VERSION` 0.1.4 (publish via `sdk-v0.1.4` tag after merge).

## Testing

- `cargo test` (160 green incl. 7 new splice-diff/actions tests), clippy + fmt clean, `aarch64-apple-ios-sim` cross-check.
- iOS simulator E2E with `list-smoke`, first against a local fork build, then re-verified against the **released `.10` xcframeworks** (SPM checksum-verified): append at the bottom holds `scroll_top` (previously reset to 0) with content height growing correctly; late-arriving data fills the viewport without any scroll; row 1 re-materializes at the top after recycling; zero panics.
- Note: an earlier hypothesis blamed a `GetHasNewLayout` gate in `FiberElement::UpdateLayoutInfoRecursively` — runtime instrumentation showed that path never fires, so no fork-side layout change ships; the fill bug was the full-replace + wedge combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)