### PR TITLE
feat(reactive): add Callback<In, Out> — Copy event-handler-prop wrapper

### DIFF
--- a/crates/whisker-runtime/src/reactive/callback.rs
+++ b/crates/whisker-runtime/src/reactive/callback.rs
@@ -1,0 +1,170 @@
+//! [`Callback<In, Out>`] — a `Copy`, owner-bound wrapper around a
+//! closure, for passing event handlers as component props.
+//!
+//! ## Why this type exists
+//!
+//! `#[component]` bodies are `FnMut` (whisker's hot-reload wrapper —
+//! see [`Signal<T>`]'s docs, whisker issue #8). Moving a captured,
+//! non-`Copy` prop into a nested `move` closure (e.g.
+//! `view(on_tap: move |_| on_tap())`) violates that `FnMut` contract:
+//! the prop is moved out of the body on the first call, so a second
+//! invocation of the body (hot-reload, or any future re-render) can't
+//! move it again — `error[E0507]`. Until now the workaround has been
+//! an `Rc<dyn Fn()>` prop plus a manual `let cb = on_tap.clone();`
+//! before each handler closure that needs it.
+//!
+//! `Callback<In, Out>` removes the workaround: like [`Signal<T>`], it
+//! stores the actual closure in an owner-bound [`StoredValue<T>`]
+//! arena slot and hands back only a `Copy` handle (a `NodeId`). A
+//! `Copy` value never needs `.clone()` — it can be moved into any
+//! number of `move` closures for free. Mirrors Leptos's
+//! `Callback<In, Out>`, which solves the identical problem the same
+//! way (an arena-backed, `Copy` handle) — see
+//! <https://docs.rs/leptos/latest/leptos/callback/index.html>.
+//!
+//! ```ignore
+//! #[component]
+//! fn tab_button(on_tap: Callback<()>) -> Element {
+//!     render! {
+//!         view(on_tap: move |_| on_tap.run(())) { … }
+//!         //           ^^^^^^^ moved into the closure directly — no `.clone()`
+//!     }
+//! }
+//!
+//! // call site — a plain closure converts via `impl Into<Callback<In, Out>>`,
+//! // which #[component]'s generated builder setter accepts (non-generic
+//! // fields get `setter(into)`):
+//! TabButton(on_tap: move |_| { nav.select("/"); })
+//! ```
+//!
+//! [`Signal<T>`]: super::prop::Signal
+
+use super::stored::StoredValue;
+
+/// A `Copy`, owner-bound callback: `In -> Out`. See the module docs for
+/// why this exists instead of `Rc<dyn Fn(In) -> Out>`.
+///
+/// `In` defaults to `()` for the common "fire on tap, no payload"
+/// case — construct with a zero-arg closure (`move || …`) and call
+/// with [`Callback::call`] rather than `.run(())`.
+//
+// NOTE: `Clone`/`Copy` are hand-written rather than `#[derive]`d, same
+// reasoning as `Signal<T>` — a derived impl would add spurious
+// `In: Clone + Copy, Out: Clone + Copy` bounds, but neither type
+// parameter is ever stored inline (they only appear in the boxed
+// closure's signature), so `Callback<In, Out>` must be `Copy`
+// unconditionally.
+pub struct Callback<In: 'static = (), Out: 'static = ()> {
+    inner: StoredValue<Box<dyn Fn(In) -> Out>>,
+}
+
+impl<In: 'static, Out: 'static> Clone for Callback<In, Out> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<In: 'static, Out: 'static> Copy for Callback<In, Out> {}
+
+impl<In: 'static, Out: 'static> Callback<In, Out> {
+    /// Wrap `f` in an owner-bound arena slot, returning a `Copy`
+    /// handle to it. Prefer converting a plain closure via `.into()`
+    /// at the prop call site — `Callback::new` is for constructing one
+    /// to store in a local binding.
+    pub fn new(f: impl Fn(In) -> Out + 'static) -> Self {
+        Self {
+            inner: StoredValue::new(Box::new(f) as Box<dyn Fn(In) -> Out>),
+        }
+    }
+
+    /// Invoke the wrapped closure with `input`.
+    pub fn run(&self, input: In) -> Out {
+        self.inner.with(|f| f(input))
+    }
+}
+
+impl<Out: 'static> Callback<(), Out> {
+    /// Convenience for the default `In = ()` case: `.call()` instead
+    /// of `.run(())`.
+    pub fn call(&self) -> Out {
+        self.run(())
+    }
+}
+
+impl<F, In, Out> From<F> for Callback<In, Out>
+where
+    F: Fn(In) -> Out + 'static,
+    In: 'static,
+    Out: 'static,
+{
+    fn from(f: F) -> Self {
+        Callback::new(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reactive::__reset_for_tests;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    #[test]
+    fn callback_is_copy() {
+        // The whole point: a Callback prop can be moved into several
+        // `move` closures without `.clone()`. Wouldn't compile if
+        // `Callback` weren't `Copy`.
+        __reset_for_tests();
+        fn assert_copy<C: Copy>(_: &C) {}
+
+        let cb: Callback<(), i32> = Callback::new(|_| 1);
+        assert_copy(&cb);
+
+        let first = move || cb.run(());
+        let second = move || cb.run(());
+        assert_eq!(first(), 1);
+        assert_eq!(second(), 1);
+    }
+
+    #[test]
+    fn run_forwards_input_and_returns_output() {
+        __reset_for_tests();
+        let cb: Callback<i32, i32> = Callback::new(|x| x * 2);
+        assert_eq!(cb.run(21), 42);
+    }
+
+    #[test]
+    fn call_is_run_with_unit_input() {
+        __reset_for_tests();
+        let log = Rc::new(Cell::new(0));
+        let log2 = log.clone();
+        let cb: Callback<()> = Callback::new(move |()| {
+            log2.set(log2.get() + 1);
+        });
+        cb.call();
+        cb.call();
+        assert_eq!(log.get(), 2);
+    }
+
+    #[test]
+    fn closure_converts_via_into() {
+        __reset_for_tests();
+        fn takes_callback(cb: impl Into<Callback<i32, i32>>) -> Callback<i32, i32> {
+            cb.into()
+        }
+        let cb = takes_callback(|x| x + 1);
+        assert_eq!(cb.run(9), 10);
+    }
+
+    #[test]
+    fn each_clone_shares_the_same_underlying_closure() {
+        __reset_for_tests();
+        let log = Rc::new(Cell::new(0));
+        let log2 = log.clone();
+        let cb: Callback<()> = Callback::new(move |()| log2.set(log2.get() + 1));
+        let a = cb;
+        let b = cb;
+        a.call();
+        b.call();
+        assert_eq!(log.get(), 2);
+    }
+}

--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -15,6 +15,11 @@
 //! - [`effect`] — [`effect`] + dependency tracking.
 //! - [`computed`] — [`computed`] (returns [`ReadSignal<T>`]).
 //! - [`scheduler`] — batching / flush.
+//! - [`prop`] — [`Signal<T>`](prop::Signal), the unified prop-value
+//!   type.
+//! - [`callback`] — [`Callback<In, Out>`](callback::Callback), a
+//!   `Copy` event-handler-prop wrapper (the `Signal<T>` idea applied
+//!   to closures instead of values).
 //!
 //! All operations are single-threaded — reactive UI runs on the Lynx
 //! TASM thread. The runtime lives in a `thread_local!`. Operations
@@ -31,6 +36,7 @@
 //! executes.
 
 pub mod arc_signal;
+pub mod callback;
 pub mod component;
 pub mod computed;
 pub mod context;
@@ -51,6 +57,7 @@ mod tests_loop_wedge;
 mod tests_resource;
 
 pub use arc_signal::{ArcReadSignal, ArcRwSignal, ArcWriteSignal, arc_signal};
+pub use callback::Callback;
 #[doc(hidden)]
 pub use component::__reset_pending_mount_for_tests;
 pub use component::{

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -134,9 +134,9 @@ macro_rules! module {
 }
 
 pub use whisker_runtime::reactive::{
-    ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, Resource, ResourceState, RwSignal,
-    Signal, StoredValue, WriteSignal, arc_signal, computed, effect, flush, on_cleanup, on_mount,
-    provide_context, resource, resource_sync, signal, use_context, with_context,
+    ArcReadSignal, ArcRwSignal, ArcWriteSignal, Callback, ReadSignal, Resource, ResourceState,
+    RwSignal, Signal, StoredValue, WriteSignal, arc_signal, computed, effect, flush, on_cleanup,
+    on_mount, provide_context, resource, resource_sync, signal, use_context, with_context,
 };
 // Component mount/unmount + mount-queue machinery. Driven by the
 // `#[component]` expansion and the hot-reload remount path, not by app
@@ -1880,10 +1880,10 @@ pub mod prelude {
         Length, NamedColor, ToCss,
     };
     pub use crate::{
-        ArcReadSignal, ArcRwSignal, ArcWriteSignal, ReadSignal, Resource, ResourceState, RwSignal,
-        Signal, StoredValue, WriteSignal, arc_signal, computed, effect, on_cleanup, on_mount,
-        provide_context, resource, resource_sync, run_blocking, run_on_main_thread, signal,
-        spawn_local, use_context, with_context,
+        ArcReadSignal, ArcRwSignal, ArcWriteSignal, Callback, ReadSignal, Resource, ResourceState,
+        RwSignal, Signal, StoredValue, WriteSignal, arc_signal, computed, effect, on_cleanup,
+        on_mount, provide_context, resource, resource_sync, run_blocking, run_on_main_thread,
+        signal, spawn_local, use_context, with_context,
     };
     pub use crate::{
         BoundingClientRect, ElementHandle, ElementRef, RefError, ScrollInfo, ScrollViewHandle,


### PR DESCRIPTION
## Summary

- `#[component]` bodies are `FnMut` (whisker's hot-reload wrapper), so moving a captured non-`Copy` prop into a nested `move` closure (e.g. `view(on_tap: move |_| on_tap())`) hits `E0507` on a second invocation of the body. The workaround so far has been an `Rc<dyn Fn()>` prop plus a manual `.clone()` before each handler closure that needs it (see `examples/bluesky`'s `search_tab`).
- `Callback<In, Out>` removes the workaround the same way `Signal<T>` already does for values: it stores the closure in an owner-bound `StoredValue` arena slot and hands back a `Copy` handle, so it moves into any number of closures for free — no `.clone()` needed.
- Mirrors Leptos's `UnsyncCallback<In, Out>` (`Rc`-backed, no `Send + Sync` bound), which is the right counterpart given whisker's reactive runtime is single-threaded (`thread_local!`) end to end.
- `impl<F: Fn(In) -> Out + 'static> From<F> for Callback<In, Out>` means `#[component]`'s generated builder setter (`setter(into)` on non-generic fields) accepts a plain closure directly at the call site — no explicit `Callback::new(...)` needed by callers.
- Exported through `whisker-runtime::reactive` and `whisker`'s `prelude`.

Known gaps vs. Leptos's `Callback`/`UnsyncCallback` (not ported — flagged as a deliberate scope cut, not an oversight):
- Single-argument `Fn(In) -> Out` only; Leptos also generates `From` impls for closures with 0–12 separate arguments. Multi-value payloads need a tuple `In` here.
- No `.matches()` (function-pointer identity comparison) or `Dispose` trait — relies on owner-scope disposal only, consistent with how `Signal`/`StoredValue` already work in this codebase.
- No nightly `Fn`-trait direct-call sugar (`on_tap(x)` instead of `on_tap.run(x)`) — matches Leptos's own stable-Rust behavior; the nightly-only variant is optional there too.

## Test plan

- [x] `cargo test -p whisker-runtime --lib` — 151 passed (incl. 5 new `Callback` tests: `Copy`-ness, `run`, `call`, `From` conversion, and that clones share the same underlying closure)
- [x] `cargo test -p whisker --lib` — 12 passed
- [x] `cargo clippy -p whisker-runtime -p whisker --all-targets` — clean
- [x] `cargo fmt --check -p whisker-runtime -p whisker` — clean
- [x] Verified end-to-end against a downstream consumer app's `TabsLayout`/`TabButton` components (via a temporary `[patch.crates-io]` path override), replacing their `Rc<dyn Fn()>` `on_tap` prop and its manual clone — compiles clean, `clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)