### PR TITLE
Enable Lynx multi-touch from the bridge, not from Swift

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/lynx_objc_stubs.h
+++ b/crates/whisker-driver-sys/bridge/include/lynx_objc_stubs.h
@@ -72,8 +72,11 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 // LynxEventHandler — owns the emitter the bridge hooks into.
+@class LynxTouchHandler;
+
 @interface LynxEventHandler : NSObject
 @property (nonatomic, readonly, nullable) LynxEventEmitter* eventEmitter;
+@property (nonatomic, readonly, nullable) LynxTouchHandler* touchRecognizer;
 @end
 
 // LynxEvent — base class. The bridge reads `eventName` / `targetSign`,
@@ -103,6 +106,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CGPoint pagePoint;
 @property (nonatomic, readonly) CGPoint clientPoint;
 @property (nonatomic, readonly, nullable) NSDictionary* uiTouchMap;
+@end
+
+// LynxTouchHandler — Lynx's own gesture recognizer.
+// `setEnableMultiTouch:` is declared in `LynxTouchHandler+Internal.h`,
+// which the shipped framework does not surface; without it Lynx drops
+// every finger but the first before any handler sees it.
+@interface LynxTouchHandler : NSObject
+- (void)setEnableMultiTouch:(BOOL)enable;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
+++ b/crates/whisker-driver-sys/bridge/src/whisker_bridge_ios.mm
@@ -251,6 +251,12 @@ void InstallEventReporterIfNeeded(WhiskerEngine* engine, LynxView* view) {
     if (handler == nil) return;
     LynxEventEmitter* emitter = handler.eventEmitter;
     if (emitter == nil) return;
+    // Lynx keeps multi-touch behind a switch that arrives through the
+    // page config — the template pipeline this runtime bypasses. Set it
+    // on the live recognizer instead, from the walk that already
+    // reaches the handler, so `TouchEvent.touches` can hold more than
+    // one finger and `DispatchMultiTouch` above has something to read.
+    [handler.touchRecognizer setEnableMultiTouch:YES];
     [emitter setEventReporterBlock:^BOOL(LynxEvent* event) {
         if (event == nil || event.eventName == nil) return NO;
         // `generateEventBody` is the public seam on `LynxEvent` (the

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -121,46 +121,6 @@ public final class WhiskerView: LynxView {
         }
     }
 
-    // MARK: - Multi-touch
-
-    private var multiTouchEnabled = false
-
-    /// Lynx drops every finger but the first unless its touch handler
-    /// is told otherwise, so `TouchEvent.touches` can never hold more
-    /// than one point and a pinch is indistinguishable from a drag.
-    ///
-    /// The switch is meant to arrive through the page config, which is
-    /// the template-loading pipeline this runtime bypasses (the engine
-    /// goes straight to Rust over the bridge), so it is set on the live
-    /// handler instead — the same shape the Android runtime uses for
-    /// `tapSlop`. Attempted per touch dispatch, because the handler
-    /// does not exist until the tree has mounted; once it takes, the
-    /// flag stops the retry.
-    private func enableMultiTouch() {
-        // Walked by key rather than by property: `uiOwner` and
-        // `setEnableMultiTouch:` are declared in headers the shipped
-        // framework does not surface to Swift, and `responds(to:)`
-        // before each hop keeps a renamed key a no-op instead of the
-        // uncatchable `NSUndefinedKeyException` a bare KVC read raises.
-        func child(_ object: NSObject, _ key: String) -> NSObject? {
-            guard object.responds(to: Selector((key))) else { return nil }
-            return object.value(forKey: key) as? NSObject
-        }
-        guard let context = getLynxContext() as NSObject?,
-              let owner = child(context, "uiOwner"),
-              let handler = child(owner, "eventHandler"),
-              let recognizer = child(handler, "touchRecognizer"),
-              recognizer.responds(to: Selector(("setEnableMultiTouch:")))
-        else { return }
-        recognizer.setValue(true, forKey: "enableMultiTouch")
-        multiTouchEnabled = true
-    }
-
-    public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        if !multiTouchEnabled { enableMultiTouch() }
-        return super.hitTest(point, with: event)
-    }
-
     public override func onEnterForeground() {
         super.onEnterForeground()
     }


### PR DESCRIPTION
iOS still delivered one finger at a time after #362. The Swift enable never worked, in two different ways:

- `v0.1.6` reached `LynxContext.uiOwner` as a property. The shipped framework declares it in a **class extension**, which Swift does not import — the runtime could not compile at all.
- `v0.1.7` replaced that with a KVC walk guarded by `responds(to:)`. It compiles, but on device it found nothing and returned silently, so multi-touch stayed off. Instrumented on the simulator: touch events kept arriving with `touches.count == 1`.

The bridge already walks to the same `LynxEventHandler` — in Objective-C++, to install the event reporter — where a stub `@interface` makes `setEnableMultiTouch:` callable without the private header. Flipping the switch there works, and the Swift version is removed: one mechanism, in the layer CI compiles.

## Verified

Simulator, two-finger gesture into giga's reader:

```
[whiskerprobe] name=touchmove multi=1 keys=1 shape=368:2(__NSArrayM) bodyNil=0
[whiskerprobe] -> tag=368 changed=2 touches=2
[zoom] move n=2 changed=2          ← Rust side
```

and the page visibly zooms. Before this change the same gesture produced `n=1` and no zoom.

Bridge-only, so no new SwiftPM tag is needed — `v0.1.7` stays current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)