### PR TITLE
fix(bluesky): timeline list key must be entry identity, not post identity

### DIFF
--- a/examples/bluesky/crates/bsky-auth/src/lib.rs
+++ b/examples/bluesky/crates/bsky-auth/src/lib.rs
@@ -333,9 +333,24 @@ pub async fn fetch_timeline(
     })
 }
 
-/// Map atrium's `FeedViewPost` into our trimmed [`bsky_domain::FeedPost`].
+/// Map atrium's `FeedViewPost` into our trimmed [`bsky_domain::FeedPost`],
+/// carrying the repost reason: it is part of the entry's identity (the
+/// same post can appear as the original AND as a repost in one page).
 fn map_feed_post(fv: &atrium_api::app::bsky::feed::defs::FeedViewPost) -> bsky_domain::FeedPost {
-    map_post_view(&fv.post)
+    use atrium_api::app::bsky::feed::defs::FeedViewPostReasonRefs;
+    use atrium_api::types::Union;
+
+    let mut post = map_post_view(&fv.post);
+    if let Some(Union::Refs(FeedViewPostReasonRefs::ReasonRepost(r))) = &fv.reason {
+        let by = &r.by;
+        post.reposted_by = Some(bsky_domain::Author {
+            did: by.did.as_str().to_string(),
+            handle: by.handle.as_str().to_string(),
+            display_name: by.display_name.clone(),
+            avatar: by.avatar.clone(),
+        });
+    }
+    post
 }
 
 /// Map a `PostView` (the shape `getTimeline` / `getPostThread` / author
@@ -367,6 +382,7 @@ fn map_post_view(p: &atrium_api::app::bsky::feed::defs::PostView) -> bsky_domain
         like_count: p.like_count.unwrap_or(0).max(0) as u64,
         like_uri,
         repost_uri,
+        reposted_by: None,
         indexed_at: p.indexed_at.as_str().to_string(),
     }
 }

--- a/examples/bluesky/crates/bsky-domain/src/lib.rs
+++ b/examples/bluesky/crates/bsky-domain/src/lib.rs
@@ -47,6 +47,12 @@ pub struct FeedPost {
     /// URI is what `deleteRecord` needs to undo it).
     pub like_uri: Option<String>,
     pub repost_uri: Option<String>,
+    /// `Some` when this feed ENTRY is a repost: the account whose
+    /// repost put the post in the timeline. Part of the entry's list
+    /// identity — the same post can appear both as the original and
+    /// as a repost, so a key of `uri` alone collides (duplicate
+    /// item-keys corrupt the native list's diff).
+    pub reposted_by: Option<Author>,
     /// ISO-8601 timestamp the post was indexed.
     pub indexed_at: String,
 }

--- a/examples/bluesky/src/lib.rs
+++ b/examples/bluesky/src/lib.rs
@@ -1900,7 +1900,13 @@ fn timeline_screen() -> Element {
                         all.extend(more.get());
                         all
                     },
-                    key: |p: &bsky_domain::FeedPost| p.uri.clone(),
+                    // Entry identity, not post identity: a post can appear
+                    // both as the original and as a repost in one timeline,
+                    // and duplicate item-keys corrupt the native list diff.
+                    key: |p: &bsky_domain::FeedPost| match &p.reposted_by {
+                        Some(by) => format!("{}#repost:{}", p.uri, by.did),
+                        None => p.uri.clone(),
+                    },
                     children: |p: bsky_domain::FeedPost| render! {
                         list_item(reuse_identifier: "post", estimated_size: 140) {
                             PostRow(post: p)


### PR DESCRIPTION
## Summary

The main-branch verification of infinite scroll surfaced an app-side bug: a **reposted post appears in the timeline twice** (as the original and as the repost) **with the same `at://` uri**, so keying the list on `uri` alone produces duplicate item-keys — and duplicate keys corrupt the native list's diff (the adapter's `item_key_map` collapses them). Symptom: the timeline materialized only the first ~2 rows whenever the first page contained a repost (`50 posts, 49 unique uris` pinned it).

- Carry the repost reason through the domain mapping: `FeedPost.reposted_by: Option<Author>` (from `FeedViewPost.reason` / `ReasonRepost.by`). Also what a future “Reposted by X” row needs.
- Key timeline entries as `uri` + `#repost:<reposter did>`.

## Verified (iOS simulator, main + this fix)

- Timeline viewport fills at launch (previously stopped after 2 rows).
- Infinite scroll pages seamlessly with the scroll position held: 4 pages / 192 posts, cursor advancing (…05-29 → 04-20 → 03-10), re-entrancy guard holding, zero panics.

## Note

With the position now holding across appends (#281), pagination is visually silent — the fetch takes ~1s, so at the bottom you bounce, and the new page is simply there on the next scroll. A loading-footer row would make the fetch visible; left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)