### PR TITLE
feat(hot-reload)!: saves only hot-reload — manual Full Reload (r/R), full-remount escalation, props-layout gate

### DIFF
--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -1,5 +1,5 @@
 //! Android cargo + gradle orchestration. Shared by `whisker-cli`'s
-//! the `whisker-build` binary (gradle plugin path) and `whisker-dev-server`'s Tier 2 cold rebuild
+//! the `whisker-build` binary (gradle plugin path) and `whisker-dev-server`'s full reload
 //! path.
 //!
 //! Three phases:
@@ -10,7 +10,7 @@
 //!    `-Wl,--exclude-libs,ALL` for `cdylib`, which strips every
 //!    mangled Rust symbol from `.dynsym`. The `dylib` flavour keeps
 //!    them — `System.loadLibrary` doesn't care which flavour, but
-//!    the symmetric Tier 1 hot-patch path (dev mode) does. Production
+//!    the symmetric hot-reload patch path (dev mode) does. Production
 //!    builds use the same shape for consistency.
 //!
 //! 2. [`stage_jni_libs`] — drop the `.so` plus the matching
@@ -23,8 +23,8 @@
 //!    against the generated project. Output is `app-{release,debug}.apk`
 //!    under `app/build/outputs/apk/<profile>/`.
 //!
-//! Tier 1 fat-build capture (see [`crate::capture`]) is opt-in via
-//! the `capture` field on [`CargoBuild`] — dev-server's Tier 2
+//! hot reload fat-build capture (see [`crate::capture`]) is opt-in via
+//! the `capture` field on [`CargoBuild`] — dev-server's full reload
 //! cold rebuild passes `Some(&shims)`; gradle-plugin and direct gradle invocations pass `None`.
 
 use anyhow::{Context, Result, anyhow};
@@ -161,10 +161,10 @@ pub struct CargoBuild<'a> {
     /// Cargo features to forward (`--features <each>`). Empty for prod.
     pub features: &'a [String],
     /// `Some` → fold rustc/linker shim env vars into the cargo
-    /// invocation, populating the Tier 1 capture caches. `None` →
+    /// invocation, populating the hot reload capture caches. `None` →
     /// plain build. Dev-server passes `Some(&shims)` for its initial
-    /// fat build and Tier 2 cold rebuilds; gradle-plugin invocations pass
-    /// `None` (no Tier 1 in prod).
+    /// fat build and full reloads; gradle-plugin invocations pass
+    /// `None` (no hot reload in prod).
     pub capture: Option<&'a CaptureShims>,
 }
 
@@ -217,7 +217,7 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
     cmd.env("ANDROID_NDK_HOME", &b.toolchain.ndk);
     cmd.current_dir(b.workspace_root);
 
-    // Tier 1 capture shims (rustc-shim + linker-shim + cache dirs).
+    // hot reload capture shims (rustc-shim + linker-shim + cache dirs).
     // `CARGO_TARGET_<triple>_LINKER` set above is overridden here so
     // the linker shim wins for this triple — the shim forwards to
     // `WHISKER_REAL_LINKER` after writing its capture JSON. Host-only

--- a/crates/whisker-build/src/capture.rs
+++ b/crates/whisker-build/src/capture.rs
@@ -1,11 +1,11 @@
-//! Tier 1 fat-build capture shim wiring.
+//! hot reload fat-build capture shim wiring.
 //!
-//! When the dev-server runs a Tier 2 cold rebuild for hot-reload, it
+//! When the dev-server runs a full reload for hot-reload, it
 //! transparently elevates that build into a **fat build**: cargo
 //! still produces the same artifact, but the rustc and linker
 //! invocations get intercepted by [`whisker-rustc-shim`] and
 //! [`whisker-linker-shim`] respectively, which dump their argv to
-//! JSON files under the configured cache dirs. The Tier 1 thin
+//! JSON files under the configured cache dirs. The hot reload thin
 //! rebuild later replays those argvs to produce a patch dylib.
 //!
 //! The setup is just env vars (cargo's RUSTC_WORKSPACE_WRAPPER +
@@ -14,11 +14,11 @@
 //!
 //! Moved here from `whisker-dev-server::builder` so `whisker-cli`'s
 //! `whisker run` path (which lives outside dev-server in Phase 3+)
-//! can also drive fat builds when it wants Tier 1 ready.
+//! can also drive fat builds when it wants hot reload ready.
 
 use std::path::PathBuf;
 
-/// Shim wiring that turns a plain cargo invocation into a Tier 1
+/// Shim wiring that turns a plain cargo invocation into a hot reload
 /// fat build. All paths are absolute; the dev-server creates the
 /// cache dirs on demand. `real_linker` is what the linker shim
 /// forwards to (typically the same `cc`/`clang` cargo would have
@@ -29,7 +29,7 @@ use std::path::PathBuf;
 /// that triple via cargo's `CARGO_TARGET_<UPPER>_LINKER` env var —
 /// host-only artifacts (build scripts, proc-macros) keep their
 /// default linker. When `None`, the shim is installed globally via
-/// `RUSTFLAGS=-Clinker=…` (fine for host-only Tier 1 setups).
+/// `RUSTFLAGS=-Clinker=…` (fine for host-only hot reload setups).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CaptureShims {
     pub rustc_shim: PathBuf,
@@ -64,7 +64,7 @@ pub fn capture_env_vars(c: &CaptureShims) -> Vec<(String, String)> {
 /// to `triple_override` instead of `c.target_triple`. Used by
 /// multi-triple builds (e.g. iOS, which emits dylibs for
 /// device + intel-sim + arm64-sim) where every per-target slice
-/// needs the same Tier-1 capture envelope — the original
+/// needs the same hot-reload capture envelope — the original
 /// `CaptureShims::target_triple` only carries one slot, so a naive
 /// `capture_env_vars(c)` call would only set
 /// `CARGO_TARGET_<that-one-triple>_RUSTFLAGS` and silently leave
@@ -98,7 +98,7 @@ pub fn capture_env_vars_for_triple(
     ];
 
     let shim = c.linker_shim.to_string_lossy().to_string();
-    // Three flags every fat build needs for Tier 1 to work:
+    // Three flags every fat build needs for hot reload to work:
     //
     // `-Csave-temps=y` keeps rustc's temp dir (containing the
     // version script and bridge-static archive the linker args
@@ -122,7 +122,7 @@ pub fn capture_env_vars_for_triple(
     // branch in `subsecond::HotFn::try_call` — in release builds
     // without this, subsecond compiles to `self.inner.call_it(args)`
     // and skips the JumpTable entirely (apply_patch becomes a no-op
-    // from the caller's perspective). Tier 1 dev builds want the
+    // from the caller's perspective). hot reload dev builds want the
     // JumpTable lookup; this flag flips the cfg without dropping to the
     // dev profile. (We also force `-Copt-level=0` below so the host's
     // per-component dispatch closures match the patch's — see there.)

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -25,7 +25,7 @@
 //! against at runtime. Matches the Android side's choice. See
 //! `docs/hot-reload-plan.md` "Second Pivot".
 //!
-//! Tier 1 fat-build capture (see [`crate::capture`]) is opt-in via
+//! hot reload fat-build capture (see [`crate::capture`]) is opt-in via
 //! the `capture` parameter on the per-arch cargo helper. The
 //! dev-server wires it up by setting `RUSTC_WORKSPACE_WRAPPER` /
 //! `CARGO_TARGET_*_LINKER` / `CARGO_TARGET_*_RUSTFLAGS` env vars on
@@ -115,7 +115,7 @@ const BRIDGE_EXPORTS: &[&str] = &[
 /// boundary.
 ///
 /// `--release` is always set regardless of `capture` — iOS dev's
-/// Tier 1 capture wants the same optimised codegen prod ships. The
+/// hot reload capture wants the same optimised codegen prod ships. The
 /// only thing that changes when `capture` is `Some` is the env-var
 /// envelope (RUSTC_WORKSPACE_WRAPPER, the linker shim, save-temps,
 /// debug-assertions, export-dynamic) — see [`crate::capture_env_vars`].

--- a/crates/whisker-build/src/lib.rs
+++ b/crates/whisker-build/src/lib.rs
@@ -1,16 +1,16 @@
 //! Whisker build orchestration.
 //!
 //! Cross-platform cargo + gradle + xcodebuild invocation, shared by
-//! `whisker-dev-server`'s Tier 2 cold rebuild path, the cli, and the
+//! `whisker-dev-server`'s full reload path, the cli, and the
 //! `whisker-build` binary that gradle / xcodebuild call into during
 //! `whisker run`.
 //!
 //! ## Public surface
 //!
 //! - [`Profile`] — Debug / Release selector.
-//! - [`capture`] — Tier 1 hot-patch capture shim wiring (rustc /
+//! - [`capture`] — hot-reload patch capture shim wiring (rustc /
 //!   linker workspace wrappers + cache dirs + env-var assembly).
-//!   Consumed by the dev-server's Tier 2 fat build (capture: Some)
+//!   Consumed by the dev-server's full reload fat build (capture: Some)
 //!   and the xcodebuild Build Phase path (capture: None).
 //! - [`android`] — NDK toolchain resolution, `cargo rustc
 //!   --crate-type dylib`, jniLibs staging, `gradle assemble{Debug,Release}`.

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -13,7 +13,7 @@
 //!   ⚠  simctl       target already booted
 //!
 //! ──── Patch ───────────────────────────────────
-//!   ✓  patch        tier 1                  730ms
+//!   ✓  patch        hot reload                  730ms
 //! ```
 //!
 //! ## Behaviour modes

--- a/crates/whisker-cli/src/build_dispatch.rs
+++ b/crates/whisker-cli/src/build_dispatch.rs
@@ -173,15 +173,15 @@ pub fn run_ios(args: IosArgs) -> Result<()> {
     })?;
 
     // `configuration` is currently informational — the iOS cargo build
-    // is always release-tier (subsecond's Tier 1 capture wants the same
+    // is always release-tier (subsecond's hot reload capture wants the same
     // optimised codegen prod ships). Logged so a Debug-mode Xcode build
     // surprised by release optimisation has the mismatch visible.
-    eprintln!(
-        "[whisker build-ios] published {} (configuration={}, archs=[{}])",
+    whisker_build::ui::info(format!(
+        "published {} (configuration={}, archs=[{}])",
         fw.display(),
         args.configuration,
         args.archs,
-    );
+    ));
     Ok(())
 }
 
@@ -222,10 +222,10 @@ pub fn run_android(args: AndroidArgs) -> Result<()> {
             )
         })?;
 
-    eprintln!(
-        "[whisker build-android] {} module(s) discovered (gradle-subproject wiring is the Gradle plugin's job)",
+    whisker_build::ui::info(format!(
+        "{} module(s) discovered (gradle-subproject wiring is the Gradle plugin's job)",
         modules.len(),
-    );
+    ));
     Ok(())
 }
 

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! In addition to the user-facing `whisker` binary, the package also
 //! produces two shim binaries used during the initial fat build to
-//! capture the rustc + linker invocations that Tier 1 hot-patch will
+//! capture the rustc + linker invocations that hot-reload patch will
 //! replay later:
 //!
 //! - `whisker-rustc-shim` (`-Cstrip=…` / `-Csave-temps=y` style

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -36,9 +36,9 @@ pub struct Args {
     #[arg(long, default_value = "127.0.0.1:9876")]
     pub bind: SocketAddr,
 
-    /// Opt out of Tier 1 subsecond hot-patching and fall back to Tier 2
-    /// cold rebuilds. `whisker run` defaults to Tier 1; this flag is
-    /// for situations where the hot-patch path is misbehaving and you
+    /// Disable Hot Reload (subsecond patching). Every save then
+    /// prompts for an explicit Full Reload (`R`) instead. For
+    /// situations where the hot-patch path is misbehaving and you
     /// just want the slower-but-bulletproof path.
     #[arg(long)]
     pub no_hot_patch: bool,
@@ -221,15 +221,15 @@ fn run_inner(
         .map(|v| format!(" (template_version {v})"))
         .unwrap_or_default();
     if sync.regenerated {
-        eprintln!(
-            "[whisker run] regenerated gen/ at {}{tv}",
+        whisker_build::ui::info(format!(
+            "regenerated gen/ at {}{tv}",
             sync.gen_dir.display(),
-        );
+        ));
     } else {
-        eprintln!(
-            "[whisker run] reused cached gen/ at {}{tv}",
+        whisker_build::ui::info(format!(
+            "reused cached gen/ at {}{tv}",
             sync.gen_dir.display(),
-        );
+        ));
     }
 
     let android = match target {
@@ -257,9 +257,9 @@ fn run_inner(
         // also defends an accidental `--bind 0.0.0.0`.
         dev_token: Some(generate_dev_token()),
         hot_patch_mode: if args.no_hot_patch {
-            HotPatchMode::Tier2ColdRebuild
+            HotPatchMode::FullReloadOnly
         } else {
-            HotPatchMode::Tier1Subsecond
+            HotPatchMode::HotReload
         },
         android,
         ios,
@@ -281,21 +281,31 @@ fn run_inner(
     let show_native_logs = args.show_native_logs;
     let tui_for_events = tui.cloned();
 
-    let server = DevServer::new(config)?.on_event(move |e| {
-        if let Some(h) = &tui_for_events {
-            // TUI mode: the handle's `apply_event` already pushes
-            // `Event::DeviceLog` into scrollback via `insert_before`
-            // as a `[device]` / `[device:err]` row. Routing the
-            // same event through `forward_event_to_ui` would
-            // double-print every device log line (once raw, once
-            // wrapped in `whisker_build::ui::info`'s `· ` prefix
-            // and captured back through stderr). Skip the legacy
-            // path entirely when the TUI is on.
-            h.apply_event(&e);
-        } else {
-            forward_event_to_ui(e, show_native_logs);
-        }
-    });
+    // Reload shortcuts (`r` / `R` in the TUI) flow through this
+    // channel into the dev loop. Reloads are user-triggered only —
+    // the dev-server never full-reloads on its own.
+    let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+    if let Some(t) = tui {
+        t.set_command_sender(cmd_tx);
+    }
+
+    let server = DevServer::new(config)?
+        .with_command_receiver(cmd_rx)
+        .on_event(move |e| {
+            if let Some(h) = &tui_for_events {
+                // TUI mode: the handle's `apply_event` already pushes
+                // `Event::DeviceLog` into scrollback via `insert_before`
+                // as a `[device]` / `[device:err]` row. Routing the
+                // same event through `forward_event_to_ui` would
+                // double-print every device log line (once raw, once
+                // wrapped in `whisker_build::ui::info`'s `· ` prefix
+                // and captured back through stderr). Skip the legacy
+                // path entirely when the TUI is on.
+                h.apply_event(&e);
+            } else {
+                forward_event_to_ui(e, show_native_logs);
+            }
+        });
 
     rt.block_on(server.run())
 }

--- a/crates/whisker-cli/src/rustc_shim.rs
+++ b/crates/whisker-cli/src/rustc_shim.rs
@@ -36,6 +36,14 @@ pub struct CapturedRustcInvocation {
     /// path itself (cargo prepends that, but the rest is what we
     /// need to replay).
     pub args: Vec<String>,
+    /// The `CARGO_*` / `OUT_DIR` environment cargo set for this
+    /// invocation (see [`capture_envs_from`] for the filter). The
+    /// thin rebuild spawns rustc *without* cargo, so any
+    /// `env!("CARGO_PKG_VERSION")` / `env!("OUT_DIR")` in the crate
+    /// fails to compile unless these are replayed. `#[serde(default)]`
+    /// so caches written by an older shim still deserialize.
+    #[serde(default)]
+    pub envs: std::collections::BTreeMap<String, String>,
     /// When the invocation happened, as microseconds since UNIX
     /// epoch. Used to disambiguate multiple invocations of the same
     /// crate within one fat build.
@@ -75,16 +83,38 @@ pub fn run() -> Result<()> {
 // ----- Pure helpers (testable) ----------------------------------------------
 
 /// Build a [`CapturedRustcInvocation`] from a rustc argv slice.
-/// Pure aside from reading the system clock for the timestamp.
+/// Pure aside from reading the system clock for the timestamp and
+/// the process environment for the `CARGO_*` capture.
 pub fn capture(rustc_args: &[String]) -> Result<CapturedRustcInvocation> {
     Ok(CapturedRustcInvocation {
         crate_name: extract_crate_name(rustc_args).unwrap_or_default(),
         args: rustc_args.to_vec(),
+        envs: capture_envs_from(std::env::vars()),
         timestamp_micros: SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_micros())
             .unwrap_or(0),
     })
+}
+
+/// Filter a process environment down to the vars worth replaying on
+/// a thin rebuild: `CARGO` (path to cargo, read by `env!("CARGO")`),
+/// everything cargo namespaces under `CARGO_*` (`CARGO_PKG_*`,
+/// `CARGO_MANIFEST_DIR`, `CARGO_CRATE_NAME`, …), and `OUT_DIR` (the
+/// build-script output dir that `include!(concat!(env!("OUT_DIR"),
+/// …))` needs).
+///
+/// `CARGO_MAKEFLAGS` is excluded: it encodes jobserver file
+/// descriptors that are only open inside cargo's own process tree,
+/// and rustc warns about the dead jobserver on every spawn that
+/// replays it.
+pub fn capture_envs_from(
+    vars: impl IntoIterator<Item = (String, String)>,
+) -> std::collections::BTreeMap<String, String> {
+    vars.into_iter()
+        .filter(|(k, _)| k == "CARGO" || k == "OUT_DIR" || k.starts_with("CARGO_"))
+        .filter(|(k, _)| k != "CARGO_MAKEFLAGS")
+        .collect()
 }
 
 /// Find the value passed to `--crate-name` in a rustc argv slice.
@@ -212,6 +242,44 @@ mod tests {
         assert_eq!(inv.crate_name, "");
     }
 
+    // ----- capture_envs_from --------------------------------------------
+
+    #[test]
+    fn capture_envs_keeps_cargo_vars_and_out_dir_only() {
+        let vars = vec![
+            ("CARGO".to_string(), "/usr/bin/cargo".to_string()),
+            ("CARGO_PKG_VERSION".to_string(), "1.2.3".to_string()),
+            ("CARGO_MANIFEST_DIR".to_string(), "/ws/app".to_string()),
+            ("OUT_DIR".to_string(), "/ws/target/build/out".to_string()),
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("RUSTC_WORKSPACE_WRAPPER".to_string(), "/shim".to_string()),
+            ("HOME".to_string(), "/home/dev".to_string()),
+        ];
+        let envs = capture_envs_from(vars);
+        assert_eq!(envs.len(), 4);
+        assert_eq!(envs["CARGO_PKG_VERSION"], "1.2.3");
+        assert_eq!(envs["OUT_DIR"], "/ws/target/build/out");
+        assert!(!envs.contains_key("PATH"));
+        assert!(!envs.contains_key("RUSTC_WORKSPACE_WRAPPER"));
+    }
+
+    #[test]
+    fn capture_envs_excludes_cargo_makeflags() {
+        // CARGO_MAKEFLAGS carries jobserver fds that are dead outside
+        // cargo's process tree; replaying it makes rustc warn on
+        // every thin rebuild.
+        let vars = vec![
+            (
+                "CARGO_MAKEFLAGS".to_string(),
+                "-j --jobserver-fds=7,8".to_string(),
+            ),
+            ("CARGO_PKG_NAME".to_string(), "demo".to_string()),
+        ];
+        let envs = capture_envs_from(vars);
+        assert!(!envs.contains_key("CARGO_MAKEFLAGS"));
+        assert!(envs.contains_key("CARGO_PKG_NAME"));
+    }
+
     // ----- invocation_filename ----------------------------------------
 
     #[test]
@@ -219,6 +287,7 @@ mod tests {
         let inv = CapturedRustcInvocation {
             crate_name: "hello-world".into(),
             args: vec![],
+            envs: Default::default(),
             timestamp_micros: 1_000_000,
         };
         assert_eq!(invocation_filename(&inv), "hello_world-1000000.json");
@@ -229,6 +298,7 @@ mod tests {
         let inv = CapturedRustcInvocation {
             crate_name: "".into(),
             args: vec![],
+            envs: Default::default(),
             timestamp_micros: 42,
         };
         assert_eq!(invocation_filename(&inv), "_unknown-42.json");
@@ -241,6 +311,7 @@ mod tests {
         let inv = CapturedRustcInvocation {
             crate_name: "weird/name".into(),
             args: vec![],
+            envs: Default::default(),
             timestamp_micros: 7,
         };
         assert_eq!(invocation_filename(&inv), "weird_name-7.json");
@@ -254,6 +325,7 @@ mod tests {
         let inv = CapturedRustcInvocation {
             crate_name: "x".into(),
             args: s(&["--crate-name", "x", "src/lib.rs"]),
+            envs: Default::default(),
             timestamp_micros: 12345,
         };
         save_invocation(&dir, &inv).expect("save");
@@ -279,6 +351,7 @@ mod tests {
         let inv = CapturedRustcInvocation {
             crate_name: "x".into(),
             args: vec![],
+            envs: Default::default(),
             timestamp_micros: 1,
         };
         save_invocation(&dir, &inv).expect("save");

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -29,7 +29,7 @@
 //!    whisker run · iOS Simulator · rs.example.bar · building · 4.1s
 //!    ⠋ xcodebuild …
 //!
-//!    q  quit
+//!    r  hot reload   R  full reload   q  quit
 //! ──────────────────────────────────────────────────────────────────
 //! ```
 //!
@@ -108,8 +108,8 @@ pub enum AppPhase {
     /// dev-server bound, initial build succeeded, watching for source
     /// changes.
     Idle,
-    /// Tier 1 hot-patch in flight. Phase exit is signalled by
-    /// `Event::PatchSent` or a Tier 2 fallback's `Event::BuildingFull`.
+    /// hot-reload patch in flight. Phase exit is signalled by
+    /// `Event::PatchSent` or a full reload fallback's `Event::BuildingFull`.
     Patching { started_at: Instant },
     /// Build failed. The live region surfaces the cause and the cli
     /// is about to exit non-zero.
@@ -159,6 +159,15 @@ pub struct LiveState {
     /// blocks forever, so without a hard exit `q` would tear down the
     /// TUI but leave the process running.
     pub user_initiated_quit: bool,
+    /// Persistent "press R to Full Reload" banner. Set by
+    /// `Event::FullReloadRequired` (the dev loop hit a change it
+    /// can't hot-reload), cleared when a Full Reload actually starts
+    /// (`Event::BuildingFull`).
+    pub full_reload_needed: Option<String>,
+    /// Channel into the dev loop for the `r` / `R` shortcuts. `None`
+    /// until the cli wires the dev-server up (early keypresses
+    /// during setup are dropped).
+    pub command_tx: Option<tokio::sync::mpsc::UnboundedSender<whisker_dev_server::DevCommand>>,
 }
 
 impl LiveState {
@@ -175,6 +184,8 @@ impl LiveState {
             last_patch: None,
             should_quit: false,
             user_initiated_quit: false,
+            full_reload_needed: None,
+            command_tx: None,
         }
     }
 }
@@ -239,6 +250,9 @@ pub fn apply_event(
             // ordering so we don't race the "▶ Initial build" entry.
         }
         Event::BuildingFull => {
+            // A Full Reload is running — the pending prompt (if any)
+            // is being acted on.
+            state.full_reload_needed = None;
             let kind = match state.phase {
                 AppPhase::Setup | AppPhase::Initializing => BuildKind::Initial,
                 _ => BuildKind::Rebuild,
@@ -308,8 +322,8 @@ pub fn apply_event(
             // assembling the hot patch (cargo + symbol-table diff
             // + ASLR rebase, the wall-clock-heavy bit of the loop).
             // `Event::PatchSent` flips back to Idle on completion;
-            // `Event::BuildingFull` covers the Tier 2 fallback case
-            // where Tier 1 errored out mid-build and the loop fell
+            // `Event::BuildingFull` covers the full reload fallback case
+            // where hot reload errored out mid-build and the loop fell
             // through to a cold rebuild — that event resets phase
             // to Building, overriding this Patching state.
             state.phase = AppPhase::Patching {
@@ -321,6 +335,20 @@ pub fn apply_event(
                 let elapsed = started_at.elapsed();
                 state.last_patch = Some(fmt_elapsed(elapsed));
             }
+            state.phase = AppPhase::Idle;
+            state.current_step = None;
+        }
+        Event::FullReloadRequired { reason } => {
+            // The dev loop declined to act on a change (or a hot
+            // reload failed) — nothing is running, the user decides
+            // when to pay for a Full Reload. Persistent banner in
+            // the live region; the dev-server's own `ui::warn` line
+            // already landed in scrollback via captured stderr.
+            state.full_reload_needed = Some(reason.clone());
+            // A `PatchBuilding` may have flipped the phase to
+            // Patching before the loop discovered it couldn't
+            // proceed — return to Idle so the spinner doesn't run
+            // forever.
             state.phase = AppPhase::Idle;
             state.current_step = None;
         }
@@ -418,6 +446,16 @@ impl TuiHandle {
 
     pub fn request_quit(&self) {
         self.with(|s| s.should_quit = true);
+    }
+
+    /// Wire the `r` / `R` shortcuts to the dev loop. Called by the
+    /// cli once the dev-server's command channel exists; presses
+    /// before that are dropped silently.
+    pub fn set_command_sender(
+        &self,
+        tx: tokio::sync::mpsc::UnboundedSender<whisker_dev_server::DevCommand>,
+    ) {
+        self.with(|s| s.command_tx = Some(tx));
     }
 
     /// Test-only: pull a snapshot of the live state. Avoid in
@@ -547,6 +585,16 @@ impl Tui {
                             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                                 self.user_quit()
                             }
+                            // Reloads are explicit, keyboard-driven
+                            // actions: `r` pushes a hot-reload patch,
+                            // `R` (shift) runs the Full Reload the
+                            // dev loop never triggers on its own.
+                            KeyCode::Char('r') => {
+                                self.send_command(whisker_dev_server::DevCommand::HotReload)
+                            }
+                            KeyCode::Char('R') => {
+                                self.send_command(whisker_dev_server::DevCommand::FullReload)
+                            }
                             _ => {}
                         }
                     }
@@ -592,6 +640,17 @@ impl Tui {
             }
         }
         Ok(())
+    }
+
+    /// Forward a reload shortcut to the dev loop. Dropped silently
+    /// when the dev-server hasn't wired its command channel yet
+    /// (setup phase) or has shut down.
+    fn send_command(&self, cmd: whisker_dev_server::DevCommand) {
+        if let Ok(s) = self.live.lock() {
+            if let Some(tx) = &s.command_tx {
+                let _ = tx.send(cmd);
+            }
+        }
     }
 
     /// User-initiated quit (q / Esc / Ctrl-C from the TUI).
@@ -947,22 +1006,54 @@ fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Line<'static>>
         lines.push(Line::from(""));
     }
 
-    // Spacer + footer hint. The key chip uses `White` (not `Black`)
-    // on the dark-gray background so it stays legible in
-    // dark-themed terminals where ANSI color 0 (`Color::Black`)
-    // resolves to the terminal's *background* hue and visually
-    // disappears against the chip's fill.
-    lines.push(Line::from(""));
-    lines.push(Line::from(vec![
-        Span::raw(" "),
+    // Banner row: persistent "press R" prompt while the dev loop is
+    // waiting on the user for a Full Reload. Doubles as the spacer
+    // row when no prompt is pending so the layout doesn't jiggle.
+    match &state.full_reload_needed {
+        Some(reason) => {
+            lines.push(Line::from(vec![
+                Span::raw(" "),
+                Span::styled(
+                    format!("⚠ {reason} — press "),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(
+                    " R ",
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" to Full Reload", Style::default().fg(Color::Yellow)),
+            ]));
+        }
+        None => lines.push(Line::from("")),
+    }
+
+    // Footer hint. The key chips use `White` (not `Black`) on the
+    // dark-gray background so they stay legible in dark-themed
+    // terminals where ANSI color 0 (`Color::Black`) resolves to the
+    // terminal's *background* hue and visually disappears against
+    // the chip's fill.
+    let key_chip = |label: &str| {
         Span::styled(
-            " q ",
+            format!(" {label} "),
             Style::default()
                 .fg(Color::White)
                 .bg(Color::DarkGray)
                 .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled("  quit", Style::default().fg(Color::DarkGray)),
+        )
+    };
+    let key_desc =
+        |text: &str| Span::styled(text.to_string(), Style::default().fg(Color::DarkGray));
+    lines.push(Line::from(vec![
+        Span::raw(" "),
+        key_chip("r"),
+        key_desc("  hot reload   "),
+        key_chip("R"),
+        key_desc("  full reload   "),
+        key_chip("q"),
+        key_desc("  quit"),
     ]));
 
     // Truncate / pad to LIVE_HEIGHT so the viewport renders cleanly.
@@ -1201,7 +1292,7 @@ mod tests {
         assert!(matches!(st.phase, AppPhase::Idle));
         assert!(st.last_patch.is_some());
         // PhaseDone is no longer emitted on PatchSent — the dev-server
-        // already emits `✓ patch tier 1 …` via `ui::step` and a
+        // already emits `✓ patch hot reload …` via `ui::step` and a
         // duplicate "Hot patch" summary row would just clutter
         // scrollback.
         assert!(h.is_empty());
@@ -1226,6 +1317,90 @@ mod tests {
         let h = drain(&mut st, &Event::BuildFailed("link error".into()));
         assert!(matches!(st.phase, AppPhase::Failed { .. }));
         assert!(h.iter().any(|i| matches!(i, HistoryItem::Failure(_))));
+    }
+
+    #[test]
+    fn full_reload_required_sets_banner_and_returns_to_idle() {
+        let mut st = s();
+        // A hot-reload attempt flips into Patching first, then the
+        // dev loop discovers it can't proceed.
+        drain(&mut st, &Event::PatchBuilding);
+        let h = drain(
+            &mut st,
+            &Event::FullReloadRequired {
+                reason: "Cargo.toml changed".into(),
+            },
+        );
+        assert_eq!(st.full_reload_needed.as_deref(), Some("Cargo.toml changed"));
+        assert!(
+            matches!(st.phase, AppPhase::Idle),
+            "spinner must not keep running after a declined reload"
+        );
+        // The dev-server's own ui::warn line reaches scrollback via
+        // captured stderr — no duplicate history row from the event.
+        assert!(h.is_empty());
+    }
+
+    #[test]
+    fn building_full_clears_the_full_reload_banner() {
+        let mut st = s();
+        drain(
+            &mut st,
+            &Event::FullReloadRequired {
+                reason: "Cargo.toml changed".into(),
+            },
+        );
+        assert!(st.full_reload_needed.is_some());
+        drain(&mut st, &Event::BuildingFull);
+        assert!(
+            st.full_reload_needed.is_none(),
+            "starting a Full Reload acts on the prompt"
+        );
+    }
+
+    #[test]
+    fn patch_sent_keeps_the_full_reload_banner() {
+        // A successful hot reload does NOT satisfy a pending
+        // dependency-graph prompt — the new dep still isn't on the
+        // device until a Full Reload runs.
+        let mut st = s();
+        drain(
+            &mut st,
+            &Event::FullReloadRequired {
+                reason: "Cargo.toml changed".into(),
+            },
+        );
+        drain(&mut st, &Event::PatchBuilding);
+        drain(&mut st, &Event::PatchSent);
+        assert!(st.full_reload_needed.is_some());
+    }
+
+    #[test]
+    fn build_live_lines_renders_full_reload_banner() {
+        let mut st = s();
+        st.full_reload_needed = Some("Cargo.toml changed".into());
+        let lines = build_live_lines(&st, 0);
+        let rendered = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|sp| sp.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(rendered.contains("Cargo.toml changed"));
+        assert!(rendered.contains("Full Reload"));
+    }
+
+    #[test]
+    fn build_live_lines_footer_lists_reload_shortcuts() {
+        let st = s();
+        let lines = build_live_lines(&st, 0);
+        let rendered = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|sp| sp.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(rendered.contains("hot reload"));
+        assert!(rendered.contains("full reload"));
+        assert!(rendered.contains("quit"));
     }
 
     #[test]

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -1,11 +1,11 @@
-//! Tier 2 cold rebuild: produce a fresh artifact + (re)install it on
+//! full reload: produce a fresh artifact + (re)install it on
 //! the active [`Target`].
 //!
 //! Delegates the cargo + gradle / xcodebuild orchestration to
 //! `whisker-build`, which is shared with `whisker-cli`'s `whisker
 //! build` subcommand. When `with_capture` is set, the cargo step
 //! doubles as a **fat build** that fills the rustc + linker capture
-//! caches the Tier 1 hot-patch pipeline replays later.
+//! caches the hot-reload patch pipeline replays later.
 
 use anyhow::{Context, Result};
 use std::path::PathBuf;
@@ -13,10 +13,10 @@ use std::path::PathBuf;
 use crate::Target;
 use whisker_build::CaptureShims;
 
-/// Builder for cold (Tier 2) rebuilds. Tier 1 hot-patches live in
+/// Builder for cold (full reload) rebuilds. hot-reload patches live in
 /// [`crate::hotpatch::Patcher`] — Builder is only invoked for
 /// dependency-shaped changes (Cargo.toml edits) and as a fallback
-/// when Tier 1 errors.
+/// when hot reload errors.
 pub struct Builder {
     workspace_root: PathBuf,
     /// User crate dir (= `Cargo.toml` parent). Needed to find
@@ -27,8 +27,8 @@ pub struct Builder {
     /// Cargo features forwarded to whichever step compiles the user
     /// crate. The dev loop turns on `whisker/hot-reload` here.
     features: Vec<String>,
-    /// `Some` → fat build (Tier 1 capture caches get populated).
-    /// `None` → plain Tier 2.
+    /// `Some` → fat build (hot reload capture caches get populated).
+    /// `None` → plain full reload.
     capture: Option<CaptureShims>,
 }
 
@@ -98,7 +98,7 @@ impl Builder {
         // Mirrors what iOS already does: cargo runs only inside
         // xcodebuild's Build Phase; the dev-server's `build_ios_simulator`
         // is module-source-staging only. Aligning Android to the same
-        // shape halves the wall-clock of every Tier 2 rebuild on a
+        // shape halves the wall-clock of every full reload on a
         // cache-warm cargo and removes one race against the TUI viewport.
         let ws = self.workspace_root.clone();
         let crate_dir = self.crate_dir.clone();
@@ -135,7 +135,7 @@ impl Builder {
         //
         // Pre-Step-7 this method also ran `build_xcframework_with` to
         // produce `target/whisker-driver/WhiskerDriver.xcframework`
-        // and to prime the Tier 1 capture shims. The xcframework is
+        // and to prime the hot reload capture shims. The xcframework is
         // no longer referenced by anything (Step 7 dropped the SPM
         // binaryTarget) so its output was wasted; the capture wiring
         // moved to `installer.rs` where it gets applied as env vars

--- a/crates/whisker-dev-server/src/hotpatch/android_ndk.rs
+++ b/crates/whisker-dev-server/src/hotpatch/android_ndk.rs
@@ -12,7 +12,7 @@
 //!   - pick a host-tag for the toolchain bin dir
 //!   - locate `<prefix><api>-clang` for an ABI
 //!
-//! Tier 1's link step (build_link_plan + run_link_plan) uses the
+//! hot reload's link step (build_link_plan + run_link_plan) uses the
 //! returned clang as both `linker_path` (what we spawn) and
 //! `WHISKER_REAL_LINKER` (what the linker shim forwards to during the
 //! fat build). Same binary on both sides keeps SDK / sysroot

--- a/crates/whisker-dev-server/src/hotpatch/jump_table.rs
+++ b/crates/whisker-dev-server/src/hotpatch/jump_table.rs
@@ -1,6 +1,6 @@
 //! Build a `subsecond::JumpTable` from old vs new symbol tables.
 //!
-//! This is the diffing brain of Tier 1: given the original binary's
+//! This is the diffing brain of hot reload: given the original binary's
 //! symbols and the freshly-linked patch dylib's symbols, walk the
 //! ones that exist in both and produce the address-to-address map
 //! that `subsecond::apply_patch` will use to rewrite call sites.

--- a/crates/whisker-dev-server/src/hotpatch/mod.rs
+++ b/crates/whisker-dev-server/src/hotpatch/mod.rs
@@ -1,4 +1,4 @@
-//! Tier 1 (subsecond) hot-reload pipeline.
+//! Hot Reload (subsecond patching) pipeline.
 //!
 //! See `docs/hot-reload-plan.md` for the architecture. The modules
 //! land one per task ID:
@@ -27,7 +27,7 @@ pub use cache::HotpatchModuleCache;
 pub use jump_table::{DiffReport, PatchPlan, build_jump_table};
 pub use link_plan::{LinkPlan, LinkerOs, build_link_plan, linker_os_for_host};
 pub use patcher::Patcher;
-pub use runner::{run_link_plan, run_obj_plan, thin_rebuild_obj};
+pub use runner::{RustcRejectedCode, run_link_plan, run_obj_plan, thin_rebuild_obj};
 pub use shim_paths::{ShimPaths, expected_shim_paths, resolve_shim_paths};
 pub use stub_object::{
     build_stub_for_needed, compute_needed_symbols, compute_needed_symbols_multi,

--- a/crates/whisker-dev-server/src/hotpatch/patcher.rs
+++ b/crates/whisker-dev-server/src/hotpatch/patcher.rs
@@ -236,7 +236,7 @@ impl Patcher {
         // (Linux) satisfies the patch's references against the
         // already-loaded test process — same as before Option B. Real
         // device dispatch always goes through the stub branch since
-        // `lib.rs::run` skips Tier 1 entirely when no aslr_reference
+        // `lib.rs::run` skips hot reload entirely when no aslr_reference
         // has been reported.
         let extras: Vec<PathBuf> = if aslr_reference == 0 {
             // Test-fixture path: even without a stub we still need to

--- a/crates/whisker-dev-server/src/hotpatch/runner.rs
+++ b/crates/whisker-dev-server/src/hotpatch/runner.rs
@@ -22,6 +22,28 @@ use super::link_plan::{LinkPlan, LinkerOs, build_link_plan};
 use super::thin_build::{ObjBuildPlan, build_obj_plan};
 use super::wrapper::CapturedRustcInvocation;
 
+/// Marker error: rustc was spawned fine and exited 1 — i.e. it
+/// *rejected the code* and printed its own diagnostics (stderr is
+/// inherited, so they're already on the dev terminal). The change
+/// loop downcasts to this to distinguish "the user's edit doesn't
+/// compile" (a full reload cargo build would fail identically after a
+/// much longer wait — don't bother) from infrastructure failures
+/// like a missing capture cache or a broken link line (where a cold
+/// rebuild genuinely can recover).
+///
+/// Exit codes other than 1 (ICE = 101, killed by signal) stay on the
+/// generic error path: they don't prove anything about the code.
+#[derive(Debug)]
+pub struct RustcRejectedCode;
+
+impl std::fmt::Display for RustcRejectedCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "rustc rejected the code (exit 1); diagnostics above")
+    }
+}
+
+impl std::error::Error for RustcRejectedCode {}
+
 /// Spawn rustc with `plan.args` from `cwd`. On success, returns
 /// the path of the emitted object (= `plan.expected_object`).
 ///
@@ -30,13 +52,21 @@ use super::wrapper::CapturedRustcInvocation;
 pub async fn run_obj_plan(plan: &ObjBuildPlan, rustc_path: &Path, cwd: &Path) -> Result<PathBuf> {
     std::fs::create_dir_all(&plan.output_dir)
         .with_context(|| format!("create out dir {}", plan.output_dir.display()))?;
+    // `plan.envs` replays the `CARGO_*` / `OUT_DIR` vars captured
+    // during the fat build — without them any `env!("CARGO_PKG_*")`
+    // in the user's code fails to compile under this raw (cargo-less)
+    // rustc spawn.
     let status = tokio::process::Command::new(rustc_path)
         .args(&plan.args)
+        .envs(&plan.envs)
         .current_dir(cwd)
         .status()
         .await
         .with_context(|| format!("spawn {}", rustc_path.display()))?;
     if !status.success() {
+        if status.code() == Some(1) {
+            return Err(anyhow::Error::new(RustcRejectedCode));
+        }
         anyhow::bail!(
             "rustc exited {} during obj rebuild (out_dir={})",
             status,
@@ -168,10 +198,15 @@ mod tests {
     // ----- run_obj_plan ------------------------------------------------
 
     #[tokio::test]
-    async fn run_obj_plan_surfaces_rustc_failure_with_path_context() {
-        // Plan that will fail because the source file doesn't exist.
+    async fn run_obj_plan_reports_rejected_code_when_rustc_exits_1() {
+        // Plan that will fail because the source file doesn't exist —
+        // rustc runs, prints a diagnostic, and exits 1, which is the
+        // same shape as a compile error in real user code. The change
+        // loop relies on downcasting to `RustcRejectedCode` here to
+        // skip the pointless full reload fallback.
         let dir = unique_tempdir();
         let plan = ObjBuildPlan {
+            envs: Default::default(),
             args: s(&[
                 "--edition=2021",
                 "--crate-name",
@@ -189,10 +224,46 @@ mod tests {
         };
         let res = run_obj_plan(&plan, Path::new("rustc"), &dir).await;
         let err = res.unwrap_err();
-        let msg = format!("{err:#}");
         assert!(
-            msg.contains("rustc exited") || msg.contains("spawn"),
-            "msg should mention rustc exit or spawn: {msg}",
+            err.downcast_ref::<RustcRejectedCode>().is_some(),
+            "exit 1 should downcast to RustcRejectedCode: {err:#}",
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn run_obj_plan_compile_error_downcasts_through_context() {
+        // Same as above but with a real source file containing a type
+        // error, and with a `.context(...)` layer like the Patcher
+        // adds — downcast_ref must still find the marker through the
+        // context chain.
+        let dir = unique_tempdir();
+        let src = dir.join("bad.rs");
+        std::fs::write(&src, "pub fn broken() -> u32 { \"not a number\" }\n").unwrap();
+        let plan = ObjBuildPlan {
+            envs: Default::default(),
+            args: s(&[
+                "--edition=2021",
+                "--crate-name",
+                "bad",
+                "--crate-type",
+                "rlib",
+                "--out-dir",
+                dir.to_string_lossy().as_ref(),
+                src.to_string_lossy().as_ref(),
+                "--emit",
+                &format!("obj={}/bad.o", dir.display()),
+            ]),
+            output_dir: dir.clone(),
+            expected_object: dir.join("bad.o"),
+        };
+        let res = run_obj_plan(&plan, Path::new("rustc"), &dir)
+            .await
+            .context("rustc --emit=obj for thin patch");
+        let err = res.unwrap_err();
+        assert!(
+            err.downcast_ref::<RustcRejectedCode>().is_some(),
+            "compile error should downcast through context: {err:#}",
         );
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -201,6 +272,7 @@ mod tests {
     async fn run_obj_plan_errors_when_rustc_binary_doesnt_exist() {
         let dir = unique_tempdir();
         let plan = ObjBuildPlan {
+            envs: Default::default(),
             args: vec![],
             output_dir: dir.clone(),
             expected_object: dir.join("demo.o"),

--- a/crates/whisker-dev-server/src/hotpatch/shim_paths.rs
+++ b/crates/whisker-dev-server/src/hotpatch/shim_paths.rs
@@ -21,7 +21,7 @@
 //!      the workspace, then re-check. Only meaningful in-workspace
 //!      (where `whisker-cli` is a member); for external users step 1
 //!      already succeeded. A build failure surfaces as `Err(_)` and the
-//!      caller falls back to Tier 2.
+//!      caller falls back to full reload.
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
@@ -84,7 +84,7 @@ fn shim_paths_beside_current_exe() -> Option<ShimPaths> {
 pub fn resolve_shim_paths(workspace_root: &Path) -> Result<ShimPaths> {
     // 1. Beside the running `whisker` binary — the crates.io install
     //    location, and the in-workspace `target/debug` location once
-    //    built. Resolving here is what keeps Tier 1 hot reload working
+    //    built. Resolving here is what keeps hot reload working
     //    for `cargo install`-only users (no whisker-cli workspace member
     //    to `cargo build`).
     if let Some(paths) = shim_paths_beside_current_exe() {

--- a/crates/whisker-dev-server/src/hotpatch/thin_build.rs
+++ b/crates/whisker-dev-server/src/hotpatch/thin_build.rs
@@ -51,6 +51,12 @@ use super::wrapper::CapturedRustcInvocation;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjBuildPlan {
     pub args: Vec<String>,
+    /// Environment to overlay on the rustc spawn — the `CARGO_*` /
+    /// `OUT_DIR` vars captured during the fat build, so `env!()`
+    /// invocations in the user's code still resolve under the raw
+    /// (cargo-less) thin rebuild. Empty for captures written before
+    /// env capture existed.
+    pub envs: std::collections::BTreeMap<String, String>,
     pub output_dir: PathBuf,
     pub expected_object: PathBuf,
 }
@@ -115,8 +121,8 @@ pub fn build_obj_plan(captured: &CapturedRustcInvocation, output_dir: &Path) -> 
     // 50–100 ms warm. The cache lives under our patch dir so it's
     // wiped together with the thin object on a fresh `whisker run`.
     set_incremental(&mut args, &output_dir.join("incremental"));
-    // The fat (release) build captured `-Copt-level=3`. For Tier 1
-    // hot patches we strip the LLVM optimization pipeline entirely —
+    // The fat (release) build captured `-Copt-level=3`. For hot-reload
+    // patches we strip the LLVM optimization pipeline entirely —
     // `time-passes` confirms LLVM passes account for ~88% of rustc's
     // wall time on opt-level=3 user crates. The patched code only
     // has to *run*, not run fast: hot reload is a dev affordance, so
@@ -128,6 +134,7 @@ pub fn build_obj_plan(captured: &CapturedRustcInvocation, output_dir: &Path) -> 
     override_opt_level(&mut args, "0");
     ObjBuildPlan {
         args,
+        envs: captured.envs.clone(),
         output_dir: output_dir.to_path_buf(),
         expected_object: object_path,
     }
@@ -343,8 +350,19 @@ mod tests {
         CapturedRustcInvocation {
             crate_name: "demo".into(),
             args,
+            envs: Default::default(),
             timestamp_micros: 0,
         }
+    }
+
+    #[test]
+    fn build_obj_plan_carries_captured_envs_through() {
+        let mut captured = captured_with(s(&["--edition=2021", "src/lib.rs"]));
+        captured
+            .envs
+            .insert("CARGO_PKG_VERSION".to_string(), "0.7.0".to_string());
+        let plan = build_obj_plan(&captured, Path::new("/tmp/patches"));
+        assert_eq!(plan.envs, captured.envs);
     }
 
     // ----- set_crate_type ----------------------------------------------
@@ -520,6 +538,7 @@ mod tests {
         let captured = CapturedRustcInvocation {
             crate_name: "thin-build-fixture".into(),
             args: s(&["src/lib.rs"]),
+            envs: Default::default(),
             timestamp_micros: 0,
         };
         let plan = build_obj_plan(&captured, Path::new("/o"));
@@ -539,6 +558,7 @@ mod tests {
             &CapturedRustcInvocation {
                 crate_name: captured.crate_name.clone(),
                 args: plan1.args.clone(),
+                envs: Default::default(),
                 timestamp_micros: 0,
             },
             Path::new("/o"),

--- a/crates/whisker-dev-server/src/hotpatch/validate.rs
+++ b/crates/whisker-dev-server/src/hotpatch/validate.rs
@@ -101,6 +101,7 @@ mod tests {
         CapturedRustcInvocation {
             crate_name: "demo".into(),
             args,
+            envs: Default::default(),
             timestamp_micros: 0,
         }
     }

--- a/crates/whisker-dev-server/src/hotpatch/wrapper.rs
+++ b/crates/whisker-dev-server/src/hotpatch/wrapper.rs
@@ -36,6 +36,13 @@ use crate::Target;
 pub struct CapturedRustcInvocation {
     pub crate_name: String,
     pub args: Vec<String>,
+    /// `CARGO_*` / `OUT_DIR` environment captured alongside the argv
+    /// (see the shim's `capture_envs_from`). Replayed on the thin
+    /// rebuild so `env!("CARGO_PKG_*")` still compiles without cargo.
+    /// `#[serde(default)]` keeps caches written by an older shim
+    /// loadable — they just replay nothing.
+    #[serde(default)]
+    pub envs: std::collections::BTreeMap<String, String>,
     pub timestamp_micros: u128,
 }
 
@@ -49,8 +56,8 @@ pub struct CapturedLinkerInvocation {
 }
 
 /// Optional linker-shim wiring for [`run_fat_build`]. Provide all
-/// three when you want the linker invocation captured (Tier 1 needs
-/// it); leave this `None` for plain Tier 2 / Tier 0 fat builds.
+/// three when you want the linker invocation captured (hot reload needs
+/// it); leave this `None` for plain non-capturing fat builds.
 #[derive(Debug, Clone)]
 pub struct LinkerCaptureConfig<'a> {
     /// Path to `whisker-linker-shim`. The shim is the value rustc sees
@@ -72,7 +79,7 @@ pub struct LinkerCaptureConfig<'a> {
 /// When `linker_capture` is `Some(_)`, the build *also* installs the
 /// linker shim by setting `RUSTFLAGS=-Clinker=<shim>` plus the
 /// shim's two env vars. The two captures (rustc-args and linker-args)
-/// then both fill up during the same fat build, and Tier 1's
+/// then both fill up during the same fat build, and hot reload's
 /// thin_rebuild_obj can replay them together.
 ///
 /// `target` is currently a hint only; the cargo command we run is the
@@ -375,6 +382,7 @@ mod tests {
                     "--target",
                     "aarch64-apple-ios-sim",
                 ]),
+                envs: Default::default(),
                 timestamp_micros: 100,
             },
         );
@@ -383,6 +391,7 @@ mod tests {
             &CapturedRustcInvocation {
                 crate_name: "podcast".into(),
                 args: s(&["--crate-name", "podcast", "--target", "x86_64-apple-ios"]),
+                envs: Default::default(),
                 timestamp_micros: 200,
             },
         );
@@ -402,6 +411,7 @@ mod tests {
             &CapturedRustcInvocation {
                 crate_name: "foo".into(),
                 args: s(&["--crate-name", "foo", "src/lib.rs"]),
+                envs: Default::default(),
                 timestamp_micros: 100,
             },
         );
@@ -410,6 +420,7 @@ mod tests {
             &CapturedRustcInvocation {
                 crate_name: "bar".into(),
                 args: s(&["--crate-name", "bar", "src/lib.rs"]),
+                envs: Default::default(),
                 timestamp_micros: 200,
             },
         );
@@ -431,6 +442,7 @@ mod tests {
             &CapturedRustcInvocation {
                 crate_name: "foo".into(),
                 args: s(&["--old-args"]),
+                envs: Default::default(),
                 timestamp_micros: 100,
             },
         );
@@ -440,6 +452,7 @@ mod tests {
             &CapturedRustcInvocation {
                 crate_name: "foo".into(),
                 args: s(&["--newer-args", "--more"]),
+                envs: Default::default(),
                 timestamp_micros: 200,
             },
         );
@@ -453,6 +466,46 @@ mod tests {
     }
 
     #[test]
+    fn load_captured_args_accepts_pre_envs_cache_files() {
+        // Cache files written by a shim from before env capture have
+        // no `envs` key — `#[serde(default)]` must let them load with
+        // an empty map instead of erroring the whole cache read.
+        let dir = unique_tempdir();
+        std::fs::write(
+            dir.join("old-1.json"),
+            r#"{ "crate_name": "old", "args": ["--crate-name", "old"], "timestamp_micros": 1 }"#,
+        )
+        .unwrap();
+
+        let map = load_captured_args(&dir, None).unwrap();
+        assert_eq!(map.len(), 1);
+        assert!(map["old"].envs.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_captured_args_round_trips_envs() {
+        let dir = unique_tempdir();
+        let mut envs = std::collections::BTreeMap::new();
+        envs.insert("CARGO_PKG_VERSION".to_string(), "0.1.0".to_string());
+        write_invocation(
+            &dir,
+            &CapturedRustcInvocation {
+                crate_name: "foo".into(),
+                args: vec![],
+                envs: envs.clone(),
+                timestamp_micros: 1,
+            },
+        );
+
+        let map = load_captured_args(&dir, None).unwrap();
+        assert_eq!(map["foo"].envs, envs);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn load_captured_args_skips_non_json_files() {
         let dir = unique_tempdir();
         std::fs::write(dir.join("README.md"), "not json").unwrap();
@@ -461,6 +514,7 @@ mod tests {
             &CapturedRustcInvocation {
                 crate_name: "foo".into(),
                 args: vec![],
+                envs: Default::default(),
                 timestamp_micros: 1,
             },
         );
@@ -481,6 +535,7 @@ mod tests {
             &CapturedRustcInvocation {
                 crate_name: "good".into(),
                 args: vec![],
+                envs: Default::default(),
                 timestamp_micros: 1,
             },
         );
@@ -502,6 +557,7 @@ mod tests {
             CapturedRustcInvocation {
                 crate_name: "x".into(),
                 args: vec![],
+                envs: Default::default(),
                 timestamp_micros: 1,
             },
         );
@@ -516,6 +572,7 @@ mod tests {
             CapturedRustcInvocation {
                 crate_name: "x".into(),
                 args: s(&["old"]),
+                envs: Default::default(),
                 timestamp_micros: 5,
             },
         );
@@ -524,6 +581,7 @@ mod tests {
             CapturedRustcInvocation {
                 crate_name: "x".into(),
                 args: s(&["new"]),
+                envs: Default::default(),
                 timestamp_micros: 10,
             },
         );
@@ -538,6 +596,7 @@ mod tests {
             CapturedRustcInvocation {
                 crate_name: "x".into(),
                 args: s(&["incumbent"]),
+                envs: Default::default(),
                 timestamp_micros: 10,
             },
         );
@@ -546,6 +605,7 @@ mod tests {
             CapturedRustcInvocation {
                 crate_name: "x".into(),
                 args: s(&["equal"]),
+                envs: Default::default(),
                 timestamp_micros: 10,
             },
         );
@@ -554,6 +614,7 @@ mod tests {
             CapturedRustcInvocation {
                 crate_name: "x".into(),
                 args: s(&["older"]),
+                envs: Default::default(),
                 timestamp_micros: 1,
             },
         );

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -1,4 +1,4 @@
-//! Tier 2 install + relaunch.
+//! full reload install + relaunch.
 //!
 //! After a successful cold-rebuild, the freshly-built artifact has to
 //! land on the target and start (re-bootstrapping the dev-runtime so
@@ -24,7 +24,7 @@ pub struct Installer {
     ios: Option<IosParams>,
     workspace_root: PathBuf,
     package: String,
-    /// Tier 1 capture shims for hot-reload. When `Some`, the
+    /// hot reload capture shims for hot-reload. When `Some`, the
     /// xcodebuild Command in [`ios_install_and_launch`] gets the
     /// `RUSTC_WORKSPACE_WRAPPER` + `CARGO_TARGET_*_LINKER` +
     /// `CARGO_TARGET_*_RUSTFLAGS` env vars set so the Step-7
@@ -40,7 +40,7 @@ pub struct Installer {
     /// with `["whisker/hot-reload"]` so the dev-runtime WebSocket
     /// client gets compiled into the user dylib — without it the app
     /// never sends its `aslr_reference` and every change falls back to
-    /// a Tier 2 cold rebuild.
+    /// a full reload.
     features: Vec<String>,
     /// Host port the dev-server's WebSocket is bound to (= the port of
     /// `Config::bind_addr`). The device must reach this exact port:
@@ -448,16 +448,16 @@ async fn ios_install_and_launch(
     // WHISKER_IOS_SPM_URL), so the old `WHISKER_IOS_RUNTIME` /
     // `WHISKER_IOS_MACROS` env injection that pointed module manifests at
     // `platforms/ios` is gone — modules no longer read it.
-    // Tier 1 capture wiring (hot-reload). Pre-Step-7 the dev-server
+    // hot reload capture wiring (hot-reload). Pre-Step-7 the dev-server
     // ran a separate `build_xcframework_with` call to prime the rustc
     // + linker capture caches before xcodebuild touched the framework.
     // Step 7's Build Phase produces the framework during xcodebuild
     // itself, so the capture envs need to ride along here — they
     // propagate xcodebuild → shell Build Phase → `whisker build-ios`
     // subprocess → cargo, where the shims actually intercept rustc +
-    // linker. Capture is opt-in (`HotPatchMode::Tier1Subsecond`); when
+    // linker. Capture is opt-in (`HotPatchMode::HotReload`); when
     // `None`, xcodebuild runs without the shims and the loop falls
-    // back to Tier 2 cold rebuilds.
+    // back to full reloads.
     if let Some(c) = capture {
         let sim_triple = "aarch64-apple-ios-sim";
         for (k, v) in whisker_build::capture_env_vars_for_triple(c, Some(sim_triple)) {
@@ -470,7 +470,7 @@ async fn ios_install_and_launch(
     // before invoking the binary. `whisker run` puts `whisker/hot-reload`
     // here so the user dylib carries the dev-runtime WebSocket client;
     // without that the app never reports `aslr_reference` and every
-    // patch falls through to a Tier 2 cold rebuild + relaunch.
+    // patch falls through to a full reload + relaunch.
     if !features.is_empty() {
         xc_cmd.env("WHISKER_FEATURES", features.join(" "));
     }

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -15,7 +15,7 @@
 //! - `builder` — translates [`Config`] into a `whisker-build`
 //!   invocation (cargo + per-platform packaging) and runs it.
 //!   Honours `RUSTC_WORKSPACE_WRAPPER` + linker shim env so the fat
-//!   build doubles as a capture pass for Tier 1.
+//!   build doubles as a capture pass for hot reload.
 //! - `installer` — for the cold-rebuild path: shells out to
 //!   `adb install` / `simctl install + launch`. Identity (bundle id,
 //!   applicationId, scheme, …) comes in flat via
@@ -28,12 +28,12 @@
 //!   `ws://<bind>/whisker-dev`. Devices dial in, send a `hello`
 //!   carrying their `subsecond::aslr_reference()`, then receive
 //!   patch envelopes.
-//! - `hotpatch` — Tier 1 implementation. Builds a thin `.o` from the
+//! - `hotpatch` — the Hot Reload implementation. Builds a thin `.o` from the
 //!   changed user crate via captured rustc args, links it into a
 //!   patch dylib with a stub-object of host-symbol jumps, ships the
 //!   resulting `subsecond_types::JumpTable` to connected clients.
 //! - `lib.rs::run` — the orchestrator: file event → `decide_action`
-//!   (Tier 1 patch vs Tier 2 rebuild) → builder/hotpatch/sender.
+//!   (hot-reload patch vs Full Reload prompt) → builder/hotpatch/sender.
 //!
 //! ## Layering
 //!
@@ -88,8 +88,11 @@ pub struct Config {
     pub package: String,
     /// Where the rebuilt artifact gets installed + launched.
     pub target: Target,
-    /// Directories to watch for source changes. Empty defaults to
-    /// `<crate_dir>/src`.
+    /// Extra paths (dirs or single files) to watch for changes, merged
+    /// with the auto-discovered roots (`<crate_dir>/src` + every
+    /// workspace path-dep's `src/`). The cli passes
+    /// `<crate_dir>/whisker.rs` here so config-script saves get a
+    /// "restart `whisker run`" hint instead of silence.
     pub watch_paths: Vec<PathBuf>,
     /// Address the WebSocket server binds.
     pub bind_addr: SocketAddr,
@@ -120,7 +123,7 @@ impl Config {
             watch_paths: Vec::new(),
             bind_addr: "127.0.0.1:9876".parse().expect("valid default addr"),
             dev_token: None,
-            hot_patch_mode: HotPatchMode::Tier2ColdRebuild,
+            hot_patch_mode: HotPatchMode::FullReloadOnly,
             android: None,
             ios: None,
         }
@@ -183,17 +186,22 @@ pub enum Target {
     IosSimulator,
 }
 
-/// How aggressive the dev loop is about reflecting edits.
+/// How the dev loop reflects edits. Note that no mode rebuilds or
+/// restarts the app automatically — a Full Reload only ever runs on
+/// an explicit [`DevCommand::FullReload`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HotPatchMode {
     /// Don't even try — every change requires a manual `whisker run` rerun.
     /// Useful for CI smoke-tests of the dev server itself.
     Disabled,
-    /// Full cargo rebuild + reinstall + relaunch (5–30s). The default.
-    Tier2ColdRebuild,
-    /// `subsecond` JumpTable patches (sub-second). Requires the I4g
-    /// pipeline to be wired up; otherwise behaves as `Tier2ColdRebuild`.
-    Tier1Subsecond,
+    /// No hot reload: every save prompts for an explicit Full Reload
+    /// (cargo rebuild + reinstall + relaunch, 5–30s). The
+    /// `--no-hot-patch` escape hatch.
+    FullReloadOnly,
+    /// Hot Reload: `subsecond` JumpTable patches (sub-second, app
+    /// keeps running). Requires the capture/patcher pipeline; when
+    /// that's unavailable the loop prompts for a Full Reload instead.
+    HotReload,
 }
 
 // ----- Public events ---------------------------------------------------------
@@ -209,7 +217,7 @@ pub enum Event {
     BuildFailed(String),
     ClientConnected,
     ClientDisconnected,
-    /// A Tier 1 hot patch build kicked off. Fires *before* the
+    /// A hot-reload patch build kicked off. Fires *before* the
     /// `Patcher::build_patch` call so consumers (the cli TUI) can
     /// flip into "patching" state while the patch is still being
     /// compiled — without this paired event, `PatchSent` is the
@@ -217,6 +225,15 @@ pub enum Event {
     /// any UI keying off it never shows a patch-in-flight indicator.
     PatchBuilding,
     PatchSent,
+    /// The loop hit a change it cannot hot-reload (dependency-graph
+    /// edit, hot-reload infrastructure unavailable, patch build
+    /// failure). Nothing was rebuilt — the user decides when to pay
+    /// for the restart by pressing `R` (Full Reload). The UI should
+    /// surface `reason` persistently until a full reload starts
+    /// (`BuildingFull` clears it).
+    FullReloadRequired {
+        reason: String,
+    },
     /// A line captured from the device-side app's stdout / stderr (via
     /// the `whisker-dev-runtime::log_capture` `dup2` hook), forwarded
     /// over the WS connection. `whisker-cli` surfaces these in the
@@ -237,11 +254,28 @@ pub enum Event {
 
 // ----- Server ---------------------------------------------------------------
 
+/// Explicit user command delivered into the dev loop (keyboard
+/// shortcuts in `whisker run`'s TUI: `r` / `R`). Reloads are
+/// user-triggered by design — the loop never full-reloads on its own,
+/// because an unexpected app restart mid-interaction loses more time
+/// than it saves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DevCommand {
+    /// Build and push a hot-reload patch now, independent of any file
+    /// change (e.g. after fixing a compile error, or to force a
+    /// re-sync).
+    HotReload,
+    /// Full reload: cargo rebuild + reinstall + relaunch. The only
+    /// way dependency-graph changes (Cargo.toml) reach the device.
+    FullReload,
+}
+
 /// The dev loop. Construct with [`DevServer::new`], then drive with
 /// [`DevServer::run`] (which returns when the server shuts down).
 pub struct DevServer {
     config: Config,
     on_event: Option<Arc<dyn Fn(Event) + Send + Sync>>,
+    commands: Option<tokio::sync::mpsc::UnboundedReceiver<DevCommand>>,
 }
 
 impl DevServer {
@@ -249,7 +283,20 @@ impl DevServer {
         Ok(Self {
             config,
             on_event: None,
+            commands: None,
         })
+    }
+
+    /// Attach the channel that delivers explicit [`DevCommand`]s
+    /// (the CLI's `r` / `R` keys). Without one, the loop is driven
+    /// by file changes only and full reloads are unreachable — fine
+    /// for tests, limiting for interactive use.
+    pub fn with_command_receiver(
+        mut self,
+        rx: tokio::sync::mpsc::UnboundedReceiver<DevCommand>,
+    ) -> Self {
+        self.commands = Some(rx);
+        self
     }
 
     /// Attach an observer for `Event`s — connect / disconnect /
@@ -260,20 +307,21 @@ impl DevServer {
         self
     }
 
-    /// Bring the dev loop up. The Tier 2 cold rebuild loop:
+    /// Bring the dev loop up. The core loop:
     ///
     ///   notify → debounce → cargo build → adb install → relaunch
     ///   → broadcast "rebuilt" hint over WebSocket.
     ///
-    /// When `hot_patch_mode == Tier1Subsecond`, the initial build
+    /// When `hot_patch_mode == HotReload`, the initial build
     /// also captures rustc + linker invocations through the
     /// `whisker-{rustc,linker}-shim` binaries, and a `Patcher` is
     /// initialised from those captures + the original binary's
-    /// symbol table. The change loop then prefers Tier 1
-    /// `subsecond::JumpTable` patches over cold rebuilds for
-    /// `ChangeKind::RustCode` events. Patcher initialisation or
-    /// `build_patch` failure falls back to Tier 2 silently.
-    pub async fn run(self) -> Result<()> {
+    /// symbol table. The change loop then serves
+    /// `ChangeKind::RustCode` events with Hot Reload
+    /// (`subsecond::JumpTable` patches). Nothing rebuilds or
+    /// restarts the app automatically: changes a patch can't express
+    /// prompt for an explicit Full Reload (`DevCommand::FullReload`).
+    pub async fn run(mut self) -> Result<()> {
         // In TUI mode the live region's header already shows the
         // package + target + phase; the `──── whisker run ────` +
         // `· podcast · Android` rows above just duplicated that
@@ -299,10 +347,10 @@ impl DevServer {
         // succeeds we bind the WS, then `install_and_launch` so the
         // device app has somewhere to connect to.
         //
-        // For Tier 1 mode this build doubles as the fat build that
+        // For hot-reload mode this build doubles as the fat build that
         // fills the rustc / linker capture caches; the shims are
         // resolved (built if missing) and installed into the builder
-        // *before* the spawn. The same Builder is reused for Tier 2
+        // *before* the spawn. The same Builder is reused for Full
         // fallback rebuilds inside the change loop.
         let mut builder = Builder::new(
             self.config.workspace_root.clone(),
@@ -312,15 +360,16 @@ impl DevServer {
         )
         .with_features(vec!["whisker/hot-reload".into()]);
 
-        let tier1_init = if self.config.hot_patch_mode == HotPatchMode::Tier1Subsecond {
-            match prepare_tier1_capture(&self.config) {
+        let hot_reload_init = if self.config.hot_patch_mode == HotPatchMode::HotReload {
+            match prepare_hot_reload_capture(&self.config) {
                 Ok(prep) => {
                     builder = builder.with_capture(prep.capture.clone());
                     Some(prep)
                 }
                 Err(e) => {
                     whisker_build::ui::warn(format!(
-                        "Tier 1 capture setup failed ({e:#}); falling back to Tier 2 cold rebuilds",
+                        "hot-reload capture setup failed ({e:#}); hot reload unavailable — \
+                         use R (Full Reload) to reflect changes",
                     ));
                     None
                 }
@@ -335,7 +384,7 @@ impl DevServer {
             self.config.ios.clone(),
             self.config.workspace_root.clone(),
             self.config.package.clone(),
-            tier1_init.as_ref().map(|p| p.capture.clone()),
+            hot_reload_init.as_ref().map(|p| p.capture.clone()),
             builder.features().to_vec(),
             self.config.bind_addr.port(),
             self.config.dev_token.clone(),
@@ -402,8 +451,8 @@ impl DevServer {
         // the change loop uses the same list to map a changed file
         // back to its owning crate. Registry / git deps are excluded
         // — their sources live outside the workspace; Cargo.toml /
-        // Cargo.lock edits trigger a Tier 2 rebuild and pick them
-        // up that way.
+        // Cargo.lock edits prompt a Full Reload, which picks them
+        // up.
         let path_deps = workspace::discover_path_deps(
             &self.config.crate_dir.join("Cargo.toml"),
             &self.config.package,
@@ -432,6 +481,20 @@ impl DevServer {
             // error to the user.
             watch_roots.push(user_src.clone());
         }
+        // Caller-specified extras (the cli passes `<crate>/src` — already
+        // covered above — plus `<crate>/whisker.rs`). Files are fine:
+        // notify watches single files too.
+        for extra in &self.config.watch_paths {
+            if extra.exists() && !watch_roots.contains(extra) {
+                watch_roots.push(extra.clone());
+            }
+        }
+        // `whisker.rs` is the config script: it's evaluated once at
+        // `whisker run` startup (probe → Config), so neither a hot
+        // reload nor a Full Reload re-applies an edit to it. Detect
+        // saves and tell the user the only fix — restarting the dev
+        // loop — instead of reacting with a doomed patch attempt.
+        let whisker_config_file = self.config.crate_dir.join("whisker.rs");
         let (tx, mut rx) = tokio::sync::mpsc::channel::<watcher::Change>(8);
         let _watcher = watcher::spawn_watcher(
             watch_roots.clone(),
@@ -463,16 +526,20 @@ impl DevServer {
 
         // After the fat build has happened, Patcher::initialize can
         // read the now-populated caches. Failure here is non-fatal
-        // — log and proceed with Tier 2 only.
-        let patcher = match tier1_init {
-            Some(prep) => match init_patcher_for(&self.config, &prep) {
+        // — log, prompt Full Reloads meanwhile, and retry the init
+        // on later changes (each Full Reload runs with the capture shims
+        // wired, so the caches that were missing or stale here may
+        // have been repopulated by the time the user saves again).
+        let mut patcher = match hot_reload_init.as_ref() {
+            Some(prep) => match init_patcher_for(&self.config, prep) {
                 Ok(p) => {
-                    whisker_build::ui::debug("Tier 1 patcher ready");
+                    whisker_build::ui::debug("hot-reload patcher ready");
                     Some(p)
                 }
                 Err(e) => {
                     whisker_build::ui::warn(format!(
-                        "Tier 1 patcher init failed ({e:#}); falling back to Tier 2 cold rebuilds",
+                        "hot-reload patcher init failed ({e:#}); \
+                         will retry on the next save — use R (Full Reload) meanwhile",
                     ));
                     None
                 }
@@ -480,125 +547,129 @@ impl DevServer {
             None => None,
         };
 
-        // Change loop. For each debounced change, decide the
-        // action (Tier 1 patch / Tier 2 rebuild / ignore) using
-        // the kind + whether we have a Patcher, then execute it.
-        // Tier 1 failures silently fall through to Tier 2 — saves
-        // the dev loop from being killed by a transient build
-        // glitch.
-        while let Some(change) = rx.recv().await {
-            // `──── Change ────` only in non-TUI mode (live
-            // region's phase flip to `building` / `patching`
-            // already announces a save has been picked up).
-            if !whisker_build::ui::is_tui() {
-                whisker_build::ui::section("Change");
+        // Command channel: `r` / `R` from the CLI. When the caller
+        // didn't attach one, park a receiver whose sender is leaked
+        // so `recv()` pends forever (a *closed* channel would return
+        // `None` immediately and spin the select).
+        let mut commands = self.commands.take().unwrap_or_else(parked_command_receiver);
+
+        // Dev loop. Two input sources: debounced file changes and
+        // explicit DevCommands (`r` Hot Reload / `R` Full Reload).
+        //
+        // Saves only ever hot-reload. Anything a patch can't express
+        // — Cargo.toml edits, multi-crate batches, missing patcher,
+        // patch build failures — *prompts* for an explicit Full
+        // Reload instead of rebuilding + restarting the app behind
+        // the user's back (an unexpected restart mid-interaction
+        // costs more than it saves). The one non-prompt failure is a
+        // compile error in the user's code (`RustcRejectedCode`): a
+        // Full Reload would fail identically, so the loop reports
+        // and waits for the next save.
+        loop {
+            enum Input {
+                Change(watcher::Change),
+                Command(DevCommand),
             }
-            whisker_build::ui::debug(format!(
-                "{:?} — {} path(s)",
-                change.kind,
-                change.paths.len(),
-            ));
-            let action = decide_action(change.kind, patcher.is_some());
-            match action {
-                LoopAction::Ignore => {
-                    whisker_build::ui::debug(format!("ignored ({:?})", change.kind));
-                }
-                LoopAction::Tier1Patch => {
-                    let p = patcher.as_ref().expect("decide_action guarantees Some");
-                    // Open the step as soon as we know we're patching;
-                    // the spinner runs across both the build + the
-                    // wire-up so the user sees a single elapsed
-                    // duration for "edit → app updated".
-                    let patch_step = whisker_build::ui::step("patch", "tier 1");
-                    // Tell the cli to flip into "patching" right now —
-                    // the patcher work that follows (`build_patch` +
-                    // dylib read + send) is the wall-clock-heavy bit,
-                    // and the matching `PatchSent` flips back to Idle.
-                    emit(&self.on_event, Event::PatchBuilding);
-                    // Map the changed file paths to the owning crate.
-                    // None = batch spans multiple crates, or a path
-                    // outside every known src dir — fall back to a
-                    // cold rebuild since we can only patch one crate
-                    // per batch.
-                    let crate_key = workspace::identify_crate_for_paths(&change.paths, &path_deps);
-                    if !path_deps.is_empty() && crate_key.is_none() {
-                        patch_step.fail("multi-crate change batch; using Tier 2");
-                        run_build_cycle(
-                            &builder,
-                            &installer,
-                            &self.on_event,
-                            &sender,
-                            "rebuild (tier2 fallback, multi-crate batch)",
-                        )
-                        .await;
+            let input = tokio::select! {
+                c = rx.recv() => match c {
+                    Some(change) => Input::Change(change),
+                    None => break,
+                },
+                c = commands.recv() => match c {
+                    Some(cmd) => Input::Command(cmd),
+                    None => {
+                        // Command side hung up — park a fresh
+                        // never-yielding receiver and keep serving
+                        // file changes.
+                        commands = parked_command_receiver();
                         continue;
                     }
-                    let Some(aslr_reference) = sender.latest_aslr_reference() else {
-                        // No client has reported its `aslr_reference` yet
-                        // (handshake hasn't completed, or never connected).
-                        // Without that value we can't build a stub-asm-style
-                        // patch — fall back to Tier 2 cold rebuild.
-                        patch_step.fail("no client aslr_reference yet; using Tier 2");
-                        run_build_cycle(
-                            &builder,
-                            &installer,
-                            &self.on_event,
-                            &sender,
-                            "rebuild (tier2 fallback, no aslr_reference)",
-                        )
-                        .await;
-                        continue;
-                    };
-                    let started = std::time::Instant::now();
-                    match p.build_patch(aslr_reference, crate_key.as_deref()).await {
-                        Ok(plan) => {
-                            let built_in = started.elapsed();
-                            log_patch_diff(&plan.report);
-                            let dylib_bytes = match read_lib_bytes(&plan.table.lib) {
-                                Ok(b) => Arc::new(b),
-                                Err(e) => {
-                                    patch_step.fail(format!(
-                                        "could not read dylib bytes ({}): {e:#}; using Tier 2",
-                                        plan.table.lib.display(),
-                                    ));
-                                    run_build_cycle(
-                                        &builder,
-                                        &installer,
-                                        &self.on_event,
-                                        &sender,
-                                        "rebuild (tier2 fallback)",
-                                    )
-                                    .await;
-                                    continue;
+                },
+            };
+            match input {
+                Input::Change(mut change) => {
+                    // `──── Change ────` only in non-TUI mode (live
+                    // region's phase flip already announces a save
+                    // has been picked up).
+                    if !whisker_build::ui::is_tui() {
+                        whisker_build::ui::section("Change");
+                    }
+                    whisker_build::ui::debug(format!(
+                        "{:?} — {} path(s)",
+                        change.kind,
+                        change.paths.len(),
+                    ));
+                    // whisker.rs first: it classifies as RustCode by
+                    // extension, but no reload of any kind re-applies
+                    // it (see `whisker_config_file` above).
+                    if change.paths.iter().any(|p| p == &whisker_config_file) {
+                        whisker_build::ui::warn(
+                            "whisker.rs changed — configuration is applied at startup; \
+                             restart `whisker run` to pick it up",
+                        );
+                        change.paths.retain(|p| p != &whisker_config_file);
+                        if change.paths.is_empty() {
+                            continue;
+                        }
+                    }
+                    if change.kind == ChangeKind::RustCode {
+                        ensure_patcher(&self.config, &hot_reload_init, &mut patcher);
+                    }
+                    match decide_action(change.kind, patcher.is_some()) {
+                        LoopAction::Ignore => {
+                            whisker_build::ui::debug(format!("ignored ({:?})", change.kind));
+                        }
+                        LoopAction::HotReload => {
+                            let p = patcher.as_ref().expect("decide_action guarantees Some");
+                            // Map the changed file paths to the owning
+                            // crate. None = batch spans multiple crates
+                            // or a path outside every known src dir —
+                            // a patch covers one crate per batch, so
+                            // that needs a Full Reload.
+                            let crate_key =
+                                workspace::identify_crate_for_paths(&change.paths, &path_deps);
+                            if !path_deps.is_empty() && crate_key.is_none() {
+                                prompt_full_reload(
+                                    &self.on_event,
+                                    "change spans multiple crates (hot reload patches \
+                                     one crate per save)",
+                                );
+                                continue;
+                            }
+                            hot_reload_cycle(p, &sender, &self.on_event, crate_key.as_deref())
+                                .await;
+                        }
+                        LoopAction::PromptFullReload => {
+                            let reason = match change.kind {
+                                ChangeKind::CargoToml => {
+                                    "Cargo.toml / Cargo.lock changed — the dependency \
+                                     graph may have moved"
                                 }
+                                _ => "hot reload unavailable (patcher not initialized)",
                             };
-                            let send_started = std::time::Instant::now();
-                            let n = sender.send(Patch {
-                                table: plan.table,
-                                dylib_bytes,
-                            });
-                            whisker_build::ui::debug(format!(
-                                "built {built_in:?} · queued {:?}",
-                                send_started.elapsed()
-                            ));
-                            patch_step.done(format!("{n} client(s)"));
-                            emit(&self.on_event, Event::PatchSent);
-                        }
-                        Err(e) => {
-                            patch_step.fail(format!("{e:#}; using Tier 2 cold rebuild"));
-                            run_build_cycle(
-                                &builder,
-                                &installer,
-                                &self.on_event,
-                                &sender,
-                                "rebuild (tier2 fallback)",
-                            )
-                            .await;
+                            prompt_full_reload(&self.on_event, reason);
                         }
                     }
                 }
-                LoopAction::Tier2Rebuild => {
-                    run_build_cycle(&builder, &installer, &self.on_event, &sender, "rebuild").await;
+                Input::Command(DevCommand::HotReload) => {
+                    if !whisker_build::ui::is_tui() {
+                        whisker_build::ui::section("Hot Reload");
+                    }
+                    ensure_patcher(&self.config, &hot_reload_init, &mut patcher);
+                    match patcher.as_ref() {
+                        Some(p) => hot_reload_cycle(p, &sender, &self.on_event, None).await,
+                        None => prompt_full_reload(
+                            &self.on_event,
+                            "hot reload unavailable (patcher not initialized)",
+                        ),
+                    }
+                }
+                Input::Command(DevCommand::FullReload) => {
+                    if !whisker_build::ui::is_tui() {
+                        whisker_build::ui::section("Full Reload");
+                    }
+                    run_build_cycle(&builder, &installer, &self.on_event, &sender, "full reload")
+                        .await;
                 }
             }
         }
@@ -611,31 +682,158 @@ impl DevServer {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoopAction {
     /// Drop on the floor — `ChangeKind::Other` doesn't warrant
-    /// either a patch or a rebuild.
+    /// either a patch or a prompt.
     Ignore,
-    /// Try a Tier 1 subsecond patch. Caller falls back to Tier 2
-    /// on Patcher error.
-    Tier1Patch,
-    /// Full cargo rebuild + reinstall + relaunch (Tier 2). Used
-    /// when the change is dependency-shaped (`Cargo.toml`) or
-    /// when no Patcher is configured.
-    Tier2Rebuild,
+    /// Build and push a hot-reload patch.
+    HotReload,
+    /// The change can't be hot-reloaded. Tell the user why and wait
+    /// for an explicit `R` (Full Reload) — never rebuild + restart
+    /// the app automatically.
+    PromptFullReload,
 }
 
-/// Pure decision helper for the change loop. Tier 1 only handles
+/// Pure decision helper for the change loop. Hot reload only handles
 /// `ChangeKind::RustCode` and only when a Patcher is available;
-/// `Cargo.toml` always needs a full rebuild because the dependency
+/// `Cargo.toml` always needs a Full Reload because the dependency
 /// graph may have shifted; everything else is ignored.
 pub fn decide_action(kind: ChangeKind, has_patcher: bool) -> LoopAction {
     match kind {
         ChangeKind::Other => LoopAction::Ignore,
-        ChangeKind::CargoToml => LoopAction::Tier2Rebuild,
-        ChangeKind::RustCode if has_patcher => LoopAction::Tier1Patch,
-        ChangeKind::RustCode => LoopAction::Tier2Rebuild,
+        ChangeKind::CargoToml => LoopAction::PromptFullReload,
+        ChangeKind::RustCode if has_patcher => LoopAction::HotReload,
+        ChangeKind::RustCode => LoopAction::PromptFullReload,
     }
 }
 
-/// Log added / removed symbols from a Tier 1 diff. Quiet when both
+/// A command receiver that never yields: fresh channel whose sender
+/// is leaked (a few bytes, once per `run`). Used when the caller
+/// attached no command channel, and after a real one hangs up —
+/// `tokio::select!` on a *closed* receiver would return `None`
+/// immediately in a hot loop.
+fn parked_command_receiver() -> tokio::sync::mpsc::UnboundedReceiver<DevCommand> {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    std::mem::forget(tx);
+    rx
+}
+
+/// Report "this change needs a Full Reload" without running one.
+/// Prints the reason + the `R` hint to the terminal and emits
+/// [`Event::FullReloadRequired`] so the TUI can keep a persistent
+/// banner up until the user acts.
+fn prompt_full_reload(on_event: &Option<Arc<dyn Fn(Event) + Send + Sync>>, reason: &str) {
+    whisker_build::ui::warn(format!("{reason} — press R to Full Reload"));
+    emit(
+        on_event,
+        Event::FullReloadRequired {
+            reason: reason.to_string(),
+        },
+    );
+}
+
+/// Late patcher init. A failed init at startup shouldn't disable hot
+/// reload for the whole session: a Full Reload runs with the capture
+/// shims wired, so the caches `init_patcher_for` reads may have been
+/// repopulated since the failure. No-op when the patcher is already
+/// up or hot reload wasn't configured.
+fn ensure_patcher(
+    config: &Config,
+    hot_reload_init: &Option<HotReloadPrep>,
+    patcher: &mut Option<hotpatch::Patcher>,
+) {
+    if patcher.is_some() {
+        return;
+    }
+    let Some(prep) = hot_reload_init.as_ref() else {
+        return;
+    };
+    match init_patcher_for(config, prep) {
+        Ok(p) => {
+            whisker_build::ui::info("hot-reload patcher ready (recovered)");
+            *patcher = Some(p);
+        }
+        Err(e) => {
+            whisker_build::ui::debug(format!("hot-reload patcher init retry failed: {e:#}"));
+        }
+    }
+}
+
+/// One hot-reload attempt: build a patch for `crate_key` (`None` =
+/// the user crate) and broadcast it to connected clients. Never
+/// falls back to a rebuild — a compile error in the user's code
+/// waits for the next save, and every infrastructure failure prompts
+/// for an explicit Full Reload.
+async fn hot_reload_cycle(
+    patcher: &hotpatch::Patcher,
+    sender: &PatchSender,
+    on_event: &Option<Arc<dyn Fn(Event) + Send + Sync>>,
+    crate_key: Option<&str>,
+) {
+    // Open the step as soon as we know we're patching; the spinner
+    // runs across both the build + the wire-up so the user sees a
+    // single elapsed duration for "edit → app updated".
+    let step = whisker_build::ui::step("hot reload", "subsecond patch");
+    // Tell the cli to flip into "reloading" right now — the patcher
+    // work that follows (`build_patch` + dylib read + send) is the
+    // wall-clock-heavy bit, and the matching `PatchSent` flips back
+    // to Idle.
+    emit(on_event, Event::PatchBuilding);
+    let Some(aslr_reference) = sender.latest_aslr_reference() else {
+        // No client has reported its `aslr_reference` yet (handshake
+        // hasn't completed, or never connected). Without that value
+        // a stub-asm-style patch can't be built.
+        step.fail("no connected device yet");
+        prompt_full_reload(
+            on_event,
+            "no device connected — a Full Reload builds, installs and launches the app",
+        );
+        return;
+    };
+    let started = std::time::Instant::now();
+    match patcher.build_patch(aslr_reference, crate_key).await {
+        Ok(plan) => {
+            let built_in = started.elapsed();
+            log_patch_diff(&plan.report);
+            let dylib_bytes = match read_lib_bytes(&plan.table.lib) {
+                Ok(b) => Arc::new(b),
+                Err(e) => {
+                    step.fail(format!(
+                        "could not read patch dylib ({}): {e:#}",
+                        plan.table.lib.display(),
+                    ));
+                    prompt_full_reload(on_event, "hot reload failed (see log above)");
+                    return;
+                }
+            };
+            let send_started = std::time::Instant::now();
+            let n = sender.send(Patch {
+                table: plan.table,
+                dylib_bytes,
+            });
+            whisker_build::ui::debug(format!(
+                "built {built_in:?} · queued {:?}",
+                send_started.elapsed()
+            ));
+            step.done(format!("{n} client(s)"));
+            emit(on_event, Event::PatchSent);
+        }
+        Err(e) if e.downcast_ref::<hotpatch::RustcRejectedCode>().is_some() => {
+            // The user's code doesn't compile. A Full Reload would
+            // fail with the exact same diagnostics after a 10-30s
+            // wait, so don't prompt for one — rustc already printed
+            // them (stderr is inherited). Report and wait for the
+            // next save.
+            let msg = "compile error — fix the code and save again";
+            step.fail(msg);
+            emit(on_event, Event::BuildFailed(msg.to_string()));
+        }
+        Err(e) => {
+            step.fail(format!("{e:#}"));
+            prompt_full_reload(on_event, "hot reload failed (see log above)");
+        }
+    }
+}
+
+/// Log added / removed symbols from a hot-reload patch diff. Quiet when both
 /// lists are empty (the common case) so the dev terminal stays
 /// readable; loud when something interesting happens (`pub fn`
 /// added or removed) so the user notices.
@@ -663,30 +861,30 @@ fn log_patch_diff(report: &hotpatch::DiffReport) {
     }
 }
 
-/// State produced by [`prepare_tier1_capture`]: enough to make the
+/// State produced by [`prepare_hot_reload_capture`]: enough to make the
 /// initial build a fat build, and to construct the patcher after the
 /// build completes.
 #[derive(Debug, Clone)]
-struct Tier1Prep {
+struct HotReloadPrep {
     capture: CaptureShims,
     real_linker: PathBuf,
 }
 
 /// Resolve shim paths (building them if missing) and assemble the
 /// CaptureShims wiring. Returns `Err` if the shim binaries can't be
-/// produced, in which case the caller falls back to Tier 2.
+/// produced, in which case hot reload is unavailable for the session.
 ///
 /// `config` carries the workspace + target + android/ios params the
 /// linker/triple pickers need:
 ///   - Android → NDK clang for `config.android.abi`.
 ///   - others → host clang via [`hotpatch::wrapper::resolve_host_linker`].
-fn prepare_tier1_capture(config: &Config) -> Result<Tier1Prep> {
+fn prepare_hot_reload_capture(config: &Config) -> Result<HotReloadPrep> {
     let shims = hotpatch::resolve_shim_paths(&config.workspace_root)?;
     let rustc_cache_dir = hotpatch::wrapper::default_cache_dir(&config.workspace_root);
     let linker_cache_dir = hotpatch::wrapper::default_linker_cache_dir(&config.workspace_root);
     let real_linker = resolve_linker_for(config)?;
     let target_triple = target_triple_for(config);
-    Ok(Tier1Prep {
+    Ok(HotReloadPrep {
         capture: CaptureShims {
             rustc_shim: shims.rustc_shim,
             linker_shim: shims.linker_shim,
@@ -759,7 +957,7 @@ fn resolve_linker_for(config: &Config) -> Result<PathBuf> {
 
 /// Construct the patcher from the captures the fat build just wrote.
 /// Splits out so [`DevServer::run`] is easier to read.
-fn init_patcher_for(config: &Config, prep: &Tier1Prep) -> Result<hotpatch::Patcher> {
+fn init_patcher_for(config: &Config, prep: &HotReloadPrep) -> Result<hotpatch::Patcher> {
     let original_binary = original_binary_path(config)?;
     hotpatch::Patcher::initialize(
         &config.workspace_root,
@@ -955,7 +1153,7 @@ mod tests {
     use std::path::Path;
 
     #[test]
-    fn config_defaults_pick_loopback_and_tier2() {
+    fn config_defaults_pick_loopback_and_full_reload_only() {
         let cfg = Config::defaults_for(
             PathBuf::from("/tmp/ws"),
             "hello-world".to_string(),
@@ -966,7 +1164,7 @@ mod tests {
         assert_eq!(cfg.target, Target::Android);
         assert_eq!(cfg.bind_addr.port(), 9876);
         assert!(cfg.bind_addr.ip().is_loopback());
-        assert_eq!(cfg.hot_patch_mode, HotPatchMode::Tier2ColdRebuild);
+        assert_eq!(cfg.hot_patch_mode, HotPatchMode::FullReloadOnly);
         assert!(cfg.watch_paths.is_empty());
     }
 
@@ -979,7 +1177,7 @@ mod tests {
     #[test]
     fn hot_patch_mode_variants_compare_by_value() {
         assert_eq!(HotPatchMode::Disabled, HotPatchMode::Disabled);
-        assert_ne!(HotPatchMode::Tier1Subsecond, HotPatchMode::Tier2ColdRebuild,);
+        assert_ne!(HotPatchMode::HotReload, HotPatchMode::FullReloadOnly,);
     }
 
     #[test]
@@ -1117,32 +1315,32 @@ mod tests {
     // ----- decide_action -----------------------------------------------
 
     #[test]
-    fn rust_code_with_patcher_chooses_tier1_patch() {
+    fn rust_code_with_patcher_chooses_hot_reload() {
         assert_eq!(
             decide_action(ChangeKind::RustCode, true),
-            LoopAction::Tier1Patch,
+            LoopAction::HotReload,
         );
     }
 
     #[test]
-    fn rust_code_without_patcher_falls_through_to_tier2_rebuild() {
+    fn rust_code_without_patcher_prompts_full_reload() {
         assert_eq!(
             decide_action(ChangeKind::RustCode, false),
-            LoopAction::Tier2Rebuild,
+            LoopAction::PromptFullReload,
         );
     }
 
     #[test]
-    fn cargo_toml_always_chooses_tier2_rebuild_even_with_patcher() {
+    fn cargo_toml_always_prompts_full_reload_even_with_patcher() {
         // Patcher can't reload deps — Cargo.toml needs a full
         // rebuild regardless of which mode we're in.
         assert_eq!(
             decide_action(ChangeKind::CargoToml, true),
-            LoopAction::Tier2Rebuild,
+            LoopAction::PromptFullReload,
         );
         assert_eq!(
             decide_action(ChangeKind::CargoToml, false),
-            LoopAction::Tier2Rebuild,
+            LoopAction::PromptFullReload,
         );
     }
 

--- a/crates/whisker-dev-server/src/server.rs
+++ b/crates/whisker-dev-server/src/server.rs
@@ -130,8 +130,8 @@ impl PatchSender {
     /// The runtime address of `main` (= `subsecond::aslr_reference()`)
     /// most recently reported by a connected client. `None` when no
     /// client has connected or sent its `hello` yet — the patcher
-    /// should withhold Tier 1 patches in that case (fall back to
-    /// Tier 2 cold rebuild).
+    /// should withhold hot-reload patches in that case (fall back to
+    /// full reload).
     pub fn latest_aslr_reference(&self) -> Option<u64> {
         self.aslr_reference.lock().ok().and_then(|g| *g)
     }
@@ -200,17 +200,23 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     let (mut tx_ws, mut rx_ws) = socket.split();
     let mut bcast_rx = state.tx.subscribe();
     whisker_build::ui::set_status(format!("{} client(s) connected", state.tx.receiver_count(),));
-    // `aslr_reference` is internal handshake plumbing; emit at debug
-    // grade so the steady-state UI stays clean.
-    if let Some(cb) = &state.on_event {
-        cb(Event::ClientConnected);
-    }
-
     // A client starts unauthenticated when a token is required, and is
     // promoted on a valid `hello`. While unauthenticated we never
     // forward a patch (the security gate). A token-less server (`None`)
     // is open by default — local loopback / tests.
     let mut authed = state.expected_token.is_none();
+
+    // Only announce clients that pass the token gate. During the
+    // initial build, a stale app from the previous session retries
+    // its (doomed) connection every few seconds — announcing each
+    // attempt makes the TUI's client count flap 0↔1 the whole build.
+    let mut announced = false;
+    if authed {
+        if let Some(cb) = &state.on_event {
+            cb(Event::ClientConnected);
+        }
+        announced = true;
+    }
 
     loop {
         tokio::select! {
@@ -254,12 +260,33 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
                             // the patch path for it.
                             if let Some(expected) = &state.expected_token {
                                 if hello.token.as_deref() != Some(expected.as_ref()) {
-                                    whisker_build::ui::warn(
-                                        "rejecting hot-reload client: missing/invalid dev token",
+                                    // Debug-only: usually an app left
+                                    // over from a previous dev session
+                                    // retrying with that session's
+                                    // token until a launch replaces
+                                    // it — expected noise, not a
+                                    // user-actionable event. The
+                                    // symptom that IS actionable (the
+                                    // *current* app being rejected)
+                                    // shows up as `0 connected` +
+                                    // "no device connected" prompts;
+                                    // WHISKER_VERBOSE=1 surfaces this
+                                    // line for that diagnosis.
+                                    whisker_build::ui::debug(
+                                        "rejected a hot-reload client (missing/invalid dev \
+                                         token) — usually an app left over from a previous \
+                                         dev session; it connects with the fresh token after \
+                                         the next launch / Full Reload (R)",
                                     );
                                     break;
                                 }
                                 authed = true;
+                                if !announced {
+                                    if let Some(cb) = &state.on_event {
+                                        cb(Event::ClientConnected);
+                                    }
+                                    announced = true;
+                                }
                             }
                             let aslr = hello.aslr_reference;
                             whisker_build::ui::debug(format!(
@@ -286,17 +313,29 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
 
     // Clear the stored `aslr_reference` on disconnect. It's the ASLR
     // slide of the *now-dead* process; reusing it to build a patch for
-    // the next process (e.g. a Tier 2 rebuild relaunch) would stamp
+    // the next process (e.g. a full reload relaunch) would stamp
     // jump stubs against meaningless addresses and crash the device.
     // The replacement process re-sends its own `hello` with a fresh
     // slide; until then `latest_aslr_reference()` returns `None` and the
     // patch path skips rather than shipping a stale-based patch.
-    if let Ok(mut g) = state.aslr_reference.lock() {
-        *g = None;
+    //
+    // Only for AUTHED sockets: a rejected client never stored a slide,
+    // and clearing here would wipe the *live* app's reference every
+    // time a stale-token app's doomed reconnect attempt bounced off
+    // the gate — leaving hot reload stuck at "no device connected"
+    // while the device is, in fact, connected.
+    if authed {
+        if let Ok(mut g) = state.aslr_reference.lock() {
+            *g = None;
+        }
     }
 
-    if let Some(cb) = &state.on_event {
-        cb(Event::ClientDisconnected);
+    // Symmetric with the announce above: only sockets that were
+    // announced as connected report a disconnect.
+    if announced {
+        if let Some(cb) = &state.on_event {
+            cb(Event::ClientDisconnected);
+        }
     }
 }
 

--- a/crates/whisker-dev-server/src/watcher.rs
+++ b/crates/whisker-dev-server/src/watcher.rs
@@ -1,7 +1,7 @@
 //! File watcher + change classifier for the dev loop.
 //!
 //! Wraps `notify` so the rest of the dev server (the builder in I4e
-//! and the Tier 1 patcher in I4g) doesn't have to deal with raw
+//! and the hot-reload patcher in I4g) doesn't have to deal with raw
 //! filesystem events. Three things happen here:
 //!
 //! 1. **Recursive watch** of a package root.
@@ -9,7 +9,7 @@
 //!    can produce 3-5 notify events on macOS (atomic rename + chmod
 //!    + …); we coalesce them into one [`Change`].
 //! 3. **Classify** the affected paths into [`ChangeKind`] so callers
-//!    can pick a rebuild strategy (Tier 2 cold rebuild for
+//!    can pick a rebuild strategy (full reload for
 //!    `RustCode`, full restart for `CargoToml`, etc).
 
 use anyhow::{Context, Result};
@@ -25,8 +25,8 @@ use tokio::sync::mpsc;
 /// (Cargo.toml beats Rust code beats anything else).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChangeKind {
-    /// `.rs` files inside the watched tree. Tier 2 cold rebuild
-    /// today; Tier 1 subsecond patch once I4g lands.
+    /// `.rs` files inside the watched tree. full reload
+    /// today; hot reload subsecond patch once I4g lands.
     RustCode,
     /// `Cargo.toml` (or `Cargo.lock`) — needs a full
     /// `cargo build` and re-launch; subsecond can't reload deps.

--- a/crates/whisker-dev-server/src/workspace.rs
+++ b/crates/whisker-dev-server/src/workspace.rs
@@ -44,7 +44,7 @@ pub struct PathDepCrate {
 /// "Path dep" = `Package.source.is_none()`. That covers workspace
 /// members and explicit `path = "..."` deps. Registry / git deps
 /// are skipped — their sources live outside the workspace and
-/// changes there would imply a `Cargo.lock` bump, which Tier 2
+/// changes there would imply a `Cargo.lock` bump, which full reload
 /// rebuild already covers.
 pub fn discover_path_deps(manifest_path: &Path, app_package: &str) -> Result<Vec<PathDepCrate>> {
     let metadata = MetadataCommand::new()
@@ -110,7 +110,7 @@ pub fn discover_path_deps(manifest_path: &Path, app_package: &str) -> Result<Vec
 /// crate name they all map to via longest-prefix match against
 /// `crates`. Returns `None` if the batch spans multiple crates or
 /// any path is outside every known src dir — the dev loop falls back
-/// to a Tier 2 cold rebuild in that case (we can patch one crate per
+/// to a full reload in that case (we can patch one crate per
 /// debounced batch, not two).
 pub fn identify_crate_for_paths(paths: &[PathBuf], crates: &[PathDepCrate]) -> Option<String> {
     let mut found: Option<&str> = None;

--- a/crates/whisker-dev-server/tests/fixtures/thin-build-fixture/src/lib.rs
+++ b/crates/whisker-dev-server/tests/fixtures/thin-build-fixture/src/lib.rs
@@ -13,7 +13,7 @@
 //!   enough that build → edit → build produces the same symbol
 //!   name on both sides so build_jump_table can match them?"
 //!   Used by the `patcher` integration test as the load-bearing
-//!   check that Tier 1 hot-patch is even possible for ordinary
+//!   check that hot-reload patch is even possible for ordinary
 //!   Rust functions.
 
 #[unsafe(no_mangle)]

--- a/crates/whisker-dev-server/tests/patcher.rs
+++ b/crates/whisker-dev-server/tests/patcher.rs
@@ -8,7 +8,7 @@
 //!      `calculate` (a mangled function) on both sides and emit a
 //!      JumpTable entry for it?"
 //!
-//! If the answer is no, Tier 1 hot-patch is impossible for any Rust
+//! If the answer is no, hot-reload patch is impossible for any Rust
 //! function that isn't `#[no_mangle]` — which is approximately every
 //! Rust function in a real Whisker app. We need to prove yes here, in
 //! isolation, before wiring Patcher into the dev loop (I4g-7).
@@ -95,6 +95,7 @@ fn captured_rustc_for_fixture(lib_rs: &Path) -> CapturedRustcInvocation {
             "--emit=link".into(),
             lib_rs.to_string_lossy().into(),
         ],
+        envs: Default::default(),
         timestamp_micros: 0,
     }
 }

--- a/crates/whisker-dev-server/tests/thin_rebuild_obj.rs
+++ b/crates/whisker-dev-server/tests/thin_rebuild_obj.rs
@@ -1,7 +1,7 @@
 //! End-to-end check that the `--emit=obj` + own-linker pipeline
 //! actually preserves mangled `pub fn` symbols in the resulting
 //! patch dylib (I4g-X2c). This is the bit cdylib couldn't give us
-//! and the load-bearing prerequisite for Tier 1 hot-patch.
+//! and the load-bearing prerequisite for hot-reload patch.
 //!
 //! Flow:
 //!   1. Build the fixture's lib.rs into an "obj" via the new
@@ -112,6 +112,7 @@ fn captured_rustc_for_fixture(lib_rs: &Path) -> CapturedRustcInvocation {
             "--emit=link".into(),
             lib_rs.to_string_lossy().into(),
         ],
+        envs: Default::default(),
         timestamp_micros: 0,
     }
 }

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -37,10 +37,13 @@
 //! ## Subsecond hot reload
 //!
 //! On every tick we first try `apply_pending_hot_patch`. If a patch
-//! landed, we run the post-patch hook which (in Strategy C, A6) will
-//! remount affected components. For now Strategy C is not wired —
-//! the patch just swaps function pointers, and unrelated reactive
-//! state stays intact.
+//! landed, `remount_components_for` disposes and re-mounts every
+//! `#[component]` whose fn pointer was rewritten, and
+//! `maybe_full_remount` escalates to a complete `app()`
+//! re-run when the per-component path can't express the change —
+//! the `app()` body itself was edited (detected via the source hash
+//! the `#[whisker::main]` macro bakes in), or the patch matched no
+//! mounted component at all.
 
 use super::renderer::BridgeRenderer;
 use std::cell::Cell;
@@ -73,13 +76,15 @@ thread_local! {
 /// signal updates fire it so the host can unpause its `CADisplayLink`
 /// (or equivalent) to schedule the next tick. May be `None` if the
 /// host runs an unconditional render loop.
-pub fn run<F>(
+pub fn run<F, H>(
     engine_raw: *mut c_void,
     request_frame: Option<extern "C" fn(*mut c_void)>,
     request_frame_data: *mut c_void,
     app_fn: F,
+    app_hash_fn: H,
 ) where
-    F: FnOnce() -> Element + 'static,
+    F: FnMut() -> Element + 'static,
+    H: Fn() -> u64 + 'static,
 {
     if engine_raw.is_null() {
         return;
@@ -92,7 +97,8 @@ pub fn run<F>(
     // Boxed init context, handed across the C ABI via raw pointer.
     let ctx = Box::new(InitCtx {
         engine: engine_raw as *mut WhiskerEngine,
-        app_fn: Some(Box::new(app_fn) as Box<dyn FnOnce() -> Element + 'static>),
+        app_fn: Some(Box::new(app_fn) as Box<dyn FnMut() -> Element + 'static>),
+        app_hash_fn: Some(Box::new(app_hash_fn) as Box<dyn Fn() -> u64 + 'static>),
         request_frame,
         request_frame_data,
     });
@@ -103,10 +109,16 @@ pub fn run<F>(
 struct InitCtx {
     engine: *mut WhiskerEngine,
     /// `Option` because we move the closure out inside `init_callback`
-    /// to call it. `FnOnce` because the user fn is invoked once at
-    /// mount; subsequent re-renders happen incrementally through the
-    /// reactive runtime, not by re-calling this fn.
-    app_fn: Option<Box<dyn FnOnce() -> Element + 'static>>,
+    /// to call it. `FnMut` (not `FnOnce`): the initial mount invokes it
+    /// once, and the hot-reload full-remount path keeps it around to re-run
+    /// `app()` from scratch when a patch changes code no `#[component]`
+    /// remount can reflect (the `app()` body itself). Release builds
+    /// still call it exactly once.
+    app_fn: Option<Box<dyn FnMut() -> Element + 'static>>,
+    /// Reads the app fn's compile-time source hash *through subsecond
+    /// dispatch* (see the `#[whisker::main]` macro), so after a patch
+    /// it reports the patch dylib's value. The full-remount trigger.
+    app_hash_fn: Option<Box<dyn Fn() -> u64 + 'static>>,
     request_frame: Option<extern "C" fn(*mut c_void)>,
     request_frame_data: *mut c_void,
 }
@@ -193,7 +205,10 @@ extern "C" fn init_callback(user_data: *mut c_void) {
 
     // Run the user's app fn (already-`subsecond::call`-wrapped by
     // the macro when the `hot-reload` feature is on).
-    let Some(app_fn) = ctx.app_fn.take() else {
+    let Some(mut app_fn) = ctx.app_fn.take() else {
+        return;
+    };
+    let Some(app_hash_fn) = ctx.app_hash_fn.take() else {
         return;
     };
 
@@ -204,8 +219,10 @@ extern "C" fn init_callback(user_data: *mut c_void) {
     // `use_context::<T>().expect(...)` then panics across this `extern
     // "C"` boundary (aborting on Android, blank-screening on iOS). The
     // owner is a *detached root*: it lives for the process lifetime and
-    // is never disposed, so the contexts / signals / effects the app
-    // creates persist for the whole session.
+    // is never disposed. What the app run creates attaches to a child
+    // "run owner" instead — that one IS disposable, which is what lets
+    // the hot reload full remount tear down one app() run (contexts,
+    // signals, effects and all) and start another.
     let root_owner = whisker_runtime::reactive::Owner::detached_root();
     root_owner.with(|| {
         // Whisker owns the root `page`. Lynx requires the shell's root to
@@ -224,7 +241,12 @@ extern "C" fn init_callback(user_data: *mut c_void) {
             page,
             "display:flex;flex-direction:column;flex-grow:1;flex-shrink:1;",
         );
-        let content = app_fn();
+        // Per-run owner: everything one `app()` invocation creates
+        // (top-level contexts included) hangs off this, so a hot reload
+        // full remount can dispose it wholesale without touching the
+        // root owner or the page.
+        let run_owner = whisker_runtime::reactive::Owner::new(None);
+        let content = run_owner.with(&mut app_fn);
         append_child(page, content);
         // Commit the initial tree: mark the page as root and ask Lynx
         // to run the first layout+paint pass.
@@ -234,6 +256,9 @@ extern "C" fn init_callback(user_data: *mut c_void) {
         // to happen after the renderer flush so user-side code that asks
         // "is my view in the tree?" sees it.
         reactive_flush_mounts();
+        // Stash what the full-remount path needs. No-op
+        // without the hot-reload feature (the closures are dropped).
+        store_hot_app_state(app_fn, app_hash_fn, page, run_owner);
     });
 
     start_hot_reload_receiver();
@@ -323,6 +348,130 @@ fn apply_pending_hot_patch() -> Vec<*const ()> {
 fn apply_pending_hot_patch() -> Vec<*const ()> {
     Vec::new()
 }
+
+/// Everything the full-remount path needs to re-run `app()`
+/// from scratch. Lives in a TASM-thread-local because both writers
+/// (`init_callback`, `maybe_full_remount`) run on that thread only.
+#[cfg(feature = "hot-reload")]
+struct HotAppState {
+    app_fn: Box<dyn FnMut() -> Element + 'static>,
+    app_hash_fn: Box<dyn Fn() -> u64 + 'static>,
+    /// The stable root page — never recreated (Lynx keeps the shell
+    /// root fixed); full remount swaps its children only.
+    page: Element,
+    /// Owner of the current `app()` run. Disposed and replaced on
+    /// full remount, cascading cleanup through every context /
+    /// signal / component owner the run created.
+    run_owner: whisker_runtime::reactive::Owner,
+    /// App-body source hash as of the last (re)run, read through
+    /// subsecond dispatch. Compared after each patch.
+    last_hash: u64,
+}
+
+#[cfg(feature = "hot-reload")]
+thread_local! {
+    static HOT_APP: std::cell::RefCell<Option<HotAppState>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(feature = "hot-reload")]
+fn store_hot_app_state(
+    app_fn: Box<dyn FnMut() -> Element + 'static>,
+    app_hash_fn: Box<dyn Fn() -> u64 + 'static>,
+    page: Element,
+    run_owner: whisker_runtime::reactive::Owner,
+) {
+    let last_hash = app_hash_fn();
+    HOT_APP.with(|slot| {
+        *slot.borrow_mut() = Some(HotAppState {
+            app_fn,
+            app_hash_fn,
+            page,
+            run_owner,
+            last_hash,
+        });
+    });
+}
+
+#[cfg(not(feature = "hot-reload"))]
+fn store_hot_app_state(
+    _app_fn: Box<dyn FnMut() -> Element + 'static>,
+    _app_hash_fn: Box<dyn Fn() -> u64 + 'static>,
+    _page: Element,
+    _run_owner: whisker_runtime::reactive::Owner,
+) {
+}
+
+/// Full-remount escalation (still hot reload). Escalates a just-applied patch to a
+/// complete `app()` re-run when the per-component remount path can't
+/// express it:
+///
+/// - **`app()` body changed** — its source hash (read through
+///   subsecond dispatch, so this sees the patch's value) differs
+///   from the last run's. `#[component]` remounts re-run component
+///   bodies, never `app()` itself, so top-level wiring edits
+///   (`provide_context` values, which root component is mounted,
+///   page-level layout) would otherwise apply-but-not-render.
+/// - **Props layout changed** — `remount_components_for` refused one
+///   or more sites because their stored body closures were built
+///   against a different props signature than the patched code
+///   expects. Only a from-scratch rebuild (fresh `app()` run, all
+///   props constructed by patched code) is safe.
+/// - **Nothing remounted** — the patch matched no attached mount
+///   site. Happens when the app has no top-level `#[component]`
+///   (everything inline in `app()`) or when prior teardown left only
+///   orphaned sites; without escalation the patch is applied but
+///   invisible.
+///
+/// All state is lost by design — this is still sub-second and keeps
+/// the process (and the dev-session socket) alive, unlike a full reload
+/// reinstall.
+#[cfg(feature = "hot-reload")]
+fn maybe_full_remount(stats: whisker_runtime::reactive::RemountStats) {
+    HOT_APP.with(|slot| {
+        let mut guard = slot.borrow_mut();
+        let Some(state) = guard.as_mut() else {
+            return;
+        };
+        let new_hash = (state.app_hash_fn)();
+        let app_changed = new_hash != state.last_hash;
+        let reason = if app_changed {
+            "app() body changed"
+        } else if stats.layout_changed > 0 {
+            "props layout changed"
+        } else if stats.remounted == 0 {
+            "patch matched no mounted component"
+        } else {
+            return;
+        };
+        whisker_dev_runtime::devlog(&format!("full remount ({reason})"));
+        state.last_hash = new_hash;
+
+        // Detach the old content BEFORE disposing its owners.
+        // `Owner::dispose` invalidates element handles (renderer slot
+        // → `None`), and removing an already-invalidated child
+        // silently no-ops against Lynx — the stale subtree would stay
+        // on screen. Same ordering rule as the batched path in
+        // `remount_components_for`.
+        let old_children = whisker_runtime::view::children_of(state.page);
+        for child in &old_children {
+            whisker_runtime::view::remove_child(state.page, *child);
+        }
+        state.run_owner.dispose();
+
+        let run_owner = whisker_runtime::reactive::Owner::new(None);
+        let content = run_owner.with(|| (state.app_fn)());
+        append_child(state.page, content);
+        state.run_owner = run_owner;
+        // No flush here: the caller is `tick_frame`, whose tail
+        // (reactive_flush → flush_mounts → renderer_flush) paints the
+        // new tree and fires its on_mount callbacks in this same
+        // frame — identical to how per-component remounts land.
+    });
+}
+
+#[cfg(not(feature = "hot-reload"))]
+fn maybe_full_remount(_stats: whisker_runtime::reactive::RemountStats) {}
 
 /// Process one frame on demand. Returns `true` when the runtime is
 /// idle after this tick so the host can pause its render loop until the
@@ -442,8 +591,15 @@ fn tick_frame() {
         // changes (new elements, new signals) reflect in the
         // visible tree. State local to the remounted component is
         // lost; state held in context / above the remount point
-        // survives.
-        remount_components_for(&patched);
+        // survives. Sites whose props layout changed are refused
+        // here (re-running their stored closures would be UB) and
+        // reported through `stats.layout_changed`.
+        let stats = remount_components_for(&patched);
+        // Full-remount escalation: escalate to a full `app()` re-run when the
+        // per-component path can't express this patch (app() body
+        // edited, props layout changed, or no mounted component
+        // matched).
+        maybe_full_remount(stats);
     }
     // Dispatch core-originated events (`<list>` scroll family) queued
     // since the last frame — before the reactive flush, so handler

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -169,6 +169,54 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         })
         .collect();
 
+    // Force the subsecond-dispatched inner closure to capture EVERY
+    // prop, not just the ones `#block` happens to reference. A `move`
+    // closure captures each path it mentions by value, so touching
+    // all props here pins the closure's environment layout to the
+    // props signature alone. Without this, an edit that merely
+    // *starts using* a previously-unused prop changes the capture
+    // set — and a hot-patched body would then read the old (smaller)
+    // environment through the new layout: garbage props / UB. With
+    // it, the layout moves only when the props signature moves,
+    // which is exactly what `__whisker_props_hash` below detects.
+    let force_capture = if prop_idents.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            #[allow(unused, clippy::no_effect_underscore_binding)]
+            let _ = ( #( &#prop_idents, )* );
+        }
+    };
+
+    // Layout hash: FNV-1a over the props signature tokens (ident +
+    // type, declaration order) — the compile-time part of what
+    // determines the inner closure's captured-environment layout
+    // given the forced capture above. The generated
+    // `__whisker_props_hash` fn additionally folds in each prop
+    // type's `size_of`/`align_of` AT ITS OWN BUILD's notion of the
+    // type, so a change to a prop type's *definition* (fields added
+    // to a struct the signature merely names) also shifts the value.
+    // Read through subsecond dispatch at remount time, so the
+    // runtime can compare "layout this site's stored closure was
+    // built for" against "layout the freshly patched code expects"
+    // and refuse the in-place remount on mismatch.
+    let props_sig = props
+        .iter()
+        .map(|p| {
+            let i = &p.ident;
+            let t = &p.ty;
+            quote!(#i : #t).to_string()
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let props_hash = crate::fnv1a64(&props_sig);
+    let prop_tys: Vec<syn::Type> = props.iter().map(|p| p.ty.clone()).collect();
+    let props_hash_fn_expr = if ty_generics_for_turbofish.is_empty() {
+        quote! { __whisker_props_hash }
+    } else {
+        quote! { __whisker_props_hash :: < #(#ty_generics_for_turbofish),* > }
+    };
+
     // `<fn>` for the `as *const ()` cast inside the body.
     //
     // Non-generic case: bare `fn_name as *const ()` works — there's
@@ -289,6 +337,27 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         #[doc(hidden)]
         mod #inner_mod {
             use super::*;
+
+            // Props-layout hash (see the macro-side comment on
+            // `props_sig`). Read through `__hot::call_hash` so a
+            // just-applied patch answers with ITS layout. The
+            // size_of/align_of folds evaluate in whichever build
+            // this fn was compiled into — that's what lets a
+            // prop-type *definition* change (same signature tokens,
+            // different struct fields) shift the patch's value.
+            #[doc(hidden)]
+            pub fn __whisker_props_hash #impl_generics () -> u64 #where_clause {
+                let mut __h: u64 = #props_hash;
+                #(
+                    __h = __h
+                        .wrapping_mul(0x0000_0100_0000_01B3)
+                        .wrapping_add(::std::mem::size_of::<#prop_tys>() as u64)
+                        .wrapping_mul(0x0000_0100_0000_01B3)
+                        .wrapping_add(::std::mem::align_of::<#prop_tys>() as u64);
+                )*
+                __h
+            }
+
             #[doc(hidden)]
             #(#attrs)*
             pub fn #fn_name #impl_generics (
@@ -306,12 +375,16 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
                 > = ::std::boxed::Box::new(move || {
                     #(#restores)*
                     ::whisker::__hot::call(move || {
+                        #force_capture
                         #block
                     })
                 });
                 ::whisker::runtime::reactive::mount_component_remountable(
                     #fn_ptr_expr,
                     __body,
+                    ::std::boxed::Box::new(|| {
+                        ::whisker::__hot::call_hash(#props_hash_fn_expr)
+                    }),
                 )
             }
         }

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -65,6 +65,17 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as ItemFn);
     let fn_name = &func.sig.ident;
 
+    // Deterministic hash of the app fn's token stream. Baked into a
+    // generated fn below so the hot-reload runtime can ask "did the
+    // `app()` source change in this patch?" — the host binary and a
+    // patch dylib each carry the hash of the source they were built
+    // from, and the runtime reads the patch's value through the same
+    // subsecond dispatch as the app body itself. FNV-1a over the
+    // token string: stable across compilations of identical tokens
+    // (unlike `DefaultHasher`'s unspecified algorithm), and token-
+    // level means formatting-only edits don't shift it.
+    let body_hash = fnv1a64(&quote!(#func).to_string());
+
     let expanded = quote! {
         #func
 
@@ -72,12 +83,30 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         // routes through `whisker::__main_runtime::call_user_app`, which
         // is `#[inline(always)]` so the wrapper body lands in the user
         // crate's compilation unit. Whether the wrapper actually
-        // dispatches through `subsecond::call` (Tier 1 / hot-reload
+        // dispatches through `subsecond::call` (hot reload / hot-reload
         // on) or just invokes `#fn_name()` directly (release) is
         // decided by `whisker`'s own `hot-reload` feature flag — the
         // user crate doesn't need a matching feature of its own.
         fn __whisker_app_dispatch() -> ::whisker::runtime::view::Element {
             ::whisker::__main_runtime::call_user_app(#fn_name)
+        }
+
+        // Source-hash pair for the full-remount trigger. The
+        // inner fn returns the compile-time hash of the `app` fn's
+        // tokens; the dispatch wrapper routes through
+        // `call_app_hash` (subsecond `call` when hot-reload is on),
+        // so after a patch the runtime reads the *patch dylib's*
+        // hash. A changed value means the user edited `app()` itself
+        // — something no `#[component]` remount can reflect — and
+        // the bootstrap re-runs `app()` from scratch.
+        #[doc(hidden)]
+        fn __whisker_app_body_hash() -> u64 {
+            #body_hash
+        }
+
+        #[doc(hidden)]
+        fn __whisker_app_hash_dispatch() -> u64 {
+            ::whisker::__main_runtime::call_app_hash(__whisker_app_body_hash)
         }
 
         // `#[unsafe(no_mangle)]` (not bare `#[no_mangle]`): in edition
@@ -99,6 +128,7 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 request_frame,
                 request_frame_data,
                 __whisker_app_dispatch,
+                __whisker_app_hash_dispatch,
             );
         }
 
@@ -132,6 +162,22 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     expanded.into()
+}
+
+/// FNV-1a 64-bit over a string. Used for the `#[whisker::main]`
+/// app-body hash and the `#[component]` props-layout hash: must
+/// produce the same value for the same token string in every rustc
+/// process (host fat build AND thin patch build), which rules out
+/// `DefaultHasher` (algorithm unspecified).
+pub(crate) fn fnv1a64(s: &str) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01B3;
+    let mut h = FNV_OFFSET;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    h
 }
 
 /// Fine-grained renderer macro. Emits imperative element-creation

--- a/crates/whisker-runtime/src/host_wake.rs
+++ b/crates/whisker-runtime/src/host_wake.rs
@@ -6,7 +6,7 @@
 //! - [`crate::reactive::scheduler`] calls [`wake_runtime`] on the
 //!   empty→non-empty edge of the pending queue so the host wakes
 //!   up to drain effects.
-//! - [`crate::whisker_dev_runtime`] (Tier 1 hot-reload receiver)
+//! - [`crate::whisker_dev_runtime`] (hot-reload receiver)
 //!   calls [`wake_runtime`] from its WebSocket thread after parking
 //!   a patch, so the host runs another tick that picks the patch
 //!   up.

--- a/crates/whisker-runtime/src/reactive/component.rs
+++ b/crates/whisker-runtime/src/reactive/component.rs
@@ -214,6 +214,18 @@ pub(crate) struct MountSite {
     /// was the first child of parent. Stable across remounts unless
     /// the anchor itself is removed by some other code path.
     pub anchor: Option<Element>,
+    /// Reads the component's props-layout hash *through subsecond
+    /// dispatch* (the `#[component]` macro bakes the hash of the
+    /// props signature into a generated fn). After a patch this
+    /// returns the patch dylib's value.
+    pub props_hash_fn: Rc<dyn Fn() -> u64 + 'static>,
+    /// The layout hash as of when this site's `body` closure was
+    /// created. If `props_hash_fn()` disagrees after a patch, the
+    /// stored closure's captured environment no longer matches what
+    /// the patched body code expects — re-running it would transmute
+    /// across mismatched layouts (garbage props / UB), so the site
+    /// must not be remounted in place.
+    pub props_hash: u64,
 }
 
 /// Called by `view::append_child` after every successful attach.
@@ -272,11 +284,23 @@ pub fn __reset_pending_mount_for_tests() {
 /// re-invokes `body` in a new owner, removes the old body_root
 /// from its parent, and inserts the new body_root at the same slot
 /// (using the recorded anchor).
-pub fn mount_component_remountable<F>(fn_ptr: *const (), body: F) -> Element
+///
+/// `props_hash_fn` reads the component's props-layout hash through
+/// subsecond dispatch (see [`MountSite::props_hash_fn`]); the value
+/// it returns *now* is recorded as the layout this site's `body`
+/// closure was built against. Non-hot-reload callers (tests) can
+/// pass `Box::new(|| 0)`.
+pub fn mount_component_remountable<F>(
+    fn_ptr: *const (),
+    body: F,
+    props_hash_fn: Box<dyn Fn() -> u64 + 'static>,
+) -> Element
 where
     F: Fn() -> Element + 'static,
 {
     let body: Rc<dyn Fn() -> Element + 'static> = Rc::new(body);
+    let props_hash_fn: Rc<dyn Fn() -> u64 + 'static> = Rc::from(props_hash_fn);
+    let props_hash = props_hash_fn();
 
     // Initial mount: fresh owner, run body, capture root.
     let body_for_first = body.clone();
@@ -306,6 +330,8 @@ where
                 body_root: Some(body_root),
                 parent: None,
                 anchor: None,
+                props_hash_fn,
+                props_hash,
             },
         );
         rt.fn_ptr_mounts.entry(fn_ptr).or_default().push(id);
@@ -338,9 +364,16 @@ where
 /// The wrapper element stays put in the parent's child list across
 /// the whole flow, so the user-visible navigation / scroll position
 /// / sibling order are preserved.
-pub fn remount_components_for(patched_fns: &[*const ()]) {
+///
+/// Returns [`RemountStats`]: how many sites were remounted, and how
+/// many were *refused* because their props layout changed. The
+/// bootstrap uses both as full-remount triggers (hot reload escalation) —
+/// `remounted == 0` means the patch had no attached component to
+/// reflect through, and `layout_changed > 0` means at least one
+/// stored body closure can no longer be re-run safely.
+pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
     if patched_fns.is_empty() {
-        return;
+        return RemountStats::default();
     }
     // Collect candidate mount sites, then filter out any whose
     // ancestor component is also in this patch batch. When a
@@ -389,7 +422,7 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
     });
 
     if ids.is_empty() {
-        return;
+        return RemountStats::default();
     }
 
     // ---- Batched remount that preserves sibling order ---------------------
@@ -423,6 +456,8 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
         old_body_root: Element,
         body: Rc<dyn Fn() -> Element + 'static>,
         fn_ptr: *const (),
+        props_hash_fn: Rc<dyn Fn() -> u64 + 'static>,
+        props_hash: u64,
     }
 
     let infos: Vec<RemountInfo> = with_runtime(|rt| {
@@ -435,13 +470,36 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
                     old_body_root: site.body_root?,
                     body: site.body.clone(),
                     fn_ptr: site.fn_ptr,
+                    props_hash_fn: site.props_hash_fn.clone(),
+                    props_hash: site.props_hash,
                 })
             })
             .collect()
     });
 
+    // Layout gate: refuse to re-run a stored body closure whose
+    // captured environment no longer matches what the patched body
+    // code expects. The site's `body` was created against
+    // `props_hash`; `props_hash_fn()` dispatches into the freshly
+    // applied patch and returns the layout the *new* code was
+    // compiled for. A mismatch means the patch changed the
+    // component's props signature — re-invoking the old closure
+    // would transmute mismatched capture layouts (garbage props /
+    // UB). The caller escalates these to a hot reload full remount,
+    // where fresh (patched) code rebuilds the props from scratch.
+    // Evaluated OUTSIDE `with_runtime`: the hash getter re-enters
+    // subsecond dispatch, which must not run under the runtime
+    // borrow.
+    let (infos, layout_changed): (Vec<RemountInfo>, Vec<RemountInfo>) = infos
+        .into_iter()
+        .partition(|info| (info.props_hash_fn)() == info.props_hash);
+    let layout_changed = layout_changed.len();
+
     if infos.is_empty() {
-        return;
+        return RemountStats {
+            remounted: 0,
+            layout_changed,
+        };
     }
 
     // 1. Snapshot each unique parent's child list.
@@ -577,4 +635,23 @@ pub fn remount_components_for(patched_fns: &[*const ()]) {
             }
         });
     }
+
+    RemountStats {
+        remounted: results.len(),
+        layout_changed,
+    }
+}
+
+/// What [`remount_components_for`] did with one patch — the
+/// bootstrap's full-remount escalation input.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RemountStats {
+    /// Mount sites disposed and re-mounted in place.
+    pub remounted: usize,
+    /// Mount sites *refused* because their props layout changed
+    /// between the stored body closure and the patched code (see
+    /// [`MountSite::props_hash`]). Non-zero means the on-screen
+    /// subtree for those sites is stale and only a full remount can
+    /// safely rebuild it.
+    pub layout_changed: usize,
 }

--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -54,7 +54,7 @@ pub use arc_signal::{ArcReadSignal, ArcRwSignal, ArcWriteSignal, arc_signal};
 #[doc(hidden)]
 pub use component::__reset_pending_mount_for_tests;
 pub use component::{
-    MountId, flush_mounts, mount_component, mount_component_remountable,
+    MountId, RemountStats, flush_mounts, mount_component, mount_component_remountable,
     on_component_root_attached, on_mount, owners_for_fn, remount_components_for, unmount_component,
 };
 pub use computed::computed;

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -960,16 +960,109 @@ fn mount_component_remountable_body_runs_with_no_tracker_when_invoked_inside_eff
         let observed_inner = observed_clone.clone();
         // Component body must return an Element. A phantom element
         // is fine — we're not asserting on the tree shape here.
-        let _root = mount_component_remountable(0x2345_6789 as *const (), move || {
-            *observed_inner.borrow_mut() = Some(observed_tracker());
-            create_phantom_element()
-        });
+        let _root = mount_component_remountable(
+            0x2345_6789 as *const (),
+            move || {
+                *observed_inner.borrow_mut() = Some(observed_tracker());
+                create_phantom_element()
+            },
+            Box::new(|| 0),
+        );
     });
     assert_eq!(
         *observed.borrow(),
         Some(None),
         "mount_component_remountable body must run with no tracker"
     );
+}
+
+#[test]
+fn remount_components_for_reports_zero_when_nothing_can_reflect() {
+    // The return value is the full-remount trigger:
+    // `remounted == 0` must mean "this patch had no attached
+    // component to reflect through". Three shapes of zero:
+    use super::component::{RemountStats, mount_component_remountable, remount_components_for};
+    use crate::view::create_phantom_element;
+    fresh();
+
+    // (a) empty patch list — nothing to do.
+    assert_eq!(remount_components_for(&[]), RemountStats::default());
+
+    // (b) patched fns that match no registered mount site.
+    assert_eq!(
+        remount_components_for(&[0xdead_beef as *const ()]),
+        RemountStats::default(),
+    );
+
+    // (c) a matching site whose body_root was never attached to a
+    // parent (orphan) — the candidate is found but filtered out.
+    // Orphans don't count as layout_changed either: their stored
+    // closures never re-run, so there's nothing to protect.
+    let fn_ptr = 0x3456_789a as *const ();
+    let _root = mount_component_remountable(fn_ptr, create_phantom_element, Box::new(|| 0));
+    assert_eq!(remount_components_for(&[fn_ptr]), RemountStats::default());
+}
+
+#[test]
+fn remount_components_for_refuses_sites_whose_props_layout_changed() {
+    // A site's stored body closure was built against the props
+    // layout its hash getter reported at mount time. If the getter
+    // reports a different value at remount time (after a patch, it
+    // dispatches into the new dylib), re-running the stored closure
+    // would transmute mismatched capture layouts — the site must be
+    // counted in `layout_changed` and NOT remounted.
+    use super::component::{
+        RemountStats, mount_component_remountable, on_component_root_attached,
+        remount_components_for,
+    };
+    use crate::view::{append_child, create_phantom_element};
+    use std::cell::Cell;
+    fresh();
+
+    thread_local! {
+        static CURRENT_LAYOUT: Cell<u64> = const { Cell::new(1) };
+    }
+    CURRENT_LAYOUT.with(|c| c.set(1));
+
+    let fn_ptr = 0x4567_89ab as *const ();
+    let runs = Rc::new(Cell::new(0_usize));
+    let runs_clone = runs.clone();
+    let root = mount_component_remountable(
+        fn_ptr,
+        move || {
+            runs_clone.set(runs_clone.get() + 1);
+            create_phantom_element()
+        },
+        Box::new(|| CURRENT_LAYOUT.with(|c| c.get())),
+    );
+    assert_eq!(runs.get(), 1, "initial mount runs the body once");
+
+    // Attach the body root so the site has a parent (otherwise the
+    // orphan filter short-circuits before the layout gate).
+    let parent = create_phantom_element();
+    append_child(parent, root);
+    on_component_root_attached(parent, root);
+
+    // Same layout → normal in-place remount.
+    assert_eq!(
+        remount_components_for(&[fn_ptr]),
+        RemountStats {
+            remounted: 1,
+            layout_changed: 0,
+        },
+    );
+    assert_eq!(runs.get(), 2, "in-place remount re-ran the body");
+
+    // "Patch" changes the layout hash → the site must be refused.
+    CURRENT_LAYOUT.with(|c| c.set(2));
+    assert_eq!(
+        remount_components_for(&[fn_ptr]),
+        RemountStats {
+            remounted: 0,
+            layout_changed: 1,
+        },
+    );
+    assert_eq!(runs.get(), 2, "refused remount must NOT re-run the body");
 }
 
 // Note: `remount_components_for`'s body invocation reuses the

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -1722,7 +1722,7 @@ pub mod __main_runtime {
     /// The cfg flip happens here, at whisker's compile-time, on whisker's
     /// own `hot-reload` feature:
     ///
-    /// - **on** (`whisker run` / Tier 1): body is
+    /// - **on** (`whisker run` / hot reload): body is
     ///   `subsecond::call(|| f())`. The `#[inline(always)]` makes the
     ///   body land in the *user crate's* compilation unit at every
     ///   call site, so the wrapper closure's `<F as HotFunction<()>>::
@@ -1760,6 +1760,29 @@ pub mod __main_runtime {
     pub fn call_user_app(f: fn() -> Element) -> Element {
         f()
     }
+
+    /// Same dispatch shape as [`call_user_app`], for the
+    /// `__whisker_app_body_hash` fn the `#[whisker::main]` macro
+    /// emits. Routing the hash read through `subsecond::call` means
+    /// that after a patch is applied, this returns the hash baked
+    /// into the *patch dylib* — a changed value is the full-remount
+    /// signal that `app()` itself was edited and needs a full
+    /// re-run. The `move` and `#[inline(always)]` are load-bearing
+    /// for the same reasons documented on `call_user_app`.
+    #[cfg(feature = "hot-reload")]
+    #[inline(always)]
+    pub fn call_app_hash(f: fn() -> u64) -> u64 {
+        #[allow(clippy::redundant_closure)]
+        {
+            ::subsecond::call(move || f())
+        }
+    }
+
+    #[cfg(not(feature = "hot-reload"))]
+    #[inline(always)]
+    pub fn call_app_hash(f: fn() -> u64) -> u64 {
+        f()
+    }
 }
 
 /// Hot-reload dispatcher namespace exposed for the `#[component]`
@@ -1785,6 +1808,27 @@ pub mod __hot {
     #[cfg(not(feature = "hot-reload"))]
     #[inline(always)]
     pub fn call<O>(mut f: impl FnMut() -> O) -> O {
+        f()
+    }
+
+    /// Dispatch a `#[component]`-generated props-layout-hash fn
+    /// through subsecond, so after a patch the caller reads the
+    /// *patch dylib's* hash. Same 8-byte fn-pointer-capture shape as
+    /// `__main_runtime::call_user_app` — the `move` and
+    /// `#[inline(always)]` are load-bearing for the same reasons
+    /// documented there.
+    #[cfg(feature = "hot-reload")]
+    #[inline(always)]
+    pub fn call_hash(f: fn() -> u64) -> u64 {
+        #[allow(clippy::redundant_closure)]
+        {
+            ::subsecond::call(move || f())
+        }
+    }
+
+    #[cfg(not(feature = "hot-reload"))]
+    #[inline(always)]
+    pub fn call_hash(f: fn() -> u64) -> u64 {
         f()
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,8 @@ Whisker itself**.
 - [`reactivity-design.md`](reactivity-design.md) — the design and
   rationale of the fine-grained reactive runtime (signals, effects,
   the owner/scope tree, batching).
-- [`hot-reload-internals.md`](hot-reload-internals.md) — how the Tier 1
-  (subsecond) and Tier 2 (cold rebuild) hot-reload pipelines actually
+- [`hot-reload-internals.md`](hot-reload-internals.md) — how Hot Reload
+  (subsecond patching) and Full Reload (cold rebuild) actually
   work, end to end.
 - [`module-api-design.md`](module-api-design.md) — how to choose the
   user-facing surface shape for a new `whisker-*` module crate. Read

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ runs on iOS and Android by driving Lynx's element tree directly.
         │
         ▼
    whisker-dev-server  — the dev loop: file-watch → whisker-build →
-                         install/launch + Tier-1 subsecond patches +
+                         install/launch + subsecond hot-reload patches +
                          WebSocket push. Manifest-agnostic (flat Config).
         │
         ▼
@@ -82,7 +82,7 @@ runs on iOS and Android by driving Lynx's element tree directly.
 | `whisker-dev-runtime` | App-side WebSocket receiver + log capture for hot patches. **Compiled only with `hot-reload`** — release builds drop it entirely. | `whisker-driver` (feature-gated) |
 | `whisker-macros` | `#[whisker::main]`, `#[component]`, `#[module_component]`, and the `render!` DSL. | `whisker` |
 | `whisker-cli` | The `whisker` / `cargo-whisker` binary: `run`, `doctor`, `new`, `new-module`. Resolves Config via the `whisker.rs` probe; hands a flat Config to dev-server. | (binary) |
-| `whisker-dev-server` | Host dev loop, manifest-agnostic. Owns watch → build → install → Tier-1 patch → WebSocket push. | `whisker-cli` |
+| `whisker-dev-server` | Host dev loop, manifest-agnostic. Owns watch → build → install → hot-reload patch → WebSocket push. | `whisker-cli` |
 | `whisker-build` | Lynx artifact fetch, cargo cross-compile, AAR/xcframework packaging. | `whisker-dev-server` |
 | `whisker-cng` | Continuous Native Generation: pure renderer of `gen/{android,ios}/` from Config, fingerprint-gated. No CLI surface, no side effects. | `whisker-cli` |
 | `whisker-plugin` | CNG plugin surface: `Plugin` trait, IR types, JSON envelope, subprocess runner shared by the engine and 3rd-party plugin binaries. | `whisker-cng`, 3rd-party plugins |
@@ -177,12 +177,12 @@ materialise `gen/{android,ios}/`, then hands a flat `Config` to
         │
         ▼
   decide_action
-   ├── Tier 1 (RustCode, hot-patch on): build a thin patch dylib from
+   ├── Hot Reload (RustCode, on save): build a thin patch dylib from
    │   the changed user crate (captured rustc + linker args + a host-
    │   symbol jump stub), parse it into a subsecond JumpTable, push it
    │   over the WebSocket to connected devices. ~½–1 s on a small app.
    │
-   └── Tier 2 (Cargo.toml change, structural edit, or no hot-patch):
+   └── Full Reload (explicit `R` only; Cargo.toml changes prompt for it):
        full whisker-build (cargo cross-compile + per-platform package)
        → install/launch via adb / simctl.
 ```

--- a/docs/hot-reload-internals.md
+++ b/docs/hot-reload-internals.md
@@ -5,53 +5,78 @@ works today. Audience: contributors hacking on `whisker-dev-server`,
 `whisker-dev-runtime`, `whisker-driver`, or the vendored
 `whisker-subsecond`.
 
-## The two tiers
+## Hot Reload and Full Reload
 
 `whisker run` watches the user crate's `src/` (plus every workspace
-path-dep `src/`) and, for each debounced change, picks one of two
-strategies:
+path-dep `src/`). There are two reload mechanisms, with one hard rule:
+**saves only ever hot-reload; a Full Reload runs only when the user
+presses `R`** (formerly "Tier 1" / "Tier 2" with automatic fallback —
+the fallback restarted the app mid-interaction, which cost more than
+it saved).
 
-- **Tier 2 — cold rebuild.** Full `cargo build` → re-install
+- **Full Reload** (`R`). Full `cargo build` → re-install
   (`adb install` / `simctl install`) → relaunch. 5–30 s. Always
-  correct, never preserves state. This is the floor: every change kind
-  can fall back to it.
-- **Tier 1 — subsecond patch.** Rebuild *only the changed crate* into a
-  thin patch dylib, ship it over a WebSocket, and swap function
-  pointers on-device via `subsecond::apply_patch`. Sub-second on a warm
-  cache. Signals, scroll positions, and animation phase survive because
-  we replace function bodies, not the whole binary.
+  correct, never preserves state. The only path that picks up
+  dependency-graph changes.
+- **Hot Reload** (on save, or `r` to force a patch without a change).
+  Rebuild *only the changed crate* into a thin patch dylib, ship it
+  over a WebSocket, and swap function pointers on-device via
+  `subsecond::apply_patch`. Sub-second on a warm cache. Signals,
+  scroll positions, and animation phase survive because we replace
+  function bodies, not the whole binary.
 
-The decision is `decide_action(kind, has_patcher)` in
+The per-change decision is `decide_action(kind, has_patcher)` in
 `whisker-dev-server/src/lib.rs`:
 
 | `ChangeKind` | Action |
 |---|---|
 | `Other` (assets, README, …) | `Ignore` |
-| `CargoToml` (also `Cargo.lock`) | `Tier2Rebuild` — the dep graph may have moved; subsecond can't reload deps |
-| `RustCode` *and* a `Patcher` is available | `Tier1Patch` |
-| `RustCode`, no `Patcher` | `Tier2Rebuild` |
+| `CargoToml` (also `Cargo.lock`) | `PromptFullReload` — the dep graph may have moved; a patch can't reload deps |
+| `RustCode` *and* a `Patcher` is available | `HotReload` |
+| `RustCode`, no `Patcher` | `PromptFullReload` |
+
+`PromptFullReload` **does not rebuild**: it prints the reason, emits
+`Event::FullReloadRequired` (the TUI keeps a persistent "press R"
+banner up until a Full Reload starts), and waits. Explicit commands
+arrive through `DevCommand::{HotReload, FullReload}` on the channel
+the CLI wires to the `r` / `R` keys.
 
 Change classification lives in `watcher.rs` (`Change::classify` picks
 the most disruptive kind among a batch). `whisker run` defaults to
-`HotPatchMode::Tier1Subsecond`; `--no-hot-patch` forces
-`Tier2ColdRebuild`.
+`HotPatchMode::HotReload`; `--no-hot-patch` forces `FullReloadOnly`
+(every save prompts).
 
-Tier 1 is best-effort. Any failure along the way — patcher init failed,
-no client `aslr_reference` reported yet, a multi-crate change batch,
-`build_patch` errored, the dylib couldn't be read — silently falls
-through to a Tier 2 cold rebuild. The dev loop is never killed by a
-transient patch glitch.
+Hot Reload never falls back to a rebuild on its own. Failure handling:
 
-## Tier 1 pipeline, end to end
+- **Infrastructure failures prompt.** Patcher init failed, no client
+  `aslr_reference` yet, a multi-crate change batch, the link failed,
+  the dylib couldn't be read — each reports its reason and prompts
+  for `R`. The dev loop is never killed by a transient patch glitch.
+- **Compile errors just wait.** When the thin rebuild's rustc exits 1
+  (`RustcRejectedCode` in `hotpatch/runner.rs`), the user's code
+  doesn't compile — a Full Reload would fail with the same
+  diagnostics after a much longer wait. The loop reports
+  `compile error — fix the code and save again` and stays put.
+- **Patcher init failure isn't permanent.** If `Patcher::initialize`
+  fails at startup, the loop retries it on every subsequent
+  `RustCode` change (Full Reloads run with the capture shims wired,
+  so the caches it reads may have been repopulated since).
+
+## Hot Reload pipeline, end to end
 
 ### 1. The fat build doubles as a capture pass
 
-When `hot_patch_mode == Tier1Subsecond`, the *initial* build (the one
+When `hot_patch_mode == HotReload`, the *initial* build (the one
 that produces the installable artifact) runs with the capture shims
-wired in (`prepare_tier1_capture` in `lib.rs`):
+wired in (`prepare_hot_reload_capture` in `lib.rs`):
 
 - `RUSTC_WORKSPACE_WRAPPER` = `whisker-rustc-shim` — records each
-  rustc invocation's argv to `<workspace>/target/.whisker/cache/rustc-args/`.
+  rustc invocation's argv to `<workspace>/target/.whisker/cache/rustc-args/`,
+  along with the `CARGO_*` / `OUT_DIR` environment cargo set for it
+  (minus `CARGO_MAKEFLAGS`, whose jobserver fds die with cargo). The
+  thin rebuild replays those vars so `env!("CARGO_PKG_*")` /
+  `env!("OUT_DIR")` in user code still compiles under the raw
+  (cargo-less) rustc spawn.
 - `-C linker=whisker-linker-shim` — records each linker invocation's
   argv (keyed by output basename) to the linker-args cache, then
   forwards to the real linker.
@@ -59,8 +84,8 @@ wired in (`prepare_tier1_capture` in `lib.rs`):
 After that build completes the caches are populated, and
 `Patcher::initialize` (`hotpatch/patcher.rs`) reads them plus the
 original on-device binary's symbol table (`HotpatchModuleCache`).
-Initialization is non-fatal: failure logs a warning and the loop runs
-Tier-2-only.
+Initialization is non-fatal: failure logs a warning, saves prompt for
+Full Reloads, and the init is retried on later changes.
 
 The shims are `[[bin]]` targets of the `whisker-cli` package, resolved
 by `hotpatch/shim_paths.rs::resolve_shim_paths` in this order:
@@ -146,7 +171,7 @@ absolute runtime addresses into trampolines, rather than relying on
 `dlopen`-time symbol resolution against the host. That only works if the
 host knows the device's live load base — which is exactly
 `aslr_reference`. Until a client reports its `aslr_reference`,
-`lib.rs::run` withholds Tier 1 and falls back to Tier 2. The value is
+`lib.rs::run` withholds Hot Reload and prompts for a Full Reload. The value is
 cleared on disconnect, because reusing a dead process's slide for the
 next process would stamp trampolines against meaningless addresses and
 crash the device.
@@ -180,6 +205,69 @@ rewritten; `remount_components_for` then disposes and re-mounts every
 `#[component]` whose body was patched, so structural edits (new
 elements, new signals) reflect on screen. State local to a remounted
 component is lost; state above the remount point survives.
+
+### Full remount — Hot Reload's escalation path
+
+Hot Reload has two on-device reflection strategies: the per-component
+remount above (state above the remount point survives), and a **full
+remount** (everything resets). Both are Hot Reload — same patch
+wire format, same sub-second apply, no reinstall — the choice is made
+per patch, on-device, after `apply_patch`.
+
+Per-component remount re-runs `#[component]` bodies, never `app()`
+itself (`app_fn` runs once at bootstrap). Two patch shapes therefore
+used to apply without rendering: an edit to the `app()` body (top-level
+`provide_context` values, which root component is mounted), and a patch
+in an app with no top-level `#[component]` at all (nothing registered
+in `fn_ptr_mounts`). `maybe_full_remount` in `bootstrap.rs` escalates
+those to a full re-run:
+
+- `#[whisker::main]` bakes an FNV-1a hash of the app fn's tokens into
+  a generated `__whisker_app_body_hash` fn, read through the same
+  subsecond dispatch as the app body (`call_app_hash`). After a patch,
+  a changed value means the user edited `app()` itself.
+- `remount_components_for` returns `RemountStats`; `remounted == 0`
+  with a non-empty patch means nothing on screen could reflect it,
+  and `layout_changed > 0` means the props-layout gate below refused
+  one or more sites.
+
+### The props-layout gate
+
+A remount re-runs the site's *stored* body closure (created at mount
+time, possibly by pre-patch code) and relies on subsecond dispatch to
+land in the patched inner body. That transmutes the stored closure's
+captured environment into what the new code expects — sound only if
+the capture layout didn't move. Two guards make it sound:
+
+- **Forced captures.** The `#[component]` macro pins the inner
+  closure's environment to *all* props (a `let _ = (&a, &b, …)` at
+  the top of the dispatched closure), so the layout is a function of
+  the props signature alone — not of which props the body happens to
+  reference this week.
+- **Layout hash.** The macro bakes `fnv1a64(props signature tokens)`
+  into a generated `__whisker_props_hash` fn, folding in each prop
+  type's `size_of`/`align_of` at runtime (so a change to a prop
+  type's *definition* — struct fields behind an unchanged signature —
+  also shifts the patch's value). The mount records the value; after
+  a patch, `remount_components_for` re-reads it through dispatch and
+  **refuses** any site whose value moved, reporting it in
+  `RemountStats::layout_changed`. The bootstrap escalates those to a
+  full remount, where fresh patched code rebuilds all props from
+  scratch.
+
+Residual gap: a prop type whose definition changes without moving its
+size or alignment (e.g. two `u32` fields swapped) still slips through
+the hash. The signature-token part catches renames/retypes at the
+declaration; byte-identical-layout semantic swaps are on the user.
+
+Either condition triggers: detach the page's children, dispose the
+current *run owner* (a per-`app()`-run child of the persistent root
+owner — contexts, signals, effects all cascade), re-invoke the kept
+`app_fn` (`FnMut` since the full-remount path landed) under a fresh
+run owner, and append
+the new content to the same fixed page. All reactive state is lost by
+design, but the process — and the dev-session WebSocket — survive, so
+it's still sub-second, unlike a Full Reload reinstall.
 
 The vendored `whisker-subsecond` (`[lib] name = "subsecond"`,
 `crates/whisker-subsecond/`) is a fork of Dioxus's subsecond 0.7.9. The
@@ -249,13 +337,13 @@ the next save anyway.
 
 ## Known boundaries
 
-- **iOS hardware is unsupported** for Tier 1: `mmap(PROT_WRITE |
+- **iOS hardware is unsupported** for Hot Reload: `mmap(PROT_WRITE |
   PROT_EXEC)` is blocked by Apple's W^X policy, so `apply_patch` can't
   run. Targets are macOS host, Android, and the iOS Simulator.
-- **`Cargo.toml` / `Cargo.lock` edits** always cold-rebuild — the
-  patcher can't reload dependencies.
+- **`Cargo.toml` / `Cargo.lock` edits** always need a Full Reload —
+  the patcher can't reload dependencies.
 - **Multi-crate change batches** can't be expressed as a single patch
-  (one crate per patch), so they fall back to Tier 2.
+  (one crate per patch), so they prompt for a Full Reload.
 - **Per-component remount loses local state.** A patch that changes a
   component's structure re-mounts it; signals owned by that component
   reset. State held above the remount point (context, parent signals)


### PR DESCRIPTION
## Summary

Overhauls the dev-loop reload story around one rule: **saves only ever hot-reload; a Full Reload (rebuild + reinstall + relaunch) runs only when the user explicitly asks for it**. The old automatic Tier 2 fallback restarted the app mid-interaction, which cost more time than it saved. Terminology follows: Tier 1 / Tier 2 → **Hot Reload / Full Reload** across code, CLI output, and docs.

### Manual Full Reload UX (`whisker-dev-server`, `whisker-cli`)

- New `DevCommand { HotReload, FullReload }` channel into the dev loop; the TUI binds **`r` = Hot Reload** (force a patch without a save), **`R` = Full Reload**. The footer now always shows ` r  hot reload   R  full reload   q  quit `.
- Every former auto-Tier2 fallback (Cargo.toml/Cargo.lock edits, multi-crate batches, missing patcher, patch build/read failures, no connected device) now emits `Event::FullReloadRequired { reason }` instead of rebuilding. The TUI keeps a persistent `⚠ <reason> — press R to Full Reload` banner until a Full Reload starts; a successful hot patch does *not* clear it (a new dep still isn't on the device).
- Public API renames: `HotPatchMode::{HotReload, FullReloadOnly}`, `LoopAction::{HotReload, PromptFullReload}`. `--no-hot-patch` now means "every save prompts" rather than "every save cold-rebuilds".

### Hot Reload coverage — every silent no-op path now acts or explains

- **`app()` body edits reflect** (full-remount escalation): `#[whisker::main]` bakes an FNV-1a hash of the app fn's tokens, read through subsecond dispatch (`call_app_hash`), so a patch that changed `app()` itself triggers a full re-run — page children detached, per-run owner disposed (top-level contexts included), `app_fn` (now `FnMut`) re-invoked. Also fires when a patch matched no mounted component (apps with no top-level `#[component]` previously showed nothing at all).
- **Props struct changes are detected instead of UB**: `#[component]` (a) force-captures *all* props in the subsecond-dispatched closure, pinning its env layout to the props signature (this also fixes the latent UB where a body edit that starts using a previously-unused prop shifted the capture layout), and (b) bakes a props-layout hash (signature tokens + per-type `size_of`/`align_of` folded at runtime, so prop-type *definition* changes shift the patch's value). `remount_components_for` refuses sites whose stored closure no longer matches the patched layout (`RemountStats::layout_changed`) and the bootstrap escalates to a full remount — "garbage props / random crash" becomes "state resets but renders correctly".
- **`env!("CARGO_*")` / `env!("OUT_DIR")` compile under thin rebuilds**: the rustc shim captures the `CARGO_*` env (minus `CARGO_MAKEFLAGS`) alongside argv and the patch build replays it. The `option_env!` workaround is no longer needed.
- **Compile errors short-circuit**: rustc exit 1 (`RustcRejectedCode`) reports "fix the code and save again" instead of burning 10–30 s on a rebuild that fails with the same diagnostics.
- **Patcher init failure is no longer permanent**: retried on every subsequent Rust change.
- **`whisker.rs` saves are no longer silent**: `Config::watch_paths` is actually wired now; a config-script save prints "restart `whisker run` to pick it up" (no reload of any kind re-applies it).

### Dev-session server fixes

- **Bug**: a rejected (bad-token) client's disconnect used to clear the live app's `aslr_reference` — a stale app from the previous session hammering the gate could wedge hot reload at "no device connected" while the real device was connected. Now only authenticated sockets clear it.
- Token-reject logging demoted to debug (`WHISKER_VERBOSE=1`); it's expected noise from the previous session's app until install+launch replaces it. `ClientConnected/Disconnected` events only fire for authenticated clients, so the TUI count no longer flaps during the initial build.
- Log format unified: `[whisker run]` / `[whisker build-ios]` / `[whisker build-android]` `eprintln!`s now go through `ui::info`.

### Known limitations (unchanged, now documented)

- `static` / `const` / thread-local initializer edits need a Full Reload (subsecond constraint).
- A prop type definition change that moves neither size nor alignment slips past the layout hash.
- After the first full remount, mount sites are registered by patch code (patch-image fn pointers), so subsequent patches escalate to full remounts until a Full Reload re-bases — correct but state-lossy; pointer versioning in the subsecond fork is the future fix.
- Keyboard shortcuts require the TUI (no `r`/`R` under `--no-tui`).

## Test plan

- `cargo test --workspace` (1380+ tests), `cargo clippy --workspace --all-targets`, `cargo fmt --all --check` all green.
- New unit tests: compile-error downcast through context chains, `CARGO_*` env capture/replay + pre-envs cache compat, `RemountStats` zero/refusal semantics, props-layout gate (same hash → in-place remount; changed hash → refused, body not re-run), TUI banner set/clear/persist + footer shortcuts.
- Not yet exercised on a device: end-to-end `whisker run ios` flow (save → hot reload, Cargo.toml edit → banner, `R` → full reload, `app()` edit → full remount). Macro changes take effect from the next fat build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
