### PR TITLE
Deliver multi-touch to Rust

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/lynx_objc_stubs.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_objc_stubs.h
@@ -91,14 +91,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setEventReporterBlock:(BOOL (^)(LynxEvent* event))block;
 @end
 
-// LynxTouchEvent — touch coordinate carrier. Multi-touch path goes
-// through `touchMap` keyed by identifier; single-touch path reads
-// `pagePoint` / `clientPoint` directly.
+// LynxTouchEvent — touch coordinate carrier. The single-touch path
+// reads `pagePoint` / `clientPoint` directly; once multi-touch is on
+// (see `WhiskerView.enableMultiTouch`) every touch event instead
+// carries its fingers in `uiTouchMap`, keyed by the tag of the element
+// each finger is over, with values `@[@[identifier, clientX, clientY,
+// pageX, pageY, x, y], …]` — the shape
+// `TouchEventHandler::GetTouchEventParam` parses engine-side.
 @interface LynxTouchEvent : LynxEvent
 @property (nonatomic, readonly) BOOL isMultiTouch;
 @property (nonatomic, readonly) CGPoint pagePoint;
 @property (nonatomic, readonly) CGPoint clientPoint;
-@property (nonatomic, readonly, nullable) NSDictionary* touchMap;
+@property (nonatomic, readonly, nullable) NSDictionary* uiTouchMap;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
@@ -143,6 +143,95 @@ void* GetShellPtr(LynxTemplateRender* render) {
     return *reinterpret_cast<void* const*>(base + offset);
 }
 
+// Fingers currently on the screen, keyed by touch identifier, in the
+// order they landed. Lynx reports only the fingers that changed in a
+// given event, so `touches` — every finger currently down, which is
+// what `whisker_runtime::event::TouchEvent` promises — is accumulated
+// here.
+NSMutableDictionary<NSNumber*, NSDictionary*>* CurrentTouches() {
+    static NSMutableDictionary<NSNumber*, NSDictionary*>* touches = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        touches = [NSMutableDictionary dictionary];
+    });
+    return touches;
+}
+
+// `[identifier, clientX, clientY, pageX, pageY, x, y]` — the per-finger
+// record `uiTouchMap` carries.
+const NSUInteger kFingerFields = 7;
+
+// Deliver one multi-touch event, one dispatch per element the fingers
+// are over. See `LynxTouchEvent`'s stub declaration for the payload.
+void DispatchMultiTouch(LynxTouchEvent* touch, NSMutableDictionary* body) {
+    NSString* name = touch.eventName;
+    NSMutableDictionary<NSNumber*, NSMutableArray*>* changed_by_tag =
+        [NSMutableDictionary dictionary];
+    NSMutableDictionary<NSNumber*, NSDictionary*>* current = CurrentTouches();
+
+    [touch.uiTouchMap enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL* stop) {
+        if (![obj isKindOfClass:[NSArray class]]) return;
+        NSNumber* tag = @([[key description] intValue]);
+        for (id entry in (NSArray*)obj) {
+            if (![entry isKindOfClass:[NSArray class]]) continue;
+            NSArray* values = (NSArray*)entry;
+            if (values.count < kFingerFields) continue;
+            NSNumber* identifier = values[0];
+            NSDictionary* finger = @{
+                @"identifier": identifier,
+                @"clientX": values[1],
+                @"clientY": values[2],
+                @"pageX": values[3],
+                @"pageY": values[4],
+                @"x": values[5],
+                @"y": values[6],
+            };
+            NSMutableArray* changed = changed_by_tag[tag];
+            if (changed == nil) {
+                changed = [NSMutableArray array];
+                changed_by_tag[tag] = changed;
+            }
+            [changed addObject:finger];
+            if ([name isEqualToString:@"touchend"]) {
+                [current removeObjectForKey:identifier];
+            } else if ([name isEqualToString:@"touchcancel"]) {
+                [current removeAllObjects];
+            } else {
+                current[identifier] = finger;
+            }
+        }
+    }];
+    if (changed_by_tag.count == 0) return;
+
+    NSArray* touches = current.allValues;
+    [changed_by_tag enumerateKeysAndObjectsUsingBlock:^(NSNumber* tag,
+                                                        NSMutableArray* changed,
+                                                        BOOL* stop) {
+        // The engine reports the primary finger's position as the
+        // event's own `detail`; anything watching a single point (a tap
+        // fraction, a drag delta) reads that and stays oblivious to the
+        // extra fingers.
+        NSDictionary* primary = changed.firstObject;
+        for (NSDictionary* finger in changed) {
+            if ([finger[@"identifier"] intValue] == 0) {
+                primary = finger;
+                break;
+            }
+        }
+        NSMutableDictionary* per_tag = [body mutableCopy];
+        per_tag[@"target"] = tag;
+        per_tag[@"currentTarget"] = tag;
+        per_tag[@"detail"] = @{@"x": primary[@"pageX"], @"y": primary[@"pageY"]};
+        per_tag[@"touches"] = touches;
+        per_tag[@"changedTouches"] = changed;
+
+        WhiskerValueRaw value = WhiskerValueFromNSObject(per_tag);
+        whisker_bridge_internal_dispatch_event((int32_t)[tag intValue],
+                                               [name UTF8String], &value);
+        whisker_bridge_value_release(&value);
+    }];
+}
+
 // Install our hook on the LynxEventEmitter so physical taps land in our
 // native callback registry instead of being dropped on the way to a
 // non-existent JS handler. Safe to call repeatedly — only installs once
@@ -229,41 +318,17 @@ void InstallEventReporterIfNeeded(WhiskerEngine* engine, LynxView* view) {
                             @"x": @(touch.pagePoint.x),
                             @"y": @(touch.pagePoint.y),
                         };
-                    } else if (touch.touchMap != nil) {
-                        // Multi-touch shape — touchMap is keyed by
-                        // touch identifier with values `@[clientX,
-                        // clientY, pageX, pageY, viewX, viewY]`.
-                        NSMutableArray* touches = [NSMutableArray array];
-                        [touch.touchMap enumerateKeysAndObjectsUsingBlock:
-                            ^(id key, id obj, BOOL* stop) {
-                                if (![obj isKindOfClass:[NSArray class]]) return;
-                                NSArray* arr = (NSArray*)obj;
-                                if (arr.count < 6) return;
-                                NSNumber* identifier = nil;
-                                if ([key isKindOfClass:[NSNumber class]]) {
-                                    identifier = (NSNumber*)key;
-                                } else {
-                                    identifier = @([[key description] integerValue]);
-                                }
-                                [touches addObject:@{
-                                    @"identifier": identifier,
-                                    @"x": arr[2],
-                                    @"y": arr[3],
-                                    @"pageX": arr[2],
-                                    @"pageY": arr[3],
-                                    @"clientX": arr[0],
-                                    @"clientY": arr[1],
-                                }];
-                            }];
-                        body[@"touches"] = touches;
-                        body[@"changedTouches"] = touches;
-                        if (touches.count > 0) {
-                            NSDictionary* first = touches.firstObject;
-                            body[@"detail"] = @{
-                                @"x": first[@"pageX"],
-                                @"y": first[@"pageY"],
-                            };
-                        }
+                    } else if (touch.uiTouchMap != nil) {
+                        // Multi-touch: the fingers arrive keyed by the
+                        // element each is over, and the event's own
+                        // target is -1 — no single element owns a
+                        // gesture that can span several. Fan out to one
+                        // dispatch per element (a native callback is
+                        // registered against exactly one tag), each
+                        // carrying its own fingers as `changedTouches`
+                        // and every finger down as `touches`.
+                        DispatchMultiTouch(touch, body);
+                        return NO;
                     }
                 }
                 value = WhiskerValueFromNSObject(body);

--- a/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/whisker-runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -16,8 +16,11 @@ import com.lynx.tasm.event.LynxInternalEvent
 import com.lynx.tasm.event.LynxTouchEvent
 import java.util.concurrent.atomic.AtomicBoolean
 
-/** See `WhiskerView.forceTapSlop`'s doc comment for why this can't just be `LynxViewBuilder`'s tapSlop. */
+/** See `WhiskerView.configureEventDispatcher`'s doc comment for why this can't just be `LynxViewBuilder`'s tapSlop. */
 private const val TAP_SLOP_DP = 18f
+
+/** `[identifier, clientX, clientY, pageX, pageY, x, y]` — the per-finger record `uiTouchMap` carries. */
+private const val FINGER_FIELDS = 7
 
 /**
  * Hosts the Lynx engine and bridges it to the Rust runtime.
@@ -53,7 +56,7 @@ class WhiskerView @JvmOverloads constructor(
         // by ordinary hand tremor; still far below the original 50dp gap.
         //
         // Kept even though it's confirmed dead for this app (see
-        // `forceTapSlop`'s doc comment below) — cheap, harmless, and
+        // `configureEventDispatcher`'s doc comment below) — cheap, harmless, and
         // becomes real again if a future Lynx version or code path
         // starts honoring it.
         LynxViewBuilder().setTapSlop("18px"),
@@ -71,6 +74,9 @@ class WhiskerView @JvmOverloads constructor(
     private val eventReporter = object : EventEmitter.LynxEventReporter {
         override fun onLynxEvent(event: LynxEvent): Boolean {
             val name = event.name ?: return false
+            if (event is LynxTouchEvent && event.getIsMultiTouch()) {
+                return dispatchMultiTouch(name, event)
+            }
             // Normalize the body to the same shape iOS's
             // `LynxEvent.generateEventBody` produces —
             // `{type, target, currentTarget, detail}` — so the typed
@@ -100,63 +106,123 @@ class WhiskerView @JvmOverloads constructor(
             } else if (event is LynxTouchEvent) {
                 // `LynxTouchEvent` doesn't carry coordinates through
                 // the generic params path above — only
-                // `getClientPoint`/`getPagePoint`/`getTouchMap` do.
+                // `getClientPoint`/`getPagePoint` do.
                 // Splice touches/changedTouches/detail on here,
                 // mirroring the shape `whisker_bridge_ios.mm`'s
                 // reporter block builds from the same Lynx class on
                 // iOS, so `whisker_runtime::event::TouchEvent`
                 // deserializes identically on both platforms instead
                 // of every field silently defaulting to zero here.
-                if (!event.getIsMultiTouch()) {
-                    val page = event.getPagePoint()
-                    val client = event.getClientPoint()
-                    if (page != null && client != null) {
-                        val x = pxToDip(page.x)
-                        val y = pxToDip(page.y)
-                        val clientX = pxToDip(client.x)
-                        val clientY = pxToDip(client.y)
-                        val touch =
-                            mapOf(
-                                "identifier" to 0,
-                                "x" to x,
-                                "y" to y,
-                                "pageX" to x,
-                                "pageY" to y,
-                                "clientX" to clientX,
-                                "clientY" to clientY,
-                            )
-                        body["touches"] = listOf(touch)
-                        body["changedTouches"] = listOf(touch)
-                        body["detail"] = mapOf("x" to x, "y" to y)
-                    }
-                } else {
-                    val touchMap = event.getTouchMap()
-                    if (touchMap != null) {
-                        val touches =
-                            touchMap.entries.map { (identifier, point) ->
-                                val x = pxToDip(point.x)
-                                val y = pxToDip(point.y)
-                                mapOf(
-                                    "identifier" to identifier,
-                                    "x" to x,
-                                    "y" to y,
-                                    "pageX" to x,
-                                    "pageY" to y,
-                                    "clientX" to x,
-                                    "clientY" to y,
-                                )
-                            }
-                        body["touches"] = touches
-                        body["changedTouches"] = touches
-                        touches.firstOrNull()?.let { first ->
-                            body["detail"] = mapOf("x" to first["pageX"], "y" to first["pageY"])
-                        }
-                    }
+                val page = event.getPagePoint()
+                val client = event.getClientPoint()
+                if (page != null && client != null) {
+                    val x = pxToDip(page.x)
+                    val y = pxToDip(page.y)
+                    val clientX = pxToDip(client.x)
+                    val clientY = pxToDip(client.y)
+                    val touch =
+                        mapOf(
+                            "identifier" to 0,
+                            "x" to x,
+                            "y" to y,
+                            "pageX" to x,
+                            "pageY" to y,
+                            "clientX" to clientX,
+                            "clientY" to clientY,
+                        )
+                    body["touches"] = listOf(touch)
+                    body["changedTouches"] = listOf(touch)
+                    body["detail"] = mapOf("x" to x, "y" to y)
                 }
             }
             return nativeOnLynxEvent(engine, event.tag, name, body)
         }
         override fun onInternalEvent(event: LynxInternalEvent) {}
+    }
+
+    /**
+     * Fingers currently on the screen, keyed by touch identifier, in
+     * the order they landed. Lynx reports only the fingers that changed
+     * in a given event, so `touches` — every finger currently down,
+     * which is what the DOM contract and
+     * `whisker_runtime::event::TouchEvent` both promise — has to be
+     * accumulated here.
+     */
+    private val currentTouches = LinkedHashMap<Int, Map<String, Any?>>()
+
+    /**
+     * Deliver one multi-touch event.
+     *
+     * Turning multi-touch on (see `configureEventDispatcher`) moves
+     * every `touchstart`/`touchmove`/`touchend`/`touchcancel` onto
+     * `EventEmitter.sendMultiTouchEvent`, which reports the fingers in
+     * `uiTouchMap` and leaves `event.tag` at -1 — no single element
+     * owns a gesture that can span several. `tap` / `longpress` /
+     * `click` are unaffected and still arrive with a real tag.
+     *
+     * `uiTouchMap` is `{ elementTag: [[identifier, clientX, clientY,
+     * pageX, pageY, x, y], …] }` — the same shape
+     * `TouchEventHandler::GetTouchEventParam` parses in the engine.
+     * Coordinates are raw device px, like every other point Lynx hands
+     * the platform (see `pxToDip`).
+     *
+     * Fans back out to one dispatch per element, because a native
+     * callback is registered against exactly one tag: two fingers on
+     * two elements is two events, each carrying its own fingers as
+     * `changedTouches` and every finger down as `touches`.
+     */
+    private fun dispatchMultiTouch(name: String, event: LynxTouchEvent): Boolean {
+        val uiTouchMap = event.getUITouchMap() ?: return false
+
+        val changedByTag = LinkedHashMap<Int, MutableList<Map<String, Any?>>>()
+        for ((tagKey, fingers) in uiTouchMap) {
+            val tag = tagKey.toIntOrNull() ?: continue
+            if (fingers !is List<*>) continue
+            for (finger in fingers) {
+                val values = finger as? List<*> ?: continue
+                if (values.size < FINGER_FIELDS) continue
+                val numbers = values.map { (it as? Number)?.toFloat() ?: return@map 0f }
+                val identifier = numbers[0].toInt()
+                val touch =
+                    mapOf<String, Any?>(
+                        "identifier" to identifier,
+                        "clientX" to pxToDip(numbers[1]),
+                        "clientY" to pxToDip(numbers[2]),
+                        "pageX" to pxToDip(numbers[3]),
+                        "pageY" to pxToDip(numbers[4]),
+                        "x" to pxToDip(numbers[5]),
+                        "y" to pxToDip(numbers[6]),
+                    )
+                changedByTag.getOrPut(tag) { mutableListOf() }.add(touch)
+                when (name) {
+                    LynxTouchEvent.EVENT_TOUCH_END -> currentTouches.remove(identifier)
+                    LynxTouchEvent.EVENT_TOUCH_CANCEL -> currentTouches.clear()
+                    else -> currentTouches[identifier] = touch
+                }
+            }
+        }
+        if (changedByTag.isEmpty()) return false
+
+        val touches = currentTouches.values.toList()
+        var handled = false
+        for ((tag, changed) in changedByTag) {
+            // The engine reports the primary finger's position as the
+            // event's own `detail`; anything watching a single point
+            // (a tap fraction, a drag delta) reads that and stays
+            // oblivious to the extra fingers.
+            val primary = changed.firstOrNull { it["identifier"] == 0 } ?: changed.first()
+            val body: MutableMap<String, Any?> =
+                mutableMapOf(
+                    "type" to name,
+                    "target" to tag,
+                    "currentTarget" to tag,
+                    "detail" to mapOf("x" to primary["pageX"], "y" to primary["pageY"]),
+                    "touches" to touches,
+                    "changedTouches" to changed,
+                )
+            handled = nativeOnLynxEvent(engine, tag, name, body) || handled
+        }
+        return handled
     }
 
     // `LynxTouchEvent.getPagePoint()`/`getClientPoint()`/`getTouchMap()`
@@ -210,15 +276,15 @@ class WhiskerView @JvmOverloads constructor(
     // directly, bypassing the page-config pipeline this app never
     // drives. Tried on every touch (idempotent past the first success)
     // since the dispatcher doesn't exist until the first one.
-    private var tapSlopForced = false
+    private var dispatcherConfigured = false
 
     override fun dispatchTouchEvent(ev: android.view.MotionEvent): Boolean {
         val result = super.dispatchTouchEvent(ev)
-        if (!tapSlopForced) forceTapSlop()
+        if (!dispatcherConfigured) configureEventDispatcher()
         return result
     }
 
-    private fun forceTapSlop() {
+    private fun configureEventDispatcher() {
         try {
             val templateRenderField = LynxView::class.java.getDeclaredField("mLynxTemplateRender")
             templateRenderField.isAccessible = true
@@ -233,10 +299,24 @@ class WhiskerView @JvmOverloads constructor(
             val dispatcher = dispatcherField.get(uiRenderer) as? TouchEventDispatcher ?: return
 
             dispatcher.setTapSlop(TAP_SLOP_DP * resources.displayMetrics.density)
-            tapSlopForced = true
-            Log.d("WhiskerTapSlop", "forced tapSlop to ${TAP_SLOP_DP}dp on live dispatcher")
+            // Off by default, and reachable only from the same
+            // page-config pipeline as tapSlop. While off, a second
+            // finger is dropped before any handler sees it, so
+            // `TouchEvent.touches` can never hold more than one point
+            // and a pinch is indistinguishable from a drag.
+            dispatcher.setEnableMultiTouch(true)
+            dispatcherConfigured = true
+            Log.d(
+                "WhiskerTouch",
+                "forced tapSlop to ${TAP_SLOP_DP}dp and enabled multi-touch on live dispatcher",
+            )
         } catch (e: Exception) {
-            Log.e("WhiskerTapSlop", "forceTapSlop failed — falling back to Lynx's 50dip default", e)
+            Log.e(
+                "WhiskerTouch",
+                "configureEventDispatcher failed — tapSlop stays at Lynx's 50dip default " +
+                    "and touches stay single-finger",
+                e,
+            )
         }
     }
 

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -121,6 +121,37 @@ public final class WhiskerView: LynxView {
         }
     }
 
+    // MARK: - Multi-touch
+
+    private var multiTouchEnabled = false
+
+    /// Lynx drops every finger but the first unless its touch handler
+    /// is told otherwise, so `TouchEvent.touches` can never hold more
+    /// than one point and a pinch is indistinguishable from a drag.
+    ///
+    /// The switch is meant to arrive through the page config, which is
+    /// the template-loading pipeline this runtime bypasses (the engine
+    /// goes straight to Rust over the bridge), so it is set on the live
+    /// handler instead — the same shape the Android runtime uses for
+    /// `tapSlop`. Attempted per touch dispatch, because the handler
+    /// does not exist until the tree has mounted; once it takes, the
+    /// flag stops the retry.
+    private func enableMultiTouch() {
+        guard let owner = getLynxContext().uiOwner,
+              let handler = owner.eventHandler?.touchRecognizer
+        else { return }
+        // `setEnableMultiTouch:` lives in `LynxTouchHandler+Internal.h`,
+        // which the shipped framework does not expose — KVC reaches the
+        // same setter without the header.
+        handler.setValue(true, forKey: "enableMultiTouch")
+        multiTouchEnabled = true
+    }
+
+    public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if !multiTouchEnabled { enableMultiTouch() }
+        return super.hitTest(point, with: event)
+    }
+
     public override func onEnterForeground() {
         super.onEnterForeground()
     }


### PR DESCRIPTION
`TouchEvent.touches` is documented as "all touch points currently on the surface" and has never held more than one — so a pinch is indistinguishable from a drag, and zoom / rotate / any two-finger gesture is out of reach for every Whisker app.

## Why it was empty

Lynx implements multi-touch but keeps it behind a switch (`TouchEventDispatcher.setEnableMultiTouch` / `LynxTouchHandler.setEnableMultiTouch:`), default off, meant to arrive through the page config — the template-loading pipeline this runtime bypasses, since the engine goes straight to Rust over the bridge. While off, Lynx drops every finger but the first before any handler sees it.

## Why the switch alone is not enough

Turning it on moves `touchstart`/`touchmove`/`touchend`/`touchcancel` onto a different channel — `EventEmitter.sendMultiTouchEvent` / `dispatchMultiTouchEvent:` — where the fingers live in `uiTouchMap` and `event.tag` is -1 (no single element owns a gesture that can span several). Measured on an Android emulator: with the switch on and nothing else changed, **no touch event reaches Rust at all** — not even a single-finger swipe. Both halves ship together here.

`tap` / `longpress` / `click` never moved channel and are unaffected.

## What was added

- Both runtimes flip the switch on the live handler — Android through the reflection it already uses for `tapSlop`, iOS through KVC (the setter lives in `LynxTouchHandler+Internal.h`, which the shipped framework does not expose).
- Both bridges implement the multi-touch channel: `uiTouchMap` (`{ elementTag: [[identifier, clientX, clientY, pageX, pageY, x, y], …] }`, the shape `TouchEventHandler::GetTouchEventParam` parses engine-side) is fanned out to one dispatch per element, each carrying its own fingers as `changedTouches` and every finger currently down as `touches`. Fingers are accumulated across events because Lynx reports only what changed.
- The previous multi-touch branches on both platforms read `touchMap`, an older shape the real dispatch never produces — replaced.

## Verified

Android emulator (two-finger injection through the emulator console, since `sendevent` is SELinux-refused on a production image), driving a pinch-to-zoom reader built on `TouchEvent.touches`:

- pinch scales, and the point under the fingers stays put
- one-finger pan while zoomed
- double tap restores
- **no regressions at rest**: single-finger swipe still pages, tap still pages (counter 4/6 → 6/6), long-press still opens the overlay

iOS is compile-verified only — the simulator has no scriptable pinch.

## Note for the release

The Android half ships in `whisker-runtime-android`, so consuming it needs an SDK release and the matching `platforms.rs` version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)