### PR TITLE
fix(reactive): run an owner's cleanups before freeing its nodes

### DIFF
--- a/crates/whisker-build/src/child_guard.rs
+++ b/crates/whisker-build/src/child_guard.rs
@@ -73,14 +73,16 @@ mod tests {
 
     #[test]
     fn guard_registers_then_unregisters() {
-        // Use a pid that won't collide with a real spawn in tests.
-        let snapshot_len = TRACKED.lock().unwrap().len();
+        // Assert only on THIS pid, never the registry's absolute length:
+        // `TRACKED` is a process-global shared with the sibling tests, which
+        // run in parallel (and one deliberately leaks a registration via
+        // `mem::forget`), so a length snapshot races them. A pid that won't
+        // collide with a real spawn keeps the check self-contained.
         {
             let _g = track(999_999_001);
             assert!(TRACKED.lock().unwrap().contains(&999_999_001));
         }
-        // Dropped → unregistered, back to the original length.
-        assert_eq!(TRACKED.lock().unwrap().len(), snapshot_len);
+        // Dropped → unregistered.
         assert!(!TRACKED.lock().unwrap().contains(&999_999_001));
     }
 

--- a/crates/whisker-runtime/src/reactive/owner.rs
+++ b/crates/whisker-runtime/src/reactive/owner.rs
@@ -196,7 +196,25 @@ impl Owner {
             child.dispose();
         }
 
-        // Step 4: free every node this owner allocated. For effects
+        // Step 4: run THIS owner's cleanups BEFORE freeing its nodes, so an
+        // `on_cleanup` callback can still read/write the signals it closed
+        // over — the natural expectation (Solid / Leptos / React all allow
+        // it) and consistent with `set` on a freed signal already being a
+        // silent no-op (`try_write_and_notify`). Freeing first (the old
+        // order) made a same-owner `get` in a cleanup panic with `signal
+        // disposed`; worse, when the cleanup ran mid-`tick_frame` (a router
+        // screen disposed on a transition's finish), that panic unwound the
+        // whole frame and stranded unrelated reactive work (frozen
+        // animations, dead event handlers). Children are already disposed
+        // above, so a cleanup reading a *child's* signal still gets nothing —
+        // but that's the uncommon case; own-signal reads are what callers
+        // expect. LIFO order, no runtime borrow held (cleanups may touch the
+        // runtime).
+        for cleanup in cleanups.into_iter().rev() {
+            cleanup();
+        }
+
+        // Step 5: free every node this owner allocated. For effects
         // / computed values, also detach them from any subscriber
         // list they were on, so other live nodes don't try to
         // notify a freed slot later.
@@ -248,7 +266,7 @@ impl Owner {
             arc_src.unsubscribe(subscriber);
         }
 
-        // Step 5: release every element handle the disposed owner
+        // Step 6: release every element handle the disposed owner
         // created. We do this AFTER recursing into children so that
         // bottom-up disposal order matches what the renderer
         // expects (a child element's release before its parent's
@@ -259,13 +277,6 @@ impl Owner {
         // released") can do so.
         for handle in elements {
             crate::view::release_element(handle);
-        }
-
-        // Step 6: run cleanups in LIFO order, with no runtime
-        // borrow held (cleanups may legitimately touch other parts
-        // of the runtime).
-        for cleanup in cleanups.into_iter().rev() {
-            cleanup();
         }
     }
 

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -306,6 +306,37 @@ fn on_cleanup_fires_lifo() {
 }
 
 #[test]
+fn on_cleanup_can_read_and_write_own_signal() {
+    // Regression: an `on_cleanup` must be able to read (and write) a signal
+    // that its owner allocated — cleanups run BEFORE the owner frees its
+    // nodes. Freeing first made `read_at_cleanup` panic with `signal
+    // disposed`; on-device that panic (fired mid-`tick_frame` when a router
+    // screen disposed on a transition's finish) unwound the whole frame and
+    // stranded unrelated reactive work.
+    fresh();
+    let owner = Owner::new(None);
+    let read_at_cleanup: Rc<RefCell<Option<i32>>> = Rc::new(RefCell::new(None));
+
+    owner.with(|| {
+        let sig = signal(0_i32);
+        sig.set(42);
+        let captured = read_at_cleanup.clone();
+        on_cleanup(move || {
+            // Must NOT panic: `sig`'s node is still alive at cleanup time.
+            sig.set(sig.get_untracked() + 1);
+            *captured.borrow_mut() = Some(sig.get_untracked());
+        });
+    });
+
+    owner.dispose();
+    assert_eq!(
+        *read_at_cleanup.borrow(),
+        Some(43),
+        "cleanup read/wrote its own signal (42 -> 43) instead of panicking"
+    );
+}
+
+#[test]
 fn disposing_owner_removes_its_effects_from_pending() {
     fresh();
     let owner = Owner::new(None);


### PR DESCRIPTION
## Problem

`Owner::dispose` freed the owner's own signal/effect nodes (Step 4) **before** running its `on_cleanup` callbacks (Step 6). So a cleanup that read a signal its owner allocated — the natural thing to do at teardown — hit a freed node and panicked with `ReadSignal: signal disposed`.

It was also **inconsistent**: `set`/`try_set` on a freed signal is already a silent no-op (`try_write_and_notify`), so inside a cleanup a `set` quietly did nothing while a `get` crashed.

And the crash was **cryptic and non-local**: when the cleanup ran mid-`tick_frame` (a router screen disposed on a transition's `on_finish`), the panic was caught by `tick_callback`'s `catch_unwind`, which drops the whole frame — surfacing as **frozen animations and dead event handlers on an unrelated part of the UI**, with no hint that an `on_cleanup` read was the cause. (Found while chasing exactly that in a real app: a reader screen's status-bar `on_cleanup` read its own `holding: RwSignal<bool>`, froze the loading spinner and killed navigation.)

## Fix

Reorder so an owner runs its cleanups (still LIFO) right after disposing its descendants and **before** freeing its own nodes:

```
Step 3  dispose descendants (bottom-up)
Step 4  run THIS owner's cleanups   ← moved up
Step 5  free this owner's nodes
Step 6  release element handles
```

A cleanup can now read/write the signals it closed over — matching Solid / Leptos / React, and consistent with the already-non-panicking `set`. Descendants are disposed first, so reading a *child's* signal in a parent cleanup still yields nothing, but that's the uncommon case; own-signal reads are what callers expect.

## Test

`on_cleanup_can_read_and_write_own_signal` — a cleanup reads then writes its own signal (42 → 43) at dispose. Fails pre-fix (`signal disposed` panic), passes post-fix.

whisker-runtime (155) + whisker-router (42/33/2) + whisker-animation (36) green. Verified on-device: the app's `on_cleanup` can now read its own `RwSignal` with zero panics (the `Rc<Cell>` workaround it needed is no longer necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)