### PR TITLE
Keep app-root contexts resolvable after a hot-reload remount

### DIFF
--- a/crates/whisker-runtime/src/reactive/component.rs
+++ b/crates/whisker-runtime/src/reactive/component.rs
@@ -538,11 +538,15 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
             site.body_root.take();
             site.owner.take()
         });
+        // Remount runs with an empty owner stack; inherit the old
+        // owner's parent or app-root contexts are lost.
+        let parent_owner =
+            old_owner.and_then(|o| with_runtime(|rt| rt.owners.get(o).and_then(|s| s.parent)));
         if let Some(o) = old_owner {
             o.dispose();
         }
 
-        let new_owner = Owner::new(None);
+        let new_owner = Owner::new(parent_owner);
         with_runtime(|rt| {
             if let Some(o) = rt.owners.get_mut(new_owner) {
                 o.mount_fn = Some(info.fn_ptr);

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -1096,20 +1096,63 @@ fn remount_components_for_refuses_sites_whose_props_layout_changed() {
     assert_eq!(runs.get(), 2, "refused remount must NOT re-run the body");
 }
 
+#[test]
+fn remounted_component_still_resolves_root_context() {
+    // Hot-reload remounts run from the tick callback with an empty
+    // owner stack; the fresh owner must inherit the old owner's
+    // parent or `use_context` loses everything the app root provided
+    // (giga: "provide_theme() must run at the app root" panic).
+    use super::component::{
+        mount_component_remountable, on_component_root_attached, remount_components_for,
+    };
+    use crate::view::{append_child, create_phantom_element};
+    fresh();
+
+    #[derive(Clone, PartialEq, Debug)]
+    struct Theme(u32);
+
+    let root_owner = Owner::new(None);
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let seen_clone = seen.clone();
+    let fn_ptr = 0x5678_9abc as *const ();
+    let root = root_owner.with(|| {
+        provide_context(Theme(7));
+        mount_component_remountable(
+            fn_ptr,
+            move || {
+                seen_clone.borrow_mut().push(use_context::<Theme>());
+                create_phantom_element()
+            },
+            Box::new(|| 0),
+        )
+    });
+    let parent = create_phantom_element();
+    append_child(parent, root);
+    on_component_root_attached(parent, root);
+    assert_eq!(seen.borrow().as_slice(), &[Some(Theme(7))]);
+
+    remount_components_for(&[fn_ptr]);
+    assert_eq!(
+        seen.borrow().as_slice(),
+        &[Some(Theme(7)), Some(Theme(7))],
+        "remounted body must still resolve the root-provided context"
+    );
+
+    // Disposing the provider now cascades into the remounted owner —
+    // a second remount would find the site's owner gone, and the
+    // context must not outlive its provider.
+    root_owner.dispose();
+    assert_eq!(
+        remount_components_for(&[fn_ptr]),
+        super::component::RemountStats::default(),
+    );
+}
+
 // Note: `remount_components_for`'s body invocation reuses the
 // exact same `untrack(|| new_owner.with(|| (*info.body)()))`
-// bracket the initial mount uses. Driving the remount path through
-// a unit test requires a full renderer install + an attached parent
-// element (otherwise `info.parent` is `None` and the path
-// short-circuits), which sits at the integration-test layer.
-// Coverage relies on:
-//   1. `mount_component_remountable_body_runs_with_no_tracker_...`
-//      below, which exercises the identical `untrack` pattern, and
-//   2. inspection of `component.rs::remount_components_for` to
-//      confirm the bracket is in place.
-// If a future contributor removes the bracket from the remount
-// path, the corresponding StackLayout / hot-reload integration
-// scenario will regress visibly.
+// bracket the initial mount uses; the no-tracker half of that
+// contract is pinned by
+// `mount_component_remountable_body_runs_with_no_tracker_...` below.
 
 #[test]
 fn flush_mounts_callback_runs_with_no_tracker_when_called_inside_effect() {


### PR DESCRIPTION
## Symptom

Once patches started reaching the device at all (#372), every hot patch on giga panicked right after `patch applied`:

```
thread '<unnamed>' panicked at src/theme.rs:103:10:
provide_theme() must run at the app root
[whisker-dev] tick: user code panicked; frame dropped, app continues
```

The remounted component's `computed` could no longer resolve a context the app provides at the root, and the affected screen went blank.

## Root cause

`Owner::new(None)` adopts the current top-of-stack owner as parent. That works on the initial mount (the parent component's body is executing, so the stack holds the parent), but hot-reload remounts run from the tick callback with an **empty owner stack** — so `remount_components_for` minted each replacement owner as a detached root. `use_context`'s parent-chain walk then never reached the `app()` run owner holding the root-provided contexts.

## Fix

Capture the old owner's `parent` before disposing it and pass it to `Owner::new`. Two behaviors are repaired beyond context lookup, since remounted owners are now real children of their original parent:

- they inherit the parent's `paused` flag (a component remounted inside a suspended route no longer starts unpaused), and
- they are cascade-disposed with their provider/route — previously they were orphaned roots that leaked their reactive state for the rest of the dev session.

The full-remount escalation path needs no change: it re-runs `app()` under its fresh run owner, so root contexts are re-provided there. The panic fired in the per-component path before escalation could run.

## Verification

- New regression test `remounted_component_still_resolves_root_context` — verified to fail against the previous `Owner::new(None)` behavior and pass with the fix; it also pins that disposing the provider cascades into the remounted owner.
- Device-verified on giga: iOS simulator and Android emulator both apply patches with no `provide_theme` panic and the screen repaints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)