### PR TITLE
perf(control-flow): rebuild <Show> only when the condition changes

### DIFF
--- a/crates/whisker/src/control_flow.rs
+++ b/crates/whisker/src/control_flow.rs
@@ -39,7 +39,7 @@
 //! in the Lynx tree, so the on-screen DOM is wrapper-less while
 //! the user code keeps its hierarchical mental model.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::Rc;
@@ -160,6 +160,18 @@ where
 /// mounted branch's owner is disposed before the other branch is
 /// instantiated, so reactive state from the previous branch can't
 /// leak.
+///
+/// The branch is rebuilt only when the condition **changes**, not on
+/// every dependency change of `when`. `WriteSignal::set` notifies
+/// unconditionally (even when the value is unchanged), so an effect
+/// keyed on a signal `when` reads would otherwise tear down and
+/// re-mount its branch for a no-op write — churning the DOM, disposing
+/// the branch's internal reactive state, re-firing its `on_mount`, and
+/// (through phantom hoisting) re-anchoring the *following siblings*,
+/// which resigns a sibling native input's focus. Tracking the last
+/// condition and skipping the rebuild avoids all of that. `when.call()`
+/// is still evaluated every run, so the effect's dependency
+/// subscription is preserved.
 #[component]
 pub fn show(
     when: WhenFn,
@@ -172,6 +184,8 @@ pub fn show(
     // can dispose + detach on every flip.
     type Mounted = Rc<RefCell<Option<(Owner, Vec<Element>)>>>;
     let mounted: Mounted = Rc::new(RefCell::new(None));
+    // The condition the mounted branch reflects; `None` until first run.
+    let last_cond: Rc<Cell<Option<bool>>> = Rc::new(Cell::new(None));
 
     // Clone props into the effect's capture set so the outer body
     // (a `FnMut` per `#[component]`'s hot-reload wrapper) never has
@@ -181,6 +195,14 @@ pub fn show(
     let fallback = fallback.clone();
 
     effect(move || {
+        // Evaluate every run (keeps the dependency subscription), but
+        // only rebuild when the condition actually changed.
+        let cond = when.call();
+        if last_cond.get() == Some(cond) {
+            return;
+        }
+        last_cond.set(Some(cond));
+
         // Tear down the previously-mounted branch.
         if let Some((owner, handles)) = mounted.borrow_mut().take() {
             for h in handles {
@@ -188,8 +210,6 @@ pub fn show(
             }
             owner.dispose();
         }
-
-        let cond = when.call();
 
         if cond {
             // Truthy branch: `children` is `Children` = `Fn() -> View`.

--- a/crates/whisker/tests/show_skip.rs
+++ b/crates/whisker/tests/show_skip.rs
@@ -1,0 +1,143 @@
+//! `Show` rebuilds its branch only when the condition **changes**, not
+//! on every dependency change of `when`.
+//!
+//! `WriteSignal::set` notifies subscribers unconditionally (even for a
+//! no-op write), so an effect keyed on a signal that `when` reads used
+//! to tear down and re-mount the branch for an unchanged condition —
+//! churning the DOM, disposing branch-internal state, and re-anchoring
+//! following siblings. These tests pin the fixed behaviour.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use whisker::Owner;
+use whisker::prelude::*;
+use whisker::runtime::reactive::{__reset_for_tests, flush};
+use whisker::runtime::view::{DynRenderer, Element, install_renderer, uninstall_renderer};
+
+// ----- Recording renderer (records the mutations we care about) --------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Op {
+    Create { id: u32 },
+    Append { parent: u32, child: u32 },
+    Remove { parent: u32, child: u32 },
+}
+
+#[derive(Default)]
+struct Recorder {
+    next: std::cell::Cell<u32>,
+    log: Rc<RefCell<Vec<Op>>>,
+}
+
+impl DynRenderer for Recorder {
+    fn create_element(&self, _tag: ElementTag) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
+        self.log.borrow_mut().push(Op::Create { id });
+        Element::from_raw(id)
+    }
+    fn create_element_by_name(&self, _tag_name: &str) -> Element {
+        let id = self.next.get();
+        self.next.set(id + 1);
+        self.log.borrow_mut().push(Op::Create { id });
+        Element::from_raw(id)
+    }
+    fn release_element(&self, _h: Element) {}
+    fn set_attribute(&self, _h: Element, _k: &str, _v: &str) {}
+    fn set_inline_styles(&self, _h: Element, _css: &str) {}
+    fn append_child(&self, p: Element, c: Element) {
+        self.log.borrow_mut().push(Op::Append {
+            parent: p.id(),
+            child: c.id(),
+        });
+    }
+    fn remove_child(&self, p: Element, c: Element) {
+        self.log.borrow_mut().push(Op::Remove {
+            parent: p.id(),
+            child: c.id(),
+        });
+    }
+    fn set_event_listener(
+        &self,
+        _h: Element,
+        _name: &str,
+        _bind_type: whisker::runtime::view::BindType,
+        _cb: Box<dyn Fn(whisker::WhiskerValue) + 'static>,
+    ) {
+    }
+    fn set_root(&self, _p: Element) {}
+    fn flush(&self) {}
+}
+
+fn with_test_env<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
+    __reset_for_tests();
+    let rec = Recorder::default();
+    let log = rec.log.clone();
+    let prev = install_renderer(Box::new(rec));
+    let owner = Owner::new(None);
+    let result = owner.with(|| f(log));
+    uninstall_renderer(prev);
+    result
+}
+
+#[test]
+fn unchanged_cond_does_not_rebuild_branch() {
+    with_test_env(|log| {
+        let s = RwSignal::new(0i32);
+        // The bool only flips at the threshold 10, so `s: 0 -> 1` leaves
+        // the condition `true` while still notifying the effect.
+        let _tree = render! {
+            view() {
+                Show(when: move || s.get() < 10) {
+                    text(value: "branch")
+                }
+                text(value: "sibling")
+            }
+        };
+        flush();
+
+        // Everything above is the initial mount — ignore it.
+        log.borrow_mut().clear();
+
+        // Unchanged condition: the effect re-runs (it reads `s`), but the
+        // branch must not be torn down / rebuilt, and the sibling must not
+        // be re-anchored.
+        s.set(1);
+        flush();
+
+        assert!(
+            log.borrow().is_empty(),
+            "unchanged condition must not mutate the tree, got: {:?}",
+            log.borrow()
+        );
+    });
+}
+
+#[test]
+fn changed_cond_still_rebuilds_branch() {
+    with_test_env(|log| {
+        let s = RwSignal::new(0i32);
+        let _tree = render! {
+            view() {
+                Show(when: move || s.get() < 10) {
+                    text(value: "branch")
+                }
+            }
+        };
+        flush();
+        log.borrow_mut().clear();
+
+        // Genuine flip true -> false: the branch must be torn down.
+        s.set(20);
+        flush();
+
+        assert!(
+            log.borrow()
+                .iter()
+                .any(|op| matches!(op, Op::Remove { .. })),
+            "a real condition flip must still rebuild the branch, got: {:?}",
+            log.borrow()
+        );
+    });
+}


### PR DESCRIPTION
## What

`show`'s effect rebuilt its branch on **every** run — whenever any signal its `when`/children read changed, even when the resulting condition was identical. Now it tracks the last condition and rebuilds only on a real flip.

## Why

`WriteSignal::set` notifies subscribers **unconditionally** (a no-op `set(x)` still fires them). So a `<Show>` whose `when` reads a frequently-written signal tore down + re-mounted its branch for nothing on every write.

That churn is not just wasteful — each rebuild:
- disposes the branch's internal reactive state and re-fires its `on_mount`;
- re-anchors the **following siblings** under the shared real parent (the branch mounts under a phantom, and maintaining child order re-appends later siblings). Re-anchoring a stateful native sibling — a `whisker-input` — detaches + reattaches it, dropping focus and the keyboard.

## How

Store the last condition in a `Cell<Option<bool>>`; if `when.call()` returns the same value, return early. `when.call()` is still evaluated every run, so the effect's dependency subscription is preserved — only the teardown/mount is gated.

## Tests

- `unchanged_cond_does_not_rebuild_branch` — a dep change that leaves the condition unchanged produces **zero** tree mutations.
- `changed_cond_still_rebuilds_branch` — a genuine flip still tears down the branch.
- Full `whisker` + `whisker-router` suites pass.

## Scope

This fixes the **unchanged-condition** case. A genuine condition flip still legitimately rebuilds the branch and still re-anchors following siblings — the root fix for *that* is a native `insert_before` in the Lynx bridge (removes the append+rotate in `bridge_insert_or_append`), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)