### PR TITLE
fix(runtime-android): align Lynx tap-cancel slop with scroll threshold

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -98,7 +98,26 @@ pub struct PlatformSync {
 /// (the `ItemMeta` API). BREAKING at the capi layer (v2 embedders
 /// refuse to attach via the abi-version handshake) — accepted while
 /// whisker is the only consumer.
-const WHISKER_SDK_VERSION: &str = "0.1.5";
+///
+/// 0.1.7 adds `WhiskerAppContext.DeepLinkListener`/
+/// `addDeepLinkListener`/`removeDeepLinkListener`/`dispatchDeepLink`
+/// (`whisker-module-android`) and `WhiskerActivity.onNewIntent`
+/// forwarding into it (`whisker-runtime-android`) — the plumbing
+/// `whisker-web-browser`'s Android `openAuthSession` needs to observe
+/// an OAuth redirect delivered as a new Intent. Non-breaking, pure
+/// Kotlin/JVM API addition — no capi/Lynx ABI change. (0.1.6 was a
+/// Kotlin-only change too — `WhiskerInsetsDispatcher` — and didn't
+/// bump this constant; do not assume every `sdk-v*` tag necessarily
+/// needs one, but check the SDK diff each time.)
+///
+/// 0.1.8 sets `LynxViewBuilder.setTapSlop("18px")` in
+/// `WhiskerView`'s constructor (`whisker-runtime-android`) — Lynx's
+/// own tap-cancel threshold defaulted to ~50dp-equivalent, far more
+/// generous than the ~8dp `ViewConfiguration.getScaledTouchSlop()`
+/// scroll containers use to start scrolling, so a finger drift big
+/// enough to visibly start a scroll could still fire a `tap` on
+/// release. Kotlin-only, no capi/Lynx ABI change.
+const WHISKER_SDK_VERSION: &str = "0.1.8";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -33,7 +33,21 @@ import java.util.concurrent.atomic.AtomicBoolean
 class WhiskerView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-) : LynxView(context, LynxViewBuilder()), WhiskerModuleHost {
+) : LynxView(
+        context,
+        // Lynx's own tap-cancel threshold (`TouchEventDispatcher.mTapSlop`)
+        // defaults to 50px (~50dip-equivalent), far more generous than the
+        // ~8dp `ViewConfiguration.getScaledTouchSlop()` Android's own
+        // scroll containers (and Lynx's `NestedScrollContainerView`) use to
+        // start scrolling. That gap let a finger drift far enough to
+        // visibly start a scroll while still firing a `tap` on release.
+        // 18dp (not the scroll threshold's own 8dp) matches Flutter's
+        // `kTouchSlop` — Flutter shipped 8dp first and raised it to 18dp
+        // after complaints that deliberate taps were too easily cancelled
+        // by ordinary hand tremor; still far below the original 50dp gap.
+        LynxViewBuilder().setTapSlop("18px"),
+    ),
+    WhiskerModuleHost {
 
     private var engine: Long = 0
     private val scheduled = AtomicBoolean(false)


### PR DESCRIPTION
## Summary
- `TouchEventDispatcher`'s tap-cancel movement threshold (`mTapSlop`) defaults to ~50dp-equivalent, far more generous than the ~8dp `ViewConfiguration.getScaledTouchSlop()` Android's own scroll containers (and Lynx's `NestedScrollContainerView`) use to start scrolling.
- That gap let a finger drift far enough to visibly start a scroll while still firing a spurious `tap` on release — reported by a downstream app as "placing a finger down to scroll sometimes also registers as a tap."
- Sets `LynxViewBuilder.setTapSlop("18px")` in `WhiskerView`'s constructor. 18dp (not the scroll threshold's own 8dp) matches Flutter's `kTouchSlop` — Flutter shipped 8dp first and raised it to 18dp after complaints that deliberate taps were too easily cancelled by ordinary hand tremor; still far below the original ~50dp gap.
- Bumps `WHISKER_SDK_VERSION` 0.1.7 → 0.1.8 (Kotlin-only, no capi/Lynx ABI change) and also lands the previously-pending 0.1.5 → 0.1.7 doc/version catch-up (that constant had fallen behind an already-published `sdk-v0.1.7` tag).

## Test plan
- [x] `cargo build -p whisker-cli` / `cargo fmt --check -p whisker-cli`
- [ ] Full compile of `whisker-runtime-android` (blocked locally — the standalone Gradle project needs the Lynx source composite build, not available in this environment; verified via careful manual review of the Kotlin syntax instead)
- [ ] End-to-end verification after `sdk-v0.1.8` publishes: downstream app (giga) bumps its SDK pin and confirms tap-during-scroll no longer double-fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)