### PR TITLE
fix(android): keep arm64 codegen on the Armv8.0 baseline

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,14 +10,18 @@ coverage-text = "llvm-cov --workspace"
 coverage-lcov = "llvm-cov --workspace --lcov --output-path lcov.info"
 
 [target.aarch64-linux-android]
-# `+lse` makes the compiler emit Armv8.1-A LSE atomic instructions
-# inline. That sidesteps the compiler-rt outline-atomics dispatcher
-# entirely — both its `init_have_lse_atomics` ELF initializer (which
+# `-outline-atomics` keeps us clear of the compiler-rt outline-atomics
+# dispatcher — both its `init_have_lse_atomics` ELF initializer (which
 # crashes inside a local `getauxval` stub when the bionic build
 # differs) and the `__aarch64_cas*` helpers (which end up unresolved
-# at .so load time when we strip compiler-rt out).
-# `-outline-atomics` then guarantees no code path falls back to the
-# dispatcher. Targets Pixel 5+ / API 30+ emulator (= Armv8.2+).
+# at .so load time when we strip compiler-rt out). With the dispatcher
+# off and no `+lse`, LLVM emits classic Armv8.0 `ldaxr`/`stlxr` loops,
+# which every `arm64-v8a` device can execute.
+#
+# Do NOT add `+lse` here (nor `-march=armv8.1-a` on the C++ side): it
+# inlines Armv8.1 `ldadd`/`cas`, and `arm64-v8a` is an Armv8.0
+# baseline, so pre-8.1 devices hit an undefined instruction and die
+# with SIGILL on the first atomic.
 #
 # `max-page-size=16384` aligns ELF LOAD segments to 16 KB pages so
 # the `.so` works on devices that boot with 16 KB pages. Pixel
@@ -27,6 +31,6 @@ coverage-lcov = "llvm-cov --workspace --lcov --output-path lcov.info"
 # becomes redundant — remove this line once we drop NDK r26
 # support.
 rustflags = [
-    "-C", "target-feature=+lse,-outline-atomics",
+    "-C", "target-feature=-outline-atomics",
     "-C", "link-arg=-Wl,-z,max-page-size=16384",
 ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ source, run an example on a device, and get a change merged.
 | **Rust** | Pinned by [`rust-toolchain.toml`](rust-toolchain.toml) (stable + `rustfmt` + `clippy`); `rustup` installs it automatically on first build. MSRV is **1.85** (edition 2024). |
 | **Targets** | `rustup target add aarch64-apple-ios-sim aarch64-apple-ios` (iOS) and `rustup target add aarch64-linux-android` (Android — only `arm64-v8a` is built). |
 | **iOS** | Xcode + an iOS Simulator. |
-| **Android** | Android SDK + an **NDK** (one of: `23.1.7779620`, `25.1.8937393`, `26.1.10909125`, `26.3.11579264`, `27.0.12077973`, `27.1.12297006` — `sdkmanager --install "ndk;<version>"`). Set `ANDROID_HOME` (or have `~/Library/Android/sdk`). An **arm64 emulator, API 30+** (Pixel 5 or newer) — the Android build uses `-Ctarget-feature=+lse` and 16 KB page alignment, which need Armv8.2+. |
+| **Android** | Android SDK + an **NDK** (one of: `23.1.7779620`, `25.1.8937393`, `26.1.10909125`, `26.3.11579264`, `27.0.12077973`, `27.1.12297006` — `sdkmanager --install "ndk;<version>"`). Set `ANDROID_HOME` (or have `~/Library/Android/sdk`). An **arm64 emulator, API 30+** (Pixel 5 or newer) — the Android build aligns to 16 KB pages. |
 
 You only need the toolchain for the platform(s) you're touching. Pure-Rust
 work (runtime, router, macros, …) needs no device tooling at all.

--- a/crates/whisker-driver-sys/build.rs
+++ b/crates/whisker-driver-sys/build.rs
@@ -121,11 +121,20 @@ fn compile_android() -> Result<()> {
         .file(bridge_src.join("whisker_bridge_lynx_loader.cc"))
         .include(bridge_root().join("include"))
         .include(&bridge_src);
-    // Force inline LSE atomics so the C++ side never reaches for
-    // compiler-rt's outline-atomics dispatcher (`__aarch64_cas*`,
-    // `init_have_lse_atomics`). The Rust side gets the same treatment
-    // via `.cargo/config.toml` target-feature flags.
-    build.flag("-march=armv8.1-a");
+    // Keep the C++ side away from compiler-rt's outline-atomics
+    // dispatcher (`__aarch64_cas*`, `init_have_lse_atomics`) — its ELF
+    // initializer crashes inside a local `getauxval` stub on some
+    // bionic builds, and the helpers go unresolved at load time once
+    // compiler-rt is stripped out.
+    //
+    // Disabling the dispatcher is enough on its own: clang then emits
+    // classic Armv8.0 `ldaxr`/`stlxr` loops inline. It must NOT be
+    // paired with `-march=armv8.1-a`, which emits LSE (`ldadd`) —
+    // `arm64-v8a` is an Armv8.0 baseline, so those are undefined
+    // instructions on a real Armv8.0 device and the app dies with
+    // SIGILL the first time it touches an atomic. Device-confirmed on
+    // a Snapdragon 636 e-reader, where every `on_event` call site
+    // crashed at `NextListenerId`'s `fetch_add`.
     build.flag("-mno-outline-atomics");
     silence_unused_parameter_warnings(&mut build);
     build.compile("whisker_bridge_static");

--- a/crates/whisker-driver-sys/src/lib.rs
+++ b/crates/whisker-driver-sys/src/lib.rs
@@ -592,3 +592,23 @@ unsafe extern "C" {
         user_data: *mut c_void,
     ) -> bool;
 }
+
+#[cfg(test)]
+mod tests {
+    /// The bridge must stay executable on every `arm64-v8a` device.
+    /// That ABI's baseline is Armv8.0, so an `-march=armv8.1-a` (or
+    /// `+lse`) flag turns C++ atomics into `ldadd`/`cas` — undefined
+    /// instructions that kill the app with SIGILL on older hardware,
+    /// which no emulator or recent phone ever reproduces. Guard the
+    /// flag list rather than wait for the next e-reader bug report.
+    #[test]
+    fn bridge_targets_the_armv8_0_baseline() {
+        // Any `-march` at all, since every form that would compile
+        // here (`armv8.1-a`, `armv8-a+lse`, …) raises the floor.
+        let build_rs = include_str!("../build.rs");
+        assert!(
+            !build_rs.contains("flag(\"-march="),
+            "build.rs sets -march on the bridge, raising it above the arm64-v8a baseline",
+        );
+    }
+}

--- a/docs/lynx-integration.md
+++ b/docs/lynx-integration.md
@@ -118,9 +118,13 @@ What `build.rs` still does:
   iOS: `Foundation`, `UIKit`, `CoreFoundation`, `QuartzCore`, `c++`,
   `objc`.
 
-On Android the bridge forces inline LSE atomics (`-march=armv8.1-a`,
-`-mno-outline-atomics`) so it never reaches for compiler-rt's
-outline-atomics dispatcher. Android support is arm64-v8a only.
+On Android the bridge compiles with `-mno-outline-atomics` so it never
+reaches for compiler-rt's outline-atomics dispatcher; clang then inlines
+Armv8.0 `ldaxr`/`stlxr` loops, which the whole `arm64-v8a` ABI can run.
+Never pair that with `-march=armv8.1-a` — the resulting LSE
+instructions (`ldadd`, `cas`) are undefined on pre-8.1 hardware and the
+app takes a SIGILL on its first atomic. Android support is arm64-v8a
+only.
 
 Forcing the bridge entry points into the iOS dylib's `.dynsym` is **not**
 done here — `cargo:rustc-link-arg` from an rlib's build.rs doesn't reach


### PR DESCRIPTION
## 何が起きていたか

Android ビルドは C++ ブリッジ (`-march=armv8.1-a`) と Rust 側 (`-Ctarget-feature=+lse`) の両方で **Armv8.1 の LSE アトミック命令** (`ldadd` / `cas`) をインライン展開していました。

`arm64-v8a` ABI のベースラインは Armv8.0 です。8.1 未満の実機ではこれらは未定義命令なので、**最初にアトミック変数へ触れた瞬間に SIGILL で即死**します。

BOOX Page (Snapdragon 636 / Android 11) で確認:

```
signal 4 (SIGILL), code 1 (ILL_ILLOPC)
  #00 NextListenerId()
  #01 whisker_bridge_module_add_event_listener
```

`on_event` の登録は全プラットフォームモジュールが起動時に通る経路なので、**該当機では whisker アプリが例外なく起動不能**でした。エミュレータでも近年の実機でも再現しないため、`CONTRIBUTING.md` はこれを「Armv8.2+ が必要」と仕様として記述してしまっていました。

## 修正

LSE そのものは目的ではなく、**compiler-rt の outline-atomics ディスパッチャを避ける**ことが目的でした（`init_have_lse_atomics` が一部の bionic ビルドでクラッシュし、compiler-rt を剥がすと `__aarch64_cas*` が未解決になる）。

`-mno-outline-atomics` / `-outline-atomics` だけでその目的は達成されます。ディスパッチャが無効かつ `+lse` が無い状態では、clang は Armv8.0 の `ldaxr`/`stlxr` ループをインライン展開します — ランタイムサポートは一切不要で、全 `arm64-v8a` 機で動きます。

## 検証

- 再ビルドした `libgiga.so`: LSE 命令 **0 個** / LL/SC ループ **2281 個**（修正前は `NextListenerId` に `ldadd`, `ldadda`）
- BOOX Page で giga が起動し、ホーム画面が正常描画（修正前は毎回 SIGILL）
- エミュレータ回帰なし

`bridge_targets_the_armv8_0_baseline` テストを追加しました。この不具合はエミュレータからも最近の端末からも一切見えないため、フラグ自体をガードします。