### PR TITLE
feat(build): whisker build appbundle/apk/ipa + age-encrypted credential store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "age"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5"
+dependencies = [
+ "age-core",
+ "base64 0.21.7",
+ "bech32",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hmac",
+ "i18n-embed",
+ "i18n-embed-fl",
+ "lazy_static",
+ "nom",
+ "pin-project",
+ "rand 0.8.6",
+ "rust-embed",
+ "scrypt",
+ "sha2",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "age-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
+dependencies = [
+ "base64 0.21.7",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hkdf",
+ "io_tee",
+ "nom",
+ "rand 0.8.6",
+ "secrecy",
+ "sha2",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +147,15 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "asset-demo"
@@ -195,7 +257,7 @@ dependencies = [
  "atrium-common",
  "atrium-identity",
  "atrium-xrpc",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "dashmap",
  "ecdsa",
@@ -248,7 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -314,6 +376,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -323,6 +391,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitflags"
@@ -498,6 +581,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +629,17 @@ dependencies = [
  "serde",
  "serde_bytes",
  "unsigned-varint",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -617,6 +735,15 @@ name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -725,6 +852,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -854,6 +1008,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -874,6 +1029,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -936,6 +1093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +1106,21 @@ checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -959,6 +1137,50 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 1.1.0",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -992,12 +1214,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1052,10 +1290,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1184,6 +1425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,7 +1530,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1295,6 +1545,72 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "log",
+ "parking_lot",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
+dependencies = [
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1483,6 +1799,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1819,31 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "io_tee"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
 
 [[package]]
 name = "ipld-core"
@@ -1606,6 +1956,12 @@ checksum = "ed60c85f254d6ae8450cec15eedd921efbc4d1bdf6fcf6202b9a58b403f6f805"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1735,6 +2091,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +2170,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1892,6 +2264,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,16 +2317,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "podcast"
@@ -2051,6 +2478,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2522,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,7 +2563,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -2123,7 +2583,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2292,7 +2752,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -2355,10 +2815,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2435,6 +2965,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,6 +2989,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,9 +3008,34 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "self_cell"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.2.2",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -2672,6 +3247,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +3349,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +3408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -2896,6 +3495,15 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite 0.29.0",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3068,10 +3676,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -3109,6 +3745,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,12 +3772,14 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
  "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "url",
  "webpki-roots 0.26.11",
 ]
@@ -3395,19 +4043,25 @@ name = "whisker-cli"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "clap",
  "crossterm",
  "ctrlc",
  "indicatif",
  "libc",
+ "p256",
+ "rand 0.8.6",
  "ratatui",
+ "rpassword",
  "serde",
  "serde_json",
  "tokio",
- "toml",
+ "toml 0.8.23",
+ "ureq",
  "whisker-build",
  "whisker-cng",
  "whisker-config",
+ "whisker-credentials",
  "whisker-dev-server",
  "whisker-fmt",
 ]
@@ -3433,6 +4087,17 @@ dependencies = [
  "serde",
  "serde_json",
  "whisker-plugin",
+]
+
+[[package]]
+name = "whisker-credentials"
+version = "0.7.0"
+dependencies = [
+ "age",
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -3505,7 +4170,7 @@ dependencies = [
  "quote",
  "similar",
  "syn",
- "toml",
+ "toml 0.8.23",
  "whisker-macro-syntax",
 ]
 
@@ -3672,7 +4337,7 @@ dependencies = [
 name = "whisker-svg"
 version = "0.7.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "roxmltree",
  "whisker",
 ]
@@ -3985,6 +4650,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4055,6 +4732,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "serde",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4074,6 +4763,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/whisker-build",
     "crates/whisker-cli",
     "crates/whisker-cng",
+    "crates/whisker-credentials",
     "crates/whisker-dev-runtime",
     "crates/whisker-dev-server",
     "crates/whisker-driver",
@@ -82,6 +83,7 @@ whisker-animation = { path = "crates/whisker-animation", version = "0.7.0" }
 whisker-config = { path = "crates/whisker-config", version = "0.7.0" }
 whisker-build = { path = "crates/whisker-build", version = "0.7.0" }
 whisker-cng = { path = "crates/whisker-cng", version = "0.7.0" }
+whisker-credentials = { path = "crates/whisker-credentials", version = "0.7.0" }
 whisker-dev-runtime = { path = "crates/whisker-dev-runtime", version = "0.7.0" }
 whisker-dev-server = { path = "crates/whisker-dev-server", version = "0.7.0" }
 whisker-driver = { path = "crates/whisker-driver", version = "0.7.0" }

--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -551,43 +551,7 @@ pub fn run_gradle_assemble(
         Profile::Debug => ":app:assembleDebug",
     };
     let gradle_step = crate::ui::step("gradle", task.to_string());
-    let java_home = resolve_java_home()?;
-    let gradlew = gen_android.join("gradlew");
-    if !gradlew.is_file() {
-        return Err(anyhow!(
-            "gradlew missing at {} — has the gen tree been synced?",
-            gradlew.display(),
-        ));
-    }
-    let mut cmd = Command::new(&gradlew);
-    cmd.arg(task)
-        .arg("--no-daemon")
-        // `--console=plain` forces gradle to emit line-by-line output
-        // instead of its default `auto` heuristic, which on a TTY
-        // upgrades to ANSI-escape-driven in-place progress redraws.
-        // We pipe gradle through `Step::pipe` so the ANSI codes never
-        // reach a real terminal — but our line-based classifier
-        // doesn't know how to strip them, and the curated TUI's inline
-        // viewport gets corrupted by cursor-moving sequences leaking
-        // through. Plain console mode side-steps both.
-        .arg("--console=plain")
-        .current_dir(gen_android)
-        .env("JAVA_HOME", &java_home);
-    // Forward the TUI-mode + verbose env vars down to `whisker-build
-    // android`, which gradle invokes inside `WhiskerBuildTask` via
-    // `execOperations.exec`. `Command` *does* inherit env by default
-    // — but the gradle Plugin sits behind a published Maven artifact,
-    // so older plugin versions whose `exec {}` block doesn't
-    // explicitly forward env names won't propagate them to grandchild
-    // processes on every gradle version. Setting the vars on the
-    // outermost gradle invocation keeps the dev-loop UI consistent
-    // regardless of which plugin version a given gen tree pins.
-    if crate::ui::is_tui() {
-        cmd.env("WHISKER_TUI", "1");
-    }
-    if crate::ui::is_verbose() {
-        cmd.env("WHISKER_VERBOSE", "1");
-    }
+    let mut cmd = gradle_command(gen_android, task)?;
     if !features.is_empty() {
         cmd.env("WHISKER_FEATURES", features.join(" "));
     }
@@ -604,7 +568,7 @@ pub fn run_gradle_assemble(
     // `whisker run` shows one summary line per subprocess.
     let status = gradle_step
         .pipe(&mut cmd)
-        .with_context(|| format!("spawn {}", gradlew.display()))?;
+        .with_context(|| format!("spawn {}", gen_android.join("gradlew").display()))?;
     if !status.success() {
         gradle_step.fail(format!("{status}"));
         return Err(anyhow!("gradle {task} failed ({status})"));
@@ -629,9 +593,162 @@ pub fn run_gradle_assemble(
     ))
 }
 
+/// Shared skeleton for one `./gradlew <task>` invocation against a
+/// synced `gen/android/` tree: JDK resolution, gradlew existence,
+/// plain-console piping, and TUI/verbose env forwarding.
+///
+/// `--console=plain` forces gradle to emit line-by-line output
+/// instead of its default `auto` heuristic, which on a TTY upgrades
+/// to ANSI-escape-driven in-place progress redraws. We pipe gradle
+/// through `Step::pipe` so the ANSI codes never reach a real
+/// terminal — but our line-based classifier doesn't know how to
+/// strip them, and the curated TUI's inline viewport gets corrupted
+/// by cursor-moving sequences leaking through. Plain console mode
+/// side-steps both.
+///
+/// The TUI/verbose env vars are set on the outermost gradle
+/// invocation (not relied on via inheritance) because the gradle
+/// Plugin sits behind a published Maven artifact — older plugin
+/// versions whose `exec {}` block doesn't explicitly forward env
+/// names won't propagate them to grandchild processes on every
+/// gradle version.
+fn gradle_command(gen_android: &Path, task: &str) -> Result<Command> {
+    let java_home = resolve_java_home()?;
+    let gradlew = gen_android.join("gradlew");
+    if !gradlew.is_file() {
+        return Err(anyhow!(
+            "gradlew missing at {} — has the gen tree been synced?",
+            gradlew.display(),
+        ));
+    }
+    let mut cmd = Command::new(&gradlew);
+    cmd.arg(task)
+        .arg("--no-daemon")
+        .arg("--console=plain")
+        .current_dir(gen_android)
+        .env("JAVA_HOME", &java_home);
+    if crate::ui::is_tui() {
+        cmd.env("WHISKER_TUI", "1");
+    }
+    if crate::ui::is_verbose() {
+        cmd.env("WHISKER_VERBOSE", "1");
+    }
+    Ok(cmd)
+}
+
+/// Release artifact kinds `whisker build` produces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseArtifact {
+    /// `.aab` for Play Store upload (`:app:bundleRelease`).
+    AppBundle,
+    /// `.apk` for direct / internal distribution
+    /// (`:app:assembleRelease`).
+    Apk,
+}
+
+/// Run the release gradle task for `artifact`, with signing material
+/// injected through `signing_env` (the `WHISKER_ANDROID_*` variables
+/// the generated `app/build.gradle.kts` reads — see the template).
+/// The values point into a credential staging dir that outlives this
+/// call and vanishes after the build; nothing is written to the gen
+/// tree. Returns the produced artifact path.
+pub fn run_gradle_release(
+    gen_android: &Path,
+    artifact: ReleaseArtifact,
+    signing_env: &[(String, String)],
+) -> Result<PathBuf> {
+    let (task, out_dir, candidates): (&str, &str, &[&str]) = match artifact {
+        ReleaseArtifact::AppBundle => (
+            ":app:bundleRelease",
+            "app/build/outputs/bundle/release",
+            &["app-release.aab"],
+        ),
+        ReleaseArtifact::Apk => (
+            ":app:assembleRelease",
+            "app/build/outputs/apk/release",
+            // `-unsigned` shows up when signing env was absent; keep
+            // it discoverable so the error path can name what it found.
+            &["app-release.apk", "app-release-unsigned.apk"],
+        ),
+    };
+    let gradle_step = crate::ui::step("gradle", task.to_string());
+    let mut cmd = gradle_command(gen_android, task)?;
+    for (k, v) in signing_env {
+        cmd.env(k, v);
+    }
+    let status = gradle_step
+        .pipe(&mut cmd)
+        .with_context(|| format!("spawn {}", gen_android.join("gradlew").display()))?;
+    if !status.success() {
+        gradle_step.fail(format!("{status}"));
+        return Err(anyhow!("gradle {task} failed ({status})"));
+    }
+    gradle_step.done("");
+    let outputs = gen_android.join(out_dir);
+    let found = candidates
+        .iter()
+        .map(|name| outputs.join(name))
+        .find(|cand| cand.is_file())
+        .ok_or_else(|| {
+            anyhow!(
+                "gradle succeeded but no release artifact found under {}",
+                outputs.display(),
+            )
+        })?;
+    ensure_release_artifact_signed(artifact, &found)?;
+    Ok(found)
+}
+
+/// Refuse to hand back an UNSIGNED release artifact — Android
+/// rejects it at install time with an opaque "app can't be
+/// installed" dialog, so failing here with the real cause is
+/// strictly better. Unsigned output means the generated gradle
+/// script never saw the `WHISKER_ANDROID_*` signingConfig (a gen
+/// tree from before signing support, or a bypassed sync).
+///
+/// Detection is per-format: an unsigned APK announces itself via the
+/// `-unsigned` filename AGP gives it; an unsigned AAB keeps the same
+/// filename, so it's checked with `jarsigner -verify` (bundles are
+/// v1/jar-signed — unlike APKs, whose v2+ signatures jarsigner can't
+/// see).
+fn ensure_release_artifact_signed(artifact: ReleaseArtifact, path: &Path) -> Result<()> {
+    let unsigned = match artifact {
+        ReleaseArtifact::Apk => path
+            .file_name()
+            .is_some_and(|n| n.to_string_lossy().contains("-unsigned")),
+        ReleaseArtifact::AppBundle => {
+            let jarsigner = resolve_java_home()?.join("bin/jarsigner");
+            let out = Command::new(&jarsigner)
+                .arg("-verify")
+                .arg(path)
+                .output()
+                .with_context(|| format!("spawn {}", jarsigner.display()))?;
+            let text = format!(
+                "{}{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr),
+            );
+            text.contains("jar is unsigned")
+        }
+    };
+    if unsigned {
+        return Err(anyhow!(
+            "{} is UNSIGNED — the generated gradle project predates release-signing \
+             support. Re-run the build (the gen tree regenerates automatically); if \
+             this persists, delete gen/android/ and try again.",
+            path.display(),
+        ));
+    }
+    Ok(())
+}
+
 /// Java 17 home for AGP 8.x. Looks at JAVA_HOME first; otherwise tries
 /// `/usr/libexec/java_home -v 17` on macOS.
-fn resolve_java_home() -> Result<PathBuf> {
+///
+/// Public because the CLI's `whisker credential android` reuses it to
+/// locate `keytool` (`<java_home>/bin/keytool`) for upload-keystore
+/// generation — same JDK the gradle build will run under.
+pub fn resolve_java_home() -> Result<PathBuf> {
     if let Some(p) = std::env::var_os("JAVA_HOME").map(PathBuf::from) {
         if p.is_dir() {
             return Ok(p);
@@ -663,6 +780,22 @@ fn resolve_java_home() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unsigned_apk_is_rejected() {
+        let tmp = std::env::temp_dir().join("whisker-build-unsigned-apk-test");
+        let _ = std::fs::create_dir_all(&tmp);
+        let unsigned = tmp.join("app-release-unsigned.apk");
+        std::fs::write(&unsigned, b"zip").unwrap();
+        let err = ensure_release_artifact_signed(ReleaseArtifact::Apk, &unsigned).unwrap_err();
+        assert!(err.to_string().contains("UNSIGNED"), "got: {err:#}");
+
+        // A properly named release APK passes the filename check.
+        let signed = tmp.join("app-release.apk");
+        std::fs::write(&signed, b"zip").unwrap();
+        assert!(ensure_release_artifact_signed(ReleaseArtifact::Apk, &signed).is_ok());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 
     #[test]
     fn abi_to_triple_maps_known_abis() {

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -847,6 +847,203 @@ pub fn run_xcodebuild_app(args: &XcodebuildArgs<'_>) -> Result<PathBuf> {
     Ok(app)
 }
 
+// ============================================================================
+// Release (ipa) pipeline — `whisker build ipa`
+// ============================================================================
+
+/// ExportOptions.plist `method` values. Spelled exactly like Apple's
+/// plist values (and Flutter's `--export-method`), so the string the
+/// user typed matches what xcodebuild's own errors echo back —
+/// deliberately NOT fastlane's hyphen-less `adhoc`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportMethod {
+    /// App Store / TestFlight distribution.
+    AppStoreConnect,
+    /// Device-limited distribution (Firebase App Distribution etc.);
+    /// requires tester UDIDs registered on the developer portal.
+    AdHoc,
+}
+
+impl ExportMethod {
+    pub fn plist_value(self) -> &'static str {
+        match self {
+            ExportMethod::AppStoreConnect => "app-store-connect",
+            ExportMethod::AdHoc => "ad-hoc",
+        }
+    }
+}
+
+/// Signing inputs for the release pipeline. All auth flows through
+/// the App Store Connect API key (whisker's one true path — no
+/// Xcode-session dependence, identical local and CI), with the
+/// cloud-managed distribution certificate doing the actual signing
+/// at export time.
+pub struct ReleaseSigning<'a> {
+    pub team_id: &'a str,
+    /// Absolute path to `AuthKey_<key_id>.p8` — points into the
+    /// caller's credential staging dir.
+    pub key_path: &'a Path,
+    pub key_id: &'a str,
+    pub issuer_id: &'a str,
+}
+
+pub struct IosReleaseInputs<'a> {
+    /// `gen/ios/` — synced by cng before this runs.
+    pub gen_dir: &'a Path,
+    pub scheme: &'a str,
+    pub workspace_root: &'a Path,
+    /// User app crate name — namespaces the archive/export output dir.
+    pub package: &'a str,
+    pub method: ExportMethod,
+    pub signing: ReleaseSigning<'a>,
+}
+
+/// `xcodebuild archive` → `xcodebuild -exportArchive` → `.ipa`.
+///
+/// Signing setup is passed as command-line build settings
+/// (`DEVELOPMENT_TEAM` / `CODE_SIGN_STYLE=Automatic`), NOT baked
+/// into the generated pbxproj — the gen tree stays team-agnostic and
+/// `whisker run` (simulator) never sees signing at all.
+/// `-allowProvisioningUpdates` + the API-key flags let xcodebuild
+/// mint dev certificates, register the bundle id, and (re)generate
+/// profiles headlessly on both dev machines and CI.
+///
+/// The archive is kept on disk between runs: adding ad-hoc test
+/// devices only needs the export step re-run, and xcodebuild archive
+/// itself overwrites stale archives.
+pub fn archive_and_export(inputs: &IosReleaseInputs<'_>) -> Result<PathBuf> {
+    let IosReleaseInputs {
+        gen_dir,
+        scheme,
+        workspace_root,
+        package,
+        method,
+        signing,
+    } = inputs;
+    let xcode_project = gen_dir.join(format!("{scheme}.xcodeproj"));
+    if !xcode_project.is_dir() {
+        return Err(anyhow!(
+            "Xcode project missing at {} — has the gen tree been synced?",
+            xcode_project.display(),
+        ));
+    }
+    let out_root = workspace_root
+        .join("target/whisker/ios-release")
+        .join(package);
+    std::fs::create_dir_all(&out_root).with_context(|| format!("mkdir {}", out_root.display()))?;
+    let archive_path = out_root.join(format!("{scheme}.xcarchive"));
+
+    // ---- archive ---------------------------------------------------
+    let archive_step = crate::ui::step("xcodebuild", format!("archive {scheme}"));
+    let mut cmd = Command::new("xcodebuild");
+    cmd.arg("-project")
+        .arg(&xcode_project)
+        .args(["-scheme", scheme])
+        .args(["-configuration", "Release"])
+        .args(["-destination", "generic/platform=iOS"])
+        .arg("-archivePath")
+        .arg(&archive_path)
+        // SwiftPM build-tool plugins sit behind an interactive trust
+        // prompt headless builds can't answer.
+        .arg("-skipPackagePluginValidation")
+        .arg("-allowProvisioningUpdates")
+        .arg("-authenticationKeyPath")
+        .arg(signing.key_path)
+        .args(["-authenticationKeyID", signing.key_id])
+        .args(["-authenticationKeyIssuerID", signing.issuer_id])
+        .arg("archive")
+        // Command-line build settings override the pbxproj: the
+        // template's dev-loop identity stays untouched, release
+        // builds get automatic signing under the credential's team.
+        .arg(format!("DEVELOPMENT_TEAM={}", signing.team_id))
+        .arg("CODE_SIGN_STYLE=Automatic")
+        .arg("CODE_SIGN_IDENTITY=Apple Development")
+        .current_dir(gen_dir);
+    let status = archive_step
+        .pipe(&mut cmd)
+        .context("spawn xcodebuild archive")?;
+    if !status.success() {
+        archive_step.fail(format!("{status}"));
+        return Err(anyhow!("xcodebuild archive failed ({status})"));
+    }
+    archive_step.done("");
+
+    // ---- export ----------------------------------------------------
+    let options_path = out_root.join("ExportOptions.plist");
+    std::fs::write(
+        &options_path,
+        export_options_plist(*method, signing.team_id),
+    )
+    .with_context(|| format!("write {}", options_path.display()))?;
+    let export_dir = out_root.join("export");
+
+    let export_step = crate::ui::step("xcodebuild", format!("export {}", method.plist_value()));
+    let mut cmd = Command::new("xcodebuild");
+    cmd.arg("-exportArchive")
+        .arg("-archivePath")
+        .arg(&archive_path)
+        .arg("-exportOptionsPlist")
+        .arg(&options_path)
+        .arg("-exportPath")
+        .arg(&export_dir)
+        .arg("-allowProvisioningUpdates")
+        .arg("-authenticationKeyPath")
+        .arg(signing.key_path)
+        .args(["-authenticationKeyID", signing.key_id])
+        .args(["-authenticationKeyIssuerID", signing.issuer_id]);
+    let status = export_step
+        .pipe(&mut cmd)
+        .context("spawn xcodebuild -exportArchive")?;
+    if !status.success() {
+        export_step.fail(format!("{status}"));
+        return Err(anyhow!(
+            "xcodebuild -exportArchive failed ({status}) — if this is a signing error, \
+             re-check the stored key with `whisker credential ios`",
+        ));
+    }
+    export_step.done("");
+
+    // Export names the ipa after the app's product name; scan rather
+    // than guess.
+    let ipa = std::fs::read_dir(&export_dir)
+        .with_context(|| format!("read {}", export_dir.display()))?
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| p.extension().is_some_and(|e| e == "ipa"))
+        .ok_or_else(|| {
+            anyhow!(
+                "export succeeded but no .ipa found under {}",
+                export_dir.display(),
+            )
+        })?;
+    Ok(ipa)
+}
+
+/// The ExportOptions.plist for one export. Nothing secret in here —
+/// it lands under `target/whisker/ios-release/` and is regenerated
+/// every run.
+fn export_options_plist(method: ExportMethod, team_id: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>{}</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>teamID</key>
+	<string>{}</string>
+	<key>destination</key>
+	<string>export</string>
+</dict>
+</plist>
+"#,
+        method.plist_value(),
+        team_id,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/whisker-build/src/modules.rs
+++ b/crates/whisker-build/src/modules.rs
@@ -412,6 +412,46 @@ pub struct ModulesReport {
     pub modules: Vec<ModulesReportModule>,
 }
 
+/// Rewrite the Gradle plugins' on-disk module-report cache with a
+/// fresh discovery pass. Call this BEFORE every CLI-driven gradle
+/// invocation (`whisker build appbundle|apk`, the dev loop's
+/// assemble).
+///
+/// Why the cache can't be trusted without this: the Settings plugin
+/// validates its cache against the `Cargo.lock` hash alone, which
+/// goes stale in two realistic ways —
+///
+/// 1. **Cross-app poisoning**: the cache file lives in the
+///    workspace-level `target/whisker/`, so in a workspace holding
+///    several apps, app A's report (possibly zero modules) gets
+///    reused for app B (same lock hash). B's modules silently
+///    vanish from the APK and every custom element dies at render
+///    time with "No BehaviorController defined".
+/// 2. **Metadata edits**: `[package.metadata.whisker]` changes in a
+///    path-dep module's Cargo.toml don't touch `Cargo.lock`, so a
+///    module author's new declaration never reaches the build.
+///
+/// Since the CLI always runs before gradle, pre-writing a fresh
+/// report turns the plugin's cache read into "always valid, always
+/// current" regardless of plugin version. Both filenames are
+/// written: the shared legacy name published plugin ≤0.4.1 reads,
+/// and the per-package name 0.4.2+ reads.
+pub fn refresh_gradle_module_cache(workspace_root: &Path, user_package: &str) -> Result<()> {
+    let report = build_modules_report(workspace_root, user_package)
+        .with_context(|| format!("build modules report for `{user_package}`"))?;
+    let json = serde_json::to_string_pretty(&report).context("serialize modules report")?;
+    let dir = workspace_root.join("target/whisker");
+    std::fs::create_dir_all(&dir).with_context(|| format!("mkdir {}", dir.display()))?;
+    for name in [
+        format!("module-info-{user_package}.json"),
+        "module-info.json".to_string(),
+    ] {
+        let path = dir.join(name);
+        std::fs::write(&path, &json).with_context(|| format!("write {}", path.display()))?;
+    }
+    Ok(())
+}
+
 /// Build a [`ModulesReport`] from a workspace + user package. Combines
 /// [`discover`], `Cargo.lock` hashing, and per-platform availability
 /// classification.

--- a/crates/whisker-cli/Cargo.toml
+++ b/crates/whisker-cli/Cargo.toml
@@ -65,6 +65,22 @@ whisker-build = { workspace = true }
 # TOML parser for reading `[package].name` from the user crate's
 # Cargo.toml. Lightweight, no async runtime.
 toml = "0.8"
+# `whisker credential` — the age-encrypted signing-credential store
+# committed to the user's repo (crates/whisker-credentials).
+whisker-credentials = { workspace = true }
+# Random upload-keystore passwords. The user never sees them (they
+# live encrypted next to the keystore), so entropy > memorability.
+rand = "0.8"
+# Hidden-input prompts (age secret key at build time, keystore
+# passwords on `whisker credential android --import`).
+rpassword = "7"
+# `whisker credential ios` validates the pasted App Store Connect API
+# key with one real request before storing it. ES256 JWT is built by
+# hand (header.payload signed with the .p8) — p256 is the pure-Rust
+# signer, ureq the tiny blocking HTTP client. No ring/openssl.
+p256 = { version = "0.13", features = ["ecdsa", "pem"] }
+ureq = { version = "2", features = ["json"] }
+base64 = { workspace = true }
 # Inline TUI for `whisker run` — anchored status bar at the bottom of
 # the terminal, scrollback above for sections/steps/device logs.
 ratatui = { workspace = true }

--- a/crates/whisker-cli/src/build/android.rs
+++ b/crates/whisker-cli/src/build/android.rs
@@ -1,0 +1,106 @@
+//! `whisker build appbundle` / `whisker build apk` — the Android
+//! release pipeline: resolve config → credential pre-step → cng
+//! sync → `gradle :app:bundleRelease` / `:app:assembleRelease` with
+//! signing injected via env vars.
+
+use anyhow::{Result, anyhow};
+use clap::Args as ClapArgs;
+use std::path::PathBuf;
+use whisker_build::android::ReleaseArtifact;
+use whisker_build::ui;
+use whisker_dev_server::Target;
+
+use crate::{credential, manifest, platforms};
+
+#[derive(ClapArgs, Debug)]
+pub struct Args {
+    /// Explicit path to the app's Cargo.toml. Defaults to walking up
+    /// from the current directory.
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
+}
+
+pub fn run(artifact: ReleaseArtifact, args: Args) -> Result<()> {
+    let m = manifest::resolve(args.manifest_path.as_deref())?;
+    let application_id = manifest::android_application_id(&m.config).ok_or_else(|| {
+        anyhow!(
+            "whisker.rs: app.android(|a| a.application_id(\"…\")) (or app.bundle_id) \
+             is required for Android builds"
+        )
+    })?;
+    let workspace_root = crate::run::find_workspace_root(&m.crate_dir).ok_or_else(|| {
+        anyhow!(
+            "no [workspace] Cargo.toml at or above {}",
+            m.crate_dir.display()
+        )
+    })?;
+
+    // Announce the fully resolved identity FIRST. `configure()` is
+    // arbitrary Rust and may branch on ambient env (WHISKER_ENV-
+    // style flavors) — silently building the wrong flavor is the
+    // failure mode this line exists to catch.
+    let version = m.config.version.clone().unwrap_or_else(|| "0.1.0".into());
+    let build_number = m.config.build_number.unwrap_or(1);
+    let label = match artifact {
+        ReleaseArtifact::AppBundle => "appbundle (.aab)",
+        ReleaseArtifact::Apk => "apk",
+    };
+    ui::section("Build");
+    ui::info(format!(
+        "building {application_id} {version} ({build_number}) — release {label}",
+    ));
+
+    // Credential pre-step BEFORE any compilation: the decryption-key
+    // prompt (if any) happens now, and key problems fail before, not
+    // after, the long gradle+cargo build. `_staging` must stay alive
+    // until gradle exits — the signing paths point into it.
+    let (_staging, signing) = credential::require_android_signing(&m.crate_dir, &application_id)?;
+
+    let sync = platforms::sync_for_target(
+        Target::Android,
+        &m.config,
+        &m.crate_dir,
+        &workspace_root,
+        &m.package,
+    )?;
+
+    // The Gradle Settings plugin trusts a Cargo.lock-keyed module
+    // report cache that goes stale in ways the lock hash can't see
+    // (multi-app workspaces, metadata-only edits). Rewrite it fresh
+    // before gradle reads it — see refresh_gradle_module_cache docs.
+    whisker_build::modules::refresh_gradle_module_cache(&workspace_root, &m.package)?;
+
+    // Contract with the generated app/build.gradle.kts — see the
+    // WHISKER_ANDROID_* block in the template.
+    let signing_env = vec![
+        (
+            "WHISKER_ANDROID_KEYSTORE".to_string(),
+            signing.keystore_path.display().to_string(),
+        ),
+        (
+            "WHISKER_ANDROID_KEYSTORE_PASSWORD".to_string(),
+            signing.store_password.clone(),
+        ),
+        (
+            "WHISKER_ANDROID_KEY_ALIAS".to_string(),
+            signing.key_alias.clone(),
+        ),
+        (
+            "WHISKER_ANDROID_KEY_PASSWORD".to_string(),
+            signing.key_password.clone(),
+        ),
+    ];
+
+    let artifact_path =
+        whisker_build::android::run_gradle_release(&sync.gen_dir, artifact, &signing_env)?;
+    ui::info(format!("✓ {}", artifact_path.display()));
+    match artifact {
+        ReleaseArtifact::AppBundle => {
+            ui::info("upload to Play Console (first release: create the app there manually)");
+        }
+        ReleaseArtifact::Apk => {
+            ui::info("ready for direct distribution (Firebase App Distribution, sideload, …)");
+        }
+    }
+    Ok(())
+}

--- a/crates/whisker-cli/src/build/ios.rs
+++ b/crates/whisker-cli/src/build/ios.rs
@@ -1,0 +1,147 @@
+//! `whisker build ipa` — the iOS release pipeline: resolve config →
+//! credential pre-step → cng sync → `xcodebuild archive` →
+//! `-exportArchive`, all authenticated through the App Store Connect
+//! API key (no Xcode sign-in, identical locally and in CI).
+
+use anyhow::{Result, anyhow};
+use clap::{Args as ClapArgs, ValueEnum};
+use std::path::PathBuf;
+use whisker_build::ios::{ExportMethod, IosReleaseInputs, ReleaseSigning};
+use whisker_build::ui;
+use whisker_dev_server::Target;
+
+use crate::{credential, manifest, platforms};
+
+/// Mirrors Apple's ExportOptions `method` spellings (`ad-hoc`, not
+/// fastlane's `adhoc`) so CLI input, plist content, and xcodebuild
+/// error output all use one vocabulary.
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Method {
+    /// App Store / TestFlight upload (default).
+    #[value(name = "app-store-connect")]
+    AppStoreConnect,
+    /// Registered-device distribution (Firebase App Distribution, …).
+    #[value(name = "ad-hoc")]
+    AdHoc,
+}
+
+impl From<Method> for ExportMethod {
+    fn from(m: Method) -> Self {
+        match m {
+            Method::AppStoreConnect => ExportMethod::AppStoreConnect,
+            Method::AdHoc => ExportMethod::AdHoc,
+        }
+    }
+}
+
+#[derive(ClapArgs, Debug)]
+pub struct Args {
+    /// Distribution method for the export step.
+    #[arg(long, value_enum, default_value = "app-store-connect")]
+    method: Method,
+
+    /// Explicit path to the app's Cargo.toml. Defaults to walking up
+    /// from the current directory.
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let m = manifest::resolve(args.manifest_path.as_deref())?;
+    // Same resolution `whisker run ios` uses (run.rs::ios_params_from).
+    let bundle_id = m
+        .config
+        .ios
+        .bundle_id
+        .clone()
+        .or_else(|| m.config.bundle_id.clone())
+        .ok_or_else(|| {
+            anyhow!(
+                "whisker.rs: app.ios(|i| i.bundle_id(\"…\")) or app.bundle_id(\"…\") \
+                 is required for iOS builds"
+            )
+        })?;
+    let scheme = m
+        .config
+        .ios
+        .scheme
+        .clone()
+        .or_else(|| m.config.name.clone())
+        .ok_or_else(|| {
+            anyhow!(
+                "whisker.rs: app.ios(|i| i.scheme(\"…\")) or app.name(\"…\") \
+                 is required for iOS builds"
+            )
+        })?;
+    let workspace_root = crate::run::find_workspace_root(&m.crate_dir).ok_or_else(|| {
+        anyhow!(
+            "no [workspace] Cargo.toml at or above {}",
+            m.crate_dir.display()
+        )
+    })?;
+
+    // Resolved-identity banner first — see build/android.rs for why.
+    let version = m.config.version.clone().unwrap_or_else(|| "0.1.0".into());
+    let build_number = m.config.build_number.unwrap_or(1);
+    let method: ExportMethod = args.method.into();
+    ui::section("Build");
+    ui::info(format!(
+        "building {bundle_id} {version} ({build_number}) — release ipa [{}]",
+        method.plist_value(),
+    ));
+
+    // Credential pre-step before any compilation (prompt up front,
+    // fail fast on key problems). `_staging` holds the decrypted .p8
+    // until xcodebuild finishes.
+    let (_staging, signing) = credential::require_ios_signing(&m.crate_dir, &bundle_id)?;
+
+    // `Target::IosSimulator` here only selects which gen tree to
+    // render — gen/ios/ is one project for simulator and device;
+    // release vs dev is xcodebuild's -destination, not cng's concern.
+    let sync = platforms::sync_for_target(
+        Target::IosSimulator,
+        &m.config,
+        &m.crate_dir,
+        &workspace_root,
+        &m.package,
+    )?;
+    // Stage Whisker modules' iOS Swift sources before xcodebuild so
+    // the pbxproj's WhiskerModules SwiftPM ref resolves — same step
+    // the dev loop runs (see whisker-dev-server::builder). Writes a
+    // no-op package even with zero modules so `import WhiskerModules`
+    // always resolves.
+    let modules = whisker_build::modules::discover(&workspace_root.join("Cargo.toml"), &m.package)?;
+    whisker_build::ios::stage_module_swift_sources(
+        &sync.gen_dir,
+        &workspace_root.join("platforms/ios"),
+        &workspace_root.join("platforms/ios/macros"),
+        &modules,
+    )?;
+
+    let ipa = whisker_build::ios::archive_and_export(&IosReleaseInputs {
+        gen_dir: &sync.gen_dir,
+        scheme: &scheme,
+        workspace_root: &workspace_root,
+        package: &m.package,
+        method,
+        signing: ReleaseSigning {
+            team_id: &signing.team_id,
+            key_path: &signing.key_path,
+            key_id: &signing.key_id,
+            issuer_id: &signing.issuer_id,
+        },
+    })?;
+    ui::info(format!("✓ {}", ipa.display()));
+    match method {
+        ExportMethod::AppStoreConnect => {
+            ui::info("upload via Transporter.app, or keep it for `whisker submit` (planned)");
+        }
+        ExportMethod::AdHoc => {
+            ui::info(
+                "installable on registered devices only — register tester UDIDs on the \
+                 developer portal, then re-run to refresh the profile",
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/whisker-cli/src/build/mod.rs
+++ b/crates/whisker-cli/src/build/mod.rs
@@ -1,0 +1,47 @@
+//! `whisker build` — produce distributable, signed artifacts.
+//!
+//! Responsibility boundary: build resolves the config, syncs `gen/`,
+//! and drives gradle/xcodebuild. Everything credential-shaped
+//! (creating keystores, acquiring keys, decrypting) is delegated to
+//! the `credential` module's pre-step — build only *consumes*
+//! staged signing inputs and never writes to `credentials/`.
+//!
+//! Sequencing rule: the credential pre-step (which may prompt for
+//! the decryption key) runs BEFORE any compilation, so the one
+//! interactive moment happens up front and the long build can be
+//! left unattended.
+
+mod android;
+mod ios;
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use whisker_build::android::ReleaseArtifact;
+
+#[derive(Args, Debug)]
+pub struct BuildArgs {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand, Debug)]
+enum Cmd {
+    /// Android App Bundle (.aab), release-signed from the
+    /// credentials/ store — the format Play Console accepts.
+    Appbundle(android::Args),
+    /// Release-signed APK for direct distribution (Firebase App
+    /// Distribution, internal testing, sideloading).
+    Apk(android::Args),
+    /// iOS .ipa — `xcodebuild archive` + export, signed via the App
+    /// Store Connect API key with Apple's cloud-managed distribution
+    /// certificate. `--method ad-hoc` for device-limited distribution.
+    Ipa(ios::Args),
+}
+
+pub fn run(args: BuildArgs) -> Result<()> {
+    match args.cmd {
+        Cmd::Appbundle(a) => android::run(ReleaseArtifact::AppBundle, a),
+        Cmd::Apk(a) => android::run(ReleaseArtifact::Apk, a),
+        Cmd::Ipa(a) => ios::run(a),
+    }
+}

--- a/crates/whisker-cli/src/credential/android.rs
+++ b/crates/whisker-cli/src/credential/android.rs
@@ -1,0 +1,219 @@
+//! `whisker credential android` — mint (or import) the upload
+//! keystore for one applicationId and store it encrypted.
+//!
+//! Generation is the default path: `keytool -genkeypair` with
+//! random passwords the user never sees. That's safe because the
+//! committed repo is the backup (the whole point of the encrypted
+//! store) and, under Play App Signing, a lost *upload* key is
+//! recoverable through Google support — unlike the pre-Play-App-
+//! Signing world where key loss killed the app.
+//!
+//! Keystores are exact-match per applicationId (no `default`
+//! fallback): separate environments (`com.example.app.dev` /
+//! `com.example.app`) get separate keys, so a leaked dev keystore
+//! never touches production.
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Args;
+use rand::Rng;
+use rand::distributions::Alphanumeric;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use whisker_credentials::{KeystoreMeta, MaterializedDir, android_keystore_rel, android_meta_rel};
+
+use super::prompt;
+use crate::manifest;
+
+#[derive(Args, Debug)]
+pub struct AndroidArgs {
+    /// applicationId to store the keystore under. Defaults to the
+    /// value your `whisker.rs` resolves to (honours WHISKER_ENV-style
+    /// branching in `configure`).
+    #[arg(long)]
+    id: Option<String>,
+
+    /// Import an existing keystore file instead of generating a new
+    /// one (migration path for already-published apps).
+    #[arg(long, value_name = "PATH")]
+    import: Option<PathBuf>,
+
+    /// Explicit path to the app's Cargo.toml. Defaults to walking up
+    /// from the current directory.
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
+}
+
+pub fn run(args: AndroidArgs) -> Result<()> {
+    let m = manifest::resolve(args.manifest_path.as_deref())?;
+    let application_id = match args.id {
+        Some(id) => id,
+        // Same resolution `whisker run android` uses: explicit
+        // android.application_id, else the shared bundle_id.
+        None => manifest::android_application_id(&m.config).ok_or_else(|| {
+            anyhow!(
+                "whisker.rs: app.android(|a| a.application_id(\"…\")) (or app.bundle_id) \
+                 is required — or pass --id <application_id>"
+            )
+        })?,
+    };
+
+    let store = super::open_or_bootstrap(&m.crate_dir)?;
+
+    let jks_rel = android_keystore_rel(&application_id);
+    if store.has(&jks_rel) {
+        if !prompt::is_interactive() {
+            bail!("a keystore for {application_id} already exists in credentials/");
+        }
+        println!(
+            "A keystore for {application_id} already exists. Replacing it means Play will\n\
+             reject uploads signed with the new key unless you reset the upload key with\n\
+             Google Play support first."
+        );
+        if !prompt::confirm("Replace it?")? {
+            bail!("aborted — existing keystore kept.");
+        }
+    }
+
+    match &args.import {
+        Some(path) => {
+            let (jks_bytes, meta) = import_keystore(path)?;
+            store_keystore(&store, &application_id, &jks_bytes, &meta)
+        }
+        None => create_and_store_keystore(&store, &application_id),
+    }
+}
+
+/// Generate + store a fresh keystore for `application_id`. Also the
+/// inline pre-step `whisker build appbundle|apk` runs when the entry
+/// is missing (interactive sessions only — build never creates
+/// credentials in CI).
+pub(crate) fn create_and_store_keystore(
+    store: &whisker_credentials::Store,
+    application_id: &str,
+) -> Result<()> {
+    let (jks_bytes, meta) = generate_keystore(application_id)?;
+    store_keystore(store, application_id, &jks_bytes, &meta)
+}
+
+fn store_keystore(
+    store: &whisker_credentials::Store,
+    application_id: &str,
+    jks_bytes: &[u8],
+    meta: &KeystoreMeta,
+) -> Result<()> {
+    let jks_rel = android_keystore_rel(application_id);
+    let meta_rel = android_meta_rel(application_id);
+    store.put(&jks_rel, jks_bytes)?;
+    store.put(
+        &meta_rel,
+        &serde_json::to_vec(meta).context("serialize keystore metadata")?,
+    )?;
+
+    println!("  ✓ credentials/{jks_rel}.age");
+    println!("  ✓ credentials/{meta_rel}.age");
+    println!();
+    println!("Commit the credentials/ directory — the repo is this keystore's backup.");
+    println!("`whisker build appbundle` / `apk` will use it automatically.");
+    Ok(())
+}
+
+/// Default path: mint a fresh keystore with `keytool` inside a
+/// 0700 staging dir (plaintext never touches the repo), then read
+/// the bytes back for encryption.
+fn generate_keystore(application_id: &str) -> Result<(Vec<u8>, KeystoreMeta)> {
+    let java_home = whisker_build::android::resolve_java_home()
+        .context("generating a keystore needs a JDK (`keytool`) — install one or set JAVA_HOME")?;
+    let keytool = java_home.join("bin/keytool");
+
+    // PKCS12 (modern keytool default) has a single password; keep
+    // both fields equal so the gradle signingConfig stays uniform
+    // across generated and imported keystores.
+    let store_password = random_password();
+    let meta = KeystoreMeta {
+        key_password: store_password.clone(),
+        store_password,
+        key_alias: "upload".to_string(),
+    };
+
+    let staging = MaterializedDir::new()?;
+    let jks_path = staging.dir_path().join("upload.jks");
+    // Passwords go via environment (`-storepass:env`), not argv —
+    // argv is world-readable in `ps` for the keytool's lifetime.
+    let out = Command::new(&keytool)
+        .args(["-genkeypair", "-keystore"])
+        .arg(&jks_path)
+        .args([
+            "-alias",
+            &meta.key_alias,
+            "-keyalg",
+            "RSA",
+            "-keysize",
+            "2048",
+            // ~30 years. Play requires validity past 2033; effectively
+            // "never expires" for an upload key.
+            "-validity",
+            "10950",
+            "-storepass:env",
+            "WHISKER_KEYTOOL_STOREPASS",
+            "-keypass:env",
+            "WHISKER_KEYTOOL_KEYPASS",
+            "-dname",
+        ])
+        .arg(format!("CN={application_id} upload key, O=whisker"))
+        .env("WHISKER_KEYTOOL_STOREPASS", &meta.store_password)
+        .env("WHISKER_KEYTOOL_KEYPASS", &meta.key_password)
+        .output()
+        .with_context(|| format!("spawn {}", keytool.display()))?;
+    if !out.status.success() {
+        bail!(
+            "keytool -genkeypair failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let bytes = std::fs::read(&jks_path)
+        .with_context(|| format!("read generated keystore {}", jks_path.display()))?;
+    println!("  ✓ generated a new upload keystore (alias `upload`, RSA 2048, 30y validity)");
+    Ok((bytes, meta))
+}
+
+/// Migration path: take an existing keystore + its passwords.
+fn import_keystore(path: &Path) -> Result<(Vec<u8>, KeystoreMeta)> {
+    if !prompt::is_interactive() {
+        bail!("--import needs an interactive terminal for the password prompts");
+    }
+    let bytes = std::fs::read(path).with_context(|| format!("read keystore {}", path.display()))?;
+    let store_password = prompt::password("Keystore password:")?;
+    let key_alias = {
+        let a = prompt::line("Key alias (see `keytool -list -keystore <file>`):")?;
+        if a.is_empty() {
+            bail!("key alias is required");
+        }
+        a
+    };
+    let key_password = {
+        let p = prompt::password("Key password (Enter = same as keystore password):")?;
+        if p.is_empty() {
+            store_password.clone()
+        } else {
+            p
+        }
+    };
+    Ok((
+        bytes,
+        KeystoreMeta {
+            store_password,
+            key_password,
+            key_alias,
+        },
+    ))
+}
+
+/// 32 alphanumeric chars (~190 bits) — nobody types these, they live
+/// encrypted next to the keystore.
+fn random_password() -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(32)
+        .map(char::from)
+        .collect()
+}

--- a/crates/whisker-cli/src/credential/asc.rs
+++ b/crates/whisker-cli/src/credential/asc.rs
@@ -1,0 +1,214 @@
+//! Minimal App Store Connect API client — exactly enough for the
+//! `whisker credential ios` wizard to validate a freshly created key
+//! and resolve its team id. Deliberately not a general client:
+//! builds authenticate through xcodebuild's own `-authenticationKey*`
+//! flags, so the only REST consumer today is the wizard.
+
+use anyhow::{Context, Result, anyhow};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub struct KeyAuth<'a> {
+    pub p8_pem: &'a str,
+    pub key_id: &'a str,
+    pub issuer_id: &'a str,
+}
+
+/// Build the ES256 bearer token (JWT) for one request burst.
+///
+/// Hand-rolled on purpose: the JWS is just
+/// `b64url(header).b64url(payload)` signed with the .p8's P-256 key,
+/// and doing it directly keeps us off ring/openssl-backed JWT crates.
+fn bearer_token(auth: &KeyAuth) -> Result<String> {
+    use p256::ecdsa::signature::Signer;
+    use p256::pkcs8::DecodePrivateKey;
+
+    let header = serde_json::json!({ "alg": "ES256", "kid": auth.key_id, "typ": "JWT" });
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before 1970")?
+        .as_secs();
+    // 10-minute expiry; Apple rejects tokens valid longer than 20.
+    let payload = serde_json::json!({
+        "iss": auth.issuer_id,
+        "iat": now,
+        "exp": now + 600,
+        "aud": "appstoreconnect-v1",
+    });
+    let signing_input = format!(
+        "{}.{}",
+        URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header)?),
+        URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload)?),
+    );
+    let key = p256::ecdsa::SigningKey::from_pkcs8_pem(auth.p8_pem)
+        .map_err(|e| anyhow!("the .p8 file is not a valid PKCS#8 P-256 private key: {e}"))?;
+    let signature: p256::ecdsa::Signature = key.sign(signing_input.as_bytes());
+    Ok(format!(
+        "{signing_input}.{}",
+        URL_SAFE_NO_PAD.encode(signature.to_bytes())
+    ))
+}
+
+/// One authenticated GET against the ASC API, with the wizard's
+/// error translation.
+fn get(auth: &KeyAuth, path: &str) -> Result<serde_json::Value> {
+    let token = bearer_token(auth)?;
+    let url = format!("https://api.appstoreconnect.apple.com{path}");
+    match ureq::get(&url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .call()
+    {
+        Ok(resp) => resp.into_json().context("parse ASC API response JSON"),
+        Err(ureq::Error::Status(code, resp)) => {
+            let body = resp.into_string().unwrap_or_default();
+            Err(translate_api_error(code, &body))
+        }
+        Err(e) => Err(e).with_context(|| format!("GET {url}")),
+    }
+}
+
+/// Turn an ASC error response into an actionable message. The body's
+/// `errors[0].code` is the real diagnosis — an Admin key can still
+/// 403 for reasons that have nothing to do with roles (expired
+/// license agreement, lapsed membership), so a canned role hint
+/// alone MISDIAGNOSES those. Always surface Apple's own code +
+/// detail, then add a translation for the cases we know.
+fn translate_api_error(http_status: u16, body: &str) -> anyhow::Error {
+    let first_error = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| v.pointer("/errors/0").cloned());
+    let api_code = first_error
+        .as_ref()
+        .and_then(|e| e.get("code"))
+        .and_then(|c| c.as_str())
+        .unwrap_or("")
+        .to_string();
+    let detail = first_error
+        .as_ref()
+        .and_then(|e| e.get("detail"))
+        .and_then(|d| d.as_str())
+        .unwrap_or("(no detail)")
+        .to_string();
+
+    let hint = if api_code.contains("REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED") {
+        "\nFix: the Apple Developer Program License Agreement needs (re-)acceptance.\n\
+         Have the ACCOUNT HOLDER sign in to https://appstoreconnect.apple.com and\n\
+         accept the pending agreement (the banner on the home page, or Business),\n\
+         then re-run this command — the same key will work."
+    } else if http_status == 401 {
+        "\nFix: Key ID / Issuer ID mismatch, or the key was revoked. Individual keys\n\
+         have no Issuer ID — make sure you created a TEAM key\n\
+         (Users and Access → Integrations → Team Keys)."
+    } else if http_status == 403 {
+        "\nFix: the key lacks permission. Cloud-managed signing needs an Admin-role\n\
+         TEAM key — create one under Team Keys with access = Admin."
+    } else {
+        ""
+    };
+    anyhow!("App Store Connect API error {http_status} ({api_code}): {detail}{hint}")
+}
+
+/// Cheapest authenticated call — proves key id + issuer id + .p8 are
+/// a working combination.
+pub fn validate(auth: &KeyAuth) -> Result<()> {
+    get(auth, "/v1/apps?limit=1").map(|_| ())
+}
+
+/// The team id ("seed id") isn't a first-class API resource, but
+/// every registered bundle id carries it as `seedId`. Returns
+/// `None` for a brand-new team with no bundle ids yet — the wizard
+/// falls back to asking.
+pub fn resolve_team_id(auth: &KeyAuth) -> Result<Option<String>> {
+    let json = get(auth, "/v1/bundleIds?limit=1")?;
+    Ok(json
+        .pointer("/data/0/attributes/seedId")
+        .and_then(|v| v.as_str())
+        .map(str::to_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p256::ecdsa::signature::Verifier;
+    use p256::pkcs8::EncodePrivateKey;
+
+    #[test]
+    fn bearer_token_is_a_verifiable_es256_jws() {
+        let signing_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let pem = signing_key
+            .to_pkcs8_pem(p256::pkcs8::LineEnding::LF)
+            .unwrap();
+        let auth = KeyAuth {
+            p8_pem: &pem,
+            key_id: "ABC123XYZ",
+            issuer_id: "57246542-96fe-1a63-e053-0824d011072a",
+        };
+        let token = bearer_token(&auth).expect("token");
+        let parts: Vec<&str> = token.split('.').collect();
+        assert_eq!(parts.len(), 3, "JWS must be header.payload.signature");
+
+        let header: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[0]).unwrap()).unwrap();
+        assert_eq!(header["alg"], "ES256");
+        assert_eq!(header["kid"], "ABC123XYZ");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+        assert_eq!(payload["aud"], "appstoreconnect-v1");
+        assert_eq!(payload["iss"], auth.issuer_id);
+
+        // The signature must be raw r||s over `header.payload`,
+        // verifiable with the key's public half — exactly what
+        // Apple's edge does.
+        let sig_bytes = URL_SAFE_NO_PAD.decode(parts[2]).unwrap();
+        let sig = p256::ecdsa::Signature::from_slice(&sig_bytes).expect("raw r||s signature");
+        let verifying = p256::ecdsa::VerifyingKey::from(&signing_key);
+        verifying
+            .verify(format!("{}.{}", parts[0], parts[1]).as_bytes(), &sig)
+            .expect("signature verifies");
+    }
+
+    #[test]
+    fn agreement_error_is_translated_not_misdiagnosed_as_role() {
+        // Captured verbatim from a real Admin key blocked by an
+        // unaccepted license agreement — the case a canned
+        // "needs Admin role" hint gets wrong.
+        let body = r#"{
+  "errors" : [ {
+    "id" : "43D2P7EFNE6CWFQL2BY3ZBPNQE",
+    "status" : "403",
+    "code" : "FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED",
+    "title" : "A required agreement is missing or has expired.",
+    "detail" : "This request requires an in-effect agreement that has not been signed or has expired.",
+    "links" : { "see" : "/business" }
+  } ]
+}"#;
+        let msg = translate_api_error(403, body).to_string();
+        assert!(msg.contains("REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED"));
+        assert!(msg.contains("ACCOUNT HOLDER"));
+        assert!(
+            !msg.contains("Admin-role"),
+            "agreement failures must not show the role hint: {msg}"
+        );
+    }
+
+    #[test]
+    fn plain_403_keeps_the_role_hint_and_unparseable_body_is_safe() {
+        let msg = translate_api_error(403, "not json").to_string();
+        assert!(msg.contains("Admin-role"));
+        assert!(msg.contains("(no detail)"));
+        let msg = translate_api_error(401, "{}").to_string();
+        assert!(msg.contains("TEAM key"));
+    }
+
+    #[test]
+    fn garbage_p8_is_a_clear_error() {
+        let auth = KeyAuth {
+            p8_pem: "not a pem",
+            key_id: "X",
+            issuer_id: "Y",
+        };
+        let err = bearer_token(&auth).unwrap_err();
+        assert!(err.to_string().contains("PKCS#8"));
+    }
+}

--- a/crates/whisker-cli/src/credential/ios.rs
+++ b/crates/whisker-cli/src/credential/ios.rs
@@ -1,0 +1,247 @@
+//! `whisker credential ios` — acquire and store the App Store
+//! Connect **Team** API key that powers the whole iOS pipeline
+//! (automatic signing, cloud-managed distribution certificates,
+//! bundle-id auto-registration, and later build upload).
+//!
+//! The ceremony this wizard compresses: create one key in the ASC
+//! web UI, then hand whisker three values. Two of the three are
+//! auto-captured (the `.p8` file and its Key ID, detected from the
+//! `AuthKey_<KEYID>.p8` download); only the Issuer ID is a paste.
+//! The key is validated with a real API call — and the team id
+//! resolved — *before* anything is stored, so a wrong key fails
+//! here with a translated message, never later inside xcodebuild.
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use whisker_credentials::{AscKey, ios_asc_rel};
+
+use super::{asc, prompt};
+use crate::manifest;
+
+/// ASC "Integrations" page — where Team Keys are created.
+const KEYS_URL: &str = "https://appstoreconnect.apple.com/access/integrations/api";
+
+/// How long to watch ~/Downloads before falling back to a manual
+/// path prompt. Creating + downloading a key takes well under a
+/// minute when things go smoothly.
+const DOWNLOAD_WAIT: Duration = Duration::from_secs(180);
+
+#[derive(Args, Debug)]
+pub struct IosArgs {
+    /// Store the key under a specific bundle id instead of the
+    /// team-wide `default` entry. Only needed when some bundle ids
+    /// ship under a DIFFERENT Apple Developer team.
+    #[arg(long, value_name = "BUNDLE_ID")]
+    id: Option<String>,
+
+    /// Explicit path to the app's Cargo.toml. Defaults to walking up
+    /// from the current directory.
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
+}
+
+pub fn run(args: IosArgs) -> Result<()> {
+    if !prompt::is_interactive() {
+        bail!(
+            "`whisker credential ios` is an interactive wizard — run it locally, commit\n\
+             the credentials/ directory, and give CI only $WHISKER_CREDENTIALS_KEY"
+        );
+    }
+    let m = manifest::resolve(args.manifest_path.as_deref())?;
+    let store = super::open_or_bootstrap(&m.crate_dir)?;
+
+    let rel = ios_asc_rel(args.id.as_deref());
+    if store.has(&rel)
+        && !prompt::confirm("An App Store Connect key is already stored. Replace it?")?
+    {
+        bail!("aborted — existing key kept.");
+    }
+    acquire_and_store(&store, &rel)
+}
+
+/// The wizard body: guide key creation, capture the .p8, validate
+/// against the API, store encrypted. Also the inline pre-step
+/// `whisker build ipa` runs when no key is stored yet (interactive
+/// sessions only).
+pub(crate) fn acquire_and_store(store: &whisker_credentials::Store, rel: &str) -> Result<()> {
+    println!("① Create an App Store Connect API key (needs the Account Holder or an Admin):");
+    println!("     {KEYS_URL}");
+    println!("   - Open the **Team Keys** tab (Individual Keys lack an Issuer ID and won't work)");
+    println!("   - Name: anything (e.g. `whisker`) / Access: **Admin**");
+    println!("     (Admin is required for cloud-managed distribution certificates)");
+    println!("   - Generate, then **Download API Key**");
+    prompt::line("Press Enter to open the page in your browser…")?;
+    open_in_browser(KEYS_URL);
+
+    let p8_path = wait_for_p8()?;
+    let key_id = key_id_from(&p8_path)
+        .map(Ok)
+        .unwrap_or_else(|| prompt::line("Key ID (shown next to the key on the page):"))?;
+    let p8_pem =
+        std::fs::read_to_string(&p8_path).with_context(|| format!("read {}", p8_path.display()))?;
+
+    println!("③ The Issuer ID is at the top of the same page (a UUID).");
+    let issuer_id = loop {
+        let v = prompt::line("Issuer ID:")?;
+        if looks_like_uuid(&v) {
+            break v;
+        }
+        println!("   That doesn't look like a UUID (8-4-4-4-12 hex) — check the page header.");
+    };
+
+    println!("   Validating against the App Store Connect API…");
+    let auth = asc::KeyAuth {
+        p8_pem: &p8_pem,
+        key_id: &key_id,
+        issuer_id: &issuer_id,
+    };
+    asc::validate(&auth)?;
+    let team_id = match asc::resolve_team_id(&auth)? {
+        Some(id) => {
+            println!("   ✓ key works — team {id}");
+            id
+        }
+        // Brand-new team with zero registered bundle ids: nothing to
+        // read the seed id from. One manual paste, with directions.
+        None => prompt::line("Team ID (developer.apple.com → Membership details, 10 characters):")?,
+    };
+
+    let entry = AscKey {
+        p8_pem,
+        key_id,
+        issuer_id,
+        team_id,
+    };
+    store.put(
+        rel,
+        &serde_json::to_vec(&entry).context("serialize AscKey")?,
+    )?;
+
+    println!("  ✓ credentials/{rel}.age");
+    println!();
+    println!("Commit the credentials/ directory. `whisker build ipa` will use this key for");
+    println!("signing, provisioning, and bundle-id registration automatically.");
+    println!(
+        "Tip: you can now delete {} — whisker keeps its own encrypted copy.",
+        p8_path.display()
+    );
+    Ok(())
+}
+
+/// Step ②: watch ~/Downloads for a fresh `AuthKey_*.p8`. Falls back
+/// to a manual path prompt on timeout (remote browser, odd download
+/// dir, …). A 60s grace window before "now" catches the
+/// clicked-download-before-Enter case.
+fn wait_for_p8() -> Result<PathBuf> {
+    let downloads = std::env::var_os("HOME")
+        .map(|h| PathBuf::from(h).join("Downloads"))
+        .filter(|p| p.is_dir());
+    let Some(downloads) = downloads else {
+        return prompt_p8_path();
+    };
+    println!(
+        "② Waiting for AuthKey_*.p8 to appear in {} (Ctrl-C to abort)…",
+        downloads.display()
+    );
+    // 60s grace before "now" catches the clicked-download-before-
+    // Enter case; after a declined candidate, only strictly newer
+    // downloads qualify.
+    let mut cutoff = SystemTime::now() - Duration::from_secs(60);
+    let deadline = std::time::Instant::now() + DOWNLOAD_WAIT;
+    while std::time::Instant::now() < deadline {
+        if let Some(found) = newest_authkey(&downloads, cutoff) {
+            println!("   ✓ detected {}", found.display());
+            if prompt::confirm("Use this key?")? {
+                return Ok(found);
+            }
+            cutoff = SystemTime::now();
+            continue;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    println!("   No download detected.");
+    prompt_p8_path()
+}
+
+fn prompt_p8_path() -> Result<PathBuf> {
+    let raw = prompt::line("Path to the downloaded .p8 file (drag & drop works):")?;
+    // Terminal drag & drop escapes spaces; undo the common cases.
+    let cleaned = raw.trim().replace("\\ ", " ");
+    let path = PathBuf::from(cleaned.trim_matches('\'').trim_matches('"'));
+    if !path.is_file() {
+        bail!("{} is not a file", path.display());
+    }
+    Ok(path)
+}
+
+/// Scan for `AuthKey_*.p8` files modified after `cutoff`; newest wins.
+fn newest_authkey(dir: &Path, cutoff: SystemTime) -> Option<PathBuf> {
+    let mut best: Option<(SystemTime, PathBuf)> = None;
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("AuthKey_") || !name.ends_with(".p8") {
+            continue;
+        }
+        let Ok(modified) = entry.metadata().and_then(|m| m.modified()) else {
+            continue;
+        };
+        if modified < cutoff {
+            continue;
+        }
+        if best.as_ref().is_none_or(|(t, _)| modified > *t) {
+            best = Some((modified, entry.path()));
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+/// `AuthKey_ABC123XYZ.p8` → `ABC123XYZ`. None if the user renamed
+/// the file (wizard then asks for the Key ID).
+fn key_id_from(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    let id = name.strip_prefix("AuthKey_")?.strip_suffix(".p8")?;
+    (!id.is_empty() && id.chars().all(|c| c.is_ascii_alphanumeric())).then(|| id.to_string())
+}
+
+fn looks_like_uuid(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('-').collect();
+    parts.len() == 5
+        && [8, 4, 4, 4, 12]
+            .iter()
+            .zip(&parts)
+            .all(|(len, part)| part.len() == *len && part.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
+/// Best-effort: failure to open a browser is not an error — the URL
+/// is already on screen.
+fn open_in_browser(url: &str) {
+    #[cfg(target_os = "macos")]
+    let _ = std::process::Command::new("open").arg(url).status();
+    #[cfg(target_os = "linux")]
+    let _ = std::process::Command::new("xdg-open").arg(url).status();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_id_parses_from_apple_filename() {
+        assert_eq!(
+            key_id_from(Path::new("/tmp/AuthKey_ABC123XYZ.p8")).as_deref(),
+            Some("ABC123XYZ")
+        );
+        assert_eq!(key_id_from(Path::new("/tmp/renamed.p8")), None);
+        assert_eq!(key_id_from(Path::new("/tmp/AuthKey_.p8")), None);
+    }
+
+    #[test]
+    fn uuid_shape_check() {
+        assert!(looks_like_uuid("57246542-96fe-1a63-e053-0824d011072a"));
+        assert!(!looks_like_uuid("ABC123XYZ"));
+        assert!(!looks_like_uuid("57246542-96fe-1a63-e053"));
+    }
+}

--- a/crates/whisker-cli/src/credential/mod.rs
+++ b/crates/whisker-cli/src/credential/mod.rs
@@ -1,0 +1,248 @@
+//! `whisker credential` — signing-credential management.
+//!
+//! ## Boundary with `whisker build`
+//!
+//! Everything that *creates or stores* signing material lives here;
+//! `whisker build` only *consumes* it (via
+//! `whisker_credentials::Store::{ios_signing, android_signing}`)
+//! and, when something is missing, either runs these wizards inline
+//! (TTY) or fails with the exact command to run (CI). Build code
+//! never writes to `credentials/`.
+//!
+//! ## Bootstrap is implicit
+//!
+//! There is deliberately no `init` subcommand: the first
+//! `whisker credential ios` / `android` bootstraps the store
+//! (generates the age key pair, writes `credentials/recipients.txt`)
+//! idempotently before running its wizard. The secret key is shown
+//! exactly once and never persisted — afterwards it arrives via
+//! `$WHISKER_CREDENTIALS_KEY` or an interactive prompt at build
+//! time. Because the store is asymmetric, a teammate's clone can
+//! ADD credentials without ever holding the secret key.
+
+mod android;
+mod asc;
+mod ios;
+mod prompt;
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::{Args, Subcommand};
+use std::path::Path;
+use whisker_credentials::{AndroidSigning, Identity, MaterializedDir, Store};
+
+pub use android::AndroidArgs;
+
+#[derive(Args, Debug)]
+pub struct CredentialArgs {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand, Debug)]
+enum Cmd {
+    /// Acquire the App Store Connect API key (Team Key, Admin) via a
+    /// guided wizard and store it encrypted under `credentials/`.
+    /// First run also bootstraps the store.
+    Ios(ios::IosArgs),
+    /// Generate (or import) the Android upload keystore for this
+    /// app's applicationId and store it encrypted under
+    /// `credentials/`. First run also bootstraps the store.
+    Android(android::AndroidArgs),
+}
+
+pub fn run(args: CredentialArgs) -> Result<()> {
+    match args.cmd {
+        Cmd::Ios(a) => ios::run(a),
+        Cmd::Android(a) => android::run(a),
+    }
+}
+
+/// Open the store, bootstrapping it interactively on first use.
+///
+/// Bootstrap runs BEFORE the calling wizard so an aborted wizard
+/// leaves a valid (empty) store, never a broken half-state. If the
+/// user declines the "saved the key?" confirmation the bootstrap is
+/// rolled back — a store whose secret key nobody saved is
+/// permanently undecryptable and must not be left behind.
+pub(crate) fn open_or_bootstrap(project_root: &Path) -> Result<Store> {
+    if Store::exists(project_root) {
+        return Store::open(project_root);
+    }
+    if !prompt::is_interactive() {
+        bail!(
+            "credentials store not found at {} — run `whisker credential ios` or \
+             `whisker credential android` locally first, then commit the credentials/ directory",
+            Store::dir_for(project_root).display()
+        );
+    }
+
+    println!("First-time credential setup:");
+    let (store, secret) = Store::bootstrap(project_root)?;
+    println!(
+        "  ✓ created {}/{} (public key — safe to commit)",
+        whisker_credentials::DIR_NAME,
+        whisker_credentials::RECIPIENTS_FILE,
+    );
+    println!();
+    println!("  Your credential encryption key (shown ONCE, never stored by whisker):");
+    println!();
+    println!("      {secret}");
+    println!();
+    println!("  Store it in your password manager now. Builds will ask for it");
+    println!(
+        "  (or read ${}). Losing it means losing every credential in this store.",
+        whisker_credentials::IDENTITY_ENV,
+    );
+    println!();
+    let saved = prompt::confirm("Saved to your password manager?")?;
+    if !saved {
+        // Roll back: an unsaved key makes the store write-only garbage.
+        std::fs::remove_dir_all(Store::dir_for(project_root))
+            .context("roll back credentials dir")?;
+        bail!("aborted — nothing was created. Re-run when ready to save the key.");
+    }
+    println!(
+        "  Note: credentials/ contents are age-encrypted, but in a PUBLIC repository the\n\
+         \x20 ciphertext lives in history forever — if the key ever leaks, rotate the\n\
+         \x20 underlying credentials themselves, not just the key."
+    );
+    println!(
+        "  CI setup: `gh secret set {}` with this key.",
+        whisker_credentials::IDENTITY_ENV,
+    );
+    println!();
+    Ok(store)
+}
+
+/// Acquire the decryption identity: `$WHISKER_CREDENTIALS_KEY` first,
+/// then an interactive hidden prompt (3 attempts). The pasted key is
+/// checked against `recipients.txt` *before* any decryption so a
+/// wrong-repo key fails with a specific message instead of age's
+/// generic "no matching keys".
+pub(crate) fn obtain_identity(store: &Store) -> Result<Identity> {
+    if let Some(identity) = Identity::from_env()? {
+        if !identity.matches(store) {
+            bail!(
+                "${} does not match this repository's credentials/recipients.txt \
+                 (key for a different repo, or the store was re-bootstrapped?)",
+                whisker_credentials::IDENTITY_ENV,
+            );
+        }
+        return Ok(identity);
+    }
+    if !prompt::is_interactive() {
+        bail!(
+            "${} is not set — add the credential key to this environment's secrets \
+             (`gh secret set {}` for GitHub Actions)",
+            whisker_credentials::IDENTITY_ENV,
+            whisker_credentials::IDENTITY_ENV,
+        );
+    }
+    for _ in 0..3 {
+        let pasted =
+            prompt::password("Credential key (AGE-SECRET-KEY-…, from your password manager):")?;
+        match Identity::parse(&pasted) {
+            Ok(identity) if identity.matches(store) => return Ok(identity),
+            Ok(_) => println!("   That key doesn't match this repository's credentials store."),
+            Err(e) => println!("   {e}"),
+        }
+    }
+    bail!("no valid credential key after 3 attempts")
+}
+
+/// Build pre-step for `whisker build ipa`: staged iOS signing
+/// inputs, with the same two invariants as the Android variant
+/// (CI never creates credentials; keep the guard alive through
+/// xcodebuild).
+pub(crate) fn require_ios_signing(
+    project_root: &Path,
+    bundle_id: &str,
+) -> Result<(MaterializedDir, whisker_credentials::IosSigning)> {
+    let store = if Store::exists(project_root) {
+        Store::open(project_root)?
+    } else {
+        if !prompt::is_interactive() {
+            bail!(
+                "no credentials store at {} — run `whisker credential ios` locally, \
+                 commit the credentials/ directory, and set ${} in CI",
+                Store::dir_for(project_root).display(),
+                whisker_credentials::IDENTITY_ENV,
+            );
+        }
+        println!("iOS release signing isn't set up for this app yet.");
+        open_or_bootstrap(project_root)?
+    };
+
+    if store.resolve_ios_rel(bundle_id).is_none() {
+        if !prompt::is_interactive() {
+            bail!(
+                "no App Store Connect key in credentials/ — run `whisker credential ios` \
+                 locally and commit"
+            );
+        }
+        println!("No App Store Connect API key stored yet — starting the setup wizard.");
+        ios::acquire_and_store(&store, &whisker_credentials::ios_asc_rel(None))?;
+    }
+
+    let identity = obtain_identity(&store)?;
+    let staging = MaterializedDir::new()?;
+    let signing = store
+        .ios_signing(bundle_id, &identity, &staging)?
+        .ok_or_else(|| {
+            anyhow!("App Store Connect key entry vanished — re-run `whisker credential ios`")
+        })?;
+    Ok((staging, signing))
+}
+
+/// Build pre-step for `whisker build appbundle|apk`: produce staged
+/// Android signing inputs, creating missing pieces inline when a
+/// human is present. Two invariants live here:
+///
+/// - **CI never creates credentials.** A keystore minted on an
+///   ephemeral runner would sign a release nobody can ever sign
+///   again — non-interactive sessions fail with the exact command
+///   to run locally instead.
+/// - Keep the returned [`MaterializedDir`] alive for the whole
+///   gradle invocation; the signing paths point into it.
+pub(crate) fn require_android_signing(
+    project_root: &Path,
+    application_id: &str,
+) -> Result<(MaterializedDir, AndroidSigning)> {
+    let store = if Store::exists(project_root) {
+        Store::open(project_root)?
+    } else {
+        if !prompt::is_interactive() {
+            bail!(
+                "no credentials store at {} — run `whisker credential android` locally, \
+                 commit the credentials/ directory, and set ${} in CI",
+                Store::dir_for(project_root).display(),
+                whisker_credentials::IDENTITY_ENV,
+            );
+        }
+        println!("Android release signing isn't set up for this app yet.");
+        open_or_bootstrap(project_root)?
+    };
+
+    if !store.has(&whisker_credentials::android_keystore_rel(application_id)) {
+        if !prompt::is_interactive() {
+            bail!(
+                "no upload keystore for {application_id} in credentials/ — run \
+                 `whisker credential android --id {application_id}` locally and commit"
+            );
+        }
+        println!("No upload keystore for {application_id} yet — creating one.");
+        android::create_and_store_keystore(&store, application_id)?;
+    }
+
+    let identity = obtain_identity(&store)?;
+    let staging = MaterializedDir::new()?;
+    let signing = store
+        .android_signing(application_id, &identity, &staging)?
+        .ok_or_else(|| {
+            anyhow!(
+                "keystore entry for {application_id} is incomplete — re-run \
+                 `whisker credential android --id {application_id}`"
+            )
+        })?;
+    Ok((staging, signing))
+}

--- a/crates/whisker-cli/src/credential/prompt.rs
+++ b/crates/whisker-cli/src/credential/prompt.rs
@@ -1,0 +1,38 @@
+//! Tiny interactive-input helpers for the credential wizards.
+//!
+//! Deliberately plain stdin/stdout — the wizards are sequential Q&A,
+//! not a TUI, so the output stays copy-pastable and agent-readable
+//! (same reasoning as `whisker doctor`'s plain scrollback).
+
+use anyhow::{Context, Result};
+use std::io::{IsTerminal, Write};
+
+/// Both ends of the conversation must be a terminal — a wizard with
+/// stdin piped from a file would silently consume garbage.
+pub fn is_interactive() -> bool {
+    std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+}
+
+/// `question [y/N]` — default no.
+pub fn confirm(question: &str) -> Result<bool> {
+    let answer = line(&format!("{question} [y/N]"))?;
+    Ok(matches!(answer.trim(), "y" | "Y" | "yes"))
+}
+
+/// Prompt on stdout, read one trimmed line from stdin.
+pub fn line(question: &str) -> Result<String> {
+    print!("{question} ");
+    std::io::stdout().flush().context("flush stdout")?;
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_line(&mut buf)
+        .context("read from stdin")?;
+    Ok(buf.trim().to_string())
+}
+
+/// Hidden input (no echo) — passwords and the age secret key.
+pub fn password(question: &str) -> Result<String> {
+    rpassword::prompt_password(format!("{question} "))
+        .context("read hidden input from terminal")
+        .map(|s| s.trim().to_string())
+}

--- a/crates/whisker-cli/src/doctor.rs
+++ b/crates/whisker-cli/src/doctor.rs
@@ -43,6 +43,10 @@ pub fn run(args: Args) -> Result<()> {
         report.add_section("iOS", check_ios);
     }
 
+    // Signing-credential health — only meaningful inside an app
+    // directory; reports a single neutral line elsewhere.
+    report.add_section("Credentials", check_credentials);
+
     // No Lynx section: Android pulls the Lynx aar from gradle's
     // `whiskerrs.github.io/lynx/maven` repository, and iOS resolves
     // the four Lynx xcframeworks via SPM's `binaryTarget(url:checksum:)`
@@ -397,6 +401,95 @@ fn check_ios() -> Vec<Check> {
         )),
     }
 
+    out
+}
+
+/// Signing-credential health for the app the cwd sits in. Pure
+/// inspection like every other check: no network calls (ASC key
+/// validity is verified online by `whisker credential ios` at store
+/// time), no prompting (a missing env key is a warn — builds prompt
+/// interactively).
+fn check_credentials() -> Vec<Check> {
+    use whisker_credentials::{Identity, Store};
+
+    let mut out = Vec::new();
+    let Ok(m) = crate::manifest::resolve(None) else {
+        out.push(Check::ok(
+            "credentials",
+            "not inside a Whisker app (skipped)",
+        ));
+        return out;
+    };
+    if !Store::exists(&m.crate_dir) {
+        out.push(Check::warn(
+            "credentials store",
+            "none yet — created by the first `whisker credential ios|android`",
+        ));
+        return out;
+    }
+    let store = match Store::open(&m.crate_dir) {
+        Ok(s) => {
+            out.push(Check::ok(
+                "credentials store",
+                Store::dir_for(&m.crate_dir).display().to_string(),
+            ));
+            s
+        }
+        Err(e) => {
+            out.push(Check::err("credentials store", format!("{e:#}")));
+            return out;
+        }
+    };
+
+    match Identity::from_env() {
+        Ok(Some(identity)) if identity.matches(&store) => out.push(Check::ok(
+            format!("${}", whisker_credentials::IDENTITY_ENV),
+            "set — decrypts this store",
+        )),
+        Ok(Some(_)) => out.push(Check::err(
+            format!("${}", whisker_credentials::IDENTITY_ENV),
+            "set but does NOT match credentials/recipients.txt",
+        )),
+        Ok(None) => out.push(Check::warn(
+            format!("${}", whisker_credentials::IDENTITY_ENV),
+            "not set — builds will prompt for the key interactively",
+        )),
+        Err(e) => out.push(Check::err(
+            format!("${}", whisker_credentials::IDENTITY_ENV),
+            format!("{e:#}"),
+        )),
+    }
+
+    // Per-identifier coverage, using the same resolution the build
+    // commands use.
+    if let Some(bundle_id) = m
+        .config
+        .ios
+        .bundle_id
+        .clone()
+        .or_else(|| m.config.bundle_id.clone())
+    {
+        match store.resolve_ios_rel(&bundle_id) {
+            Some(rel) => out.push(Check::ok(format!("ios {bundle_id}"), rel)),
+            None => out.push(Check::warn(
+                format!("ios {bundle_id}"),
+                "no App Store Connect key — run `whisker credential ios`",
+            )),
+        }
+    }
+    if let Some(application_id) = crate::manifest::android_application_id(&m.config) {
+        if store.has(&whisker_credentials::android_keystore_rel(&application_id)) {
+            out.push(Check::ok(
+                format!("android {application_id}"),
+                whisker_credentials::android_keystore_rel(&application_id),
+            ));
+        } else {
+            out.push(Check::warn(
+                format!("android {application_id}"),
+                "no upload keystore — run `whisker credential android`",
+            ));
+        }
+    }
     out
 }
 

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -35,7 +35,9 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+pub mod build;
 pub mod build_dispatch;
+pub mod credential;
 pub mod doctor;
 pub mod fmt;
 pub mod linker_shim;
@@ -87,6 +89,18 @@ enum Command {
     /// `whisker run ios` from inside the new directory.
     New(new_app::NewAppArgs),
 
+    /// Produce distributable, signed artifacts — `appbundle` (.aab)
+    /// and `apk` today; `ipa` next. Signing material comes from the
+    /// encrypted `credentials/` store; missing pieces are set up
+    /// interactively on first use.
+    Build(build::BuildArgs),
+
+    /// Manage signing credentials — the age-encrypted `credentials/`
+    /// store committed to the repo. `whisker build` runs these
+    /// wizards automatically when something is missing; invoke them
+    /// directly to rotate or import.
+    Credential(credential::CredentialArgs),
+
     /// Format Rust source — a rustfmt drop-in that ALSO formats
     /// Whisker's `render!` / `css!` macro bodies (which rustfmt leaves
     /// untouched). Respects `rustfmt.toml` only; no whisker-specific
@@ -131,6 +145,8 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<()> {
         Command::Run(a) => run::run(a),
         Command::NewModule(a) => new_module::run(a),
         Command::New(a) => new_app::run(a),
+        Command::Build(a) => build::run(a),
+        Command::Credential(a) => credential::run(a),
         Command::Fmt(a) => fmt::run(a),
         Command::BuildIos(a) => build_dispatch::run_ios(a),
         Command::BuildAndroid(a) => build_dispatch::run_android(a),

--- a/crates/whisker-cli/src/manifest.rs
+++ b/crates/whisker-cli/src/manifest.rs
@@ -105,6 +105,19 @@ fn find_package_cargo_toml(start: &Path) -> Option<PathBuf> {
     }
 }
 
+/// The applicationId an Android build of this config uses — the
+/// explicit `android.application_id`, else the shared `bundle_id`.
+/// Single source of truth for `whisker run android`,
+/// `whisker credential android`, and `whisker build appbundle|apk`,
+/// so the credential lookup key always matches what gradle builds.
+pub fn android_application_id(config: &Config) -> Option<String> {
+    config
+        .android
+        .application_id
+        .clone()
+        .or_else(|| config.bundle_id.clone())
+}
+
 /// Cheap test for `[package]` without pulling in a full TOML parser
 /// just for the walk-up phase. We do a real `toml::from_str` once
 /// we've picked a winning candidate (see `parse_package_name`).

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -529,7 +529,7 @@ fn ios_params_from(m: &manifest::ResolvedManifest, project_dir: &Path) -> Result
 /// Walk up from `start` looking for a `Cargo.toml` containing a
 /// `[workspace]` section. Returns the directory holding the matching
 /// Cargo.toml, or `None` if we walk off the top of the filesystem.
-fn find_workspace_root(start: &Path) -> Option<PathBuf> {
+pub(crate) fn find_workspace_root(start: &Path) -> Option<PathBuf> {
     // Canonicalize so the upward walk doesn't bottom out at an empty
     // PathBuf when `start` is relative and the workspace root happens
     // to be the process's cwd. An empty `workspace_root` later feeds

--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -680,7 +680,14 @@ pub fn inputs_from_with_engine(
         // (`extra_application_attributes`): the template's
         // `<application` open tag grew a placeholder + the inputs/
         // fingerprint shape grew a field, so existing trees regenerate.
-        template_version: 10,
+        // Bumped 10 → 11 for release signing: app/build.gradle.kts
+        // grew the env-var-driven `whiskerRelease` signingConfig
+        // (`WHISKER_ANDROID_*`) that `whisker build appbundle|apk`
+        // injects. Without the bump, pre-existing gen trees keep the
+        // signing-less gradle script and release builds come out
+        // UNSIGNED (uninstallable) even though the build command
+        // exported the env vars.
+        template_version: 11,
     })
 }
 
@@ -723,7 +730,7 @@ mod tests {
             extra_gradle_plugins: Vec::new(),
             extra_gradle_dependencies: Vec::new(),
             extra_files: BTreeMap::new(),
-            template_version: 10,
+            template_version: 11,
         }
     }
 

--- a/crates/whisker-cng/src/templates/android/app/build.gradle.kts
+++ b/crates/whisker-cng/src/templates/android/app/build.gradle.kts
@@ -47,6 +47,24 @@ android {
         jvmTarget = "17"
     }
 
+    // Release signing is injected by `whisker build appbundle|apk`
+    // through environment variables, materialized from the app's
+    // encrypted credentials/ store for the duration of one gradle
+    // invocation. No secret ever lands in this generated tree. When
+    // the vars are absent (plain ./gradlew runs), release builds
+    // stay unsigned — signing is whisker's job, not gradle's.
+    val whiskerKeystore = System.getenv("WHISKER_ANDROID_KEYSTORE")
+    if (whiskerKeystore != null) {
+        signingConfigs {
+            create("whiskerRelease") {
+                storeFile = file(whiskerKeystore)
+                storePassword = System.getenv("WHISKER_ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("WHISKER_ANDROID_KEY_ALIAS")
+                keyPassword = System.getenv("WHISKER_ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         getByName("debug") {
             isMinifyEnabled = false
@@ -57,6 +75,9 @@ android {
         }
         getByName("release") {
             isMinifyEnabled = false
+            if (whiskerKeystore != null) {
+                signingConfig = signingConfigs.getByName("whiskerRelease")
+            }
         }
     }
 }

--- a/crates/whisker-credentials/Cargo.toml
+++ b/crates/whisker-credentials/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "whisker-credentials"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories = ["development-tools"]
+description = "Whisker credential store — age-encrypted signing credentials committed to the app repo."
+
+[dependencies]
+# X25519 file encryption (the `age` format). Chosen over a
+# passphrase/openssl scheme because the recipient model lets clones
+# WITHOUT the secret key still add credentials (encrypt-to-public-key),
+# and the format has a maintained pure-Rust implementation.
+age = "0.11"
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# Session-scoped plaintext staging (deleted on drop) — decrypted
+# keystores / .p8 files exist on disk only while a build runs.
+tempfile = "3"

--- a/crates/whisker-credentials/src/entries.rs
+++ b/crates/whisker-credentials/src/entries.rs
@@ -1,0 +1,233 @@
+//! Typed entry payloads + the store layout paths, plus the
+//! build-facing resolvers that turn "give me signing inputs for this
+//! identifier" into materialized files.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::materialize::MaterializedDir;
+use crate::store::{Identity, Store};
+
+/// App Store Connect **Team** API key (Admin role). One entry powers
+/// everything iOS: automatic signing, cloud-managed distribution,
+/// bundle-id auto-registration, and (later) build upload.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AscKey {
+    /// The `AuthKey_<key_id>.p8` contents (PKCS#8 PEM).
+    pub p8_pem: String,
+    pub key_id: String,
+    pub issuer_id: String,
+    /// Resolved at wizard time from the key itself (bundleIds
+    /// `seedId`) so builds never have to ask the user for it.
+    pub team_id: String,
+}
+
+/// Android upload-keystore metadata; the keystore bytes themselves
+/// live in a sibling binary entry ([`android_keystore_rel`]).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KeystoreMeta {
+    pub store_password: String,
+    pub key_password: String,
+    pub key_alias: String,
+}
+
+/// `ios/<bundle_id or "default">/asc.json`
+pub fn ios_asc_rel(bundle_id: Option<&str>) -> String {
+    format!("ios/{}/asc.json", bundle_id.unwrap_or("default"))
+}
+
+/// `android/<application_id>/keystore.jks`
+pub fn android_keystore_rel(application_id: &str) -> String {
+    format!("android/{application_id}/keystore.jks")
+}
+
+/// `android/<application_id>/keystore.json`
+pub fn android_meta_rel(application_id: &str) -> String {
+    format!("android/{application_id}/keystore.json")
+}
+
+/// Decrypted, on-disk iOS signing inputs for one build. Paths live
+/// inside a [`MaterializedDir`] owned by the caller — they vanish
+/// when the build's guard drops.
+pub struct IosSigning {
+    /// `AuthKey_<key_id>.p8` — the filename shape Apple's tools
+    /// conventionally search for.
+    pub key_path: PathBuf,
+    pub key_id: String,
+    pub issuer_id: String,
+    pub team_id: String,
+}
+
+/// Decrypted, on-disk Android signing inputs for one build.
+pub struct AndroidSigning {
+    pub keystore_path: PathBuf,
+    pub store_password: String,
+    pub key_password: String,
+    pub key_alias: String,
+}
+
+impl Store {
+    /// Which entry would an iOS build for `bundle_id` use, if any?
+    /// Exact per-bundle override wins; otherwise the team-wide
+    /// `default` entry.
+    pub fn resolve_ios_rel(&self, bundle_id: &str) -> Option<String> {
+        let exact = ios_asc_rel(Some(bundle_id));
+        if self.has(&exact) {
+            return Some(exact);
+        }
+        let default = ios_asc_rel(None);
+        self.has(&default).then_some(default)
+    }
+
+    /// Decrypt + stage the iOS signing inputs for `bundle_id`.
+    /// `Ok(None)` = no entry (caller runs the wizard or errors with
+    /// the exact `whisker credential ios` invocation to run).
+    pub fn ios_signing(
+        &self,
+        bundle_id: &str,
+        identity: &Identity,
+        dir: &MaterializedDir,
+    ) -> Result<Option<IosSigning>> {
+        let Some(rel) = self.resolve_ios_rel(bundle_id) else {
+            return Ok(None);
+        };
+        let json = self.get(&rel, identity)?;
+        let key: AscKey = serde_json::from_slice(&json)
+            .with_context(|| format!("parse decrypted {rel} as AscKey JSON"))?;
+        let key_path = dir.write(&format!("AuthKey_{}.p8", key.key_id), key.p8_pem.as_bytes())?;
+        Ok(Some(IosSigning {
+            key_path,
+            key_id: key.key_id,
+            issuer_id: key.issuer_id,
+            team_id: key.team_id,
+        }))
+    }
+
+    /// Decrypt + stage the Android signing inputs for
+    /// `application_id`. Exact-match only — upload keystores are
+    /// per-app assets (see crate docs).
+    pub fn android_signing(
+        &self,
+        application_id: &str,
+        identity: &Identity,
+        dir: &MaterializedDir,
+    ) -> Result<Option<AndroidSigning>> {
+        let jks_rel = android_keystore_rel(application_id);
+        let meta_rel = android_meta_rel(application_id);
+        if !self.has(&jks_rel) || !self.has(&meta_rel) {
+            return Ok(None);
+        }
+        let meta: KeystoreMeta = serde_json::from_slice(&self.get(&meta_rel, identity)?)
+            .with_context(|| format!("parse decrypted {meta_rel} as KeystoreMeta JSON"))?;
+        let jks = self.get(&jks_rel, identity)?;
+        let keystore_path = dir.write(&format!("{application_id}.jks"), &jks)?;
+        Ok(Some(AndroidSigning {
+            keystore_path,
+            store_password: meta.store_password,
+            key_password: meta.key_password,
+            key_alias: meta.key_alias,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> (tempfile::TempDir, Store, Identity) {
+        let root = tempfile::Builder::new()
+            .prefix("whisker-credentials-test-")
+            .tempdir()
+            .unwrap();
+        let (store, secret) = Store::bootstrap(root.path()).unwrap();
+        let identity = Identity::parse(&secret).unwrap();
+        (root, store, identity)
+    }
+
+    #[test]
+    fn ios_resolution_falls_back_to_default() {
+        let (_root, store, _id) = store();
+        store.put(&ios_asc_rel(None), b"{}").unwrap();
+        assert_eq!(
+            store.resolve_ios_rel("com.example.app"),
+            Some("ios/default/asc.json".to_string())
+        );
+        store
+            .put(&ios_asc_rel(Some("com.example.app")), b"{}")
+            .unwrap();
+        assert_eq!(
+            store.resolve_ios_rel("com.example.app"),
+            Some("ios/com.example.app/asc.json".to_string())
+        );
+    }
+
+    #[test]
+    fn ios_signing_materializes_p8_with_apple_filename() {
+        let (_root, store, identity) = store();
+        let key = AscKey {
+            p8_pem: "-----BEGIN PRIVATE KEY-----\nMAo=\n-----END PRIVATE KEY-----\n".into(),
+            key_id: "ABC123XYZ".into(),
+            issuer_id: "57246542-96fe-1a63-e053-0824d011072a".into(),
+            team_id: "ABCDE12345".into(),
+        };
+        store
+            .put(
+                &ios_asc_rel(None),
+                serde_json::to_vec(&key).unwrap().as_slice(),
+            )
+            .unwrap();
+
+        let dir = MaterializedDir::new().unwrap();
+        let signing = store
+            .ios_signing("com.example.app", &identity, &dir)
+            .unwrap()
+            .expect("entry present");
+        assert!(signing.key_path.ends_with("AuthKey_ABC123XYZ.p8"));
+        assert_eq!(
+            std::fs::read_to_string(&signing.key_path).unwrap(),
+            key.p8_pem
+        );
+        assert_eq!(signing.team_id, "ABCDE12345");
+    }
+
+    #[test]
+    fn android_signing_requires_both_entries() {
+        let (_root, store, identity) = store();
+        let dir = MaterializedDir::new().unwrap();
+        store
+            .put(&android_keystore_rel("com.example.app"), b"jksbytes")
+            .unwrap();
+        // meta missing → not resolvable yet
+        assert!(
+            store
+                .android_signing("com.example.app", &identity, &dir)
+                .unwrap()
+                .is_none()
+        );
+        let meta = KeystoreMeta {
+            store_password: "sp".into(),
+            key_password: "kp".into(),
+            key_alias: "upload".into(),
+        };
+        store
+            .put(
+                &android_meta_rel("com.example.app"),
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .unwrap();
+        let signing = store
+            .android_signing("com.example.app", &identity, &dir)
+            .unwrap()
+            .expect("both entries present");
+        assert_eq!(std::fs::read(&signing.keystore_path).unwrap(), b"jksbytes");
+        assert_eq!(signing.key_alias, "upload");
+        // exact-match only: a different application id resolves to none
+        assert!(
+            store
+                .android_signing("com.example.other", &identity, &dir)
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/crates/whisker-credentials/src/lib.rs
+++ b/crates/whisker-credentials/src/lib.rs
@@ -1,0 +1,65 @@
+//! Age-encrypted credential store, committed to the user's repo.
+//!
+//! ## Model
+//!
+//! Signing credentials (Android upload keystores, App Store Connect
+//! API keys) live **encrypted inside the app repository** under
+//! `<project>/credentials/`, so the repo itself is the backup and
+//! the team-share mechanism. One asymmetric age key pair protects
+//! the whole store:
+//!
+//! - `credentials/recipients.txt` — the **public** key(s). Committed
+//!   in plaintext. Anyone with a clone can *add* credentials
+//!   (encryption needs only this file).
+//! - The **secret** key (`AGE-SECRET-KEY-1…`) is never written to
+//!   disk by whisker. It is shown exactly once at bootstrap (the
+//!   user stores it in a password manager) and afterwards arrives
+//!   via [`IDENTITY_ENV`] or an interactive prompt at build time.
+//!
+//! ## Layout
+//!
+//! ```text
+//! credentials/
+//!   recipients.txt                                  (plaintext, committed)
+//!   ios/default/asc.json.age                        (team-wide ASC API key)
+//!   ios/<bundle_id>/asc.json.age                    (per-bundle override)
+//!   android/<application_id>/keystore.jks.age       (upload keystore)
+//!   android/<application_id>/keystore.json.age      (passwords + alias)
+//! ```
+//!
+//! iOS resolution falls back `<bundle_id>` → `default` because an
+//! ASC key is team-scoped (one key signs every bundle id in the
+//! team); the per-bundle entry exists for the rare "dev builds ship
+//! under a different Apple team" setup. Android is exact-match only:
+//! an upload keystore is a per-app asset.
+//!
+//! ## Boundary
+//!
+//! This crate owns encrypt/decrypt, layout, and plaintext staging
+//! ([`MaterializedDir`], deleted on drop). It deliberately has **no
+//! TTY or UI dependencies** — prompting for the secret key and
+//! running wizards is the CLI's job (`whisker credential …`), which
+//! keeps `whisker build`'s pre-step a pure library call.
+
+mod entries;
+mod materialize;
+mod store;
+
+pub use entries::{
+    AndroidSigning, AscKey, IosSigning, KeystoreMeta, android_keystore_rel, android_meta_rel,
+    ios_asc_rel,
+};
+pub use materialize::MaterializedDir;
+pub use store::{Identity, Store};
+
+/// Environment variable carrying the age secret key
+/// (`AGE-SECRET-KEY-1…`). Checked before any interactive prompt; the
+/// only credential-related secret a CI environment needs.
+pub const IDENTITY_ENV: &str = "WHISKER_CREDENTIALS_KEY";
+
+/// Store directory name under the project root. Committed to git —
+/// everything inside except `recipients.txt` is age ciphertext.
+pub const DIR_NAME: &str = "credentials";
+
+/// Public-key list file inside [`DIR_NAME`].
+pub const RECIPIENTS_FILE: &str = "recipients.txt";

--- a/crates/whisker-credentials/src/materialize.rs
+++ b/crates/whisker-credentials/src/materialize.rs
@@ -1,0 +1,83 @@
+//! Plaintext staging for the duration of one build.
+//!
+//! xcodebuild and gradle take *file paths* (an `AuthKey_….p8`, a
+//! `.jks`), so fully in-memory secrets aren't possible. The
+//! compromise: decrypted bytes land in a fresh `0700` temp
+//! directory whose lifetime is tied to this guard — dropped (or
+//! unwound on panic) → directory and contents are deleted. Build
+//! code must never copy these files anywhere else, in particular
+//! not into `gen/` or the credentials dir.
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+/// Guard owning the staging directory. Keep it alive for the whole
+/// build; everything under it disappears on drop.
+pub struct MaterializedDir {
+    dir: tempfile::TempDir,
+}
+
+impl MaterializedDir {
+    pub fn new() -> Result<Self> {
+        let dir = tempfile::Builder::new()
+            .prefix("whisker-credentials-")
+            .tempdir()
+            .context("create credential staging dir")?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+                .context("chmod 700 credential staging dir")?;
+        }
+        Ok(Self { dir })
+    }
+
+    /// The staging directory itself — for tools that need to *create*
+    /// a file in the protected area (e.g. `keytool -genkeypair`
+    /// writing a fresh keystore) rather than receive bytes.
+    pub fn dir_path(&self) -> &std::path::Path {
+        self.dir.path()
+    }
+
+    /// Write `bytes` as `<staging>/<name>` with owner-only
+    /// permissions. Returns the absolute path to hand to
+    /// xcodebuild / gradle.
+    pub fn write(&self, name: &str, bytes: &[u8]) -> Result<PathBuf> {
+        let path = self.dir.path().join(name);
+        std::fs::write(&path, bytes).with_context(|| format!("write {}", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("chmod 600 {}", path.display()))?;
+        }
+        Ok(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn files_are_owner_only_and_deleted_on_drop() {
+        let staged;
+        {
+            let dir = MaterializedDir::new().unwrap();
+            staged = dir.write("secret.p8", b"key material").unwrap();
+            assert!(staged.is_file());
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mode = std::fs::metadata(&staged).unwrap().permissions().mode();
+                assert_eq!(mode & 0o777, 0o600);
+                let dir_mode = std::fs::metadata(staged.parent().unwrap())
+                    .unwrap()
+                    .permissions()
+                    .mode();
+                assert_eq!(dir_mode & 0o777, 0o700);
+            }
+        }
+        assert!(!staged.exists(), "staging dir must vanish on drop");
+    }
+}

--- a/crates/whisker-credentials/src/store.rs
+++ b/crates/whisker-credentials/src/store.rs
@@ -1,0 +1,273 @@
+//! The on-disk store: recipients parsing, age encrypt/decrypt, and
+//! the bootstrap that mints the one-and-only secret key.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use age::secrecy::ExposeSecret;
+use age::x25519;
+use anyhow::{Context, Result, anyhow, bail};
+
+/// Handle to an opened `credentials/` directory. Holds the parsed
+/// recipient (public key) list; never holds the secret key.
+pub struct Store {
+    dir: PathBuf,
+    recipients: Vec<x25519::Recipient>,
+}
+
+/// The age secret key (`AGE-SECRET-KEY-1…`), parsed. Wrapped so the
+/// rest of the workspace never touches `age` types directly, and so
+/// the raw string can be dropped as early as possible.
+pub struct Identity(x25519::Identity);
+
+impl Identity {
+    /// Parse a pasted / env-provided secret key. Trims whitespace —
+    /// clipboard copies and CI secret UIs love trailing newlines.
+    pub fn parse(s: &str) -> Result<Self> {
+        s.trim()
+            .parse::<x25519::Identity>()
+            .map(Self)
+            .map_err(|e| anyhow!("not a valid age secret key (AGE-SECRET-KEY-…): {e}"))
+    }
+
+    /// Read the identity from [`crate::IDENTITY_ENV`] if set.
+    /// `Ok(None)` means "not set" (caller falls back to prompting);
+    /// a set-but-invalid value is an error, not a silent fallback —
+    /// a typo'd CI secret should fail loudly, not interactively hang.
+    pub fn from_env() -> Result<Option<Self>> {
+        match std::env::var(crate::IDENTITY_ENV) {
+            Ok(v) if !v.trim().is_empty() => Self::parse(&v)
+                .map(Some)
+                .with_context(|| format!("${} is set but invalid", crate::IDENTITY_ENV)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Does this secret key correspond to one of the store's
+    /// recipients? Lets callers reject a wrong-repo key *before*
+    /// attempting decryption, with a message better than age's
+    /// generic "no matching keys".
+    pub fn matches(&self, store: &Store) -> bool {
+        let pk = self.0.to_public().to_string();
+        store.recipients.iter().any(|r| r.to_string() == pk)
+    }
+}
+
+impl Store {
+    /// `<project_root>/credentials`.
+    pub fn dir_for(project_root: &Path) -> PathBuf {
+        project_root.join(crate::DIR_NAME)
+    }
+
+    /// A store exists once `recipients.txt` does. The directory
+    /// alone doesn't count — half-created state from an aborted
+    /// bootstrap must read as "not bootstrapped".
+    pub fn exists(project_root: &Path) -> bool {
+        Self::dir_for(project_root)
+            .join(crate::RECIPIENTS_FILE)
+            .is_file()
+    }
+
+    pub fn open(project_root: &Path) -> Result<Self> {
+        let dir = Self::dir_for(project_root);
+        let path = dir.join(crate::RECIPIENTS_FILE);
+        let text =
+            std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        let recipients =
+            parse_recipients(&text).with_context(|| format!("parse {}", path.display()))?;
+        if recipients.is_empty() {
+            bail!(
+                "{} contains no age public keys — re-run `whisker credential ios` or `android` to bootstrap",
+                path.display()
+            );
+        }
+        Ok(Self { dir, recipients })
+    }
+
+    /// Create the store: generate a fresh key pair, write the public
+    /// half to `recipients.txt`, and return the secret half as a
+    /// string. **This is the only moment the secret exists outside
+    /// the caller's memory** — the CLI shows it once and forgets it.
+    pub fn bootstrap(project_root: &Path) -> Result<(Self, String)> {
+        let dir = Self::dir_for(project_root);
+        let path = dir.join(crate::RECIPIENTS_FILE);
+        if path.exists() {
+            bail!("credentials store already exists ({})", path.display());
+        }
+        std::fs::create_dir_all(&dir).with_context(|| format!("mkdir {}", dir.display()))?;
+        let identity = x25519::Identity::generate();
+        let recipient = identity.to_public();
+        let contents = format!(
+            "# Whisker credential recipients — age PUBLIC keys. Safe to commit.\n\
+             # The matching secret key (AGE-SECRET-KEY-…) decrypts this store;\n\
+             # it lives in your password manager / CI secrets, never in the repo.\n\
+             {recipient}\n"
+        );
+        std::fs::write(&path, contents).with_context(|| format!("write {}", path.display()))?;
+        let secret = identity.to_string().expose_secret().to_string();
+        Ok((
+            Self {
+                dir,
+                recipients: vec![recipient],
+            },
+            secret,
+        ))
+    }
+
+    /// Does `<rel>.age` exist? `rel` is the plaintext-relative path
+    /// (e.g. `android/com.example.app/keystore.jks`).
+    pub fn has(&self, rel: &str) -> bool {
+        self.age_path(rel).is_file()
+    }
+
+    /// Encrypt `plaintext` to **all** recipients and write
+    /// `<dir>/<rel>.age`. Needs no secret key — see module docs.
+    pub fn put(&self, rel: &str, plaintext: &[u8]) -> Result<()> {
+        let path = self.age_path(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("mkdir {}", parent.display()))?;
+        }
+        let encryptor = age::Encryptor::with_recipients(
+            self.recipients.iter().map(|r| r as &dyn age::Recipient),
+        )
+        .context("build age encryptor")?;
+        let mut ciphertext = Vec::new();
+        let mut writer = encryptor
+            .wrap_output(&mut ciphertext)
+            .context("start age encryption")?;
+        writer.write_all(plaintext).context("encrypt payload")?;
+        writer.finish().context("finalize age ciphertext")?;
+        std::fs::write(&path, ciphertext).with_context(|| format!("write {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Decrypt `<rel>.age`. Callers should have checked
+    /// [`Identity::matches`] first for a friendlier error, but a
+    /// mismatched key still fails safely here.
+    pub fn get(&self, rel: &str, identity: &Identity) -> Result<Vec<u8>> {
+        let path = self.age_path(rel);
+        let bytes = std::fs::read(&path).with_context(|| format!("read {}", path.display()))?;
+        let decryptor = age::Decryptor::new(&bytes[..])
+            .with_context(|| format!("{} is not an age file", path.display()))?;
+        let mut reader = decryptor
+            .decrypt(std::iter::once(&identity.0 as &dyn age::Identity))
+            .with_context(|| {
+                format!(
+                    "decrypt {} — wrong WHISKER_CREDENTIALS_KEY?",
+                    path.display()
+                )
+            })?;
+        let mut plaintext = Vec::new();
+        reader
+            .read_to_end(&mut plaintext)
+            .with_context(|| format!("decrypt {}", path.display()))?;
+        Ok(plaintext)
+    }
+
+    fn age_path(&self, rel: &str) -> PathBuf {
+        self.dir.join(format!("{rel}.age"))
+    }
+}
+
+/// Parse `recipients.txt`: one age public key per line, `#` comments
+/// and blank lines ignored.
+fn parse_recipients(text: &str) -> Result<Vec<x25519::Recipient>> {
+    let mut out = Vec::new();
+    for (i, line) in text.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let recipient = line
+            .parse::<x25519::Recipient>()
+            .map_err(|e| anyhow!("line {}: not an age public key: {e}", i + 1))?;
+        out.push(recipient);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("whisker-credentials-test-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    #[test]
+    fn bootstrap_then_roundtrip() {
+        let root = tmp();
+        assert!(!Store::exists(root.path()));
+        let (store, secret) = Store::bootstrap(root.path()).expect("bootstrap");
+        assert!(Store::exists(root.path()));
+        assert!(secret.starts_with("AGE-SECRET-KEY-1"));
+
+        store
+            .put("android/com.example.app/keystore.json", b"{\"k\":1}")
+            .unwrap();
+        assert!(store.has("android/com.example.app/keystore.json"));
+
+        // Re-open (fresh parse of recipients.txt) and decrypt.
+        let reopened = Store::open(root.path()).expect("open");
+        let identity = Identity::parse(&secret).expect("parse identity");
+        assert!(identity.matches(&reopened));
+        let plain = reopened
+            .get("android/com.example.app/keystore.json", &identity)
+            .expect("decrypt");
+        assert_eq!(plain, b"{\"k\":1}");
+    }
+
+    #[test]
+    fn put_works_without_secret_key() {
+        // A clone that only has recipients.txt (no identity anywhere)
+        // must still be able to add credentials.
+        let root = tmp();
+        let (_, secret) = Store::bootstrap(root.path()).unwrap();
+        drop(secret);
+        let store = Store::open(root.path()).unwrap();
+        store.put("ios/default/asc.json", b"payload").unwrap();
+        assert!(store.has("ios/default/asc.json"));
+    }
+
+    #[test]
+    fn wrong_identity_is_detected_before_decrypt() {
+        let root_a = tmp();
+        let root_b = tmp();
+        let (store_a, _secret_a) = Store::bootstrap(root_a.path()).unwrap();
+        let (_store_b, secret_b) = Store::bootstrap(root_b.path()).unwrap();
+        let wrong = Identity::parse(&secret_b).unwrap();
+        assert!(!wrong.matches(&store_a));
+        store_a.put("ios/default/asc.json", b"x").unwrap();
+        assert!(store_a.get("ios/default/asc.json", &wrong).is_err());
+    }
+
+    #[test]
+    fn bootstrap_refuses_to_overwrite() {
+        let root = tmp();
+        Store::bootstrap(root.path()).unwrap();
+        assert!(Store::bootstrap(root.path()).is_err());
+    }
+
+    #[test]
+    fn recipients_parser_skips_comments_and_blanks() {
+        let (_, secret) = {
+            let root = tmp();
+            Store::bootstrap(root.path()).unwrap()
+        };
+        // Build a recipients file with noise around a real key.
+        let identity = Identity::parse(&secret).unwrap();
+        let pk = identity.0.to_public().to_string();
+        let parsed = parse_recipients(&format!("# comment\n\n{pk}\n  \n")).expect("parse");
+        assert_eq!(parsed.len(), 1);
+    }
+
+    #[test]
+    fn invalid_recipient_line_errors_with_line_number() {
+        let err = parse_recipients("# ok\nnot-a-key\n").unwrap_err();
+        assert!(err.to_string().contains("line 2"));
+    }
+}

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -113,6 +113,12 @@ impl Builder {
             // declares android.kotlin_sources.
             let modules = whisker_build::modules::discover(&ws.join("Cargo.toml"), &pkg)?;
             whisker_build::android::stage_module_kotlin_sources(&gen_android, &modules)?;
+            // The Settings plugin's module-report cache is keyed on
+            // Cargo.lock alone and can be stale (other apps in the
+            // workspace, metadata-only edits) — rewrite it fresh so
+            // gradle wires the module subprojects this app actually
+            // has. See refresh_gradle_module_cache docs.
+            whisker_build::modules::refresh_gradle_module_cache(&ws, &pkg)?;
             whisker_build::android::run_gradle_assemble(
                 &gen_android,
                 whisker_build::Profile::Debug,

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,10 @@ yanked = "deny"
 # replacement reaches our tree or the upstream lib drops them:
 #   RUSTSEC-2024-0436  paste         ← ratatui   (dev-loop TUI)
 #   RUSTSEC-2025-0119  number_prefix ← indicatif (progress output)
+#   RUSTSEC-2026-0173  proc-macro-error2 ← age's i18n-embed-fl proc-macro
+#     (whisker-credentials' file encryption). Build-time only — never
+#     compiled into shipped binaries. age has no feature to drop its
+#     localization layer; revisit when age moves off i18n-embed-fl.
 #
 # Vulnerability accepted with rationale (no compatible fixed version):
 #   RUSTSEC-2026-0119  hickory-proto 0.24.4 ← atrium-identity's DoH TXT
@@ -28,6 +32,7 @@ yanked = "deny"
 ignore = [
     "RUSTSEC-2024-0436",
     "RUSTSEC-2025-0119",
+    "RUSTSEC-2026-0173",
     "RUSTSEC-2026-0119",
 ]
 

--- a/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerProjectPlugin.kt
+++ b/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerProjectPlugin.kt
@@ -49,7 +49,7 @@ class WhiskerProjectPlugin : Plugin<Project> {
                 )
 
         val (workspaceFile, userPackageStr) = readConfig(project.rootDir)
-        val report = readModulesReport(workspaceFile)
+        val report = readModulesReport(workspaceFile, userPackageStr)
 
         // Module deps onto this project (each android-capable Whisker
         // module is a Gradle subproject the Settings plugin `include`d).
@@ -152,8 +152,11 @@ class WhiskerProjectPlugin : Plugin<Project> {
         return File(ws) to pkg
     }
 
-    private fun readModulesReport(workspace: File): ModulesReport {
-        val path = File(workspace, "target/whisker/module-info.json")
+    private fun readModulesReport(workspace: File, userPackage: String): ModulesReport {
+        // Per-package filename, matching the Settings plugin's cache
+        // writer — a workspace-shared name lets one app's (possibly
+        // empty) module report poison sibling apps in a monorepo.
+        val path = File(workspace, "target/whisker/module-info-$userPackage.json")
         if (!path.isFile) {
             error(
                 "rs.whisker.gradle: missing ${path.absolutePath} — the Settings " +

--- a/platforms/android/gradle-plugin/whisker-settings-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerPlugin.kt
+++ b/platforms/android/gradle-plugin/whisker-settings-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerPlugin.kt
@@ -32,9 +32,16 @@ import java.util.Properties
 //
 //   1. Spawns `whisker modules --workspace=... --package=...`
 //      and writes the JSON output to
-//      `<workspace>/target/whisker/module-info.json`. Cached by
-//      Cargo.lock SHA-256 so a warm Sync skips cargo metadata
-//      (mirrors Flutter's `.flutter-plugins-dependencies` model).
+//      `<workspace>/target/whisker/module-info-<package>.json`.
+//      Cached by Cargo.lock SHA-256 so a warm Sync skips cargo
+//      metadata (mirrors Flutter's `.flutter-plugins-dependencies`
+//      model). The filename carries the user package because the
+//      cache lives in the WORKSPACE-level target dir: in a monorepo
+//      with several apps (examples/*), a shared filename lets app
+//      A's report (possibly zero modules) poison app B's build —
+//      B's modules silently vanish from the APK and every custom
+//      element (`<input>`, `<svg>`, …) dies at render time with
+//      "No BehaviorController defined".
 //   2. Reads the JSON, `include()`s each Whisker module as a Gradle
 //      subproject, sets each one's `projectDir` to the module's
 //      package root.
@@ -92,7 +99,9 @@ class WhiskerPlugin : Plugin<Settings> {
     }
 
     private fun loadOrRefreshModulesReport(workspace: File, userPackage: String): ModulesReport {
-        val cachePath = File(workspace, "target/whisker/module-info.json")
+        // Per-package filename — see the header comment for the
+        // monorepo cache-poisoning failure a shared name causes.
+        val cachePath = File(workspace, "target/whisker/module-info-$userPackage.json")
         val expectedHash = sha256OfCargoLock(workspace)
 
         if (cachePath.isFile && expectedHash != null) {


### PR DESCRIPTION
## Summary

Production release builds become first-class CLI commands, with signing material managed so users never need to learn what a keystore, certificate, or provisioning profile is:

```
whisker credential android   # mint (or --import) the upload keystore → encrypted into credentials/
whisker credential ios       # guided ASC Team-Key wizard → validated, team auto-resolved, encrypted
whisker build appbundle      # signed .aab (Play)
whisker build apk            # signed .apk (Firebase App Distribution / sideload)
whisker build ipa            # archive + export via ASC API key + cloud-managed signing
                             #   --method ad-hoc for device-limited distribution
```

### Credential model (new crate: `whisker-credentials`)

- age (X25519)-encrypted store **committed to the app repo** under `credentials/` — the repo is the backup and the team-share mechanism. `recipients.txt` (public key) is plaintext; the secret key is shown once at bootstrap, then only ever arrives via `$WHISKER_CREDENTIALS_KEY` or an interactive prompt at build start. Clones can *add* credentials without the secret (recipient model).
- iOS auth is **ASC API key only** (Team Key, Admin): automatic signing, cloud-managed distribution certs, bundle-id auto-registration — no Xcode sign-in, identical local/CI. The wizard auto-detects the `AuthKey_*.p8` download, validates with a real API call (hand-rolled ES256 JWS on `p256`, no ring/openssl), resolves the Team ID from `bundleIds.seedId`, and surfaces Apple's `errors[0].code` on failure (e.g. an unaccepted license agreement is reported as such, not misdiagnosed as a role problem).
- **CI never creates credentials** — an ephemeral keystore would sign an unrepeatable release; non-TTY failures name the exact command to run locally. Decrypted material lives in a 0700 staging dir deleted on drop; nothing lands in `gen/` or argv.
- `whisker doctor` gains a Credentials section.

### Fixes surfaced by E2E testing

- **cng android `template_version` 10 → 11** — the new env-var-driven signingConfig must regenerate existing gen trees, else releases come out unsigned (Android rejects them with an opaque install error). `run_gradle_release` now also refuses unsigned artifacts outright (filename check for APKs, `jarsigner -verify` for AABs).
- **Module-report cache poisoning** — the Settings plugin caches `target/whisker/module-info.json` keyed on Cargo.lock alone; in a multi-app workspace one app's (empty) report was reused for another, dropping all module Kotlin from the APK (`No BehaviorController defined for class whisker-svg:Svg` → screen renders up to the first custom element). Metadata-only edits go equally stale. The CLI now rewrites a fresh report before every gradle run (both the legacy shared filename ≤0.4.1 reads and the new per-package name), and both gradle plugins move to per-package cache files.

## Verification

- **Android**: list-smoke E2E — signed `app-release.apk` (apksigner cert matches the minted upload key) and `app-release.aab`; the bluesky module regression reproduced and confirmed fixed on-emulator (8 modules restored, login screen fully renders).
- **iOS**: bluesky E2E with a real ASC key — exported ipa passes `codesign --verify --deep --strict`; App Store provisioning profile (no device list, `get-task-allow=false`, `beta-reports-active`); arm64-only; zero dev-runtime strings in WhiskerDriver; 27 bridge exports intact.
- 23 test suites green across the five touched crates; fmt/clippy clean; both gradle plugins compile.

## Known follow-ups (intentionally out of scope)

- **App-icon pipeline** — App Store validation rejects the icon-less bundle (Transporter: `Missing required icon file … exactly '120x120' pixels`). Needs the icon-source → Assets.xcassets / mipmap generation designed earlier; Android will hit the equivalent at Play submission.
- `whisker submit` (WWDC25 Build Upload API / Play Edits API), ad-hoc device registration (`POST /v1/devices`).
- **gradle-plugin 0.4.2 release** — the per-package cache fix only reaches IDE-driven syncs once published; CLI-driven builds are already safe via the pre-gradle rewrite.
- `examples/bluesky/credentials/` is deliberately **not** included — committing real (encrypted) account credentials to this public repo is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)