### PR TITLE
Sweep whisker-runtime comments

### DIFF
--- a/crates/whisker-runtime/src/element.rs
+++ b/crates/whisker-runtime/src/element.rs
@@ -1,13 +1,5 @@
 //! Element tag enum, shared between the `render!` macro emit and
 //! the bridge tag-mapping table.
-//!
-//! Pre-Phase-6.5a this module also held the `Element` value-tree
-//! struct + attribute / event / child data and the diff/patch flow
-//! consumed by `render.rs`. That entire pipeline retired with A3 —
-//! the fine-grained reactive runtime mutates the Lynx element tree
-//! directly through `view::*` rather than building an intermediate
-//! Rust-side data structure. Only the tag enum survives because the
-//! C bridge still keys element creation off it.
 
 /// Element tag. Numeric repr stays in sync with `WhiskerElementTag`
 /// in `crates/whisker-driver-sys/bridge/include/whisker_bridge.h`.

--- a/crates/whisker-runtime/src/event.rs
+++ b/crates/whisker-runtime/src/event.rs
@@ -49,10 +49,9 @@ pub use crate::view::BindType;
 /// happened" is the primary signal; the typed payload is
 /// supplementary. So if the body is absent (a bodyless event arrives
 /// as [`WhiskerValue::Null`]) or its shape doesn't match `E`, the
-/// handler is still called with `E::default()` — and the mismatch is
-/// logged with the raw value so it stays diagnosable (the Case ②
-/// philosophy: conversion mistakes are loggable, not invisible)
-/// rather than silently swallowing the whole event.
+/// handler is still called with `E::default()`, and the mismatch is
+/// logged with the raw value rather than silently swallowing the whole
+/// event.
 pub fn bind_typed<E, F>(handle: Element, event_name: &'static str, bind_type: BindType, handler: F)
 where
     E: DeserializeOwned + Default + 'static,
@@ -107,15 +106,13 @@ pub struct Target {
     pub dataset: BTreeMap<String, WhiskerValue>,
 }
 
-// The platform reporter hands us the *raw* event body, where `target`
+// The platform reporter hands over the *raw* event body, where `target`
 // and `currentTarget` are plain integer signs (Lynx
-// `LynxEvent.generateEventBody`: `body["target"] = targetSign`). The
-// richer `{id, dataset, uid}` object is only synthesized downstream in
-// the JS layer, which Whisker bypasses. So `Target` must deserialize
-// from EITHER an integer (→ `uid`, with empty `id`/`dataset`) or a
-// `{id, uid, dataset}` object — a hard "expected struct, got number"
-// error here would otherwise fail the *whole* event struct and blank
-// every field (including `detail`).
+// `LynxEvent.generateEventBody`); the richer `{id, dataset, uid}`
+// object is synthesized downstream in the JS layer, which Whisker
+// bypasses. `Target` must therefore accept EITHER form — a hard
+// "expected struct, got number" here fails the *whole* event struct and
+// blanks every field, `detail` included.
 impl<'de> Deserialize<'de> for Target {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -579,8 +576,6 @@ mod tests {
 
     #[test]
     fn missing_fields_default_rather_than_fail() {
-        // A body with only some keys (e.g. an event Lynx fills
-        // partially) must still deserialize — every field defaults.
         let e: TouchEvent = WhiskerValue::map([("type", WhiskerValue::String("touchend".into()))])
             .deserialize_into()
             .expect("partial body deserializes");
@@ -625,7 +620,6 @@ mod tests {
         assert_eq!(e.detail.scroll_height, 2000.0);
         assert_eq!(e.detail.delta_y, 12.0);
         assert!(e.detail.is_dragging);
-        // Absent key degrades to default rather than failing.
         assert_eq!(e.detail.delta_x, 0.0);
     }
 
@@ -672,11 +666,9 @@ mod tests {
 
     #[test]
     fn integer_target_signs_dont_blank_the_event() {
-        // The REAL reporter body: `target` / `currentTarget` are plain
-        // integer signs (LynxEvent.generateEventBody), not objects.
-        // Target's int-or-object deserialize must accept that so the
-        // sibling `detail` still populates (a type mismatch here used
-        // to fail the whole struct → all-zero payload).
+        // The real reporter body carries integer signs, not objects; a
+        // type mismatch there fails the whole struct and zeroes the
+        // sibling `detail`.
         let v = WhiskerValue::map([
             ("type", WhiskerValue::String("scroll".into())),
             ("target", WhiskerValue::Int(33)),
@@ -696,7 +688,6 @@ mod tests {
         assert_eq!(e.target.uid, 33); // sign mapped to uid
         assert_eq!(e.target.id, ""); // raw body carries no id
         assert_eq!(e.current_target.uid, 33);
-        // The sibling detail must survive the integer target.
         assert_eq!(e.detail.scroll_left, 640.0);
         assert_eq!(e.detail.scroll_width, 832.0);
         assert!(e.detail.is_dragging);

--- a/crates/whisker-runtime/src/host_wake.rs
+++ b/crates/whisker-runtime/src/host_wake.rs
@@ -10,9 +10,6 @@
 //!   calls [`wake_runtime`] from its WebSocket thread after parking
 //!   a patch, so the host runs another tick that picks the patch
 //!   up.
-//!
-//! Pre-Phase-6.5a this lived in `signal.rs` alongside the old
-//! `Signal<T>` API. With that gone it's a standalone module.
 
 use std::ffi::c_void;
 use std::sync::Mutex;

--- a/crates/whisker-runtime/src/lib.rs
+++ b/crates/whisker-runtime/src/lib.rs
@@ -1,6 +1,6 @@
 //! Core runtime for Whisker.
 //!
-//! Public surface, after the Phase 6.5a A3 cleanup:
+//! Public surface:
 //!
 //! - [`element`] — the [`ElementTag`](element::ElementTag) enum that
 //!   the macro emit and the C bridge agree on.
@@ -15,10 +15,6 @@
 //! - [`main_thread`] — `run_on_main_thread`, the worker-thread →
 //!   TASM-thread marshaling primitive used to update signals from
 //!   background work (HTTP fetch, channels, etc.).
-//!
-//! Pre-A3 the crate also exposed an `Element` value tree + diff/patch
-//! pipeline; that retired when the macro switched to emitting
-//! imperative `view::*` calls driven by reactive effects.
 
 pub mod anim_hook;
 pub mod element;

--- a/crates/whisker-runtime/src/main_thread.rs
+++ b/crates/whisker-runtime/src/main_thread.rs
@@ -31,21 +31,15 @@
 //! }
 //! ```
 //!
-//! ## Why not `spawn_local` / async?
+//! ## Versus `spawn_local`
 //!
-//! `spawn_local` (Leptos, wasm-bindgen-futures, Tauri, …) is a
-//! main-thread async executor: it takes a `Future` and polls it on
-//! the UI thread. `run_on_main_thread` is the simpler primitive on
-//! the other side of the boundary — it takes a plain `FnOnce` and
-//! posts it to the main-thread queue. The same idea as Android's
-//! `Activity.runOnUiThread(r)`, iOS's `DispatchQueue.main.async {}`,
-//! Slint's `invoke_from_event_loop`, or gtk-rs's
-//! `MainContext::invoke`.
-//!
-//! Whisker doesn't run an async executor on the main thread (yet),
-//! so we expose only the marshaling primitive. If A4 lands a
-//! single-threaded executor later, `spawn_local` will sit on top of
-//! this same dispatcher.
+//! [`spawn_local`](crate::tasks::spawn_local) is the main-thread async
+//! executor: it takes a `Future` and polls it on the UI thread.
+//! `run_on_main_thread` is the simpler primitive underneath — it takes
+//! a plain `FnOnce` and posts it to the main-thread queue, the same
+//! idea as Android's `Activity.runOnUiThread(r)`, iOS's
+//! `DispatchQueue.main.async {}`, Slint's `invoke_from_event_loop`, or
+//! gtk-rs's `MainContext::invoke`.
 //!
 //! ## How it routes
 //!
@@ -90,15 +84,9 @@ static DISPATCHER: Mutex<Option<Dispatcher>> = Mutex::new(None);
 /// it (on the main thread, right after the marshaled closure runs)
 /// instead of merely requesting a vsync frame. The callback runs the
 /// driver's `tick_frame` — flush + drain the task pool + flush +
-/// mounts + renderer flush — so an async completion that was just
-/// marshaled onto the main thread is drained and painted immediately,
-/// on this main-run-loop post, with the vsync render loop untouched.
-///
-/// This is the proper fix for the resource hang: the worker's result
-/// is delivered via the host's main-thread dispatch (CFRunLoop /
-/// Looper), which the OS services even while CADisplayLink /
-/// Choreographer is paused, and we DRIVE the consequence here rather
-/// than racing an unpause of the paused vsync loop.
+/// mounts + renderer flush — so an async completion just marshaled
+/// onto the main thread is drained and painted on this same
+/// main-run-loop post, with the vsync render loop untouched.
 ///
 /// A plain `extern "C" fn()` pointer — no `user_data` needed; the
 /// driver's `tick_frame` reads its own thread-locals.
@@ -107,17 +95,13 @@ static DRIVE: Mutex<Option<extern "C" fn()>> = Mutex::new(None);
 std::thread_local! {
     /// Re-entrancy depth for main-thread render/tick/drive work.
     ///
-    /// The [`trampoline`] runs the driver's `tick_frame` directly on a
-    /// main-loop post. That is correct when the host dispatcher genuinely
-    /// *posts* the trampoline to a later run-loop turn. But some
-    /// dispatchers (Lynx's `run_on_tasm_thread`, iOS `Thread.isMainThread`
-    /// fast paths) invoke it **inline** when called from the TASM thread.
-    /// If `run_on_main_thread` is called from inside the initial render or
-    /// a `tick_frame` (e.g. a module's startup wiring), an inline trampoline
-    /// would re-enter `tick_frame` while the renderer/reactive runtime is
-    /// already active — a re-entrant borrow that aborts. This depth lets the
-    /// trampoline detect that nesting and DEFER (request a vsync frame)
-    /// instead of re-entering.
+    /// Some dispatchers (Lynx's `run_on_tasm_thread`, iOS
+    /// `Thread.isMainThread` fast paths) invoke the [`trampoline`]
+    /// **inline** when called from the TASM thread. Called from inside
+    /// the initial render or a `tick_frame`, that would re-enter
+    /// `tick_frame` while the renderer / reactive runtime is already
+    /// active — a re-entrant borrow that aborts. The depth lets the
+    /// trampoline see the nesting and defer instead.
     static MAIN_WORK_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
 
@@ -188,12 +172,10 @@ pub fn set_drive_callback(cb: Option<extern "C" fn()>) {
 /// dirty will wake the host's render loop automatically (via
 /// `host_wake::wake_runtime` from the scheduler).
 ///
-/// After `f` runs, the [`trampoline`] DRIVES the runtime directly (via
+/// After `f` runs, the [`trampoline`] drives the runtime directly (via
 /// the registered [`set_drive_callback`]) on this same main-thread
 /// post, so an async result marshaled here (the `run_blocking` /
-/// `resource()` path) is drained and painted immediately — see
-/// [`trampoline`]'s comment for why this beats requesting a vsync
-/// frame.
+/// `resource()` path) is drained and painted immediately.
 pub fn run_on_main_thread<F>(f: F)
 where
     F: FnOnce() + Send + 'static,
@@ -219,8 +201,8 @@ where
 
     let ok = (dispatcher.func)(dispatcher.engine, trampoline, user_data);
     if !ok {
-        // Dispatch refused (typically: engine torn down). Reclaim
-        // the box so we don't leak the closure.
+        // Dispatch refused (typically: engine torn down) — reclaim the
+        // box so the closure isn't leaked.
         let _: Box<Box<dyn FnOnce() + Send + 'static>> =
             unsafe { Box::from_raw(user_data as *mut Box<dyn FnOnce() + Send + 'static>) };
     }
@@ -236,33 +218,19 @@ extern "C" fn trampoline(user_data: *mut c_void) {
     let boxed: Box<Box<dyn FnOnce() + Send + 'static>> =
         unsafe { Box::from_raw(user_data as *mut Box<dyn FnOnce() + Send + 'static>) };
     boxed();
-    // We're now on the MAIN thread (this trampoline ran via the host's
-    // main-thread dispatch — a real CFRunLoop / Looper post, which the
-    // OS services even while the vsync render loop is paused). The
-    // closure we just ran is typically `tx.send(value)` from a
-    // `run_blocking` worker (the `resource()` path): it woke the
-    // awaiting future's `Waker`, re-queuing it in `LocalPool`. But
-    // `LocalPool` only re-polls when `run_until_stalled` runs, which
-    // happens inside the driver's `tick_frame`.
+    // The closure just run is typically `tx.send(value)` from a
+    // `run_blocking` worker: it woke the awaiting future's `Waker` and
+    // re-queued it in `LocalPool`, which only re-polls from
+    // `run_until_stalled` inside the driver's `tick_frame`. Driving
+    // that here — on the host's main-thread post, which the OS services
+    // even while the vsync loop is paused — avoids racing an unpause of
+    // a paused CADisplayLink / Choreographer.
     //
-    // If a drive callback is registered (production + the
-    // `cross_thread_wake` tests), invoke it: it runs `tick_frame` HERE,
-    // on this main-loop post — draining the pool, flushing, and
-    // painting the fetch's consequences immediately. The vsync loop is
-    // untouched, so there is NO race against an end-of-frame pause and
-    // NO need to busy-tick. This is the proper fix for the resource
-    // hang (was: request a vsync frame, which races the paused
-    // CADisplayLink/Choreographer and is silently clobbered).
+    // With no drive callback wired (tests that don't model the driver),
+    // fall back to requesting a vsync frame.
     //
-    // Fall back to `wake_runtime()` (request a vsync frame) when no
-    // drive callback is wired — e.g. tests that don't model the driver.
-    //
-    // RE-ENTRANCY: if this trampoline was invoked INLINE by the host
-    // dispatcher while we're already inside the initial render or a
-    // `tick_frame` (some dispatchers run same-thread posts synchronously),
-    // running `tick_frame` again would re-enter the renderer/reactive
-    // runtime and abort. In that case, defer via a vsync frame request
-    // instead — the deferred tick drains the pool on the next frame.
+    // An INLINE trampoline (see `MAIN_WORK_DEPTH`) must defer instead:
+    // running `tick_frame` from inside one aborts.
     if main_work_in_progress() {
         crate::host_wake::wake_runtime();
         return;
@@ -306,17 +274,12 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, MutexGuard};
 
-    /// Tests poke process-global host state (the registered
-    /// dispatcher), so they must run one at a time AND not race tests
-    /// in sibling modules that touch the same globals — hence the
-    /// shared [`super::host_test_lock`].
     fn lock<'a>() -> MutexGuard<'a, ()> {
         super::host_test_lock()
     }
 
     /// Pretend-host dispatcher: invokes the callback synchronously on
-    /// the caller's thread. Good enough to verify the trampoline /
-    /// boxing / unbox cycle without spawning a real second thread.
+    /// the caller's thread.
     extern "C" fn sync_invoke(
         _engine: *mut c_void,
         callback: extern "C" fn(*mut c_void),
@@ -357,7 +320,6 @@ mod tests {
     fn closure_dropped_when_no_dispatcher() {
         let _guard = lock();
         __reset_for_tests();
-        // Closure captures a state we can observe via Drop.
         struct DropFlag(Arc<AtomicBool>);
         impl Drop for DropFlag {
             fn drop(&mut self) {
@@ -367,8 +329,6 @@ mod tests {
         let dropped = Arc::new(AtomicBool::new(false));
         let flag = DropFlag(dropped.clone());
         run_on_main_thread(move || {
-            // Move `flag` in; if the closure is dropped without
-            // running, `flag` is also dropped.
             let _ = &flag;
         });
         assert!(

--- a/crates/whisker-runtime/src/reactive/arc_signal.rs
+++ b/crates/whisker-runtime/src/reactive/arc_signal.rs
@@ -53,12 +53,13 @@
 //!
 //! ## Conversions
 //!
-//! For now this module only provides the Arc-native primitives. A
-//! follow-up may add `From<ArcRwSignal<T>> for RwSignal<T>` so module
-//! authors can stash `ArcRwSignal` at the storage boundary and hand
-//! out arena-backed Copy handles at the API surface (the Leptos
-//! pattern). The Arc-only API already covers the bug class that
-//! motivated this change.
+//! Each Arc handle has a `From` impl into its arena-backed
+//! counterpart ([`RwSignal`](super::signal::RwSignal),
+//! [`ReadSignal`](super::signal::ReadSignal),
+//! [`WriteSignal`](super::signal::WriteSignal)), so a module can stash
+//! an `ArcRwSignal` at the storage boundary and hand out `Copy` handles
+//! at its API surface. The arena entry is only a lifecycle pin — reads
+//! and writes forward through the shared `Rc`.
 
 use std::cell::RefCell;
 use std::marker::PhantomData;
@@ -123,19 +124,15 @@ fn track<T: 'static>(inner: &Rc<ArcSignalInner<T>>) {
 /// the subscriber list from the Arc signal's own storage instead of
 /// from an arena node.
 ///
-/// Subscribers go through [`super::scheduler::schedule`] (not a raw
-/// `rt.pending.push`) so the host wake on the empty→non-empty edge
-/// fires. Without that, writes from a bridge callback (e.g.
-/// `module.on_event(...)` updating a global `ArcRwSignal`) queued
-/// dirty effects but never flushed them until some other source
-/// happened to trigger a reactive cycle — manifesting as a UI
-/// bound to the signal that simply never re-rendered. Stale
-/// subscriber pruning is independent of the wake.
+/// Subscribers go through [`super::scheduler::schedule`] rather than a
+/// raw `rt.pending.push` so the host wake on the empty→non-empty edge
+/// fires. A write arriving from a bridge callback is otherwise the only
+/// thing happening, and the dirty effects sit queued and unflushed.
 fn notify_subscribers<T: 'static>(inner: &Rc<ArcSignalInner<T>>) {
     let subscribers: Vec<NodeId> = inner.subscribers.borrow().clone();
     let mut stale: Vec<NodeId> = Vec::new();
-    // First pass: identify stale subscribers so the dedupe walk
-    // inside `schedule()` doesn't end up with freed slots.
+    // Identified up front so `schedule()`'s dedupe walk never sees a
+    // freed slot.
     with_runtime(|rt| {
         for sub in &subscribers {
             if !rt.nodes.contains_key(*sub) {

--- a/crates/whisker-runtime/src/reactive/callback.rs
+++ b/crates/whisker-runtime/src/reactive/callback.rs
@@ -4,22 +4,17 @@
 //! ## Why this type exists
 //!
 //! `#[component]` bodies are `FnMut` (whisker's hot-reload wrapper —
-//! see [`Signal<T>`]'s docs, whisker issue #8). Moving a captured,
-//! non-`Copy` prop into a nested `move` closure (e.g.
-//! `view(on_tap: move |_| on_tap())`) violates that `FnMut` contract:
-//! the prop is moved out of the body on the first call, so a second
-//! invocation of the body (hot-reload, or any future re-render) can't
-//! move it again — `error[E0507]`. Until now the workaround has been
-//! an `Rc<dyn Fn()>` prop plus a manual `let cb = on_tap.clone();`
-//! before each handler closure that needs it.
+//! see [`Signal<T>`]'s docs). Moving a captured, non-`Copy` prop into a
+//! nested `move` closure (e.g. `view(on_tap: move |_| on_tap())`)
+//! violates that `FnMut` contract: the prop is moved out of the body on
+//! the first call, so a second invocation can't move it again —
+//! `error[E0507]`. The alternative is an `Rc<dyn Fn()>` prop plus a
+//! manual `let cb = on_tap.clone();` before every handler closure.
 //!
-//! `Callback<In, Out>` removes the workaround: like [`Signal<T>`], it
-//! stores the actual closure in an owner-bound [`StoredValue<T>`]
-//! arena slot and hands back only a `Copy` handle (a `NodeId`). A
-//! `Copy` value never needs `.clone()` — it can be moved into any
-//! number of `move` closures for free. Mirrors Leptos's
-//! `Callback<In, Out>`, which solves the identical problem the same
-//! way (an arena-backed, `Copy` handle) — see
+//! `Callback<In, Out>` avoids that: like [`Signal<T>`], it stores the
+//! closure in an owner-bound [`StoredValue<T>`] arena slot and hands
+//! back only a `Copy` handle, which moves into any number of `move`
+//! closures for free. Mirrors Leptos's `Callback<In, Out>` — see
 //! <https://docs.rs/leptos/latest/leptos/callback/index.html>.
 //!
 //! ```ignore
@@ -48,12 +43,9 @@ use super::stored::StoredValue;
 /// case — construct with a zero-arg closure (`move || …`) and call
 /// with [`Callback::call`] rather than `.run(())`.
 //
-// NOTE: `Clone`/`Copy` are hand-written rather than `#[derive]`d, same
-// reasoning as `Signal<T>` — a derived impl would add spurious
-// `In: Clone + Copy, Out: Clone + Copy` bounds, but neither type
-// parameter is ever stored inline (they only appear in the boxed
-// closure's signature), so `Callback<In, Out>` must be `Copy`
-// unconditionally.
+// `Clone`/`Copy` are hand-written for the same reason as `Signal<T>`:
+// `#[derive]` would add spurious `In: Copy, Out: Copy` bounds, though
+// neither is ever stored inline.
 pub struct Callback<In: 'static = (), Out: 'static = ()> {
     inner: StoredValue<Box<dyn Fn(In) -> Out>>,
 }
@@ -110,9 +102,8 @@ mod tests {
 
     #[test]
     fn callback_is_copy() {
-        // The whole point: a Callback prop can be moved into several
-        // `move` closures without `.clone()`. Wouldn't compile if
-        // `Callback` weren't `Copy`.
+        // A Callback prop must move into several `move` closures
+        // without `.clone()`.
         __reset_for_tests();
         fn assert_copy<C: Copy>(_: &C) {}
 

--- a/crates/whisker-runtime/src/reactive/component.rs
+++ b/crates/whisker-runtime/src/reactive/component.rs
@@ -10,15 +10,14 @@
 //!    keeps the handle; disposing the parent will cascade).
 //!
 //! The macro also passes its own fn pointer to
-//! [`register_component`] so the Strategy C hot-reload path (A6) can
-//! map subsecond-patched fn pointers back to live owners.
+//! [`register_component`] so the hot-reload path can map
+//! subsecond-patched fn pointers back to live owners.
 //!
 //! Lifecycle hooks:
 //!
 //! - [`on_mount`] — registered against the current owner; fires once
-//!   on the next [`flush_mounts`]. The renderer (A3) calls
-//!   `flush_mounts` after appending the component's view to its
-//!   parent.
+//!   on the next [`flush_mounts`], which runs after the component's
+//!   view has been appended to its parent.
 //! - `on_cleanup` lives in `owner.rs` — symmetric LIFO callback that
 //!   fires when the owner is disposed.
 
@@ -46,15 +45,10 @@ pub fn mount_component<R>(fn_ptr: *const (), body: impl FnOnce() -> R) -> (Owner
         }
         rt.component_owners.entry(fn_ptr).or_default().push(owner);
     });
-    // Component bodies build a static Element tree; the reactive
-    // dependencies they declare must come from explicit
-    // `effect` / `computed` calls *inside* the body, not from
-    // ambient signal reads contaminating whatever outer reactive
-    // node we happened to be constructed inside (a parent
-    // component's `Show` effect, `StackLayout`'s route mount, etc.).
-    // Clear the tracker around the body call so a direct
-    // `signal.get()` in user code doesn't silently subscribe the
-    // outer node.
+    // A component's reactive dependencies must come from the explicit
+    // `effect` / `computed` calls inside its body. Without `untrack`, a
+    // bare `signal.get()` in the body subscribes whatever outer node is
+    // constructing us (a parent's `Show` effect, a route mount).
     let result = untrack(|| owner.with(body));
     (owner, result)
 }
@@ -78,8 +72,8 @@ pub fn unmount_component(owner: Owner) {
 }
 
 /// Register `f` as a post-mount callback for the current owner. Fires
-/// once on the next [`flush_mounts`] call (driven by the renderer
-/// after the component's view is appended to its parent).
+/// once on the next [`flush_mounts`] call, which runs after the
+/// component's view is appended to its parent.
 ///
 /// No-op (with debug-build warning) if there is no current owner.
 pub fn on_mount(f: impl FnOnce() + 'static) {
@@ -95,32 +89,26 @@ pub fn on_mount(f: impl FnOnce() + 'static) {
     }
 }
 
-/// Run all queued on_mount callbacks in registration order. Called by
-/// the renderer (A3) after a batch of component views has been
-/// appended to the tree. Safe to call when the queue is empty
-/// (no-op).
+/// Run all queued on_mount callbacks in registration order. Called
+/// after a batch of component views has been appended to the tree.
+/// Safe to call when the queue is empty (no-op).
 pub fn flush_mounts() {
-    // Drain the queue under a short borrow so callback bodies (which
-    // may themselves register new on_mount) land in a fresh queue.
+    // Drained under a short borrow so callbacks that register their own
+    // `on_mount` land in a fresh queue.
     let queue: Vec<Box<dyn FnOnce()>> = with_runtime(|rt| std::mem::take(&mut rt.pending_mounts));
     for cb in queue {
-        // `on_mount` callbacks are fire-once side effects that may
-        // read signals to inspect post-mount state but should never
-        // subscribe whatever node happens to be on the call stack
-        // when the queue gets drained. In production `flush_mounts`
-        // runs after `reactive_flush` returns (tracker already
-        // cleared by the scheduler), but other integrations may
-        // call it from inside a reactive scope — wrap each `cb` in
-        // `untrack` so the invariant is enforced by the queue itself.
+        // An `on_mount` may read signals to inspect post-mount state
+        // but must never subscribe whatever node is on the stack at
+        // drain time — an integration is free to call `flush_mounts`
+        // from inside a reactive scope, so the queue enforces it.
         untrack(cb);
     }
 }
 
-/// Look up the owners currently associated with `fn_ptr`. Used by the
-/// A6 hot-reload path to find which live owners need disposal +
-/// remount when subsecond patches a component function body. Returns
-/// a snapshot — modifying the runtime's `component_owners` after
-/// this call won't affect the returned `Vec`.
+/// Look up the owners currently associated with `fn_ptr` — which live
+/// owners need disposal + remount when subsecond patches a component
+/// function body. Returns a snapshot; later mutations of the runtime's
+/// `component_owners` don't affect the returned `Vec`.
 #[doc(hidden)]
 pub fn owners_for_fn(fn_ptr: *const ()) -> Vec<Owner> {
     with_runtime(|rt| {
@@ -131,44 +119,25 @@ pub fn owners_for_fn(fn_ptr: *const ()) -> Vec<Owner> {
     })
 }
 
-// ===========================================================================
-// True per-component remount — wrapper-less (issue #17 / Y-2 P1)
-// ===========================================================================
+// Per-component remount. `mount_component_remountable` returns the
+// body's root element directly — no wrapper element sits between a
+// component body and its parent, so the Whisker component tree maps
+// 1:1 onto the Lynx element tree.
 //
-// `mount_component_remountable` runs the user's body inside a fresh
-// owner and **returns the body's root element directly** — no wrapper
-// `view` is inserted between the body and its parent. The Whisker
-// component tree maps 1:1 with the Lynx element tree.
+// With no wrapper to serve as a stable placeholder, each mount's
+// `(parent, previous_sibling)` is captured lazily: the mount stashes
+// its `MountId` + body_root in `PENDING_MOUNT`, and `view::append_child`
+// calls back through [`on_component_root_attached`] once that root is
+// attached.
 //
-// To make remount still work without a wrapper as a stable
-// placeholder, we capture each mount's `(parent, previous_sibling)`
-// lazily: `mount_component_remountable` stashes the freshly-created
-// `MountId` + body_root in a thread-local `PENDING_MOUNT` slot,
-// and `view::append_child` (when it sees that body_root being
-// attached) calls back via [`on_component_root_attached`] to
-// populate `MountSite.parent` / `MountSite.anchor`.
-//
-// On a subsecond patch:
-// 1. Look up the MountSite by patched fn_ptr.
-// 2. Detach old body_root from parent (Whisker-side child mirror
-//    keeps the position information so we know where to re-insert).
-// 3. Dispose old owner — cascading reactive cleanup, on_cleanup,
-//    nested component disposal.
-// 4. Re-invoke body inside a fresh owner → new body_root.
-// 5. Insert new body_root at the same slot (after the same
-//    previous-sibling anchor, or at the start if no anchor).
-//
-// Trade-offs / known limitations:
-// - The "previous sibling" anchor must remain alive across remounts.
-//   If a sibling-managed component disposed itself between mount
-//   and patch, the anchor is stale and remount falls back to
-//   inserting at the previous numeric position (best effort).
-//   For/Show interactions don't normally cause this because their
-//   wrappers are themselves stable elements.
+// Known limitations:
+// - The anchor must outlive the remount. A sibling-managed component
+//   that disposed itself between mount and patch leaves a stale anchor,
+//   and remount falls back to the previous numeric position.
 // - Component-local signal state is lost on remount; context-stored
-//   state survives because its owners live above the disposed scope.
-// - Props must implement `Clone` so the body closure can hand the
-//   user code fresh owned values on each invocation.
+//   state survives, its owners being above the disposed scope.
+// - Props must implement `Clone` so the body closure can hand user code
+//   fresh owned values on each invocation.
 
 use std::cell::Cell;
 
@@ -242,9 +211,8 @@ pub fn on_component_root_attached(parent: Element, child: Element) {
         return;
     };
     if root != child {
-        // The attach was for some other element. Put the pending
-        // entry back so the body_root's eventual `append_child`
-        // can still pick it up.
+        // Some other element; put the entry back so the body_root's
+        // eventual `append_child` can still claim it.
         PENDING_MOUNT.with(|cell| cell.set(Some((mount_id, root))));
         return;
     }
@@ -267,9 +235,8 @@ pub fn __reset_pending_mount_for_tests() {
 /// Mount a component with full remount support — wrapper-less.
 ///
 /// Runs `body` inside a fresh owner and returns the body's root
-/// element directly to the caller. No wrapper element is created,
-/// so the Whisker component tree maps 1:1 with the Lynx element
-/// tree (issue #17).
+/// element directly to the caller. No wrapper element is created, so
+/// the Whisker component tree maps 1:1 with the Lynx element tree.
 ///
 /// To make remount work without a stable wrapper handle in the
 /// parent's child list, the function stashes a pending-mount entry
@@ -302,7 +269,6 @@ where
     let props_hash_fn: Rc<dyn Fn() -> u64 + 'static> = Rc::from(props_hash_fn);
     let props_hash = props_hash_fn();
 
-    // Initial mount: fresh owner, run body, capture root.
     let body_for_first = body.clone();
     let owner = Owner::new(None);
     with_runtime(|rt| {
@@ -311,13 +277,12 @@ where
         }
         rt.component_owners.entry(fn_ptr).or_default().push(owner);
     });
-    // See `mount_component` for the rationale on the `untrack`
-    // bracket. Same invariant applies to the remountable variant.
+    // See `mount_component` for why the body runs untracked.
     let body_root = untrack(|| owner.with(|| (*body_for_first)()));
 
-    // Register the MountSite with parent / anchor as `None` for now
-    // — the next `view::append_child` that attaches `body_root`
-    // will populate them via `on_component_root_attached`.
+    // `parent` / `anchor` stay `None` until the next
+    // `view::append_child` attaches `body_root` and calls back through
+    // `on_component_root_attached`.
     let mount_id = with_runtime(|rt| {
         rt.mount_id_counter += 1;
         let id = MountId(rt.mount_id_counter);
@@ -338,13 +303,10 @@ where
         id
     });
 
-    // Hand the (MountId, body_root) pair to the pending slot. The
-    // caller's `view::append_child(parent, body_root)` consumes it
-    // and binds parent + anchor. Any previously-stashed pending
-    // mount that *wasn't* consumed (orphaned — body returned a root
-    // that was never attached) gets dropped here; the orphan's
-    // MountSite stays in the registry without a parent and will
-    // simply be skipped by remount lookups.
+    // The caller's `view::append_child(parent, body_root)` consumes
+    // this and binds parent + anchor. An unconsumed predecessor (a body
+    // whose root was never attached) is dropped here; its MountSite
+    // stays parentless in the registry and remount lookups skip it.
     PENDING_MOUNT.with(|cell| cell.set(Some((mount_id, body_root))));
 
     body_root
@@ -352,37 +314,28 @@ where
 
 /// Re-mount every remountable site whose `fn_ptr` is in the given
 /// list. Called by the bootstrap's tick callback after a successful
-/// subsecond patch. Internally:
+/// subsecond patch.
 ///
-/// 1. Collect the set of `MountId`s to remount (deduplicated, even
-///    if the patch list contains the same fn pointer multiple times).
-/// 2. For each: detach the previous body root from its wrapper,
-///    dispose the previous owner (cascading reactive cleanup), then
-///    create a fresh owner, re-invoke the body, append the new root
-///    to the same wrapper, and update the site's `owner` / `body_root`.
-///
-/// The wrapper element stays put in the parent's child list across
-/// the whole flow, so the user-visible navigation / scroll position
-/// / sibling order are preserved.
+/// The whole list is remounted as one batch: every old body root is
+/// detached first, then each site's owner is disposed and its body
+/// re-run, and finally the new roots are inserted at the indices their
+/// old roots held. Non-remounted siblings never move, so sibling order
+/// and their native state survive the patch.
 ///
 /// Returns [`RemountStats`]: how many sites were remounted, and how
 /// many were *refused* because their props layout changed. The
-/// bootstrap uses both as full-remount triggers (hot reload escalation) —
-/// `remounted == 0` means the patch had no attached component to
-/// reflect through, and `layout_changed > 0` means at least one
-/// stored body closure can no longer be re-run safely.
+/// bootstrap escalates on either — `remounted == 0` means the patch had
+/// no attached component to reflect through, and `layout_changed > 0`
+/// means at least one stored body closure can no longer be re-run
+/// safely.
 pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
     if patched_fns.is_empty() {
         return RemountStats::default();
     }
-    // Collect candidate mount sites, then filter out any whose
-    // ancestor component is also in this patch batch. When a
-    // parent component's body is patched, remounting it
-    // re-creates the whole subtree from scratch — separately
-    // remounting children would either operate on stale parent
-    // state (if processed first) or no-op (if scrubbed by the
-    // cascading dispose). Both outcomes are wrong; skipping the
-    // descendant entirely is the correct semantics.
+    // A site whose ancestor component is in the same batch is skipped:
+    // remounting the ancestor rebuilds the whole subtree, so handling
+    // the descendant separately either works on stale parent state or
+    // no-ops against a cascade-disposed owner.
     let patched_set: std::collections::HashSet<*const ()> = patched_fns.iter().copied().collect();
     let ids: Vec<MountId> = with_runtime(|rt| {
         let mut candidates: Vec<MountId> = Vec::new();
@@ -398,8 +351,6 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
         candidates
             .into_iter()
             .filter(|mount_id| {
-                // Walk the owner chain upward; if any ancestor
-                // owner's mount_fn is in `patched_set`, skip.
                 let site = match rt.mount_sites.get(mount_id) {
                     Some(s) => s,
                     None => return false,
@@ -425,30 +376,11 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
         return RemountStats::default();
     }
 
-    // ---- Batched remount that preserves sibling order ---------------------
-    //
-    // The naive "one-at-a-time" version (`remount_one` per site) suffers
-    // anchor staleness when sibling components are remounted together:
-    // each site's `anchor` is a sibling's body_root, and once that
-    // sibling has been remounted earlier in the loop, the anchor points
-    // at an element that has already been detached → fallback to
-    // index 0 → siblings clump at the top of the parent in
-    // hash-iteration order, visibly scrambling the layout.
-    //
-    // Instead we do the whole batch as one operation:
-    //   1. Snapshot each unique parent's current child list before
-    //      anything mutates.
-    //   2. For every site, dispose old owner + run new body to get the
-    //      new body_root. The new body runs against a fresh owner so
-    //      reactive state is isolated. None of this touches the parent's
-    //      child list.
-    //   3. For each parent, build the desired final child list by
-    //      replacing each old body_root with its new body_root, leaving
-    //      non-replaced siblings untouched.
-    //   4. Remove every old body_root from the parent, then re-insert
-    //      each new body_root at its desired index (ascending order).
-    //   5. Refresh anchors from the post-mutation child list so future
-    //      individual remounts also see a coherent state.
+    // The batch must be one operation rather than a per-site loop:
+    // a site's `anchor` is a sibling's body_root, so remounting siblings
+    // one at a time detaches the anchors the later ones depend on and
+    // they all fall back to index 0, clumping at the top of the parent
+    // in hash-iteration order.
 
     struct RemountInfo {
         mount_id: MountId,
@@ -477,19 +409,13 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
             .collect()
     });
 
-    // Layout gate: refuse to re-run a stored body closure whose
-    // captured environment no longer matches what the patched body
-    // code expects. The site's `body` was created against
-    // `props_hash`; `props_hash_fn()` dispatches into the freshly
-    // applied patch and returns the layout the *new* code was
-    // compiled for. A mismatch means the patch changed the
-    // component's props signature — re-invoking the old closure
-    // would transmute mismatched capture layouts (garbage props /
-    // UB). The caller escalates these to a hot reload full remount,
-    // where fresh (patched) code rebuilds the props from scratch.
-    // Evaluated OUTSIDE `with_runtime`: the hash getter re-enters
-    // subsecond dispatch, which must not run under the runtime
-    // borrow.
+    // `props_hash_fn()` dispatches into the freshly applied patch and
+    // returns the layout the *new* code was compiled for. A mismatch
+    // against the site's stored hash means the patch changed the props
+    // signature, and re-invoking the old closure would transmute across
+    // mismatched capture layouts (garbage props / UB); the caller
+    // escalates those to a full remount instead. Evaluated OUTSIDE
+    // `with_runtime` — the hash getter re-enters subsecond dispatch.
     let (infos, layout_changed): (Vec<RemountInfo>, Vec<RemountInfo>) = infos
         .into_iter()
         .partition(|info| (info.props_hash_fn)() == info.props_hash);
@@ -502,7 +428,7 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
         };
     }
 
-    // 1. Snapshot each unique parent's child list.
+    // Snapshot each unique parent's child list before anything mutates.
     let mut parent_snapshot: std::collections::HashMap<Element, Vec<Element>> =
         std::collections::HashMap::new();
     for info in &infos {
@@ -511,13 +437,10 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
             .or_insert_with(|| crate::view::children_of(info.parent));
     }
 
-    // 2. Detach every old body_root from its parent *before* any
-    //    dispose runs. Element handles get invalidated by
-    //    `Owner::dispose` (renderer slot becomes `None`), so once
-    //    disposed, subsequent `remove_child` calls would silently
-    //    no-op against Lynx — visible as "stale subtree still on
-    //    screen" after hot reload. Doing the remove first keeps the
-    //    handle live.
+    // Detach every old body_root *before* any dispose runs.
+    // `Owner::dispose` invalidates element handles, after which
+    // `remove_child` silently no-ops against Lynx and the stale subtree
+    // stays on screen.
     let mut by_parent: std::collections::HashMap<Element, Vec<(Element, Option<Element>)>> =
         std::collections::HashMap::new();
     for info in &infos {
@@ -528,8 +451,6 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
             .push((info.old_body_root, None));
     }
 
-    // 3. Dispose old owners + run new bodies, collecting (mount_id,
-    //    parent, old_root, new_root, new_owner).
     let mut results: Vec<(MountId, Element, Element, Element, Owner)> =
         Vec::with_capacity(infos.len());
     for info in infos {
@@ -556,19 +477,16 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
                 .or_default()
                 .push(new_owner);
         });
-        // `untrack` so the remounted body's signal reads register
-        // against its own nested `effect`/`computed`s, not against
-        // whatever scheduler context happens to be active when
-        // `tick_callback` calls into us.
+        // `untrack` so the body's signal reads register against its own
+        // nested `effect`/`computed`s, not against whatever scheduler
+        // context was active when the tick called into us.
         let new_body_root = untrack(|| new_owner.with(|| (*info.body)()));
-        // The body's `mount_component_remountable` calls leave a
-        // PENDING_MOUNT entry behind; we drain it here because the
-        // batched path attaches the new root via `insert_child_at`
-        // directly, not via the caller's `append_child`.
+        // The body's own `mount_component_remountable` calls leave a
+        // PENDING_MOUNT entry behind, and nothing will consume it — the
+        // batched path attaches roots via `insert_child_at`, not the
+        // caller's `append_child`.
         PENDING_MOUNT.with(|cell| cell.set(None));
 
-        // Backfill the new_root into by_parent so step 4 can map
-        // old → new when computing the desired final order.
         if let Some(list) = by_parent.get_mut(&info.parent) {
             if let Some(entry) = list
                 .iter_mut()
@@ -587,9 +505,6 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
         ));
     }
 
-    // 4. Per-parent: compute desired final order, insert new roots
-    //    at their target indices. (Removes already happened in
-    //    step 2 — the live-handle requirement.)
     for (parent, pairs) in &by_parent {
         let snapshot = parent_snapshot.get(parent).cloned().unwrap_or_default();
         let old_to_new: std::collections::HashMap<Element, Element> = pairs
@@ -597,17 +512,15 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
             .filter_map(|(o, n)| n.map(|new_root| (*o, new_root)))
             .collect();
 
-        // Desired final list = snapshot with each old replaced by its
-        // matching new (leaving non-replaced siblings untouched).
+        // Snapshot with each old root replaced by its matching new one,
+        // leaving non-replaced siblings untouched.
         let desired: Vec<Element> = snapshot
             .iter()
             .map(|c| old_to_new.get(c).copied().unwrap_or(*c))
             .collect();
 
-        // Insert new body_roots at their desired indices in ascending
-        // order. Non-replaced siblings remain in place; inserting at
-        // index `i` only shifts elements from `i` onwards by one slot,
-        // which is exactly the semantics we want.
+        // Ascending order matters: inserting at index `i` shifts only
+        // the elements from `i` onwards, so earlier placements stay put.
         let new_set: std::collections::HashSet<Element> =
             pairs.iter().filter_map(|(_, n)| *n).collect();
         for (idx, child) in desired.iter().enumerate() {
@@ -617,7 +530,6 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
         }
     }
 
-    // 4. Update each MountSite to point at its new owner + new root.
     for (mount_id, _, _, new_root, new_owner) in &results {
         with_runtime(|rt| {
             if let Some(site) = rt.mount_sites.get_mut(mount_id) {
@@ -627,10 +539,9 @@ pub fn remount_components_for(patched_fns: &[*const ()]) -> RemountStats {
         });
     }
 
-    // 5. Refresh anchors based on the now-final parent children
-    //    layout — otherwise a *future* solo patch of one of these
-    //    siblings would inherit a stale anchor and fall back to
-    //    index 0 again.
+    // Refresh anchors from the now-final child order, or a future solo
+    // patch of one of these siblings inherits a stale anchor and falls
+    // back to index 0.
     for (mount_id, parent, _, new_root, _) in &results {
         let new_anchor = crate::view::previous_sibling(*parent, *new_root);
         with_runtime(|rt| {

--- a/crates/whisker-runtime/src/reactive/computed.rs
+++ b/crates/whisker-runtime/src/reactive/computed.rs
@@ -45,27 +45,21 @@ use super::{untrack, with_runtime};
 pub fn computed<T: 'static + Clone + PartialEq>(
     mut f: impl FnMut() -> T + 'static,
 ) -> ReadSignal<T> {
-    // Seed inside `untrack` so the read graph it produces doesn't
-    // leak into whatever outer reactive node we may be constructed
-    // inside. The seed only initialises the cache; real dependency
-    // edges are registered by the explicit `schedule + flush` below.
-    // Without this guard, calling `computed(move || sig.get())` from
-    // inside an effect makes that effect a subscriber of `sig` — and
-    // a write to `sig` then re-runs the outer effect (often a route /
-    // component mount), silently leaking a fresh computed node every
-    // tick.
+    // The seed only initialises the cache; real dependency edges come
+    // from the `schedule + flush` below. Without `untrack`, a
+    // `computed(move || sig.get())` written inside an effect would make
+    // that effect a subscriber of `sig`, so a write to `sig` re-runs
+    // the effect and leaks a fresh computed node every tick.
     let initial = untrack(&mut f);
     let value: Rc<RefCell<dyn Any>> = Rc::new(RefCell::new(initial));
 
-    // Compute closure is set after we know the NodeId, so recomputes
-    // can write back into the same slot and notify subscribers on
-    // change.
+    // The real closure needs the NodeId to notify subscribers, so the
+    // node is registered with this trampoline and filled in after.
     type ComputeCell = Rc<RefCell<Option<Box<dyn FnMut()>>>>;
     let compute_cell: ComputeCell = Rc::new(RefCell::new(None));
     let compute_cell_clone = compute_cell.clone();
     let trampoline: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(move || {
-        // Take/run/put-back so we never hold the cell's borrow across
-        // user code — mirrors the scheduler's pattern for the compute Rc.
+        // Take/run/put-back so the cell's borrow never spans user code.
         let mut taken = compute_cell_clone.borrow_mut().take();
         if let Some(ref mut inner) = taken {
             inner();
@@ -99,8 +93,6 @@ pub fn computed<T: 'static + Clone + PartialEq>(
         id
     });
 
-    // Real compute closure: knows the node id, writes back to the
-    // value slot, notifies subscribers on change.
     let value_clone = value.clone();
     *compute_cell.borrow_mut() = Some(Box::new(move || {
         let new = f();
@@ -131,10 +123,8 @@ pub fn computed<T: 'static + Clone + PartialEq>(
         }
     }));
 
-    // First tracked run: populates the source graph. The initial
-    // value was already cached via the untracked seed above; we
-    // explicitly schedule + flush here because a bare `flush()` over
-    // an empty pending queue would miss tracking.
+    // First tracked run, which populates the source graph. Scheduled
+    // explicitly — a bare `flush()` over an empty queue does nothing.
     scheduler::schedule(node_id);
     scheduler::flush();
 

--- a/crates/whisker-runtime/src/reactive/context.rs
+++ b/crates/whisker-runtime/src/reactive/context.rs
@@ -54,23 +54,13 @@ pub fn use_context<T: 'static + Clone>() -> Option<T> {
 /// call back into the runtime (signals, effects, nested context
 /// lookups all work).
 pub fn with_context<T: 'static, R>(f: impl FnOnce(&T) -> R) -> Option<R> {
-    // First locate the owner that holds the context. We can't return
-    // a reference into the arena (borrow-checker, plus we want `f` to
-    // re-enter the runtime), so we instead do a two-step: find +
-    // dispatch. The downside is two borrows per lookup, but contexts
-    // are not on a hot path.
+    // Two borrows rather than one reference into the arena: `f` must be
+    // able to re-enter the runtime, so no borrow may span the call.
     let owner_id = with_runtime(|rt| find_owner_with::<T>(rt, rt.current_owner()))?;
 
-    // Clone the `Rc` handle out under a short borrow, then DROP the
-    // runtime borrow before invoking `f`. This is what makes `f` free
-    // to re-enter the runtime (read signals, create effects, nested
-    // `use_context`) — calling `f` while the thread-local runtime was
-    // still borrowed would double-borrow its `RefCell` and panic.
-    //
-    // Holding our own `Rc` clone also means the value stays alive for
-    // the whole call even if `f` re-provides the same `T` on this owner
-    // (which would replace the map entry); `f` simply observes the
-    // value that was current at lookup time.
+    // Owning an `Rc` clone also keeps the value alive for the whole
+    // call if `f` re-provides the same `T` on this owner — `f` then
+    // observes the value that was current at lookup time.
     let any_rc: std::rc::Rc<dyn Any> = with_runtime(|rt| {
         let owner = rt.owners.get(owner_id)?;
         owner.contexts.get(&TypeId::of::<T>()).cloned()

--- a/crates/whisker-runtime/src/reactive/effect.rs
+++ b/crates/whisker-runtime/src/reactive/effect.rs
@@ -20,13 +20,12 @@ use super::with_runtime;
 /// Register `f` as a reactive effect. Returns the node id (so tests
 /// can inspect it; user code generally discards the return value).
 ///
-/// The closure receives no arguments and returns nothing. The
-/// `Option<R>`-of-previous-value variant from Solid/Leptos is omitted
-/// in v1 — it can be layered on later without breaking this API.
+/// Unlike Solid / Leptos, the closure takes no previous value and
+/// returns nothing.
 pub fn effect(f: impl FnMut() + 'static) -> NodeId {
-    // Wrap in `Rc<RefCell<dyn FnMut()>>` so the scheduler can clone a
-    // handle out of the runtime in a short borrow before invoking
-    // user code (avoiding a runtime double-borrow on re-entrant reads).
+    // `Rc<RefCell<dyn FnMut()>>` so the scheduler can clone a handle
+    // out under a short borrow and invoke user code with the runtime
+    // released — a re-entrant read would otherwise double-borrow.
     let compute: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(f));
 
     let needs_warning = with_runtime(|rt| rt.current_owner().is_none());

--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -67,11 +67,6 @@ pub use component::{
 pub use computed::computed;
 pub use context::{provide_context, use_context, with_context};
 pub use effect::effect;
-// `on_cleanup` lives at the module top-level because it acts on
-// whichever owner is currently on the runtime stack — the caller
-// can't name it. Everything else owner-related lives behind the
-// `owner` module path (re-exported below) so users write
-// `whisker::owner::Owner::new(None)` / `owner.with(...)` / etc.
 pub use owner::on_cleanup;
 pub use prop::Signal;
 pub use resource::{Resource, ResourceState, resource, resource_sync};
@@ -145,10 +140,8 @@ pub(crate) fn untrack<R>(f: impl FnOnce() -> R) -> R {
     struct Restore(Option<NodeId>);
     impl Drop for Restore {
         fn drop(&mut self) {
-            // `with_runtime` reborrows the thread-local; the previous
-            // borrow opened in `untrack` was already released before
-            // `f` started, so this is a fresh borrow — no
-            // double-borrow risk.
+            // Safe to reborrow: `untrack`'s own borrow was released
+            // before `f` started.
             with_runtime(|rt| rt.current_tracker = self.0);
         }
     }

--- a/crates/whisker-runtime/src/reactive/owner.rs
+++ b/crates/whisker-runtime/src/reactive/owner.rs
@@ -108,12 +108,9 @@ impl Owner {
     /// Recursive — disposes children first, then this owner. Safe
     /// to call even if the owner has already been disposed (no-op).
     pub fn dispose(self) {
-        // Step 1: collect what needs cleaning. We pull data out of
-        // the runtime in a short borrow rather than holding it
-        // through the recursion, because each level may itself need
-        // to mutate the runtime (running cleanup callbacks does not,
-        // but symmetrically we keep the pattern simple by avoiding
-        // nested borrows).
+        // Everything is pulled out under a short borrow rather than
+        // held across the recursion — deeper levels re-enter the
+        // runtime.
         let children;
         let nodes;
         let cleanups;
@@ -131,10 +128,8 @@ impl Owner {
             elements = o.elements;
         }
 
-        // Step 1b: if this was a component owner, scrub the hot-
-        // reload registry so the fn pointer doesn't list a freed
-        // slot. Without this, A6's `owners_for_fn` would return a
-        // dangling Owner and remount logic would fault.
+        // A component owner must leave the hot-reload registry, or
+        // `owners_for_fn` hands remount logic a dangling Owner.
         if let Some(fp) = mount_fn {
             with_runtime(|rt| {
                 if let Some(list) = rt.component_owners.get_mut(&fp) {
@@ -145,19 +140,14 @@ impl Owner {
                 }
             });
 
-            // Step 1c: also clean up any remountable MountSite whose
-            // owner is this one. Without this scrub, cascading
-            // disposal (e.g. parent component re-mounts and discards
-            // its sub-tree) leaves orphan MountSites behind, and
-            // the next `remount_components_for` call processes
-            // them — operating on freed parent / body_root handles,
-            // with visible corruption (issue #17 follow-up).
+            // Likewise its remountable MountSites: an orphan site
+            // survives cascading disposal and the next
+            // `remount_components_for` then operates on freed parent /
+            // body_root handles.
             //
             // `site.owner` is `None` *during* a remount (the
-            // takes-then-reinstalls window in `remount_one`), so
-            // this scan won't accidentally evict the site that's
-            // mid-flight. It only matches MountSites whose
-            // component owner is the one actually being disposed.
+            // take-then-reinstall window in `remount_one`), so this
+            // scan can't evict a site that is mid-flight.
             with_runtime(|rt| {
                 let stale: Vec<super::component::MountId> = rt
                     .mount_sites
@@ -182,7 +172,6 @@ impl Owner {
             });
         }
 
-        // Step 2: detach from parent's children list.
         if let Some(p) = parent {
             with_runtime(|rt| {
                 if let Some(parent_scope) = rt.owners.get_mut(p) {
@@ -191,37 +180,25 @@ impl Owner {
             });
         }
 
-        // Step 3: dispose descendants (post-order — bottom up).
         for child in children {
             child.dispose();
         }
 
-        // Step 4: run THIS owner's cleanups BEFORE freeing its nodes, so an
-        // `on_cleanup` callback can still read/write the signals it closed
-        // over — the natural expectation (Solid / Leptos / React all allow
-        // it) and consistent with `set` on a freed signal already being a
-        // silent no-op (`try_write_and_notify`). Freeing first (the old
-        // order) made a same-owner `get` in a cleanup panic with `signal
-        // disposed`; worse, when the cleanup ran mid-`tick_frame` (a router
-        // screen disposed on a transition's finish), that panic unwound the
-        // whole frame and stranded unrelated reactive work (frozen
-        // animations, dead event handlers). Children are already disposed
-        // above, so a cleanup reading a *child's* signal still gets nothing —
-        // but that's the uncommon case; own-signal reads are what callers
-        // expect. LIFO order, no runtime borrow held (cleanups may touch the
-        // runtime).
+        // Cleanups run before this owner's nodes are freed, so an
+        // `on_cleanup` can still read and write the signals it closed
+        // over (what Solid / Leptos / React all allow). Children are
+        // already disposed above, so a *child's* signal still reads as
+        // gone. LIFO, and with no runtime borrow held — a cleanup may
+        // re-enter the runtime.
         for cleanup in cleanups.into_iter().rev() {
             cleanup();
         }
 
-        // Step 5: free every node this owner allocated. For effects
-        // / computed values, also detach them from any subscriber
-        // list they were on, so other live nodes don't try to
-        // notify a freed slot later.
-        //
-        // Arc-signal back-references (`arc_sources`) get collected
-        // here and unsubscribed below, outside the runtime borrow —
-        // the unsubscribe callees may re-enter the runtime.
+        // Freeing a node also detaches it from every subscriber list
+        // it was on, so no live node notifies a freed slot later.
+        // Arc-signal back-refs are collected here and unsubscribed
+        // below, outside the borrow — those callees re-enter the
+        // runtime.
         let arc_unsubscribes: Vec<(Rc<dyn super::runtime::ArcSubscription>, NodeId)> =
             with_runtime(|rt| {
                 let mut out: Vec<(Rc<dyn super::runtime::ArcSubscription>, NodeId)> = Vec::new();
@@ -229,52 +206,40 @@ impl Owner {
                     let Some(node) = rt.nodes.remove(*node_id) else {
                         continue;
                     };
-                    // Remove ourselves from every source's subscriber list.
                     for source in node.sources {
                         if let Some(src_node) = rt.nodes.get_mut(source) {
                             src_node.subscribers.remove(node_id);
                         }
                     }
-                    // Remove ourselves from every subscriber's source list —
-                    // a signal we owned may have been read by an outer effect.
+                    // A signal this owner held may have been read by an
+                    // outer effect, so clear the reverse edge too.
                     for sub in node.subscribers {
                         if let Some(sub_node) = rt.nodes.get_mut(sub) {
                             sub_node.sources.remove(node_id);
                         }
                     }
-                    // Collect arc-signal back-refs so we can call
-                    // `unsubscribe` outside the runtime borrow.
                     for arc_src in node.arc_sources {
                         out.push((arc_src, *node_id));
                     }
                 }
-                // Strip these nodes from the pending and deferred queues
-                // if any were scheduled — otherwise a later flush /
-                // resume would try to re-run a freed slot.
+                // A scheduled node left in these queues would be re-run
+                // from its freed slot on the next flush / resume.
                 rt.pending.retain(|n| !nodes.contains(n));
                 rt.deferred.retain(|n| !nodes.contains(n));
                 out
             });
 
-        // Tell every Arc-backed signal that one of our disposed
-        // nodes used to be on its subscriber list. The signal itself
-        // stays alive (Arc refcount), but pruning here keeps its
-        // list bounded so a long-lived signal doesn't accumulate
-        // dead `NodeId`s from every transient subscriber that came
-        // and went.
+        // An Arc-backed signal outlives its subscribers, so pruning
+        // here is what keeps its list from accumulating dead
+        // `NodeId`s across transient subscribers.
         for (arc_src, subscriber) in arc_unsubscribes {
             arc_src.unsubscribe(subscriber);
         }
 
-        // Step 6: release every element handle the disposed owner
-        // created. We do this AFTER recursing into children so that
-        // bottom-up disposal order matches what the renderer
-        // expects (a child element's release before its parent's
-        // is fine; the bridge only complains if a parent is missing
-        // when a child reaches up). Done with the runtime borrow
-        // released so a future renderer that wants to call back
-        // into the reactive system (e.g. to notify "element
-        // released") can do so.
+        // Element release comes after the child recursion so the
+        // renderer sees children released before their parents, and
+        // runs with no runtime borrow held so a renderer may call back
+        // into the reactive system.
         for handle in elements {
             crate::view::release_element(handle);
         }
@@ -338,9 +303,8 @@ impl Owner {
             if !any {
                 return false;
             }
-            // Drain deferred → pending for every node whose owner
-            // is no longer paused. Stale entries (node disposed
-            // under a paused owner) are dropped here.
+            // Nodes disposed while their owner was paused are still
+            // listed here; they get dropped rather than re-queued.
             let deferred = std::mem::take(&mut rt.deferred);
             for node in deferred {
                 let still_paused = rt

--- a/crates/whisker-runtime/src/reactive/prop.rs
+++ b/crates/whisker-runtime/src/reactive/prop.rs
@@ -61,12 +61,11 @@
 //!
 //! ## Why not a closure variant?
 //!
-//! Earlier design passes considered a `Closure(Box<dyn Fn() -> T>)`
-//! variant so callers could write `text(value: || format!(…))` and
-//! get reactivity without naming an intermediate. Dropped: the
-//! "closure ⇒ dynamic" rule is hard to internalise for newcomers,
-//! and the explicit alternative (`computed(move || …)`) names the
-//! derivation and gives it memoisation for free.
+//! A `Closure(Box<dyn Fn() -> T>)` variant would let callers write
+//! `text(value: || format!(…))` and get reactivity without naming an
+//! intermediate, but the "closure ⇒ dynamic" rule is hard to
+//! internalise, and the explicit `computed(move || …)` both names the
+//! derivation and memoises it.
 //!
 //! [`computed`]: super::computed
 //! [`effect`]: super::effect
@@ -92,15 +91,13 @@ use super::stored::StoredValue;
 /// arm is a `Copy` [`ReadSignal`] handle (internally a [`NodeId`]).
 /// This is what lets `#[component]` bodies (`FnMut`) move a
 /// `Signal<T>` prop into several nested `move` closures without
-/// `.clone()` — see whisker issue #8.
+/// `.clone()`.
 ///
 /// [`NodeId`]: super::NodeId
 //
-// NOTE: `Clone`/`Copy` are implemented by hand below rather than
-// `#[derive]`d. A derived impl would add a spurious `T: Copy` bound,
-// but both arms (`StoredValue<T>` / `ReadSignal<T>`) are `Copy` for
-// *any* `T: 'static` — they're arena handles, not inline values — so
-// `Signal<T>` must be `Copy` unconditionally (e.g. `Signal<String>`).
+// `Clone`/`Copy` are hand-written: `#[derive]` would add a spurious
+// `T: Copy` bound, but both arms are arena handles and so `Copy` for
+// any `T: 'static` — `Signal<String>` included.
 pub enum Signal<T: 'static> {
     /// Plain value, held in an owner-bound [`StoredValue<T>`] arena
     /// slot. The builder method that consumes this calls
@@ -119,8 +116,6 @@ pub enum Signal<T: 'static> {
     Dynamic(ReadSignal<T>),
 }
 
-// Hand-written so the bound is `T: 'static`, not `T: Copy` — see the
-// note on the enum. Both variants wrap `Copy` arena handles.
 impl<T: 'static> Clone for Signal<T> {
     fn clone(&self) -> Self {
         *self
@@ -162,33 +157,25 @@ impl<T: 'static + Clone> Signal<T> {
     }
 }
 
-// From impls — the conversions builder methods rely on.
-//
-// `impl<T> From<T> for Signal<T>` is the catch-all "plain value
-// becomes Static" path; the others handle reactive handles. Coherence
-// holds because the source types are concrete (`ReadSignal<T>`,
-// `RwSignal<T>`) — they match a specific generic instantiation, not
-// any `T`.
+// From impls — the conversions builder methods rely on. The blanket
+// `From<T>` and the reactive-handle impls coexist because the latter
+// name concrete source types, matching one generic instantiation
+// rather than any `T`.
 
 impl<T: 'static> From<T> for Signal<T> {
     fn from(v: T) -> Self {
-        // NOTE: constructing a *static* `Signal` now allocates an
-        // owner-bound arena slot ([`StoredValue::new`]) rather than
-        // storing `v` inline — this is the cost of making `Signal<T>`
-        // `Copy`. Mirrors `StoredValue`'s detached-owner fallback: if
-        // there's no current reactive owner it logs a warning and
-        // parks the value in a detached scope (no panic). So a static
-        // `Signal` built entirely outside a reactive context still
-        // works, it just isn't tied to a disposable scope.
+        // Allocating an owner-bound arena slot instead of storing `v`
+        // inline is the price of `Signal<T>: Copy`. Built outside any
+        // reactive owner it lands in `StoredValue`'s detached scope
+        // (warning, no panic) and still works.
         Signal::Stored(StoredValue::new(v))
     }
 }
 
-// `Signal<T: Default>::default() -> Signal::Stored(T::default())`.
-// Used by `#[whisker::module_component]`'s builder: a prop the caller
-// omits falls back to `unwrap_or_default()`, which produces a
+// A prop the caller omits falls back to `unwrap_or_default()` in
+// `#[whisker::module_component]`'s builder, which needs to produce a
 // reasonable "attribute not set" value (`""` for `Signal<String>`,
-// `false` for `Signal<bool>`, etc.). Phase 7-Φ.H.2 follow-up.
+// `false` for `Signal<bool>`).
 impl<T: 'static + Default> Default for Signal<T> {
     fn default() -> Self {
         Signal::Stored(StoredValue::new(T::default()))
@@ -203,16 +190,13 @@ impl<T: 'static + Clone> From<ReadSignal<T>> for Signal<T> {
 
 impl<T: 'static + Clone> From<RwSignal<T>> for Signal<T> {
     fn from(s: RwSignal<T>) -> Self {
-        // RwSignal and ReadSignal share an arena `NodeId`; project to
-        // the read-only handle for storage.
         Signal::Dynamic(s.read_only())
     }
 }
 
-// Convenience: `&str` literal → `Signal<String>::Static`. Without
-// this specific impl users would have to write `.style("foo".to_string())`
-// because `&str` doesn't directly impl `Into<Signal<String>>` (only
-// `Into<Signal<&str>>` via the blanket `From<T> for Signal<T>`).
+// Without this impl a `&str` literal only reaches
+// `Into<Signal<&str>>` through the blanket `From<T>`, forcing callers
+// to write `.style("foo".to_string())`.
 impl From<&str> for Signal<String> {
     fn from(s: &str) -> Self {
         Signal::Stored(StoredValue::new(s.to_string()))
@@ -236,9 +220,8 @@ mod tests {
 
     #[test]
     fn signal_is_copy() {
-        // The whole point of issue #8: a non-Copy-`T` `Signal<T>` prop
-        // can be moved into multiple `move` closures without `.clone()`.
-        // This wouldn't even compile if `Signal<T>` weren't `Copy`.
+        // A `Signal<T>` prop with non-`Copy` `T` must still move into
+        // several `move` closures without `.clone()`.
         __reset_for_tests();
 
         fn assert_copy<C: Copy>(_: &C) {}
@@ -252,7 +235,6 @@ mod tests {
         assert_eq!(first(), "abc");
         assert_eq!(second(), "abc");
 
-        // A dynamic Signal is Copy too.
         let (count, _set) = signal(5_i32).split();
         let d: Signal<i32> = count.into();
         assert_copy(&d);
@@ -285,9 +267,6 @@ mod tests {
 
     #[test]
     fn dynamic_signal_get_inside_effect_registers_dep() {
-        // The whole reason this type exists — make sure a
-        // `Signal::Dynamic(...).get()` call inside an effect
-        // produces a subscription that fires on .set.
         __reset_for_tests();
         let (count, set_count) = signal(0_i32).split();
         let s: Signal<i32> = count.into();
@@ -296,9 +275,7 @@ mod tests {
         effect(move || {
             log_clone.borrow_mut().push(s.get());
         });
-        // initial run
         assert_eq!(&*log.borrow(), &[0]);
-        // update → effect re-runs
         set_count.set(1);
         flush();
         set_count.set(2);
@@ -308,10 +285,6 @@ mod tests {
 
     #[test]
     fn static_signal_get_inside_effect_does_not_subscribe() {
-        // Symmetric check: a Static signal never registers a
-        // subscription, so changes to "the value it was made from"
-        // (none, really, since it's just a value) can't affect the
-        // effect.
         __reset_for_tests();
         let s: Signal<i32> = 100.into();
         let log: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
@@ -324,9 +297,6 @@ mod tests {
 
     #[test]
     fn computed_return_value_converts_into_dynamic_signal() {
-        // `computed` returns ReadSignal<T>, which `From<ReadSignal<T>>
-        // for Signal<T>` picks up. End-to-end: derivations flow as
-        // dynamic props.
         __reset_for_tests();
         let (count, set_count) = signal(0_i32).split();
         let doubled = computed(move || count.get() * 2);

--- a/crates/whisker-runtime/src/reactive/resource.rs
+++ b/crates/whisker-runtime/src/reactive/resource.rs
@@ -75,9 +75,8 @@ pub struct Resource<T: Clone + 'static> {
     state: RwSignal<ResourceState<T>>,
 }
 
-// Hand-written Copy/Clone — `derive(Copy)` would require `T: Copy`
-// which is unnecessarily strict (the resource only holds a u32-ish
-// signal handle, not the T itself).
+// Hand-written Copy/Clone — `derive(Copy)` would demand `T: Copy`,
+// though the resource holds only a signal handle, not the `T`.
 impl<T: Clone + 'static> Copy for Resource<T> {}
 impl<T: Clone + 'static> Clone for Resource<T> {
     fn clone(&self) -> Self {
@@ -192,24 +191,20 @@ where
     let fetcher = Rc::new(fetcher);
 
     super::effect::effect(move || {
-        // Inside an effect run the runtime's `current_tracker` IS this
-        // effect's node. Capture it so the spawned future can re-install
-        // it as the observer around each poll (so post-`.await` reads
-        // register as deps of this node too).
+        // Captured so the spawned future can re-install it as the
+        // observer around each poll, making post-`.await` reads deps of
+        // this node too.
         let node = super::current_tracker().expect("resource effect must run under a tracker");
 
         let my_gen = generation.get().wrapping_add(1);
         generation.set(my_gen);
 
-        // Build the future. The fetcher's SYNCHRONOUS prefix runs here,
-        // and because we're inside the effect run, its signal reads
-        // register as dependencies of `node`.
+        // The fetcher's synchronous prefix runs here, inside the effect
+        // run, so its signal reads register as deps of `node`.
         let fut = (fetcher)();
 
-        // Return to Loading on every (re)fetch. Write untracked so this
-        // never creates a dependency edge — the effect must not depend
-        // on `state` (the signal it writes) or it would re-trigger
-        // itself in an infinite loop.
+        // Untracked: the effect must not depend on the signal it writes
+        // or it re-triggers itself forever.
         state.update_untracked(|s| *s = ResourceState::Loading);
 
         spawn_local(ScopedFetch {
@@ -251,23 +246,21 @@ impl<T: Clone + 'static> Future for ScopedFetch<T> {
         // other fields.
         let this = self.get_mut();
 
-        // A newer run superseded us: abandon WITHOUT installing the
-        // observer (add no stale dependency edges) and WITHOUT writing
-        // state. The inner future is dropped with this `ScopedFetch`.
+        // Superseded: abandon without installing the observer (no stale
+        // dependency edges) and without writing state.
         if this.generation.get() != this.my_gen {
             return Poll::Ready(());
         }
 
         let node = this.node;
         let fut = &mut this.fut;
-        // Re-install the resource's effect node as the current observer
-        // for THIS poll so reads after `.await` register as deps of it.
+        // Observer installed per-poll so reads after `.await` still
+        // register as deps of the resource's effect node.
         let poll = super::with_observer(node, || fut.as_mut().poll(cx));
 
         match poll {
             Poll::Pending => Poll::Pending,
             Poll::Ready(result) => {
-                // Commit only if we're still the latest run.
                 if this.generation.get() == this.my_gen {
                     this.state.set(match result {
                         Ok(v) => ResourceState::Ready(v),
@@ -293,12 +286,9 @@ where
     T: Clone + 'static,
     F: FnOnce() -> Result<T, String>,
 {
-    // `fetcher` is a one-shot seed for the resource's RwSignal —
-    // its signal reads are meant to compute an initial value, not to
-    // re-fire the resource when those signals change. Run it under
-    // `untrack` so the reads don't leak into whatever outer effect
-    // / computed / component body happens to be calling
-    // `resource_sync`. Same principle as the computed seed guard.
+    // `fetcher` is a one-shot seed, so its signal reads must not leak
+    // into whatever outer effect / computed / component body is calling
+    // `resource_sync` and re-fire it later.
     let state = RwSignal::new(match super::untrack(fetcher) {
         Ok(v) => ResourceState::Ready(v),
         Err(e) => ResourceState::Error(e),

--- a/crates/whisker-runtime/src/reactive/runtime.rs
+++ b/crates/whisker-runtime/src/reactive/runtime.rs
@@ -157,27 +157,22 @@ pub struct Scope {
     pub parent: Option<Owner>,
     pub children: Vec<Owner>,
     pub nodes: Vec<NodeId>,
-    // `Rc` (not `Box`) so `with_context` can clone the handle out in a
-    // short runtime borrow, drop the borrow, and only then invoke the
-    // user closure — letting the closure safely re-enter the runtime
-    // (read signals, nested `use_context`, etc.) without a double
-    // borrow, and keeping the value alive even if the closure
-    // re-provides the same type mid-call.
+    // `Rc` (not `Box`) so `with_context` can clone the handle out under
+    // a short borrow and invoke the user closure with the runtime
+    // released — the closure may re-enter, and the value must survive
+    // the closure re-providing the same type mid-call.
     pub contexts: HashMap<TypeId, Rc<dyn Any>>,
     pub cleanups: Vec<Box<dyn FnOnce()>>,
     /// Function-pointer fingerprint of the component fn that created
-    /// this scope. Used by Strategy C hot reload (A6) to map
-    /// subsecond-patched fn pointers back to live owners. `None` for
-    /// non-component scopes (e.g. the root, or manually-created
-    /// scopes in tests).
+    /// this scope, mapping subsecond-patched fn pointers back to live
+    /// owners on hot reload. `None` for non-component scopes (the
+    /// root, or manually-created scopes in tests).
     pub mount_fn: Option<*const ()>,
     /// Element handles created via `view::create_element` while this
     /// scope was at the top of the owner stack. Released through
-    /// `view::release_element` when the scope is disposed (or its
-    /// ancestor disposes via cascade), preventing the renderer-side
-    /// `BridgeRenderer::elements` map from accumulating dangling
-    /// `WhiskerElement*` pointers across `<Show>` flips, `<For>`
-    /// item removals, and per-component remounts.
+    /// `view::release_element` on disposal, so the renderer's element
+    /// map doesn't accumulate dangling native pointers across `<Show>`
+    /// flips, `<For>` item removals, and per-component remounts.
     pub elements: Vec<crate::view::Element>,
     /// When `true`, effects / computeds owned by this scope skip
     /// flush — they're deferred onto [`ReactiveRuntime::deferred`]
@@ -247,9 +242,9 @@ pub struct ReactiveRuntime {
     /// rather than recursing).
     pub flushing: bool,
     /// Component-fn-pointer → list of live owners that ran that fn.
-    /// Populated by `register_component`; consulted by the A6 hot-
-    /// reload path to find which owners to dispose when a fn body
-    /// gets subsecond-patched.
+    /// Populated by `register_component`; the hot-reload path reads it
+    /// to find which owners to dispose when a fn body gets
+    /// subsecond-patched.
     pub component_owners: HashMap<*const (), Vec<Owner>>,
     /// Side table of remountable component mount sites
     /// (`#[component]` with all-`Clone` props), keyed by a stable
@@ -266,8 +261,8 @@ pub struct ReactiveRuntime {
     /// Monotonic counter for fresh `MountId`s.
     pub mount_id_counter: u64,
     /// Pending on_mount callbacks, in the order they were registered.
-    /// Drained by [`super::flush_mounts`] — which the renderer (A3)
-    /// will call after appending a component's view to its parent.
+    /// Drained by [`super::flush_mounts`] once a component's view has
+    /// been appended to its parent.
     pub pending_mounts: Vec<Box<dyn FnOnce()>>,
 }
 

--- a/crates/whisker-runtime/src/reactive/scheduler.rs
+++ b/crates/whisker-runtime/src/reactive/scheduler.rs
@@ -52,13 +52,14 @@ pub(crate) fn schedule(node: NodeId) {
 
 /// True if there is undrained reactive work (scheduled effects/computeds
 /// or pending on_mount callbacks) that a frame would make progress on.
-/// Used by the driver's `tick()` to report busy so the host keeps its
-/// render loop running until the queue genuinely drains — closing the
-/// edge-triggered lost-wakeup that wedged the loop when a node was
-/// scheduled during the final `renderer_flush` (native-view layout
-/// re-entry). NOTE: deliberately does NOT count `deferred` (paused-owner
-/// nodes are intentionally frozen) nor outstanding async tasks (those
-/// resume via the main-loop drive, not vsync).
+/// The driver's `tick()` reports busy from this, so the host keeps its
+/// render loop running until the queue genuinely drains — a
+/// level-triggered check, since work can be scheduled during the final
+/// `renderer_flush` and an edge-triggered wake would be lost.
+///
+/// Deliberately counts neither `deferred` (paused-owner nodes are meant
+/// to stay frozen) nor outstanding async tasks (those resume from the
+/// main-loop drive, not vsync).
 pub fn has_pending_work() -> bool {
     with_runtime(|rt| !rt.pending.is_empty() || !rt.pending_mounts.is_empty())
         || crate::anim_hook::is_animating()
@@ -86,14 +87,11 @@ pub fn flush() {
         return;
     }
 
-    // RAII reset of the `flushing` flag. A re-running effect runs
-    // arbitrary user code (step 3 of `run_node_if_alive`) which may
-    // panic. Without this guard the trailing `rt.flushing = false`
-    // would be skipped on unwind, latching the flag true — every
-    // subsequent `flush` would then early-return as a no-op and the UI
-    // would freeze permanently. The guard restores the flag on both the
-    // normal return and the unwind path. (Safe to touch the runtime in
-    // `drop`: user code only ever runs while the runtime is unborrowed.)
+    // A re-running effect is arbitrary user code and may panic. The
+    // flag must be reset on the unwind path too, or it latches true and
+    // every later `flush` early-returns — a permanently frozen UI.
+    // (Safe to touch the runtime in `drop`: user code only ever runs
+    // while the runtime is unborrowed.)
     struct FlushGuard;
     impl Drop for FlushGuard {
         fn drop(&mut self) {
@@ -102,9 +100,8 @@ pub fn flush() {
     }
     let _flush_guard = FlushGuard;
 
-    // Drain loop. We `take` the current queue so signals written
-    // during a re-run land in a fresh queue and don't perturb the
-    // ordering of the current wave.
+    // `take` the queue each round so signals written during a re-run
+    // land in a fresh one and can't perturb the current wave's order.
     let mut iterations = 0;
     loop {
         let batch: Vec<NodeId> = with_runtime(|rt| std::mem::take(&mut rt.pending));
@@ -113,9 +110,6 @@ pub fn flush() {
         }
         iterations += 1;
         if iterations > FLUSH_ITERATION_CAP {
-            // Drop the residual queue so we don't keep spinning, and
-            // warn loudly — this almost always indicates an effect
-            // that writes a signal it reads (a feedback loop).
             eprintln!(
                 "whisker-reactive: flush exceeded {FLUSH_ITERATION_CAP} iterations; \
                  likely an effect with a self-feedback loop. Dropping {} pending nodes.",
@@ -128,7 +122,6 @@ pub fn flush() {
             run_node_if_alive(node);
         }
     }
-    // `_flush_guard` resets `rt.flushing = false` on drop here.
 }
 
 /// Re-run the compute closure for an effect or computed, if it's still
@@ -148,23 +141,11 @@ pub fn flush() {
 /// initial run — instead of leaking into whatever owner happened to
 /// be current at flush time.
 fn run_node_if_alive(node: NodeId) {
-    // Step 1: grab the compute handle, clear old sources, set the
-    // tracker. Short borrow.
-    //
-    // `arc_sources` is taken out of the runtime borrow first because
-    // its `unsubscribe` callees re-enter the runtime via Arc-signal
-    // internals (and even if they don't today, they're free user
-    // code that may grow that way). Drop the runtime borrow before
-    // iterating.
     let prep = with_runtime(|rt| {
         let n = rt.nodes.get(node)?;
         let owner = n.owner;
-        // Paused-owner gate: defer the run and skip. The node lands
-        // on `rt.deferred`; `Owner::resume` moves it back into
-        // `pending` so the effect catches up once its scope is
-        // active again. We snapshot the kind early — pure Signal
-        // nodes never need the gate (they have no compute), so we
-        // only check the flag for Effect / Computed.
+        // Signal nodes have no compute, so the paused-owner gate below
+        // only concerns Effect / Computed.
         let compute = match &n.data {
             NodeData::Effect { compute } => compute.clone(),
             NodeData::Computed { compute, .. } => compute.clone(),
@@ -187,8 +168,8 @@ fn run_node_if_alive(node: NodeId) {
         if let Some(n) = rt.nodes.get_mut(node) {
             n.sources.clear();
         }
-        // Take the arc_sources out — we'll call unsubscribe on each
-        // outside the runtime borrow.
+        // Taken out here so `unsubscribe` runs below with the runtime
+        // borrow dropped — those callees re-enter it.
         let arc_sources = rt
             .nodes
             .get_mut(node)
@@ -203,22 +184,16 @@ fn run_node_if_alive(node: NodeId) {
         return;
     };
 
-    // Step 2: tell each Arc-backed signal "drop me from your subscriber
-    // list" so a stale subscription doesn't outlast our last
-    // dependency on it. The compute body below will re-register a
-    // fresh subscription against every Arc signal it reads.
+    // Drop the old Arc subscriptions so a stale one can't outlast the
+    // dependency; the compute body re-registers whatever it still reads.
     for arc_src in arc_sources {
         arc_src.unsubscribe(node);
     }
 
-    // Step 4 as an RAII guard so the tracker/owner-stack book-keeping
-    // is restored even if the compute body panics. Without this, a
-    // panicking effect would leave `current_tracker` pointing at a
-    // disposed node and a stale owner pushed on `owner_stack` —
-    // corrupting dependency tracking and owner scoping for every later
-    // reactive operation (only observable if the panic is caught at the
-    // FFI boundary; otherwise the process aborts). Mirrors the
-    // pre-existing `untrack` Drop guard.
+    // A panicking compute body must not leave `current_tracker` on a
+    // disposed node and a stale owner on `owner_stack` — that corrupts
+    // dependency tracking and owner scoping for every later reactive
+    // operation.
     struct RunGuard;
     impl Drop for RunGuard {
         fn drop(&mut self) {
@@ -230,11 +205,10 @@ fn run_node_if_alive(node: NodeId) {
     }
     let _run_guard = RunGuard;
 
-    // Step 3: invoke compute. The runtime is unborrowed at this
-    // point, so user code inside is free to enter `with_runtime`.
+    // The runtime is unborrowed here, so the compute body is free to
+    // enter `with_runtime`.
     {
         let mut borrow = compute.borrow_mut();
         (*borrow)();
     }
-    // `_run_guard` restores the tracker + owner stack on drop here.
 }

--- a/crates/whisker-runtime/src/reactive/signal.rs
+++ b/crates/whisker-runtime/src/reactive/signal.rs
@@ -350,16 +350,11 @@ impl<T: 'static + Clone> RwSignal<T> {
     }
 }
 
-// Conversions: Arc-backed handle → arena-backed `Copy` handle.
-//
-// Module pattern: stash an [`ArcRwSignal`] in a `OnceLock` so the
-// value lives for the process; expose it as [`RwSignal`] /
-// [`ReadSignal`] / [`WriteSignal`] so callers get a `Copy` handle
-// with the same ergonomics as a component-local signal. The arena
-// entry is a lifecycle pin only: when its owner disposes, one Arc
-// strong count decrements but every other holder keeps the value
-// alive. Reads forward through the Arc, so every handle observes the
-// same value and the same subscriber graph.
+// Conversions: Arc-backed handle → arena-backed `Copy` handle. The
+// arena entry is a lifecycle pin only — disposing its owner drops one
+// Arc strong count and every other holder keeps the value alive. Reads
+// forward through the Arc, so all handles observe the same value and
+// the same subscriber graph.
 
 fn register_arc_in_current_owner<T: 'static>(arc: super::arc_signal::ArcRwSignal<T>) -> NodeId {
     let value: Rc<RefCell<dyn Any>> = Rc::new(RefCell::new(arc));
@@ -467,10 +462,9 @@ fn write_and_notify<T: 'static>(id: NodeId, f: impl FnOnce(&mut T), notify: bool
 
 /// `write_and_notify` variant that returns `false` instead of
 /// panicking when the signal is disposed. Used by callers that
-/// legitimately may race against owner disposal — most notably the
-/// Phase N `ElementRef::__unbind` path, which runs from an
-/// `on_cleanup` callback after the underlying RwSignal's owner has
-/// already freed its nodes.
+/// legitimately race owner disposal — `ElementRef::__unbind` runs from
+/// an `on_cleanup` callback that may fire after the underlying
+/// RwSignal's owner has freed its nodes.
 fn try_write_and_notify<T: 'static>(id: NodeId, f: impl FnOnce(&mut T), notify: bool) -> bool {
     // Short borrow to pull the Rc handle, then drop before mutating.
     let Some(value) = with_runtime(|rt| rt.nodes.get(id).and_then(|n| n.data.value().cloned()))
@@ -478,9 +472,8 @@ fn try_write_and_notify<T: 'static>(id: NodeId, f: impl FnOnce(&mut T), notify: 
         return false;
     };
 
-    // Arc-backed entries forward to `ArcRwSignal::update` so the
-    // change propagates through the shared inner (every other handle,
-    // including the original `OnceLock`-stashed Arc, sees it).
+    // Arc-backed entries forward to `ArcRwSignal::update` so the change
+    // propagates through the shared inner to every other handle.
     let arc_handle: Option<super::arc_signal::ArcRwSignal<T>> = {
         let borrow = value.borrow();
         borrow
@@ -496,8 +489,6 @@ fn try_write_and_notify<T: 'static>(id: NodeId, f: impl FnOnce(&mut T), notify: 
         return true;
     }
 
-    // Direct-T storage: mutate under the borrow, then schedule
-    // arena subscribers.
     {
         let mut borrow = value.borrow_mut();
         let typed = borrow

--- a/crates/whisker-runtime/src/reactive/tests.rs
+++ b/crates/whisker-runtime/src/reactive/tests.rs
@@ -98,16 +98,12 @@ fn panicking_effect_does_not_latch_flushing_flag() {
         }
     });
 
-    // Drive the panicking re-run through a caught flush. Without the
-    // RAII `FlushGuard`, the unwind would skip `flushing = false` and
-    // latch the flag — every later flush would become a silent no-op.
     set_count.set(1);
     let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(flush));
     assert!(caught.is_err(), "the effect was supposed to panic");
 
-    // A fresh effect created after the panic must still run on flush —
-    // proof the runtime recovered (flushing flag cleared, tracker/owner
-    // stack restored).
+    // A fresh effect must still run on flush: the unwind has to leave
+    // `flushing` cleared and the tracker / owner stack restored.
     let ran = Rc::new(RefCell::new(0));
     let r = ran.clone();
     let (dep, set_dep) = signal(0_i32).split();
@@ -250,12 +246,10 @@ fn dispose_owner_frees_nested_signals() {
     fresh();
     let owner = Owner::new(None);
     let (read, _write) = owner.with(|| signal(123_i32)).split();
-    // Signal works while owner is alive.
     assert_eq!(read.get(), 123);
     owner.dispose();
-    // After disposal the underlying node is gone; reads panic in debug
-    // and we don't want to fault the test, so we just verify the
-    // owner slot itself is freed by trying to dispose again (no-op).
+    // Reading the freed node would panic, so the second dispose (a
+    // no-op) is what shows the owner slot itself is gone.
     owner.dispose();
 }
 
@@ -307,12 +301,8 @@ fn on_cleanup_fires_lifo() {
 
 #[test]
 fn on_cleanup_can_read_and_write_own_signal() {
-    // Regression: an `on_cleanup` must be able to read (and write) a signal
-    // that its owner allocated — cleanups run BEFORE the owner frees its
-    // nodes. Freeing first made `read_at_cleanup` panic with `signal
-    // disposed`; on-device that panic (fired mid-`tick_frame` when a router
-    // screen disposed on a transition's finish) unwound the whole frame and
-    // stranded unrelated reactive work.
+    // Cleanups run BEFORE the owner frees its nodes, so an `on_cleanup`
+    // can still read and write a signal that owner allocated.
     fresh();
     let owner = Owner::new(None);
     let read_at_cleanup: Rc<RefCell<Option<i32>>> = Rc::new(RefCell::new(None));
@@ -322,7 +312,6 @@ fn on_cleanup_can_read_and_write_own_signal() {
         sig.set(42);
         let captured = read_at_cleanup.clone();
         on_cleanup(move || {
-            // Must NOT panic: `sig`'s node is still alive at cleanup time.
             sig.set(sig.get_untracked() + 1);
             *captured.borrow_mut() = Some(sig.get_untracked());
         });
@@ -444,16 +433,9 @@ fn computed_notifies_downstream_subscribers() {
 
 #[test]
 fn on_mount_callback_inside_effect_does_not_leak_subscription_to_outer() {
-    // Regression: `flush_mounts` invokes each queued `on_mount`
-    // callback as plain user code. If a callback performs a direct
-    // `signal.get()` while a tracker is still active on the call
-    // stack (e.g. `flush_mounts` invoked from inside an effect, or
-    // from a non-standard tick driver), the signal would subscribe
-    // the outer tracker instead of nothing.
-    //
-    // After fix: `flush_mounts` brackets each `cb()` invocation in
-    // `untrack`, so on_mount callbacks never leak subscriptions
-    // upward regardless of the call-stack context.
+    // An `on_mount` callback's direct `signal.get()` must not subscribe
+    // whatever tracker happens to be live where `flush_mounts` is
+    // called from.
     use super::component::{flush_mounts, on_mount};
     fresh();
     let (effect_dep, set_effect_dep) = signal(0_i32).split();
@@ -471,18 +453,15 @@ fn on_mount_callback_inside_effect_does_not_leak_subscription_to_outer() {
                 let _ = mount_src.get();
             });
         });
-        // Flush inside the effect — same call stack as the outer
-        // effect's tracker. With the fix, the callback runs under a
-        // cleared tracker, so its signal read doesn't leak.
+        // Flushed inside the effect, so the outer tracker is on the
+        // call stack.
         flush_mounts();
     });
     assert_eq!(*outer_runs.borrow(), 1);
     set_mount_src.set(1);
     flush();
-    // No leak: `mount_src` write does not re-run the outer effect.
     assert_eq!(*outer_runs.borrow(), 1);
-    // Sanity check that the outer effect's legitimate dependency
-    // still works.
+    // The outer effect's legitimate dependency still fires.
     set_effect_dep.set(1);
     flush();
     assert_eq!(*outer_runs.borrow(), 2);
@@ -490,17 +469,9 @@ fn on_mount_callback_inside_effect_does_not_leak_subscription_to_outer() {
 
 #[test]
 fn mount_component_body_inside_effect_does_not_leak_subscription_to_outer() {
-    // Regression: a `#[component]` body invoked from inside another
-    // effect / computed used to run with that outer node's
-    // `current_tracker` still set. Any direct `signal.get()` the
-    // body performed (not via a nested `effect`/`computed`) silently
-    // subscribed the outer node, turning innocent component reads
-    // into recursive remount triggers when the read signal changed.
-    //
-    // After fix: `mount_component` wraps the body invocation in
-    // `untrack`, so component bodies are tracker-isolated. Reactivity
-    // inside a body must come from explicit `effect`/`computed`
-    // calls, which establish their own tracker scope.
+    // A component body is tracker-isolated: a direct `signal.get()` in
+    // it must not subscribe the effect that mounted it, or an innocent
+    // read becomes a recursive remount trigger.
     use super::component::mount_component;
     fresh();
     let (effect_dep, set_effect_dep) = signal(0_i32).split();
@@ -510,19 +481,15 @@ fn mount_component_body_inside_effect_does_not_leak_subscription_to_outer() {
     effect(move || {
         let _ = effect_dep.get();
         *outer_runs_clone.borrow_mut() += 1;
-        // Mount a synthetic "component": fresh owner, body reads a
-        // signal directly (the typical hazard pattern for a top-level
-        // `#[component]` body that derives a value inline).
+        // Synthetic component whose body reads a signal directly — the
+        // hazard pattern for a body that derives a value inline.
         let (_owner, _value) = mount_component(0xdead_beef as *const (), || body_src.get());
     });
     assert_eq!(*outer_runs.borrow(), 1);
-    // No leak: writing to `body_src` MUST NOT re-run the outer
-    // effect — the outer effect never legitimately subscribed.
     set_body_src.set(1);
     flush();
     assert_eq!(*outer_runs.borrow(), 1);
-    // Sanity check the outer effect's legitimate dependency still
-    // fires.
+    // The outer effect's legitimate dependency still fires.
     set_effect_dep.set(1);
     flush();
     assert_eq!(*outer_runs.borrow(), 2);
@@ -530,45 +497,25 @@ fn mount_component_body_inside_effect_does_not_leak_subscription_to_outer() {
 
 #[test]
 fn computed_constructed_inside_effect_does_not_leak_subscription_to_outer() {
-    // Regression: `computed(...)`'s construction-time seed call used
-    // to run with whatever `current_tracker` happened to be set on
-    // entry. If you built a `computed` inside an `effect`, the seed's
-    // `signal.get()` registered the *outer effect* as a subscriber of
-    // every signal the computed body read — so a write to one of
-    // those signals re-ran the outer effect (whose job is often to
-    // re-mount a component subtree), leaking a fresh `computed` node
-    // on every tick.
-    //
-    // After fix: the seed run is wrapped in `untrack`, so the only
-    // subscriber registered against the signal is the computed node
-    // itself. Verified by counting outer-effect runs: a single write
-    // to the signal must produce exactly one extra effect run (the
-    // initial one + one for the explicit `effect_dep` change), not
-    // two.
+    // `computed`'s construction-time seed run must register only the
+    // computed node against the signals it reads. Subscribing the
+    // enclosing effect instead would re-run it — and leak a fresh
+    // computed node — on every write.
     fresh();
     let (effect_dep, set_effect_dep) = signal(0_i32).split();
     let (computed_src, set_computed_src) = signal(0_i32).split();
     let outer_runs = Rc::new(RefCell::new(0));
     let outer_runs_clone = outer_runs.clone();
     effect(move || {
-        // Subscribe to `effect_dep` so the outer effect has a
-        // legitimate reason to re-run.
+        // `effect_dep` is the outer effect's one legitimate dependency.
         let _ = effect_dep.get();
         *outer_runs_clone.borrow_mut() += 1;
-        // Construct a computed that reads `computed_src`. Pre-fix,
-        // this would register the outer effect as a subscriber of
-        // `computed_src` via the seed run's `track_and_fetch`.
         let _doubled = computed(move || computed_src.get() * 2);
     });
     assert_eq!(*outer_runs.borrow(), 1);
-    // Writing to `computed_src` MUST NOT re-run the outer effect —
-    // the outer effect never subscribed to it (only the inner
-    // computed should have).
     set_computed_src.set(99);
     flush();
     assert_eq!(*outer_runs.borrow(), 1);
-    // Writing to `effect_dep` IS a legitimate trigger and should
-    // re-run the outer effect exactly once.
     set_effect_dep.set(1);
     flush();
     assert_eq!(*outer_runs.borrow(), 2);
@@ -615,16 +562,13 @@ fn context_round_trip_in_same_owner() {
 #[test]
 fn with_context_closure_can_reenter_runtime() {
     // The `with_context` closure must be able to call back into the
-    // runtime (read signals, nested context lookups). Before the Rc
-    // fix, `f` ran while the thread-local runtime was still borrowed,
-    // so any re-entry double-borrowed its RefCell and panicked.
+    // runtime — no runtime borrow may span the call.
     fresh();
     let owner = Owner::new(None);
     owner.with(|| {
         provide_context(Theme("ctx"));
         let (count, _set) = signal(7_i32).split();
-        // Read a signal AND do a nested context lookup from inside the
-        // with_context closure — both re-enter the runtime.
+        // Both the signal read and the nested lookup re-enter.
         let combined = with_context::<Theme, _>(|theme| {
             let n = count.get();
             let nested = use_context::<Theme>();
@@ -804,8 +748,6 @@ fn flush_breaks_self_feedback_loop_with_warning() {
     });
     set_count.set(1);
     flush();
-    // We don't assert the exact run count, only that flush returned
-    // rather than spinning forever, and that the run count is bounded.
     let runs_after = *runs.borrow();
     assert!(
         runs_after < 1000,
@@ -844,15 +786,10 @@ fn effect_reading_and_writing_unrelated_signals_terminates() {
 // `computed` calls, which establish their own tracker scope via the
 // scheduler. The runtime guarantees no ambient subscription leaks.
 //
-// The tests below enforce this invariant for each entrypoint in the
-// public surface. A future contributor who adds a new entrypoint that
-// invokes user code without `untrack`-bracketing will break one of
-// these tests.
-//
-// The pattern: enter an outer `effect`, which sets `current_tracker` to
-// the effect's node id. From inside that effect, call the entrypoint
-// under test and capture `current_tracker` as observed by the user
-// closure. Assert it was `None`.
+// The tests below enforce this for each entrypoint in the public
+// surface: enter an outer `effect` (which sets `current_tracker`), call
+// the entrypoint from inside it, and assert the tracker the user
+// closure observes is `None`.
 
 /// Snapshot the runtime's `current_tracker` at call time.
 fn observed_tracker() -> Option<super::runtime::NodeId> {
@@ -936,11 +873,9 @@ fn untrack_restores_tracker_when_f_panics() {
 
 #[test]
 fn computed_seed_runs_with_no_tracker_when_constructed_inside_effect() {
-    // The computed's compute closure runs at construction-time
-    // (seed) AND again on every scheduled re-run. We only care
-    // about the seed observation — capture the FIRST call and
-    // ignore later scheduled runs (those legitimately get
-    // tracker = Some(computed_node) set by `run_node_if_alive`).
+    // Only the seed observation matters — later scheduled runs
+    // legitimately see `tracker = Some(computed_node)`, so capture the
+    // FIRST call and ignore the rest.
     fresh();
     let observed: Rc<RefCell<Option<Option<super::runtime::NodeId>>>> = Rc::new(RefCell::new(None));
     let observed_clone = observed.clone();
@@ -989,8 +924,6 @@ fn mount_component_remountable_body_runs_with_no_tracker_when_invoked_inside_eff
     let observed_clone = observed.clone();
     effect(move || {
         let observed_inner = observed_clone.clone();
-        // Component body must return an Element. A phantom element
-        // is fine — we're not asserting on the tree shape here.
         let _root = mount_component_remountable(
             0x2345_6789 as *const (),
             move || {
@@ -1009,9 +942,8 @@ fn mount_component_remountable_body_runs_with_no_tracker_when_invoked_inside_eff
 
 #[test]
 fn remount_components_for_reports_zero_when_nothing_can_reflect() {
-    // The return value is the full-remount trigger:
-    // `remounted == 0` must mean "this patch had no attached
-    // component to reflect through". Three shapes of zero:
+    // `remounted == 0` is the full-remount trigger, so it must mean
+    // "this patch had no attached component to reflect through".
     use super::component::{RemountStats, mount_component_remountable, remount_components_for};
     use crate::view::create_phantom_element;
     fresh();
@@ -1025,10 +957,9 @@ fn remount_components_for_reports_zero_when_nothing_can_reflect() {
         RemountStats::default(),
     );
 
-    // (c) a matching site whose body_root was never attached to a
-    // parent (orphan) — the candidate is found but filtered out.
-    // Orphans don't count as layout_changed either: their stored
-    // closures never re-run, so there's nothing to protect.
+    // (c) a matching site whose body_root was never attached (orphan).
+    // Orphans aren't layout_changed either — their stored closures
+    // never re-run, so there is nothing to protect.
     let fn_ptr = 0x3456_789a as *const ();
     let _root = mount_component_remountable(fn_ptr, create_phantom_element, Box::new(|| 0));
     assert_eq!(remount_components_for(&[fn_ptr]), RemountStats::default());
@@ -1099,9 +1030,8 @@ fn remount_components_for_refuses_sites_whose_props_layout_changed() {
 #[test]
 fn remounted_component_still_resolves_root_context() {
     // Hot-reload remounts run from the tick callback with an empty
-    // owner stack; the fresh owner must inherit the old owner's
-    // parent or `use_context` loses everything the app root provided
-    // (giga: "provide_theme() must run at the app root" panic).
+    // owner stack, so the fresh owner must inherit the old owner's
+    // parent or `use_context` loses everything the app root provided.
     use super::component::{
         mount_component_remountable, on_component_root_attached, remount_components_for,
     };
@@ -1148,10 +1078,9 @@ fn remounted_component_still_resolves_root_context() {
     );
 }
 
-// Note: `remount_components_for`'s body invocation reuses the
-// exact same `untrack(|| new_owner.with(|| (*info.body)()))`
-// bracket the initial mount uses; the no-tracker half of that
-// contract is pinned by
+// `remount_components_for`'s body invocation reuses the same
+// `untrack(|| new_owner.with(|| (*info.body)()))` bracket as the
+// initial mount, whose no-tracker half is pinned by
 // `mount_component_remountable_body_runs_with_no_tracker_...` below.
 
 #[test]
@@ -1209,8 +1138,6 @@ fn computed_constructed_inside_computed_does_not_leak_subscription_to_outer_comp
     let outer_runs_clone = outer_runs.clone();
     let outer = computed(move || {
         *outer_runs_clone.borrow_mut() += 1;
-        // Construct an inner computed reading `src`. Pre-fix this
-        // would have subscribed `outer` to `src` via the seed leak.
         let inner = computed(move || src.get() * 2);
         inner.get()
     });
@@ -1274,9 +1201,8 @@ fn arc_signal_split_round_trip() {
 
 #[test]
 fn arc_signal_survives_caller_owner_disposal() {
-    // The bug this whole family exists to fix: a signal whose
-    // declaring owner is disposed must still be readable through
-    // any clone of its handle, because the value lives by Arc
+    // A signal whose declaring owner is disposed must still be readable
+    // through any clone of its handle — the value lives by Arc
     // refcount, not by an arena slot.
     fresh();
     let stash: Rc<RefCell<Option<ArcReadSignal<i32>>>> = Rc::new(RefCell::new(None));
@@ -1285,16 +1211,12 @@ fn arc_signal_survives_caller_owner_disposal() {
     let owner = Owner::new(None);
     owner.with(|| {
         let (r, w) = arc_signal(99_i32).split();
-        // Pretend `w` is the write half kept by a native module's
-        // event callback; we don't need to keep it for this test.
         drop(w);
         *stash_for_install.borrow_mut() = Some(r);
     });
 
     owner.dispose();
 
-    // Pre-fix this would have panicked (`expect("signal disposed")`)
-    // for Copy signals. Post-fix Arc signals survive the disposal.
     let cached = stash.borrow().clone().expect("stashed signal");
     assert_eq!(cached.get(), 99);
 }

--- a/crates/whisker-runtime/src/reactive/tests_loop_wedge.rs
+++ b/crates/whisker-runtime/src/reactive/tests_loop_wedge.rs
@@ -1,7 +1,6 @@
-//! Regression tests for the reactive-loop wedge (edge-triggered lost
-//! wakeup).
+//! Tests pinning the loop's level-triggered idle rule.
 //!
-//! ## The bug being guarded
+//! ## The wedge these guard against
 //!
 //! The render loop is wake-driven: `signal.set()` → `schedule()` pushes
 //! a node onto `rt.pending` and calls `host_wake::wake_runtime()` ONLY on
@@ -9,24 +8,20 @@
 //! whenever a frame reports idle. A native-view layout/measure callback
 //! can re-enter Rust DURING the final `renderer_flush` of a frame and
 //! `schedule()` a signal write; that node lands in `rt.pending` but is
-//! past the frame's drain. If idle were judged purely on "dispatch
-//! completed", the host would pause with work still queued — and because
-//! the queue is now non-empty, no later `set()` fires a wake → permanent
-//! wedge (values change, screen never repaints).
+//! past the frame's drain. Judging idle purely on "dispatch completed"
+//! would pause the host with work still queued — and since the queue is
+//! now non-empty, no later `set()` fires a wake, so values change and
+//! the screen never repaints again.
 //!
-//! The fix is two-fold and these two tests **contrast the wedge**:
+//! The two tests contrast the outcomes:
 //!
-//! - [`fixed_loop_drains_settle_and_tap_renders`] runs the loop with the
-//!   PRODUCTION idle rule — idle == `!has_pending_work()`. A commit-time
-//!   re-entry that schedules a settle node keeps the loop busy until the
-//!   queue drains, so a subsequent "tap" re-renders. The loop makes
-//!   progress.
-//! - [`unfixed_loop_wedges_when_pending_left_dirty`] runs the SAME
-//!   scenario with the PRE-FIX idle rule — idle is hard-coded `true` (the
-//!   frame "always completed"). The commit-time re-entry leaves a node in
-//!   `rt.pending`, the host pauses, and because `schedule()` only wakes on
-//!   the empty→non-empty edge the later "tap" fires no wake. The render
-//!   counter never advances → the wedge is reproduced.
+//! - [`fixed_loop_drains_settle_and_tap_renders`] uses the production
+//!   idle rule, `!has_pending_work()`. A commit-time re-entry keeps the
+//!   loop busy until the queue drains, and a subsequent "tap"
+//!   re-renders.
+//! - [`unfixed_loop_wedges_when_pending_left_dirty`] runs the same
+//!   scenario with idle hard-coded `true`, reproducing the wedge: the
+//!   render counter never advances again.
 
 use std::cell::Cell;
 use std::ffi::c_void;
@@ -120,14 +115,10 @@ fn tick_fixed(settle_signal: RwSignal<i32>, reentry: &Cell<u32>) -> bool {
     !has_pending_work()
 }
 
-/// One host vsync `tick()` using the PRE-FIX idle rule: the frame
-/// "always completed", so it reports idle unconditionally — IGNORING any
-/// node a commit-time re-entry left in `rt.pending`. This is the buggy
-/// `!dispatch_pending` (with no `has_pending_work` term) and no
-/// same-frame settle loop.
+/// One host vsync `tick()` under the rejected idle rule: the frame
+/// "always completed", so it reports idle unconditionally, ignoring any
+/// node a commit-time re-entry left in `rt.pending`.
 fn tick_unfixed(settle_signal: RwSignal<i32>, reentry: &Cell<u32>) {
-    // No settle loop: drain only what the in-frame flush sees, then leave
-    // any commit-time re-entry node dirty in the queue.
     flush();
     tasks::run_until_stalled();
     flush();
@@ -135,17 +126,16 @@ fn tick_unfixed(settle_signal: RwSignal<i32>, reentry: &Cell<u32>) {
     for _ in 0..pending_reentry {
         settle_signal.set(settle_signal.get_untracked() + 1);
     }
-    // NOTE: deliberately NO settle loop and the caller treats idle as a
+    // Deliberately no settle loop, and the caller treats idle as a
     // hard-coded `true` — the node scheduled above is left undrained.
 }
 
 // ----- Tests ----------------------------------------------------------------
 
-/// FIXED loop: with the production level-triggered idle + same-frame
-/// settle loop, a commit-time re-entry never wedges the loop and a later
-/// "tap" re-renders. Contrast with
-/// [`unfixed_loop_wedges_when_pending_left_dirty`], which runs the same
-/// scenario under the pre-fix idle rule and stays frozen.
+/// With the production level-triggered idle plus the same-frame settle
+/// loop, a commit-time re-entry never wedges the loop and a later "tap"
+/// re-renders. Contrast with
+/// [`unfixed_loop_wedges_when_pending_left_dirty`].
 #[test]
 fn fixed_loop_drains_settle_and_tap_renders() {
     let _g = lock();
@@ -167,7 +157,6 @@ fn fixed_loop_drains_settle_and_tap_renders() {
             settle_signal.get();
             rc.set(rc.get() + 1);
         });
-        // Initial effect run.
         flush();
         let baseline = render_count.get();
 
@@ -175,9 +164,8 @@ fn fixed_loop_drains_settle_and_tap_renders() {
         // `settle_signal` ONCE during the next frame's commit.
         let reentry = Cell::new(1u32);
 
-        // ----- Drive the host loop (bounded iterations) -----
-        // The vsync loop ticks while running; on idle it pauses and only a
-        // wake (from a `set()` empty→non-empty edge) resumes it.
+        // The vsync loop ticks while running; on idle it pauses, and only
+        // a wake (a `set()` on the empty→non-empty edge) resumes it.
         let mut vsync_idle = false;
         for _ in 0..50 {
             if VSYNC_RUNNING.with(|v| v.get()) {
@@ -186,9 +174,6 @@ fn fixed_loop_drains_settle_and_tap_renders() {
                     VSYNC_RUNNING.with(|v| v.set(false));
                 }
             } else {
-                // Vsync paused. The settle re-entry must already have been
-                // drained in-frame, so pausing here is correct. Fire the
-                // "tap" exactly once: a user write that must wake the loop.
                 break;
             }
         }
@@ -196,7 +181,6 @@ fn fixed_loop_drains_settle_and_tap_renders() {
             vsync_idle,
             "fixed loop should reach idle after draining settle"
         );
-        // The commit-time re-entry rendered in the same frame.
         assert!(
             render_count.get() > baseline,
             "settle re-entry must have re-rendered (render_count advanced past baseline)"
@@ -204,8 +188,8 @@ fn fixed_loop_drains_settle_and_tap_renders() {
 
         let after_settle = render_count.get();
 
-        // ----- Tap while paused ----- a single user `set()` must wake the
-        // host (empty→non-empty edge) and the resumed loop must re-render.
+        // Tapping while paused: a single user `set()` must wake the host
+        // on the empty→non-empty edge, and the resumed loop re-render.
         let wakes_before = WAKE_COUNT.with(|c| c.get());
         count.set(1);
         assert!(
@@ -217,7 +201,6 @@ fn fixed_loop_drains_settle_and_tap_renders() {
             "wake must unpause the vsync loop"
         );
 
-        // Drain the resumed loop.
         let mut settled = false;
         for _ in 0..50 {
             if VSYNC_RUNNING.with(|v| v.get()) {
@@ -241,13 +224,12 @@ fn fixed_loop_drains_settle_and_tap_renders() {
     reset_all();
 }
 
-/// UNFIXED loop: with the pre-fix idle rule (frame always reports idle,
-/// no same-frame settle), a commit-time re-entry leaves a node dirty in
-/// `rt.pending`. The host pauses; because `schedule()` only wakes on the
-/// empty→non-empty edge and the queue is already non-empty, a later "tap"
-/// `set()` fires NO wake — the loop stays frozen and never re-renders.
-/// This reproduces the wedge that
-/// [`fixed_loop_drains_settle_and_tap_renders`] proves the fix closes.
+/// With the rejected idle rule (frame always reports idle, no same-frame
+/// settle), a commit-time re-entry leaves a node dirty in `rt.pending`.
+/// The host pauses; because `schedule()` only wakes on the empty→non-empty
+/// edge and the queue is already non-empty, a later "tap" `set()` fires no
+/// wake and the loop stays frozen. The counterpart to
+/// [`fixed_loop_drains_settle_and_tap_renders`].
 #[test]
 fn unfixed_loop_wedges_when_pending_left_dirty() {
     let _g = lock();
@@ -272,15 +254,15 @@ fn unfixed_loop_wedges_when_pending_left_dirty() {
         // frame's commit, leaving its subscriber node dirty in `pending`.
         let reentry = Cell::new(1u32);
 
-        // Drive the host loop with the PRE-FIX idle (hard-coded true: the
-        // frame "always completed"). After one tick the re-entry node sits
-        // undrained in `pending`, and the host pauses.
+        // Drive the host loop with the rejected idle rule (hard-coded
+        // true: the frame "always completed"). After one tick the re-entry
+        // node sits undrained in `pending`, and the host pauses.
         let mut vsync_idle = false;
         for _ in 0..50 {
             if VSYNC_RUNNING.with(|v| v.get()) {
                 tick_unfixed(settle_signal, &reentry);
-                // PRE-FIX: idle is unconditionally true (no
-                // `has_pending_work` term, no settle loop).
+                // Idle unconditionally: no `has_pending_work` term and
+                // no settle loop.
                 vsync_idle = true;
                 VSYNC_RUNNING.with(|v| v.set(false));
             } else {
@@ -297,9 +279,9 @@ fn unfixed_loop_wedges_when_pending_left_dirty() {
 
         let render_before_tap = render_count.get();
 
-        // ----- Tap while wedged ----- the queue is already non-empty, so
-        // `schedule()` takes the was_empty == false branch and fires NO
-        // wake. The vsync loop stays paused.
+        // Tapping while wedged: the queue is already non-empty, so
+        // `schedule()` takes the `was_empty == false` branch and fires no
+        // wake at all.
         let wakes_before = WAKE_COUNT.with(|c| c.get());
         count.set(1);
         assert_eq!(

--- a/crates/whisker-runtime/src/reactive/tests_resource.rs
+++ b/crates/whisker-runtime/src/reactive/tests_resource.rs
@@ -276,47 +276,34 @@ fn async_resource_returns_to_loading_during_refetch() {
     });
 }
 
-/// Regression repro for the field bug on 0.2.4: a **reactive resource
-/// whose fetcher reads a signal AND does blocking IO via `run_blocking`**
-/// hangs after the tracked signal changes — the re-fetch starts
-/// (`loading` flips true) but the result never lands.
+/// A reactive resource whose fetcher reads a signal AND does blocking IO
+/// via `run_blocking` must still land its result after the tracked
+/// signal changes.
 ///
-/// ## Why this reproduces the device hang (and earlier attempts didn't)
+/// ## What makes this hard
 ///
-/// On device the host render loop pauses whenever `whisker_tick`
-/// reports **idle**, and resumes only on a `request_frame` wake. The
-/// interim "busy-tick" fix kept the host ticking while tasks were
-/// outstanding; the PROPER fix (modelled here) drives the parked fetch
-/// off the **main run loop** instead.
+/// The host render loop pauses whenever `whisker_tick` reports idle, and
+/// resumes only on a `request_frame` wake. A `run_blocking` result is
+/// marshaled back via the host's main-thread dispatch
+/// (`run_on_main_thread` → CFRunLoop / Looper post), which the OS
+/// services even while the vsync loop is paused. So the trampoline runs
+/// on the main thread and invokes the registered DRIVE callback there —
+/// drain the pool + flush — rather than requesting a vsync frame it
+/// would race.
 ///
-/// A `run_blocking` fetch's result is marshaled back via the host's
-/// main-thread dispatch (`run_on_main_thread` → CFRunLoop / Looper
-/// post). The OS services that post even while the vsync render loop is
-/// paused, and it is race-free (kernel-level wake). The `trampoline`
-/// runs ON the main thread and, instead of requesting a (paused,
-/// clobberable) vsync frame, invokes the registered DRIVE callback —
-/// which runs a `tick_frame` equivalent there: drain the pool + flush,
-/// completing and committing the fetch immediately.
+/// ## How the harness models the worker→main-thread post
 ///
-/// ## How this harness faithfully models the worker→main-thread post
+/// `run_blocking` calls `run_on_main_thread(|| tx.send(value))` from the
+/// WORKER thread, and the trampoline must run on the TEST thread where
+/// the `POOL` / runtime thread-locals live — not inline on the worker.
+/// The test dispatcher therefore enqueues `(callback, user_data)` into a
+/// thread-safe queue ([`POSTS`]) that the test's host loop drains on the
+/// test thread, invoking the trampoline there.
 ///
-/// `run_blocking` calls `run_on_main_thread(|| tx.send(value))` from
-/// the WORKER thread. The real host dispatch POSTS that to the MAIN
-/// thread; the trampoline (and thus the drive) must run on the TEST
-/// thread where the `POOL`/runtime thread-locals live — NOT inline on
-/// the worker. So the test dispatcher ENQUEUES `(callback, user_data)`
-/// into a thread-safe queue ([`POSTS`]); the test's host loop drains
-/// that queue on the test thread each iteration, invoking the
-/// trampoline there, which fires the test DRIVE callback (a stand-in
-/// for the driver's `tick_frame`).
-///
-/// The frame-request callback is a NO-OP (the clobbered / lost vsync
-/// wake): the ONLY thing that can finish a parked fetch is the
-/// main-thread-posted trampoline → drive. The idle verdict is purely
-/// `!dispatch_pending` (NO busy-tick). With the fix (trampoline drives)
-/// the re-fetch COMPLETES; revert step 1 (trampoline back to
-/// `wake_runtime` / no-op) and the drive never runs → the fetch is
-/// never re-polled → these tests hit the deadline (the field hang).
+/// The frame-request callback is a no-op, standing in for the lost vsync
+/// wake: the only thing that can finish a parked fetch is the
+/// main-thread-posted trampoline → drive. Break that link and these
+/// tests hit their deadline.
 mod cross_thread_wake {
     use super::*;
     use crate::main_thread::{DispatchFn, set_drive_callback, set_main_thread_dispatcher};
@@ -325,10 +312,6 @@ mod cross_thread_wake {
     use std::sync::{Mutex, MutexGuard};
     use std::time::{Duration, Instant};
 
-    // These tests reach into process-global state (the main-thread
-    // dispatcher + drive callback + frame-request callback). Use the
-    // shared host-test lock so sibling modules can't clear our wiring
-    // mid-fetch.
     fn lock<'a>() -> MutexGuard<'a, ()> {
         crate::main_thread::host_test_lock()
     }
@@ -357,12 +340,10 @@ mod cross_thread_wake {
     // must NOT depend on it to finish an in-flight fetch.
     extern "C" fn request_frame_noop(_: *mut c_void) {}
 
-    // FAITHFUL main-thread dispatcher: ENQUEUES the marshaled
-    // (callback, user_data) for the MAIN (test) thread to run, rather
-    // than invoking it inline on the caller (worker) thread. This is
-    // what makes the trampoline — and the drive it triggers — run where
-    // the runtime thread-locals live, exactly as the real Lynx
-    // main-thread dispatch does.
+    // Enqueues the marshaled (callback, user_data) for the MAIN (test)
+    // thread rather than invoking it inline on the caller (worker)
+    // thread, so the trampoline — and the drive it triggers — runs where
+    // the runtime thread-locals live, as the real Lynx dispatch does.
     extern "C" fn enqueue_post(
         _engine: *mut c_void,
         callback: extern "C" fn(*mut c_void),
@@ -377,11 +358,9 @@ mod cross_thread_wake {
         true
     }
 
-    // The TEST drive callback — stand-in for the driver's `tick_frame`
-    // (the runtime crate can't call the driver). Runs the same shape:
-    // reactive flush, drain the task pool, reactive flush (to surface
-    // signal writes the drained fetch made, e.g. `state.set(Ready)`).
-    // Invoked by the trampoline on the test thread.
+    // Stand-in for the driver's `tick_frame`, which the runtime crate
+    // can't call. Same shape: reactive flush, drain the task pool,
+    // reactive flush (to surface signal writes the drained fetch made).
     extern "C" fn test_drive() {
         flush();
         tasks::run_until_stalled();
@@ -428,17 +407,14 @@ mod cross_thread_wake {
         drained
     }
 
-    /// One "frame": exactly what the driver's `tick_frame` +
-    /// `tick`-idle-reporting do. Runs reactive flush, drains the task
-    /// pool, runs a SECOND reactive flush (to surface signal writes
-    /// made by tasks that resolved during the drain), and returns the
-    /// runtime's idle/busy verdict — `true` == idle == "host may pause".
+    /// One "frame": reactive flush, task-pool drain, a SECOND reactive
+    /// flush (to surface signal writes made by tasks that resolved
+    /// during the drain), then the idle/busy verdict — `true` == idle ==
+    /// "host may pause".
     ///
-    /// The idle verdict mirrors `whisker-driver`'s reverted `tick`:
-    /// purely `!dispatch_pending`. There is NO busy-tick — a parked
-    /// fetch does NOT keep this returning busy. Modeled here as: a frame
-    /// always completes its dispatched work synchronously, so it's
-    /// always idle afterward.
+    /// The verdict is purely `!dispatch_pending`, with no busy-tick, so
+    /// a parked fetch does NOT keep it busy. Modelled as: a frame always
+    /// completes its dispatched work synchronously.
     fn tick() -> bool {
         flush();
         tasks::run_until_stalled();
@@ -449,31 +425,22 @@ mod cross_thread_wake {
     /// Drive the host loop until `done()` or the deadline.
     ///
     /// Models the real render loop: tick once; on idle the vsync loop
-    /// "pauses" (stops ticking). Because the frame-request callback is
-    /// the clobbered no-op, vsync can NOT resume a parked fetch. The
-    /// ONLY resume path is the MAIN-THREAD POST queue: each loop
-    /// iteration we [`drain_posts`] (the OS servicing CFRunLoop / Looper
-    /// while vsync sleeps), which runs the trampoline → drive →
-    /// `tick_frame`, completing the fetch. With step 1's fix the
-    /// trampoline drives, so draining a post finishes the work; revert
-    /// it (trampoline → `wake_runtime`/no-op) and draining a post does
-    /// nothing useful → the fetch never re-polls → deadline → hang.
+    /// "pauses" (stops ticking). The frame-request callback being a
+    /// no-op, vsync can NOT resume a parked fetch — the only resume path
+    /// is the main-thread post queue, which each iteration
+    /// [`drain_posts`] services (as the OS services CFRunLoop / Looper
+    /// while vsync sleeps), running the trampoline → drive →
+    /// `tick_frame` and completing the fetch.
     fn drive_until(mut done: impl FnMut() -> bool) {
-        // 2s is ample margin over the worker sleeps (15–40ms) on the
-        // happy path; on a reverted fix the main-loop drive is inert and
-        // the loop burns the full deadline (the hang).
+        // 2s is ample margin over the worker sleeps (15–40ms); a broken
+        // main-loop drive burns the whole deadline instead.
         let deadline = Instant::now() + Duration::from_secs(2);
 
-        // The vsync side ticks ONLY while it's busy. The moment it
-        // reports idle it "pauses" and we NEVER tick it again from here
-        // — exactly as the host pauses CADisplayLink/Choreographer. From
-        // that point the ONLY thing that can advance the runtime is a
-        // MAIN-THREAD POST being drained (the trampoline → drive). This
-        // is what isolates the fix: with the proper fix the drained
-        // post's trampoline runs `tick_frame` (completing the fetch);
-        // reverted, the trampoline only fires the no-op vsync wake, the
-        // value is delivered to the channel but NOTHING re-polls the pool
-        // → deadline → hang.
+        // The vsync side ticks ONLY while busy. The moment it reports
+        // idle it "pauses" and is never ticked again from here — exactly
+        // as the host pauses CADisplayLink / Choreographer — so from
+        // that point only a drained main-thread post can advance the
+        // runtime. That is what isolates the behaviour under test.
         let mut vsync_idle = false;
         while !done() && Instant::now() < deadline {
             if !vsync_idle {
@@ -529,12 +496,9 @@ mod cross_thread_wake {
                 }
             });
 
-            // A consuming effect, as a component's render would have:
-            // it READS the resource state (subscribing to the state
-            // signal) so that each commit (`state.set`) schedules a
-            // re-run on the trailing flush — faithfully modelling the
-            // device, where the resource is rendered by `{expr}` text
-            // bindings.
+            // A consuming effect, as a component's render would have: it
+            // reads the resource state, so each commit (`state.set`)
+            // schedules a re-run on the trailing flush.
             let seen = Rc::new(Cell::new(0i32));
             let seen_for_effect = seen.clone();
             crate::reactive::effect::effect(move || {
@@ -551,15 +515,12 @@ mod cross_thread_wake {
                 "initial reactive+run_blocking fetch must complete (query=1 → 10)"
             );
 
-            // Change the tracked signal. On device the write's wake
-            // requests a frame; the host tick flushes the effect re-run
-            // (which spawns the new fetch). Do NOT flush inline — let
-            // the on-demand tick loop pick up the frame request, exactly
-            // as the host does.
+            // Deliberately no inline flush: let the tick loop pick up
+            // the frame request the write's wake made, as the host does.
             query.set(7);
 
-            // Drive the RE-FETCH to completion. THIS is what hangs on
-            // 0.2.4: loading flips true but the result never arrives.
+            // Drive the RE-FETCH to completion — the case where loading
+            // flips true but the result never arrives.
             drive_until(|| matches!(r.state(), ResourceState::Ready(70)));
             assert_eq!(
                 r.get(),
@@ -581,11 +542,9 @@ mod cross_thread_wake {
         reset_host();
     }
 
-    /// Reporter's after-`.await` variant: the tracked signal is read
-    /// AFTER the `run_blocking().await` resumes — so the read happens
-    /// during a cross-thread-woken poll, inside `with_observer`. This
-    /// is the path the reporter's hypothesis points at (re-subscription
-    /// during the cross-thread-woken poll).
+    /// After-`.await` variant: the tracked signal is read AFTER the
+    /// `run_blocking().await` resumes, so the read happens during a
+    /// cross-thread-woken poll, inside `with_observer`.
     #[test]
     fn reactive_resource_signal_read_after_run_blocking_await_refetches() {
         let _g = lock();
@@ -627,9 +586,9 @@ mod cross_thread_wake {
     /// Overlapping re-fetch: the tracked signal changes WHILE the first
     /// fetch's worker is still in flight. This leaves a stale (gen-1)
     /// ScopedFetch in the pool that must be abandoned, and a fresh
-    /// (gen-2) ScopedFetch that must run to completion. The bug: the
-    /// stale task's cross-thread wake (its worker finishes later) gets
-    /// tangled with the live task so the live result never lands.
+    /// (gen-2) ScopedFetch that must run to completion. The stale task's
+    /// cross-thread wake arrives later and must not tangle with the live
+    /// one.
     #[test]
     fn reactive_resource_overlapping_refetch_completes_latest() {
         use std::cell::Cell;

--- a/crates/whisker-runtime/src/tasks.rs
+++ b/crates/whisker-runtime/src/tasks.rs
@@ -55,25 +55,19 @@ thread_local! {
 ///
 /// # Why this exists
 ///
-/// `LocalPool`'s built-in waker, when woken, only re-queues the task
-/// into the pool's internal ready-queue — it does NOT poke the native
-/// main loop. The pool is re-polled only from the driver's
-/// `tick_frame` → [`run_until_stalled`], which fires on a host vsync
-/// `tick()` or on a `run_on_main_thread` DRIVE post. So a task awaiting
-/// a future that completes on a FOREIGN thread (e.g. a tokio runtime
-/// thread, or a `std::thread` worker) gets re-queued by the wake but
-/// never re-polled — it hangs forever while vsync is parked (issue #7).
+/// `LocalPool`'s built-in waker only re-queues the task into the pool's
+/// ready-queue; it does not poke the native main loop. The pool is
+/// re-polled only from the driver's `tick_frame` →
+/// [`run_until_stalled`], so a task awaiting a future that completes on
+/// a FOREIGN thread (a tokio runtime thread, a `std::thread` worker)
+/// would be re-queued and never re-polled — hanging for as long as
+/// vsync stays parked. Every spawned future is therefore polled through
+/// a [`DriveWaker`] that forwards to the pool's inner waker AND calls
+/// this hook.
 ///
-/// We fix this by polling each spawned future through a [`DriveWaker`]
-/// that, on `wake`/`wake_by_ref`, forwards to the pool's inner waker
-/// (to re-queue the task) AND calls this hook (to poke the main loop).
-///
-/// In production the hook is [`request_main_loop_drive`], which routes
-/// through [`crate::main_thread::run_on_main_thread`] — documented as
-/// safe to call from any thread — so the registered DRIVE callback
-/// (`tick_frame` → `run_until_stalled`) runs and re-polls the pool.
-/// Tests can override it via [`set_drive_hook`] to observe wakes
-/// without a full main-loop harness.
+/// In production the hook is [`request_main_loop_drive`]. Tests can
+/// override it via [`set_drive_hook`] to observe wakes without a full
+/// main-loop harness.
 type DriveHook = fn();
 
 static DRIVE_HOOK: std::sync::Mutex<DriveHook> = std::sync::Mutex::new(request_main_loop_drive);
@@ -81,21 +75,16 @@ static DRIVE_HOOK: std::sync::Mutex<DriveHook> = std::sync::Mutex::new(request_m
 /// Production drive hook: ask the host to run another drive of the
 /// runtime (which calls [`run_until_stalled`]).
 ///
-/// Routed through `run_on_main_thread(|| {})`: posting an empty
-/// closure to the host's main-thread dispatcher makes the trampoline
-/// fire the registered DRIVE callback on the main thread, which runs
+/// Posting an empty closure to the host's main-thread dispatcher makes
+/// the trampoline fire the registered DRIVE callback, which runs
 /// `tick_frame` → `run_until_stalled` and re-polls the ready task.
-/// `run_on_main_thread` is any-thread-safe (it snapshots a global
-/// dispatcher behind a `Mutex`), so this is sound to call from a
-/// foreign thread's wake.
+/// `run_on_main_thread` is any-thread-safe, so this is sound to call
+/// from a foreign thread's wake.
 ///
-/// Re-entrancy: if the wake happens on the MAIN thread while a drive
-/// is already in progress (e.g. a task self-wakes during
-/// `run_until_stalled`), the trampoline consults
-/// `main_work_in_progress()` and defers to a vsync frame instead of
-/// re-entering `tick_frame`. The re-queued task is then picked up by
-/// the in-flight `run_until_stalled` loop (it drains to a stall) or by
-/// the next frame. See `main_thread::trampoline`.
+/// A wake on the MAIN thread while a drive is already in progress (a
+/// task self-waking during `run_until_stalled`) defers to a vsync
+/// frame — see `main_thread::trampoline`. The re-queued task is picked
+/// up by the in-flight drain or by the next frame.
 fn request_main_loop_drive() {
     crate::main_thread::run_on_main_thread(|| {});
 }
@@ -116,26 +105,19 @@ fn invoke_drive_hook() {
 /// A `Waker` that bridges a foreign-thread wake to Whisker's main
 /// loop.
 ///
-/// Holds the pool's own inner `Waker` for the task (so waking still
-/// re-queues the task into `LocalPool`'s ready-queue, preserving the
-/// stock same-thread / self-wake behavior). On `wake`, it:
-///
-/// 1. forwards to the inner waker → the task is marked ready; then
-/// 2. calls the drive hook → the main loop is poked so
-///    `run_until_stalled` actually re-polls.
-///
-/// Step 2 is the missing link the bare `LocalPool` lacked. It is safe
-/// from any thread: the inner waker is `Send + Sync` and the drive
-/// hook funnels through the any-thread-safe `run_on_main_thread`.
+/// Holds the pool's own inner `Waker` for the task, so waking still
+/// re-queues it into `LocalPool`'s ready-queue and the stock
+/// same-thread / self-wake behaviour is preserved; then calls the drive
+/// hook so the main loop actually re-polls. Safe from any thread — the
+/// inner waker is `Send + Sync` and the hook funnels through the
+/// any-thread-safe `run_on_main_thread`.
 struct DriveWaker {
     inner: std::task::Waker,
 }
 
 impl ArcWake for DriveWaker {
     fn wake_by_ref(arc_self: &Arc<Self>) {
-        // (a) mark the task ready in the pool's ready-queue.
         arc_self.inner.wake_by_ref();
-        // (b) ensure the main loop will re-poll the pool.
         invoke_drive_hook();
     }
 }
@@ -143,13 +125,11 @@ impl ArcWake for DriveWaker {
 /// Wraps a spawned future so that it is always polled with a
 /// [`DriveWaker`]-composed `Context`.
 ///
-/// `LocalPool` polls this wrapper with ITS waker (`cx.waker()`). We
-/// build a `DriveWaker` around that inner waker and poll the user
-/// future with it, so whatever waker the user future stashes (and
-/// later wakes, possibly from a foreign thread) is the drive-bridging
-/// one — not the bare pool waker. The pool's own scheduling is
-/// preserved (the inner waker is still forwarded on every wake); we
-/// only ADD the main-loop poke.
+/// `LocalPool` polls this wrapper with ITS waker (`cx.waker()`); the
+/// user future is polled with a `DriveWaker` built around that one, so
+/// whatever waker the user future stashes — and later wakes, possibly
+/// from a foreign thread — is the drive-bridging one rather than the
+/// bare pool waker.
 struct DriveBridged<F> {
     future: F,
 }
@@ -196,17 +176,11 @@ where
 {
     SPAWNER.with(|s| {
         s.borrow()
-            // Wrap so the future is polled with a `DriveWaker`-composed
-            // context: a wake from ANY thread re-queues the task in the
-            // pool AND pokes the main loop (see `DriveBridged` /
-            // `DRIVE_HOOK`). This is what lets a future awaited here
-            // resume when woken from a foreign (e.g. tokio) thread.
             .spawn_local(DriveBridged { future })
             .expect("whisker tasks: local pool is shut down");
     });
-    // Nudge the host so the next frame's tick callback actually
-    // runs and drains the queue. Without this, a freshly spawned
-    // task would sit dormant until something else woke the runtime.
+    // Without this nudge a freshly spawned task sits dormant until
+    // something else happens to wake the runtime.
     crate::host_wake::wake_runtime();
 }
 
@@ -253,26 +227,15 @@ where
     let (tx, rx) = futures_channel::oneshot::channel::<T>();
     std::thread::spawn(move || {
         let value = closure();
-        // Hop back to the main thread before sending so the receiver
-        // wakes up on the TASM thread (same thread the awaiting task
-        // polls on). Without this, the receiver would wake from the
-        // worker — fine for futures-channel's own internal locking
-        // but pessimistic for the runtime: the wake would still go
-        // through `host_wake::wake_runtime`, which posts to the main
-        // thread, but the order of operations is cleaner this way.
+        // Hop to the main thread before sending so the receiver wakes
+        // on the TASM thread, the same one the awaiting task polls on.
         crate::main_thread::run_on_main_thread(move || {
-            // `send` fails only if the awaiting half was dropped
-            // (its owner was disposed mid-fetch). In that case the
-            // result is simply discarded; no panic, no warning —
-            // this is the documented `resource` cancel-on-dispose
-            // semantics.
+            // `send` fails only when the awaiting half was dropped
+            // because its owner was disposed mid-fetch — the documented
+            // `resource` cancel-on-dispose semantics, so drop silently.
             let _ = tx.send(value);
         });
     });
-    // Wrap the receiver so user code awaits `T`. Cancellation (sender
-    // dropped because the awaiting owner was disposed) parks the
-    // future forever — the task will be GC'd when its owner cascade
-    // fires.
     BlockingResult { rx }
 }
 
@@ -306,7 +269,6 @@ impl<T> Future for BlockingResult<T> {
 /// doesn't bleed across.
 #[doc(hidden)]
 pub fn __reset_for_tests() {
-    // Replacing the pool drops every queued task.
     POOL.with(|p| *p.borrow_mut() = LocalPool::new());
     SPAWNER.with(|s| {
         POOL.with(|p| {
@@ -324,10 +286,6 @@ mod tests {
     use std::rc::Rc;
     use std::sync::MutexGuard;
 
-    /// Tests in this module reach into thread-local state (executor)
-    /// AND process-global state (dispatcher / frame callback). Use the
-    /// shared [`crate::main_thread::host_test_lock`] so they don't race
-    /// the host-global tests in sibling modules.
     fn lock<'a>() -> MutexGuard<'a, ()> {
         crate::main_thread::host_test_lock()
     }
@@ -337,9 +295,8 @@ mod tests {
         crate::main_thread::__reset_for_tests();
     }
 
-    /// Synchronous in-test dispatcher: invokes the callback inline
-    /// (on the caller's thread). Good enough to verify run_blocking
-    /// without spinning up a real event loop.
+    /// Synchronous in-test dispatcher: invokes the callback inline on
+    /// the caller's thread.
     extern "C" fn sync_invoke(
         _engine: *mut c_void,
         callback: extern "C" fn(*mut c_void),
@@ -420,8 +377,6 @@ mod tests {
             .await;
         });
         run_until_stalled();
-        // First poll → Pending + self-wake → second poll → Ready,
-        // all inside the same `run_until_stalled` invocation.
         assert_eq!(phase.get(), 2);
     }
 
@@ -438,10 +393,8 @@ mod tests {
             *got_for_task.borrow_mut() = Some(v);
         });
 
-        // The worker thread + sync dispatcher + receiver poll cycle
-        // is not synchronous from the spawning thread's POV (the
-        // worker may not have scheduled yet). Poll-loop with a cap
-        // until the value lands.
+        // The worker may not have scheduled yet, so poll-loop with a
+        // cap until the value lands.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         while got.borrow().is_none() && std::time::Instant::now() < deadline {
             run_until_stalled();
@@ -453,23 +406,15 @@ mod tests {
 
     #[test]
     fn run_on_main_thread_trampoline_wakes_runtime() {
-        // Regression for the hn-reader "Loading top stories stuck"
-        // bug: a worker thread that calls
-        // `run_on_main_thread(|| tx.send(value))` must wake the
-        // runtime after the closure runs, so the host re-enters
-        // `tick` and `run_until_stalled` polls the awaiting future.
-        //
-        // Without the wake, the receiver's Waker re-queues the task
-        // in `LocalPool`, but `LocalPool` is only polled from `tick`
-        // — which doesn't fire if `CADisplayLink` is paused. Result:
-        // future sleeps forever, `Resource::state` stays at
-        // `Loading`, screen stuck on the loading banner.
+        // The trampoline must wake the runtime after the closure runs,
+        // or the awaiting future is never re-polled: `LocalPool` is
+        // only drained from `tick`, which doesn't fire while the host's
+        // vsync loop is paused.
         use std::sync::atomic::{AtomicBool, Ordering};
         let _g = lock();
         reset_all();
         install_sync_dispatcher();
 
-        // Install a wake callback that flips a flag.
         static WOKE: AtomicBool = AtomicBool::new(false);
         WOKE.store(false, Ordering::SeqCst);
         extern "C" fn wake_cb(_: *mut c_void) {
@@ -477,9 +422,6 @@ mod tests {
         }
         crate::host_wake::set_request_frame_callback(Some(wake_cb), std::ptr::null_mut());
 
-        // Schedule a no-op closure through `run_on_main_thread`.
-        // The sync dispatcher runs it inline; the trampoline must
-        // then call `wake_runtime`.
         crate::main_thread::run_on_main_thread(|| {});
 
         assert!(
@@ -497,18 +439,14 @@ mod tests {
     fn run_blocking_future_parks_when_no_dispatcher_registered() {
         let _g = lock();
         reset_all();
-        // No dispatcher installed → run_on_main_thread drops the
-        // closure, sender never fires, receiver stays Pending
-        // forever. The awaiting task body never advances past the
-        // .await.
-
+        // No dispatcher installed → `run_on_main_thread` drops the
+        // closure, so the sender never fires.
         let polled = Rc::new(Cell::new(false));
         let polled_for_task = polled.clone();
         spawn_local(async move {
             let _v: () = run_blocking(|| {}).await;
             polled_for_task.set(true);
         });
-        // Generous wait so worker definitely runs.
         for _ in 0..20 {
             run_until_stalled();
             std::thread::sleep(std::time::Duration::from_millis(5));
@@ -551,11 +489,8 @@ mod tests {
         let _g = lock();
         reset_all();
 
-        // Inject a test drive hook that records that it was poked. In
-        // production this hook routes through `run_on_main_thread`,
-        // poking the host main loop; here we just count the pokes and
-        // (crucially) re-poll the pool, the way the real DRIVE callback
-        // (`tick_frame` → `run_until_stalled`) would.
+        // The test hook counts pokes; the re-poll the real DRIVE
+        // callback would do is done explicitly below.
         static DRIVE_POKES: AtomicUsize = AtomicUsize::new(0);
         DRIVE_POKES.store(0, Ordering::SeqCst);
         fn test_hook() {
@@ -580,7 +515,6 @@ mod tests {
             completed_for_task.set(true);
         });
 
-        // First drive: polls the task to Pending, stashing its waker.
         run_until_stalled();
         assert!(!completed.get(), "task should be parked awaiting signal");
         assert!(
@@ -588,31 +522,24 @@ mod tests {
             "task must have stashed its waker on the first poll"
         );
 
-        // Now complete the future from a SEPARATE std::thread — exactly
-        // the foreign-thread wake the bug is about. The thread flips the
-        // done flag and wakes the stored (drive-bridging) waker.
+        // Complete the future from a SEPARATE std::thread — the
+        // foreign-thread wake this test exists for.
         let done_for_thread = done.clone();
         let slot_for_thread = waker_slot.clone();
         let handle = std::thread::spawn(move || {
             done_for_thread.store(true, Ordering::SeqCst);
             let waker = slot_for_thread.lock().unwrap().take().unwrap();
-            // Wake from the foreign thread. This must (a) re-queue the
-            // task in the pool and (b) invoke the drive hook so the main
-            // loop knows to re-poll.
             waker.wake();
         });
         handle.join().unwrap();
 
-        // The drive hook MUST have been invoked by the foreign-thread
-        // wake — this is the link the bare LocalPool lacked.
         assert!(
             DRIVE_POKES.load(Ordering::SeqCst) >= 1,
             "foreign-thread wake must invoke the drive hook so the main \
              loop re-polls the pool (issue #7)"
         );
 
-        // Simulate the DRIVE callback the hook would have triggered: a
-        // re-poll of the pool. The task is now ready and resolves.
+        // Stand in for the DRIVE callback the hook would have triggered.
         run_until_stalled();
         assert!(
             completed.get(),
@@ -632,7 +559,6 @@ mod tests {
         spawn_local(async move {
             c.set(c.get() + 1);
         });
-        // Reset without running — task should be discarded.
         __reset_for_tests();
         run_until_stalled();
         assert_eq!(counter.get(), 0, "reset should drop pending tasks");
@@ -640,10 +566,8 @@ mod tests {
 
     #[test]
     fn spawn_local_after_reset_uses_fresh_spawner() {
-        // Regression: __reset_for_tests must rebuild SPAWNER from
-        // the fresh POOL. If we accidentally kept the old spawner,
-        // subsequent spawn_local calls would fail to enqueue on the
-        // new pool.
+        // `__reset_for_tests` must rebuild SPAWNER from the fresh POOL,
+        // or later `spawn_local` calls enqueue onto the dead one.
         let _g = lock();
         reset_all();
         __reset_for_tests();

--- a/crates/whisker-runtime/src/value.rs
+++ b/crates/whisker-runtime/src/value.rs
@@ -5,7 +5,7 @@
 //! Rust ⇄ native boundary as data rather than a handle:
 //!
 //!   - **module function args / returns** (`ElementRef::invoke`,
-//!     `PlatformModule::invoke`) — Case ② raw values, no typed-arg
+//!     `PlatformModule::invoke`) — raw values, with no typed-arg
 //!     deserialization at the boundary, and
 //!   - **event payloads** — the body Lynx hands a tap / touch /
 //!     animation handler, delivered to the Rust closure as a
@@ -26,9 +26,8 @@
 //! `serde::Deserialize` type (the typed event structs in
 //! [`crate::event`] use this). The conversion goes through
 //! `serde_json::Value` as a mature, well-tested `Deserializer`
-//! rather than hand-rolling one over `WhiskerValue` — the
-//! intermediate is in-memory (no string parse), so the binary-wire
-//! win over the old JSON-string event payload is preserved.
+//! rather than hand-rolling one over `WhiskerValue`. The intermediate
+//! is in-memory, with no string parse on the path.
 
 use std::collections::BTreeMap;
 use std::fmt;

--- a/crates/whisker-runtime/src/view/apply.rs
+++ b/crates/whisker-runtime/src/view/apply.rs
@@ -1,15 +1,9 @@
-//! `apply_*` helpers — Static-vs-Dynamic dispatch over [`Signal<T>`]
+//! `apply_*` helpers — Stored-vs-Dynamic dispatch over [`Signal<T>`]
 //! used by every prop-setting code path emitted by the macros.
 //!
-//! Lives in `whisker_runtime` (not the umbrella `whisker` crate or
-//! the proc-macro crate) so the umbrella can re-export it. Both app
-//! and module crates depend on the umbrella `whisker` and reach
-//! these via `::whisker::runtime::view::apply_styles` / `apply_attr`.
-//!
-//! The two helpers are intentionally generic over
-//! `V: Into<Signal<T>>` plus `T: ToString + Clone + 'static`, so a
-//! caller can hand them a `&'static str`, a `String`, a
-//! `ReadSignal<String>`, or any other source that
+//! They are generic over `V: Into<Signal<T>>` plus
+//! `T: ToString + Clone + 'static`, so a caller can hand them a
+//! `&'static str`, a `String`, a `ReadSignal<String>`, or anything else
 //! `From<...> for Signal<String>` covers. The `Dynamic` branch wraps
 //! the read in `effect(...)` so the value re-applies whenever the
 //! signal source changes.
@@ -22,7 +16,7 @@ use crate::view::renderer::{
 
 /// Apply an inline-styles value to `h`, picking a static vs reactive
 /// code path based on the [`Signal<T>`] variant. The `Dynamic` case
-/// wraps the read in an `effect` so the returned
+/// wraps the read in an `effect` so the
 /// [`ReadSignal<T>::get`](crate::reactive::ReadSignal::get) call
 /// registers the source as a dependency.
 pub fn apply_styles<V, T>(h: Element, v: V)
@@ -38,7 +32,7 @@ where
     }
 }
 
-/// Apply a named attribute value to `h`. Same Static / Dynamic
+/// Apply a named attribute value to `h`. Same Stored / Dynamic
 /// dispatch as [`apply_styles`].
 pub fn apply_attr<V, T>(h: Element, name: &'static str, v: V)
 where

--- a/crates/whisker-runtime/src/view/control_flow.rs
+++ b/crates/whisker-runtime/src/view/control_flow.rs
@@ -1,12 +1,12 @@
-//! (Removed in the wrapper-less control-flow refactor.)
+//! Where control flow lives.
 //!
-//! Built-in `for_each` / `show` now live as `#[component]` functions
-//! in the `whisker` crate (the user-facing layer) so they share the
-//! exact same author surface as user-defined control flow. They use
-//! the primitives exposed from this crate
-//! ([`create_phantom_element`](super::create_phantom_element),
-//! [`effect`](crate::reactive::effect), the per-control-flow function
-//! types in [`super::into_view`]).
+//! Built-in `for_each` / `show` are `#[component]` functions in the
+//! `whisker` crate (the user-facing layer), so they share the exact
+//! same author surface as user-defined control flow. They build on the
+//! primitives this crate exposes:
+//! [`create_phantom_element`](super::create_phantom_element),
+//! [`effect`](crate::reactive::effect), and the per-control-flow
+//! function types in [`super::into_view`].
 //!
 //! Custom control flow follows the same outline:
 //!

--- a/crates/whisker-runtime/src/view/into_view.rs
+++ b/crates/whisker-runtime/src/view/into_view.rs
@@ -6,9 +6,8 @@
 //! components nested inside `render!`).
 //!
 //! The trait is intentionally minimal: every implementor produces a
-//! `View`. A `View` is either a single element, a fragment of
-//! children, or a "marker" view (used by `Show`/`For` to mark
-//! reactive boundaries — Phase 6.5a A3 Step 4).
+//! [`View`], which is a single element, a text snippet, a fragment of
+//! children, or empty.
 
 use super::handle::Element;
 
@@ -26,14 +25,9 @@ pub trait IntoView {
 /// the component body invokes it to materialise the children at the
 /// point in the tree where they should appear.
 ///
-/// Two design points:
-///
-/// - `Fn` (not `FnOnce`) so the closure can be re-invoked across
-///   hot-reload remounts and similar "re-run the body" paths.
-/// - `Rc` (not `Box`) so `Children` itself implements `Clone`. The
-///   `#[component]` macro re-clones every prop on every body
-///   invocation, so a `Children` prop has to be a cheaply-cloneable
-///   handle — `Rc<dyn Fn>` is one machine word.
+/// `Fn` (not `FnOnce`) so the closure survives being re-invoked across
+/// hot-reload remounts, and `Rc` (not `Box`) so `Children` is `Clone` —
+/// `#[component]` re-clones every prop on every body invocation.
 pub type Children = ::std::rc::Rc<dyn ::std::ops::Fn() -> View + 'static>;
 
 /// Mount a `Children` prop at the current position in the tree.
@@ -44,15 +38,11 @@ pub type Children = ::std::rc::Rc<dyn ::std::ops::Fn() -> View + 'static>;
 /// hands this back to the parent's `.child(...)` chain so the parent
 /// sees a single Element handle, exactly like any other child node.
 ///
-/// `&Children` (not `Children`) on purpose — `Rc::clone` would also
-/// work, but a borrow makes the FnMut re-invocation case unambiguous:
-/// nothing here moves out of the surrounding `#[component]` body,
-/// so the hot-reload outer can re-call without `cannot move out of`.
-///
-/// Calling the children closure here is a `Fn::call(&self, ())`,
-/// which only takes `&Rc<…>` — the children Rc itself is left
-/// untouched and can be passed to additional `mount_children` calls
-/// at other positions (multi-projection a la Leptos `ChildrenFn`).
+/// Takes `&Children` so nothing moves out of the surrounding
+/// `#[component]` body and the hot-reload outer can re-call it without
+/// `cannot move out of`. The children `Rc` is left untouched, so it can
+/// be handed to further `mount_children` calls at other positions
+/// (multi-projection a la Leptos `ChildrenFn`).
 pub fn mount_children(children: &Children) -> Element {
     let ph = super::create_phantom_element();
     let view = children();
@@ -60,13 +50,10 @@ pub fn mount_children(children: &Children) -> Element {
     ph
 }
 
-// Function-shaped prop types for control-flow components.
-//
-// These newtypes let `#[component]`-annotated control-flow functions
-// (`For`, `Show`, user-defined ones) accept closure literals via
-// `Into` in the typed-builder `Props`. Each wraps `Rc<dyn Fn>` (not
-// `Box`) so the newtype is `Clone` — `#[component]` re-clones every
-// prop on each body invocation, matching what [`Children`] does.
+// Function-shaped prop types for control-flow components. These
+// newtypes let `#[component]`-annotated control-flow functions accept
+// closure literals via `Into` in the typed-builder `Props`, and wrap
+// `Rc<dyn Fn>` for the same `Clone` reason as [`Children`].
 
 /// `Fn() -> Vec<T>` — the "what items to render" closure for a
 /// keyed-list control flow. Wrapping in a newtype gives typed-builder
@@ -179,13 +166,10 @@ impl WhenFn {
 /// `fallback: || …`.
 ///
 /// `From<F: Fn() -> Element + 'static>` lets a closure literal flow
-/// through typed-builder's `Into<Fallback>` path; `Default` (used
-/// via `#[prop(default)]`) is `None`. (`Fallback` uses an
-/// element-returning closure rather than `Children`'s
-/// view-returning shape because the typical fallback is a single
-/// component invocation like `|| render! { status_banner(...) }`,
-/// which evaluates to `Element`. The implementation re-wraps it
-/// into a `View::Element` before attaching.)
+/// through typed-builder's `Into<Fallback>` path; `Default` (used via
+/// `#[prop(default)]`) is `None`. The closure returns an `Element`
+/// rather than `Children`'s `View` because the typical fallback is a
+/// single component invocation like `|| render! { status_banner(...) }`.
 #[derive(Clone, Default)]
 pub struct Fallback(pub Option<::std::rc::Rc<dyn ::std::ops::Fn() -> Element + 'static>>);
 
@@ -300,17 +284,11 @@ impl<T: IntoView> IntoView for Option<T> {
     }
 }
 
-// Text-shaped `IntoView` impls.
-//
-// Inside `render!`, any `{expr}` that evaluates to a string- or
-// number-shaped value is routed through one of these into a
-// `View::Text`, which becomes a `raw_text` element when the surrounding
-// effect's `attach_to` runs. This is what lets the user write
-// `text { {count.get()} }` and `text { {label} }` interchangeably.
-//
-// We intentionally avoid a blanket `impl<T: Display>` to keep the
-// surface predictable and the orphan rules tractable — primitives
-// list explicitly, custom types implement `IntoView` themselves.
+// Text-shaped `IntoView` impls. These are what let a `{expr}` inside
+// `render!` interpolate a scalar directly. No blanket
+// `impl<T: Display>`: an explicit list keeps the surface predictable
+// and the orphan rules tractable, and custom types implement
+// `IntoView` themselves.
 
 impl IntoView for String {
     fn into_view(self) -> View {

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -1,26 +1,20 @@
 //! View layer — element handles, type-erased renderer, `IntoView`.
 //!
-//! This is the surface the new (Phase 6.5a) `render!` macro emits
-//! against. It deliberately mirrors the shape of [`crate::renderer`]
-//! but with two key differences:
+//! This is the surface the `render!` macro emits against. Two choices
+//! shape it, both matching the reactive runtime's own pattern of a
+//! thread-local arena behind opaque handles:
 //!
-//! 1. **Type-erased handle**. The new system uses a single
-//!    [`Element`] (a `Copy` newtype around a `u32` ID) regardless
-//!    of which backend is mounted. The renderer maps these IDs to
-//!    whatever concrete types it needs internally — `MockRenderer`
-//!    keeps a `HashMap<u32, MockOp>`, the production bridge maps each
-//!    to a `Rc<LynxElement>`.
+//! 1. **Type-erased handle**. A single [`Element`] (a `Copy` newtype
+//!    around a `u32` ID) regardless of which backend is mounted. The
+//!    renderer maps these IDs to whatever concrete types it needs
+//!    internally — `MockRenderer` keeps a `HashMap<u32, MockOp>`, the
+//!    production bridge maps each to a `Rc<LynxElement>`.
 //!
-//! 2. **Thread-local active renderer**. The macro expansion calls
-//!    free functions ([`create_element`], [`set_attribute`], etc.)
-//!    that dispatch through a thread-local "currently mounted"
-//!    renderer. Avoids threading `R` through every closure the macro
+//! 2. **Thread-local active renderer**. The macro expansion calls free
+//!    functions ([`create_element`], [`set_attribute`], etc.) that
+//!    dispatch through a thread-local "currently mounted" renderer,
+//!    rather than threading an `R` through every closure the macro
 //!    generates.
-//!
-//! Both choices match the reactive runtime's pattern (thread-local
-//! arena, opaque handles). The old [`crate::renderer::Renderer`]
-//! trait + [`crate::render`] module stay until A3 Step 5 deletes
-//! them; both APIs co-exist during the transition.
 
 pub mod apply;
 pub mod control_flow;
@@ -61,9 +55,7 @@ pub use renderer::{
 // Renderer-wiring internals. Public because `whisker-driver` (and test
 // renderers) link against them across the crate boundary and the macro
 // expansions name them by path — but NOT part of the app- or
-// module-author API. `#[doc(hidden)]` keeps them out of docs.rs and
-// signals "do not depend on this" without breaking the existing
-// cross-crate references.
+// module-author API, hence `#[doc(hidden)]`.
 #[doc(hidden)]
 pub use renderer::{
     DynRenderer, EventDispatchPlan, PHANTOM_BASE, current_renderer_id, element_sign,

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -72,24 +72,6 @@ pub struct EventDispatchPlan {
     pub firings: Vec<EventFiring>,
 }
 
-/// Object-safe renderer trait. The renderer owns whatever per-element
-/// state it needs and answers in `Element` IDs.
-///
-/// Mirrors the shape of [`crate::renderer::Renderer`] but is
-/// type-erased — the handle type is always [`Element`]. Existing
-/// `R: Renderer` implementations bridge into here via a small adapter
-/// that maintains its own `Element → R::Element` map.
-/// All mutating methods take `&self`, not `&mut self`. This is the
-/// core of the re-entrancy fix for whisker issue #3: a native event
-/// can fire *synchronously* during a renderer operation (e.g. Lynx
-/// teardown inside [`remove_child`](Self::remove_child) triggering a
-/// UIKit callback that dispatches a custom event), which re-enters the
-/// renderer through [`dispatch_event`]. With `&self` methods the
-/// thread-local [`CURRENT_RENDERER`] is held by a *shared* borrow in
-/// [`with_renderer`], so a re-entrant call (also shared) is permitted
-/// rather than panicking with "RefCell already borrowed". Renderers
-/// own their mutable state behind per-field `RefCell`s and must scope
-/// each field borrow so it does **not** span a re-entrant FFI call.
 /// One `<list>` diff-action entry as it crosses the renderer: the
 /// resolved (stable) item-key plus the per-item layout metadata Lynx's
 /// adapter ingests from the action stream. For inserts `position` is
@@ -107,12 +89,26 @@ pub struct ListItemAction {
     pub recyclable: bool,
 }
 
+/// Object-safe renderer trait. The renderer owns whatever per-element
+/// state it needs and answers in [`Element`] IDs.
+///
+/// All mutating methods take `&self`, not `&mut self`, so the renderer
+/// survives re-entrancy: a native event can fire *synchronously*
+/// during a renderer operation (e.g. Lynx teardown inside
+/// [`remove_child`](Self::remove_child) triggering a UIKit callback
+/// that dispatches a custom event) and re-enter through
+/// [`dispatch_event`]. With `&self` methods the thread-local
+/// [`CURRENT_RENDERER`] is held by a *shared* borrow in
+/// [`with_renderer`], so the nested call is granted instead of
+/// panicking with "RefCell already borrowed". Renderers own their
+/// mutable state behind per-field `RefCell`s and must scope each field
+/// borrow so it does **not** span a re-entrant FFI call.
 pub trait DynRenderer {
     fn create_element(&self, tag: ElementTag) -> Element;
-    /// Phase 7: tag-by-name dispatch for custom / xelement-style
-    /// tags ("x-input", etc.) not in the built-in [`ElementTag`]
-    /// enum. Returns [`Element::INVALID`] when the tag is unknown
-    /// to Lynx's behaviour registry.
+    /// Tag-by-name dispatch for custom / xelement-style tags
+    /// ("x-input", etc.) not in the built-in [`ElementTag`] enum.
+    /// Returns a handle whose [`id`](Element::id) is `u32::MAX` when the
+    /// tag is unknown to Lynx's behaviour registry.
     fn create_element_by_name(&self, tag_name: &str) -> Element;
     fn release_element(&self, handle: Element);
 
@@ -281,8 +277,6 @@ pub trait DynRenderer {
     /// crate having to know about the bridge's C types. Renderers
     /// that don't have a native pointer return `0`, which the
     /// driver surfaces as `WhiskerValue::Error` to the caller.
-    ///
-    /// Phase 7-Φ.H.2.3.
     fn module_component_ptr(&self, _handle: Element) -> usize {
         0
     }
@@ -301,28 +295,21 @@ thread_local! {
     /// relationship the runtime has emitted. Maintained by
     /// [`append_child`] / [`remove_child`].
     ///
-    /// Used by `mount_component_remountable` (#17 wrapper-removal
-    /// follow-up) to compute the "previous sibling at mount time"
-    /// anchor without asking Lynx — Lynx's C API doesn't expose a
-    /// child-position query, and we'd rather not add one. Side
-    /// effect: the mirror also enables `previous_sibling` /
-    /// `next_sibling` queries for any future need (e.g. insert_after
-    /// shimming when we ship the wrapper-less remount path).
+    /// The mirror exists because Lynx's C API exposes no
+    /// child-position query, so sibling/index lookups (component
+    /// remount anchors, phantom hoisting) have nowhere else to read
+    /// child order from.
     static CHILDREN_OF: RefCell<HashMap<Element, Vec<Element>>> =
         RefCell::new(HashMap::new());
 
     /// Reverse direction of [`CHILDREN_OF`]: child → its mirror
     /// parent. Maintained in lockstep with [`append_child`] /
-    /// [`remove_child`]. We need this to walk *up* the mirror — the
-    /// [phantom hoisting](create_phantom_element) machinery looks for
-    /// the nearest non-phantom ancestor on every tree mutation, and
-    /// the mirror-only direction is the only place that information
-    /// lives.
+    /// [`remove_child`] so [phantom hoisting](create_phantom_element)
+    /// can walk *up* to the nearest non-phantom ancestor.
     ///
-    /// Each child has at most one parent (we don't model the DOM's
-    /// "move from one parent to another" — every move is detach +
-    /// re-attach through us). Missing-entry = the child is currently
-    /// detached (no parent).
+    /// Each child has at most one parent — every move is a detach +
+    /// re-attach through us, never a DOM-style reparent. A missing
+    /// entry means the child is currently detached.
     static PARENT_OF: RefCell<HashMap<Element, Element>> =
         RefCell::new(HashMap::new());
 
@@ -337,11 +324,7 @@ thread_local! {
     static PHANTOM_ELEMENTS: RefCell<HashSet<Element>> =
         RefCell::new(HashSet::new());
 
-    /// Monotonic counter for phantom IDs, starting at [`PHANTOM_BASE`]
-    /// (`1 << 31`). The bridge renderer allocates real IDs from 0
-    /// upward, so the two ranges can't realistically collide (a
-    /// session would need 2 billion real elements before the real
-    /// counter reached `PHANTOM_BASE`).
+    /// Monotonic counter for phantom IDs, starting at [`PHANTOM_BASE`].
     static NEXT_PHANTOM_ID: Cell<u32> = const { Cell::new(PHANTOM_BASE) };
 }
 
@@ -360,9 +343,10 @@ pub fn install_renderer(r: Box<dyn DynRenderer>) -> Option<Box<dyn DynRenderer>>
     CURRENT_RENDERER.with_borrow_mut(|slot| slot.replace(r))
 }
 
-/// Remove the current renderer, returning it to the caller. The
-/// thread-local slot is left `None`. Subsequent dispatch calls warn
-/// (in debug) and no-op.
+/// Restore `prev` (typically what [`install_renderer`] handed back) as
+/// the current renderer, dropping whatever is installed now. Passing
+/// `None` leaves the slot empty, after which dispatch calls warn (in
+/// debug) and no-op.
 pub fn uninstall_renderer(prev: Option<Box<dyn DynRenderer>>) {
     CURRENT_RENDERER.with_borrow_mut(|slot| *slot = prev);
 }
@@ -391,18 +375,15 @@ pub fn current_renderer_id() -> Option<&'static str> {
 /// Run `f` against the installed renderer under a **shared** borrow of
 /// the [`CURRENT_RENDERER`] slot.
 ///
-/// The shared borrow is the re-entrancy fix: `RefCell` permits any
-/// number of simultaneous shared borrows, so if `f` (e.g. a
-/// `remove_child` that synchronously tears down native views) causes a
-/// native callback to re-enter Whisker through [`dispatch_event`] →
-/// another `with_renderer`, that nested shared borrow is granted
-/// instead of aborting with "already borrowed". This works because
-/// every [`DynRenderer`] method now takes `&self` and owns its mutable
-/// state behind interior `RefCell`s.
+/// The borrow must stay shared: if `f` (e.g. a `remove_child` that
+/// synchronously tears down native views) causes a native callback to
+/// re-enter Whisker through [`dispatch_event`] → another
+/// `with_renderer`, `RefCell` grants the nested shared borrow instead
+/// of aborting with "already borrowed".
 ///
-/// Slot *swapping* ([`install_renderer`] / [`uninstall_renderer`])
-/// still uses `with_borrow_mut`; those are never called during
-/// dispatch, so they can't conflict with an outstanding shared borrow.
+/// Slot *swapping* ([`install_renderer`] / [`uninstall_renderer`]) uses
+/// `with_borrow_mut`; those are never called during dispatch, so they
+/// can't conflict with an outstanding shared borrow.
 fn with_renderer<R>(f: impl FnOnce(&dyn DynRenderer) -> R, default: R) -> R {
     CURRENT_RENDERER.with_borrow(|slot| match slot.as_ref() {
         Some(r) => f(r.as_ref()),
@@ -417,10 +398,8 @@ fn with_renderer<R>(f: impl FnOnce(&dyn DynRenderer) -> R, default: R) -> R {
 // Free-function dispatch — what the `render!` macro and reactive
 // effects call.
 
-/// Free-fn helper used by the `render!` macro and reactive effects to
-/// allocate an element of any tag the bridge knows. Routes both the
-/// built-in `ElementTag` enum and tag-by-name strings through the
-/// same owner-tracking + invalid-handle logic.
+/// Allocate an element by tag name, registering it with the current
+/// reactive owner so `Owner::dispose` releases it.
 pub fn create_element_by_name(tag_name: &str) -> Element {
     let handle = with_renderer(|r| r.create_element_by_name(tag_name), Element(u32::MAX));
     if handle.id() != u32::MAX {
@@ -437,10 +416,10 @@ pub fn create_element_by_name(tag_name: &str) -> Element {
 
 pub fn create_element(tag: ElementTag) -> Element {
     let handle = with_renderer(|r| r.create_element(tag), Element(u32::MAX));
-    // Register the element with the current reactive owner so
-    // `Owner::dispose` releases it. Without this, `BridgeRenderer`'s
-    // element map (and Lynx FiberElement refcounts) accumulate across
-    // `<Show>` flips, `<For>` removals, and component remounts.
+    // Register with the current reactive owner so `Owner::dispose`
+    // releases it — otherwise the renderer's element map and Lynx's
+    // FiberElement refcounts accumulate across every `<Show>` flip,
+    // `<For>` removal, and component remount.
     if handle.id() != u32::MAX {
         crate::reactive::with_runtime(|rt| {
             if let Some(owner_id) = rt.current_owner() {
@@ -476,23 +455,16 @@ pub fn release_element(handle: Element) {
 /// attached under a phantom is hoisted to the phantom's nearest
 /// non-phantom mirror ancestor in Lynx, preserving source order.
 ///
-/// Phantom IDs come from [`NEXT_PHANTOM_ID`], starting at
-/// [`PHANTOM_BASE`] (`1 << 31`); the bridge renderer's real-element
-/// counter starts at 0, so the two ranges are disjoint in any
-/// realistic session.
-///
-/// Owner-tracking parity: the freshly-allocated phantom is added to
-/// the currently-active reactive owner's `elements` list, so the
-/// same dispose-cascade that releases real elements also reaches
-/// phantoms — [`release_element`] detects the phantom case and
-/// clears its mirror + set membership without touching Lynx.
+/// The phantom joins the current reactive owner's `elements` list like
+/// a real element, so the same dispose-cascade reaches it;
+/// [`release_element`] then clears its mirror state without touching
+/// Lynx.
 ///
 /// **Use case**: the wrapper-less `fragment` builtin and the
 /// `For` / `Show` control-flow components — each allocates one
 /// phantom as its "transparent grouping" element so its reactive
-/// children appear in the user's mirror tree as a group while
-/// landing in Lynx as flat siblings of the surrounding non-phantom
-/// container.
+/// children appear in the mirror tree as a group while landing in Lynx
+/// as flat siblings of the surrounding non-phantom container.
 pub fn create_phantom_element() -> Element {
     let id = NEXT_PHANTOM_ID.with(|c| {
         let id = c.get();
@@ -513,10 +485,9 @@ pub fn create_phantom_element() -> Element {
     handle
 }
 
-/// Whether `handle` was allocated by [`create_phantom_element`].
-/// Cheap thread-local lookup — the bridge dispatchers below call
-/// this on every tree-mutation to decide whether to skip the FFI
-/// step.
+/// Whether `handle` was allocated by [`create_phantom_element`]. The
+/// dispatchers below call this on every tree mutation to decide
+/// whether to skip the FFI step.
 pub fn is_phantom(handle: Element) -> bool {
     if handle.id() < PHANTOM_BASE {
         return false;
@@ -528,11 +499,9 @@ pub fn is_phantom(handle: Element) -> bool {
 /// until a non-phantom ancestor is found. Returns `None` if `start`
 /// has no parent or the entire chain to the root is phantoms.
 ///
-/// `start` may itself be either a phantom or a real element — the
-/// function just looks at its ancestors. For the hoisting path the
-/// caller usually passes the *parent* of the just-mutated child,
-/// because the child's own type isn't what determines the
-/// effective Lynx parent; the surrounding tree is.
+/// The hoisting path passes the *parent* of the just-mutated child:
+/// what determines the effective Lynx parent is the surrounding tree,
+/// not the child's own type.
 fn nearest_real_ancestor(start: Element) -> Option<Element> {
     let mut current = start;
     loop {
@@ -711,7 +680,6 @@ pub fn install_list_native_item_provider(
 ///     phantom is later attached to a real ancestor, the same
 ///     replay path handles the queued descendants in source order.
 pub fn append_child(parent: Element, child: Element) {
-    // Mirror update — unconditional.
     CHILDREN_OF.with_borrow_mut(|map| {
         map.entry(parent).or_default().push(child);
     });
@@ -719,16 +687,13 @@ pub fn append_child(parent: Element, child: Element) {
         map.insert(child, parent);
     });
 
-    // Realize on the Lynx side. When both ends are real, this is the
-    // hot path — a direct O(1) tail append.
     if !realize_hoisted_child(parent, child) {
         with_renderer(|r| r.append_child(parent, child), ());
     }
 
-    // Wrapper-less component mount handshake: if `child` is the body
-    // root of a freshly-mounted `#[component]`, its MountSite now
-    // learns where it landed (parent + previous sibling). Hot-reload
-    // remount uses this to keep mount sites anchored across patches.
+    // If `child` is the body root of a freshly-mounted `#[component]`,
+    // its MountSite learns where it landed — hot-reload remount reads
+    // that anchor to put the replacement back in the same place.
     crate::reactive::on_component_root_attached(parent, child);
 }
 
@@ -746,22 +711,18 @@ fn realize_hoisted_child(parent: Element, child: Element) -> bool {
     let parent_is_phantom = is_phantom(parent);
     let child_is_phantom = is_phantom(child);
     if parent_is_phantom {
-        // Hoist into the nearest real ancestor. When no real ancestor
-        // exists yet (topmost phantom still detached), skip the bridge
-        // step — the next attach will replay things.
+        // No real ancestor yet (topmost phantom still detached) means
+        // nothing to tell Lynx — the next attach replays this subtree.
         if let Some(real_anc) = nearest_real_ancestor(parent) {
             let to_attach: Vec<Element> = if child_is_phantom {
                 collect_transparent_real_descendants(child)
             } else {
                 vec![child]
             };
-            // Insert back-to-front: each child's positioned-insert
-            // reference is its next real sibling, which must already be
-            // in the Lynx tree. Attaching the last child first makes each
-            // subsequent (earlier) child's reference a node inserted a
-            // step ago — a forward pass would reference batch-mates that
-            // don't exist on-device yet, and Lynx would drop all but the
-            // final (append-with-null-reference) child.
+            // Back-to-front: each child's positioned-insert reference
+            // is its next real sibling, so it must already be in the
+            // Lynx tree. A forward pass references batch-mates that
+            // aren't on-device yet and Lynx drops all but the last.
             for real in to_attach.into_iter().rev() {
                 let pos = count_real_descendants_before(real_anc, real);
                 bridge_insert_or_append(real_anc, real, pos);
@@ -769,11 +730,7 @@ fn realize_hoisted_child(parent: Element, child: Element) -> bool {
         }
         true
     } else if child_is_phantom {
-        // Phantom child carries a transparent subtree; replay any real
-        // descendants at their positions. Back-to-front so each
-        // positioned-insert reference (the next real sibling) is already
-        // in the Lynx tree — see the reversed loop in the phantom-parent
-        // branch above for why a forward pass drops all but one child.
+        // Back-to-front for the same reason as the branch above.
         for real in collect_transparent_real_descendants(child)
             .into_iter()
             .rev()
@@ -831,15 +788,11 @@ pub fn remove_child(parent: Element, child: Element) {
 /// *after* it in Lynx is the next real descendant (`position + 1`), if
 /// any — that's the reference node for a positioned insert.
 ///
-/// The production `BridgeRenderer` (backed by Lynx v3.8.0-whisker.13+)
-/// reports `supports_insert_before`, so this is one native bridge call
-/// with no sibling churn. The append + rotate below is the generic
-/// algorithm for renderers *without* positioned insert (test mocks, a
-/// future non-Lynx backend): append to the tail, then detach every real
-/// sibling that must sit after `real_child` and re-append it past the
-/// child. That detach + reattach re-anchors stateful native siblings (an
-/// `<input>` loses focus) — which is exactly why the Lynx path never
-/// takes it.
+/// A renderer reporting `supports_insert_before` gets one native call
+/// with no sibling churn. The append + rotate fallback (test mocks, a
+/// Lynx too old for the capi) detaches and re-appends every real
+/// sibling that must sit after `real_child`, which re-anchors stateful
+/// native siblings — a focused `<input>` loses focus.
 fn bridge_insert_or_append(real_parent: Element, real_child: Element, position: usize) {
     let real_descendants = collect_transparent_real_descendants(real_parent);
     let reference = real_descendants.get(position + 1).copied();
@@ -852,9 +805,8 @@ fn bridge_insert_or_append(real_parent: Element, real_child: Element, position: 
         return;
     }
 
-    // Generic path (no positioned insert): append then rotate.
-    // `real_descendants` already includes `real_child` at `position`, so
-    // the "after" slice is everything past it.
+    // `real_descendants` already includes `real_child` at `position`,
+    // so the siblings to rotate past it are everything after it.
     with_renderer(|r| r.append_child(real_parent, real_child), ());
     if position + 1 < real_descendants.len() {
         let to_move: Vec<Element> = real_descendants[position + 1..].to_vec();
@@ -872,10 +824,8 @@ fn bridge_insert_or_append(real_parent: Element, real_child: Element, position: 
 /// the Lynx side: `child` is realized with a positioned insert
 /// ([`bridge_insert_or_append`] → native `insert_before` on Lynx), so a
 /// stateful native sibling (a focused `<input>`, a scrolled list) keeps
-/// its state — unlike the old detach-siblings / append / re-append
-/// simulation this replaced.
+/// its state.
 pub fn insert_child_at(parent: Element, child: Element, index: usize) {
-    // Mirror update — insert at `index` (append if out of range).
     CHILDREN_OF.with_borrow_mut(|map| {
         let children = map.entry(parent).or_default();
         if index < children.len() {
@@ -888,9 +838,6 @@ pub fn insert_child_at(parent: Element, child: Element, index: usize) {
         map.insert(child, parent);
     });
 
-    // Realize at the mirror position. Both-real case: a positioned
-    // insert (native `insert_before`), not a tail append — so the child
-    // lands at `index` without moving its following siblings.
     if !realize_hoisted_child(parent, child) {
         let pos = count_real_descendants_before(parent, child);
         bridge_insert_or_append(parent, child, pos);
@@ -984,12 +931,11 @@ pub fn flush() {
     with_renderer(|r| r.flush(), ())
 }
 
-/// Opaque platform pointer for `handle`. Phase 7-Φ.H.2.3 — used by
-/// `whisker-driver`'s `ElementRef::invoke` to call the C bridge
-/// without leaking the bridge's `WhiskerElement*` type into the
-/// runtime crate's public surface. Returns `0` if no renderer is
-/// installed or the renderer doesn't have a native pointer for
-/// `handle`.
+/// Opaque platform pointer for `handle` — used by `whisker-driver`'s
+/// `ElementRef::invoke` to call the C bridge without leaking the
+/// bridge's `WhiskerElement*` type into the runtime crate's public
+/// surface. Returns `0` if no renderer is installed or the renderer
+/// doesn't have a native pointer for `handle`.
 pub fn module_component_ptr(handle: Element) -> usize {
     if is_phantom(handle) {
         return 0;

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -50,9 +50,8 @@ enum Op {
 
 #[derive(Default)]
 struct RecordingRenderer {
-    // `Cell` because `DynRenderer` methods take `&self` now (the
-    // re-entrancy fix): the renderer owns its mutable state behind
-    // interior mutability instead of `&mut self`.
+    // `Cell` because `DynRenderer` methods take `&self`: a renderer owns
+    // its mutable state behind interior mutability.
     next_id: std::cell::Cell<u32>,
     ops: std::rc::Rc<std::cell::RefCell<Vec<Op>>>,
     /// When set, the renderer advertises positioned insert and records
@@ -299,9 +298,8 @@ fn view_attach_appends_each_leaf() {
 /// to a PHANTOM slot (`mount_children`), then that phantom is appended to a
 /// REAL parent (`append_child(root, content)`). Every real child must reach
 /// the renderer attached to the real root — the mirror's phantom-hoist must
-/// not drop the 2nd..Nth child. (Pins the layer for the Android
-/// "only the first Router child mounts" symptom: if this passes, the mirror
-/// is correct and the divergence is renderer/bridge-side.)
+/// not drop the 2nd..Nth child. If this passes, the mirror is correct and
+/// any "only the first child mounts" divergence is renderer/bridge-side.
 #[test]
 fn multi_child_fragment_through_phantom_slot_hoists_all_children() {
     let (renderer, log) = RecordingRenderer::with_log();
@@ -347,7 +345,7 @@ fn multi_child_fragment_through_phantom_slot_hoists_all_children() {
 /// time of the insert — Lynx's `InsertNodeBefore` needs the reference to
 /// be a live child of the parent. A reference pointing at a batch-mate
 /// that hasn't been inserted yet silently fails on-device, dropping all
-/// but one child (the "only the first history card renders" symptom).
+/// but one child.
 #[test]
 fn multi_child_hoist_insert_support_references_already_present() {
     let (renderer, log) = RecordingRenderer::with_log_insert_support();
@@ -402,10 +400,10 @@ fn multi_child_hoist_insert_support_references_already_present() {
 
 #[test]
 fn phantom_hoist_into_non_tail_position_uses_positioned_insert() {
-    // A renderer that supports positioned insert must place a
-    // hoisted child with a single `insert_before` and NOT rotate the
-    // following sibling (the append + rotate that detaches a stateful
-    // native sibling and drops its focus).
+    // A renderer that supports positioned insert must place a hoisted
+    // child with a single `insert_before` and NOT rotate the following
+    // sibling — the rotate detaches a stateful native sibling and drops
+    // its focus.
     let (renderer, log) = RecordingRenderer::with_log_insert_support();
     let (root, a, b) = with_installed_renderer(Box::new(renderer), || {
         let root = create_element(ElementTag::View);
@@ -441,8 +439,8 @@ fn phantom_hoist_into_non_tail_position_uses_positioned_insert() {
 #[test]
 fn insert_child_at_non_tail_uses_positioned_insert_not_rotate() {
     // `insert_child_at` (hot-reload remount) must place the child with a
-    // single `insert_before` and leave the following siblings attached —
-    // not detach + re-append them (the old rotate).
+    // single `insert_before` and leave the following siblings attached,
+    // not detach and re-append them.
     let (renderer, log) = RecordingRenderer::with_log_insert_support();
     let (root, b, c, d) = with_installed_renderer(Box::new(renderer), || {
         let root = create_element(ElementTag::View);
@@ -478,12 +476,12 @@ fn insert_child_at_non_tail_uses_positioned_insert_not_rotate() {
 }
 
 // ===========================================================================
-// Re-entrancy (whisker #3) — these tests pin the root-cause fix: a native
-// event that fires *synchronously during* a renderer operation must be able
-// to re-enter the dispatch path without aborting on "RefCell already
-// borrowed". The fix is: `DynRenderer` methods take `&self`, renderers own
-// their state behind interior `RefCell`s with FFI-scoped borrows, and
-// `with_renderer` takes a *shared* borrow of the renderer slot.
+// Re-entrancy — a native event that fires *synchronously during* a renderer
+// operation must be able to re-enter the dispatch path without aborting on
+// "RefCell already borrowed". That rests on three things: `DynRenderer`
+// methods take `&self`, renderers own their state behind interior
+// `RefCell`s with FFI-scoped borrows, and `with_renderer` takes a *shared*
+// borrow of the renderer slot.
 // ===========================================================================
 mod reentrancy {
     use super::*;
@@ -635,12 +633,10 @@ mod reentrancy {
 
     /// Re-entrant *renderer op* during a renderer op does not panic.
     /// `remove_child` synchronously calls back into `set_attribute`
-    /// (another `with_renderer` shared borrow). Pre-fix this aborted
-    /// with "already borrowed".
+    /// (another `with_renderer` shared borrow).
     #[test]
     fn reentrant_renderer_op_during_remove_does_not_panic() {
         let (renderer, log) = ReentrantRenderer::new();
-        // Install a hook that re-enters the public dispatch path.
         *renderer.on_remove_hook.borrow_mut() = Some(Box::new(|| {
             // This goes through `with_renderer` again — a NESTED shared
             // borrow of CURRENT_RENDERER. Must be granted, not aborted.
@@ -681,8 +677,7 @@ mod reentrancy {
     /// synchronously and in order. `remove_child` synchronously
     /// dispatches an event whose listener performs another renderer op
     /// — both the outer op and the inner listener's effect are observed
-    /// in order. This proves there is no one-tick deferral (the #3
-    /// `DispatchQueue.main.async` workaround is no longer needed).
+    /// in order, so there is no one-tick deferral.
     #[test]
     fn reentrant_event_dispatch_runs_synchronously_in_order() {
         let (renderer, log) = ReentrantRenderer::new();

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -2,11 +2,10 @@
 //! item provider (Lynx's `componentAtIndex` / `enqueueComponent`
 //! contract) on demand.
 //!
-//! Per whisker#83 the reusable core is split from the element it drives:
-//! `ListMount = Virtualizer + <list> element`; a future `PagerMount`
-//! would be `Virtualizer + <module element>`. This module is that
-//! `Virtualizer` — it knows nothing about `<list>` specifically, only
-//! that `handle` carries a native item provider and a count broadcast.
+//! The core is deliberately split from the element it drives —
+//! `ListMount = Virtualizer + <list> element` — so it knows nothing
+//! about `<list>` specifically, only that `handle` carries a native
+//! item provider and a count broadcast.
 //!
 //! # Model (pull, on-demand)
 //!
@@ -30,17 +29,16 @@
 //! On owner disposal every live slot is disposed and the provider is
 //! released through `whisker-driver`'s `trampoline_free`.
 //!
-//! # Provider contract (verified on device)
+//! # Provider contract
 //!
 //! Lynx `ListElement::ComponentAtIndex` requires the embedder callback
 //! to **attach the item to the list** (`append_child(list, item)`) and
 //! return its `impl_id`; it then runs `OnComponentFinished` → layout
 //! over that freshly-appended subtree. Returning the sign *without*
 //! appending leaves the item unparented and the native list crashes in
-//! `OnListItemWillAppear` (null `element_container`) — found on device,
-//! fixed by the `append_child` here. Re-entrant element creation during
-//! the callback is safe (the bridge renderer holds no field borrow
-//! across an FFI call, #214).
+//! `OnListItemWillAppear` (null `element_container`). Re-entrant
+//! element creation during the callback is safe — the bridge renderer
+//! holds no field borrow across an FFI call.
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -89,8 +87,8 @@ pub struct ItemMeta<K> {
 
 impl<K> ItemMeta<K> {
     /// Stable logical identity — the same key must identify the same
-    /// item across data updates (it drives the native reorder /
-    /// insert / remove diff, exactly like the former `key:` prop).
+    /// item across data updates, since it drives the native reorder /
+    /// insert / remove diff.
     pub fn key(key: K) -> Self {
         Self {
             key,
@@ -185,10 +183,9 @@ impl MetaFields {
 /// remove → insert → update in that order).
 ///
 /// A reorder that survives neither prefix nor suffix degrades to a
-/// full-window remove+insert — same identity loss as the legacy full
-/// replace, no worse. When the renderer can't deliver explicit actions
-/// (a Lynx build predating the capi, or a test renderer), falls back
-/// to the full-replace [`set_update_list_info`].
+/// full-window remove+insert. When the renderer can't deliver explicit
+/// actions (a Lynx build predating the capi, or a test renderer), falls
+/// back to the full-replace [`set_update_list_info`].
 fn send_data_source_update(
     handle: Element,
     prev: &[String],
@@ -217,7 +214,6 @@ fn send_data_source_update(
     }
 
     if removals.is_empty() && inserts.is_empty() && updates.is_empty() {
-        // Identical key list + metadata — nothing to send.
         return;
     }
     if !update_list_actions(handle, &removals, &inserts, &updates) {
@@ -288,21 +284,17 @@ pub fn virtualize<T, K, ItemsFn, MetaFn, BuildFn>(
     let next_id: Rc<Cell<u64>> = Rc::new(Cell::new(0));
     let layout_id: Rc<Cell<i64>> = Rc::new(Cell::new(0));
     // Item-key list + per-key metadata from the previous data-source
-    // update — the minimal diff (common prefix/suffix splice) is
-    // computed against the keys, so untouched items keep their native
-    // identity and the list can hold its scroll position across
-    // appends; metadata changes on surviving keys become in-place
-    // update actions.
+    // update — the prefix/suffix splice diffs against these, so
+    // untouched items keep their native identity and the list holds its
+    // scroll position across appends.
     let prev_keys: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
     let prev_meta: Rc<RefCell<HashMap<String, MetaFields>>> = Rc::new(RefCell::new(HashMap::new()));
     let meta = Rc::new(meta);
     let build = Rc::new(build);
-    // Anchor slot owners to the owner active at SETUP (the list component's
-    // scope) so items built on demand in the native callback still inherit
-    // context — `use_context` / `use_navigator` walk the owner chain.
-    // `component_at_index` fires outside any reactive scope, so a detached
-    // slot owner would sever the chain (on-device: `use_navigator() outside
-    // a Router`).
+    // Anchored to the owner active at SETUP so items built on demand
+    // inherit context — `use_context` / `use_navigator` walk the owner
+    // chain, and `component_at_index` fires outside any reactive scope,
+    // where a detached slot owner would sever it.
     let parent_owner = Owner::new(None);
 
     // Dispose the deferred batch. Safe to call whenever control is back in a
@@ -318,8 +310,6 @@ pub fn virtualize<T, K, ItemsFn, MetaFn, BuildFn>(
         }
     };
 
-    // Effect: items() -> snapshot + stable item-key list + layout-id bump +
-    // data-source update (drives the native diff).
     {
         let current_items = current_items.clone();
         let layout_id = layout_id.clone();
@@ -332,11 +322,9 @@ pub fn virtualize<T, K, ItemsFn, MetaFn, BuildFn>(
         effect(move || {
             flush_pending();
             let new_items = items();
-            // Stable item-key + metadata for every item in current order
-            // (assign an id to first-seen keys). `component_at_index`
-            // stamps the matching `item-key="w_{id}"` on each built
-            // wrapper, so the native list reconciles them and can diff a
-            // reorder.
+            // `component_at_index` stamps the matching
+            // `item-key="w_{id}"` on each wrapper it builds, which is
+            // how the native list reconciles a reorder.
             let mut keys: Vec<String> = Vec::with_capacity(new_items.len());
             let mut metas: Vec<MetaFields> = Vec::with_capacity(new_items.len());
             {
@@ -389,14 +377,12 @@ pub fn virtualize<T, K, ItemsFn, MetaFn, BuildFn>(
             let build = build.clone();
             let flush_pending = flush_pending.clone();
             Box::new(move |index, _op_id, _reuse| {
-                // Dispose the previous batch of enqueued-and-detached elements.
                 flush_pending();
                 let item = match current_items.borrow().get(index as usize) {
                     Some(t) => t.clone(),
                     None => return INVALID_ITEM_INDEX,
                 };
                 let m = meta(&item);
-                // Stable id for the `item-key` (assign on first sight).
                 let id = {
                     let mut ids = key_ids.borrow_mut();
                     match ids.get(&m.key) {
@@ -409,17 +395,12 @@ pub fn virtualize<T, K, ItemsFn, MetaFn, BuildFn>(
                         }
                     }
                 };
-                // Build the slot: the virtualizer OWNS the native
-                // `list-item` wrapper (the user's `build` returns plain
-                // content). Both are created under a per-item owner
-                // (context inherited via `parent_owner`), the wrapper is
-                // stamped with the stable item-key + recycle-pool id, and
-                // ATTACHED — Lynx `ComponentAtIndex` then runs
-                // `OnComponentFinished` → layout over the appended
-                // subtree. Returning a sign without appending crashes the
-                // native list. `full-span` is stamped AFTER the append:
-                // its element-side half (the LayoutNode list-component
-                // type) only applies when the parent is already the list.
+                // The virtualizer owns the native `list-item` wrapper;
+                // the user's `build` returns plain content. The wrapper
+                // must be ATTACHED before the sign is returned (see the
+                // provider contract in the module doc), and `full-span`
+                // stamped AFTER that append — its element-side half only
+                // applies once the parent is already the list.
                 let owner = Owner::new(Some(parent_owner));
                 let (wrapper, content) = owner.with(|| {
                     let wrapper = create_element_by_name("list-item");
@@ -448,9 +429,8 @@ pub fn virtualize<T, K, ItemsFn, MetaFn, BuildFn>(
             let live = live.clone();
             let pending = pending.clone();
             Box::new(move |sign| {
-                // Move the slot to the deferred-disposal queue. Do NOT destroy
-                // it here — the native still detaches the element after this
-                // callback returns (use-after-free otherwise).
+                // Deferred, never destroyed here — the native detaches
+                // the element after this callback returns.
                 if let Some(slot) = live.borrow_mut().remove(&sign) {
                     pending.borrow_mut().push(slot);
                 }
@@ -781,7 +761,8 @@ mod tests {
         );
     }
 
-    /// One recorded `update_list_actions` call: `(removals, inserts)`.
+    /// One recorded `update_list_actions` call:
+    /// `(removals, inserts, updates)`.
     type RecordedActions = (Vec<i32>, Vec<ListItemAction>, Vec<ListItemAction>);
 
     /// Renderer that accepts explicit actions (like the real bridge on a


### PR DESCRIPTION
Part of the per-crate sweep [docs/comment-style.md](docs/comment-style.md) announces (pilot: #376; siblings: #377, #378, #379, #380). Covers the reactive core — the largest crate in the sweep.

## What was applied

User-facing rustdoc (signals, `Owner`, `resource`, props, the `DynRenderer` contract methods) keeps its concept paragraphs and examples per the guide; the cut lands on history, design diary, issue archaeology, and what-narration. Load-bearing why-nots stay, including the reverse-order batch-insert rule in `realize_hoisted_child` (a live trap) and the scheduler's deliberate exclusions from `has_pending_work`. Four files already met the bar and are untouched.

## Stale comments corrected (13 found)

The notable ones:

- **`pub trait DynRenderer` had no rustdoc at all** — its intended doc block had fused onto `ListItemAction` above it. Split and reattached.
- **`uninstall_renderer`'s doc described "returning it to the caller"** — the signature returns `()` and the body restores the previous renderer instead.
- **`remount_components_for` was documented in terms of a wrapper element** ("the wrapper stays put") that the wrapper-less path removed, and as a one-site-at-a-time loop when the implementation is a batched detach/rebuild/reinsert; its numbered inline steps also disagreed with the header (two step-4s).
- **`arc_signal` promised conversions "a follow-up may add"** — all three exist in `signal.rs`.
- References to retired modules (`crate::renderer`, the old Element value-tree diff pipeline, "A3 Step 5 deletes them"), a nonexistent `Element::INVALID` sentinel (the real sentinel is a `u32::MAX` handle), a `Signal::Static` variant that is named `Stored`, and a "no async executor on the main thread (yet)" note contradicted by `spawn_local`.

## Numbers & verification

Comment lines 4149 → 3513 (−15%); 30 files, +709/−1346. **No code changes** — verified mechanically (`git diff -U0` filtered to non-comment lines is empty). `cargo test -p whisker-runtime` 156 passed, clippy 0 warnings, `cargo fmt -p` clean. Doc-fence `ignore` markers untouched (converting them would create new doc-tests, out of scope for a comment sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)