### PR TITLE
feat(status-bar): graduate whisker-status-bar into the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4542,6 +4542,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-status-bar"
+version = "0.9.2"
+dependencies = [
+ "anyhow",
+ "serde",
+ "whisker",
+ "whisker-plugin",
+]
+
+[[package]]
 name = "whisker-subsecond"
 version = "0.7.11"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "packages/whisker-safe-area",
     "packages/whisker-secure-store",
     "packages/whisker-secure-store/example",
+    "packages/whisker-status-bar",
     "packages/whisker-web-browser",
     "packages/whisker-svg",
     "packages/whisker-svg/example",

--- a/packages/whisker-status-bar/Cargo.toml
+++ b/packages/whisker-status-bar/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "whisker-status-bar"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Whisker platform module — status-bar hide/show + content style, mirroring expo-status-bar. Android-only for now (iOS is a no-op TODO)."
+
+# Explicit `include` list — mirrors `whisker-safe-area` / `whisker-image`.
+include = [
+    "Cargo.toml",
+    "Package.swift",
+    "build.gradle.kts",
+    "bin/**/*.rs",
+    "src/**/*.rs",
+    "android/**/*.kt",
+    "ios/**/*.swift",
+    "README.md",
+]
+
+[lib]
+crate-type = ["rlib"]
+
+# Module-system opt-in marker.
+[package.metadata.whisker]
+
+# Plugin registration — no-op today (Android needs no config; iOS is a
+# TODO). Kept registered so `app.plugin::<WhiskerStatusBar>(|c| c)` stays
+# valid and future iOS work has a home.
+[package.metadata.whisker.plugins.whisker-status-bar]
+bin = "whisker-status-bar-plugin"
+
+[[bin]]
+name = "whisker-status-bar-plugin"
+path = "bin/whisker_status_bar_plugin.rs"
+test = false
+bench = false
+doc = false
+
+[dependencies]
+# `whisker` gated behind the `runtime` feature so the config probe can
+# pull this crate with `default-features = false` and skip the Lynx
+# bridge/driver build. Default-on so app deps "just work".
+whisker = { workspace = true, optional = true }
+whisker-plugin = { workspace = true }
+serde = { workspace = true }
+anyhow = { workspace = true }
+
+[features]
+default = ["runtime"]
+runtime = ["dep:whisker"]

--- a/packages/whisker-status-bar/Package.swift
+++ b/packages/whisker-status-bar/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for the local `whisker-status-bar` module's iOS
+// half.
+//
+// No external SwiftPM dependency: `UIApplication` (status-bar setters)
+// lives in the system `UIKit` framework (auto-linked).
+
+import PackageDescription
+
+let package = Package(
+    name: "whisker-status-bar",
+    // macOS 13 is required because the SwiftPM build plugin
+    // (`WhiskerModuleCodegenPlugin`) is hosted by SwiftSyntax, which
+    // requires that floor at build time. Runtime artefacts only need
+    // iOS 13.
+    platforms: [.iOS(.v13), .macOS(.v13)],
+    products: [
+        .library(name: "WhiskerStatusBar", targets: ["WhiskerStatusBar"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+    ],
+    targets: [
+        .target(
+            name: "WhiskerStatusBar",
+            dependencies: [
+                .product(name: "WhiskerModule", package: "whisker"),
+            ],
+            // Swift sources under the package's `ios/` directory
+            // (Expo-style layout), next to `android/` and `src/`.
+            path: "ios/Sources/WhiskerStatusBar",
+            plugins: [
+                .plugin(name: "WhiskerModuleCodegenPlugin", package: "whisker"),
+            ]
+        ),
+    ]
+)

--- a/packages/whisker-status-bar/README.md
+++ b/packages/whisker-status-bar/README.md
@@ -1,0 +1,16 @@
+# whisker-status-bar
+
+Whisker platform module for imperative status-bar control, mirroring
+[`expo-status-bar`](https://docs.expo.dev/versions/latest/sdk/status-bar/).
+
+```rust
+use whisker_status_bar::{WhiskerStatusBar, StatusBarStyle};
+let _ = WhiskerStatusBar::set_hidden(true);
+let _ = WhiskerStatusBar::set_style(StatusBarStyle::Light);
+```
+
+> **Android-only** for now. On iOS the calls are a no-op: the only
+> status-bar API reachable from a view-less module is the deprecated
+> app-level `UIApplication.setStatusBarHidden`, which corrupts
+> `whisker-router`'s transition animations. iOS support is a TODO — it
+> needs a view-controller-based `prefersStatusBarHidden` implementation.

--- a/packages/whisker-status-bar/android/src/main/kotlin/rs/whisker/modules/status_bar/StatusBarModule.kt
+++ b/packages/whisker-status-bar/android/src/main/kotlin/rs/whisker/modules/status_bar/StatusBarModule.kt
@@ -1,0 +1,88 @@
+// `whisker-status-bar` ModuleDefinition (Android).
+//
+// A view-less DSL module: `definition()` has no `View(...)` block, just
+// module-level `Function`s. The KSP processor finds the `Module`
+// subclass and registers its functions with `WhiskerModuleRegistry`
+// under the `Name(...)`, so `whisker::platform_module::invoke(
+// "WhiskerStatusBar", ...)` from Rust routes into these handlers.
+//
+// Status-bar visibility + icon style are driven through
+// `WindowInsetsControllerCompat` (androidx.core), which backports the
+// modern `WindowInsetsController` API down to API 21. All mutation runs
+// on the UI thread (`activity.runOnUiThread`) since window changes are
+// main-thread-only and a Rust caller may invoke from any thread.
+
+package rs.whisker.modules.status_bar
+
+import android.app.Activity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import rs.whisker.runtime.Module
+import rs.whisker.runtime.ModuleDefinition
+import rs.whisker.runtime.WhiskerValue
+
+public class StatusBarModule : Module() {
+    public override fun definition(): ModuleDefinition = ModuleDefinition {
+        Name("WhiskerStatusBar")
+
+        // setHidden(hidden: Bool) -> Null | Err
+        Function("setHidden") { args ->
+            try {
+                val hidden = args.getOrNull(0)?.asBool() ?: false
+                onActivity { activity ->
+                    StatusBar.setHidden(activity, hidden)
+                }
+                WhiskerValue.Null
+            } catch (t: Throwable) {
+                WhiskerValue.Err("WhiskerStatusBar.setHidden failed: ${t.message}")
+            }
+        }
+
+        // setStyle(style: "light" | "dark") -> Null | Err
+        Function("setStyle") { args ->
+            try {
+                val style = args.getOrNull(0)?.asString() ?: "dark"
+                onActivity { activity ->
+                    StatusBar.setStyle(activity, style)
+                }
+                WhiskerValue.Null
+            } catch (t: Throwable) {
+                WhiskerValue.Err("WhiskerStatusBar.setStyle failed: ${t.message}")
+            }
+        }
+    }
+
+    /// Resolve the host activity and run `block` on its UI thread. No-op
+    /// if no activity is attached (e.g. dispatch during teardown).
+    private fun onActivity(block: (Activity) -> Unit) {
+        val activity = appContext.currentActivity ?: return
+        activity.runOnUiThread { block(activity) }
+    }
+}
+
+/// Plain helper — no Whisker types. Kept separate from `StatusBarModule`
+/// so the window logic is testable/readable on its own, matching the
+/// `whisker-haptics` `HapticsModule`/`Haptics` split.
+private object StatusBar {
+    private fun controller(activity: Activity): WindowInsetsControllerCompat =
+        WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+
+    fun setHidden(activity: Activity, hidden: Boolean) {
+        val controller = controller(activity)
+        if (hidden) {
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            controller.hide(WindowInsetsCompat.Type.statusBars())
+        } else {
+            controller.show(WindowInsetsCompat.Type.statusBars())
+        }
+    }
+
+    fun setStyle(activity: Activity, style: String) {
+        // `isAppearanceLightStatusBars = true` → dark icons (for a light
+        // background); expo's `style="dark"`. `false` → light/white icons
+        // (for a dark background); expo's `style="light"`.
+        controller(activity).isAppearanceLightStatusBars = (style == "dark")
+    }
+}

--- a/packages/whisker-status-bar/bin/whisker_status_bar_plugin.rs
+++ b/packages/whisker-status-bar/bin/whisker_status_bar_plugin.rs
@@ -1,0 +1,12 @@
+//! `whisker-status-bar-plugin` subprocess plugin binary.
+//!
+//! The Whisker engine discovers this via the
+//! `[package.metadata.whisker.plugins.whisker-status-bar]` table in
+//! this crate's `Cargo.toml`, builds it, and spawns it with a
+//! `PluginRequest` JSON on stdin / `PluginResponse` JSON on stdout. The
+//! plugin logic lives in [`whisker_status_bar::WhiskerStatusBar`]; this
+//! file is just the wrapper.
+
+fn main() -> anyhow::Result<()> {
+    whisker_plugin::run_as_subprocess(whisker_status_bar::WhiskerStatusBar)
+}

--- a/packages/whisker-status-bar/build.gradle.kts
+++ b/packages/whisker-status-bar/build.gradle.kts
@@ -1,0 +1,49 @@
+// Gradle build for the local `whisker-status-bar` module's Android half.
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27"
+}
+
+android {
+    namespace = "rs.whisker.modules.status_bar"
+    compileSdk = 34
+
+    defaultConfig {
+        // `WindowInsetsControllerCompat` (androidx.core) backports
+        // status-bar hide/show to API 21, so no floor bump beyond the
+        // app's own minSdk.
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    // build.gradle.kts sits at the package root (alongside Package.swift
+    // + Cargo.toml). Point the Kotlin source set at the package's
+    // `android/` subdir so AGP doesn't scan the Rust `src/`.
+    sourceSets {
+        getByName("main") {
+            kotlin.srcDirs("android/src/main/kotlin")
+        }
+    }
+}
+
+ksp {
+    arg("whisker.moduleName", "WhiskerStatusBar")
+    arg("whisker.crateName", "whisker-status-bar")
+}
+
+dependencies {
+    implementation("rs.whisker:whisker-module-android:0.1.6")
+    ksp("rs.whisker:ksp:0.1.0")
+    // `WindowInsetsControllerCompat` / `WindowCompat` live in
+    // androidx.core — the runtime already depends on it transitively,
+    // but declare it so this module builds standalone too.
+    implementation("androidx.core:core-ktx:1.13.1")
+}

--- a/packages/whisker-status-bar/ios/Sources/WhiskerStatusBar/StatusBarModule.swift
+++ b/packages/whisker-status-bar/ios/Sources/WhiskerStatusBar/StatusBarModule.swift
@@ -1,0 +1,49 @@
+// `whisker-status-bar` ModuleDefinition (iOS).
+//
+// A view-less DSL module: `definition()` has no `View(...)` block, just
+// module-level `Function`s. The SwiftPM codegen plugin discovers the
+// `Module` subclass, emits a `@_cdecl` dispatch shim, and registers it
+// so `whisker::platform_module::invoke("WhiskerStatusBar", ...)` from
+// Rust routes into these handlers.
+//
+// iOS decides status-bar appearance per view controller by default, so
+// these app-level `UIApplication` setters are no-ops UNLESS
+// `UIViewControllerBasedStatusBarAppearance = false` is set in
+// Info.plist — which this crate's plugin injects (see `src/plugin.rs`).
+// The setters are deprecated (since iOS 9) but remain fully functional
+// with that plist key, and are the only way for a view-less module to
+// drive the status bar without owning a view controller. This mirrors
+// what `expo-status-bar` does on iOS.
+//
+// All calls hop to the main thread — UIKit status-bar mutation is main-
+// thread-only, and a Rust caller may invoke from any thread.
+
+import UIKit
+import WhiskerModule
+
+public final class StatusBarModule: Module {
+    public override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("WhiskerStatusBar")
+
+            // setHidden(hidden: Bool) -> Null
+            Function("setHidden") { (args: [WhiskerValue]) -> WhiskerValue in
+                let hidden = args.first?.asBool ?? false
+                DispatchQueue.main.async {
+                    UIApplication.shared.setStatusBarHidden(hidden, with: .fade)
+                }
+                return .null
+            }
+
+            // setStyle(style: "light" | "dark") -> Null
+            Function("setStyle") { (args: [WhiskerValue]) -> WhiskerValue in
+                let style: UIStatusBarStyle =
+                    (args.first?.asString == "light") ? .lightContent : .darkContent
+                DispatchQueue.main.async {
+                    UIApplication.shared.setStatusBarStyle(style, animated: true)
+                }
+                return .null
+            }
+        }
+    }
+}

--- a/packages/whisker-status-bar/src/lib.rs
+++ b/packages/whisker-status-bar/src/lib.rs
@@ -1,0 +1,58 @@
+//! `whisker-status-bar` — imperative status-bar control, mirroring
+//! [`expo-status-bar`](https://docs.expo.dev/versions/latest/sdk/status-bar/)'s
+//! `setStatusBarHidden` / `setStatusBarStyle`.
+//!
+//! **API shape — 5 (Static methods).** Two stateless one-shot
+//! operations namespaced under the unit struct [`WhiskerStatusBar`]:
+//!
+//! - [`set_hidden`](WhiskerStatusBar::set_hidden) — show/hide the system
+//!   status bar (animated fade on iOS).
+//! - [`set_style`](WhiskerStatusBar::set_style) — set the content color
+//!   ([`StatusBarStyle::Light`] = light icons for a dark background,
+//!   [`StatusBarStyle::Dark`] = dark icons for a light background).
+//!
+//! Deliberately **not async** — the native module DSL only supports
+//! synchronous `Function`s today, and toggling the status bar is
+//! effectively instant on both platforms. The native handlers hop to
+//! the UI thread themselves ([`DispatchQueue.main`] / `runOnUiThread`),
+//! so callers may invoke from a reactive-thread `on_mount`/`on_cleanup`
+//! without wrapping.
+//!
+//! ## iOS setup (handled automatically)
+//!
+//! iOS routes status-bar appearance through the foreground view
+//! controller by default, which a view-less module can't reach. This
+//! crate's [`plugin`] injects `UIViewControllerBasedStatusBarAppearance
+//! = false` into `Info.plist` (when the app opts in via
+//! `app.plugin::<WhiskerStatusBar>(|c| c)`), which re-enables the
+//! app-level `UIApplication` status-bar APIs the native module calls.
+//! Android needs no such setup — `WindowInsetsControllerCompat` drives
+//! the status bar directly off the host activity's window.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use whisker_status_bar::WhiskerStatusBar;
+//!
+//! let _ = WhiskerStatusBar::set_hidden(true);
+//! ```
+//!
+//! ## Native source
+//!
+//! - iOS: `crates/whisker-status-bar/ios/Sources/WhiskerStatusBar/StatusBarModule.swift`
+//! - Android: `crates/whisker-status-bar/android/src/main/kotlin/rs/whisker/modules/status_bar/StatusBarModule.kt`
+
+/// Plugin (iOS `Info.plist` injection). Always compiles — independent
+/// of the `runtime` feature so the `whisker.rs` config probe (which
+/// pulls this crate with `default-features = false`) can resolve
+/// `WhiskerStatusBar`.
+mod plugin;
+pub use plugin::*;
+
+/// `WhiskerStatusBar` runtime API. Gated behind the default-on
+/// `runtime` feature so the config-probe build path can skip the
+/// heavyweight `whisker` umbrella crate.
+#[cfg(feature = "runtime")]
+mod runtime;
+#[cfg(feature = "runtime")]
+pub use runtime::StatusBarStyle;

--- a/packages/whisker-status-bar/src/plugin.rs
+++ b/packages/whisker-status-bar/src/plugin.rs
@@ -1,0 +1,66 @@
+//! Whisker plugin for the status-bar module.
+//!
+//! Currently a no-op: the module is **Android-only** (see `runtime.rs`),
+//! and Android needs no manifest/config entry to drive the status bar.
+//! It previously injected `UIViewControllerBasedStatusBarAppearance =
+//! false` for the deprecated app-level iOS API — that API is no longer
+//! used (it broke router transitions), so the injection is gone. When
+//! iOS is implemented via `WhiskerViewController.prefersStatusBarHidden`,
+//! this plugin should instead ensure that key is `true` (its default).
+//! Kept as a registered no-op so that future work has a home and
+//! `app.plugin::<WhiskerStatusBar>(|c| c)` stays valid.
+//!
+//! ## Usage in `whisker.rs`
+//!
+//! ```ignore
+//! use whisker_status_bar::WhiskerStatusBar;
+//!
+//! app.plugin::<WhiskerStatusBar>(|c| c);
+//! ```
+
+use serde::{Deserialize, Serialize};
+use whisker_plugin::{GenerateContext, Plugin, PluginConfig};
+
+/// No fields — see this module's doc comment for why.
+#[derive(Default, Serialize, Deserialize)]
+pub struct WhiskerStatusBarConfig;
+
+impl PluginConfig for WhiskerStatusBarConfig {
+    const NAME: &'static str = "whisker-status-bar";
+}
+
+/// The plugin the Whisker engine drives, and the namespace for the
+/// runtime API (`set_hidden`/`set_style`, defined in `runtime.rs`) —
+/// one unit struct serves both roles (Shape 5: no handle to carry).
+pub struct WhiskerStatusBar;
+
+impl Plugin for WhiskerStatusBar {
+    type Config = WhiskerStatusBarConfig;
+    fn apply(
+        &self,
+        _ctx: &mut GenerateContext,
+        _cfg: &WhiskerStatusBarConfig,
+    ) -> anyhow::Result<()> {
+        // No-op — Android-only module, no config to inject. See module docs.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_plugin::IosProjectIr;
+
+    /// The plugin injects nothing today (Android-only, iOS is a TODO).
+    #[test]
+    fn apply_is_a_no_op() {
+        let mut ctx = GenerateContext {
+            ios: Some(IosProjectIr::default()),
+            ..Default::default()
+        };
+        WhiskerStatusBar
+            .apply(&mut ctx, &WhiskerStatusBarConfig)
+            .unwrap();
+        assert!(ctx.ios.unwrap().info_plist.is_empty());
+    }
+}

--- a/packages/whisker-status-bar/src/runtime.rs
+++ b/packages/whisker-status-bar/src/runtime.rs
@@ -1,0 +1,80 @@
+//! `WhiskerStatusBar` runtime API — hand-written wrapper over the
+//! framework primitive: each method builds the raw `Vec<WhiskerValue>`
+//! arg list, dispatches via
+//! `whisker::module!("WhiskerStatusBar").invoke(method, args)`, and
+//! lifts the returned `WhiskerValue` into a typed result.
+//!
+//! **Android-only.** The native calls fire only on Android. On iOS they
+//! are a no-op: the only status-bar API reachable from a view-less module
+//! is the deprecated app-level `UIApplication.setStatusBarHidden`, and
+//! that call corrupts `whisker-router`'s transform-based transition
+//! animations whenever it lands around one (verified on-device). iOS
+//! support is a TODO — it needs to drive the status bar through
+//! `WhiskerViewController.prefersStatusBarHidden` (the non-deprecated,
+//! view-controller-based API) instead. Until then the methods no-op on
+//! iOS so call sites work unchanged on both platforms.
+
+use whisker::platform_module::WhiskerModuleError;
+#[cfg(target_os = "android")]
+use whisker::platform_module::WhiskerValue;
+
+use crate::plugin::WhiskerStatusBar;
+
+/// Status-bar content color, matching `expo-status-bar`'s `style`.
+/// [`Light`](StatusBarStyle::Light) draws light (white) icons for a dark
+/// background; [`Dark`](StatusBarStyle::Dark) draws dark icons for a
+/// light background.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StatusBarStyle {
+    Light,
+    Dark,
+}
+
+#[cfg(target_os = "android")]
+impl StatusBarStyle {
+    fn as_str(self) -> &'static str {
+        match self {
+            StatusBarStyle::Light => "light",
+            StatusBarStyle::Dark => "dark",
+        }
+    }
+}
+
+/// Typed Rust API for the `WhiskerStatusBar` platform module. The struct
+/// itself lives in `plugin.rs` (see its doc comment for why); this
+/// `impl` block just adds the runtime methods.
+impl WhiskerStatusBar {
+    /// Show or hide the system status bar (Android only — see the module
+    /// docs; no-op on iOS). Immediate on Android.
+    pub fn set_hidden(hidden: bool) -> Result<(), WhiskerModuleError> {
+        #[cfg(target_os = "android")]
+        {
+            let result = whisker::module!("WhiskerStatusBar")
+                .invoke("setHidden", vec![WhiskerValue::Bool(hidden)]);
+            if let WhiskerValue::Error(msg) = result {
+                return Err(WhiskerModuleError(msg));
+            }
+        }
+        #[cfg(not(target_os = "android"))]
+        let _ = hidden;
+        Ok(())
+    }
+
+    /// Set the status-bar content color (Android only; no-op on iOS).
+    /// See [`StatusBarStyle`].
+    pub fn set_style(style: StatusBarStyle) -> Result<(), WhiskerModuleError> {
+        #[cfg(target_os = "android")]
+        {
+            let result = whisker::module!("WhiskerStatusBar").invoke(
+                "setStyle",
+                vec![WhiskerValue::String(style.as_str().to_string())],
+            );
+            if let WhiskerValue::Error(msg) = result {
+                return Err(WhiskerModuleError(msg));
+            }
+        }
+        #[cfg(not(target_os = "android"))]
+        let _ = style;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

Graduates the giga-local **`whisker-status-bar`** module into `packages/` (Shape 5 — static methods).

```rust
use whisker_status_bar::{WhiskerStatusBar, StatusBarStyle};
let _ = WhiskerStatusBar::set_hidden(true);
let _ = WhiskerStatusBar::set_style(StatusBarStyle::Light);
```

Mirrors [`expo-status-bar`](https://docs.expo.dev/versions/latest/sdk/status-bar/) (`setStatusBarHidden` / `setStatusBarStyle`).

## Android-only

The native `invoke` is gated behind `#[cfg(target_os = "android")]` (Android `WindowInsetsControllerCompat`). **On iOS the methods no-op** — the only status-bar API reachable from a view-less module is the deprecated app-level `UIApplication.setStatusBarHidden`, which (device-verified) corrupts `whisker-router`'s transform-based transition animations whenever it fires around one. iOS support needs a view-controller-based `prefersStatusBarHidden` (via `WhiskerViewController`) — a TODO.

## Changes vs the giga-local crate

- `[package]` version + metadata via `.workspace = true`; deps via `{ workspace = true }`.
- `build.gradle.kts`: `whisker-module-android` `0.1.0` → `0.1.6`.
- Added to the workspace `members`.

Compiles in the workspace on both the runtime and config-probe paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2spNCoFjuxT8FWnhw3xaa
