### PR TITLE
Let hot-reload patches larger than 16 MiB reach the device

### DIFF
--- a/crates/whisker-dev-runtime/src/hot_reload.rs
+++ b/crates/whisker-dev-runtime/src/hot_reload.rs
@@ -136,9 +136,18 @@ pub fn start_receiver() {
 }
 
 async fn client_loop(addr: String) {
+    use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+
     let url = format!("ws://{addr}/whisker-dev");
+    // Patch dylibs for large apps exceed tungstenite's 16 MiB read
+    // default; dev-only loopback channel, so lift the limits entirely.
+    let ws_config = WebSocketConfig {
+        max_frame_size: None,
+        max_message_size: None,
+        ..Default::default()
+    };
     loop {
-        match tokio_tungstenite::connect_async(&url).await {
+        match tokio_tungstenite::connect_async_with_config(&url, Some(ws_config), false).await {
             Ok((ws, _)) => {
                 devlog(&format!("connected: {url}"));
                 if let Err(e) = handle_session(ws).await {

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -804,6 +804,7 @@ async fn hot_reload_cycle(
                     return;
                 }
             };
+            let patch_mib = dylib_bytes.len() as f64 / (1024.0 * 1024.0);
             let send_started = std::time::Instant::now();
             let n = sender.send(Patch {
                 table: plan.table,
@@ -813,7 +814,7 @@ async fn hot_reload_cycle(
                 "built {built_in:?} · queued {:?}",
                 send_started.elapsed()
             ));
-            step.done(format!("{n} client(s)"));
+            step.done(format!("{n} client(s) · {patch_mib:.1} MiB patch"));
             emit(on_event, Event::PatchSent);
         }
         Err(e) if e.downcast_ref::<hotpatch::RustcRejectedCode>().is_some() => {

--- a/crates/whisker-dev-server/src/server.rs
+++ b/crates/whisker-dev-server/src/server.rs
@@ -522,6 +522,74 @@ mod tests {
         assert_eq!(dylib, b"FAKE_DYLIB_BYTES");
     }
 
+    #[tokio::test]
+    async fn a_patch_larger_than_the_default_frame_limit_reaches_an_unlimited_client() {
+        use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+
+        let (sender, addr) = spawn_test_server(None).await;
+        // Mirror the device receiver's lifted read limits
+        // (whisker-dev-runtime::hot_reload::client_loop).
+        let config = WebSocketConfig {
+            max_frame_size: None,
+            max_message_size: None,
+            ..Default::default()
+        };
+        let url = format!("ws://{addr}/whisker-dev");
+        let (mut unlimited, _) =
+            tokio_tungstenite::connect_async_with_config(&url, Some(config), false)
+                .await
+                .expect("connect");
+        let mut default_limits = connect(addr).await;
+
+        for _ in 0..100 {
+            if sender.client_count() == 2 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert_eq!(sender.client_count(), 2);
+
+        // 17 MiB — over tungstenite's 16 MiB default max_frame_size,
+        // the size class a large app's subsecond patch lands in.
+        let dylib = vec![0xABu8; 17 * 1024 * 1024];
+        let n = sender.send(Patch {
+            table: make_dummy_jump_table(),
+            dylib_bytes: Arc::new(dylib.clone()),
+        });
+        assert_eq!(n, 2);
+
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(10), unlimited.next())
+            .await
+            .expect("recv timed out")
+            .expect("stream ended")
+            .expect("ws error");
+        let bytes = match msg {
+            tokio_tungstenite::tungstenite::Message::Binary(b) => b,
+            other => panic!("expected binary, got a {other:?} frame"),
+        };
+        let (header, got) = decode_patch_frame(&bytes);
+        assert_eq!(header["kind"], "patch");
+        assert_eq!(got, dylib);
+
+        // A client with tungstenite's default read limits (the old
+        // device behavior) rejects the same frame as too long.
+        let rejected = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                match default_limits.next().await {
+                    Some(Ok(tokio_tungstenite::tungstenite::Message::Binary(_))) => return false,
+                    Some(Err(_)) | None => return true,
+                    _ => continue,
+                }
+            }
+        })
+        .await
+        .expect("default-limit client neither errored nor received");
+        assert!(
+            rejected,
+            "a 17 MiB frame must exceed the default 16 MiB read limit"
+        );
+    }
+
     async fn spawn_test_server_with_token(token: Option<String>) -> (PatchSender, SocketAddr) {
         let any: SocketAddr = "127.0.0.1:0".parse().unwrap();
         let (sender, addr, _handle) = serve(any, None, token).await.expect("serve");


### PR DESCRIPTION
## Symptom

On a large app (giga), every save during `whisker run` printed "✓ hot reload subsecond patch — 1 client(s)" on the host, yet nothing changed on the device — not even a one-line CSS edit.

## Root cause

The patch dylib (17.7 MB on iOS, 73.6 MB on Android for giga) exceeds tungstenite's default 16 MiB `max_frame_size` on the **device-side** WebSocket. The host sends each patch as a single binary frame, so the device dropped the frame with `Message too long: 17739431 > 16777216` and reconnected, every time. `PatchSender::send` only returns the number of queued receivers, so the host kept reporting success.

## Fix

- `whisker-dev-runtime/src/hot_reload.rs`: connect with `WebSocketConfig { max_frame_size: None, max_message_size: None }` — a dev-only loopback channel, so the read limits are lifted entirely rather than guessing a ceiling a bigger app would breach again.
- `whisker-dev-server/src/lib.rs`: show the patch size next to the client count (`✓ … 1 client(s) · 17.7 MiB patch`) so a size-shaped failure is diagnosable from the host output.

## Verification

- Regression test: a 17 MiB patch reaches a lifted-limit client intact and is rejected by a default-config client (the old device behavior).
- Device-verified on giga: iOS simulator (17.7 MB patch) and Android emulator (73.6 MB patch) both receive and apply patches; `Message too long` no longer appears in the device log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)