### PR TITLE
feat(keyboard): whisker-keyboard — keyboard avoidance + dismiss-on-navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "whisker-icons",
  "whisker-image",
  "whisker-input",
+ "whisker-keyboard",
  "whisker-local-store",
  "whisker-router",
  "whisker-safe-area",
@@ -4331,6 +4332,13 @@ version = "0.1.0"
 dependencies = [
  "whisker",
  "whisker-input",
+]
+
+[[package]]
+name = "whisker-keyboard"
+version = "0.8.0"
+dependencies = [
+ "whisker",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "packages/whisker-image",
     "packages/whisker-input",
     "packages/whisker-input/example",
+    "packages/whisker-keyboard",
     "packages/whisker-local-store",
     "packages/whisker-router",
     "packages/whisker-router/example",

--- a/examples/bluesky/Cargo.toml
+++ b/examples/bluesky/Cargo.toml
@@ -17,6 +17,10 @@ whisker-local-store = { path = "../../packages/whisker-local-store" }
 whisker-image = { path = "../../packages/whisker-image" }
 whisker-icons = { path = "../../packages/whisker-icons" }
 whisker-safe-area = { path = "../../packages/whisker-safe-area" }
+# Keyboard height (avoidance) + dismiss-on-navigation. Adding the dep
+# also links the native Keyboard module, which is what lets
+# whisker-router release focus on every navigation.
+whisker-keyboard = { path = "../../packages/whisker-keyboard" }
 bsky-domain = { path = "crates/bsky-domain" }
 bsky-auth = { path = "crates/bsky-auth" }
 # percent-encode at:// post URIs into a single route path segment

--- a/examples/bluesky/src/lib.rs
+++ b/examples/bluesky/src/lib.rs
@@ -20,6 +20,7 @@ use whisker::runtime::view::Element;
 use whisker_icons::{Icon, lucide};
 use whisker_image::{Image, ImageMode};
 use whisker_input::{AutoCapitalize, Input, KeyboardType, ReturnKey};
+use whisker_keyboard::keyboard_height;
 use whisker_router::render::{
     AndroidPredictiveBack, Outlet, Router, RouterHandle, SwipeBack, use_navigator, use_param,
     use_pathname,
@@ -1610,9 +1611,17 @@ fn login_screen() -> Element {
     // (status bar / notch / home indicator) so the title and CTA never sit
     // under system chrome. Reactive via `computed` — re-pads on rotation /
     // Dynamic Island / Android edge-to-edge toggle.
+    //
+    // Keyboard avoidance: add the keyboard's height to the bottom padding
+    // (taking the larger of it and the home-indicator inset, since the
+    // keyboard already covers that region). On a centered column this
+    // lifts the whole form clear of the keyboard when the handle field is
+    // focused; it settles back as the keyboard dismisses.
     let insets = safe_area_insets();
+    let kb = keyboard_height();
     let root_style = computed(move || {
         let i = insets.get();
+        let bottom = (i.bottom as f32).max(kb.get() as f32);
         css!(
             flex_grow: 1.0,
             flex_direction: FlexDirection::Column,
@@ -1620,7 +1629,7 @@ fn login_screen() -> Element {
             align_items: AlignItems::Stretch,
             background_color: theme::BG,
             padding_top: px(24.0 + i.top as f32),
-            padding_bottom: px(24.0 + i.bottom as f32),
+            padding_bottom: px(24.0 + bottom),
             padding_left: px(24.0 + i.leading as f32),
             padding_right: px(24.0 + i.trailing as f32),
         )

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
@@ -143,7 +143,18 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
                     }
                 }
 
-                override fun onViewDetachedFromWindow(v: android.view.View) {}
+                override fun onViewDetachedFromWindow(v: android.view.View) {
+                    // Safety net for non-navigation unmounts (a
+                    // conditionally-rendered field being removed while
+                    // focused, a list row recycling): release focus and
+                    // hide the IME so a detached EditText never lingers as
+                    // the keyboard target. Navigation-driven dismissal is
+                    // handled up front by whisker-router; this covers the
+                    // cases that don't go through a route change. iOS gets
+                    // this for free (UIKit resigns first responder on
+                    // window removal); Android does not.
+                    blurField()
+                }
             },
         )
 

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
@@ -45,15 +45,42 @@ import UIKit
 import WhiskerModule
 
 @objc(WhiskerInputView)
+/// A container `UIView` that invokes `onDetach` when it leaves its
+/// window (a real unmount). Used by [`WhiskerInputView`] to resign the
+/// field's first responder on teardown so a removed input never lingers
+/// as the keyboard target.
+private final class DetachAwareView: UIView {
+    var onDetach: (() -> Void)?
+
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        // `nil` newWindow = the view is being removed from the hierarchy.
+        // (A single↔multiline control swap replaces the *inner* control,
+        // not this container, so it doesn't spuriously trigger here.)
+        if newWindow == nil {
+            onDetach?()
+        }
+    }
+}
+
 public final class WhiskerInputView: WhiskerUI<UIView> {
 
     // MARK: - Hosted controls
 
     /// Transparent container that fills the LynxUI frame; holds
     /// either the `textField` or `textView` as a subview.
+    ///
+    /// A [`DetachAwareView`] so it can resign focus on unmount. UIKit
+    /// already auto-resigns a first responder that's removed from its
+    /// window, but doing it explicitly also dismisses the IME promptly
+    /// and keeps parity with the Android `onViewDetachedFromWindow`
+    /// hook. Navigation-driven dismissal is handled up front by
+    /// whisker-router; this covers non-navigation unmounts (a
+    /// conditionally-rendered field removed while focused).
     private lazy var containerView: UIView = {
-        let v = UIView()
+        let v = DetachAwareView()
         v.backgroundColor = .clear
+        v.onDetach = { [weak self] in self?.blurField() }
         return v
     }()
 

--- a/packages/whisker-keyboard/Cargo.toml
+++ b/packages/whisker-keyboard/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "whisker-keyboard"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Whisker module for the on-screen keyboard: a reactive keyboard_height() ReadSignal for keyboard avoidance, plus dismiss() (a real global unfocus — resignFirstResponder / clearFocus). iOS observes keyboardWillChangeFrame; Android reads WindowInsetsCompat.Type.ime()."
+
+# Explicit `include` list — mirrors `whisker-safe-area`. `cargo publish`
+# ships the Kotlin + Swift platform sources alongside `src/lib.rs`, but
+# never the local Gradle / Xcode build artifacts.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "src/lib.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker. The bare table identifies this cargo
+# crate as a Whisker module; `whisker-build` walks the consuming app's
+# dep tree, picks out every dep carrying it, and wires the Android
+# Gradle subproject + iOS SwiftPM package into the host build.
+[package.metadata.whisker]
+
+[dependencies]
+whisker = { workspace = true }

--- a/packages/whisker-keyboard/Package.swift
+++ b/packages/whisker-keyboard/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for the `whisker-keyboard` module package.
+//
+// Mirrors `whisker-safe-area`'s shape: one library target with sources
+// under `ios/Sources/WhiskerKeyboard`, the WhiskerModuleCodegenPlugin
+// wired so the Module subclass registration lands in
+// `<Target>+Generated.swift` at build time.
+
+import PackageDescription
+
+let package = Package(
+    name: "whisker-keyboard",
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerKeyboard", targets: ["WhiskerKeyboard"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerKeyboard",
+            dependencies: [
+                // WhiskerModule provides the Module base + DSL;
+                // WhiskerRuntime is pulled for parity with the other
+                // module packages (and to keep the codegen plugin's
+                // generated registration compiling against the same
+                // runtime symbols).
+                .product(name: "WhiskerModule", package: "whisker"),
+                .product(name: "WhiskerRuntime", package: "whisker"),
+            ],
+            path: "ios/Sources/WhiskerKeyboard",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "whisker"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-keyboard/README.md
+++ b/packages/whisker-keyboard/README.md
@@ -1,0 +1,36 @@
+# whisker-keyboard
+
+The on-screen keyboard as a reactive resource for [Whisker](https://github.com/whiskerrs/whisker) apps.
+
+Two capabilities, routed through one native `Keyboard` module:
+
+- **`keyboard_height() -> ReadSignal<f64>`** — the keyboard's current
+  overlap from the bottom of the screen (points on iOS, dp on Android),
+  `0.0` when hidden. Pad or scroll a container by this value so a focused
+  input isn't covered. Whisker's analogue of Flutter's
+  `MediaQuery.viewInsets.bottom` / React Native's keyboard-frame events.
+
+- **`dismiss()`** — a **real global unfocus** (not merely "hide the
+  keyboard"): iOS `resignFirstResponder` via the key window's
+  `endEditing(true)`, Android `clearFocus()` on the focused view + IME
+  hide. Removing focus is what stops a **hardware keyboard** from
+  continuing to type into an input that has scrolled or navigated off
+  screen.
+
+```rust
+use whisker::prelude::*;
+use whisker_keyboard::keyboard_height;
+
+#[component]
+fn form() -> Element {
+    let kb = keyboard_height();
+    let pad = move || format!("padding-bottom: {}px;", kb.get());
+    render! {
+        scroll_view(style: pad()) { /* fields … */ }
+    }
+}
+```
+
+Adding this crate as a dependency also links the native module, which is
+what lets [`whisker-router`](../whisker-router) release focus on every
+navigation (so the keyboard drops crisply as the user leaves a screen).

--- a/packages/whisker-keyboard/android/src/main/kotlin/rs/whisker/modules/keyboard/KeyboardModule.kt
+++ b/packages/whisker-keyboard/android/src/main/kotlin/rs/whisker/modules/keyboard/KeyboardModule.kt
@@ -1,0 +1,132 @@
+// `whisker-keyboard` Module (Android).
+//
+// View-less module with two jobs:
+//
+//  * `keyboardChanged` event — while a Rust listener is registered,
+//    hook `ViewCompat.setOnApplyWindowInsetsListener` onto the host
+//    Activity's decor view and forward the IME inset height (dp) as
+//    `{ height }`. The Rust side (`packages/whisker-keyboard/src/lib.rs`)
+//    holds the `RwSignal<f64>` `keyboard_height()` returns.
+//
+//  * `dismiss` function — a **real global unfocus**. On Android,
+//    `hideSoftInputFromWindow` only hides the soft keyboard; the focused
+//    `EditText` keeps focus (cursor, and — critically — a hardware
+//    keyboard keeps delivering key events to it). So we `clearFocus()`
+//    on the currently-focused view FIRST, then hide the IME. Clearing
+//    focus fires `onFocusChange(false)`, which flows back to the
+//    per-input `on_blur`, keeping Rust state consistent.
+//
+// ## Why an inset listener (not `windowSoftInputMode`)
+//
+// `WhiskerActivity` forces edge-to-edge
+// (`WindowCompat.setDecorFitsSystemWindows(window, false)`), so the OS
+// does NOT resize the window for the IME regardless of
+// `android:windowSoftInputMode`. Edge-to-edge apps must read the IME
+// inset themselves and apply it — which is exactly what this module
+// surfaces to Rust so the app can pad/scroll its content.
+//
+// ## Lifecycle + configuration-change handling
+//
+// Same approach as `whisker-safe-area`: the inset listener is
+// (re)installed inside a permanent `HostAttachedListener`, so a
+// config-change Activity recreation (rotation, multi-window resize)
+// transparently rewires onto the fresh decor view.
+
+package rs.whisker.modules.keyboard
+
+import android.app.Activity
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import rs.whisker.runtime.HostAttachedListener
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerValue
+
+public class KeyboardModule : Module() {
+
+    /**
+     * Live host-attached listener. `null` between `OnStopObserving`
+     * tearing it down and the next `OnStartObserving` re-registering.
+     */
+    private var attachListener: HostAttachedListener? = null
+
+    public override fun definition(): ModuleDefinition = ModuleDefinition {
+        Name("Keyboard")
+        Events("keyboardChanged")
+
+        OnStartObserving("keyboardChanged") {
+            if (attachListener != null) return@OnStartObserving
+            val listener = HostAttachedListener { installOnCurrentHost() }
+            attachListener = listener
+            appContext.addOnHostAttachedListener(listener)
+        }
+
+        OnStopObserving("keyboardChanged") {
+            attachListener?.let { appContext.removeOnHostAttachedListener(it) }
+            attachListener = null
+        }
+
+        // Real global unfocus. Marshalled to the UI thread because the
+        // function body may run on the Lynx TASM thread and clearFocus /
+        // IMM are View work.
+        Function("dismiss") {
+            val activity = appContext.currentActivity
+            activity?.runOnUiThread { dismissOn(activity) }
+            WhiskerValue.Null
+        }
+    }
+
+    /**
+     * Clear focus on the currently-focused view and hide the IME. Order
+     * matters: clearing focus removes the hardware-keyboard target; the
+     * IMM hide then dismisses the soft keyboard.
+     */
+    private fun dismissOn(activity: Activity) {
+        val focused = activity.currentFocus
+        val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE)
+            as? InputMethodManager
+        // Hide before clearing focus so we still have a valid window
+        // token; clearing focus afterwards removes the input target.
+        val token = focused?.windowToken ?: activity.window?.decorView?.windowToken
+        if (token != null) {
+            imm?.hideSoftInputFromWindow(token, 0)
+        }
+        focused?.clearFocus()
+    }
+
+    /**
+     * Install (or re-install) the IME-inset listener on the current
+     * host Activity's decor view, and seed the Rust signal with the
+     * current IME inset so a late subscriber doesn't sit at 0 until the
+     * next genuine change.
+     */
+    private fun installOnCurrentHost() {
+        val activity = appContext.currentActivity ?: return
+        val decor = activity.window?.decorView ?: return
+
+        ViewCompat.setOnApplyWindowInsetsListener(decor) { _, insetsCompat ->
+            dispatch(activity, insetsCompat)
+            // Pass through unmodified so Lynx's own listeners still see
+            // the same insets.
+            insetsCompat
+        }
+
+        ViewCompat.getRootWindowInsets(decor)?.let { dispatch(activity, it) }
+    }
+
+    /**
+     * Forward the IME inset (keyboard) height in dp as `{ height }`.
+     * `Type.ime()` reports the full keyboard overlap from the bottom of
+     * the window — already inclusive of the navigation bar it sits over
+     * — so padding a bottom-anchored container by it clears the keyboard
+     * exactly.
+     */
+    private fun dispatch(activity: Activity, insets: WindowInsetsCompat) {
+        val imeBottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+        val density = activity.resources.displayMetrics.density.takeIf { it > 0f } ?: 1f
+        val heightDp = (imeBottom / density).toDouble()
+        sendEvent("keyboardChanged", WhiskerValue.Map(mapOf("height" to WhiskerValue.Float(heightDp))))
+    }
+}

--- a/packages/whisker-keyboard/build.gradle.kts
+++ b/packages/whisker-keyboard/build.gradle.kts
@@ -1,0 +1,56 @@
+// Gradle build for `whisker-keyboard`'s Android half.
+//
+// Mirrors `whisker-safe-area`'s shape: one KSP-processed module
+// subproject with sources under `android/src/main/kotlin`, depending on
+// Whisker's runtime + AndroidX core for the `WindowInsetsCompat.Type.ime()`
+// API.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.keyboard"
+    compileSdk = 34
+
+    defaultConfig {
+        // AndroidX core's `WindowInsetsCompat.Type.ime()` works back to
+        // API 21 (it reads the platform IME inset on 30+, and best-effort
+        // below); keep Whisker's standard minSdk = 21 baseline.
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    // Source set redirection so AGP only scans the `android/` subtree;
+    // Rust's `src/` next to this file stays out of the Kotlin compiler's
+    // view.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerKeyboard")
+    arg("whisker.crateName", "whisker-keyboard")
+}
+
+dependencies {
+    implementation("rs.whisker:whisker-module-android:0.1.0")
+    ksp("rs.whisker:ksp:0.1.0")
+
+    // `WindowInsetsCompat.Type.ime()` + `ViewCompat.setOnApplyWindowInsetsListener`
+    // — the AndroidX wrappers that expose the IME inset uniformly across
+    // API levels.
+    implementation("androidx.core:core-ktx:1.13.1")
+}

--- a/packages/whisker-keyboard/ios/Sources/WhiskerKeyboard/KeyboardModule.swift
+++ b/packages/whisker-keyboard/ios/Sources/WhiskerKeyboard/KeyboardModule.swift
@@ -1,0 +1,134 @@
+// `whisker-keyboard` Module (iOS).
+//
+// View-less module with two jobs:
+//
+//  * `keyboardChanged` event — while a Rust listener is registered,
+//    observe the keyboard frame notifications and forward the keyboard's
+//    overlap from the bottom of the screen (in points) as `{ height }`.
+//    The Rust side (`packages/whisker-keyboard/src/lib.rs`) holds the
+//    `RwSignal<f64>` `keyboard_height()` returns and updates it from
+//    these events.
+//
+//  * `dismiss` function — a real global unfocus. `endEditing(true)` on
+//    the key window walks the responder chain and resigns the current
+//    first responder, so the keyboard goes down AND the field stops
+//    receiving input (including from a hardware keyboard). This is not
+//    the same as "hide the keyboard": on iOS the software keyboard's
+//    presence is a consequence of first-responder status, so resigning
+//    it is the correct, complete dismissal.
+//
+// ## Height semantics
+//
+// We report `max(0, screenHeight - keyboardFrameEnd.origin.y)` — the
+// number of points the keyboard covers, measured from the bottom of the
+// screen. That already includes the home-indicator safe area the
+// keyboard sits over, so padding a bottom-anchored container by this
+// value lifts its content exactly clear of the keyboard. On hide, the
+// end frame sits fully off-screen and the value collapses to 0.
+
+import Foundation
+import UIKit
+import WhiskerModule
+
+public final class KeyboardModule: Module {
+
+    /// Live notification observer tokens. Empty between the
+    /// `OnStopObserving` removal and the next `OnStartObserving`.
+    private var observers: [NSObjectProtocol] = []
+
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("Keyboard")
+            Events("keyboardChanged")
+
+            OnStartObserving("keyboardChanged") { [weak self] in
+                self?.startObserving()
+            }
+            OnStopObserving("keyboardChanged") { [weak self] in
+                self?.stopObserving()
+            }
+
+            // Real global unfocus. Marshalled to the main thread because
+            // `invoke` may dispatch the function body on the Lynx TASM
+            // thread, and `endEditing` is UIKit work.
+            Function("dismiss") { _ in
+                DispatchQueue.main.async {
+                    Self.keyWindow()?.endEditing(true)
+                }
+                return .null
+            }
+        }
+    }
+
+    private func startObserving() {
+        if !observers.isEmpty { return }
+
+        // `keyboardWillChangeFrame` covers show, hide, and interactive
+        // height changes (e.g. an accessory bar appearing, the floating
+        // iPad keyboard docking) in one path; `willHide` guarantees a
+        // clean 0 even if a `changeFrame` is missed.
+        let center = NotificationCenter.default
+        observers.append(
+            center.addObserver(
+                forName: UIResponder.keyboardWillChangeFrameNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] note in
+                self?.emit(from: note)
+            }
+        )
+        observers.append(
+            center.addObserver(
+                forName: UIResponder.keyboardWillHideNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.sendEvent("keyboardChanged", .map(["height": .float(0)]))
+            }
+        )
+    }
+
+    private func stopObserving() {
+        let center = NotificationCenter.default
+        for token in observers {
+            center.removeObserver(token)
+        }
+        observers.removeAll()
+    }
+
+    /// Convert a keyboard-frame notification into the covered height in
+    /// points and dispatch it.
+    private func emit(from note: Notification) {
+        guard
+            let frameEnd = (note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
+                as? NSValue)?.cgRectValue
+        else { return }
+
+        // `keyboardFrameEnd` is in screen coordinates. Prefer the key
+        // window's screen so multi-scene apps measure against the right
+        // bounds; fall back to `UIScreen.main`.
+        let screenHeight = Self.keyWindow()?.screen.bounds.height
+            ?? UIScreen.main.bounds.height
+        let covered = max(0, screenHeight - frameEnd.origin.y)
+        sendEvent("keyboardChanged", .map(["height": .float(Double(covered))]))
+    }
+
+    /// The foreground-active key window across connected scenes.
+    private static func keyWindow() -> UIWindow? {
+        for scene in UIApplication.shared.connectedScenes {
+            guard
+                let windowScene = scene as? UIWindowScene,
+                windowScene.activationState == .foregroundActive
+            else { continue }
+            if let key = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                return key
+            }
+        }
+        // Fallback: any key window (cold start before a scene is marked
+        // foreground-active).
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+}

--- a/packages/whisker-keyboard/src/lib.rs
+++ b/packages/whisker-keyboard/src/lib.rs
@@ -1,0 +1,208 @@
+//! `whisker-keyboard` — the on-screen keyboard as a reactive resource.
+//!
+//! Two capabilities, both routed through one native `Keyboard` module:
+//!
+//! - [`keyboard_height`] — a process-global
+//!   `ReadSignal<f64>` carrying the keyboard's current overlap from the
+//!   bottom of the screen (points on iOS, dp on Android), `0.0` when
+//!   hidden. Pad or scroll a container by this value so a focused input
+//!   isn't covered. This is Whisker's analogue of Flutter's
+//!   `MediaQuery.viewInsets.bottom` / React Native's
+//!   `keyboardWillShow` end-coordinates.
+//! - [`dismiss`] — a **real global unfocus**, not merely a
+//!   "hide the keyboard". iOS resigns the key window's first responder
+//!   (`endEditing(true)`); Android clears focus on the focused view
+//!   (`clearFocus()`) *and* hides the IME. Removing focus — rather than
+//!   only hiding the soft keyboard — is what prevents a **hardware
+//!   keyboard** from continuing to type into an input that has scrolled
+//!   or navigated off screen (on Android, `hideSoftInputFromWindow`
+//!   alone leaves the field focused). Mirrors React Native's
+//!   `Keyboard.dismiss()` / Flutter's `FocusManager.primaryFocus.unfocus()`.
+//!
+//! ## Usage
+//!
+//! Keyboard avoidance — pad a scroll container by the keyboard height:
+//!
+//! ```ignore
+//! use whisker::prelude::*;
+//! use whisker_keyboard::keyboard_height;
+//!
+//! #[component]
+//! fn form() -> Element {
+//!     let kb = keyboard_height();
+//!     let pad = move || format!("padding-bottom: {}px;", kb.get());
+//!     render! {
+//!         scroll_view(style: pad()) { /* fields … */ }
+//!     }
+//! }
+//! ```
+//!
+//! Dismiss on demand (e.g. a "Done" button or tap-outside):
+//!
+//! ```ignore
+//! whisker_keyboard::dismiss();
+//! ```
+//!
+//! `whisker-router` also calls the native `dismiss` at every navigation
+//! so the keyboard goes down (and focus is genuinely released) when the
+//! user moves between screens — see that crate. That wiring only fires
+//! when this module is present in the app; add `whisker-keyboard` as a
+//! dependency to get it.
+//!
+//! ## Native source
+//!
+//! - iOS: `packages/whisker-keyboard/ios/Sources/WhiskerKeyboard/KeyboardModule.swift`
+//! - Android: `packages/whisker-keyboard/android/src/main/kotlin/rs/whisker/modules/keyboard/KeyboardModule.kt`
+
+use std::sync::OnceLock;
+
+use whisker::module;
+use whisker::{ArcRwSignal, ArcWriteSignal, Owner, ReadSignal, WhiskerValue};
+
+/// Dismiss the keyboard by releasing focus globally.
+///
+/// This is a **real unfocus**: iOS `endEditing(true)` on the key
+/// window (resign first responder), Android `clearFocus()` on the
+/// focused view + IME hide. A no-op when nothing is focused. Safe to
+/// call from any Whisker event handler; the native side marshals the
+/// UIKit / Android View work to the main thread.
+pub fn dismiss() {
+    // Fire-and-forget; an unregistered module (app didn't add
+    // whisker-keyboard's native half) surfaces as a swallowed
+    // `WhiskerValue::Error`, degrading to a no-op.
+    let _ = module!("Keyboard").invoke("dismiss", vec![]);
+}
+
+/// Reactive accessor for the on-screen keyboard's current height —
+/// the overlap from the bottom of the screen in points (iOS) / dp
+/// (Android), `0.0` when the keyboard is hidden.
+///
+/// All calls share one process-global signal (see [`safe_area_insets`
+/// in `whisker-safe-area`] for the identical pattern and the
+/// detached-root minting rationale). The first call wires the native
+/// subscription; later calls are free. The value stays live for the
+/// process lifetime.
+///
+/// **Must be called from the main thread.** The reactive runtime is
+/// thread-local.
+///
+/// [`safe_area_insets` in `whisker-safe-area`]: https://docs.rs/whisker-safe-area
+pub fn keyboard_height() -> ReadSignal<f64> {
+    install();
+    SLOT.get().expect("install() ran above").read.inner
+}
+
+// ---- Internals -------------------------------------------------------------
+
+struct Slot {
+    read: MainThreadOnly<ReadSignal<f64>>,
+    #[allow(dead_code)]
+    write: MainThreadOnly<ArcWriteSignal<f64>>,
+}
+
+/// One-shot install of the global signal + native subscription.
+/// Idempotent. The `Copy` arena handle callers receive is minted once
+/// under a never-disposed [`Owner::detached_root`] so a transient
+/// per-route / per-component scope can't free it out from under a
+/// surviving reader (the footgun documented at length in
+/// `whisker-safe-area`).
+fn install() {
+    SLOT.get_or_init(|| {
+        let (read, write) = ArcRwSignal::new(0.0_f64).split();
+        subscribe_to_native(MainThreadOnly {
+            inner: write.clone(),
+        });
+        let root = Owner::detached_root();
+        let read_handle: ReadSignal<f64> = root.with(|| read.into());
+        Slot {
+            read: MainThreadOnly { inner: read_handle },
+            write: MainThreadOnly { inner: write },
+        }
+    });
+}
+
+/// Wire the global signal to the native module's `keyboardChanged`
+/// event. The subscription is intentionally leaked — the signal lives
+/// for the process lifetime.
+fn subscribe_to_native(writer: MainThreadOnly<ArcWriteSignal<f64>>) {
+    let module = module!("Keyboard");
+    let sub = module.on_event("keyboardChanged", move |payload| {
+        if let Some(height) = decode_payload(payload) {
+            let w = &writer;
+            w.inner.set(height);
+        }
+    });
+    if let Some(err) = sub.error() {
+        eprintln!("[whisker-keyboard] failed to subscribe: {err}");
+    }
+    std::mem::forget(sub);
+}
+
+/// Decode a `{ height }` map payload. A missing / non-numeric `height`
+/// degrades to `0.0` (keyboard treated as hidden) rather than wedging
+/// the subscription.
+fn decode_payload(value: WhiskerValue) -> Option<f64> {
+    let WhiskerValue::Map(fields) = value else {
+        return None;
+    };
+    let height = match fields.get("height") {
+        Some(WhiskerValue::Float(v)) => *v,
+        Some(WhiskerValue::Int(v)) => *v as f64,
+        _ => 0.0,
+    };
+    // Guard against a stray negative from a mid-animation frame.
+    Some(height.max(0.0))
+}
+
+static SLOT: OnceLock<Slot> = OnceLock::new();
+
+/// Locally-scoped wrapper asserting main-thread-only access to
+/// `inner`. Same pattern (and safety contract) as
+/// `whisker-safe-area`'s `MainThreadOnly`: every access path runs on
+/// the Lynx TASM thread by contract.
+#[derive(Copy, Clone)]
+struct MainThreadOnly<T> {
+    inner: T,
+}
+// Safety: signal read (`keyboard_height`) and write (the `on_event`
+// callback) both run on the Lynx TASM thread by contract. Misuse
+// would corrupt the reactive arena — same risk as touching any signal
+// API from a worker thread.
+unsafe impl<T> Send for MainThreadOnly<T> {}
+unsafe impl<T> Sync for MainThreadOnly<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn decode_reads_float_and_int_height() {
+        let mut m = BTreeMap::new();
+        m.insert("height".to_string(), WhiskerValue::Float(291.0));
+        assert_eq!(decode_payload(WhiskerValue::Map(m)), Some(291.0));
+
+        let mut m = BTreeMap::new();
+        m.insert("height".to_string(), WhiskerValue::Int(216));
+        assert_eq!(decode_payload(WhiskerValue::Map(m)), Some(216.0));
+    }
+
+    #[test]
+    fn decode_missing_height_is_zero() {
+        let m = BTreeMap::new();
+        assert_eq!(decode_payload(WhiskerValue::Map(m)), Some(0.0));
+    }
+
+    #[test]
+    fn decode_clamps_negative_to_zero() {
+        let mut m = BTreeMap::new();
+        m.insert("height".to_string(), WhiskerValue::Float(-5.0));
+        assert_eq!(decode_payload(WhiskerValue::Map(m)), Some(0.0));
+    }
+
+    #[test]
+    fn decode_non_map_is_none() {
+        assert_eq!(decode_payload(WhiskerValue::Null), None);
+        assert_eq!(decode_payload(WhiskerValue::Float(1.0)), None);
+    }
+}

--- a/packages/whisker-router/src/render/gesture.rs
+++ b/packages/whisker-router/src/render/gesture.rs
@@ -281,6 +281,10 @@ pub(crate) fn settle(
                 if let Some(d) = dim_drive {
                     d.set(None);
                 }
+                // Swipe-back commits like any other navigation — drop the
+                // keyboard + release focus (a search field on the popped
+                // screen must not keep a hardware-keyboard target).
+                crate::render::handle::dismiss_keyboard();
                 let _ = nav.back();
             }
         });
@@ -415,6 +419,7 @@ pub fn android_predictive_back() -> Element {
                 Some(bridge) => settle(nav, &bridge, /* commit = */ true, None),
                 // No preview (API < 34, or a discrete press): just pop.
                 None => {
+                    crate::render::handle::dismiss_keyboard();
                     let _ = nav.back();
                 }
             }

--- a/packages/whisker-router/src/render/handle.rs
+++ b/packages/whisker-router/src/render/handle.rs
@@ -246,6 +246,10 @@ impl RouterHandle {
     /// bound to a *clone* of the current state; whatever it returns is
     /// propagated to the caller.
     fn with_navigator<T>(&self, op: impl FnOnce(&mut Navigator) -> T) -> T {
+        // Release keyboard focus at the moment navigation is invoked —
+        // before the transition animates — so the keyboard drops crisply
+        // as the user leaves the screen. See [`dismiss_keyboard`].
+        dismiss_keyboard();
         let mut state = self.inner.state.get();
         let out = {
             let mut nav = Navigator::new(&self.inner.tree, &mut state);
@@ -290,6 +294,28 @@ impl RouterHandle {
     pub fn reset(&self, url: &str) -> Result<(), NavError> {
         self.with_navigator(|nav| nav.reset(url))
     }
+}
+
+/// The `whisker-keyboard` native module, referenced by its
+/// fully-qualified name (`<crate>:<Name>`). The router ships in a
+/// different crate than `whisker-keyboard`, so `module!` — which
+/// prepends *this* crate's name — can't name it; we spell the qualified
+/// name directly.
+const KEYBOARD_MODULE: &str = "whisker-keyboard:Keyboard";
+
+/// Release keyboard focus globally on navigation.
+///
+/// Mirrors React Navigation's `keyboardHandlingEnabled`: when the user
+/// moves between screens, blur the focused field. This is a **real
+/// unfocus** on the native side (iOS `resignFirstResponder`, Android
+/// `clearFocus`), not merely a "hide the keyboard" — so an input that
+/// has navigated off screen can't keep receiving hardware-keyboard
+/// input. See the `whisker-keyboard` crate.
+///
+/// Fire-and-forget: if the app didn't add `whisker-keyboard`, the
+/// module is unregistered and the invoke degrades to a no-op.
+pub(crate) fn dismiss_keyboard() {
+    let _ = whisker::PlatformModule::named(KEYBOARD_MODULE).invoke("dismiss", vec![]);
 }
 
 /// Walk `state` to the subtree at `path` (positional descent mirroring


### PR DESCRIPTION
## Summary

Fixes the two input/keyboard problems:

1. **Keyboard didn't dismiss on navigation.** A focused `Input` never released focus on unmount (iOS had no deinit/detach hook; Android's `onViewDetachedFromWindow` was empty `{}`), so the keyboard lingered — and on Android a **hardware keyboard kept typing into the off-screen field** because `hideSoftInputFromWindow` alone doesn't clear focus.
2. **No keyboard avoidance.** Nothing exposed the keyboard height, so a focused input could sit behind the keyboard. `whisker-safe-area` only reports static system chrome, and Android's forced edge-to-edge means the OS won't resize for the IME by itself.

## New package: `whisker-keyboard`

A native module (mirrors `whisker-safe-area`'s shape), providing:

- **`keyboard_height() -> ReadSignal<f64>`** — the keyboard's overlap from the bottom (pt/dp, `0` when hidden). iOS observes `keyboardWillChangeFrame`; Android reads `WindowInsetsCompat.Type.ime()`. Whisker's analogue of Flutter's `MediaQuery.viewInsets.bottom`.
- **`dismiss()`** — a **real global unfocus**, not a bare keyboard-hide: iOS `endEditing(true)` (resignFirstResponder), Android `clearFocus()` on the focused view + IME hide. Removing focus is what prevents a hardware keyboard from typing into an input that navigated/scrolled off screen. Native focus-change events flow back to the input's `on_blur`, so Rust state stays consistent **without a focus registry** (native stays the source of truth).

## Design notes

Matches the industry split: **React Native / React Navigation** dismiss explicitly on transition (`keyboardHandlingEnabled`) — whisker mirrors that with an explicit router-triggered unfocus, since whisker delegates focus to native views rather than owning a **Flutter**-style focus tree. Adding a core focus subsystem was considered and deferred: `input` is the only focus consumer today, and a Rust focus tree would fight the native-owns-focus reality. Keyboard height is orthogonal to focus (Flutter also exposes it separately via `viewInsets`).

## Wiring

- **`whisker-router`** calls the native `dismiss` at the single navigation choke point (`with_navigator`) and on swipe-back commit. References the module by qualified name (`whisker-keyboard:Keyboard`); no-ops if the app didn't add `whisker-keyboard`.
- **`whisker-input`** adds a teardown unfocus for **non-navigation** unmounts (a conditionally-rendered field removed while focused): iOS `DetachAwareView` resigns on window removal, Android fills `onViewDetachedFromWindow`. Safety net alongside the router's up-front dismiss.
- **bluesky** login consumes `keyboard_height()` for avoidance.

## Verification (both platforms, device)

bluesky login on **iOS 26 simulator** and **Android emulator**:

| | ① dismiss on nav | ② avoidance |
|---|---|---|
| iOS | focus handle → keyboard up; tap 続ける → auth screen, **keyboard gone** | `keyboard_height` = 336 pt (confirmed via device log + on-screen probe); form **lifts clear** of the keyboard |
| Android | same → **keyboard gone** (clearFocus + IME hide) | `Type.ime()` = 336 dp; form **lifts** |

Rust: 4 unit tests (payload decode), clippy/fmt clean, workspace compiles.

## Follow-ups (out of scope)

- Field-to-field navigation (return-key "next") — the one plausible future driver for a lightweight core focus registry; add when requested.
- The swipe-back keyboard dismissal fires at gesture commit (not gesture start), so during an interactive back-swipe the keyboard drops at the end rather than as the drag begins — a minor snappiness refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)