### PR TITLE
feat(modules): real async module functions — AsyncFunction + Promise

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_bridge.h
@@ -445,6 +445,35 @@ WHISKER_BRIDGE_EXPORT bool whisker_bridge_invoke_module_async(
     WhiskerModuleCallback callback,
     void* user_data);
 
+// Per-module ASYNC dispatch function — the async parallel of
+// `WhiskerModuleDispatchFn`. Emitted by the platform-side codegen for a
+// module that declares any `AsyncFunction`. Unlike the sync variant it
+// does not return the result: it takes the `callback` + `user_data` and
+// is responsible for invoking `callback(user_data, &result)` exactly once
+// — either inline or later (e.g. from a StoreKit / coroutine completion),
+// after resolving the module's `Promise`.
+//
+// Returns true if the async dispatch OWNED the method (an `AsyncFunction`
+// with that name exists; it will fire the callback). Returns false if the
+// method is not an async method here — the bridge then falls back to the
+// sync path (sync-forwarded through `whisker_bridge_invoke_module`), so a
+// sync-only module, or a sync method on a mixed module, keeps working when
+// reached via `invoke_async`.
+typedef bool (*WhiskerModuleAsyncDispatchFn)(
+    const char* method_name,
+    const WhiskerValueRaw* args,
+    size_t arg_count,
+    WhiskerModuleCallback callback,
+    void* user_data);
+
+// Register `dispatch` as the per-method ASYNC router for `module_name`.
+// Parallel to `whisker_bridge_register_module_dispatch`; the codegen
+// registers this in addition when the module has `AsyncFunction`s.
+// Last-write-wins; `dispatch=NULL` unregisters.
+WHISKER_BRIDGE_EXPORT void whisker_bridge_register_module_dispatch_async(
+    const char* module_name,
+    WhiskerModuleAsyncDispatchFn dispatch);
+
 // ============================================================================
 // Module event subscription (Phase L-2c)
 // ============================================================================

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_android.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_android.cc
@@ -409,6 +409,7 @@ struct WhiskerValueJni {
 
     jclass registry_cls = nullptr;
     jmethodID registry_dispatch = nullptr;
+    jmethodID registry_dispatch_async = nullptr;
 
     // Phase L-2c — event subscription routing. The C++ trampolines
     // call back into Kotlin via these handles so the per-Module
@@ -511,6 +512,16 @@ bool init_wvjni(JNIEnv* env) {
         "(Ljava/lang/String;Ljava/lang/String;[Lrs/whisker/runtime/WhiskerValue;)"
         "Lrs/whisker/runtime/WhiskerValue;");
     if (h.registry_dispatch == nullptr) {
+        if (env->ExceptionCheck()) env->ExceptionClear();
+        return false;
+    }
+
+    // Async parallel: invokeDispatchAsync(String, String,
+    // WhiskerValue[], long callbackPtr, long userDataPtr) -> boolean.
+    h.registry_dispatch_async = env->GetStaticMethodID(
+        h.registry_cls, "invokeDispatchAsync",
+        "(Ljava/lang/String;Ljava/lang/String;[Lrs/whisker/runtime/WhiskerValue;JJ)Z");
+    if (h.registry_dispatch_async == nullptr) {
         if (env->ExceptionCheck()) env->ExceptionClear();
         return false;
     }
@@ -889,10 +900,64 @@ extern "C" bool whisker_bridge_invoke_module_async(
     WhiskerModuleCallback callback, void* user_data
 ) {
     if (callback == nullptr) return false;
+
+    // Try the Kotlin async dispatch first: it constructs a WhiskerPromise
+    // over (callback, user_data) and resolves it later (via
+    // nativeResolveAsync). If no AsyncFunction owns the method it returns
+    // false and we fall back to sync-forward — matching the iOS/host common
+    // bridge, so a sync-only or mixed module keeps working via invoke_async.
+    if (module_name != nullptr && method_name != nullptr) {
+        ScopedJNIEnv_M guard;
+        JNIEnv* env = guard.get();
+        if (env != nullptr && init_wvjni(env)) {
+            auto& h = wvjni();
+            jobjectArray jargs = env->NewObjectArray((jsize)arg_count, h.base, nullptr);
+            for (size_t i = 0; i < arg_count; i++) {
+                jobject jv = value_to_jvalue(env, &args[i]);
+                env->SetObjectArrayElement(jargs, (jsize)i, jv);
+                if (jv != nullptr) env->DeleteLocalRef(jv);
+            }
+            jstring jmod = env->NewStringUTF(module_name);
+            jstring jmtd = env->NewStringUTF(method_name);
+            jboolean owned = env->CallStaticBooleanMethod(
+                h.registry_cls, h.registry_dispatch_async, jmod, jmtd, jargs,
+                (jlong)(uintptr_t)callback, (jlong)(uintptr_t)user_data);
+            env->DeleteLocalRef(jmod);
+            env->DeleteLocalRef(jmtd);
+            env->DeleteLocalRef(jargs);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            } else if (owned) {
+                // Kotlin owns the callback; it fires later via
+                // nativeResolveAsync. Do NOT fire it here.
+                return true;
+            }
+        }
+    }
+
     WhiskerValueRaw r = whisker_bridge_invoke_module(module_name, method_name, args, arg_count);
     callback(user_data, &r);
     whisker_bridge_value_release(&r);
     return true;
+}
+
+// JNI: WhiskerModuleRegistry.nativeResolveAsync(long callbackPtr,
+// long userDataPtr, WhiskerValue value). Called from WhiskerPromise's
+// resolve/reject — invokes the C bridge callback exactly once with the
+// encoded value, then releases the heap allocations. Runs on whatever
+// thread resolved the promise (already JVM-attached: it's a Kotlin call);
+// the callback (a Rust oneshot sender via async_trampoline) is Send.
+extern "C" JNIEXPORT void JNICALL
+Java_rs_whisker_runtime_WhiskerModuleRegistry_nativeResolveAsync(
+    JNIEnv* env, jclass /*self*/,
+    jlong callback_ptr, jlong user_data_ptr, jobject value_obj) {
+    if (callback_ptr == 0) return;
+    if (!init_wvjni(env)) return;
+    WhiskerValueRaw raw = jvalue_to_value(env, value_obj);
+    auto callback = reinterpret_cast<WhiskerModuleCallback>((uintptr_t)callback_ptr);
+    callback(reinterpret_cast<void*>((uintptr_t)user_data_ptr), &raw);
+    whisker_bridge_value_release(&raw);
 }
 
 // ============================================================================

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_common.cc
@@ -527,6 +527,10 @@ std::unordered_map<std::string, WhiskerModuleDispatchFn>& ModuleRegistry() {
     static std::unordered_map<std::string, WhiskerModuleDispatchFn> m;
     return m;
 }
+std::unordered_map<std::string, WhiskerModuleAsyncDispatchFn>& AsyncModuleRegistry() {
+    static std::unordered_map<std::string, WhiskerModuleAsyncDispatchFn> m;
+    return m;
+}
 
 WhiskerValueRaw MakeBridgeErrorValue(const char* message) {
     WhiskerValueRaw v;
@@ -553,6 +557,18 @@ extern "C" void whisker_bridge_register_module_dispatch(
         ModuleRegistry().erase(module_name);
     } else {
         ModuleRegistry()[module_name] = dispatch;
+    }
+}
+
+extern "C" void whisker_bridge_register_module_dispatch_async(
+    const char* module_name,
+    WhiskerModuleAsyncDispatchFn dispatch) {
+    if (module_name == nullptr) return;
+    std::lock_guard<std::mutex> g(ModuleRegistryMutex());
+    if (dispatch == nullptr) {
+        AsyncModuleRegistry().erase(module_name);
+    } else {
+        AsyncModuleRegistry()[module_name] = dispatch;
     }
 }
 
@@ -587,9 +603,25 @@ extern "C" bool whisker_bridge_invoke_module_async(
     WhiskerModuleCallback callback,
     void* user_data) {
     if (callback == nullptr) return false;
-    // Foundation: sync-forward on the calling thread. Worker-pool
-    // dispatch + cancel semantics land alongside the first
-    // async-API module (out of Phase F scope).
+    // Prefer a registered async dispatch: it owns the callback and
+    // resolves later (e.g. from a StoreKit / URLSession completion). If
+    // the module has no async dispatch, or that dispatch disowns the
+    // method (returns false), fall back to sync-forward so sync-only and
+    // mixed modules keep working when reached via `invoke_async`.
+    if (module_name != nullptr && method_name != nullptr) {
+        WhiskerModuleAsyncDispatchFn afn = nullptr;
+        {
+            std::lock_guard<std::mutex> g(ModuleRegistryMutex());
+            auto it = AsyncModuleRegistry().find(module_name);
+            if (it != AsyncModuleRegistry().end()) {
+                afn = it->second;
+            }
+        }
+        if (afn != nullptr &&
+            afn(method_name, args, arg_count, callback, user_data)) {
+            return true;
+        }
+    }
     WhiskerValueRaw result = whisker_bridge_invoke_module(
         module_name, method_name, args, arg_count);
     callback(user_data, &result);

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_host_stub.cc
@@ -36,6 +36,10 @@ std::unordered_map<std::string, WhiskerModuleDispatchFn>& ModuleRegistry() {
     static std::unordered_map<std::string, WhiskerModuleDispatchFn> m;
     return m;
 }
+std::unordered_map<std::string, WhiskerModuleAsyncDispatchFn>& AsyncModuleRegistry() {
+    static std::unordered_map<std::string, WhiskerModuleAsyncDispatchFn> m;
+    return m;
+}
 
 WhiskerValueRaw MakeHostStubError(const char* message) {
     WhiskerValueRaw v;
@@ -62,6 +66,18 @@ extern "C" void whisker_bridge_register_module_dispatch(
         ModuleRegistry().erase(module_name);
     } else {
         ModuleRegistry()[module_name] = dispatch;
+    }
+}
+
+extern "C" void whisker_bridge_register_module_dispatch_async(
+    const char* module_name,
+    WhiskerModuleAsyncDispatchFn dispatch) {
+    if (module_name == nullptr) return;
+    std::lock_guard<std::mutex> g(ModuleRegistryMutex());
+    if (dispatch == nullptr) {
+        AsyncModuleRegistry().erase(module_name);
+    } else {
+        AsyncModuleRegistry()[module_name] = dispatch;
     }
 }
 
@@ -138,6 +154,23 @@ extern "C" bool whisker_bridge_invoke_module_async(
     WhiskerModuleCallback callback,
     void* user_data) {
     if (callback == nullptr) return false;
+    // Prefer a registered async dispatch (owns the callback, resolves
+    // later); else sync-forward. Mirrors the iOS/Android common bridge so
+    // host cargo tests exercise the same routing.
+    if (module_name != nullptr && method_name != nullptr) {
+        WhiskerModuleAsyncDispatchFn afn = nullptr;
+        {
+            std::lock_guard<std::mutex> g(ModuleRegistryMutex());
+            auto it = AsyncModuleRegistry().find(module_name);
+            if (it != AsyncModuleRegistry().end()) {
+                afn = it->second;
+            }
+        }
+        if (afn != nullptr &&
+            afn(method_name, args, arg_count, callback, user_data)) {
+            return true;
+        }
+    }
     WhiskerValueRaw result = whisker_bridge_invoke_module(
         module_name, method_name, args, arg_count);
     callback(user_data, &result);

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -240,6 +240,19 @@ pub type WhiskerModuleDispatchFn = extern "C" fn(
     arg_count: usize,
 ) -> WhiskerValueRaw;
 
+/// Async per-module dispatch — the async parallel of
+/// [`WhiskerModuleDispatchFn`]. Takes the completion `callback` +
+/// `user_data` and returns `true` if it owns the method (will fire the
+/// callback later), `false` to let the bridge fall back to the sync
+/// dispatch. See `whisker_bridge.h`.
+pub type WhiskerModuleAsyncDispatchFn = extern "C" fn(
+    method_name: *const c_char,
+    args: *const WhiskerValueRaw,
+    arg_count: usize,
+    callback: WhiskerModuleCallback,
+    user_data: *mut c_void,
+) -> bool;
+
 unsafe extern "C" {
     pub fn whisker_bridge_engine_attach(lynx_view_ptr: *mut c_void) -> *mut WhiskerEngine;
     pub fn whisker_bridge_engine_release(engine: *mut WhiskerEngine);
@@ -422,6 +435,15 @@ unsafe extern "C" {
     pub fn whisker_bridge_register_module_dispatch(
         module_name: *const c_char,
         dispatch: WhiskerModuleDispatchFn,
+    );
+
+    /// Register an ASYNC dispatch function for `module_name` — the
+    /// parallel of [`whisker_bridge_register_module_dispatch`], consulted
+    /// first by [`whisker_bridge_invoke_module_async`]. Emitted by the
+    /// platform codegen when a module declares any `AsyncFunction`.
+    pub fn whisker_bridge_register_module_dispatch_async(
+        module_name: *const c_char,
+        dispatch: WhiskerModuleAsyncDispatchFn,
     );
 
     // ------------------------------------------------------------------

--- a/crates/whisker-driver/src/module.rs
+++ b/crates/whisker-driver/src/module.rs
@@ -728,4 +728,138 @@ mod tests {
         assert_eq!(WhiskerValue::Null.as_error(), None);
         assert_eq!(WhiskerValue::Int(5).as_error(), None);
     }
+
+    // ---- async dispatch routing (C bridge; host_stub in cargo test) ------
+    //
+    // These exercise `whisker_bridge_invoke_module_async`'s new routing:
+    // prefer a registered async dispatch (which owns the callback and may
+    // resolve later), and fall back to sync-forward otherwise.
+
+    use std::os::raw::c_char;
+    use std::sync::mpsc;
+
+    /// Test callback: `user_data` is a `*const mpsc::Sender<WhiskerValue>`;
+    /// decode the borrowed result and send it out.
+    extern "C" fn capture_cb(user_data: *mut c_void, result: *const ffi::WhiskerValueRaw) {
+        let tx = unsafe { &*(user_data as *const mpsc::Sender<WhiskerValue>) };
+        let v = unsafe { from_raw(&*result) };
+        let _ = tx.send(v);
+    }
+
+    /// Async dispatch that owns the method and resolves inline with 42.
+    extern "C" fn async_int42_inline(
+        _m: *const c_char,
+        _a: *const ffi::WhiskerValueRaw,
+        _c: usize,
+        cb: ffi::WhiskerModuleCallback,
+        ud: *mut c_void,
+    ) -> bool {
+        let mut b = RawBuilder::default();
+        let raw = b.encode(&WhiskerValue::Int(42));
+        cb(ud, &raw); // result borrowed only for this call
+        drop(b);
+        true
+    }
+
+    /// Async dispatch that resolves LATER, from another thread, with 7.
+    extern "C" fn async_int7_deferred(
+        _m: *const c_char,
+        _a: *const ffi::WhiskerValueRaw,
+        _c: usize,
+        cb: ffi::WhiskerModuleCallback,
+        ud: *mut c_void,
+    ) -> bool {
+        let ud = ud as usize; // raw ptr isn't Send; carry as usize
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let mut b = RawBuilder::default();
+            let raw = b.encode(&WhiskerValue::Int(7));
+            cb(ud as *mut c_void, &raw);
+            drop(b);
+        });
+        true
+    }
+
+    /// Async dispatch that disowns every method (→ bridge falls back).
+    extern "C" fn async_disown(
+        _m: *const c_char,
+        _a: *const ffi::WhiskerValueRaw,
+        _c: usize,
+        _cb: ffi::WhiskerModuleCallback,
+        _ud: *mut c_void,
+    ) -> bool {
+        false
+    }
+
+    /// Sync dispatch returning scalar 99 (no heap alloc → release no-op).
+    extern "C" fn sync_int99(
+        _m: *const c_char,
+        _a: *const ffi::WhiskerValueRaw,
+        _c: usize,
+    ) -> ffi::WhiskerValueRaw {
+        let mut raw: ffi::WhiskerValueRaw = unsafe { std::mem::zeroed() };
+        raw.type_ = ffi::WhiskerValueType::Int as u8;
+        raw.v.i = 99;
+        raw
+    }
+
+    fn call_async(module: &str, method: &str) -> WhiskerValue {
+        let (tx, rx) = mpsc::channel::<WhiskerValue>();
+        let module_c = CString::new(module).unwrap();
+        let method_c = CString::new(method).unwrap();
+        let ok = unsafe {
+            ffi::whisker_bridge_invoke_module_async(
+                module_c.as_ptr(),
+                method_c.as_ptr(),
+                std::ptr::null(),
+                0,
+                capture_cb,
+                &tx as *const _ as *mut c_void,
+            )
+        };
+        assert!(ok, "bridge accepted the async dispatch");
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("async callback fired")
+    }
+
+    #[test]
+    fn async_dispatch_is_preferred_and_resolves_inline() {
+        let m = "test:async-inline";
+        let mc = CString::new(m).unwrap();
+        unsafe {
+            ffi::whisker_bridge_register_module_dispatch_async(mc.as_ptr(), async_int42_inline)
+        };
+        assert_eq!(call_async(m, "anything"), WhiskerValue::Int(42));
+    }
+
+    #[test]
+    fn async_dispatch_can_resolve_later_from_another_thread() {
+        let m = "test:async-deferred";
+        let mc = CString::new(m).unwrap();
+        unsafe {
+            ffi::whisker_bridge_register_module_dispatch_async(mc.as_ptr(), async_int7_deferred)
+        };
+        assert_eq!(call_async(m, "later"), WhiskerValue::Int(7));
+    }
+
+    #[test]
+    fn invoke_async_falls_back_to_sync_when_no_async_dispatch() {
+        let m = "test:sync-only";
+        let mc = CString::new(m).unwrap();
+        unsafe { ffi::whisker_bridge_register_module_dispatch(mc.as_ptr(), sync_int99) };
+        // No async dispatch registered → invoke_async sync-forwards.
+        assert_eq!(call_async(m, "m"), WhiskerValue::Int(99));
+    }
+
+    #[test]
+    fn invoke_async_falls_back_when_async_dispatch_disowns() {
+        let m = "test:async-disowns";
+        let mc = CString::new(m).unwrap();
+        unsafe {
+            ffi::whisker_bridge_register_module_dispatch(mc.as_ptr(), sync_int99);
+            ffi::whisker_bridge_register_module_dispatch_async(mc.as_ptr(), async_disown);
+        }
+        // Async dispatch returns false → bridge falls back to sync (99).
+        assert_eq!(call_async(m, "m"), WhiskerValue::Int(99));
+    }
 }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ModuleDefinition.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ModuleDefinition.kt
@@ -111,6 +111,21 @@ public data class WhiskerFunctionComponent(
 ) : WhiskerDefinitionComponent
 
 /**
+ * Type-erased ASYNC function handler. Like [WhiskerFunctionHandlerFn]
+ * but instead of returning a value it resolves the given [promise] —
+ * now or later, e.g. from a purchase / network completion. `view` is
+ * `null` for module-level `AsyncFunction`s. Mirrors Expo's
+ * `AsyncFunction` + `Promise` (callback-resolved form).
+ */
+public typealias WhiskerAsyncFunctionHandlerFn =
+    (view: Any?, args: List<WhiskerValue>, promise: WhiskerPromise) -> Unit
+
+public data class WhiskerAsyncFunctionComponent(
+    public val name: String,
+    public val handler: WhiskerAsyncFunctionHandlerFn,
+) : WhiskerDefinitionComponent
+
+/**
  * `Events("a", "b", ...)` — declare event names this module emits.
  * Metadata only; dispatch goes through
  * [Module.sendEvent], which fans the payload out to every Rust
@@ -237,6 +252,18 @@ public class WhiskerModuleDefinitionBuilder {
         handler: (args: List<WhiskerValue>) -> WhiskerValue,
     ): WhiskerDefinitionComponent =
         WhiskerFunctionComponent(name) { _, args -> handler(args) }.also { components.add(it) }
+
+    /**
+     * `AsyncFunction("getOfferings") { args, promise -> ...; promise.resolve(x) }`
+     * — module-level async function. The author resolves/rejects the
+     * [promise], now or from a completion callback.
+     */
+    public fun AsyncFunction(
+        name: String,
+        handler: (args: List<WhiskerValue>, promise: WhiskerPromise) -> Unit,
+    ): WhiskerDefinitionComponent =
+        WhiskerAsyncFunctionComponent(name) { _, args, promise -> handler(args, promise) }
+            .also { components.add(it) }
 }
 
 /**
@@ -283,6 +310,16 @@ public class WhiskerViewDefinitionBuilder {
             @Suppress("UNCHECKED_CAST")
             handler(viewAny as V, args)
         }.also { components.add(it) }
+
+    /** View-bound `AsyncFunction` — view + raw args + a [WhiskerPromise]. */
+    public fun <V : Any> AsyncFunction(
+        name: String,
+        handler: (view: V, args: List<WhiskerValue>, promise: WhiskerPromise) -> Unit,
+    ): WhiskerDefinitionComponent =
+        WhiskerAsyncFunctionComponent(name) { viewAny, args, promise ->
+            @Suppress("UNCHECKED_CAST")
+            handler(viewAny as V, args, promise)
+        }.also { components.add(it) }
 }
 
 // ----- ModuleDefinition value -----------------------------------------------
@@ -313,6 +350,10 @@ public data class ModuleDefinition(public val components: List<WhiskerDefinition
     /** Module-level (view-less) [Function] declarations. */
     public val functions: List<WhiskerFunctionComponent>
         get() = components.filterIsInstance<WhiskerFunctionComponent>()
+
+    /** Module-level (view-less) [AsyncFunction] declarations. */
+    public val asyncFunctions: List<WhiskerAsyncFunctionComponent>
+        get() = components.filterIsInstance<WhiskerAsyncFunctionComponent>()
 
     /** Module-level [OnStartObserving] hooks. */
     public val onStartObservingHooks: List<WhiskerOnStartObservingComponent>

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -96,22 +96,37 @@ private fun registerViewBearing(viewBlock: WhiskerViewComponent) {
 private fun registerViewLess(def: ModuleDefinition, crateName: String?) {
     val name = def.name ?: return
     val functions = def.functions
-    if (functions.isEmpty()) return
+    val asyncFunctions = def.asyncFunctions
+    if (functions.isEmpty() && asyncFunctions.isEmpty()) return
 
     // `<crate>:<Name>` so the Rust side's `module!("Name")` (which
     // prepends its own crate name) resolves to the same key.
     val qualifiedName = if (crateName.isNullOrEmpty()) name else "$crateName:$name"
 
-    val byName = functions.associateBy { it.name }
-    WhiskerModuleRegistry.registerDispatch(qualifiedName) { method, args ->
-        val fn = byName[method]
-            ?: return@registerDispatch WhiskerValue.Err("unknown method `$method` on module `$name`")
-        // Case ②: hand the raw `List<WhiskerValue>` straight to the
-        // handler, which returns a `WhiskerValue`.
-        try {
-            fn.handler(null, args.asList())
-        } catch (t: Throwable) {
-            WhiskerValue.Err("exception in module `$name` method `$method`: ${t.message}")
+    if (functions.isNotEmpty()) {
+        val byName = functions.associateBy { it.name }
+        WhiskerModuleRegistry.registerDispatch(qualifiedName) { method, args ->
+            val fn = byName[method]
+                ?: return@registerDispatch WhiskerValue.Err("unknown method `$method` on module `$name`")
+            // Case ②: hand the raw `List<WhiskerValue>` straight to the
+            // handler, which returns a `WhiskerValue`.
+            try {
+                fn.handler(null, args.asList())
+            } catch (t: Throwable) {
+                WhiskerValue.Err("exception in module `$name` method `$method`: ${t.message}")
+            }
+        }
+    }
+
+    if (asyncFunctions.isNotEmpty()) {
+        val asyncByName = asyncFunctions.associateBy { it.name }
+        WhiskerModuleRegistry.registerDispatchAsync(qualifiedName) { method, args, promise ->
+            val fn = asyncByName[method] ?: return@registerDispatchAsync false
+            // Owned: invoke the handler with the promise; it resolves now
+            // or later. Exceptions surface via `invokeDispatchAsync`'s
+            // catch (→ promise.reject).
+            fn.handler(null, args.asList(), promise)
+            true
         }
     }
 }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistry.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistry.kt
@@ -7,6 +7,14 @@ import java.util.concurrent.ConcurrentHashMap
 /// Kotlin disallows nested `typealias` declarations.
 public typealias WhiskerModuleDispatchFn = (String, Array<WhiskerValue>) -> WhiskerValue
 
+/// Signature of a module's ASYNC dispatch closure. Given a method,
+/// its args, and a [WhiskerPromise] to resolve. Returns true if an
+/// `AsyncFunction` with that name exists (it was invoked and owns the
+/// promise); false if not — the C bridge then falls back to the sync
+/// dispatch.
+public typealias WhiskerModuleAsyncDispatchFn =
+    (String, Array<WhiskerValue>, WhiskerPromise) -> Boolean
+
 /**
  * Whisker native-module dispatch registry — Kotlin side.
  *
@@ -29,6 +37,7 @@ public typealias WhiskerModuleDispatchFn = (String, Array<WhiskerValue>) -> Whis
  */
 public object WhiskerModuleRegistry {
     private val dispatchers = ConcurrentHashMap<String, WhiskerModuleDispatchFn>()
+    private val asyncDispatchers = ConcurrentHashMap<String, WhiskerModuleAsyncDispatchFn>()
 
     /**
      * Register a dispatch closure under [name]. Subsequent
@@ -42,6 +51,13 @@ public object WhiskerModuleRegistry {
     @JvmStatic
     public fun registerDispatch(name: String, dispatch: WhiskerModuleDispatchFn) {
         dispatchers[name] = dispatch
+    }
+
+    /** Register the ASYNC dispatch closure for [name]. Parallel to
+     *  [registerDispatch]; consulted first by [invokeDispatchAsync]. */
+    @JvmStatic
+    public fun registerDispatchAsync(name: String, dispatch: WhiskerModuleAsyncDispatchFn) {
+        asyncDispatchers[name] = dispatch
     }
 
     /**
@@ -69,4 +85,43 @@ public object WhiskerModuleRegistry {
             WhiskerValue.Err("module $moduleName.$method threw: ${t.message ?: t.javaClass.simpleName}")
         }
     }
+
+    /**
+     * Async parallel of [invokeDispatch], called from the C bridge's
+     * `whisker_bridge_invoke_module_async`. Constructs a [WhiskerPromise]
+     * wrapping the bridge callback (passed as raw pointers) and hands it
+     * to the module's async dispatcher.
+     *
+     * Returns true if an async dispatcher owned the method (it will fire
+     * the callback later, via [nativeResolveAsync]); false if not — the C
+     * side then falls back to the sync path, so it must NOT have touched
+     * the callback.
+     */
+    @JvmStatic
+    public fun invokeDispatchAsync(
+        moduleName: String,
+        method: String,
+        args: Array<WhiskerValue>,
+        callbackPtr: Long,
+        userDataPtr: Long,
+    ): Boolean {
+        val fn = asyncDispatchers[moduleName] ?: return false
+        val promise = WhiskerPromise(callbackPtr, userDataPtr)
+        return try {
+            fn(method, args, promise)
+        } catch (t: Throwable) {
+            // An async method existed but threw before/at invocation:
+            // reject (resolving the awaiting future) and report as owned.
+            promise.reject("module $moduleName.$method threw: ${t.message ?: t.javaClass.simpleName}")
+            true
+        }
+    }
+
+    /**
+     * JNI: invoke the C bridge callback `callbackPtr(userDataPtr, value)`
+     * exactly once, from [WhiskerPromise.resolve]/`reject`. Implemented in
+     * `whisker_bridge_android.cc`.
+     */
+    @JvmStatic
+    public external fun nativeResolveAsync(callbackPtr: Long, userDataPtr: Long, value: WhiskerValue)
 }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerPromise.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerPromise.kt
@@ -1,0 +1,43 @@
+package rs.whisker.runtime
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * The resolver handed to an `AsyncFunction` handler (Android).
+ *
+ * Wraps the C bridge's completion callback + opaque `user_data` (the
+ * Rust `oneshot::Sender` boxed by `PlatformModule::invoke_async`),
+ * carried across JNI as raw `Long` pointers, so a module can deliver
+ * its result *later* — e.g. from a RevenueCat / coroutine completion —
+ * instead of returning synchronously.
+ *
+ * Mirrors Expo's `Promise` (`resolve` / `reject`). One-shot: the first
+ * `resolve`/`reject` wins and fires the callback exactly once; further
+ * calls are ignored, matching the Rust side whose `async_trampoline`
+ * consumes the boxed sender on the first callback.
+ *
+ * Constructed only by [WhiskerModuleRegistry.invokeDispatchAsync].
+ */
+public class WhiskerPromise internal constructor(
+    private val callbackPtr: Long,
+    private val userDataPtr: Long,
+) {
+    private val settled = AtomicBoolean(false)
+
+    /** Resolve the call with [value] (`WhiskerValue.Null` for "no result"). */
+    public fun resolve(value: WhiskerValue) {
+        fire(value)
+    }
+
+    /** Reject with an error message — surfaces as `WhiskerValue.Err` on the
+     *  Rust side (the awaiting `invoke_async` future resolves to it). */
+    public fun reject(message: String) {
+        fire(WhiskerValue.Err(message))
+    }
+
+    private fun fire(value: WhiskerValue) {
+        if (callbackPtr == 0L) return
+        if (!settled.compareAndSet(false, true)) return
+        WhiskerModuleRegistry.nativeResolveAsync(callbackPtr, userDataPtr, value)
+    }
+}

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_bridge.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_bridge.h
@@ -381,6 +381,26 @@ WHISKER_BRIDGE_EXPORT bool whisker_bridge_invoke_module_async(
     WhiskerModuleCallback callback,
     void* user_data);
 
+// Per-module ASYNC dispatch function — the async parallel of
+// `WhiskerModuleDispatchFn`. Emitted by the codegen for a module that
+// declares any `AsyncFunction`. Takes the completion `callback` +
+// `user_data` and invokes `callback(user_data, &result)` exactly once
+// (inline or later, after resolving the module's `Promise`). Returns true
+// if it owns the method; false lets the bridge fall back to the sync path.
+typedef bool (*WhiskerModuleAsyncDispatchFn)(
+    const char* method_name,
+    const WhiskerValueRaw* args,
+    size_t arg_count,
+    WhiskerModuleCallback callback,
+    void* user_data);
+
+// Register `dispatch` as the per-method ASYNC router for `module_name`.
+// Parallel to `whisker_bridge_register_module_dispatch`; consulted first
+// by `whisker_bridge_invoke_module_async`. Last-write-wins; NULL unregisters.
+WHISKER_BRIDGE_EXPORT void whisker_bridge_register_module_dispatch_async(
+    const char* module_name,
+    WhiskerModuleAsyncDispatchFn dispatch);
+
 // ============================================================================
 // Module event subscription (Phase L-2c)
 // ============================================================================

--- a/platforms/ios/Sources/WhiskerModule/ModuleDefinition.swift
+++ b/platforms/ios/Sources/WhiskerModule/ModuleDefinition.swift
@@ -143,6 +143,27 @@ public struct WhiskerFunctionComponent: WhiskerDefinitionComponent {
     }
 }
 
+/// Type-erased ASYNC function handler. Like `WhiskerFunctionHandler`
+/// but instead of returning a value it resolves the given `promise`
+/// — now or later, e.g. from a StoreKit / URLSession completion.
+/// `view` is `nil` for module-level `AsyncFunction`s. Mirrors Expo's
+/// `AsyncFunction` + `Promise` (the callback-resolved form).
+public typealias WhiskerAsyncFunctionHandler =
+    (_ view: AnyObject?, _ args: [WhiskerValue], _ promise: WhiskerPromise) -> Void
+
+/// Async function component — the async parallel of
+/// `WhiskerFunctionComponent`. Dispatched through the C bridge's
+/// async path (`whisker_bridge_invoke_module_async`), which hands the
+/// handler a `WhiskerPromise` wrapping the completion callback.
+public struct WhiskerAsyncFunctionComponent: WhiskerDefinitionComponent {
+    public let name: String
+    public let handler: WhiskerAsyncFunctionHandler
+    public init(name: String, handler: @escaping WhiskerAsyncFunctionHandler) {
+        self.name = name
+        self.handler = handler
+    }
+}
+
 /// Event-name declaration component. Authors declare event names
 /// they intend to emit; the runtime uses the list for type-checking
 /// + future docs generation. Dispatch from inside the module body
@@ -304,6 +325,12 @@ public struct ModuleDefinition {
         components.compactMap { $0 as? WhiskerFunctionComponent }
     }
 
+    /// Module-level (view-less) async functions — `AsyncFunction(...)`
+    /// declared OUTSIDE a `View(...)` block.
+    public var asyncFunctions: [WhiskerAsyncFunctionComponent] {
+        components.compactMap { $0 as? WhiskerAsyncFunctionComponent }
+    }
+
     /// All `OnStartObserving(...)` hooks declared at module-level.
     public var onStartObservingHooks: [WhiskerOnStartObservingComponent] {
         components.compactMap { $0 as? WhiskerOnStartObservingComponent }
@@ -419,4 +446,30 @@ public func Function(
     _ handler: @escaping ([WhiskerValue]) -> WhiskerValue
 ) -> WhiskerDefinitionComponent {
     WhiskerFunctionComponent(name: name) { _, args in handler(args) }
+}
+
+// MARK: - AsyncFunction factories (Expo-style `AsyncFunction` + `Promise`)
+
+/// `AsyncFunction("purchase") { (view: RCView, args, promise) in
+/// ...; promise.resolve(info) }` — view-bound async function. The
+/// author resolves/rejects the `promise`, now or from a completion.
+public func AsyncFunction<V: AnyObject>(
+    _ name: String,
+    _ handler: @escaping (V, [WhiskerValue], WhiskerPromise) -> Void
+) -> WhiskerDefinitionComponent {
+    WhiskerAsyncFunctionComponent(name: name) { viewAny, args, promise in
+        guard let view = viewAny as? V else {
+            return promise.reject("AsyncFunction(\"\(name)\") view type mismatch")
+        }
+        handler(view, args, promise)
+    }
+}
+
+/// `AsyncFunction("getOfferings") { (args, promise) in ... }` —
+/// module-level (view-less) async function for a function-only module.
+public func AsyncFunction(
+    _ name: String,
+    _ handler: @escaping ([WhiskerValue], WhiskerPromise) -> Void
+) -> WhiskerDefinitionComponent {
+    WhiskerAsyncFunctionComponent(name: name) { _, args, promise in handler(args, promise) }
 }

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleDispatch.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleDispatch.swift
@@ -45,5 +45,47 @@ extension Module {
         let args = WhiskerValue.decodeArray(argsPtr, count: argCount)
         return dispatchModuleFunction(method, args).toRaw()
     }
+
+    /// Dispatch a module-level `AsyncFunction` by name, handing it a
+    /// `WhiskerPromise` to resolve. Returns true if such an async function
+    /// exists (it was invoked and owns the promise); false if not — the
+    /// bridge then falls back to the sync path. Public for unit-testing
+    /// against `[WhiskerValue]` without the C ABI.
+    public func dispatchModuleFunctionAsync(
+        _ method: String,
+        _ args: [WhiskerValue],
+        _ promise: WhiskerPromise
+    ) -> Bool {
+        guard
+            let fn = self.definitionLazy.asyncFunctions.first(where: { $0.name == method })
+        else {
+            return false
+        }
+        fn.handler(nil, args, promise)
+        return true
+    }
+
+    /// C-ABI async bridge the codegen-emitted `@_cdecl` async shim calls
+    /// (matches `WhiskerModuleAsyncDispatchFn`). Returns true if an async
+    /// function with that name owned the call. On unknown method it returns
+    /// false WITHOUT touching the callback, so the bridge sync-forwards.
+    public func dispatchModuleFunctionRawAsync(
+        _ methodName: UnsafePointer<CChar>?,
+        _ argsPtr: UnsafePointer<WhiskerValueRaw>?,
+        _ argCount: Int,
+        _ callback: WhiskerModuleCallback?,
+        _ userData: UnsafeMutableRawPointer?
+    ) -> Bool {
+        guard let callback = callback else { return false }
+        let method = methodName == nil ? "" : String(cString: methodName!)
+        // Look up before constructing the promise so a non-async method
+        // leaves the callback untouched for the bridge's sync fallback.
+        guard self.definitionLazy.asyncFunctions.contains(where: { $0.name == method }) else {
+            return false
+        }
+        let args = WhiskerValue.decodeArray(argsPtr, count: argCount)
+        let promise = WhiskerPromise(callback: callback, userData: userData)
+        return dispatchModuleFunctionAsync(method, args, promise)
+    }
 }
 

--- a/platforms/ios/Sources/WhiskerModule/WhiskerPromise.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerPromise.swift
@@ -1,0 +1,58 @@
+// The resolver handed to an `AsyncFunction` handler (iOS).
+//
+// Wraps the C bridge's completion `callback` + opaque `user_data` (the
+// Rust `oneshot::Sender` boxed by `PlatformModule::invoke_async`), so a
+// module can deliver its result *later* — e.g. from a StoreKit purchase
+// or `URLSession` completion — instead of returning synchronously.
+//
+// Mirrors Expo's `Promise` (`resolve` / `reject`). One-shot: the first
+// `resolve`/`reject` wins and fires the callback exactly once; further
+// calls are ignored. This matches the Rust side, whose `async_trampoline`
+// consumes the boxed sender on the first callback and would have nothing
+// left to resolve on a second.
+
+import Foundation
+
+public final class WhiskerPromise {
+    private let callback: WhiskerModuleCallback
+    private let userData: UnsafeMutableRawPointer?
+    private let lock = NSLock()
+    private var settled = false
+
+    /// `callback` is the bridge's `WhiskerModuleCallback`; `userData` the
+    /// opaque pointer the async dispatch was handed. Constructed only by
+    /// the module-dispatch layer.
+    init(callback: WhiskerModuleCallback, userData: UnsafeMutableRawPointer?) {
+        self.callback = callback
+        self.userData = userData
+    }
+
+    /// Resolve the call with `value` (`.null` for "no result").
+    public func resolve(_ value: WhiskerValue) {
+        fire(value)
+    }
+
+    /// Reject with an error message — surfaces as `WhiskerValue.error` on
+    /// the Rust side (the awaiting `invoke_async` future resolves to it).
+    public func reject(_ message: String) {
+        fire(.error(message))
+    }
+
+    private func fire(_ value: WhiskerValue) {
+        lock.lock()
+        if settled {
+            lock.unlock()
+            return
+        }
+        settled = true
+        lock.unlock()
+
+        // Same encode → hand-to-bridge → release sequence the event
+        // center uses (`WhiskerModuleEventCenter.dispatchSend`): the
+        // callback copies the value out before returning, so releasing
+        // right after is safe.
+        var raw = value.toRaw()
+        callback(userData, &raw)
+        whisker_bridge_value_release(&raw)
+    }
+}

--- a/platforms/ios/macros/Sources/WhiskerModuleCodegen/main.swift
+++ b/platforms/ios/macros/Sources/WhiskerModuleCodegen/main.swift
@@ -213,6 +213,7 @@ func render(
     for hit in sortedDSLModules {
         let instance = "_whiskerDSLInstance_\(hit.className)"
         let shim = "_whiskerDSLDispatch_\(hit.className)"
+        let asyncShim = "_whiskerDSLDispatchAsync_\(hit.className)"
         out += """
                 do {
                     let module = \(instance)
@@ -234,6 +235,10 @@ func render(
                             // same-named function-only modules — matches
                             // the Rust `module!("Name")` prefix.
                             whisker_bridge_register_module_dispatch(qname, \(shim))
+                            // Async parallel: consulted first by
+                            // `invoke_async`, falls back to the sync
+                            // dispatch above for non-async methods.
+                            whisker_bridge_register_module_dispatch_async(qname, \(asyncShim))
                         }
                     }
                 }
@@ -256,6 +261,7 @@ func render(
     for hit in sortedDSLModules {
         let instance = "_whiskerDSLInstance_\(hit.className)"
         let shim = "_whiskerDSLDispatch_\(hit.className)"
+        let asyncShim = "_whiskerDSLDispatchAsync_\(hit.className)"
         out += """
             // Top-level instance + C-ABI dispatch shim for the DSL
             // module `\(hit.className)`. The `let` is lazily
@@ -269,6 +275,22 @@ func render(
                 _ argCount: Int
             ) -> WhiskerValueRaw {
                 return \(instance).dispatchModuleFunctionRaw(methodName, argsPtr, argCount)
+            }
+
+            // Async C-ABI shim (matches `WhiskerModuleAsyncDispatchFn`).
+            // Returns true if `\(hit.className)` has an `AsyncFunction`
+            // with the given name (it then owns `callback`); false lets
+            // the bridge sync-forward.
+            @_cdecl("\(asyncShim)")
+            public func \(asyncShim)(
+                _ methodName: UnsafePointer<CChar>?,
+                _ argsPtr: UnsafePointer<WhiskerValueRaw>?,
+                _ argCount: Int,
+                _ callback: WhiskerModuleCallback?,
+                _ userData: UnsafeMutableRawPointer?
+            ) -> Bool {
+                return \(instance).dispatchModuleFunctionRawAsync(
+                    methodName, argsPtr, argCount, callback, userData)
             }
 
         """


### PR DESCRIPTION
## Summary

Turns `whisker_bridge_invoke_module_async` from a **sync-forward stub** into real async module functions — the Expo-style `AsyncFunction` + `Promise` the DSL comment ("`AsyncFunction` lands later") and bridge comment ("Worker-pool dispatch … lands alongside the first async-API module") were deferring until a consumer needed it. That consumer is a RevenueCat module (StoreKit completion-handler async); no prior module needed request-response async (they were sync reads, fire-and-forget, or event-driven).

```swift
AsyncFunction("getOfferings") { (args, promise) in
    Purchases.shared.getOfferings { offerings, _ in
        promise.resolve(encode(offerings))   // resolves later, off the call
    }
}
```

## Design

A parallel **async dispatch table** alongside the sync one. `invoke_module_async` consults it first; if no `AsyncFunction` owns the method it **falls back to sync-forward** (`whisker_bridge_invoke_module`). So sync-only modules — and sync methods on mixed modules — keep working unchanged when reached via `invoke_async`. Backward compatible.

The Rust side was already resolve-later capable (`invoke_async`'s `oneshot` + `async_trampoline`); only the C bridge dispatch and the native DSL surface were missing.

## Changes

- **C bridge** (`whisker_bridge.h` + `common.cc` + `host_stub.cc` + `android.cc`, FFI in `whisker-driver-sys`): `WhiskerModuleAsyncDispatchFn` + `whisker_bridge_register_module_dispatch_async`; `invoke_module_async` reroutes. Android goes through a new `WhiskerModuleRegistry.invokeDispatchAsync` JNI call + a `nativeResolveAsync` JNI export (Kotlin-registry based, like the sync path — no C async table on Android).
- **iOS** (`WhiskerModule` + codegen): `AsyncFunction` DSL, `WhiskerPromise` (one-shot resolve/reject), `dispatchModuleFunctionRawAsync` (unknown method → false, callback untouched → bridge sync-forwards). Codegen emits a 2nd `@_cdecl` async shim and registers it for view-less modules.
- **Android** (`WhiskerModule`): `AsyncFunction` DSL, `WhiskerPromise` (holds the bridge callback/user_data as `Long`, `AtomicBoolean` one-shot), async registry + `invokeDispatchAsync` + `nativeResolveAsync external`, registrar registration.

## Tests

4 host tests (`whisker-driver` `module.rs`, exercising the real C bridge via the host stub): async dispatch is preferred and resolves inline; resolves later from another thread; falls back to sync when no async dispatch is registered; falls back when the async dispatch disowns the method. The iOS codegen tool builds on host and was run against a sample module to confirm the emitted async shim + registration.

## Notes

- `invoke_async` (`crates/whisker-driver/src/module.rs`) is unchanged — it already tolerated a late callback.
- The `WhiskerModule` Swift/Kotlin frameworks aren't host-compilable (Lynx binary deps), so those layers are review-verified; a downstream device build (via a whisker release bump) is the next validation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)