### PR TITLE
chore(ios): whisker SPM pin 0.1.1 → 0.1.2

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,7 +49,7 @@ use std::process::Command;
 /// Keep in lockstep with the `Package.swift` at the repo root and the
 /// `v<version>` git tag published for SwiftPM to resolve.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
-pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.1";
+pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.2";
 
 use crate::capture::{CaptureShims, capture_env_vars_for_triple};
 


### PR DESCRIPTION
Generated apps resolve the whisker Swift package (and transitively the Lynx binaryTargets) from the `v0.1.2` git tag, whose `Package.swift` pins v3.8.0-whisker.12 — required by the ABI v3 bridge (#284). Tag `v0.1.2` lands on main right after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)