### PR TITLE
fix(keyboard,safe-area): share decor inset listener via WhiskerInsetsDispatcher

### DIFF
--- a/packages/whisker-keyboard/android/src/main/kotlin/rs/whisker/modules/keyboard/KeyboardModule.kt
+++ b/packages/whisker-keyboard/android/src/main/kotlin/rs/whisker/modules/keyboard/KeyboardModule.kt
@@ -3,10 +3,10 @@
 // View-less module with two jobs:
 //
 //  * `keyboardChanged` event — while a Rust listener is registered,
-//    hook `ViewCompat.setOnApplyWindowInsetsListener` onto the host
-//    Activity's decor view and forward the IME inset height (dp) as
-//    `{ height }`. The Rust side (`packages/whisker-keyboard/src/lib.rs`)
-//    holds the `RwSignal<f64>` `keyboard_height()` returns.
+//    subscribe to `WhiskerInsetsDispatcher` and forward the IME inset
+//    height (dp) as `{ height }`. The Rust side
+//    (`packages/whisker-keyboard/src/lib.rs`) holds the `RwSignal<f64>`
+//    `keyboard_height()` returns.
 //
 //  * `dismiss` function — a **real global unfocus**. On Android,
 //    `hideSoftInputFromWindow` only hides the soft keyboard; the focused
@@ -25,47 +25,51 @@
 // inset themselves and apply it — which is exactly what this module
 // surfaces to Rust so the app can pad/scroll its content.
 //
-// ## Lifecycle + configuration-change handling
+// ## Why `WhiskerInsetsDispatcher` (not a private decor listener)
 //
-// Same approach as `whisker-safe-area`: the inset listener is
-// (re)installed inside a permanent `HostAttachedListener`, so a
-// config-change Activity recreation (rotation, multi-window resize)
-// transparently rewires onto the fresh decor view.
+// Android stores exactly one `OnApplyWindowInsetsListener` per view, so
+// this module and `whisker-safe-area` used to clobber each other's
+// listener on the shared decor view (last installer wins; the loser's
+// inset signal freezes). We subscribe through the runtime's shared
+// `WhiskerInsetsDispatcher` instead — it owns the single decor slot,
+// handles config-change re-installation, and fans the raw insets out to
+// every subscriber. See `WhiskerInsetsDispatcher` for the lifecycle.
 
 package rs.whisker.modules.keyboard
 
 import android.app.Activity
 import android.content.Context
 import android.view.inputmethod.InputMethodManager
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import rs.whisker.runtime.HostAttachedListener
 import rs.whisker.runtime.Module
 import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerInsetsDispatcher
 import rs.whisker.runtime.WhiskerValue
 
 public class KeyboardModule : Module() {
 
     /**
-     * Live host-attached listener. `null` between `OnStopObserving`
-     * tearing it down and the next `OnStartObserving` re-registering.
+     * Live inset-dispatcher subscription. `null` between
+     * `OnStopObserving` tearing it down and the next `OnStartObserving`
+     * re-subscribing.
      */
-    private var attachListener: HostAttachedListener? = null
+    private var insetsRegistration: WhiskerInsetsDispatcher.Registration? = null
 
     public override fun definition(): ModuleDefinition = ModuleDefinition {
         Name("Keyboard")
         Events("keyboardChanged")
 
         OnStartObserving("keyboardChanged") {
-            if (attachListener != null) return@OnStartObserving
-            val listener = HostAttachedListener { installOnCurrentHost() }
-            attachListener = listener
-            appContext.addOnHostAttachedListener(listener)
+            if (insetsRegistration != null) return@OnStartObserving
+            insetsRegistration = WhiskerInsetsDispatcher.addListener { insets ->
+                val activity = appContext.currentActivity ?: return@addListener
+                dispatch(activity, insets)
+            }
         }
 
         OnStopObserving("keyboardChanged") {
-            attachListener?.let { appContext.removeOnHostAttachedListener(it) }
-            attachListener = null
+            insetsRegistration?.let { WhiskerInsetsDispatcher.removeListener(it) }
+            insetsRegistration = null
         }
 
         // Real global unfocus. Marshalled to the UI thread because the
@@ -94,26 +98,6 @@ public class KeyboardModule : Module() {
             imm?.hideSoftInputFromWindow(token, 0)
         }
         focused?.clearFocus()
-    }
-
-    /**
-     * Install (or re-install) the IME-inset listener on the current
-     * host Activity's decor view, and seed the Rust signal with the
-     * current IME inset so a late subscriber doesn't sit at 0 until the
-     * next genuine change.
-     */
-    private fun installOnCurrentHost() {
-        val activity = appContext.currentActivity ?: return
-        val decor = activity.window?.decorView ?: return
-
-        ViewCompat.setOnApplyWindowInsetsListener(decor) { _, insetsCompat ->
-            dispatch(activity, insetsCompat)
-            // Pass through unmodified so Lynx's own listeners still see
-            // the same insets.
-            insetsCompat
-        }
-
-        ViewCompat.getRootWindowInsets(decor)?.let { dispatch(activity, it) }
     }
 
     /**

--- a/packages/whisker-keyboard/build.gradle.kts
+++ b/packages/whisker-keyboard/build.gradle.kts
@@ -46,7 +46,10 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
+    // 0.1.6 is the first SDK release carrying `WhiskerInsetsDispatcher`
+    // (the shared decor-view inset multiplexer this module subscribes
+    // to). Requires cutting `sdk-v0.1.6`; see the module refactor commit.
+    implementation("rs.whisker:whisker-module-android:0.1.6")
     ksp("rs.whisker:ksp:0.1.0")
 
     // `WindowInsetsCompat.Type.ime()` + `ViewCompat.setOnApplyWindowInsetsListener`

--- a/packages/whisker-safe-area/android/src/main/kotlin/rs/whisker/modules/safe_area/SafeAreaModule.kt
+++ b/packages/whisker-safe-area/android/src/main/kotlin/rs/whisker/modules/safe_area/SafeAreaModule.kt
@@ -1,7 +1,7 @@
 // `whisker-safe-area` Module (Android).
 //
-// View-less. Hooks `ViewCompat.setOnApplyWindowInsetsListener` onto
-// the host Activity's decor view while at least one Rust listener is
+// View-less. Subscribes to the runtime's shared
+// `WhiskerInsetsDispatcher` while at least one Rust listener is
 // registered against the `insetsChanged` event; converts the system-
 // bar + display-cutout insets to dp and dispatches.
 //
@@ -19,105 +19,51 @@
 // displayCutout())` — therefore map 1:1 to padding on the WhiskerView
 // (no double-padding to dodge, regardless of theme).
 //
-// ## Lifecycle + configuration change handling
+// ## Why `WhiskerInsetsDispatcher` (not a private decor listener)
 //
-// Activities without `android:configChanges="orientation|screenSize"`
-// get destroyed + recreated on rotation; the new WhiskerView calls
-// `WhiskerAppContext.pushHost`, which re-fires every registered
-// `HostAttachedListener`. We exploit that: the inset listener is
-// (re)installed inside the HostAttachedListener body so each
-// recreation transparently picks up the fresh decor view. The old
-// listener pins nothing (Android stores it on the dead view) and
-// gets GC'd with its host.
-//
-// * `OnStartObserving("insetsChanged")` — register a permanent
-//   HostAttachedListener. It fires synchronously if a host is
-//   already attached (covering steady-state), and every subsequent
-//   `pushHost` (covering rotation, multi-window resize that
-//   recreates the activity, etc.).
-// * `OnStopObserving("insetsChanged")` — drop the host listener.
-//   The most recently installed inset listener stays on its view
-//   until the view dies, but no more Rust events fire because the
-//   bridge has no Rust subscribers.
+// Android stores exactly one `OnApplyWindowInsetsListener` per view, so
+// this module and `whisker-keyboard` used to clobber each other's
+// listener on the shared decor view (last installer wins; the loser's
+// inset signal freezes). We subscribe through the runtime's shared
+// `WhiskerInsetsDispatcher` instead — it owns the single decor slot,
+// handles config-change re-installation (rotation, multi-window
+// resize), seeds late subscribers, and fans the raw insets out to every
+// subscriber. See `WhiskerInsetsDispatcher` for the lifecycle.
 
 package rs.whisker.modules.safe_area
 
 import android.app.Activity
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import rs.whisker.runtime.HostAttachedListener
 import rs.whisker.runtime.Module
 import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerInsetsDispatcher
 import rs.whisker.runtime.WhiskerValue
 
 public class SafeAreaModule : Module() {
 
     /**
-     * Live host-attached listener. `null` between `OnStopObserving`
-     * tearing it down and the next `OnStartObserving` re-registering.
-     * The listener body re-installs the inset listener on whichever
-     * decor view is current at fire time, so a config-change
-     * Activity recreation transparently rewires.
+     * Live inset-dispatcher subscription. `null` between
+     * `OnStopObserving` tearing it down and the next `OnStartObserving`
+     * re-subscribing.
      */
-    private var attachListener: HostAttachedListener? = null
+    private var insetsRegistration: WhiskerInsetsDispatcher.Registration? = null
 
     public override fun definition(): ModuleDefinition = ModuleDefinition {
         Name("SafeArea")
         Events("insetsChanged")
 
         OnStartObserving("insetsChanged") {
-            if (attachListener != null) return@OnStartObserving
-
-            val listener = HostAttachedListener { installOnCurrentHost() }
-            attachListener = listener
-            // `addOnHostAttachedListener` fires synchronously once if
-            // a host is already attached (the steady-state case) and
-            // every time a new host attaches afterwards (the rotation
-            // case). Either way we end up with the inset listener
-            // installed on the live decor view.
-            appContext.addOnHostAttachedListener(listener)
+            if (insetsRegistration != null) return@OnStartObserving
+            insetsRegistration = WhiskerInsetsDispatcher.addListener { insets ->
+                val activity = appContext.currentActivity ?: return@addListener
+                dispatch(activity, insets)
+            }
         }
 
         OnStopObserving("insetsChanged") {
-            attachListener?.let {
-                appContext.removeOnHostAttachedListener(it)
-            }
-            attachListener = null
-            // Note: we don't bother clearing the inset listener off
-            // the most recently used decor view — when the Rust side
-            // has no subscribers, `sendEvent` becomes a no-op on the
-            // bridge, so the listener firing harmlessly drops into
-            // the void. The view will GC its listener slot when it
-            // itself goes away.
+            insetsRegistration?.let { WhiskerInsetsDispatcher.removeListener(it) }
+            insetsRegistration = null
         }
-    }
-
-    /**
-     * Install (or re-install) the inset listener on the current host
-     * Activity's decor view, and seed the Rust signal with the
-     * currently-known insets so a fresh activity doesn't sit at the
-     * last rotation's values until the next genuine inset change.
-     */
-    private fun installOnCurrentHost() {
-        val activity = appContext.currentActivity ?: return
-        val decor = activity.window?.decorView ?: return
-
-        ViewCompat.setOnApplyWindowInsetsListener(decor) { _, insetsCompat ->
-            dispatch(activity, insetsCompat)
-            // Pass through unmodified so other consumers in the
-            // hierarchy (e.g. Lynx's own listeners) still see the
-            // same `WindowInsetsCompat`. Consuming here would mask
-            // the insets from the rest of the view tree.
-            insetsCompat
-        }
-
-        // Seed with current insets so a late subscriber (or a
-        // post-rotation freshly-attached activity) doesn't sit at
-        // `default()` until the next genuine WindowInsets dispatch.
-        // `getRootWindowInsets` returns null until the view has been
-        // measured at least once — that's fine, the listener will
-        // pick the first real fire up.
-        ViewCompat.getRootWindowInsets(decor)?.let { dispatch(activity, it) }
     }
 
     /**

--- a/packages/whisker-safe-area/build.gradle.kts
+++ b/packages/whisker-safe-area/build.gradle.kts
@@ -45,7 +45,10 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
+    // 0.1.6 is the first SDK release carrying `WhiskerInsetsDispatcher`
+    // (the shared decor-view inset multiplexer this module subscribes
+    // to). Requires cutting `sdk-v0.1.6`; see the module refactor commit.
+    implementation("rs.whisker:whisker-module-android:0.1.6")
     ksp("rs.whisker:ksp:0.1.0")
 
     // `WindowInsetsCompat` + `ViewCompat.setOnApplyWindowInsetsListener`

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -71,6 +71,13 @@ dependencies {
     }
     api("org.lynxsdk.lynx:primjs:3.7.0")
 
+    // `WhiskerInsetsDispatcher` exposes `WindowInsetsCompat` in its
+    // public API and calls `ViewCompat.setOnApplyWindowInsetsListener` /
+    // `getRootWindowInsets`. `api` (not `implementation`) so consuming
+    // modules see `WindowInsetsCompat` on their compile classpath when
+    // they write an inset callback.
+    api("androidx.core:core-ktx:1.13.1")
+
     // No annotation re-export needed (Phase M / Issue #59): a
     // module's `build.gradle.kts` depends on this AAR alone for
     // runtime types; the `ksp(...)` processor stays separate as a

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerInsetsDispatcher.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerInsetsDispatcher.kt
@@ -1,0 +1,159 @@
+// `WhiskerInsetsDispatcher` — the single owner of the host Activity's
+// `decorView.setOnApplyWindowInsetsListener` slot, fanned out to any
+// number of module subscribers.
+//
+// ## Why this exists
+//
+// Android stores exactly ONE `OnApplyWindowInsetsListener` per view
+// (`View.ListenerInfo.mOnApplyWindowInsetsListener`) — the setter
+// overwrites, it does not append. `whisker-safe-area` and
+// `whisker-keyboard` both need the decor view's insets, and both were
+// independently calling `ViewCompat.setOnApplyWindowInsetsListener` on
+// the SAME `decorView`. Whichever installed last silently clobbered the
+// other, so one module's inset signal froze (for keyboard that means
+// `keyboardChanged` never fires — IME show/hide doesn't recreate the
+// Activity, so nothing ever re-installs the lost listener).
+//
+// This dispatcher owns the single slot and multiplexes it: every module
+// that wants insets calls [addListener] and receives the same
+// `WindowInsetsCompat` the platform delivers. No module touches the
+// decor slot directly anymore, so there is nothing left to clobber.
+//
+// ## Generic on purpose
+//
+// The public surface is `(WindowInsetsCompat) -> Unit` — the dispatcher
+// knows nothing about IME vs system-bars vs cutout. Each subscriber
+// reads whatever `Type` it cares about from the raw insets in its own
+// callback. A future inset consumer needs zero changes here: it just
+// calls [addListener].
+//
+// ## Lifecycle + configuration-change handling
+//
+// The decor view is replaced on every config-change Activity recreation
+// (rotation, multi-window resize). We rewire transparently by owning a
+// single [HostAttachedListener]: registered lazily on the 0→1
+// subscriber transition, it (re)installs the inset listener on whichever
+// decor view is current each time a host attaches, and dropped on the
+// 1→0 transition. This is the same host-attach trick the modules used
+// individually — now centralised so there is one host listener and one
+// decor slot regardless of how many modules subscribe.
+
+package rs.whisker.runtime
+
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import java.util.concurrent.CopyOnWriteArrayList
+
+public object WhiskerInsetsDispatcher {
+
+    /**
+     * Opaque handle returned by [addListener]. Pass it back to
+     * [removeListener] to unsubscribe. Holds the callback so the
+     * dispatcher can fan out to it.
+     */
+    public class Registration internal constructor(
+        internal val callback: (WindowInsetsCompat) -> Unit,
+    )
+
+    /**
+     * Live subscribers. `CopyOnWriteArrayList` so the decor-view
+     * listener (UI thread) can iterate while `add`/`removeListener`
+     * (possibly the TASM thread, from `OnStartObserving`) mutate.
+     */
+    private val listeners: CopyOnWriteArrayList<Registration> = CopyOnWriteArrayList()
+
+    /** Guards the 0↔1 host-listener register/unregister transitions. */
+    private val lock = Any()
+
+    /**
+     * The permanent host-attached listener — non-null exactly while at
+     * least one subscriber is registered. Its body re-installs the inset
+     * listener on the current decor view, so a config-change recreation
+     * transparently rewires.
+     */
+    private var hostListener: HostAttachedListener? = null
+
+    private val appContext: WhiskerAppContext get() = WhiskerAppContext.shared
+
+    /**
+     * Subscribe to decor-view window insets. The callback fires on the
+     * UI thread with the raw `WindowInsetsCompat` every time the platform
+     * dispatches insets, plus once synchronously with the current insets
+     * if a host is already attached (so a late subscriber doesn't sit at
+     * its default until the next genuine change).
+     */
+    public fun addListener(callback: (WindowInsetsCompat) -> Unit): Registration {
+        val registration = Registration(callback)
+        var listenerToRegister: HostAttachedListener? = null
+        synchronized(lock) {
+            val wasEmpty = listeners.isEmpty()
+            listeners.add(registration)
+            if (wasEmpty) {
+                val listener = HostAttachedListener { installOnCurrentHost() }
+                hostListener = listener
+                listenerToRegister = listener
+            }
+        }
+        val toRegister = listenerToRegister
+        if (toRegister != null) {
+            // 0→1: register the host listener OUTSIDE the lock (its body
+            // installs the decor slot and seeds every subscriber, incl.
+            // this one, if a host is already attached).
+            appContext.addOnHostAttachedListener(toRegister)
+        } else {
+            // 1→N: the decor slot is already installed and seeds only
+            // fire on install / genuine change, so seed just the new
+            // subscriber with the current insets.
+            seedInto(registration)
+        }
+        return registration
+    }
+
+    /**
+     * Unsubscribe. On the 1→0 transition the host listener is dropped.
+     * We deliberately leave the decor view's inset listener in place —
+     * with no subscribers its fan-out loop is a harmless no-op, and the
+     * next 0→1 transition re-installs it on the current host anyway.
+     */
+    public fun removeListener(registration: Registration) {
+        var listenerToRemove: HostAttachedListener? = null
+        synchronized(lock) {
+            listeners.remove(registration)
+            if (listeners.isEmpty()) {
+                listenerToRemove = hostListener
+                hostListener = null
+            }
+        }
+        listenerToRemove?.let { appContext.removeOnHostAttachedListener(it) }
+    }
+
+    /**
+     * Install (or re-install) the inset listener on the current host
+     * Activity's decor view and seed every subscriber with the current
+     * insets. Runs on each host attach.
+     */
+    private fun installOnCurrentHost() {
+        val decor = appContext.currentActivity?.window?.decorView ?: return
+
+        ViewCompat.setOnApplyWindowInsetsListener(decor) { _, insets ->
+            for (l in listeners) l.callback(insets)
+            // Pass through unmodified so consumers further down the view
+            // tree (e.g. Lynx's own listeners) still see the same insets.
+            insets
+        }
+
+        // Seed all current subscribers so a freshly-attached (or rotated)
+        // host doesn't sit at defaults until the next genuine dispatch.
+        // `getRootWindowInsets` returns null until first measure — fine,
+        // the listener above picks up the first real fire.
+        ViewCompat.getRootWindowInsets(decor)?.let { insets ->
+            for (l in listeners) l.callback(insets)
+        }
+    }
+
+    /** Seed a single freshly-added subscriber with the current insets. */
+    private fun seedInto(registration: Registration) {
+        val decor = appContext.currentActivity?.window?.decorView ?: return
+        ViewCompat.getRootWindowInsets(decor)?.let { registration.callback(it) }
+    }
+}


### PR DESCRIPTION
## Problem

Android stores exactly **one** `OnApplyWindowInsetsListener` per view (`setOnApplyWindowInsetsListener` overwrites, never appends). `whisker-keyboard` and `whisker-safe-area` each installed their own listener on the **same** host `decorView`, so whichever ran `installOnCurrentHost()` last silently clobbered the other.

- **keyboard loses** → `keyboardChanged` never fires (IME show/hide doesn't recreate the Activity, so nothing re-installs the lost listener) → the whole keyboard-avoidance feature goes dark.
- **safe-area loses** → `insetsChanged` stops updating mid-session.

Which one loses is non-deterministic (registration order = whichever module's Rust signal gets its first subscriber first). Surfaced in review of #293. iOS is unaffected — `NotificationCenter` observers are additive.

## Fix

Introduce `WhiskerInsetsDispatcher` in the runtime module (`platforms/android/module/.../rs/whisker/runtime/`):

- Owns the single `decorView` inset slot and one `HostAttachedListener` for config-change re-installation (rotation / multi-window resize).
- Seeds late subscribers, fans the raw `WindowInsetsCompat` out to N subscribers.
- Generic public API `addListener((WindowInsetsCompat) -> Unit): Registration` / `removeListener` — each subscriber reads whatever `Type` it needs, so **a future inset consumer needs zero runtime changes**.

Both modules drop their private decor listener and just `addListener`/`removeListener`. `module/build.gradle.kts` gains an `api` `androidx.core` dep since the dispatcher exposes `WindowInsetsCompat`.

## ⚠️ Release lockstep — blocking

`WhiskerInsetsDispatcher` ships in the `whisker-module-android` AAR, published only on `sdk-v*` tags (currently `sdk-v0.1.5`). This PR bumps the two package pins `0.1.0 → 0.1.6`, so **`sdk-v0.1.6` must be cut before these packages resolve**. `WHISKER_ANDROID_MAVEN_TAG` (new_module.rs) stays `0.1.0` — anchored to webview; newly-generated modules don't consume insets.

## Verification

Full gradle build is Lynx-AAR-heavy and impractical locally. Needs on-device check after `sdk-v0.1.6`: an app using **both** keyboard + safe-area, confirming both signals stay live (keyboard height updates on IME open **and** safe-area insets update), across rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)