### PR TITLE
feat(whisker-paths): set_excluded_from_backup for iCloud backup exclusion

### DIFF
--- a/packages/whisker-paths/CHANGELOG.md
+++ b/packages/whisker-paths/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(whisker-paths)* `set_excluded_from_backup` — exclude a file/dir from iCloud backup (iOS `NSURLIsExcludedFromBackupKey`; no-op on Android). Required for re-downloadable content under `document_dir`.
+
 ## [0.9.0](https://github.com/whiskerrs/whisker/releases/tag/whisker-paths-v0.9.0) - 2026-07-21
 
 ### Added

--- a/packages/whisker-paths/README.md
+++ b/packages/whisker-paths/README.md
@@ -21,6 +21,14 @@ std::fs::write(dir.join("cover.jpg"), &bytes)?;
 
 Each returns a `PathBuf`. The directory is a valid path but **may not exist yet** — create it with `std::fs::create_dir_all` before writing. All four are resolved once from the native module and cached for the process lifetime.
 
+### Backup exclusion
+
+```rust
+whisker_paths::set_excluded_from_backup(&downloads_dir, true)?;
+```
+
+Excludes a file/directory from device backup — on iOS it sets `NSURLIsExcludedFromBackupKey` (required for re-downloadable content under `document_dir`, or Apple rejects the app); on Android it's a no-op (backup exclusion is manifest-level). The flag lives on the inode, so calling it once on a directory covers all its children.
+
 ## Choosing a directory
 
 - **`cache_dir()`** — regenerable data (downloaded thumbnails, HTTP caches). The OS may delete it under storage pressure.

--- a/packages/whisker-paths/android/src/main/kotlin/rs/whisker/modules/paths/PathsModule.kt
+++ b/packages/whisker-paths/android/src/main/kotlin/rs/whisker/modules/paths/PathsModule.kt
@@ -22,5 +22,10 @@ class PathsModule : Module() {
         Function("directories") {
             WhiskerValue.Map(Paths.directories().mapValues { WhiskerValue.Str(it.value) })
         }
+
+        // setExcludedFromBackup(path, excluded) -> Bool. No-op on Android:
+        // backup exclusion is configured at the manifest level
+        // (android:allowBackup / fullBackupContent), not per-file.
+        Function("setExcludedFromBackup") { WhiskerValue.Bool(true) }
     }
 }

--- a/packages/whisker-paths/example/src/lib.rs
+++ b/packages/whisker-paths/example/src/lib.rs
@@ -41,10 +41,21 @@ pub fn app() -> Element {
             .and_then(|_| std::fs::read_to_string(&file))
         {
             Ok(s) if s == "hello from whisker-paths" => {
-                out.push_str("fs round-trip: ok (wrote + read back match)")
+                out.push_str("fs round-trip: ok (wrote + read back match)\n")
             }
-            Ok(s) => out.push_str(&format!("fs round-trip: MISMATCH {s}")),
-            Err(e) => out.push_str(&format!("fs round-trip: ERROR {e}")),
+            Ok(s) => out.push_str(&format!("fs round-trip: MISMATCH {s}\n")),
+            Err(e) => out.push_str(&format!("fs round-trip: ERROR {e}\n")),
+        }
+
+        let backup_dir = whisker_paths::document_dir().join("whisker-paths-example");
+        match std::fs::create_dir_all(&backup_dir)
+            .map_err(|e| e.to_string())
+            .and_then(|_| {
+                whisker_paths::set_excluded_from_backup(&backup_dir, true)
+                    .map_err(|e| e.to_string())
+            }) {
+            Ok(()) => out.push_str("backup-exclusion: ok"),
+            Err(e) => out.push_str(&format!("backup-exclusion: ERROR {e}")),
         }
         log.set(out);
     });

--- a/packages/whisker-paths/ios/Sources/WhiskerPaths/Paths.swift
+++ b/packages/whisker-paths/ios/Sources/WhiskerPaths/Paths.swift
@@ -27,4 +27,16 @@ enum Paths {
         NSSearchPathForDirectoriesInDomains(directory, .userDomainMask, true).first
             ?? NSTemporaryDirectory()
     }
+
+    /// Set (or clear) `NSURLIsExcludedFromBackupKey` on a file or
+    /// directory. The flag is stored on the inode, so setting it once on
+    /// a directory excludes that directory and all current/future
+    /// children from iCloud / iTunes backups. `path` is a plain
+    /// filesystem path (as returned by `directories()` + std::fs).
+    static func setExcludedFromBackup(_ path: String, _ excluded: Bool) throws {
+        var url = URL(fileURLWithPath: path)
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = excluded
+        try url.setResourceValues(values)
+    }
 }

--- a/packages/whisker-paths/ios/Sources/WhiskerPaths/PathsModule.swift
+++ b/packages/whisker-paths/ios/Sources/WhiskerPaths/PathsModule.swift
@@ -19,6 +19,18 @@ public final class PathsModule: Module {
             Function("directories") { (_: [WhiskerValue]) -> WhiskerValue in
                 .map(Paths.directories().mapValues { WhiskerValue.string($0) })
             }
+
+            // setExcludedFromBackup(path, excluded) -> Bool | Error
+            Function("setExcludedFromBackup") { (args: [WhiskerValue]) -> WhiskerValue in
+                let path = args.first?.asString ?? ""
+                let excluded = args.count > 1 ? (args[1].asBool ?? true) : true
+                do {
+                    try Paths.setExcludedFromBackup(path, excluded)
+                    return .bool(true)
+                } catch {
+                    return .error("setExcludedFromBackup failed: \(error.localizedDescription)")
+                }
+            }
         }
     }
 }

--- a/packages/whisker-paths/src/lib.rs
+++ b/packages/whisker-paths/src/lib.rs
@@ -5,8 +5,10 @@
 //! `rename`, `read_dir`, …) directly. The one thing `std` *can't* do is
 //! find the platform's per-app directories, whose absolute paths the OS
 //! only hands out at runtime — there is no portable "app cache dir" in
-//! `std`. This crate supplies exactly those paths and nothing else; you
-//! use ordinary `std::fs` against them.
+//! `std`. This crate supplies those paths; you use ordinary `std::fs`
+//! against them. It also exposes the one other genuinely-native
+//! filesystem operation `std` can't do — [`set_excluded_from_backup`]
+//! (iOS `NSURLIsExcludedFromBackupKey`).
 //!
 //! ```ignore
 //! let dir = whisker_paths::cache_dir().join("thumbnails");
@@ -42,10 +44,10 @@
 //! - Android: `packages/whisker-paths/android/src/main/kotlin/rs/whisker/modules/paths/PathsModule.kt`
 //!   (resolver: `Paths.kt`)
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-use whisker::platform_module::WhiskerValue;
+use whisker::platform_module::{WhiskerModuleError, WhiskerValue};
 
 /// The four resolved directories. Populated once via the native module.
 struct Directories {
@@ -131,4 +133,36 @@ pub fn support_dir() -> PathBuf {
 /// `Context.getCacheDir()`.
 pub fn temp_dir() -> PathBuf {
     directories().temp.clone()
+}
+
+/// Exclude (or re-include) a file or directory from device backup.
+///
+/// On **iOS** this sets `NSURLIsExcludedFromBackupKey` — required for
+/// re-downloadable content kept under [`document_dir`], since Apple
+/// rejects apps that back up regenerable data to iCloud. The flag lives
+/// on the inode, so calling this once on a directory covers all its
+/// current and future children. On **Android** it is a no-op (backup
+/// exclusion is configured at the manifest level, not per-file) and
+/// returns `Ok(())`.
+///
+/// Best-effort: callers generally ignore the error (matching the
+/// platform behaviour of a directory that simply isn't excluded).
+pub fn set_excluded_from_backup(path: &Path, excluded: bool) -> Result<(), WhiskerModuleError> {
+    let result = whisker::module!("WhiskerPaths").invoke(
+        "setExcludedFromBackup",
+        vec![
+            WhiskerValue::String(path.to_string_lossy().into_owned()),
+            WhiskerValue::Bool(excluded),
+        ],
+    );
+    match result {
+        WhiskerValue::Bool(true) => Ok(()),
+        WhiskerValue::Bool(false) => Err(WhiskerModuleError(
+            "WhiskerPaths::set_excluded_from_backup returned false".to_string(),
+        )),
+        WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
+        other => Err(WhiskerModuleError(format!(
+            "WhiskerPaths::set_excluded_from_backup expected Bool, got {other:?}"
+        ))),
+    }
 }


### PR DESCRIPTION
## What

Adds `whisker_paths::set_excluded_from_backup(path, excluded)` — the one other genuinely-native filesystem operation `std` can't do, alongside path resolution.

```rust
whisker_paths::set_excluded_from_backup(&downloads_dir, true)?;
```

- **iOS**: sets `NSURLIsExcludedFromBackupKey` via `URLResourceValues.isExcludedFromBackup`. The flag lives on the inode, so setting it once on a directory excludes that directory and all current/future children from iCloud / iTunes backups.
- **Android**: no-op (backup exclusion is manifest-level — `android:allowBackup` / `fullBackupContent` — not per-file), returns `Ok(())`.

## Why

iOS **requires** that re-downloadable content stored under `document_dir` be excluded from iCloud backup — Apple rejects apps that back up regenerable data. First consumer: giga's downloads feature, whose downloads root lives under `document_dir`.

## Verification

E2E on the **iOS simulator** via the example app: `set_excluded_from_backup` on a real `Documents/` subdirectory returns `ok` (Swift module compiles, `setResourceValues` succeeds). `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)