### PR TITLE
Leave Android's back gesture to Android

### DIFF
--- a/packages/whisker-router/src/render/gesture.rs
+++ b/packages/whisker-router/src/render/gesture.rs
@@ -89,6 +89,17 @@ pub fn swipe_back() -> Element {
     // published by `router()` BEFORE the children mount, so it is visible here.
     let container = use_context::<RouterRoot>().map(|r| r.0);
     on_mount(move || {
+        // Android's back gesture belongs to the platform: it arrives
+        // through `AndroidPredictiveBack`, and the two mounted together
+        // is the documented setup. Installing here as well would let a
+        // left-edge swipe drive both — and the platform cancels the
+        // touch stream once it takes the gesture over, so this half
+        // reads that as a cancelled swipe and *restores* the focus the
+        // gesture had just dismissed. The keyboard drops and springs
+        // back, on the left edge only.
+        if cfg!(target_os = "android") {
+            return;
+        }
         if let Some(container) = container {
             install(container, nav.clone());
         }


### PR DESCRIPTION
On Android, a **left-edge** back gesture with the keyboard up drops the keyboard and then springs it straight back. The right edge is fine.

## Why

`SwipeBack` is the iOS edge swipe, and `AndroidPredictiveBack`'s docs say the two are mounted together because "each simply waits on its own platform's input". `SwipeBack` does not — it binds a plain Lynx `touchstart`, which fires on Android too, so a left-edge swipe drives both halves.

The platform cancels the app's touch stream once it takes the gesture over. `SwipeBack` sees `touchcancel` with `progress == 0` and reads that as a swipe released below the commit threshold — a **cancel**. Cancelling a back gesture restores the focus captured at gesture start, so the keyboard the gesture had just dismissed comes back. Only the left edge, because that is the only edge `SwipeBack` qualifies.

Traced on a device (search screen, keyboard up, left edge):

```
SwipeBack touchstart x=3.0
on_page_change_start focused=true       ← blur, field remembered
predictive backStarted edge=Left
SwipeBack end progress=0 commit=false
on_page_change_cancel remembered=true   ← refocus — the bug
on_page_change_confirm gesture=true     ← the back had committed all along
```

The right edge produced no `SwipeBack` lines at all, and the keyboard stayed down — the asymmetry the report describes.

## After

Same gesture, same screen: only the platform path runs, and `mInputShown` reads false from 0.3s through 3s. iOS is untouched (`cfg!(target_os = "android")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)