### PR TITLE
diag(android): read live tapSlop after ACTION_UP, not a fixed delay

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -143,7 +143,15 @@ pub struct PlatformSync {
 /// constructs, tagged `WhiskerTapSlop`. Investigating a report that
 /// 0.1.8's 18px tapSlop fix stopped taking effect. Remove once
 /// root-caused. Kotlin-only, no capi/Lynx ABI change.
-const WHISKER_SDK_VERSION: &str = "0.1.11";
+///
+/// 0.1.12 fixes that diagnostic itself — `TouchEventDispatcher` is
+/// lazily created on the first real touch event
+/// (`LynxUIRenderer.EnsureEventDispatcher`), not at `WhiskerView`
+/// construction, so the fixed 1s-post-construction read always logged
+/// `null` (confirmed on-device). Moved the read to fire after
+/// `ACTION_UP` instead, guaranteeing the dispatcher already exists.
+/// Kotlin-only, no capi/Lynx ABI change.
+const WHISKER_SDK_VERSION: &str = "0.1.12";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -171,17 +171,29 @@ class WhiskerView @JvmOverloads constructor(
             installEventReporter()
             nativeAppMain(engine)
         }
-        // Temporary diagnostic — reports what tapSlop value actually
-        // ends up armed on `TouchEventDispatcher` (the value the
-        // engine really compares touch drift against), vs. what we
-        // asked for via the `LynxViewBuilder` constructor above.
-        // `TouchEventDispatcher.onPageConfigDecoded`'s own tapSlop
-        // resolution runs once the page/template config decodes,
-        // which can happen after this constructor returns, so read
-        // it on a short delay rather than inline here. Remove once
-        // the tapSlop regression is root-caused. Filter with
-        // `adb logcat -s WhiskerTapSlop`.
-        postDelayed({ logTapSlopDiagnostic() }, 1000)
+    }
+
+    // Temporary diagnostic — reports what tapSlop value actually ends
+    // up armed on `TouchEventDispatcher` (the value the engine really
+    // compares touch drift against), vs. what we asked for via the
+    // `LynxViewBuilder` constructor above. `TouchEventDispatcher`
+    // itself is lazily created (`LynxUIRenderer.EnsureEventDispatcher`)
+    // on the FIRST real touch event, not at construction time — a
+    // fixed post-construction delay logged `null` unconditionally
+    // (confirmed on-device) since no touch had happened yet. Logging
+    // after `ACTION_UP` instead guarantees the dispatcher already
+    // exists. Capped at 5 logs so this doesn't spam every tap forever.
+    // Remove once the tapSlop regression is root-caused. Filter with
+    // `adb logcat -s WhiskerTapSlop`.
+    private var tapSlopLogsRemaining = 5
+
+    override fun dispatchTouchEvent(ev: android.view.MotionEvent): Boolean {
+        val result = super.dispatchTouchEvent(ev)
+        if (tapSlopLogsRemaining > 0 && ev.action == android.view.MotionEvent.ACTION_UP) {
+            tapSlopLogsRemaining--
+            logTapSlopDiagnostic()
+        }
+        return result
     }
 
     private fun logTapSlopDiagnostic() {
@@ -196,6 +208,7 @@ class WhiskerView @JvmOverloads constructor(
                 "WhiskerTapSlop",
                 "LynxContext.tapSlop=$builderValue " +
                     "TouchEventDispatcher.mTapSlop(px)=$liveValue " +
+                    "dispatcher=$dispatcher " +
                     "density=${resources.displayMetrics.density}",
             )
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- Follow-up to #313 — that diagnostic's fixed 1s-post-construction read always logged `TouchEventDispatcher.mTapSlop(px)=null` (confirmed on real-device logcat: `LynxContext.tapSlop=18px TouchEventDispatcher.mTapSlop(px)=null density=3.0`).
- Root cause of the *diagnostic* being null (not the tapSlop regression itself yet): `TouchEventDispatcher` is lazily created by `LynxUIRenderer.EnsureEventDispatcher()` on the first real touch event, not at `WhiskerView` construction — reading 1s after construction, before any touch happened, was always going to see `null`.
- Moves the reflective read to fire right after `dispatchTouchEvent`'s `ACTION_UP`, guaranteeing the dispatcher already exists by then. Capped at 5 logs total so it doesn't spam every subsequent tap forever.

## Test plan
- [x] `cargo build -p whisker-cli` (bumps `WHISKER_SDK_VERSION` 0.1.11 → 0.1.12)
- [ ] CI green
- [ ] `adb logcat -s WhiskerTapSlop` on a rebuilt downstream app, after a real touch, shows a non-null `TouchEventDispatcher.mTapSlop(px)` this time — compare it against the requested 18dp-equivalent to actually root-cause the regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)