### PR TITLE
fix(list-smoke): back-to-top choreography fires once, not on every append

### DIFF
--- a/examples/list-smoke/src/lib.rs
+++ b/examples/list-smoke/src/lib.rs
@@ -116,22 +116,23 @@ pub fn app() -> Element {
             return;
         }
         let mut v = ids.get();
-        if v.len() >= 60 {
-            if !back_to_top_done.get() {
-                back_to_top_done.set(true);
-                eprintln!("[SMOKE] cap reached — scrolling back to top");
-                list_handle.scroll_to_position(0, true);
-            }
-            return;
+        if v.len() >= 120 {
+            return; // cap the smoke run
         }
         let n = next.get();
         next.set(n + 10);
         v.extend(n..n + 10);
         ids.set(v);
-        // Chase via the NEXT layoutcomplete (scrolling now would target
-        // an index the NATIVE list doesn't have yet — the append flushes
-        // later this tick).
-        chase_bottom.set(true);
+        // ONCE, after the first (auto-scroll-driven) append: revisit the
+        // top on the next layoutcomplete to exercise item-0
+        // re-materialization. (Scrolling now would target an index the
+        // NATIVE list doesn't have yet — the append flushes later this
+        // tick.) Manual appends afterwards behave like a real infinite
+        // scroll: the position holds and nothing jumps.
+        if !back_to_top_done.get() {
+            back_to_top_done.set(true);
+            chase_bottom.set(true);
+        }
     };
 
     let on_upper = |e: whisker::event::ScrollEvent| {


### PR DESCRIPTION
The default scenario's item-0 re-materialization step (scroll back to the top after an append) re-triggered on every MANUAL trip to the bottom — reaching the end yanked the view to the top, making hands-on infinite-scroll play look broken. Gate it to the first (auto-scroll-driven) append; manual appends now behave like a real infinite scroll. Cap raised to 120 rows.

Verified hands-on via `whisker run ios` (remote whisker v0.1.2 / Lynx .12) with a hot patch + cold restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)