### PR TITLE
fix(animation): a disposed controller must not crash the animation step

### DIFF
--- a/crates/whisker-animation/src/controller.rs
+++ b/crates/whisker-animation/src/controller.rs
@@ -116,6 +116,19 @@ impl ControllerState {
         if !self.active {
             return false;
         }
+        // The controller's owner can be torn down mid-run (e.g. a router
+        // wrapper disposed while its transition — or a still-active spring
+        // in its subtree — is animating). That frees the `value` node, and
+        // a subsequent read (`get_untracked` on the spring path) would
+        // panic — inside `step`, that panic bails the whole frame's
+        // animation pass, freezing EVERY controller (a stuck router
+        // transition strands the incoming screen off-screen). Self-
+        // terminate instead: there's nothing left to drive, so report
+        // finished and let the scheduler deregister us.
+        if self.value.is_disposed() {
+            self.active = false;
+            return false;
+        }
         match self.cfg.timing {
             Timing::Curved { duration_ms, curve } => {
                 self.advance_curved(now_ms, duration_ms, curve)

--- a/crates/whisker-animation/src/tests.rs
+++ b/crates/whisker-animation/src/tests.rs
@@ -895,3 +895,41 @@ fn owner_dispose_does_not_fire_on_finish() {
     );
     drop(ctrl);
 }
+
+// ----- Regression: disposed controller must not crash the step pass --------
+
+/// A controller whose backing `value` node is freed WHILE it is still active
+/// (owner torn down mid-run) must not panic the animation `step`. `advance`
+/// reads/writes `value`; reading a freed node panics, and inside `step` that
+/// unwinds the whole frame's animation pass — freezing EVERY controller. On
+/// device this stranded a router transition's incoming screen off-screen
+/// forever (a stuck "next chapter"). The controller must self-terminate.
+///
+/// Reproduced directly: forward a spring (spring `advance` reads `value` every
+/// frame — the panic path), then free the reactive arena out from under it
+/// (mirrors the wrapper owner's disposal) while leaving it registered in the
+/// animation scheduler, then step.
+#[test]
+fn step_survives_active_controller_with_freed_value_node() {
+    fresh();
+    let owner = Owner::new(None);
+    let ctrl = owner.with(|| {
+        let c = AnimationController::new(AnimConfig::spring());
+        c.forward();
+        c
+    });
+    assert_eq!(__active_count(), 1, "spring active after forward()");
+    // Free every reactive node (the controller's `value` among them) but do
+    // NOT touch the animation scheduler — so `ctrl` lingers in `active` with a
+    // dangling `value`, exactly the on-device shape.
+    whisker_runtime::reactive::__reset_for_tests();
+    assert_eq!(__active_count(), 1, "still registered after arena reset");
+
+    // Must NOT panic (pre-fix: `advance`'s `value` read panics, bailing step).
+    let still = __step_for_tests(16.0);
+    assert!(!still, "a controller with a freed value self-terminates");
+    assert_eq!(__active_count(), 0, "and is deregistered");
+
+    let _ = ctrl;
+    owner.dispose();
+}

--- a/crates/whisker-runtime/src/reactive/signal.rs
+++ b/crates/whisker-runtime/src/reactive/signal.rs
@@ -318,6 +318,18 @@ impl<T: 'static> RwSignal<T> {
     pub fn try_update(self, f: impl FnOnce(&mut T)) -> bool {
         try_write_and_notify(self.id, f, true)
     }
+
+    /// Whether this signal's backing node is still live in the arena.
+    /// `false` once the owner that allocated it has been disposed
+    /// (which frees the node). Non-panicking and non-notifying — a
+    /// cheap probe for callers that outlive their signal's owner and
+    /// must not touch a freed slot (e.g. the animation scheduler
+    /// advancing a controller whose owning wrapper was torn down
+    /// mid-run). Reading (`get`/`with`) such a signal panics; this does
+    /// not.
+    pub fn is_disposed(self) -> bool {
+        with_runtime(|rt| rt.nodes.get(self.id).is_none())
+    }
 }
 
 impl<T: 'static + Clone> RwSignal<T> {


### PR DESCRIPTION
## Problem

`AnimationScheduler::step` advances every active controller once per frame. `ControllerState::advance` reads/writes the controller's `value` signal — the **spring path reads it every frame** (`get_untracked`). If the owner that allocated `value` is torn down while the controller is still active, that node is freed and the read **panics**. Because `step` runs inside `tick_frame` (before the reactive flush), that panic unwinds the **entire frame's animation pass**, freezing *every* controller — not just the dead one.

## On-device symptom

A stuck router transition. A `replace` (giga's reader **"次/前のチャプター"**) disposes the outgoing wrapper on the slide's finish. When a still-active controller in that subtree is freed mid-run, the **incoming** screen's own slide/fade controller never advances → the new chapter stays off-screen forever and the frozen outgoing shows through. Flaky, because it hinges on disposal-vs-frame timing.

Diagnosed by instrumenting `step` (per-controller `catch_unwind` + a value dump): the panic is `ReadSignal: signal disposed` inside `advance`, and dropping the offending controller lets the incoming slide complete.

## Fix

`advance` self-terminates when its `value` node is gone — nothing left to drive, so it reports finished and the scheduler deregisters it, and the rest of the frame's controllers advance normally.

Adds `RwSignal::is_disposed` — a non-panicking, non-notifying liveness probe (the read analogue of the existing `try_set` "legitimately races owner disposal" path).

## Test

`step_survives_active_controller_with_freed_value_node` forwards a spring, frees the reactive arena out from under it while it stays registered (the on-device shape), then steps. It **reproduces the exact panic pre-fix** (`ReadSignal: signal disposed`, from `step`) and passes post-fix. `whisker-animation` (36) + `whisker-runtime` (154) green.

## Relationship to #333

#333 (freeze the outgoing screen on `replace`) fixes the double-mount that blanked the next chapter. Pausing the outgoing is what exposed this latent animation-step crash on the reader chapter-swap; both are needed for the swap to complete reliably. This fix is independently correct — a freed controller should never crash the whole animation frame, regardless of the router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)