### PR TITLE
fix(android): actually apply tapSlop, bypassing the page-config path

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -151,7 +151,20 @@ pub struct PlatformSync {
 /// `null` (confirmed on-device). Moved the read to fire after
 /// `ACTION_UP` instead, guaranteeing the dispatcher already exists.
 /// Kotlin-only, no capi/Lynx ABI change.
-const WHISKER_SDK_VERSION: &str = "0.1.12";
+///
+/// 0.1.13 fixes the actual regression 0.1.11/0.1.12 were diagnosing —
+/// confirmed on-device that `TouchEventDispatcher.mTapSlop` stayed at
+/// Lynx's built-in 50dip default regardless of
+/// `LynxViewBuilder().setTapSlop(...)`. Root cause: that value only
+/// reaches the live dispatcher via `onPageConfigDecoded` →
+/// `updateEventDispatcherConfig()`, both driven by Lynx's own
+/// template-loading pipeline, which this app bypasses entirely (see
+/// `WhiskerView`'s own class doc comment). Reflects through
+/// `LynxView.mLynxTemplateRender` → `LynxTemplateRender.mLynxUIRender`
+/// → `LynxUIRenderer.mEventDispatcher` to reach the live dispatcher
+/// directly and set its tapSlop, bypassing the page-config path this
+/// app never drives. Kotlin-only, no capi/Lynx ABI change.
+const WHISKER_SDK_VERSION: &str = "0.1.13";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -16,6 +16,9 @@ import com.lynx.tasm.event.LynxInternalEvent
 import com.lynx.tasm.event.LynxTouchEvent
 import java.util.concurrent.atomic.AtomicBoolean
 
+/** See `WhiskerView.forceTapSlop`'s doc comment for why this can't just be `LynxViewBuilder`'s tapSlop. */
+private const val TAP_SLOP_DP = 18f
+
 /**
  * Hosts the Lynx engine and bridges it to the Rust runtime.
  *
@@ -48,6 +51,11 @@ class WhiskerView @JvmOverloads constructor(
         // `kTouchSlop` — Flutter shipped 8dp first and raised it to 18dp
         // after complaints that deliberate taps were too easily cancelled
         // by ordinary hand tremor; still far below the original 50dp gap.
+        //
+        // Kept even though it's confirmed dead for this app (see
+        // `forceTapSlop`'s doc comment below) — cheap, harmless, and
+        // becomes real again if a future Lynx version or code path
+        // starts honoring it.
         LynxViewBuilder().setTapSlop("18px"),
     ),
     WhiskerModuleHost {
@@ -173,46 +181,62 @@ class WhiskerView @JvmOverloads constructor(
         }
     }
 
-    // Temporary diagnostic — reports what tapSlop value actually ends
-    // up armed on `TouchEventDispatcher` (the value the engine really
-    // compares touch drift against), vs. what we asked for via the
-    // `LynxViewBuilder` constructor above. `TouchEventDispatcher`
-    // itself is lazily created (`LynxUIRenderer.EnsureEventDispatcher`)
-    // on the FIRST real touch event, not at construction time — a
-    // fixed post-construction delay logged `null` unconditionally
-    // (confirmed on-device) since no touch had happened yet. Logging
-    // after `ACTION_UP` instead guarantees the dispatcher already
-    // exists. Capped at 5 logs so this doesn't spam every tap forever.
-    // Remove once the tapSlop regression is root-caused. Filter with
-    // `adb logcat -s WhiskerTapSlop`.
-    private var tapSlopLogsRemaining = 5
+    // `LynxViewBuilder().setTapSlop(...)` above is a no-op for this
+    // app — confirmed on-device via reflection (`adb logcat -s
+    // WhiskerTapSlop`: `TouchEventDispatcher.mTapSlop` stayed at
+    // Lynx's built-in 50dip default no matter what the builder was
+    // given). Root cause, traced in the Lynx fork source
+    // (`LynxUIRenderer.java`): the builder's tapSlop string only ever
+    // reaches the live `TouchEventDispatcher` via
+    // `onPageConfigDecoded()` → `updateEventDispatcherConfig()`, both
+    // driven by Lynx's own template-loading pipeline — the one this
+    // class's own doc comment says whisker bypasses entirely (engine
+    // handed to Rust via JNI instead). `onPageConfigDecoded` never
+    // fires, `mIsUpdatedConfig` never flips true, so
+    // `EnsureEventDispatcher()` creates the dispatcher (lazily, on the
+    // first real touch — `LynxUIRenderer.onTouchEvent`/
+    // `onInterceptTouchEvent`) but never calls
+    // `updateEventDispatcherConfig()`, and the dispatcher is left on
+    // its own constructor default.
+    //
+    // Since nothing ever calls `LynxContext.setTouchEventDispatcher`
+    // either, `lynxContext.touchEventDispatcher` stays null forever
+    // too — there's no public path to the live dispatcher at all.
+    // Reflects through `LynxView.mLynxTemplateRender` (protected,
+    // direct field access) → `LynxTemplateRender.mLynxUIRender`
+    // (private, declared as the `ILynxUIRenderer` interface but always
+    // a `LynxUIRenderer` at runtime) → `LynxUIRenderer.mEventDispatcher`
+    // (private) to reach the actual instance and set its tapSlop
+    // directly, bypassing the page-config pipeline this app never
+    // drives. Tried on every touch (idempotent past the first success)
+    // since the dispatcher doesn't exist until the first one.
+    private var tapSlopForced = false
 
     override fun dispatchTouchEvent(ev: android.view.MotionEvent): Boolean {
         val result = super.dispatchTouchEvent(ev)
-        if (tapSlopLogsRemaining > 0 && ev.action == android.view.MotionEvent.ACTION_UP) {
-            tapSlopLogsRemaining--
-            logTapSlopDiagnostic()
-        }
+        if (!tapSlopForced) forceTapSlop()
         return result
     }
 
-    private fun logTapSlopDiagnostic() {
+    private fun forceTapSlop() {
         try {
-            val ctx = lynxContext
-            val builderValue = ctx?.tapSlop
-            val dispatcher = ctx?.touchEventDispatcher
-            val field = TouchEventDispatcher::class.java.getDeclaredField("mTapSlop")
-            field.isAccessible = true
-            val liveValue = dispatcher?.let { field.get(it) }
-            Log.d(
-                "WhiskerTapSlop",
-                "LynxContext.tapSlop=$builderValue " +
-                    "TouchEventDispatcher.mTapSlop(px)=$liveValue " +
-                    "dispatcher=$dispatcher " +
-                    "density=${resources.displayMetrics.density}",
-            )
+            val templateRenderField = LynxView::class.java.getDeclaredField("mLynxTemplateRender")
+            templateRenderField.isAccessible = true
+            val templateRender = templateRenderField.get(this) ?: return
+
+            val uiRenderField = templateRender.javaClass.getDeclaredField("mLynxUIRender")
+            uiRenderField.isAccessible = true
+            val uiRenderer = uiRenderField.get(templateRender) ?: return
+
+            val dispatcherField = uiRenderer.javaClass.getDeclaredField("mEventDispatcher")
+            dispatcherField.isAccessible = true
+            val dispatcher = dispatcherField.get(uiRenderer) as? TouchEventDispatcher ?: return
+
+            dispatcher.setTapSlop(TAP_SLOP_DP * resources.displayMetrics.density)
+            tapSlopForced = true
+            Log.d("WhiskerTapSlop", "forced tapSlop to ${TAP_SLOP_DP}dp on live dispatcher")
         } catch (e: Exception) {
-            Log.e("WhiskerTapSlop", "diagnostic failed", e)
+            Log.e("WhiskerTapSlop", "forceTapSlop failed — falling back to Lynx's 50dip default", e)
         }
     }
 


### PR DESCRIPTION
## Summary
- Follow-up to #313/#314's diagnostics — confirmed on-device (real touch, `adb logcat -s WhiskerTapSlop`) that `TouchEventDispatcher.mTapSlop` stayed at Lynx's built-in 50dip default no matter what `LynxViewBuilder().setTapSlop(...)` was given. The 0.1.8 "fix" (PR #309) never actually took effect.
- Root cause, traced in the Lynx fork source: the builder's tapSlop string only reaches the live `TouchEventDispatcher` via `onPageConfigDecoded()` → `updateEventDispatcherConfig()`, both driven by Lynx's own template-loading pipeline. `WhiskerView` bypasses that pipeline entirely — it hands the engine shell pointer to the Rust runtime via JNI instead (per its own class doc comment) — so `onPageConfigDecoded` never fires, `mIsUpdatedConfig` never flips true, and `EnsureEventDispatcher()` creates the dispatcher (lazily, on the first real touch) but skips `updateEventDispatcherConfig()` — the only place the tapSlop transfer (and `LynxContext.setTouchEventDispatcher`) happens.
- Fix: reflects through `LynxView.mLynxTemplateRender` → `LynxTemplateRender.mLynxUIRender` → `LynxUIRenderer.mEventDispatcher` to reach the live dispatcher directly and call `setTapSlop()` on it, bypassing the page-config path this app never drives. Tried on every touch via a `dispatchTouchEvent` override (idempotent past the first success, since the dispatcher doesn't exist until the first touch creates it).
- Keeps the (now-documented-dead) `LynxViewBuilder().setTapSlop("18px")` call too — harmless, and becomes real again if a future Lynx version starts honoring it.

## Test plan
- [x] `cargo build -p whisker-cli` (bumps `WHISKER_SDK_VERSION` 0.1.12 → 0.1.13)
- [ ] CI green
- [ ] On a rebuilt downstream app, real-device touch confirms `adb logcat -s WhiskerTapSlop` now logs `forced tapSlop to 18.0dp on live dispatcher`, and the original symptom (spurious taps firing during scroll, all screens) is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)