### PR TITLE
feat(list)!: ItemMeta — identity + per-item metadata unified; list_item removed

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,23 +74,23 @@ let package = Package(
         // `swiftpm-manifest-<ver>.txt` published alongside each release.
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/Lynx-3.8.0-whisker.11.xcframework.zip",
-            checksum: "42659f63021d6419a6d1fdfa8dc4be15ee449ac4ffd597c4a8564e976968e69c"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/Lynx-3.8.0-whisker.12.xcframework.zip",
+            checksum: "4ce496517fa600d295213235ff33d914eba6f68957f88972699c1be90a0d986c"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/LynxBase-3.8.0-whisker.11.xcframework.zip",
-            checksum: "82a8f9dcf17cb9dbfb776d0ec726a1110270940b727719449153b27ec9bb559e"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/LynxBase-3.8.0-whisker.12.xcframework.zip",
+            checksum: "e581e5754cd3f2abe9eca11c372d2d18a0c0dae3cd726faeff2c6a6823adb656"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/LynxServiceAPI-3.8.0-whisker.11.xcframework.zip",
-            checksum: "576fa37640cf6c0bd16096cb4ba2282c30a7f36ceaa803d457faa94e25ea38f4"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/LynxServiceAPI-3.8.0-whisker.12.xcframework.zip",
+            checksum: "0059201634a27ca331c329f01c4eab1ff604c31a40628c5f8d3b02f91f5661e2"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/PrimJS-3.8.0-whisker.11.xcframework.zip",
-            checksum: "08ddf094a3ff8b83449a3f567bb6c86cda2ec5947a21b218f490a473adeeb0d5"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/PrimJS-3.8.0-whisker.12.xcframework.zip",
+            checksum: "f095f00b22434823a33fbf7653a3e6ee609446f693a4fbb1f840e99ee65b70b5"
         ),
 
         // Header-only mirror of `WhiskerDriver`'s public C ABI. Source

--- a/Package.swift
+++ b/Package.swift
@@ -74,23 +74,23 @@ let package = Package(
         // `swiftpm-manifest-<ver>.txt` published alongside each release.
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/Lynx-3.8.0-whisker.10.xcframework.zip",
-            checksum: "b0e2e3f2a1f0b828222b529ffa25c69a06c0b5f16ca5b8d7762ab91a5981757d"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/Lynx-3.8.0-whisker.11.xcframework.zip",
+            checksum: "42659f63021d6419a6d1fdfa8dc4be15ee449ac4ffd597c4a8564e976968e69c"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/LynxBase-3.8.0-whisker.10.xcframework.zip",
-            checksum: "4ca0bde69e6f65b4023e12ae45e6cabcb64640c5c4c86966a2a161f70c439d9f"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/LynxBase-3.8.0-whisker.11.xcframework.zip",
+            checksum: "82a8f9dcf17cb9dbfb776d0ec726a1110270940b727719449153b27ec9bb559e"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/LynxServiceAPI-3.8.0-whisker.10.xcframework.zip",
-            checksum: "905a192eb633611e2892f20fc874b24bbed691255f1946d88bcd46605198c37c"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/LynxServiceAPI-3.8.0-whisker.11.xcframework.zip",
+            checksum: "576fa37640cf6c0bd16096cb4ba2282c30a7f36ceaa803d457faa94e25ea38f4"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/PrimJS-3.8.0-whisker.10.xcframework.zip",
-            checksum: "f5077dee5ba24d33895e35d027e67f72e5f82158f8fd346aa3edbe0f07d356b4"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/PrimJS-3.8.0-whisker.11.xcframework.zip",
+            checksum: "08ddf094a3ff8b83449a3f567bb6c86cda2ec5947a21b218f490a473adeeb0d5"
         ),
 
         // Header-only mirror of `WhiskerDriver`'s public C ABI. Source

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -88,7 +88,17 @@ pub struct PlatformSync {
 /// (infinite scroll) instead of resetting to the top. Non-breaking:
 /// feature-detected; on 0.1.3's Lynx whisker falls back to the
 /// full-replace update (the pre-fix behaviour).
-const WHISKER_SDK_VERSION: &str = "0.1.4";
+///
+/// 0.1.5 rolls the SDK's transitive Lynx pin `v3.8.0-whisker.10` →
+/// `v3.8.0-whisker.11`, which adds
+/// `lynx_element_update_list_actions_v2` (tail addition, ABI stays
+/// v2) — per-item metadata (estimated size / full-span / sticky /
+/// recyclable) on the diff actions plus in-place metadata updates.
+/// This is what makes sticky headers, waterfall full-span and item
+/// size estimates actually work (the `ItemMeta` API). Non-breaking:
+/// feature-detected; on 0.1.4's Lynx whisker degrades to keys-only
+/// actions (metadata stays dark, as before).
+const WHISKER_SDK_VERSION: &str = "0.1.5";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -90,14 +90,14 @@ pub struct PlatformSync {
 /// full-replace update (the pre-fix behaviour).
 ///
 /// 0.1.5 rolls the SDK's transitive Lynx pin `v3.8.0-whisker.10` →
-/// `v3.8.0-whisker.11`, which adds
-/// `lynx_element_update_list_actions_v2` (tail addition, ABI stays
-/// v2) — per-item metadata (estimated size / full-span / sticky /
-/// recyclable) on the diff actions plus in-place metadata updates.
-/// This is what makes sticky headers, waterfall full-span and item
-/// size estimates actually work (the `ItemMeta` API). Non-breaking:
-/// feature-detected; on 0.1.4's Lynx whisker degrades to keys-only
-/// actions (metadata stays dark, as before).
+/// `v3.8.0-whisker.12` (capi ABI v3):
+/// `lynx_element_update_list_actions` now carries per-item metadata
+/// (estimated size / full-span / sticky / recyclable) on the diff
+/// actions plus in-place metadata updates — what makes sticky
+/// headers, waterfall full-span and item size estimates actually work
+/// (the `ItemMeta` API). BREAKING at the capi layer (v2 embedders
+/// refuse to attach via the abi-version handshake) — accepted while
+/// whisker is the only consumer.
 const WHISKER_SDK_VERSION: &str = "0.1.5";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`

--- a/crates/whisker-driver-sys/bridge/include/lynx_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_capi.h
@@ -34,7 +34,7 @@ extern "C" {
 // Whisker refuses to load a Lynx whose ABI version differs from this.
 // Bumped in lockstep with the fork's `kLynxCapiAbiVersion` whenever the
 // C ABI changes incompatibly.
-#define WHISKER_LYNX_CAPI_ABI_VERSION 2
+#define WHISKER_LYNX_CAPI_ABI_VERSION 3
 
 // ----- Opaque handle types --------------------------------------------------
 
@@ -179,19 +179,7 @@ typedef void (*lynx_element_set_update_list_info_fn)(lynx_fiber_element_t* eleme
                                                       const uint8_t* sticky_bottom,
                                                       const uint8_t* recyclable,
                                                       int32_t count);
-// Explicit diff actions for the decoupled `<list>` data source —
-// minimal-action alternative to `lynx_element_set_update_list_info`.
-// Removals: ascending pre-update indices, applied first. Inserts:
-// ascending splice points into the post-removal list.
-typedef void (*lynx_element_update_list_actions_fn)(
-    lynx_fiber_element_t* element,
-    const int32_t* remove_indices,
-    int32_t remove_count,
-    const int32_t* insert_positions,
-    const char* const* insert_keys,
-    int32_t insert_count);
-
-// Mirror of the fork's `lynx_list_item_action_t` (v3.8.0-whisker.11):
+// Mirror of the fork's `lynx_list_item_action_t` (ABI v3):
 // one insert/update entry with the per-item layout metadata the
 // adapter ingests from the action stream. Fixed-width fields; layout
 // is part of the ABI.
@@ -205,10 +193,12 @@ typedef struct lynx_list_item_action_t {
   uint8_t recyclable;
 } lynx_list_item_action_t;
 
-// Metadata-carrying successor to `lynx_element_update_list_actions`.
-// `updates` refresh SURVIVING items' metadata in place
-// (updateAction {from == to, flush: false}).
-typedef void (*lynx_element_update_list_actions_v2_fn)(
+// Explicit diff actions for the decoupled `<list>` data source —
+// minimal-action alternative to `lynx_element_set_update_list_info`.
+// Removals: ascending pre-update indices, applied first; inserts carry
+// the per-item layout metadata; `updates` refresh SURVIVING items'
+// metadata in place (updateAction {from == to, flush: false}).
+typedef void (*lynx_element_update_list_actions_fn)(
     lynx_fiber_element_t* element,
     const int32_t* remove_indices,
     int32_t remove_count,
@@ -335,16 +325,8 @@ typedef struct WhiskerLynxCapi {
   // the call site; list events simply stay dark on old engines).
   lynx_shell_set_custom_event_callback_fn shell_set_custom_event_callback;
 
-  // Explicit list diff actions. OPTIONAL (tail-added after ABI v2) —
-  // NULL on an older Lynx; the caller falls back to the full-replace
-  // `element_set_update_list_info` (pre-feature behaviour: scroll
-  // position resets on data updates, but nothing breaks).
+  // Explicit list diff actions (metadata-carrying, ABI v3+).
   lynx_element_update_list_actions_fn element_update_list_actions;
-
-  // Metadata-carrying v2 (v3.8.0-whisker.11). OPTIONAL — NULL on an
-  // older Lynx; the bridge degrades to v1 (metadata + in-place updates
-  // dropped), then to the full replace.
-  lynx_element_update_list_actions_v2_fn element_update_list_actions_v2;
 } WhiskerLynxCapi;
 
 // ----- Loader API -----------------------------------------------------------

--- a/crates/whisker-driver-sys/bridge/include/lynx_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_capi.h
@@ -190,6 +190,32 @@ typedef void (*lynx_element_update_list_actions_fn)(
     const int32_t* insert_positions,
     const char* const* insert_keys,
     int32_t insert_count);
+
+// Mirror of the fork's `lynx_list_item_action_t` (v3.8.0-whisker.11):
+// one insert/update entry with the per-item layout metadata the
+// adapter ingests from the action stream. Fixed-width fields; layout
+// is part of the ABI.
+typedef struct lynx_list_item_action_t {
+  int32_t position;
+  const char* item_key;
+  int32_t estimated_main_axis_px;  // < 0 = unset
+  uint8_t full_span;
+  uint8_t sticky_top;
+  uint8_t sticky_bottom;
+  uint8_t recyclable;
+} lynx_list_item_action_t;
+
+// Metadata-carrying successor to `lynx_element_update_list_actions`.
+// `updates` refresh SURVIVING items' metadata in place
+// (updateAction {from == to, flush: false}).
+typedef void (*lynx_element_update_list_actions_v2_fn)(
+    lynx_fiber_element_t* element,
+    const int32_t* remove_indices,
+    int32_t remove_count,
+    const lynx_list_item_action_t* inserts,
+    int32_t insert_count,
+    const lynx_list_item_action_t* updates,
+    int32_t update_count);
 typedef void (*lynx_element_set_event_handler_fn)(lynx_fiber_element_t* element,
                                                     const char* event_name);
 typedef void (*lynx_element_append_child_fn)(lynx_fiber_element_t* parent,
@@ -314,6 +340,11 @@ typedef struct WhiskerLynxCapi {
   // `element_set_update_list_info` (pre-feature behaviour: scroll
   // position resets on data updates, but nothing breaks).
   lynx_element_update_list_actions_fn element_update_list_actions;
+
+  // Metadata-carrying v2 (v3.8.0-whisker.11). OPTIONAL — NULL on an
+  // older Lynx; the bridge degrades to v1 (metadata + in-place updates
+  // dropped), then to the full replace.
+  lynx_element_update_list_actions_v2_fn element_update_list_actions_v2;
 } WhiskerLynxCapi;
 
 // ----- Loader API -----------------------------------------------------------

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -125,20 +125,37 @@ WHISKER_BRIDGE_EXPORT void whisker_bridge_list_set_item_count(
     WhiskerElement* element, int32_t prev_count, const char* const* item_keys,
     int32_t count);
 
+// One `<list>` insert/update action entry: the stable item-key plus the
+// per-item layout metadata Lynx's adapter ingests from the action
+// stream. For inserts `position` is the ascending splice point into
+// the post-removal list; for updates it is the item's index in the
+// FINAL list.
+typedef struct WhiskerListItemAction {
+    int32_t position;
+    const char* item_key;              // NUL-terminated, borrowed
+    int32_t estimated_main_axis_px;    // < 0 = unset
+    uint8_t full_span;
+    uint8_t sticky_top;
+    uint8_t sticky_bottom;
+    uint8_t recyclable;
+} WhiskerListItemAction;
+
 // Explicit `<list>` diff actions — the minimal-action alternative to
 // `whisker_bridge_list_set_item_count`'s full replace. Items mentioned
-// in neither action keep their native ItemHolder identity, which is
-// what lets the list hold its scroll position across an append.
-// Removals: ascending pre-update indices (applied first). Inserts:
-// `insert_positions`/`insert_keys` parallel arrays, ascending splice
-// points into the post-removal list.
+// in no action keep their native ItemHolder identity, which is what
+// lets the list hold its scroll position across an append. Removals:
+// ascending pre-update indices (applied first). Inserts carry per-item
+// metadata; updates refresh a surviving item's metadata in place.
 //
-// Returns false when the loaded Lynx predates the capi (tail-added
-// after ABI v2) — the caller then falls back to the full replace.
+// Degrades by capability of the loaded Lynx: the metadata-carrying v2
+// capi when present, else the v1 keys-only capi (metadata and updates
+// dropped), else returns false and the caller falls back to the full
+// replace.
 WHISKER_BRIDGE_EXPORT bool whisker_bridge_list_update_actions(
     WhiskerElement* element, const int32_t* remove_indices,
-    int32_t remove_count, const int32_t* insert_positions,
-    const char* const* insert_keys, int32_t insert_count);
+    int32_t remove_count, const WhiskerListItemAction* inserts,
+    int32_t insert_count, const WhiskerListItemAction* updates,
+    int32_t update_count);
 
 // Object-valued attribute (`{obj_keys[i]: obj_values[i]}` of doubles),
 // e.g. `<list>` `item-snap` {factor, offset}.

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -147,10 +147,8 @@ typedef struct WhiskerListItemAction {
 // ascending pre-update indices (applied first). Inserts carry per-item
 // metadata; updates refresh a surviving item's metadata in place.
 //
-// Degrades by capability of the loaded Lynx: the metadata-carrying v2
-// capi when present, else the v1 keys-only capi (metadata and updates
-// dropped), else returns false and the caller falls back to the full
-// replace.
+// Requires the ABI v3 capi (a strict loader bind, so present whenever
+// the engine attached); returns false only for a null/unknown element.
 WHISKER_BRIDGE_EXPORT bool whisker_bridge_list_update_actions(
     WhiskerElement* element, const int32_t* remove_indices,
     int32_t remove_count, const WhiskerListItemAction* inserts,

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -311,19 +311,58 @@ extern "C" void whisker_bridge_list_set_item_count(WhiskerElement* element,
 
 extern "C" bool whisker_bridge_list_update_actions(
     WhiskerElement* element, const int32_t* remove_indices,
-    int32_t remove_count, const int32_t* insert_positions,
-    const char* const* insert_keys, int32_t insert_count) {
+    int32_t remove_count, const WhiskerListItemAction* inserts,
+    int32_t insert_count, const WhiskerListItemAction* updates,
+    int32_t update_count) {
     if (element == nullptr || element->handle == nullptr) return false;
     const WhiskerLynxCapi* capi = whisker_lynx_capi();
-    // Feature-detect: tail-added after ABI v2 — NULL on an older Lynx.
-    // The caller falls back to the full-replace update.
-    if (capi == nullptr || capi->element_update_list_actions == nullptr) {
-        return false;
+    if (capi == nullptr) return false;
+    if (capi->element_update_list_actions_v2 != nullptr) {
+        // The bridge struct mirrors `lynx_list_item_action_t` field for
+        // field, but convert explicitly — the two headers evolve
+        // independently and a silent layout drift would corrupt every
+        // list update.
+        std::vector<lynx_list_item_action_t> ins(
+            static_cast<size_t>(insert_count > 0 ? insert_count : 0));
+        for (int32_t i = 0; inserts != nullptr && i < insert_count; ++i) {
+            ins[i] = {inserts[i].position,        inserts[i].item_key,
+                      inserts[i].estimated_main_axis_px, inserts[i].full_span,
+                      inserts[i].sticky_top,      inserts[i].sticky_bottom,
+                      inserts[i].recyclable};
+        }
+        std::vector<lynx_list_item_action_t> ups(
+            static_cast<size_t>(update_count > 0 ? update_count : 0));
+        for (int32_t i = 0; updates != nullptr && i < update_count; ++i) {
+            ups[i] = {updates[i].position,        updates[i].item_key,
+                      updates[i].estimated_main_axis_px, updates[i].full_span,
+                      updates[i].sticky_top,      updates[i].sticky_bottom,
+                      updates[i].recyclable};
+        }
+        capi->element_update_list_actions_v2(
+            element->handle, remove_indices, remove_count,
+            ins.empty() ? nullptr : ins.data(), insert_count,
+            ups.empty() ? nullptr : ups.data(), update_count);
+        return true;
     }
-    capi->element_update_list_actions(element->handle, remove_indices,
-                                      remove_count, insert_positions,
-                                      insert_keys, insert_count);
-    return true;
+    if (capi->element_update_list_actions != nullptr) {
+        // v1 degrade: keys-only inserts; metadata and in-place updates
+        // are dropped (the pre-.11 behaviour — sticky / full-span /
+        // estimates simply stay dark).
+        std::vector<int32_t> positions(
+            static_cast<size_t>(insert_count > 0 ? insert_count : 0));
+        std::vector<const char*> keys(
+            static_cast<size_t>(insert_count > 0 ? insert_count : 0));
+        for (int32_t i = 0; inserts != nullptr && i < insert_count; ++i) {
+            positions[i] = inserts[i].position;
+            keys[i] = inserts[i].item_key;
+        }
+        capi->element_update_list_actions(
+            element->handle, remove_indices, remove_count,
+            positions.empty() ? nullptr : positions.data(),
+            keys.empty() ? nullptr : keys.data(), insert_count);
+        return true;
+    }
+    return false;
 }
 
 // Install a native item provider on a `<list>` element so Whisker can

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -315,54 +315,31 @@ extern "C" bool whisker_bridge_list_update_actions(
     int32_t insert_count, const WhiskerListItemAction* updates,
     int32_t update_count) {
     if (element == nullptr || element->handle == nullptr) return false;
-    const WhiskerLynxCapi* capi = whisker_lynx_capi();
-    if (capi == nullptr) return false;
-    if (capi->element_update_list_actions_v2 != nullptr) {
-        // The bridge struct mirrors `lynx_list_item_action_t` field for
-        // field, but convert explicitly — the two headers evolve
-        // independently and a silent layout drift would corrupt every
-        // list update.
-        std::vector<lynx_list_item_action_t> ins(
-            static_cast<size_t>(insert_count > 0 ? insert_count : 0));
-        for (int32_t i = 0; inserts != nullptr && i < insert_count; ++i) {
-            ins[i] = {inserts[i].position,        inserts[i].item_key,
-                      inserts[i].estimated_main_axis_px, inserts[i].full_span,
-                      inserts[i].sticky_top,      inserts[i].sticky_bottom,
-                      inserts[i].recyclable};
-        }
-        std::vector<lynx_list_item_action_t> ups(
-            static_cast<size_t>(update_count > 0 ? update_count : 0));
-        for (int32_t i = 0; updates != nullptr && i < update_count; ++i) {
-            ups[i] = {updates[i].position,        updates[i].item_key,
-                      updates[i].estimated_main_axis_px, updates[i].full_span,
-                      updates[i].sticky_top,      updates[i].sticky_bottom,
-                      updates[i].recyclable};
-        }
-        capi->element_update_list_actions_v2(
-            element->handle, remove_indices, remove_count,
-            ins.empty() ? nullptr : ins.data(), insert_count,
-            ups.empty() ? nullptr : ups.data(), update_count);
-        return true;
+    // The bridge struct mirrors `lynx_list_item_action_t` field for
+    // field, but convert explicitly — the two headers evolve
+    // independently and a silent layout drift would corrupt every
+    // list update.
+    std::vector<lynx_list_item_action_t> ins(
+        static_cast<size_t>(insert_count > 0 ? insert_count : 0));
+    for (int32_t i = 0; inserts != nullptr && i < insert_count; ++i) {
+        ins[i] = {inserts[i].position,        inserts[i].item_key,
+                  inserts[i].estimated_main_axis_px, inserts[i].full_span,
+                  inserts[i].sticky_top,      inserts[i].sticky_bottom,
+                  inserts[i].recyclable};
     }
-    if (capi->element_update_list_actions != nullptr) {
-        // v1 degrade: keys-only inserts; metadata and in-place updates
-        // are dropped (the pre-.11 behaviour — sticky / full-span /
-        // estimates simply stay dark).
-        std::vector<int32_t> positions(
-            static_cast<size_t>(insert_count > 0 ? insert_count : 0));
-        std::vector<const char*> keys(
-            static_cast<size_t>(insert_count > 0 ? insert_count : 0));
-        for (int32_t i = 0; inserts != nullptr && i < insert_count; ++i) {
-            positions[i] = inserts[i].position;
-            keys[i] = inserts[i].item_key;
-        }
-        capi->element_update_list_actions(
-            element->handle, remove_indices, remove_count,
-            positions.empty() ? nullptr : positions.data(),
-            keys.empty() ? nullptr : keys.data(), insert_count);
-        return true;
+    std::vector<lynx_list_item_action_t> ups(
+        static_cast<size_t>(update_count > 0 ? update_count : 0));
+    for (int32_t i = 0; updates != nullptr && i < update_count; ++i) {
+        ups[i] = {updates[i].position,        updates[i].item_key,
+                  updates[i].estimated_main_axis_px, updates[i].full_span,
+                  updates[i].sticky_top,      updates[i].sticky_bottom,
+                  updates[i].recyclable};
     }
-    return false;
+    whisker_lynx_capi()->element_update_list_actions(
+        element->handle, remove_indices, remove_count,
+        ins.empty() ? nullptr : ins.data(), insert_count,
+        ups.empty() ? nullptr : ups.data(), update_count);
+    return true;
 }
 
 // Install a native item provider on a `<list>` element so Whisker can

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
@@ -194,6 +194,12 @@ int DoLoad() {
         reinterpret_cast<lynx_element_update_list_actions_fn>(
             dlsym(handle, "lynx_element_update_list_actions"));
 
+    // Metadata-carrying v2 — OPTIONAL (v3.8.0-whisker.11).
+    (void)dlerror();
+    g_capi.element_update_list_actions_v2 =
+        reinterpret_cast<lynx_element_update_list_actions_v2_fn>(
+            dlsym(handle, "lynx_element_update_list_actions_v2"));
+
     if (!ok) return WHISKER_BRIDGE_LYNX_LOAD_ERR_MISSING_SYMBOL;
     return WHISKER_BRIDGE_LYNX_LOAD_OK;
 }

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
@@ -186,19 +186,9 @@ int DoLoad() {
         reinterpret_cast<lynx_shell_set_custom_event_callback_fn>(
             dlsym(handle, "lynx_shell_set_custom_event_callback"));
 
-    // Explicit list diff actions — OPTIONAL (tail-added after ABI v2).
-    // NULL on an older Lynx; the bridge falls back to the full-replace
-    // update (scroll position resets on data updates, as before).
-    (void)dlerror();
-    g_capi.element_update_list_actions =
-        reinterpret_cast<lynx_element_update_list_actions_fn>(
-            dlsym(handle, "lynx_element_update_list_actions"));
-
-    // Metadata-carrying v2 — OPTIONAL (v3.8.0-whisker.11).
-    (void)dlerror();
-    g_capi.element_update_list_actions_v2 =
-        reinterpret_cast<lynx_element_update_list_actions_v2_fn>(
-            dlsym(handle, "lynx_element_update_list_actions_v2"));
+    // Explicit list diff actions — part of the ABI v3 surface, so a
+    // strict bind like the rest.
+    BindSymbol(handle, "lynx_element_update_list_actions", &g_capi.element_update_list_actions, &ok);
 
     if (!ok) return WHISKER_BRIDGE_LYNX_LOAD_ERR_MISSING_SYMBOL;
     return WHISKER_BRIDGE_LYNX_LOAD_OK;

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -74,6 +74,22 @@ pub const LYNX_LIST_INVALID_INDEX: i32 = -1;
 pub type WhiskerEventValueCallback =
     extern "C" fn(user_data: *mut c_void, payload: *const WhiskerValueRaw);
 
+/// `#[repr(C)]` mirror of the bridge's `WhiskerListItemAction`: one
+/// `<list>` insert/update action entry (stable item-key + the per-item
+/// layout metadata Lynx's adapter ingests from the action stream).
+#[repr(C)]
+pub struct WhiskerListItemActionRaw {
+    pub position: i32,
+    /// NUL-terminated, borrowed for the duration of the call.
+    pub item_key: *const c_char,
+    /// `< 0` = unset.
+    pub estimated_main_axis_px: i32,
+    pub full_span: u8,
+    pub sticky_top: u8,
+    pub sticky_bottom: u8,
+    pub recyclable: u8,
+}
+
 /// The Rust event dispatcher the bridge calls when its reporter hook
 /// fires. Receives the hit-tested target's element sign, the event
 /// name (NUL-terminated), and the event body (`WhiskerValueRaw` tree,
@@ -286,16 +302,19 @@ unsafe extern "C" {
     );
 
     /// Explicit `<list>` diff actions (minimal-action alternative to
-    /// the full replace above). Returns `false` when the loaded Lynx
-    /// predates the capi — fall back to
-    /// [`whisker_bridge_list_set_item_count`].
+    /// the full replace above), carrying per-item layout metadata on
+    /// inserts and in-place metadata updates for surviving items.
+    /// Degrades by Lynx capability (v2 → v1 keys-only → `false`, at
+    /// which point fall back to
+    /// [`whisker_bridge_list_set_item_count`]).
     pub fn whisker_bridge_list_update_actions(
         element: *mut WhiskerElement,
         remove_indices: *const i32,
         remove_count: i32,
-        insert_positions: *const i32,
-        insert_keys: *const *const c_char,
+        inserts: *const WhiskerListItemActionRaw,
         insert_count: i32,
+        updates: *const WhiskerListItemActionRaw,
+        update_count: i32,
     ) -> bool;
 
     pub fn whisker_bridge_list_set_native_item_provider(

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -266,28 +266,47 @@ impl DynRenderer for BridgeRenderer {
         &self,
         handle: Element,
         removals: &[i32],
-        inserts: &[(i32, String)],
+        inserts: &[whisker_runtime::view::ListItemAction],
+        updates: &[whisker_runtime::view::ListItemAction],
     ) -> bool {
         let Some(ptr) = self.lookup(handle) else {
             return false;
         };
         // Own the C strings for the duration of the call; no renderer
         // field borrow spans the FFI.
-        let c_keys: Vec<std::ffi::CString> = inserts
-            .iter()
-            .map(|(_, k)| std::ffi::CString::new(k.as_str()).unwrap_or_default())
-            .collect();
-        let key_ptrs: Vec<*const std::os::raw::c_char> =
-            c_keys.iter().map(|c| c.as_ptr()).collect();
-        let positions: Vec<i32> = inserts.iter().map(|(p, _)| *p).collect();
+        fn to_raw(
+            actions: &[whisker_runtime::view::ListItemAction],
+        ) -> (Vec<std::ffi::CString>, Vec<ffi::WhiskerListItemActionRaw>) {
+            let keys: Vec<std::ffi::CString> = actions
+                .iter()
+                .map(|a| std::ffi::CString::new(a.key.as_str()).unwrap_or_default())
+                .collect();
+            let raw: Vec<ffi::WhiskerListItemActionRaw> = actions
+                .iter()
+                .zip(keys.iter())
+                .map(|(a, k)| ffi::WhiskerListItemActionRaw {
+                    position: a.position,
+                    item_key: k.as_ptr(),
+                    estimated_main_axis_px: a.estimated_size.unwrap_or(-1),
+                    full_span: a.full_span as u8,
+                    sticky_top: a.sticky_top as u8,
+                    sticky_bottom: a.sticky_bottom as u8,
+                    recyclable: a.recyclable as u8,
+                })
+                .collect();
+            (keys, raw)
+        }
+        let (_insert_keys, insert_raw) = to_raw(inserts);
+        let (_update_keys, update_raw) = to_raw(updates);
         unsafe {
             ffi::whisker_bridge_list_update_actions(
                 ptr.as_ptr(),
                 removals.as_ptr(),
                 removals.len() as i32,
-                positions.as_ptr(),
-                key_ptrs.as_ptr(),
-                inserts.len() as i32,
+                insert_raw.as_ptr(),
+                insert_raw.len() as i32,
+                update_raw.as_ptr(),
+                update_raw.len() as i32,
             )
         }
     }

--- a/crates/whisker-macro-syntax/src/render.rs
+++ b/crates/whisker-macro-syntax/src/render.rs
@@ -246,7 +246,7 @@ pub fn snake_to_pascal(name: &str) -> String {
 pub fn is_builtin_tag(name: &str) -> bool {
     matches!(
         name,
-        "view" | "text" | "raw_text" | "scroll_view" | "list" | "list_item" | "fragment"
+        "view" | "text" | "raw_text" | "scroll_view" | "list" | "fragment"
     )
 }
 

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -331,15 +331,8 @@ fn is_known_attr_method(tag: &str, attr: &str) -> bool {
             // through the right `Into` impl (the generic `attr`
             // fallback would try `Into<Signal<String>>`).
             | ("list", "each")
-            | ("list", "key")
+            | ("list", "meta")
             | ("list", "children")
-            // Per-item props on the user-written `<list-item>` (Option E).
-            | ("list_item", "full_span")
-            | ("list_item", "sticky_top")
-            | ("list_item", "sticky_bottom")
-            | ("list_item", "reuse_identifier")
-            | ("list_item", "estimated_size")
-            | ("list_item", "recyclable")
     )
 }
 
@@ -530,32 +523,9 @@ mod tests {
 
     #[test]
     fn builtin_tags_recognised() {
-        for t in [
-            "view",
-            "text",
-            "raw_text",
-            "scroll_view",
-            "list",
-            "list_item",
-        ] {
+        for t in ["view", "text", "raw_text", "scroll_view", "list"] {
             assert!(is_builtin_tag(t));
         }
-    }
-
-    #[test]
-    fn list_item_emission_uses_builder_chain() {
-        // Option E: `list_item { .. }` lowers as a built-in element
-        // (`__list_item_ctor()`), not a user component.
-        let input: TokenStream2 = quote::quote! { list_item(full_span: true) };
-        let output = super::expand_test(input).to_string();
-        assert!(
-            output.contains("__list_item_ctor"),
-            "list_item must lower via `__list_item_ctor()`; output was: {output}"
-        );
-        assert!(
-            output.contains(". full_span"),
-            "list_item full_span kwarg must lower to `.full_span(..)`; output was: {output}"
-        );
     }
 
     #[test]

--- a/crates/whisker-runtime/src/view/into_view.rs
+++ b/crates/whisker-runtime/src/view/into_view.rs
@@ -110,6 +110,13 @@ impl<T: 'static, K: 'static, F: Fn(&T) -> K + 'static> From<F> for KeyFn<T, K> {
     }
 }
 
+/// The `list` `meta:` prop's function shape: identity + per-item
+/// layout metadata derived from the data (see
+/// [`ItemMeta`](super::virtualizer::ItemMeta)). Structurally a
+/// [`KeyFn`] whose output is the full `ItemMeta` rather than a bare
+/// key.
+pub type MetaFn<T, K> = KeyFn<T, super::virtualizer::ItemMeta<K>>;
+
 impl<T: 'static, K: 'static> KeyFn<T, K> {
     /// Invoke the wrapped closure on `item`.
     pub fn call(&self, item: &T) -> K {

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -38,12 +38,13 @@ pub use apply::{
 };
 pub use handle::Element;
 pub use into_view::{
-    Children, EachFn, Fallback, IntoView, ItemFn, KeyFn, View, WhenFn, mount_children,
+    Children, EachFn, Fallback, IntoView, ItemFn, KeyFn, MetaFn, View, WhenFn, mount_children,
 };
 pub use list_provider::{INVALID_ITEM_INDEX, NativeItemProvider};
 #[doc(hidden)]
 pub use renderer::__reset_children_mirror_for_tests;
-pub use virtualizer::virtualize;
+pub use renderer::ListItemAction;
+pub use virtualizer::{ItemMeta, virtualize};
 
 // Element-manipulation + lifecycle surface the `render!` macro expands
 // against and that framework-extension authors (custom control flow,

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -90,6 +90,23 @@ pub struct EventDispatchPlan {
 /// rather than panicking with "RefCell already borrowed". Renderers
 /// own their mutable state behind per-field `RefCell`s and must scope
 /// each field borrow so it does **not** span a re-entrant FFI call.
+/// One `<list>` diff-action entry as it crosses the renderer: the
+/// resolved (stable) item-key plus the per-item layout metadata Lynx's
+/// adapter ingests from the action stream. For inserts `position` is
+/// the ascending splice point into the post-removal list; for updates
+/// it is the item's index in the FINAL list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListItemAction {
+    pub position: i32,
+    pub key: String,
+    /// Estimated main-axis size in px; `None` = native default.
+    pub estimated_size: Option<i32>,
+    pub full_span: bool,
+    pub sticky_top: bool,
+    pub sticky_bottom: bool,
+    pub recyclable: bool,
+}
+
 pub trait DynRenderer {
     fn create_element(&self, tag: ElementTag) -> Element;
     /// Phase 7: tag-by-name dispatch for custom / xelement-style
@@ -146,10 +163,13 @@ pub trait DynRenderer {
 
     /// Explicit `<list>` diff actions — the minimal-action form.
     /// `removals` are ascending indices into the PRE-update item-key
-    /// list (applied first); `inserts` are `(position, item_key)`
-    /// pairs with ascending splice points into the post-removal list.
-    /// Items mentioned in neither action keep their native identity,
-    /// which lets the list hold its scroll position across appends.
+    /// list (applied first); `inserts` splice into the post-removal
+    /// list at ascending positions, carrying the per-item layout
+    /// metadata (the action stream is the ONLY channel Lynx's adapter
+    /// ingests it from); `updates` refresh a SURVIVING item's metadata
+    /// in place (`position` = its index in the FINAL list). Items
+    /// mentioned in no action keep their native identity, which lets
+    /// the list hold its scroll position across appends.
     ///
     /// Returns whether the renderer delivered the actions — `false`
     /// (the default, also reported when the loaded Lynx predates the
@@ -159,7 +179,8 @@ pub trait DynRenderer {
         &self,
         _handle: Element,
         _removals: &[i32],
-        _inserts: &[(i32, String)],
+        _inserts: &[ListItemAction],
+        _updates: &[ListItemAction],
     ) -> bool {
         false
     }
@@ -619,11 +640,19 @@ pub fn set_update_list_info(handle: Element, item_keys: &[String], prev_count: u
     )
 }
 
-pub fn update_list_actions(handle: Element, removals: &[i32], inserts: &[(i32, String)]) -> bool {
+pub fn update_list_actions(
+    handle: Element,
+    removals: &[i32],
+    inserts: &[ListItemAction],
+    updates: &[ListItemAction],
+) -> bool {
     if is_phantom(handle) {
         return false;
     }
-    with_renderer(|r| r.update_list_actions(handle, removals, inserts), false)
+    with_renderer(
+        |r| r.update_list_actions(handle, removals, inserts, updates),
+        false,
+    )
 }
 
 pub fn set_attribute_object(handle: Element, key: &str, obj: &[(String, f64)]) {

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -53,64 +53,195 @@ use super::apply::apply_attr_owned;
 use super::handle::Element;
 use super::list_provider::{INVALID_ITEM_INDEX, NativeItemProvider};
 use super::renderer::{
-    append_child, element_sign, install_list_native_item_provider, remove_child, set_attribute_int,
+    ListItemAction, append_child, create_element_by_name, element_sign,
+    install_list_native_item_provider, remove_child, set_attribute_bool, set_attribute_int,
     set_update_list_info, update_list_actions,
 };
+
+/// Identity + per-item layout metadata for one list item, derived from
+/// the DATA by the list's `meta` closure. This is the single source of
+/// truth: items build on demand, so nothing element-side exists when
+/// the data-source diff is sent — Lynx's adapter ingests exactly these
+/// fields from the action stream (and re-ingests them via an in-place
+/// update when they change for a surviving key).
+///
+/// ```ignore
+/// meta: |r: &Row| match r {
+///     Row::Header => ItemMeta::key("header")
+///         .estimated_size(160)
+///         .full_span(true)
+///         .sticky_top(true),
+///     Row::Item(n) => ItemMeta::key(format!("item-{n}"))
+///         .reuse_identifier("row")
+///         .estimated_size(84),
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ItemMeta<K> {
+    key: K,
+    reuse_identifier: Option<String>,
+    estimated_size: Option<i32>,
+    full_span: bool,
+    sticky_top: bool,
+    sticky_bottom: bool,
+    recyclable: bool,
+}
+
+impl<K> ItemMeta<K> {
+    /// Stable logical identity — the same key must identify the same
+    /// item across data updates (it drives the native reorder /
+    /// insert / remove diff, exactly like the former `key:` prop).
+    pub fn key(key: K) -> Self {
+        Self {
+            key,
+            reuse_identifier: None,
+            estimated_size: None,
+            full_span: false,
+            sticky_top: false,
+            sticky_bottom: false,
+            recyclable: true,
+        }
+    }
+
+    /// Recycle-pool identifier: slots sharing one are reused for each
+    /// other. Defaults to a single shared pool.
+    pub fn reuse_identifier(mut self, id: impl Into<String>) -> Self {
+        self.reuse_identifier = Some(id.into());
+        self
+    }
+
+    /// Estimated main-axis size (px) used to lay out the slot before
+    /// its real content is measured.
+    pub fn estimated_size(mut self, px: i32) -> Self {
+        self.estimated_size = Some(px);
+        self
+    }
+
+    /// Span every column in a multi-column (`flow` / `waterfall`) list.
+    pub fn full_span(mut self, v: bool) -> Self {
+        self.full_span = v;
+        self
+    }
+
+    /// Pin to the top edge while scrolled past (requires `sticky` on
+    /// the list).
+    pub fn sticky_top(mut self, v: bool) -> Self {
+        self.sticky_top = v;
+        self
+    }
+
+    /// Pin to the bottom edge (requires `sticky` on the list).
+    pub fn sticky_bottom(mut self, v: bool) -> Self {
+        self.sticky_bottom = v;
+        self
+    }
+
+    /// Opt the slot out of recycling (`false`) — e.g. a page in a
+    /// pager list whose state must survive off-screen.
+    pub fn recyclable(mut self, v: bool) -> Self {
+        self.recyclable = v;
+        self
+    }
+}
+
+/// The metadata half of a resolved item entry (identity handled
+/// separately as the stable `w_<id>` wire key).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MetaFields {
+    reuse_identifier: Option<String>,
+    estimated_size: Option<i32>,
+    full_span: bool,
+    sticky_top: bool,
+    sticky_bottom: bool,
+    recyclable: bool,
+}
+
+impl MetaFields {
+    fn action(&self, position: i32, key: &str) -> ListItemAction {
+        ListItemAction {
+            position,
+            key: key.to_string(),
+            estimated_size: self.estimated_size,
+            full_span: self.full_span,
+            sticky_top: self.sticky_top,
+            sticky_bottom: self.sticky_bottom,
+            recyclable: self.recyclable,
+        }
+    }
+}
 
 /// Send a data-source update as the MINIMAL action set against the
 /// previous key list: the longest common prefix and suffix survive
 /// untouched (keeping their native `ItemHolder` identity — which is
 /// what lets the list hold its scroll position across an append), and
-/// only the middle window is expressed as remove+insert.
+/// only the middle window is expressed as remove+insert. Surviving
+/// items whose METADATA changed get an in-place update entry.
 ///
 /// Index contract (what Lynx's `AdapterHelper` expects, matching
 /// ReactLynx's `ListUpdateInfoRecording` output): removals are
 /// ascending indices into the PRE-update list and apply first; insert
-/// positions are ascending splice points into the post-removal list.
+/// positions are ascending splice points into the post-removal list;
+/// update positions index the FINAL list (the adapter applies
+/// remove → insert → update in that order).
 ///
 /// A reorder that survives neither prefix nor suffix degrades to a
 /// full-window remove+insert — same identity loss as the legacy full
 /// replace, no worse. When the renderer can't deliver explicit actions
 /// (a Lynx build predating the capi, or a test renderer), falls back
 /// to the full-replace [`set_update_list_info`].
-fn send_data_source_update(handle: Element, prev: &[String], keys: &[String]) {
-    let (removals, inserts) = splice_diff(prev, keys);
-    if removals.is_empty() && inserts.is_empty() {
-        // Identical key list — nothing structural to update.
+fn send_data_source_update(
+    handle: Element,
+    prev: &[String],
+    keys: &[String],
+    prev_meta: &HashMap<String, MetaFields>,
+    metas: &[MetaFields],
+) {
+    let (p, s) = splice_bounds(prev, keys);
+
+    let removals: Vec<i32> = (p..prev.len() - s).map(|i| i as i32).collect();
+    let inserts: Vec<ListItemAction> = keys[p..keys.len() - s]
+        .iter()
+        .zip(metas[p..keys.len() - s].iter())
+        .enumerate()
+        .map(|(k, (key, meta))| meta.action((p + k) as i32, key))
+        .collect();
+    // Surviving (prefix + suffix) keys whose metadata changed: refresh
+    // it in place. Positions index the FINAL list.
+    let mut updates: Vec<ListItemAction> = Vec::new();
+    let survivors = (0..p).chain((keys.len() - s)..keys.len());
+    for i in survivors {
+        let key = &keys[i];
+        if prev_meta.get(key).is_some_and(|m| *m != metas[i]) {
+            updates.push(metas[i].action(i as i32, key));
+        }
+    }
+
+    if removals.is_empty() && inserts.is_empty() && updates.is_empty() {
+        // Identical key list + metadata — nothing to send.
         return;
     }
-    if !update_list_actions(handle, &removals, &inserts) {
+    if !update_list_actions(handle, &removals, &inserts, &updates) {
         set_update_list_info(handle, keys, prev.len());
     }
 }
 
-/// The common-prefix/suffix splice between two key lists, as
-/// `(removals, inserts)` in `AdapterHelper`'s index spaces (removals:
-/// ascending pre-update indices; inserts: ascending `(position, key)`
-/// splice points into the post-removal list).
-fn splice_diff(prev: &[String], keys: &[String]) -> (Vec<i32>, Vec<(i32, String)>) {
+/// Longest common prefix / suffix lengths between two key lists. The
+/// zip over the two post-prefix slices yields at most
+/// `min(prev.len(), keys.len()) - p` pairs, so the suffix can never
+/// overlap the prefix.
+fn splice_bounds(prev: &[String], keys: &[String]) -> (usize, usize) {
     let p = prev
         .iter()
         .zip(keys.iter())
         .take_while(|(a, b)| a == b)
         .count();
-    // The zip over the two post-prefix slices yields at most
-    // `min(prev.len(), keys.len()) - p` pairs, so the suffix can never
-    // overlap the prefix.
     let s = prev[p..]
         .iter()
         .rev()
         .zip(keys[p..].iter().rev())
         .take_while(|(a, b)| a == b)
         .count();
-
-    let removals: Vec<i32> = (p..prev.len() - s).map(|i| i as i32).collect();
-    let inserts: Vec<(i32, String)> = keys[p..keys.len() - s]
-        .iter()
-        .enumerate()
-        .map(|(k, key)| ((p + k) as i32, key.clone()))
-        .collect();
-    (removals, inserts)
+    (p, s)
 }
 
 /// Drive `handle`'s native item provider on demand.
@@ -118,21 +249,24 @@ fn splice_diff(prev: &[String], keys: &[String]) -> (Vec<i32>, Vec<(i32, String)
 /// - `handle` — the container element (already created) that carries a
 ///   native item provider (e.g. a `<list>`).
 /// - `items` — reactive data source; re-read on any change it tracks.
-/// - `key` — stable identity extractor. A logical key keeps the same
-///   `item-key` across data updates so the native diff can move/remove.
-/// - `build` — slot builder; called *once per slot creation* with a
-///   clone of `items()[i]`, returns the slot element (e.g. a
-///   `<list-item>`).
-pub fn virtualize<T, K, ItemsFn, KeyFn, BuildFn>(
+/// - `meta` — identity + per-item layout metadata extractor (see
+///   [`ItemMeta`]). The key keeps the same `item-key` across data
+///   updates so the native diff can move/remove; the metadata rides
+///   the same actions (it can't come from the built elements — they
+///   don't exist yet at diff time).
+/// - `build` — slot CONTENT builder; called *once per slot creation*
+///   with a clone of `items()[i]`, returns any element. The
+///   virtualizer owns the native `list-item` wrapper around it.
+pub fn virtualize<T, K, ItemsFn, MetaFn, BuildFn>(
     handle: Element,
     items: ItemsFn,
-    key: KeyFn,
+    meta: MetaFn,
     build: BuildFn,
 ) where
     T: Clone + 'static,
     K: Eq + Hash + Clone + 'static,
     ItemsFn: Fn() -> Vec<T> + 'static,
-    KeyFn: Fn(&T) -> K + 'static,
+    MetaFn: Fn(&T) -> ItemMeta<K> + 'static,
     BuildFn: Fn(T) -> Element + 'static,
 {
     let current_items: Rc<RefCell<Vec<T>>> = Rc::new(RefCell::new(Vec::new()));
@@ -153,12 +287,15 @@ pub fn virtualize<T, K, ItemsFn, KeyFn, BuildFn>(
     let key_ids: Rc<RefCell<HashMap<K, u64>>> = Rc::new(RefCell::new(HashMap::new()));
     let next_id: Rc<Cell<u64>> = Rc::new(Cell::new(0));
     let layout_id: Rc<Cell<i64>> = Rc::new(Cell::new(0));
-    // Item-key list from the previous data-source update — the minimal
-    // diff (common prefix/suffix splice) is computed against it, so
-    // untouched items keep their native identity and the list can hold
-    // its scroll position across appends.
+    // Item-key list + per-key metadata from the previous data-source
+    // update — the minimal diff (common prefix/suffix splice) is
+    // computed against the keys, so untouched items keep their native
+    // identity and the list can hold its scroll position across
+    // appends; metadata changes on surviving keys become in-place
+    // update actions.
     let prev_keys: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
-    let key = Rc::new(key);
+    let prev_meta: Rc<RefCell<HashMap<String, MetaFields>>> = Rc::new(RefCell::new(HashMap::new()));
+    let meta = Rc::new(meta);
     let build = Rc::new(build);
     // Anchor slot owners to the owner active at SETUP (the list component's
     // scope) so items built on demand in the native callback still inherit
@@ -187,41 +324,57 @@ pub fn virtualize<T, K, ItemsFn, KeyFn, BuildFn>(
         let current_items = current_items.clone();
         let layout_id = layout_id.clone();
         let prev_keys = prev_keys.clone();
+        let prev_meta = prev_meta.clone();
         let key_ids = key_ids.clone();
         let next_id = next_id.clone();
-        let key = key.clone();
+        let meta = meta.clone();
         let flush_pending = flush_pending.clone();
         effect(move || {
             flush_pending();
             let new_items = items();
-            // Stable item-key for every item in current order (assign an id
-            // to first-seen keys). `component_at_index` stamps the matching
-            // `item-key="w_{id}"` on each built element, so the native list
-            // reconciles them and can diff a reorder.
-            let keys: Vec<String> = {
+            // Stable item-key + metadata for every item in current order
+            // (assign an id to first-seen keys). `component_at_index`
+            // stamps the matching `item-key="w_{id}"` on each built
+            // wrapper, so the native list reconciles them and can diff a
+            // reorder.
+            let mut keys: Vec<String> = Vec::with_capacity(new_items.len());
+            let mut metas: Vec<MetaFields> = Vec::with_capacity(new_items.len());
+            {
                 let mut ids = key_ids.borrow_mut();
-                new_items
-                    .iter()
-                    .map(|item| {
-                        let k = key(item);
-                        let id = match ids.get(&k) {
-                            Some(id) => *id,
-                            None => {
-                                let id = next_id.get();
-                                next_id.set(id + 1);
-                                ids.insert(k, id);
-                                id
-                            }
-                        };
-                        format!("w_{id}")
-                    })
-                    .collect()
-            };
+                for item in &new_items {
+                    let m = meta(item);
+                    let id = match ids.get(&m.key) {
+                        Some(id) => *id,
+                        None => {
+                            let id = next_id.get();
+                            next_id.set(id + 1);
+                            ids.insert(m.key.clone(), id);
+                            id
+                        }
+                    };
+                    keys.push(format!("w_{id}"));
+                    metas.push(MetaFields {
+                        reuse_identifier: m.reuse_identifier,
+                        estimated_size: m.estimated_size,
+                        full_span: m.full_span,
+                        sticky_top: m.sticky_top,
+                        sticky_bottom: m.sticky_bottom,
+                        recyclable: m.recyclable,
+                    });
+                }
+            }
             *current_items.borrow_mut() = new_items;
             let lid = layout_id.get();
             layout_id.set(lid + 1);
             set_attribute_int(handle, "layout-id", lid);
-            send_data_source_update(handle, &prev_keys.borrow(), &keys);
+            send_data_source_update(
+                handle,
+                &prev_keys.borrow(),
+                &keys,
+                &prev_meta.borrow(),
+                &metas,
+            );
+            *prev_meta.borrow_mut() = keys.iter().cloned().zip(metas).collect();
             *prev_keys.borrow_mut() = keys;
         });
     }
@@ -232,7 +385,7 @@ pub fn virtualize<T, K, ItemsFn, KeyFn, BuildFn>(
             let live = live.clone();
             let key_ids = key_ids.clone();
             let next_id = next_id.clone();
-            let key = key.clone();
+            let meta = meta.clone();
             let build = build.clone();
             let flush_pending = flush_pending.clone();
             Box::new(move |index, _op_id, _reuse| {
@@ -242,31 +395,52 @@ pub fn virtualize<T, K, ItemsFn, KeyFn, BuildFn>(
                     Some(t) => t.clone(),
                     None => return INVALID_ITEM_INDEX,
                 };
-                let k = key(&item);
+                let m = meta(&item);
                 // Stable id for the `item-key` (assign on first sight).
                 let id = {
                     let mut ids = key_ids.borrow_mut();
-                    match ids.get(&k) {
+                    match ids.get(&m.key) {
                         Some(id) => *id,
                         None => {
                             let id = next_id.get();
                             next_id.set(id + 1);
-                            ids.insert(k, id);
+                            ids.insert(m.key.clone(), id);
                             id
                         }
                     }
                 };
-                // Build a FRESH element under a per-item owner (context
-                // inherited via `parent_owner`), stamp the stable item-key,
-                // and ATTACH it — Lynx `ComponentAtIndex` then runs
-                // `OnComponentFinished` → layout over the appended subtree.
-                // Returning a sign without appending crashes the native list.
+                // Build the slot: the virtualizer OWNS the native
+                // `list-item` wrapper (the user's `build` returns plain
+                // content). Both are created under a per-item owner
+                // (context inherited via `parent_owner`), the wrapper is
+                // stamped with the stable item-key + recycle-pool id, and
+                // ATTACHED — Lynx `ComponentAtIndex` then runs
+                // `OnComponentFinished` → layout over the appended
+                // subtree. Returning a sign without appending crashes the
+                // native list. `full-span` is stamped AFTER the append:
+                // its element-side half (the LayoutNode list-component
+                // type) only applies when the parent is already the list.
                 let owner = Owner::new(Some(parent_owner));
-                let element = owner.with(|| (build)(item));
-                apply_attr_owned::<_, String>(element, "item-key".to_string(), format!("w_{id}"));
-                append_child(handle, element);
-                let sign = element_sign(element);
-                live.borrow_mut().insert(sign, (element, owner));
+                let (wrapper, content) = owner.with(|| {
+                    let wrapper = create_element_by_name("list-item");
+                    let content = (build)(item);
+                    (wrapper, content)
+                });
+                append_child(wrapper, content);
+                apply_attr_owned::<_, String>(wrapper, "item-key".to_string(), format!("w_{id}"));
+                if let Some(reuse) = &m.reuse_identifier {
+                    apply_attr_owned::<_, String>(
+                        wrapper,
+                        "reuse-identifier".to_string(),
+                        reuse.clone(),
+                    );
+                }
+                append_child(handle, wrapper);
+                if m.full_span {
+                    set_attribute_bool(wrapper, "full-span", true);
+                }
+                let sign = element_sign(wrapper);
+                live.borrow_mut().insert(sign, (wrapper, owner));
                 sign
             })
         },
@@ -391,7 +565,7 @@ mod tests {
                 virtualize(
                     handle,
                     || vec![10_i32, 20, 30],
-                    |x| *x,
+                    |x| ItemMeta::<i32>::key(*x),
                     |_x| create_element_by_name("list-item"),
                 );
             });
@@ -411,7 +585,7 @@ mod tests {
                 virtualize(
                     handle,
                     || vec![100_i32, 200, 300],
-                    |x| *x,
+                    |x| ItemMeta::<i32>::key(*x),
                     |_x| create_element_by_name("list-item"),
                 );
             });
@@ -442,7 +616,7 @@ mod tests {
                 virtualize(
                     handle,
                     move || items.get(),
-                    |x| *x,
+                    |x| ItemMeta::<i32>::key(*x),
                     |_x| create_element_by_name("list-item"),
                 );
             });
@@ -484,7 +658,7 @@ mod tests {
                 virtualize(
                     handle,
                     || vec![1_i32, 2],
-                    |x| *x,
+                    |x| ItemMeta::<i32>::key(*x),
                     move |_x| {
                         let dr = dr.clone();
                         crate::reactive::on_cleanup(move || *dr.borrow_mut() += 1);
@@ -521,7 +695,7 @@ mod tests {
                 virtualize(
                     handle,
                     || vec![1_i32, 2],
-                    |x| *x,
+                    |x| ItemMeta::<i32>::key(*x),
                     |_x| create_element_by_name("list-item"),
                 );
             });
@@ -539,16 +713,30 @@ mod tests {
         keys.iter().map(|s| s.to_string()).collect()
     }
 
+    /// The splice as `(removals, insert (position, key) pairs)` —
+    /// mirrors what `send_data_source_update` derives from
+    /// `splice_bounds`.
+    fn splice(prev: &[String], keys: &[String]) -> (Vec<i32>, Vec<(i32, String)>) {
+        let (p, s) = splice_bounds(prev, keys);
+        let removals: Vec<i32> = (p..prev.len() - s).map(|i| i as i32).collect();
+        let inserts: Vec<(i32, String)> = keys[p..keys.len() - s]
+            .iter()
+            .enumerate()
+            .map(|(k, key)| ((p + k) as i32, key.clone()))
+            .collect();
+        (removals, inserts)
+    }
+
     #[test]
     fn splice_diff_append_is_insert_only() {
-        let (removals, inserts) = splice_diff(&ks(&["a", "b"]), &ks(&["a", "b", "c", "d"]));
+        let (removals, inserts) = splice(&ks(&["a", "b"]), &ks(&["a", "b", "c", "d"]));
         assert!(removals.is_empty());
         assert_eq!(inserts, vec![(2, "c".to_string()), (3, "d".to_string())]);
     }
 
     #[test]
     fn splice_diff_prepend_is_insert_at_zero() {
-        let (removals, inserts) = splice_diff(&ks(&["a", "b"]), &ks(&["x", "a", "b"]));
+        let (removals, inserts) = splice(&ks(&["a", "b"]), &ks(&["x", "a", "b"]));
         assert!(removals.is_empty());
         assert_eq!(inserts, vec![(0, "x".to_string())]);
     }
@@ -556,7 +744,7 @@ mod tests {
     #[test]
     fn splice_diff_mid_replace_touches_only_the_window() {
         // [a b c d e] -> [a b X Y e]: remove old 2,3; insert X@2, Y@3.
-        let (removals, inserts) = splice_diff(
+        let (removals, inserts) = splice(
             &ks(&["a", "b", "c", "d", "e"]),
             &ks(&["a", "b", "X", "Y", "e"]),
         );
@@ -566,14 +754,14 @@ mod tests {
 
     #[test]
     fn splice_diff_removal_only() {
-        let (removals, inserts) = splice_diff(&ks(&["a", "b", "c"]), &ks(&["a", "c"]));
+        let (removals, inserts) = splice(&ks(&["a", "b", "c"]), &ks(&["a", "c"]));
         assert_eq!(removals, vec![1]);
         assert!(inserts.is_empty());
     }
 
     #[test]
     fn splice_diff_identical_is_empty() {
-        let (removals, inserts) = splice_diff(&ks(&["a", "b"]), &ks(&["a", "b"]));
+        let (removals, inserts) = splice(&ks(&["a", "b"]), &ks(&["a", "b"]));
         assert!(removals.is_empty());
         assert!(inserts.is_empty());
     }
@@ -581,7 +769,7 @@ mod tests {
     #[test]
     fn splice_diff_reorder_degrades_to_full_window() {
         // No common prefix/suffix survives a rotate — remove all, insert all.
-        let (removals, inserts) = splice_diff(&ks(&["a", "b", "c"]), &ks(&["b", "c", "a"]));
+        let (removals, inserts) = splice(&ks(&["a", "b", "c"]), &ks(&["b", "c", "a"]));
         assert_eq!(removals, vec![0, 1, 2]);
         assert_eq!(
             inserts,
@@ -594,7 +782,7 @@ mod tests {
     }
 
     /// One recorded `update_list_actions` call: `(removals, inserts)`.
-    type RecordedActions = (Vec<i32>, Vec<(i32, String)>);
+    type RecordedActions = (Vec<i32>, Vec<ListItemAction>, Vec<ListItemAction>);
 
     /// Renderer that accepts explicit actions (like the real bridge on a
     /// new-enough Lynx) — the virtualizer must prefer them and NOT fall
@@ -625,11 +813,12 @@ mod tests {
             &self,
             _h: Element,
             removals: &[i32],
-            inserts: &[(i32, String)],
+            inserts: &[ListItemAction],
+            updates: &[ListItemAction],
         ) -> bool {
             self.actions
                 .borrow_mut()
-                .push((removals.to_vec(), inserts.to_vec()));
+                .push((removals.to_vec(), inserts.to_vec(), updates.to_vec()));
             true
         }
         fn install_list_native_item_provider(&self, _h: Element, _p: NativeItemProvider) -> bool {
@@ -664,23 +853,29 @@ mod tests {
             virtualize(
                 handle,
                 move || items.get(),
-                |x| *x,
-                |_x| create_element_by_name("list-item"),
+                |x| ItemMeta::<i32>::key(*x).estimated_size(84),
+                |_x| create_element_by_name("view"),
             );
         });
         flush();
-        // Initial population: pure insert of both keys.
+        // Initial population: pure insert of both keys, metadata riding
+        // the entries.
         assert_eq!(actions.borrow().len(), 1);
         assert_eq!(actions.borrow()[0].0, Vec::<i32>::new());
         assert_eq!(actions.borrow()[0].1.len(), 2);
+        assert_eq!(actions.borrow()[0].1[0].estimated_size, Some(84));
+        assert!(actions.borrow()[0].2.is_empty());
 
         // Append: insert-only at the tail, untouched items unmentioned.
         set_items.set(vec![1_i32, 2, 3]);
         flush();
         assert_eq!(actions.borrow().len(), 2);
-        let (removals, inserts) = actions.borrow()[1].clone();
+        let (removals, inserts, updates) = actions.borrow()[1].clone();
         assert!(removals.is_empty());
-        assert_eq!(inserts, vec![(2, "w_2".to_string())]);
+        assert_eq!(inserts.len(), 1);
+        assert_eq!(inserts[0].position, 2);
+        assert_eq!(inserts[0].key, "w_2");
+        assert!(updates.is_empty());
 
         // Identical re-run: nothing sent.
         set_items.set(vec![1_i32, 2, 3]);
@@ -688,6 +883,47 @@ mod tests {
         assert_eq!(actions.borrow().len(), 2);
 
         assert_eq!(*full_replace.borrow(), 0, "must not fall back");
+        owner.dispose();
+        uninstall_renderer(prev);
+    }
+
+    #[test]
+    fn metadata_change_on_surviving_key_sends_in_place_update() {
+        crate::reactive::__reset_for_tests();
+        let recorder = ActionsRenderer::default();
+        let actions = recorder.actions.clone();
+        let prev = install_renderer(Box::new(recorder));
+
+        let owner = Owner::new(None);
+        // `full_span` derives from the DATA (value >= 100), so flipping
+        // an item's value past the threshold changes its metadata while
+        // its key (the index-stable first element) survives.
+        let (items, set_items) = crate::reactive::signal(vec![(1_i32, 0_i32), (2, 0)]).split();
+        owner.with(|| {
+            let handle = create_element_by_name("list");
+            virtualize(
+                handle,
+                move || items.get(),
+                |x: &(i32, i32)| ItemMeta::<i32>::key(x.0).full_span(x.1 >= 100),
+                |_x| create_element_by_name("view"),
+            );
+        });
+        flush();
+        assert_eq!(actions.borrow().len(), 1);
+
+        // Same keys, item 1's metadata flips → one in-place update, no
+        // structural actions.
+        set_items.set(vec![(1_i32, 0_i32), (2, 100)]);
+        flush();
+        assert_eq!(actions.borrow().len(), 2);
+        let (removals, inserts, updates) = actions.borrow()[1].clone();
+        assert!(removals.is_empty());
+        assert!(inserts.is_empty());
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].position, 1);
+        assert_eq!(updates[0].key, "w_1");
+        assert!(updates[0].full_span);
+
         owner.dispose();
         uninstall_renderer(prev);
     }

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -164,7 +164,7 @@ pub use style::{Style, apply_style};
 
 pub use control_flow::{ForEach, ForEachProps, Show, ShowProps};
 pub use whisker_runtime::view::Children;
-pub use whisker_runtime::view::{EachFn, Fallback, ItemFn, KeyFn, WhenFn};
+pub use whisker_runtime::view::{EachFn, Fallback, ItemFn, ItemMeta, KeyFn, MetaFn, WhenFn};
 
 /// Built-in tag builders. The `render!` macro lowers each built-in
 /// element invocation (`view(style: "x", on_tap: move |_| {})`) into a
@@ -1191,7 +1191,7 @@ pub mod __tags {
     // `<list-item>` children present in the element tree (via the native
     // `ListChildrenHelper`), with no framework callbacks. That fits
     // Whisker's direct-tree model — author code writes
-    // `list { list_item { … } … }` like any other container.
+    // `list { … }` like any other container.
     //
     // Two flags gate that mode (see `list_element.cc`):
     //   • `custom-list-name="list-container"` → `ResolveEnableNativeList`
@@ -1247,10 +1247,10 @@ pub mod __tags {
     ///   3. `set_update_list_info(handle, count)` on every reactive
     ///      update — what tells Lynx how many slots to lay out.
     #[allow(non_camel_case_types)]
-    pub struct list<EachF = (), KeyF = (), ChildF = ()> {
+    pub struct list<EachF = (), MetaF = (), ChildF = ()> {
         handle: Element,
         each: EachF,
-        key: KeyF,
+        meta: MetaF,
         children: ChildF,
     }
     #[allow(non_snake_case)]
@@ -1264,11 +1264,11 @@ pub mod __tags {
         list {
             handle,
             each: (),
-            key: (),
+            meta: (),
             children: (),
         }
     }
-    impl<EachF, KeyF, ChildF> ElementBuilder for list<EachF, KeyF, ChildF> {
+    impl<EachF, MetaF, ChildF> ElementBuilder for list<EachF, MetaF, ChildF> {
         fn __element(&self) -> Element {
             self.handle
         }
@@ -1278,7 +1278,7 @@ pub mod __tags {
         // default `.child()` semantics (a regular `append_child`)
         // would still work but is not the supported shape.
     }
-    impl<EachF, KeyF, ChildF> list<EachF, KeyF, ChildF> {
+    impl<EachF, MetaF, ChildF> list<EachF, MetaF, ChildF> {
         /// `list-type` layout — takes the typed
         /// [`ListType`](crate::attrs::ListType) enum (default
         /// `Single`).
@@ -1542,50 +1542,57 @@ pub mod __tags {
     // on the fully-populated state. The user can call the three in
     // any order — the render! macro emits them in whatever order
     // they appear in the source.
-    impl<KeyF, ChildF> list<(), KeyF, ChildF> {
+    impl<MetaF, ChildF> list<(), MetaF, ChildF> {
         pub fn each<T: 'static, F>(
             self,
             f: F,
-        ) -> list<::whisker_runtime::view::EachFn<T>, KeyF, ChildF>
+        ) -> list<::whisker_runtime::view::EachFn<T>, MetaF, ChildF>
         where
             F: ::std::convert::Into<::whisker_runtime::view::EachFn<T>>,
         {
             list {
                 handle: self.handle,
                 each: f.into(),
-                key: self.key,
+                meta: self.meta,
                 children: self.children,
             }
         }
     }
     impl<EachF, ChildF> list<EachF, (), ChildF> {
-        pub fn key<T: 'static, K: 'static, F>(
+        /// Identity + per-item layout metadata extractor — see
+        /// [`ItemMeta`]. Replaces the former `key:` prop: the key is
+        /// `ItemMeta::key(...)`, and the metadata (estimated size,
+        /// full-span, sticky, recyclable, reuse-identifier) rides the
+        /// same closure because it must be derivable from the DATA —
+        /// items build on demand, so no element exists yet when the
+        /// native data-source diff is sent.
+        pub fn meta<T: 'static, K: 'static, F>(
             self,
             f: F,
-        ) -> list<EachF, ::whisker_runtime::view::KeyFn<T, K>, ChildF>
+        ) -> list<EachF, ::whisker_runtime::view::MetaFn<T, K>, ChildF>
         where
-            F: ::std::convert::Into<::whisker_runtime::view::KeyFn<T, K>>,
+            F: ::std::convert::Into<::whisker_runtime::view::MetaFn<T, K>>,
         {
             list {
                 handle: self.handle,
                 each: self.each,
-                key: f.into(),
+                meta: f.into(),
                 children: self.children,
             }
         }
     }
-    impl<EachF, KeyF> list<EachF, KeyF, ()> {
+    impl<EachF, MetaF> list<EachF, MetaF, ()> {
         pub fn children<T: 'static, F>(
             self,
             f: F,
-        ) -> list<EachF, KeyF, ::whisker_runtime::view::ItemFn<T>>
+        ) -> list<EachF, MetaF, ::whisker_runtime::view::ItemFn<T>>
         where
             F: ::std::convert::Into<::whisker_runtime::view::ItemFn<T>>,
         {
             list {
                 handle: self.handle,
                 each: self.each,
-                key: self.key,
+                meta: self.meta,
                 children: f.into(),
             }
         }
@@ -1594,7 +1601,7 @@ pub mod __tags {
     impl<T, K>
         list<
             ::whisker_runtime::view::EachFn<T>,
-            ::whisker_runtime::view::KeyFn<T, K>,
+            ::whisker_runtime::view::MetaFn<T, K>,
             ::whisker_runtime::view::ItemFn<T>,
         >
     where
@@ -1617,111 +1624,19 @@ pub mod __tags {
         pub fn __h(self) -> Element {
             let handle = self.handle;
             let each = self.each;
-            let key = self.key;
+            let meta = self.meta;
             let children = self.children;
 
             ::whisker_runtime::view::virtualize(
                 handle,
                 move || each.call(),
-                move |t: &T| key.call(t),
+                move |t: &T| meta.call(t),
                 move |t: T| children.call(t),
             );
 
             handle
         }
     }
-    /// `<list-item>` — the slot wrapper for a [`list`] item (Option E).
-    ///
-    /// A `<list>`'s `children` closure returns a `list_item` directly —
-    /// it realises the platform `UIComponent` contract
-    /// (`LynxUIListItem : LynxUIComponent` on iOS, `UIListItem extends
-    /// UIComponent` on Android) the recycler / sticky / virtualisation
-    /// machinery depends on, mirroring Lynx's mandatory `<list-item>`.
-    ///
-    /// `item-key` is **owned by the `list`** (stamped from the `key`
-    /// extractor), so it is not a `list_item` kwarg. The kwargs here are
-    /// the per-item attributes Lynx reads off each `<list-item>`.
-    ///
-    /// ```ignore
-    /// children: |p: Post| render! {
-    ///     list_item(full_span: p.is_header, reuse_identifier: "post") {
-    ///         post_card(post: p)
-    ///     }
-    /// }
-    /// ```
-    #[allow(non_camel_case_types)]
-    pub struct list_item {
-        handle: Element,
-    }
-    #[allow(non_snake_case)]
-    pub fn __list_item_ctor() -> list_item {
-        list_item {
-            handle: create_element_by_name("list-item"),
-        }
-    }
-    impl ElementBuilder for list_item {
-        fn __element(&self) -> Element {
-            self.handle
-        }
-    }
-    impl list_item {
-        /// `full-span` — occupy the full row/column (e.g. a header in a
-        /// grid). Lynx reads via `IsBool()`.
-        pub fn full_span<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<bool>>,
-        {
-            apply_attr_bool(self.handle, "full-span", v);
-            self
-        }
-        /// `sticky-top` — stick to the top edge while scrolling (needs
-        /// `sticky` on the parent `list`).
-        pub fn sticky_top<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<bool>>,
-        {
-            apply_attr_bool(self.handle, "sticky-top", v);
-            self
-        }
-        /// `sticky-bottom` — stick to the bottom edge while scrolling.
-        pub fn sticky_bottom<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<bool>>,
-        {
-            apply_attr_bool(self.handle, "sticky-bottom", v);
-            self
-        }
-        /// `recyclable` — whether this cell may be recycled (default
-        /// `true`). Lynx reads via `IsBool()`.
-        pub fn recyclable<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<bool>>,
-        {
-            apply_attr_bool(self.handle, "recyclable", v);
-            self
-        }
-        /// `estimated-main-axis-size-px` — placeholder main-axis size
-        /// (px) used before the cell is measured. Stabilises recycling
-        /// of non-uniform cells. Lynx reads via `IsNumber()`.
-        pub fn estimated_size<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<i32>>,
-        {
-            apply_attr_int(self.handle, "estimated-main-axis-size-px", v);
-            self
-        }
-        /// `reuse-identifier` — recycling group. Cells sharing an
-        /// identifier reuse each other; distinct shapes (header vs row)
-        /// should use distinct identifiers.
-        pub fn reuse_identifier<V>(self, v: V) -> Self
-        where
-            V: ::std::convert::Into<Signal<::std::string::String>>,
-        {
-            apply_attr(self.handle, "reuse-identifier", v);
-            self
-        }
-    }
-
     /// `<fragment>` — *transparent grouping container*. Mounts as a
     /// phantom element ([`create_phantom_element`]) the runtime
     /// tracks in its mirror but never forwards to Lynx. Children
@@ -1930,7 +1845,7 @@ pub mod prelude {
         BoundingClientRect, ElementHandle, ElementRef, RefError, ScrollInfo, ScrollViewHandle,
         TextBoundingRect, TextHandle,
     };
-    pub use crate::{EachFn, Fallback, ItemFn, KeyFn, WhenFn};
+    pub use crate::{EachFn, Fallback, ItemFn, ItemMeta, KeyFn, MetaFn, WhenFn};
     pub use crate::{Element, ElementTag};
     pub use crate::{ForEach, ForEachProps, Show, ShowProps};
     pub use crate::{component, main, render};
@@ -1952,6 +1867,6 @@ pub mod prelude {
     // method-call shape regardless of what `view` resolves to.
     #[doc(hidden)]
     pub use crate::__tags::{fragment, list, page, raw_text, scroll_view, text, view};
-    // `list_item` intentionally absent — the `list` render-props
+    // A separate list-item builder is intentionally absent — the `list` render-props
     // builder auto-wraps every item internally.
 }

--- a/examples/bluesky/src/lib.rs
+++ b/examples/bluesky/src/lib.rs
@@ -370,29 +370,29 @@ fn search_screen() -> Element {
                     }
                 },
                 each: move || vec![SearchMode::People, SearchMode::Posts],
-                key: |m: &SearchMode| match m {
-                    SearchMode::People => "people".to_string(),
-                    SearchMode::Posts => "posts".to_string(),
+                meta: |m: &SearchMode| match m {
+                    SearchMode::People => ItemMeta::key("people".to_string())
+                        .reuse_identifier("page-people")
+                        .recyclable(false),
+                    SearchMode::Posts => ItemMeta::key("posts".to_string())
+                        .reuse_identifier("page-posts")
+                        .recyclable(false),
                 },
                 children: move |m: SearchMode| match m {
                     SearchMode::People => render! {
-                        list_item(reuse_identifier: "page-people", recyclable: false) {
-                            view(style: css!(width: vw(100), flex_grow: 1.0, flex_direction: FlexDirection::Column)) {
-                                Show(when: move || !query.get().trim().is_empty(), fallback: || render! { status_pane(message: "ユーザーを検索できます".to_string()) }) {
-                                    Show(when: move || actors.get().is_some(), fallback: || render! { status_pane(message: "検索中…".to_string()) }) {
-                                        actor_list(actors: actors.get().unwrap_or_default())
-                                    }
+                        view(style: css!(width: vw(100), flex_grow: 1.0, flex_direction: FlexDirection::Column)) {
+                            Show(when: move || !query.get().trim().is_empty(), fallback: || render! { status_pane(message: "ユーザーを検索できます".to_string()) }) {
+                                Show(when: move || actors.get().is_some(), fallback: || render! { status_pane(message: "検索中…".to_string()) }) {
+                                    actor_list(actors: actors.get().unwrap_or_default())
                                 }
                             }
                         }
                     },
                     SearchMode::Posts => render! {
-                        list_item(reuse_identifier: "page-posts", recyclable: false) {
-                            view(style: css!(width: vw(100), flex_grow: 1.0, flex_direction: FlexDirection::Column)) {
-                                Show(when: move || !query.get().trim().is_empty(), fallback: || render! { status_pane(message: "投稿を検索できます".to_string()) }) {
-                                    Show(when: move || posts.get().is_some(), fallback: || render! { status_pane(message: "検索中…".to_string()) }) {
-                                        post_list(posts: posts.get().unwrap_or_default())
-                                    }
+                        view(style: css!(width: vw(100), flex_grow: 1.0, flex_direction: FlexDirection::Column)) {
+                            Show(when: move || !query.get().trim().is_empty(), fallback: || render! { status_pane(message: "投稿を検索できます".to_string()) }) {
+                                Show(when: move || posts.get().is_some(), fallback: || render! { status_pane(message: "検索中…".to_string()) }) {
+                                    post_list(posts: posts.get().unwrap_or_default())
                                 }
                             }
                         }
@@ -450,8 +450,8 @@ fn actor_list(actors: Vec<bsky_domain::ActorView>) -> Element {
                 let actors = actors.clone();
                 move || actors.clone()
             },
-            key: |a: &bsky_domain::ActorView| a.did.clone(),
-            children: |a: bsky_domain::ActorView| render! { list_item { actor_row(actor: a) } },
+            meta: |a: &bsky_domain::ActorView| ItemMeta::key(a.did.clone()),
+            children: |a: bsky_domain::ActorView| render! { actor_row(actor: a) },
         )
     }
 }
@@ -600,8 +600,8 @@ fn notification_list(items: Vec<bsky_domain::Notification>) -> Element {
                 let items = items.clone();
                 move || items.clone()
             },
-            key: |n: &bsky_domain::Notification| n.uri.clone(),
-            children: |n: bsky_domain::Notification| render! { list_item { notification_row(item: n) } },
+            meta: |n: &bsky_domain::Notification| ItemMeta::key(n.uri.clone()),
+            children: |n: bsky_domain::Notification| render! { notification_row(item: n) },
         )
     }
 }
@@ -829,9 +829,14 @@ fn profile_view(actor: String, show_logout: bool) -> Element {
                         );
                         rows
                     },
-                    key: |r: &ProfileRow| match r {
-                        ProfileRow::Header { .. } => "header".to_string(),
-                        ProfileRow::Post(p) => p.uri.clone(),
+                    meta: |r: &ProfileRow| match r {
+                        ProfileRow::Header { .. } => ItemMeta::key("header".to_string())
+                            .reuse_identifier("profile-header")
+                            .estimated_size(320)
+                            .full_span(true),
+                        ProfileRow::Post(p) => ItemMeta::key(p.uri.clone())
+                            .reuse_identifier("post")
+                            .estimated_size(96),
                     },
                     children: |r: ProfileRow| match r {
                         ProfileRow::Header {
@@ -839,22 +844,14 @@ fn profile_view(actor: String, show_logout: bool) -> Element {
                             my_did,
                             show_logout,
                         } => render! {
-                            list_item(
-                                full_span: true,
-                                reuse_identifier: "profile-header",
-                                estimated_size: 320,
-                            ) {
-                                profile_header(
-                                    profile: profile,
-                                    my_did: my_did,
-                                    show_logout: show_logout,
-                                )
-                            }
+                            profile_header(
+                                profile: profile,
+                                my_did: my_did,
+                                show_logout: show_logout,
+                            )
                         },
                         ProfileRow::Post(p) => render! {
-                            list_item(reuse_identifier: "post", estimated_size: 96) {
-                                PostRow(post: p)
-                            }
+                            PostRow(post: p)
                         },
                     },
                 )
@@ -1903,14 +1900,15 @@ fn timeline_screen() -> Element {
                     // Entry identity, not post identity: a post can appear
                     // both as the original and as a repost in one timeline,
                     // and duplicate item-keys corrupt the native list diff.
-                    key: |p: &bsky_domain::FeedPost| match &p.reposted_by {
-                        Some(by) => format!("{}#repost:{}", p.uri, by.did),
-                        None => p.uri.clone(),
+                    meta: |p: &bsky_domain::FeedPost| {
+                        let key = match &p.reposted_by {
+                            Some(by) => format!("{}#repost:{}", p.uri, by.did),
+                            None => p.uri.clone(),
+                        };
+                        ItemMeta::key(key).reuse_identifier("post").estimated_size(140)
                     },
                     children: |p: bsky_domain::FeedPost| render! {
-                        list_item(reuse_identifier: "post", estimated_size: 140) {
-                            PostRow(post: p)
-                        }
+                        PostRow(post: p)
                     },
                 )
             }
@@ -1958,8 +1956,8 @@ fn post_list(posts: Vec<bsky_domain::FeedPost>) -> Element {
                 let posts = posts.clone();
                 move || posts.clone()
             },
-            key: |p: &bsky_domain::FeedPost| p.uri.clone(),
-            children: |p: bsky_domain::FeedPost| render! { list_item { PostRow(post: p) } },
+            meta: |p: &bsky_domain::FeedPost| ItemMeta::key(p.uri.clone()),
+            children: |p: bsky_domain::FeedPost| render! { PostRow(post: p) },
         )
     }
 }

--- a/examples/list-smoke/src/lib.rs
+++ b/examples/list-smoke/src/lib.rs
@@ -1,6 +1,6 @@
 //! Smoke test for whisker's `<list>` (on-demand virtualization + Option E).
 //!
-//! - A **full-span header** as item 0 (`list_item(full_span, estimated_size)`)
+//! - A **full-span header** as item 0 (`ItemMeta … .full_span(true)`)
 //!   — verifies bugs ② (header crush) / ③ (cross-axis width).
 //! - **Variable-height rows** — verifies uniform width + recycling under scroll.
 //! - **Rotate / Prepend** buttons mutate the data order — verifies bug ①
@@ -266,47 +266,51 @@ pub fn app() -> Element {
                     rows.extend(ids.get().into_iter().map(Row::Item));
                     rows
                 },
-                key: |r: &Row| r.key(),
+                // Identity + per-item layout metadata, derived from the
+                // DATA (items build on demand, so no element exists when
+                // the native diff is sent). The metadata rides the diff
+                // actions — the only channel Lynx's adapter reads it from.
+                meta: |r: &Row| match r {
+                    Row::Header => ItemMeta::key(r.key())
+                        .reuse_identifier("header")
+                        .estimated_size(160)
+                        .full_span(true)
+                        .sticky_top(scenario() == "sticky"),
+                    Row::Item(_) => ItemMeta::key(r.key())
+                        .reuse_identifier("row")
+                        .estimated_size(84),
+                },
                 children: |r: Row| match r {
                     Row::Header => render! {
-                        list_item(
-                            full_span: true,
-                            sticky_top: scenario() == "sticky",
-                            estimated_size: 160,
-                            reuse_identifier: "header",
-                        ) {
-                            view(style: css!(
-                                width: percent(100),
-                                height: px(160),
-                                background_color: Color::hex(0x2563EB),
-                                align_items: AlignItems::Center,
-                                justify_content: JustifyContent::Center,
-                            )) {
-                                text(
-                                    style: css!(color: Color::hex(0xFFFFFF), font_size: px(20), font_weight: FontWeight::Bold),
-                                    value: "FULL-SPAN HEADER (item 0)",
-                                )
-                            }
+                        view(style: css!(
+                            width: percent(100),
+                            height: px(160),
+                            background_color: Color::hex(0x2563EB),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                        )) {
+                            text(
+                                style: css!(color: Color::hex(0xFFFFFF), font_size: px(20), font_weight: FontWeight::Bold),
+                                value: "FULL-SPAN HEADER (item 0)",
+                            )
                         }
                     },
                     Row::Item(n) => render! {
-                        list_item(reuse_identifier: "row", estimated_size: 84) {
-                            view(style: css!(
-                                width: percent(100),
-                                padding: px(16),
-                                flex_direction: FlexDirection::Column,
-                                background_color: Color::hex(0x18181B),
-                                margin_bottom: px(1),
-                            )) {
-                                text(
-                                    style: css!(color: Color::hex(0xF5F5F7), font_size: px(16), font_weight: FontWeight::Bold),
-                                    value: format!("Row {n}"),
-                                )
-                                text(
-                                    style: css!(color: Color::hex(0x9AA0AA), font_size: px(13)),
-                                    value: body_text(n),
-                                )
-                            }
+                        view(style: css!(
+                            width: percent(100),
+                            padding: px(16),
+                            flex_direction: FlexDirection::Column,
+                            background_color: Color::hex(0x18181B),
+                            margin_bottom: px(1),
+                        )) {
+                            text(
+                                style: css!(color: Color::hex(0xF5F5F7), font_size: px(16), font_weight: FontWeight::Bold),
+                                value: format!("Row {n}"),
+                            )
+                            text(
+                                style: css!(color: Color::hex(0x9AA0AA), font_size: px(13)),
+                                value: body_text(n),
+                            )
                         }
                     },
                 },

--- a/examples/podcast/crates/podcast-feature-browse/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-browse/src/lib.rs
@@ -199,7 +199,7 @@ fn browse_body(sections: Vec<ChartSection>) -> Element {
                         move || items.clone()
                     },
                     key: |s: &ChartSection| s.title.clone(),
-                    children: |s: ChartSection| render! { list_item { section_block(section: s) } },
+                    children: |s: ChartSection| render! { section_block(section: s) },
                 )
             }
         }
@@ -235,7 +235,7 @@ fn section_block(section: ChartSection) -> Element {
                     },
                     key: |(_, p): &(u32, Podcast)| p.id,
                     children: move |(rank, podcast): (u32, Podcast)| render! {
-                        list_item { card_with_gap(podcast: podcast, rank: rank, layout: layout) }
+                        card_with_gap(podcast: podcast, rank: rank, layout: layout)
                     },
                 )
             }

--- a/examples/podcast/crates/podcast-feature-detail/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-detail/src/lib.rs
@@ -421,13 +421,11 @@ fn episode_list(episodes: Vec<Episode>, show_title: String, show_artwork: String
                     let show_title = show_title.clone();
                     let show_artwork = show_artwork.clone();
                     move |ep: Episode| render! {
-                        list_item {
-                            episode_row(
-                                episode: ep,
-                                show_title: show_title.clone(),
-                                show_artwork: show_artwork.clone(),
-                            )
-                        }
+                        episode_row(
+                            episode: ep,
+                            show_title: show_title.clone(),
+                            show_artwork: show_artwork.clone(),
+                        )
                     }
                 },
             )

--- a/examples/podcast/crates/podcast-feature-search/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-search/src/lib.rs
@@ -331,7 +331,7 @@ fn result_list(podcasts: Vec<Podcast>) -> Element {
                     move || items.clone()
                 },
                 key: |p: &Podcast| p.id,
-                children: |p: Podcast| render! { list_item { result_row(podcast: p) } },
+                children: |p: Podcast| render! { result_row(podcast: p) },
             )
         }
     }

--- a/packages/whisker-icons/example/src/lib.rs
+++ b/packages/whisker-icons/example/src/lib.rs
@@ -69,9 +69,11 @@ pub fn app() -> Element {
             }
             list(
                 each: || icons::ALL.to_vec(),
-                key: |(name, _): &(&'static str, &'static str)| name.to_string(),
+                meta: |(name, _): &(&'static str, &'static str)| {
+                    ItemMeta::key(name.to_string())
+                },
                 children: |(name, svg): (&'static str, &'static str)| render! {
-                    list_item { tile(label: name, svg: svg) }
+                    tile(label: name, svg: svg)
                 },
                 // `list-type: "flow"` activates Lynx's multi-column
                 // flow layout. iOS Lynx reads `span-count`; Android

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.11").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.12").removePrefix("v")
 
 dependencies {
     if (whiskerSdkRelease) {

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.10").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.11").removePrefix("v")
 
 dependencies {
     if (whiskerSdkRelease) {

--- a/platforms/android/whisker-runtime/build.gradle.kts
+++ b/platforms/android/whisker-runtime/build.gradle.kts
@@ -20,7 +20,7 @@
 // `whiskerSdkRelease` Gradle property toggles the dep form: unset
 // (default) → flatDir-friendly `:LynxAndroid@aar`; `true` → Maven
 // coords pinned to `lynxFork`. The CI publish workflow sets
-// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.11`; local CLI
+// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.12`; local CLI
 // flows leave both unset and use flatDir as before.
 
 plugins {
@@ -70,7 +70,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.11").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.12").removePrefix("v")
 
 dependencies {
     api(project(":module"))

--- a/platforms/android/whisker-runtime/build.gradle.kts
+++ b/platforms/android/whisker-runtime/build.gradle.kts
@@ -20,7 +20,7 @@
 // `whiskerSdkRelease` Gradle property toggles the dep form: unset
 // (default) → flatDir-friendly `:LynxAndroid@aar`; `true` → Maven
 // coords pinned to `lynxFork`. The CI publish workflow sets
-// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.10`; local CLI
+// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.11`; local CLI
 // flows leave both unset and use flatDir as before.
 
 plugins {
@@ -70,7 +70,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.10").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.11").removePrefix("v")
 
 dependencies {
     api(project(":module"))

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -99,23 +99,23 @@ let package = Package(
         // until the matching module-side refactor lands).
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/Lynx-3.8.0-whisker.11.xcframework.zip",
-            checksum: "42659f63021d6419a6d1fdfa8dc4be15ee449ac4ffd597c4a8564e976968e69c"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/Lynx-3.8.0-whisker.12.xcframework.zip",
+            checksum: "4ce496517fa600d295213235ff33d914eba6f68957f88972699c1be90a0d986c"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/LynxBase-3.8.0-whisker.11.xcframework.zip",
-            checksum: "82a8f9dcf17cb9dbfb776d0ec726a1110270940b727719449153b27ec9bb559e"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/LynxBase-3.8.0-whisker.12.xcframework.zip",
+            checksum: "e581e5754cd3f2abe9eca11c372d2d18a0c0dae3cd726faeff2c6a6823adb656"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/LynxServiceAPI-3.8.0-whisker.11.xcframework.zip",
-            checksum: "576fa37640cf6c0bd16096cb4ba2282c30a7f36ceaa803d457faa94e25ea38f4"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/LynxServiceAPI-3.8.0-whisker.12.xcframework.zip",
+            checksum: "0059201634a27ca331c329f01c4eab1ff604c31a40628c5f8d3b02f91f5661e2"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/PrimJS-3.8.0-whisker.11.xcframework.zip",
-            checksum: "08ddf094a3ff8b83449a3f567bb6c86cda2ec5947a21b218f490a473adeeb0d5"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/PrimJS-3.8.0-whisker.12.xcframework.zip",
+            checksum: "f095f00b22434823a33fbf7653a3e6ee609446f693a4fbb1f840e99ee65b70b5"
         ),
 
         // Phase J — minimal module-author surface. Carved out of the

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -99,23 +99,23 @@ let package = Package(
         // until the matching module-side refactor lands).
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/Lynx-3.8.0-whisker.10.xcframework.zip",
-            checksum: "b0e2e3f2a1f0b828222b529ffa25c69a06c0b5f16ca5b8d7762ab91a5981757d"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/Lynx-3.8.0-whisker.11.xcframework.zip",
+            checksum: "42659f63021d6419a6d1fdfa8dc4be15ee449ac4ffd597c4a8564e976968e69c"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/LynxBase-3.8.0-whisker.10.xcframework.zip",
-            checksum: "4ca0bde69e6f65b4023e12ae45e6cabcb64640c5c4c86966a2a161f70c439d9f"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/LynxBase-3.8.0-whisker.11.xcframework.zip",
+            checksum: "82a8f9dcf17cb9dbfb776d0ec726a1110270940b727719449153b27ec9bb559e"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/LynxServiceAPI-3.8.0-whisker.10.xcframework.zip",
-            checksum: "905a192eb633611e2892f20fc874b24bbed691255f1946d88bcd46605198c37c"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/LynxServiceAPI-3.8.0-whisker.11.xcframework.zip",
+            checksum: "576fa37640cf6c0bd16096cb4ba2282c30a7f36ceaa803d457faa94e25ea38f4"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.10/PrimJS-3.8.0-whisker.10.xcframework.zip",
-            checksum: "f5077dee5ba24d33895e35d027e67f72e5f82158f8fd346aa3edbe0f07d356b4"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.11/PrimJS-3.8.0-whisker.11.xcframework.zip",
+            checksum: "08ddf094a3ff8b83449a3f567bb6c86cda2ec5947a21b218f490a473adeeb0d5"
         ),
 
         // Phase J — minimal module-author surface. Carved out of the


### PR DESCRIPTION
## Summary

**BREAKING**: the list's `key:` prop and the `list_item` element are removed. The list takes exactly three render-props:

```rust
list(
    each: move || rows(),
    meta: |r| ItemMeta::key(r.key())
        .reuse_identifier("row")
        .estimated_size(84)
        .full_span(is_header)
        .sticky_top(is_header),
    children: |r| render! { view(…) { … } },   // plain content — no wrapper
)
```

## Why

Lynx's adapter ingests per-item layout metadata (estimated size / full-span / sticky / recyclable) **exclusively from the data-source action stream** (`fiber_full_spans_` / `fiber_sticky_*` / `fiber_estimated_sizes_px_` → positional vectors in `UpdateFiberExtraInfo`). `list_item` element attributes were never read by the decoupled list — sticky pinning and waterfall full-span silently didn't work (#283's two FAILs), and size estimates fell back to the native default (~540px/row placeholders). Items build on demand, so the metadata must derive from the DATA before any element exists — exactly ReactLynx's model (`<list-item>` props live on the retained snapshot). `ItemMeta` is whisker's equivalent; folding the key in leaves one source of item identity.

## Changes

- **virtualizer**: metadata rides insert actions; per-key metadata is diffed and changes on surviving keys become in-place `updateAction {from == to, flush: false}` entries (the ReactLynx `onSetAttribute` equivalence). The virtualizer owns the native `list-item` wrapper — stamps item-key / reuse-identifier / full-span (element-side LayoutNode half applies post-append).
- **capi**: `lynx_element_update_list_actions_v2` (fork v3.8.0-whisker.11, tail addition, ABI stays v2). Bridge degrades v2 → v1 keys-only → full replace by Lynx capability.
- **builders/macro**: `meta` replaces `key`; `list_item` builder, macro dispatch rows and builtin tag removed.
- **examples migrated**: list-smoke, bluesky (6 sites incl. the search pager's `recyclable(false)`), whisker-icons. podcast's `ForEach` `key:` props untouched (eager control flow, not the virtualized list).
- Pins: `.11` (released checksums), gradle `lynxFork`, `WHISKER_SDK_VERSION` 0.1.5 (publish via `sdk-v0.1.5` after merge).

## Verified (iOS simulator, released .11 xcframeworks, SPM checksum-verified)

| scenario | result |
|---|---|
| `sticky` header pinning | ✅ **now works** (was ❌ in #283) |
| `waterfall` full-span header | ✅ **now works** (was ⚠️ in #283) |
| estimated sizes reach layout | ✅ content estimates ~3.2k for 31 rows (was ~16.8k native default) |
| append position hold / late-data fill / prepend / remove / upper / initial / item-0 re-materialization | ✅ all regressions green |
| Bluesky timeline (real app) | ✅ renders + session restore, zero panics |

Unit tests: metadata on inserts, in-place update emission on meta change, splice shapes (160 tests green; clippy/fmt clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)