### PR TITLE
feat(renderer): positioned insert via Lynx insert_before (requires v3.8.0-whisker.13)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,23 +74,23 @@ let package = Package(
         // `swiftpm-manifest-<ver>.txt` published alongside each release.
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/Lynx-3.8.0-whisker.12.xcframework.zip",
-            checksum: "4ce496517fa600d295213235ff33d914eba6f68957f88972699c1be90a0d986c"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/Lynx-3.8.0-whisker.13.xcframework.zip",
+            checksum: "13287093478b2b637a52028f795f22b3759fc2233bc11de55fc24fe92eb18594"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/LynxBase-3.8.0-whisker.12.xcframework.zip",
-            checksum: "e581e5754cd3f2abe9eca11c372d2d18a0c0dae3cd726faeff2c6a6823adb656"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/LynxBase-3.8.0-whisker.13.xcframework.zip",
+            checksum: "8127acb7f472f170fd6734e57a0fe0028b27c6c2c184d8d859b2a703f2cc4393"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/LynxServiceAPI-3.8.0-whisker.12.xcframework.zip",
-            checksum: "0059201634a27ca331c329f01c4eab1ff604c31a40628c5f8d3b02f91f5661e2"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/LynxServiceAPI-3.8.0-whisker.13.xcframework.zip",
+            checksum: "ecd61fd412faa5e35a3e35e2550f8d9225550eb613437a0234447147a2748861"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/PrimJS-3.8.0-whisker.12.xcframework.zip",
-            checksum: "f095f00b22434823a33fbf7653a3e6ee609446f693a4fbb1f840e99ee65b70b5"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/PrimJS-3.8.0-whisker.13.xcframework.zip",
+            checksum: "0a82703ba212e61b56dfe63791b219f61517f8867fd64bd0b6ee23005f4e8e0f"
         ),
 
         // Header-only mirror of `WhiskerDriver`'s public C ABI. Source

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -164,7 +164,18 @@ pub struct PlatformSync {
 /// → `LynxUIRenderer.mEventDispatcher` to reach the live dispatcher
 /// directly and set its tapSlop, bypassing the page-config path this
 /// app never drives. Kotlin-only, no capi/Lynx ABI change.
-const WHISKER_SDK_VERSION: &str = "0.1.13";
+///
+/// 0.1.14 rolls the SDK's transitive Lynx pin `v3.8.0-whisker.12` →
+/// `v3.8.0-whisker.13`, which adds `lynx_element_insert_child_before`
+/// (positioned insert — tail addition, ABI stays v3). whisker's bridge
+/// now binds it strictly and always drives the native positioned-insert
+/// path, so a hoisted / reordered child no longer append+rotates its
+/// following siblings — which used to detach + reattach a stateful
+/// native sibling (a focused `<input>` lost focus). Apps must move to
+/// 0.1.14 to get the Lynx that exports the symbol; the per-app
+/// `WhiskerDriver` bridge built for this SDK refuses to attach to the
+/// older Lynx that lacks it (strict loader bind).
+const WHISKER_SDK_VERSION: &str = "0.1.14";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/crates/whisker-driver-sys/bridge/include/lynx_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_capi.h
@@ -212,6 +212,15 @@ typedef void (*lynx_element_append_child_fn)(lynx_fiber_element_t* parent,
                                               lynx_fiber_element_t* child);
 typedef void (*lynx_element_remove_child_fn)(lynx_fiber_element_t* parent,
                                               lynx_fiber_element_t* child);
+// Insert `child` into `parent` immediately before `reference_child`; a
+// NULL `reference_child` appends at the tail. Maps to the fiber
+// element's positioned insert (the same primitive the `<list>` diff
+// stream already relies on). OPTIONAL: an older Lynx that predates this
+// symbol leaves the pointer NULL, and callers fall back to
+// append-then-rotate.
+typedef void (*lynx_element_insert_child_before_fn)(
+    lynx_fiber_element_t* parent, lynx_fiber_element_t* child,
+    lynx_fiber_element_t* reference_child);
 typedef void (*lynx_list_set_native_item_provider_fn)(
     lynx_fiber_element_t* element,
     lynx_list_component_at_index_fn component_at_index,
@@ -327,6 +336,12 @@ typedef struct WhiskerLynxCapi {
 
   // Explicit list diff actions (metadata-carrying, ABI v3+).
   lynx_element_update_list_actions_fn element_update_list_actions;
+
+  // Positioned insert. OPTIONAL: bound tail-additively — NULL when the
+  // loaded Lynx predates the symbol. Callers feature-detect (see
+  // `whisker_bridge_supports_insert_child_before`) and fall back to
+  // append-then-rotate on old engines.
+  lynx_element_insert_child_before_fn element_insert_child_before;
 } WhiskerLynxCapi;
 
 // ----- Loader API -----------------------------------------------------------

--- a/crates/whisker-driver-sys/bridge/include/lynx_capi.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_capi.h
@@ -337,10 +337,8 @@ typedef struct WhiskerLynxCapi {
   // Explicit list diff actions (metadata-carrying, ABI v3+).
   lynx_element_update_list_actions_fn element_update_list_actions;
 
-  // Positioned insert. OPTIONAL: bound tail-additively — NULL when the
-  // loaded Lynx predates the symbol. Callers feature-detect (see
-  // `whisker_bridge_supports_insert_child_before`) and fall back to
-  // append-then-rotate on old engines.
+  // Positioned insert. Required (v3.8.0-whisker.13+); whisker pins a Lynx
+  // that exports it and the loader binds it strictly.
   lynx_element_insert_child_before_fn element_insert_child_before;
 } WhiskerLynxCapi;
 

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -187,12 +187,8 @@ WHISKER_BRIDGE_EXPORT void whisker_bridge_append_child(WhiskerElement* parent, W
 // Remove `child` from `parent`. No-op if not present.
 WHISKER_BRIDGE_EXPORT void whisker_bridge_remove_child(WhiskerElement* parent, WhiskerElement* child);
 
-// Whether the loaded Lynx exposes positioned insert (1) or not (0). When
-// 0, callers must use append + rotate instead.
-WHISKER_BRIDGE_EXPORT int32_t whisker_bridge_supports_insert_child_before(void);
-
 // Insert `child` into `parent` before `reference_child` (NULL = append).
-// Only valid when `whisker_bridge_supports_insert_child_before()` is 1.
+// Backed by the required `lynx_element_insert_child_before` symbol.
 WHISKER_BRIDGE_EXPORT void whisker_bridge_insert_child_before(
     WhiskerElement* parent, WhiskerElement* child, WhiskerElement* reference_child);
 

--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -187,6 +187,15 @@ WHISKER_BRIDGE_EXPORT void whisker_bridge_append_child(WhiskerElement* parent, W
 // Remove `child` from `parent`. No-op if not present.
 WHISKER_BRIDGE_EXPORT void whisker_bridge_remove_child(WhiskerElement* parent, WhiskerElement* child);
 
+// Whether the loaded Lynx exposes positioned insert (1) or not (0). When
+// 0, callers must use append + rotate instead.
+WHISKER_BRIDGE_EXPORT int32_t whisker_bridge_supports_insert_child_before(void);
+
+// Insert `child` into `parent` before `reference_child` (NULL = append).
+// Only valid when `whisker_bridge_supports_insert_child_before()` is 1.
+WHISKER_BRIDGE_EXPORT void whisker_bridge_insert_child_before(
+    WhiskerElement* parent, WhiskerElement* child, WhiskerElement* reference_child);
+
 // Register a native event listener on `element`. When the event fires,
 // `callback(user_data)` is invoked from the Lynx TASM thread. The bridge
 // also wires the corresponding gesture/handler so the platform UI layer

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -385,6 +385,30 @@ extern "C" void whisker_bridge_remove_child(WhiskerElement* parent,
     whisker_lynx_capi()->element_remove_child(parent->handle, child->handle);
 }
 
+// Whether the loaded Lynx exposes the positioned-insert symbol. The
+// renderer queries this once to choose the fast path
+// (`whisker_bridge_insert_child_before`) over append-then-rotate.
+extern "C" int32_t whisker_bridge_supports_insert_child_before(void) {
+    return whisker_lynx_capi()->element_insert_child_before != nullptr ? 1 : 0;
+}
+
+// Insert `child` into `parent` before `reference_child` (NULL = append).
+// Only call when `whisker_bridge_supports_insert_child_before()` is true.
+extern "C" void whisker_bridge_insert_child_before(WhiskerElement* parent,
+                                                  WhiskerElement* child,
+                                                  WhiskerElement* reference_child) {
+    if (parent == nullptr || child == nullptr) return;
+    auto* insert = whisker_lynx_capi()->element_insert_child_before;
+    if (insert == nullptr) {
+        // Defensive: should not be reached (the renderer feature-detects),
+        // but degrade to an append rather than crash on a NULL call.
+        whisker_lynx_capi()->element_append_child(parent->handle, child->handle);
+        return;
+    }
+    insert(parent->handle, child->handle,
+           reference_child != nullptr ? reference_child->handle : nullptr);
+}
+
 // Superseded by Rust-side propagation reconstruction: listeners now
 // live in the `whisker-driver` renderer (keyed by element sign, with
 // their bind/catch/capture type), and dispatch runs through the

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -385,28 +385,15 @@ extern "C" void whisker_bridge_remove_child(WhiskerElement* parent,
     whisker_lynx_capi()->element_remove_child(parent->handle, child->handle);
 }
 
-// Whether the loaded Lynx exposes the positioned-insert symbol. The
-// renderer queries this once to choose the fast path
-// (`whisker_bridge_insert_child_before`) over append-then-rotate.
-extern "C" int32_t whisker_bridge_supports_insert_child_before(void) {
-    return whisker_lynx_capi()->element_insert_child_before != nullptr ? 1 : 0;
-}
-
 // Insert `child` into `parent` before `reference_child` (NULL = append).
-// Only call when `whisker_bridge_supports_insert_child_before()` is true.
+// The symbol is a required bind (see the loader), so it's always present.
 extern "C" void whisker_bridge_insert_child_before(WhiskerElement* parent,
                                                   WhiskerElement* child,
                                                   WhiskerElement* reference_child) {
     if (parent == nullptr || child == nullptr) return;
-    auto* insert = whisker_lynx_capi()->element_insert_child_before;
-    if (insert == nullptr) {
-        // Defensive: should not be reached (the renderer feature-detects),
-        // but degrade to an append rather than crash on a NULL call.
-        whisker_lynx_capi()->element_append_child(parent->handle, child->handle);
-        return;
-    }
-    insert(parent->handle, child->handle,
-           reference_child != nullptr ? reference_child->handle : nullptr);
+    whisker_lynx_capi()->element_insert_child_before(
+        parent->handle, child->handle,
+        reference_child != nullptr ? reference_child->handle : nullptr);
 }
 
 // Superseded by Rust-side propagation reconstruction: listeners now

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
@@ -190,6 +190,14 @@ int DoLoad() {
     // strict bind like the rest.
     BindSymbol(handle, "lynx_element_update_list_actions", &g_capi.element_update_list_actions, &ok);
 
+    // Positioned insert — OPTIONAL (tail-added). A missing symbol is not
+    // an error: the field stays NULL and the renderer feature-detects,
+    // falling back to append-then-rotate on an older Lynx.
+    (void)dlerror();
+    g_capi.element_insert_child_before =
+        reinterpret_cast<lynx_element_insert_child_before_fn>(
+            dlsym(handle, "lynx_element_insert_child_before"));
+
     if (!ok) return WHISKER_BRIDGE_LYNX_LOAD_ERR_MISSING_SYMBOL;
     return WHISKER_BRIDGE_LYNX_LOAD_OK;
 }

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_lynx_loader.cc
@@ -190,13 +190,11 @@ int DoLoad() {
     // strict bind like the rest.
     BindSymbol(handle, "lynx_element_update_list_actions", &g_capi.element_update_list_actions, &ok);
 
-    // Positioned insert — OPTIONAL (tail-added). A missing symbol is not
-    // an error: the field stays NULL and the renderer feature-detects,
-    // falling back to append-then-rotate on an older Lynx.
-    (void)dlerror();
-    g_capi.element_insert_child_before =
-        reinterpret_cast<lynx_element_insert_child_before_fn>(
-            dlsym(handle, "lynx_element_insert_child_before"));
+    // Positioned insert — required (v3.8.0-whisker.13+). whisker pins a
+    // Lynx that exports it, so bind it strictly: a missing symbol means
+    // the engine is too old and attach should fail loudly rather than
+    // silently degrading.
+    BindSymbol(handle, "lynx_element_insert_child_before", &g_capi.element_insert_child_before, &ok);
 
     if (!ok) return WHISKER_BRIDGE_LYNX_LOAD_ERR_MISSING_SYMBOL;
     return WHISKER_BRIDGE_LYNX_LOAD_OK;

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -332,6 +332,16 @@ unsafe extern "C" {
     pub fn whisker_bridge_append_child(parent: *mut WhiskerElement, child: *mut WhiskerElement);
     pub fn whisker_bridge_remove_child(parent: *mut WhiskerElement, child: *mut WhiskerElement);
 
+    // Positioned insert (optional Lynx symbol; see the loader). Query
+    // support first — `whisker_bridge_insert_child_before` is only valid
+    // when this returns 1.
+    pub fn whisker_bridge_supports_insert_child_before() -> i32;
+    pub fn whisker_bridge_insert_child_before(
+        parent: *mut WhiskerElement,
+        child: *mut WhiskerElement,
+        reference_child: *mut WhiskerElement,
+    );
+
     pub fn whisker_bridge_set_event_listener(
         element: *mut WhiskerElement,
         event_name: *const c_char,

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -332,10 +332,7 @@ unsafe extern "C" {
     pub fn whisker_bridge_append_child(parent: *mut WhiskerElement, child: *mut WhiskerElement);
     pub fn whisker_bridge_remove_child(parent: *mut WhiskerElement, child: *mut WhiskerElement);
 
-    // Positioned insert (optional Lynx symbol; see the loader). Query
-    // support first — `whisker_bridge_insert_child_before` is only valid
-    // when this returns 1.
-    pub fn whisker_bridge_supports_insert_child_before() -> i32;
+    // Positioned insert (required Lynx symbol, v3.8.0-whisker.13+).
     pub fn whisker_bridge_insert_child_before(
         parent: *mut WhiskerElement,
         child: *mut WhiskerElement,

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -383,9 +383,10 @@ impl DynRenderer for BridgeRenderer {
     }
 
     fn supports_insert_before(&self) -> bool {
-        // Feature-detect the optional Lynx symbol (bound by the loader
-        // via dlsym; NULL on an engine that predates it).
-        unsafe { ffi::whisker_bridge_supports_insert_child_before() != 0 }
+        // Always: whisker pins a Lynx (v3.8.0-whisker.13+) that exports
+        // the positioned-insert symbol, and the loader binds it strictly,
+        // so the bridge always drives the native path.
+        true
     }
 
     fn insert_child_before(&self, parent: Element, child: Element, reference: Option<Element>) {

--- a/crates/whisker-driver/src/lynx/renderer.rs
+++ b/crates/whisker-driver/src/lynx/renderer.rs
@@ -382,6 +382,28 @@ impl DynRenderer for BridgeRenderer {
         }
     }
 
+    fn supports_insert_before(&self) -> bool {
+        // Feature-detect the optional Lynx symbol (bound by the loader
+        // via dlsym; NULL on an engine that predates it).
+        unsafe { ffi::whisker_bridge_supports_insert_child_before() != 0 }
+    }
+
+    fn insert_child_before(&self, parent: Element, child: Element, reference: Option<Element>) {
+        // Same FFI-borrow discipline as `append_child`: do the FFI first
+        // (it can synchronously dispatch), then record the sign edge.
+        let Some(p) = self.lookup(parent) else { return };
+        let Some(c) = self.lookup(child) else { return };
+        // A `reference` that isn't currently mounted degrades to append
+        // (null reference), matching the mirror's intent.
+        let r_ptr = reference
+            .and_then(|r| self.lookup(r))
+            .map_or(std::ptr::null_mut(), |r| r.as_ptr());
+        unsafe { ffi::whisker_bridge_insert_child_before(p.as_ptr(), c.as_ptr(), r_ptr) };
+        if let (Some(cs), Some(ps)) = (self.sign_of(child), self.sign_of(parent)) {
+            self.parent_sign.borrow_mut().insert(cs, ps);
+        }
+    }
+
     fn set_event_listener(
         &self,
         handle: Element,

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -209,6 +209,22 @@ pub trait DynRenderer {
     fn append_child(&self, parent: Element, child: Element);
     fn remove_child(&self, parent: Element, child: Element);
 
+    /// Whether this renderer can insert a child before a reference
+    /// sibling in one operation. When `false`, positioned insertion is
+    /// simulated by append + rotate (see [`bridge_insert_or_append`]).
+    /// Defaults to `false` so mock / host renderers opt in explicitly.
+    fn supports_insert_before(&self) -> bool {
+        false
+    }
+
+    /// Insert `child` into `parent` immediately before `reference`
+    /// (`None` = append at the tail). Only called when
+    /// [`supports_insert_before`](Self::supports_insert_before) is
+    /// `true`; the default panics to catch a mis-wired caller.
+    fn insert_child_before(&self, _parent: Element, _child: Element, _reference: Option<Element>) {
+        unreachable!("insert_child_before called on a renderer without support");
+    }
+
     /// Register `callback` for `event_name` on `handle`.
     ///
     /// The callback receives the event body Lynx hands the handler
@@ -775,26 +791,39 @@ pub fn remove_child(parent: Element, child: Element) {
     });
 }
 
-/// Internal helper: ask the bridge to place `real_child` at
-/// `position` inside `real_parent`'s Lynx child list. The C ABI
-/// doesn't expose `insert_at`, so we simulate by appending and
-/// rotating: every real sibling that should sit *after* the child
-/// (per the mirror's DFS pre-order of real-only descendants) is
-/// detached and re-appended, ending up to the right of the new
-/// child. O(siblings_to_move) bridge calls.
+/// Internal helper: place `real_child` at `position` inside
+/// `real_parent`'s Lynx child list.
+///
+/// The mirror already includes `real_child` at `position` in the
+/// parent's real-only DFS pre-order, so the element that should sit
+/// *after* it in Lynx is the next real descendant (`position + 1`), if
+/// any — that's the reference node for a positioned insert.
+///
+/// When the renderer supports `insert_before` (a native Lynx that
+/// exposes positioned insert) this is one bridge call with no sibling
+/// churn. Otherwise it degrades to the historical append + rotate:
+/// append to the tail, then detach every real sibling that must sit
+/// after `real_child` and re-append it past the child.
+/// O(siblings_to_move) bridge calls — and, crucially, that detach +
+/// reattach re-anchors stateful native siblings (an `<input>` loses
+/// focus). Removing the fallback once the native symbol ships is the
+/// point of the whole change.
 fn bridge_insert_or_append(real_parent: Element, real_child: Element, position: usize) {
-    // Append lands the child at the tail in Lynx.
-    with_renderer(|r| r.append_child(real_parent, real_child), ());
-
-    // Mirror already includes the child at its target slot; compute
-    // the DFS real-only order to find the siblings that need to be
-    // rotated past it.
     let real_descendants = collect_transparent_real_descendants(real_parent);
+    let reference = real_descendants.get(position + 1).copied();
 
-    // Everything after `position` in mirror order must end up to the
-    // right of `real_child` in Lynx — detach and re-append in order.
-    // The "after" slice excludes `real_child` itself (at
-    // `real_descendants[position]`).
+    if with_renderer(|r| r.supports_insert_before(), false) {
+        with_renderer(
+            |r| r.insert_child_before(real_parent, real_child, reference),
+            (),
+        );
+        return;
+    }
+
+    // Fallback: append then rotate. `real_descendants` already includes
+    // `real_child` at `position`, so the "after" slice is everything
+    // past it.
+    with_renderer(|r| r.append_child(real_parent, real_child), ());
     if position + 1 < real_descendants.len() {
         let to_move: Vec<Element> = real_descendants[position + 1..].to_vec();
         for sib in &to_move {

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -799,15 +799,15 @@ pub fn remove_child(parent: Element, child: Element) {
 /// *after* it in Lynx is the next real descendant (`position + 1`), if
 /// any — that's the reference node for a positioned insert.
 ///
-/// When the renderer supports `insert_before` (a native Lynx that
-/// exposes positioned insert) this is one bridge call with no sibling
-/// churn. Otherwise it degrades to the historical append + rotate:
-/// append to the tail, then detach every real sibling that must sit
-/// after `real_child` and re-append it past the child.
-/// O(siblings_to_move) bridge calls — and, crucially, that detach +
-/// reattach re-anchors stateful native siblings (an `<input>` loses
-/// focus). Removing the fallback once the native symbol ships is the
-/// point of the whole change.
+/// The production `BridgeRenderer` (backed by Lynx v3.8.0-whisker.13+)
+/// reports `supports_insert_before`, so this is one native bridge call
+/// with no sibling churn. The append + rotate below is the generic
+/// algorithm for renderers *without* positioned insert (test mocks, a
+/// future non-Lynx backend): append to the tail, then detach every real
+/// sibling that must sit after `real_child` and re-append it past the
+/// child. That detach + reattach re-anchors stateful native siblings (an
+/// `<input>` loses focus) — which is exactly why the Lynx path never
+/// takes it.
 fn bridge_insert_or_append(real_parent: Element, real_child: Element, position: usize) {
     let real_descendants = collect_transparent_real_descendants(real_parent);
     let reference = real_descendants.get(position + 1).copied();
@@ -820,9 +820,9 @@ fn bridge_insert_or_append(real_parent: Element, real_child: Element, position: 
         return;
     }
 
-    // Fallback: append then rotate. `real_descendants` already includes
-    // `real_child` at `position`, so the "after" slice is everything
-    // past it.
+    // Generic path (no positioned insert): append then rotate.
+    // `real_descendants` already includes `real_child` at `position`, so
+    // the "after" slice is everything past it.
     with_renderer(|r| r.append_child(real_parent, real_child), ());
     if position + 1 < real_descendants.len() {
         let to_move: Vec<Element> = real_descendants[position + 1..].to_vec();

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -9,14 +9,42 @@ use crate::element::ElementTag;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
-    Create { id: u32, tag: ElementTag },
-    Release { id: u32 },
-    SetAttr { id: u32, key: String, value: String },
-    SetStyles { id: u32, css: String },
-    Append { parent: u32, child: u32 },
-    Remove { parent: u32, child: u32 },
-    Event { id: u32, name: String },
-    SetRoot { id: u32 },
+    Create {
+        id: u32,
+        tag: ElementTag,
+    },
+    Release {
+        id: u32,
+    },
+    SetAttr {
+        id: u32,
+        key: String,
+        value: String,
+    },
+    SetStyles {
+        id: u32,
+        css: String,
+    },
+    Append {
+        parent: u32,
+        child: u32,
+    },
+    Remove {
+        parent: u32,
+        child: u32,
+    },
+    Insert {
+        parent: u32,
+        child: u32,
+        reference: Option<u32>,
+    },
+    Event {
+        id: u32,
+        name: String,
+    },
+    SetRoot {
+        id: u32,
+    },
     Flush,
 }
 
@@ -27,11 +55,23 @@ struct RecordingRenderer {
     // interior mutability instead of `&mut self`.
     next_id: std::cell::Cell<u32>,
     ops: std::rc::Rc<std::cell::RefCell<Vec<Op>>>,
+    /// When set, the renderer advertises positioned insert and records
+    /// [`Op::Insert`] instead of the append + rotate fallback.
+    supports_insert: bool,
 }
 
 impl RecordingRenderer {
     fn with_log() -> (Self, std::rc::Rc<std::cell::RefCell<Vec<Op>>>) {
         let renderer = Self::default();
+        let log = renderer.ops.clone();
+        (renderer, log)
+    }
+
+    fn with_log_insert_support() -> (Self, std::rc::Rc<std::cell::RefCell<Vec<Op>>>) {
+        let renderer = Self {
+            supports_insert: true,
+            ..Self::default()
+        };
         let log = renderer.ops.clone();
         (renderer, log)
     }
@@ -83,6 +123,16 @@ impl DynRenderer for RecordingRenderer {
         self.ops.borrow_mut().push(Op::Remove {
             parent: parent.id(),
             child: child.id(),
+        });
+    }
+    fn supports_insert_before(&self) -> bool {
+        self.supports_insert
+    }
+    fn insert_child_before(&self, parent: Element, child: Element, reference: Option<Element>) {
+        self.ops.borrow_mut().push(Op::Insert {
+            parent: parent.id(),
+            child: child.id(),
+            reference: reference.map(|r| r.id()),
         });
     }
     fn set_event_listener(
@@ -289,6 +339,44 @@ fn multi_child_fragment_through_phantom_slot_hoists_all_children() {
             root.id()
         );
     }
+}
+
+#[test]
+fn phantom_hoist_into_non_tail_position_uses_positioned_insert() {
+    // A renderer that supports positioned insert must place a
+    // hoisted child with a single `insert_before` and NOT rotate the
+    // following sibling (the append + rotate that detaches a stateful
+    // native sibling and drops its focus).
+    let (renderer, log) = RecordingRenderer::with_log_insert_support();
+    let (root, a, b) = with_installed_renderer(Box::new(renderer), || {
+        let root = create_element(ElementTag::View);
+        // A phantom slot, then a real sibling `b` after it — so the
+        // slot's future content hoists to a non-tail position.
+        let slot = create_phantom_element();
+        append_child(root, slot); // root mirror = [slot]
+        let b = create_element(ElementTag::View);
+        append_child(root, b); // root real children = [b]
+        // Now a real child `a` under the slot: it hoists to `root`
+        // *before* `b`.
+        let a = create_element(ElementTag::View);
+        append_child(slot, a);
+        (root, a, b)
+    });
+
+    let ops = log.borrow();
+    assert!(
+        ops.iter().any(|o| matches!(
+            o,
+            Op::Insert { parent, child, reference }
+                if *parent == root.id() && *child == a.id() && *reference == Some(b.id())
+        )),
+        "hoisted child must be inserted before its following sibling; ops={ops:?}"
+    );
+    assert!(
+        !ops.iter()
+            .any(|o| matches!(o, Op::Remove { child, .. } if *child == b.id())),
+        "positioned insert must not rotate (remove/re-append) the sibling; ops={ops:?}"
+    );
 }
 
 // ===========================================================================

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.12").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.13").removePrefix("v")
 
 dependencies {
     if (whiskerSdkRelease) {

--- a/platforms/android/whisker-runtime/build.gradle.kts
+++ b/platforms/android/whisker-runtime/build.gradle.kts
@@ -20,7 +20,7 @@
 // `whiskerSdkRelease` Gradle property toggles the dep form: unset
 // (default) → flatDir-friendly `:LynxAndroid@aar`; `true` → Maven
 // coords pinned to `lynxFork`. The CI publish workflow sets
-// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.12`; local CLI
+// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.13`; local CLI
 // flows leave both unset and use flatDir as before.
 
 plugins {
@@ -70,7 +70,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.12").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.13").removePrefix("v")
 
 dependencies {
     api(project(":module"))

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -99,23 +99,23 @@ let package = Package(
         // until the matching module-side refactor lands).
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/Lynx-3.8.0-whisker.12.xcframework.zip",
-            checksum: "4ce496517fa600d295213235ff33d914eba6f68957f88972699c1be90a0d986c"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/Lynx-3.8.0-whisker.13.xcframework.zip",
+            checksum: "13287093478b2b637a52028f795f22b3759fc2233bc11de55fc24fe92eb18594"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/LynxBase-3.8.0-whisker.12.xcframework.zip",
-            checksum: "e581e5754cd3f2abe9eca11c372d2d18a0c0dae3cd726faeff2c6a6823adb656"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/LynxBase-3.8.0-whisker.13.xcframework.zip",
+            checksum: "8127acb7f472f170fd6734e57a0fe0028b27c6c2c184d8d859b2a703f2cc4393"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/LynxServiceAPI-3.8.0-whisker.12.xcframework.zip",
-            checksum: "0059201634a27ca331c329f01c4eab1ff604c31a40628c5f8d3b02f91f5661e2"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/LynxServiceAPI-3.8.0-whisker.13.xcframework.zip",
+            checksum: "ecd61fd412faa5e35a3e35e2550f8d9225550eb613437a0234447147a2748861"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.12/PrimJS-3.8.0-whisker.12.xcframework.zip",
-            checksum: "f095f00b22434823a33fbf7653a3e6ee609446f693a4fbb1f840e99ee65b70b5"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/PrimJS-3.8.0-whisker.13.xcframework.zip",
+            checksum: "0a82703ba212e61b56dfe63791b219f61517f8867fd64bd0b6ee23005f4e8e0f"
         ),
 
         // Phase J — minimal module-author surface. Carved out of the


### PR DESCRIPTION
Removes the append+rotate that re-anchors siblings, by using Lynx's positioned insert. **No feature-detect fallback in the Lynx path** — requires Lynx **v3.8.0-whisker.13** (released; whiskerrs/lynx PR #29).

## Problem

Lynx's C ABI had no positioned insert, so `bridge_insert_or_append` (the phantom-hoisting insert used by `<Show>`, `ForEach`, component remount) placed a hoisted child by **appending to the tail, then detaching + re-appending every following real sibling**. That rotate re-anchors a stateful native sibling — a focused `<input>` loses focus + keyboard. It's also O(siblings) bridge calls.

## Change

Threads `lynx_element_insert_child_before(parent, child, reference)` through every layer and uses it:

| Layer | Change |
|---|---|
| `lynx_capi.h` / loader | typedef + **strict** bind (required symbol; missing → attach fails) |
| bridge | `whisker_bridge_insert_child_before` (the `_supports_` feature query is gone) |
| `whisker-driver-sys` | FFI decl |
| `Renderer` trait | `insert_child_before`; `BridgeRenderer::supports_insert_before` → `true` |
| `renderer.rs` | `bridge_insert_or_append` uses one native positioned insert on the Lynx path; append+rotate is retained only as the generic algorithm for renderers **without** positioned insert (test mocks / a future non-Lynx backend) |
| pins | iOS `Package.swift` (+ `platforms/ios`) → v3.8.0-whisker.13 (url + checksum); Android gradle `lynxFork` default → .13; `WHISKER_SDK_VERSION` → 0.1.14 |

## Native side

`whiskerrs/lynx` **PR #29 merged**, tagged **v3.8.0-whisker.13**, released (`build-whisker-tarballs.yml`): `lynx_element_insert_child_before` wraps `FiberElement::InsertNodeBefore` (null reference → append). Tail addition, ABI stays v3.

## Follow-up

Publish the Android SDK **0.1.14** (`sdk-v0.1.14` tag → `publish-sdk.yml`) so external apps get the whisker.13 Lynx. `insert_child_at` (the `ForEach`-reorder rotate) can get the same treatment next.

## Tests

- `phantom_hoist_into_non_tail_position_uses_positioned_insert` — hoisted child inserts before its sibling, no rotate.
- iOS bridge cross-compiles; `whisker-runtime` (152) + `whisker-driver` (17) + view suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)