### PR TITLE
fix(svg): parse rgb()/rgba() colors in the native tint parser

### DIFF
--- a/packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/WhiskerSvgView.kt
+++ b/packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/WhiskerSvgView.kt
@@ -99,12 +99,13 @@ class WhiskerSvgDrawingView(context: Context) : View(context) {
 
 /**
  * Best-effort CSS colour parser. Supports `#RGB`, `#RRGGBB`,
- * `#RRGGBBAA`, plus the small named colours the Rust compiler
- * accepts. Returns the resolved ARGB int, or falls back to
- * opaque black on parse failure.
+ * `#RRGGBBAA`, `rgb(…)`, `rgba(…)`, plus the small named colours the
+ * Rust compiler accepts. Returns the resolved ARGB int, or falls back
+ * to opaque black on parse failure.
  */
 private fun parseCssColor(raw: String): Int {
     val s = raw.trim()
+    parseRgbFunction(s)?.let { return it }
     if (s.startsWith("#")) {
         val hex = s.substring(1)
         when (hex.length) {
@@ -140,4 +141,30 @@ private fun parseCssColor(raw: String): Int {
         "transparent" -> 0x00000000
         else -> 0xFF000000.toInt()
     }
+}
+
+/**
+ * Parses `rgb(r, g, b)` / `rgba(r, g, b, a)` — the format
+ * `whisker-css`'s `Color::to_css_string()` actually emits for any
+ * non-hex-literal, non-named color (e.g. every `Color::hex(...)`
+ * constant reactively interpolated into a string, as opposed to a
+ * hardcoded hex literal). Without this, those colors fell through to
+ * the opaque-black fallback below — silently discarding the app's
+ * intended color.
+ */
+private fun parseRgbFunction(s: String): Int? {
+    val isRgba = s.startsWith("rgba(")
+    if (!isRgba && !s.startsWith("rgb(")) return null
+    if (!s.endsWith(")")) return null
+    val inner = s.substring(if (isRgba) 5 else 4, s.length - 1)
+    val parts = inner.split(",").map { it.trim() }
+    if (parts.size != if (isRgba) 4 else 3) return null
+    val r = parts[0].toDoubleOrNull() ?: return null
+    val g = parts[1].toDoubleOrNull() ?: return null
+    val b = parts[2].toDoubleOrNull() ?: return null
+    val a = if (isRgba) (parts[3].toDoubleOrNull() ?: 1.0) else 1.0
+    return ((a * 255).toInt() and 0xFF shl 24) or
+        (r.toInt() and 0xFF shl 16) or
+        (g.toInt() and 0xFF shl 8) or
+        (b.toInt() and 0xFF)
 }

--- a/packages/whisker-svg/ios/Sources/WhiskerSvg/WhiskerSvgView.swift
+++ b/packages/whisker-svg/ios/Sources/WhiskerSvg/WhiskerSvgView.swift
@@ -147,6 +147,9 @@ private func parseCssColor(_ raw: String) -> UIColor {
             }
         }
     }
+    if let c = parseRgbFunction(s) {
+        return c
+    }
     switch s.lowercased() {
     case "black": return .black
     case "white": return .white
@@ -156,4 +159,32 @@ private func parseCssColor(_ raw: String) -> UIColor {
     case "transparent": return .clear
     default: return .label
     }
+}
+
+/// Parses `rgb(r, g, b)` / `rgba(r, g, b, a)` — the format
+/// `whisker-css`'s `Color::to_css_string()` actually emits for any
+/// non-hex-literal, non-named color (e.g. every `Color::hex(...)`
+/// constant reactively interpolated into a string, as opposed to a
+/// `&'static str` hex literal written by hand). Without this, those
+/// colors fell through to the `default: return .label` case above —
+/// silently substituting the OS appearance's semantic label color
+/// for whatever the app's own color was.
+private func parseRgbFunction(_ s: String) -> UIColor? {
+    let isRgba = s.hasPrefix("rgba(")
+    guard isRgba || s.hasPrefix("rgb(") else { return nil }
+    guard s.hasSuffix(")") else { return nil }
+    let inner = s.dropFirst(isRgba ? 5 : 4).dropLast()
+    let parts = inner.split(separator: ",").map {
+        $0.trimmingCharacters(in: .whitespaces)
+    }
+    guard parts.count == (isRgba ? 4 : 3),
+        let r = Double(parts[0]), let g = Double(parts[1]), let b = Double(parts[2])
+    else { return nil }
+    let a = isRgba ? (Double(parts[3]) ?? 1.0) : 1.0
+    return UIColor(
+        red: CGFloat(r) / 255.0,
+        green: CGFloat(g) / 255.0,
+        blue: CGFloat(b) / 255.0,
+        alpha: CGFloat(a)
+    )
 }


### PR DESCRIPTION
## Summary
- `whisker-css`'s `Color::to_css_string()` emits `rgb(r, g, b)` / `rgba(r, g, b, a)` for any `Color` value that isn't a hand-written literal (e.g. `Color::hex(...)` interpolated reactively into a `color:` string prop).
- Both native SVG color parsers (`WhiskerSvgView.swift` on iOS, `WhiskerSvgView.kt` on Android) only ever implemented `#hex` + a small named-color set. An `rgb()`/`rgba()` string silently fell through to a default color instead of erroring — iOS's `.label` (an OS-appearance-driven semantic color) and Android's opaque black.
- Net effect: any `Svg`/`Icon` `color:` prop driven by a `Color` value (as opposed to a hardcoded hex literal) renders the wrong color and never visibly reacts to changes, with no error anywhere — it looks exactly like a reactivity bug in the prop pipeline, but isn't one. Confirmed via a hex-literal control case (`color: "#ff0000"` worked; the identical reactive setup via `.to_css_string()` didn't) before tracing it to the native parsers.
- Adds a `parseRgbFunction` helper on each platform, tried before falling back to the existing hex/named-color/default paths.

## Test plan
- [x] `cargo build`/`cargo clippy` clean in a downstream app exercising this path
- [x] iOS Simulator: confirmed a `computed()`-driven `Icon` color (light/dark theme foreground vs. muted-foreground) now renders and updates correctly across a light↔dark theme switch, where it previously rendered a wrong static color regardless of theme
- [ ] Android: fix applied by parallel code review to match the iOS logic; not independently device-verified in this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)