### PR TITLE
Put the iOS release behind CI

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -1,0 +1,98 @@
+name: publish-ios
+
+# Cuts the `whisker` Swift package release — the `v0.1.*` tag stream the
+# iOS runtime resolves from.
+#
+# Inverted from `publish-sdk`, and it has to be. Android's tag triggers a
+# build that uploads an AAR: the tag is the input, the artifact is the
+# output. SwiftPM has no artifact — it resolves the git tag directly, so
+# the tag IS the release. A tag-triggered workflow could only verify
+# after the fact, with the broken tag already public (`v0.1.6` shipped a
+# runtime no app could compile, exactly that way).
+#
+# So this runs on `workflow_dispatch`, verifies, and only then creates
+# the tag.
+#
+# The `v0.1.*` stream is independent from the crates' own versions and
+# from `sdk-v*`: an iOS-only change doesn't need a crate release, and a
+# Rust-only change doesn't need a Swift tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Swift package version to tag, e.g. 0.1.8 (no leading v)'
+        required: true
+      dry_run:
+        description: 'Verify only — do not create the tag'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-ios
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Tags are needed to reject a version that already exists.
+          fetch-depth: 0
+
+      - name: Reject an existing tag
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "::error::v$VERSION already exists. SwiftPM caches by revision, so a moved tag reaches consumers as a stale checkout — pick the next version."
+            exit 1
+          fi
+
+      # Every module package resolves by path alongside the app, so one
+      # pin left behind makes the whole graph unresolvable for every
+      # consumer ("root depends on 0.1.4 and X depends on 0.1.5"). The
+      # crate-side constant and the 15 module manifests have to name the
+      # version being tagged, in the commit being tagged.
+      - name: Check the pins name this version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          fail=0
+          if ! grep -q "WHISKER_IOS_SPM_VERSION: &str = \"$VERSION\"" \
+               crates/whisker-build/src/ios.rs; then
+            echo "::error file=crates/whisker-build/src/ios.rs::WHISKER_IOS_SPM_VERSION is not $VERSION"
+            fail=1
+          fi
+          for manifest in packages/*/Package.swift; do
+            grep -q 'whiskerrs/whisker.git' "$manifest" || continue
+            if ! grep -q "whiskerrs/whisker.git\", exact: \"$VERSION\"" "$manifest"; then
+              echo "::error file=$manifest::pin is not $VERSION"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      # The runtime is Swift, and a Swift-only break is invisible to
+      # every Rust job in `ci`. This scheme pulls the Lynx binary target
+      # the same way an app does.
+      - name: Build the runtime
+        working-directory: platforms/ios
+        run: |
+          xcodebuild -scheme WhiskerRuntime \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            build
+
+      - name: Tag
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+          echo "### Tagged \`v$VERSION\`" >> "$GITHUB_STEP_SUMMARY"

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -1107,6 +1107,45 @@ fn export_options_plist(method: ExportMethod, team_id: &str) -> String {
 mod tests {
     use super::*;
 
+    /// Every module package pins the runtime `exact:`, and all of them
+    /// are resolved by path alongside the app, which pins
+    /// [`WHISKER_IOS_SPM_VERSION`]. One manifest left on the old
+    /// version makes the whole graph unresolvable for every consumer
+    /// ("root depends on 0.1.4 and X depends on 0.1.5"), and nothing
+    /// else in the workspace notices — the manifests are data to Rust.
+    #[test]
+    fn module_packages_pin_the_runtime_version_the_cli_generates() {
+        let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("crates/<name> sits two levels under the workspace root")
+            .to_path_buf();
+        let packages = workspace.join("packages");
+        // Absent when this crate is built from its published .crate,
+        // which carries no sibling packages to check.
+        let Ok(entries) = std::fs::read_dir(&packages) else {
+            return;
+        };
+
+        let expected = format!(
+            "\"https://github.com/whiskerrs/whisker.git\", exact: \"{WHISKER_IOS_SPM_VERSION}\""
+        );
+        let mut stale = Vec::new();
+        for entry in entries.flatten() {
+            let manifest = entry.path().join("Package.swift");
+            let Ok(source) = std::fs::read_to_string(&manifest) else {
+                continue;
+            };
+            if source.contains("whiskerrs/whisker.git") && !source.contains(&expected) {
+                stale.push(manifest.display().to_string());
+            }
+        }
+        assert!(
+            stale.is_empty(),
+            "these manifests do not pin {WHISKER_IOS_SPM_VERSION}: {stale:#?}"
+        );
+    }
+
     #[test]
     fn bridge_exports_have_leading_underscore() {
         // ld64's `-exported_symbol` expects the Mach-O C symbol form.


### PR DESCRIPTION
The Swift package release is the one artifact stream still cut by hand — `git tag v0.1.x && git push` — and it is the one that shipped broken. `v0.1.6` tagged a runtime no app could compile, and 0.10.7 and 0.10.8 went out afterwards carrying nothing but pin bumps to chase it.

## Why it can't mirror `publish-sdk`

Android's `sdk-v*` tag **triggers** a build that uploads an AAR: tag in, artifact out. SwiftPM has no artifact — it resolves the git tag directly, so **the tag is the release**. A tag-triggered check could only run once the broken tag was already public, which is exactly how `v0.1.6` reached giga.

So `publish-ios` inverts it: `workflow_dispatch` takes the version, verifies, and only then creates the tag.

| | Android (`publish-sdk`) | iOS (`publish-ios`) |
|---|---|---|
| trigger | `sdk-v*` tag push | `workflow_dispatch` (version input) |
| output | AAR → gh-pages Maven | the `v0.1.x` tag itself |
| verification | build must succeed to upload | build + pins must pass to tag |

## Guards

- **Existing tag is rejected.** SwiftPM caches by revision, so moving a tag reaches consumers as a stale checkout.
- **Pins must name the version being tagged** — `WHISKER_IOS_SPM_VERSION` plus all 15 `packages/*/Package.swift`.
- **The runtime must build** (`xcodebuild -scheme WhiskerRuntime`), the check added in #362.
- `dry_run` input verifies without tagging.

The pin check *also* runs as a unit test, because that failure belongs at PR time rather than release time: the module manifests resolve by path alongside the app, so one left on the old version makes the graph unresolvable for every consumer (`root depends on 0.1.4 and X depends on 0.1.5` — hit twice while releasing multi-touch), and nothing else in the workspace reads them.

Verified locally: the test fails on a hand-staled pin and passes on the current tree; the workflow's guards accept `0.1.7`, reject `0.1.8` against today's pins, and reject the already-existing `v0.1.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)