### PR TITLE
fix(pan-intercept): encode direction/scope as wire ints, not strings

### DIFF
--- a/crates/whisker-runtime/src/view/apply.rs
+++ b/crates/whisker-runtime/src/view/apply.rs
@@ -72,6 +72,26 @@ where
     }
 }
 
+/// Same as [`apply_attr_int`] but for a signal whose element type
+/// isn't already `i32` — maps each read through `to_wire` first.
+/// Exists for typed attribute enums (e.g. `PanInterceptDirection`)
+/// whose Lynx-side prop setter is integer-typed but where the Rust
+/// API keeps the ergonomic enum type; see [`apply_attr_int`]'s doc
+/// comment for why the plain string [`apply_attr`] path silently
+/// no-ops for these.
+pub fn apply_attr_int_mapped<V, T>(h: Element, name: &'static str, v: V, to_wire: fn(T) -> i32)
+where
+    V: ::std::convert::Into<Signal<T>>,
+    T: ::std::marker::Copy + 'static,
+{
+    match v.into() {
+        Signal::Stored(sv) => sv.with(|t| set_attribute_int(h, name, i64::from(to_wire(*t)))),
+        Signal::Dynamic(sig) => {
+            effect(move || set_attribute_int(h, name, i64::from(to_wire(sig.get()))));
+        }
+    }
+}
+
 pub fn apply_attr_bool<V>(h: Element, name: &'static str, v: V)
 where
     V: ::std::convert::Into<Signal<bool>>,

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -34,7 +34,8 @@ pub mod virtualizer;
 mod tests;
 
 pub use apply::{
-    apply_attr, apply_attr_bool, apply_attr_f64, apply_attr_int, apply_attr_owned, apply_styles,
+    apply_attr, apply_attr_bool, apply_attr_f64, apply_attr_int, apply_attr_int_mapped,
+    apply_attr_owned, apply_styles,
 };
 pub use handle::Element;
 pub use into_view::{

--- a/crates/whisker/src/attrs.rs
+++ b/crates/whisker/src/attrs.rs
@@ -135,6 +135,16 @@ attr_enum! {
     /// Maps to Lynx's `pan-intercept-direction` attribute. Pair
     /// with [`PanInterceptScope`] to choose which elements in the
     /// hit-test chain the interception applies to.
+    ///
+    /// Sent as an **int** ([`Self::as_wire_int`]), not the
+    /// `as_str`/`Display` string above — unlike most attribute enums
+    /// in this file, Lynx's native prop setter for this one is
+    /// integer-typed on both platforms (`LynxBaseUI.setPanInterceptDirection(int)`
+    /// on Android, `setPanInterceptDirection(NSInteger)` on iOS via
+    /// `LYNX_PROP_DEFINE`). Sending the string form is a **silent
+    /// no-op** — confirmed on-device: the attribute never reached the
+    /// native element at all, so the value stayed at its class
+    /// default (`None`) regardless of what was set from Rust.
     PanInterceptDirection {
         /// `"horizontal"`.
         Horizontal => "horizontal",
@@ -142,6 +152,20 @@ attr_enum! {
         Vertical => "vertical",
         /// `"none"` — disable the intercept (default).
         None => "none",
+    }
+}
+
+impl PanInterceptDirection {
+    /// Wire ordinal — must match `LynxPanInterceptDirection` exactly
+    /// (`LynxEventTarget.h` on iOS, `EventTarget.java` on Android;
+    /// both declare the same order). See the type's own doc comment
+    /// for why this (not `as_str`) is what actually reaches Lynx.
+    pub const fn as_wire_int(self) -> i32 {
+        match self {
+            Self::Horizontal => 0,
+            Self::Vertical => 1,
+            Self::None => 2,
+        }
     }
 }
 
@@ -153,6 +177,10 @@ attr_enum! {
     /// names track the wire strings 1:1; `SelfElement` reads `"self"`
     /// (the variant rename dodges Rust's `Self` keyword without
     /// resorting to `r#Self`).
+    ///
+    /// Sent as an **int** ([`Self::as_wire_int`]) — see
+    /// [`PanInterceptDirection`]'s doc comment; the same
+    /// string-attribute-on-an-int-prop gap applies here.
     PanInterceptScope {
         /// `"self"` — intercept on this element only.
         SelfElement => "self",
@@ -168,6 +196,23 @@ attr_enum! {
         All => "all",
         /// `"none"`.
         None => "none",
+    }
+}
+
+impl PanInterceptScope {
+    /// Wire ordinal — must match `LynxPanInterceptScope` exactly
+    /// (`LynxEventTarget.h` on iOS, `EventTarget.java` on Android;
+    /// both declare the same order). See [`PanInterceptDirection::as_wire_int`].
+    pub const fn as_wire_int(self) -> i32 {
+        match self {
+            Self::SelfElement => 0,
+            Self::Ancestors => 1,
+            Self::Descendants => 2,
+            Self::SelfAndAncestors => 3,
+            Self::SelfAndDescendants => 4,
+            Self::All => 5,
+            Self::None => 6,
+        }
     }
 }
 
@@ -259,6 +304,29 @@ mod tests {
         );
         assert_eq!(PanInterceptScope::All.as_str(), "all");
         assert_eq!(PanInterceptScope::None.as_str(), "none");
+    }
+
+    #[test]
+    fn pan_intercept_direction_wire_ints() {
+        // Must match `LynxPanInterceptDirection`'s declared order
+        // exactly (`LynxEventTarget.h` on iOS, `EventTarget.java` on
+        // Android) — this is what actually reaches Lynx; the `as_str`
+        // form above is a silent no-op on-device (int-typed native
+        // prop setter on both platforms).
+        assert_eq!(PanInterceptDirection::Horizontal.as_wire_int(), 0);
+        assert_eq!(PanInterceptDirection::Vertical.as_wire_int(), 1);
+        assert_eq!(PanInterceptDirection::None.as_wire_int(), 2);
+    }
+
+    #[test]
+    fn pan_intercept_scope_wire_ints() {
+        assert_eq!(PanInterceptScope::SelfElement.as_wire_int(), 0);
+        assert_eq!(PanInterceptScope::Ancestors.as_wire_int(), 1);
+        assert_eq!(PanInterceptScope::Descendants.as_wire_int(), 2);
+        assert_eq!(PanInterceptScope::SelfAndAncestors.as_wire_int(), 3);
+        assert_eq!(PanInterceptScope::SelfAndDescendants.as_wire_int(), 4);
+        assert_eq!(PanInterceptScope::All.as_wire_int(), 5);
+        assert_eq!(PanInterceptScope::None.as_wire_int(), 6);
     }
 
     #[test]

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -196,8 +196,8 @@ pub mod __tags {
     use whisker_runtime::value::WhiskerValue;
     use whisker_runtime::view::{
         BindType, Element, append_child, apply_attr, apply_attr_bool, apply_attr_int,
-        apply_attr_owned, create_element, create_element_by_name, create_phantom_element,
-        set_attribute_object, set_event_listener,
+        apply_attr_int_mapped, apply_attr_owned, create_element, create_element_by_name,
+        create_phantom_element, set_attribute_object, set_event_listener,
     };
 
     // Why a trait (and not `macro_rules!`): RA's method-completion
@@ -479,6 +479,13 @@ pub mod __tags {
         /// [`PanInterceptDirection`](crate::attrs::PanInterceptDirection)
         /// enum.
         ///
+        /// Sent as an int, not the enum's wire *string* — Lynx's
+        /// native prop setter for this attribute is integer-typed on
+        /// both platforms (confirmed on-device: the string form is a
+        /// silent no-op, the attribute never reaches the native
+        /// element). See `PanInterceptDirection::as_wire_int`'s doc
+        /// comment.
+        ///
         /// ```ignore
         /// view(pan_intercept_direction: PanInterceptDirection::Horizontal)
         /// ```
@@ -486,7 +493,12 @@ pub mod __tags {
         where
             V: Into<Signal<crate::attrs::PanInterceptDirection>>,
         {
-            apply_attr(self.__element(), "pan-intercept-direction", v);
+            apply_attr_int_mapped(
+                self.__element(),
+                "pan-intercept-direction",
+                v,
+                crate::attrs::PanInterceptDirection::as_wire_int,
+            );
             self
         }
 
@@ -495,6 +507,9 @@ pub mod __tags {
         /// [`PanInterceptScope`](crate::attrs::PanInterceptScope)
         /// enum.
         ///
+        /// Sent as an int — see [`Self::pan_intercept_direction`]'s
+        /// doc comment; the same gap applies to this attribute.
+        ///
         /// ```ignore
         /// view(pan_intercept_scope: PanInterceptScope::SelfAndAncestors)
         /// ```
@@ -502,7 +517,12 @@ pub mod __tags {
         where
             V: Into<Signal<crate::attrs::PanInterceptScope>>,
         {
-            apply_attr(self.__element(), "pan-intercept-scope", v);
+            apply_attr_int_mapped(
+                self.__element(),
+                "pan-intercept-scope",
+                v,
+                crate::attrs::PanInterceptScope::as_wire_int,
+            );
             self
         }
 

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -297,10 +297,11 @@ fn typed_attribute_methods_route_to_named_setters() {
         let ops = log.borrow();
         assert!(has(&ops, "flatten", "true"), "got {ops:?}");
         assert!(has(&ops, "hit-slop", "10px"), "got {ops:?}");
-        assert!(
-            has(&ops, "pan-intercept-direction", "horizontal"),
-            "got {ops:?}"
-        );
+        // Sent as the wire int (0 = Horizontal), not the enum's
+        // display string — Lynx's native prop setter for this
+        // attribute is integer-typed on both platforms; see
+        // `PanInterceptDirection::as_wire_int`'s doc comment.
+        assert!(has(&ops, "pan-intercept-direction", "0"), "got {ops:?}");
     });
 }
 


### PR DESCRIPTION
## Summary
- `pan-intercept-direction`/`pan-intercept-scope`'s native Lynx prop setters are integer-typed on both platforms (`LynxBaseUI.setPanInterceptDirection(int)` on Android, `setPanInterceptDirection(NSInteger)` via `LYNX_PROP_DEFINE` on iOS).
- whisker's Rust builder methods sent the enum's `Display` string (`apply_attr`) instead — a silent no-op on both platforms. Confirmed on-device: the attribute never reached the native element, regardless of scope, so `pan-intercept-*` has effectively never worked through whisker's Rust API.
- Adds `PanInterceptDirection`/`PanInterceptScope::as_wire_int()` matching the native enums' declared ordinal order (verified identical between `LynxEventTarget.h` on iOS and `EventTarget.java` on Android), and a new `apply_attr_int_mapped()` runtime helper so enum-typed attributes can route through the existing integer wire path instead of `ToString`.
- Updates the one existing test (`typed_attribute_methods_route_to_named_setters`) that asserted the old (silently broken) string encoding, and adds explicit `as_wire_int()` coverage for both enums.

## Test plan
- [x] `cargo build -p whisker-runtime -p whisker`
- [x] `cargo test -p whisker-runtime -p whisker` (all green, including the updated/new tests)
- [x] `cargo clippy -p whisker-runtime -p whisker --all-targets`
- [x] `cargo fmt -- --check`
- [ ] CI green
- [ ] Downstream app (giga) rebuilt against this, confirms a `<scroll-view>` nested inside opposite-axis ancestor `<list>`s (previously unable to win gesture arbitration) now scrolls correctly on Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)