### PR TITLE
Fix whisker-asset's iOS e2e call to the 4-arg inputs_from_with_engine

### DIFF
--- a/packages/whisker-asset/tests/plugin_e2e.rs
+++ b/packages/whisker-asset/tests/plugin_e2e.rs
@@ -64,7 +64,6 @@ fn ios_generation_lands_assets_and_folder_reference() {
     let inputs = whisker_cng::ios::inputs_from_with_engine(
         &engine,
         &app_config(),
-        PathBuf::from("/abs/platforms/ios"),
         crate_dir.join("gen/ios/whisker_modules"),
         PathBuf::from("/abs/workspace"),
         "asset-demo".into(),


### PR DESCRIPTION
#382 removed `IosInputs.whisker_runtime_path` and its constructor argument, but the call-site search was scoped to `crates/` and missed this one test under `packages/` — breaking `cargo test --workspace` on main (E0061). One line: drop the removed path argument.

Verified: `cargo build --workspace` clean, `whisker-asset` + `whisker-router` plugin e2e tests green (106 passed), clippy 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)