### PR TITLE
fix(ios): export whisker_bridge_register_module_dispatch_async

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -95,6 +95,11 @@ const BRIDGE_EXPORTS: &[&str] = &[
     // previous `_OBJC_CLASS_$_WhiskerModuleRegistry` export (the
     // Obj-C class is gone — pure C function pointer table now).
     "_whisker_bridge_register_module_dispatch",
+    // The `AsyncFunction` half of the same table. The codegen plugin
+    // emits a call to this in EVERY module's register fn — including
+    // modules that declare no async function — so leaving it out fails
+    // the link for any app with any module at all, not just async ones.
+    "_whisker_bridge_register_module_dispatch_async",
     // whisker-module event system (Phase L-2c). `add/remove_event_listener`
     // is consumed by Rust subscribers (e.g. AndroidPredictiveBack);
     // `send_event` is the native module → Rust fan-out;

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -1167,4 +1167,70 @@ mod tests {
             None
         );
     }
+
+    /// Every bridge function Swift *calls* has to be in
+    /// [`BRIDGE_EXPORTS`], or it never lands in the dylib's `.dynsym`
+    /// and the app fails to link. The list is hand-maintained and the
+    /// comment asking for that was not enough — #338 added
+    /// `whisker_bridge_register_module_dispatch_async` and every
+    /// module-using iOS app stopped linking.
+    #[test]
+    fn swift_call_sites_are_all_exported() {
+        fn swift_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    swift_files(&path, out);
+                } else if path.extension().is_some_and(|e| e == "swift") {
+                    out.push(path);
+                }
+            }
+        }
+
+        // Monorepo layout only — a published crate has no `platforms/`.
+        let ios = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../platforms/ios");
+        if !ios.is_dir() {
+            return;
+        }
+        let mut files = Vec::new();
+        swift_files(&ios, &mut files);
+        assert!(!files.is_empty(), "no .swift files under {}", ios.display());
+
+        let mut missing: Vec<String> = Vec::new();
+        for file in &files {
+            let Ok(contents) = std::fs::read_to_string(file) else {
+                continue;
+            };
+            for line in contents.lines() {
+                let code = line.split("//").next().unwrap_or("");
+                let mut rest = code;
+                while let Some(at) = rest.find("whisker_bridge_") {
+                    let tail = &rest[at..];
+                    let name: String = tail
+                        .chars()
+                        .take_while(|c| c.is_ascii_lowercase() || *c == '_' || c.is_ascii_digit())
+                        .collect();
+                    // Only call sites — a bare mention in a type
+                    // signature or a string isn't a link dependency.
+                    if tail[name.len()..].starts_with('(') {
+                        let exported = format!("_{name}");
+                        if !BRIDGE_EXPORTS.contains(&exported.as_str())
+                            && !missing.contains(&exported)
+                        {
+                            missing.push(exported);
+                        }
+                    }
+                    rest = &tail[name.len().max(1)..];
+                }
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "Swift calls these bridge functions but BRIDGE_EXPORTS omits them, \
+             so the dylib won't export them and the app won't link: {missing:?}",
+        );
+    }
 }


### PR DESCRIPTION
## The break

#338 added the async half of the module dispatch table but did not add it to `BRIDGE_EXPORTS`, so the symbol never reached the `WhiskerDriver` dylib's `.dynsym` and **every module-using iOS app failed to link**:

```
Undefined symbols for architecture x86_64:
  "_whisker_bridge_register_module_dispatch_async", referenced from:
      WhiskerHaptics._whiskerRegisterModules_WhiskerHaptics() -> () in WhiskerHaptics.o
      WhiskerImage._whiskerRegisterModules_WhiskerImage() -> () in WhiskerImage.o
      ...
```

Not limited to modules that declare an `AsyncFunction` — the codegen plugin emits the call in *every* module's register fn, so one module dependency of any kind was enough.

## The guard

The whitelist is hand-maintained and its "keep this in sync" comment was the only thing standing between a new bridge function and a broken link. Added a test that scans every `.swift` under `platforms/ios` for `whisker_bridge_*(` call sites and asserts each is exported.

Call sites only, with comments stripped: a bare mention in a signature, or a symbol the ObjC bridge implements and Rust calls, isn't a link dependency. On the tree as of this commit the heuristic flags exactly the one real omission and nothing else.

## Verification

Device-verified end to end on the iOS simulator with a real `AsyncFunction`-declaring module (a RevenueCat bridge): before this fix the app failed to link; after it, the app builds, launches, and the async round trip (`invoke_async` → Swift `AsyncFunction` → `WhiskerPromise` → Rust) returns live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)