### PR TITLE
chore(release): SDK pins for AsyncFunction + module-driven iOS floor

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,7 +49,7 @@ use std::process::Command;
 /// Keep in lockstep with the `Package.swift` at the repo root and the
 /// `v<version>` git tag published for SwiftPM to resolve.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
-pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.3";
+pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.4";
 
 use crate::capture::{CaptureShims, capture_env_vars_for_triple};
 
@@ -668,6 +668,37 @@ fn crate_to_spm_target(crate_name: &str) -> String {
     out
 }
 
+/// iOS floor for the aggregator when no module asks for more.
+const DEFAULT_IOS_PLATFORM_MAJOR: u32 = 13;
+
+/// `.iOS(.v15)` → `15`, read from the `platforms:` list. `None` for a
+/// manifest that declares no iOS floor or spells it some other way
+/// (e.g. the `.iOS("16.4")` string form) — such a module just doesn't
+/// raise the aggregator's floor.
+fn parse_ios_platform_major(manifest: &str) -> Option<u32> {
+    const NEEDLE: &str = ".iOS(.v";
+    let rest = &manifest[manifest.find(NEEDLE)? + NEEDLE.len()..];
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// The aggregator's iOS floor: the highest any module package declares.
+///
+/// SwiftPM refuses to resolve a dependency whose minimum platform is
+/// higher than its consumer's, so pinning one version here caps what a
+/// module may require — `whisker-revenuecat` needs iOS 15 (RevenueCatUI's
+/// Customer Center) and could never resolve against a hardcoded `.v13`.
+/// Reading it back off the modules keeps that a module-local decision.
+fn ios_platform_major(modules: &[&crate::modules::ResolvedModule]) -> u32 {
+    modules
+        .iter()
+        .filter_map(|m| std::fs::read_to_string(m.manifest_dir.join("Package.swift")).ok())
+        .filter_map(|manifest| parse_ios_platform_major(&manifest))
+        .chain(std::iter::once(DEFAULT_IOS_PLATFORM_MAJOR))
+        .max()
+        .unwrap_or(DEFAULT_IOS_PLATFORM_MAJOR)
+}
+
 /// Render `Package.swift` for the generated `WhiskerModules`
 /// aggregator. Depends on `WhiskerRuntime` + each discovered
 /// module package via local-path SwiftPM dependency.
@@ -693,7 +724,10 @@ fn render_modules_package_swift(modules: &[&crate::modules::ResolvedModule]) -> 
     out.push_str("import PackageDescription\n\n");
     out.push_str("let package = Package(\n");
     out.push_str("    name: \"WhiskerModules\",\n");
-    out.push_str("    platforms: [.iOS(.v13)],\n");
+    out.push_str(&format!(
+        "    platforms: [.iOS(.v{})],\n",
+        ios_platform_major(modules)
+    ));
     out.push_str("    products: [\n");
     out.push_str("        .library(name: \"WhiskerModules\", targets: [\"WhiskerModules\"]),\n");
     out.push_str("    ],\n");
@@ -1111,5 +1145,21 @@ mod tests {
         let err = run_xcodebuild_app(&args).unwrap_err();
         assert!(err.to_string().contains("unknown SDK"), "got: {err:#}");
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn ios_platform_major_reads_the_declared_floor() {
+        assert_eq!(
+            parse_ios_platform_major("    platforms: [.iOS(.v15), .macOS(.v13)],"),
+            Some(15)
+        );
+    }
+
+    #[test]
+    fn ios_platform_major_ignores_a_manifest_without_an_ios_floor() {
+        assert_eq!(
+            parse_ios_platform_major("    platforms: [.macOS(.v13)],"),
+            None
+        );
     }
 }

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -175,7 +175,15 @@ pub struct PlatformSync {
 /// 0.1.14 to get the Lynx that exports the symbol; the per-app
 /// `WhiskerDriver` bridge built for this SDK refuses to attach to the
 /// older Lynx that lacks it (strict loader bind).
-const WHISKER_SDK_VERSION: &str = "0.1.14";
+///
+/// 0.1.15 ships `AsyncFunction` + `WhiskerPromise`
+/// (`whisker-module-android`, plus the registrar/registry plumbing that
+/// resolves an async function and the KSP codegen that emits it) — the
+/// Kotlin half of real async module functions. A module whose native
+/// half declares an `AsyncFunction` doesn't compile against 0.1.14, so
+/// apps shipping one must move to 0.1.15. Kotlin-only, no capi/Lynx ABI
+/// change.
+const WHISKER_SDK_VERSION: &str = "0.1.15";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/packages/whisker-asset/Package.swift
+++ b/packages/whisker-asset/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WhiskerAsset", targets: ["WhiskerAsset"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-haptics/Package.swift
+++ b/packages/whisker-haptics/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerHaptics", targets: ["WhiskerHaptics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
         // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
         // via Core Image, animated GIF via `AnimatedImageView`, in-
         // memory `NSCache` + disk cache out of the box. WebP requires

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-keyboard/Package.swift
+++ b/packages/whisker-keyboard/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "WhiskerKeyboard", targets: ["WhiskerKeyboard"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "WhiskerLocalStore", targets: ["WhiskerLocalStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
         // PoC — an external SwiftPM dependency. swift-collections is
         // Apple-maintained, header-only Swift, small enough that
         // resolving it is fast even on a cold cache. Use is minimal

--- a/packages/whisker-paths/Package.swift
+++ b/packages/whisker-paths/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerPaths", targets: ["WhiskerPaths"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-status-bar/Package.swift
+++ b/packages/whisker-status-bar/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .library(name: "WhiskerStatusBar", targets: ["WhiskerStatusBar"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "WhiskerSvg", targets: ["WhiskerSvg"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // it there, and the package identity (the crate's dir name)
         // is unique, so the app aggregator references it via
         // `.package(path: …)` without the `ios`-dir-name collision.
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-web-browser/Package.swift
+++ b/packages/whisker-web-browser/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "WhiskerWebBrowser", targets: ["WhiskerWebBrowser"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.3"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Why

The AsyncFunction / Promise work (#338) landed **after** both SDK releases, so a module whose native half declares an `AsyncFunction` cannot compile against either published SDK:

- iOS SwiftPM `v0.1.3` has no `WhiskerPromise.swift` (verified with `git ls-tree -r v0.1.3`)
- Android `sdk-v0.1.14` has no `WhiskerPromise.kt`

## What

- `WHISKER_IOS_SPM_VERSION` 0.1.3 → **0.1.4**, with every `packages/*/Package.swift` `exact:` pin moved in lockstep (the `spm_pin_consistency` guard test covers this).
- `WHISKER_SDK_VERSION` 0.1.14 → **0.1.15**, documented in the running per-version log in `platforms.rs`.
- The generated `WhiskerModules` aggregator hardcoded `platforms: [.iOS(.v13)]`, which capped what any module could require — SwiftPM refuses a dependency whose minimum platform is higher than its consumer's, so a module needing iOS 15 (RevenueCatUI's Customer Center) could never resolve. The floor is now the highest one the module manifests themselves declare, so raising it stays a module-local decision instead of needing a whisker release.

Tag `v0.1.4` and `sdk-v0.1.15` from the merge commit.

## Test

`cargo test -p whisker-build -p whisker-cli` — all green, including two new units for the platform-floor parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)