### PR TITLE
fix(cng): stop the system panning the window for the keyboard

### DIFF
--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -800,9 +800,10 @@ pub fn inputs_from_with_engine(
         extra_gradle_plugins,
         extra_gradle_dependencies,
         extra_files,
-        // Bumped 12 → 13: `{{android_theme}}` + MainActivity import/body
-        // placeholders (plugin-driven theme override + onCreate injection).
-        template_version: 13,
+        // Bumped 13 → 14: the MainActivity carries
+        // `windowSoftInputMode="adjustResize"` (app-owned keyboard
+        // avoidance — see the manifest template).
+        template_version: 14,
     })
 }
 
@@ -850,7 +851,7 @@ mod tests {
             extra_gradle_plugins: Vec::new(),
             extra_gradle_dependencies: Vec::new(),
             extra_files: BTreeMap::new(),
-            template_version: 13,
+            template_version: 14,
         }
     }
 
@@ -991,6 +992,9 @@ mod tests {
         assert!(manifest.contains("android:name=\".HelloWorldApplication\""));
         assert!(manifest.contains("android:label=\"HelloWorld\""));
         assert!(!manifest.contains("{{"));
+        // The activity opts out of system keyboard avoidance — the app
+        // lays out around the IME inset itself.
+        assert!(manifest.contains("android:windowSoftInputMode=\"adjustResize\""));
 
         let main_activity = std::fs::read_to_string(
             out.join("app/src/main/kotlin/rs/whisker/examples/helloworld/MainActivity.kt"),

--- a/crates/whisker-cng/src/templates/android/app/src/main/AndroidManifest.xml
+++ b/crates/whisker-cng/src/templates/android/app/src/main/AndroidManifest.xml
@@ -15,9 +15,22 @@
         android:theme="{{android_theme}}"
 {{extra_application_attributes}}        >
 {{extra_application_meta_data}}
+        <!-- Keyboard avoidance is the app's job here: `WhiskerActivity`
+             forces edge-to-edge and `whisker-keyboard` surfaces the IME
+             inset to Rust for the content to lay out around. Left
+             unspecified, the system ALSO pans the window whenever the
+             focused field would be covered — the content jumps past the
+             app's own avoidance and eases back down, a full-screen slide
+             iOS has no counterpart for. `adjustResize` stops the pan
+             without resizing anything (an edge-to-edge window keeps its
+             size and just receives the inset); `adjustNothing` would
+             stop it too, but it would also leave pre-API-30 devices —
+             where `WindowInsetsCompat.Type.ime()` reports nothing —
+             with no keyboard avoidance at all. -->
         <activity
             android:name=".MainActivity"
-            android:exported="true"{{main_activity_launch_mode}}>
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize"{{main_activity_launch_mode}}>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Problem

`WhiskerActivity` forces edge-to-edge and `whisker-keyboard` hands the IME inset
to Rust, so a Whisker screen lays its own content out around the keyboard. The
generated manifest leaves `windowSoftInputMode` unspecified, which leaves the
system free to pan the window on top of that whenever the focused field would be
covered.

Both then run at once. Frame-by-frame on a screen that focuses its field on
mount (a search screen with a floating, keyboard-avoiding bar):

1. the search screen opens, bar at the bottom edge;
2. before the keyboard is even visible, the app's own avoidance moves the bar up
   to its keyboard-avoided position (~60% of screen height);
3. the system pan carries the whole window further up (bar overshoots to ~34%);
4. as the IME animation completes the pan eases back to zero — the entire screen
   visibly slides downward into place.

iOS has no counterpart: UIKit never moves the window, so the app's avoidance is
the only thing that moves and the bar simply rises with the keyboard.

## Fix

`android:windowSoftInputMode="adjustResize"` on the generated `MainActivity`
(+ `template_version` 13 → 14 so existing `gen/` trees regenerate, + an
assertion on the rendered manifest).

`adjustResize` stops the pan without resizing anything — an edge-to-edge window
keeps its size and just receives the inset. `adjustNothing` would also stop it,
but it would leave pre-API-30 devices, where `WindowInsetsCompat.Type.ime()`
reports nothing, with no keyboard avoidance at all; `adjustResize` still
degrades to the legacy resize there.

## What this makes the app responsible for

With the system pan gone, a screen that does not read `keyboard_height()` no
longer gets bailed out by the OS — it behaves like the same screen on iOS. That
is the intended alignment, but it is a visible change for apps that were relying
on the pan without knowing it.

## Verification

Ruled out first, so the diagnosis isn't guesswork:

- not the route transition — Android's default (`SmallSlideFade`) is
  `translateX` + opacity, no vertical component;
- not `whisker-keyboard` — instrumenting `KeyboardModule.dispatch` and reading
  logcat shows the IME inset arriving once, cleanly (`817px = 297.0dp`), with no
  transient overshoot.

Screen recordings before/after on an arm64 emulator (Android 11 / API 30,
Gboard), opening a search screen that calls `InputRef::focus()` on mount: the
overshoot and the downward slide are both gone, and the floating bar goes from
the bottom edge straight to just above the keyboard while the keyboard slides up
beneath it. `cargo test -p whisker-cng` (118 tests), `cargo fmt --all --check`,
and `cargo clippy -p whisker-cng --all-targets -- -D warnings` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)