### PR TITLE
fix(web-browser): defer Android cancel-detection past onNewIntent race

### DIFF
--- a/packages/whisker-web-browser/android/src/main/kotlin/rs/whisker/modules/webbrowser/WebBrowserModule.kt
+++ b/packages/whisker-web-browser/android/src/main/kotlin/rs/whisker/modules/webbrowser/WebBrowserModule.kt
@@ -11,7 +11,15 @@
 //  * cancel — detected via `Application.ActivityLifecycleCallbacks`:
 //    if the launching Activity resumes while a redirect is still
 //    pending (i.e. `onNewIntent` never fired), the user dismissed
-//    the Custom Tab without completing.
+//    the Custom Tab without completing. Android's documented order
+//    for a reused (singleTask) Activity is `onNewIntent()` then
+//    `onResume()`, but that ordering is not reliable in practice on
+//    every OEM/OS-version combination for a Custom Tabs redirect —
+//    the same race AppAuth-Android and others work around. The
+//    `onActivityResumed` check below is deferred a beat via
+//    `Handler.postDelayed` so a same-event `onNewIntent` gets a
+//    chance to resolve success (and null out `pendingRedirectPrefix`)
+//    before the cancel check runs.
 
 package rs.whisker.modules.webbrowser
 
@@ -19,6 +27,8 @@ import android.app.Activity
 import android.app.Application
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.browser.customtabs.CustomTabsIntent
 import rs.whisker.runtime.DeepLinkListener
 import rs.whisker.runtime.Module
@@ -26,11 +36,17 @@ import rs.whisker.runtime.ModuleDefinition
 import rs.whisker.runtime.WhiskerAppContext
 import rs.whisker.runtime.WhiskerValue
 
+/** How long to wait for a same-event `onNewIntent` before treating an
+ *  `onActivityResumed` as a genuine user cancel. See the header
+ *  comment above for why this exists. */
+private const val CANCEL_CHECK_DELAY_MS = 300L
+
 class WebBrowserModule : Module() {
     private var pendingRedirectPrefix: String? = null
     private var deepLinkListener: DeepLinkListener? = null
     private var lifecycleCallbacks: Application.ActivityLifecycleCallbacks? = null
     private var launchingActivity: Activity? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     override fun definition() = ModuleDefinition {
         Name("WebBrowser")
@@ -86,9 +102,13 @@ class WebBrowserModule : Module() {
         val callbacks = object : Application.ActivityLifecycleCallbacks {
             override fun onActivityResumed(resumed: Activity) {
                 if (resumed !== launchingActivity) return
-                if (pendingRedirectPrefix != null) {
-                    resolveAuthSession(WhiskerValue.Map(mapOf("type" to WhiskerValue.Str("cancel"))))
-                }
+                mainHandler.postDelayed({
+                    if (pendingRedirectPrefix != null) {
+                        resolveAuthSession(
+                            WhiskerValue.Map(mapOf("type" to WhiskerValue.Str("cancel")))
+                        )
+                    }
+                }, CANCEL_CHECK_DELAY_MS)
             }
             override fun onActivityCreated(a: Activity, b: Bundle?) {}
             override fun onActivityStarted(a: Activity) {}
@@ -116,5 +136,10 @@ class WebBrowserModule : Module() {
         lifecycleCallbacks?.let { launchingActivity?.application?.unregisterActivityLifecycleCallbacks(it) }
         lifecycleCallbacks = null
         launchingActivity = null
+        // Drops a still-pending deferred cancel-check (see
+        // `onActivityResumed`) so it can't fire against a *later*
+        // session — its `pendingRedirectPrefix != null` guard alone
+        // isn't enough once a new session has set a new prefix.
+        mainHandler.removeCallbacksAndMessages(null)
     }
 }


### PR DESCRIPTION
## Summary
- `WebBrowserModule.onActivityResumed` was resolving the auth session as `cancel` synchronously, racing against `onNewIntent` delivering the actual OAuth redirect on the same event.
- Found while testing GDrive sign-in in a downstream app (giga): the Custom Tab closed and the app returned, but the flow always resolved as cancelled instead of navigating forward, even though the redirect had genuinely landed.
- Fix: defer the cancel check via `Handler.postDelayed(300ms)`, giving a same-event `onNewIntent` time to resolve success first (which clears `pendingRedirectPrefix`, making the deferred cancel check a no-op). `clearPending()` also now cancels any still-pending deferred check so it can't fire against a later session.

## Test plan
- [x] `:whisker-web-browser` compiles as a Gradle source-subproject inside a consumer app (giga, via its `[patch.crates-io]` local path).
- [x] End-to-end on-device: GDrive OAuth sign-in via Chrome Custom Tabs now returns to the app and correctly navigates to the folder-picker screen instead of falling back to the sign-in screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)