### PR TITLE
refactor(renderer): insert_child_at via positioned insert, no rotate

### DIFF
--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -719,13 +719,36 @@ pub fn append_child(parent: Element, child: Element) {
         map.insert(child, parent);
     });
 
-    // Lynx-side effect depends on phantom-ness of either end.
+    // Realize on the Lynx side. When both ends are real, this is the
+    // hot path — a direct O(1) tail append.
+    if !realize_hoisted_child(parent, child) {
+        with_renderer(|r| r.append_child(parent, child), ());
+    }
+
+    // Wrapper-less component mount handshake: if `child` is the body
+    // root of a freshly-mounted `#[component]`, its MountSite now
+    // learns where it landed (parent + previous sibling). Hot-reload
+    // remount uses this to keep mount sites anchored across patches.
+    crate::reactive::on_component_root_attached(parent, child);
+}
+
+/// Realize `child` — already placed in the mirror at its target
+/// position — into the real Lynx tree, hoisting/replaying real
+/// descendants when either end is a phantom. Reads `child`'s *current*
+/// mirror position, so it serves both a tail append ([`append_child`])
+/// and a positioned insert ([`insert_child_at`]) unchanged.
+///
+/// Returns `true` when a phantom was involved (and handled here);
+/// `false` when both ends are real, leaving the caller to do the direct
+/// real-to-real attach (`r.append_child` for a tail append, or a
+/// positioned [`bridge_insert_or_append`] for a mid-list insert).
+fn realize_hoisted_child(parent: Element, child: Element) -> bool {
     let parent_is_phantom = is_phantom(parent);
     let child_is_phantom = is_phantom(child);
     if parent_is_phantom {
         // Hoist into the nearest real ancestor. When no real ancestor
-        // exists yet (topmost phantom still detached), skip the
-        // bridge step — the next attach will replay things.
+        // exists yet (topmost phantom still detached), skip the bridge
+        // step — the next attach will replay things.
         if let Some(real_anc) = nearest_real_ancestor(parent) {
             let to_attach: Vec<Element> = if child_is_phantom {
                 collect_transparent_real_descendants(child)
@@ -737,22 +760,18 @@ pub fn append_child(parent: Element, child: Element) {
                 bridge_insert_or_append(real_anc, real, pos);
             }
         }
+        true
     } else if child_is_phantom {
-        // Phantom child carries a transparent subtree; replay any
-        // real descendants now in DFS pre-order.
+        // Phantom child carries a transparent subtree; replay any real
+        // descendants at their positions.
         for real in collect_transparent_real_descendants(child) {
             let pos = count_real_descendants_before(parent, real);
             bridge_insert_or_append(parent, real, pos);
         }
+        true
     } else {
-        with_renderer(|r| r.append_child(parent, child), ());
+        false
     }
-
-    // Wrapper-less component mount handshake: if `child` is the body
-    // root of a freshly-mounted `#[component]`, its MountSite now
-    // learns where it landed (parent + previous sibling). Hot-reload
-    // remount uses this to keep mount sites anchored across patches.
-    crate::reactive::on_component_root_attached(parent, child);
 }
 
 /// Detach `child` from `parent` in the mirror. Lynx-side: any real
@@ -835,35 +854,36 @@ fn bridge_insert_or_append(real_parent: Element, real_child: Element, position: 
     }
 }
 
-/// Insert `child` into `parent`'s child list at position `index`.
-/// If `index >= current_len`, behaves like [`append_child`].
-///
-/// First-pass implementation: Lynx's C ABI doesn't yet expose
-/// `insert_before` / `insert_at`, so we simulate ordered insertion
-/// by detaching every sibling at or after `index`, appending the
-/// new child, then re-appending the detached siblings in order. The
-/// O(N) cost is fine for `<For>` reorders and #[component] remounts
-/// where N is the parent's current child count. Replace with a
-/// direct Lynx API once the bridge gains one.
+/// Places `child` at mirror `index` in `parent`'s child list (appends
+/// when `index >= len`). The following siblings are **not touched** on
+/// the Lynx side: `child` is realized with a positioned insert
+/// ([`bridge_insert_or_append`] → native `insert_before` on Lynx), so a
+/// stateful native sibling (a focused `<input>`, a scrolled list) keeps
+/// its state — unlike the old detach-siblings / append / re-append
+/// simulation this replaced.
 pub fn insert_child_at(parent: Element, child: Element, index: usize) {
-    let to_re_append: Vec<Element> = CHILDREN_OF.with_borrow(|map| {
-        map.get(&parent)
-            .map(|children| {
-                if index >= children.len() {
-                    Vec::new()
-                } else {
-                    children[index..].to_vec()
-                }
-            })
-            .unwrap_or_default()
+    // Mirror update — insert at `index` (append if out of range).
+    CHILDREN_OF.with_borrow_mut(|map| {
+        let children = map.entry(parent).or_default();
+        if index < children.len() {
+            children.insert(index, child);
+        } else {
+            children.push(child);
+        }
     });
-    for c in &to_re_append {
-        remove_child(parent, *c);
+    PARENT_OF.with_borrow_mut(|map| {
+        map.insert(child, parent);
+    });
+
+    // Realize at the mirror position. Both-real case: a positioned
+    // insert (native `insert_before`), not a tail append — so the child
+    // lands at `index` without moving its following siblings.
+    if !realize_hoisted_child(parent, child) {
+        let pos = count_real_descendants_before(parent, child);
+        bridge_insert_or_append(parent, child, pos);
     }
-    append_child(parent, child);
-    for c in to_re_append {
-        append_child(parent, c);
-    }
+
+    crate::reactive::on_component_root_attached(parent, child);
 }
 
 /// Return the element handle that appears immediately before `child`

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -379,6 +379,45 @@ fn phantom_hoist_into_non_tail_position_uses_positioned_insert() {
     );
 }
 
+#[test]
+fn insert_child_at_non_tail_uses_positioned_insert_not_rotate() {
+    // `insert_child_at` (hot-reload remount) must place the child with a
+    // single `insert_before` and leave the following siblings attached —
+    // not detach + re-append them (the old rotate).
+    let (renderer, log) = RecordingRenderer::with_log_insert_support();
+    let (root, b, c, d) = with_installed_renderer(Box::new(renderer), || {
+        let root = create_element(ElementTag::View);
+        let a = create_element(ElementTag::View);
+        let b = create_element(ElementTag::View);
+        let c = create_element(ElementTag::View);
+        append_child(root, a);
+        append_child(root, b);
+        append_child(root, c); // root = [a, b, c]
+        // Insert `d` at index 1 → [a, d, b, c], i.e. before `b`.
+        let d = create_element(ElementTag::View);
+        insert_child_at(root, d, 1);
+        (root, b, c, d)
+    });
+
+    let ops = log.borrow();
+    assert!(
+        ops.iter().any(|o| matches!(
+            o,
+            Op::Insert { parent, child, reference }
+                if *parent == root.id() && *child == d.id() && *reference == Some(b.id())
+        )),
+        "insert_child_at must position `d` before `b`; ops={ops:?}"
+    );
+    // No sibling was detached: `b` / `c` are never removed.
+    assert!(
+        !ops.iter().any(|o| matches!(
+            o,
+            Op::Remove { child, .. } if *child == b.id() || *child == c.id()
+        )),
+        "insert_child_at must not rotate the following siblings; ops={ops:?}"
+    );
+}
+
 // ===========================================================================
 // Re-entrancy (whisker #3) — these tests pin the root-cause fix: a native
 // event that fires *synchronously during* a renderer operation must be able


### PR DESCRIPTION
Completes the append+rotate removal. Phase C (#318) made the phantom-hoisting insert (`bridge_insert_or_append`) native; this does the same for the **other** insert site, `insert_child_at` (mid-list insert used by `#[component]` hot-reload remount).

## Before

`insert_child_at` simulated ordered insertion by **detaching every sibling at/after the index, appending the child, then re-appending the siblings** — re-anchoring stateful native siblings (a focused `<input>`, a scrolled `<list>`) on every hot-reload remount insert.

## After

- Place `child` at its mirror index, then realize it via `bridge_insert_or_append` → native `insert_before` on the Lynx path. Following siblings are left attached.
- Extract `realize_hoisted_child` (phantom parent/child hoisting) shared with `append_child`; `append_child` keeps its O(1) both-real tail append.
- **Anchor-safe:** `on_component_root_attached` is a no-op during the hot-reload insert pass (`PENDING_MOUNT` drained first), so the old re-append never updated mount-site anchors — the native reorder was pure churn. Verified: full `whisker-runtime` (153) incl. `remount_components_*` tests pass.

## Result

append+rotate is gone from **both** production insert paths. The only remaining rotate is the generic fallback in `bridge_insert_or_append` for renderers **without** positioned insert (test mocks / a future non-Lynx backend) — never taken on Lynx.

Test: `insert_child_at_non_tail_uses_positioned_insert_not_rotate`.

Note: hot-reload is device-sensitive; on-device hot-patch verification (edit a component with a focused sibling input, confirm focus survives the remount) is recommended before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)