### PR TITLE
feat(whisker-image): send request headers, report outcomes, prefetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4398,7 +4398,16 @@ dependencies = [
 name = "whisker-image"
 version = "0.10.1"
 dependencies = [
+ "serde",
  "whisker",
+]
+
+[[package]]
+name = "whisker-image-example"
+version = "0.1.0"
+dependencies = [
+ "whisker",
+ "whisker-image",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "packages/whisker-icons",
     "packages/whisker-icons/example",
     "packages/whisker-image",
+    "packages/whisker-image/example",
     "packages/whisker-input",
     "packages/whisker-input/example",
     "packages/whisker-keyboard",

--- a/packages/whisker-image/Cargo.toml
+++ b/packages/whisker-image/Cargo.toml
@@ -36,3 +36,5 @@ crate-type = ["rlib"]
 
 [dependencies]
 whisker = { workspace = true }
+# Event payloads cross as JSON bodies; `bind_typed` deserialises them.
+serde = { workspace = true, features = ["derive"] }

--- a/packages/whisker-image/android/src/main/kotlin/rs/whisker/elements/image/ImageModule.kt
+++ b/packages/whisker-image/android/src/main/kotlin/rs/whisker/elements/image/ImageModule.kt
@@ -17,6 +17,35 @@ import rs.whisker.runtime.WhiskerValue
 class ImageModule : Module() {
     override fun definition() = ModuleDefinition {
         Name("Image")
+
+        // Prefetching belongs to no particular view — the pages after
+        // the one on screen have no element yet.
+        AsyncFunction("prefetch") { args: List<WhiskerValue>, promise ->
+            val urls = (args.firstOrNull() as? WhiskerValue.Array)
+                ?.value
+                ?.mapNotNull { it.asString() }
+                .orEmpty()
+            val headers = args.getOrNull(1)?.asString().orEmpty()
+            // The activity's application context: `AppContext` exposes
+            // the live host, and Coil's loader belongs to the process
+            // rather than to whatever is on screen.
+            val context = appContext.currentActivity?.applicationContext
+            if (context != null) {
+                val parsed: kotlin.collections.Map<String, String> = runCatching {
+                    val fields = org.json.JSONObject(headers)
+                    fields.keys().asSequence().associateWith { fields.optString(it) }
+                }.getOrDefault(emptyMap())
+                val loader = coil.Coil.imageLoader(context)
+                for (url in urls) {
+                    val request = coil.request.ImageRequest.Builder(context)
+                        .data(url)
+                        .apply { parsed.forEach { (name, value) -> addHeader(name, value) } }
+                        .build()
+                    loader.enqueue(request)
+                }
+            }
+            promise.resolve(WhiskerValue.Null)
+        }
         View(WhiskerImageView::class.java) {
             Prop("src") { view: WhiskerImageView, value ->
                 view.setSrc(value.asString() ?: "")
@@ -24,6 +53,10 @@ class ImageModule : Module() {
             Prop("mode") { view: WhiskerImageView, value ->
                 view.setMode(value.asString() ?: "aspectFill")
             }
+            Prop("headers") { view: WhiskerImageView, value ->
+                view.setHeaders(value.asString() ?: "")
+            }
+            Events("load", "error")
         }
     }
 }

--- a/packages/whisker-image/android/src/main/kotlin/rs/whisker/elements/image/WhiskerImageView.kt
+++ b/packages/whisker-image/android/src/main/kotlin/rs/whisker/elements/image/WhiskerImageView.kt
@@ -13,11 +13,13 @@ import coil.request.Disposable
 import coil.transform.RoundedCornersTransformation
 import com.lynx.tasm.behavior.StylesDiffMap
 import rs.whisker.runtime.WhiskerContext
+import rs.whisker.runtime.WhiskerCustomEvent
 import rs.whisker.runtime.WhiskerUI
 
 open class WhiskerImageView(context: WhiskerContext) : WhiskerUI<ImageView>(context) {
 
     private var currentSrc: String? = null
+    private var currentHeaders: Map<String, String> = emptyMap()
     private var currentRequest: Disposable? = null
     /// Active corner radius in **device pixels** — the value Lynx's
     /// CSS pipeline has already converted from the `8px` source. Fed
@@ -87,6 +89,24 @@ open class WhiskerImageView(context: WhiskerContext) : WhiskerUI<ImageView>(cont
      * strings onto `ImageView.ScaleType`. Unknown values fall back
      * to `aspectFill` (CENTER_CROP).
      */
+    /// Backing of the `headers` prop: a JSON object of request
+    /// headers. Re-fetches, because a host that answers differently
+    /// per header answers differently per change.
+    fun setHeaders(json: String) {
+        val parsed = parseHeaders(json)
+        if (parsed == currentHeaders) return
+        currentHeaders = parsed
+        reload()
+    }
+
+    private fun parseHeaders(json: String): Map<String, String> {
+        if (json.isBlank()) return emptyMap()
+        return runCatching {
+            val object_ = org.json.JSONObject(json)
+            object_.keys().asSequence().associateWith { object_.optString(it) }
+        }.getOrDefault(emptyMap())
+    }
+
     fun setMode(value: String) {
         val imageView = view ?: return
         imageView.scaleType = when (value) {
@@ -120,6 +140,43 @@ open class WhiskerImageView(context: WhiskerContext) : WhiskerUI<ImageView>(cont
 
         currentRequest = imageView.load(src) {
             crossfade(200)
+            // Two requests that differ only by header are two different
+            // resources: the cache is keyed by URL alone, so without
+            // this a header change hands back the answer to the old one.
+            if (currentHeaders.isNotEmpty()) {
+                val key = src + "|" + currentHeaders.entries
+                    .sortedBy { it.key }
+                    .joinToString(";") { "${it.key}=${it.value}" }
+                memoryCacheKey(key)
+                diskCacheKey(key)
+            }
+            // The outcome is reported either way: a page that 403s is
+            // otherwise a blank the app never hears about.
+            listener(
+                onSuccess = { _, result ->
+                    WhiskerCustomEvent.dispatch(
+                        this@WhiskerImageView,
+                        "load",
+                        mapOf(
+                            "width" to result.drawable.intrinsicWidth,
+                            "height" to result.drawable.intrinsicHeight,
+                        ),
+                    )
+                },
+                onError = { _, result ->
+                    WhiskerCustomEvent.dispatch(
+                        this@WhiskerImageView,
+                        "error",
+                        mapOf("error" to (result.throwable.message ?: "load failed")),
+                    )
+                },
+            )
+            // Hot-link protection is the reason: those hosts answer 403
+            // unless the request carries the `Referer` their own pages
+            // send.
+            for ((name, value) in currentHeaders) {
+                addHeader(name, value)
+            }
             memoryCachePolicy(CachePolicy.ENABLED)
             diskCachePolicy(CachePolicy.ENABLED)
             if (cornerRadiusPx > 0f) {

--- a/packages/whisker-image/build.gradle.kts
+++ b/packages/whisker-image/build.gradle.kts
@@ -46,7 +46,9 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
+    // 0.1.15 for the module-level `AsyncFunction` the `prefetch`
+    // entry point needs; the view-only packages still build on 0.1.0.
+    implementation("rs.whisker:whisker-module-android:0.1.15")
     ksp("rs.whisker:ksp:0.1.0")
 
     // Coil 2.7 — Kotlin-first, coroutine-native image loader. Base

--- a/packages/whisker-image/example/Cargo.toml
+++ b/packages/whisker-image/example/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "whisker-image-example"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Example app for `whisker-image`. Loads a public image, a URL that fails, and a host that only answers with the right `Referer` — so `headers`, `on_load`, `on_error` and `prefetch` are verified against a real device rather than a mock."
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+whisker = { workspace = true }
+whisker-image = { path = ".." }

--- a/packages/whisker-image/example/src/lib.rs
+++ b/packages/whisker-image/example/src/lib.rs
@@ -1,0 +1,200 @@
+//! `whisker-image` example app.
+//!
+//! Every card here is a question the module can only answer on a device:
+//!
+//! * **headers** — `https://httpbin.org/image` answers `406` unless the
+//!   request carries an `Accept` the host likes, so the same URL loading
+//!   or failing is proof of whether the header left the phone.
+//! * **on_load** — a public image reports the pixel size it decoded.
+//! * **on_error** — a URL that 404s says so, rather than leaving a blank.
+//! * **prefetch** — three images warmed before any element points at
+//!   them; showing them afterwards should paint from cache.
+
+use whisker::prelude::*;
+use whisker::runtime::view::Element;
+use whisker_image::{Image, ImageEvent, ImageMode, prefetch};
+
+const BG: &str = "#101012";
+const CARD_BG: &str = "#1c1c1f";
+const FG: &str = "#f0f0f3";
+const MUTED: &str = "#9a9aa2";
+const OK: &str = "#5bd68a";
+const BAD: &str = "#ff5577";
+
+/// Answers `200 image/png` with an `Accept` it likes and `406` without.
+const HEADER_PROBE: &str = "https://httpbin.org/image";
+const ACCEPT_PNG: &str = r#"{"Accept": "image/png"}"#;
+/// An `Accept` the host refuses, so a platform that sends a usable one
+/// by default still shows the header arriving: the load starts failing
+/// only because of what we asked for.
+const ACCEPT_TEXT: &str = r#"{"Accept": "text/plain"}"#;
+const MISSING: &str = "https://httpbin.org/status/404";
+const PHOTO: &str = "https://picsum.photos/seed/whisker/600/400";
+const WARM: [&str; 3] = [
+    "https://picsum.photos/seed/one/300/200",
+    "https://picsum.photos/seed/two/300/200",
+    "https://picsum.photos/seed/three/300/200",
+];
+
+#[whisker::main]
+pub fn app() -> Element {
+    let page = format!(
+        "background-color: {BG}; flex-grow: 1; flex-direction: column; \
+         padding: 16px; padding-top: 64px;"
+    );
+    let card = format!(
+        "background-color: {CARD_BG}; border-radius: 12px; padding: 12px; \
+         margin-bottom: 16px; flex-direction: column;"
+    );
+    let heading = format!("color: {FG}; font-size: 16px; font-weight: bold;");
+    let note = format!("color: {MUTED}; font-size: 13px; margin-top: 4px;");
+    let thumb = "width: 100%; height: 140px; border-radius: 8px; margin-top: 8px;";
+    let button = format!(
+        "background-color: {BAD}; border-radius: 8px; padding: 10px; \
+         align-items: center; justify-content: center; margin-top: 8px;"
+    );
+    let button_text = format!("color: {FG}; font-size: 14px; font-weight: bold;");
+
+    // Card 1 — the header actually leaving the phone.
+    // 0 none, 1 an Accept the host likes, 2 one it refuses. Platforms
+    // differ in what they send by default — iOS asks for `*/*` and is
+    // refused, Android asks for `image/*` and is served — so one step
+    // or the other proves the header left the phone on either.
+    let accept = RwSignal::new(0u8);
+    let probe_status = RwSignal::new("waiting".to_string());
+    let probe_style = computed(move || {
+        let colour = if probe_status.get().starts_with("loaded") {
+            OK
+        } else {
+            BAD
+        };
+        format!("color: {colour}; font-size: 13px; margin-top: 4px;")
+    });
+
+    // Card 2 / 3 — the two outcomes reported plainly.
+    let photo_status = RwSignal::new("loading…".to_string());
+    let missing_status = RwSignal::new("loading…".to_string());
+
+    // Card 4 — warmed before anything points at them.
+    let warmed = RwSignal::new(false);
+
+    render! {
+        scroll_view(style: page, scroll_orientation: ScrollOrientation::Vertical) {
+            view(style: card.clone()) {
+                text(value: "headers", style: heading.clone())
+                text(
+                    value: "httpbin answers 406 without an Accept it likes. \
+                            Toggling the header changes nothing else.",
+                    style: note.clone(),
+                )
+                text(value: probe_status, style: probe_style)
+                Image(
+                    src: HEADER_PROBE,
+                    mode: ImageMode::AspectFit,
+                    headers: computed(move || match accept.get() {
+                        1 => ACCEPT_PNG.to_string(),
+                        2 => ACCEPT_TEXT.to_string(),
+                        _ => String::new(),
+                    }),
+                    on_load: move |event: ImageEvent| {
+                        probe_status.set(format!(
+                            "loaded {}x{}",
+                            event.detail.width as i64, event.detail.height as i64
+                        ));
+                    },
+                    on_error: move |event: ImageEvent| {
+                        probe_status.set(format!("error: {}", event.error()));
+                    },
+                    style: thumb,
+                )
+                view(
+                    style: button.clone(),
+                    on_tap: move |_| {
+                        probe_status.set("waiting".to_string());
+                        accept.set((accept.get_untracked() + 1) % 3);
+                    },
+                ) {
+                    text(
+                        value: computed(move || match accept.get() {
+                            1 => "Accept: image/png — tap for one the host refuses".to_string(),
+                            2 => "Accept: text/plain — tap to drop headers".to_string(),
+                            _ => "no headers — tap to send Accept: image/png".to_string(),
+                        }),
+                        style: button_text.clone(),
+                    )
+                }
+            }
+
+            view(style: card.clone()) {
+                text(value: "on_load", style: heading.clone())
+                text(value: photo_status, style: note.clone())
+                Image(
+                    src: PHOTO,
+                    mode: ImageMode::AspectFill,
+                    on_load: move |event: ImageEvent| {
+                        photo_status.set(format!(
+                            "{}x{}",
+                            event.detail.width as i64, event.detail.height as i64
+                        ));
+                    },
+                    on_error: move |event: ImageEvent| {
+                        photo_status.set(format!("error: {}", event.error()));
+                    },
+                    style: thumb,
+                )
+            }
+
+            view(style: card.clone()) {
+                text(value: "on_error", style: heading.clone())
+                text(value: missing_status, style: note.clone())
+                Image(
+                    src: MISSING,
+                    on_load: move |_: ImageEvent| {
+                        missing_status.set("loaded — expected a failure".to_string());
+                    },
+                    on_error: move |event: ImageEvent| {
+                        missing_status.set(format!("error: {}", event.error()));
+                    },
+                    style: thumb,
+                )
+            }
+
+            view(style: card) {
+                text(value: "prefetch", style: heading)
+                text(
+                    value: "Warm three URLs, then show them. The second tap \
+                            should paint without a network wait.",
+                    style: note,
+                )
+                view(
+                    style: button,
+                    on_tap: move |_| {
+                        prefetch(
+                            &WARM.iter().map(|u| u.to_string()).collect::<Vec<_>>(),
+                            "",
+                        );
+                        warmed.set(true);
+                    },
+                ) {
+                    text(
+                        value: computed(move || {
+                            if warmed.get() {
+                                "warmed — tap again to show".to_string()
+                            } else {
+                                "prefetch three images".to_string()
+                            }
+                        }),
+                        style: button_text,
+                    )
+                }
+                Show(when: move || warmed.get()) {
+                    view(style: "flex-direction: row; gap: 8px; margin-top: 8px;") {
+                        Image(src: WARM[0], style: "flex-grow: 1; height: 80px;")
+                        Image(src: WARM[1], style: "flex-grow: 1; height: 80px;")
+                        Image(src: WARM[2], style: "flex-grow: 1; height: 80px;")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/whisker-image/example/whisker.rs
+++ b/packages/whisker-image/example/whisker.rs
@@ -1,0 +1,24 @@
+// `whisker.rs` for the `whisker-image` example.
+//
+// Tells `whisker run` how to install / launch / hot-patch this app.
+
+pub fn configure(app: &mut whisker_config::Config) {
+    app.name("WhiskerImageExample")
+        .bundle_id("rs.whisker.imageexample")
+        .version("0.1.0")
+        .build_number(1);
+
+    app.android(|a| {
+        a.package("rs.whisker.imageexample")
+            .application_id("rs.whisker.imageexample")
+            .launcher_activity(".MainActivity")
+            .min_sdk(24)
+            .target_sdk(34);
+    });
+
+    app.ios(|i| {
+        i.bundle_id("rs.whisker.imageexample")
+            .scheme("WhiskerImageExample")
+            .deployment_target("13.0");
+    });
+}

--- a/packages/whisker-image/ios/Sources/WhiskerImage/ImageModule.swift
+++ b/packages/whisker-image/ios/Sources/WhiskerImage/ImageModule.swift
@@ -20,6 +20,21 @@ public final class ImageModule: Module {
     public override func definition() -> ModuleDefinition {
         ModuleDefinition {
             Name("Image")
+
+            AsyncFunction("prefetch") { (args: [WhiskerValue], promise: WhiskerPromise) in
+                let urls: [String] = {
+                    guard case .array(let items)? = args.first else { return [] }
+                    return items.compactMap { $0.asString }
+                }()
+                let headers = args.count > 1 ? (args[1].asString ?? "") : ""
+                DispatchQueue.main.async {
+                    WhiskerImageView.prefetch(
+                        urls: urls,
+                        headers: WhiskerImageView.headers(from: headers)
+                    )
+                    promise.resolve(.null)
+                }
+            }
             View(WhiskerImageView.self) {
                 Prop("src") { (view: WhiskerImageView, value: WhiskerValue) in
                     view.setSrc(value.asString ?? "")
@@ -27,6 +42,10 @@ public final class ImageModule: Module {
                 Prop("mode") { (view: WhiskerImageView, value: WhiskerValue) in
                     view.setMode(value.asString ?? "aspectFill")
                 }
+                Prop("headers") { (view: WhiskerImageView, value: WhiskerValue) in
+                    view.setHeaders(value.asString ?? "")
+                }
+                Events("load", "error")
             }
         }
     }

--- a/packages/whisker-image/ios/Sources/WhiskerImage/ImageView.swift
+++ b/packages/whisker-image/ios/Sources/WhiskerImage/ImageView.swift
@@ -33,6 +33,7 @@ import WhiskerModule
 public final class WhiskerImageView: WhiskerUI<UIImageView> {
 
     private var currentSrc: String?
+    private var currentHeaders: [String: String] = [:]
 
     @objc public override func createView() -> UIImageView {
         let v = UIImageView()
@@ -57,6 +58,31 @@ public final class WhiskerImageView: WhiskerUI<UIImageView> {
         // the request is non-zero.
         if currentSrc == value { return }
         currentSrc = value
+        load()
+    }
+
+    /// Backing of the `headers` prop: a JSON object of request
+    /// headers. Re-fetches, because a host that answers differently
+    /// per header answers differently per change.
+    public func setHeaders(_ json: String) {
+        let parsed = Self.parseHeaders(json)
+        if parsed == currentHeaders { return }
+        currentHeaders = parsed
+        load()
+    }
+
+    private static func parseHeaders(_ json: String) -> [String: String] {
+        guard !json.isEmpty,
+              let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return [:]
+        }
+        return object.compactMapValues { $0 as? String }
+    }
+
+    private func load() {
+        guard let value = currentSrc else { return }
 
         let imageView: UIImageView = self.view()
         guard let url = URL(string: value) else {
@@ -77,11 +103,25 @@ public final class WhiskerImageView: WhiskerUI<UIImageView> {
         //     to redecode from disk.
         //   - `.scaleFactor(UIScreen.main.scale)` — request 2x / 3x
         //     bitmaps on Retina so the rendered image is sharp.
-        let options: KingfisherOptionsInfo = [
+        var options: KingfisherOptionsInfo = [
             .transition(.fade(0.2)),
             .cacheOriginalImage,
             .scaleFactor(UIScreen.main.scale),
         ]
+
+        // Hot-link protection is the reason: those hosts answer 403
+        // unless the request carries the `Referer` their own pages
+        // send.
+        if !currentHeaders.isEmpty {
+            let headers = currentHeaders
+            options.append(.requestModifier(AnyModifier { request in
+                var request = request
+                for (name, value) in headers {
+                    request.setValue(value, forHTTPHeaderField: name)
+                }
+                return request
+            }))
+        }
 
         // `whisker-asset` resolves bundled assets to a
         // `file://<bundle>/whisker_assets/<rel>` URL (the iOS base is
@@ -93,12 +133,74 @@ public final class WhiskerImageView: WhiskerUI<UIImageView> {
         // `LocalFileImageDataProvider` explicitly so on-disk bundle
         // assets load via the documented local path; http(s) URLs
         // keep the normal network source.
+        // The outcome is reported either way: a page that 403s is
+        // otherwise a blank the app never hears about.
+        let done: (Result<RetrieveImageResult, KingfisherError>) -> Void = { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let loaded):
+                WhiskerCustomEvent.dispatch(
+                    from: self,
+                    name: "load",
+                    params: [
+                        "width": loaded.image.size.width * loaded.image.scale,
+                        "height": loaded.image.size.height * loaded.image.scale,
+                    ]
+                )
+            case .failure(let error):
+                WhiskerCustomEvent.dispatch(
+                    from: self,
+                    name: "error",
+                    params: ["error": error.localizedDescription]
+                )
+            }
+        }
+
         if url.isFileURL {
             let provider = LocalFileImageDataProvider(fileURL: url)
-            imageView.kf.setImage(with: .provider(provider), options: options)
+            imageView.kf.setImage(with: .provider(provider), options: options, completionHandler: done)
         } else {
-            imageView.kf.setImage(with: url, options: options)
+            // Two requests that differ only by header are two different
+            // resources: Kingfisher keys its cache by URL alone, so
+            // without a composed key a header change hands back the
+            // answer to the old one.
+            let resource = KF.ImageResource(downloadURL: url, cacheKey: cacheKey(for: url))
+            imageView.kf.setImage(with: resource, options: options, completionHandler: done)
         }
+    }
+
+    /// URL plus the headers that shape the answer.
+    private func cacheKey(for url: URL) -> String {
+        guard !currentHeaders.isEmpty else { return url.absoluteString }
+        let headers = currentHeaders
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: ";")
+        return "\(url.absoluteString)|\(headers)"
+    }
+
+    /// Warms Kingfisher's cache. Static because prefetching belongs to
+    /// no particular view — the pages after the one on screen have no
+    /// element yet.
+    static func prefetch(urls: [String], headers: [String: String]) {
+        let targets = urls.compactMap(URL.init(string:)).filter { !$0.isFileURL }
+        guard !targets.isEmpty else { return }
+        var options: KingfisherOptionsInfo = [.cacheOriginalImage]
+        if !headers.isEmpty {
+            options.append(.requestModifier(AnyModifier { request in
+                var request = request
+                for (name, value) in headers {
+                    request.setValue(value, forHTTPHeaderField: name)
+                }
+                return request
+            }))
+        }
+        ImagePrefetcher(urls: targets, options: options).start()
+    }
+
+    /// Shared with the module's `prefetch`, which has no view to ask.
+    static func headers(from json: String) -> [String: String] {
+        parseHeaders(json)
     }
 
     /// Backing of the `mode` prop. Maps the Lynx-convention mode

--- a/packages/whisker-image/src/lib.rs
+++ b/packages/whisker-image/src/lib.rs
@@ -114,8 +114,97 @@ impl std::fmt::Display for ImageMode {
 /// `clipsToBounds`; Android extracts the parsed radius from Lynx's
 /// `onBorderRadiusUpdated` callback and feeds it to Coil's
 /// `RoundedCornersTransformation`).
+/// What a finished or failed load reports.
+///
+/// The body of a custom event, whose payload lands under `detail` on
+/// both platforms (the iOS bridge normalises `params` to `detail`, and
+/// the Android reporter nests it there). Every field defaults, so a
+/// partial body still calls the handler — the event firing is the
+/// signal; its contents are the detail.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[non_exhaustive]
+pub struct ImageEvent {
+    #[serde(default)]
+    pub detail: ImageDetail,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[non_exhaustive]
+pub struct ImageDetail {
+    /// Pixel size of the loaded bitmap. Zero on failure.
+    #[serde(default)]
+    pub width: f64,
+    #[serde(default)]
+    pub height: f64,
+    /// Why the load failed, as the platform described it. Empty on
+    /// success.
+    #[serde(default)]
+    pub error: String,
+}
+
+impl ImageEvent {
+    /// Why the load failed — shorthand for `self.detail.error`.
+    pub fn error(&self) -> &str {
+        &self.detail.error
+    }
+}
+
 #[whisker::module_component("Image")]
-pub fn image(src: Signal<String>, mode: Signal<ImageMode>, style: whisker::Style) {}
+pub fn image(
+    src: Signal<String>,
+    mode: Signal<ImageMode>,
+    /// Extra request headers for remote sources, as a JSON object.
+    ///
+    /// ```ignore
+    /// Image(src: url, headers: r#"{"Referer": "https://example.com/"}"#)
+    /// // built from data:
+    /// Image(src: url, headers: json!({ "Referer": origin }).to_string())
+    /// ```
+    ///
+    /// A string rather than a map because element attributes cross to
+    /// the platform as strings, and JSON is what every caller already
+    /// has a way to write. Changing it re-fetches: a host that answers
+    /// differently per header answers differently per change.
+    ///
+    /// Sites that block hot-linking are the reason this exists — their
+    /// images 403 without the `Referer` their own pages send. A value
+    /// that isn't a JSON object of strings is ignored.
+    headers: Signal<String>,
+    style: whisker::Style,
+    /// The bitmap arrived and is on screen; `detail` carries its size.
+    on_load: ImageEvent,
+    /// The load failed; `detail.error` says how. A reader that shows a
+    /// site's own images needs this — a page that 403s is otherwise a
+    /// blank the app never hears about.
+    on_error: ImageEvent,
+) {
+}
+
+/// Warm the cache for `urls` without showing them.
+///
+/// The next [`image`] pointing at one of these paints from cache
+/// instead of the network — what a reader does with the pages after
+/// the one being read. Fire-and-forget: failures are the next real
+/// load's problem, not this call's.
+pub fn prefetch(urls: &[String], headers: &str) {
+    let list = urls.to_vec();
+    let headers = headers.to_string();
+    whisker::spawn_local(async move {
+        let _ = whisker::module!("Image")
+            .invoke_async(
+                "prefetch",
+                vec![
+                    whisker::platform_module::WhiskerValue::Array(
+                        list.into_iter()
+                            .map(whisker::platform_module::WhiskerValue::String)
+                            .collect(),
+                    ),
+                    whisker::platform_module::WhiskerValue::String(headers),
+                ],
+            )
+            .await;
+    });
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## What

Three additions to `whisker-image`, each something an app can't do with an element that only takes a URL.

- **`headers`** — a JSON object put on the request. Hosts that block hot-linking answer 403 without the `Referer` their own pages send.
- **`on_load` / `on_error`** — the outcome, with the decoded size or the platform's message. A page that 403s was previously a blank the app never heard about.
- **`prefetch(urls, headers)`** — warms the cache for images nothing points at yet. Module-level, because those images have no element.

## Why the cache key changed

`headers` joins the cache key. Kingfisher and Coil both key by URL alone, so changing a header handed back the answer to the old request — which reads as a success and isn't. Two requests differing only by header are two different resources.

## Verification

New example app at `packages/whisker-image/example`, run on both platforms.

`httpbin.org/image` answers 200 or 406 depending on the `Accept` it is given, so the same URL loading or failing shows whether the header left the phone. The platforms differ in what they send by default — iOS asks for `*/*` and is refused, Android asks for `image/*` and is served — so the card cycles through none, an `Accept` the host likes, and one it refuses; one step proves it on either device.

| | iOS | Android |
|---|---|---|
| `on_load` | `600x400` | `933x622` |
| `on_error` | 406 message | `HTTP 404:` |
| `headers` | no header → 406 | `Accept: text/plain` → 406 |

## Note

`packages/whisker-image/build.gradle.kts` moves from `rs.whisker:whisker-module-android:0.1.0` to `0.1.15` — module-level `AsyncFunction` (what `prefetch` registers) doesn't exist in 0.1.0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)