### PR TITLE
fix(runtime-android): populate touch coordinates in event reporter

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -117,7 +117,18 @@ pub struct PlatformSync {
 /// scroll containers use to start scrolling, so a finger drift big
 /// enough to visibly start a scroll could still fire a `tap` on
 /// release. Kotlin-only, no capi/Lynx ABI change.
-const WHISKER_SDK_VERSION: &str = "0.1.8";
+///
+/// 0.1.9 populates `touches`/`changedTouches`/`detail` for
+/// `LynxTouchEvent` in `WhiskerView`'s event reporter
+/// (`whisker-runtime-android`) — Android previously sent every touch
+/// event with an empty body (`detail: null`, no `touches`), so
+/// `whisker_runtime::event::TouchEvent`'s coordinate fields all
+/// silently defaulted to zero (`#[serde(default)]`), breaking any
+/// Rust-side drag-to-seek/gesture math that reads touch coordinates
+/// on Android specifically — iOS's `whisker_bridge_ios.mm` already
+/// populated this shape, this brings Android to parity with it.
+/// Kotlin-only, no capi/Lynx ABI change.
+const WHISKER_SDK_VERSION: &str = "0.1.9";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -11,6 +11,7 @@ import com.lynx.tasm.LynxViewBuilder
 import com.lynx.tasm.event.LynxCustomEvent
 import com.lynx.tasm.event.LynxEvent
 import com.lynx.tasm.event.LynxInternalEvent
+import com.lynx.tasm.event.LynxTouchEvent
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -72,18 +73,71 @@ class WhiskerView @JvmOverloads constructor(
             // typed `detail` (and `target`) blank. `target`/`currentTarget`
             // are the integer sign (the Rust `Target` deserializes an
             // int → `uid`). `detail` is the params dict for
-            // `LynxCustomEvent` (scroll / layout / …), null otherwise
-            // (touch events carry no body on Android). The marshaller
+            // `LynxCustomEvent` (scroll / layout / …). The marshaller
             // turns this Java map into a `WhiskerValueRaw` tree (no JSON).
-            val detail: Map<String, Any?>? =
-                if (event is LynxCustomEvent) event.eventParams() else null
-            val body: Map<String, Any?> =
-                mapOf(
+            val body: MutableMap<String, Any?> =
+                mutableMapOf(
                     "type" to name,
                     "target" to event.tag,
                     "currentTarget" to event.tag,
-                    "detail" to detail,
+                    // Overwritten below for custom/touch events; stays
+                    // explicitly null (not just absent) for anything
+                    // else, matching this reporter's previous behavior.
+                    "detail" to null,
                 )
+            if (event is LynxCustomEvent) {
+                body["detail"] = event.eventParams()
+            } else if (event is LynxTouchEvent) {
+                // `LynxTouchEvent` doesn't carry coordinates through
+                // the generic params path above — only
+                // `getClientPoint`/`getPagePoint`/`getTouchMap` do.
+                // Splice touches/changedTouches/detail on here,
+                // mirroring the shape `whisker_bridge_ios.mm`'s
+                // reporter block builds from the same Lynx class on
+                // iOS, so `whisker_runtime::event::TouchEvent`
+                // deserializes identically on both platforms instead
+                // of every field silently defaulting to zero here.
+                if (!event.getIsMultiTouch()) {
+                    val page = event.getPagePoint()
+                    val client = event.getClientPoint()
+                    if (page != null && client != null) {
+                        val touch =
+                            mapOf(
+                                "identifier" to 0,
+                                "x" to page.x,
+                                "y" to page.y,
+                                "pageX" to page.x,
+                                "pageY" to page.y,
+                                "clientX" to client.x,
+                                "clientY" to client.y,
+                            )
+                        body["touches"] = listOf(touch)
+                        body["changedTouches"] = listOf(touch)
+                        body["detail"] = mapOf("x" to page.x, "y" to page.y)
+                    }
+                } else {
+                    val touchMap = event.getTouchMap()
+                    if (touchMap != null) {
+                        val touches =
+                            touchMap.entries.map { (identifier, point) ->
+                                mapOf(
+                                    "identifier" to identifier,
+                                    "x" to point.x,
+                                    "y" to point.y,
+                                    "pageX" to point.x,
+                                    "pageY" to point.y,
+                                    "clientX" to point.x,
+                                    "clientY" to point.y,
+                                )
+                            }
+                        body["touches"] = touches
+                        body["changedTouches"] = touches
+                        touches.firstOrNull()?.let { first ->
+                            body["detail"] = mapOf("x" to first["pageX"], "y" to first["pageY"])
+                        }
+                    }
+                }
+            }
             return nativeOnLynxEvent(engine, event.tag, name, body)
         }
         override fun onInternalEvent(event: LynxInternalEvent) {}


### PR DESCRIPTION
## Summary
- `WhiskerView`'s Android event reporter only extracted `detail` from `LynxCustomEvent` — every `LynxTouchEvent` (touchstart/touchmove/touchend, tap, longpress) was reported with an empty body.
- `whisker_runtime::event::TouchEvent`'s coordinate fields (`detail.x`/`.y`, `touches[].pageX`/`.clientX`/etc.) are `#[serde(default)]`, so they silently zeroed out instead of erroring — any Rust-side gesture math reading touch coordinates (e.g. a drag-to-seek progress bar) always computed a zero delta on Android.
- iOS's `whisker_bridge_ios.mm` already splices `touches`/`changedTouches`/`detail` onto the event body from the same underlying Lynx event class (`LynxTouchEvent`/its Obj-C counterpart) — this change brings Android's reporter to the same shape, reading `LynxTouchEvent.getClientPoint()`/`getPagePoint()`/`getTouchMap()` (single- and multi-touch) the same way the iOS bridge reads `clientPoint`/`pagePoint`/`touchMap`.
- Bumps `WHISKER_SDK_VERSION` 0.1.8 → 0.1.9 (Kotlin-only, no capi/Lynx ABI change).

## Test plan
- [x] `cargo build -p whisker-cli` / `cargo fmt --check -p whisker-cli`
- [ ] Full compile of `whisker-runtime-android` (relying on CI — the standalone Gradle project needs the Lynx source composite build, not available for an ad-hoc local check in this environment; the Kotlin was reviewed carefully by hand against the Java `LynxTouchEvent` API surface)
- [ ] End-to-end verification after `sdk-v0.1.9` publishes: downstream app (giga) bumps its SDK pin and confirms the reader's drag-to-seek progress bar now tracks the touch position on Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)