### PR TITLE
Sweep packages/* comments

### DIFF
--- a/packages/whisker-asset-macros/src/lib.rs
+++ b/packages/whisker-asset-macros/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! - [`asset!`] — a **runtime** call `::whisker_asset::resolve("<rel>")`
 //!   that composes a platform-absolute path/URL from the process-global
-//!   base. The file is *not* embedded; it is expected to be bundled by a
-//!   later build-plugin phase.
+//!   base. The file is *not* embedded — `whisker-asset`'s build plugin
+//!   bundles it into the app instead.
 //! - [`asset_str!`] — `include_str!` of the file content → `&'static str`.
 //! - [`asset_bytes!`] — `include_bytes!` of the file content →
 //!   `&'static [u8]`.

--- a/packages/whisker-asset/src/lib.rs
+++ b/packages/whisker-asset/src/lib.rs
@@ -143,11 +143,6 @@ pub fn resolve(rel: &str) -> String {
     }
 }
 
-// ---------------------------------------------------------------------------
-// C ABI — called by native (iOS/Android) at startup. Phase 1 only wires
-// these to `set_base`; native registration lands in a later phase.
-// ---------------------------------------------------------------------------
-
 /// Install an iOS directory base from native code.
 ///
 /// # C ABI
@@ -197,30 +192,13 @@ pub extern "C" fn whisker_asset_set_android() {
     set_base(AssetBase::AndroidAssets);
 }
 
-// ---------------------------------------------------------------------------
-// Android startup wiring (Phase 3).
-//
-// Unlike iOS — where the bundle path is only known at runtime, so the
-// base MUST be installed by native Swift after `Bundle.main.bundlePath`
-// resolves — the Android base is a compile-time constant
-// (`file:///android_asset/whisker/`). There is therefore no runtime
-// data to ferry across the Kotlin↔Rust boundary, and wiring a Kotlin
-// `external fun` would require a JNI C++ shim living in the driver
-// bridge crate (not here). Instead we install the Android base from
-// Rust, deterministically, the moment this crate's object code is
-// loaded into the app's `cdylib`.
-//
-// The user app links `whisker-asset` because `asset!(…)` expands to
-// `::whisker_asset::resolve(…)`, so this translation unit is always
-// present in the final `.so`. The `.init_array` entry below runs at
-// `dlopen`/`System.loadLibrary` time — long before `whisker_app_main`
-// and the first render — so `resolve` already returns the
-// `file:///android_asset/whisker/…` form on the very first call.
-//
-// `whisker_asset_set_android()` (the C-ABI entry above) remains
-// exported so native Kotlin/JNI can still flip the base explicitly if
-// a future host wants to; the constructor just means it doesn't have
-// to.
+// The Android base is a compile-time constant, so nothing has to cross the
+// Kotlin↔Rust boundary to install it — the `.init_array` constructor below
+// does it at `.so` load, long before the first render, and `resolve` returns
+// the `file:///android_asset/whisker/…` form on the very first call. The
+// `whisker_asset_set_android()` C-ABI entry stays exported so a host that
+// wants to set it explicitly still can.
+
 /// Install the fixed Android base. Shared body for the `.init_array`
 /// constructor (Android) and the unit test (host) so the exact
 /// install path is exercised off-device.
@@ -346,8 +324,6 @@ mod tests {
     fn install_android_base_sets_android_form() {
         let _g = GUARD.lock().unwrap();
         reset();
-        // Exercises the exact body the Android `.init_array`
-        // constructor runs at `.so` load.
         install_android_base();
         assert!(base_is_set());
         assert_eq!(resolve("a/b.png"), "file:///android_asset/whisker/a/b.png");
@@ -359,7 +335,6 @@ mod tests {
         let _g = GUARD.lock().unwrap();
         reset();
         set_base(AssetBase::IosDir("/base".into()));
-        // A leading slash is stripped so the base is preserved.
         assert_eq!(resolve("/images/logo.png"), "/base/images/logo.png");
         reset();
     }
@@ -369,7 +344,6 @@ mod tests {
         let _g = GUARD.lock().unwrap();
         reset();
         set_base(AssetBase::AndroidAssets);
-        // `..` components are dropped; the base can't be escaped.
         assert_eq!(
             resolve("images/../../../etc/passwd"),
             "file:///android_asset/whisker/etc/passwd"

--- a/packages/whisker-asset/src/plugin.rs
+++ b/packages/whisker-asset/src/plugin.rs
@@ -271,7 +271,6 @@ impl Plugin for WhiskerAsset {
             return Ok(());
         }
 
-        // ----- Android: drop each file under app/src/main/assets/whisker/ ----
         if let Some(android) = ctx.android.as_mut() {
             let mut count = 0usize;
             for asset in &assets {
@@ -291,7 +290,6 @@ impl Plugin for WhiskerAsset {
             );
         }
 
-        // ----- iOS: drop under whisker_assets/ + one folder reference --------
         if let Some(ios) = ctx.ios.as_mut() {
             let mut count = 0usize;
             for asset in &assets {
@@ -307,10 +305,8 @@ impl Plugin for WhiskerAsset {
                 Operation::ArrayPush { count },
             );
 
-            // Register the whole `whisker_assets` directory as a single
-            // folder reference so Xcode copies the tree into the bundle
-            // preserving subdirectories (one op regardless of file
-            // count — the folder ref covers everything beneath it).
+            // One folder reference (not per-file) so Xcode copies the tree
+            // into the bundle with its subdirectories preserved.
             ios.pbxproj_ops.push(PbxprojOp::AddResourceFolder {
                 path: PathBuf::from(IOS_NAMESPACE),
             });
@@ -331,8 +327,6 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
     use whisker_plugin::{AndroidProjectIr, IosProjectIr};
-
-    // ----- Temp-dir + fixture helpers --------------------------------------
 
     fn unique_tempdir(label: &str) -> PathBuf {
         static SEQ: AtomicU64 = AtomicU64::new(0);
@@ -359,8 +353,6 @@ mod tests {
         }
     }
 
-    // ----- Builder ---------------------------------------------------------
-
     #[test]
     fn dir_and_file_accumulate() {
         let mut cfg = WhiskerAssetConfig::default();
@@ -372,8 +364,6 @@ mod tests {
         assert_eq!(cfg.files, vec![PathBuf::from("branding/logo.png")]);
     }
 
-    // ----- validate --------------------------------------------------------
-
     #[test]
     fn validate_rejects_missing_dir() {
         let root = unique_tempdir("vmissing-dir");
@@ -382,8 +372,8 @@ mod tests {
             c.dir("assets");
             c
         };
-        // validate itself doesn't touch disk; apply does. Verify the
-        // missing-path error surfaces via apply (the real pipeline path).
+        // validate itself doesn't touch disk; apply does, so the
+        // missing-path error only surfaces there.
         let mut ctx = ctx_both(&root);
         let err = WhiskerAsset.apply(&mut ctx, &cfg).unwrap_err();
         assert!(err.to_string().contains("does not exist"), "{err}");
@@ -437,8 +427,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    // ----- apply -----------------------------------------------------------
-
     #[test]
     fn apply_bundles_dir_into_both_platforms() {
         let root = unique_tempdir("apply-dir");
@@ -449,7 +437,6 @@ mod tests {
         let mut ctx = ctx_both(&root);
         WhiskerAsset.apply(&mut ctx, &cfg).unwrap();
 
-        // Android: app/src/main/assets/whisker/<rel>
         let android = ctx.android.as_ref().unwrap();
         let a_logo = PathBuf::from("app/src/main/assets/whisker/images/logo.png");
         assert!(
@@ -464,7 +451,6 @@ mod tests {
             "app/src/main/assets/whisker/data/config.json"
         )));
 
-        // iOS: whisker_assets/<rel>
         let ios = ctx.ios.as_ref().unwrap();
         let i_logo = PathBuf::from("whisker_assets/images/logo.png");
         assert!(ios.extra_files.contains_key(&i_logo), "ios logo missing");
@@ -473,7 +459,6 @@ mod tests {
             vec![0x89, 0x50, 0x4e, 0x47],
         );
 
-        // iOS folder reference registered exactly once.
         let folder_refs: Vec<_> = ios
             .pbxproj_ops
             .iter()
@@ -499,7 +484,6 @@ mod tests {
         let mut ctx = ctx_both(&root);
         WhiskerAsset.apply(&mut ctx, &cfg).unwrap();
 
-        // Bundles under basename, not the source subpath.
         assert!(
             ctx.ios
                 .as_ref()

--- a/packages/whisker-asset/tests/plugin_e2e.rs
+++ b/packages/whisker-asset/tests/plugin_e2e.rs
@@ -74,7 +74,6 @@ fn ios_generation_lands_assets_and_folder_reference() {
     let r#gen = unique_tempdir("ios-gen").join("gen/ios");
     whisker_cng::ios::sync(&r#gen, &inputs).unwrap();
 
-    // Assets written under whisker_assets/<rel>, bytes intact.
     let logo = r#gen.join("whisker_assets/images/logo.png");
     assert!(logo.exists(), "logo not written to {}", logo.display());
     assert_eq!(
@@ -83,7 +82,6 @@ fn ios_generation_lands_assets_and_folder_reference() {
     );
     assert!(r#gen.join("whisker_assets/data/config.json").exists());
 
-    // pbxproj carries the folder reference so the bundle keeps subdirs.
     let pbxproj =
         std::fs::read_to_string(r#gen.join(format!("{}.xcodeproj/project.pbxproj", inputs.scheme)))
             .unwrap();
@@ -122,7 +120,6 @@ fn android_generation_lands_assets_under_whisker_namespace() {
     let r#gen = unique_tempdir("android-gen").join("gen/android");
     whisker_cng::android::sync(&r#gen, &inputs).unwrap();
 
-    // AGP source set: app/src/main/assets/whisker/<rel>
     let logo = r#gen.join("app/src/main/assets/whisker/images/logo.png");
     assert!(logo.exists(), "logo not written to {}", logo.display());
     assert_eq!(std::fs::read(&logo).unwrap(), vec![0x00, 0xff, 0x10]);

--- a/packages/whisker-audio/src/plugin.rs
+++ b/packages/whisker-audio/src/plugin.rs
@@ -92,7 +92,6 @@ pub struct WhiskerAudio;
 impl Plugin for WhiskerAudio {
     type Config = WhiskerAudioConfig;
     fn apply(&self, ctx: &mut GenerateContext, cfg: &WhiskerAudioConfig) -> anyhow::Result<()> {
-        // ----- iOS Info.plist contributions ------------------------------
         if let Some(ios) = ctx.ios.as_mut() {
             if let Some(desc) = cfg.microphone_permission.as_ref() {
                 ios.info_plist.insert(
@@ -107,10 +106,8 @@ impl Plugin for WhiskerAudio {
                 );
             }
 
-            // Both flags map to the SAME `UIBackgroundModes` entry
-            // (just `"audio"`). Set it once if either is on; dedup
-            // is internal to this plugin so the rendered plist
-            // doesn't show duplicates.
+            // Both flags map to the SAME `UIBackgroundModes` entry, so set it
+            // once if either is on — otherwise the plist shows duplicates.
             if cfg.enable_background_recording || cfg.enable_background_playback {
                 ios.info_plist.insert(
                     "UIBackgroundModes".into(),
@@ -125,7 +122,6 @@ impl Plugin for WhiskerAudio {
             }
         }
 
-        // ----- Android manifest contributions --------------------------
         if let Some(android) = ctx.android.as_mut() {
             if cfg.record_audio_android {
                 android
@@ -258,7 +254,6 @@ mod tests {
 
     #[test]
     fn no_ios_target_skips_ios_entries() {
-        // Single-target compose run for Android only.
         let mut cfg = WhiskerAudioConfig::default();
         cfg.microphone_permission("…").record_audio_android(true);
         let mut ctx = GenerateContext {
@@ -266,7 +261,6 @@ mod tests {
             ..Default::default()
         };
         WhiskerAudio.apply(&mut ctx, &cfg).unwrap();
-        // Android permission landed.
         assert_eq!(
             ctx.android.unwrap().manifest.permissions,
             vec!["android.permission.RECORD_AUDIO".to_string()],

--- a/packages/whisker-audio/src/runtime.rs
+++ b/packages/whisker-audio/src/runtime.rs
@@ -15,14 +15,11 @@ use whisker::{ArcReadSignal, ArcRwSignal, ReadSignal, module};
 /// bar can branch on `is_loaded` to fade in once the value is
 /// meaningful.
 ///
-/// `#[non_exhaustive]` so the surface can grow (e.g. a future
-/// `is_buffering` flag, an `error: Option<...>`) without breaking
-/// downstream code. Users read fields directly but should not
-/// match the struct exhaustively — `PlaybackStatus { position,
-/// duration, .. }` is the supported destructure form, and
-/// construction from outside the crate is intentionally not
-/// supported (the value is produced by the native module, never by
-/// the consumer).
+/// `#[non_exhaustive]` so the surface can grow without breaking
+/// downstream code. Read fields directly; `PlaybackStatus { position,
+/// duration, .. }` is the supported destructure form. Construction
+/// from outside the crate is deliberately unsupported — the value is
+/// produced by the native module, never by the consumer.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[non_exhaustive]
 pub struct PlaybackStatus {
@@ -231,8 +228,6 @@ impl Player {
     }
 }
 
-// ---- Process-global status subscription dispatch --------------------------
-
 // Atomic so any thread that managed to construct a `Player` can
 // allocate; the dispatch path that consumes the id is main-thread-only.
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
@@ -323,16 +318,15 @@ fn read_bool(fields: &BTreeMap<String, WhiskerValue>, key: &str) -> bool {
     matches!(fields.get(key), Some(WhiskerValue::Bool(true)))
 }
 
-/// Main-thread-only wrapper (mirrors `whisker-safe-area`'s). Asserts
-/// the Lynx TASM-thread contract so `OnceLock<T>`'s `T: Sync` bound
-/// passes without making `Rc` actually `Sync`.
+/// Main-thread-only wrapper. Asserts the Lynx TASM-thread contract so
+/// `OnceLock<T>`'s `T: Sync` bound passes without making `Rc` actually
+/// `Sync`.
 #[derive(Clone)]
 struct MainThreadOnly<T> {
     inner: T,
 }
-// Safety: every consumer runs on the reactive thread by contract
-// (the bridge dispatches status events on the main thread). Misuse
-// would corrupt the arena — same risk as any signal-touching code
-// off the main thread.
+// SAFETY: every consumer runs on the reactive thread by contract — the
+// bridge dispatches status events on the main thread. Misuse would corrupt
+// the arena.
 unsafe impl<T> Send for MainThreadOnly<T> {}
 unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/packages/whisker-haptics/src/lib.rs
+++ b/packages/whisker-haptics/src/lib.rs
@@ -36,8 +36,8 @@
 //!
 //! ## Native source
 //!
-//! - iOS: `crates/whisker-haptics/ios/Sources/WhiskerHaptics/HapticsModule.swift`
-//! - Android: `crates/whisker-haptics/android/src/main/kotlin/rs/whisker/modules/haptics/HapticsModule.kt`
+//! - iOS: `packages/whisker-haptics/ios/Sources/WhiskerHaptics/HapticsModule.swift`
+//! - Android: `packages/whisker-haptics/android/src/main/kotlin/rs/whisker/modules/haptics/HapticsModule.kt`
 
 /// Plugin (`Android VIBRATE` manifest injection). Always compiles —
 /// independent of the `runtime` feature so the `whisker.rs` config

--- a/packages/whisker-haptics/src/plugin.rs
+++ b/packages/whisker-haptics/src/plugin.rs
@@ -1,10 +1,9 @@
 //! Whisker plugin for the haptics module.
 //!
 //! Haptic feedback is meaningless without `android.permission.VIBRATE`
-//! (a "normal" permission — auto-granted, no runtime dialog), so
-//! unlike `whisker-audio`'s config plugin, there's no opt-in flag to
-//! spell: opting into the plugin at all means opting into the
-//! permission.
+//! (a "normal" permission — auto-granted, no runtime dialog), so the
+//! config carries no opt-in flag: opting into the plugin at all means
+//! opting into the permission.
 //!
 //! ## Usage in `whisker.rs`
 //!
@@ -29,10 +28,8 @@ impl PluginConfig for WhiskerHapticsConfig {
 /// subprocess via the bundled `whisker-haptics-plugin` binary,
 /// depending on the engine's plugin pipeline. Also the namespace for
 /// the runtime API (`impact`/`selection`/`notification`, defined in
-/// `runtime.rs`) — one unit struct serves both roles, unlike
-/// `whisker-audio`'s split (`WhiskerAudio` the plugin vs. `Player`
-/// the runtime handle), since haptics has no handle/identity to
-/// carry, just static methods (Shape 5).
+/// `runtime.rs`) — one unit struct serves both roles, since haptics has
+/// no handle to carry, just static methods (Shape 5).
 pub struct WhiskerHaptics;
 
 impl Plugin for WhiskerHaptics {

--- a/packages/whisker-haptics/src/runtime.rs
+++ b/packages/whisker-haptics/src/runtime.rs
@@ -50,9 +50,9 @@ impl NotificationType {
     }
 }
 
-/// Typed Rust API for the `WhiskerHaptics` platform module. The
-/// struct itself lives in `plugin.rs` (see its doc comment for why);
-/// this `impl` block just adds the runtime methods.
+/// Typed Rust API for the `WhiskerHaptics` platform module. The struct
+/// itself lives in `plugin.rs` — one unit struct serves as both the
+/// plugin and this namespace.
 impl WhiskerHaptics {
     /// Fire a physical "bump", scaled by `style`. Use when a tap
     /// resolves (e.g. inside an `on_tap` handler) — not on every

--- a/packages/whisker-icons/build.rs
+++ b/packages/whisker-icons/build.rs
@@ -11,15 +11,10 @@
 //! drops the bytes of any icon the consumer doesn't reference, so a
 //! binary that uses 5 icons only pays for those 5.
 //!
-//! ## Why bake the wrapper into every const
-//!
-//! An earlier draft stripped the common Lucide `<svg …>` wrapper
-//! and re-synthesised it at runtime in the `Icon` component. That
-//! cut generated source ~10x, but coupled `Icon` to Lucide's exact
-//! attribute set — meaning a future Heroicons / Phosphor backend
-//! would need its own component. Keeping the wrapper per-const
-//! makes `Icon` a pure `Svg` forwarder and lets new icon sets
-//! plug in by emitting their own constants in their own module.
+//! Each const carries the full `<svg …>` wrapper rather than just the
+//! inner shapes: ~10x more generated source, but it keeps `Icon` a pure
+//! `Svg` forwarder instead of coupling it to Lucide's attribute set, so
+//! another icon set can plug in by emitting its own constants.
 
 use std::env;
 use std::fs;
@@ -90,23 +85,10 @@ fn pascal_case(kebab: &str) -> String {
     s
 }
 
-/// Lucide ships SVGs with each attribute on its own line:
-///
-/// ```svg
-/// <svg
-///   xmlns="..."
-///   viewBox="0 0 24 24"
-/// >
-///   <path d="m9 18 6-6-6-6" />
-/// </svg>
-/// ```
-///
-/// Whisker-svg's `roxmltree`-based parser accepts that as-is, but
-/// the multi-line form bloats the resulting `pub const` strings
-/// with newlines + per-line indentation. Trim each line and join
-/// with a single space — preserves valid XML (the space between
-/// `>` `<` is just an inter-tag text node, which roxmltree
-/// ignores) and shrinks each icon string by ~60%.
+/// Collapse Lucide's one-attribute-per-line SVGs onto a single line,
+/// shrinking each generated `pub const` by ~60%. Joining with a space
+/// keeps the XML valid — the space between `>` and `<` is an inter-tag
+/// text node roxmltree ignores.
 fn normalise(svg: &str) -> String {
     svg.lines()
         .map(str::trim)

--- a/packages/whisker-icons/src/lib.rs
+++ b/packages/whisker-icons/src/lib.rs
@@ -69,13 +69,10 @@ use whisker_svg::Svg;
 ///   (`"1.5em"`, `"100%"`, `"24px"`) pass through unchanged.
 #[component]
 pub fn icon(svg: Signal<String>, color: Signal<String>, size: Signal<String>) -> Element {
-    // `Signal<T>` is `Copy` (whisker #8), so `size`/`svg`/`color` move
-    // freely into the closure and builder below — no `.clone()`.
     let style = computed(move || {
         let raw = size.get();
         let t = raw.trim();
-        // Common CSS length units pass through; bare numbers
-        // are treated as `px`.
+        // A bare number means `px`; anything with a unit passes through.
         let has_unit = ["px", "em", "rem", "%", "vw", "vh"]
             .iter()
             .any(|u| t.ends_with(u));
@@ -114,8 +111,6 @@ mod tests {
 
     #[test]
     fn well_known_icons_resolve_to_nonempty_svg() {
-        // Compile-time existence checks the PascalCase rule + the
-        // build.rs walk; runtime non-empty checks that bytes landed.
         for (label, body) in [
             ("Heart", lucide::Heart),
             ("ChevronRight", lucide::ChevronRight),

--- a/packages/whisker-image/src/lib.rs
+++ b/packages/whisker-image/src/lib.rs
@@ -115,10 +115,9 @@ impl std::fmt::Display for ImageMode {
 /// What a finished or failed load reports.
 ///
 /// The body of a custom event, whose payload lands under `detail` on
-/// both platforms (the iOS bridge normalises `params` to `detail`, and
-/// the Android reporter nests it there). Every field defaults, so a
-/// partial body still calls the handler — the event firing is the
-/// signal; its contents are the detail.
+/// both platforms. Every field defaults, so a partial body still calls
+/// the handler — the event firing is the signal; its contents are the
+/// detail.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 #[non_exhaustive]
 pub struct ImageEvent {
@@ -150,8 +149,7 @@ impl ImageEvent {
 /// Wraps `Rc<dyn Fn(ImageEvent)>` so it's `Clone` (required:
 /// `#[component]` re-clones every prop for the hot-reload remount path)
 /// and so a bare closure coerces into it via `Into` at the call site
-/// (`on_load: move |event| …`). Same reasoning as `whisker-input`'s
-/// `InputCallback`: a `Box<dyn Fn>` has neither property.
+/// (`on_load: move |event| …`). A `Box<dyn Fn>` has neither property.
 #[derive(Clone)]
 pub struct ImageCallback(std::rc::Rc<dyn Fn(ImageEvent) + 'static>);
 
@@ -288,9 +286,8 @@ mod tests {
 
     #[test]
     fn an_image_needs_only_a_src() {
-        // That this builds at all is most of the assertion: on the
-        // element, the event props were required, and every caller who
-        // only wanted a picture got a panic at mount.
+        // That this builds at all is most of the assertion: the element's
+        // own event props are required, the wrapper's are not.
         let props = ImageProps::builder()
             .src("https://example.com/a.png")
             .build();

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -151,21 +151,12 @@ use whisker::platform_module::WhiskerValue;
 use whisker::prelude::*;
 use whisker::{ElementRef, RefError, Signal, Style};
 
-// ---------------------------------------------------------------------------
-// Event payload
-// ---------------------------------------------------------------------------
-
 /// Payload of an input event (`input` / `change` / `submit`).
 ///
 /// The native view dispatches the event with the field's current text
-/// under `detail.value`. Both platforms deliver it under `detail`: the
-/// Android event reporter wraps a custom event's params there, and the
-/// iOS bridge normalizes `LynxCustomEvent`'s `params` key to `detail`
-/// (see `whisker_bridge_ios.mm`) so this struct reads one shape on both.
-/// Every field is `#[serde(default)]` so a partial / mismatched body
-/// degrades to an empty string rather than dropping the handler call
-/// (the "the event fired is the primary signal" philosophy `bind_typed`
-/// follows).
+/// under `detail.value`; both platforms deliver that same shape. Every
+/// field is `#[serde(default)]` so a partial / mismatched body degrades
+/// to an empty string rather than dropping the handler call.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 #[non_exhaustive]
 pub struct InputEvent {
@@ -196,10 +187,6 @@ impl InputEvent {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Callback newtype
-// ---------------------------------------------------------------------------
-
 /// A cloneable user callback for an [`Input`] event prop.
 ///
 /// Wraps `Rc<dyn Fn(A)>` so it's `Clone` (required: `#[component]`
@@ -208,11 +195,6 @@ impl InputEvent {
 /// (`on_input: move |s| …`). `A` is `String` for value-carrying
 /// events (`on_input` / `on_change` / `on_submit`) and `()` for the
 /// bare focus / blur events.
-///
-/// This is the one deviation from the original `Box<dyn Fn(..)>`
-/// design sketch: a `Box<dyn Fn>` is neither `Clone` (the macro needs
-/// it) nor `Into`-coercible from a closure through the generated
-/// `Optional` setter, so the newtype carries both properties.
 #[derive(Clone)]
 pub struct InputCallback<A>(Rc<dyn Fn(A) + 'static>);
 
@@ -247,10 +229,6 @@ impl<F: Fn() + 'static> From<F> for InputAction {
         InputAction(Rc::new(f))
     }
 }
-
-// ---------------------------------------------------------------------------
-// Keyboard / return-key enums
-// ---------------------------------------------------------------------------
 
 /// On-screen keyboard layout for an [`Input`]. Variant wire strings
 /// are locked against the native modules' string dispatch.
@@ -365,10 +343,6 @@ impl AutoCapitalize {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Imperative handle
-// ---------------------------------------------------------------------------
-
 /// Typed imperative handle for a mounted [`Input`].
 ///
 /// Wraps the framework-internal `ElementRef` bound on mount when
@@ -441,11 +415,10 @@ impl InputRef {
     ///
     /// **iOS:** reliable — the result arrives over Lynx's UI-method
     /// callback. **Android:** result-returning custom element methods
-    /// may require a Lynx fork release (per repo notes — `componentAt`
-    /// / result-method plumbing is iOS-only-compiled upstream). On an
-    /// unforked Android runtime this resolves to
-    /// [`RefError::DispatchFailed`] or `NotBound`; prefer reading a
-    /// bound `text` signal there.
+    /// may require a Lynx fork release (the result-method plumbing is
+    /// iOS-only-compiled upstream). On an unforked Android runtime this
+    /// resolves to [`RefError::DispatchFailed`] or `NotBound`; prefer
+    /// reading a bound `text` signal there.
     pub async fn get_value(&self) -> Result<String, RefError> {
         self.r
             .invoke_typed::<GetValueResult>("getValue", WhiskerValue::Null)
@@ -469,19 +442,10 @@ struct GetValueResult {
     value: String,
 }
 
-// ---------------------------------------------------------------------------
-// Inner native binding — the thin element.
-//
-// `value` / `placeholder` / `…color` are reactive `Signal<String>`
-// attrs (kebab-cased: `placeholder-color`, `caret-color`,
-// `selection-color`). The bool / number / enum props are passed as
-// pre-stringified `Signal<String>` attrs ("true" / "false", a decimal
-// string, the enum's `as_attr`) so the macro's `apply_attr`
-// stringifies them uniformly and the native view reads one stable
-// string form. `on_*: InputEvent` props are typed events wired via
-// `bind_typed`. Crate-internal — only the outer `input` component
-// uses it; not part of the public doc surface.
-// ---------------------------------------------------------------------------
+// Bool / number / enum props reach the native side pre-stringified ("true" /
+// "false", a decimal string, the enum's `as_attr`), so it reads one stable
+// string form per attr. Attr names are the kebab-cased field names
+// (`placeholder-color`, `caret-color`, `selection-color`).
 
 #[doc(hidden)]
 #[whisker::module_component("Input")]
@@ -510,10 +474,6 @@ pub fn native_input(
     on_submit: InputEvent,
 ) {
 }
-
-// ---------------------------------------------------------------------------
-// Public ergonomic component.
-// ---------------------------------------------------------------------------
 
 /// `whisker-input:Input` — a native text field with Leptos-style
 /// two-way binding.
@@ -597,24 +557,10 @@ pub fn input(
     /// Imperative handle ([`InputRef`]).
     input_ref: Option<InputRef>,
 ) -> Element {
-    // ----- Effective displayed value (reactive) ------------------------
-    //
-    // Priority: `text` (two-way) → `value` (controlled) → empty. Feed
-    // it down to `NativeInput`'s `value` prop as a `Signal::Dynamic`
-    // so an external `text.set(...)` / a controlled `value` change
-    // re-applies natively.
-    //
-    // We do NOT guard cursor-jump / echo here: the native view only
-    // re-sets its displayed text when the incoming `value` differs
-    // from what it currently shows, so feeding the round-tripped value
-    // straight back down is safe.
-    //
-    // `text` is `Option<RwSignal<String>>` — `RwSignal` is `Copy`, so
-    // the whole `Option` is `Copy` and freely usable in every closure
-    // below. The other props (`value`, the callbacks) are `Clone`
-    // (Rc-backed / signal handles), so we clone them into each closure
-    // rather than moving them out of the `#[component]` re-invokable
-    // body.
+    // Priority: `text` (two-way) → `value` (controlled) → empty, fed down as
+    // a `Signal::Dynamic` so an external write re-applies natively. No
+    // cursor-jump / echo guard is needed here: the native view only re-sets
+    // its displayed text when the incoming value differs from what it shows.
     let value_prop: Signal<String> = {
         Signal::Dynamic(computed(move || {
             if let Some(t) = text {
@@ -627,11 +573,8 @@ pub fn input(
         }))
     };
 
-    // ----- Event wiring -----------------------------------------------
-    //
-    // on_input: update the bound `text` signal FIRST (so reads inside
-    // the user callback already see the new value), then call the
-    // user's `on_input`.
+    // Update the bound `text` signal BEFORE calling the user's `on_input`, so
+    // reads inside that callback already see the new value.
     let on_input_cb = {
         let on_input = on_input.clone();
         move |ev: InputEvent| {
@@ -652,9 +595,8 @@ pub fn input(
             }
         }
     };
-    // The element handle this field is bound to. If the caller passed an
-    // `input_ref`, reuse it; otherwise mint an internal one so the field
-    // still registers itself in the focused-element registry (below).
+    // Mint an internal handle when the caller passed none, so the field still
+    // registers itself in the focused-element registry below.
     let element_ref = input_ref
         .as_ref()
         .map(|h| h.r())
@@ -663,10 +605,8 @@ pub fn input(
     let on_focus_cb = {
         let on_focus = on_focus.clone();
         move |_ev: InputEvent| {
-            // Publish ourselves as the currently-focused field — the
-            // signal `whisker-router` reads to blur/restore this exact
-            // input on navigation (mirrors RN's
-            // `TextInput.State.currentlyFocusedInput()`).
+            // `whisker-router` reads this registry to blur/restore this exact
+            // input across a navigation.
             whisker::focus::note_focused(element_ref);
             if let Some(cb) = &on_focus {
                 cb.call();
@@ -691,7 +631,6 @@ pub fn input(
         }
     };
 
-    // ----- Pass-through attrs (None → sensible default) ----------------
     let placeholder_prop: Signal<String> = placeholder.unwrap_or_default();
     let caret_color_prop: Signal<String> = caret_color.unwrap_or_default();
     let placeholder_color_prop: Signal<String> = placeholder_color.unwrap_or_default();
@@ -711,7 +650,6 @@ pub fn input(
     let autocorrect_attr = bool_attr(autocorrect);
     let spell_check_attr = bool_attr(spell_check);
 
-    // ----- Imperative handle: forward its ElementRef as `ref:` ---------
     let mut builder = NativeInput::builder()
         .value(value_prop)
         .placeholder(placeholder_prop)
@@ -782,8 +720,6 @@ mod tests {
     fn enum_defaults() {
         assert_eq!(KeyboardType::default(), KeyboardType::Default);
         assert_eq!(ReturnKey::default(), ReturnKey::Default);
-        // Default matches iOS UIKit's `.sentences` so existing iOS behaviour
-        // is preserved; Android honours the same default explicitly.
         assert_eq!(AutoCapitalize::default(), AutoCapitalize::Sentences);
     }
 
@@ -807,9 +743,8 @@ mod tests {
 
     #[test]
     fn input_event_empty_body_defaults_to_empty() {
-        // focus / blur carry no value: the native side emits an empty
-        // (or `detail`-less) body. An empty map deserializes cleanly to
-        // an empty value via the `#[serde(default)]` on `detail`.
+        // focus / blur carry no value: the native side emits an empty (or
+        // `detail`-less) body.
         let empty: [(&str, WhiskerValue); 0] = [];
         let ev: InputEvent = WhiskerValue::map(empty)
             .deserialize_into()
@@ -819,9 +754,8 @@ mod tests {
 
     #[test]
     fn input_event_default_is_empty() {
-        // serde refuses to build a struct from a bare `null`, so for a
-        // truly null body `bind_typed` falls back to `E::default()` —
-        // which must be the empty-value event.
+        // serde refuses to build a struct from a bare `null`, so `bind_typed`
+        // falls back to `E::default()` for a null body.
         assert_eq!(InputEvent::default().value(), "");
     }
 

--- a/packages/whisker-keyboard/src/lib.rs
+++ b/packages/whisker-keyboard/src/lib.rs
@@ -67,8 +67,7 @@ use whisker::{ArcRwSignal, ArcWriteSignal, Owner, ReadSignal, WhiskerValue};
 /// call from any Whisker event handler; the native side marshals the
 /// UIKit / Android View work to the main thread.
 pub fn dismiss() {
-    // Fire-and-forget; an unregistered module (app didn't add
-    // whisker-keyboard's native half) surfaces as a swallowed
+    // An app without whisker-keyboard's native half surfaces a swallowed
     // `WhiskerValue::Error`, degrading to a no-op.
     let _ = module!("Keyboard").invoke("dismiss", vec![]);
 }
@@ -92,8 +91,6 @@ pub fn keyboard_height() -> ReadSignal<f64> {
     SLOT.get().expect("install() ran above").read.inner
 }
 
-// ---- Internals -------------------------------------------------------------
-
 struct Slot {
     read: MainThreadOnly<ReadSignal<f64>>,
     #[allow(dead_code)]
@@ -104,8 +101,7 @@ struct Slot {
 /// Idempotent. The `Copy` arena handle callers receive is minted once
 /// under a never-disposed [`Owner::detached_root`] so a transient
 /// per-route / per-component scope can't free it out from under a
-/// surviving reader (the footgun documented at length in
-/// `whisker-safe-area`).
+/// surviving reader.
 fn install() {
     SLOT.get_or_init(|| {
         let (read, write) = ArcRwSignal::new(0.0_f64).split();
@@ -164,10 +160,9 @@ static SLOT: OnceLock<Slot> = OnceLock::new();
 struct MainThreadOnly<T> {
     inner: T,
 }
-// Safety: signal read (`keyboard_height`) and write (the `on_event`
-// callback) both run on the Lynx TASM thread by contract. Misuse
-// would corrupt the reactive arena — same risk as touching any signal
-// API from a worker thread.
+// SAFETY: the signal read (`keyboard_height`) and write (the `on_event`
+// callback) both run on the Lynx TASM thread by contract. Misuse would
+// corrupt the reactive arena.
 unsafe impl<T> Send for MainThreadOnly<T> {}
 unsafe impl<T> Sync for MainThreadOnly<T> {}
 

--- a/packages/whisker-router-macros/src/routes.rs
+++ b/packages/whisker-router-macros/src/routes.rs
@@ -160,14 +160,12 @@ fn parse_route(input: ParseStream, kw: Ident) -> syn::Result<Node> {
                     ));
                 }
             }
-            // Eat optional trailing comma.
             if content.peek(Token![,]) {
                 content.parse::<Token![,]>()?;
             }
         }
     }
 
-    // Parse optional braced children.
     let children = if input.peek(syn::token::Brace) {
         let content;
         braced!(content in input);
@@ -453,7 +451,6 @@ fn collect(
                 children,
                 ..
             } => {
-                // Only register routes that have a component.
                 if let Some(comp) = component {
                     let id = route_id(&Some(comp.clone()), path);
                     match reg.iter_mut().find(|e| e.id == id) {
@@ -500,7 +497,6 @@ fn collect(
                         }),
                     }
                 }
-                // Recurse into children.
                 collect(children, reg, spreads, err);
             }
         }
@@ -525,7 +521,6 @@ fn node_to_tree(
             let id = route_id(component, seg);
             let anchor = kw_anchor(kw);
 
-            // Build the RouteDef.
             let segment_expr = match seg {
                 Some(s) => quote! { ::std::option::Option::Some(::std::string::String::from(#s)) },
                 None => quote! { ::std::option::Option::None },
@@ -539,8 +534,6 @@ fn node_to_tree(
             };
             let is_group = seg.as_ref().map(is_group_path).unwrap_or(false);
 
-            // If this Route has a component and children, it's a layout route:
-            // register it in the layout registry.
             if component.is_some() && !children.is_empty() {
                 layouts.push((path.to_vec(), component.as_ref().unwrap().clone()));
             }
@@ -551,7 +544,6 @@ fn node_to_tree(
                 children_vec_tokens(children, path, switch_n, layouts)
             };
 
-            // Extract params from the path segment.
             let params: Vec<String> = seg
                 .as_ref()
                 .map(|s| {

--- a/packages/whisker-router/src/core/mod.rs
+++ b/packages/whisker-router/src/core/mod.rs
@@ -1,25 +1,21 @@
-//! # New router core — `RouteTree` + `RouteState` (phase 1)
+//! # Router core — `RouteTree` + `RouteState`
 //!
-//! This module is the **pure-logic** model of the redesigned router
-//! described in [`docs/router-design.md`]. It is deliberately free of
-//! the macro, of rendering (`Outlet` / `Stack` components), of signals
-//! and `Element` wiring, and of any device/gesture concern. It is just
-//! the in-memory navigation graph and the operations over it, so the
-//! model can be exhaustively unit-tested without a reactive runtime.
-//!
-//! The old `whisker-router` files (the signal-backed stack) are
-//! untouched and still compile; this `core` module is the new system
-//! and will grow the macro / rendering / device layers in later phases.
+//! The **pure-logic** model of the router described in
+//! [`docs/router-design.md`]. It is deliberately free of the macro, of
+//! rendering (`Outlet` / `Stack` components), of signals and `Element`
+//! wiring, and of any device/gesture concern. It is just the in-memory
+//! navigation graph and the operations over it, so the model can be
+//! exhaustively unit-tested without a reactive runtime.
 //!
 //! ## The two graphs
 //!
 //! - [`RouteTree`] — the **static** structure: a tree of [`RouteTree`]
 //!   nodes ([`RouteTree::Route`] leaves, [`RouteTree::Stack`] ordered
 //!   containers, [`RouteTree::Switch`] parallel containers). It
-//!   determines URLs and the set of legal targets. Built by hand here
-//!   via the constructor helpers ([`RouteTree::route`],
-//!   [`RouteTree::stack`], [`RouteTree::switch`]) since there is no
-//!   `routes!` macro yet.
+//!   determines URLs and the set of legal targets. Built by the
+//!   `routes!` macro, or by hand via the constructor helpers
+//!   ([`RouteTree::route`], [`RouteTree::stack`],
+//!   [`RouteTree::switch`]).
 //! - [`RouteState`] — the **dynamic** state: the tree *instantiated*
 //!   with `Stack.history` and `Switch.selected`. The shown screen
 //!   ([`RouteState::current`]) is **derived** by walking the tree — it

--- a/packages/whisker-router/src/core/nav.rs
+++ b/packages/whisker-router/src/core/nav.rs
@@ -59,8 +59,6 @@ impl<'a> Navigator<'a> {
         self.state.current().path.clone()
     }
 
-    // ----- navigate -------------------------------------------------
-
     /// Navigate forward to `url`. The URL is matched against route
     /// patterns (group segments optional, `:param`s captured), and the
     /// matched route is pushed onto the active Stack.
@@ -94,8 +92,6 @@ impl<'a> Navigator<'a> {
         walk_navigate(tree, self.state, dest, 0, &params);
     }
 
-    // ----- select ---------------------------------------------------
-
     /// Select the `Switch` branch that leads toward `target`, **without
     /// pushing** anything onto any `Stack`.
     ///
@@ -118,8 +114,6 @@ impl<'a> Navigator<'a> {
         Ok(())
     }
 
-    // ----- back -----------------------------------------------------
-
     /// Pop the top of the deepest non-trivial `Stack` on the active path.
     /// [`NavError::NothingToPop`] when there is nothing poppable (e.g. at a
     /// tab root) — a no-op surfaced as an error for a uniform verb result.
@@ -130,8 +124,6 @@ impl<'a> Navigator<'a> {
             Err(NavError::NothingToPop)
         }
     }
-
-    // ----- replace --------------------------------------------------
 
     /// Swap the **top** of the current stack with `target`. Same stack
     /// only: if `target` resolves outside the current stack,
@@ -155,8 +147,6 @@ impl<'a> Navigator<'a> {
         Ok(())
     }
 
-    // ----- pop_to ---------------------------------------------------
-
     /// Pop the current stack until `target` is the top. Same stack
     /// only. Errors with [`NavError::CrossStack`] if the target is not a
     /// child of the current stack, or [`NavError::NotInStack`] if no
@@ -179,8 +169,6 @@ impl<'a> Navigator<'a> {
         Ok(())
     }
 
-    // ----- reset ----------------------------------------------------
-
     /// **Reset the whole navigation state** onto a single clean path to the
     /// route matched by `url` (the logout / clear-everything case). Unlike
     /// the other verbs this is *global*, not same-stack: `url` is resolved
@@ -197,10 +185,6 @@ impl<'a> Navigator<'a> {
         Ok(())
     }
 }
-
-// ===================================================================
-// navigate machinery
-// ===================================================================
 
 /// Recursively drive `state` toward `dest`, starting at child-index
 /// `depth` of `dest`.
@@ -343,10 +327,6 @@ fn make_entry(
     }
 }
 
-// ===================================================================
-// back machinery
-// ===================================================================
-
 /// Pop the deepest non-trivial `Stack` (history > 1) on the active
 /// path. Returns whether anything was popped.
 ///
@@ -377,10 +357,6 @@ fn back_at(state: &mut RouteState) -> bool {
     }
 }
 
-// ===================================================================
-// active-stack helpers (for replace / pop_to / reset)
-// ===================================================================
-
 /// The path of the deepest `Stack` on the active path (the stack whose
 /// top is/leads to the current leaf). `None` if there is no stack on the
 /// active path at all.
@@ -396,17 +372,14 @@ fn deepest_active_stack_path(state: &RouteState) -> Option<NodePath> {
 
 /// A mutable reference to the deepest `Stack` on the active path.
 fn active_stack_mut(state: &mut RouteState) -> Option<&mut StackState> {
-    // Walk down the active path, remembering the deepest stack via raw
-    // recursion that returns the deepest one.
     fn go(state: &mut RouteState) -> Option<&mut StackState> {
         match state {
             RouteState::Route(r) => {
-                // A *leaf* Route has no stack below it. A layout/group Route
-                // (`Route(component:) { … }` / a pathless `(group)`) wraps a
-                // Switch/Stack/Route child — we must descend into it, exactly
-                // as `active_chain`/`deepest_active_stack_path` do. Without
-                // this the two disagreed (path found, but no `&mut` stack)
-                // and `replace`/`reset`/`pop_to` panicked on `expect`.
+                // A *leaf* Route has no stack below it, but a layout/group
+                // Route wraps a Switch/Stack/Route child and must be
+                // descended into — exactly as `active_chain` /
+                // `deepest_active_stack_path` do. The three have to agree, or
+                // `replace`/`reset`/`pop_to` find a path with no `&mut` stack.
                 if r.children.is_empty() {
                     return None;
                 }

--- a/packages/whisker-router/src/core/resolve.rs
+++ b/packages/whisker-router/src/core/resolve.rs
@@ -15,11 +15,10 @@ use super::tree::{CompiledTree, NodePath};
 
 /// An explicit resolution-scope override hook (`within(scope)`).
 ///
-/// This is the rare cross-branch case. The **API surface is provided**
-/// so callers can be written against it, but full behaviour is deferred
-/// to a later phase; [`resolve_within`] currently restricts the candidate
-/// set to the scope subtree and then applies the ordinary
-/// deepest-common-ancestor rule within it.
+/// This is the rare cross-branch case. [`resolve_within`] restricts the
+/// candidate set to the scope subtree and then applies the ordinary
+/// deepest-common-ancestor rule within it — it does not yet implement a
+/// scope-specific resolution rule.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Scope {
     /// The subtree to resolve within (a container node's path).

--- a/packages/whisker-router/src/core/state.rs
+++ b/packages/whisker-router/src/core/state.rs
@@ -259,11 +259,9 @@ impl RouteState {
                 if r.children.is_empty() {
                     r
                 } else {
-                    // A Route with children: descend through each child's
-                    // active path to find the deepest current leaf. The
-                    // first child that carries a non-trivial active path wins.
-                    // (In practice a Route has one container child —
-                    // Stack or Switch — that determines the active leaf.)
+                    // The first child carrying a non-trivial active path wins.
+                    // In practice a Route has one container child — a Stack
+                    // or Switch — and that determines the active leaf.
                     for child in &r.children {
                         let c = child.current();
                         if c.path != r.path {

--- a/packages/whisker-router/src/core/tree.rs
+++ b/packages/whisker-router/src/core/tree.rs
@@ -594,11 +594,8 @@ mod tests {
     #[test]
     fn match_url_index_literal_and_param() {
         let t = tree();
-        // Index route ("") derives "/".
         assert_eq!(t.match_url("/").map(|(id, _)| id), Some("home".into()));
-        // Literal segment.
         assert_eq!(t.match_url("/list").map(|(id, _)| id), Some("list".into()));
-        // Dynamic segment captures the param.
         let (id, params) = t.match_url("/detail/123").expect("matches detail/:id");
         assert_eq!(id, "detail");
         assert_eq!(params.get("id").map(String::as_str), Some("123"));
@@ -607,11 +604,8 @@ mod tests {
     #[test]
     fn match_url_no_match_and_arity() {
         let t = tree();
-        // Unknown path.
         assert!(t.match_url("/nope").is_none());
-        // Right prefix, wrong arity (extra segment).
         assert!(t.match_url("/detail/123/extra").is_none());
-        // Missing the dynamic segment.
         assert!(t.match_url("/detail").is_none());
     }
 
@@ -668,14 +662,10 @@ mod tests {
             .filter_map(|i| Some((i.route_id.as_deref()?, i.url.as_deref()?)))
             .collect();
         eprintln!("URLS: {urls:#?}");
-        // Group routes get their own URL.
         assert!(urls.contains(&("(home)", "/(home)")));
         assert!(urls.contains(&("(search)", "/(search)")));
-        // Home sits *under* (home) group — its "" segment → same URL as group.
-        // Check it exists (the exact URL is the key question here).
         let home_url = urls.iter().find(|(id, _)| *id == "home").map(|(_, u)| *u);
         eprintln!("home_url = {home_url:?}");
-        // The list screen is under (search) group.
         let list_url = urls.iter().find(|(id, _)| *id == "list").map(|(_, u)| *u);
         assert_eq!(list_url, Some("/(search)/list"));
     }
@@ -683,7 +673,6 @@ mod tests {
     #[test]
     fn grouped_match_url() {
         let t = grouped_tree();
-        // Group-inclusive: verbatim.
         assert_eq!(
             t.match_url("/(home)").map(|(id, _)| id),
             Some("(home)".into())
@@ -692,16 +681,13 @@ mod tests {
             t.match_url("/(search)").map(|(id, _)| id),
             Some("(search)".into())
         );
-        // Group-omitted: "/detail/42" should match either tab's detail.
         let r = t.match_url("/detail/42");
         assert!(r.is_some(), "'/detail/42' should match with group skipped");
         let (id, params) = r.unwrap();
         assert_eq!(id, "detail");
         assert_eq!(params.get("id").map(String::as_str), Some("42"));
-        // Group-inclusive detail.
         let r = t.match_url("/(home)/detail/7");
         assert!(r.is_some(), "'/(home)/detail/7' should match");
-        // "/" should match home (whose URL is "/(home)" with group optional).
         let r = t.match_url("/");
         eprintln!("match_url('/') = {r:?}");
     }

--- a/packages/whisker-router/src/lib.rs
+++ b/packages/whisker-router/src/lib.rs
@@ -10,22 +10,22 @@
 //!
 //! ## The two layers
 //!
-//! - [`core`] — the **pure-logic** model (phase 1):
+//! - [`core`] — the **pure-logic** model:
 //!   [`RouteTree`](core::RouteTree) / [`CompiledTree`](core::CompiledTree),
 //!   [`RouteState`](core::RouteState), and the [`Navigator`](core::Navigator)
 //!   with the five operations (`navigate` / `select` / `back` / `replace` /
 //!   `pop_to` / `reset`). No signals, no `Element` — unit-testable on its own.
 //! - [`render`] — the **reactive rendering** of that core in the Whisker
-//!   runtime (phase 2). A signal-backed [`RouterHandle`](render::RouterHandle)
+//!   runtime. A signal-backed [`RouterHandle`](render::RouterHandle)
 //!   plus [`use_navigator`](render::use_navigator), the
 //!   [`Outlet`](render::Outlet), [`Stack`](render::Stack) and
 //!   [`Switch`](render::Switch) renderers, the [`Tabs`](render::Tabs) chrome,
 //!   float-`Tween` transitions (via `whisker-animation`, not Lynx's animator),
 //!   and the iOS [`SwipeBack`](render::SwipeBack) gesture.
 //!
-//! The route id → component mapping is a hand-written
-//! [`RouteRegistry`](render::RouteRegistry) for now; the `routes!` macro
-//! will generate it in a later phase.
+//! The route id → component mapping lives in a
+//! [`RouteRegistry`](render::RouteRegistry), which the `routes!` macro
+//! generates; it can also be built by hand.
 //!
 //! ## Minimal usage
 //!
@@ -82,7 +82,6 @@ pub mod __kw {
     pub struct Route;
 }
 
-// The new API: the pure core graphs/ops + the reactive render layer.
 pub use crate::core::{
     CompiledTree, NavError, Navigator, NodeId, NodeInfo, NodePath, RouteDef, RouteInstance,
     RouteState, RouteTree, StackEntry, StackState, SwitchDef, SwitchState, resolve,

--- a/packages/whisker-router/src/render/components.rs
+++ b/packages/whisker-router/src/render/components.rs
@@ -67,19 +67,16 @@ pub fn router(routes: RouteSet, children: Children) -> Element {
     // container (wrappers are `position: absolute`) and the swipe-back
     // gesture has something to bind to.
     //
-    // The `children()` slot is bundled behind a phantom; appending that
-    // phantom directly would hoist the children with NO column container,
-    // and Lynx defaults a style-less container to `flex-direction: row`
-    // (see memory `lynx_view_flex_direction_default`) — collapsing the
-    // children horizontally (the tab content eats the row, side-effect
-    // gesture/marker views shrink to 0). So `root` itself is the real
-    // `flex-direction: column` container the children mount into directly.
-    // Build the root view EMPTY first, then publish the `RouterRoot`
-    // context, and only THEN mount the children into it. Ordering matters:
-    // `children()` (e.g. a `SwipeBack` that reads `RouterRoot` to bind its
-    // gesture) mounts at the point it is rendered, so it must run *after*
-    // `provide_context(RouterRoot(root))` — otherwise it sees `None` and the
-    // gesture is silently never installed (the iOS swipe-back bug).
+    // The `children()` slot is bundled behind a phantom, and appending that
+    // phantom directly would hoist the children into a style-less container,
+    // which Lynx defaults to `flex-direction: row` (memory
+    // `lynx_view_flex_direction_default`) — collapsing them horizontally. So
+    // `root` itself is the `flex-direction: column` container they mount into.
+    //
+    // Build `root` EMPTY, publish the `RouterRoot` context, and only THEN
+    // mount the children: `children()` mounts where it is rendered, so a
+    // `SwipeBack` reading `RouterRoot` must run after the context exists or
+    // it silently never installs its gesture.
     let root = render! {
         view(style: css!(
             flex_grow: 1.0,
@@ -88,12 +85,9 @@ pub fn router(routes: RouteSet, children: Children) -> Element {
         ).raw("position", "relative")) {}
     };
     provide_context(RouterRoot(root));
-    // Mount the children now that `RouterRoot` is in context. The tree is
-    // drawn by `children` (an Outlet / Tabs / Stack), NOT here — drawing
-    // root ourselves *and* letting a child draw the same subtree would
-    // double-mount it. Appending them under the column `root` keeps the
-    // `flex-direction: column` container (a style-less phantom would hoist
-    // them into Lynx's default `row`).
+    // The tree is drawn by `children` (an Outlet / Tabs / Stack), NOT here —
+    // drawing root ourselves *and* letting a child draw the same subtree
+    // would double-mount it.
     whisker::runtime::view::append_child(root, whisker::runtime::view::mount_children(&children));
 
     // Prime the device screen corner radius at router init (it feeds the

--- a/packages/whisker-router/src/render/gesture.rs
+++ b/packages/whisker-router/src/render/gesture.rs
@@ -110,7 +110,6 @@ pub fn swipe_back() -> Element {
 fn install(container: Element, nav: RouterHandle) {
     let gesture: Rc<RefCell<Option<Gesture>>> = Rc::new(RefCell::new(None));
 
-    // touchstart — qualify the edge swipe and grab the active bridge.
     {
         let gesture = gesture.clone();
         let nav = nav.clone();
@@ -146,7 +145,6 @@ fn install(container: Element, nav: RouterHandle) {
         });
     }
 
-    // touchmove — finger delta → back-progress, scrub both wrappers.
     {
         let gesture = gesture.clone();
         bind_typed::<TouchEvent, _>(container, "touchmove", BindType::Bind, move |e| {
@@ -174,7 +172,6 @@ fn install(container: Element, nav: RouterHandle) {
         });
     }
 
-    // touchend / touchcancel — hand off to the controller with velocity.
     for end_name in ["touchend", "touchcancel"] {
         let gesture = gesture.clone();
         let nav = nav.clone();
@@ -191,10 +188,6 @@ fn install(container: Element, nav: RouterHandle) {
         });
     }
 }
-
-// =====================================================================
-// Shared coordinated-scrub helpers (iOS + Android)
-// =====================================================================
 
 /// Start a back gesture (from `edge`) on the deepest active stack:
 /// validate it can pop and supports an edge gesture, point **both**
@@ -341,10 +334,6 @@ fn point(binding: &PoseBinding, c: &AnimationController, role: Role, mode: PoseM
     binding.role.set(role);
     binding.mode.set(mode);
 }
-
-// =====================================================================
-// Android predictive-back
-// =====================================================================
 
 /// Android 13+ predictive-back gesture component — the platform-back twin
 /// of [`SwipeBack`], driving the identical coordinated scrub.
@@ -539,6 +528,6 @@ fn back_edge(payload: &WhiskerValue) -> SwipeEdge {
 struct MainThreadOnly<T> {
     inner: T,
 }
-// Safety: see the type-level comment.
+// SAFETY: see the type-level comment.
 unsafe impl<T> Send for MainThreadOnly<T> {}
 unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/packages/whisker-router/src/render/handle.rs
+++ b/packages/whisker-router/src/render/handle.rs
@@ -239,8 +239,6 @@ impl RouterHandle {
         })
     }
 
-    // ----- the five verbs (clone → core op → write back) ------------
-
     /// Mutate the state via a Phase-1 [`Navigator`] op, writing the
     /// result back into the signal. The closure receives a `Navigator`
     /// bound to a *clone* of the current state; whatever it returns is

--- a/packages/whisker-router/src/render/keyboard.rs
+++ b/packages/whisker-router/src/render/keyboard.rs
@@ -5,11 +5,11 @@
 //! ## Why not a global dismiss
 //!
 //! The obvious implementation — call [`whisker_keyboard::dismiss`] on
-//! every navigation — is what this crate used to do, and it is *more*
-//! aggressive than React Navigation. A global unfocus dispatched at
-//! navigation time is fire-and-forget on the native side; it can land
-//! *after* the screen being entered has already auto-focused its own
-//! input, resigning it (the "focus flashes then drops ~0.5s in" bug).
+//! every navigation — is *more* aggressive than React Navigation. A
+//! global unfocus dispatched at navigation time is fire-and-forget on
+//! the native side, so it can land *after* the screen being entered has
+//! auto-focused its own input, resigning it: focus appears, then drops
+//! half a second later.
 //!
 //! React Navigation avoids this by capturing the concrete focused input
 //! (`TextInput.State.currentlyFocusedInput()`) and blurring *that ref*,

--- a/packages/whisker-router/src/render/node.rs
+++ b/packages/whisker-router/src/render/node.rs
@@ -20,9 +20,7 @@
 //! [`RouterHandle::slice_at`](crate::render::RouterHandle::slice_at)), so
 //! an op that doesn't touch a given container produces an unchanged slice
 //! and that container's effect does not re-run — the fine-grained
-//! property. The mount/swap mechanics follow the old `outlet.rs` phantom
-//! slot pattern, rebuilt against the new core + the continuous animation
-//! engine.
+//! property.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -85,10 +83,6 @@ fn mount_with_layout(handle: &RouterHandle, path: NodePath, layout: LayoutFn) ->
     layout.call()
 }
 
-// =====================================================================
-// Route leaf
-// =====================================================================
-
 fn mount_route(handle: &RouterHandle, path: NodePath) -> Element {
     // Route with children: mount each child (the Route is a structural
     // grouping node — its children are Stack/Switch/Route).
@@ -128,15 +122,12 @@ fn mount_route(handle: &RouterHandle, path: NodePath) -> Element {
     effect(move || {
         let inst = instance.get();
 
-        // CRITICAL: when the instance becomes `None` — i.e. this leaf's
-        // entry was just removed from `RouteState` by a `back()`/pop — DO
-        // NOT tear the content down. The leaf's content lifetime is owned
-        // by its enclosing `Stack` wrapper, which keeps the popped screen
-        // mounted through its exit animation and disposes the whole
-        // subtree (cascading to this leaf's owner) only when the animation
-        // finishes. Removing here on `None` is exactly what made the
-        // popped screen vanish on frame 1 while its wrapper was still
-        // sliding out. So `None` is a no-op; teardown is by owner dispose.
+        // CRITICAL: `None` — this leaf's entry was just removed from
+        // `RouteState` by a `back()`/pop — must NOT tear the content down.
+        // The leaf's content lifetime belongs to its enclosing `Stack`
+        // wrapper, which keeps the popped screen mounted through its exit
+        // animation and disposes the whole subtree only when that finishes.
+        // Removing here would blank the screen on frame 1 of the slide-out.
         let Some(inst) = inst else {
             return;
         };
@@ -174,10 +165,6 @@ fn mount_route(handle: &RouterHandle, path: NodePath) -> Element {
 
     slot
 }
-
-// =====================================================================
-// Switch — all branches mounted, display toggled on `selected`
-// =====================================================================
 
 fn mount_switch(handle: &RouterHandle, path: NodePath) -> Element {
     // A real, positioned container holds the branch wrappers: it
@@ -238,10 +225,6 @@ fn branch_base_style(visible: bool) -> String {
          left: 0; top: 0; right: 0; bottom: 0;"
     )
 }
-
-// =====================================================================
-// Stack — history kept mounted, transitions on push/pop
-// =====================================================================
 
 /// One live history wrapper.
 ///
@@ -451,7 +434,7 @@ fn reconcile_stack(
     // transient `Under`), and the old wrapper is disposed when the slide
     // finishes. The entry *below* the old top is left untouched (it stays
     // covered), so the lower screen never flashes into view behind the
-    // incoming one. (#265)
+    // incoming one.
     if new_len == old_len && new_len > 0 {
         let top_idx = new_len - 1;
         let entry = &stack.history[top_idx];
@@ -466,17 +449,13 @@ fn reconcile_stack(
             let old = live.borrow_mut().remove(top_idx);
 
             // FREEZE the outgoing screen. Its leaf shares the incoming
-            // wrapper's static path, so the top-instance swap this `replace`
-            // performs would otherwise flip the outgoing leaf's `instance`
-            // computed to the NEW route and re-mount it — mounting the new
-            // screen twice (once here in the disposing under-wrapper, once in
-            // the incoming top). The two instances then fight over shared
-            // reader state / native `<list>` handles, and disposing this
-            // wrapper on finish tears down state the survivor still needs,
-            // blanking the incoming screen. A `pop` is immune (the popped
-            // entry leaves `history`, so its slice goes `None` and the leaf
-            // no-ops); only `replace` hits the `Some(new)` path, so pause the
-            // outgoing subtree to hold it on its own route until disposed.
+            // wrapper's static path, so the top-instance swap would otherwise
+            // flip the outgoing leaf's `instance` computed to the NEW route
+            // and mount that screen twice — once in this disposing
+            // under-wrapper, once in the incoming top — leaving the two
+            // fighting over shared state and native handles. Only `replace`
+            // hits this: a pop's entry leaves `history`, so its slice goes
+            // `None` and the leaf no-ops.
             old.owner.pause();
 
             let w = mount_wrapper(handle, slot, top_idx, entry);
@@ -547,10 +526,9 @@ fn reconcile_stack(
     // ONLY for a push / steady state. During a **pop** the live top is the
     // revealed survivor, but the wrapper that must paint on top is the
     // *leaving* one (it slides off ABOVE the survivor) — `run_pop` keeps it
-    // last. Re-appending the survivor here would put it over the leaving
-    // card (Lynx ignores z-index during transform animations, so paint
-    // order = DOM order), which is exactly the "previous screen on top
-    // during the back slide" bug.
+    // last. Lynx ignores z-index during transform animations, so paint
+    // order is DOM order and re-appending the survivor here would draw it
+    // over the leaving card.
     if new_len >= old_len {
         let l = live.borrow();
         if let Some(top_w) = l.last() {
@@ -704,14 +682,11 @@ fn mount_wrapper(
         });
         let _ = idx;
 
-        // Clip layer: `overflow: hidden; border-radius` on the *wrapper*
-        // did NOT clip the user's screen view on Lynx — the opaque child
-        // covers the wrapper and isn't rounded (a Lynx draw quirk, like the
-        // row-default one). The proven structure is a dedicated clip view
-        // BETWEEN the transform wrapper and the child: wrapper (transform /
-        // opacity only) → clip_view (border-radius + overflow:hidden, sized
-        // 100%) → child. The clip view is the *direct* parent of the screen
-        // content, so Lynx rounds it.
+        // Lynx only rounds a view's *direct* children, so
+        // `overflow: hidden; border-radius` on the transform wrapper does
+        // not clip the screen — the opaque child covers it unrounded. Hence
+        // a dedicated clip view in between: wrapper (transform / opacity) →
+        // clip (border-radius + overflow:hidden, 100%) → child.
         let clip = create_element(ElementTag::View);
         // `clip-radius` is a Lynx **prop** (`@LynxProp`), NOT a CSS style —
         // it must be set as an attribute, not in the inline style string.

--- a/packages/whisker-router/src/render/registry.rs
+++ b/packages/whisker-router/src/render/registry.rs
@@ -1,10 +1,10 @@
-//! The hand-written **route id → render fn** registry, plus the
-//! per-route [`RouteTransition`] choice.
+//! The **route id → render fn** registry, plus the per-route
+//! [`RouteTransition`] choice.
 //!
-//! In a later phase the `routes!` macro will *generate* this map from
-//! the declared screens. For now it is built by hand: the app registers
-//! a render closure for every [`RouteDef::id`](crate::core::RouteDef::id)
-//! in its [`CompiledTree`], optionally with a transition, and the
+//! The `routes!` macro generates this map from the declared screens; it
+//! can equally be built by hand. Either way it holds a render closure for
+//! every [`RouteDef::id`](crate::core::RouteDef::id) in the
+//! [`CompiledTree`], optionally with a transition, and the
 //! [`RouterHandle`](crate::render::RouterHandle) looks the closure up
 //! when an `Outlet` needs to mount a leaf.
 //!
@@ -61,7 +61,7 @@ struct Entry {
     transition: RouteTransition,
 }
 
-/// The hand-written map from a route id to its [`RenderFn`] +
+/// The map from a route id to its [`RenderFn`] +
 /// [`RouteTransition`].
 ///
 /// Cloneable (cheap — the closures are `Rc`-backed) so it can be moved
@@ -183,8 +183,8 @@ impl RouteFragment {
 /// `RouterHandle::new((tree, registry))`), so the macro and the manual path
 /// share one constructor.
 ///
-/// (Composable sub-sets — the design's `..content` spread — land with the
-/// macro in a later phase; today a `RouteSet` is a single rooted tree.)
+/// A `RouteSet` is a single rooted tree; the composable un-rooted form is
+/// [`RouteFragment`], spliced in with the macro's `..spread`.
 #[derive(Clone)]
 pub struct RouteSet {
     pub(crate) tree: CompiledTree,

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -78,8 +78,6 @@ fn tabbed_handle() -> RouterHandle {
     RouterHandle::new((tree, registry()))
 }
 
-// ----- registry -------------------------------------------------------
-
 #[test]
 fn registry_resolves_ids_and_transitions() {
     with_runtime(|| {
@@ -99,25 +97,20 @@ fn registry_resolves_ids_and_transitions() {
     });
 }
 
-// ----- navigate / back ------------------------------------------------
-
 #[test]
 fn navigate_pushes_and_current_tracks_signal() {
     with_runtime(|| {
         let h = simple_handle();
         let current = h.current();
-        // Starts on home (root stack child 0).
         assert_eq!(current.get().path, NodePath(vec![0]));
 
         h.navigate("/detail/1").unwrap();
         flush();
-        // Now on detail (child 1).
         assert_eq!(current.get().path, NodePath(vec![1]));
 
         assert!(h.back().is_ok());
         flush();
         assert_eq!(current.get().path, NodePath(vec![0]));
-        // Nothing left to pop.
         assert_eq!(h.back(), Err(crate::core::NavError::NothingToPop));
     });
 }
@@ -133,14 +126,11 @@ fn navigate_url_params_land_on_signal() {
     });
 }
 
-// ----- replace / pop_to / reset --------------------------------------
-
 #[test]
 fn replace_swaps_top_same_depth() {
     with_runtime(|| {
         let h = simple_handle();
         h.navigate("/detail/1").unwrap();
-        // replace the top detail with another detail (same stack).
         h.replace("/detail/1").unwrap();
         // Still depth 2 (home + detail), still on detail.
         assert_eq!(h.current().get().path, NodePath(vec![1]));
@@ -157,7 +147,6 @@ fn pop_to_returns_to_target() {
         let h = simple_handle();
         h.navigate("/detail/1").unwrap();
         h.navigate("/detail/1").unwrap();
-        // pop back to home.
         h.pop_to("/").unwrap();
         assert_eq!(h.current().get().path, NodePath(vec![0]));
     });
@@ -202,7 +191,7 @@ fn layout_stack_history_len(h: &RouterHandle) -> usize {
     s.history.len()
 }
 
-/// Regression: `replace` / `reset` (and `pop_to`) must work when a layout
+/// `replace` / `reset` (and `pop_to`) must work when a layout
 /// Route sits above the active stack. `active_stack_mut` returned `None` for
 /// any `Route`, so it disagreed with `deepest_active_stack_path` and the
 /// `.expect("stack exists")` panicked — surfaced by the tabbed router example
@@ -232,8 +221,6 @@ fn stack_ops_work_under_a_layout_route() {
     });
 }
 
-// ----- select / tabs --------------------------------------------------
-
 #[test]
 fn select_switches_tab_and_keeps_history() {
     with_runtime(|| {
@@ -242,7 +229,6 @@ fn select_switches_tab_and_keeps_history() {
         let selected = h.selected_at(switch_path.clone());
         assert_eq!(selected.get(), Some(0));
 
-        // Push a detail in tab 0, then switch to tab 1.
         h.navigate("/detail/1").unwrap();
         h.select("/list").unwrap();
         flush();
@@ -276,7 +262,6 @@ fn slice_only_changes_for_touched_tab() {
         let before_b = slice_b.get();
         let before_a = slice_a.get();
 
-        // Push a detail into tab A.
         h.navigate("/detail/1").unwrap();
         flush();
 
@@ -286,8 +271,6 @@ fn slice_only_changes_for_touched_tab() {
         assert_eq!(slice_b.get(), before_b);
     });
 }
-
-// ----- state_at slice walk -------------------------------------------
 
 #[test]
 fn state_at_walks_to_active_child() {
@@ -313,8 +296,6 @@ fn state_at_walks_to_active_child() {
         ));
     });
 }
-
-// ----- single draw path (no double-mount) ----------------------------
 
 /// Per-id render-invocation counts. Render fns return a phantom (no
 /// renderer needed) and bump their id's counter, so a test can assert how
@@ -368,7 +349,6 @@ fn tree_is_drawn_once_no_double_mount() {
         let c = counts.borrow();
         assert_eq!(c.get("home").copied(), Some(1), "home mounted once");
         assert_eq!(c.get("list").copied(), Some(1), "list mounted once");
-        // detail not navigated to yet.
         assert_eq!(c.get("detail").copied(), None);
     });
 }
@@ -381,7 +361,6 @@ fn navigate_mounts_new_leaf_exactly_once() {
         let _slot = mount_node(&h, NodePath::root());
         flush();
 
-        // Push a detail into the Home tab.
         h.navigate("/detail/1").unwrap();
         flush();
 
@@ -415,11 +394,11 @@ fn counting_simple_handle(counts: Counts) -> RouterHandle {
     RouterHandle::new((tree, registry))
 }
 
-/// Regression for #264. When `reset` replaces the whole history with a route
-/// that differs from the surviving index-0 wrapper, the reconcile must dispose
-/// the stale survivor and mount the new route — not re-show the old screen.
-/// (Wrappers are keyed by history index; a naive shrink kept the stale
-/// survivor, so the cleared screen reappeared and its native views leaked.)
+/// When `reset` replaces the whole history with a route that differs from the
+/// surviving index-0 wrapper, the reconcile must dispose the stale survivor
+/// and mount the new route — not re-show the old screen. Wrappers are keyed by
+/// history index, so a naive shrink would keep the cleared screen mounted and
+/// leak its native views.
 #[test]
 fn reset_to_different_route_reinstantiates_revealed_top() {
     with_runtime(|| {
@@ -446,8 +425,7 @@ fn reset_to_different_route_reinstantiates_revealed_top() {
         assert_eq!(s.history.len(), 1, "reset collapses to a single entry");
 
         // The revealed top is a NEW detail leaf (mounted for /2), so detail
-        // mounted twice total. Pre-fix this stayed at 1 — the stale `home`
-        // wrapper was kept and `detail/2` never mounted.
+        // mounted twice total.
         assert_eq!(
             counts.borrow().get("detail").copied(),
             Some(2),
@@ -455,8 +433,6 @@ fn reset_to_different_route_reinstantiates_revealed_top() {
         );
     });
 }
-
-// ----- coordinated pop: survivor returns to the active (0%) pose -------
 
 /// A single-stack handle with Slide routes so a push/pop runs a real
 /// transition we can step to completion.
@@ -582,9 +558,8 @@ fn push_settles_top_to_full_progress() {
     owner.dispose();
 }
 
-/// Regression for #265. `replace` used to snap the new top to its final pose
-/// (`ctrl.set_value(1.0)`); it must instead slide the new screen in (drive
-/// 0 → 1) using the route transition.
+/// `replace` must slide the new screen in (drive 0 → 1) using the route
+/// transition, not snap it to its final pose.
 #[test]
 fn replace_animates_the_new_top_in() {
     whisker::runtime::reactive::__reset_for_tests();
@@ -610,7 +585,7 @@ fn replace_animates_the_new_top_in() {
 
         // Step a few frames WITHOUT settling: the new top's progress must
         // traverse intermediate values (a visible slide-in), not be pinned at
-        // 1.0 from the first frame (the pre-fix instant-swap bug).
+        // 1.0 from the first frame.
         let mut t = 1000.0;
         let mut traj = Vec::new();
         for _ in 0..6 {
@@ -730,8 +705,7 @@ fn back_after_replace_animates_under_a_layout_route() {
 /// is mid-animation and so stays live). An interactive swipe-back must resume
 /// it so its pose effect follows the finger through the scrub; the gesture can
 /// only re-point the bridge's pose bindings, so the bridge carries the under's
-/// owner for exactly this. Regression for "SwipeBack intermediate animation
-/// doesn't work after replace".
+/// owner for exactly this.
 #[test]
 fn swipe_back_resumes_the_paused_under_after_replace() {
     whisker::runtime::reactive::__reset_for_tests();
@@ -794,7 +768,7 @@ fn pop_animates_outgoing_top_through_intermediate_frames() {
         // Pop, then step a few frames WITHOUT fully settling and record the
         // outgoing top's progress trajectory: it must descend through
         // intermediate values (a visible slide-out), not instant-finish at
-        // 0 on the first frame (the "Detail vanishes from frame 1" bug).
+        // 0 on the first frame.
         assert!(h.back().is_ok());
         flush();
         let mut t = 1000.0;
@@ -853,12 +827,10 @@ fn popped_leaf_content_survives_until_exit_animation_finishes() {
         assert_eq!(*cleanups.borrow(), 0, "detail content alive after push");
 
         // Pop. Immediately after `back()` + flush — BEFORE the exit
-        // animation finishes — the detail content must STILL be mounted
-        // (this is the bug: the leaf used to tear itself down the moment
-        // its RouteState entry vanished, blanking the sliding-out screen).
+        // animation finishes — the detail content must STILL be mounted, or
+        // the sliding-out screen blanks.
         assert!(h.back().is_ok());
         flush();
-        // step a couple of mid-animation frames
         whisker_animation::__step_for_tests(1000.0);
         flush();
         whisker_animation::__step_for_tests(1016.0);
@@ -882,8 +854,6 @@ fn popped_leaf_content_survives_until_exit_animation_finishes() {
     owner.dispose();
 }
 
-// ----- Android predictive-back: event → coordinated-scrub mapping -----
-//
 // The native module delivery can't run headless, but the mapping the
 // `AndroidPredictiveBack` component performs — `backProgressed{progress}`
 // -> scrub the top controller, `backInvoked` -> commit -> `back()` — is
@@ -972,8 +942,7 @@ fn predictive_back_invoke_commits_pop() {
 #[test]
 fn settle_commit_animates_from_current_value_without_jumping_back() {
     // A *partial* release commits by animating from the current value to 0
-    // — it must NOT jump backward (toward 1) first. (Regression for the
-    // bad re-anchor that pushed a deep-swipe value 0.05 back up to 0.18.)
+    // — it must NOT jump backward (toward 1) first.
     whisker::runtime::reactive::__reset_for_tests();
     whisker_animation::__reset_for_tests();
     let owner = Owner::new(None);
@@ -994,7 +963,6 @@ fn settle_commit_animates_from_current_value_without_jumping_back() {
 
         settle(&h, &bridge, /* commit = */ true, None);
         // The value must never exceed the release point — no backward jump.
-        // (The bad re-anchor set it to 0.18 here; the fix leaves it at 0.05.)
         let after_settle = ctrl.value().get_untracked();
         assert!(
             after_settle <= start + 1e-3,
@@ -1057,7 +1025,6 @@ fn predictive_back_cancel_restores_top() {
         let bridge = begin(&h, SwipeEdge::Left).expect("bridge");
         let ctrl = bridge.top_ctrl.clone().expect("top ctrl");
         scrub(&bridge, 0.4);
-        // Cancel: forward() back to present; no pop.
         settle(&h, &bridge, /* commit = */ false, None);
         settle_animations();
 
@@ -1136,19 +1103,16 @@ fn predictive_back_works_with_grouped_tabs() {
         let _slot = mount_node(&h, NodePath::root());
         flush();
 
-        // Navigate to detail in home tab.
         h.navigate("/detail/1").unwrap();
         flush();
         settle_animations();
 
-        // Verify we're on detail.
         assert_eq!(
             h.current().get().path,
             NodePath(vec![0, 0, 0, 1]),
             "should be on detail in home tab"
         );
 
-        // Try to begin a predictive-back gesture.
         let bridge = begin(&h, SwipeEdge::Left);
         assert!(
             bridge.is_some(),
@@ -1158,12 +1122,10 @@ fn predictive_back_works_with_grouped_tabs() {
         let bridge = bridge.unwrap();
         assert!(bridge.can_back, "can_back must be true");
 
-        // Scrub and commit.
         scrub(&bridge, 0.5);
         settle(&h, &bridge, true, None);
         settle_animations();
 
-        // Back should have popped to Home.
         assert_eq!(
             h.current().get().path,
             NodePath(vec![0, 0, 0, 0]),
@@ -1178,8 +1140,6 @@ fn progress_payload(p: f64) -> WhiskerValue {
     m.insert("progress".to_string(), WhiskerValue::Float(p));
     WhiskerValue::Map(m)
 }
-
-// ----- Material predictive-back pose ----------------------------------
 
 #[test]
 fn back_edge_decodes_payload() {
@@ -1405,9 +1365,7 @@ fn one_transition_poses_all_four_directional_slots() {
     assert_eq!(pose_for(&pop, Role::Under, 0.5).transform, "pop_enter");
 }
 
-// =====================================================================
-// Renderer-level reproduction: `replace` content-attach (next-chapter)
-// =====================================================================
+// Renderer-level reproduction of the `replace` content-attach path.
 //
 // The tests above run without a renderer, so they never exercise the
 // real Lynx op sequence. This block installs a recording renderer that
@@ -1546,7 +1504,7 @@ mod replace_repro {
         }
         fn set_inline_styles(&self, handle: Element, css: &str) {
             // Record `display` transitions so tests can assert Switch
-            // branch visibility + mount ordering (#306).
+            // branch visibility + mount ordering.
             if let Some(d) = parse_display(css) {
                 let mut inner = self.0.borrow_mut();
                 inner
@@ -1686,7 +1644,7 @@ mod replace_repro {
         });
     }
 
-    /// Regression: on a `replace`, the OUTGOING screen (kept mounted as the
+    /// On a `replace`, the OUTGOING screen (kept mounted as the
     /// slide-out `Under`) must be FROZEN showing its own route. It shares the
     /// leaf's static path with the incoming wrapper, so when `replace` swaps
     /// the top instance the outgoing leaf's `instance` computed also flips to

--- a/packages/whisker-router/src/render/transition.rs
+++ b/packages/whisker-router/src/render/transition.rs
@@ -227,8 +227,6 @@ impl SwipeEdge {
     }
 }
 
-// ----- Material predictive-back tunables ------------------------------
-
 /// Minimum scale the cards shrink to at full back progress (Android's
 /// system preview shrinks to ~0.9).
 const PB_MIN_SCALE: f32 = 0.9;
@@ -476,8 +474,6 @@ pub fn predictive_dim(value: f32) -> f32 {
     let dismiss = ((PB_PREVIEW_SPLIT - v) / PB_PREVIEW_SPLIT).clamp(0.0, 1.0);
     (1.0 - dismiss) * PB_MAX_DIM
 }
-
-// ----- Built-in transitions -------------------------------------------
 
 /// Push/pop duration (ms) of the iOS [`Slide`].
 const SLIDE_MS: u32 = 300;

--- a/packages/whisker-router/tests/core_router.rs
+++ b/packages/whisker-router/tests/core_router.rs
@@ -1,10 +1,10 @@
-//! Exhaustive unit tests for the new router core (`whisker_router::core`).
+//! Exhaustive unit tests for the router core (`whisker_router::core`).
 //!
 //! These build the Twitter-style tree from `docs/router-design.md` by
 //! hand and assert URL derivation, `current` derivation, the five
 //! operations, relative resolution, the buried-container reveal, and the
-//! no-stored-marker invariant. The 14 numbered behaviours from the phase
-//! brief are tagged in the test names / comments.
+//! no-stored-marker invariant. The 14 numbered behaviours the design doc
+//! enumerates are tagged in the section comments below.
 
 use whisker_router::core::{
     CompiledTree, NavError, Navigator, NodePath, RouteDef, RouteState, RouteTree, Scope, SwitchDef,
@@ -91,7 +91,8 @@ fn bare_group_url_resolves_to_its_first_screen() {
 }
 
 // ===================================================================
-// The Twitter-style tree (built by hand — no macro yet)
+// The Twitter-style tree, built by hand so the core is tested without
+// the `routes!` macro.
 // ===================================================================
 //
 // The root node has the empty NodePath [], so its children start at [0]:
@@ -566,8 +567,8 @@ fn reset_crosses_into_another_branch() {
     {
         let mut nav = Navigator::new(&t, &mut st);
         nav.navigate("/post/1").unwrap(); // timeline depth 2, switch on timeline
-        // Reset straight into the search tab (a different Switch branch) —
-        // the old same-stack `reset` would have errored CrossStack.
+        // Reset straight into the search tab — a different Switch branch,
+        // not just a same-stack reset.
         nav.reset("/search").unwrap();
         assert_eq!(nav.current().path, p(&[0, 1, 0]), "current = search home");
     }
@@ -774,7 +775,7 @@ fn select_is_nondestructive_and_returns_to_retained_screen() {
 }
 
 // ===================================================================
-// within(scope) API-surface smoke (deferred behaviour)
+// within(scope): resolution restricted to a subtree
 // ===================================================================
 
 #[test]

--- a/packages/whisker-safe-area/src/lib.rs
+++ b/packages/whisker-safe-area/src/lib.rs
@@ -101,18 +101,11 @@ pub struct SafeAreaInsets {
 /// `SafeAreaInsets::default()` and updates as soon as the native side
 /// can push the host view's current values.
 ///
-/// The returned handle is a `Copy` [`ReadSignal`]. Crucially it is
-/// minted **once**, under a process-lifetime
-/// [`Owner::detached_root`], and cached in [`SLOT`] — every call hands
-/// back the *same* arena entry. An earlier design converted the
-/// underlying `ArcReadSignal` on every call, minting a fresh arena
-/// entry in *whichever owner was current*; when that owner was a
-/// short-lived per-route / per-component scope (e.g. under
-/// `whisker_router::StackLayout`), disposing it freed the entry, and a
-/// surviving reader (a `computed`/effect, or a late native event)
-/// would then read a disposed node and panic — aborting at the FFI
-/// tick boundary. Pinning the entry to a never-disposed root removes
-/// that footgun entirely.
+/// The returned handle is a `Copy` [`ReadSignal`], minted **once**
+/// under a process-lifetime [`Owner::detached_root`] and cached in
+/// [`SLOT`], so every call hands back the *same* arena entry. That
+/// pinning is what keeps a short-lived owner (a per-route scope, say)
+/// from freeing the entry out from under a surviving reader.
 ///
 /// **Must be called from the main thread.** The underlying reactive
 /// runtime is thread-local.
@@ -121,12 +114,6 @@ pub fn safe_area_insets() -> ReadSignal<SafeAreaInsets> {
     SLOT.get().expect("install() ran above").read.inner
 }
 
-// ---- Internals -------------------------------------------------------------
-
-// Slot contents. `read` is the cached `Copy` arena handle minted
-// once under a detached root owner (see `install`) — what
-// `safe_area_insets()` hands out. The write half stays here so the
-// native event callback can `set()` through it.
 struct Slot {
     read: MainThreadOnly<ReadSignal<SafeAreaInsets>>,
     // Kept reachable from the on-event closure; never read here.
@@ -137,31 +124,20 @@ struct Slot {
 /// One-shot install of the global signal + the native subscription.
 /// Idempotent — re-entry is a single `OnceLock::get()` check.
 ///
-/// The signal is allocated as an [`ArcRwSignal`] so its lifetime is
-/// governed by [`SLOT`]'s Arc strong count rather than the caller's
-/// owner; the owner that triggered the first call can come and go
-/// without affecting subsequent reads.
-///
-/// The `Copy` arena handle that callers receive is also minted here,
-/// **once**, under an [`Owner::detached_root`] that we deliberately
-/// leak (never dispose). Pinning it to a process-lifetime root — not
-/// the owner that happens to be current on first call — is what keeps
-/// `safe_area_insets()` from handing out a handle that a transient
-/// scope can free out from under a surviving reader. See the
-/// `safe_area_insets` doc for the failure mode this avoids.
+/// The signal is an [`ArcRwSignal`] so its lifetime follows [`SLOT`]'s
+/// Arc strong count, not the owner that happened to trigger the first
+/// call. The `Copy` handle callers receive is minted here under a
+/// deliberately-leaked [`Owner::detached_root`] for the same reason.
 fn install() {
     SLOT.get_or_init(|| {
         let (read, write) = ArcRwSignal::new(SafeAreaInsets::default()).split();
-        // `ArcWriteSignal` is `!Send`; both platforms post their
-        // events from the UI thread (iOS `safeAreaInsetsDidChange`,
-        // Android `OnApplyWindowInsetsListener`), so wrap in
-        // `MainThreadOnly` and trust the contract. If a future host
-        // breaks it, route through `run_on_main_thread` first.
+        // `ArcWriteSignal` is `!Send`; both platforms post their events from
+        // the UI thread, so `MainThreadOnly` asserts that contract. A host
+        // that breaks it must route through `run_on_main_thread` first.
         subscribe_to_native(MainThreadOnly {
             inner: write.clone(),
         });
-        // Mint the shared arena handle under a never-disposed root so
-        // it outlives every per-route / per-component owner.
+        // Never-disposed root, so the handle outlives every per-route owner.
         let root = Owner::detached_root();
         let read_handle: ReadSignal<SafeAreaInsets> = root.with(|| read.into());
         Slot {
@@ -191,8 +167,7 @@ fn subscribe_to_native(writer: MainThreadOnly<ArcWriteSignal<SafeAreaInsets>>) {
     std::mem::forget(sub);
 }
 
-// Decode a `{ top, leading, trailing, bottom }` map payload. Missing
-// or non-numeric keys default to `0.0` — a malformed message
+// Missing or non-numeric keys default to `0.0` — a malformed message
 // degrades silently rather than wedging the subscription.
 fn decode_payload(value: WhiskerValue) -> Option<SafeAreaInsets> {
     let WhiskerValue::Map(fields) = value else {
@@ -213,26 +188,22 @@ fn decode_payload(value: WhiskerValue) -> Option<SafeAreaInsets> {
     })
 }
 
-// `OnceLock<T>` requires `T: Sync`; the inner `ArcReadSignal` /
-// `ArcWriteSignal` are `!Send` / `!Sync` because the underlying
-// `Rc` is thread-local. `MainThreadOnly` asserts the contract
-// rather than enforcing it.
+// `OnceLock<T>` requires `T: Sync`, which the `Rc`-backed signal halves are
+// not; `MainThreadOnly` asserts the contract rather than enforcing it.
 static SLOT: OnceLock<Slot> = OnceLock::new();
 
 /// Locally-scoped wrapper asserting main-thread-only access to
 /// `inner`. Used twice: once for the static slot
 /// (`OnceLock<…>: Sync`), once for the `on_event` closure capture
-/// (bridge callback's `Send + Sync`). Mirrors the pattern
-/// `whisker-router::AndroidPredictiveBack` uses for its
-/// `Rc<dyn Fn()>` capture. Lives here (not in `whisker-runtime`)
-/// until the bridge gains a proper main-thread-only listener API.
+/// (bridge callback's `Send + Sync`). Lives here rather than in
+/// `whisker-runtime` until the bridge gains a proper main-thread-only
+/// listener API.
 #[derive(Copy, Clone)]
 struct MainThreadOnly<T> {
     inner: T,
 }
-// Safety: every access path (signal read in `safe_area_insets`,
-// signal write in the `on_event` callback) runs on the Lynx TASM
-// thread by contract. Misuse would corrupt the reactive arena —
-// same risk as touching any signal API from a worker thread.
+// SAFETY: every access path — the signal read in `safe_area_insets`, the
+// write in the `on_event` callback — runs on the Lynx TASM thread by
+// contract. Misuse would corrupt the reactive arena.
 unsafe impl<T> Send for MainThreadOnly<T> {}
 unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/packages/whisker-splash-screen/src/plugin.rs
+++ b/packages/whisker-splash-screen/src/plugin.rs
@@ -129,13 +129,11 @@ impl PluginConfig for WhiskerSplashScreenConfig {
 /// The plugin the Whisker engine drives, and the config-plugin marker.
 pub struct WhiskerSplashScreen;
 
-// -- Android resource names (kept in one place) -----------------------
-
 const ANDROID_THEME: &str = "@style/Theme.Whisker.Splash";
 const ANDROID_BG_COLOR: &str = "whisker_splash_background";
 const ANDROID_ICON: &str = "whisker_splash_icon";
 /// The app's normal theme, restored after the splash (`postSplashScreenTheme`).
-/// Matches the manifest template's historical default.
+/// Must match the manifest template's default.
 const ANDROID_POST_THEME: &str = "@style/Theme.AppCompat.NoActionBar";
 const ANDROID_SPLASHSCREEN_DEP: &str = "implementation(\"androidx.core:core-splashscreen:1.0.1\")";
 
@@ -146,9 +144,7 @@ impl Plugin for WhiskerSplashScreen {
         ctx: &mut GenerateContext,
         cfg: &WhiskerSplashScreenConfig,
     ) -> anyhow::Result<()> {
-        // Read the splash image up-front (needs the app crate dir; the
-        // config path is spelled relative to it). Done before mutating
-        // the per-target IR so the borrows stay simple.
+        // Read before mutating the per-target IR, so the borrows stay simple.
         let image_bytes =
             match &cfg.image {
                 Some(rel) => {
@@ -183,11 +179,9 @@ impl Plugin for WhiskerSplashScreen {
 fn apply_android(ctx: &mut GenerateContext, cfg: &WhiskerSplashScreenConfig, image: Option<&[u8]>) {
     let android = ctx.android.as_mut().expect("android checked by caller");
 
-    // 1. Point `<application android:theme>` at the splash theme.
     android.manifest.application_theme = Some(ANDROID_THEME.to_string());
 
-    // 2. Inject `installSplashScreen()` into MainActivity.onCreate
-    //    (before super.onCreate — required by the SplashScreen API).
+    // `installSplashScreen()` must run before `super.onCreate`.
     android
         .manifest
         .main_activity_imports
@@ -197,13 +191,12 @@ fn apply_android(ctx: &mut GenerateContext, cfg: &WhiskerSplashScreenConfig, ima
         .main_activity_pre_super
         .push("installSplashScreen()".to_string());
 
-    // 3. androidx SplashScreen backport (also enables it on API < 31).
+    // The backport also enables the splash on API < 31.
     android
         .gradle
         .dependencies
         .push(ANDROID_SPLASHSCREEN_DEP.to_string());
 
-    // 4. Emit the splash theme + background color (one values file).
     let icon_item = if image.is_some() {
         format!(
             "\n        <item name=\"windowSplashScreenAnimatedIcon\">@drawable/{ANDROID_ICON}</item>"
@@ -227,8 +220,7 @@ fn apply_android(ctx: &mut GenerateContext, cfg: &WhiskerSplashScreenConfig, ima
         FileEntry::text(styles),
     );
 
-    // 5. Emit the icon drawable (density-independent so the system just
-    //    scales it into the splash icon slot).
+    // `-nodpi` so the system scales the one bitmap into the icon slot.
     if let Some(bytes) = image {
         android.extra_files.insert(
             PathBuf::from(format!(
@@ -265,8 +257,6 @@ fn apply_android(ctx: &mut GenerateContext, cfg: &WhiskerSplashScreenConfig, ima
     );
 }
 
-// -- iOS asset names ---------------------------------------------------
-
 const IOS_IMAGE_NAME: &str = "WhiskerSplashLogo";
 const IOS_COLOR_NAME: &str = "WhiskerSplashBackground";
 
@@ -280,7 +270,6 @@ const IOS_COLOR_NAME: &str = "WhiskerSplashBackground";
 fn apply_ios(ctx: &mut GenerateContext, cfg: &WhiskerSplashScreenConfig, image: Option<&[u8]>) {
     let ios = ctx.ios.as_mut().expect("ios checked by caller");
 
-    // Background color asset.
     let (r, g, b) = parse_hex_rgb(cfg.bg());
     ios.extra_files.insert(
         PathBuf::from(format!(
@@ -299,7 +288,6 @@ fn apply_ios(ctx: &mut GenerateContext, cfg: &WhiskerSplashScreenConfig, image: 
         PlistValue::Boolean(false),
     );
 
-    // Logo image asset (optional).
     if let Some(bytes) = image {
         ios.extra_files.insert(
             PathBuf::from(format!(
@@ -393,7 +381,6 @@ mod tests {
 
     #[test]
     fn android_wires_theme_activity_gradle_and_styles() {
-        // No image → styles still emitted (background only), no drawable.
         let mut ctx = ctx_with_android();
         let cfg = {
             let mut c = WhiskerSplashScreenConfig::default();
@@ -430,7 +417,6 @@ mod tests {
         assert!(styles.contents.contains("#123456"));
         assert!(styles.contents.contains("parent=\"Theme.SplashScreen\""));
         assert!(styles.contents.contains("postSplashScreenTheme"));
-        // No image → no animated-icon item, no drawable file.
         assert!(!styles.contents.contains("windowSplashScreenAnimatedIcon"));
         assert!(
             !a.extra_files
@@ -451,7 +437,6 @@ mod tests {
 
     #[test]
     fn ios_sets_launch_screen_dict_and_colorset() {
-        // No-image path (color only) to avoid file I/O.
         let mut ctx = GenerateContext {
             ios: Some(IosProjectIr::default()),
             ..Default::default()
@@ -466,7 +451,6 @@ mod tests {
                 assert!(
                     matches!(d.get("UIColorName"), Some(PlistValue::String(s)) if s == IOS_COLOR_NAME)
                 );
-                // No image → no UIImageName.
                 assert!(!d.contains_key("UIImageName"));
             }
             other => panic!("expected UILaunchScreen dict, got {other:?}"),

--- a/packages/whisker-status-bar/src/lib.rs
+++ b/packages/whisker-status-bar/src/lib.rs
@@ -6,28 +6,22 @@
 //! operations namespaced under the unit struct [`WhiskerStatusBar`]:
 //!
 //! - [`set_hidden`](WhiskerStatusBar::set_hidden) — show/hide the system
-//!   status bar (animated fade on iOS).
+//!   status bar.
 //! - [`set_style`](WhiskerStatusBar::set_style) — set the content color
 //!   ([`StatusBarStyle::Light`] = light icons for a dark background,
 //!   [`StatusBarStyle::Dark`] = dark icons for a light background).
 //!
+//! **Android-only** — both methods no-op on iOS. The only status-bar API
+//! a view-less module can reach there is the deprecated app-level
+//! `UIApplication.setStatusBarHidden`, which corrupts `whisker-router`'s
+//! transform-based transition animations; iOS support needs
+//! `WhiskerViewController.prefersStatusBarHidden` instead.
+//!
 //! Deliberately **not async** — the native module DSL only supports
 //! synchronous `Function`s today, and toggling the status bar is
-//! effectively instant on both platforms. The native handlers hop to
-//! the UI thread themselves ([`DispatchQueue.main`] / `runOnUiThread`),
-//! so callers may invoke from a reactive-thread `on_mount`/`on_cleanup`
-//! without wrapping.
-//!
-//! ## iOS setup (handled automatically)
-//!
-//! iOS routes status-bar appearance through the foreground view
-//! controller by default, which a view-less module can't reach. This
-//! crate's [`plugin`] injects `UIViewControllerBasedStatusBarAppearance
-//! = false` into `Info.plist` (when the app opts in via
-//! `app.plugin::<WhiskerStatusBar>(|c| c)`), which re-enables the
-//! app-level `UIApplication` status-bar APIs the native module calls.
-//! Android needs no such setup — `WindowInsetsControllerCompat` drives
-//! the status bar directly off the host activity's window.
+//! effectively instant. The native handler hops to the UI thread itself
+//! (`runOnUiThread`), so callers may invoke from a reactive-thread
+//! `on_mount` / `on_cleanup` without wrapping.
 //!
 //! ## Usage
 //!
@@ -39,8 +33,8 @@
 //!
 //! ## Native source
 //!
-//! - iOS: `crates/whisker-status-bar/ios/Sources/WhiskerStatusBar/StatusBarModule.swift`
-//! - Android: `crates/whisker-status-bar/android/src/main/kotlin/rs/whisker/modules/status_bar/StatusBarModule.kt`
+//! - iOS: `packages/whisker-status-bar/ios/Sources/WhiskerStatusBar/StatusBarModule.swift`
+//! - Android: `packages/whisker-status-bar/android/src/main/kotlin/rs/whisker/modules/status_bar/StatusBarModule.kt`
 
 /// Plugin (iOS `Info.plist` injection). Always compiles — independent
 /// of the `runtime` feature so the `whisker.rs` config probe (which

--- a/packages/whisker-status-bar/src/plugin.rs
+++ b/packages/whisker-status-bar/src/plugin.rs
@@ -1,14 +1,12 @@
 //! Whisker plugin for the status-bar module.
 //!
-//! Currently a no-op: the module is **Android-only** (see `runtime.rs`),
-//! and Android needs no manifest/config entry to drive the status bar.
-//! It previously injected `UIViewControllerBasedStatusBarAppearance =
-//! false` for the deprecated app-level iOS API — that API is no longer
-//! used (it broke router transitions), so the injection is gone. When
-//! iOS is implemented via `WhiskerViewController.prefersStatusBarHidden`,
-//! this plugin should instead ensure that key is `true` (its default).
-//! Kept as a registered no-op so that future work has a home and
-//! `app.plugin::<WhiskerStatusBar>(|c| c)` stays valid.
+//! A no-op: the module is **Android-only** (see `runtime.rs`), and Android
+//! needs no manifest/config entry to drive the status bar. Registered
+//! anyway so `app.plugin::<WhiskerStatusBar>(|c| c)` stays valid and iOS
+//! support has a home — once that lands via
+//! `WhiskerViewController.prefersStatusBarHidden`, this plugin should
+//! ensure `UIViewControllerBasedStatusBarAppearance` is `true` (its
+//! default).
 //!
 //! ## Usage in `whisker.rs`
 //!

--- a/packages/whisker-status-bar/src/runtime.rs
+++ b/packages/whisker-status-bar/src/runtime.rs
@@ -4,15 +4,14 @@
 //! `whisker::module!("WhiskerStatusBar").invoke(method, args)`, and
 //! lifts the returned `WhiskerValue` into a typed result.
 //!
-//! **Android-only.** The native calls fire only on Android. On iOS they
-//! are a no-op: the only status-bar API reachable from a view-less module
-//! is the deprecated app-level `UIApplication.setStatusBarHidden`, and
-//! that call corrupts `whisker-router`'s transform-based transition
-//! animations whenever it lands around one (verified on-device). iOS
-//! support is a TODO — it needs to drive the status bar through
+//! **Android-only.** On iOS the methods are a no-op: the only status-bar
+//! API reachable from a view-less module is the deprecated app-level
+//! `UIApplication.setStatusBarHidden`, and that call corrupts
+//! `whisker-router`'s transform-based transition animations whenever it
+//! lands around one. TODO: drive iOS through
 //! `WhiskerViewController.prefersStatusBarHidden` (the non-deprecated,
-//! view-controller-based API) instead. Until then the methods no-op on
-//! iOS so call sites work unchanged on both platforms.
+//! view-controller-based API) instead. Until then the no-op keeps call
+//! sites working unchanged on both platforms.
 
 use whisker::platform_module::WhiskerModuleError;
 #[cfg(target_os = "android")]
@@ -41,8 +40,8 @@ impl StatusBarStyle {
 }
 
 /// Typed Rust API for the `WhiskerStatusBar` platform module. The struct
-/// itself lives in `plugin.rs` (see its doc comment for why); this
-/// `impl` block just adds the runtime methods.
+/// itself lives in `plugin.rs` — one unit struct serves as both the
+/// plugin and this namespace.
 impl WhiskerStatusBar {
     /// Show or hide the system status bar (Android only — see the module
     /// docs; no-op on iOS). Immediate on Android.

--- a/packages/whisker-svg/src/builder.rs
+++ b/packages/whisker-svg/src/builder.rs
@@ -139,8 +139,6 @@ impl DisplayListBuilder {
         self.buf.len() == HEADER_LEN
     }
 
-    // ---- container / canvas state -----------------------------------------
-
     pub fn save(&mut self) {
         self.buf.push(OP_SAVE);
     }
@@ -162,8 +160,6 @@ impl DisplayListBuilder {
             self.buf.extend_from_slice(&v.to_le_bytes());
         }
     }
-
-    // ---- paint state ------------------------------------------------------
 
     pub fn fill_color(&mut self, c: Color) {
         self.buf.push(OP_PAINT_FILL_COLOR);
@@ -192,8 +188,6 @@ impl DisplayListBuilder {
     pub fn stroke_tint(&mut self) {
         self.buf.push(OP_PAINT_STROKE_TINT);
     }
-
-    // ---- path commands ----------------------------------------------------
 
     pub fn path_begin(&mut self) {
         self.buf.push(OP_PATH_BEGIN);
@@ -228,8 +222,6 @@ impl DisplayListBuilder {
     pub fn close(&mut self) {
         self.buf.push(OP_PATH_CLOSE);
     }
-
-    // ---- path execution ---------------------------------------------------
 
     pub fn fill(&mut self) {
         self.buf.push(OP_PATH_FILL);

--- a/packages/whisker-svg/src/compile.rs
+++ b/packages/whisker-svg/src/compile.rs
@@ -493,8 +493,6 @@ fn strip_unit_f32(s: &str) -> Option<f32> {
     s[..digits_end].parse::<f32>().ok()
 }
 
-// ---- shape → path normalisation -------------------------------------------
-
 fn shape_to_path(node: &roxmltree::Node, ctx: &mut Ctx) -> Vec<PathCommand> {
     match node.tag_name().name() {
         "path" => node

--- a/packages/whisker-svg/src/lib.rs
+++ b/packages/whisker-svg/src/lib.rs
@@ -100,9 +100,6 @@ use whisker::runtime::view::Element;
 ///   `preserveAspectRatio="xMidYMid meet"` semantics.
 #[component]
 pub fn svg(content: Signal<String>, color: Signal<String>, style: Style) -> Element {
-    // `Signal<T>` is `Copy`, so `content` is freely moved into the
-    // closure and `color` into the builder below even though the
-    // `#[component]` body re-fires as a `FnMut` (whisker #8).
     let display_list = computed(move || encode(&content.get()));
 
     render! {

--- a/packages/whisker-svg/src/path_parse.rs
+++ b/packages/whisker-svg/src/path_parse.rs
@@ -340,8 +340,6 @@ fn arc_to_cubics(
     }
 }
 
-// ---- low-level tokenizer ---------------------------------------------------
-
 struct Parser<'a> {
     bytes: &'a [u8],
     pos: usize,

--- a/packages/whisker-svg/src/replay.rs
+++ b/packages/whisker-svg/src/replay.rs
@@ -208,8 +208,6 @@ impl<'a> Cursor<'a> {
     }
 }
 
-// ---- helpers ---------------------------------------------------------------
-
 /// `Visitor` that records every dispatched call as a text line —
 /// the primary tool for golden-file tests in `tests/`. Trace
 /// lines mirror the human-readable opcode names in SPEC.md so a

--- a/packages/whisker-svg/tests/fixtures_test.rs
+++ b/packages/whisker-svg/tests/fixtures_test.rs
@@ -39,7 +39,6 @@ fn run_fixture(svg_path: &Path) {
         compiled.warnings
     );
 
-    // ---- trace golden ----
     let mut tracer = TraceVisitor::new();
     replay(&compiled.bytes, &mut tracer).expect("replay clean");
     let actual_trace = tracer.into_string();
@@ -62,7 +61,7 @@ fn run_fixture(svg_path: &Path) {
         );
     }
 
-    // ---- bin golden — the cross-platform fixture ----
+    // The `.bin` golden is the fixture the native replayers read too.
     let bin_path = svg_path.with_extension("bin");
     if update_mode() {
         fs::write(&bin_path, &compiled.bytes).expect("write bin golden");

--- a/packages/whisker-svg/tests/root_paint_cascade_test.rs
+++ b/packages/whisker-svg/tests/root_paint_cascade_test.rs
@@ -47,8 +47,7 @@ fn root_svg_paint_cascades_to_child_shapes() {
 
 #[test]
 fn child_can_still_override_root_paint() {
-    // The cascade fix mustn't break shapes that pull their own
-    // explicit colour over the inherited tint.
+    // An explicit colour on the shape wins over the inherited tint.
     let svg = r##"<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M 0 0 L 10 10" stroke="#ff0000"/></svg>"##;
     let compiled = compile(svg).expect("compile");
     let mut trace = TraceVisitor::new();

--- a/packages/whisker-web-browser/src/lib.rs
+++ b/packages/whisker-web-browser/src/lib.rs
@@ -71,19 +71,15 @@ pub async fn open_auth_session_async(
     let module = module!("WebBrowser");
     let (tx, rx) = futures_channel::oneshot::channel::<AuthSessionResult>();
     let tx = Arc::new(Mutex::new(Some(tx)));
-    // Held as a plain local for the whole function body (across the
-    // `.await` below) so it only drops once this fn returns — NOT
-    // inside the callback that fires it. Dropping a `ModuleSubscription`
-    // frees the very `Box<EventCallback>` the bridge is currently
-    // executing; doing that synchronously from within its own callback
-    // is a use-after-free (crashed with SIGSEGV during on-device testing).
+    // Held as a plain local across the `.await` below so it drops only once
+    // this fn returns, never inside the callback that fires it: dropping a
+    // `ModuleSubscription` frees the very `Box<EventCallback>` the bridge is
+    // executing, so a drop from within its own callback is a use-after-free.
     let subscription = module.on_event("authSessionCompleted", move |payload| {
-        // Resolve in its own statement, not `if let Some(x) =
-        // mutex.lock().unwrap().take() { ... }` — that form holds the
-        // `MutexGuard` alive through the whole body, still locked
-        // during `send()` below. `send()` can reentrantly drop
-        // `subscription` (freeing `tx`), and the guard then unlocks
-        // freed memory — confirmed SIGSEGV on device.
+        // Take in its own statement, not `if let Some(x) =
+        // mutex.lock().unwrap().take()` — that form holds the `MutexGuard`
+        // alive through `send()`, which can reentrantly drop `subscription`
+        // (freeing `tx`), leaving the guard to unlock freed memory.
         let sender = tx.lock().unwrap().take();
         if let Some(sender) = sender {
             let _ = sender.send(decode_auth_result(payload));

--- a/packages/whisker-webview/src/lib.rs
+++ b/packages/whisker-webview/src/lib.rs
@@ -157,16 +157,9 @@ use whisker::platform_module::WhiskerValue;
 use whisker::prelude::*;
 use whisker::{ElementRef, RefError, Signal, Style};
 
-// ---------------------------------------------------------------------------
-// Event payloads
-//
-// Every native event delivers its body under `detail` (the Android event
-// reporter wraps a custom event's params there, and the iOS bridge
-// normalizes `LynxCustomEvent`'s `params` key to `detail`), so each struct
-// reads one shape on both platforms. Every field is `#[serde(default)]` so
-// a partial / mismatched body degrades to a default rather than dropping
-// the handler call.
-// ---------------------------------------------------------------------------
+// Every native event delivers its body under `detail` on both platforms, so
+// each payload struct reads one shape. Fields are `#[serde(default)]` so a
+// partial body degrades to a default rather than dropping the handler call.
 
 /// Payload of the JS-bridge message event (`message`).
 ///
@@ -282,10 +275,6 @@ pub struct ProgressDetail {
     pub progress: f64,
 }
 
-// ---------------------------------------------------------------------------
-// Public error type
-// ---------------------------------------------------------------------------
-
 /// A navigation / load failure surfaced to [`on_error`](WebViewProps).
 ///
 /// The ergonomic, app-facing shape of an [`ErrorEvent`]'s `detail`.
@@ -298,10 +287,6 @@ pub struct WebViewError {
     /// Human-readable error description.
     pub description: String,
 }
-
-// ---------------------------------------------------------------------------
-// Callback newtype
-// ---------------------------------------------------------------------------
 
 /// A cloneable user callback for a [`WebView`] event prop.
 ///
@@ -326,10 +311,6 @@ impl<A, F: Fn(A) + 'static> From<F> for Callback<A> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Origin whitelist default
-// ---------------------------------------------------------------------------
-
 /// The default navigation origin whitelist: `["https://*", "http://*"]`.
 ///
 /// Permits any HTTPS or HTTP origin. Tighten it per-app by passing an
@@ -337,10 +318,6 @@ impl<A, F: Fn(A) + 'static> From<F> for Callback<A> {
 pub fn default_origin_whitelist() -> Vec<String> {
     vec!["https://*".to_string(), "http://*".to_string()]
 }
-
-// ---------------------------------------------------------------------------
-// Imperative handle
-// ---------------------------------------------------------------------------
 
 /// Typed imperative handle for a mounted [`WebView`].
 ///
@@ -413,10 +390,9 @@ impl WebViewRef {
     /// To get a value BACK from the page, have the script post it to the
     /// host and read it via [`on_message`](web_view): e.g.
     /// `evaluate_javascript("window.whisker.postMessage(document.title)")`
-    /// and handle it in `on_message`. (A direct result-returning
-    /// `evaluate_javascript_result` awaits an async-native-result module
-    /// feature; the native WebView's JS eval is inherently asynchronous
-    /// and the current sync `Function` dispatch can't carry its result.)
+    /// and handle it in `on_message`. There is no result-returning
+    /// variant: the native JS eval is asynchronous and the sync `Function`
+    /// dispatch it goes through cannot carry a result back.
     pub fn evaluate_javascript(&self, script: &str) {
         let _ = self.r.invoke(
             "evaluateJavaScript",
@@ -445,17 +421,9 @@ impl Default for WebViewRef {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Inner native binding — the thin element.
-//
-// `url` / `html` / `user_agent` / `style` are reactive `Signal<String>`
-// attrs (kebab-cased: `user-agent`). The bool props are passed as
-// pre-stringified `Signal<String>` attrs ("true" / "false"); the origin
-// whitelist is a JSON-array string (e.g. `["https://*","http://*"]`) so
-// the native side parses one stable form. `on_*` props are typed events
-// wired via `bind_typed`. Crate-internal — only the outer `web_view`
-// component uses it; not part of the public doc surface.
-// ---------------------------------------------------------------------------
+// Bool props reach the native side pre-stringified ("true" / "false") and the
+// origin whitelist as a JSON-array string, so it parses one stable form per
+// attr. Attr names are the kebab-cased field names (`user-agent`).
 
 #[doc(hidden)]
 #[whisker::module_component("WebView")]
@@ -475,10 +443,6 @@ pub fn native_webview(
     on_navigation: NavEvent,
 ) {
 }
-
-// ---------------------------------------------------------------------------
-// Public ergonomic component.
-// ---------------------------------------------------------------------------
 
 /// `whisker-webview:WebView` — a native web view with reactive content,
 /// a JS bridge, and an imperative handle.
@@ -523,19 +487,14 @@ pub fn web_view(
     /// Imperative handle ([`WebViewRef`]).
     webview_ref: Option<WebViewRef>,
 ) -> Element {
-    // ----- Content (reactive) -----------------------------------------
-    //
-    // Feed `url` down as a `Signal::Dynamic` so an external
-    // `url.set(...)` re-applies natively (a controlled load prop). When
-    // `url` is unset, the attr stays empty and the native side falls
-    // back to `html`. `url` is `Option<RwSignal<String>>` — `RwSignal`
-    // is `Copy`, so the whole `Option` is `Copy`.
+    // `Signal::Dynamic` so an external `url.set(...)` re-applies natively.
+    // An unset `url` leaves the attr empty and the native side falls back
+    // to `html`.
     let url_prop: Signal<String> = Signal::Dynamic(computed(move || match url {
         Some(u) => u.get(),
         None => String::new(),
     }));
 
-    // ----- Event wiring -----------------------------------------------
     let on_message_cb = {
         let on_message = on_message.clone();
         move |ev: MessageEvent| {
@@ -589,7 +548,6 @@ pub fn web_view(
         }
     };
 
-    // ----- Pass-through attrs (None → sensible default) ----------------
     let html_prop: Signal<String> = html.unwrap_or_default();
     let user_agent_prop: Signal<String> = user_agent.unwrap_or_default();
     let style_prop: Style = style.clone().unwrap_or_default();
@@ -598,7 +556,6 @@ pub fn web_view(
     let scroll_enabled_attr = bool_attr(scroll_enabled);
     let origin_whitelist_attr = origin_whitelist_json(&origin_whitelist);
 
-    // ----- Imperative handle: forward its ElementRef as `ref:` ---------
     let element_ref = webview_ref.as_ref().map(|h| h.r());
 
     let mut builder = NativeWebview::builder()
@@ -738,8 +695,6 @@ mod tests {
 
     #[test]
     fn empty_body_defaults() {
-        // Events with no body (or a `detail`-less body) degrade to
-        // defaults via the `#[serde(default)]` on `detail`.
         let empty: [(&str, WhiskerValue); 0] = [];
         let ev: NavEvent = WhiskerValue::map(empty)
             .deserialize_into()


### PR DESCRIPTION
Part of the per-crate sweep [docs/comment-style.md](docs/comment-style.md) announces (pilot: #376; siblings: #377, #378). Covers all 20 crates under `packages/`.

## What was applied

These are published, user-facing module crates — 78% of their comment lines are pub rustdoc the guide protects, so the headline number is modest (−6.9%) by design. The comparable number is **internal `//` comments: −25%** (1205 → 904). Six tiny crates with 0–4 internal comments are essentially untouched, deliberately.

Kept: platform-asymmetry contracts in rustdoc (iOS vs Android behavior), Lynx workaround rationale (`clip-radius` must be an attribute, z-index is ignored during transform animations so paint order = DOM order, exit-transition freeze rules), the SVG wire-format opcode-range headers (they document the format's opcode allocation), and the router test banners that tie tests to `docs/router-design.md`'s enumerated behaviors.

## Stale comments corrected (11 found)

- **`whisker-status-bar` documented an "iOS setup (handled automatically)"** — Info.plist injection by the plugin (which is a no-op whose own test asserts empty output), animated fades, and main-thread hops that the iOS runtime (entirely unimplemented) never does. Rewritten to the real Android-only contract.
- **`whisker-router` carried five "later phase" claims for shipped features**: the `routes!` macro ("no macro yet" / "will generate the registry in a later phase" — it does today), fragment spreads ("land with the macro later" — `RouteFragment` + `merge` exist in the same file), and references to `outlet.rs` / "the old signal-backed stack files", which no longer exist.
- `whisker-asset` / `whisker-asset-macros`: "native registration lands in a later phase" — the Android `.init_array` ctor is 50 lines below; bundling ships with passing e2e tests.
- Two `crates/` → `packages/` path rot instances in native-source pointers (status-bar, haptics).

Known follow-up, deliberately not done here (would be writing new docs, not sweeping): `whisker-local-store`'s module doc shows a `path = "../whisker/packages/…"` dependency snippet that is wrong for crates.io users.

## Numbers & verification

Comment lines 5394 → 5020; 44 files, +263/−688. **No code changes** — verified mechanically (`git diff -U0 packages/` filtered to non-comment lines is empty). `cargo test -p` (incl. doc-tests) green for all 20 crates, clippy 0 warnings ×20, `cargo fmt -p … -- --check` clean ×20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)