### PR TITLE
feat(web-browser): add whisker-web-browser module for in-app OAuth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,6 +4557,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-web-browser"
+version = "0.8.2"
+dependencies = [
+ "futures-channel",
+ "whisker",
+]
+
+[[package]]
 name = "whisker-webview"
 version = "0.8.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "packages/whisker-safe-area",
     "packages/whisker-secure-store",
     "packages/whisker-secure-store/example",
+    "packages/whisker-web-browser",
     "packages/whisker-svg",
     "packages/whisker-svg/example",
     "packages/whisker-video",

--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -119,6 +119,9 @@ pub struct AndroidInputs {
     /// post-pipeline IR. Dedup'd by attribute name (last writer wins).
     #[serde(default)]
     pub extra_application_attributes: Vec<ApplicationAttribute>,
+    /// `MainActivity` deep-link schemes. See `AndroidManifest::main_activity_url_schemes`.
+    #[serde(default)]
+    pub main_activity_url_schemes: Vec<String>,
     /// Extra entries the renderer drops into the app module's
     /// `plugins { … }` block, just after the baseline Whisker /
     /// AGP / Kotlin plugin ids. Bare ids (e.g.
@@ -217,6 +220,18 @@ pub(crate) fn template_vars(inputs: &AndroidInputs) -> HashMap<&'static str, Str
     v.insert(
         "extra_application_attributes",
         render_extra_application_attributes(&inputs.extra_application_attributes),
+    );
+    v.insert(
+        "main_activity_launch_mode",
+        if inputs.main_activity_url_schemes.is_empty() {
+            String::new()
+        } else {
+            "\n            android:launchMode=\"singleTask\"".to_string()
+        },
+    );
+    v.insert(
+        "extra_main_activity_intent_filter",
+        render_main_activity_intent_filter(&inputs.main_activity_url_schemes),
     );
     v.insert(
         "extra_gradle_plugins",
@@ -343,6 +358,25 @@ fn render_extra_application_attributes(attrs: &[ApplicationAttribute]) -> String
     if out.ends_with('\n') {
         out.pop();
     }
+    out
+}
+
+/// A second `<intent-filter>` for `MainActivity` catching each
+/// scheme's `VIEW` deep links. Empty input → empty string.
+fn render_main_activity_intent_filter(schemes: &[String]) -> String {
+    if schemes.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from(
+        "\n            <intent-filter>\n                <action android:name=\"android.intent.action.VIEW\" />\n                <category android:name=\"android.intent.category.DEFAULT\" />\n                <category android:name=\"android.intent.category.BROWSABLE\" />\n",
+    );
+    for scheme in schemes {
+        out.push_str(&format!(
+            "                <data android:scheme=\"{}\" />\n",
+            escape_xml(scheme),
+        ));
+    }
+    out.push_str("            </intent-filter>");
     out
 }
 
@@ -652,6 +686,7 @@ pub fn inputs_from_with_engine(
     let extra_permissions = android_ir.manifest.permissions.clone();
     let extra_meta_data = android_ir.manifest.application_meta_data.clone();
     let extra_application_attributes = android_ir.manifest.application_attributes.clone();
+    let main_activity_url_schemes = android_ir.manifest.main_activity_url_schemes.clone();
     let extra_gradle_plugins = android_ir.gradle.apply_plugins.clone();
     let extra_gradle_dependencies = android_ir.gradle.dependencies.clone();
     let extra_files = android_ir.extra_files.clone();
@@ -673,21 +708,12 @@ pub fn inputs_from_with_engine(
         extra_permissions,
         extra_meta_data,
         extra_application_attributes,
+        main_activity_url_schemes,
         extra_gradle_plugins,
         extra_gradle_dependencies,
         extra_files,
-        // Bumped 9 → 10 for `<application>` attribute injection
-        // (`extra_application_attributes`): the template's
-        // `<application` open tag grew a placeholder + the inputs/
-        // fingerprint shape grew a field, so existing trees regenerate.
-        // Bumped 10 → 11 for release signing: app/build.gradle.kts
-        // grew the env-var-driven `whiskerRelease` signingConfig
-        // (`WHISKER_ANDROID_*`) that `whisker build appbundle|apk`
-        // injects. Without the bump, pre-existing gen trees keep the
-        // signing-less gradle script and release builds come out
-        // UNSIGNED (uninstallable) even though the build command
-        // exported the env vars.
-        template_version: 11,
+        // Bumped 11 → 12: MainActivity intent-filter/launchMode placeholders.
+        template_version: 12,
     })
 }
 
@@ -727,10 +753,11 @@ mod tests {
             extra_permissions: Vec::new(),
             extra_meta_data: Vec::new(),
             extra_application_attributes: Vec::new(),
+            main_activity_url_schemes: Vec::new(),
             extra_gradle_plugins: Vec::new(),
             extra_gradle_dependencies: Vec::new(),
             extra_files: BTreeMap::new(),
-            template_version: 11,
+            template_version: 12,
         }
     }
 
@@ -930,6 +957,26 @@ mod tests {
         assert_eq!(std::fs::read(&dylib).unwrap(), b"FAKE_DYLIB");
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn render_main_activity_intent_filter_empty_is_empty() {
+        assert_eq!(render_main_activity_intent_filter(&[]), "");
+    }
+
+    #[test]
+    fn render_main_activity_intent_filter_includes_scheme() {
+        let out = render_main_activity_intent_filter(&["giga".to_string()]);
+        assert!(out.contains("android:scheme=\"giga\""));
+        assert!(out.contains("android.intent.action.VIEW"));
+    }
+
+    #[test]
+    fn template_vars_set_launch_mode_only_when_scheme_present() {
+        let mut inputs = sample_inputs();
+        assert_eq!(template_vars(&inputs)["main_activity_launch_mode"], "");
+        inputs.main_activity_url_schemes = vec!["giga".to_string()];
+        assert!(template_vars(&inputs)["main_activity_launch_mode"].contains("singleTask"));
     }
 
     #[test]

--- a/crates/whisker-cng/src/compose.rs
+++ b/crates/whisker-cng/src/compose.rs
@@ -37,8 +37,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use whisker_config::Config;
 use whisker_plugin::{
-    AndroidProjectIr, AppMeta, GenerateContext, IosProjectIr, MutationJournal, MutationRecord,
-    Operation, Plugin, PluginRequest, PluginResponse, Target,
+    AndroidManifest, AndroidProjectIr, AppMeta, GenerateContext, IosProjectIr, MutationJournal,
+    MutationRecord, Operation, Plugin, PluginRequest, PluginResponse, Target,
 };
 
 // ============================================================================
@@ -285,6 +285,10 @@ fn build_initial_context(app_config: &Config, enabled: EnabledTargets) -> Genera
         application_id: app_meta.android_application_id.clone(),
         min_sdk: app_config.android.min_sdk,
         target_sdk: app_config.android.target_sdk,
+        manifest: AndroidManifest {
+            main_activity_url_schemes: app_config.url_scheme.clone().into_iter().collect(),
+            ..Default::default()
+        },
         ..Default::default()
     });
 

--- a/crates/whisker-cng/src/templates/android/app/src/main/AndroidManifest.xml
+++ b/crates/whisker-cng/src/templates/android/app/src/main/AndroidManifest.xml
@@ -17,11 +17,11 @@
 {{extra_application_meta_data}}
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"{{main_activity_launch_mode}}>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+            </intent-filter>{{extra_main_activity_intent_filter}}
         </activity>
     </application>
 

--- a/crates/whisker-config/src/lib.rs
+++ b/crates/whisker-config/src/lib.rs
@@ -44,6 +44,10 @@ pub struct Config {
     pub bundle_id: Option<String>,
     pub version: Option<String>,
     pub build_number: Option<u32>,
+    /// Custom URL scheme for incoming deep links (e.g. `"giga"`).
+    /// Currently only wired into Android's manifest; iOS's
+    /// `ASWebAuthenticationSession` doesn't need it registered.
+    pub url_scheme: Option<String>,
     pub ios: IosConfig,
     pub android: AndroidConfig,
     /// Per-plugin Config serialized as JSON, keyed by the Config
@@ -76,6 +80,13 @@ impl Config {
 
     pub fn build_number(&mut self, n: u32) -> &mut Self {
         self.build_number = Some(n);
+        self
+    }
+
+    /// Claim a custom URL scheme for incoming deep links. See
+    /// [`Self::url_scheme`]'s field doc.
+    pub fn url_scheme(&mut self, s: impl Into<String>) -> &mut Self {
+        self.url_scheme = Some(s.into());
         self
     }
 

--- a/crates/whisker-plugin/src/lib.rs
+++ b/crates/whisker-plugin/src/lib.rs
@@ -494,6 +494,11 @@ pub struct AndroidManifest {
     /// child elements.
     #[serde(default)]
     pub application_attributes: Vec<ApplicationAttribute>,
+
+    /// Extra `MainActivity` URL schemes (second `<intent-filter>`).
+    /// Non-empty also sets `launchMode="singleTask"`.
+    #[serde(default)]
+    pub main_activity_url_schemes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/packages/whisker-web-browser/Cargo.toml
+++ b/packages/whisker-web-browser/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "whisker-web-browser"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Whisker module mirroring Expo's expo-web-browser: openBrowserAsync (SFSafariViewController / Custom Tabs) and openAuthSessionAsync (ASWebAuthenticationSession / Custom Tabs + deep link) for in-app OAuth flows."
+
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "src/lib.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+[lib]
+crate-type = ["rlib"]
+
+[package.metadata.whisker]
+
+[dependencies]
+whisker = { workspace = true }
+futures-channel = "0.3"

--- a/packages/whisker-web-browser/Package.swift
+++ b/packages/whisker-web-browser/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "whisker-web-browser",
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerWebBrowser", targets: ["WhiskerWebBrowser"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerWebBrowser",
+            dependencies: [
+                .product(name: "WhiskerModule", package: "whisker"),
+                .product(name: "WhiskerRuntime", package: "whisker"),
+            ],
+            path: "ios/Sources/WhiskerWebBrowser",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "whisker"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-web-browser/android/src/main/kotlin/rs/whisker/modules/webbrowser/WebBrowserModule.kt
+++ b/packages/whisker-web-browser/android/src/main/kotlin/rs/whisker/modules/webbrowser/WebBrowserModule.kt
@@ -1,0 +1,120 @@
+// `whisker-web-browser` Module (Android).
+//
+// Mirrors Expo's expo-web-browser: `openBrowser`/`openAuthSession`
+// via Chrome Custom Tabs. Unlike iOS's ASWebAuthenticationSession,
+// Custom Tabs has no built-in "session ended" callback, so:
+//
+//  * success — the OAuth redirect lands back in the app as a new
+//    Intent, forwarded via `WhiskerAppContext.dispatchDeepLink`.
+//    Requires `Config::url_scheme` so the redirect's scheme matches
+//    a registered intent-filter.
+//  * cancel — detected via `Application.ActivityLifecycleCallbacks`:
+//    if the launching Activity resumes while a redirect is still
+//    pending (i.e. `onNewIntent` never fired), the user dismissed
+//    the Custom Tab without completing.
+
+package rs.whisker.modules.webbrowser
+
+import android.app.Activity
+import android.app.Application
+import android.net.Uri
+import android.os.Bundle
+import androidx.browser.customtabs.CustomTabsIntent
+import rs.whisker.runtime.DeepLinkListener
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerAppContext
+import rs.whisker.runtime.WhiskerValue
+
+class WebBrowserModule : Module() {
+    private var pendingRedirectPrefix: String? = null
+    private var deepLinkListener: DeepLinkListener? = null
+    private var lifecycleCallbacks: Application.ActivityLifecycleCallbacks? = null
+    private var launchingActivity: Activity? = null
+
+    override fun definition() = ModuleDefinition {
+        Name("WebBrowser")
+        Events("authSessionCompleted", "browserClosed")
+
+        Function("openAuthSession") { args ->
+            val url = args.getOrNull(0)?.asString()
+            val redirectUrl = args.getOrNull(1)?.asString()
+            val activity = appContext.currentActivity
+            if (url != null && redirectUrl != null && activity != null) {
+                startAuthSession(activity, url, redirectUrl)
+            }
+            WhiskerValue.Null
+        }
+
+        Function("dismissAuthSession") {
+            resolveAuthSession(WhiskerValue.Map(mapOf("type" to WhiskerValue.Str("cancel"))))
+            WhiskerValue.Null
+        }
+
+        Function("openBrowser") { args ->
+            val url = args.getOrNull(0)?.asString()
+            val activity = appContext.currentActivity
+            if (url != null && activity != null) {
+                CustomTabsIntent.Builder().build().launchUrl(activity, Uri.parse(url))
+            }
+            WhiskerValue.Null
+        }
+
+        Function("dismissBrowser") {
+            sendEvent("browserClosed", WhiskerValue.Map(mapOf("type" to WhiskerValue.Str("dismiss"))))
+            WhiskerValue.Null
+        }
+    }
+
+    private fun startAuthSession(activity: Activity, url: String, redirectUrl: String) {
+        clearPending()
+        pendingRedirectPrefix = redirectUrl
+        launchingActivity = activity
+
+        val listener = DeepLinkListener { receivedUrl ->
+            if (pendingRedirectPrefix != null && receivedUrl.startsWith(pendingRedirectPrefix!!)) {
+                resolveAuthSession(
+                    WhiskerValue.Map(
+                        mapOf("type" to WhiskerValue.Str("success"), "url" to WhiskerValue.Str(receivedUrl))
+                    )
+                )
+            }
+        }
+        deepLinkListener = listener
+        WhiskerAppContext.addDeepLinkListener(listener)
+
+        val callbacks = object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityResumed(resumed: Activity) {
+                if (resumed !== launchingActivity) return
+                if (pendingRedirectPrefix != null) {
+                    resolveAuthSession(WhiskerValue.Map(mapOf("type" to WhiskerValue.Str("cancel"))))
+                }
+            }
+            override fun onActivityCreated(a: Activity, b: Bundle?) {}
+            override fun onActivityStarted(a: Activity) {}
+            override fun onActivityPaused(a: Activity) {}
+            override fun onActivityStopped(a: Activity) {}
+            override fun onActivitySaveInstanceState(a: Activity, b: Bundle) {}
+            override fun onActivityDestroyed(a: Activity) {}
+        }
+        lifecycleCallbacks = callbacks
+        activity.application.registerActivityLifecycleCallbacks(callbacks)
+
+        CustomTabsIntent.Builder().build().launchUrl(activity, Uri.parse(url))
+    }
+
+    private fun resolveAuthSession(result: WhiskerValue) {
+        if (pendingRedirectPrefix == null) return
+        clearPending()
+        sendEvent("authSessionCompleted", result)
+    }
+
+    private fun clearPending() {
+        pendingRedirectPrefix = null
+        deepLinkListener?.let { WhiskerAppContext.removeDeepLinkListener(it) }
+        deepLinkListener = null
+        lifecycleCallbacks?.let { launchingActivity?.application?.unregisterActivityLifecycleCallbacks(it) }
+        lifecycleCallbacks = null
+        launchingActivity = null
+    }
+}

--- a/packages/whisker-web-browser/build.gradle.kts
+++ b/packages/whisker-web-browser/build.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.webbrowser"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerWebBrowser")
+    arg("whisker.crateName", "whisker-web-browser")
+}
+
+dependencies {
+    // `0.1.7` — needs `WhiskerAppContext.DeepLinkListener`/
+    // `addDeepLinkListener`/`removeDeepLinkListener`, added in this
+    // same change and published by the `sdk-v0.1.7` release.
+    implementation("rs.whisker:whisker-module-android:0.1.7")
+    ksp("rs.whisker:ksp:0.1.7")
+    implementation("androidx.browser:browser:1.8.0")
+}

--- a/packages/whisker-web-browser/ios/Sources/WhiskerWebBrowser/WebBrowserModule.swift
+++ b/packages/whisker-web-browser/ios/Sources/WhiskerWebBrowser/WebBrowserModule.swift
@@ -1,0 +1,129 @@
+// `whisker-web-browser` Module (iOS).
+//
+// View-less module mirroring Expo's `expo-web-browser`: `openBrowser`
+// (SFSafariViewController, no cookie sharing) and `openAuthSession`
+// (ASWebAuthenticationSession, shares cookies + handles the OAuth
+// redirect). Both are fire-and-forget `Function`s that report their
+// result later via `sendEvent("authSessionCompleted"/"browserClosed", ...)`
+// — Whisker's native `Function` dispatch is sync-only; see
+// `docs/module-api-design.md` Shape 4.
+//
+// `ASWebAuthenticationSession` needs no `CFBundleURLTypes`
+// registration — it intercepts the redirect before the OS would
+// route it, as long as `callbackURLScheme` matches the redirect
+// URI's scheme.
+
+import AuthenticationServices
+import Foundation
+import SafariServices
+import UIKit
+import WhiskerModule
+
+private final class PresentationAnchor: NSObject, ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        WebBrowserModule.keyWindow() ?? ASPresentationAnchor()
+    }
+}
+
+public final class WebBrowserModule: Module {
+    private var authSession: ASWebAuthenticationSession?
+    private var safari: SFSafariViewController?
+    private let anchor = PresentationAnchor()
+
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("WebBrowser")
+            Events("authSessionCompleted", "browserClosed")
+
+            Function("openAuthSession") { [weak self] (args: [WhiskerValue]) -> WhiskerValue in
+                guard let url = args.first?.asString.flatMap(URL.init),
+                    let redirectUrl = args.count > 1 ? args[1].asString : nil
+                else { return .null }
+                let ephemeral = args.count > 2 ? (args[2].asBool ?? false) : false
+                let scheme = URL(string: redirectUrl)?.scheme
+                DispatchQueue.main.async {
+                    self?.startAuthSession(url: url, callbackScheme: scheme, ephemeral: ephemeral)
+                }
+                return .null
+            }
+
+            Function("dismissAuthSession") { [weak self] _ in
+                DispatchQueue.main.async {
+                    self?.authSession?.cancel()
+                    self?.authSession = nil
+                }
+                return .null
+            }
+
+            Function("openBrowser") { [weak self] (args: [WhiskerValue]) -> WhiskerValue in
+                guard let url = args.first?.asString.flatMap(URL.init) else { return .null }
+                DispatchQueue.main.async {
+                    self?.openBrowser(url: url)
+                }
+                return .null
+            }
+
+            Function("dismissBrowser") { [weak self] _ in
+                DispatchQueue.main.async {
+                    self?.safari?.dismiss(animated: true)
+                    self?.safari = nil
+                    self?.sendEvent("browserClosed", .map(["type": .string("dismiss")]))
+                }
+                return .null
+            }
+        }
+    }
+
+    private func startAuthSession(url: URL, callbackScheme: String?, ephemeral: Bool) {
+        let session = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackScheme) {
+            [weak self] callbackUrl, error in
+            self?.authSession = nil
+            if let callbackUrl = callbackUrl {
+                self?.sendEvent(
+                    "authSessionCompleted",
+                    .map(["type": .string("success"), "url": .string(callbackUrl.absoluteString)])
+                )
+                return
+            }
+            if let error = error as? ASWebAuthenticationSessionError,
+                error.code == .canceledLogin
+            {
+                self?.sendEvent("authSessionCompleted", .map(["type": .string("cancel")]))
+                return
+            }
+            self?.sendEvent(
+                "authSessionCompleted",
+                .map([
+                    "type": .string("error"),
+                    "message": .string(error?.localizedDescription ?? "unknown error"),
+                ])
+            )
+        }
+        session.presentationContextProvider = anchor
+        session.prefersEphemeralWebBrowserSession = ephemeral
+        authSession = session
+        session.start()
+    }
+
+    private func openBrowser(url: URL) {
+        guard let presenter = Self.keyWindow()?.rootViewController else { return }
+        let vc = SFSafariViewController(url: url)
+        safari = vc
+        presenter.present(vc, animated: true)
+    }
+
+    fileprivate static func keyWindow() -> UIWindow? {
+        for scene in UIApplication.shared.connectedScenes {
+            guard let windowScene = scene as? UIWindowScene,
+                windowScene.activationState == .foregroundActive
+            else { continue }
+            if let key = windowScene.windows.first(where: { $0.isKeyWindow }) {
+                return key
+            }
+        }
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+}

--- a/packages/whisker-web-browser/src/lib.rs
+++ b/packages/whisker-web-browser/src/lib.rs
@@ -1,0 +1,234 @@
+//! `whisker-web-browser` — mirrors Expo's `expo-web-browser`:
+//! `open_auth_session_async` (`ASWebAuthenticationSession` /
+//! Chrome Custom Tabs) for in-app OAuth, plus a plain
+//! `open_browser_async` (`SFSafariViewController` / Custom Tabs).
+//!
+//! ## OAuth redirect
+//!
+//! `open_auth_session_async`'s `redirect_url` must use a scheme the
+//! app owns. iOS needs no registration — `ASWebAuthenticationSession`
+//! intercepts the redirect before the OS routes it. Android needs
+//! `Config::url_scheme` set in `whisker.rs` (`app.url_scheme("giga")`
+//! → register `giga://...` redirect URIs), which wires a matching
+//! `MainActivity` intent-filter — see `whisker-config`'s docs.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use whisker_web_browser::{open_auth_session_async, AuthSessionResult};
+//!
+//! let result = open_auth_session_async(&authorize_url, "giga://oauth2redirect", false).await;
+//! match result {
+//!     AuthSessionResult::Success { url } => { /* extract `code` from `url` */ }
+//!     AuthSessionResult::Cancel => { /* user backed out */ }
+//!     AuthSessionResult::Error(msg) => { /* show msg */ }
+//! }
+//! ```
+//!
+//! ## Native source
+//!
+//! - iOS: `packages/whisker-web-browser/ios/Sources/WhiskerWebBrowser/WebBrowserModule.swift`
+//! - Android: `packages/whisker-web-browser/android/src/main/kotlin/rs/whisker/modules/webbrowser/WebBrowserModule.kt`
+
+use std::sync::{Arc, Mutex};
+
+use whisker::WhiskerValue;
+use whisker::module;
+
+/// Outcome of [`open_auth_session_async`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum AuthSessionResult {
+    /// The OAuth redirect fired; `url` is the full redirect URL
+    /// (query string included — parse `code`/`error` out of it).
+    Success { url: String },
+    /// The user backed out of the auth flow without completing it.
+    Cancel,
+    /// [`dismiss_auth_session`] was called mid-flow.
+    Dismiss,
+    /// The native module is unavailable, or a platform-side failure.
+    Error(String),
+}
+
+/// Outcome of [`open_browser_async`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum BrowserResult {
+    Dismiss,
+    Cancel,
+    Error(String),
+}
+
+/// Open `url` in an in-app auth browser (`ASWebAuthenticationSession`
+/// / Chrome Custom Tabs) and wait for it to complete. `redirect_url`
+/// is the OAuth redirect URI — see the module docs for scheme setup.
+/// `prefers_ephemeral` (iOS only) requests a private-browsing-style
+/// session that shares no cookies/state with the user's regular
+/// browsing (ignored on Android).
+pub async fn open_auth_session_async(
+    url: &str,
+    redirect_url: &str,
+    prefers_ephemeral: bool,
+) -> AuthSessionResult {
+    let module = module!("WebBrowser");
+    let (tx, rx) = futures_channel::oneshot::channel::<AuthSessionResult>();
+    let tx = Arc::new(Mutex::new(Some(tx)));
+    // Held as a plain local for the whole function body (across the
+    // `.await` below) so it only drops once this fn returns — NOT
+    // inside the callback that fires it. Dropping a `ModuleSubscription`
+    // frees the very `Box<EventCallback>` the bridge is currently
+    // executing; doing that synchronously from within its own callback
+    // is a use-after-free (crashed with SIGSEGV during on-device testing).
+    let subscription = module.on_event("authSessionCompleted", move |payload| {
+        // Resolve in its own statement, not `if let Some(x) =
+        // mutex.lock().unwrap().take() { ... }` — that form holds the
+        // `MutexGuard` alive through the whole body, still locked
+        // during `send()` below. `send()` can reentrantly drop
+        // `subscription` (freeing `tx`), and the guard then unlocks
+        // freed memory — confirmed SIGSEGV on device.
+        let sender = tx.lock().unwrap().take();
+        if let Some(sender) = sender {
+            let _ = sender.send(decode_auth_result(payload));
+        }
+    });
+    if let Some(err) = subscription.error() {
+        return AuthSessionResult::Error(err.to_string());
+    }
+
+    let _ = module.invoke(
+        "openAuthSession",
+        vec![
+            WhiskerValue::String(url.to_string()),
+            WhiskerValue::String(redirect_url.to_string()),
+            WhiskerValue::Bool(prefers_ephemeral),
+        ],
+    );
+
+    let result = rx
+        .await
+        .unwrap_or_else(|_| AuthSessionResult::Error("native module unavailable".to_string()));
+    drop(subscription);
+    result
+}
+
+/// Cancel an in-flight [`open_auth_session_async`] call — it resolves
+/// with [`AuthSessionResult::Dismiss`].
+pub fn dismiss_auth_session() {
+    let _ = module!("WebBrowser").invoke("dismissAuthSession", vec![]);
+}
+
+/// Open `url` in a plain in-app browser (`SFSafariViewController` /
+/// Chrome Custom Tabs — no cookie sharing with `open_auth_session_async`
+/// on iOS) and wait for it to close.
+pub async fn open_browser_async(url: &str) -> BrowserResult {
+    let module = module!("WebBrowser");
+    let (tx, rx) = futures_channel::oneshot::channel::<BrowserResult>();
+    let tx = Arc::new(Mutex::new(Some(tx)));
+    let subscription = module.on_event("browserClosed", move |payload| {
+        let sender = tx.lock().unwrap().take();
+        if let Some(sender) = sender {
+            let _ = sender.send(decode_browser_result(payload));
+        }
+    });
+    if let Some(err) = subscription.error() {
+        return BrowserResult::Error(err.to_string());
+    }
+
+    let _ = module.invoke("openBrowser", vec![WhiskerValue::String(url.to_string())]);
+
+    let result = rx
+        .await
+        .unwrap_or_else(|_| BrowserResult::Error("native module unavailable".to_string()));
+    drop(subscription);
+    result
+}
+
+/// Close a browser opened via [`open_browser_async`] — it resolves
+/// with [`BrowserResult::Dismiss`].
+pub fn dismiss_browser() {
+    let _ = module!("WebBrowser").invoke("dismissBrowser", vec![]);
+}
+
+fn decode_auth_result(payload: WhiskerValue) -> AuthSessionResult {
+    let WhiskerValue::Map(fields) = payload else {
+        return AuthSessionResult::Error("malformed authSessionCompleted payload".to_string());
+    };
+    let kind = match fields.get("type") {
+        Some(WhiskerValue::String(s)) => s.as_str(),
+        _ => "",
+    };
+    match kind {
+        "success" => {
+            let url = match fields.get("url") {
+                Some(WhiskerValue::String(s)) => s.clone(),
+                _ => String::new(),
+            };
+            AuthSessionResult::Success { url }
+        }
+        "cancel" => AuthSessionResult::Cancel,
+        "dismiss" => AuthSessionResult::Dismiss,
+        _ => {
+            let message = match fields.get("message") {
+                Some(WhiskerValue::String(s)) => s.clone(),
+                _ => "unknown error".to_string(),
+            };
+            AuthSessionResult::Error(message)
+        }
+    }
+}
+
+fn decode_browser_result(payload: WhiskerValue) -> BrowserResult {
+    let WhiskerValue::Map(fields) = payload else {
+        return BrowserResult::Dismiss;
+    };
+    match fields.get("type") {
+        Some(WhiskerValue::String(s)) if s == "cancel" => BrowserResult::Cancel,
+        _ => BrowserResult::Dismiss,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_auth_success_extracts_url() {
+        let v = WhiskerValue::map([
+            ("type", WhiskerValue::String("success".into())),
+            (
+                "url",
+                WhiskerValue::String("giga://oauth2redirect?code=abc".into()),
+            ),
+        ]);
+        assert_eq!(
+            decode_auth_result(v),
+            AuthSessionResult::Success {
+                url: "giga://oauth2redirect?code=abc".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn decode_auth_cancel() {
+        let v = WhiskerValue::map([("type", WhiskerValue::String("cancel".into()))]);
+        assert_eq!(decode_auth_result(v), AuthSessionResult::Cancel);
+    }
+
+    #[test]
+    fn decode_auth_error_carries_message() {
+        let v = WhiskerValue::map([
+            ("type", WhiskerValue::String("error".into())),
+            ("message", WhiskerValue::String("boom".into())),
+        ]);
+        assert_eq!(
+            decode_auth_result(v),
+            AuthSessionResult::Error("boom".to_string())
+        );
+    }
+
+    #[test]
+    fn decode_browser_cancel_vs_dismiss() {
+        let cancel = WhiskerValue::map([("type", WhiskerValue::String("cancel".into()))]);
+        assert_eq!(decode_browser_result(cancel), BrowserResult::Cancel);
+        let dismiss = WhiskerValue::map([("type", WhiskerValue::String("dismiss".into()))]);
+        assert_eq!(decode_browser_result(dismiss), BrowserResult::Dismiss);
+    }
+}

--- a/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WhiskerWebView.kt
+++ b/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WhiskerWebView.kt
@@ -260,8 +260,16 @@ open class WhiskerWebView(context: WhiskerContext) :
              *
              * Returns true  (block, WebView won't load it) when the URL is NOT
              * in the whitelist.
-             * Returns false (allow) when the URL matches a whitelist pattern;
-             * also emits `navigation` so Rust can observe internal link clicks.
+             * Returns false (allow) when the URL matches a whitelist pattern.
+             *
+             * `navigation` is emitted in BOTH cases, not just when allowed: a
+             * custom scheme (e.g. an in-app OAuth flow's redirect URI,
+             * `com.googleusercontent.apps.<id>:/oauth2redirect?code=...`)
+             * never matches the whitelist and WebView could never load it
+             * anyway, so this denial is the only place Rust can observe the
+             * attempted URL (and thus an auth code in its query string)
+             * without a separate native module. Consumers that only care
+             * about real page loads can filter by scheme themselves.
              */
             private fun handleNavigation(
                 view: android.webkit.WebView,
@@ -269,14 +277,12 @@ open class WhiskerWebView(context: WhiskerContext) :
             ): Boolean {
                 val allowed = originWhitelist.isEmpty() ||
                     originWhitelist.any { pattern -> matchesGlob(pattern, url) }
-                if (!allowed) return true // block
-                // Allowed — let WebView load it and inform Rust.
                 WhiskerCustomEvent.dispatch(
                     ui = this@WhiskerWebView,
                     name = "navigation",
                     params = mapOf("url" to url),
                 )
-                return false // proceed with load
+                return !allowed // true = block, false = proceed with load
             }
         }
 

--- a/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
+++ b/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
@@ -518,10 +518,12 @@ extension WhiskerWebViewView: WKNavigationDelegate {
         // whitelist.
         if scheme == "http" || scheme == "https" {
             if !isAllowed(urlString) {
+                // Denied, but still observable — see the note on the
+                // "everything else" branch below.
+                emitNavigation(urlString)
                 decisionHandler(.cancel)
                 return
             }
-            // Emit `navigation` only for real web navigations.
             emitNavigation(urlString)
             decisionHandler(.allow)
             return
@@ -541,6 +543,16 @@ extension WhiskerWebViewView: WKNavigationDelegate {
         // plus `javascript:` and custom deep-link schemes — is denied.
         // The component exposes no file-access prop, so there is no
         // legitimate in-webview navigation to those schemes; fail closed.
+        //
+        // Still emit `navigation` before cancelling: a custom scheme is
+        // exactly how an in-app OAuth flow's redirect URI (e.g.
+        // `com.googleusercontent.apps.<id>:/oauth2redirect?code=...`)
+        // surfaces — WKWebView can never actually load it, so this
+        // denial is the only place Rust can observe the attempted URL
+        // (and thus the auth code in its query string) without a
+        // separate native module. `on_navigation` consumers that only
+        // care about real page loads can filter by scheme themselves.
+        emitNavigation(urlString)
         decisionHandler(.cancel)
     }
 

--- a/packages/whisker-webview/src/lib.rs
+++ b/packages/whisker-webview/src/lib.rs
@@ -90,7 +90,7 @@
 //! | `on_message`        | `Fn(String)`               | —                             | JS → Rust message (`window.whisker.postMessage`). |
 //! | `on_load_start`     | `Fn(String)`               | —                             | A navigation started; carries the URL. |
 //! | `on_load`           | `Fn(String)`               | —                             | A navigation finished; carries the URL. |
-//! | `on_navigation`     | `Fn(String)`               | —                             | An internal navigation was requested; carries the URL. |
+//! | `on_navigation`     | `Fn(String)`               | —                             | An internal navigation was requested; carries the URL. Fires for BOTH allowed and denied (off-whitelist / non-http(s), e.g. a custom-scheme OAuth redirect) attempts — filter by URL/scheme if you only care about one. |
 //! | `on_progress`       | `Fn(f32)`                  | —                             | Load progress `0.0..=1.0`. |
 //! | `on_error`          | `Fn(WebViewError)`         | —                             | Navigation failed (url / code / description). |
 //! | `style`             | `Signal<String>`           | `""`                          | Standard Whisker CSS style string. |

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerAppContext.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerAppContext.kt
@@ -68,6 +68,11 @@ public fun interface HostAttachedListener {
     public fun onHostAttached()
 }
 
+/** Fires with the full URL when a deep link arrives via `onNewIntent`. */
+public fun interface DeepLinkListener {
+    public fun onDeepLink(url: String)
+}
+
 public interface WhiskerModuleHost {
     /**
      * The host's Android `Context`. [WhiskerAppContext.currentActivity]
@@ -134,6 +139,25 @@ public class WhiskerAppContext internal constructor() {
         CopyOnWriteArrayList()
 
     public companion object {
+        private val deepLinkListeners: CopyOnWriteArrayList<DeepLinkListener> =
+            CopyOnWriteArrayList()
+
+        /** Called by [rs.whisker.runtime.WhiskerActivity.onNewIntent]. */
+        @JvmStatic
+        public fun dispatchDeepLink(url: String) {
+            for (l in deepLinkListeners) l.onDeepLink(url)
+        }
+
+        @JvmStatic
+        public fun addDeepLinkListener(listener: DeepLinkListener) {
+            deepLinkListeners.add(listener)
+        }
+
+        @JvmStatic
+        public fun removeDeepLinkListener(listener: DeepLinkListener) {
+            deepLinkListeners.remove(listener)
+        }
+
         /** The single instance every [Module] reaches via `appContext`. */
         @JvmStatic
         public val shared: WhiskerAppContext = WhiskerAppContext()

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerActivity.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerActivity.kt
@@ -1,5 +1,6 @@
 package rs.whisker.runtime
 
+import android.content.Intent
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Build
@@ -177,5 +178,11 @@ open class WhiskerActivity : ComponentActivity() {
         whiskerView?.destroy()
         whiskerView = null
         super.onDestroy()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        intent.data?.toString()?.let { WhiskerAppContext.dispatchDeepLink(it) }
     }
 }


### PR DESCRIPTION
## Summary
- New `whisker-web-browser` package mirroring Expo's `expo-web-browser`: `open_auth_session_async` (ASWebAuthenticationSession / Chrome Custom Tabs) and `open_browser_async` (SFSafariViewController / Custom Tabs).
- Android: OAuth redirect success detected via a new `WhiskerAppContext.DeepLinkListener` pub/sub, fed by `WhiskerActivity.onNewIntent`; cancellation detected via `ActivityLifecycleCallbacks`.
- `whisker-config`: new `Config::url_scheme` to claim a custom URL scheme for OAuth redirects; `whisker-cng` wires it into a second `MainActivity` intent-filter + `launchMode="singleTask"` (Android manifest template 11 → 12).
- `whisker-webview` (iOS + Android): `on_navigation` now also fires for denied/blocked navigations, not just allowed ones — needed to observe a custom-scheme OAuth redirect, which WebView can never actually load.

## Why
Built to support an in-app Google Drive OAuth flow in a downstream app (giga). Custom Tabs / ASWebAuthenticationSession is the standard pattern for in-app OAuth (matches Expo's own `expo-web-browser`), rather than routing it through a plain `WebView`.

## Follow-up required after merge
This PR alone does not unblock consumers — `whisker-web-browser`'s Android build depends on `rs.whisker:whisker-module-android:0.1.7` (bumped from the currently-published `0.1.6`) for the new `DeepLinkListener` API. **A `sdk-v0.1.7` tag needs to be pushed after this merges** to publish that SDK version via `publish-sdk.yml`.

## Test plan
- [x] `cargo build`/`clippy`/`fmt --check`/`test` clean for `whisker-web-browser`, `whisker-webview`, `whisker-cng`, `whisker-config`, `whisker-plugin`.
- [x] `:module:compileDebugKotlin` and `:whisker-runtime:compileDebugKotlin` (with `-PwhiskerSdkRelease=true`) build clean, confirming `WhiskerAppContext.kt`/`WhiskerActivity.kt` changes compile.
- [ ] End-to-end on a consumer app (giga) — blocked on the `sdk-v0.1.7` publish above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)