### PR TITLE
fix(ios): bump module Package.swift whisker pins 0.1.1 → 0.1.2 + lockstep guard

### DIFF
--- a/crates/whisker-build/tests/spm_pin_consistency.rs
+++ b/crates/whisker-build/tests/spm_pin_consistency.rs
@@ -1,0 +1,65 @@
+//! Guard against whisker-SwiftPM pin drift between the generated
+//! host project and the module packages.
+//!
+//! The pbxproj cng renders references the remote `whisker` package at
+//! [`whisker_build::ios::WHISKER_IOS_SPM_VERSION`], while every
+//! module under `packages/*/Package.swift` pins the same package with
+//! `exact:`. When the two disagree — as happened when #285 bumped the
+//! root to 0.1.2 and left the modules at 0.1.1 — SwiftPM resolution
+//! fails for every module-using app the moment its `gen/ios` is
+//! regenerated:
+//!
+//! ```text
+//! Dependencies could not be resolved because 'whisker-webview'
+//! depends on 'whisker' 0.1.1 and root depends on 'whisker' 0.1.2.
+//! ```
+//!
+//! This test fails the build when a bump forgets either side.
+
+use std::path::Path;
+use whisker_build::ios::{WHISKER_IOS_SPM_URL, WHISKER_IOS_SPM_VERSION};
+
+#[test]
+fn module_package_swift_pins_match_whisker_ios_spm_version() {
+    // Monorepo layout only: from a published crate there is no
+    // `packages/` tree to check, and the guard is meaningless there.
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let packages = workspace_root.join("packages");
+    if !packages.is_dir() {
+        return;
+    }
+
+    let expected =
+        format!(r#".package(url: "{WHISKER_IOS_SPM_URL}", exact: "{WHISKER_IOS_SPM_VERSION}")"#);
+    let mut checked = 0usize;
+    let mut bad: Vec<String> = Vec::new();
+
+    for entry in std::fs::read_dir(&packages).expect("read packages/") {
+        let manifest = entry.expect("dir entry").path().join("Package.swift");
+        let Ok(contents) = std::fs::read_to_string(&manifest) else {
+            continue; // package without an iOS half
+        };
+        for line in contents.lines() {
+            if line.contains(WHISKER_IOS_SPM_URL) {
+                checked += 1;
+                if !line.contains(&expected) {
+                    bad.push(format!("{}: {}", manifest.display(), line.trim()));
+                }
+            }
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "no Package.swift references {WHISKER_IOS_SPM_URL} under {} — \
+         if module manifests moved, update this test's search path",
+        packages.display(),
+    );
+    assert!(
+        bad.is_empty(),
+        "module Package.swift pins out of lockstep with \
+         WHISKER_IOS_SPM_VERSION (= {WHISKER_IOS_SPM_VERSION}). When bumping the \
+         whisker SwiftPM release, bump every module pin in the same change:\n{}",
+        bad.join("\n"),
+    );
+}

--- a/packages/whisker-asset/Package.swift
+++ b/packages/whisker-asset/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WhiskerAsset", targets: ["WhiskerAsset"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
     ],
     targets: [
         .target(

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
     ],
     targets: [
         .target(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
         // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
         // via Core Image, animated GIF via `AnimatedImageView`, in-
         // memory `NSCache` + disk cache out of the box. WebP requires

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
     ],
     targets: [
         .target(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "WhiskerLocalStore", targets: ["WhiskerLocalStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
         // PoC — an external SwiftPM dependency. swift-collections is
         // Apple-maintained, header-only Swift, small enough that
         // resolving it is fast even on a cold cache. Use is minimal

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
     ],
     targets: [
         .target(

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
     ],
     targets: [
         .target(

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "WhiskerSvg", targets: ["WhiskerSvg"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
     ],
     targets: [
         .target(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // it there, and the package identity (the crate's dir name)
         // is unique, so the app aggregator references it via
         // `.package(path: …)` without the `ios`-dir-name collision.
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
     ],
     targets: [
         .target(

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.1"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

#285 bumped the generated pbxproj's remote whisker SwiftPM reference (`WHISKER_IOS_SPM_VERSION`) to 0.1.2 but left every module manifest under `packages/*/Package.swift` pinned at `exact: "0.1.1"`. SwiftPM requires a single version for the shared `whisker` identity, so dependency resolution failed for **every module-using app** as soon as its `gen/ios` was regenerated:

```
xcodebuild: error: Could not resolve package dependencies:
Dependencies could not be resolved because 'whisker-webview' depends on 'whisker' 0.1.1 and root depends on 'whisker' 0.1.2.
```

(Found while verifying #289 — regenerating bluesky's gen/ios surfaced it.)

## Changes

- Bump all 10 module pins (`whisker-asset`, `-audio`, `-image`, `-input`, `-local-store`, `-safe-area`, `-secure-store`, `-svg`, `-video`, `-webview`) to `exact: "0.1.2"`.
- New `whisker-build` integration test `spm_pin_consistency` that walks `packages/*/Package.swift` and asserts every whisker pin matches `WHISKER_IOS_SPM_VERSION` — the next release bump fails CI instead of breaking user builds. (Skips gracefully outside the monorepo layout.)

## Verification

- `examples/bluesky` (webview / input / local-store / image modules) resolves, builds, installs, and launches on the iOS 26.5 simulator — the exact configuration that failed before this change.
- New guard test passes; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)