### PR TITLE
fix(fmt): use `?` instead of match for clippy::question-mark

### DIFF
--- a/crates/whisker-fmt/src/expr_fmt.rs
+++ b/crates/whisker-fmt/src/expr_fmt.rs
@@ -238,10 +238,7 @@ fn extract_bodies(formatted_file: &str, count: usize) -> Option<Vec<Option<Strin
     // Require every expected wrapper to be present.
     let mut bodies = Vec::with_capacity(count);
     for i in 0..count {
-        match found.remove(&i) {
-            Some(b) => bodies.push(Some(b)),
-            None => return None,
-        }
+        bodies.push(Some(found.remove(&i)?));
     }
     Some(bodies)
 }


### PR DESCRIPTION
## Problem

`main` CI (stable clippy 1.97) is red: `crates/whisker-fmt/src/expr_fmt.rs:241` trips `clippy::question-mark` (`-D warnings`). The `match found.remove(&i) { Some(b) => bodies.push(Some(b)), None => return None }` is reducible to the `?` operator. Landed via #291 (release) — local clippy was 1.96, which doesn't flag it.

## Fix

Collapse to `bodies.push(Some(found.remove(&i)?));`. No behavior change — same early-return-`None` semantics.

Swept the workspace for other `question_mark`-reducible shapes (`None => return None`, `is_none()` + `return None`); none remain. `let … else { return None }` patterns are let-else (pattern match, not `Option` unwrap) — not flagged by this lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)