### PR TITLE
feat(router): mirror React Navigation's Stack Navigator keyboard handling

### DIFF
--- a/crates/whisker-driver/src/element_ref.rs
+++ b/crates/whisker-driver/src/element_ref.rs
@@ -235,7 +235,7 @@ impl std::error::Error for RefError {}
 /// `Clone` produces a shared handle (same backing `RwSignal` arena
 /// slot), so any number of bridge `effect`s can hold their own
 /// `ElementRef` clone and observe the same mount / unmount events.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct ElementRef {
     /// Single source of truth: holds the currently-bound `Element`
     /// (or `None` while unmounted), and is the `Signal` that

--- a/crates/whisker-driver/src/focus.rs
+++ b/crates/whisker-driver/src/focus.rs
@@ -1,0 +1,47 @@
+//! Process-global "currently focused element" registry — Whisker's
+//! analogue of React Native's `TextInput.State.currentlyFocusedInput()`.
+//!
+//! A focusable native element (an `<input>`) records itself here when it
+//! gains focus and clears itself when it loses focus. Navigation code
+//! (`whisker-router`) reads [`focused_element`] so it can blur — or later
+//! restore — the *specific* field that was focused, instead of firing a
+//! global unfocus. A global unfocus dispatched at navigation time can
+//! land late on the native side and resign a field the *incoming* screen
+//! has since auto-focused; a targeted blur of the captured departing
+//! field cannot (blurring an already-unmounted field is a no-op). This is
+//! exactly why React Navigation captures the concrete input and blurs
+//! *that* ref rather than calling `Keyboard.dismiss()` on forward pushes.
+//!
+//! Main-thread only: the reactive/UI world is thread-local, and the cell
+//! is only ever touched from focus/blur event handlers and navigation
+//! verbs, all of which run on the Lynx TASM thread.
+
+use std::cell::Cell;
+
+use crate::element_ref::ElementRef;
+
+thread_local! {
+    static FOCUSED: Cell<Option<ElementRef>> = const { Cell::new(None) };
+}
+
+/// Record `el` as the element that currently holds focus. Call from an
+/// input's focus handler.
+pub fn note_focused(el: ElementRef) {
+    FOCUSED.with(|f| f.set(Some(el)));
+}
+
+/// Clear the focused element **iff** it is still `el`, so a stale blur
+/// (fired after another field already took focus) can't wipe the newer
+/// registration. Call from an input's blur handler.
+pub fn note_blurred(el: ElementRef) {
+    FOCUSED.with(|f| {
+        if f.get() == Some(el) {
+            f.set(None);
+        }
+    });
+}
+
+/// The element that currently holds focus, if any.
+pub fn focused_element() -> Option<ElementRef> {
+    FOCUSED.with(Cell::get)
+}

--- a/crates/whisker-driver/src/lib.rs
+++ b/crates/whisker-driver/src/lib.rs
@@ -20,6 +20,7 @@
 //!   replay and list-provider trampolines.
 
 pub mod element_ref;
+pub mod focus;
 pub mod lynx;
 pub mod module;
 

--- a/crates/whisker-runtime/src/reactive/signal.rs
+++ b/crates/whisker-runtime/src/reactive/signal.rs
@@ -209,6 +209,16 @@ impl<T: 'static> Clone for RwSignal<T> {
 }
 impl<T: 'static> Copy for RwSignal<T> {}
 
+/// Identity equality: two handles are equal when they address the same
+/// reactive node, not when their *values* are equal (the value isn't even
+/// read). Lets a `Copy` handle be used as a map/registry key.
+impl<T: 'static> PartialEq for RwSignal<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl<T: 'static> Eq for RwSignal<T> {}
+
 impl<T: 'static> RwSignal<T> {
     /// Allocate a new combined-handle signal. Equivalent to
     /// [`signal`].

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -94,6 +94,12 @@ pub use whisker_driver::{
 
 pub use whisker_driver::module::PlatformModule;
 
+/// The process-global focused-element registry (Whisker's analogue of
+/// React Native's `TextInput.State.currentlyFocusedInput()`). Focusable
+/// elements record themselves here; navigation code reads it to blur or
+/// restore the specific field that was focused.
+pub use whisker_driver::focus;
+
 /// The universal tagged-union value model. Crosses the native
 /// boundary as both module args/returns and event payloads, so it
 /// lives at the crate root rather than buried under

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -652,9 +652,22 @@ pub fn input(
             }
         }
     };
+    // The element handle this field is bound to. If the caller passed an
+    // `input_ref`, reuse it; otherwise mint an internal one so the field
+    // still registers itself in the focused-element registry (below).
+    let element_ref = input_ref
+        .as_ref()
+        .map(|h| h.r())
+        .unwrap_or_else(ElementRef::new);
+
     let on_focus_cb = {
         let on_focus = on_focus.clone();
         move |_ev: InputEvent| {
+            // Publish ourselves as the currently-focused field — the
+            // signal `whisker-router` reads to blur/restore this exact
+            // input on navigation (mirrors RN's
+            // `TextInput.State.currentlyFocusedInput()`).
+            whisker::focus::note_focused(element_ref);
             if let Some(cb) = &on_focus {
                 cb.call();
             }
@@ -663,6 +676,7 @@ pub fn input(
     let on_blur_cb = {
         let on_blur = on_blur.clone();
         move |_ev: InputEvent| {
+            whisker::focus::note_blurred(element_ref);
             if let Some(cb) = &on_blur {
                 cb.call();
             }
@@ -698,8 +712,6 @@ pub fn input(
     let spell_check_attr = bool_attr(spell_check);
 
     // ----- Imperative handle: forward its ElementRef as `ref:` ---------
-    let element_ref = input_ref.as_ref().map(|h| h.r());
-
     let mut builder = NativeInput::builder()
         .value(value_prop)
         .placeholder(placeholder_prop)
@@ -724,9 +736,7 @@ pub fn input(
         .on_blur(on_blur_cb)
         .on_submit(on_submit_cb);
 
-    if let Some(r) = element_ref {
-        builder = builder.with_ref(r);
-    }
+    builder = builder.with_ref(element_ref);
 
     NativeInput(builder.build())
 }

--- a/packages/whisker-router/src/render/gesture.rs
+++ b/packages/whisker-router/src/render/gesture.rs
@@ -231,6 +231,11 @@ pub(crate) fn begin(nav: &RouterHandle, edge: SwipeEdge) -> Option<StackBridge> 
             }
         }
     }
+    // A back gesture is starting: blur and remember the focused field so
+    // a cancelled swipe can restore it (RN `onPageChangeStart`). Runs on
+    // the genuine start of both the iOS edge swipe and Android
+    // predictive back; the hook is idempotent for a replayed start.
+    crate::render::keyboard::on_page_change_start();
     Some(bridge)
 }
 
@@ -281,10 +286,11 @@ pub(crate) fn settle(
                 if let Some(d) = dim_drive {
                     d.set(None);
                 }
-                // Swipe-back commits like any other navigation — drop the
-                // keyboard + release focus (a search field on the popped
-                // screen must not keep a hardware-keyboard target).
-                crate::render::handle::dismiss_keyboard();
+                // Swipe-back commits like any other navigation — the
+                // field captured at gesture start stays blurred, so a
+                // search field on the popped screen can't keep a
+                // hardware-keyboard target (RN `onPageChangeConfirm`).
+                crate::render::keyboard::on_page_change_confirm(true);
                 let _ = nav.back();
             }
         });
@@ -297,6 +303,10 @@ pub(crate) fn settle(
         // pointed at the same controller as `Under`, slides back to covered
         // in lockstep. The dim fades to 0 reactively as the controller
         // returns to 1.0, then the drive is released on finish.
+        //
+        // Restore focus to the field blurred at gesture start (RN
+        // `onPageChangeCancel`), with the flash guard for a fast release.
+        crate::render::keyboard::on_page_change_cancel();
         let done = Rc::new(RefCell::new(false));
         ctrl.on_finish(move |finished| {
             if finished && !*done.borrow() {
@@ -418,8 +428,9 @@ pub fn android_predictive_back() -> Element {
                 // commit it (animate the top off, then `back()`).
                 Some(bridge) => settle(nav, &bridge, /* commit = */ true, None),
                 // No preview (API < 34, or a discrete press): just pop.
+                // `back()` routes through `with_navigator`, which handles
+                // the keyboard (targeted blur of the focused field).
                 None => {
-                    crate::render::handle::dismiss_keyboard();
                     let _ = nav.back();
                 }
             }

--- a/packages/whisker-router/src/render/handle.rs
+++ b/packages/whisker-router/src/render/handle.rs
@@ -248,8 +248,11 @@ impl RouterHandle {
     fn with_navigator<T>(&self, op: impl FnOnce(&mut Navigator) -> T) -> T {
         // Release keyboard focus at the moment navigation is invoked —
         // before the transition animates — so the keyboard drops crisply
-        // as the user leaves the screen. See [`dismiss_keyboard`].
-        dismiss_keyboard();
+        // as the user leaves the screen. Blurs the *specific* field that
+        // was focused (never a blanket dismiss), so a late-landing blur
+        // can't resign a field the screen being entered has since
+        // auto-focused. See [`crate::render::keyboard`].
+        crate::render::keyboard::on_page_change_confirm(false);
         let mut state = self.inner.state.get();
         let out = {
             let mut nav = Navigator::new(&self.inner.tree, &mut state);
@@ -294,28 +297,6 @@ impl RouterHandle {
     pub fn reset(&self, url: &str) -> Result<(), NavError> {
         self.with_navigator(|nav| nav.reset(url))
     }
-}
-
-/// The `whisker-keyboard` native module, referenced by its
-/// fully-qualified name (`<crate>:<Name>`). The router ships in a
-/// different crate than `whisker-keyboard`, so `module!` — which
-/// prepends *this* crate's name — can't name it; we spell the qualified
-/// name directly.
-const KEYBOARD_MODULE: &str = "whisker-keyboard:Keyboard";
-
-/// Release keyboard focus globally on navigation.
-///
-/// Mirrors React Navigation's `keyboardHandlingEnabled`: when the user
-/// moves between screens, blur the focused field. This is a **real
-/// unfocus** on the native side (iOS `resignFirstResponder`, Android
-/// `clearFocus`), not merely a "hide the keyboard" — so an input that
-/// has navigated off screen can't keep receiving hardware-keyboard
-/// input. See the `whisker-keyboard` crate.
-///
-/// Fire-and-forget: if the app didn't add `whisker-keyboard`, the
-/// module is unregistered and the invoke degrades to a no-op.
-pub(crate) fn dismiss_keyboard() {
-    let _ = whisker::PlatformModule::named(KEYBOARD_MODULE).invoke("dismiss", vec![]);
 }
 
 /// Walk `state` to the subtree at `path` (positional descent mirroring

--- a/packages/whisker-router/src/render/keyboard.rs
+++ b/packages/whisker-router/src/render/keyboard.rs
@@ -1,0 +1,124 @@
+//! Keyboard focus handling across navigations — a faithful port of
+//! React Navigation's Stack Navigator `useKeyboardManager`
+//! (`@react-navigation/stack`, `utils/useKeyboardManager`).
+//!
+//! ## Why not a global dismiss
+//!
+//! The obvious implementation — call [`whisker_keyboard::dismiss`] on
+//! every navigation — is what this crate used to do, and it is *more*
+//! aggressive than React Navigation. A global unfocus dispatched at
+//! navigation time is fire-and-forget on the native side; it can land
+//! *after* the screen being entered has already auto-focused its own
+//! input, resigning it (the "focus flashes then drops ~0.5s in" bug).
+//!
+//! React Navigation avoids this by capturing the concrete focused input
+//! (`TextInput.State.currentlyFocusedInput()`) and blurring *that ref*,
+//! never a blanket dismiss on a forward push. Whisker mirrors it: the
+//! focused-element registry ([`whisker::focus`]) is the
+//! `currentlyFocusedInput()` analogue, and we blur/refocus that exact
+//! [`ElementRef`]. Blurring a field that has since unmounted (the screen
+//! we left) is a no-op, so a late-landing blur can never steal the
+//! incoming screen's focus.
+//!
+//! ## The three hooks (named after the RN originals)
+//!
+//! - [`on_page_change_start`] — a back gesture began. Blur the focused
+//!   field and remember it, so a cancelled gesture can restore it.
+//! - [`on_page_change_cancel`] — the gesture was released below the
+//!   commit threshold. Refocus the remembered field. If the whole
+//!   interaction was shorter than [`KEYBOARD_FLASH_GUARD`], defer the
+//!   refocus: the platform force-hides the keyboard for a beat after an
+//!   interactive dismiss begins, so an immediate refocus would only
+//!   flash it.
+//! - [`on_page_change_confirm`] — a navigation committed. For a
+//!   programmatic verb, blur whatever is focused (targeted). For a
+//!   committed gesture, the remembered field stays blurred.
+
+use std::cell::Cell;
+use std::time::{Duration, Instant};
+
+use whisker::{ElementRef, WhiskerValue, run_blocking, spawn_local};
+
+/// Below this interaction length, defer a cancel's refocus to dodge the
+/// keyboard-dismiss tail. Matches RN's 100ms guard.
+const KEYBOARD_FLASH_GUARD: Duration = Duration::from_millis(100);
+
+thread_local! {
+    /// The field focused when the current back gesture began — restored
+    /// on cancel, dropped on commit.
+    static REMEMBERED: Cell<Option<ElementRef>> = const { Cell::new(None) };
+    /// When that gesture began, for the flash guard.
+    static STARTED_AT: Cell<Option<Instant>> = const { Cell::new(None) };
+}
+
+/// Blur a specific field. A no-op when the element is unmounted, which is
+/// exactly why targeting the captured departing field is race-free.
+fn blur(el: ElementRef) {
+    let _ = el.invoke("blur", WhiskerValue::Null);
+}
+
+/// Focus a specific field (raises the keyboard).
+fn focus(el: ElementRef) {
+    let _ = el.invoke("focus", WhiskerValue::Null);
+}
+
+/// A back gesture began: blur the currently-focused field and remember it
+/// so [`on_page_change_cancel`] can put it back. (RN `onPageChangeStart`.)
+pub(crate) fn on_page_change_start() {
+    // Idempotent: a gesture can signal "start" more than once (Android
+    // retries `begin()` on the first progress event when `backStarted`
+    // was dropped). Only the first capture of a gesture counts, else a
+    // second call would overwrite the remembered field with `None`.
+    if STARTED_AT.with(|s| s.get().is_some()) {
+        return;
+    }
+    let current = whisker::focus::focused_element();
+    REMEMBERED.with(|r| r.set(current));
+    STARTED_AT.with(|s| s.set(Some(Instant::now())));
+    if let Some(el) = current {
+        blur(el);
+    }
+}
+
+/// The gesture was cancelled: refocus the remembered field, deferring
+/// briefly for a too-fast interaction so the keyboard doesn't flash.
+/// (RN `onPageChangeCancel`.)
+pub(crate) fn on_page_change_cancel() {
+    let Some(el) = REMEMBERED.with(Cell::take) else {
+        return;
+    };
+    let elapsed = STARTED_AT
+        .with(Cell::take)
+        .map(|t| t.elapsed())
+        .unwrap_or(KEYBOARD_FLASH_GUARD);
+    if elapsed >= KEYBOARD_FLASH_GUARD {
+        focus(el);
+    } else {
+        let wait = KEYBOARD_FLASH_GUARD - elapsed;
+        spawn_local(async move {
+            run_blocking(move || std::thread::sleep(wait)).await;
+            focus(el);
+        });
+    }
+}
+
+/// A navigation committed. `gesture` marks an interactive back gesture
+/// (vs a programmatic verb). (RN `onPageChangeConfirm` with `closing`
+/// always true here — the verb already happened.)
+pub(crate) fn on_page_change_confirm(gesture: bool) {
+    if gesture {
+        // The interactive back committed. The field captured at gesture
+        // start stays blurred; just release it.
+        if let Some(el) = REMEMBERED.with(Cell::take) {
+            blur(el);
+        }
+        STARTED_AT.with(|s| s.set(None));
+    } else {
+        // Programmatic navigation: blur the currently-focused field, if
+        // any. Targeted, so a late-landing blur hits only the departing
+        // field — never the incoming screen's freshly-focused input.
+        if let Some(el) = whisker::focus::focused_element() {
+            blur(el);
+        }
+    }
+}

--- a/packages/whisker-router/src/render/mod.rs
+++ b/packages/whisker-router/src/render/mod.rs
@@ -54,6 +54,7 @@
 pub mod components;
 pub mod gesture;
 pub mod handle;
+pub(crate) mod keyboard;
 pub mod node;
 pub mod registry;
 pub mod transition;


### PR DESCRIPTION
## What

Replaces the blanket global keyboard dismiss that fired on **every** navigator verb with a faithful port of React Navigation's `@react-navigation/stack` `useKeyboardManager`.

## Why

The old `dismiss_keyboard()` (in `with_navigator`) was a fire-and-forget **global** unfocus (`whisker-keyboard::dismiss()` → iOS `endEditing`, Android `clearFocus`). Its native dispatch could land *after* the screen being entered had already auto-focused its own input — resigning it (the "focus flashes then drops ~0.5s in" class of bug).

React Navigation avoids this by capturing the concrete focused input (`TextInput.State.currentlyFocusedInput()`) and blurring **that ref**. A targeted blur can't be misdirected onto the incoming screen even if it lands late (blurring an already-unmounted field is a no-op).

## How

- **whisker-driver** `focus` registry — a thread-local "currently focused `ElementRef`", the `currentlyFocusedInput()` analogue. Re-exported as `whisker::focus`.
- **whisker-runtime** — identity `PartialEq`/`Eq` on `RwSignal` (compare node id) so `ElementRef` derives them; the registry keys by element identity.
- **whisker-input** — each field registers itself on focus / clears on blur (mints an internal `ElementRef` when the caller passes no `input_ref`).
- **whisker-router** `render::keyboard` — the `useKeyboardManager` mirror: `on_page_change_start` (blur + remember focused field), `on_page_change_cancel` (restore, with RN's 100ms flash guard), `on_page_change_confirm` (programmatic → targeted blur; committed gesture → release). Wired into `with_navigator` and the shared gesture `begin`/`settle` helpers. Removes the old `dismiss_keyboard()`.

## Verification

- Workspace `cargo check` clean; `whisker-router` (40) + `whisker-input` (9) + `whisker-runtime` tests pass.
- iOS sim: `on_page_change_confirm(programmatic)` correctly finds nothing focused on a Home→Search nav (no spurious blur).
- ⚠️ Gesture cancel-restore + Android predictive-back paths are **not yet device-verified**.

## Note

This is a correct, independent improvement to the router's keyboard handling. It is **not** a fix for the giga search-screen focus-loss bug — that had a separate root cause (a `<Show>` re-anchoring its sibling `<Input>`; fixed app-side and tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)