### PR TITLE
Sweep whisker, css, macros, macro-syntax, fmt comments

### DIFF
--- a/crates/whisker-css/src/css.rs
+++ b/crates/whisker-css/src/css.rs
@@ -126,8 +126,6 @@ impl Css {
     /// only the final occurrence of each property name is yielded,
     /// in the position of that final occurrence.
     pub fn resolved(&self) -> Vec<&CssProp> {
-        // Walk backwards, recording the first time we see each name,
-        // then reverse for forward order.
         let mut seen: std::collections::HashSet<&'static str> = std::collections::HashSet::new();
         let mut out: Vec<&CssProp> = Vec::new();
         for prop in self.props.iter().rev() {
@@ -212,17 +210,14 @@ mod tests {
             .raw("color", "blue")
             .raw("color", "green");
         assert_eq!(s.to_css_string(), "color: green;");
-        // Internal `entries` keeps all three — only `resolved`
-        // collapses.
         assert_eq!(s.len(), 3);
         assert_eq!(s.resolved().len(), 1);
     }
 
     #[test]
     fn duplicate_property_preserves_position_of_last() {
-        // color appears at index 0 then again at 2; final order
-        // should place `color: blue` where the last occurrence sits
-        // (after `background-color`).
+        // The last write decides where the property lands in the
+        // resolved order.
         let s = Css::new()
             .raw("color", "red")
             .raw("background-color", "white")

--- a/crates/whisker-css/src/data_type/color.rs
+++ b/crates/whisker-css/src/data_type/color.rs
@@ -164,14 +164,12 @@ mod tests {
 
     #[test]
     fn hex_constructor() {
-        // 0x1A1A2E → rgb(26, 26, 46)
         assert_eq!(Color::hex(0x1A1A2E).to_css_string(), "rgb(26, 26, 46)");
     }
 
     #[test]
     fn hex_alpha_constructor() {
         let c = Color::hex_alpha(0xFF000080);
-        // 0x80 / 255 ≈ 0.5019608 — alpha drops it to rgba.
         let s = c.to_css_string();
         assert!(s.starts_with("rgba(255, 0, 0,"), "got {s}");
     }

--- a/crates/whisker-css/src/data_type/length_percentage.rs
+++ b/crates/whisker-css/src/data_type/length_percentage.rs
@@ -230,7 +230,6 @@ mod tests {
 
     #[test]
     fn calc_div_right_assoc_parens() {
-        // 100% / (2 / 4) keeps the inner division grouped.
         let inner = CalcExpr::number(2.0).div(CalcExpr::number(4.0));
         let expr = CalcExpr::value(Percentage(100.0)).div(inner);
         assert_eq!(

--- a/crates/whisker-css/src/lib.rs
+++ b/crates/whisker-css/src/lib.rs
@@ -52,12 +52,10 @@ pub mod shorthand;
 mod to_css;
 pub mod value;
 
-// `css!(name: value, …)` — kwarg syntax for the [`Css`] builder.
-// Lives in `whisker-macros` so it can be a proc macro (the
-// partial-input recovery driving rust-analyzer completion needs
-// fine-grained control over the expansion). Re-exported here so
-// callers can spell `whisker_css::css!` without a direct dep on
-// the macros crate.
+// `css!` lives in `whisker-macros` because the partial-input recovery
+// that drives rust-analyzer completion needs a proc macro. Re-exported
+// here so callers can spell `whisker_css::css!` without depending on
+// the macros crate directly.
 pub use whisker_macros::css;
 
 pub use crate::css::{Css, CssProp};

--- a/crates/whisker-css/src/shorthand/animation.rs
+++ b/crates/whisker-css/src/shorthand/animation.rs
@@ -93,8 +93,8 @@ impl Animation {
 impl ToCss for Animation {
     fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
         dest.write_str(&self.name)?;
-        // The CSS animation shorthand grammar allows any order; we
-        // emit a stable order matching the Lynx spec for clarity.
+        // The shorthand grammar allows any order; this emits the Lynx
+        // spec's order so output stays stable.
         if let Some(d) = &self.duration {
             dest.write_char(' ')?;
             d.to_css(dest)?;

--- a/crates/whisker-css/src/shorthand/border.rs
+++ b/crates/whisker-css/src/shorthand/border.rs
@@ -174,8 +174,6 @@ mod tests {
                     .color(Color::hex(0x000000)),
             )
             .border_bottom(Border::new().width(px(3)).color(Color::hex(0xFF0000)));
-        // Last-write-wins keeps the first 3 sides at width 1px and
-        // overrides bottom to 3px / red.
         let css = s.to_string();
         assert!(css.contains("border-bottom-width: 3px"));
         assert!(css.contains("border-bottom-color: rgb(255, 0, 0)"));

--- a/crates/whisker-css/src/to_css.rs
+++ b/crates/whisker-css/src/to_css.rs
@@ -89,12 +89,9 @@ mod tests {
     #[test]
     fn write_number_handles_non_finite_safely() {
         let mut buf = String::new();
-        // Non-finite values fall through to `{n}` formatting; the
-        // helper just needs to not panic and to keep something on
-        // the buffer.
+        // Non-finite values fall through to `{n}` formatting.
         let _ = write_number(&mut buf, f32::NAN);
         let _ = write_number(&mut buf, f32::INFINITY);
-        // Smoke check — output is non-empty.
         assert!(!buf.is_empty());
     }
 
@@ -116,7 +113,6 @@ mod tests {
 
     #[test]
     fn to_css_blanket_reference_impl() {
-        // Verify `&T: ToCss` where `T: ToCss` works.
         let t = Token("ident");
         let r: &Token = &t;
         let s = r.to_css_string();

--- a/crates/whisker-css/tests/compound_cases.rs
+++ b/crates/whisker-css/tests/compound_cases.rs
@@ -46,8 +46,6 @@ fn realistic_card_layout() {
 fn padding_shorthand_then_longhand_wins() {
     let s = Css::new().padding(px(16)).padding_top(px(4));
     let css = s.to_string();
-    // padding_top is overridden by the explicit setter; the other
-    // three sides remain at 16px.
     assert!(css.contains("padding-top: 4px"));
     assert!(css.contains("padding-right: 16px"));
     assert!(css.contains("padding-bottom: 16px"));
@@ -57,7 +55,6 @@ fn padding_shorthand_then_longhand_wins() {
 #[test]
 fn padding_longhand_then_shorthand_resets() {
     let s = Css::new().padding_top(px(4)).padding(px(16));
-    // Shorthand follows longhand → all four sides should be 16px.
     assert_eq!(
         s.to_string(),
         "padding-top: 16px; padding-right: 16px; padding-bottom: 16px; padding-left: 16px;"
@@ -93,11 +90,9 @@ fn border_full_then_per_side_override() {
                 .color(Color::hex(0xFF0000)),
         );
     let css = s.to_string();
-    // The bottom side should win for all three dimensions.
     assert!(css.contains("border-bottom-width: 3px"));
     assert!(css.contains("border-bottom-style: solid"));
     assert!(css.contains("border-bottom-color: rgb(255, 0, 0)"));
-    // Other sides retain the 1px / #CCC.
     assert!(css.contains("border-top-width: 1px"));
     assert!(css.contains("border-right-color: rgb(204, 204, 204)"));
 }
@@ -151,7 +146,6 @@ fn gap_then_row_gap_override_keeps_column() {
 
 #[test]
 fn last_write_wins_over_many_repeats() {
-    // 5 rewrites of the same property; only the last appears.
     let s = Css::new()
         .color(Color::hex(0x111111))
         .color(Color::hex(0x222222))
@@ -184,7 +178,6 @@ fn merge_overlays_other_onto_self() {
     let overlay = Css::new().color(Color::hex(0xFFFFFF));
     let merged = base.merge(overlay);
     let css = merged.to_string();
-    // Color from overlay wins; padding from base remains.
     assert!(css.contains("color: rgb(255, 255, 255)"));
     assert!(css.contains("padding-top: 4px"));
 }
@@ -334,9 +327,8 @@ fn into_string_yields_full_css() {
 
 #[test]
 fn duplicate_then_late_repeat_keeps_late_position() {
-    // `color` is declared at index 0, then again at index 2; in the
-    // resolved order it appears where the last write occurred (after
-    // background-color).
+    // A property re-declared later resolves at the position of its
+    // LAST write, not its first.
     let s = Css::new()
         .color(Color::hex(0xFF0000))
         .background_color(Color::hex(0x00FF00))
@@ -394,8 +386,7 @@ fn color_conversion_named_to_hex_round_trip_shape() {
         .color(Color::Named(NamedColor::Red))
         .background_color(Color::hex(0xFF0000));
     let css = s.to_string();
-    // Both forms appear distinctly — Whisker preserves the form
-    // chosen by the caller rather than normalizing internally.
+    // The caller's chosen form is preserved rather than normalized.
     assert!(css.contains("color: red"));
     assert!(css.contains("background-color: rgb(255, 0, 0)"));
 }
@@ -405,7 +396,6 @@ fn transform_then_secondary_transform_replaces() {
     let s = Css::new()
         .transform([TransformFn::TranslateX(px(10).into())])
         .transform([TransformFn::Rotate(45.deg())]);
-    // Last `transform` wins entirely; the first sequence is discarded.
     assert_eq!(s.to_string(), "transform: rotate(45deg);");
 }
 
@@ -422,7 +412,6 @@ fn entries_iteration_preserves_duplicates() {
 
 #[test]
 fn style_to_css_via_trait_object() {
-    // Verify ToCss can be exercised through a trait object.
     let s = Css::new().padding(px(4));
     let mut buf = String::new();
     let dyn_to_css: &dyn ToCss = &s;

--- a/crates/whisker-css/tests/coverage_gaps.rs
+++ b/crates/whisker-css/tests/coverage_gaps.rs
@@ -22,7 +22,6 @@ use whisker_css::{Css, ToCss};
 // on every public type, including the ones that are also `Copy`.
 #[allow(clippy::clone_on_copy)]
 fn debug_and_clone_pass_through() {
-    // Exercise auto-derived `Clone` + `Debug` on every public type.
     let n = Number(1.0);
     let p = Percentage(50.0);
     let l = Length::Px(8.0);
@@ -66,7 +65,7 @@ fn debug_and_clone_pass_through() {
         radial.clone(),
     );
 
-    // Force `Debug` (drops the verbose result on the floor).
+    // Force `Debug`, dropping the result.
     let _ = format!(
         "{:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?} {:?}",
         n, p, l, lp, a, t, cs, c, g, f, m, calc, i, pos, stop, easing, stop_pos, lin, radial,
@@ -75,10 +74,9 @@ fn debug_and_clone_pass_through() {
 
 #[test]
 fn length_zero_via_constructor_helpers() {
-    // ZERO constant and is_zero detection.
     let z = whisker_css::ext::ZERO;
     assert!(z.is_zero());
-    // Construct via `0.px()` — non-Zero variant whose value is 0.
+    // `0.px()` is a non-Zero variant whose value is 0.
     assert!(0.px().is_zero());
 }
 
@@ -96,7 +94,6 @@ fn length_percentage_calc_all_operators() {
 
 #[test]
 fn color_hex_alpha_opaque_path() {
-    // alpha = 255 → opaque rgb form.
     assert_eq!(
         Color::hex_alpha(0xFF0000FF).to_css_string(),
         "rgb(255, 0, 0)"
@@ -116,7 +113,6 @@ fn color_named_round_trip_via_from() {
 
 #[test]
 fn gradient_radial_with_shape_keywords() {
-    // Exercise Circle / Ellipse keyword paths.
     let g = Gradient::Radial {
         shape: RadialShape::Ellipse,
         stops: vec![ColorStop::new(Color::Named(NamedColor::Red))],
@@ -264,10 +260,9 @@ fn repeated_empty_collection() {
 
 #[test]
 fn animation_only_a_few_fields_set() {
-    // Exercises individual setters being absent without crashing.
     let s = Css::new().animation(Animation::new("x"));
     assert_eq!(s.to_string(), "animation: x;");
-    // Now exercise the path with delay set but iteration_count omitted.
+    // Delay set but iteration_count omitted.
     let s = Css::new().animation(Animation::new("y").delay(50.ms()));
     assert!(s.to_string().contains("50ms"));
 }
@@ -306,7 +301,6 @@ fn calc_expr_value_and_number_constructors() {
     let v = CalcExpr::value(px(4));
     let n = CalcExpr::number(2.0);
     let _ = LengthPercentage::calc(v.clone().mul(n.clone()));
-    // Smoke check on stand-alone formatting.
     assert!(v.to_css_string().contains("4px"));
     assert!(n.to_css_string() == "2");
 }
@@ -339,14 +333,12 @@ fn linear_direction_keyword_directions_in_gradient() {
 
 #[test]
 fn fit_content_keyword_path() {
-    // FitContent::keyword() variant — no limit.
     let fc = FitContent::keyword();
     assert_eq!(fc.to_css_string(), "fit-content");
 }
 
 #[test]
 fn length_each_unit_zero_path() {
-    // is_zero for every variant where value == 0.0.
     assert!(Length::Px(0.0).is_zero());
     assert!(Length::Rpx(0.0).is_zero());
     assert!(Length::Ppx(0.0).is_zero());

--- a/crates/whisker-css/tests/css_macro.rs
+++ b/crates/whisker-css/tests/css_macro.rs
@@ -35,8 +35,8 @@ fn multiple_properties_emit_in_order() {
         border_radius: px(10)
     );
     let out = s.to_css_string();
-    // Padding expands to four longhands; border-radius too. We assert
-    // the salient pieces rather than the full ordering.
+    // Padding and border-radius each expand to four longhands; only
+    // the salient pieces are asserted, not the full ordering.
     assert!(out.contains("background-color: rgb(26, 19, 48)"));
     assert!(out.contains("color: white"));
     assert!(out.contains("padding-top: 12px"));
@@ -153,14 +153,11 @@ fn computed_inside_block() {
     fn light() -> Color {
         Color::Named(NamedColor::Blue)
     }
-    // The block holds a load-bearing local + a conditional — the
-    // `{ … }` is genuinely a block expr, not a redundant brace
-    // around a single call (which would trip `unused_braces`).
     let theme = "dark";
     let s = css!(color: {
-        // Two statements + the trailing expr so the block expression
-        // form is actually load-bearing (and `unused_braces` /
-        // `let_and_return` stay silent).
+        // Two statements plus a trailing expr keep the block genuinely
+        // load-bearing, so `unused_braces` / `let_and_return` stay
+        // silent.
         let primary = dark();
         let secondary = light();
         if theme == "dark" { primary } else { secondary }
@@ -170,8 +167,6 @@ fn computed_inside_block() {
 
 #[test]
 fn css_macro_returns_css_type_for_chaining() {
-    // The macro result is `Css`, so it can be `.<method>()`-chained
-    // afterwards as a regular builder value.
     let s = css!(color: Color::Named(NamedColor::Red)).padding(px(8));
     let out = s.to_css_string();
     assert!(out.contains("color: red"));
@@ -187,9 +182,8 @@ fn css_macro_value_is_clonable() {
 
 #[test]
 fn flex_keyword_method_via_no_arg_path() {
-    // Methods that take no value (`display_flex()`, etc.) aren't
-    // expressible as kwargs here because `css!` requires `name:
-    // value`. The follow-up chain handles them:
+    // `css!` requires `name: value`, so value-less methods
+    // (`display_flex()`, …) can only be reached by chaining after it.
     let s = css!(color: Color::Named(NamedColor::Red))
         .display_flex()
         .flex_direction(FlexDirection::Row);
@@ -225,7 +219,6 @@ fn nested_shorthand_within_kwarg() {
 
 #[test]
 fn many_properties_in_one_call() {
-    // A larger call exercising the `+` repetition path.
     let s = css!(
         display: whisker_css::Display::Flex,
         flex_direction: FlexDirection::Column,

--- a/crates/whisker-fmt/src/comments.rs
+++ b/crates/whisker-fmt/src/comments.rs
@@ -42,8 +42,6 @@ pub(crate) fn collect_grammar_comments(
     expr_spans: &[Span],
     body_map: &SourceMap,
 ) -> Vec<GrammarComment> {
-    // Byte ranges of the embedded exprs; a comment overlapping any of
-    // these is skipped.
     let mut expr_ranges: Vec<(usize, usize)> = Vec::new();
     for &span in expr_spans {
         if let Some((s, e)) = body_map.byte_range(span) {
@@ -79,13 +77,11 @@ pub(crate) fn collect_grammar_comments(
                     in_str = Some(b);
                     i += 1;
                 } else if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
-                    // `//` line comment to end of line.
                     let start = i;
                     let mut j = i + 2;
                     while j < bytes.len() && bytes[j] != b'\n' {
                         j += 1;
                     }
-                    // `end` excludes the newline; right-trim text.
                     let text = body[start..j].trim_end().to_string();
                     let end = start + text.len();
                     if !in_expr(start, j) {
@@ -98,7 +94,7 @@ pub(crate) fn collect_grammar_comments(
                     }
                     i = j;
                 } else if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
-                    // `/* ... */` block comment — nests.
+                    // Block comments nest, per Rust semantics.
                     let start = i;
                     let mut j = i + 2;
                     let mut depth = 1usize;
@@ -211,12 +207,9 @@ mod tests {
 
     #[test]
     fn comment_inside_expr_span_excluded() {
-        // body has one comment inside an expr range and one outside.
         let body = "a // outside\nb";
         let map = SourceMap::new(body);
-        // Build a span covering byte 0..1 ("a"); easier: use no spans
-        // here and instead assert collection works; expr exclusion is
-        // covered via integration tests in lib.rs.
+        // Expr-span exclusion is covered by the lib.rs integration tests.
         let cs = collect_grammar_comments(body, &[], &map);
         assert_eq!(cs.len(), 1);
         assert_eq!(cs[0].text, "// outside");

--- a/crates/whisker-fmt/src/expr_fmt.rs
+++ b/crates/whisker-fmt/src/expr_fmt.rs
@@ -33,24 +33,20 @@
 //! the formatted expr at column 0, ready for the printer to splice in
 //! and re-indent to the kwarg's column.
 //!
-//! # Column-shift limitation (MVP)
+//! # Column-shift limitation
 //!
 //! rustfmt wraps each expr against the synthetic wrapper's SHALLOW
 //! indent (one level), not against the expr's true, possibly-deeper
-//! column in the macro. So a value that lands at, say, column 24 in the
-//! final output may wrap a few columns later than a from-scratch rustfmt
-//! run would. dioxus-fmt and yew-fmt have the same limitation. A future
-//! refinement could compute a per-expr `max_width` adjusted by the
-//! expr's target column and run a wrapper per width-bucket — deliberately
-//! NOT done in this pass.
+//! column in the macro, so a value may wrap a few columns later than a
+//! from-scratch rustfmt run would. dioxus-fmt and yew-fmt share this
+//! limitation.
 //!
 //! # Fallbacks
 //!
-//! Every step degrades gracefully to the verbatim slice (the prior
-//! behavior): no rustfmt binary, a wrapper that fails to format, or an
-//! individual `__wsk_eN` body that can't be re-extracted all leave that
-//! expr (or all exprs of the body) verbatim. A formatting hiccup in one
-//! expr never errors the whole file.
+//! Every step degrades to the verbatim slice: no rustfmt binary, a
+//! wrapper that fails to format, or an individual `__wsk_eN` body that
+//! can't be re-extracted all leave that expr (or all exprs of the body)
+//! verbatim. A formatting hiccup in one expr never errors the file.
 
 use crate::options::FmtOptions;
 use proc_macro2::{LineColumn, Span};
@@ -154,7 +150,6 @@ impl ExprFormatter {
             return map;
         }
 
-        // ---- build the batched synthetic source ----
         let mut synthetic = String::new();
         for (i, (_, src)) in exprs.iter().enumerate() {
             synthetic.push_str(&format!("fn __wsk_e{i}() {{\n"));
@@ -167,16 +162,13 @@ impl ExprFormatter {
             synthetic.push_str("}\n");
         }
 
-        // ---- one rustfmt spawn for the whole batch ----
         let formatted_file =
             match crate::run_rustfmt(&synthetic, &self.opts, self.config_dir.as_deref()) {
                 Ok(s) => s,
-                // No rustfmt, or the batch failed to parse/format as a whole
-                // → leave every expr verbatim.
+                // No rustfmt, or the batch failed as a whole → verbatim.
                 Err(_) => return map,
             };
 
-        // ---- extract each __wsk_eN body ----
         let bodies = match extract_bodies(&formatted_file, exprs.len()) {
             Some(b) => b,
             None => return map,
@@ -201,7 +193,6 @@ fn extract_bodies(formatted_file: &str, count: usize) -> Option<Vec<Option<Strin
     let parsed: syn::File = syn::parse_file(formatted_file).ok()?;
     let map = crate::source_map::SourceMap::new(formatted_file);
 
-    // index -> body text
     let mut found: HashMap<usize, String> = HashMap::new();
     for item in &parsed.items {
         let syn::Item::Fn(f) = item else { continue };
@@ -212,30 +203,23 @@ fn extract_bodies(formatted_file: &str, count: usize) -> Option<Vec<Option<Strin
         else {
             continue;
         };
-        // The block's brace span covers `{ … }`. Slice the inside.
         let brace = f.block.brace_token.span;
-        // `Span::join` of the open/close delimiters gives the full
-        // `{ … }` range; use the group span directly.
         let span: Span = brace.join();
         let Some((open, close)) = map.byte_range(span) else {
             continue;
         };
-        // Strip the outer braces: byte `open` is `{`, `close-1` is `}`.
         if close <= open + 1 {
-            // Empty body — keep as empty string.
             found.insert(idx, String::new());
             continue;
         }
         let inner = &formatted_file[open + 1..close - 1];
-        // Trim a single leading / trailing newline introduced by the
-        // braces being on their own lines; keep internal indentation so
-        // `dedent_one_level` can strip exactly one level.
+        // Keep internal indentation so `dedent_one_level` can strip
+        // exactly one level.
         let inner = inner.strip_prefix('\n').unwrap_or(inner);
         let inner = inner.strip_suffix('\n').unwrap_or(inner);
         found.insert(idx, inner.to_string());
     }
 
-    // Require every expected wrapper to be present.
     let mut bodies = Vec::with_capacity(count);
     for i in 0..count {
         bodies.push(Some(found.remove(&i)?));
@@ -301,7 +285,6 @@ mod tests {
     #[test]
     fn extract_requires_all() {
         let file = "fn __wsk_e0() {\n    a\n}\n";
-        // Asking for 2 but only 1 present → None.
         assert!(extract_bodies(file, 2).is_none());
     }
 

--- a/crates/whisker-fmt/src/ir.rs
+++ b/crates/whisker-fmt/src/ir.rs
@@ -4,15 +4,10 @@
 //! printer walks with a single recursive function.
 //!
 //! This is deliberately a `whisker-fmt`-internal type, NOT something
-//! added to `whisker-macro-syntax`. `whisker-macro-syntax::render`'s
-//! `Node`/`ElementNode`/`UserComponentNode`/`Kwarg` and
-//! `whisker-macro-syntax::css`'s `CssInput`/`CssKwarg` are consumed
-//! directly by the real `render!`/`css!` codegen in `whisker-macros` (see
-//! that crate's doc comment) — changing their shape would change what
-//! real apps compile to. `routes!`'s mirror type has no such consumer
-//! (the real `routes!` proc-macro in `whisker-router-macros` has its own,
-//! separate parser), but is adapted here too for consistency and because
-//! its printer is what this refactor is actually simplifying.
+//! added to `whisker-macro-syntax`: that crate's `render` and `css`
+//! parse types are consumed directly by the real codegen in
+//! `whisker-macros`, so changing their shape would change what real apps
+//! compile to.
 //!
 //! `css!`'s body doesn't fit this shape at all (it's a flat kwarg list
 //! with no tag and no children — see `Printer::css`), so it is NOT
@@ -25,8 +20,8 @@ use syn::Expr;
 pub(crate) enum IrNode {
     /// A tag with optional kwargs and optional children — covers
     /// render!'s `Element`/`UserComponent` (indistinguishable to the
-    /// printer, which never treated them differently) and routes!'s
-    /// `Switch`/`Stack`/`Route`/unrecognized-ident nodes.
+    /// printer) and routes!'s `Switch`/`Stack`/`Route`/unknown-ident
+    /// nodes.
     Tag(IrTag),
     /// render!'s `children()` slot — always prints literally as
     /// `children()`, never subject to the "omit `()` with no kwargs"
@@ -39,26 +34,20 @@ pub(crate) enum IrNode {
 pub(crate) struct IrTag {
     /// Text to print for this tag. For render! this is ALREADY the
     /// classified/derived name (`ElementNode.tag` or
-    /// `UserComponentNode.alias_ident`, post `snake_to_pascal`) — this
-    /// module does no classification of its own, it just carries
-    /// whatever `whisker-macro-syntax::render` already decided. For
-    /// routes! this is the literal `Switch`/`Stack`/`Route`/unknown-ident
-    /// keyword.
+    /// `UserComponentNode.alias_ident`, post `snake_to_pascal`); this
+    /// module classifies nothing of its own. For routes! it is the
+    /// literal `Switch`/`Stack`/`Route`/unknown-ident keyword.
     pub tag: String,
     /// Span of the source ident this tag was built from, used to locate
-    /// the node's `(kwargs)? {children}?` extent (for comment
-    /// placement). Reused even for a render! `UserComponent`'s derived
-    /// `alias_ident` — that ident's span still points at the ORIGINAL
-    /// tag text in source (`Ident::new` there just swaps the text, not
-    /// the span).
+    /// the node's `(kwargs)? {children}?` extent for comment placement.
+    /// Safe even for a `UserComponent`'s derived `alias_ident`: `Ident::new`
+    /// swaps the text but keeps the original source span.
     pub tag_span: Option<Span>,
     pub kwargs: Vec<IrKwarg>,
     pub children: Vec<IrNode>,
     /// `true` only for routes!'s `Switch`/`Stack`, whose `{ … }` is
-    /// mandatory in the grammar even when empty (`braced!` requires the
-    /// braces to be present at parse time) — never omit the block for
-    /// these, even with zero children. Every other tag omits an empty,
-    /// comment-free block, per the shared "optional block" rule.
+    /// mandatory in the grammar even when empty. Every other tag omits
+    /// an empty, comment-free block.
     pub always_block: bool,
 }
 
@@ -76,13 +65,10 @@ pub(crate) enum IrValue {
     /// [`IrValue::Literal`]'s `String`, and this enum lives inside every
     /// [`IrKwarg`] in a tree.
     Expr(Box<Expr>),
-    /// Pre-rendered text, printed as-is with no `expr_src` machinery —
-    /// used for routes!'s `Route(path: "…", component: Foo)`, whose
-    /// `path`/`component` aren't full exprs in
-    /// `whisker-macro-syntax::routes` (`LitStr`/`Ident` respectively) and
-    /// are reconstructed the same way `Printer::routes_route` always
-    /// has: a debug-quoted string for `path`, a bare ident for
-    /// `component`.
+    /// Pre-rendered text, printed as-is with no `expr_src` machinery.
+    /// Used for routes!'s `Route(path: "…", component: Foo)`, whose
+    /// `path`/`component` are a `LitStr`/`Ident` rather than full exprs:
+    /// a debug-quoted string and a bare ident respectively.
     Literal(String),
 }
 
@@ -195,12 +181,10 @@ fn adapt_routes_node(node: &whisker_macro_syntax::routes::RoutesNode) -> IrNode 
     }
 }
 
-/// Walk an adapted tree collecting the span of every embedded `Expr` —
-/// mirrors what `collect_render_expr_spans` / `collect_routes_expr_spans`
-/// used to do separately, now over the shared shape. `IrValue::Literal`
-/// values (routes!'s `path`/`component`) contribute no span — they were
-/// never batch-rustfmt'd or excluded from comment recovery, matching
-/// today's behavior.
+/// Walk an adapted tree collecting the span of every embedded `Expr`.
+/// `IrValue::Literal` values (routes!'s `path`/`component`) contribute
+/// no span: they are neither batch-rustfmt'd nor excluded from comment
+/// recovery.
 pub(crate) fn collect_ir_expr_spans(node: &IrNode, out: &mut Vec<Span>) {
     use syn::spanned::Spanned;
     match node {

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -14,9 +14,8 @@
 //!    back over the original body token range. ([`reformat_macros`])
 //!
 //! [`format_source`] runs the whole pipeline. [`reformat_macros`] is
-//! the macro-only pass and is independently testable WITHOUT the
-//! rustfmt binary (feed it already-rust-formatted input) — useful in
-//! CI environments where rustfmt may be absent.
+//! the macro-only pass; it needs no rustfmt binary, so it stays
+//! testable where rustfmt is absent.
 //!
 //! # Config
 //!
@@ -28,20 +27,17 @@
 //!
 //! `syn` drops comments and `proc-macro2` exposes them only as
 //! whitespace between tokens, so reprinting a `render!` / `css!` body
-//! from the parsed AST would lose them. To preserve them we recover the
-//! comments straight from the body source text ([`comments`]) and
-//! reattach them while pretty-printing ([`printer`]): own-line comments
-//! go on their own line at the block's indent, trailing comments are
-//! appended to the end of the preceding line. Comments INSIDE an embedded
-//! expr value are excluded from this pass — they ride along with the
-//! verbatim / rustfmt-formatted expr source instead.
+//! from the parsed AST would lose them. They are recovered from the
+//! body source text ([`comments`]) and reattached while pretty-printing
+//! ([`printer`]): own-line comments go on their own line at the block's
+//! indent, trailing comments are appended to the end of the preceding
+//! line. Comments INSIDE an embedded expr value are excluded — they
+//! ride along with the verbatim / rustfmt-formatted expr source.
 //!
-//! A **fail-safe** guards the result: after formatting, if any recovered
-//! comment would be dropped, or the output is not idempotent
-//! (`f(f(x)) != f(x)`), the body is left **untouched** (the original
-//! verbatim text) — so a comment can never be silently lost. See
-//! [`macro_body_edit`]. Comments OUTSIDE macros are preserved by rustfmt
-//! as usual.
+//! A **fail-safe** guards the result: if any recovered comment would be
+//! dropped, or the output is not idempotent (`f(f(x)) != f(x)`), the
+//! body is left **untouched** — so a comment can never be silently
+//! lost. See [`macro_body_edit`].
 
 mod comments;
 mod expr_fmt;
@@ -159,16 +155,10 @@ fn run_rustfmt(src: &str, opts: &FmtOptions, config_dir: Option<&Path>) -> Resul
         cmd.arg("--edition").arg(ed);
     }
     if let Some(dir) = config_dir {
-        // Run with cwd = the file's directory so rustfmt's own upward
-        // search finds the nearest `rustfmt.toml`. Only pass an explicit
-        // `--config-path` when a config actually exists at/above `dir`,
-        // and point it at the ACTUAL config file `find_rustfmt_toml`
-        // returned — NOT at `dir`. The config may live at a PARENT (e.g.
-        // the project root) while `dir` is a nested subdir with no
-        // rustfmt.toml of its own; `--config-path <dir>` would then make
-        // rustfmt error "unable to find a config file for the given
-        // path". Passing the found file path is deterministic and always
-        // resolves.
+        // `--config-path` must be the config FILE, not `dir`: the config
+        // often lives at a parent while `dir` is a subdir with none of
+        // its own, and `--config-path <dir>` then makes rustfmt error
+        // "unable to find a config file for the given path".
         cmd.current_dir(dir);
         if let Some(toml_path) = find_rustfmt_toml(dir) {
             cmd.arg("--config-path").arg(&toml_path);
@@ -218,8 +208,7 @@ pub fn find_rustfmt_toml(dir: &Path) -> Option<std::path::PathBuf> {
 
 /// The edition assumed when neither `rustfmt.toml` nor any `Cargo.toml`
 /// up the tree declares one. rustfmt's *own* default is 2015, which
-/// rejects 2018+ syntax (`async move`, etc.); we pick a modern default
-/// so `whisker fmt` never falls into the 2015 trap.
+/// rejects 2018+ syntax (`async move`, etc.).
 const DEFAULT_EDITION: &str = "2021";
 
 /// Walk upward from `dir` looking for the nearest `Cargo.toml`.
@@ -271,7 +260,7 @@ fn edition_from_cargo_value(value: &toml::Value) -> Option<String> {
 /// 1. The nearest `rustfmt.toml`'s `edition` key, if present (wins).
 /// 2. else the nearest `Cargo.toml`'s edition (`[package]` or
 ///    `[workspace.package]`), searching upward from `dir`.
-/// 3. else [`DEFAULT_EDITION`] (`"2021"`).
+/// 3. else [`DEFAULT_EDITION`].
 ///
 /// The non-edition layout keys (`max_width`, `tab_spaces`, `hard_tabs`)
 /// come from the same `rustfmt.toml`. The returned `edition` is ALWAYS
@@ -285,8 +274,7 @@ pub fn resolve_options(dir: &Path) -> FmtOptions {
         None => FmtOptions::default(),
     };
 
-    // rustfmt.toml edition wins; otherwise fall back to Cargo.toml, then
-    // the modern default. Never leave `edition` as `None` (2015).
+    // Never leave `edition` as `None` — rustfmt would then assume 2015.
     if opts.edition.is_none() {
         opts.edition = Some(cargo_toml_edition(dir).unwrap_or_else(|| DEFAULT_EDITION.to_string()));
     }
@@ -310,10 +298,8 @@ pub fn resolve_options(dir: &Path) -> FmtOptions {
 /// comment would be dropped or the result is not idempotent, so comments
 /// are never lost.
 pub fn reformat_macros(rust_src: &str, opts: &FmtOptions) -> Result<String> {
-    // Public entry point: the rustfmt-FREE core. No `ExprFormatter`, so
-    // every embedded expr is rendered verbatim (the printer's empty-map
-    // path). This is what keeps the 17 unit tests in this file passing
-    // without a rustfmt binary.
+    // No `ExprFormatter`, so every embedded expr renders verbatim (the
+    // printer's empty-map path) and no rustfmt binary is needed.
     reformat_macros_inner(rust_src, opts, None)
 }
 
@@ -351,9 +337,6 @@ fn reformat_macros_pass(
 
     let file_map = SourceMap::new(rust_src);
 
-    // Collect (body_open_offset, body_close_offset, replacement) for
-    // every macro, then splice from the end backwards so earlier
-    // offsets stay valid.
     let mut edits: Vec<MacroEdit> = Vec::new();
     collect_macro_edits(
         tokens, &file_map, rust_src, opts, exprfmt, verify, &mut edits,
@@ -405,22 +388,15 @@ fn collect_macro_edits(
                     {
                         edits.push(edit);
                     }
-                    // Don't recurse into a macro body we've already
-                    // reformatted as a whole; but DO recurse if we
-                    // skipped it (comments etc.) so nested macros still
-                    // get a chance. Simplest correct choice: recurse
-                    // into the body always — the inner macro edits use
-                    // the same global byte offsets and the outer edit
-                    // (if any) reformats the body text from the AST,
-                    // which re-prints nested render!/css! via slicing.
-                    // To avoid double-editing the same bytes we only
-                    // recurse when no outer edit was produced.
+                    // Never recurse into a macro body: nested
+                    // `render!`/`css!` are re-printed by the body's own
+                    // printer, so an inner edit would splice into byte
+                    // ranges the outer edit already owns.
                     i += 3;
                     continue;
                 }
             }
         }
-        // Recurse into any group we didn't treat as a macro body.
         if let TokenTree::Group(group) = &trees[i] {
             collect_macro_edits(
                 group.stream(),
@@ -451,12 +427,11 @@ fn macro_body_edit(
     verify: bool,
 ) -> Result<Option<MacroEdit>> {
     let span = group.span();
-    // Byte offsets of the WHOLE group (including delimiters).
+    // Byte offsets of the WHOLE group, delimiters included.
     let Some((group_start, group_end)) = file_map.byte_range(span) else {
         return Ok(None);
     };
-    // The opening / closing delimiters are single chars; the body is
-    // between them.
+    // Delimiters are single chars, so the body is one byte inside each.
     let open_byte = group_start + 1;
     let close_byte = group_end - 1;
     if close_byte <= open_byte {
@@ -464,7 +439,6 @@ fn macro_body_edit(
     }
     let body_src = &rust_src[open_byte..close_byte];
 
-    // Base indent = the indent level of the line the macro sits on.
     let line_start = rust_src[..group_start]
         .rfind('\n')
         .map(|n| n + 1)
@@ -472,9 +446,8 @@ fn macro_body_edit(
     let line_prefix = &rust_src[line_start..group_start];
     let base_indent = indent_level_of(line_prefix, opts);
 
-    // Re-parse the body with whisker-macro-syntax. The span locations
-    // inside `body_ts` are relative to `body_src`, so build a fresh
-    // SourceMap over exactly that substring.
+    // Span locations inside `body_ts` are relative to `body_src`, so the
+    // SourceMap must cover exactly that substring.
     let body_ts: TokenStream = body_src
         .parse()
         .map_err(|e| anyhow!("whisker-fmt: could not lex {macro_name}! body: {e}"))?;
@@ -482,11 +455,10 @@ fn macro_body_edit(
 
     let body_len = body_src.len();
 
-    // Collect the embedded-expr spans up front: we need them both to
-    // batch-format the exprs AND to mask out expr-internal comments when
-    // recovering the grammar comments to reattach. Comments INSIDE an
-    // expr value are kept by slicing / rustfmt-ing the expr source; only
-    // GRAMMAR comments are reattached here.
+    // The embedded-expr spans are collected up front because they serve
+    // twice: batch-formatting the exprs, and masking out expr-internal
+    // comments so only GRAMMAR comments get reattached (expr-internal
+    // ones ride along with the expr's own source).
     let (formatted, grammar_comments) = match macro_name {
         "render" => match whisker_macro_syntax::render::parse_root(body_ts.clone()) {
             Ok(root) => {
@@ -494,9 +466,6 @@ fn macro_body_edit(
                 let mut spans = Vec::new();
                 ir::collect_ir_expr_spans(&ir_root, &mut spans);
                 let comments = comments::collect_grammar_comments(body_src, &spans, &body_map);
-                // Batch-format every embedded expr with one rustfmt spawn.
-                // With no `exprfmt` (rustfmt-free core) the map stays
-                // empty and every expr renders verbatim.
                 let expr_map = build_expr_map(&spans, &body_map, exprfmt);
                 let s = printer::print_render(
                     &ir_root,
@@ -509,7 +478,7 @@ fn macro_body_edit(
                 );
                 (s, comments)
             }
-            // Not a well-formed render! body (e.g. mid-edit) — leave it.
+            // Not a well-formed body (e.g. mid-edit) — leave it.
             Err(_) => return Ok(None),
         },
         "routes" => match whisker_macro_syntax::routes::parse_input(body_ts.clone()) {
@@ -566,39 +535,27 @@ fn macro_body_edit(
         _ => return Ok(None),
     };
 
-    // Wrap with the delimiter-relative newlines: the printer emits the
-    // body already indented to `base_indent + 1`; surround with a
-    // leading newline and a trailing newline + closing-brace indent.
+    // The printer emits the body already indented to `base_indent + 1`,
+    // so only the surrounding newlines and closing indent are added
+    // here. Every delimiter form breaks onto its own lines, matching
+    // rustfmt's treatment of multi-item macros.
     let closing_indent = opts.indent_prefix(base_indent);
     let replacement = match group.delimiter() {
-        // `render! { … }` — the common form. Put body on its own lines.
         Delimiter::Brace => format!("\n{formatted}\n{closing_indent}"),
-        // `css!( … )` / `css![ … ]` — also break onto lines for
-        // consistency with rustfmt's treatment of multi-item macros.
         _ => format!("\n{formatted}\n{closing_indent}"),
     };
 
-    // Idempotency guard: if the body already equals the replacement,
-    // skip (avoids spurious diffs and keeps format(format(x))==format(x)).
     if body_src == replacement {
         return Ok(None);
     }
 
-    // ---- comment-preservation fail-safe ------------------------------
-    //
-    // If reattaching the comments could possibly have dropped one, or the
-    // result isn't a fixed point, leave the body UNTOUCHED (today's old
-    // behavior — no regression, no comment ever lost).
+    // Comment-preservation fail-safe: if reattaching the comments could
+    // have dropped one, or the result isn't a fixed point, leave the body
+    // UNTOUCHED rather than risk losing a comment.
     if verify && !grammar_comments.is_empty() {
-        // (1) No comment lost: every recovered comment's text must appear
-        // in the formatted output, counting duplicates.
         if !all_comments_present(&replacement, &grammar_comments) {
             return Ok(None);
         }
-        // (2) Idempotency: re-running the formatter on the produced body
-        // must be a fixed point. We re-run the SAME macro pass over a
-        // minimal synthetic wrapper containing the produced body and check
-        // the body comes back unchanged.
         if !macro_replacement_is_fixed_point(macro_name, &replacement, base_indent, opts) {
             return Ok(None);
         }
@@ -618,7 +575,6 @@ fn macro_body_edit(
 /// survive. Uses a per-text occurrence count.
 fn all_comments_present(output: &str, comments: &[comments::GrammarComment]) -> bool {
     use std::collections::HashMap;
-    // Required count per comment text.
     let mut need: HashMap<&str, usize> = HashMap::new();
     for c in comments {
         *need.entry(c.text.trim()).or_insert(0) += 1;
@@ -661,15 +617,12 @@ fn macro_replacement_is_fixed_point(
     opts: &FmtOptions,
 ) -> bool {
     let indent = opts.indent_prefix(base_indent);
-    // Wrap in a trivial fn so the source is valid Rust. The macro sits at
-    // `base_indent` (the wrapper body is at base_indent, the fn at 0).
-    // To get `base_indent` levels of indent for the macro line we open
-    // (base_indent) nested-block-free wrapper: a single fn plus manual
-    // indent prefix on the macro line works because rustfmt isn't run.
+    // A trivial fn wrapper plus a manual indent prefix is enough to put
+    // the macro line at `base_indent`, since rustfmt never runs on this.
     let src = format!("fn _w() {{\n{indent}{macro_name}! {{{replacement}}}\n}}\n");
-    // Re-run WITHOUT the verify guard (`verify = false`) so this check does
-    // not recurse into itself — otherwise each fixed-point check would
-    // spawn another, blowing the stack on large / nested bodies.
+    // `verify = false` so this check does not recurse into itself —
+    // otherwise each fixed-point check spawns another, blowing the stack
+    // on large / nested bodies.
     let once = match reformat_macros_pass(&src, opts, None, false) {
         Ok(s) => s,
         Err(_) => return false,
@@ -688,11 +641,6 @@ fn span_of_expr(expr: &syn::Expr) -> Span {
     use syn::spanned::Spanned;
     expr.span()
 }
-
-// `render!`/`routes!` embedded-expr span collection now walks the
-// adapted `ir::IrNode` tree (see `ir::collect_ir_expr_spans`) instead of
-// each macro's own parse type — one shared walk instead of two near-
-// identical ones.
 
 /// Slice each expr's verbatim source from `body_map` and batch-format
 /// the whole set with one rustfmt spawn (via `exprfmt`). Returns an
@@ -748,8 +696,8 @@ mod tests {
         }
     }
 
-    // All tests below feed already-rust-formatted input to
-    // `reformat_macros`, so they DO NOT require the rustfmt binary.
+    // Every test below feeds already-rust-formatted input to
+    // `reformat_macros`, so none require the rustfmt binary.
 
     #[test]
     fn reformats_messy_render_body() {
@@ -788,8 +736,6 @@ mod tests {
 
     #[test]
     fn wraps_kwargs_over_max_width() {
-        // A node whose kwargs blow past a tiny max_width breaks each
-        // kwarg onto its own line with a trailing comma.
         let input = "fn ui() -> Element {\n    render! { view(style: \"a-long-value\", class: \"another-long-value\") }\n}\n";
         let out = reformat_macros(input, &opts(4, 40)).unwrap();
         assert!(out.contains("view(\n"), "expected broken kwargs:\n{out}");
@@ -801,8 +747,6 @@ mod tests {
 
     #[test]
     fn preserves_user_expression_source() {
-        // The embedded closure expression should be kept verbatim
-        // (sliced), not re-printed from tokens.
         let input =
             "fn ui() -> Element {\n    render! { view(on_tap: move |_| do_thing(a, b)) }\n}\n";
         let out = reformat_macros(input, &opts(4, 100)).unwrap();
@@ -824,8 +768,6 @@ mod tests {
 
     #[test]
     fn trailing_block_comment_preserved_and_reflowed() {
-        // A trailing block comment after a node is now KEPT (reattached to
-        // the node's line) while the body is reflowed.
         let input = "fn ui() -> Element {\n    render! { view(style:\"x\") /* keep me */ }\n}\n";
         let out = reformat_macros(input, &opts(4, 100)).unwrap();
         let expected = "fn ui() -> Element {\n    render! {\n        view(style: \"x\") /* keep me */\n    }\n}\n";
@@ -914,9 +856,6 @@ mod tests {
 
     #[test]
     fn nested_css_in_render_kwarg_reformats() {
-        // A `css!(...)` kwarg value is no longer passed through verbatim —
-        // it's reformatted by the same grammar-aware printer as a
-        // top-level `css!`, so messy spacing/commas get cleaned up.
         let input =
             "fn ui() -> Element {\n    render! { view(style: css!(color:red,padding:px(8))) }\n}\n";
         let out = reformat_macros(input, &opts(4, 100)).unwrap();
@@ -956,14 +895,9 @@ mod tests {
 
     #[test]
     fn nested_render_in_render_kwarg_reformats() {
-        // A kwarg value that is itself a `render!{...}` call now recurses
-        // through the same shared IR-based printer as css!/routes! — a
-        // capability that fell out of unifying render!/routes! tree
-        // printing onto one `IrNode`, not something render! itself is
-        // expected to use in practice. Nesting the whole thing inside an
-        // OUTER render! is what actually routes the inner call through
-        // `nested_macro_src` (a bare top-level `render!{...}` would just
-        // hit `macro_body_edit`'s own "render" arm directly).
+        // The OUTER render! is load-bearing: it routes the inner call
+        // through `nested_macro_src`, whereas a bare top-level
+        // `render!{...}` hits `macro_body_edit`'s own "render" arm.
         let input = "fn ui() -> Element {\n    render! { view(child: render!{text(value:\"nested\")}) }\n}\n";
         let out = reformat_macros(input, &opts(4, 100)).unwrap();
         assert!(
@@ -985,12 +919,8 @@ mod tests {
 
     #[test]
     fn nested_css_with_comment_left_untouched() {
-        // Comment-safety fail-safe: a nested css!/routes! whose source
-        // contains a comment is NOT recursively reformatted (comments
-        // inside a nested macro aren't threaded through the
-        // grammar-comment recovery pass), so it falls back to the normal
-        // verbatim / rustfmt-free expr path rather than risk dropping
-        // the comment.
+        // A nested macro carrying a comment is left to the verbatim expr
+        // path — grammar-comment recovery doesn't reach inside it.
         let input = "fn ui() -> Element {\n    render! { view(style: css!(\n        // keep me\n        flex_grow: 1.0,\n    )) }\n}\n";
         let out = reformat_macros(input, &opts(4, 100)).unwrap();
         assert!(out.contains("// keep me"), "comment must survive:\n{out}");
@@ -998,14 +928,9 @@ mod tests {
 
     #[test]
     fn nested_css_wraps_using_its_real_depth_not_a_fixed_shallow_one() {
-        // Regression: a nested `css!`'s OWN inline-vs-wrap fit check must
-        // use the depth it will ACTUALLY be printed at — one level deeper
-        // than the kwarg line it sits on, once a wide sibling kwarg
-        // (`value: "…"` here) forces the enclosing tag to break its
-        // kwargs onto their own lines — not a fixed shallow depth.
-        // Checking against a fixed shallow depth let content that clearly
-        // doesn't fit at its real column collapse onto one badly-overlong
-        // line instead of wrapping.
+        // A nested `css!`'s inline-vs-wrap fit check must use the depth
+        // it will ACTUALLY print at — one deeper than its kwarg line once
+        // a wide sibling forces the enclosing tag to break.
         let input = "fn ui() -> Element {\n    render! { text(value: \"a-fairly-long-value-string-here\", style: css!(font_size: 24.0.px(), font_weight: FontWeight::Bold, color: Color::Named(NamedColor::Black))) }\n}\n";
         let out = reformat_macros(input, &opts(4, 100)).unwrap();
         assert!(
@@ -1054,7 +979,6 @@ mod tests {
 
     #[test]
     fn cargo_toml_package_edition_used_without_rustfmt_edition() {
-        // No rustfmt.toml at all, but a Cargo.toml up the tree.
         let tmp = unique_tmp("cargo-pkg");
         let sub = tmp.join("src");
         std::fs::create_dir_all(&sub).unwrap();
@@ -1083,7 +1007,6 @@ mod tests {
 
     #[test]
     fn defaults_to_2021_without_any_config() {
-        // Neither rustfmt.toml nor Cargo.toml anywhere in the (temp) tree.
         let tmp = unique_tmp("none");
         let o = resolve_options(&tmp);
         assert_eq!(o.edition.as_deref(), Some("2021"));
@@ -1093,8 +1016,7 @@ mod tests {
     #[test]
     fn resolved_edition_is_always_some() {
         let tmp = unique_tmp("always-some");
-        // rustfmt.toml present but WITHOUT an edition key → must still
-        // fall through to Cargo.toml / default, never None.
+        // rustfmt.toml without an edition key must still resolve.
         std::fs::write(tmp.join("rustfmt.toml"), "tab_spaces = 2\n").unwrap();
         let o = resolve_options(&tmp);
         assert_eq!(o.tab_spaces, 2);
@@ -1102,11 +1024,9 @@ mod tests {
         std::fs::remove_dir_all(&tmp).unwrap();
     }
 
-    /// Integration: an `async move { … }` snippet — which rustfmt rejects
-    /// under its 2015 default — formats SUCCESSFULLY when the resolved
-    /// edition comes from a temp `Cargo.toml` with `edition = "2021"` and
-    /// NO rustfmt.toml is present. Reproduces-then-verifies the reported
-    /// failure. Gated on a real rustfmt binary.
+    /// An `async move { … }` snippet — which rustfmt rejects under its
+    /// 2015 default — must format when the edition comes from a
+    /// `Cargo.toml` and no rustfmt.toml is present. Needs a real rustfmt.
     #[test]
     fn async_move_formats_with_cargo_edition_no_rustfmt_toml() {
         if !rustfmt_available() {
@@ -1127,30 +1047,24 @@ mod tests {
         std::fs::remove_dir_all(&tmp).unwrap();
     }
 
-    /// Regression: a `rustfmt.toml` at the project ROOT must govern even
-    /// when formatting from a NESTED subdir that has no rustfmt.toml of
-    /// its own. Before the fix, `run_rustfmt` passed `--config-path
-    /// <subdir>` and rustfmt errored "unable to find a config file for
-    /// the given path"; now it passes the found config file path.
+    /// A `rustfmt.toml` at the project ROOT must govern even when
+    /// formatting from a NESTED subdir that has none of its own.
     #[test]
     fn root_rustfmt_toml_governs_nested_subdir() {
         if !rustfmt_available() {
             return;
         }
         let root = unique_tmp("nested-config");
-        // 2-space indent at the root, no rustfmt.toml in the subdir.
         std::fs::write(root.join("rustfmt.toml"), "tab_spaces = 2\n").unwrap();
         let nested = root.join("src").join("screens");
         std::fs::create_dir_all(&nested).unwrap();
 
         let opts = resolve_options(&nested);
-        // Resolver picked up the root rustfmt.toml's tab_spaces.
         assert_eq!(opts.tab_spaces, 2);
 
         let src = "fn f() {\nlet x = 1;\n}\n";
         let out = format_source_in_dir(src, &opts, &nested)
             .expect("root rustfmt.toml must govern a nested subdir");
-        // rustfmt applied 2-space indent from the root config.
         assert!(out.contains("\n  let x = 1;"), "got:\n{out}");
         std::fs::remove_dir_all(&root).unwrap();
     }
@@ -1158,9 +1072,8 @@ mod tests {
 
 // ---- comment-preservation tests -----------------------------------------
 //
-// All feed already-rust-formatted input to `reformat_macros`, so they do
-// NOT need the rustfmt binary. They assert EXACT output to prove real
-// comment-preserving formatting happens (not just fallback).
+// These assert EXACT output, so a silent fall-back to the untouched body
+// fails them rather than passing.
 #[cfg(test)]
 mod comment_tests {
     use super::*;
@@ -1178,7 +1091,6 @@ mod comment_tests {
         reformat_macros(input, &o()).unwrap()
     }
 
-    // 1. Own-line `//` before a top-level element (also reflows the body).
     #[test]
     fn own_line_before_top_element() {
         let input = "fn d() -> Element {\n    render! {\n        // header\n        view(style: \"x\") { text(value: \"hi\") }\n    }\n}\n";
@@ -1186,96 +1098,82 @@ mod comment_tests {
         assert_eq!(fmt(input), expected);
     }
 
-    // 2. Own-line comment between two sibling children.
     #[test]
     fn own_line_between_siblings() {
         let input = "fn d() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n            // mid\n            text(value: \"b\")\n        }\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 3. Own-line comment as the first child (right after `{`).
     #[test]
     fn own_line_first_child() {
         let input = "fn d() -> Element {\n    render! {\n        view {\n            // first\n            text(value: \"a\")\n        }\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 4. Own-line comment after the last child, before `}` (inside block).
     #[test]
     fn own_line_after_last_child() {
         let input = "fn d() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n            // last\n        }\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 5. Trailing `//` on the same line as a child.
     #[test]
     fn trailing_line_comment_on_child() {
         let input = "fn d() -> Element {\n    render! {\n        view {\n            text(value: \"a\") // tail\n        }\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 6. Trailing comment after a `css!` field.
     #[test]
     fn trailing_comment_after_css_field() {
         let input = "fn s() -> Css {\n    css! {\n        color: red, // c\n        padding: px(8),\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 7. Own-line comment between two `css!` fields.
     #[test]
     fn own_line_between_css_fields() {
         let input = "fn s() -> Css {\n    css! {\n        color: red,\n        // gap\n        padding: px(8),\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 8. `/* block */` single-line comment.
     #[test]
     fn block_comment_single_line() {
         let input = "fn d() -> Element {\n    render! {\n        /* b */\n        view(style: \"x\")\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 9. Multi-line `/* … */` block comment, kept verbatim.
     #[test]
     fn block_comment_multiline_verbatim() {
         let input = "fn d() -> Element {\n    render! {\n        /* line1\n           line2 */\n        view(style: \"x\")\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 10. Two consecutive own-line comments.
     #[test]
     fn two_consecutive_comments() {
         let input = "fn d() -> Element {\n    render! {\n        // one\n        // two\n        view(style: \"x\")\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 11. A comment INSIDE an embedded expr is not touched by
-    // reattachment and survives (handled by the expr path).
+    // A comment INSIDE an embedded expr survives via the expr path, not
+    // via reattachment.
     #[test]
     fn comment_inside_embedded_expr_survives() {
         let input = "fn d() -> Element {\n    render! {\n        view(on_tap: move |_| { /* keep */ go() })\n    }\n}\n";
         let out = fmt(input);
         assert!(out.contains("/* keep */"), "got:\n{out}");
-        // Not duplicated.
         assert_eq!(out.matches("/* keep */").count(), 1, "got:\n{out}");
     }
 
-    // 12. Deeply nested element: own-line comment before an inner child
-    // lands at the correct (deeper) indent.
     #[test]
     fn nested_inner_child_indent() {
         let input = "fn d() -> Element {\n    render! {\n        view {\n            scroll_view {\n                // inner\n                text(value: \"a\")\n            }\n        }\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 13. Mixed leading + trailing comments in the same body.
     #[test]
     fn mixed_leading_and_trailing() {
         let input = "fn d() -> Element {\n    render! {\n        // lead\n        view {\n            text(value: \"a\") // tail\n        }\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 14. Idempotency over several comment-bearing inputs.
     #[test]
     fn idempotent_with_comments() {
         let inputs = [
@@ -1291,8 +1189,8 @@ mod comment_tests {
         }
     }
 
-    // 15a. Fallback safety: directly exercise the `all_comments_present`
-    // guard — a dropped duplicate makes it report "not present".
+    // Exercises the `all_comments_present` guard directly: a dropped
+    // duplicate must make it report "not present".
     #[test]
     fn fallback_guard_detects_dropped_comment() {
         let comments = vec![
@@ -1309,15 +1207,12 @@ mod comment_tests {
                 own_line: true,
             },
         ];
-        // Output with only ONE `// hi` must fail the duplicate-aware check.
         assert!(!all_comments_present("only one // hi here", &comments));
-        // Output with BOTH passes.
         assert!(all_comments_present("// hi and // hi", &comments));
     }
 
-    // 15b. Fallback safety end-to-end: even a comment in an awkward spot
-    // (between a tag and its parens) is never lost — either reflowed or
-    // left untouched, but always present.
+    // A comment in an awkward spot (between a tag and its parens) is
+    // never lost — reflowed or left untouched, but always present.
     #[test]
     fn fallback_keeps_comment_when_in_doubt() {
         let input =
@@ -1326,42 +1221,28 @@ mod comment_tests {
         assert!(out.contains("/* odd */"), "comment must survive:\n{out}");
     }
 
-    // 16. Wallet-style section comments kept on their own lines.
     #[test]
     fn wallet_style_section_comments() {
         let input = "fn d() -> Element {\n    render! {\n        view {\n            // \u{2500}\u{2500} Header \u{2500}\u{2500}\n            text(value: \"hi\")\n            // \u{2500}\u{2500} Body \u{2500}\u{2500}\n            text(value: \"yo\")\n        }\n    }\n}\n";
         assert_eq!(fmt(input), input);
     }
 
-    // 17. Wallet-faithful reduction: a `render!` with section comments,
-    // irregular OVER-INDENTATION (page→view migration leftovers), and a
-    // user-component call whose closing `)` sits on its own line at a weird
-    // column. This is the exact shape that previously fell back (the body
-    // got NO formatting). It must now actually reflow — comments kept on
-    // their own lines at the corrected indent — AND be idempotent. The
-    // nested `css!(…)` kwarg value is now reformatted by the grammar-aware
-    // `css!` printer (not left verbatim), so its two kwargs collapse onto
-    // one line since they fit under `max_width` — the same rule a
-    // top-level `css! { … }` follows — which in turn lets the whole
-    // `view(style: css!(…))` collapse fully inline too.
+    // A `render!` combining section comments, irregular over-indentation
+    // and a stray closing paren: it must reflow (not fall back), keep the
+    // comments at the corrected indent, and be idempotent.
     #[test]
     fn wallet_faithful_reduction_formats_and_preserves_comments() {
         let input = "fn d() -> Element {\n    render! {\n        view(style: css!(\n            flex_grow: 1.0,\n            background_color: BG,\n        )) {\n        view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false\n    )\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n        }\n        }\n    }\n}\n";
         let expected = "fn d() -> Element {\n    render! {\n        view(style: css!(flex_grow: 1.0, background_color: BG)) {\n            view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false)\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n            }\n        }\n    }\n}\n";
         let out = fmt(input);
-        // The body MUST be reformatted (not the fallback), with the section
-        // comment preserved at the right indent.
         assert_ne!(out, input, "must not fall back:\n{out}");
         assert_eq!(out, expected, "got:\n{out}");
-        // And it must be a fixed point.
         assert_eq!(fmt(&out), out, "not idempotent");
     }
 
-    // 18. Regression: a multi-line embedded-expr value (e.g. a wrapped
-    // `css!( … )` kwarg) must format idempotently via the rustfmt-free
-    // core — the verbatim slice is dedented before re-indenting so the
-    // continuation lines don't gain indentation on every pass. This is the
-    // bug that made the whole wallet body fail the idempotency fail-safe.
+    // A multi-line embedded-expr value must be dedented before
+    // re-indenting, or its continuation lines gain a level per pass and
+    // the body never reaches a fixed point.
     #[test]
     fn multiline_expr_value_is_idempotent() {
         let input = "fn s() -> Element {\n    render! {\n        view(style: css!(\n            flex_grow: 1.0,\n            background_color: BG,\n            display: Display::Flex,\n        ))\n    }\n}\n";
@@ -1371,7 +1252,6 @@ mod comment_tests {
             once, twice,
             "not idempotent:\nonce:\n{once}\ntwice:\n{twice}"
         );
-        // The css! values survive verbatim.
         assert!(once.contains("flex_grow: 1.0,"), "got:\n{once}");
         assert!(once.contains("background_color: BG,"), "got:\n{once}");
     }
@@ -1379,9 +1259,8 @@ mod comment_tests {
 
 // ---- broad grammar coverage ----------------------------------------------
 //
-// A wide sweep of render!/css!/routes! shapes and nesting combinations,
-// beyond the earlier bug-driven regression tests. All feed already-
-// rust-formatted input to `reformat_macros` (no rustfmt binary needed).
+// A wide sweep of render!/css!/routes! shapes and nesting combinations.
+// All feed already-rust-formatted input (no rustfmt binary needed).
 #[cfg(test)]
 mod coverage_tests {
     use super::*;
@@ -1430,9 +1309,8 @@ mod coverage_tests {
 
     #[test]
     fn render_snake_case_user_component_gets_pascal_alias() {
-        // A snake_case tag that ISN'T in the built-in whitelist is the
-        // back-compat user-component path: it prints under its derived
-        // PascalCase alias, not the literal source text.
+        // A snake_case tag outside the built-in whitelist is a user
+        // component: it prints under its derived PascalCase alias.
         let input = "fn ui() -> Element {\n    render! { my_card(title: \"hi\") }\n}\n";
         let out = fmt(input);
         assert!(
@@ -1452,7 +1330,7 @@ mod coverage_tests {
 
     #[test]
     fn render_partial_kwarg_mid_typing_preserved() {
-        // No `:` yet — mid-typing. Printed as the bare name, no value.
+        // No `:` yet — mid-typing.
         let input = "fn ui() -> Element {\n    render! { view(style) }\n}\n";
         let out = fmt(input);
         assert!(out.contains("view(style)"), "got:\n{out}");
@@ -1478,7 +1356,6 @@ mod coverage_tests {
         ] {
             let input = format!("fn ui() -> Element {{\n    render! {{ {tag}(key: 1) }}\n}}\n");
             let out = fmt(&input);
-            // Built-in tags print verbatim (no PascalCase alias derivation).
             assert!(
                 out.contains(&format!("{tag}(key: 1)")),
                 "builtin tag {tag} mis-formatted:\n{out}"
@@ -1488,11 +1365,8 @@ mod coverage_tests {
 
     #[test]
     fn render_bare_tag_no_parens_no_children() {
-        // No kwargs, no children — parens fully omitted. The top-level
-        // `render!` body still always breaks onto its own lines (pre-
-        // existing behavior: `macro_body_edit` unconditionally wraps a
-        // macro's body, regardless of how short it is — same as css!/
-        // routes!), so `view` alone still lands on its own line.
+        // Parens are omitted, but `macro_body_edit` wraps every macro
+        // body onto its own lines however short, so `view` still breaks.
         let input = "fn ui() -> Element {\n    render! { view }\n}\n";
         let out = fmt(input);
         let expected = "fn ui() -> Element {\n    render! {\n        view\n    }\n}\n";
@@ -1617,8 +1491,8 @@ mod coverage_tests {
 
     #[test]
     fn routes_empty_stack_keeps_mandatory_braces() {
-        // Switch/Stack's `{ … }` is mandatory even when empty — must
-        // never collapse away, unlike every other tag's optional block.
+        // Switch/Stack's `{ … }` is mandatory even when empty, unlike
+        // every other tag's optional block.
         let input = "fn r() -> Routes {\n    routes! { Stack {} }\n}\n";
         let out = fmt(input);
         assert!(
@@ -1678,8 +1552,7 @@ mod coverage_tests {
 
     #[test]
     fn exactly_at_max_width_stays_inline() {
-        // "        view(style: \"1234567890123456789012345678901234567\")"
-        // is engineered to land exactly at width 60.
+        // Engineered to land exactly at width 60.
         let value = "1".repeat(37);
         let input =
             format!("fn ui() -> Element {{\n    render! {{ view(style: \"{value}\") }}\n}}\n");
@@ -1733,9 +1606,8 @@ mod coverage_tests {
 
     #[test]
     fn nested_css_empty_parens_left_as_opaque_expr() {
-        // `css!()` with no kwargs doesn't fit the nested-macro grammar
-        // (empty input) — falls back to being treated as a normal opaque
-        // expr rather than crashing or vanishing.
+        // `css!()` has no kwargs to parse, so it falls back to being an
+        // opaque expr rather than vanishing.
         let input = "fn ui() -> Element {\n    render! { view(style: css!()) }\n}\n";
         let out = fmt(input);
         assert!(out.contains("css!()"), "got:\n{out}");
@@ -1745,10 +1617,8 @@ mod coverage_tests {
 
     #[test]
     fn comment_before_nested_css_kwarg_value_survives() {
-        // The comment sits INSIDE the nested css! call — excluded from
-        // the outer body's grammar-comment recovery, and the comment
-        // fail-safe inside `nested_macro_src` bails out (leaves the
-        // whole nested call untouched) rather than risk dropping it.
+        // The comment sits INSIDE the nested css! call, so
+        // `nested_macro_src`'s own fail-safe leaves that call untouched.
         let input = "fn ui() -> Element {\n    render! { view(style: css!(\n        // keep\n        flex_grow: 1.0,\n    )) }\n}\n";
         let out = fmt(input);
         assert!(out.contains("// keep"), "comment must survive:\n{out}");
@@ -1804,7 +1674,6 @@ mod coverage_tests {
         let input = "fn ui() -> Element {\n  render! { view { text(value: \"a-fairly-long-value-string-here\", style: css!(font_size: 24.0.px(), font_weight: FontWeight::Bold, color: Color::Named(NamedColor::Black))) } }\n}\n";
         let out = reformat_macros(input, &opts(2, 100)).unwrap();
         assert!(out.contains("style: css!(\n"), "got:\n{out}");
-        // 2-space continuation lines inside the nested css! wrap.
         assert!(
             out.contains("  font_size: 24.0.px(),\n") || out.contains("      font_size:"),
             "got:\n{out}"

--- a/crates/whisker-fmt/src/options.rs
+++ b/crates/whisker-fmt/src/options.rs
@@ -10,13 +10,11 @@
 //! | `hard_tabs`  | `hard_tabs`      | false   |
 //! | `edition`    | (CLI `--edition`)| 2015    |
 //!
-//! `format_source` lets the rustfmt *binary* read `rustfmt.toml` for
-//! the base Rust pass (so any key rustfmt understands is honored). The
-//! subset captured here is exactly the subset the macro-body
-//! pretty-printer needs in order to match rustfmt's indentation /
-//! wrapping. We resolve those few keys from the same `rustfmt.toml`
-//! ([`FmtOptions::from_rustfmt_config`]) so the macro bodies line up
-//! with the surrounding code.
+//! The rustfmt *binary* reads `rustfmt.toml` itself for the base Rust
+//! pass, so any key it understands is honored. The subset captured here
+//! is what the macro-body pretty-printer needs to match rustfmt's
+//! indentation and wrapping, resolved from that same `rustfmt.toml`
+//! ([`FmtOptions::from_rustfmt_config`]).
 
 /// Layout options for the macro-body pretty-printer. Mirrors the
 /// rustfmt keys that affect indentation and wrapping.
@@ -39,7 +37,6 @@ pub struct FmtOptions {
 
 impl Default for FmtOptions {
     fn default() -> Self {
-        // rustfmt's documented defaults.
         Self {
             max_width: 100,
             tab_spaces: 4,
@@ -74,10 +71,6 @@ impl FmtOptions {
     /// `rustfmt.toml` text blob. Unknown keys are ignored (rustfmt
     /// itself still sees them on the base pass). Missing keys keep
     /// their default.
-    ///
-    /// This is a tiny hand-rolled `key = value` reader rather than a
-    /// full TOML parse so the crate doesn't take a `toml` dependency
-    /// just for four scalar keys.
     pub fn from_rustfmt_config(toml_src: &str) -> Self {
         let mut opts = FmtOptions::default();
         for line in toml_src.lines() {
@@ -158,7 +151,6 @@ mod tests {
         o.hard_tabs = true;
         assert_eq!(o.indent_unit(), "\t");
         assert_eq!(o.indent_prefix(2), "\t\t");
-        // width accounting still charges tab_spaces per level
         assert_eq!(o.indent_width(2), 4);
     }
 }

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -76,7 +76,6 @@ pub(crate) fn print_render(
         next: Cell::new(0),
     };
     let mut out = String::new();
-    // Leading comments before the root node.
     if let Some(start) = p.ir_node_start_byte(root) {
         p.flush(start, base_indent + 1, &mut out);
     }
@@ -88,8 +87,6 @@ pub(crate) fn print_render(
             p.flush(before, base_indent + 1, &mut out);
         }
     }
-    // Any remaining (own-line) comments after the root node, on their own
-    // lines at the body indent.
     let idx = p.next.get();
     if idx < comments.len() {
         let mut tail = String::new();
@@ -211,13 +208,9 @@ impl Printer<'_> {
             return formatted.to_string();
         }
         if let Some(s) = self.map.slice(span) {
-            // Trim surrounding whitespace; internal formatting is kept.
-            // For multi-line values, dedent continuation lines to column 0
-            // (matching the [`ExprMap`] contract) so the surrounding
-            // [`reindent`] call adds exactly the kwarg-column prefix and
-            // re-formatting is a fixed point. Without this, slicing an
-            // already-indented value and re-indenting it compounds the
-            // indentation on every pass (non-idempotent).
+            // Continuation lines must be dedented to column 0 (the
+            // [`ExprMap`] contract) or the later [`reindent`] compounds
+            // the indentation on every pass.
             dedent_continuation(s.trim())
         } else {
             expr.to_token_stream().to_string()
@@ -226,36 +219,24 @@ impl Printer<'_> {
 
     /// If `expr` is a `css!( … )` / `render!{ … }` / `routes!{ … }` macro
     /// call, recursively format its body with the grammar-aware printer
-    /// instead of treating it as an opaque expression — this is what
-    /// makes `render! { view(style: css!(…)) }` reformat the nested
-    /// `css!`/`routes!` call instead of passing it through verbatim.
+    /// instead of treating it as an opaque expression.
     ///
     /// `level` is the caller's best estimate of the indent level the
-    /// nested macro's own line will actually sit at once the OUTER node's
-    /// inline-vs-wrap decision has been made — callers pass their own
-    /// `level` (+1 when the value would land one level deeper if the
-    /// surrounding kwargs end up wrapped, which is the common case for
-    /// anything wide enough to need this decision at all). It is used
-    /// ONLY as the width reference for the nested call's own
-    /// inline-vs-wrap fit check ([`Printer::delimited_list`]) so a
-    /// deeply-nested `css!`/`routes!` doesn't wrongly collapse onto one,
-    /// far-too-long line by measuring itself against a shallow assumed
-    /// depth. This is a best-effort estimate, not an exact final column
-    /// (the true depth isn't known until the OUTER node's own wrap
-    /// decision, which depends circularly on this one) — the same
-    /// approximation [`crate::expr_fmt`] already accepts for
-    /// rustfmt-formatted embedded exprs.
+    /// nested macro's line will sit at once the OUTER node's
+    /// inline-vs-wrap decision is made (callers pass their own `level`,
+    /// +1 when a wrap would push the value one level deeper). It is used
+    /// ONLY as the width reference for the nested call's own fit check
+    /// ([`Printer::delimited_list`]), so a deeply-nested value doesn't
+    /// measure itself against a shallow assumed depth. It cannot be
+    /// exact: the true depth depends on the outer wrap decision, which
+    /// depends circularly on this one.
     ///
-    /// Returns `None` (falling back to the normal [`ExprMap`] / verbatim
-    /// path in [`Printer::expr_src`]) when `expr` isn't a
-    /// `css!`/`render!`/`routes!` call, its body doesn't parse as that
-    /// grammar, is empty, or — the comment fail-safe — its source
-    /// contains `//` or `/*` anywhere. Comments inside a nested macro
-    /// aren't threaded through this recursive call (the grammar-comment
-    /// recovery pass that collects them runs once, over the OUTER body,
-    /// before this nested printer exists), so rather than risk dropping
-    /// one we leave the whole nested call untouched, matching the
-    /// fail-safe used everywhere else in this crate.
+    /// Returns `None` — falling back to the [`ExprMap`] / verbatim path
+    /// in [`Printer::expr_src`] — when `expr` isn't one of those macros,
+    /// its body doesn't parse or is empty, or its source contains `//`
+    /// or `/*`. Grammar-comment recovery runs once over the OUTER body,
+    /// before this nested printer exists, so a nested call carrying a
+    /// comment is left untouched rather than risk dropping it.
     fn nested_macro_src(&self, expr: &Expr, level: usize) -> Option<String> {
         let Expr::Macro(em) = expr else {
             return None;
@@ -264,12 +245,9 @@ impl Printer<'_> {
         if name != "css" && name != "render" && name != "routes" {
             return None;
         }
-        // The delimiter token's own span covers everything BETWEEN AND
-        // INCLUDING the open/close delimiters — unlike `mac.tokens`'s
-        // (joined-from-real-tokens) span, which excludes any comment
-        // sitting in the gap right after `(`/`{` or right before `)`/`}`.
-        // We need the delimiter span, not the tokens' span, so the
-        // comment fail-safe below can't miss a leading/trailing comment.
+        // The delimiter span, not `mac.tokens`'s: the latter excludes a
+        // comment sitting right inside `(`/`{` or right before `)`/`}`,
+        // which the fail-safe below must see.
         let (open, close, delim_span) = match &em.mac.delimiter {
             syn::MacroDelimiter::Paren(p) => ('(', ')', p.span),
             syn::MacroDelimiter::Brace(b) => ('{', '}', b.span),
@@ -279,10 +257,7 @@ impl Printer<'_> {
         if full_src.contains("//") || full_src.contains("/*") {
             return None;
         }
-        // Rust/rustfmt convention: a space before a brace-delimited
-        // macro's `{` (`render!`/`routes! { … }`), none before `(`/`[`
-        // (`css!(…)`) — matches how the base rustfmt pass spaces the
-        // user's own top-level invocations.
+        // rustfmt spaces a brace-delimited macro's `{` but not `(`/`[`.
         let bang = if open == '{' { "! " } else { "!" };
         match name.as_str() {
             "css" => {
@@ -347,17 +322,13 @@ impl Printer<'_> {
     /// name (already written to `out`, or folded into `prefix_width`).
     ///
     /// `check_level` is the level the group ACTUALLY sits at once
-    /// printed — used ONLY for the width decision. This is what makes a
-    /// deeply-nested value wrap instead of measuring itself against a
-    /// shallow assumed depth; see [`Printer::nested_macro_src`].
-    /// `output_level` is the level the WRAPPED form is indented to in the
-    /// returned string: pass the same value as `check_level` for output
-    /// written directly into the current line (tag/component kwargs,
-    /// `Route(...)` kwargs), or `0` for a relative, column-0-anchored
-    /// fragment the caller will [`reindent`] itself (a nested macro's own
-    /// kwarg list, per the [`ExprMap`] contract). The two differ because
-    /// the real ambient depth used for the width check is often not yet
-    /// decided at output time — see [`Printer::kwarg`].
+    /// printed, used ONLY for the width decision; see
+    /// [`Printer::nested_macro_src`]. `output_level` is the level the
+    /// WRAPPED form is indented to: the same value as `check_level` for
+    /// output written straight into the current line, or `0` for a
+    /// column-0-anchored fragment the caller [`reindent`]s itself (per
+    /// the [`ExprMap`] contract). They differ because the real ambient
+    /// depth is often not yet decided at output time.
     ///
     /// `prefix_width`/`suffix_width` account for text sharing the
     /// group's own line that isn't one of `parts` (e.g. a tag name
@@ -409,9 +380,8 @@ impl Printer<'_> {
                 out.push_str(&reindent(&c.text, &indent));
                 out.push('\n');
             } else {
-                // Trailing: append to the end of the current output. Strip
-                // a single trailing newline the caller may have already
-                // pushed, append ` text`, then restore the newline.
+                // Strip a trailing newline the caller may already have
+                // pushed, append ` text`, then restore it.
                 let had_nl = out.ends_with('\n');
                 if had_nl {
                     out.pop();
@@ -496,7 +466,6 @@ impl Printer<'_> {
         out.push_str(&indent);
         out.push_str(&tag.tag);
 
-        // ---- kwargs ----
         if !tag.kwargs.is_empty() {
             let parts: Vec<String> = tag
                 .kwargs
@@ -515,7 +484,6 @@ impl Printer<'_> {
             ));
         }
 
-        // ---- children ----
         // Resolve this node's block byte bounds so comments are placed
         // relative to its `{ … }`.
         let inner_close = tag
@@ -541,22 +509,18 @@ impl Printer<'_> {
             out.push_str(" {\n");
             let child_level = level + 1;
             for child in &tag.children {
-                // Leading own-line comments before this child.
                 if let Some(cs) = self.ir_node_start_byte(child) {
                     self.flush(cs, child_level, out);
                 }
                 self.ir_node(child, child_level, out);
-                // Trailing same-line comment on the child.
                 if let Some((_, child_end)) = self.ir_node_extent(child) {
                     if let Some(idx) = self.pending_trailing_on_line(child_end) {
-                        // Append trailing comment to the end of this line.
                         let before = self.comments[idx].start + 1;
                         self.flush(before, child_level, out);
                     }
                 }
                 out.push('\n');
             }
-            // Comments sitting before the closing `}`.
             if let Some(close) = inner_close {
                 self.flush(close, child_level, out);
             }
@@ -565,15 +529,11 @@ impl Printer<'_> {
         }
     }
 
-    /// `level` is the tag's own indent level — if the value turns out to
-    /// need wrapping (e.g. a nested `css!` that doesn't fit), it lands
-    /// one level deeper (`level + 1`) once the kwargs break onto their
-    /// own lines, so that is what gets passed to [`Printer::expr_src`]
-    /// as the nested macro's width reference (`IrValue::Literal` values —
-    /// routes!'s `path`/`component` — never go through `expr_src` at all,
-    /// matching how they were always hand-formatted rather than treated
-    /// as embedded exprs). See [`Printer::nested_macro_src`] for why this
-    /// is a same-turn estimate rather than the exact final depth.
+    /// `level` is the tag's own indent level; a value that needs wrapping
+    /// lands at `level + 1`, so that is what reaches
+    /// [`Printer::expr_src`] as the nested macro's width reference.
+    /// `IrValue::Literal` values (routes!'s `path`/`component`) are
+    /// hand-formatted and never go through `expr_src` at all.
     fn ir_kwarg(&self, kw: &IrKwarg, level: usize) -> String {
         match &kw.value {
             // Partial kwarg: just the name (mid-typing). Preserve the
@@ -610,7 +570,6 @@ impl Printer<'_> {
                 let indent = self.indent(level);
                 return format!("{indent}{inline}");
             }
-            // Otherwise one kwarg per line, trailing comma.
             let indent = self.indent(level);
             let mut out = String::new();
             for part in &parts {
@@ -634,7 +593,6 @@ impl Printer<'_> {
             out.push_str(&indent);
             out.push_str(&reindent(&self.css_kwarg(kw, level), &indent));
             out.push(',');
-            // Trailing same-line comment after this field.
             let field_end = self
                 .map
                 .byte_range(kw.name.span())
@@ -653,7 +611,6 @@ impl Printer<'_> {
             }
             out.push('\n');
         }
-        // Any comments after the last field, before the body end.
         self.flush(body_len, level, &mut out);
         // strip trailing newline (caller adds delimiters)
         while out.ends_with('\n') {
@@ -690,14 +647,11 @@ fn ir_brace_width(children: &[IrNode], always_block: bool) -> usize {
 
 /// Dedent the continuation (2nd..=Nth) lines of a multi-line fragment by
 /// their common leading-whitespace amount, so they sit at column 0
-/// relative to the first line. The first line is already at column 0 (the
-/// caller trimmed it). This makes the later [`reindent`] idempotent: a
-/// value re-sliced from already-formatted output has its kwarg-column
-/// indentation stripped back off before being re-indented.
+/// relative to the first line (which the caller already trimmed). This is
+/// what makes the later [`reindent`] idempotent.
 ///
-/// Lines that are entirely whitespace are ignored when computing the
-/// common indent (and emitted empty) so they don't force the common
-/// dedent to zero.
+/// All-whitespace lines are ignored when computing the common indent, so
+/// they can't force it to zero.
 fn dedent_continuation(fragment: &str) -> String {
     if !fragment.contains('\n') {
         return fragment.to_string();
@@ -705,7 +659,6 @@ fn dedent_continuation(fragment: &str) -> String {
     let mut lines = fragment.split('\n');
     let first = lines.next().unwrap_or("");
     let rest: Vec<&str> = lines.collect();
-    // Common leading-whitespace width across non-blank continuation lines.
     let common = rest
         .iter()
         .filter(|l| !l.trim().is_empty())

--- a/crates/whisker-fmt/src/source_map.rs
+++ b/crates/whisker-fmt/src/source_map.rs
@@ -37,7 +37,6 @@ impl<'a> SourceMap<'a> {
     /// `proc_macro2::LineColumn`).
     fn offset(&self, line: usize, column: usize) -> Option<usize> {
         let line_start = *self.line_starts.get(line.checked_sub(1)?)?;
-        // `column` counts chars; walk that many chars from line_start.
         let rest = &self.src[line_start..];
         let mut byte = line_start;
         let mut chars = column;
@@ -93,23 +92,18 @@ impl<'a> SourceMap<'a> {
     pub(crate) fn node_extent(&self, start: usize) -> (Option<usize>, usize) {
         let bytes = self.src.as_bytes();
         let len = bytes.len();
-        // Skip the ident: identifier chars (alnum / `_`).
         let mut i = start;
         while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
             i += 1;
         }
-        // Skip whitespace + comments to the next significant byte.
         i = self.skip_trivia(i);
-        // Optional `( … )`.
         if i < len && bytes[i] == b'(' {
             i = self.skip_balanced(i, b'(', b')');
         }
         let after_parens = i;
         i = self.skip_trivia(i);
-        // Optional `{ … }`.
         if i < len && bytes[i] == b'{' {
             let close = self.skip_balanced(i, b'{', b'}');
-            // `close` is just past `}`; the `}` byte is `close - 1`.
             return (Some(close - 1), close);
         }
         (None, after_parens)
@@ -121,7 +115,6 @@ impl<'a> SourceMap<'a> {
         let bytes = self.src.as_bytes();
         let len = bytes.len();
         loop {
-            // whitespace
             while i < len && bytes[i].is_ascii_whitespace() {
                 i += 1;
             }
@@ -230,8 +223,7 @@ impl<'a> SourceMap<'a> {
     pub(crate) fn slice(&self, span: Span) -> Option<&'a str> {
         let start = span.start();
         let end = span.end();
-        // A synthesized/`call_site` span reports (1,0)..(1,0); guard
-        // against that producing an empty (or bogus) slice.
+        // A synthesized/`call_site` span reports (1,0)..(1,0).
         if start.line == 0 {
             return None;
         }
@@ -268,7 +260,6 @@ mod tests {
         let ts: TokenStream = src.parse().unwrap();
         let call: syn::ExprCall = syn::parse2(ts).unwrap();
         let map = SourceMap::new(src);
-        // first (and only) argument is `bar + 1`
         let arg = call.args.first().unwrap();
         assert_eq!(map.slice(arg.span()).unwrap(), "bar + 1");
     }
@@ -284,8 +275,6 @@ mod tests {
 
     #[test]
     fn slices_multiline_expr_verbatim() {
-        // A user expression that spans lines should come back exactly
-        // as written (this is what preserves the user's formatting).
         let src = "a\n    + b\n    + c";
         let ts: TokenStream = src.parse().unwrap();
         let expr: Expr = syn::parse2(ts).unwrap();

--- a/crates/whisker-fmt/tests/integration.rs
+++ b/crates/whisker-fmt/tests/integration.rs
@@ -24,9 +24,7 @@ fn full_pipeline_formats_rust_and_macro() {
         "fn   ui()->Element{ render!{view(style:\"x\",class:\"y\"){text(value:\"hi\")}} }\n";
     let out = format_source(messy, &opts(4, 100)).expect("format_source");
 
-    // rustfmt normalized the fn signature …
     assert!(out.contains("fn ui() -> Element {"), "rust pass:\n{out}");
-    // … and the macro body got reformatted onto its own indented lines.
     assert!(out.contains("    render! {"), "macro indent:\n{out}");
     assert!(
         out.contains("        view(style: \"x\", class: \"y\") {"),
@@ -58,10 +56,8 @@ fn check_reports_diff_then_clean() {
         return;
     }
     let messy = "fn ui()->Element{render!{view(style:\"x\")}}\n";
-    // First check: not formatted → Some(diff).
     let diff = check_source(messy, &opts(4, 100)).unwrap();
     assert!(diff.is_some(), "expected a diff for messy input");
-    // After formatting, check is clean.
     let formatted = format_source(messy, &opts(4, 100)).unwrap();
     let clean = check_source(&formatted, &opts(4, 100)).unwrap();
     assert!(
@@ -77,8 +73,6 @@ fn formats_embedded_format_macro_expr() {
     if !rustfmt_available() {
         return;
     }
-    // The kwarg value is a `format!` call with a missing comma-space:
-    // rustfmt should normalize it.
     let src =
         "fn ui() -> Element {\n    render! { text(value: format!(\"count: {}\",c.get())) }\n}\n";
     let out = format_source(src, &opts(4, 100)).unwrap();
@@ -93,14 +87,12 @@ fn long_kwarg_value_wraps_at_max_width() {
     if !rustfmt_available() {
         return;
     }
-    // A long call expression as a kwarg value should be wrapped by
-    // rustfmt onto multiple lines.
     let long = "some_function_with_a_fairly_long_name(argument_one, argument_two, argument_three, argument_four)";
     let src = format!("fn ui() -> Element {{\n    render! {{ text(value: {long}) }}\n}}\n");
     let narrow = format_source(&src, &opts(4, 40)).unwrap();
     let wide = format_source(&src, &opts(4, 200)).unwrap();
-    // Narrow max_width forces the expr to wrap (more body lines); wide
-    // keeps it on one line — proving rustfmt.toml/max_width flows in.
+    // Narrow max_width must wrap the expr where wide keeps it inline,
+    // proving rustfmt.toml's max_width reaches the embedded-expr pass.
     assert!(
         narrow.matches('\n').count() > wide.matches('\n').count(),
         "narrow max_width should wrap the embedded expr more than wide:\n--narrow--\n{narrow}\n--wide--\n{wide}"
@@ -112,14 +104,10 @@ fn multi_statement_closure_handler_reindented() {
     if !rustfmt_available() {
         return;
     }
-    // A multi-statement closure handler should be rustfmt-formatted and
-    // re-indented under the kwarg column in the macro body.
     let src = "fn ui() -> Element {\n    render! { view(on_tap: move |_| { let x=1;do_thing(x); }) }\n}\n";
     let out = format_source(src, &opts(4, 100)).unwrap();
-    // rustfmt splits the two statements onto their own lines …
     assert!(out.contains("let x = 1;"), "statement formatted:\n{out}");
     assert!(out.contains("do_thing(x);"), "statement formatted:\n{out}");
-    // … and they sit indented inside the macro body (not at col 0).
     assert!(
         out.contains("\n            let x = 1;") || out.contains("\n                let x = 1;"),
         "closure body re-indented into the macro:\n{out}"
@@ -131,8 +119,8 @@ fn comment_inside_expr_preserved() {
     if !rustfmt_available() {
         return;
     }
-    // A block comment INSIDE the expr must survive — proving we format
-    // the SOURCE SLICE, not the (comment-stripped) AST.
+    // A comment inside the expr only survives if the SOURCE SLICE is
+    // formatted rather than the comment-stripped AST.
     let src = "fn ui() -> Element {\n    render! { text(value: foo(/* keep me */ x)) }\n}\n";
     let out = format_source(src, &opts(4, 100)).unwrap();
     assert!(
@@ -160,11 +148,8 @@ fn tab_spaces_option_changes_output() {
     if !rustfmt_available() {
         return;
     }
-    // Proves the layout flows from FmtOptions, not a hardcoded value.
-    // NOTE: rustfmt itself defaults to 4-space indent for the *Rust*
-    // part regardless of `opts.tab_spaces` (it reads rustfmt.toml, not
-    // our opts), so we assert on the MACRO-BODY indentation, which the
-    // whisker pretty-printer controls via `opts.tab_spaces`.
+    // rustfmt indents the *Rust* part from rustfmt.toml, not from
+    // `opts`, so only the MACRO-BODY indentation reflects `tab_spaces`.
     let src =
         "fn ui() -> Element {\n    render! { view(style: \"x\") { text(value: \"hi\") } }\n}\n";
     let four = format_source(src, &opts(4, 100)).unwrap();
@@ -177,11 +162,9 @@ fn full_pipeline_nested_css_in_render_reformats() {
     if !rustfmt_available() {
         return;
     }
-    // The real rustfmt pass runs FIRST (normalizing the `fn` signature
-    // and the macro's own opening line), then our macro pass must still
-    // reach into the nested `css!(...)` kwarg value — exercising the
-    // full pipeline's embedded-expr batching (`ExprFormatter`) alongside
-    // the nested-macro recursion, not just the rustfmt-free core.
+    // The macro pass must still reach into the nested `css!(...)` kwarg
+    // after the real rustfmt pass has run over the file — exercising
+    // `ExprFormatter` batching, not just the rustfmt-free core.
     let messy = "fn   ui( )->Element{render!{view(style:css!(flex_grow:1.0,background_color:BG)){text(value:\"hi\")}}}\n";
     let out = format_source(messy, &opts(4, 100)).unwrap();
     assert!(out.contains("fn ui() -> Element {"), "rust pass:\n{out}");
@@ -211,11 +194,8 @@ fn full_pipeline_composite_podcast_like_tree() {
     if !rustfmt_available() {
         return;
     }
-    // A shape close to the real `examples/podcast` app: a wide nested
-    // css!, a nested routes! with a Stack of Routes, and plain
-    // zero-kwarg user-component children — through the FULL pipeline
-    // (real rustfmt + our macro pass), checked for both idempotency and
-    // the max_width budget on every line.
+    // A shape close to the real `examples/podcast` app, through the FULL
+    // pipeline, checked for idempotency and the max_width budget.
     let messy = "fn app()->Element{render!{view(style:css!(flex_grow:1.0,width:vw(100),height:vh(100),background_color:BG,display:Display::Flex)){Router(routes:routes!{Stack{Route(path:\"\",component:Home)Route(path:\"detail/:id\",component:Detail)}}){Outlet{}SwipeBack{}}}}}\n";
     let once = format_source(messy, &opts(4, 100)).unwrap();
     let twice = format_source(&once, &opts(4, 100)).unwrap();

--- a/crates/whisker-macro-syntax/src/css.rs
+++ b/crates/whisker-macro-syntax/src/css.rs
@@ -27,10 +27,8 @@ impl Parse for CssInput {
     fn parse(input: ParseStream) -> SynResult<Self> {
         let mut kwargs = Vec::new();
         while !input.is_empty() {
-            // Bail out if the next token isn't an ident — RA may
-            // inject other sentinels we don't want to chase. The
-            // already-collected kwargs still produce a useful
-            // expansion.
+            // RA injects sentinels that aren't idents; stopping here
+            // still leaves the collected kwargs to expand.
             if !input.peek(Ident) {
                 break;
             }
@@ -38,13 +36,11 @@ impl Parse for CssInput {
 
             let value = if input.peek(Token![:]) {
                 let _: Token![:] = input.parse()?;
-                // Try to parse the value expression. If the user is
-                // mid-typing and the parse fails, fall through with
-                // `None`; the emitter uses `()` so the method-call
-                // shape survives for RA's completion.
+                // A failed parse (mid-typing) falls through as `None`;
+                // the emitter uses `()` so the method-call shape
+                // survives for RA's completion.
                 input.parse::<Expr>().ok()
             } else {
-                // No `:` yet — cursor sits right after the ident.
                 None
             };
 
@@ -53,9 +49,8 @@ impl Parse for CssInput {
             if input.peek(Token![,]) {
                 let _: Token![,] = input.parse()?;
             } else {
-                // No comma, but the stream might still have trailing
-                // tokens (e.g. an unfinished partial after the last
-                // kwarg). Drain them so the macro doesn't error out.
+                // Drain any trailing tokens (an unfinished partial
+                // after the last kwarg) so the macro doesn't error.
                 while !input.is_empty() {
                     let _: proc_macro2::TokenTree = input.parse()?;
                 }

--- a/crates/whisker-macro-syntax/src/lib.rs
+++ b/crates/whisker-macro-syntax/src/lib.rs
@@ -7,10 +7,10 @@
 //! reformat them.
 //!
 //! The codegen side (the `to_tokens` lowering) lives in
-//! `whisker-macros`. Because these types are now defined here, the
-//! orphan rule forbids `whisker-macros` from adding *inherent* methods
-//! to them; the lowering is expressed there as free functions over
-//! `&Root` / `&Node` / … (see `whisker-macros/src/render.rs`).
+//! `whisker-macros`. The orphan rule forbids it from adding *inherent*
+//! methods to these types, so the lowering is expressed there as free
+//! functions over `&Root` / `&Node` / … (see
+//! `whisker-macros/src/render.rs`).
 //!
 //! Spans are retained throughout the AST (every ident / expr carries
 //! its `proc_macro2::Span`) so the formatter can recover source slices

--- a/crates/whisker-macro-syntax/src/render.rs
+++ b/crates/whisker-macro-syntax/src/render.rs
@@ -10,8 +10,7 @@
 //!
 //! Each `node` is classified by its leading ident:
 //!
-//! - Built-in tag (`view`, `page`, `text`, `raw_text`,
-//!   `scroll_view`) → [`Node::Element`].
+//! - Built-in tag (see [`is_builtin_tag`]) → [`Node::Element`].
 //! - `children()` (lowercase ident + empty parens, no block) →
 //!   [`Node::ChildrenSlot`].
 //! - Anything else → user `#[component]` invocation →
@@ -20,10 +19,9 @@
 //! ## Children-block restriction
 //!
 //! Every item in a `{ … }` children block MUST be node-shaped
-//! (`IDENT(kwargs?) { … }?`). Bare string literals and bare
-//! `{expr}` blocks are rejected with a hard parser error (see the
-//! comment in [`Node`]'s `Parse` impl for why — it keeps the block on
-//! rust-analyzer's completion happy-path).
+//! (`IDENT(kwargs?) { … }?`). Bare string literals and bare `{expr}`
+//! blocks are rejected with a hard parser error, which keeps the block
+//! on rust-analyzer's completion happy-path.
 
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{
@@ -90,10 +88,9 @@ pub struct Kwarg {
 
 impl Parse for Node {
     fn parse(input: ParseStream) -> Result<Self> {
-        // Every node starts with an ident. Reject anything else at
-        // this position with a targeted error message — that's the
-        // only way to give a useful hint when the user writes bare
-        // `"hi"` or `{ count }` as a child.
+        // Every node starts with an ident. A targeted error at this
+        // position is the only way to give a useful hint when the user
+        // writes bare `"hi"` or `{ count }` as a child.
         if input.peek(LitStr) {
             let lit: LitStr = input.parse()?;
             return Err(syn::Error::new(
@@ -103,8 +100,7 @@ impl Parse for Node {
             ));
         }
         if input.peek(token::Brace) {
-            // Take the span from the brace itself for a clean
-            // arrow in the diagnostic.
+            // The brace's own span gives a clean diagnostic arrow.
             let body;
             let _ = braced!(body in input);
             let _ = body; // discard contents — we're erroring out
@@ -116,29 +112,22 @@ impl Parse for Node {
 
         let tag: Ident = input.parse()?;
 
-        // Special-case the `children()` slot before the regular
-        // kwarg path runs. Shape requirements:
-        //   - ident `children`
-        //   - immediately followed by an EMPTY paren group `()`
-        //   - no `{ … }` block after it
-        // Anything else (`children(arg)`, `children { … }`, bare
-        // `children`) falls through to the standard tag path.
+        // The `children()` slot requires ident `children`, an empty
+        // `()` immediately after, and no `{ … }` block. Anything else
+        // (`children(arg)`, `children { … }`, bare `children`) falls
+        // through to the standard tag path.
         if tag == "children" && input.peek(token::Paren) {
-            // Speculative parse of the paren body — we only commit
-            // to the slot interpretation if the body is empty AND
-            // no `{}` block follows.
+            // Speculative: commit to the slot interpretation only if
+            // the body is empty AND no `{}` block follows.
             let fork = input.fork();
             let body;
             parenthesized!(body in fork);
             if body.is_empty() && !fork.peek(token::Brace) {
-                // Consume the same tokens off the real input cursor
-                // now that we've decided.
                 let consume;
                 parenthesized!(consume in input);
                 debug_assert!(consume.is_empty());
                 return Ok(Node::ChildrenSlot { span: tag.span() });
             }
-            // Not a slot — fall through to the regular tag path.
         }
 
         let mut kwargs = Vec::new();
@@ -146,9 +135,7 @@ impl Parse for Node {
             let body;
             parenthesized!(body in input);
             while !body.is_empty() {
-                // `Ident::peek_any` / `Ident::parse_any` admits
-                // raw-style identifiers AND Rust keywords (needed for
-                // the `ref:` kwarg).
+                // `parse_any` admits Rust keywords, needed for `ref:`.
                 if !body.peek(syn::Ident::peek_any) {
                     return Err(body.error(
                         "kwargs must be `name: expr` — positional arguments \
@@ -160,9 +147,8 @@ impl Parse for Node {
                     body.parse::<Token![:]>()?;
                     (body.parse::<Expr>()?, false)
                 } else {
-                    // Partial — synthesize `()` as a placeholder so
-                    // the emitter can still place the method-name
-                    // token at the user's source span.
+                    // A `()` placeholder lets the emitter still put the
+                    // method-name token at the user's source span.
                     let placeholder: Expr = syn::parse_quote_spanned!(name.span()=> ());
                     (placeholder, true)
                 };

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -16,21 +16,16 @@
 //!    module — that's what render! calls and what RA surfaces in
 //!    identifier completion.
 //!
-//! Why hand-roll the builder instead of `#[derive(TypedBuilder)]`:
-//! typed-builder generates per-field type-state markers
-//! (`<Name>PropsBuilder_Error_Missing_required_field_<field>` etc.)
-//! that, while marked `pub`, are pulled into RA's auto-import
-//! completion at the user's call site as noise even when nested in a
-//! private module. The hand-rolled builder emits exactly two types:
-//! the `Props` struct and one builder struct. Required-field validation
-//! moves from compile-time (typed-builder's type-state) to runtime
-//! (`.expect(...)` at `.build()`); the panic fires at component-mount
-//! time with a clear "required field `xxx` was not set" message.
+//! The builder is hand-rolled rather than `#[derive(TypedBuilder)]`:
+//! typed-builder's per-field type-state markers
+//! (`<Name>PropsBuilder_Error_Missing_required_field_<field>` etc.) are
+//! `pub`, so RA pulls them into auto-import completion at the user's
+//! call site even from a private module. The cost is that required-field
+//! validation is a runtime `.expect(...)` at `.build()` instead of a
+//! compile error.
 //!
-//! The function signature change (positional args → single Props arg)
-//! deliberately breaks the old `xxx(arg1, arg2)` calling convention:
-//! user components must be invoked through `render!`'s
-//! `XxxName(kwarg: value)` syntax, which expands to
+//! Components take a single Props arg, so they can only be invoked
+//! through `render!`'s `XxxName(kwarg: value)` syntax, which expands to
 //! `XxxName(XxxProps::builder().kwarg(value).build())`.
 
 use proc_macro2::TokenStream as TokenStream2;
@@ -52,21 +47,16 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
     let output = &sig.output;
     let generics = &sig.generics;
 
-    // Generic params split:
-    //   `<T: Bound, U>` → `<T: Bound, U>` (impl) + `<T, U>` (ty)
-    //
-    // We use both: the function and Props struct carry the full
-    // bounds in declaration position, and the turbofish on the
-    // `as *const ()` cast inside the body needs the type-only form
-    // so the fn pointer monomorphizes correctly.
+    // Both forms are needed: the fn and Props struct carry the full
+    // bounds in declaration position, while the turbofish on the
+    // `as *const ()` cast needs the type-only form so the fn pointer
+    // monomorphizes correctly.
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let ty_generics_for_turbofish = ty_generics_to_turbofish(generics);
 
-    // Collect the names of the fn's generic *type* params so
-    // `builder_annotation` can recognise a prop whose type is a bare
-    // generic param (`value: T`) and skip `setter(into)` — `Into<T>`
-    // with an unconstrained `T` blows up call-site inference (the
-    // compiler can't pick a concrete `T` from `From<i32>` candidates).
+    // A prop whose type is a bare generic param (`value: T`) must skip
+    // `setter(into)`: `Into<T>` with an unconstrained `T` blows up
+    // call-site inference.
     let generic_type_params: Vec<Ident> = generics
         .params
         .iter()
@@ -76,10 +66,6 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         })
         .collect();
 
-    // Walk the parameter list. For each `Typed` arg, collect a
-    // `Prop` (binding name + type + classification) so the emission
-    // step can generate per-field tokens for the Props struct, the
-    // Builder struct, the setters, and the `.build()` body.
     let mut props: Vec<Prop> = Vec::new();
     for arg in &sig.inputs {
         let pat_type = match arg {
@@ -110,11 +96,9 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
             Err(e) => return e.to_compile_error(),
         };
 
-        // Strip the param's `#[prop(...)]` attribute from forwarding
-        // attrs — it's a `#[component]` directive, not something the
-        // emitted Props struct should carry forward. Other attrs
-        // (`#[allow(...)]`, doc comments) ride along on the Props
-        // field unchanged.
+        // `#[prop(...)]` is a `#[component]` directive, not something
+        // the Props struct carries forward. Other attrs
+        // (`#[allow(...)]`, doc comments) ride along unchanged.
         let other_attrs: Vec<syn::Attribute> = pat_type
             .attrs
             .iter()
@@ -131,7 +115,6 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
     }
     let prop_idents: Vec<Ident> = props.iter().map(|p| p.ident.clone()).collect();
 
-    // ---- Generate per-field tokens for the Props struct + Builder ----
     let props_fields: Vec<TokenStream2> = props.iter().map(prop_struct_field).collect();
     let builder_fields: Vec<TokenStream2> = props.iter().map(prop_builder_field).collect();
     let builder_init: Vec<TokenStream2> = props.iter().map(prop_builder_init).collect();
@@ -140,8 +123,8 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
 
     let props_name = props_struct_name(fn_name);
 
-    // Generate the destructure + capture + re-clone pattern that the
-    // existing remount machinery expects:
+    // The destructure + capture + re-clone pattern the remount
+    // machinery expects:
     //
     //   let XxxProps { a, b, c } = __props;
     //   let __whisker_prop_a = a;
@@ -169,16 +152,11 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         })
         .collect();
 
-    // Force the subsecond-dispatched inner closure to capture EVERY
-    // prop, not just the ones `#block` happens to reference. A `move`
-    // closure captures each path it mentions by value, so touching
-    // all props here pins the closure's environment layout to the
-    // props signature alone. Without this, an edit that merely
-    // *starts using* a previously-unused prop changes the capture
-    // set — and a hot-patched body would then read the old (smaller)
-    // environment through the new layout: garbage props / UB. With
-    // it, the layout moves only when the props signature moves,
-    // which is exactly what `__whisker_props_hash` below detects.
+    // Touching every prop pins the subsecond-dispatched closure's
+    // captured-environment layout to the props signature alone.
+    // Without it, an edit that merely *starts using* a previously-unused
+    // prop changes the capture set, and the hot-patched body then reads
+    // the old, smaller environment through the new layout: UB.
     let force_capture = if prop_idents.is_empty() {
         quote! {}
     } else {
@@ -188,18 +166,14 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         }
     };
 
-    // Layout hash: FNV-1a over the props signature tokens (ident +
-    // type, declaration order) — the compile-time part of what
-    // determines the inner closure's captured-environment layout
-    // given the forced capture above. The generated
-    // `__whisker_props_hash` fn additionally folds in each prop
-    // type's `size_of`/`align_of` AT ITS OWN BUILD's notion of the
-    // type, so a change to a prop type's *definition* (fields added
-    // to a struct the signature merely names) also shifts the value.
-    // Read through subsecond dispatch at remount time, so the
-    // runtime can compare "layout this site's stored closure was
-    // built for" against "layout the freshly patched code expects"
-    // and refuse the in-place remount on mismatch.
+    // Layout hash: FNV-1a over the props signature tokens, the
+    // compile-time part of the closure's captured-environment layout.
+    // The generated `__whisker_props_hash` also folds in each prop
+    // type's `size_of`/`align_of` AT ITS OWN BUILD, so a change to a
+    // prop type's *definition* shifts the value too. Read through
+    // subsecond dispatch at remount time so the runtime can refuse an
+    // in-place remount when the stored closure's layout no longer
+    // matches what the patched code expects.
     let props_sig = props
         .iter()
         .map(|p| {
@@ -217,65 +191,43 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         quote! { __whisker_props_hash :: < #(#ty_generics_for_turbofish),* > }
     };
 
-    // `<fn>` for the `as *const ()` cast inside the body.
-    //
-    // Non-generic case: bare `fn_name as *const ()` works — there's
-    //   only one monomorphization, so the fn ptr is unambiguous.
-    // Generic case: must turbofish: `fn_name::<T, U> as *const ()`
-    //   so we cast the *current monomorphization*. Each `T` =
-    //   different `*const ()` value, which is what we want — the
-    //   per-component remount registry keys on it.
+    // A generic fn must be turbofished so the cast picks the CURRENT
+    // monomorphization: each `T` yields a distinct `*const ()`, which
+    // is what the per-component remount registry keys on.
     let fn_ptr_expr = if ty_generics_for_turbofish.is_empty() {
         quote! { #fn_name as *const () }
     } else {
         quote! { #fn_name :: < #(#ty_generics_for_turbofish),* > as *const () }
     };
 
-    // Props struct + hand-rolled Builder live inside a PRIVATE
-    // module so the builder type's name doesn't surface as
-    // identifier-completion noise at the user's call sites. Only
-    // `XxxProps` is re-exported outward (doc-hidden); the builder
-    // is reached via the `.builder()` method chain and never needs
-    // to be in scope by name.
-    //
-    // Generics + where clause carry through from the user's fn so
-    // a `#[component] fn xxx<T>(value: T)` gets a `XxxProps<T>` and
-    // a `XxxPropsBuilder<T>`.
+    // Props + Builder live inside a PRIVATE module so the builder
+    // type's name isn't identifier-completion noise at the user's call
+    // sites. Only `XxxProps` is re-exported (doc-hidden); the builder
+    // is reached through `.builder()` and never needs to be in scope.
     let internal_mod = format_ident!("__{}_props_internal", fn_name);
     let builder_name = format_ident!("{}Builder", props_name);
     let props_struct = quote! {
-        // No `#vis` on the module — visibility is deliberately
-        // tighter than the surrounding fn so the builder type
-        // stays unreachable as a bare identifier from outside.
+        // No `#vis`: the module is deliberately tighter than the
+        // surrounding fn so the builder stays unreachable by name.
         #[doc(hidden)]
         mod #internal_mod {
-            // Pull in everything from the outer scope so prop types
-            // referenced in fields (`Children`, user types, etc.)
-            // resolve.
+            // Prop types referenced in fields must resolve here.
             use super::*;
 
             pub struct #props_name #impl_generics #where_clause {
                 #(#props_fields),*
             }
 
-            // Builder: every field becomes `Option<T>` (or, for
-            // already-`Option<T>` props, `Option<Option<T>>`) so we
-            // can tell "user hasn't set this" from "user set it to
-            // None". `.build()` collapses each Option back into the
-            // field's declared type, with the appropriate
-            // default / panic-on-missing for required fields.
+            // Every builder field becomes `Option<T>` (or
+            // `Option<Option<T>>` for an already-`Option<T>` prop) so
+            // "not set" is distinguishable from "set to None".
             //
-            // The struct stays `pub` (with `#[doc(hidden)]`) because
-            // a `pub` struct's `pub fn` methods are only callable
-            // from outside if the struct itself is reachable. A
-            // truly-private builder breaks `XxxProps::builder()
-            // .setter(…).build()` from outside the mod — Rust's
-            // method-resolution sees the methods as private when
-            // the type is private, even though the value is held
-            // by the caller. So the builder's name is necessarily
-            // visible at the user's call site; `#[doc(hidden)]` is
-            // the best signal we can give RA. Newer RA versions
-            // honour it for auto-import filtering.
+            // The struct must stay `pub`: a private type's `pub fn`
+            // methods are unreachable from outside the module even when
+            // the caller holds the value, which would break
+            // `XxxProps::builder().setter(…).build()`. Its name is
+            // therefore visible at the call site, and `#[doc(hidden)]`
+            // is the only signal RA's auto-import filter can act on.
             #[doc(hidden)]
             pub struct #builder_name #impl_generics #where_clause {
                 #(#builder_fields),*
@@ -307,44 +259,30 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         #vis use #internal_mod::#props_name;
     };
 
-    // PascalCase alias is the user-facing call-site name. Visible
-    // (NOT doc-hidden) because this is the canonical name in
-    // render! syntax — surfacing it in completion is the whole
-    // point. `non_snake_case` opt-out for the fn-as-PascalCase
-    // alias.
-    // `props_name` is `<PascalCase fn>Props`. Strip the suffix
-    // exactly once to recover the alias name — `trim_end_matches`
-    // is the wrong tool here because it greedily strips repeats
-    // (`TwoPropsProps` → `Two`, dropping the user's actual name).
+    // The PascalCase alias is the canonical render! call-site name, so
+    // it stays visible (NOT doc-hidden) for completion.
+    //
+    // Strip the `Props` suffix exactly once: `trim_end_matches` would
+    // greedily strip repeats (`TwoPropsProps` → `Two`).
     let props_name_str = props_name.to_string();
     let alias_str = props_name_str
         .strip_suffix("Props")
         .unwrap_or(&props_name_str);
     let fn_name_str = fn_name.to_string();
 
-    // Rewritten function: same signature except parameters are
-    // collapsed into a single `__props: XxxProps<...>` arg. Body
-    // destructures and runs the existing remount machinery.
-    //
-    // The fn lives inside a PRIVATE inner module so its
-    // snake_case name (`art_tile`) doesn't pollute outer-scope
-    // completion candidates. Only the PascalCase alias (declared
-    // below) re-exports it outward. `#[doc(hidden)]` is
-    // redundant given the private module, but kept as belt-and-
-    // suspenders for tools that filter by doc-attribute.
+    // The rewritten fn lives inside a PRIVATE inner module so its
+    // snake_case name doesn't pollute outer-scope completion. Only the
+    // PascalCase alias below re-exports it outward.
     let inner_mod = format_ident!("__{}_inner", fn_name);
     let new_fn = quote! {
         #[doc(hidden)]
         mod #inner_mod {
             use super::*;
 
-            // Props-layout hash (see the macro-side comment on
-            // `props_sig`). Read through `__hot::call_hash` so a
-            // just-applied patch answers with ITS layout. The
-            // size_of/align_of folds evaluate in whichever build
-            // this fn was compiled into — that's what lets a
-            // prop-type *definition* change (same signature tokens,
-            // different struct fields) shift the patch's value.
+            // Read through `__hot::call_hash` so a just-applied patch
+            // answers with ITS layout: the size_of/align_of folds
+            // evaluate in whichever build this fn was compiled into,
+            // which is what catches a prop-type *definition* change.
             #[doc(hidden)]
             pub fn __whisker_props_hash #impl_generics () -> u64 #where_clause {
                 let mut __h: u64 = #props_hash;
@@ -366,10 +304,10 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
                 let #props_name { #(#prop_idents),* } = __props;
                 #(#captures)*
 
-                // Two-closure layering: the outer closure keeps the
-                // re-clone bookkeeping out of the subsecond-dispatched
-                // inner, which has to live at the user crate's source
-                // position for hot reload to find it.
+                // The outer closure keeps re-clone bookkeeping out of
+                // the subsecond-dispatched inner one, which must sit at
+                // the user crate's source position for hot reload to
+                // find it.
                 let __body: ::std::boxed::Box<
                     dyn ::std::ops::Fn() -> ::whisker::runtime::view::Element + 'static,
                 > = ::std::boxed::Box::new(move || {
@@ -390,20 +328,14 @@ pub fn expand(item: TokenStream2) -> TokenStream2 {
         }
     };
 
-    // PascalCase alias re-exports the fn from the inner module.
-    // This (and only this) is the user-facing call-site name.
+    // `#[component]` must sit at module level: `pub use` only works
+    // there.
     //
-    // `#[component]` is expected at module level (not nested
-    // inside fn bodies) — both because `pub use` only works at
-    // module level and because components benefit from being
-    // visible to their crate's `render!` callers.
-    // Alongside the callable alias (value namespace), expose the same
-    // PascalCase name as a TYPE alias to the Props struct (type
-    // namespace). The two coexist because Rust keeps separate value and
-    // type namespaces, and a single `use crate::Icon` imports the name
-    // from *both* — so `render!` can lower a call to
-    // `Icon(Icon::builder()…build())` using only the component name, and
-    // users never have to import `IconProps` separately.
+    // The PascalCase name is emitted twice — a callable alias in the
+    // value namespace and a type alias to Props in the type namespace.
+    // A single `use crate::Icon` imports both, so `render!` can lower a
+    // call to `Icon(Icon::builder()…build())` from the component name
+    // alone and users never import `IconProps` separately.
     let pascal_alias = if alias_str == fn_name_str {
         quote! {
             #[doc(hidden)]
@@ -439,12 +371,9 @@ struct PropAttr {
     /// `expr` for them.
     default: Option<Expr>,
     /// `#[prop(optional)]` — equivalent to declaring the type as
-    /// `Option<T>` from the caller's perspective. Emits
-    /// `#[builder(default, setter(into, strip_option))]`. Currently
-    /// the macro is conservative and the user is expected to write
-    /// `Option<T>` directly; this attribute is reserved for future
-    /// use (e.g., explicit opt-in to `strip_option` on a wrapper
-    /// type the macro can't auto-detect).
+    /// `Option<T>` from the caller's perspective. User code is expected
+    /// to write `Option<T>` directly; this is reserved for opting into
+    /// the same treatment on a wrapper type the macro can't detect.
     optional: bool,
 }
 
@@ -506,10 +435,10 @@ enum PropKind {
     /// Setter: `pub fn x(self, v: T) -> Self`.
     /// Build:  `self.x.expect(...)`.
     RequiredGeneric,
-    /// `Option<U>` prop. Builder stores `Option<Option<U>>` so we
-    /// can tell "user didn't set it" (outer None) apart from "user
-    /// set it to None" (outer Some, inner None — currently
-    /// unreachable in render! but kept for direct construction).
+    /// `Option<U>` prop. Builder stores `Option<Option<U>>` so "user
+    /// didn't set it" (outer None) is distinguishable from "user set it
+    /// to None" (outer Some, inner None — reachable only via direct
+    /// construction, not render!).
     /// Setter takes the inner `U` (or `impl Into<U>` when U isn't
     /// generic) and wraps to `Some(Some(...))`. Build collapses
     /// the outer `Option` with `.unwrap_or(None)` so missing props
@@ -523,10 +452,8 @@ enum PropKind {
     },
     /// `Children` prop. Builder field is `Option<Children>`. Setter
     /// takes `Children` directly (the type is already a wrapped
-    /// `Rc<dyn Fn>` — there's no useful `Into` story). Build
-    /// defaults a missing children prop to a closure returning
-    /// `View::Empty`, matching the typed-builder behaviour from
-    /// before.
+    /// `Rc<dyn Fn>` — there's no useful `Into` story). Build defaults a
+    /// missing children prop to a closure returning `View::Empty`.
     Children,
     /// `#[prop(default = expr)]`. Behaves like Required for the
     /// setter and like `unwrap_or_else(|| expr)` at build time.
@@ -541,14 +468,11 @@ enum PropKind {
 }
 
 /// Decide the [`PropKind`] for a given type + user `#[prop(...)]`
-/// directive. The precedence (mirrors what `typed_builder` did for us
-/// before):
+/// directive. The precedence:
 ///
 /// 1. `#[prop(default = expr)]` wins regardless of type.
 /// 2. `#[prop(optional)]` on a non-`Option<T>` type → upgrade to
-///    `Optional { inner: T, ... }` so the user can omit. (Currently
-///    user code uses `Option<T>` directly; this branch is reserved
-///    for future opt-in.)
+///    `Optional { inner: T, ... }` so the user can omit.
 /// 3. `Children` (last path segment) → `Children` kind.
 /// 4. `Option<U>` (last path segment) → `Optional { inner: U, ... }`.
 /// 5. Bare generic param → `RequiredGeneric`.
@@ -569,10 +493,8 @@ fn classify_prop(ty: &Type, attr: &PropAttr, generic_type_params: &[Ident]) -> P
                 inner_is_generic,
             };
         }
-        // `#[prop(optional)]` on a non-`Option<T>` — wrap the user's
-        // type into an Optional with the same inner so the
-        // setter/build still typecheck. typed-builder's
-        // `strip_option` did the same.
+        // Wrap into an Optional with the same inner so setter/build
+        // still typecheck.
         return PropKind::Optional {
             inner: ty.clone(),
             inner_is_generic: is_generic,
@@ -595,7 +517,7 @@ fn classify_prop(ty: &Type, attr: &PropAttr, generic_type_params: &[Ident]) -> P
 }
 
 /// One field in the public `XxxProps` struct. Types stay exactly as
-/// the user wrote them — Props is the user-visible struct.
+/// the user wrote them.
 fn prop_struct_field(prop: &Prop) -> TokenStream2 {
     let ident = &prop.ident;
     let ty = &prop.ty;
@@ -656,10 +578,8 @@ fn prop_setter_method(prop: &Prop) -> TokenStream2 {
             inner,
             inner_is_generic,
         } => {
-            // Setter takes the inner (unwrapped) T — same surface
-            // typed-builder's `strip_option` gave us. Stored as
-            // `Some(Some(v))` to record both "set" and "set to a
-            // Some-value".
+            // Setter takes the inner (unwrapped) T; stored as
+            // `Some(Some(v))` to record both "set" and "set to Some".
             if *inner_is_generic {
                 quote! {
                     #[allow(unused_mut)]
@@ -721,9 +641,8 @@ fn prop_build_assignment(prop: &Prop) -> TokenStream2 {
             #ident: self.#ident.expect(#missing_msg)
         },
         PropKind::Optional { .. } => quote! {
-            // Outer Option = "did the user call .ident(…)?"
-            // — collapse missing → None so the public `Option<T>`
-            // field is the user's chosen value or None.
+            // Outer Option = "did the user call .ident(…)?" — collapse
+            // missing to None.
             #ident: self.#ident.unwrap_or(::std::option::Option::None)
         },
         PropKind::Children => quote! {
@@ -813,11 +732,9 @@ fn props_struct_name(fn_name: &Ident) -> Ident {
     Ident::new(&camel, fn_name.span())
 }
 
-/// Pull the type-parameter identifiers out of the function generics
-/// so we can build a turbofish for the `as *const ()` cast. Lifetimes
-/// and const generics are skipped (lifetimes aren't part of
-/// turbofish; const generics aren't yet supported on
-/// `#[component]`).
+/// Pull the type-parameter identifiers out of the function generics to
+/// build a turbofish for the `as *const ()` cast. Lifetimes aren't part
+/// of a turbofish; const generics aren't supported on `#[component]`.
 fn ty_generics_to_turbofish(generics: &syn::Generics) -> Vec<TokenStream2> {
     generics
         .params
@@ -836,8 +753,6 @@ fn ty_generics_to_turbofish(generics: &syn::Generics) -> Vec<TokenStream2> {
 mod tests {
     use super::*;
     use syn::parse_quote;
-
-    // -- Naming + helpers ---------------------------------------------------
 
     #[test]
     fn props_struct_name_pascal_case_conversion() {
@@ -884,15 +799,12 @@ mod tests {
         let not_option: Type = parse_quote!(String);
         assert!(option_inner_type(&not_option).is_none());
 
-        // `MyOptional` ends in `al` not `Option`. Not an Option.
         let custom: Type = parse_quote!(MyOptional);
         assert!(option_inner_type(&custom).is_none());
 
-        // `Option` without generic args → not a valid Option<T> for us.
         let bare_option: Type = parse_quote!(Option);
         assert!(option_inner_type(&bare_option).is_none());
 
-        // Non-path type (tuple).
         let tup: Type = parse_quote!((u8, u8));
         assert!(option_inner_type(&tup).is_none());
     }
@@ -914,21 +826,14 @@ mod tests {
         assert!(is_generic_type_param(&parse_quote!(T), &generics));
         assert!(is_generic_type_param(&parse_quote!(U), &generics));
 
-        // `Option<T>` — the outer type is `Option`, not bare T.
         assert!(!is_generic_type_param(&parse_quote!(Option<T>), &generics));
-        // Multi-segment path with same final ident does NOT match.
         assert!(!is_generic_type_param(&parse_quote!(crate::T), &generics));
-        // Concrete non-generic type.
         assert!(!is_generic_type_param(&parse_quote!(String), &generics));
-        // Generic-shaped (T<X>) doesn't match.
         let t_with_args: Type = parse_quote!(T<i32>);
         assert!(!is_generic_type_param(&t_with_args, &generics));
-        // Non-path type (reference) doesn't match.
         let reference: Type = parse_quote!(&'a str);
         assert!(!is_generic_type_param(&reference, &generics));
     }
-
-    // -- #[prop(...)] attribute parser -------------------------------------
 
     #[test]
     fn parse_prop_default_attribute() {
@@ -972,8 +877,6 @@ mod tests {
         assert!(parsed.default.is_none());
         assert!(!parsed.optional);
     }
-
-    // -- classify_prop decision table --------------------------------------
 
     fn classify(ty: Type, attr: PropAttr, generics: &[Ident]) -> PropKind {
         classify_prop(&ty, &attr, generics)
@@ -1028,7 +931,6 @@ mod tests {
     fn classify_children_for_children_type() {
         let k = classify(parse_quote!(Children), PropAttr::default(), &[]);
         assert!(matches!(k, PropKind::Children));
-        // Qualified path also matches.
         let k = classify(parse_quote!(whisker::Children), PropAttr::default(), &[]);
         assert!(matches!(k, PropKind::Children));
     }
@@ -1079,8 +981,6 @@ mod tests {
 
     #[test]
     fn classify_optional_attribute_wraps_non_option_type() {
-        // `#[prop(optional)]` on `String` should treat the field as
-        // Optional<String>.
         let attr = PropAttr {
             optional: true,
             ..PropAttr::default()
@@ -1099,8 +999,6 @@ mod tests {
 
     #[test]
     fn classify_optional_attribute_on_option_uses_inner() {
-        // `#[prop(optional)]` on `Option<String>` extracts the inner
-        // String — same as a plain Option<String>.
         let attr = PropAttr {
             optional: true,
             ..PropAttr::default()
@@ -1108,8 +1006,6 @@ mod tests {
         let k = classify(parse_quote!(Option<String>), attr, &[]);
         assert!(matches!(k, PropKind::Optional { .. }));
     }
-
-    // -- Per-prop emission helpers (struct field / builder field / setter / build assignment) -----
 
     fn make_prop(ident: &str, ty: Type, kind: PropKind) -> Prop {
         Prop {
@@ -1217,9 +1113,7 @@ mod tests {
             },
         );
         let out = prop_setter_method(&p).to_string();
-        // Setter takes the inner String (not Option<String>).
         assert!(out.contains("impl :: std :: convert :: Into < String >"));
-        // Stored as Some(Some(v.into())) — double wrap.
         assert!(out.contains("Option :: Some (:: std :: option :: Option :: Some"));
     }
 
@@ -1302,7 +1196,6 @@ mod tests {
             },
         );
         let out = prop_build_assignment(&p).to_string();
-        // unwrap_or(None) — missing prop becomes None.
         assert!(out.contains("unwrap_or"));
         assert!(out.contains("Option :: None"));
     }
@@ -1331,8 +1224,6 @@ mod tests {
         assert!(out.contains("99"));
     }
 
-    // -- expand() end-to-end shape ----------------------------------------
-
     #[test]
     fn expand_emits_props_struct_and_rewritten_fn() {
         let input: TokenStream2 = quote! {
@@ -1341,13 +1232,11 @@ mod tests {
             }
         };
         let output = expand(input).to_string();
-        // Props struct lives inside the hidden inner mod.
         assert!(output.contains("struct CardProps"));
         assert!(output.contains("struct CardPropsBuilder"));
         assert!(output.contains("fn card"));
         assert!(output.contains("__props : CardProps"));
         assert!(output.contains("CardProps { title }"));
-        // PascalCase alias is emitted.
         assert!(output.contains("use __card_inner :: card as Card"));
     }
 
@@ -1364,16 +1253,13 @@ mod tests {
             output.contains("HeaderProps { }") || output.contains("HeaderProps {}"),
             "no-param destructure should be empty braces; got: {output}"
         );
-        // No setters for a zero-param component, just builder()+build().
         assert!(output.contains("pub fn builder"));
         assert!(output.contains("pub fn build"));
     }
 
     #[test]
     fn expand_does_not_reference_typed_builder() {
-        // Regression: we replaced typed-builder with a hand-rolled
-        // builder. The emission must not reference the old crate
-        // path or its derive macro.
+        // The emission must not reference typed-builder.
         let input: TokenStream2 = quote! {
             fn card(title: String, count: i32) -> Element {
                 render! { view {} }
@@ -1408,8 +1294,6 @@ mod tests {
             }
         };
         let output = expand(input).to_string();
-        // The expansion replaces the body with a compile_error!() —
-        // detect it via the macro path.
         assert!(
             output.contains("compile_error"),
             "method receiver should produce a compile error; got: {output}"
@@ -1429,9 +1313,8 @@ mod tests {
 
     #[test]
     fn expand_props_alias_strips_props_suffix_once() {
-        // Regression test for the `TwoPropsProps -> Two` greedy-trim
-        // bug. The alias derived from `TwoPropsProps` must be
-        // `TwoProps`, not `Two`.
+        // The alias derived from `TwoPropsProps` must be `TwoProps`,
+        // not `Two` — only one `Props` suffix comes off.
         let input: TokenStream2 = quote! {
             fn two_props(title: String, count: i32) -> Element {
                 render! { view {} }
@@ -1446,7 +1329,6 @@ mod tests {
 
     #[test]
     fn expand_forwards_attribute_on_param_to_props_field() {
-        // Non-`#[prop]` attrs ride along on the emitted Props field.
         let input: TokenStream2 = quote! {
             fn card(#[allow(dead_code)] title: String) -> Element {
                 render! { view {} }
@@ -1458,8 +1340,6 @@ mod tests {
             "user attr should appear on the Props field; got: {output}"
         );
     }
-
-    // -- Helper used by classify_* assertions -----------------------------
 
     fn kind_name(k: &PropKind) -> &'static str {
         match k {

--- a/crates/whisker-macros/src/css.rs
+++ b/crates/whisker-macros/src/css.rs
@@ -19,17 +19,12 @@ use whisker_macro_syntax::css::CssInput;
 
 /// Expand `css!(name: value, …)` into `Css::new().name(value).…`.
 ///
-/// Paths resolve against the call site. `Css` itself is taken
-/// straight from the call site's scope — `use whisker::prelude::*`
-/// brings it in. Falling through unqualified keeps the macro usable
-/// from both `whisker` (umbrella) and `whisker-css` standalone
-/// without runtime-aware path detection.
+/// `Css` is taken unqualified from the call site's scope (via
+/// `use whisker::prelude::*`), which keeps the macro usable from both
+/// the `whisker` umbrella and `whisker-css` standalone.
 pub fn expand(input: TokenStream2) -> TokenStream2 {
     let parsed: CssInput = match syn::parse2(input) {
         Ok(p) => p,
-        // On total parse failure, still emit the root `Css::new()`
-        // so the user sees a real type at the cursor instead of a
-        // raw macro error.
         Err(_) => return quote! { Css::new() },
     };
 
@@ -40,9 +35,8 @@ pub fn expand(input: TokenStream2) -> TokenStream2 {
             Some(expr) => quote! { #expr },
             None => quote! { () },
         };
-        // Keep the method-call's identifier span attached to the
-        // user's source span so RA's jump-to-definition / hover
-        // resolve to the right method on `Css`.
+        // Keep the identifier on the user's source span so RA's
+        // jump-to-definition / hover resolve to the right `Css` method.
         chain = quote_spanned! {name.span()=> #chain.#name(#value) };
     }
     chain
@@ -84,27 +78,18 @@ mod tests {
 
     #[test]
     fn partial_ident_only_emits_unit_arg() {
-        // Cursor sits right after `back` — no `:` yet. The expansion
-        // still surfaces `.back(())` so RA's method-name completion
-        // fires on the `.back` part.
         let out = expand(quote! { back });
         assert_eq!(norm(out), "Css::new().back(())");
     }
 
     #[test]
     fn partial_ident_with_colon_no_value_emits_unit_arg() {
-        // `color:` with no expression after — common when the user
-        // is about to start typing the value. We still emit a
-        // method call so RA can complete the value position.
         let out = expand(quote! { color: });
         assert_eq!(norm(out), "Css::new().color(())");
     }
 
     #[test]
     fn partial_kwarg_after_complete_ones_keeps_both() {
-        // Earlier complete kwargs survive; the trailing partial
-        // contributes a `.<name>(())` so the user still gets
-        // method-name completion at the cursor.
         let out = expand(quote! { color: red, back });
         assert_eq!(norm(out), "Css::new().color(red).back(())");
     }
@@ -112,15 +97,13 @@ mod tests {
     #[test]
     fn complete_value_with_tuple_passes_through() {
         let out = expand(quote! { padding: (px(8), px(16)) });
-        // Whitespace-normalised; the `:` etc. is fine inside the call.
         assert_eq!(norm(out), "Css::new().padding((px(8),px(16)))");
     }
 
     #[test]
     fn unparseable_value_falls_back_to_unit() {
-        // `color: !` is not a valid expression. The parser bails
-        // on the value and we emit `.color(())` so the call shape
-        // survives for RA.
+        // `color: !` is not a valid expression; the parser bails on the
+        // value and emits `.color(())` so the shape survives for RA.
         let out = expand(quote! { color: ! });
         assert_eq!(norm(out), "Css::new().color(())");
     }

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -65,40 +65,30 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as ItemFn);
     let fn_name = &func.sig.ident;
 
-    // Deterministic hash of the app fn's token stream. Baked into a
-    // generated fn below so the hot-reload runtime can ask "did the
-    // `app()` source change in this patch?" — the host binary and a
-    // patch dylib each carry the hash of the source they were built
-    // from, and the runtime reads the patch's value through the same
-    // subsecond dispatch as the app body itself. FNV-1a over the
-    // token string: stable across compilations of identical tokens
-    // (unlike `DefaultHasher`'s unspecified algorithm), and token-
-    // level means formatting-only edits don't shift it.
+    // Deterministic hash of the app fn's token stream, so the
+    // hot-reload runtime can ask "did the `app()` source change in this
+    // patch?". FNV-1a over the token string: stable across compilations
+    // of identical tokens (unlike `DefaultHasher`), and token-level so
+    // formatting-only edits don't shift it.
     let body_hash = fnv1a64(&quote!(#func).to_string());
 
     let expanded = quote! {
         #func
 
-        // The app fn the runtime invokes every frame. Unconditionally
-        // routes through `whisker::__main_runtime::call_user_app`, which
-        // is `#[inline(always)]` so the wrapper body lands in the user
-        // crate's compilation unit. Whether the wrapper actually
-        // dispatches through `subsecond::call` (hot reload / hot-reload
-        // on) or just invokes `#fn_name()` directly (release) is
-        // decided by `whisker`'s own `hot-reload` feature flag — the
-        // user crate doesn't need a matching feature of its own.
+        // `call_user_app` is `#[inline(always)]` so the wrapper body
+        // lands in the USER crate's compilation unit. Whether it
+        // dispatches through `subsecond::call` or invokes `#fn_name()`
+        // directly is decided by `whisker`'s own `hot-reload` feature,
+        // so the user crate needs no matching feature.
         fn __whisker_app_dispatch() -> ::whisker::runtime::view::Element {
             ::whisker::__main_runtime::call_user_app(#fn_name)
         }
 
-        // Source-hash pair for the full-remount trigger. The
-        // inner fn returns the compile-time hash of the `app` fn's
-        // tokens; the dispatch wrapper routes through
-        // `call_app_hash` (subsecond `call` when hot-reload is on),
-        // so after a patch the runtime reads the *patch dylib's*
-        // hash. A changed value means the user edited `app()` itself
-        // — something no `#[component]` remount can reflect — and
-        // the bootstrap re-runs `app()` from scratch.
+        // Source-hash pair for the full-remount trigger. The dispatch
+        // wrapper routes through `call_app_hash`, so after a patch the
+        // runtime reads the *patch dylib's* hash. A changed value means
+        // the user edited `app()` itself — which no `#[component]`
+        // remount can reflect — and the bootstrap re-runs it.
         #[doc(hidden)]
         fn __whisker_app_body_hash() -> u64 {
             #body_hash
@@ -109,12 +99,9 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
             ::whisker::__main_runtime::call_app_hash(__whisker_app_body_hash)
         }
 
-        // `#[unsafe(no_mangle)]` (not bare `#[no_mangle]`): in edition
-        // 2024 a bare `#[no_mangle]` is a hard error, and this macro
-        // expands in the USER crate's edition. The `#[unsafe(...)]`
-        // attribute spelling was stabilized in Rust 1.82 — below the
-        // workspace MSRV of 1.85 — so it compiles cleanly in both 2021
-        // and 2024 user crates.
+        // `#[unsafe(no_mangle)]`, not bare `#[no_mangle]`: this macro
+        // expands in the USER crate's edition, and a bare `#[no_mangle]`
+        // is a hard error under edition 2024.
         #[unsafe(no_mangle)]
         pub extern "C" fn whisker_app_main(
             engine: *mut ::std::ffi::c_void,
@@ -137,26 +124,21 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
             ::whisker::__main_runtime::tick(engine)
         }
 
-        // Anchor symbol used by Whisker's vendored subsecond fork to
-        // compute the ASLR slide between this dylib's static layout
-        // (cached server-side) and its runtime load address. Both the
-        // host dylib and every patch dylib must export this so
-        // `dlsym(RTLD_DEFAULT, "whisker_aslr_anchor")` resolves
-        // unambiguously inside the user's `.so`.
+        // Anchor symbol the vendored subsecond fork uses to compute
+        // the ASLR slide between this dylib's static layout and its
+        // runtime load address. Both the host dylib and every patch
+        // dylib must export it so
+        // `dlsym(RTLD_DEFAULT, "whisker_aslr_anchor")` resolves inside
+        // the user's `.so`.
         //
-        // Why a unique name instead of `main` (upstream subsecond's
-        // sentinel): on Android, Whisker is loaded via
-        // `System.loadLibrary` into a process whose linker namespace
-        // already contains several `main` symbols
-        // (`app_process64`'s, plus any prior memfd patches), so a
-        // dlsym for `main` returns the wrong one and the slide math
-        // computes garbage. A unique name only exists in the user's
-        // `.so`, so the lookup is collision-free regardless of
-        // namespace order.
+        // A unique name rather than upstream subsecond's `main`
+        // sentinel: on Android the process linker namespace already
+        // holds several `main` symbols (`app_process64`'s, plus prior
+        // memfd patches), so a dlsym for `main` returns the wrong one
+        // and the slide math computes garbage.
         //
-        // The stub never runs — Whisker is JNI-loaded, never executed
-        // as a process entry point. It only needs to exist in the
-        // export list at a known static address.
+        // The stub never runs — it only needs to exist in the export
+        // list at a known static address.
         #[unsafe(no_mangle)]
         pub extern "C" fn whisker_aslr_anchor() -> ::std::ffi::c_int { 0 }
     };
@@ -165,10 +147,10 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// FNV-1a 64-bit over a string. Used for the `#[whisker::main]`
-/// app-body hash and the `#[component]` props-layout hash: must
-/// produce the same value for the same token string in every rustc
-/// process (host fat build AND thin patch build), which rules out
-/// `DefaultHasher` (algorithm unspecified).
+/// app-body hash and the `#[component]` props-layout hash, both of
+/// which must produce the same value for the same token string in every
+/// rustc process (host fat build AND thin patch build) — which rules
+/// out `DefaultHasher`.
 pub(crate) fn fnv1a64(s: &str) -> u64 {
     const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
     const FNV_PRIME: u64 = 0x0000_0100_0000_01B3;
@@ -263,11 +245,10 @@ pub fn css(input: TokenStream) -> TokenStream {
 ///    remount + subsecond hot-reload integration).
 ///
 /// The signature change is deliberate: positional `xxx(a, b)`
-/// invocations no longer compile. User components are now invoked
-/// exclusively through `render!`'s `xxx { a: …, b: … }` syntax,
-/// which the `render!` macro lowers to
-/// `xxx(XxxProps::builder().a(…).b(…).build())`. This unifies the
-/// call-site shape with built-in elements (`view { … }`).
+/// invocations do not compile. User components are invoked exclusively
+/// through `render!`'s `Xxx(a: …, b: …)` syntax, which lowers to
+/// `Xxx(XxxProps::builder().a(…).b(…).build())`. This unifies the
+/// call-site shape with built-in elements (`view(…)`).
 ///
 /// ```ignore
 /// use whisker::prelude::*;
@@ -278,8 +259,8 @@ pub fn css(input: TokenStream) -> TokenStream {
 ///     render! { /* ... */ }
 /// }
 ///
-/// // Call site (always through `render!`):
-/// render! { counter { initial: 0 } }
+/// // Call site (always through `render!`, under the PascalCase alias):
+/// render! { Counter(initial: 0) }
 /// ```
 #[proc_macro_attribute]
 pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -324,8 +305,7 @@ pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 ///
 /// See `crates/whisker-macros/src/module_component.rs` for the
-/// emission details (children props are NOT yet supported; tracked
-/// in follow-ups).
+/// emission details.
 #[proc_macro_attribute]
 pub fn module_component(attr: TokenStream, item: TokenStream) -> TokenStream {
     module_component::expand(attr.into(), item.into()).into()

--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -26,11 +26,10 @@
 //! //  empty body — the macro replaces it.
 //! ```
 //!
-//! Rust's grammar requires a body for top-level `fn` items (no
-//! `extern fn ...;` outside an `extern {}` block), so the
-//! placeholder `{}` is unavoidable. The macro discards whatever
-//! return type and body the user supplies — the auto-generated
-//! body always returns `whisker::runtime::view::Element`.
+//! Rust's grammar requires a body for top-level `fn` items, so the
+//! placeholder `{}` is unavoidable. The macro discards whatever return
+//! type and body the user supplies — the generated body always returns
+//! `whisker::runtime::view::Element`.
 //!
 //! ## Prop classification
 //!
@@ -101,8 +100,6 @@ use syn::{
 };
 
 pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
-    // Attribute payload: a single string literal — the tag name
-    // `lynx_create_fiber_element_by_name` will register against.
     let tag_name: LitStr = match parse2(attr.clone()) {
         Ok(s) => s,
         Err(_) => {
@@ -170,8 +167,6 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
     let builder_name = format_ident!("{}Builder", props_name);
     let internal_mod = format_ident!("__{}_props_internal", fn_name);
 
-    // ----- Per-prop tokens -------------------------------------------
-
     let props_fields: Vec<TokenStream2> = props.iter().map(prop_struct_field).collect();
 
     let builder_fields: Vec<TokenStream2> = props.iter().map(prop_builder_field).collect();
@@ -193,8 +188,6 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
 
     let apply_calls: Vec<TokenStream2> = props.iter().map(prop_apply_call).collect();
 
-    // ----- Drop-unused guard for prop-less elements ------------------
-
     let drop_unused = if props.is_empty() {
         quote! { let _ = props; }
     } else {
@@ -203,15 +196,12 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
 
     let inner_mod = format_ident!("__{}_inner", fn_name);
 
-    // PascalCase alias — same scheme as `#[component]`.
     let pascal_alias_ident = format_ident!("{}", to_pascal_case(&fn_name.to_string()));
     let fn_name_str = fn_name.to_string();
-    // Alongside the value-namespace `pub use` we emit a type alias of
-    // the same name pointing at the Props struct. Rust keeps value and
-    // type namespaces separate, so `XZeroProps` resolves to the fn in
-    // call position and to `XZeroPropsProps` in type position — letting
-    // `render!` write `Alias::builder()` with only the alias imported,
-    // no separate `…Props` import. See `#[component]` for the twin.
+    // The alias name is emitted into both namespaces — a `pub use` for
+    // the fn and a type alias for Props — so `render!` can write
+    // `Alias::builder()` with only the alias imported. Same scheme as
+    // `#[component]`.
     let alias_emission = if pascal_alias_ident == fn_name_str.as_str() {
         quote! {
             #[doc(hidden)]
@@ -230,12 +220,9 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
     };
 
     // Every platform component implicitly carries a `__ref:
-    // Option<ElementRef>` Props field. `render!` recognises
-    // `ref: <expr>` at the call site and routes it to the
-    // `.with_ref(expr)` setter the macro emits below. Inside the
-    // body we `bind(__handle)` the ref after creating the element,
-    // so the `ElementRef` reaches a live `Element` handle as soon
-    // as the call site hits this code path.
+    // Option<ElementRef>` Props field. `render!` routes a call-site
+    // `ref: <expr>` to the `.with_ref(expr)` setter emitted below; the
+    // generated body then binds it to the freshly-created handle.
 
     quote! {
         #[doc(hidden)]
@@ -299,27 +286,20 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
             #(#attrs)*
             pub fn #fn_name(props: #props_name) -> ::whisker::runtime::view::Element {
                 #drop_unused
-                // Tag string is namespaced by the cargo crate name to
-                // avoid collisions between elements from independent
-                // module packages. Two unrelated crates that both
-                // declare `#[whisker::module_component("Video")]` end up
-                // with distinct platform-side registrations
-                // (`crate-a:Video` vs `crate-b:Video`). The platform
-                // SwiftPM plugin / KSP processor prepends the same
-                // namespace when emitting the matching
-                // `LynxComponentRegistry.registerUI` / `addBehavior`
-                // call, so the lookup matches end-to-end.
+                // Namespacing the tag by cargo crate name keeps two
+                // unrelated crates declaring the same tag from
+                // colliding. The SwiftPM plugin / KSP processor
+                // prepends the same namespace when emitting the
+                // matching registration, so the lookup matches
+                // end-to-end.
                 let __handle = ::whisker::runtime::view::create_element_by_name(
                     concat!(env!("CARGO_PKG_NAME"), ":", #tag_name)
                 );
                 #(#apply_calls)*
-                // Bind the user-supplied `ElementRef` (if any) to the
-                // freshly-created handle so `ref.invoke("play", ...)`
-                // calls route through the C bridge. The matching
-                // `on_cleanup(...)` clears the binding on unmount so
-                // post-unmount calls surface as `RefError::NotBound`
-                // rather than dispatching against a recycled
-                // `Element` ID.
+                // The matching `on_cleanup` clears the binding on
+                // unmount so post-unmount calls surface as
+                // `RefError::NotBound` rather than dispatching against
+                // a recycled `Element` ID.
                 if let ::std::option::Option::Some(__r) = props.__ref {
                     __r.__bind(__handle);
                     ::whisker::on_cleanup(move || __r.__unbind());
@@ -331,8 +311,6 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
         #alias_emission
     }
 }
-
-// ----- Prop classification ------------------------------------------------
 
 struct Prop {
     ident: Ident,
@@ -369,22 +347,18 @@ enum PropKind {
 }
 
 /// Event names Lynx's native gesture / animation pipeline claims for
-/// itself. A `#[whisker::module_component]` that dispatches a custom
-/// event under one of these names is **silently swallowed** — Lynx's
-/// built-in gesture recognition consumes the name before it reaches the
-/// custom-event path, so the `on_<event>` handler never fires (no
-/// error, no log). It cost an evaluation project hours to find, so the
-/// macro now rejects it at compile time.
+/// itself, rejected at compile time. A custom event dispatched under
+/// one of these is **silently swallowed** — Lynx's built-in gesture
+/// recognition consumes the name before it reaches the custom-event
+/// path, so the `on_<event>` handler never fires, with no error or log.
 ///
 /// The list mirrors Lynx's touch + animation event families (see
 /// `whisker_runtime::event` and <https://lynxjs.org/api/lynx-api/event/event.html>).
 /// Both the canonical spelling (`longpress`) and the snake_case form an
-/// `on_<event>` prop would naturally produce (`long_press`) are
-/// reserved, since authors hit the collision either way. Component-level
-/// custom events Lynx does NOT intercept (`scroll`, `change`, …) are
-/// fine — only the gesture/animation names below collide.
+/// `on_<event>` prop produces (`long_press`) are reserved, since
+/// authors hit the collision either way. Component-level custom events
+/// Lynx does NOT intercept (`scroll`, `change`, …) are fine.
 const RESERVED_EVENT_NAMES: &[&str] = &[
-    // TouchEvent family (canonical + snake_case variants).
     "tap",
     "click",
     "longpress",
@@ -397,7 +371,6 @@ const RESERVED_EVENT_NAMES: &[&str] = &[
     "touch_end",
     "touchcancel",
     "touch_cancel",
-    // AnimationEvent family (canonical + snake_case variants).
     "animationstart",
     "animation_start",
     "animationend",
@@ -409,15 +382,13 @@ const RESERVED_EVENT_NAMES: &[&str] = &[
 fn classify(ident: &Ident, ty: &Type) -> syn::Result<PropKind> {
     let name = ident.to_string();
 
-    // Children always wins, regardless of type.
     if name == "children" {
         return Ok(PropKind::Children);
     }
 
-    // Event handler? The `on_<event>` naming convention picks these out.
-    // Payload classification comes from the declared TYPE — `()` means
-    // the payload is ignored; any other type is deserialized from the
-    // event body via `bind_typed` (must be `serde::Deserialize`).
+    // The `on_<event>` naming convention picks out handlers; the
+    // declared TYPE then decides the payload — `()` ignores it, any
+    // other type is deserialized from the event body via `bind_typed`.
     if let Some(event) = name.strip_prefix("on_") {
         if event.is_empty() {
             return Err(syn::Error::new(
@@ -443,26 +414,22 @@ fn classify(ident: &Ident, ty: &Type) -> syn::Result<PropKind> {
         if is_unit_type(ty) {
             return Ok(PropKind::EventNoPayload { event });
         }
-        // Any other type → typed-payload handler. `E` must be
-        // `serde::Deserialize` (enforced at the `bind_typed` call
-        // site); the typed event structs in `whisker::event` and
-        // `WhiskerValue` (raw body) all qualify.
+        // `E` must be `serde::Deserialize`, enforced at the
+        // `bind_typed` call site.
         return Ok(PropKind::EventTyped {
             event,
             payload: ty.clone(),
         });
     }
 
-    // Style prop → `::whisker::Style`. The authored type is ignored
-    // (the macro always emits a `::whisker::Style` field + an
-    // `apply_style` call), so no inner-type extraction is needed.
+    // The authored type of a `style` prop is ignored — always a
+    // `::whisker::Style` field plus an `apply_style` call.
     if name == "style" {
         return Ok(PropKind::Style);
     }
 
-    // Otherwise: an attribute prop. Strip the `Signal<…>` wrapper if
-    // present so the apply_attr turbofish picks the right T (= the
-    // value's ToString-able payload, not the wrapped Signal).
+    // Strip any `Signal<…>` wrapper so the `apply_attr` turbofish picks
+    // the ToString-able payload rather than the wrapped Signal.
     Ok(PropKind::Attr {
         inner: signal_inner(ty).unwrap_or_else(|| ty.clone()),
     })
@@ -491,15 +458,9 @@ fn is_unit_type(ty: &Type) -> bool {
     matches!(ty, Type::Tuple(TypeTuple { elems, .. }) if elems.is_empty())
 }
 
-// ----- Codegen helpers ----------------------------------------------------
-
 fn prop_struct_field(p: &Prop) -> TokenStream2 {
     let i = &p.ident;
     match &p.kind {
-        // The style prop is ALWAYS typed `::whisker::Style` (the same
-        // wrapper built-in elements accept), regardless of the
-        // authored param type — so callers can pass a `Css` builder,
-        // a raw string, or a reactive signal of either directly.
         PropKind::Style => {
             quote! { pub #i: ::whisker::Style }
         }
@@ -544,9 +505,6 @@ fn prop_builder_field(p: &Prop) -> TokenStream2 {
 fn prop_setter(p: &Prop) -> TokenStream2 {
     let i = &p.ident;
     match &p.kind {
-        // Style setter accepts anything `Into<::whisker::Style>` —
-        // `Css`, `&Css`, `String`, `&str`, and reactive signals of
-        // either, exactly like a built-in element's `style(...)`.
         PropKind::Style => {
             quote! {
                 #[allow(unused_mut)]
@@ -567,8 +525,6 @@ fn prop_setter(p: &Prop) -> TokenStream2 {
             }
         }
         PropKind::Children => {
-            // Match the render! macro's UserComponent emission shape:
-            //   .children(::std::rc::Rc::new(move || { … }))
             // So the setter accepts a `Children` directly.
             quote! {
                 #[allow(unused_mut)]

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -5,13 +5,11 @@
 //! codegen AND the `whisker-fmt` formatter can share it. This module
 //! holds only the lowering.
 //!
-//! Because the AST types ([`Root`], [`Node`], …) are now defined in
-//! another crate, the orphan rule forbids adding *inherent* methods to
-//! them here. The lowering is therefore expressed as FREE FUNCTIONS
-//! over `&Root` / `&Node` / `&ElementNode` / `&UserComponentNode`
-//! (`root_to_tokens`, `node_to_tokens`, …). The emitted token streams
-//! are byte-for-byte identical to the previous inherent-method form, so
-//! all existing macro behavior and tests are preserved.
+//! Because the AST types ([`Root`], [`Node`], …) live in another crate,
+//! the orphan rule forbids adding *inherent* methods to them here. The
+//! lowering is therefore expressed as FREE FUNCTIONS over `&Root` /
+//! `&Node` / `&ElementNode` / `&UserComponentNode` (`root_to_tokens`,
+//! `node_to_tokens`, …).
 //!
 //! See `whisker-macro-syntax/src/render.rs` for the grammar.
 
@@ -26,11 +24,9 @@ pub fn expand(input: TokenStream) -> TokenStream {
     match syn::parse2::<Root>(tokens) {
         Ok(root) => root_to_tokens(&root).into(),
         Err(err) => {
-            // Pair the compile_error with a same-typed placeholder
-            // so the surrounding code (`let h: Element = render!
-            // { … };`) keeps type-checking and diagnostics stay
-            // confined to the actual syntax error. Same approach
-            // leptos uses for its `view!` macro.
+            // Pairing the compile_error with a same-typed placeholder
+            // keeps `let h: Element = render! { … };` type-checking, so
+            // diagnostics stay confined to the actual syntax error.
             let err_tokens = err.to_compile_error();
             quote! {
                 {
@@ -62,14 +58,11 @@ fn node_to_tokens_returning_handle(node: &Node) -> TokenStream2 {
     match node {
         Node::Element(el) => element_to_tokens(el),
         Node::UserComponent(u) => user_component_to_tokens(u),
-        // `children()` resolves the surrounding `#[component]`'s
-        // `children: Children` prop by name. The body of a
-        // `#[component]` fn always destructures `children` into
-        // scope when the prop is declared, so this is a plain
-        // local-ident reference — no closure capture, no `move`,
-        // and (crucially) no `Rc::clone` either: `mount_children`
-        // takes `&Children` so the outer `FnMut` body can re-run
-        // (e.g. hot-reload remount) without `cannot move out`.
+        // A plain local-ident reference to the surrounding
+        // `#[component]`'s destructured `children` prop. Deliberately
+        // no `Rc::clone`: `mount_children` takes `&Children` so the
+        // outer `FnMut` body can re-run (hot-reload remount) without
+        // `cannot move out`.
         Node::ChildrenSlot { span } => quote_spanned! {*span=>
             ::whisker::runtime::view::mount_children(&children)
         },
@@ -97,13 +90,12 @@ fn element_to_tokens(el: &ElementNode) -> TokenStream2 {
     let tag_name = tag_ident.to_string();
     let tag_span = tag_ident.span();
     let ctor_ident = format_ident!("__{}_ctor", tag_ident, span = tag_span);
-    // Inline the full `::whisker::__tags::__<tag>_ctor()` path
-    // into the outer `quote!`s below. Storing it into an
-    // intermediate TokenStream and interpolating captures span /
-    // grouping info differently and breaks RA's kwarg completion.
+    // The full `::whisker::__tags::__<tag>_ctor()` path must be inlined
+    // into the outer `quote!`s: interpolating an intermediate
+    // TokenStream captures span / grouping differently and breaks RA's
+    // kwarg completion.
 
-    // One `.kwarg(value)` token group per attr, span-anchored
-    // at the user's kwarg-name source position so RA's
+    // Span-anchored at the user's kwarg-name source position so RA's
     // method-name completion lands on the right token.
     let setter_calls: Vec<TokenStream2> = el
         .kwargs
@@ -111,13 +103,9 @@ fn element_to_tokens(el: &ElementNode) -> TokenStream2 {
         .filter_map(|kw| element_kwarg_to_setter(el, kw))
         .collect();
 
-    // Every partial kwarg routes through the setter chain as a
-    // method call — see the long comment in `element_kwarg_to_setter`.
     let ident_refs: Vec<TokenStream2> = Vec::new();
     let _ = tag_name;
 
-    // Children: each child becomes a `.child({ inner_chain })`
-    // method call on the builder.
     let child_calls: Vec<TokenStream2> = el
         .children
         .iter()
@@ -127,9 +115,8 @@ fn element_to_tokens(el: &ElementNode) -> TokenStream2 {
         })
         .collect();
 
-    // No children AND no ident-refs → bare expression form.
-    // Keeps the chain on RA's happy path for partial-kwarg
-    // completion.
+    // Bare expression form keeps the chain on RA's happy path for
+    // partial-kwarg completion.
     if child_calls.is_empty() && ident_refs.is_empty() {
         return quote! {
             {
@@ -139,10 +126,9 @@ fn element_to_tokens(el: &ElementNode) -> TokenStream2 {
         };
     }
 
-    // Has children or ident-refs → still keep chain inline (no
-    // `let __h = … ; __h` binding around it), but add the
-    // ident-refs in a side block. The chain itself stays
-    // a single expression so RA can thread its receiver type.
+    // The chain must stay a single expression (no `let __h = …; __h`)
+    // so RA can thread its receiver type; ident-refs go in a side
+    // block.
     let ident_refs_block = if ident_refs.is_empty() {
         quote! {}
     } else {
@@ -183,56 +169,37 @@ fn element_kwarg_to_setter(el: &ElementNode, kw: &Kwarg) -> Option<TokenStream2>
     let tag_name = el.tag.to_string();
 
     if name_str == "key" && tag_name != "list" {
-        // `key:` on a direct element is a no-op (reconciliation
-        // hint with no semantic effect outside keyed lists). The
-        // `list` builder has its own typed `key` setter for the
-        // keyed-list key extractor closure, so let it through.
+        // `key:` on a direct element is a no-op outside keyed lists.
+        // `list` has its own typed `key` setter, so let that through.
         return None;
     }
 
     if kw.partial {
-        // ALWAYS emit a method call for partial kwargs. RA
-        // injects a sentinel suffix at the cursor during its
-        // expansion-for-completion pass, so any prefix-match
-        // heuristic (e.g. "only emit `.sty(())` if some builder
-        // method starts with `sty`") sees the suffixed name and
-        // returns false, breaking method-name completion.
+        // ALWAYS emit a method call for partial kwargs: RA injects a
+        // sentinel suffix at the cursor during its
+        // expansion-for-completion pass, so any prefix-match heuristic
+        // sees the suffixed name and fails, killing completion.
         return Some(quote_spanned! {span=> .#name(()) });
     }
 
     let call = if is_known_attr_method(&tag_name, &name_str) {
-        // Named builder attribute method (`style`, `class`, the
-        // universal trait attrs, and per-tag ones like
-        // `scroll_view::bounces`, `text::text_maxline`). The method
-        // takes `impl Into<Signal<T>>` for its semantic `T` and
-        // handles Static / Dynamic dispatch internally; the value
-        // flows as-is and type inference picks the right `From`
-        // (`From<T>` static / `From<ReadSignal<T>>` reactive) — so
-        // `bounces: true` / `text_maxline: 3` /
-        // `mode: ImageMode::AspectFit` all just work.
+        // Named builder attribute method. Each takes
+        // `impl Into<Signal<T>>` for its semantic `T`, so the value
+        // flows as-is and inference picks `From<T>` (static) or
+        // `From<ReadSignal<T>>` (reactive).
         quote_spanned! {span=> .#name(#value) }
     } else if name_str == "ref" {
-        // `ref: <ElementRef>` on a built-in element → bind the ref
-        // to this element so its UI methods are invokable after
-        // mount. (`ref` is a keyword, so the builder method is
-        // `bind_ref`.)
+        // `ref` is a keyword, so the builder method is `bind_ref`.
         quote_spanned! {span=> .bind_ref(#value) }
     } else if is_known_event_method(&name_str) {
-        // Typed event helper on `ElementBuilder` — `.on_tap(f)`,
-        // `.on_longpress(f)`, … — where `f` receives a typed
-        // `TouchEvent` / `CustomEvent` / `AnimationEvent`. The
-        // closure flows through unchanged; the builder method
-        // fixes the event type.
+        // Typed event helper on `ElementBuilder`: the closure flows
+        // through unchanged and the builder method fixes the event
+        // type.
         quote_spanned! {span=> .#name(#value) }
     } else if let Some(event) = strip_on_prefix(&name_str) {
-        // Unknown event name → raw `WhiskerValue` escape hatch
-        // (`.on("name", |e: WhiskerValue| …)`).
         let event_lit = LitStr::new(&event, span);
         quote_spanned! {span=> .on(#event_lit, #value) }
     } else {
-        // Catch-all → `.attr("kebab-name", value)`. The builder's
-        // `.attr` accepts `impl Into<Signal<T>>` like the named
-        // attr methods; no closure wrapping here either.
         let kebab = name_str.replace('_', "-");
         let kebab_lit = LitStr::new(&kebab, span);
         quote_spanned! {span=>
@@ -245,12 +212,11 @@ fn element_kwarg_to_setter(el: &ElementNode, kw: &Kwarg) -> Option<TokenStream2>
 /// Kwargs that map to a **named** builder attribute method
 /// (`.#name(value)`) rather than the catch-all `.attr("kebab", value)`.
 /// Each method takes `impl Into<Signal<T>>` for its semantic `T`
-/// (bool / number / String), so the value flows through unchanged and
-/// type inference picks the right `From` — crucial for bool/number
-/// attrs, which `.attr` (String-only) couldn't accept. Mirrors the
-/// methods on `ElementBuilder` + the per-tag inherent impls in
-/// `whisker::__tags`; tag-specific names only match their tag, so using
-/// one on the wrong element is a clear "no method" error.
+/// (bool / number / String), which is what lets bool and number attrs
+/// through — `.attr` is String-only. Mirrors the methods on
+/// `ElementBuilder` + the per-tag inherent impls in `whisker::__tags`;
+/// a tag-specific name used on the wrong element is a clear "no method"
+/// error.
 fn is_known_attr_method(tag: &str, attr: &str) -> bool {
     // Universal attributes (the `ElementBuilder` trait — any tag).
     let common = matches!(
@@ -325,11 +291,9 @@ fn is_known_attr_method(tag: &str, attr: &str) -> bool {
             | ("list", "preload_buffer_count")
             | ("list", "list_main_axis_gap")
             | ("list", "list_cross_axis_gap")
-            // Render-props setters on `list` — type-stated, take
-            // closure literals via `Into<EachFn<T>>` etc. The
-            // typed-setter route is what makes the closure flow
-            // through the right `Into` impl (the generic `attr`
-            // fallback would try `Into<Signal<String>>`).
+            // Typed render-props setters on `list`: the closure needs
+            // `Into<EachFn<T>>`, whereas the generic `attr` fallback
+            // would try `Into<Signal<String>>`.
             | ("list", "each")
             | ("list", "meta")
             | ("list", "children")
@@ -363,10 +327,8 @@ fn is_known_event_method(name: &str) -> bool {
             | "on_transitionstart"
             | "on_transitionend"
             | "on_transitioncancel"
-            // Component-specific events (CustomEvent → bind only). These
-            // are inherent methods on a single tag's builder (scroll_view
-            // / text), so the macro emits `.on_scroll(f)` etc.;
-            // using one on the wrong tag is a clear "no method" error.
+            // Inherent methods on a single tag's builder, so using one
+            // on the wrong tag is a clear "no method" error.
             | "on_scroll"
             | "on_scrolltoupper"
             | "on_scrolltolower"
@@ -379,11 +341,9 @@ fn is_known_event_method(name: &str) -> bool {
             | "on_layout"
             | "on_selectionchange"
     );
-    // … plus the catch / capture propagation variants for the touch
-    // family (`on_tap_catch`, `on_capture_tap`, `on_capture_tap_catch`,
-    // …). These map 1:1 to Lynx's `catchtap` / `capture-bindtap` /
-    // `capture-catchtap` handler kinds. Mirrors the `on_*` methods on
-    // `ElementBuilder` in `whisker::__tags`.
+    // … plus the catch / capture propagation variants, which map 1:1 to
+    // Lynx's `catchtap` / `capture-bindtap` / `capture-catchtap`
+    // handler kinds.
     let propagation_variant = matches!(
         name,
         "on_tap_catch"
@@ -424,15 +384,12 @@ fn user_component_to_tokens(uc: &UserComponentNode) -> TokenStream2 {
             let name_str = name.to_string();
             let span = name.span();
             if kw.partial {
-                // Partial kwarg on a user component → emit
-                // `.name(())` so typed-builder's per-field
-                // setter shows up under RA's method completion.
+                // `.name(())` so the Props builder's per-field setter
+                // shows up under RA's method completion.
                 quote_spanned! {span=> .#name(()) }
             } else if name_str == "ref" {
-                // `ref:` is the canonical call-site name for the
-                // implicit ElementRef prop. `ref` is a Rust
-                // keyword so the setter is exposed as
-                // `.with_ref(...)`; re-route here.
+                // `ref` is a Rust keyword, so the implicit ElementRef
+                // prop's setter is exposed as `.with_ref(...)`.
                 let value = &kw.value;
                 quote_spanned! {span=> .with_ref(#value) }
             } else {
@@ -442,9 +399,8 @@ fn user_component_to_tokens(uc: &UserComponentNode) -> TokenStream2 {
         })
         .collect();
 
-    // `key` flows as a regular Props field — control-flow
-    // components like `ForEach` are themselves `#[component]`s
-    // and read it directly off `XxxProps`.
+    // `key` flows as a regular Props field: control-flow components
+    // are themselves `#[component]`s and read it off `XxxProps`.
 
     let children_call = if uc.children.is_empty() {
         quote! {}
@@ -466,12 +422,10 @@ fn user_component_to_tokens(uc: &UserComponentNode) -> TokenStream2 {
         }
     };
 
-    // `#fn_ident::builder()` (not `#props_ident::builder()`): the
-    // component name doubles as a TYPE alias to its Props struct (see
-    // `#[component]`), so a single `use crate::Icon` is enough — no
-    // separate `IconProps` import. The outer `#fn_ident(…)` resolves
-    // to the callable (value namespace), the inner `#fn_ident::` to
-    // the Props type (type namespace).
+    // `#fn_ident::builder()`, not `#props_ident::builder()`: the
+    // component name doubles as a TYPE alias to its Props struct, so a
+    // single `use crate::Icon` covers both namespaces and users never
+    // import `IconProps`.
     quote! {
         #fn_ident(
             #fn_ident::builder()
@@ -542,8 +496,6 @@ mod tests {
         assert_eq!(snake_to_pascal("tab_item"), "TabItem");
     }
 
-    // ---- Compose-syntax parser & emission --------------------------------
-
     #[test]
     fn view_emission_uses_builder_chain() {
         let input: TokenStream2 = quote::quote! { view(style: "x") };
@@ -564,9 +516,6 @@ mod tests {
 
     #[test]
     fn ref_kwarg_on_builtin_routes_to_bind_ref() {
-        // `ref:` on a built-in element binds an ElementRef to the
-        // element (vs the catch-all `.attr("ref", …)`), so its UI
-        // methods (bounding_client_rect, …) are invokable after mount.
         let input: TokenStream2 = quote::quote! { view(ref: my_ref) };
         let output = super::expand_test(input).to_string();
         assert!(
@@ -581,8 +530,6 @@ mod tests {
 
     #[test]
     fn no_children_emits_bare_chain_expression() {
-        // No-children case must stay a bare chain expression — a
-        // `let __h = …; __h` wrapper breaks RA's kwarg completion.
         let input: TokenStream2 = quote::quote! { view(style: "x") };
         let output = super::expand_test(input).to_string();
         assert!(
@@ -606,10 +553,9 @@ mod tests {
 
     #[test]
     fn every_partial_kwarg_emits_method_call() {
-        // All partial kwargs route through `.name(())` — even
-        // prefixes that don't match any builder method. RA's
-        // sentinel-suffix injection during completion makes any
-        // "does this prefix match a method" heuristic unreliable.
+        // Even prefixes matching no builder method must route through
+        // `.name(())`; RA's sentinel-suffix injection makes any
+        // prefix-match heuristic unreliable.
         let input: TokenStream2 = quote::quote! { view(v) };
         let output = super::expand_test(input).to_string();
         assert!(
@@ -681,12 +627,8 @@ mod tests {
             "user components must not touch the built-in tags module; \
              output was: {output}"
         );
-        // Emission goes through the PascalCase alias the `#[component]`
-        // macro emits — both the value-namespace fn AND the
-        // type-namespace `type MyCard = MyCardProps` alias share that
-        // name, so `MyCard::builder()` resolves without a separate
-        // `MyCardProps` import (issue #1). The `…Props` name must NOT
-        // appear in the emission.
+        // `MyCard::builder()` must resolve through the PascalCase alias
+        // alone; the `…Props` name must NOT appear in the emission.
         assert!(
             output.contains("MyCard (MyCard :: builder ()") && !output.contains("MyCardProps"),
             "user component must lower to `MyCard(MyCard::builder()…)` \
@@ -698,9 +640,8 @@ mod tests {
 
     #[test]
     fn snake_case_non_builtin_is_back_compat_user_component() {
-        // Snake-case still parses (so mid-typing partials like `my_c|`
-        // don't blow up the macro), but the emission still goes
-        // through the PascalCase alias derived from the input.
+        // Snake-case must still parse so mid-typing partials like
+        // `my_c|` don't blow up the macro.
         let input: TokenStream2 = quote::quote! { my_card(title: "x") };
         let output = super::expand_test(input).to_string();
         assert!(
@@ -726,8 +667,6 @@ mod tests {
 
     #[test]
     fn nested_children_use_inline_chain() {
-        // Verify the chain stays a single expression even with
-        // children — no `let __h = …; __h` wrapper.
         let input: TokenStream2 = quote::quote! {
             view(style: "outer") {
                 view(class: "inner")
@@ -741,14 +680,8 @@ mod tests {
         );
     }
 
-    // ---- `children()` slot ---------------------------------------------
-
     #[test]
     fn children_slot_lowers_to_mount_children() {
-        // `children()` inside a `render!` body should resolve to
-        // `view::mount_children(&children)`, where `children` is the
-        // surrounding `#[component]`'s `children: Children` prop in
-        // local scope.
         let input: TokenStream2 = quote::quote! {
             view(style: "x") {
                 children()
@@ -769,9 +702,8 @@ mod tests {
 
     #[test]
     fn children_slot_can_appear_multiple_times() {
-        // Multi-projection: `children()` appearing N times produces
-        // N independent `mount_children(&children)` calls. The Rc
-        // is borrowed, never moved, so all N calls succeed.
+        // The Rc is borrowed, never moved, so N projections all
+        // succeed.
         let input: TokenStream2 = quote::quote! {
             view(style: "x") {
                 children()
@@ -790,10 +722,6 @@ mod tests {
 
     #[test]
     fn children_slot_sits_inside_child_method_call() {
-        // The slot lowers to a `.child(mount_children(&children))`
-        // call on the parent builder — i.e. it goes through the
-        // exact same shape as any other child node, so the parent's
-        // builder chain stays a single expression.
         let input: TokenStream2 = quote::quote! {
             view(style: "x") {
                 children()
@@ -814,10 +742,8 @@ mod tests {
 
     #[test]
     fn children_with_args_is_not_a_slot() {
-        // `children(arg: x)` is NOT the slot — falls through to the
-        // regular user-component path so a user fn named `children`
-        // with props still resolves correctly. (Esoteric, but the
-        // grammar must not steal the identifier.)
+        // The grammar must not steal the `children` identifier from a
+        // user component that happens to be named it.
         let input: TokenStream2 = quote::quote! {
             children(title: "x")
         };
@@ -836,10 +762,6 @@ mod tests {
 
     #[test]
     fn children_with_block_is_not_a_slot() {
-        // `children() { … }` is also NOT the slot — that's a tag
-        // invocation with empty kwargs and a children block. The
-        // user is using a component literally named `children`; let
-        // the regular path handle it.
         let input: TokenStream2 = quote::quote! {
             children() {
                 text(value: "y")

--- a/crates/whisker-macros/tests/ra_completion.rs
+++ b/crates/whisker-macros/tests/ra_completion.rs
@@ -10,21 +10,13 @@
 //!
 //! ## Why this exists
 //!
-//! Unit tests on the macro's emitted token stream prove the
-//! shape of the expansion but say nothing about whether RA can
-//! thread its completion through it. That gap let two real
-//! regressions slip past macro unit-tests:
+//! Unit tests on the macro's emitted token stream prove the shape of
+//! the expansion but say nothing about whether RA can thread its
+//! completion through it — the gap where completion regressions hide.
 //!
-//! 1. `view(sty|)` partial-kwarg completion broke when the macro
-//!    fell back to an `ident_ref` side block because RA injects
-//!    a sentinel suffix at the cursor and the prefix-match
-//!    heuristic stopped matching.
-//! 2. (open) `vie|` tag-name completion at child position
-//!    doesn't surface any candidates because the macro emits a
-//!    `UserComponent`-shaped call that RA can't resolve.
-//!
-//! These tests reproduce both directly. Adding a test before
-//! changing the macro / runtime keeps us from re-breaking them.
+//! Known gap: `vie|` tag-name completion at CHILD position surfaces no
+//! candidates, because the macro emits a `UserComponent`-shaped call RA
+//! can't resolve. Root position (covered below) works.
 //!
 //! ## Running
 //!
@@ -58,15 +50,12 @@ use serde_json::{Value, json};
 /// fresh download — the cache key is the version string.
 const RA_VERSION: &str = "2026-05-18";
 
-// ----- Test cases ---------------------------------------------------------
-
 /// Whether RA surfaced a completion for builder method `name`.
 ///
-/// The built-in builder methods (`style`, `class`, `on_tap`, …) live
-/// on the `ElementBuilder` trait now, and RA labels trait-provided
-/// methods as `name(as ElementBuilder)` to disambiguate them from
-/// inherent ones — selecting either inserts `name`. So accept the
-/// bare name or the trait-qualified form.
+/// The built-in builder methods (`style`, `class`, `on_tap`, …) live on
+/// the `ElementBuilder` trait, and RA labels trait-provided methods as
+/// `name(as ElementBuilder)` to disambiguate them from inherent ones —
+/// selecting either inserts `name`. So accept either form.
 fn surfaces_method(labels: &[String], name: &str) -> bool {
     labels
         .iter()
@@ -98,8 +87,8 @@ fn probe() -> Element {
 
 #[test]
 fn partial_kwarg_inside_component_body_completes_builder_methods() {
-    // The non-trivial case: the render! is inside a #[component]
-    // body, which the proc-macro rewrites into nested closures.
+    // The render! sits inside a #[component] body, which the macro
+    // rewrites into nested closures.
     let source = r#"
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
@@ -120,8 +109,6 @@ fn probe() -> Element {
 
 #[test]
 fn partial_tag_name_at_root_completes_to_builtin_view() {
-    // Regression test for tag-name completion. `vie|` at the
-    // root of a render! should surface `view` (built-in tag).
     let source = r#"
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
@@ -141,15 +128,10 @@ fn probe() -> Element {
 
 #[test]
 fn props_builder_helper_types_are_hidden_from_completion() {
-    // typed-builder generates a handful of marker types per Props
-    // (`<Name>PropsBuilder<((),(),()...)>` and friends). They're
-    // technically `pub` but pure plumbing — RA shouldn't surface
-    // them at user call sites because they pollute the candidate
-    // list with `ArtTilePropsBuilder_*` entries on every keystroke.
-    // The `#[component]` macro tucks the Props struct behind a
-    // `#[doc(hidden)] pub mod __<name>_props_internal` to gate
-    // those helpers off; only `ArtTileProps` itself re-exports
-    // outward.
+    // The builder type is `pub` but pure plumbing. `#[component]` tucks
+    // it behind a `#[doc(hidden)]` private module so RA doesn't pollute
+    // the candidate list with `ArtTilePropsBuilder` on every keystroke;
+    // only `ArtTileProps` re-exports outward.
     let source = r#"
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
@@ -197,11 +179,9 @@ fn probe() -> Element {
 
 #[test]
 fn longer_prefix_does_not_surface_builder_via_autoimport() {
-    // RA's auto-import path may surface `pub` items inside private
-    // modules when the user has typed enough characters to uniquely
-    // identify the target. Probe at `ArtTilePropsBu|` — if Builder
-    // is properly `#[doc(hidden)]` and inside a `#[doc(hidden)]`
-    // private mod, RA must not offer to auto-import it.
+    // RA's auto-import path can surface `pub` items inside private
+    // modules once the user has typed enough to identify the target, so
+    // probe at a near-complete prefix.
     let source = r#"
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
@@ -237,10 +217,8 @@ fn probe() -> Element {
 
 #[test]
 fn short_prefix_user_component_does_not_leak_builder_helpers() {
-    // VS Code users typically start typing with just a few chars
-    // (`Art|`). RA's fuzzy-match may include items the strict
-    // prefix path filters out — let's verify the leak set stays
-    // empty at 3 chars too.
+    // RA's fuzzy-match at a short prefix can include items the strict
+    // prefix path filters out.
     let source = r#"
 use whisker::prelude::*;
 use whisker::runtime::view::Element;

--- a/crates/whisker/src/attrs.rs
+++ b/crates/whisker/src/attrs.rs
@@ -1,8 +1,8 @@
 //! Typed enums for built-in element attributes whose Lynx-side
 //! contract is a closed set of strings.
 //!
-//! The element-builder setters take a typed enum directly —
-//! raw strings no longer compile:
+//! The element-builder setters take a typed enum directly; raw strings
+//! do not compile:
 //!
 //! ```ignore
 //! use whisker::prelude::*;
@@ -10,18 +10,16 @@
 //! scroll_view(scroll_orientation: ScrollOrientation::Vertical)
 //! ```
 //!
-//! Reactivity still works the same way: anything implementing
+//! Reactivity is unaffected: anything implementing
 //! `Into<Signal<EnumType>>` is accepted, so passing a
 //! `RwSignal<ScrollOrientation>` flips the attribute live.
 //!
 //! ## Why typed enums
 //!
-//! Previously these props took `Signal<String>` and pumped whatever
-//! string the caller wrote straight through `apply_attr` to Lynx.
-//! A typo (`"verticle"`, `"List-Single"`, …) parsed fine on the Rust
-//! side and was silently ignored on the Lynx side, so the failure
-//! surfaced as a render glitch with no compile-time hint. Typed
-//! enums turn those typos into compile errors.
+//! A misspelled attribute string (`"verticle"`, `"List-Single"`, …)
+//! reaches Lynx fine and is then silently ignored, surfacing as a
+//! render glitch with no compile-time hint. Typed enums turn those
+//! typos into compile errors.
 //!
 //! Each enum is `#[non_exhaustive]` so a future Lynx-side addition
 //! (a new `pan-intercept-scope` keyword, an additional `list-type`,
@@ -37,16 +35,10 @@
 // ---------------------------------------------------------------------------
 // Macro: stamp out an enum + `as_str` + `Display`.
 //
-// Centralising the boilerplate keeps every attribute enum identical
-// in shape (Copy, Clone, Debug, PartialEq, Eq, Hash, non_exhaustive)
-// and removes the temptation to hand-roll the Display impl per
-// variant. Adding a new attribute is a single `attr_enum!`
-// invocation.
-//
-// The setter sends the enum through `apply_attr`'s `T: ToString`
-// bound (which `Display` satisfies via the standard blanket impl),
-// so no explicit `From<EnumType>` is needed — the wire string
-// emerges naturally on each reactive read.
+// Every attribute enum shares one shape (Copy, Clone, Debug,
+// PartialEq, Eq, Hash, non_exhaustive), so adding an attribute is a
+// single `attr_enum!` invocation. `Display` satisfies `apply_attr`'s
+// `T: ToString` bound, so no explicit `From<EnumType>` is needed.
 // ---------------------------------------------------------------------------
 
 macro_rules! attr_enum {
@@ -347,8 +339,7 @@ mod tests {
 
     #[test]
     fn display_is_wire_string() {
-        // `Display` is the standard "render as the canonical
-        // string" path — should never diverge from `as_str`.
+        // `Display` must never diverge from `as_str`.
         assert_eq!(ScrollOrientation::Vertical.to_string(), "vertical");
         assert_eq!(PanInterceptScope::SelfElement.to_string(), "self");
     }

--- a/crates/whisker/src/control_flow.rs
+++ b/crates/whisker/src/control_flow.rs
@@ -1,15 +1,14 @@
 //! Built-in control-flow components — `for_each` (keyed list) and
 //! `show` (conditional).
 //!
-//! Both are written exactly as a user-defined control flow would
-//! be: regular `#[component]` functions that allocate a *fragment*
+//! Both are written exactly as a user-defined control flow would be:
+//! regular `#[component]` functions that allocate a *fragment*
 //! ([`create_phantom_element`](whisker_runtime::view::create_phantom_element)),
 //! install a reactive [`effect`](whisker_runtime::reactive::effect) to
-//! diff their input source, and return the fragment. There's no
-//! `ControlFlow` trait, no `View::ControlFlow` enum variant, no
-//! special path through the surrounding container builder — the
-//! `render!` macro treats `ForEach(...)` / `Show(...)` like any
-//! other user component (`PropsBuilder` pattern).
+//! diff their input source, and return the fragment. There is no
+//! `ControlFlow` trait and no special path through the surrounding
+//! builder — `render!` treats `ForEach(...)` / `Show(...)` like any
+//! other user component.
 //!
 //! A user implementing their own control flow follows the same
 //! outline:
@@ -87,9 +86,9 @@ where
     }
     let entries: Rc<RefCell<HashMap<K, Entry>>> = Rc::new(RefCell::new(HashMap::new()));
 
-    // Clone the closure props into the effect's capture set so the
-    // outer body (a `FnMut` per `#[component]`'s hot-reload wrapper)
-    // never gets them moved out of.
+    // The outer body is a `FnMut` (per `#[component]`'s hot-reload
+    // wrapper), so the closure props must be cloned in rather than
+    // moved out of it.
     let each = each.clone();
     let key = key.clone();
     let children = children.clone();
@@ -123,16 +122,14 @@ where
             new_keys_in_order.push(k);
         }
 
-        // Disappeared items: detach + dispose.
         for (_, entry) in old.drain() {
             remove_child(frag, entry.handle);
             entry.owner.dispose();
         }
 
-        // Reorder: detach every surviving handle, then re-attach in
-        // the new order. The fragment's phantom-hoisting routes each
-        // detach + re-attach pair to the real ancestor on the Lynx
-        // side, one element at a time.
+        // Reorder by detaching every surviving handle and re-attaching
+        // in the new order; phantom-hoisting routes each pair to the
+        // real Lynx ancestor one element at a time.
         for k in &new_keys_in_order {
             if let Some(entry) = new_entries.get(k) {
                 remove_child(frag, entry.handle);
@@ -180,30 +177,26 @@ pub fn show(
 ) -> Element {
     let frag = create_phantom_element();
 
-    // Track the currently-mounted (owner, leaf handles) pair so we
-    // can dispose + detach on every flip.
     type Mounted = Rc<RefCell<Option<(Owner, Vec<Element>)>>>;
     let mounted: Mounted = Rc::new(RefCell::new(None));
     // The condition the mounted branch reflects; `None` until first run.
     let last_cond: Rc<Cell<Option<bool>>> = Rc::new(Cell::new(None));
 
-    // Clone props into the effect's capture set so the outer body
-    // (a `FnMut` per `#[component]`'s hot-reload wrapper) never has
-    // them moved out of. `Rc<dyn Fn>` clones are cheap.
+    // The outer body is a `FnMut`, so props are cloned in rather than
+    // moved out of it. `Rc<dyn Fn>` clones are cheap.
     let when = when.clone();
     let children = children.clone();
     let fallback = fallback.clone();
 
     effect(move || {
-        // Evaluate every run (keeps the dependency subscription), but
-        // only rebuild when the condition actually changed.
+        // Evaluate on every run to keep the dependency subscription,
+        // but only rebuild when the condition actually changed.
         let cond = when.call();
         if last_cond.get() == Some(cond) {
             return;
         }
         last_cond.set(Some(cond));
 
-        // Tear down the previously-mounted branch.
         if let Some((owner, handles)) = mounted.borrow_mut().take() {
             for h in handles {
                 remove_child(frag, h);
@@ -212,7 +205,6 @@ pub fn show(
         }
 
         if cond {
-            // Truthy branch: `children` is `Children` = `Fn() -> View`.
             let owner = Owner::new(None);
             let handles = owner.with(|| {
                 let view = children();
@@ -220,8 +212,6 @@ pub fn show(
             });
             *mounted.borrow_mut() = Some((owner, handles));
         } else if let Some(fb) = &fallback.0 {
-            // Falsy branch: `fallback` is `Fn() -> Element` (single
-            // element). Mount it directly under the fragment.
             let owner = Owner::new(None);
             let handle = owner.with(|| {
                 let h = fb();

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -67,15 +67,10 @@ pub use whisker_runtime as runtime;
 pub use whisker_css as css;
 
 // Continuous, signal-based animation engine (Flutter-style
-// AnimationController + Tween). See `docs/animation-design.md`. The
-// public surface is also re-exported flat into the prelude below so
-// `whisker::{animated, AnimationController, Tween, AnimConfig,
-// Animatable, Curve}` work directly.
+// AnimationController + Tween). See `docs/animation-design.md`.
 pub use whisker_animation as animation;
 pub use whisker_animation::{AnimConfig, Animatable, AnimationController, Curve, Tween, animated};
 
-// The macro expansions reference this through `::whisker::ElementTag`;
-// the C bridge keys element creation off the same enum.
 pub use whisker_runtime::element::ElementTag;
 
 /// The return type of a `#[component]` / `#[whisker::main]` function —
@@ -146,8 +141,7 @@ pub use whisker_runtime::reactive::{
 };
 // Component mount/unmount + mount-queue machinery. Driven by the
 // `#[component]` expansion and the hot-reload remount path, not by app
-// code — `#[doc(hidden)]` keeps it out of the public docs while
-// remaining reachable for the macro and framework internals.
+// code.
 #[doc(hidden)]
 pub use whisker_runtime::reactive::{flush_mounts, mount_component, unmount_component};
 // Owner / scope API. Application code rarely touches these —
@@ -206,14 +200,12 @@ pub mod __tags {
         create_phantom_element, set_attribute_object, set_event_listener,
     };
 
-    // Why a trait (and not `macro_rules!`): RA's method-completion
-    // does NOT surface methods produced by a `macro_rules!` expansion
-    // inside an `impl` block (which is why the per-tag methods used
-    // to be hand-inlined). Trait methods are first-class items RA
-    // indexes and completes, provided the trait is in scope — the
-    // `render!` / `#[component]` expansions bring it in with
-    // `use ::whisker::__tags::ElementBuilder as _;` right before the
-    // builder chain. End-to-end guard:
+    // A trait, not `macro_rules!`: RA's method-completion does NOT
+    // surface methods produced by a `macro_rules!` expansion inside an
+    // `impl` block, whereas trait methods are first-class items it
+    // indexes — provided the trait is in scope, which the `render!` /
+    // `#[component]` expansions arrange with
+    // `use ::whisker::__tags::ElementBuilder as _;`. End-to-end guard:
     // `crates/whisker-macros/tests/ra_completion.rs`.
 
     /// Shared builder methods for every built-in element tag.
@@ -433,9 +425,6 @@ pub mod __tags {
             apply_attr(self.__element(), "accessibility-exclusive-focus", v);
             self
         }
-
-        // Advanced gesture-coordination attrs: tune what reaches the
-        // Lynx hit-tester / native scroll. Most apps never set these.
 
         /// `hit-slop` — expand the touch-responsive area beyond the
         /// element's bounds (e.g. `"10px"`, or per-side
@@ -1210,25 +1199,18 @@ pub mod __tags {
 
     // ---- list / list-item (Lynx's virtualized list) ---------------------
     //
-    // The standard Lynx `list` creates its items through lepus
-    // `componentAtIndex` callbacks the JS framework registers — Whisker
-    // has no such runtime. So the `list` builder opts into Lynx's
-    // *decoupled native* list: it virtualizes / recycles the actual
-    // `<list-item>` children present in the element tree (via the native
-    // `ListChildrenHelper`), with no framework callbacks. That fits
-    // Whisker's direct-tree model — author code writes
-    // `list { … }` like any other container.
-    //
-    // Two flags gate that mode (see `list_element.cc`):
+    // The builder opts into Lynx's *decoupled native* list. Two flags
+    // gate that mode (see `list_element.cc`):
     //   • `custom-list-name="list-container"` → `ResolveEnableNativeList`
-    //     Case 2 sets `disable_list_platform_implementation_ = true`. This
-    //     is a *string* compare, so it survives `apply_attr`'s
+    //     Case 2 sets `disable_list_platform_implementation_ = true`.
+    //     This is a *string* compare, so it survives `apply_attr`'s
     //     stringification.
-    //   • the decoupled mediator additionally needs `enable_decoupled_list_`,
-    //     which `ResolveEnableDecoupledList` only reads from the attr when
-    //     the value `IsBool()` — a stringified attr never is, so it falls
-    //     back to `LynxEnv::EnableDecoupledList()`, which defaults to
-    //     `true`. So `custom-list-name` alone activates the decoupled path.
+    //   • the decoupled mediator additionally needs
+    //     `enable_decoupled_list_`, which `ResolveEnableDecoupledList`
+    //     only reads from the attr when the value `IsBool()` — a
+    //     stringified attr never is, so it falls back to
+    //     `LynxEnv::EnableDecoupledList()`, which defaults to `true`.
+    // So `custom-list-name` alone activates the decoupled path.
 
     /// `<list>` — Lynx's native-virtualised list. Pass the items
     /// source as three kwargs and Lynx mounts only the visible items
@@ -1282,10 +1264,9 @@ pub mod __tags {
     #[allow(non_snake_case)]
     pub fn __list_ctor() -> list<(), (), ()> {
         let handle = create_element_by_name("list");
-        // Drive the list natively from its tree children rather than through
-        // (absent) JS `componentAtIndex` callbacks. `custom-list-name` is the
-        // string-compare flag that disables the platform list impl; the
-        // decoupled mediator then activates via the env default (true).
+        // `custom-list-name` is the string-compare flag that disables
+        // the platform list impl; the decoupled mediator then activates
+        // via the env default (true).
         apply_attr::<_, ::std::string::String>(handle, "custom-list-name", "list-container");
         list {
             handle,
@@ -1298,11 +1279,8 @@ pub mod __tags {
         fn __element(&self) -> Element {
             self.handle
         }
-        // `list` doesn't accept body children — the macro is
-        // responsible for rejecting `list { … }` at parse time.
-        // Should the user reach this through a non-macro path, the
-        // default `.child()` semantics (a regular `append_child`)
-        // would still work but is not the supported shape.
+        // `list` takes its items through the `each`/`key`/`children`
+        // render props, never body children.
     }
     impl<EachF, MetaF, ChildF> list<EachF, MetaF, ChildF> {
         /// `list-type` layout — takes the typed

--- a/crates/whisker/src/style.rs
+++ b/crates/whisker/src/style.rs
@@ -8,11 +8,10 @@
 //! 2. A raw CSS string (`String` or `&str` / `&String`).
 //! 3. A reactive [`ReadSignal<T>`] / [`RwSignal<T>`] of either form.
 //!
-//! Having one wrapper lets the same `view(style: ...)` keyword
-//! accept all three shapes without callers having to call
-//! `.to_css_string()` themselves. Reactive paths re-fire the
-//! attribute apply inside the element's `effect`, matching the
-//! semantics every other `Signal<T>`-driven prop already has.
+//! One wrapper lets the same `view(style: ...)` keyword accept every
+//! shape without callers calling `.to_css_string()` themselves.
+//! Reactive paths re-fire the attribute apply inside the element's
+//! `effect`, matching every other `Signal<T>`-driven prop.
 //!
 //! `Style` is defined in the `whisker` umbrella crate (rather than
 //! in `whisker-css`) so the `Css` crate stays `whisker-runtime`-free
@@ -88,9 +87,8 @@ impl From<&String> for Style {
 // ---- Reactive sources -------------------------------------------------------
 //
 // One impl per (`ReadSignal` × `RwSignal`) × (`Css` × `String`) pair.
-// Hand-written rather than blanket so coherence has no chance of
-// complaining and the user-facing type-inference error pointing at
-// an unsupported `T` stays sharp.
+// Hand-written rather than blanket to keep coherence out of it and the
+// type-inference error on an unsupported `T` sharp.
 
 impl From<ReadSignal<Css>> for Style {
     fn from(sig: ReadSignal<Css>) -> Self {
@@ -154,7 +152,6 @@ mod tests {
         let style: Style = (&s).into();
         let out = css(style);
         assert!(out.contains("padding-top: 8px"));
-        // `s` still usable after the conversion.
         assert!(!s.is_empty());
     }
 
@@ -178,9 +175,7 @@ mod tests {
         assert_eq!(owner, "color: green;");
     }
 
-    // Reactive From impls rely on the reactive runtime arena; the
-    // standalone test environment doesn't bootstrap one, so the
-    // dynamic-branch tests are exercised by the end-to-end runs in
-    // `examples/podcast`. The static cases above already cover
-    // the discriminant + serialization paths.
+    // The reactive `From` impls need the runtime arena, which this
+    // standalone test environment doesn't bootstrap; the static cases
+    // above cover the discriminant + serialization paths.
 }

--- a/crates/whisker/tests/children_slot.rs
+++ b/crates/whisker/tests/children_slot.rs
@@ -15,8 +15,6 @@
 //!    (per-component remount / hot-reload) without `cannot move out
 //!    of` errors — `mount_children` takes `&Children`, never moves.
 //!
-//! Naming convention matches `component_invocation.rs` (the longer
-//! file that exercises every other Props-derived behaviour).
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -27,9 +25,8 @@ use whisker::runtime::view::{DynRenderer, Element, install_renderer, uninstall_r
 
 // ----- Recording renderer ----------------------------------------------------
 //
-// Same shape as `component_invocation.rs` — duplicated rather than
-// shared because integration tests don't have a `tests/common`
-// module convention yet, and the helper code is small.
+// Same shape as `component_invocation.rs`, duplicated because
+// integration tests have no shared `tests/common` module.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
@@ -154,8 +151,6 @@ fn slot_mounts_children_between_siblings_in_order() {
             }
         };
 
-        // Verify the three raw_text "text" attributes appear in the
-        // expected order: header → slot → footer.
         let texts: Vec<String> = log
             .borrow()
             .iter()
@@ -175,10 +170,9 @@ fn slot_mounts_children_between_siblings_in_order() {
 #[test]
 fn slot_mounts_multi_element_children_as_fragment() {
     with_test_env(|log| {
-        // Caller passes two text elements inside the braces — the
-        // macro routes them through a Fragment-returning closure.
-        // The slot's `mount_children` flattens the fragment so both
-        // texts end up at the slot position.
+        // Two text elements at the call site route through a
+        // Fragment-returning closure, which `mount_children` flattens
+        // at the slot position.
         let _h = render! {
             CardWithSlot() {
                 text(value: "first")
@@ -205,12 +199,9 @@ fn slot_mounts_multi_element_children_as_fragment() {
 #[test]
 fn slot_can_be_used_more_than_once() {
     with_test_env(|log| {
-        // `double_mount` writes `children()` twice. The caller's
-        // children closure is `Fn`, so invoking it twice produces
-        // two independent renders of the same content. The
-        // assertions count `raw_text` "text" attrs rather than
-        // exact equality so we don't depend on phantom-element
-        // ordering details.
+        // The assertions count `raw_text` "text" attrs rather than
+        // comparing exactly, so they don't depend on phantom-element
+        // ordering.
         let _h = render! {
             DoubleMount() {
                 text(value: "echo")
@@ -229,10 +220,9 @@ fn slot_can_be_used_more_than_once() {
 #[test]
 fn slot_with_omitted_children_renders_nothing_extra() {
     with_test_env(|log| {
-        // No `{ … }` block at the call site → children defaults
-        // to a closure returning View::Empty. `mount_children`
-        // still creates a phantom but attaches nothing to it, so
-        // no raw_text elements get created.
+        // With no `{ … }` block, children defaults to a closure
+        // returning `View::Empty`: the phantom is still created but
+        // nothing attaches to it.
         let _h = render! { BareSlot() };
 
         let raw_text_creates = log
@@ -257,11 +247,9 @@ fn slot_with_omitted_children_renders_nothing_extra() {
 
 #[test]
 fn slot_body_can_be_reinvoked() {
-    // Per-component remount / hot-reload re-invoke the component's
-    // outer `FnMut` body. `children()` lowers to a `&children`
-    // borrow inside `mount_children`, so nothing moves and the
-    // second invocation succeeds. We simulate the re-invocation by
-    // constructing the Props once and calling the inner fn twice.
+    // Remount / hot-reload re-invoke the component's outer `FnMut`.
+    // Simulated here by building the Props once and calling the inner
+    // fn twice; nothing moves, because `mount_children` borrows.
     with_test_env(|log| {
         use whisker::runtime::view::{Children, View};
         let children: Children = Rc::new(|| View::Text("echo".to_string()));
@@ -272,9 +260,6 @@ fn slot_body_can_be_reinvoked() {
         let props2 = BareSlotProps::builder().children(children.clone()).build();
         let _h2 = BareSlot(props2);
 
-        // Each invocation should produce one raw_text("echo"). Two
-        // invocations → two echoes. (If `mount_children` moved the
-        // Rc, the second call would panic / fail to compile.)
         let echoes = log
             .borrow()
             .iter()

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -1,18 +1,16 @@
-//! Integration tests for the unified component invocation syntax
-//! (issue #18). Verifies that `render! { my_component { … } }` lowers
-//! to `my_component(MyComponentProps::builder().…build())` and that
-//! the auto-generated `Props` struct exposes all the expected setter
-//! behaviours: `Into` coercion, `Option<T>` strip, `Children` default,
+//! Integration tests for the unified component invocation syntax:
+//! `render! { MyComponent(…) }` lowers to
+//! `MyComponent(MyComponentProps::builder().…build())`, and the
+//! auto-generated `Props` struct exposes the expected setter
+//! behaviours — `Into` coercion, `Option<T>` strip, `Children` default,
 //! and generics.
 //!
-//! For `String`-shaped props we side-channel the received value into
-//! a thread-local `Vec<String>` rather than trying to interpolate the
-//! prop inside `render!` — interpolation routes through an `Fn +
-//! 'static` effect closure that has to take ownership of any
-//! non-`Copy` capture, which conflicts with the `#[component]`-wrapped
-//! `FnMut` outer closure. (Real apps that need to interpolate a
-//! `String` prop typically `clone()` it into a local, then move that
-//! into the effect.)
+//! `String`-shaped props are side-channelled into a thread-local
+//! `Vec<String>` rather than interpolated inside `render!`:
+//! interpolation routes through an `Fn + 'static` effect closure that
+//! must own any non-`Copy` capture, which conflicts with the
+//! `#[component]`-wrapped `FnMut` outer closure. (Real apps `clone()`
+//! such a prop into a local first.)
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -103,9 +101,6 @@ fn with_test_env<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
     result
 }
 
-// Side-channel for prop captures. Component bodies push the
-// stringified values of the props they received here; tests read it
-// back to assert what made it through the builder.
 thread_local! {
     static PROP_CAPTURES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
 }
@@ -140,10 +135,9 @@ fn two_props(title: String, count: i32) -> Element {
 
 #[component]
 fn option_prop(alt: Option<String>) -> Element {
-    // `.as_deref()` borrows the inner str so the FnMut closure
-    // surrounding this body can be invoked more than once (per-
-    // component remount). Calling `.unwrap_or_else(...)` directly
-    // moves `alt` out of the closure.
+    // `.as_deref()` borrows the inner str so the surrounding FnMut can
+    // be invoked more than once; `.unwrap_or_else(...)` directly would
+    // move `alt` out of the closure.
     let v = alt
         .as_deref()
         .map(str::to_owned)
@@ -161,11 +155,8 @@ fn with_default_prop(#[prop(default = 5)] count: i32) -> Element {
 #[component]
 fn with_children(label: String, children: Children) -> Element {
     push_capture(format!("with_children:label={label}"));
-    // The `children()` slot is the canonical way to mount a
-    // `children: Children` prop inside `render!`. It lowers to
-    // `view::mount_children(&children)` — borrows the Rc (no move,
-    // so the surrounding FnMut can re-run) and attaches the
-    // children's view to a phantom element at this position.
+    // `children()` lowers to `view::mount_children(&children)`, which
+    // borrows the Rc so the surrounding FnMut can re-run.
     render! {
         view() {
             children()
@@ -186,10 +177,8 @@ fn component_with_no_props_invokable_via_braces() {
     with_test_env(|log| {
         let _h = render! { NoPropsComponent() };
 
-        // Side-channel: body ran.
         assert_eq!(captures(), vec!["no_props_component:invoked"]);
 
-        // Sanity: at least one view element was created by the body.
         let view_creates = log
             .borrow()
             .iter()
@@ -210,8 +199,6 @@ fn component_with_no_props_invokable_via_braces() {
 #[test]
 fn component_with_string_prop_accepts_str_literal_via_into_coercion() {
     with_test_env(|_log| {
-        // `label: "hello"` — typed-builder `setter(into)` should
-        // convert the `&'static str` to `String`.
         let _h = render! { OneStringProp(label: "hello") };
         assert_eq!(captures(), vec!["one_string_prop:label=hello"]);
     });
@@ -242,7 +229,7 @@ fn component_with_two_props_uses_named_setters() {
 #[test]
 fn option_prop_can_be_omitted() {
     with_test_env(|_log| {
-        // No `alt:` kwarg — typed-builder's `default` kicks in → None.
+        // No `alt:` kwarg — the builder's default kicks in.
         let _h = render! { OptionProp() };
         assert_eq!(captures(), vec!["option_prop:alt=default"]);
     });
@@ -251,8 +238,6 @@ fn option_prop_can_be_omitted() {
 #[test]
 fn option_prop_accepts_inner_via_strip_option_into() {
     with_test_env(|_log| {
-        // `strip_option + into` lets the user pass `&str` directly
-        // (no `Some(...)` wrapping needed).
         let _h = render! { OptionProp(alt: "custom") };
         assert_eq!(captures(), vec!["option_prop:alt=custom"]);
     });
@@ -277,10 +262,6 @@ fn prop_default_attribute_overridable_at_call_site() {
 #[test]
 fn children_prop_receives_wrapped_closure() {
     with_test_env(|log| {
-        // Nested children should be routed into a `.children(...)`
-        // closure that the component invokes inside its body. The
-        // body emits one outer `view`; the children closure emits
-        // two `text` elements inside it.
         let _h = render! {
             WithChildren(label: "wrapper") {
                 text(value: "child-1")
@@ -292,7 +273,6 @@ fn children_prop_receives_wrapped_closure() {
         assert_eq!(captured.len(), 1, "with_children should be invoked once");
         assert_eq!(captured[0], "with_children:label=wrapper");
 
-        // Both children should have rendered their text.
         let texts: Vec<_> = log
             .borrow()
             .iter()
@@ -315,7 +295,6 @@ fn children_prop_defaults_to_empty_view_when_omitted() {
 
         assert_eq!(captures(), vec!["with_children:label=only label"]);
 
-        // No raw_text elements (empty children closure → View::Empty).
         let raw_text_creates = log
             .borrow()
             .iter()
@@ -357,8 +336,6 @@ fn generic_component_with_string_arg() {
 #[test]
 fn nested_component_invocations() {
     with_test_env(|_log| {
-        // Component inside a component, both via the new brace syntax.
-        // Outer's children closure invokes the inner component.
         let _h = render! {
             WithChildren(label: "outer") {
                 OneStringProp(label: "inner")
@@ -366,9 +343,8 @@ fn nested_component_invocations() {
         };
 
         let captured = captures();
-        // Outer body runs first (sees its label), then the children
-        // closure runs as part of the outer body's `view { {body} }`,
-        // invoking one_string_prop.
+        // The outer body runs first, then its children closure invokes
+        // the inner component.
         assert!(
             captured.iter().any(|s| s == "with_children:label=outer"),
             "outer captured; got: {captured:?}",
@@ -383,21 +359,16 @@ fn nested_component_invocations() {
 #[test]
 #[should_panic(expected = "required field `label` was not set")]
 fn build_panics_when_required_field_missing() {
-    // Regression pin for the hand-rolled builder's runtime
-    // required-field check. Pre-typed-builder migration this would
-    // have been a compile error; with the hand-rolled builder we
-    // surface the same constraint at mount time. The panic message
-    // must name the field for the user to find the offending
-    // call-site quickly.
+    // The builder checks required fields at runtime, so the panic
+    // message must name the field for the user to find the call site.
     fresh();
     let _ = OneStringPropProps::builder().build();
 }
 
 #[test]
 fn build_default_field_uses_user_supplied_default() {
-    // `#[prop(default = 5)] count: i32` — omitting `.count(…)`
-    // produces 5 at build time. Verifies the build_assignment
-    // emission path for PropKind::Default { is_generic: false }.
+    // Covers the build_assignment path for
+    // `PropKind::Default { is_generic: false }`.
     fresh();
     let props = WithDefaultPropProps::builder().build();
     assert_eq!(props.count, 5);
@@ -419,9 +390,8 @@ fn build_option_field_defaults_to_none() {
 
 #[test]
 fn build_option_field_strips_outer_option_in_setter() {
-    // Setter takes `impl Into<String>`, wraps to Some(_) at build.
-    // This is the `strip_option` ergonomics the typed-builder
-    // version gave us, now hand-rolled.
+    // Setter takes `impl Into<String>` and wraps to `Some(_)` at build
+    // — the strip-option ergonomics.
     fresh();
     let props = OptionPropProps::builder().alt("hi").build();
     assert_eq!(props.alt.as_deref(), Some("hi"));
@@ -429,9 +399,6 @@ fn build_option_field_strips_outer_option_in_setter() {
 
 #[test]
 fn build_children_defaults_to_empty_view_closure() {
-    // Missing `children:` should produce a closure that returns
-    // View::Empty so iterating the result of `(children)()` is a
-    // no-op.
     fresh();
     let props = WithChildrenProps::builder().label("x").build();
     let v = (props.children)();
@@ -440,8 +407,6 @@ fn build_children_defaults_to_empty_view_closure() {
 
 #[test]
 fn build_into_setter_accepts_str_literal_for_string_field() {
-    // `setter(into)` ergonomics — `&str` flows into a `String`
-    // field through `impl Into<String>` on the setter.
     fresh();
     let props = OneStringPropProps::builder().label("from str").build();
     assert_eq!(props.label, "from str");
@@ -457,9 +422,8 @@ fn build_into_setter_accepts_owned_string() {
 
 #[test]
 fn build_generic_setter_accepts_concrete_type() {
-    // Generic prop's setter takes `T` directly (no Into) — the
-    // call site picks T at the chain head and the setter just
-    // stores the value.
+    // A generic prop's setter takes `T` directly: the call site picks
+    // `T` at the chain head.
     fresh();
     let props = GenericLabelProps::builder().value(7_i32).build();
     assert_eq!(props.value, 7);
@@ -467,18 +431,15 @@ fn build_generic_setter_accepts_concrete_type() {
 
 #[test]
 fn props_struct_is_constructable_directly() {
-    // Smoke test: the auto-generated builder is reachable from user
-    // code as `XxxProps::builder()`. Not the recommended path (users
-    // go through `render!`), but it's the typed-builder API surface
-    // and shouldn't break by accident.
+    // The builder must stay reachable as `XxxProps::builder()` even
+    // though `render!` is the recommended path.
     fresh();
     let owner = Owner::new(None);
     let rec = Recorder::default();
     let prev = install_renderer(Box::new(rec));
     owner.with(|| {
-        // Direct (non-render!) call must go through the PascalCase
-        // alias the `#[component]` macro emits — the snake_case fn
-        // is private inside the `__one_string_prop_inner` module.
+        // The snake_case fn is private inside its inner module, so a
+        // direct call must go through the PascalCase alias.
         let _h = OneStringProp(
             OneStringPropProps::builder()
                 .label("direct construction")
@@ -495,19 +456,15 @@ fn props_struct_is_constructable_directly() {
 
 #[test]
 fn view_module_exposes_children_alias() {
-    // The `Children` type alias must be reachable for users to
-    // declare component props of that type.
     fn _accepts(_: whisker::Children) {}
     let c: whisker::Children = ::std::rc::Rc::new(|| View::Empty);
     _accepts(c);
 }
 
-// A component defined in its own module exporting ONLY its
-// PascalCase alias (its `…Props` struct stays unimported). The
-// `#[component]` macro emits a same-named type alias in the type
-// namespace alongside the value-namespace fn, so `render!` can
-// lower `Card(...)` to `Card::builder()` without a separate
-// `CardProps` import. This is the ergonomics fix for issue #1.
+// A component whose module exports ONLY its PascalCase alias. The
+// macro emits a same-named type alias in the type namespace alongside
+// the value-namespace fn, so `render!` can lower `Card(...)` to
+// `Card::builder()` without a separate `CardProps` import.
 mod alias_only {
     use whisker::prelude::*;
     use whisker::runtime::view::Element;
@@ -523,10 +480,8 @@ mod alias_only {
 
 #[test]
 fn component_usable_in_render_with_only_pascal_alias_imported() {
-    // Import the component by its PascalCase name only — crucially
-    // NOT `alias_only::CardProps`. If the macro failed to emit the
-    // type-namespace alias, `Card::builder()` inside `render!` would
-    // not resolve and this file would not compile.
+    // Imported by PascalCase name only — NOT `alias_only::CardProps`.
+    // Without the type-namespace alias this file would not compile.
     use alias_only::Card;
 
     with_test_env(|_log| {

--- a/crates/whisker/tests/component_macro.rs
+++ b/crates/whisker/tests/component_macro.rs
@@ -1,13 +1,9 @@
 //! Integration test for component mounting.
 //!
-//! Originally tested `#[component]` decorated functions with various
-//! return types. After the True per-component remount change
-//! (`#[component]` now always returns `Element` via the
-//! remountable mount path), this file exercises the underlying
-//! `mount_component` API directly to verify owner cascade /
-//! cleanup semantics that the proc-macro is built on. The macro's
-//! own remount behaviour is covered by a separate test that
-//! installs a recording renderer.
+//! Exercises the `mount_component` API directly to verify the owner
+//! cascade / cleanup semantics the `#[component]` proc-macro is built
+//! on. The macro's own remount behaviour is covered by a separate test
+//! that installs a recording renderer.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -16,9 +12,8 @@ use whisker::runtime::reactive::{
     __reset_for_tests, mount_component, on_cleanup, owners_for_fn, unmount_component,
 };
 
-// Stable fn pointers for the tests. Using these instead of
-// component fns since the macro now forces an `Element`
-// return type and the owner-mechanic tests don't render anything.
+// Stable fn pointers: `#[component]` forces an `Element` return type,
+// and the owner-mechanic tests don't render anything.
 fn dummy_outer() {}
 fn dummy_inner() {}
 

--- a/crates/whisker/tests/element_ref.rs
+++ b/crates/whisker/tests/element_ref.rs
@@ -1,4 +1,4 @@
-//! Phase N — `ElementRef` end-to-end tests.
+//! `ElementRef` end-to-end tests.
 //!
 //! Covers:
 //! - `ElementRef::new()` allocates an unbound ref.
@@ -103,8 +103,6 @@ fn passing_ref_at_call_site_binds_on_mount() {
         let r = ElementRef::new();
         assert!(!r.is_bound());
 
-        // Mount the element. The macro emits __bind on the returned
-        // handle.
         let _h = render! {
             XRefTarget(ref: r, value: "hello")
         };
@@ -123,21 +121,15 @@ fn disposing_owner_unbinds_ref() {
     let (rec, _log) = Recorder::with_log();
     let prev = install_renderer(Box::new(rec));
 
-    // Allocate the ref in an outer owner so the bind/unbind cycle
-    // doesn't take the ref's storage with it.
     let outer = Owner::new(None);
     let r = outer.with(ElementRef::new);
 
-    // Mount inside an inner owner — the macro emits on_cleanup
-    // against the inner owner.
     let inner = Owner::new(None);
     inner.with(|| {
         let _h = render! { XRefTarget(ref: r, value: "x") };
     });
     assert!(r.is_bound(), "ref should bind on mount");
 
-    // Disposing the inner owner triggers the on_cleanup that
-    // __unbinds the ref.
     inner.dispose();
     assert!(!r.is_bound(), "ref should unbind on inner-owner disposal");
 
@@ -157,7 +149,6 @@ fn bound_signal_is_reactive() {
     let observed = Rc::new(RefCell::new(Vec::<bool>::new()));
     let observed_clone = observed.clone();
 
-    // Effect must run in *some* owner; the outer one is fine.
     outer.with(|| {
         let bound = r.bound();
         effect(move || {
@@ -211,9 +202,9 @@ fn invoke_on_unbound_ref_returns_error_variant() {
 #[test]
 fn try_from_whisker_value_f64_rejects_string() {
     use whisker::platform_module::WhiskerValue;
-    // `invoke_typed::<T>` now deserializes results via serde, but the
-    // `TryFrom<WhiskerValue>` primitive conversions remain a public
-    // surface — a String must not silently coerce to f64.
+    // `TryFrom<WhiskerValue>`'s primitive conversions are a public
+    // surface even though `invoke_typed::<T>` goes through serde: a
+    // String must not silently coerce to f64.
     let bad_payload = WhiskerValue::String("not-a-number".into());
     let result: Result<f64, _> = f64::try_from(bad_payload);
     let msg = result.expect_err("String can't convert to f64");
@@ -233,7 +224,6 @@ fn try_from_whisker_value_primitives_roundtrip() {
     assert_eq!(i32::try_from(WhiskerValue::Int(42)), Ok(42));
     assert!(i32::try_from(WhiskerValue::Int(i64::MAX)).is_err());
     assert_eq!(f64::try_from(WhiskerValue::Float(2.5)), Ok(2.5));
-    // Int widens to f64
     assert_eq!(f64::try_from(WhiskerValue::Int(3)), Ok(3.0));
     assert_eq!(
         String::try_from(WhiskerValue::String("hi".into())),
@@ -244,7 +234,6 @@ fn try_from_whisker_value_primitives_roundtrip() {
         Ok(vec![1, 2, 3])
     );
 
-    // Type mismatch surfaces a String error.
     let err = bool::try_from(WhiskerValue::Int(1)).unwrap_err();
     assert!(err.contains("expected Bool"), "got {err:?}");
 }

--- a/crates/whisker/tests/module_component.rs
+++ b/crates/whisker/tests/module_component.rs
@@ -117,8 +117,6 @@ pub fn x_styled(style: Signal<String>) {}
 #[whisker::module_component("x-input")]
 pub fn x_input(value: Signal<String>, placeholder: Signal<String>) {}
 
-// ---- Phase 7-Φ.D v2 elements ----------------------------------------------
-
 #[whisker::module_component("x-typed-checkbox")]
 pub fn x_typed_checkbox(checked: Signal<bool>, count: Signal<i32>) {}
 
@@ -150,19 +148,17 @@ fn zero_props_creates_element_with_tag_name() {
                 _ => None,
             })
             .collect();
-        // Tag is namespaced with the cargo crate name. Phase
-        // 7-Φ.H.2.1 — `concat!(env!("CARGO_PKG_NAME"), ":", tag)`
-        // resolves at the integration-test crate to
-        // `whisker:x-zero-props`.
+        // `concat!(env!("CARGO_PKG_NAME"), ":", tag)` resolves in this
+        // integration-test crate to `whisker:x-zero-props`.
         assert_eq!(creates, vec!["whisker:x-zero-props".to_string()]);
     });
 }
 
 #[test]
 fn style_prop_routes_through_set_inline_styles() {
-    // The `style` prop is special — it must call set_inline_styles
-    // (Lynx's SetRawInlineStyles), not set_attribute. Mirrors what
-    // built-in `view(style: …)` does.
+    // The `style` prop must call set_inline_styles (Lynx's
+    // SetRawInlineStyles), not set_attribute — as built-in
+    // `view(style: …)` does.
     with_recorder_and_owner(|log| {
         let _h = render! {
             XStyled(style: "background: red; height: 8px;")
@@ -209,10 +205,9 @@ fn dynamic_style_re_runs_on_signal_change() {
 
 #[test]
 fn non_style_props_route_through_set_attribute_with_kebab_case() {
-    // `value` and `placeholder` are regular SetAttribute calls.
-    // Snake-case prop name → kebab-case attribute name (matches the
-    // built-in `attr()` mapping in __tags). For these two props the
-    // names are already single-word so kebab == snake.
+    // Regular SetAttribute calls. Snake-case prop names map to
+    // kebab-case attribute names; both of these are single-word, so
+    // kebab == snake here.
     with_recorder_and_owner(|log| {
         let _h = render! {
             XInput(value: "hello", placeholder: "type here")
@@ -258,14 +253,11 @@ fn read_signal_prop_tracks_underlying_signal() {
     });
 }
 
-// ---- Phase 7-Φ.D v2 tests -------------------------------------------------
-
 #[test]
 fn typed_signal_bool_serialises_via_to_string() {
-    // `Signal<bool>` extracts T = bool. The Static / Dynamic dispatch
-    // path goes through `apply_attr::<_, bool>`, which calls
-    // `bool::to_string()` → "true" / "false". Verifies the macro's
-    // turbofish picks the inner T correctly (not hardcoded String).
+    // Pins that the macro's turbofish extracts `T = bool` from
+    // `Signal<bool>` rather than hardcoding String:
+    // `apply_attr::<_, bool>` stringifies to "true" / "false".
     with_recorder_and_owner(|log| {
         let (checked, set_checked) = signal(false).split();
         let _h = render! {
@@ -292,9 +284,8 @@ fn typed_signal_bool_serialises_via_to_string() {
 
 #[test]
 fn no_payload_event_handler_registers_listener() {
-    // `on_press: ()` → builder takes `Fn() + 'static`, body wires through
-    // `set_event_listener`. The Recorder logs as `Op::Event`. (`on_press`,
-    // not `on_tap`: `tap` is a reserved Lynx gesture name the macro rejects.)
+    // `on_press`, not `on_tap`: `tap` is a reserved Lynx gesture name
+    // the macro rejects.
     with_recorder_and_owner(|log| {
         let _h = render! {
             XButton(label: "Click me", on_press: || {})
@@ -313,10 +304,6 @@ fn no_payload_event_handler_registers_listener() {
 
 #[test]
 fn raw_payload_event_handler_registers_listener() {
-    // `on_input: WhiskerValue` → builder takes `Fn(WhiskerValue) +
-    // 'static`, body wires through `event::bind_typed` (the raw
-    // body, no field deserialization). The recorder logs the
-    // event-name registration so we can verify the wiring.
     with_recorder_and_owner(|log| {
         let _h = render! {
             XInputPayload(value: "", on_input: |_raw: ::whisker::WhiskerValue| {})
@@ -335,9 +322,6 @@ fn raw_payload_event_handler_registers_listener() {
 
 #[test]
 fn typed_payload_event_handler_registers_listener() {
-    // `on_change: TouchEvent` → builder takes `Fn(TouchEvent) +
-    // 'static`, body wires through `event::bind_typed::<TouchEvent>`
-    // which deserializes the event body before calling the handler.
     with_recorder_and_owner(|log| {
         let _h = render! {
             XTypedInput(on_change: |_e: ::whisker::event::TouchEvent| {})
@@ -356,9 +340,7 @@ fn typed_payload_event_handler_registers_listener() {
 
 #[test]
 fn children_prop_attaches_inner_view() {
-    // `children: Children` → builder takes a `Children` (= Rc<dyn Fn() -> View>),
-    // body calls the closure and attaches the View to the element.
-    // The render! macro lowers the `{ Inner() ... }` block to a
+    // `render!` lowers the `{ Inner() … }` block to a
     // `.children(Rc::new(move || { … }))` setter call.
     with_recorder_and_owner(|log| {
         let _h = render! {
@@ -367,9 +349,6 @@ fn children_prop_attaches_inner_view() {
                 text(value: "child 2")
             }
         };
-        // The container should be appended-to by the two text
-        // elements. Find the container's id (CreateByName) and
-        // count Append entries whose parent is that id.
         let log_b = log.borrow();
         let container_id = log_b.iter().find_map(|op| match op {
             Op::CreateByName { id, tag_name } if tag_name == "whisker:x-container" => Some(*id),

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -8,10 +8,10 @@
 //! body, swap element subtree under the same parent slot — is fully
 //! exercised.
 //!
-//! The wrapper-less model (issue #17): `#[component]` returns its
-//! body root directly. The runtime captures `(parent, anchor)` from
-//! the next `view::append_child` after the component fn returns, so
-//! tests need to attach the result to some parent before invoking
+//! `#[component]` returns its body root directly (no wrapper). The
+//! runtime captures `(parent, anchor)` from the next
+//! `view::append_child` after the component fn returns, so tests must
+//! attach the result to a parent before invoking
 //! `remount_components_for`.
 
 use std::cell::RefCell;
@@ -145,10 +145,9 @@ fn leaf(label: &'static str) -> Element {
 
 // ----------------------------------------------------------------------------
 // Module-level components for tests that exercise mount-site behaviour.
-// `#[component]` emits a `mod __<name>_inner` + `pub use` pair which is
-// only legal at module level (not inside fn bodies), so test fixtures
-// that used to be nested are pulled up here and given prefixed names
-// to avoid collisions.
+// `#[component]` emits a `mod __<name>_inner` + `pub use` pair, only
+// legal at module level, so these fixtures can't be nested inside the
+// test fns; the name prefixes keep them from colliding.
 // ----------------------------------------------------------------------------
 
 #[component]
@@ -237,9 +236,6 @@ fn component_returns_body_root_directly() {
                 _ => None,
             })
             .collect();
-        // First created element should be the body's outer `view`
-        // (id 0), not a separate wrapper. The text and raw_text
-        // follow.
         assert!(!creates.is_empty(), "leaf must create at least one element");
         assert_eq!(
             creates[0],
@@ -255,11 +251,9 @@ fn remount_replaces_root_at_same_parent_slot() {
         let (parent, root_initial) = mount_under_test_parent(|| render! { Leaf(label: "v1") });
         log.borrow_mut().clear();
 
-        // Simulate a subsecond patch on `leaf`'s fn pointer.
         remount_components_for(&[Leaf as *const ()]);
 
         let ops = log.borrow();
-        // The old body root was removed from the test parent.
         assert!(
             ops.iter().any(|op| matches!(
                 op,
@@ -268,14 +262,13 @@ fn remount_replaces_root_at_same_parent_slot() {
             )),
             "old body root removed from parent; ops were {ops:?}"
         );
-        // A fresh `view` was created for the new body.
         assert!(
             ops.iter()
                 .any(|op| matches!(op, Op::Create { tag, .. } if *tag == ElementTag::View)),
             "new body's view created; ops were {ops:?}"
         );
-        // The label re-renders to the same value (subsecond didn't
-        // actually swap the body; we just re-invoke it).
+        // The label re-renders to the same value — the body isn't
+        // actually swapped here, just re-invoked.
         assert!(
             ops.iter().any(|op| matches!(
                 op,
@@ -284,7 +277,6 @@ fn remount_replaces_root_at_same_parent_slot() {
             )),
             "new body re-rendered the same label; ops were {ops:?}"
         );
-        // The new root was attached under the *same* parent.
         assert!(
             ops.iter().any(|op| matches!(
                 op,
@@ -322,16 +314,11 @@ fn remount_disposes_old_owner_and_registers_new() {
 fn remount_releases_old_body_elements() {
     with_recorder_and_owner(|log| {
         let (_parent, _root) = mount_under_test_parent(|| render! { Leaf(label: "v1") });
-        // Count elements created by the component itself (everything
-        // the test parent's setup added is also in the log; we just
-        // count Creates from after our parent's creation).
         let creates_initial_total = log
             .borrow()
             .iter()
             .filter(|op| matches!(op, Op::Create { .. }))
             .count();
-        // The test parent is the first Create; the rest belong to
-        // the component.
         let component_elements = creates_initial_total - 1;
 
         log.borrow_mut().clear();
@@ -352,17 +339,14 @@ fn remount_releases_old_body_elements() {
 
 #[test]
 fn dispose_owner_releases_owned_elements() {
-    // A leaf component mount creates several elements through
-    // `view::*` while the component's owner is live. Disposing the
-    // outer owner (e.g. when `<Show>` flips false, `<For>` removes
-    // an item) cascades through the component owner and must
-    // release every element it tracked.
+    // Disposing the outer owner (a `<Show>` flipping false, a `<For>`
+    // dropping an item) cascades through the component owner, which
+    // must release every element it tracked.
     reset_state();
     let (rec, log) = Recorder::new();
     let _prev = install_renderer(Box::new(rec));
 
     let root_owner = Owner::new(None);
-    // Mount the component inside the root owner.
     let _root = root_owner.with(|| render! { Leaf(label: "hi") });
 
     let creates_initial = log
@@ -390,24 +374,17 @@ fn dispose_owner_releases_owned_elements() {
 
 #[test]
 fn nested_component_mount_sites_cleared_on_parent_remount() {
-    // Regression test for the iOS-side breakage when `scroll_body`
-    // (a parent #[component]) was remounted after a string-literal
-    // edit: child `#[component]` MountSites from the disposed
-    // subtree were left in the runtime registry, and the next
-    // `remount_components_for` call processed them too — touching
-    // freed parent / body_root handles and corrupting the screen.
-    //
-    // The fix in `Owner::dispose` scrubs `mount_sites` /
-    // `fn_ptr_mounts` for any orphaned child. This test pins that
-    // behaviour: after a parent remount, the child fn pointer's
-    // MountSite list should equal the count of live child
-    // invocations, not double up with the pre-remount entries.
+    // `Owner::dispose` must scrub `mount_sites` / `fn_ptr_mounts` for
+    // orphaned children: a MountSite left behind by a disposed subtree
+    // gets processed by the next `remount_components_for`, touching
+    // freed parent / body_root handles. After a parent remount the
+    // child fn pointer's MountSite list must equal the count of LIVE
+    // child invocations, not double up with pre-remount entries.
     use whisker::runtime::reactive::owners_for_fn;
 
     with_recorder_and_owner(|_log| {
         let (_parent, _root) = mount_under_test_parent(|| render! { NestedOuter() });
 
-        // After initial mount: 1 outer + 3 inner owners.
         assert_eq!(owners_for_fn(NestedOuter as *const ()).len(), 1);
         assert_eq!(
             owners_for_fn(NestedInner as *const ()).len(),
@@ -415,9 +392,8 @@ fn nested_component_mount_sites_cleared_on_parent_remount() {
             "three inner invocations expected after initial mount",
         );
 
-        // Remount outer (simulates subsecond patching outer's body).
-        // This should dispose the 3 old inner owners + their
-        // MountSites, then create 3 fresh inner invocations.
+        // Remounting outer must dispose the 3 old inner owners and
+        // their MountSites, then create 3 fresh inner invocations.
         remount_components_for(&[NestedOuter as *const ()]);
 
         // The count must stay at 3 — not balloon to 6.

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -183,10 +183,9 @@ fn nested_view_with_text_child() {
                 tag: ElementTag::RawText
             }
         );
-        // The raw_text gets its text attr set in an effect. We check
-        // the attr appears in the op stream and the raw_text is
-        // attached to the text. Order between the SetAttr and the
-        // append is an implementation detail of the value() method.
+        // The raw_text's text attr is set in an effect, so its order
+        // relative to the append is an implementation detail of
+        // `value()`.
         assert!(ops.iter().any(|op| matches!(op, Op::SetAttr {
             id: 2, key, value
         } if key == "text" && value == "Hello")));
@@ -260,15 +259,14 @@ fn arbitrary_attribute_emits_set_attribute() {
 
 #[test]
 fn typed_attribute_methods_route_to_named_setters() {
-    // Phase: built-in attribute coverage. Named attribute methods route
-    // to `.method(v)` (not the String-only `.attr`), so bool / number /
-    // enum-string values stringify to the right Lynx attribute name.
+    // Named attribute methods route to `.method(v)`, not the
+    // String-only `.attr`, so bool / number / enum-string values reach
+    // the right Lynx attribute name.
     let has = |ops: &[Op], key: &str, val: &str| {
         ops.iter()
             .any(|op| matches!(op, Op::SetAttr { key: k, value: v, .. } if k == key && v == val))
     };
 
-    // scroll_view: bool + number attrs.
     with_recorder(|log| {
         let _ = render! {
             scroll_view(bounces: true, enable_scroll: false, upper_threshold: 50)
@@ -279,7 +277,6 @@ fn typed_attribute_methods_route_to_named_setters() {
         assert!(has(&ops, "upper-threshold", "50"), "got {ops:?}");
     });
 
-    // text: number + bool.
     with_recorder(|log| {
         let _ = render! {
             text(value: "hi", text_maxline: 2, text_selection: true)
@@ -289,7 +286,6 @@ fn typed_attribute_methods_route_to_named_setters() {
         assert!(has(&ops, "text-selection", "true"), "got {ops:?}");
     });
 
-    // common (trait) attrs on a plain view: bool + string.
     with_recorder(|log| {
         let _ = render! {
             view(flatten: true, hit_slop: "10px", pan_intercept_direction: PanInterceptDirection::Horizontal)
@@ -318,16 +314,16 @@ fn on_tap_emits_set_event_listener() {
             op,
             Op::Event { name, bind_type, .. } if name == "tap" && *bind_type == BindType::Bind
         )));
-        // The recorder stored but doesn't fire the callback —
-        // verifying registration is enough at the macro layer.
+        // The recorder stores but never fires the callback;
+        // registration is all the macro layer can be held to.
         assert!(!*fired.borrow());
     });
 }
 
 #[test]
 fn tap_propagation_variants_route_to_bind_types() {
-    // The 1:1 mapping: each `on_[capture_]tap[_catch]` kwarg registers
-    // a "tap" listener with the matching propagation `BindType`.
+    // Each `on_[capture_]tap[_catch]` kwarg registers a "tap" listener
+    // with the matching propagation `BindType`.
     with_recorder(|log| {
         let _ = render! {
             view {
@@ -361,9 +357,8 @@ fn tap_propagation_variants_route_to_bind_types() {
 
 #[test]
 fn component_specific_events_route_bind_only() {
-    // Phase 6 coverage: tag-specific CustomEvents (scroll_view /
-    // text) register their named listener as BindType::Bind. They have
-    // no catch/capture variants (Lynx CustomEvent = target-only).
+    // Tag-specific CustomEvents register as `BindType::Bind` and have
+    // no catch/capture variants — Lynx CustomEvents are target-only.
     with_recorder(|log| {
         let _ = render! {
             scroll_view {
@@ -466,10 +461,9 @@ fn multiple_children_append_in_order() {
 fn dynamic_value_renders_initial_via_effect() {
     with_recorder_and_owner(|log| {
         let (count, _set_count) = signal(0_i32).split();
-        // Phase 7-Φ.B: macro no longer auto-wraps kwargs. For
-        // reactive numeric → string interpolation, derive a
-        // `ReadSignal<String>` via `computed`. Passes through as
-        // `Signal::Dynamic` to the `value` builder.
+        // The macro does not auto-wrap kwargs: reactive numeric →
+        // string interpolation goes through a `computed`, which reaches
+        // the `value` builder as `Signal::Dynamic`.
         let label = computed(move || count.get().to_string());
         let _h = render! {
             text(value: label)
@@ -515,9 +509,6 @@ fn dynamic_value_updates_on_signal_write() {
 fn dynamic_style_re_runs_on_dep_change() {
     with_recorder_and_owner(|log| {
         let (color, set_color) = signal("red".to_string()).split();
-        // `format!` expression captured inside `computed` so the
-        // closure (and the underlying signal read) re-runs on
-        // change.
         let css = computed(move || format!("color: {};", color.get()));
         let _h = render! {
             view(style: css)
@@ -541,8 +532,6 @@ fn dynamic_style_re_runs_on_dep_change() {
 fn dynamic_attribute_re_runs_on_dep_change() {
     with_recorder_and_owner(|log| {
         let (src, set_src) = signal("a.png".to_string()).split();
-        // Already a `ReadSignal<String>` — pass the handle directly,
-        // it converts to `Signal::Dynamic`.
         let _h = render! {
             view(src: src)
         };
@@ -581,9 +570,8 @@ fn static_value_only_sets_text_once() {
 
 #[test]
 fn mixed_static_and_dynamic_children_via_raw_text() {
-    // Two separate raw_text siblings — first static, second
-    // reading the signal. Same op-stream shape the legacy
-    // `<text>"count=" {count.get()}</text>` produced.
+    // Two raw_text siblings: the first static, the second reading the
+    // signal.
     with_recorder_and_owner(|log| {
         let (count, _set) = signal(7_i32).split();
         let count_label = computed(move || count.get().to_string());
@@ -621,7 +609,6 @@ fn signal_only_updates_elements_that_read_it() {
         log.borrow_mut().clear(); // ignore initial ops
         set_a.set(1);
         flush();
-        // Only the element reading `a` should have its SetAttr fire.
         let set_text_count = log
             .borrow()
             .iter()
@@ -703,7 +690,6 @@ fn show_swaps_on_condition_flip() {
         set_cond.set(false);
         flush();
 
-        // After flip: a new "fb" element gets created + text set.
         let texts_after: Vec<_> = log
             .borrow()
             .iter()

--- a/crates/whisker/tests/show_skip.rs
+++ b/crates/whisker/tests/show_skip.rs
@@ -1,11 +1,10 @@
 //! `Show` rebuilds its branch only when the condition **changes**, not
 //! on every dependency change of `when`.
 //!
-//! `WriteSignal::set` notifies subscribers unconditionally (even for a
-//! no-op write), so an effect keyed on a signal that `when` reads used
-//! to tear down and re-mount the branch for an unchanged condition —
-//! churning the DOM, disposing branch-internal state, and re-anchoring
-//! following siblings. These tests pin the fixed behaviour.
+//! `WriteSignal::set` notifies subscribers unconditionally, even for a
+//! no-op write, so the branch must not be rebuilt just because the
+//! effect re-ran: doing so churns the DOM, disposes branch-internal
+//! state, and re-anchors following siblings.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -85,8 +84,6 @@ fn with_test_env<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
 fn unchanged_cond_does_not_rebuild_branch() {
     with_test_env(|log| {
         let s = RwSignal::new(0i32);
-        // The bool only flips at the threshold 10, so `s: 0 -> 1` leaves
-        // the condition `true` while still notifying the effect.
         let _tree = render! {
             view() {
                 Show(when: move || s.get() < 10) {
@@ -97,12 +94,10 @@ fn unchanged_cond_does_not_rebuild_branch() {
         };
         flush();
 
-        // Everything above is the initial mount — ignore it.
         log.borrow_mut().clear();
 
-        // Unchanged condition: the effect re-runs (it reads `s`), but the
-        // branch must not be torn down / rebuilt, and the sibling must not
-        // be re-anchored.
+        // Unchanged condition: the effect re-runs (it reads `s`), but
+        // the branch must not be rebuilt nor the sibling re-anchored.
         s.set(1);
         flush();
 
@@ -128,7 +123,6 @@ fn changed_cond_still_rebuilds_branch() {
         flush();
         log.borrow_mut().clear();
 
-        // Genuine flip true -> false: the branch must be torn down.
         s.set(20);
         flush();
 

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -1,9 +1,8 @@
-//! Phase 7-Φ.C end-to-end test: a `#[component]` declared with a
-//! `Signal<T>` prop receives a parent's reactive value and tracks
-//! it through to the underlying element's attribute.
+//! End-to-end test: a `#[component]` declared with a `Signal<T>` prop
+//! receives a parent's reactive value and tracks it through to the
+//! underlying element's attribute.
 //!
-//! This is the user-facing assertion of the unified reactivity
-//! model:
+//! The user-facing assertion of the unified reactivity model:
 //!
 //! - Parent passes a `ReadSignal<String>` (or `RwSignal<String>`,
 //!   or a `String`, or a `&str`) to a child component prop typed
@@ -11,9 +10,9 @@
 //! - The child's body reads the prop inside a `computed` /
 //!   `effect`, so the underlying signal is registered as a
 //!   dependency.
-//! - When the parent updates its signal, the child's element
-//!   updates via the effect chain — same fine-grained reactivity
-//!   that built-in tags already enjoy.
+//! - When the parent updates its signal, the child's element updates
+//!   via the effect chain — the same fine-grained reactivity built-in
+//!   tags get.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -131,9 +130,9 @@ fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
 /// inside a `computed` to drive a reactive `style` attribute.
 #[component]
 fn colored_tile(color: Signal<String>) -> Element {
-    // `Signal<T>` is `Copy` (whisker #8), so `color` moves freely into
-    // the `computed` closure even though the `#[component]` body is the
-    // `FnMut` the macro wraps for hot-patch dispatch — no `.clone()`.
+    // `Signal<T>` is `Copy`, so `color` moves into the `computed`
+    // closure without a `.clone()` even though the `#[component]` body
+    // is the `FnMut` the macro wraps for hot-patch dispatch.
     let style = computed(move || format!("background: {};", color.get()));
     render! {
         view(style: style)
@@ -217,15 +216,13 @@ fn rw_signal_prop_tracks_underlying_signal() {
     });
 }
 
-// ----- Show + Resource-like state flip (the hn-reader pattern) ----------
+// ----- Show + Resource-like state flip --------------------------------
 
 #[test]
 fn show_flips_when_signal_holding_option_transitions() {
-    // Reproduces the hn-reader pattern: a `Show` whose `when` reads
-    // a signal that goes from `None` (fallback shown) to `Some(_)`
-    // (children shown). Catches any reactivity regression in the
-    // Show + signal-read chain that the simpler `text(value: …)`
-    // tests don't exercise.
+    // A `Show` whose `when` reads a signal going from `None` (fallback)
+    // to `Some(_)` (children) — the Show + signal-read chain the
+    // simpler `text(value: …)` tests don't reach.
     with_recorder_and_owner(|log| {
         let (state, set_state) = signal::<Option<&'static str>>(None).split();
         let _h = render! {
@@ -236,7 +233,6 @@ fn show_flips_when_signal_holding_option_transitions() {
                 ColoredTile(color: "loaded")
             }
         };
-        // Initial: fallback mounted → "loading" attribute set.
         let initial_styles: Vec<_> = log
             .borrow()
             .iter()
@@ -250,8 +246,6 @@ fn show_flips_when_signal_holding_option_transitions() {
             "initial render must mount the fallback branch (got styles {initial_styles:?})"
         );
 
-        // Flip the signal — Show effect should re-run and swap to
-        // the children branch.
         set_state.set(Some("done"));
         flush();
         let after_styles: Vec<_> = log
@@ -275,9 +269,6 @@ fn show_flips_when_signal_holding_option_transitions() {
 fn computed_prop_tracks_chain_of_signals() {
     with_recorder_and_owner(|log| {
         let (count, set_count) = signal(0_i32).split();
-        // Caller-side computed → ReadSignal<String> → flows into
-        // ColoredTile as Signal::Dynamic. Updates to `count`
-        // propagate end-to-end.
         let color_label = computed(move || {
             if count.get() % 2 == 0 {
                 "even".to_string()


### PR DESCRIPTION
Part of the per-crate sweep [docs/comment-style.md](docs/comment-style.md) announces (pilot: #376). Covers the umbrella crate and the language/formatting crates: `whisker`, `whisker-css`, `whisker-macros`, `whisker-macro-syntax`, `whisker-fmt`.

## What was applied

Internal comments keep only the non-obvious why; **user-facing rustdoc keeps its summaries, examples, and trade-off sections** and loses only history/design-diary. The small delta on `whisker-css` (−3%) is deliberate — it is nearly all pub rustdoc, which the guide protects.

## Stale comments corrected (found while sweeping)

The sweep surfaced nine comments that had drifted from the code; the notable ones:

- **`#[component]` rustdoc documented the old brace call syntax** (`render! { counter { initial: 0 } }`) — the real syntax is parens under the PascalCase alias (`Counter(initial: 0)`), as `crates/whisker/tests/component_invocation.rs` exercises. Actively misleading user-facing docs.
- **`module_component` claimed children props are "NOT yet supported"** — they are (`PropKind::Children` + passing test).
- **The `list` section described a children-virtualizing model** ("no framework callbacks") that the `NativeItemProvider` data-source model replaced; the live `custom-list-name` flag mechanics are kept.
- `whisker-fmt` justified its hand-rolled TOML reader as avoiding a `toml` dependency the crate meanwhile grew; a recursion description in `collect_macro_edits` contradicted the (non-recursive) code; `whisker-macro-syntax` listed a built-in tag set that no longer matches `is_builtin_tag` (now links the function instead, so it can't drift again).
- Multiple references to the retired typed-builder implementation restated for the hand-rolled Props builder.

## Numbers & verification

Comment lines 5416 → 4618 (−15%); 40 files, +702/−1517. **No code changes** — verified mechanically per crate (`git diff -U0` filtered to non-comment lines is empty). `cargo test -p` green for all five at baseline parity (incl. doc-tests), clippy 0 warnings, fmt clean. Pre-existing rustdoc warning count (20) confirmed unchanged by stash-compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)