### PR TITLE
feat(whisker-paths): resolve per-app directories for std::fs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4453,6 +4453,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-paths"
+version = "0.9.0"
+dependencies = [
+ "whisker",
+]
+
+[[package]]
+name = "whisker-paths-example"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+ "whisker-paths",
+]
+
+[[package]]
 name = "whisker-plugin"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ members = [
     "packages/whisker-input/example",
     "packages/whisker-keyboard",
     "packages/whisker-local-store",
+    "packages/whisker-paths",
+    "packages/whisker-paths/example",
     "packages/whisker-router",
     "packages/whisker-router/example",
     "packages/whisker-router-macros",

--- a/packages/whisker-paths/CHANGELOG.md
+++ b/packages/whisker-paths/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- *(whisker-paths)* resolve per-app directories (cache / document / support / temp) via a native module, for use with `std::fs`

--- a/packages/whisker-paths/Cargo.toml
+++ b/packages/whisker-paths/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "whisker-paths"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Whisker platform module — resolve the OS's per-app directories (cache, documents, application-support, temp). std::fs already does file I/O on-device; this crate only supplies the runtime paths std can't know. iOS: NSSearchPathForDirectoriesInDomains / NSTemporaryDirectory. Android: Context.getCacheDir / getFilesDir."
+
+# Explicit `include` list — mirrors `whisker-secure-store`. `cargo
+# publish` ships the Kotlin + Swift platform sources alongside
+# `src/lib.rs`, but never the local Gradle / Xcode build artifacts.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "src/lib.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+# rlib only. The Whisker module system distributes the native sources
+# out-of-band via the `android/` + `ios/` package dirs — no cdylib here.
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker. Identifies this crate as a Whisker
+# module so `whisker-build` wires its Android Gradle subproject + iOS
+# SwiftPM package into any consuming app's build.
+[package.metadata.whisker]
+
+[dependencies]
+whisker = { workspace = true }

--- a/packages/whisker-paths/Package.swift
+++ b/packages/whisker-paths/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for the `whisker-paths` module package's iOS half.
+// See `whisker-secure-store/Package.swift` for the architectural
+// rationale (env-injected whisker package path, codegen plugin, etc.).
+//
+// No external SwiftPM dependency: the directory APIs live in
+// `Foundation`, auto-linked on Apple platforms.
+
+import PackageDescription
+
+let package = Package(
+    name: "whisker-paths",
+    // macOS 13 is required because the SwiftPM build plugin
+    // (`WhiskerModuleCodegenPlugin`) is hosted by SwiftSyntax, which
+    // requires that floor at build time. Runtime artefacts only need
+    // iOS 13.
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerPaths", targets: ["WhiskerPaths"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerPaths",
+            dependencies: [
+                .product(name: "WhiskerModule", package: "whisker"),
+            ],
+            // Swift sources under the package's `ios/` directory
+            // (Expo-style layout), next to `android/` and `src/`.
+            path: "ios/Sources/WhiskerPaths",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "whisker"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-paths/README.md
+++ b/packages/whisker-paths/README.md
@@ -1,0 +1,45 @@
+# whisker-paths
+
+Resolve the OS's per-app directories (cache, documents, application-support, temp) for a Whisker app.
+
+Whisker apps run their Rust on-device, so [`std::fs`](https://doc.rust-lang.org/std/fs/) already performs every file operation directly. The one thing `std` can't do is find the platform's per-app directories, whose absolute paths the OS only hands out at runtime. `whisker-paths` supplies exactly those paths — you use ordinary `std::fs` against them.
+
+```rust
+let dir = whisker_paths::cache_dir().join("thumbnails");
+std::fs::create_dir_all(&dir)?;
+std::fs::write(dir.join("cover.jpg"), &bytes)?;
+```
+
+## API
+
+| fn | lifetime | iOS | Android |
+|----|----------|-----|---------|
+| `cache_dir()`    | evictable under storage pressure | `NSCachesDirectory` | `Context.getCacheDir()` |
+| `document_dir()` | persistent, user data, backed up  | `NSDocumentDirectory` | `Context.getFilesDir()` |
+| `support_dir()`  | persistent, non-user, backed up   | `NSApplicationSupportDirectory` | `filesDir/support` |
+| `temp_dir()`     | cleared aggressively by the OS    | `NSTemporaryDirectory()` | `cacheDir/tmp` |
+
+Each returns a `PathBuf`. The directory is a valid path but **may not exist yet** — create it with `std::fs::create_dir_all` before writing. All four are resolved once from the native module and cached for the process lifetime.
+
+## Choosing a directory
+
+- **`cache_dir()`** — regenerable data (downloaded thumbnails, HTTP caches). The OS may delete it under storage pressure.
+- **`document_dir()`** — data the user would be upset to lose. Included in device backups.
+- **`support_dir()`** — app-managed persistent state that isn't user content. Included in device backups.
+- **`temp_dir()`** — short-lived scratch. Cleared aggressively.
+
+## Setup
+
+Add the dependency and the native module ships automatically via the Whisker module system:
+
+```toml
+[dependencies]
+whisker-paths = "0.8"
+```
+
+If the native module isn't present at runtime, the accessors log a warning and fall back to `std::env::temp_dir()`-based paths so file I/O still works.
+
+## Native source
+
+- iOS: `ios/Sources/WhiskerPaths/PathsModule.swift` (resolver: `Paths.swift`)
+- Android: `android/src/main/kotlin/rs/whisker/modules/paths/PathsModule.kt` (resolver: `Paths.kt`)

--- a/packages/whisker-paths/android/src/main/kotlin/rs/whisker/modules/paths/Paths.kt
+++ b/packages/whisker-paths/android/src/main/kotlin/rs/whisker/modules/paths/Paths.kt
@@ -1,0 +1,43 @@
+// Resolves the app's per-directory sandbox paths from the Android
+// Context.
+//
+// Plain helper — no Whisker / Lynx types. The DSL module that exposes
+// it to Rust lives in `PathsModule.kt`. Returns plain filesystem paths
+// so the Rust side can use them with std::fs directly.
+//
+// Android has no distinct "documents" / "application-support" / "temp"
+// dirs the way iOS does, so we derive them from the two real internal
+// roots: cacheDir (evictable) and filesDir (persistent). `support` and
+// `temp` are subdirectories; a returned path may not exist yet, so the
+// caller creates it with std::fs::create_dir_all.
+
+package rs.whisker.modules.paths
+
+import android.content.Context
+import rs.whisker.runtime.WhiskerApplication
+import java.io.File
+
+internal object Paths {
+    /**
+     * Resolve the app context, installed by the host app's
+     * `Application.onCreate()` before any module dispatch reaches here.
+     */
+    private fun context(): Context =
+        WhiskerApplication.appContext
+            ?: throw IllegalStateException(
+                "WhiskerPaths: WhiskerApplication.appContext not initialised — " +
+                    "ensure your Application extends WhiskerApplication and " +
+                    "super.onCreate() runs before any module dispatch",
+            )
+
+    /// The four per-app directories, keyed to match the Rust side.
+    fun directories(): Map<String, String> {
+        val ctx = context()
+        return mapOf(
+            "cache" to ctx.cacheDir.absolutePath,
+            "document" to ctx.filesDir.absolutePath,
+            "support" to File(ctx.filesDir, "support").absolutePath,
+            "temp" to File(ctx.cacheDir, "tmp").absolutePath,
+        )
+    }
+}

--- a/packages/whisker-paths/android/src/main/kotlin/rs/whisker/modules/paths/PathsModule.kt
+++ b/packages/whisker-paths/android/src/main/kotlin/rs/whisker/modules/paths/PathsModule.kt
@@ -1,0 +1,26 @@
+// `whisker-paths` ModuleDefinition (Android).
+//
+// A view-less DSL module: `definition()` has no `View(...)` block, just
+// a module-level `Function`. The KSP processor finds the `Module`
+// subclass and registers its functions with `WhiskerModuleRegistry`
+// under the `Name(...)`, so `whisker::module!("WhiskerPaths").invoke(...)`
+// from Rust routes into this handler.
+//
+// The resolution logic lives in `Paths.kt`.
+
+package rs.whisker.modules.paths
+
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerValue
+
+class PathsModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("WhiskerPaths")
+
+        // directories() -> Map { cache, document, support, temp }
+        Function("directories") {
+            WhiskerValue.Map(Paths.directories().mapValues { WhiskerValue.Str(it.value) })
+        }
+    }
+}

--- a/packages/whisker-paths/build.gradle.kts
+++ b/packages/whisker-paths/build.gradle.kts
@@ -1,0 +1,46 @@
+// Gradle build for the `whisker-paths` module's Android half.
+// See `whisker-secure-store/build.gradle.kts` for the architectural
+// rationale.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.paths"
+    compileSdk = 34
+
+    defaultConfig {
+        // Only needs Context.getCacheDir/getFilesDir, available since
+        // API 1 — floor at 21 to match whisker-local-store.
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    // build.gradle.kts sits at the package root (alongside Package.swift
+    // + Cargo.toml). Point the Kotlin source set at the package's
+    // `android/` subdir so AGP doesn't scan the Rust `src/`.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerPaths")
+    arg("whisker.crateName", "whisker-paths")
+}
+
+dependencies {
+    implementation("rs.whisker:whisker-module-android:0.1.0")
+    ksp("rs.whisker:ksp:0.1.0")
+}

--- a/packages/whisker-paths/example/Cargo.toml
+++ b/packages/whisker-paths/example/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "whisker-paths-example"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Example app for `whisker-paths`. On launch it resolves all four per-app directories, writes and reads back a file under the cache dir, and shows each result, so on-device verification of the module wiring happens in one place."
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+whisker = { workspace = true }
+whisker-paths = { path = ".." }

--- a/packages/whisker-paths/example/src/lib.rs
+++ b/packages/whisker-paths/example/src/lib.rs
@@ -1,0 +1,65 @@
+//! `whisker-paths` example app.
+//!
+//! On launch it resolves all four per-app directories, then does a
+//! write → read round-trip against a file under the cache dir, so a
+//! `whisker run` on a real device verifies the native module wiring and
+//! that `std::fs` works against the resolved paths.
+
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+
+const BG: &str = "#101012";
+const FG: &str = "#f0f0f3";
+
+#[whisker::main]
+pub fn app() -> Element {
+    let log = RwSignal::new("resolving paths…".to_string());
+
+    on_mount(move || {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "cache:    {}\n",
+            whisker_paths::cache_dir().display()
+        ));
+        out.push_str(&format!(
+            "document: {}\n",
+            whisker_paths::document_dir().display()
+        ));
+        out.push_str(&format!(
+            "support:  {}\n",
+            whisker_paths::support_dir().display()
+        ));
+        out.push_str(&format!(
+            "temp:     {}\n\n",
+            whisker_paths::temp_dir().display()
+        ));
+
+        let dir = whisker_paths::cache_dir().join("whisker-paths-example");
+        let file = dir.join("roundtrip.txt");
+        match std::fs::create_dir_all(&dir)
+            .and_then(|_| std::fs::write(&file, b"hello from whisker-paths"))
+            .and_then(|_| std::fs::read_to_string(&file))
+        {
+            Ok(s) if s == "hello from whisker-paths" => {
+                out.push_str("fs round-trip: ok (wrote + read back match)")
+            }
+            Ok(s) => out.push_str(&format!("fs round-trip: MISMATCH {s}")),
+            Err(e) => out.push_str(&format!("fs round-trip: ERROR {e}")),
+        }
+        log.set(out);
+    });
+
+    let page = format!(
+        "background-color: {BG}; flex-grow: 1; display: flex; flex-direction: column; \
+         padding-top: 72px; padding-left: 20px; padding-right: 20px;"
+    );
+    let title = format!("color: {FG}; font-size: 22px; font-weight: 700; margin-bottom: 20px;");
+    let body = format!("color: {FG}; font-size: 13px; line-height: 22px;");
+
+    render! {
+        view(style: page) {
+            text(style: title, value: "whisker-paths")
+            text(style: body, value: computed(move || log.get()))
+        }
+    }
+}

--- a/packages/whisker-paths/example/whisker.rs
+++ b/packages/whisker-paths/example/whisker.rs
@@ -1,0 +1,24 @@
+// `whisker.rs` for the `whisker-paths` example.
+//
+// Tells `whisker run` how to install / launch / hot-patch this app.
+
+pub fn configure(app: &mut whisker_config::Config) {
+    app.name("WhiskerPathsExample")
+        .bundle_id("rs.whisker.pathsexample")
+        .version("0.1.0")
+        .build_number(1);
+
+    app.android(|a| {
+        a.package("rs.whisker.pathsexample")
+            .application_id("rs.whisker.pathsexample")
+            .launcher_activity(".MainActivity")
+            .min_sdk(24)
+            .target_sdk(34);
+    });
+
+    app.ios(|i| {
+        i.bundle_id("rs.whisker.pathsexample")
+            .scheme("WhiskerPathsExample")
+            .deployment_target("13.0");
+    });
+}

--- a/packages/whisker-paths/ios/Sources/WhiskerPaths/Paths.swift
+++ b/packages/whisker-paths/ios/Sources/WhiskerPaths/Paths.swift
@@ -1,0 +1,30 @@
+// Resolves the app's per-directory sandbox paths from Foundation.
+//
+// Plain helper — no Whisker / Lynx types. The DSL module that exposes
+// it to Rust lives in `PathsModule.swift`. Returns plain filesystem
+// paths (not file:// URLs) so the Rust side can use them with std::fs
+// directly. The directories are not created here — a returned path may
+// not exist yet; the caller creates it with std::fs::create_dir_all.
+
+import Foundation
+
+enum Paths {
+    /// The four per-app directories, keyed to match the Rust side's
+    /// `cache` / `document` / `support` / `temp` lookup.
+    static func directories() -> [String: String] {
+        [
+            "cache": search(.cachesDirectory),
+            "document": search(.documentDirectory),
+            "support": search(.applicationSupportDirectory),
+            "temp": NSTemporaryDirectory(),
+        ]
+    }
+
+    /// First path for `directory` in the user domain, or the temp dir
+    /// as a last resort (the search only returns nil in exotic sandbox
+    /// configurations).
+    private static func search(_ directory: FileManager.SearchPathDirectory) -> String {
+        NSSearchPathForDirectoriesInDomains(directory, .userDomainMask, true).first
+            ?? NSTemporaryDirectory()
+    }
+}

--- a/packages/whisker-paths/ios/Sources/WhiskerPaths/PathsModule.swift
+++ b/packages/whisker-paths/ios/Sources/WhiskerPaths/PathsModule.swift
@@ -1,0 +1,24 @@
+// `whisker-paths` ModuleDefinition (iOS).
+//
+// A view-less DSL module: `definition()` has no `View(...)` block, just
+// a module-level `Function`. The SwiftPM codegen plugin discovers the
+// `Module` subclass, emits a `@_cdecl` dispatch shim, and registers it
+// so `whisker::module!("WhiskerPaths").invoke(...)` from Rust routes
+// into this handler.
+//
+// The resolution logic lives in `Paths.swift`.
+
+import WhiskerModule    // Module, ModuleDefinition, DSL
+
+public final class PathsModule: Module {
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("WhiskerPaths")
+
+            // directories() -> Map { cache, document, support, temp }
+            Function("directories") { (_: [WhiskerValue]) -> WhiskerValue in
+                .map(Paths.directories().mapValues { WhiskerValue.string($0) })
+            }
+        }
+    }
+}

--- a/packages/whisker-paths/src/lib.rs
+++ b/packages/whisker-paths/src/lib.rs
@@ -1,0 +1,134 @@
+//! `whisker-paths` — resolve the OS's per-app directories.
+//!
+//! Whisker apps run their Rust on-device, so [`std::fs`] already does
+//! every file operation (read, write, `create_dir_all`, `copy`,
+//! `rename`, `read_dir`, …) directly. The one thing `std` *can't* do is
+//! find the platform's per-app directories, whose absolute paths the OS
+//! only hands out at runtime — there is no portable "app cache dir" in
+//! `std`. This crate supplies exactly those paths and nothing else; you
+//! use ordinary `std::fs` against them.
+//!
+//! ```ignore
+//! let dir = whisker_paths::cache_dir().join("thumbnails");
+//! std::fs::create_dir_all(&dir)?;
+//! std::fs::write(dir.join("cover.jpg"), &bytes)?;
+//! ```
+//!
+//! ## The four directories
+//!
+//! | fn | lifetime | iOS | Android |
+//! |----|----------|-----|---------|
+//! | [`cache_dir`]    | evictable under storage pressure | `NSCachesDirectory` | `Context.getCacheDir()` |
+//! | [`document_dir`] | persistent, user data, backed up  | `NSDocumentDirectory` | `Context.getFilesDir()` |
+//! | [`support_dir`]  | persistent, non-user, backed up   | `NSApplicationSupportDirectory` | `filesDir/support` |
+//! | [`temp_dir`]     | cleared aggressively by the OS    | `NSTemporaryDirectory()` | `cacheDir/tmp` |
+//!
+//! Pick [`cache_dir`] for regenerable data (downloaded thumbnails,
+//! HTTP response caches), [`document_dir`] for data the user would be
+//! upset to lose, [`support_dir`] for app-managed persistent state that
+//! isn't user content, and [`temp_dir`] for short-lived scratch.
+//!
+//! The returned directory is guaranteed to be a valid path but **may
+//! not exist yet** — create it with [`std::fs::create_dir_all`] before
+//! writing. All four are resolved once from the native module and
+//! cached for the process lifetime (an app's sandbox paths never move).
+//!
+//! ## Native source
+//!
+//! The matching platform module lives at
+//!
+//! - iOS: `packages/whisker-paths/ios/Sources/WhiskerPaths/PathsModule.swift`
+//!   (resolver: `Paths.swift`)
+//! - Android: `packages/whisker-paths/android/src/main/kotlin/rs/whisker/modules/paths/PathsModule.kt`
+//!   (resolver: `Paths.kt`)
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use whisker::platform_module::WhiskerValue;
+
+/// The four resolved directories. Populated once via the native module.
+struct Directories {
+    cache: PathBuf,
+    document: PathBuf,
+    support: PathBuf,
+    temp: PathBuf,
+}
+
+fn directories() -> &'static Directories {
+    static DIRS: OnceLock<Directories> = OnceLock::new();
+    DIRS.get_or_init(resolve)
+}
+
+fn resolve() -> Directories {
+    let result = whisker::module!("WhiskerPaths").invoke("directories", Vec::new());
+
+    if let WhiskerValue::Map(map) = &result {
+        let get = |k: &str| match map.get(k) {
+            Some(WhiskerValue::String(s)) => Some(PathBuf::from(s)),
+            _ => None,
+        };
+        if let (Some(cache), Some(document), Some(support), Some(temp)) =
+            (get("cache"), get("document"), get("support"), get("temp"))
+        {
+            return Directories {
+                cache,
+                document,
+                support,
+                temp,
+            };
+        }
+    }
+
+    // The native module isn't registered (or returned an unexpected
+    // shape). Degrade to temp-based paths so file I/O keeps working, but
+    // warn — the app almost certainly forgot to add whisker-paths to its
+    // build.
+    eprintln!(
+        "whisker-paths: `WhiskerPaths.directories()` unavailable ({result:?}); \
+         falling back to std::env::temp_dir(). Ensure the whisker-paths native \
+         module is included in your app build."
+    );
+    let base = std::env::temp_dir().join("whisker-paths-fallback");
+    Directories {
+        cache: base.join("cache"),
+        document: base.join("document"),
+        support: base.join("support"),
+        temp: base.join("temp"),
+    }
+}
+
+/// App cache directory. May be evicted by the OS under storage
+/// pressure, so store only regenerable data here.
+///
+/// iOS: `NSCachesDirectory`. Android: `Context.getCacheDir()`.
+pub fn cache_dir() -> PathBuf {
+    directories().cache.clone()
+}
+
+/// Persistent user-document directory, included in device backups. Use
+/// for data the user would be upset to lose.
+///
+/// iOS: `NSDocumentDirectory`. Android: `Context.getFilesDir()`.
+pub fn document_dir() -> PathBuf {
+    directories().document.clone()
+}
+
+/// Persistent application-support directory (non-user data), included
+/// in device backups. Use for app-managed state that isn't user
+/// content.
+///
+/// iOS: `NSApplicationSupportDirectory`. Android: a `support`
+/// subdirectory of `Context.getFilesDir()`.
+pub fn support_dir() -> PathBuf {
+    directories().support.clone()
+}
+
+/// Temporary directory, cleared aggressively by the OS. Use for
+/// short-lived scratch files only.
+///
+/// iOS: `NSTemporaryDirectory()`. Android: a `tmp` subdirectory of
+/// `Context.getCacheDir()`.
+pub fn temp_dir() -> PathBuf {
+    directories().temp.clone()
+}


### PR DESCRIPTION
## What

New platform module **`whisker-paths`** exposing the OS's per-app directory paths so on-device Rust can use `std::fs` against real per-app locations.

Whisker apps run their Rust on-device, so `std::fs` already performs every file operation directly. The one thing `std` can't do is find the platform's per-app directories, whose absolute paths the OS only hands out at runtime. `whisker-paths` fills exactly that gap and nothing more.

## API

Four std-style accessors returning `PathBuf`, resolved once from a native module and cached:

| fn | lifetime | iOS | Android |
|----|----------|-----|---------|
| `cache_dir()`    | evictable under storage pressure | `NSCachesDirectory` | `Context.getCacheDir()` |
| `document_dir()` | persistent, user data, backed up  | `NSDocumentDirectory` | `Context.getFilesDir()` |
| `support_dir()`  | persistent, non-user, backed up   | `NSApplicationSupportDirectory` | `filesDir/support` |
| `temp_dir()`     | cleared aggressively by the OS    | `NSTemporaryDirectory()` | `cacheDir/tmp` |

```rust
let dir = whisker_paths::cache_dir().join("thumbnails");
std::fs::create_dir_all(&dir)?;
std::fs::write(dir.join("cover.jpg"), &bytes)?;
```

If the native module isn't registered, the accessors log a warning and fall back to `std::env::temp_dir()`-based paths.

## Design

Unlike expo-file-system (which must bridge everything because JS can't touch files), this crate is thin: the genuinely-native part is only path resolution. File I/O stays in `std::fs`. `dirs`/`directories` are unreliable on iOS/Android (desktop conventions), so paths come from the OS APIs via a small native module — same `whisker-module` shape as `whisker-secure-store`.

## Verification

E2E on **iOS simulator** and **Android emulator** via the example app — all four dirs resolve to the correct sandbox paths and a `std::fs` write → read round-trip succeeds on both.

| | cache | document | support | temp | round-trip |
|---|---|---|---|---|---|
| Android | `…/cache` | `…/files` | `…/files/support` | `…/cache/tmp` | ✅ |
| iOS | `…/Library/Caches` | `…/Documents` | `…/Library/Application Support` | `…/tmp/` | ✅ |

`cargo check` / `fmt` / `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)