### PR TITLE
Reach Lynx's touch handler without its private headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,26 @@ jobs:
       # Add it via `cargo-ndk` / an NDK setup step when wiring Android CI.
       - run: cargo check -p whisker --target aarch64-apple-ios-sim
 
+  build-ios-runtime:
+    name: swift build (WhiskerRuntime)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      # The iOS runtime is Swift, and nothing else in this workflow
+      # compiles Swift: `cross build` above builds the Rust half for an
+      # iOS target and stops there. A Swift-only break therefore reached
+      # a tagged SwiftPM release and only surfaced when an app built
+      # against it (a property read against a Lynx header the shipped
+      # framework doesn't surface). This scheme pulls the Lynx binary
+      # target the same way an app does, so it catches that class of
+      # break here instead.
+      - run: |
+          xcodebuild -scheme WhiskerRuntime \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build
+        working-directory: platforms/ios
+
   coverage:
     name: coverage (cargo-llvm-cov)
     runs-on: ubuntu-latest

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,7 +49,7 @@ use std::process::Command;
 /// Keep in lockstep with the `Package.swift` at the repo root and the
 /// `v<version>` git tag published for SwiftPM to resolve.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
-pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.6";
+pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.7";
 
 use crate::capture::{CaptureShims, capture_env_vars_for_triple};
 

--- a/packages/whisker-asset/Package.swift
+++ b/packages/whisker-asset/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WhiskerAsset", targets: ["WhiskerAsset"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-haptics/Package.swift
+++ b/packages/whisker-haptics/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerHaptics", targets: ["WhiskerHaptics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
         // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
         // via Core Image, animated GIF via `AnimatedImageView`, in-
         // memory `NSCache` + disk cache out of the box. WebP requires

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-keyboard/Package.swift
+++ b/packages/whisker-keyboard/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "WhiskerKeyboard", targets: ["WhiskerKeyboard"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "WhiskerLocalStore", targets: ["WhiskerLocalStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
         // PoC — an external SwiftPM dependency. swift-collections is
         // Apple-maintained, header-only Swift, small enough that
         // resolving it is fast even on a cold cache. Use is minimal

--- a/packages/whisker-paths/Package.swift
+++ b/packages/whisker-paths/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerPaths", targets: ["WhiskerPaths"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-status-bar/Package.swift
+++ b/packages/whisker-status-bar/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .library(name: "WhiskerStatusBar", targets: ["WhiskerStatusBar"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "WhiskerSvg", targets: ["WhiskerSvg"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // it there, and the package identity (the crate's dir name)
         // is unique, so the app aggregator references it via
         // `.package(path: …)` without the `ios`-dir-name collision.
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-web-browser/Package.swift
+++ b/packages/whisker-web-browser/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "WhiskerWebBrowser", targets: ["WhiskerWebBrowser"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.6"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
     ],
     targets: [
         .target(

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -137,13 +137,22 @@ public final class WhiskerView: LynxView {
     /// does not exist until the tree has mounted; once it takes, the
     /// flag stops the retry.
     private func enableMultiTouch() {
-        guard let owner = getLynxContext().uiOwner,
-              let handler = owner.eventHandler?.touchRecognizer
+        // Walked by key rather than by property: `uiOwner` and
+        // `setEnableMultiTouch:` are declared in headers the shipped
+        // framework does not surface to Swift, and `responds(to:)`
+        // before each hop keeps a renamed key a no-op instead of the
+        // uncatchable `NSUndefinedKeyException` a bare KVC read raises.
+        func child(_ object: NSObject, _ key: String) -> NSObject? {
+            guard object.responds(to: Selector((key))) else { return nil }
+            return object.value(forKey: key) as? NSObject
+        }
+        guard let context = getLynxContext() as NSObject?,
+              let owner = child(context, "uiOwner"),
+              let handler = child(owner, "eventHandler"),
+              let recognizer = child(handler, "touchRecognizer"),
+              recognizer.responds(to: Selector(("setEnableMultiTouch:")))
         else { return }
-        // `setEnableMultiTouch:` lives in `LynxTouchHandler+Internal.h`,
-        // which the shipped framework does not expose — KVC reaches the
-        // same setter without the header.
-        handler.setValue(true, forKey: "enableMultiTouch")
+        recognizer.setValue(true, forKey: "enableMultiTouch")
         multiTouchEnabled = true
     }
 


### PR DESCRIPTION
`v0.1.6` shipped a runtime **no app can compile**:

```
WhiskerView.swift:140:44: error: value of type 'LynxContext' has no member 'uiOwner'
```

`LynxContext.uiOwner` and `LynxTouchHandler.enableMultiTouch` are declared in headers the shipped `Lynx.framework` does not surface to Swift, so the multi-touch enable added in #355 never compiled. It reached a tag because **nothing in CI compiles Swift** — `cross build (aarch64-apple-ios-sim)` builds the Rust half for an iOS target and stops. The break only surfaced when giga built against `v0.1.6`.

## What changed

- Walk `uiOwner → eventHandler → touchRecognizer → setEnableMultiTouch:` by key instead of by property, with `responds(to:)` before each hop — a renamed key degrades to "no multi-touch" instead of the uncatchable `NSUndefinedKeyException` a bare KVC read raises.
- **CI now builds the Swift runtime** (`xcodebuild -scheme WhiskerRuntime`), which pulls the Lynx binary target the same way an app does. Verified locally: `** BUILD SUCCEEDED **` with the fix, and the old code fails the app build.
- SwiftPM pin moves to 0.1.7 across the runtime constant and all 15 module packages — they resolve by path alongside the app, so one left behind makes the graph unresolvable.

Needs a `v0.1.7` tag on the merge commit and a crates release so the module packages ship the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)