### PR TITLE
Verify the Android dev token actually landed on the device

### DIFF
--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -329,6 +329,33 @@ impl SimctlNoise {
     }
 }
 
+/// Write the dev token property and verify it landed by reading it
+/// back, retrying on mismatch. Only the `getprop` round-trip proves
+/// the write: `adb shell` exit codes are historically unreliable, and
+/// emulator quick-boot snapshots restore a previous session's value —
+/// a silently-failed `setprop` then leaves that stale token in place
+/// and the server rejects every hello for the whole session.
+async fn deliver_android_dev_token(token: &str) -> bool {
+    for attempt in 0..5 {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        }
+        let mut setprop_cmd = Command::new("adb");
+        setprop_cmd.args(["shell", "setprop", "debug.whisker_dev_token", token]);
+        let _ = run_filtered(setprop_cmd, SimctlNoise::Other).await;
+        let read_back = Command::new("adb")
+            .args(["shell", "getprop", "debug.whisker_dev_token"])
+            .output()
+            .await;
+        if let Ok(out) = read_back {
+            if String::from_utf8_lossy(&out.stdout).trim() == token {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 async fn android_install_and_launch(
     p: &AndroidParams,
     dev_port: u16,
@@ -362,9 +389,13 @@ async fn android_install_and_launch(
     // reads via `__system_property_get`. Without a matching token the
     // dev-server refuses to ship patches to the app.
     if let Some(token) = dev_token {
-        let mut setprop_cmd = Command::new("adb");
-        setprop_cmd.args(["shell", "setprop", "debug.whisker_dev_token", token]);
-        let _ = run_filtered(setprop_cmd, SimctlNoise::Other).await;
+        if !deliver_android_dev_token(token).await {
+            whisker_build::ui::warn(format!(
+                "dev token did not land on the device — the app will keep being \
+                 rejected by the hot-reload server (0 clients). Fix manually: \
+                 adb shell setprop debug.whisker_dev_token {token}"
+            ));
+        }
     }
 
     let install_step = whisker_build::ui::step(


### PR DESCRIPTION
## Symptom

Repeatedly on clean `whisker run android` sessions with giga, the host kept logging `rejected a hot-reload client (missing/invalid dev token)` and sat at 0 clients — hot reload silently dead until a manual `setprop` + relaunch.

## Root cause chain

The token delivery was fire-and-forget: `adb shell setprop debug.whisker_dev_token <token>` with the result discarded. Three researched facts turn one silent failure into a session-long wedge:

- `adb shell` historically does not propagate exit codes ([issuetracker 36908392](https://issuetracker.google.com/issues/36908392)), so even checking the status wouldn't be reliable.
- Emulator [quick-boot snapshots](https://developer.android.com/studio/run/emulator-snapshots) restore the property area, so the **previous session's token is the default starting state** on emulators — a failed setprop doesn't leave the property empty, it leaves a plausible-looking stale token.
- `__system_property_set` waits for property_service's ack ([bionic](https://android.googlesource.com/platform/bionic/+/master/libc/bionic/system_property_set.cpp)), so there is no commit race: the only failure mode is the command not running/failing — which retry absorbs.

The device side needs no change: it re-reads the property on every 2s reconnect, so a verified write is sufficient for the session to self-heal.

## Fix

`deliver_android_dev_token`: write, read back with `getprop`, compare **output** (not exit codes), retry up to 5 times. If it never matches, print an actionable warning carrying the manual `setprop` command instead of staying silent — so the failure either heals or is visible, never a quiet 0-client wedge.

## Verification

E2E on giga (Android emulator, API 36, quick boot enabled): 5 clean back-to-back sessions, a deliberately planted bogus token, and a quick-boot-restored stale token — all ended with the fresh session token in place and the client authed with no manual intervention; the warning never had to fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)