### PR TITLE
chore(ios): bump module SwiftPM whisker pins 0.1.2 → 0.1.3

### DIFF
--- a/packages/whisker-asset/Package.swift
+++ b/packages/whisker-asset/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WhiskerAsset", targets: ["WhiskerAsset"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
         // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
         // via Core Image, animated GIF via `AnimatedImageView`, in-
         // memory `NSCache` + disk cache out of the box. WebP requires

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(

--- a/packages/whisker-keyboard/Package.swift
+++ b/packages/whisker-keyboard/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "WhiskerKeyboard", targets: ["WhiskerKeyboard"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "WhiskerLocalStore", targets: ["WhiskerLocalStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
         // PoC — an external SwiftPM dependency. swift-collections is
         // Apple-maintained, header-only Swift, small enough that
         // resolving it is fast even on a cold cache. Use is minimal

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "WhiskerSvg", targets: ["WhiskerSvg"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // it there, and the package identity (the crate's dir name)
         // is unique, so the app aggregator references it via
         // `.package(path: …)` without the `ios`-dir-name collision.
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(

--- a/packages/whisker-web-browser/Package.swift
+++ b/packages/whisker-web-browser/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "WhiskerWebBrowser", targets: ["WhiskerWebBrowser"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.2"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Lockstep follow-up to #319: bump the 12 module `Package.swift` `.package(exact:)` whisker pins 0.1.2 → 0.1.3 so a generated app's root (0.1.3) and its staged modules resolve to one whisker SwiftPM version. The `v0.1.3` tag is re-pointed to include this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)