### PR TITLE
fix(android): convert touch coordinates to dip in event reporter

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -128,7 +128,15 @@ pub struct PlatformSync {
 /// on Android specifically — iOS's `whisker_bridge_ios.mm` already
 /// populated this shape, this brings Android to parity with it.
 /// Kotlin-only, no capi/Lynx ABI change.
-const WHISKER_SDK_VERSION: &str = "0.1.9";
+///
+/// 0.1.10 fixes those same touch coordinates being forwarded in raw
+/// device px instead of dip — `LynxTouchEvent.getPagePoint()`/
+/// `getClientPoint()`/`getTouchMap()` hand back unconverted
+/// `MotionEvent` coordinates, while `boundingClientRect()` and all
+/// other layout geometry reaching Rust is in dip. Divides by
+/// `resources.displayMetrics.density` before packing the event body.
+/// Kotlin-only, no capi/Lynx ABI change.
+const WHISKER_SDK_VERSION: &str = "0.1.10";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -101,33 +101,39 @@ class WhiskerView @JvmOverloads constructor(
                     val page = event.getPagePoint()
                     val client = event.getClientPoint()
                     if (page != null && client != null) {
+                        val x = pxToDip(page.x)
+                        val y = pxToDip(page.y)
+                        val clientX = pxToDip(client.x)
+                        val clientY = pxToDip(client.y)
                         val touch =
                             mapOf(
                                 "identifier" to 0,
-                                "x" to page.x,
-                                "y" to page.y,
-                                "pageX" to page.x,
-                                "pageY" to page.y,
-                                "clientX" to client.x,
-                                "clientY" to client.y,
+                                "x" to x,
+                                "y" to y,
+                                "pageX" to x,
+                                "pageY" to y,
+                                "clientX" to clientX,
+                                "clientY" to clientY,
                             )
                         body["touches"] = listOf(touch)
                         body["changedTouches"] = listOf(touch)
-                        body["detail"] = mapOf("x" to page.x, "y" to page.y)
+                        body["detail"] = mapOf("x" to x, "y" to y)
                     }
                 } else {
                     val touchMap = event.getTouchMap()
                     if (touchMap != null) {
                         val touches =
                             touchMap.entries.map { (identifier, point) ->
+                                val x = pxToDip(point.x)
+                                val y = pxToDip(point.y)
                                 mapOf(
                                     "identifier" to identifier,
-                                    "x" to point.x,
-                                    "y" to point.y,
-                                    "pageX" to point.x,
-                                    "pageY" to point.y,
-                                    "clientX" to point.x,
-                                    "clientY" to point.y,
+                                    "x" to x,
+                                    "y" to y,
+                                    "pageX" to x,
+                                    "pageY" to y,
+                                    "clientX" to x,
+                                    "clientY" to y,
                                 )
                             }
                         body["touches"] = touches
@@ -142,6 +148,19 @@ class WhiskerView @JvmOverloads constructor(
         }
         override fun onInternalEvent(event: LynxInternalEvent) {}
     }
+
+    // `LynxTouchEvent.getPagePoint()`/`getClientPoint()`/`getTouchMap()`
+    // hand back raw `MotionEvent` coordinates (device px, no density
+    // conversion) — confirmed against the Lynx fork's own
+    // `TouchEventDispatcher.dispatchEvent`. Every other geometry value
+    // reaching Rust (`boundingClientRect()`, layout `left`/`top`/…) is
+    // in dip, via `LynxBaseUI.boundingClientRectInner`'s explicit
+    // `/ density`. Forwarding touch points unconverted made drag
+    // gestures (e.g. the reader's progress-bar seek, which divides a
+    // touch delta by a dip-based measured width) scale with the
+    // device's density instead of the physical drag distance — up to
+    // ~3x too sensitive on a high-density phone.
+    private fun pxToDip(px: Float): Float = px / resources.displayMetrics.density
 
     init {
         engine = nativeEngineAttach(this)


### PR DESCRIPTION
## Summary
- `LynxTouchEvent.getPagePoint()`/`getClientPoint()`/`getTouchMap()` return raw device-px `MotionEvent` coordinates, not dip.
- `boundingClientRect()` and all other layout geometry reaching Rust is in dip (`LynxBaseUI.boundingClientRectInner` divides by `density`).
- PR #310 forwarded touch coordinates unconverted, so any Rust-side code computing a drag delta against a dip-based measured width (e.g. a drag-to-seek progress bar) scaled the drag by the device's density factor — up to ~3x too sensitive on a high-density phone.
- Divides `x`/`y`/`pageX`/`pageY`/`clientX`/`clientY` by `resources.displayMetrics.density` before packing the event body, for both the single- and multi-touch paths.
- iOS is unaffected — `UITouch`/`CGRect` are already both in points, no raw-px/dip split exists there.

## Test plan
- [x] `cargo build -p whisker-cli` (bumps `WHISKER_SDK_VERSION` 0.1.9 → 0.1.10)
- [ ] CI green
- [ ] Downstream app (giga) rebuilt against the new SDK version, confirms progress-bar drag now tracks 1:1 with physical finger movement on a real Android device

🤖 Generated with [Claude Code](https://claude.com/claude-code)