### PR TITLE
Lynx 4.0.1 へのアップデート (fork v4.0.1-whisker.1 / SDK 0.1.16 / SwiftPM v0.1.5)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,23 +74,23 @@ let package = Package(
         // `swiftpm-manifest-<ver>.txt` published alongside each release.
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/Lynx-3.8.0-whisker.13.xcframework.zip",
-            checksum: "13287093478b2b637a52028f795f22b3759fc2233bc11de55fc24fe92eb18594"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/Lynx-4.0.1-whisker.1.xcframework.zip",
+            checksum: "e5161bf110a1d22869412689b89362798fd35e53dad9467980e9390918261c1d"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/LynxBase-3.8.0-whisker.13.xcframework.zip",
-            checksum: "8127acb7f472f170fd6734e57a0fe0028b27c6c2c184d8d859b2a703f2cc4393"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/LynxBase-4.0.1-whisker.1.xcframework.zip",
+            checksum: "875c389e2a33ad846ae43a29bcb1dad131d8b1e75ab36a2d41f39355e68cd25e"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/LynxServiceAPI-3.8.0-whisker.13.xcframework.zip",
-            checksum: "ecd61fd412faa5e35a3e35e2550f8d9225550eb613437a0234447147a2748861"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/LynxServiceAPI-4.0.1-whisker.1.xcframework.zip",
+            checksum: "9347769f21d9c41e0274cdb555698d7489f67ab9ed26fe2146688061f55a9b24"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/PrimJS-3.8.0-whisker.13.xcframework.zip",
-            checksum: "0a82703ba212e61b56dfe63791b219f61517f8867fd64bd0b6ee23005f4e8e0f"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/PrimJS-4.0.1-whisker.1.xcframework.zip",
+            checksum: "76502d535310b42d7c15d9dcb8e802622d17f8541bcee5a8dcf8863b59d8f45b"
         ),
 
         // Header-only mirror of `WhiskerDriver`'s public C ABI. Source

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,7 +49,7 @@ use std::process::Command;
 /// Keep in lockstep with the `Package.swift` at the repo root and the
 /// `v<version>` git tag published for SwiftPM to resolve.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
-pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.4";
+pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.5";
 
 use crate::capture::{CaptureShims, capture_env_vars_for_triple};
 

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -183,7 +183,14 @@ pub struct PlatformSync {
 /// half declares an `AsyncFunction` doesn't compile against 0.1.14, so
 /// apps shipping one must move to 0.1.15. Kotlin-only, no capi/Lynx ABI
 /// change.
-const WHISKER_SDK_VERSION: &str = "0.1.15";
+///
+/// 0.1.16 rolls the SDK's transitive Lynx pin `v3.8.0-whisker.13` →
+/// `v4.0.1-whisker.1` — the fork rebased onto upstream Lynx 4.0.1. The
+/// capi is untouched (ABI stays v3), so this is a pure engine bump;
+/// what forces the move is the `org.lynxsdk.lynx:primjs` coordinate
+/// going 3.7.0 → 4.0.0 alongside it, since 0.1.15's POM would resolve
+/// a Lynx 4.0 AAR against a PrimJS the engine wasn't built for.
+const WHISKER_SDK_VERSION: &str = "0.1.16";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/crates/whisker-css/src/prop/effects.rs
+++ b/crates/whisker-css/src/prop/effects.rs
@@ -148,10 +148,11 @@ impl Css {
         self.push("outline-offset", v)
     }
 
-    /// Sets `caret-width`. Lynx accepts a length controlling the
-    /// rendered caret thickness.
+    /// Sets `-x-caret-width`. Lynx accepts a length controlling the
+    /// rendered caret thickness. Lynx 4.0 renamed the unprefixed
+    /// `caret-width` (unlike `caret-color`, which kept its name).
     pub fn caret_width(self, v: Length) -> Self {
-        self.push("caret-width", v)
+        self.push("-x-caret-width", v)
     }
 
     /// Sets `-x-handle-color` — Lynx-only selection-handle color.
@@ -292,7 +293,7 @@ mod tests {
             .caret_width(2.px());
         assert_eq!(
             s.to_string(),
-            "caret-color: rgb(255, 0, 255); caret-width: 2px;"
+            "caret-color: rgb(255, 0, 255); -x-caret-width: 2px;"
         );
     }
 

--- a/docs/ios-spm-distribution.md
+++ b/docs/ios-spm-distribution.md
@@ -98,6 +98,8 @@ Keep these aligned per release:
 |---|---|---|---|---|
 | `0.1.0` | `v0.1.0` | `0.1.1` | `0.4.0` | `3.8.0-whisker.7` |
 | `0.1.1` | `v0.1.1` | `0.1.2` | `0.4.0` | `3.8.0-whisker.8` |
+| `0.10.2` | `v0.1.4` | `0.1.15` | `0.4.1` | `3.8.0-whisker.13` |
+| `0.10.3` | `v0.1.5` | `0.1.16` | `0.4.1` | `4.0.1-whisker.1` |
 
 The `3.8.0-whisker.8` row bumps the Lynx fork on both platforms, raising
 the capi ABI to **v2** (list data source driven by real item-keys +
@@ -111,6 +113,13 @@ must move to the new pins:
   `sdk-v0.1.2` tag. Its POM rolls the transitive `lynx-android` pin
   `3.8.0-whisker.7` → `.8` via the `lynxFork` default in
   `platforms/android/{whisker-runtime,module}/build.gradle.kts`.
+
+The `4.0.1-whisker.1` row rebases the fork onto upstream Lynx 4.0.1 (898
+commits since 3.8.0). The capi is untouched, so the ABI stays **v3** and
+the engine handshake is not what forces the move — the PrimJS coordinate
+shipping in the same POM does (`org.lynxsdk.lynx:primjs` 3.7.0 → 4.0.0).
+On the Rust side the same release renames `Css::caret_width`'s output to
+`-x-caret-width`, which Lynx 4.0 requires and 3.8 does not accept.
 
 The iOS SwiftPM tag and the Android `sdk-v*` tag are independent version
 streams (hence `v0.1.1` vs `0.1.2`), aligned here only by the Lynx fork.

--- a/docs/lynx-integration.md
+++ b/docs/lynx-integration.md
@@ -16,7 +16,7 @@ Audience: contributors bumping Lynx or debugging the C++ bridge build.
 ## How the dependency is wired
 
 The fork publishes pre-built Lynx artifacts per `v<ver>` tag (currently
-`v3.8.0-whisker.7`). Whisker consumes them per platform:
+`v4.0.1-whisker.1`). Whisker consumes them per platform:
 
 ### iOS — SwiftPM binary targets
 
@@ -59,7 +59,7 @@ modes toggled by the `whiskerSdkRelease` Gradle property:
   against `target/lynx-android/` — harmless when empty.
 
 PrimJS comes from Maven Central in both modes:
-`org.lynxsdk.lynx:primjs:3.7.0`.
+`org.lynxsdk.lynx:primjs:4.0.0`.
 
 ## Version pinning points — move these in lockstep
 

--- a/packages/whisker-asset/Package.swift
+++ b/packages/whisker-asset/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WhiskerAsset", targets: ["WhiskerAsset"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-haptics/Package.swift
+++ b/packages/whisker-haptics/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerHaptics", targets: ["WhiskerHaptics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
         // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
         // via Core Image, animated GIF via `AnimatedImageView`, in-
         // memory `NSCache` + disk cache out of the box. WebP requires

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-keyboard/Package.swift
+++ b/packages/whisker-keyboard/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "WhiskerKeyboard", targets: ["WhiskerKeyboard"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "WhiskerLocalStore", targets: ["WhiskerLocalStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
         // PoC — an external SwiftPM dependency. swift-collections is
         // Apple-maintained, header-only Swift, small enough that
         // resolving it is fast even on a cold cache. Use is minimal

--- a/packages/whisker-paths/Package.swift
+++ b/packages/whisker-paths/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerPaths", targets: ["WhiskerPaths"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-status-bar/Package.swift
+++ b/packages/whisker-status-bar/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .library(name: "WhiskerStatusBar", targets: ["WhiskerStatusBar"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "WhiskerSvg", targets: ["WhiskerSvg"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // it there, and the package identity (the crate's dir name)
         // is unique, so the app aggregator references it via
         // `.package(path: …)` without the `ios`-dir-name collision.
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-web-browser/Package.swift
+++ b/packages/whisker-web-browser/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "WhiskerWebBrowser", targets: ["WhiskerWebBrowser"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.4"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.5"),
     ],
     targets: [
         .target(

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.13").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v4.0.1-whisker.1").removePrefix("v")
 
 dependencies {
     if (whiskerSdkRelease) {
@@ -69,7 +69,7 @@ dependencies {
         api(":LynxTrace@aar")
         api(":ServiceAPI@aar")
     }
-    api("org.lynxsdk.lynx:primjs:3.7.0")
+    api("org.lynxsdk.lynx:primjs:4.0.0")
 
     // `WhiskerInsetsDispatcher` exposes `WindowInsetsCompat` in its
     // public API and calls `ViewCompat.setOnApplyWindowInsetsListener` /

--- a/platforms/android/whisker-runtime/build.gradle.kts
+++ b/platforms/android/whisker-runtime/build.gradle.kts
@@ -20,7 +20,7 @@
 // `whiskerSdkRelease` Gradle property toggles the dep form: unset
 // (default) → flatDir-friendly `:LynxAndroid@aar`; `true` → Maven
 // coords pinned to `lynxFork`. The CI publish workflow sets
-// `-PwhiskerSdkRelease=true -PlynxFork=v3.8.0-whisker.13`; local CLI
+// `-PwhiskerSdkRelease=true -PlynxFork=v4.0.1-whisker.1`; local CLI
 // flows leave both unset and use flatDir as before.
 
 plugins {
@@ -70,7 +70,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v3.8.0-whisker.13").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v4.0.1-whisker.1").removePrefix("v")
 
 dependencies {
     api(project(":module"))
@@ -95,7 +95,7 @@ dependencies {
         api(":LynxTrace@aar")
         api(":ServiceAPI@aar")
     }
-    api("org.lynxsdk.lynx:primjs:3.7.0")
+    api("org.lynxsdk.lynx:primjs:4.0.0")
 
     implementation("androidx.appcompat:appcompat:1.7.0")
 }

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -99,23 +99,23 @@ let package = Package(
         // until the matching module-side refactor lands).
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/Lynx-3.8.0-whisker.13.xcframework.zip",
-            checksum: "13287093478b2b637a52028f795f22b3759fc2233bc11de55fc24fe92eb18594"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/Lynx-4.0.1-whisker.1.xcframework.zip",
+            checksum: "e5161bf110a1d22869412689b89362798fd35e53dad9467980e9390918261c1d"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/LynxBase-3.8.0-whisker.13.xcframework.zip",
-            checksum: "8127acb7f472f170fd6734e57a0fe0028b27c6c2c184d8d859b2a703f2cc4393"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/LynxBase-4.0.1-whisker.1.xcframework.zip",
+            checksum: "875c389e2a33ad846ae43a29bcb1dad131d8b1e75ab36a2d41f39355e68cd25e"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/LynxServiceAPI-3.8.0-whisker.13.xcframework.zip",
-            checksum: "ecd61fd412faa5e35a3e35e2550f8d9225550eb613437a0234447147a2748861"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/LynxServiceAPI-4.0.1-whisker.1.xcframework.zip",
+            checksum: "9347769f21d9c41e0274cdb555698d7489f67ab9ed26fe2146688061f55a9b24"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v3.8.0-whisker.13/PrimJS-3.8.0-whisker.13.xcframework.zip",
-            checksum: "0a82703ba212e61b56dfe63791b219f61517f8867fd64bd0b6ee23005f4e8e0f"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/PrimJS-4.0.1-whisker.1.xcframework.zip",
+            checksum: "76502d535310b42d7c15d9dcb8e802622d17f8541bcee5a8dcf8863b59d8f45b"
         ),
 
         // Phase J — minimal module-author surface. Carved out of the


### PR DESCRIPTION
Lynx フォークを上流 4.0.1 にリベースし、両プラットフォームのピンを更新します。

## フォーク側 (`whiskerrs/lynx`)

リリース [`v4.0.1-whisker.1`](https://github.com/whiskerrs/lynx/releases/tag/v4.0.1-whisker.1) を公開済み。

- 上流 3.8.0 → 4.0.1 は **898 コミット / 2,524 ファイル**
- whisker の 22 パッチは **競合ゼロ**で載り、`core/native_renderer_capi/` は無変更 → **capi ABI は v3 のまま**
- podspec 3 種を CocoaPods trunk の 4.0.1 に同期（Lynx/Framework: source_files +70/-10、private headers +33/-4 ほか）。フォーク独自の `:path => '.'` / `PODS_TARGET_SRCROOT` / capi エントリは保持
- **PrimJS 3.8.0 → 4.0.0**

## このPRの変更

| 対象 | 変更 |
|---|---|
| `Package.swift` / `platforms/ios/Package.swift` | 4つの `binaryTarget` の URL + checksum |
| `platforms/android/{whisker-runtime,module}/build.gradle.kts` | `lynxFork` → `v4.0.1-whisker.1`、`primjs` 3.7.0 → **4.0.0** |
| `crates/whisker-css/.../effects.rs` | `caret_width()` → `-x-caret-width` |
| `crates/whisker-build/src/ios.rs` | `WHISKER_IOS_SPM_VERSION` 0.1.4 → **0.1.5** |
| `packages/*/Package.swift` (15件) | `exact:` を 0.1.5 にロックステップ |
| `crates/whisker-cli/src/platforms.rs` | `WHISKER_SDK_VERSION` 0.1.15 → **0.1.16** |
| `docs/{lynx-integration,ios-spm-distribution}.md` | 現行ピン + 互換性マトリクス |

### 唯一の破壊的変更: `caret-width`

Lynx 4.0 が editable キャレットのプロパティを `-x-caret-*` にリネームしました（`caret-color` は据え置き）。`Css::caret_width` は 4.0 が解釈しないプロパティを出力していたため、**エラーも警告もなく効かなくなる**箇所でした。

## 検証

- `swift package resolve` が 4つの xcframework を実際に取得し **checksum 検証通過**
- 公開バイナリのシンボル確認 — `lynx_capi_abi_version` / `lynx_shell_from_native_ptr` / `lynx_element_animate` / `lynx_element_insert_child_before`
  - iOS: `ios-arm64` と `ios-arm64_x86_64-simulator` の両スライス
  - Android: `arm64-v8a/liblynx.so`（エクスポート `lynx_*` 30個）
- capi が呼ぶ C++ API、および whisker が使う iOS/Android の Lynx 公開 API は 3.8.0 と同一シグネチャ
- `cargo test -p whisker-css` 285件パス / `cargo check --workspace` / `cargo fmt --check`

**未実施**: 実機・シミュレータでの起動確認。生成アプリは公開済み SDK を参照するため、このPRのマージ後に `v0.1.5` と `sdk-v0.1.16` を打ってからでないと確認できません。

## マージ後のリリース手順

1. `git tag v0.1.5 && git push origin v0.1.5` — iOS SwiftPM
2. `git tag sdk-v0.1.16 && git push origin sdk-v0.1.16` — Android SDK (publish-sdk.yml)
3. 実機で E2E 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)