### PR TITLE
feat(haptics): graduate whisker-haptics into the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,6 +4378,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-haptics"
+version = "0.9.2"
+dependencies = [
+ "anyhow",
+ "serde",
+ "whisker",
+ "whisker-plugin",
+]
+
+[[package]]
 name = "whisker-icons"
 version = "0.9.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "examples/bluesky/crates/bsky-theme",
     "examples/bluesky/crates/bsky-ui-kit",
     "examples/list-smoke",
+    "packages/whisker-haptics",
     "packages/whisker-icons",
     "packages/whisker-icons/example",
     "packages/whisker-image",

--- a/packages/whisker-haptics/Cargo.toml
+++ b/packages/whisker-haptics/Cargo.toml
@@ -1,0 +1,70 @@
+[package]
+name = "whisker-haptics"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Whisker platform module — haptic feedback (impact/selection/notification) via UIFeedbackGenerator (iOS) / Vibrator (Android), mirroring expo-haptics."
+
+# Explicit `include` list — mirrors `whisker-safe-area` / `whisker-image`.
+# `cargo publish` ships the Kotlin + Swift platform sources + the plugin
+# binary alongside `src/`, but never the local Gradle / Xcode artifacts.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "bin/**/*.rs",
+    "src/**/*.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+# rlib only. The Whisker module system distributes native sources
+# out-of-band via the `android/` + `ios/` package dirs.
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker: identifies this cargo crate as a Whisker
+# module so `whisker-build` wires the Android Gradle subproject + iOS
+# SwiftPM package into the host build.
+[package.metadata.whisker]
+
+# Plugin registration — Whisker builds the `whisker-haptics-plugin`
+# binary below and runs it during every gen-tree sync. It appends the
+# Android `VIBRATE` permission (a "normal" permission — no runtime
+# dialog); haptics is meaningless without it, so opting into the plugin
+# opts into the permission. Enable via `app.plugin::<WhiskerHaptics>(|c| c)`.
+[package.metadata.whisker.plugins.whisker-haptics]
+bin = "whisker-haptics-plugin"
+
+# Subprocess binary entry point Whisker spawns.
+[[bin]]
+name = "whisker-haptics-plugin"
+path = "bin/whisker_haptics_plugin.rs"
+test = false
+bench = false
+doc = false
+
+[dependencies]
+# `whisker` (the umbrella runtime crate) is gated behind the `runtime`
+# feature so the config probe — which only needs the `plugin` module —
+# can pull this crate with `default-features = false` and skip the
+# multi-minute Lynx-bridge/driver build. Default-on so normal app deps
+# "just work".
+whisker = { workspace = true, optional = true }
+
+# Plugin support — always on (light deps: trait + IR types + JSON
+# envelope + subprocess runner).
+whisker-plugin = { workspace = true }
+serde = { workspace = true }
+anyhow = { workspace = true }
+
+[features]
+default = ["runtime"]
+runtime = ["dep:whisker"]

--- a/packages/whisker-haptics/Package.swift
+++ b/packages/whisker-haptics/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for the local `whisker-haptics` module's iOS
+// half.
+//
+// No external SwiftPM dependency: `UIImpactFeedbackGenerator` /
+// `UISelectionFeedbackGenerator` / `UINotificationFeedbackGenerator`
+// live in the system `UIKit` framework (auto-linked).
+
+import PackageDescription
+
+let package = Package(
+    name: "whisker-haptics",
+    // macOS 13 is required because the SwiftPM build plugin
+    // (`WhiskerModuleCodegenPlugin`) is hosted by SwiftSyntax, which
+    // requires that floor at build time. Runtime artefacts only need
+    // iOS 13.
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerHaptics", targets: ["WhiskerHaptics"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerHaptics",
+            dependencies: [
+                .product(name: "WhiskerModule", package: "whisker"),
+            ],
+            // Swift sources under the package's `ios/` directory
+            // (Expo-style layout), next to `android/` and `src/`.
+            path: "ios/Sources/WhiskerHaptics",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "whisker"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-haptics/README.md
+++ b/packages/whisker-haptics/README.md
@@ -1,0 +1,19 @@
+# whisker-haptics
+
+Whisker platform module for haptic feedback, mirroring
+[`expo-haptics`](https://docs.expo.dev/versions/latest/sdk/haptics/).
+
+Three stateless one-shot operations on `WhiskerHaptics` (API shape 5):
+
+- `impact(ImpactStyle)` — a physical bump (Light / Medium / Heavy).
+- `selection()` — a light tick for discrete value changes.
+- `notification(NotificationType)` — success / warning / error pattern.
+
+iOS uses `UIImpact/Selection/NotificationFeedbackGenerator`; Android uses
+`Vibrator` / `VibratorManager` (needs `android.permission.VIBRATE`, added
+automatically by this crate's plugin).
+
+```rust
+use whisker_haptics::{ImpactStyle, WhiskerHaptics};
+let _ = WhiskerHaptics::impact(ImpactStyle::Light);
+```

--- a/packages/whisker-haptics/android/src/main/kotlin/rs/whisker/modules/haptics/HapticsModule.kt
+++ b/packages/whisker-haptics/android/src/main/kotlin/rs/whisker/modules/haptics/HapticsModule.kt
@@ -1,0 +1,148 @@
+// `whisker-haptics` ModuleDefinition (Android).
+//
+// A view-less DSL module: `definition()` has no `View(...)` block, just
+// module-level `Function`s. The KSP processor finds the `Module`
+// subclass and registers its functions with `WhiskerModuleRegistry`
+// under the `Name(...)`, so `whisker::platform_module::invoke(
+// "WhiskerHaptics", ...)` from Rust routes into these handlers.
+//
+// Android has no predefined `VibrationEffect` mapping to
+// success/warning/error the way iOS's `UINotificationFeedbackGenerator`
+// does, so `notification` uses short waveform patterns instead — a
+// single tap (success), one longer buzz (warning), or three short taps
+// (error). SDK branching: `VibratorManager` needs API 31+,
+// `VibrationEffect.createPredefined`/`createWaveform` need API
+// 29+/26+ respectively; below that this falls back to the deprecated
+// `Vibrator.vibrate(ms)` / `vibrate(LongArray, repeat)` overloads.
+
+package rs.whisker.modules.haptics
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerApplication
+import rs.whisker.runtime.WhiskerValue
+
+class HapticsModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("WhiskerHaptics")
+
+        // impact(style: "light" | "medium" | "heavy") -> Null | Err
+        Function("impact") { args ->
+            try {
+                val style = args.getOrNull(0)?.asString() ?: "light"
+                Haptics.impact(style)
+                WhiskerValue.Null
+            } catch (t: Throwable) {
+                WhiskerValue.Err("WhiskerHaptics.impact failed: ${t.message}")
+            }
+        }
+
+        // selection() -> Null | Err
+        Function("selection") { _ ->
+            try {
+                Haptics.selection()
+                WhiskerValue.Null
+            } catch (t: Throwable) {
+                WhiskerValue.Err("WhiskerHaptics.selection failed: ${t.message}")
+            }
+        }
+
+        // notification(kind: "success" | "warning" | "error") -> Null | Err
+        Function("notification") { args ->
+            try {
+                val kind = args.getOrNull(0)?.asString() ?: "success"
+                Haptics.notification(kind)
+                WhiskerValue.Null
+            } catch (t: Throwable) {
+                WhiskerValue.Err("WhiskerHaptics.notification failed: ${t.message}")
+            }
+        }
+    }
+}
+
+/// Plain helper — no Whisker / Lynx types. Kept separate from
+/// `HapticsModule` so the vibration logic is testable/readable on its
+/// own, matching `whisker-pdf`'s `PdfModule`/`PdfRenderer` split.
+private object Haptics {
+    private fun context(): Context =
+        WhiskerApplication.appContext
+            ?: throw IllegalStateException(
+                "WhiskerHaptics: WhiskerApplication.appContext not initialised — " +
+                    "ensure your Application extends WhiskerApplication and " +
+                    "super.onCreate() runs before any module dispatch",
+            )
+
+    private fun vibrator(): Vibrator {
+        val ctx = context()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val manager = ctx.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+            manager.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            ctx.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        }
+    }
+
+    private fun predefined(effectId: Int, fallbackMs: Long, fallbackAmplitude: Int) {
+        val v = vibrator()
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ->
+                v.vibrate(VibrationEffect.createPredefined(effectId))
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ->
+                v.vibrate(VibrationEffect.createOneShot(fallbackMs, fallbackAmplitude))
+            else -> {
+                @Suppress("DEPRECATION")
+                v.vibrate(fallbackMs)
+            }
+        }
+    }
+
+    private fun waveform(timingsMs: LongArray, amplitudes: IntArray, fallbackPatternMs: LongArray) {
+        val v = vibrator()
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O ->
+                v.vibrate(VibrationEffect.createWaveform(timingsMs, amplitudes, -1))
+            else -> {
+                @Suppress("DEPRECATION")
+                v.vibrate(fallbackPatternMs, -1)
+            }
+        }
+    }
+
+    fun impact(style: String) {
+        when (style) {
+            "heavy" -> predefined(VibrationEffect.EFFECT_HEAVY_CLICK, fallbackMs = 30, fallbackAmplitude = 255)
+            "medium" -> predefined(VibrationEffect.EFFECT_CLICK, fallbackMs = 20, fallbackAmplitude = 180)
+            else -> predefined(VibrationEffect.EFFECT_TICK, fallbackMs = 10, fallbackAmplitude = 100)
+        }
+    }
+
+    fun selection() {
+        predefined(VibrationEffect.EFFECT_TICK, fallbackMs = 5, fallbackAmplitude = 80)
+    }
+
+    fun notification(kind: String) {
+        when (kind) {
+            "warning" -> waveform(
+                timingsMs = longArrayOf(0, 60),
+                amplitudes = intArrayOf(0, 180),
+                fallbackPatternMs = longArrayOf(0, 60),
+            )
+            "error" -> waveform(
+                timingsMs = longArrayOf(0, 40, 60, 40, 60, 40),
+                amplitudes = intArrayOf(0, 255, 0, 255, 0, 255),
+                fallbackPatternMs = longArrayOf(0, 40, 60, 40, 60, 40),
+            )
+            else -> waveform(
+                timingsMs = longArrayOf(0, 20, 40, 20),
+                amplitudes = intArrayOf(0, 150, 0, 220),
+                fallbackPatternMs = longArrayOf(0, 20, 40, 20),
+            )
+        }
+    }
+}

--- a/packages/whisker-haptics/bin/whisker_haptics_plugin.rs
+++ b/packages/whisker-haptics/bin/whisker_haptics_plugin.rs
@@ -1,0 +1,13 @@
+//! `whisker-haptics-plugin` subprocess plugin binary.
+//!
+//! The Whisker engine discovers this binary via the
+//! `[package.metadata.whisker.plugins.whisker-haptics]` table in
+//! this crate's `Cargo.toml`, builds it via `cargo build --bin
+//! whisker-haptics-plugin`, and spawns it with a `PluginRequest`
+//! JSON on stdin / `PluginResponse` JSON on stdout. The plugin logic
+//! lives in [`whisker_haptics::WhiskerHaptics`]; this file is just
+//! the wrapper.
+
+fn main() -> anyhow::Result<()> {
+    whisker_plugin::run_as_subprocess(whisker_haptics::WhiskerHaptics)
+}

--- a/packages/whisker-haptics/build.gradle.kts
+++ b/packages/whisker-haptics/build.gradle.kts
@@ -1,0 +1,49 @@
+// Gradle build for the local `whisker-haptics` module's Android half.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.haptics"
+    compileSdk = 34
+
+    defaultConfig {
+        // `VibratorManager` needs API 31; predefined `VibrationEffect`s
+        // need API 29 — both are branched at runtime in
+        // `HapticsModule.kt`, falling back to `Vibrator.vibrate(ms)`
+        // below that. No extra floor bump needed beyond the app's own
+        // minSdk.
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    // build.gradle.kts sits at the package root (alongside Package.swift
+    // + Cargo.toml). Point the Kotlin source set at the package's
+    // `android/` subdir so AGP doesn't scan the Rust `src/`.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerHaptics")
+    arg("whisker.crateName", "whisker-haptics")
+}
+
+dependencies {
+    implementation("rs.whisker:whisker-module-android:0.1.6")
+    ksp("rs.whisker:ksp:0.1.0")
+    // No extra native dep: `Vibrator`/`VibratorManager` are platform
+    // APIs — see `src/lib.rs`'s doc comment.
+}

--- a/packages/whisker-haptics/ios/Sources/WhiskerHaptics/HapticsModule.swift
+++ b/packages/whisker-haptics/ios/Sources/WhiskerHaptics/HapticsModule.swift
@@ -1,0 +1,70 @@
+// `whisker-haptics` ModuleDefinition (iOS).
+//
+// A view-less DSL module: `definition()` has no `View(...)` block, just
+// module-level `Function`s. The SwiftPM codegen plugin discovers the
+// `Module` subclass, emits a `@_cdecl` dispatch shim, and registers it
+// so `whisker::platform_module::invoke("WhiskerHaptics", ...)` from Rust
+// routes into these handlers.
+//
+// `UIImpactFeedbackGenerator`/`UISelectionFeedbackGenerator`/
+// `UINotificationFeedbackGenerator` are the same three generators
+// `expo-haptics` wraps — no permission entry needed (permission-free
+// on iOS, unlike Android's `VIBRATE`). `prepare()` is called just
+// before each trigger to minimize latency, matching Apple's own
+// recommended usage pattern; generators are created fresh per call
+// rather than cached, since holding one alive continuously would keep
+// the Taptic Engine "warmed up" for no benefit here (calls are rare,
+// user-initiated taps, not a rapid sequence).
+
+import UIKit
+import WhiskerModule // Module, ModuleDefinition, DSL
+
+public final class HapticsModule: Module {
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("WhiskerHaptics")
+
+            // impact(style: "light" | "medium" | "heavy") -> Null
+            Function("impact") { (args: [WhiskerValue]) -> WhiskerValue in
+                let style = args.first?.asString ?? "light"
+                let generator = UIImpactFeedbackGenerator(style: Self.impactStyle(style))
+                generator.prepare()
+                generator.impactOccurred()
+                return .null
+            }
+
+            // selection() -> Null
+            Function("selection") { (_: [WhiskerValue]) -> WhiskerValue in
+                let generator = UISelectionFeedbackGenerator()
+                generator.prepare()
+                generator.selectionChanged()
+                return .null
+            }
+
+            // notification(kind: "success" | "warning" | "error") -> Null
+            Function("notification") { (args: [WhiskerValue]) -> WhiskerValue in
+                let kind = args.first?.asString ?? "success"
+                let generator = UINotificationFeedbackGenerator()
+                generator.prepare()
+                generator.notificationOccurred(Self.notificationType(kind))
+                return .null
+            }
+        }
+    }
+
+    private static func impactStyle(_ raw: String) -> UIImpactFeedbackGenerator.FeedbackStyle {
+        switch raw {
+        case "heavy": return .heavy
+        case "medium": return .medium
+        default: return .light
+        }
+    }
+
+    private static func notificationType(_ raw: String) -> UINotificationFeedbackGenerator.FeedbackType {
+        switch raw {
+        case "warning": return .warning
+        case "error": return .error
+        default: return .success
+        }
+    }
+}

--- a/packages/whisker-haptics/src/lib.rs
+++ b/packages/whisker-haptics/src/lib.rs
@@ -1,4 +1,4 @@
-//! `whisker-haptics` — haptic feedback for the giga reader UI.
+//! `whisker-haptics` — haptic feedback.
 //!
 //! **API shape — 5 (Static methods).** See
 //! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
@@ -13,9 +13,7 @@
 //!   pattern communicating success/warning/error.
 //!
 //! Mirrors [`expo-haptics`](https://docs.expo.dev/versions/latest/sdk/haptics/)'s
-//! three functions exactly — this app's only RN precedent
-//! (`useReaderProgressBar.ts`) uses `selectionAsync()` +
-//! `impactAsync(Light)` and nothing else.
+//! three functions exactly.
 //!
 //! Deliberately **not async**: the native module DSL only supports
 //! synchronous `Function`s today (no `AsyncFunction` yet). Firing a

--- a/packages/whisker-haptics/src/lib.rs
+++ b/packages/whisker-haptics/src/lib.rs
@@ -1,0 +1,60 @@
+//! `whisker-haptics` — haptic feedback for the giga reader UI.
+//!
+//! **API shape — 5 (Static methods).** See
+//! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
+//! §"Shape 5". Three stateless one-shot operations, namespaced under
+//! the unit struct [`WhiskerHaptics`]:
+//!
+//! - [`impact`](WhiskerHaptics::impact) — a physical "bump", scaled
+//!   by [`ImpactStyle`]. Use for a button/card tap resolving.
+//! - [`selection`](WhiskerHaptics::selection) — a light tick, for
+//!   discrete value changes (e.g. a drag gesture starting).
+//! - [`notification`](WhiskerHaptics::notification) — a longer
+//!   pattern communicating success/warning/error.
+//!
+//! Mirrors [`expo-haptics`](https://docs.expo.dev/versions/latest/sdk/haptics/)'s
+//! three functions exactly — this app's only RN precedent
+//! (`useReaderProgressBar.ts`) uses `selectionAsync()` +
+//! `impactAsync(Light)` and nothing else.
+//!
+//! Deliberately **not async**: the native module DSL only supports
+//! synchronous `Function`s today (no `AsyncFunction` yet). Firing a
+//! haptic is already effectively instant on both platforms, so no
+//! `resource()`/`run_blocking()` wrapping is needed at call sites.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use whisker_haptics::{ImpactStyle, WhiskerHaptics};
+//!
+//! let _ = WhiskerHaptics::impact(ImpactStyle::Light);
+//! ```
+//!
+//! ## Android permission
+//!
+//! Requires `android.permission.VIBRATE` — injected automatically by
+//! this crate's [`plugin`] when the consuming app opts in via
+//! `app.plugin::<WhiskerHaptics>(|c| c)` in `whisker.rs`.
+//!
+//! ## Native source
+//!
+//! - iOS: `crates/whisker-haptics/ios/Sources/WhiskerHaptics/HapticsModule.swift`
+//! - Android: `crates/whisker-haptics/android/src/main/kotlin/rs/whisker/modules/haptics/HapticsModule.kt`
+
+/// Plugin (`Android VIBRATE` manifest injection). Always compiles —
+/// independent of the `runtime` feature so the `whisker.rs` config
+/// probe (which pulls this crate with `default-features = false`)
+/// can still resolve `WhiskerHaptics`.
+mod plugin;
+pub use plugin::*;
+
+/// `WhiskerHaptics` runtime API. Gated behind the default-on
+/// `runtime` feature so the config probe build path can skip the
+/// heavyweight `whisker` umbrella crate (Lynx bridge, driver, render
+/// layer). Apps depending on `whisker-haptics` for actual haptic
+/// calls get this re-exported automatically; the probe only sees the
+/// plugin types.
+#[cfg(feature = "runtime")]
+mod runtime;
+#[cfg(feature = "runtime")]
+pub use runtime::{ImpactStyle, NotificationType};

--- a/packages/whisker-haptics/src/plugin.rs
+++ b/packages/whisker-haptics/src/plugin.rs
@@ -1,0 +1,85 @@
+//! Whisker plugin for the haptics module.
+//!
+//! Haptic feedback is meaningless without `android.permission.VIBRATE`
+//! (a "normal" permission — auto-granted, no runtime dialog), so
+//! unlike `whisker-audio`'s config plugin, there's no opt-in flag to
+//! spell: opting into the plugin at all means opting into the
+//! permission.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! use whisker_haptics::WhiskerHaptics;
+//!
+//! app.plugin::<WhiskerHaptics>(|c| c);
+//! ```
+
+use serde::{Deserialize, Serialize};
+use whisker_plugin::{GenerateContext, Operation, Plugin, PluginConfig, Target};
+
+/// No fields — see this module's doc comment for why.
+#[derive(Default, Serialize, Deserialize)]
+pub struct WhiskerHapticsConfig;
+
+impl PluginConfig for WhiskerHapticsConfig {
+    const NAME: &'static str = "whisker-haptics";
+}
+
+/// The plugin the Whisker engine drives — either in-process or as a
+/// subprocess via the bundled `whisker-haptics-plugin` binary,
+/// depending on the engine's plugin pipeline. Also the namespace for
+/// the runtime API (`impact`/`selection`/`notification`, defined in
+/// `runtime.rs`) — one unit struct serves both roles, unlike
+/// `whisker-audio`'s split (`WhiskerAudio` the plugin vs. `Player`
+/// the runtime handle), since haptics has no handle/identity to
+/// carry, just static methods (Shape 5).
+pub struct WhiskerHaptics;
+
+impl Plugin for WhiskerHaptics {
+    type Config = WhiskerHapticsConfig;
+    fn apply(&self, ctx: &mut GenerateContext, _cfg: &WhiskerHapticsConfig) -> anyhow::Result<()> {
+        if let Some(android) = ctx.android.as_mut() {
+            android
+                .manifest
+                .permissions
+                .push("android.permission.VIBRATE".into());
+            ctx.journal.record(
+                WhiskerHapticsConfig::NAME,
+                Target::Android,
+                "manifest.permissions",
+                Operation::ArrayPush { count: 1 },
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::AndroidProjectIr;
+
+    #[test]
+    fn appends_vibrate_permission() {
+        let mut ctx = GenerateContext {
+            android: Some(AndroidProjectIr::default()),
+            ..Default::default()
+        };
+        WhiskerHaptics
+            .apply(&mut ctx, &WhiskerHapticsConfig)
+            .unwrap();
+        assert_eq!(
+            ctx.android.unwrap().manifest.permissions,
+            vec!["android.permission.VIBRATE".to_string()],
+        );
+    }
+
+    #[test]
+    fn no_android_target_is_a_no_op() {
+        let mut ctx = GenerateContext::default();
+        WhiskerHaptics
+            .apply(&mut ctx, &WhiskerHapticsConfig)
+            .unwrap();
+        assert!(ctx.android.is_none());
+    }
+}

--- a/packages/whisker-haptics/src/runtime.rs
+++ b/packages/whisker-haptics/src/runtime.rs
@@ -1,0 +1,93 @@
+//! `WhiskerHaptics` runtime API — hand-written wrapper over the
+//! framework primitive: each method builds the raw `Vec<WhiskerValue>`
+//! arg list, dispatches via
+//! `whisker::module!("WhiskerHaptics").invoke(method, args)`, and
+//! lifts the returned `WhiskerValue` into a typed result. `module!`
+//! prepends this crate's name (→ `whisker-haptics:WhiskerHaptics`) so
+//! module names never collide across crates.
+
+use whisker::platform_module::{WhiskerModuleError, WhiskerValue};
+
+use crate::plugin::WhiskerHaptics;
+
+/// Physical "bump" intensity for [`WhiskerHaptics::impact`]. Matches
+/// `expo-haptics`'s `ImpactFeedbackStyle` (`Soft`/`Rigid` aren't
+/// exposed — no call site needs them, and Android has no equivalent
+/// predefined effect).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImpactStyle {
+    Light,
+    Medium,
+    Heavy,
+}
+
+impl ImpactStyle {
+    fn as_str(self) -> &'static str {
+        match self {
+            ImpactStyle::Light => "light",
+            ImpactStyle::Medium => "medium",
+            ImpactStyle::Heavy => "heavy",
+        }
+    }
+}
+
+/// Outcome pattern for [`WhiskerHaptics::notification`]. Matches
+/// `expo-haptics`'s `NotificationFeedbackType`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotificationType {
+    Success,
+    Warning,
+    Error,
+}
+
+impl NotificationType {
+    fn as_str(self) -> &'static str {
+        match self {
+            NotificationType::Success => "success",
+            NotificationType::Warning => "warning",
+            NotificationType::Error => "error",
+        }
+    }
+}
+
+/// Typed Rust API for the `WhiskerHaptics` platform module. The
+/// struct itself lives in `plugin.rs` (see its doc comment for why);
+/// this `impl` block just adds the runtime methods.
+impl WhiskerHaptics {
+    /// Fire a physical "bump", scaled by `style`. Use when a tap
+    /// resolves (e.g. inside an `on_tap` handler) — not on every
+    /// touchstart, since a touch that turns into a scroll/drag and
+    /// never becomes a real tap shouldn't buzz.
+    pub fn impact(style: ImpactStyle) -> Result<(), WhiskerModuleError> {
+        let result = whisker::module!("WhiskerHaptics").invoke(
+            "impact",
+            vec![WhiskerValue::String(style.as_str().to_string())],
+        );
+        match result {
+            WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
+            _ => Ok(()),
+        }
+    }
+
+    /// Fire a light tick — for discrete value changes, e.g. a drag
+    /// gesture starting.
+    pub fn selection() -> Result<(), WhiskerModuleError> {
+        let result = whisker::module!("WhiskerHaptics").invoke("selection", vec![]);
+        match result {
+            WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
+            _ => Ok(()),
+        }
+    }
+
+    /// Fire a longer pattern communicating success/warning/error.
+    pub fn notification(kind: NotificationType) -> Result<(), WhiskerModuleError> {
+        let result = whisker::module!("WhiskerHaptics").invoke(
+            "notification",
+            vec![WhiskerValue::String(kind.as_str().to_string())],
+        );
+        match result {
+            WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
+            _ => Ok(()),
+        }
+    }
+}


### PR DESCRIPTION
## What

Graduates the giga-local **`whisker-haptics`** module into `packages/` as a first-class Whisker module crate (Shape 5 — static methods).

Haptic feedback mirroring [`expo-haptics`](https://docs.expo.dev/versions/latest/sdk/haptics/):

- `WhiskerHaptics::impact(ImpactStyle)` — physical bump (Light / Medium / Heavy)
- `WhiskerHaptics::selection()` — light tick
- `WhiskerHaptics::notification(NotificationType)` — success / warning / error

iOS uses `UIImpact/Selection/NotificationFeedbackGenerator`; Android uses `Vibrator` / `VibratorManager`. The bundled plugin auto-adds `android.permission.VIBRATE`.

## Changes vs the giga-local crate

- `[package]` version + metadata via `.workspace = true`; deps via `{ workspace = true }`.
- `build.gradle.kts`: `rs.whisker:whisker-module-android` `0.1.0` → `0.1.6` (matches the other `packages/` modules).
- Added to the workspace `members`.

Device-verified on iOS + Android (in giga). Compiles in the workspace on both the runtime and config-probe (`--no-default-features`) paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2spNCoFjuxT8FWnhw3xaa
