### PR TITLE
docs: add Whisker app development skill

### DIFF
--- a/.agents/skills/build-whisker-apps/SKILL.md
+++ b/.agents/skills/build-whisker-apps/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: build-whisker-apps
+description: Build, extend, diagnose, and validate native iOS and Android apps written in Rust with Whisker. Use for Whisker app scaffolding, render! and css! components, signals, input, persistence, routing, native modules and plugins, hot reload, whisker run, whisker fmt, and whisker doctor. For changes to the Whisker framework itself, follow the repository's CONTRIBUTING.md instead.
+---
+
+# Build Whisker Apps
+
+Use the API resolved by the target app. Whisker changes quickly, so confirm the app's dependency and CLI versions before copying current examples or documentation.
+
+## Select the matching source
+
+1. Inspect `Cargo.toml`, `Cargo.lock`, path or Git dependencies, and `whisker --version`.
+2. Treat the matching release source or resolved crate source as authoritative for API shape.
+3. Use examples, package rustdoc, tests, changelogs, and the editable website source to fill in details.
+4. When sources disagree, compile against the target dependency instead of silently upgrading it.
+
+Read [source selection](references/source-selection.md) when choosing documentation, resolving a version mismatch, or diagnosing the toolchain.
+
+## Work within the app repository
+
+- Read applicable repository instructions before editing.
+- Inspect the worktree, workspace members, manifests, and lockfile without disturbing unrelated changes.
+- Determine whether the app is already scaffolded or belongs to a larger Cargo workspace.
+- Preserve the existing structure unless the task explicitly calls for scaffolding or migration.
+- Keep `src/lib.rs` focused on the `#[whisker::main]` entry point and top-level composition as the app grows.
+- Put domain models, commands, serialization, and repositories in ordinary Rust modules that can be tested without a simulator.
+- Keep app identity and platform or plugin configuration in `whisker.rs`.
+- Do not hand-edit or commit `gen/`; `whisker run` can regenerate it.
+
+## Apply Whisker's reactive model
+
+- Assume component bodies run once at mount. Put mutable UI state in signals.
+- Pass signal handles or tracked closures for live attributes. A plain `.get()` passed during mount is a snapshot.
+- Derive values with `computed` instead of synchronizing duplicate writable state.
+- Mutate collections with `update`.
+- Render short collections with `ForEach` and stable unique keys. A retained key preserves its child and does not rerun `children(item)`, so mutable rows should read current state reactively by ID.
+- Use the virtualized `list` element for large scrolling collections.
+- Use `Show` for reactive branch mounting and disposal.
+- Keep signal reads and writes on Whisker's UI thread.
+- Set flex direction explicitly; Lynx defaults it to row.
+- Add accessibility labels and traits to interactive elements.
+
+Read [application patterns](references/app-patterns.md) when implementing components, input, lists, persistence, async work, modules, or plugins.
+
+## Handle native capability and IO
+
+- Confirm that each first-party package exists in the app's target version before adding it.
+- Use `whisker-local-store` for small string values. Serialize structured values explicitly and surface bridge or decoding errors.
+- Do not block the UI thread. Use `run_blocking` for synchronous filesystem, database, CPU, or HTTP work.
+- Use `spawn_local` or `resource` for async flows. When the `tokio` feature is enabled, follow the current Tokio example rather than adding a second runtime.
+- Add native capability through a module and native project configuration through a plugin registered in `whisker.rs`.
+- Register only the permissions and platform configuration the app needs.
+
+## Validate the change
+
+Run the narrowest relevant checks first:
+
+```sh
+cargo check --workspace --all-targets
+cargo test --workspace --all-targets
+whisker fmt --check <changed-rust-files>
+whisker doctor
+```
+
+- Include every changed Rust file in `whisker fmt`; `cargo fmt` does not format Whisker macro bodies.
+- Run `whisker run ios` or `whisker run android` for UI or native changes and inspect the app and logs.
+- Restart the development loop after dependency, function signature, `whisker.rs`, or native configuration changes. Hot reload alone does not prove a clean launch.
+- If platform execution is unavailable, complete pure Rust checks and state the exact SDK, simulator, emulator, signing, or device gap.
+- Record framework defects in the upstream issue tracker only after separating them from application code and reducing them to a reproducible case.

--- a/.agents/skills/build-whisker-apps/evals/evals.json
+++ b/.agents/skills/build-whisker-apps/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill_name": "build-whisker-apps",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Build a Whisker todo app in this existing Rust repository without replacing its README or unrelated workspace members. It needs native text input, stable keyed rows, and local persistence.",
+      "expected_output": "A Whisker app integrated into the existing repository with reactive input, stable item identity, serialized local persistence, pure Rust state tests, and platform validation that preserves unrelated files."
+    },
+    {
+      "id": 2,
+      "prompt": "A Whisker ForEach list reorders correctly, but toggling a retained row does not update its label. Diagnose and fix it without recreating every row.",
+      "expected_output": "A diagnosis of retained keyed children using their mount-time item snapshot, followed by a fix that keeps the stable key and derives mutable row fields reactively from shared state by ID."
+    },
+    {
+      "id": 3,
+      "prompt": "whisker doctor passes on macOS, but whisker run ios cannot find a simulator destination. Investigate the failure and prepare a minimal upstream report if it is a Whisker defect.",
+      "expected_output": "A version-aware diagnosis covering the CLI, resolved crates, Xcode, iOS SDK, installed simulator runtimes, and build destination, with application and framework causes separated before drafting a concise reproduction."
+    }
+  ]
+}

--- a/.agents/skills/build-whisker-apps/references/app-patterns.md
+++ b/.agents/skills/build-whisker-apps/references/app-patterns.md
@@ -1,0 +1,104 @@
+# Application Patterns
+
+Use these patterns as boundaries, then confirm syntax in the target version's source and examples.
+
+## Components and state
+
+Keep components responsible for view composition and event wiring. Put state transitions, validation, serialization, and migration logic in plain Rust functions.
+
+Component bodies run once at mount. Dynamic values must be read by an effect-backed attribute, a signal prop, `computed`, or another tracked closure.
+
+```rust
+let items = signal(Vec::<Item>::new());
+let remaining = computed(move || {
+    items.with(|items| items.iter().filter(|item| !item.done).count())
+});
+```
+
+Passing `remaining` to a compatible prop stays reactive. Passing `remaining.get()` while mounting produces the current value only.
+
+Use `update` for mutations that belong to one state transition:
+
+```rust
+items.update(|items| {
+    if let Some(item) = items.iter_mut().find(|item| item.id == id) {
+        item.done = !item.done;
+    }
+});
+```
+
+## Keyed collections
+
+Use stable persisted identity rather than a list index.
+
+```rust
+ForEach(
+    each: move || items.get(),
+    key: |item: &Item| item.id,
+    children: move |item: Item| render! {
+        ItemRow(id: item.id, items: items)
+    },
+)
+```
+
+`ForEach` preserves the owner and element for a retained key. It does not call `children(item)` again, so `ItemRow` should derive mutable fields from the shared signal and stable ID. This preserves row-local state while allowing the row to repaint.
+
+Use `list` when the collection is large enough to require native virtualization.
+
+## Text input
+
+Use `whisker-input` when it exists in the selected release. Prefer two-way binding for ordinary fields and controlled binding when input must be transformed.
+
+```rust
+let draft = signal(String::new());
+
+render! {
+    Input(
+        text: draft,
+        placeholder: "Add an item",
+    )
+}
+```
+
+Keep submission as one transition: normalize and validate the string, update state, persist it, then clear the field after success.
+
+The input component accepts a raw style string in current releases. Confirm its props in `packages/whisker-input` instead of assuming every core `css!` value is accepted directly.
+
+## Persistence
+
+`whisker-local-store` stores strings. Serialize structured state with a versioned key and handle absent or malformed values explicitly.
+
+```rust
+const STATE_KEY: &str = "items.state.v1";
+
+fn save_state(state: &StoredState) -> Result<(), String> {
+    let json = serde_json::to_string(state).map_err(|error| error.to_string())?;
+    WhiskerLocalStore::save(STATE_KEY.to_owned(), json)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+```
+
+Persist monotonic IDs with the data when identity must survive deletion, restart, and reordering. Treat schema migration separately from UI rendering.
+
+Use secure storage for credentials and secrets. Local store is not a credential vault or cross-device database.
+
+## Async work
+
+Use `resource` for loadable async state and `spawn_local` for event-driven async work. Use `run_blocking` for synchronous work that would otherwise block the UI thread.
+
+When the app enables Whisker's `tokio` feature, use the runtime already entered by Whisker. Current examples await Tokio-backed IO and `tokio::task::spawn_blocking` directly; verify that behavior in the target release before copying it.
+
+Keep signal access on the UI thread. Return owned values from background work and apply them after awaiting on the Whisker task.
+
+## Modules, plugins, and generated projects
+
+- Use a module for a callable native capability.
+- Use a plugin for native build or project configuration.
+- Register plugins and app configuration in `whisker.rs`.
+- Treat `gen/` as disposable output.
+- Add only the platform permissions required by the feature.
+
+## Validation
+
+Test pure state transitions and serialization without a simulator. For UI behavior, verify input, keyboard handling, empty and long content, reordering, persistence after relaunch, accessibility, and a clean build in addition to hot reload.

--- a/.agents/skills/build-whisker-apps/references/source-selection.md
+++ b/.agents/skills/build-whisker-apps/references/source-selection.md
@@ -1,0 +1,68 @@
+# Source Selection
+
+Use the smallest set of sources that establishes the API for the app's resolved version.
+
+## Authority order
+
+1. The exact source selected by `Cargo.lock`, a path dependency, or a Git revision
+2. The matching release tag in `whiskerrs/whisker`
+3. Examples, tests, changelogs, and rustdoc from that source tree
+4. The editable documentation in `whiskerrs/website`
+5. The rendered documentation at `https://whisker.rs/`
+
+The framework source determines compile-time API shape. Documentation from another release can still explain a concept, but it cannot prove that an item exists in the target version.
+
+When working inside the Whisker framework repository, follow `CONTRIBUTING.md` and run the workspace CLI with `cargo run -p whisker-cli -- ...`. Do not test local framework changes with a globally installed CLI.
+
+## Establish the target version
+
+```sh
+rg -n 'whisker|version|git|path' Cargo.toml Cargo.lock
+whisker --version
+cargo tree | rg '^whisker'
+cargo metadata --format-version 1
+```
+
+- `Cargo.lock` and `cargo tree` describe the app build.
+- `whisker --version` describes the installed CLI and may differ from the app crates.
+- Path and Git dependencies must be inspected at their exact path or revision.
+- Do not change versions as a side effect of an unrelated feature.
+
+## Find the implementation surface
+
+| Capability | Framework source |
+| --- | --- |
+| Components and macros | `crates/whisker`, `crates/whisker-macros` |
+| CSS and layout | `crates/whisker-css`, examples |
+| Signals, resources, and tasks | `crates/whisker-runtime` |
+| CLI, scaffolding, and platform runs | `crates/whisker-cli`, `crates/whisker-cng` |
+| Input | `packages/whisker-input` |
+| Persistence | `packages/whisker-local-store`, `packages/whisker-secure-store` |
+| Routing | `packages/whisker-router` |
+| Native capability | the corresponding package and example |
+| Modules and plugins | `crates/whisker-plugin`, first-party packages |
+
+Prefer targeted searches:
+
+```sh
+rg -n 'Input\(|on_input|text:' packages/whisker-input examples
+rg -n 'WhiskerLocalStore|fn save|fn load' packages/whisker-local-store examples
+rg -n 'run_blocking|spawn_local|resource\(' crates examples
+rg -n 'routes!|use_navigator|use_param' packages/whisker-router examples
+rg -n 'package.metadata.whisker|plugin::<' packages examples
+```
+
+Read a public API and a current example before copying internal types. Use tests for edge cases.
+
+## Diagnose platform failures
+
+Capture the versions that participate in the failed path:
+
+- Whisker crates and CLI
+- Rust toolchain and target
+- macOS and Xcode, including installed iOS SDK and simulator runtime
+- Android SDK, NDK, ABI, and emulator API level
+
+Run `whisker doctor`, then compare its result with the failing build or run command. A successful probe does not establish that the selected build destination, runtime, or signing configuration is usable.
+
+Search existing issues before reporting a framework defect. Include the smallest reproduction, expected and actual behavior, environment versions, and any verified workaround.


### PR DESCRIPTION
Adds a project-level Agent Skill under `.agents/skills/build-whisker-apps` for building, debugging, and validating Whisker apps.

It covers version-aware source selection, reactive state and keyed lists, native input and persistence, async work, modules and plugins, platform diagnostics, validation, and three evaluation prompts.
