### PR TITLE
feat(cng,plugin): plugin-settable splash-screen enablers

### DIFF
--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -122,6 +122,22 @@ pub struct AndroidInputs {
     /// `MainActivity` deep-link schemes. See `AndroidManifest::main_activity_url_schemes`.
     #[serde(default)]
     pub main_activity_url_schemes: Vec<String>,
+    /// Overrides `<application android:theme>`. `None` → the template
+    /// default. See `AndroidManifest::application_theme`.
+    #[serde(default)]
+    pub android_theme: Option<String>,
+    /// Extra `MainActivity.kt` imports. See
+    /// `AndroidManifest::main_activity_imports`.
+    #[serde(default)]
+    pub main_activity_imports: Vec<String>,
+    /// `MainActivity.onCreate` statements before `super.onCreate`. See
+    /// `AndroidManifest::main_activity_pre_super`.
+    #[serde(default)]
+    pub main_activity_pre_super: Vec<String>,
+    /// `MainActivity.onCreate` statements after `super.onCreate`. See
+    /// `AndroidManifest::main_activity_post_super`.
+    #[serde(default)]
+    pub main_activity_post_super: Vec<String>,
     /// Extra entries the renderer drops into the app module's
     /// `plugins { … }` block, just after the baseline Whisker /
     /// AGP / Kotlin plugin ids. Bare ids (e.g.
@@ -241,7 +257,71 @@ pub(crate) fn template_vars(inputs: &AndroidInputs) -> HashMap<&'static str, Str
         "extra_gradle_dependencies",
         render_extra_gradle_dependencies(&inputs.extra_gradle_dependencies),
     );
+    v.insert(
+        "android_theme",
+        inputs
+            .android_theme
+            .clone()
+            .unwrap_or_else(|| "@style/Theme.AppCompat.NoActionBar".to_string()),
+    );
+    let (main_activity_imports, main_activity_body) = render_main_activity(
+        &inputs.main_activity_imports,
+        &inputs.main_activity_pre_super,
+        &inputs.main_activity_post_super,
+    );
+    v.insert("main_activity_imports", main_activity_imports);
+    v.insert("main_activity_body", main_activity_body);
     v
+}
+
+/// Render `MainActivity.kt`'s extra imports + `onCreate` override body.
+///
+/// Returns `(imports, body)`:
+/// - `imports` — extra `import` lines to append after the baseline
+///   `WhiskerActivity` import (each prefixed with a leading `\n`), or
+///   empty. When a body is generated, `android.os.Bundle` is added
+///   automatically.
+/// - `body` — either empty (`class MainActivity : WhiskerActivity()`
+///   stays a one-liner) or ` { override fun onCreate(…) { … } }` when
+///   `pre_super`/`post_super` inject statements. `pre_super` runs before
+///   `super.onCreate`, `post_super` after.
+fn render_main_activity(
+    imports: &[String],
+    pre_super: &[String],
+    post_super: &[String],
+) -> (String, String) {
+    let has_body = !pre_super.is_empty() || !post_super.is_empty();
+
+    let mut import_lines: Vec<String> = Vec::new();
+    if has_body {
+        import_lines.push("android.os.Bundle".to_string());
+    }
+    for i in imports {
+        if !import_lines.contains(i) {
+            import_lines.push(i.clone());
+        }
+    }
+    let imports_str = import_lines
+        .iter()
+        .map(|i| format!("\nimport {i}"))
+        .collect::<String>();
+
+    if !has_body {
+        return (imports_str, String::new());
+    }
+
+    let indent = |lines: &[String]| {
+        lines
+            .iter()
+            .map(|l| format!("        {l}\n"))
+            .collect::<String>()
+    };
+    let body = format!(
+        " {{\n    override fun onCreate(savedInstanceState: Bundle?) {{\n{pre}        super.onCreate(savedInstanceState)\n{post}    }}\n}}",
+        pre = indent(pre_super),
+        post = indent(post_super),
+    );
+    (imports_str, body)
 }
 
 /// Render `apply_plugins` entries as Kotlin DSL lines inside the
@@ -687,6 +767,10 @@ pub fn inputs_from_with_engine(
     let extra_meta_data = android_ir.manifest.application_meta_data.clone();
     let extra_application_attributes = android_ir.manifest.application_attributes.clone();
     let main_activity_url_schemes = android_ir.manifest.main_activity_url_schemes.clone();
+    let android_theme = android_ir.manifest.application_theme.clone();
+    let main_activity_imports = android_ir.manifest.main_activity_imports.clone();
+    let main_activity_pre_super = android_ir.manifest.main_activity_pre_super.clone();
+    let main_activity_post_super = android_ir.manifest.main_activity_post_super.clone();
     let extra_gradle_plugins = android_ir.gradle.apply_plugins.clone();
     let extra_gradle_dependencies = android_ir.gradle.dependencies.clone();
     let extra_files = android_ir.extra_files.clone();
@@ -709,11 +793,16 @@ pub fn inputs_from_with_engine(
         extra_meta_data,
         extra_application_attributes,
         main_activity_url_schemes,
+        android_theme,
+        main_activity_imports,
+        main_activity_pre_super,
+        main_activity_post_super,
         extra_gradle_plugins,
         extra_gradle_dependencies,
         extra_files,
-        // Bumped 11 → 12: MainActivity intent-filter/launchMode placeholders.
-        template_version: 12,
+        // Bumped 12 → 13: `{{android_theme}}` + MainActivity import/body
+        // placeholders (plugin-driven theme override + onCreate injection).
+        template_version: 13,
     })
 }
 
@@ -754,10 +843,14 @@ mod tests {
             extra_meta_data: Vec::new(),
             extra_application_attributes: Vec::new(),
             main_activity_url_schemes: Vec::new(),
+            android_theme: None,
+            main_activity_imports: Vec::new(),
+            main_activity_pre_super: Vec::new(),
+            main_activity_post_super: Vec::new(),
             extra_gradle_plugins: Vec::new(),
             extra_gradle_dependencies: Vec::new(),
             extra_files: BTreeMap::new(),
-            template_version: 12,
+            template_version: 13,
         }
     }
 
@@ -794,6 +887,48 @@ mod tests {
         assert_eq!(vars["rust_lib_name"], "hello_world");
         assert_eq!(vars["build_number"], "1");
         assert_eq!(vars["version"], "0.1.0");
+    }
+
+    #[test]
+    fn android_theme_defaults_and_overrides() {
+        let mut inputs = sample_inputs();
+        // Default → the AppCompat NoActionBar theme (matches the manifest
+        // template's historical hardcoded value).
+        assert_eq!(
+            template_vars(&inputs)["android_theme"],
+            "@style/Theme.AppCompat.NoActionBar"
+        );
+        inputs.android_theme = Some("@style/Theme.App.Splash".into());
+        assert_eq!(
+            template_vars(&inputs)["android_theme"],
+            "@style/Theme.App.Splash"
+        );
+    }
+
+    #[test]
+    fn main_activity_stays_empty_without_injection() {
+        let (imports, body) = render_main_activity(&[], &[], &[]);
+        assert_eq!(imports, "");
+        assert_eq!(body, "");
+    }
+
+    #[test]
+    fn main_activity_injects_oncreate_with_pre_super() {
+        let (imports, body) = render_main_activity(
+            &["androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen".into()],
+            &["installSplashScreen()".into()],
+            &[],
+        );
+        // `Bundle` auto-added; the splash import follows.
+        assert!(imports.contains("\nimport android.os.Bundle"));
+        assert!(imports.contains(
+            "\nimport androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen"
+        ));
+        // The pre-super statement lands before `super.onCreate`.
+        let pre = body.find("installSplashScreen()").unwrap();
+        let sup = body.find("super.onCreate(savedInstanceState)").unwrap();
+        assert!(pre < sup, "installSplashScreen must precede super.onCreate");
+        assert!(body.starts_with(" {\n    override fun onCreate("));
     }
 
     #[test]

--- a/crates/whisker-cng/src/ios.rs
+++ b/crates/whisker-cng/src/ios.rs
@@ -82,12 +82,12 @@ pub struct IosInputs {
     /// engine's post-pipeline IR (`ctx.ios.info_plist`). Emitted
     /// just before the closing `</dict>`.
     ///
-    /// Supported `PlistValue` variants: `String`, `Boolean`,
-    /// `Integer`, and `Array<String>`. Other shapes (nested Dict,
-    /// Array of non-strings, Real) are silently dropped; the
-    /// Info.plist template is hand-rolled XML rather than a real
-    /// plist serializer, and we extend the variant set on demand
-    /// as built-in or 3rd-party plugins require it.
+    /// Rendered by [`render_extra_info_plist`], which handles every
+    /// `PlistValue` variant — `String` / `Boolean` / `Integer` / `Real`
+    /// / nested `Dict` / `Array` — recursively. The only thing dropped
+    /// is a **mixed-type array** (an array whose items aren't all
+    /// strings), since the hand-rolled XML renderer has no meaningful
+    /// mapping for it.
     #[serde(default)]
     pub extra_info_plist: BTreeMap<String, PlistValue>,
     /// Plugin-supplied additional files dropped into `gen/ios/`.
@@ -160,10 +160,14 @@ pub(crate) fn template_vars(inputs: &IosInputs) -> HashMap<&'static str, String>
         inputs.workspace_root.display().to_string(),
     );
     v.insert("whisker_user_package", inputs.user_package.clone());
-    v.insert(
-        "extra_info_plist_kvs",
-        render_extra_info_plist(&inputs.extra_info_plist),
-    );
+    // `UILaunchScreen` is no longer hardcoded in the template (so a
+    // plugin can supply the launch image/color); default it to an empty
+    // dict here, matching the old behavior, unless a plugin set it.
+    let mut info_plist = inputs.extra_info_plist.clone();
+    info_plist
+        .entry("UILaunchScreen".to_string())
+        .or_insert_with(|| PlistValue::Dict(BTreeMap::new()));
+    v.insert("extra_info_plist_kvs", render_extra_info_plist(&info_plist));
     let pbx = render_pbxproj_op_placeholders(&inputs.pbxproj_ops);
     v.insert("extra_pbxproj_build_file_entries", pbx.build_file_entries);
     v.insert(
@@ -424,44 +428,7 @@ fn render_extra_info_plist(entries: &BTreeMap<String, PlistValue>) -> String {
     }
     let mut out = String::new();
     for (key, value) in entries {
-        match value {
-            PlistValue::String(s) => {
-                out.push_str(&format!(
-                    "\t<key>{}</key>\n\t<string>{}</string>\n",
-                    escape_xml(key),
-                    escape_xml(s),
-                ));
-            }
-            PlistValue::Boolean(b) => {
-                out.push_str(&format!(
-                    "\t<key>{}</key>\n\t<{}/>\n",
-                    escape_xml(key),
-                    if *b { "true" } else { "false" },
-                ));
-            }
-            PlistValue::Integer(i) => {
-                out.push_str(&format!(
-                    "\t<key>{}</key>\n\t<integer>{i}</integer>\n",
-                    escape_xml(key),
-                ));
-            }
-            PlistValue::Array(items) => {
-                // Only String-of-string arrays land in the rendered
-                // plist; mixed arrays are dropped (see docs above).
-                if !items.iter().all(|v| matches!(v, PlistValue::String(_))) {
-                    continue;
-                }
-                out.push_str(&format!("\t<key>{}</key>\n\t<array>\n", escape_xml(key)));
-                for item in items {
-                    if let PlistValue::String(s) = item {
-                        out.push_str(&format!("\t\t<string>{}</string>\n", escape_xml(s)));
-                    }
-                }
-                out.push_str("\t</array>\n");
-            }
-            // Real / Dict / unsupported variants → drop.
-            _ => {}
-        }
+        push_plist_kv(&mut out, key, value, 1);
     }
     // Strip the trailing newline so the template's own newline
     // before `</dict>` isn't doubled up.
@@ -469,6 +436,61 @@ fn render_extra_info_plist(entries: &BTreeMap<String, PlistValue>) -> String {
         out.pop();
     }
     out
+}
+
+/// Push a `<key>…</key>` + its rendered value at `level` tabs of indent.
+fn push_plist_kv(out: &mut String, key: &str, value: &PlistValue, level: usize) {
+    // Arrays/dicts we can't render (a mixed-type array) drop the whole
+    // key rather than emit a dangling `<key>`.
+    if let PlistValue::Array(items) = value {
+        if !items.iter().all(|v| matches!(v, PlistValue::String(_))) {
+            return;
+        }
+    }
+    let ind = "\t".repeat(level);
+    out.push_str(&format!("{ind}<key>{}</key>\n", escape_xml(key)));
+    push_plist_value(out, value, level);
+}
+
+/// Render a `PlistValue` at `level` tabs of indent. Nested (dict/array)
+/// values recurse. Mirrors the plist XML the CoreFoundation serializer
+/// accepts.
+fn push_plist_value(out: &mut String, value: &PlistValue, level: usize) {
+    let ind = "\t".repeat(level);
+    match value {
+        PlistValue::String(s) => {
+            out.push_str(&format!("{ind}<string>{}</string>\n", escape_xml(s)));
+        }
+        PlistValue::Boolean(b) => {
+            out.push_str(&format!("{ind}<{}/>\n", if *b { "true" } else { "false" }));
+        }
+        PlistValue::Integer(i) => {
+            out.push_str(&format!("{ind}<integer>{i}</integer>\n"));
+        }
+        PlistValue::Real(r) => {
+            out.push_str(&format!("{ind}<real>{r}</real>\n"));
+        }
+        PlistValue::Array(items) => {
+            // String-of-string arrays only (mixed arrays are dropped by
+            // `push_plist_kv` before we get here).
+            out.push_str(&format!("{ind}<array>\n"));
+            for item in items {
+                push_plist_value(out, item, level + 1);
+            }
+            out.push_str(&format!("{ind}</array>\n"));
+        }
+        PlistValue::Dict(map) => {
+            if map.is_empty() {
+                out.push_str(&format!("{ind}<dict/>\n"));
+            } else {
+                out.push_str(&format!("{ind}<dict>\n"));
+                for (k, v) in map {
+                    push_plist_kv(out, k, v, level + 1);
+                }
+                out.push_str(&format!("{ind}</dict>\n"));
+            }
+        }
+    }
 }
 
 fn write_files(out_dir: &Path, inputs: &IosInputs) -> Result<()> {
@@ -709,7 +731,7 @@ pub fn inputs_from_with_engine(
         // The renderer handles String, Boolean, Integer, and
         // Array<String> variants; existing `gen/ios/` trees
         // regenerate so the new placeholder rendering takes effect.
-        template_version: 14,
+        template_version: 15,
     })
 }
 
@@ -746,7 +768,7 @@ mod tests {
             extra_info_plist: BTreeMap::new(),
             extra_files: BTreeMap::new(),
             pbxproj_ops: Vec::new(),
-            template_version: 14,
+            template_version: 15,
         }
     }
 

--- a/crates/whisker-cng/src/templates/android/app/src/main/AndroidManifest.xml
+++ b/crates/whisker-cng/src/templates/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:name=".{{android_application_class}}"
         android:label="{{app_name}}"
         android:usesCleartextTraffic="true"
-        android:theme="@style/Theme.AppCompat.NoActionBar"
+        android:theme="{{android_theme}}"
 {{extra_application_attributes}}        >
 {{extra_application_meta_data}}
         <activity

--- a/crates/whisker-cng/src/templates/android/app/src/main/kotlin/MainActivity.kt
+++ b/crates/whisker-cng/src/templates/android/app/src/main/kotlin/MainActivity.kt
@@ -1,15 +1,14 @@
 package {{android_application_id}}
 
-import rs.whisker.runtime.WhiskerActivity
+import rs.whisker.runtime.WhiskerActivity{{main_activity_imports}}
 
 /**
  * Host Activity for the Whisker app.
  *
- * Empty by design — [WhiskerActivity] handles WhiskerView instantiation,
+ * Empty by default — [WhiskerActivity] handles WhiskerView instantiation,
  * lifecycle forwarding, edge-to-edge window configuration, and system-bar
- * styling. Override `onCreate(savedInstanceState)` here only if the app
- * needs to wire something **before** the WhiskerView is set as the
- * content view (e.g. installing a SplashScreen). Always call
- * `super.onCreate(savedInstanceState)` last in that case.
+ * styling. A plugin may inject an `onCreate` override (e.g. to install a
+ * SplashScreen before `super.onCreate`) via the manifest IR's
+ * `main_activity_pre_super` / `main_activity_post_super`.
  */
-class MainActivity : WhiskerActivity()
+class MainActivity : WhiskerActivity(){{main_activity_body}}

--- a/crates/whisker-cng/src/templates/ios/Info.plist
+++ b/crates/whisker-cng/src/templates/ios/Info.plist
@@ -25,8 +25,6 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 	</dict>
-	<key>UILaunchScreen</key>
-	<dict/>
 {{extra_info_plist_kvs}}
 </dict>
 </plist>

--- a/crates/whisker-plugin/src/lib.rs
+++ b/crates/whisker-plugin/src/lib.rs
@@ -499,6 +499,33 @@ pub struct AndroidManifest {
     /// Non-empty also sets `launchMode="singleTask"`.
     #[serde(default)]
     pub main_activity_url_schemes: Vec<String>,
+
+    /// Overrides the `<application android:theme="…">` value. `None`
+    /// keeps the template default (`@style/Theme.AppCompat.NoActionBar`).
+    /// Set it to point the app at a plugin-generated theme — e.g. an
+    /// Android 12 splash theme (`Theme.SplashScreen` parent). Last
+    /// writer wins if several plugins set it.
+    #[serde(default)]
+    pub application_theme: Option<String>,
+
+    /// Extra `import …` lines for the generated `MainActivity.kt`
+    /// (fully-qualified, without the `import` keyword — e.g.
+    /// `"androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen"`).
+    #[serde(default)]
+    pub main_activity_imports: Vec<String>,
+
+    /// Statements injected into `MainActivity.onCreate` **before**
+    /// `super.onCreate(savedInstanceState)` — e.g. `installSplashScreen()`,
+    /// which must run before the content view is set. An `onCreate`
+    /// override is generated only when this or [`Self::main_activity_post_super`]
+    /// is non-empty; otherwise `MainActivity` stays empty.
+    #[serde(default)]
+    pub main_activity_pre_super: Vec<String>,
+
+    /// Statements injected into `MainActivity.onCreate` **after**
+    /// `super.onCreate(savedInstanceState)`.
+    #[serde(default)]
+    pub main_activity_post_super: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## What

Adds the generic `whisker-cng` / `whisker-plugin` capabilities a splash-screen config plugin needs — the whisker equivalent of Expo's `withMainActivity` + theme/plist config-plugin mods. All are reusable beyond splash.

### Android
- **App-theme override** — `AndroidManifest.application_theme` (IR) + `{{android_theme}}` in the manifest template (default `@style/Theme.AppCompat.NoActionBar`). The theme was hardcoded, so a plugin couldn't point the app at e.g. an Android 12 `Theme.SplashScreen`.
- **MainActivity code injection** — `main_activity_imports` / `main_activity_pre_super` / `main_activity_post_super` generate an `onCreate` override only when injected (`pre_super` runs before `super.onCreate`, for `installSplashScreen()`).

### iOS
- **Recursive plist rendering** — `render_extra_info_plist` now renders `Dict` / `Real` / nested values (previously dropped), so a plugin can emit e.g. a `UILaunchScreen` dict.
- **Settable `UILaunchScreen`** — removed the hardcoded empty `<key>UILaunchScreen</key><dict/>` from the Info.plist template (it blocked a plugin-set launch screen and, on iOS 14+, overrode `UILaunchStoryboardName`). `template_vars` seeds an empty default so behavior is unchanged when no plugin sets it.

## Tests

New whisker-cng tests: `android_theme_defaults_and_overrides`, `main_activity_stays_empty_without_injection`, `main_activity_injects_oncreate_with_pre_super`. `template_version` bumped (android 12→13, ios 14→15).

## Notes

The `whisker-splash-screen` config plugin that consumes these currently lives app-side (giga-local) and will graduate separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2spNCoFjuxT8FWnhw3xaa
