### PR TITLE
fix(deps): bump crossbeam-epoch → 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

`cargo deny check advisories` is failing on `main` (the `chore: release v0.8.0 (#263)` run) with **no code change** — a new advisory, **RUSTSEC-2026-0204**, was published after #290/#289 last ran. It flags `crossbeam-epoch 0.9.18`: an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the pointer is null.

`bans` and `sources` still pass; only `advisories` broke, because cargo-deny checks against the live advisory DB.

## Fix

Lockfile-only bump: `crossbeam-epoch 0.9.18 → 0.9.20` (upstream fix, crossbeam PR #1276). It reaches the tree transitively through the bluesky example:

```
bsky-auth → atrium-oauth → atrium-* → atrium-common → moka → crossbeam-epoch
```

Reproduced and verified locally with `cargo-deny 0.19.9` (same command as CI, `check advisories bans sources`): failing before, `advisories ok, bans ok, sources ok` after. Only the `crossbeam-epoch` version + checksum change in `Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)