### PR TITLE
Sweep whisker-dev-runtime comments per the comment style guide

### DIFF
--- a/crates/whisker-dev-runtime/src/hot_reload.rs
+++ b/crates/whisker-dev-runtime/src/hot_reload.rs
@@ -18,10 +18,6 @@
 //! `subsecond::apply_patch` while **no** `subsecond::call` is on the
 //! stack — the only safe window.
 //!
-//! Connection address is taken from the `WHISKER_DEV_ADDR` env var. If
-//! unset, [`start_receiver`] no-ops, so a stray `hot-reload`-built
-//! binary running without a dev server stays inert.
-//!
 //! The receiver retries on disconnect with a small backoff so a
 //! `whisker run` restart on the host doesn't require restarting the
 //! app on the device.
@@ -31,20 +27,16 @@ use std::time::Duration;
 
 use subsecond::JumpTable;
 
-/// Log a one-line message tagged `whisker-dev`. On Android, writes to
-/// logcat via `__android_log_write` (Rust's `eprintln!` doesn't go
-/// anywhere useful on Android — stderr is dropped). On other
-/// platforms it's a plain `eprintln!` so dev sessions on host /
-/// macOS / Linux still get readable output.
+/// Log a one-line message tagged `whisker-dev`. On Android this goes
+/// to logcat and on iOS to `syslog(3)` — plain `eprintln!` reaches
+/// neither platform's log surface. Elsewhere it is an `eprintln!`.
 ///
-/// Public so whisker-driver's `apply_pending_hot_patch` can log under
-/// the same `whisker-dev` tag without duplicating the helper.
+/// Public so whisker-driver's patch-apply path can log under the same
+/// tag.
 pub fn devlog(line: &str) {
     #[cfg(target_os = "android")]
     {
-        // bionic exports __android_log_write(prio, tag, text) → int.
-        // ANDROID_LOG_INFO = 4. Both tag and text must be
-        // NUL-terminated.
+        // Both tag and text must be NUL-terminated.
         unsafe extern "C" {
             fn __android_log_write(
                 prio: std::os::raw::c_int,
@@ -67,15 +59,11 @@ pub fn devlog(line: &str) {
     }
     #[cfg(target_os = "ios")]
     {
-        // iOS app stderr from `eprintln!` doesn't reach the unified
-        // log, so use `syslog(3)` which does. `simctl spawn booted log
-        // stream` then picks it up — the simplest device-side
-        // observability for dev builds.
         unsafe extern "C" {
             fn syslog(priority: std::os::raw::c_int, fmt: *const std::os::raw::c_char, ...);
         }
-        // LOG_INFO = 6 — surfaces in `log stream` without being
-        // filtered as noisy debug output by default.
+        // LOG_INFO surfaces in `log stream` without being filtered as
+        // debug noise.
         const LOG_INFO: std::os::raw::c_int = 6;
         let mut buf: Vec<u8> = Vec::with_capacity(line.len() + 16);
         buf.extend_from_slice(b"[whisker-dev] ");
@@ -94,7 +82,6 @@ pub fn devlog(line: &str) {
 }
 
 /// Most-recent-wins: an older queued patch is silently superseded.
-/// `whisker run` should be sending fully-replaced JumpTables anyway.
 static PENDING: Mutex<Option<JumpTable>> = Mutex::new(None);
 
 /// TASM-thread entry — pop the queued patch, if any. Safe to call
@@ -105,10 +92,10 @@ pub fn take_pending_patch() -> Option<JumpTable> {
 
 /// Spawn the receiver thread. Reads `WHISKER_DEV_ADDR` from the env;
 /// if unset, falls back to `127.0.0.1:9876` (the dev-server's
-/// default), which works on Android once `adb reverse` is in
-/// place. Safe to call unconditionally from app bootstrap — the
-/// loop retries on connection failure so a dev server starting
-/// later still gets picked up.
+/// default), which works on Android once `adb reverse` is in place.
+/// Safe to call unconditionally from app bootstrap — the loop retries
+/// on connection failure so a dev server starting later still gets
+/// picked up.
 pub fn start_receiver() {
     let addr = std::env::var("WHISKER_DEV_ADDR")
         .ok()
@@ -160,36 +147,24 @@ async fn client_loop(addr: String) {
     }
 }
 
-/// `dlsym(RTLD_DEFAULT, "whisker_aslr_anchor")` on the device,
-/// computed once at app startup by the vendored subsecond fork. We
-/// hand this value to the dev server on connect so it can build
-/// patches with the host's runtime base address baked in via
-/// stub-asm objects (Option B / Dioxus-style symbol resolution).
-///
-/// Falls back to `0` when `subsecond` isn't linked in (release builds
-/// without the `hot-reload` feature) — those builds never reach this
-/// code path anyway, the constant is just here so the cfg gating
-/// stays local to one line.
+/// Runtime address of `whisker_aslr_anchor` on the device, handed to
+/// the dev server on connect so it can bake the ASLR slide into the
+/// patches it builds.
 fn device_aslr_reference() -> u64 {
     subsecond::aslr_reference() as u64
 }
 
 /// The shared dev-session token, if `whisker run` provisioned one.
 ///
-/// `whisker run` generates a random token per session and hands it to
-/// the device so the dev-server can reject any other client that
-/// connects to its WebSocket (the patch channel `dlopen`s whatever it
-/// receives, so an unauthenticated connection on a LAN-exposed bind is
-/// a remote-code-execution surface). Delivery is per-platform:
-///   * iOS Simulator / host: the `WHISKER_DEV_TOKEN` env var (set via
-///     `SIMCTL_CHILD_WHISKER_DEV_TOKEN`).
-///   * Android: the `debug.whisker_dev_token` system property (the app
-///     process doesn't inherit adb-set env vars), set with
-///     `adb shell setprop`.
+/// The server rejects clients whose `hello` doesn't carry the
+/// session's token (the patch channel `dlopen`s whatever it receives,
+/// so an unauthenticated connection on a LAN-exposed bind is a
+/// remote-code-execution surface). Delivery is per-platform:
+///   * iOS Simulator / host: the `WHISKER_DEV_TOKEN` env var.
+///   * Android: the `debug.whisker_dev_token` system property — the
+///     app process doesn't inherit adb-set env vars.
 ///
-/// `None` when no token was provisioned — older `whisker run`s, or a
-/// token-less local setup; the server then runs unauthenticated as
-/// before.
+/// `None` = token-less setup; the server then runs unauthenticated.
 fn dev_token() -> Option<String> {
     if let Ok(t) = std::env::var("WHISKER_DEV_TOKEN") {
         if !t.is_empty() {
@@ -208,15 +183,12 @@ fn dev_token() -> Option<String> {
 }
 
 /// Read an Android system property by name via bionic's
-/// `__system_property_get`. The value buffer is `PROP_VALUE_MAX` (92)
-/// bytes including the NUL, per the platform contract.
+/// `__system_property_get`.
 #[cfg(target_os = "android")]
 fn android_system_property(name: &str) -> Option<String> {
     let cname = std::ffi::CString::new(name).ok()?;
-    // PROP_VALUE_MAX = 92. Use `c_char` for the buffer so its pointer matches
-    // bionic's `__system_property_get` signature regardless of `c_char`
-    // signedness (it is unsigned on Android — `libc` 0.2.186 made this a hard
-    // type mismatch against a plain `i8` buffer).
+    // PROP_VALUE_MAX = 92. `c_char` (unsigned on Android) so the
+    // buffer pointer matches bionic's signature.
     let mut buf = [0 as libc::c_char; 92];
     // SAFETY: `cname` is a valid NUL-terminated C string; `buf` is a
     // 92-byte buffer matching PROP_VALUE_MAX, which is the size bionic
@@ -239,10 +211,8 @@ where
     use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::Message;
 
-    // Send the hello envelope first — the server needs our
-    // `aslr_reference` (= runtime address of `whisker_aslr_anchor`
-    // here) to compute the ASLR slide when building patches under
-    // the stub-asm scheme.
+    // The hello goes first — the server needs our `aslr_reference` to
+    // build patches at all.
     let hello = serde_json::json!({
         "kind": "hello",
         "aslr_reference": device_aslr_reference(),
@@ -257,10 +227,8 @@ where
 
     loop {
         tokio::select! {
-            // device → host: forward any captured stdout/stderr lines
-            // accumulated by `log_capture`. Drains in batches so a
-            // burst of `println!`s sends one frame per round-trip
-            // rather than one frame per line.
+            // device → host: forward captured stdout/stderr lines,
+            // batched so a burst of `println!`s is one frame.
             lines = crate::log_capture::drain_pending_logs() => {
                 for line in lines {
                     let frame = serde_json::json!({
@@ -273,14 +241,12 @@ where
                     ws.send(Message::Text(frame)).await?;
                 }
             }
-            // host → device: receive patches + close.
+            // host → device: patches + close.
             msg = ws.next() => {
                 let Some(msg) = msg else { return Ok(()); };
                 match msg? {
                     Message::Binary(bytes) => handle_patch_frame(&bytes),
                     Message::Close(_) => return Ok(()),
-                    // Ignore Ping/Pong (auto-handled) and Text (no
-                    // server→client text frames defined today).
                     _ => {}
                 }
             }
@@ -289,9 +255,7 @@ where
 }
 
 /// Decode one patch frame from the dev-server and park it in
-/// [`PENDING`] for the TASM thread to apply on the next tick. Pulled
-/// out so [`handle_session`]'s `select!` arm stays readable; the
-/// match-arm depth was 7 levels otherwise.
+/// [`PENDING`] for the TASM thread to apply on the next tick.
 fn handle_patch_frame(bytes: &[u8]) {
     devlog(&format!("patch frame received ({} bytes)", bytes.len()));
     let (mut table, dylib_bytes) = match parse_patch_frame(bytes) {
@@ -320,20 +284,18 @@ fn handle_patch_frame(bytes: &[u8]) {
         devlog("patch queued");
     }
     // Wake the host so a frame is scheduled — `take_pending_patch`
-    // only runs inside `tick_callback` and the TASM thread is idle
-    // when nothing else is happening.
+    // only runs inside the tick and the TASM thread may be idle.
     whisker_runtime::host_wake::wake_runtime();
 }
 
-/// Write the patch dylib payload to a local file under the app's
-/// cache dir, and return the local path. The returned path is what
-/// `table.lib` gets overwritten with, so `subsecond::apply_patch`'s
-/// `dlopen` sees a real on-device file.
+/// Write the patch dylib payload to a file under the app's cache dir
+/// and return the local path — what `table.lib` gets overwritten
+/// with, so `subsecond::apply_patch`'s `dlopen` sees a real on-device
+/// file.
 ///
 /// File naming uses a monotonic counter + timestamp so multiple
-/// patches in one session don't collide; old files are left around
-/// (cleaned up when the OS reclaims the cache dir). Total disk use
-/// per session is tiny — each patch is ~tens of KB.
+/// patches in one session don't collide; old files are left for the
+/// OS to reclaim with the cache dir.
 fn materialise_patch_dylib(
     bytes: &[u8],
 ) -> Result<std::path::PathBuf, Box<dyn std::error::Error + Send + Sync>> {
@@ -354,13 +316,9 @@ fn materialise_patch_dylib(
     Ok(path)
 }
 
-/// Resolve a writable, dlopen-able directory for patch dylibs.
-///
-/// On Android, `/data/data/<package>/cache/whisker-patches/` is the
-/// canonical "owned by this app process" location. The package
-/// name comes from `/proc/self/cmdline` (the Linux process-init
-/// name Android writes there). On other platforms (host POC builds),
-/// `$TMPDIR/whisker-patches/` is enough.
+/// Resolve a writable, dlopen-able directory for patch dylibs: on
+/// Android `/data/data/<package>/cache/whisker-patches/` (package
+/// name from `/proc/self/cmdline`), elsewhere `$TMPDIR/whisker-patches/`.
 fn patch_cache_dir() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "android")]
     {
@@ -392,8 +350,8 @@ enum Header {
 
 /// Counterpart of `whisker-dev-server::server::wire_jump_table::serialize`.
 /// Reads the address map as a JSON array of `[old, new]` pairs and
-/// reconstructs the `subsecond_types::JumpTable`. See the server
-/// side for the JSON-object-vs-array rationale.
+/// reconstructs the `subsecond_types::JumpTable`. See the server side
+/// for the JSON-object-vs-array rationale.
 fn deserialize_jump_table<'de, D>(d: D) -> Result<JumpTable, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -473,8 +431,6 @@ mod tests {
 
     #[test]
     fn parses_a_minimal_patch_frame() {
-        // The wire format encodes `map` as an array of [old, new]
-        // pairs — see deserialize_jump_table for the rationale.
         let json = r#"{
             "kind": "patch",
             "table": {
@@ -522,7 +478,6 @@ mod tests {
         let path = materialise_patch_dylib(payload).expect("write");
         let read_back = std::fs::read(&path).unwrap();
         assert_eq!(read_back, payload);
-        // Cleanup so repeated runs don't accumulate.
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/whisker-dev-runtime/src/lib.rs
+++ b/crates/whisker-dev-runtime/src/lib.rs
@@ -3,13 +3,6 @@
 //! Compiled into Whisker apps only when the umbrella crate is built
 //! with `--features hot-reload`. Release builds end up with an empty
 //! crate (no tokio / no WebSocket / no subsecond).
-//!
-//! ## What lives here
-//! - [`hot_reload`]: WebSocket *client* that connects to the
-//!   `whisker run` dev server, deserialises incoming `subsecond::JumpTable`
-//!   messages, and parks them on a single-slot mutex. The Lynx TASM
-//!   thread drains the mutex at the top of every tick and invokes
-//!   `subsecond::apply_patch`.
 
 #[cfg(feature = "hot-reload")]
 pub mod hot_reload;

--- a/crates/whisker-dev-runtime/src/log_capture.rs
+++ b/crates/whisker-dev-runtime/src/log_capture.rs
@@ -1,53 +1,31 @@
 //! Capture stdout/stderr from device-side Rust code and forward over
-//! the dev-server WebSocket.
-//!
-//! `whisker run` previously surfaced only its own dev-loop status —
-//! a `println!` from the user's app went to fd 1, which on Android is
-//! redirected to `/dev/null` by the Android runtime and on iOS is
-//! sunk into the simulator container with no host-side observability.
-//! Users had to attach a separate terminal (`adb logcat` / `simctl log
-//! stream`) to read their own code's output. This module fixes that:
-//! it installs a pipe over stdout/stderr at app bootstrap, reads the
-//! pipe on a background thread, and forwards each completed line over
-//! the dev-server WebSocket to `whisker-cli`.
+//! the dev-server WebSocket, so a `println!` in user code reaches the
+//! `whisker run` terminal (on Android fd 1 goes to `/dev/null`, on iOS
+//! into the simulator container).
 //!
 //! ## What gets captured
 //!
-//! Anything that eventually writes to fd 1 / fd 2:
-//!
-//! - `println!` / `eprintln!` / `dbg!`
-//! - `log` crate macros (`log::info!` etc.) with the standard backends —
-//!   `env_logger`, `simple_logger`, `pretty_env_logger` all emit to
-//!   stderr
-//! - `tracing` macros with the default `fmt::Subscriber` (writes to
-//!   stderr)
-//! - Rust's default panic hook (`set_hook` users may override this)
-//! - C FFI `printf` / `fprintf(stderr, …)` from third-party native libs
-//!
-//! Not captured:
-//!
-//! - Backends that bypass stdio and target the OS log directly
-//!   (`tracing-android` / `tracing-oslog` / `android_logger`,
-//!   `__android_log_write` / `os_log` called from FFI). Users who pick
-//!   those backends already opted into platform-log delivery; they
-//!   can read those with `adb logcat` / `simctl log stream`.
+//! Anything that eventually writes to fd 1 / fd 2: `println!` /
+//! `eprintln!` / `dbg!`, `log` and `tracing` macros with their
+//! stdio-based default backends, the default panic hook, and C FFI
+//! `printf` / `fprintf(stderr, …)`. Backends that target the OS log
+//! directly (`android_logger`, `tracing-oslog`, …) are not captured —
+//! those already deliver to `adb logcat` / `log stream`.
 //!
 //! ## Fan-out
 //!
 //! Each captured line is also written back to the original
 //! stdout/stderr fd (saved via `dup` before the redirect) and pushed
-//! to `__android_log_write` / `syslog`. That way `adb logcat -s
-//! whisker-stdout` / `simctl spawn booted log stream` still surface
-//! the same lines for users who prefer external tools, and the
-//! Xcode console attached to a simulator launch keeps working.
+//! to `__android_log_write` / `syslog`, so external tools (`adb
+//! logcat`, `simctl … log stream`, the Xcode console) keep seeing the
+//! same lines.
 //!
 //! ## Order
 //!
 //! [`start_log_capture`] must be called **before** any other code
-//! emits to stdout/stderr — calls that fire earlier go to the
-//! original (typically /dev/null on Android) destination. The
-//! canonical entry is `whisker_driver::lynx::bootstrap` right after
-//! the driver attach, before the first user component renders.
+//! emits to stdout/stderr — earlier writes go to the original
+//! destination. The canonical entry is `whisker_driver::lynx::bootstrap`
+//! right after the driver attach.
 
 use std::collections::VecDeque;
 use std::os::raw::c_int;
@@ -74,23 +52,19 @@ impl Stream {
     }
 }
 
-/// One captured line. The reader thread strips the trailing `\n`
-/// (and `\r\n` on macOS terminals) before pushing, so `text` is the
-/// payload only.
+/// One captured line, trailing newline (and `\r`) stripped.
 #[derive(Debug, Clone)]
 pub struct LogLine {
     pub stream: Stream,
     pub text: String,
-    /// Microseconds since UNIX_EPOCH, stamped on the device at the
-    /// moment the line was completed. Useful for interleaving with
-    /// host-side events. `0` if the system clock is unavailable.
+    /// Microseconds since UNIX_EPOCH, stamped on the device when the
+    /// line was completed. `0` if the system clock is unavailable.
     pub ts_micros: u128,
 }
 
 /// Bounded ring buffer shared between the reader threads and the WS
 /// session task. Drop-oldest on overflow: pre-connect buffering
-/// shouldn't crowd out fresh state when the buffer fills. `Notify`
-/// wakes the session task as soon as a line lands.
+/// shouldn't crowd out fresh state when the buffer fills.
 struct LogBuffer {
     inner: Mutex<VecDeque<LogLine>>,
     notify: Notify,
@@ -100,16 +74,14 @@ struct LogBuffer {
 impl LogBuffer {
     fn push(&self, line: LogLine) {
         let Ok(mut g) = self.inner.lock() else {
-            // Poisoned mutex — drop the line rather than propagating
-            // a panic out of the reader thread.
+            // Poisoned mutex — drop the line rather than propagating a
+            // panic out of the reader thread.
             return;
         };
         if g.len() >= self.capacity {
             g.pop_front();
         }
         g.push_back(line);
-        // `notify_one` is cheap and idempotent — extra wakeups are
-        // harmless because the drainer re-checks under lock.
         self.notify.notify_one();
     }
 
@@ -131,19 +103,16 @@ impl LogBuffer {
 
 static LOG_BUFFER: OnceLock<Arc<LogBuffer>> = OnceLock::new();
 
-/// ~1024 lines × typical short-string ~80 B ≈ 80 KB worst case.
-/// Bounded to backstop runaway log spam (panic loop, accidental
-/// `loop { println!() }`) before connect.
+/// Bounded to backstop runaway log spam (panic loop, `loop {
+/// println!() }`) before the WS session connects.
 const BUFFER_CAPACITY: usize = 1024;
 
-/// Install the stdout/stderr capture pipes. Idempotent — subsequent
-/// calls are no-ops. Returns `true` the first time, `false` on
-/// repeat calls.
+/// Install the stdout/stderr capture pipes. Idempotent — returns
+/// `true` the first time, `false` on repeat calls.
 ///
-/// Failures inside the install (pipe / dup / dup2 / thread spawn)
-/// are logged through [`super::hot_reload::devlog`] but never
-/// panic. A failed install leaves the original fds intact — the dev
-/// loop continues to function (just without device-side log capture).
+/// Failures inside the install (pipe / dup / dup2 / thread spawn) are
+/// logged through [`super::hot_reload::devlog`] but never panic. A
+/// failed install leaves the original fds intact.
 pub fn start_log_capture() -> bool {
     static INITIALIZED: AtomicBool = AtomicBool::new(false);
     if INITIALIZED.swap(true, Ordering::AcqRel) {
@@ -155,10 +124,6 @@ pub fn start_log_capture() -> bool {
         notify: Notify::new(),
         capacity: BUFFER_CAPACITY,
     });
-    // `OnceLock::set` only fails when the slot was already populated.
-    // The `INITIALIZED` swap above guarantees we're first, so the
-    // `is_err` branch is unreachable in practice; treat it as a
-    // defensive no-op.
     let _ = LOG_BUFFER.set(Arc::clone(&buffer));
 
     if let Err(e) = install_pipe(libc::STDOUT_FILENO, Stream::Stdout, Arc::clone(&buffer)) {
@@ -171,13 +136,11 @@ pub fn start_log_capture() -> bool {
 }
 
 /// Drain pending captured log lines, awaiting at least one if the
-/// buffer is currently empty. Used by the hot-reload WS session task
-/// to forward batched log frames to the server.
+/// buffer is currently empty.
 ///
 /// If [`start_log_capture`] wasn't called (capture disabled / install
 /// failed), this returns a future that never resolves — the session
-/// task's `select!` arm parks forever and the other arms keep
-/// running unchanged.
+/// task's `select!` arm parks forever and the other arms keep running.
 pub(crate) async fn drain_pending_logs() -> Vec<LogLine> {
     match LOG_BUFFER.get() {
         Some(b) => b.drain().await,
@@ -186,7 +149,6 @@ pub(crate) async fn drain_pending_logs() -> Vec<LogLine> {
 }
 
 fn install_pipe(target_fd: c_int, stream: Stream, buffer: Arc<LogBuffer>) -> std::io::Result<()> {
-    // POSIX `pipe(2)` — two fds, [0] = read end, [1] = write end.
     let mut fds: [c_int; 2] = [-1, -1];
     let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
     if rc != 0 {
@@ -195,12 +157,8 @@ fn install_pipe(target_fd: c_int, stream: Stream, buffer: Arc<LogBuffer>) -> std
     let read_fd = fds[0];
     let write_fd = fds[1];
 
-    // Snapshot the original fd so the reader thread can fan-out the
-    // captured bytes back to whatever was wired up before us (Xcode
-    // console on iOS sim, /dev/null on Android, the host terminal on
-    // desktop). `dup` allocates a fresh fd pointing at the same open
-    // file description; the original target_fd then becomes safe to
-    // replace via `dup2`.
+    // Snapshot the original fd so the reader thread can fan the
+    // captured bytes back out to whatever was wired up before us.
     let original_fd = unsafe { libc::dup(target_fd) };
     if original_fd == -1 {
         let err = std::io::Error::last_os_error();
@@ -211,10 +169,6 @@ fn install_pipe(target_fd: c_int, stream: Stream, buffer: Arc<LogBuffer>) -> std
         return Err(err);
     }
 
-    // Atomically replace target_fd with a duplicate of write_fd.
-    // `dup2` closes target_fd first if it's open. After this call,
-    // anything that writes to fd `target_fd` (STDOUT_FILENO /
-    // STDERR_FILENO) goes into our pipe.
     if unsafe { libc::dup2(write_fd, target_fd) } == -1 {
         let err = std::io::Error::last_os_error();
         unsafe {
@@ -224,8 +178,6 @@ fn install_pipe(target_fd: c_int, stream: Stream, buffer: Arc<LogBuffer>) -> std
         }
         return Err(err);
     }
-    // We have a duplicate at target_fd now; drop the original
-    // write_fd handle so we don't leak it.
     unsafe {
         libc::close(write_fd);
     }
@@ -243,18 +195,14 @@ fn install_pipe(target_fd: c_int, stream: Stream, buffer: Arc<LogBuffer>) -> std
 
 fn reader_loop(read_fd: c_int, original_fd: c_int, stream: Stream, buffer: Arc<LogBuffer>) {
     let mut read_buf = [0u8; 4096];
-    // Bytes from a previous read that didn't end on a newline yet.
-    // Held across iterations so a `println!` that straddles a 4 KB
-    // boundary surfaces as one logical line, not two.
+    // Carryover so a line straddling a read boundary surfaces as one
+    // logical line.
     let mut partial: Vec<u8> = Vec::new();
     loop {
         let n = unsafe { libc::read(read_fd, read_buf.as_mut_ptr() as *mut _, read_buf.len()) };
         if n == -1 {
-            // EINTR = signal interrupted the syscall before any bytes
-            // were transferred. The POSIX idiom is to retry; without
-            // it a stray signal silently kills log capture for the
-            // rest of the session. Other errors (EBADF, EFAULT, …)
-            // mean the pipe is unrecoverably broken — exit.
+            // Retry on EINTR; other errors mean the pipe is
+            // unrecoverably broken.
             let err = std::io::Error::last_os_error();
             if err.raw_os_error() == Some(libc::EINTR) {
                 continue;
@@ -262,35 +210,24 @@ fn reader_loop(read_fd: c_int, original_fd: c_int, stream: Stream, buffer: Arc<L
             return;
         }
         if n == 0 {
-            // EOF: every write end of the pipe is closed. In normal
-            // operation this should never fire — the process keeps
-            // STDOUT_FILENO / STDERR_FILENO open for life — but
-            // returning cleanly is safer than spinning.
             return;
         }
         let chunk = &read_buf[..n as usize];
-        // Fan out RAW bytes to the original fd FIRST so consumers of
-        // the original stdout/stderr (Xcode console attached to the
-        // sim launch, host terminal on a desktop dev build) see them
-        // exactly as the producer wrote them — no line-buffering
-        // delay, no partial-line withholding.
+        // Fan out RAW bytes to the original fd FIRST so its consumers
+        // see them exactly as written — no line-buffering delay, no
+        // partial-line withholding.
         unsafe {
             let _ = libc::write(original_fd, chunk.as_ptr() as *const _, chunk.len());
         }
 
-        // Line-split for the WS frame stream. Partial-line carryover
-        // means each `println!` reaches the host as one line even if
-        // a large payload spans multiple `read` chunks.
         partial.extend_from_slice(chunk);
         while let Some(nl_pos) = partial.iter().position(|b| *b == b'\n') {
             let mut line: Vec<u8> = partial.drain(..=nl_pos).collect();
-            // Trim trailing newline + any \r before it.
             while matches!(line.last(), Some(b'\n') | Some(b'\r')) {
                 line.pop();
             }
-            // Use `from_utf8_lossy` so a non-UTF-8 byte (raw bytes
-            // from a C lib, locale mismatch) shows up as U+FFFD
-            // rather than silently dropping the line.
+            // Lossy so a non-UTF-8 byte shows up as U+FFFD rather than
+            // dropping the line.
             let text = match String::from_utf8(line) {
                 Ok(s) => s,
                 Err(e) => String::from_utf8_lossy(&e.into_bytes()).into_owned(),
@@ -311,10 +248,8 @@ fn reader_loop(read_fd: c_int, original_fd: c_int, stream: Stream, buffer: Arc<L
 
 #[cfg(target_os = "android")]
 fn push_platform_log(stream: Stream, line: &str) {
-    // Fan out to logcat so external observers (`adb logcat -s
-    // whisker-stdout`) see the same lines. Tag chosen distinct from
-    // `whisker-dev` (the hot-reload runtime's own diagnostics) so
-    // users can filter cleanly.
+    // Tags are distinct from `whisker-dev` (the runtime's own
+    // diagnostics) so users can filter cleanly.
     unsafe extern "C" {
         fn __android_log_write(
             prio: std::os::raw::c_int,
@@ -341,8 +276,6 @@ fn push_platform_log(stream: Stream, line: &str) {
 
 #[cfg(target_os = "ios")]
 fn push_platform_log(stream: Stream, line: &str) {
-    // Fan out to syslog so `simctl spawn booted log stream` surfaces
-    // the same lines. Prefix mirrors the Android tag layout.
     unsafe extern "C" {
         fn syslog(priority: std::os::raw::c_int, fmt: *const std::os::raw::c_char, ...);
     }
@@ -363,9 +296,8 @@ fn push_platform_log(stream: Stream, line: &str) {
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn push_platform_log(_stream: Stream, _line: &str) {
-    // Host / Linux desktop: the `libc::write(original_fd, …)` above
-    // already lands lines on the user's terminal, which is the only
-    // sink that matters off-device. No additional platform log.
+    // The write to `original_fd` already lands on the terminal, which
+    // is the only sink that matters off-device.
 }
 
 // ============================================================================
@@ -377,9 +309,8 @@ mod tests {
     use super::*;
     use tokio::time::{Duration, timeout};
 
-    /// Construct a fresh LogBuffer for direct testing — the global
-    /// `LOG_BUFFER` static can only be initialised once per process,
-    /// so unit tests build their own instance.
+    /// The global `LOG_BUFFER` can only be initialised once per
+    /// process, so tests build their own instance.
     fn fresh_buffer(capacity: usize) -> Arc<LogBuffer> {
         Arc::new(LogBuffer {
             inner: Mutex::new(VecDeque::with_capacity(capacity)),
@@ -420,7 +351,6 @@ mod tests {
             });
         }
         let drained = timeout(Duration::from_secs(1), b.drain()).await.unwrap();
-        // Capacity 3: lines 0 and 1 should have been dropped.
         assert_eq!(drained.len(), 3);
         assert_eq!(drained[0].text, "line 2");
         assert_eq!(drained[1].text, "line 3");
@@ -430,7 +360,6 @@ mod tests {
     #[tokio::test]
     async fn drain_blocks_until_pushed() {
         let b = fresh_buffer(8);
-        // Spawn a producer that pushes after a delay.
         let b_clone = Arc::clone(&b);
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/docs/comment-style.md
+++ b/docs/comment-style.md
@@ -162,6 +162,13 @@ not to narrate the code.
   *before* invoking the callback — otherwise re-entering the
   runtime panics."
 
+- **`SAFETY:` comments on `unsafe`** — always. State the invariants
+  that make the block sound; trim wording, never delete.
+
+- **Wire-format / protocol contracts** that two crates must agree
+  on (e.g. the hot-reload patch frame layout shared by
+  `whisker-dev-server` and `whisker-dev-runtime`).
+
 ### Delete
 
 - **Sentences that paraphrase the next line.** `// increment the


### PR DESCRIPTION
First crate of the per-crate sweep that [docs/comment-style.md](docs/comment-style.md) announces ("later PRs sweep existing code crate-by-crate to match"). Pilot for calibration; the remaining crates follow in a handful of grouped PRs.

## What was applied

Internal comments keep only the non-obvious why (invariants, ordering constraints, why-not decisions); deleted what-narration, design diary, and change-justification. History stays reachable in git blame and PR bodies.

Two comments had gone stale against the code and are simply gone:
- the module doc claimed the receiver **no-ops when `WHISKER_DEV_ADDR` is unset** — it has fallen back to `127.0.0.1:9876` since the Android bring-up;
- patches were described as "~tens of KB" — a large app's patch is 17–73 MB (#372).

Kept: the wire-format layout (protocol contract with whisker-dev-server), every `SAFETY:` comment, fd-snapshot/fan-out ordering constraints, and the per-platform token delivery contract.

Also adds two bullets to the guide's Keep list that the sweep needs: `SAFETY:` comments are always kept, and wire-format/protocol contracts shared across crates are always kept.

## Numbers

Comment lines 302 → 179 (−41%), total lines 1033 → 910. **No code changes** — verified mechanically (`git diff -U0` filtered to non-comment lines is empty), `cargo test -p whisker-dev-runtime --features hot-reload` green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)