### PR TITLE
fix(renderer): insert multi-child phantom hoist back-to-front

### DIFF
--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -755,7 +755,14 @@ fn realize_hoisted_child(parent: Element, child: Element) -> bool {
             } else {
                 vec![child]
             };
-            for real in to_attach {
+            // Insert back-to-front: each child's positioned-insert
+            // reference is its next real sibling, which must already be
+            // in the Lynx tree. Attaching the last child first makes each
+            // subsequent (earlier) child's reference a node inserted a
+            // step ago — a forward pass would reference batch-mates that
+            // don't exist on-device yet, and Lynx would drop all but the
+            // final (append-with-null-reference) child.
+            for real in to_attach.into_iter().rev() {
                 let pos = count_real_descendants_before(real_anc, real);
                 bridge_insert_or_append(real_anc, real, pos);
             }
@@ -763,8 +770,14 @@ fn realize_hoisted_child(parent: Element, child: Element) -> bool {
         true
     } else if child_is_phantom {
         // Phantom child carries a transparent subtree; replay any real
-        // descendants at their positions.
-        for real in collect_transparent_real_descendants(child) {
+        // descendants at their positions. Back-to-front so each
+        // positioned-insert reference (the next real sibling) is already
+        // in the Lynx tree — see the reversed loop in the phantom-parent
+        // branch above for why a forward pass drops all but one child.
+        for real in collect_transparent_real_descendants(child)
+            .into_iter()
+            .rev()
+        {
             let pos = count_real_descendants_before(parent, real);
             bridge_insert_or_append(parent, real, pos);
         }

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -341,6 +341,65 @@ fn multi_child_fragment_through_phantom_slot_hoists_all_children() {
     }
 }
 
+/// Same multi-child phantom hoist, but against a renderer that supports
+/// positioned insert (the production Lynx path). Every `insert_before`
+/// reference must be a sibling that is ALREADY in the real tree at the
+/// time of the insert — Lynx's `InsertNodeBefore` needs the reference to
+/// be a live child of the parent. A reference pointing at a batch-mate
+/// that hasn't been inserted yet silently fails on-device, dropping all
+/// but one child (the "only the first history card renders" symptom).
+#[test]
+fn multi_child_hoist_insert_support_references_already_present() {
+    let (renderer, log) = RecordingRenderer::with_log_insert_support();
+    let (root, c1, c2, c3) = with_installed_renderer(Box::new(renderer), || {
+        let root = create_element(ElementTag::View);
+        let c1 = create_element(ElementTag::View);
+        let c2 = create_element(ElementTag::View);
+        let c3 = create_element(ElementTag::View);
+        let slot = create_phantom_element();
+        View::Fragment(vec![
+            View::Element(c1),
+            View::Element(c2),
+            View::Element(c3),
+        ])
+        .attach_to(slot);
+        append_child(root, slot);
+        (root, c1, c2, c3)
+    });
+
+    let ops = log.borrow();
+    // Replay the ops as Lynx would, tracking the real child list. Every
+    // insert reference must already be present, and the final order must
+    // be c1, c2, c3.
+    let mut present: Vec<u32> = Vec::new();
+    for o in ops.iter() {
+        match o {
+            Op::Insert {
+                parent,
+                child,
+                reference,
+            } if *parent == root.id() => match reference {
+                Some(r) => {
+                    let pos = present.iter().position(|x| x == r).unwrap_or_else(|| {
+                        panic!(
+                            "insert of {child} used reference {r} not yet in the real tree; ops={ops:?}"
+                        )
+                    });
+                    present.insert(pos, *child);
+                }
+                None => present.push(*child),
+            },
+            Op::Append { parent, child } if *parent == root.id() => present.push(*child),
+            _ => {}
+        }
+    }
+    assert_eq!(
+        present,
+        vec![c1.id(), c2.id(), c3.id()],
+        "final real child order wrong; ops={ops:?}"
+    );
+}
+
 #[test]
 fn phantom_hoist_into_non_tail_position_uses_positioned_insert() {
     // A renderer that supports positioned insert must place a


### PR DESCRIPTION
## The bug

Hoisting a phantom subtree with **more than one** real descendant into a real ancestor — a `ForEach` of N items, a multi-child `Fragment` or `Router` slot — rendered only **one** child on-device.

`realize_hoisted_child` loops the batch and calls `bridge_insert_or_append(parent, real, pos)` per child. The positioned-insert reference is computed as the next real sibling **in the mirror**, but during the batch that sibling is in the mirror yet **not yet in the Lynx tree**. A forward pass produced:

```
insert(c1, ref=c2)    // c2 not a live child yet
insert(c2, ref=c3)    // c3 not a live child yet
insert(c3, ref=None)  // append
```

Lynx's `FiberElement::InsertNodeBefore` needs the reference to be a live child of the parent, so every insert but the last (which appends) silently failed — **only the last child rendered**.

This regressed when positioned insert (PR #318/#321) replaced the append+rotate simulation; the old path always appended to the tail first, so it had no reference dependency. Symptom in the field: a home "continue reading" carousel (`ForEach` of history cards) that only ever showed one card, and the older "only the first Router child mounts" Android report.

## The fix

Iterate the batch **back-to-front** in both branches of `realize_hoisted_child`. Attaching the last child first makes each earlier child's reference a node inserted a step ago — every reference is live and the final child order is preserved.

## Test

New `multi_child_hoist_insert_support_references_already_present` replays the ops against a `with_log_insert_support()` renderer and asserts every insert reference is already present + final order is c1,c2,c3. The pre-existing multi-child hoist test only used the append-fallback renderer (`with_log()`), which is why it missed this — hoisting is now covered against both renderer variants.

All 154 `whisker-runtime` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)