### PR TITLE
fix(cli): correct plugin build + config-probe for locally-patched deps

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -321,42 +321,58 @@ fn build_engine_with_discovered_plugins(
     Ok(engine)
 }
 
-/// Run a single `cargo build` that builds every discovered
-/// plugin's `[[bin]]` target. We use the workspace's existing
-/// `target/debug` so subsequent runs are no-op when the plugin
-/// crates haven't changed (cargo's own incremental cache).
+/// Build every discovered plugin's `[[bin]]` target, one `cargo
+/// build` per plugin. We use the workspace's existing `target/debug`
+/// so subsequent runs are no-op when a plugin crate hasn't changed
+/// (cargo's own incremental cache).
+///
+/// One invocation per plugin, not a single batched `-p A -p B --bin
+/// X --bin Y` command: cargo's package-id-spec resolution for a
+/// bare-name `-p` spec only reliably searches the *current* build's
+/// package selection, and mixing a workspace member (e.g. an app's
+/// own local module crate) with a non-member patched path dependency
+/// (e.g. `whisker-router`) in one `-p`/`-p` invocation intermittently
+/// fails with "package ID specification `<name>` did not match any
+/// packages" even though each package resolves fine on its own
+/// (confirmed via `cargo pkgid`). Building separately sidesteps the
+/// ambiguity entirely and gives cleaner per-plugin error attribution
+/// as a side benefit.
 ///
 /// Output streams through the curated `Step::pipe` machinery so the
 /// cargo progress (`    Compiling …` / `    Finished …` lines) folds
-/// into a single spinner row instead of leaking unfiltered ahead of
-/// the dev loop's `── whisker run ──` section header — and, with
-/// the TUI on, ahead of the inline status bar where stray
+/// into a single spinner row per plugin instead of leaking unfiltered
+/// ahead of the dev loop's `── whisker run ──` section header — and,
+/// with the TUI on, ahead of the inline status bar where stray
 /// `eprintln!`s race the viewport redraw.
 fn build_discovered_plugins(workspace_root: &Path, discovered: &[DiscoveredPlugin]) -> Result<()> {
-    let bins: Vec<&str> = discovered
-        .iter()
-        .map(|p| p.bin_target_name.as_str())
-        .collect();
-    let step = whisker_build::ui::step("compile", format!("plugins ({})", bins.join(", ")));
-    let mut cmd = Command::new("cargo");
-    cmd.arg("build").current_dir(workspace_root);
     for plugin in discovered {
-        cmd.arg("--bin")
+        let step = whisker_build::ui::step("compile", format!("plugin ({})", plugin.name));
+        let mut cmd = Command::new("cargo");
+        cmd.arg("build")
+            .arg("--bin")
             .arg(&plugin.bin_target_name)
             .arg("--package")
-            .arg(&plugin.source_crate);
+            .arg(&plugin.source_crate)
+            .current_dir(workspace_root);
+        let status = step.pipe(&mut cmd).with_context(|| {
+            format!(
+                "spawn `cargo build` for discovered Whisker CNG plugin `{}`",
+                plugin.name,
+            )
+        })?;
+        if !status.success() {
+            step.fail(format!("{status}"));
+            return Err(anyhow!(
+                "`cargo build` for discovered Whisker CNG plugin `{}` (crate `{}`) exited with \
+                 {status}. Re-run with `RUST_BACKTRACE=1 cargo build --bin {} --package {}` to \
+                 see the underlying compile error.",
+                plugin.name,
+                plugin.source_crate,
+                plugin.bin_target_name,
+                plugin.source_crate,
+            ));
+        }
+        step.done("");
     }
-    let status = step
-        .pipe(&mut cmd)
-        .with_context(|| "spawn `cargo build` for discovered Whisker CNG plugin binaries")?;
-    if !status.success() {
-        step.fail(format!("{status}"));
-        return Err(anyhow!(
-            "`cargo build` for discovered Whisker CNG plugin binaries exited with {status}. \
-             Re-run with `RUST_BACKTRACE=1 cargo build --bin <bin> --package <crate>` to see \
-             the underlying compile error."
-        ));
-    }
-    step.done("");
     Ok(())
 }

--- a/crates/whisker-cli/src/probe.rs
+++ b/crates/whisker-cli/src/probe.rs
@@ -62,14 +62,51 @@ pub fn run(whisker_rs: &Path, crate_dir: &Path, crate_name: &str) -> Result<Conf
     let plugins = discover_plugins(&user_manifest, crate_name)
         .with_context(|| format!("discover Whisker CNG plugins for `{crate_name}`"))?;
 
+    // Carry over the user crate's own `[patch.crates-io]` table, if
+    // any — see `read_patch_crates_io_table`'s doc comment for why.
+    let patch_table = read_patch_crates_io_table(&user_manifest)?;
+
     let probe_dir = crate_dir.join("target/.whisker/config-probe");
-    write_probe_project(&probe_dir, whisker_rs, crate_name, &plugins)?;
+    write_probe_project(
+        &probe_dir,
+        whisker_rs,
+        crate_name,
+        &plugins,
+        patch_table.as_deref(),
+    )?;
     let json = run_cargo_probe(&probe_dir, crate_name)?;
     if let Some(parent) = cache.parent() {
         std::fs::create_dir_all(parent).with_context(|| format!("mkdir {}", parent.display()))?;
     }
     std::fs::write(&cache, &json).with_context(|| format!("write cache {}", cache.display()))?;
     serde_json::from_str(&json).with_context(|| "parse probe stdout as Config JSON")
+}
+
+/// The user crate's own `[patch.crates-io]` table, if any, re-rendered
+/// as a standalone TOML snippet ready to append to the probe's
+/// `Cargo.toml`.
+///
+/// Without this, an app that patches every `whisker-*` dependency to
+/// a local, unreleased checkout (the standard way to develop against
+/// whiskerrs/whisker HEAD ahead of a crates.io release — see e.g.
+/// `whisker_config_dep_spec`'s own in-workspace-vs-published split)
+/// would still resolve the probe's OWN `whisker-config` dependency
+/// from whatever's published, silently drifting behind the app's
+/// actual dependency graph and breaking on any `whisker.rs` API
+/// surface added since the last release.
+fn read_patch_crates_io_table(user_manifest: &Path) -> Result<Option<String>> {
+    let contents = std::fs::read_to_string(user_manifest)
+        .with_context(|| format!("read {}", user_manifest.display()))?;
+    let doc: toml::Value = contents
+        .parse()
+        .with_context(|| format!("parse {} as TOML", user_manifest.display()))?;
+    let Some(patch) = doc.get("patch") else {
+        return Ok(None);
+    };
+    let mut table = toml::value::Table::new();
+    table.insert("patch".to_string(), patch.clone());
+    let rendered = toml::to_string(&table).context("serialize [patch] table")?;
+    Ok(Some(rendered))
 }
 
 fn cache_is_fresh(cache: &Path, sources: &[&Path]) -> bool {
@@ -103,6 +140,7 @@ fn write_probe_project(
     whisker_rs: &Path,
     crate_name: &str,
     plugins: &[DiscoveredPlugin],
+    patch_table: Option<&str>,
 ) -> Result<()> {
     let src_dir = probe_dir.join("src");
     std::fs::create_dir_all(&src_dir).with_context(|| format!("mkdir {}", src_dir.display()))?;
@@ -129,8 +167,11 @@ path = "src/main.rs"
 # the parent workspace sets (rust-version, license, …) would have to
 # match here. Stand-alone keeps the probe immune to workspace churn.
 [workspace]
+
+{patch_table}
 "#,
         whisker_config_dep = whisker_config_dep_spec(),
+        patch_table = patch_table.unwrap_or_default(),
     );
     std::fs::write(probe_dir.join("Cargo.toml"), cargo_toml)
         .with_context(|| format!("write {}/Cargo.toml", probe_dir.display()))?;


### PR DESCRIPTION
## Summary

Two independent `whisker run` dev-loop fixes for apps that develop against a **locally-patched** whisker (the standard `[patch.crates-io]` → local checkout setup used to track whiskerrs/whisker HEAD before a crates.io release). Both surfaced building [chantoinc/giga](https://github.com/chantoinc/giga)'s port.

### 1. Propagate the app's `[patch.crates-io]` into the config-probe (`probe.rs`)

The config-probe builds a throwaway crate depending on `whisker-config` to evaluate `whisker.rs`. It didn't carry over the app's own `[patch]` table, so an app patching every `whisker-*` dep to a local checkout still resolved the probe's `whisker-config` from whatever was **published** — silently drifting behind the app's real dependency graph and breaking on any `whisker.rs` API added since the last release. Now the app manifest's `[patch]` table is re-rendered into the probe's `Cargo.toml`.

### 2. Build discovered CNG plugins one `cargo` invocation per plugin (`platforms.rs`)

A single batched `cargo build -p A -p B --bin X --bin Y` intermittently failed with `package ID specification `<name>` did not match any packages` when the set mixed a workspace member (an app's own local module crate) with a non-member patched path dependency (e.g. `whisker-router`) — even though each package resolves fine alone (`cargo pkgid`). Cargo's bare-name `-p` resolution only reliably searches the current build's package selection. Building one plugin per invocation sidesteps the ambiguity and gives cleaner per-plugin error attribution + one spinner row per plugin.

Both are dev-loop-only (no runtime/ABI impact). `cargo check -p whisker-cli` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)