### PR TITLE
Point the CLI at SDK 0.1.17

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -190,7 +190,14 @@ pub struct PlatformSync {
 /// what forces the move is the `org.lynxsdk.lynx:primjs` coordinate
 /// going 3.7.0 → 4.0.0 alongside it, since 0.1.15's POM would resolve
 /// a Lynx 4.0 AAR against a PrimJS the engine wasn't built for.
-const WHISKER_SDK_VERSION: &str = "0.1.16";
+///
+/// 0.1.17 carries the Android half of multi-touch: the runtime turns
+/// Lynx's multi-touch switch on and implements the channel it moves
+/// touch events onto. Apps on 0.1.16 see `TouchEvent.touches` hold one
+/// finger at most — a pinch is indistinguishable from a drag — so
+/// anything reading a second finger must move to 0.1.17. Kotlin-only,
+/// no capi/Lynx ABI change.
+const WHISKER_SDK_VERSION: &str = "0.1.17";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the


### PR DESCRIPTION
`sdk-v0.1.17` carries the Android half of multi-touch (the runtime turns Lynx's switch on and implements the channel it moves touch events onto — #355). The Rust and iOS halves shipped in v0.10.4, but a generated `gen/android` still asks for `whisker-runtime-android:0.1.16`, so an Android app sees `TouchEvent.touches` hold one finger at most and a pinch stays indistinguishable from a drag.

AAR verified live: `https://whiskerrs.github.io/whisker/maven/rs/whisker/whisker-runtime-android/0.1.17/whisker-runtime-android-0.1.17.aar` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)