### PR TITLE
diag(android): log live tapSlop value on WhiskerView init

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -136,7 +136,14 @@ pub struct PlatformSync {
 /// other layout geometry reaching Rust is in dip. Divides by
 /// `resources.displayMetrics.density` before packing the event body.
 /// Kotlin-only, no capi/Lynx ABI change.
-const WHISKER_SDK_VERSION: &str = "0.1.10";
+///
+/// 0.1.11 is a temporary diagnostic build — logs the tapSlop value
+/// `TouchEventDispatcher` actually ends up armed with (via reflection
+/// on its private `mTapSlop` field) 1s after each `WhiskerView`
+/// constructs, tagged `WhiskerTapSlop`. Investigating a report that
+/// 0.1.8's 18px tapSlop fix stopped taking effect. Remove once
+/// root-caused. Kotlin-only, no capi/Lynx ABI change.
+const WHISKER_SDK_VERSION: &str = "0.1.11";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -3,11 +3,13 @@ package rs.whisker.runtime
 import android.content.Context
 import android.os.Looper
 import android.util.AttributeSet
+import android.util.Log
 import android.view.Choreographer
 import androidx.annotation.Keep
 import com.lynx.tasm.EventEmitter
 import com.lynx.tasm.LynxView
 import com.lynx.tasm.LynxViewBuilder
+import com.lynx.tasm.behavior.TouchEventDispatcher
 import com.lynx.tasm.event.LynxCustomEvent
 import com.lynx.tasm.event.LynxEvent
 import com.lynx.tasm.event.LynxInternalEvent
@@ -168,6 +170,36 @@ class WhiskerView @JvmOverloads constructor(
             nativeBindWhiskerView(engine)
             installEventReporter()
             nativeAppMain(engine)
+        }
+        // Temporary diagnostic — reports what tapSlop value actually
+        // ends up armed on `TouchEventDispatcher` (the value the
+        // engine really compares touch drift against), vs. what we
+        // asked for via the `LynxViewBuilder` constructor above.
+        // `TouchEventDispatcher.onPageConfigDecoded`'s own tapSlop
+        // resolution runs once the page/template config decodes,
+        // which can happen after this constructor returns, so read
+        // it on a short delay rather than inline here. Remove once
+        // the tapSlop regression is root-caused. Filter with
+        // `adb logcat -s WhiskerTapSlop`.
+        postDelayed({ logTapSlopDiagnostic() }, 1000)
+    }
+
+    private fun logTapSlopDiagnostic() {
+        try {
+            val ctx = lynxContext
+            val builderValue = ctx?.tapSlop
+            val dispatcher = ctx?.touchEventDispatcher
+            val field = TouchEventDispatcher::class.java.getDeclaredField("mTapSlop")
+            field.isAccessible = true
+            val liveValue = dispatcher?.let { field.get(it) }
+            Log.d(
+                "WhiskerTapSlop",
+                "LynxContext.tapSlop=$builderValue " +
+                    "TouchEventDispatcher.mTapSlop(px)=$liveValue " +
+                    "density=${resources.displayMetrics.density}",
+            )
+        } catch (e: Exception) {
+            Log.e("WhiskerTapSlop", "diagnostic failed", e)
         }
     }
 


### PR DESCRIPTION
## Summary
- Temporary diagnostic PR — investigating a report that 0.1.8's 18px tapSlop fix (`LynxViewBuilder().setTapSlop("18px")`) stopped taking effect on Android; user reports spurious taps firing during scroll again, on all screens.
- Traced the Lynx fork's own tapSlop resolution (`LynxUIRenderer.onPageConfigDecoded`/`updateEventDispatcherConfig`) — there's a page-config-vs-builder-value precedence path, and the actual float `TouchEventDispatcher` compares touch drift against isn't directly observable without reflection.
- Adds a `postDelayed` diagnostic in `WhiskerView`'s `init` block that reflects into `TouchEventDispatcher`'s private `mTapSlop` field and logs it alongside `LynxContext.tapSlop`, tagged `WhiskerTapSlop`.
- No behavior change — purely additive logging. Will be removed once the regression is root-caused.

## Test plan
- [x] `cargo build -p whisker-cli` (bumps `WHISKER_SDK_VERSION` 0.1.10 → 0.1.11)
- [ ] CI green
- [ ] `adb logcat -s WhiskerTapSlop` on a rebuilt downstream app confirms whether the live value matches the requested 18px (in px, density-adjusted) or has reverted to the 50px default

🤖 Generated with [Claude Code](https://claude.com/claude-code)