### PR TITLE
chore(ios): whisker SPM pin 0.1.2 → 0.1.3 (Lynx v3.8.0-whisker.13)

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,7 +49,7 @@ use std::process::Command;
 /// Keep in lockstep with the `Package.swift` at the repo root and the
 /// `v<version>` git tag published for SwiftPM to resolve.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
-pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.2";
+pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.3";
 
 use crate::capture::{CaptureShims, capture_env_vars_for_triple};
 


### PR DESCRIPTION
Bumps `WHISKER_IOS_SPM_VERSION` so generated iOS projects pin the whisker SwiftPM **0.1.3** tag, whose `Package.swift` Lynx binaryTargets reference **v3.8.0-whisker.13** (the release exporting `lynx_element_insert_child_before`).

Required after #318: the per-app WhiskerDriver bridge now binds that symbol strictly, so the 0.1.2 pin (Lynx .12, no symbol) would fail engine attach. The `v0.1.3` tag is cut from `main` (post-#318, so its root `Package.swift` already carries the .13 pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)