### PR TITLE
Fix three native-side issues the comment sweep surfaced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ platforms/ios/*.xcodeproj/
 platforms/ios/*.xcworkspace/
 platforms/bridge/build/
 
+# SwiftPM caches from standalone `swift build` runs inside a module's
+# ios/ package dir. Same story as the root `.build/`.
+packages/**/.build/
+packages/**/Package.resolved
+
 # Gradle build artifacts under per-package module trees
 # (`packages/<name>/build/`, `packages/<name>/.gradle/`). KSP outputs +
 # transform caches live there during dev; same story as native/.

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
@@ -307,15 +307,10 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
         val parsed = parseColor(color) ?: return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             et.textCursorDrawable?.setColorFilter(parsed, PorterDuff.Mode.SRC_IN)
-        } else {
-            // Pre-API-29 has no typed cursor-tint API; the caret keeps the
-            // theme color. Cosmetic only.
-            try {
-                val field = android.widget.TextView::class.java
-                    .getDeclaredField("mCursorDrawableRes")
-                field.isAccessible = true
-            } catch (_: Throwable) { }
         }
+        // Pre-API-29 the caret keeps the theme color: there is no typed
+        // cursor-tint API, and the `mCursorDrawableRes` reflection hack is
+        // greylisted from API 28. Cosmetic only.
     }
 
     fun setSelectionColor(color: String) {

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
@@ -2,10 +2,8 @@
 // (multiline) behind a unified interface. Registration is driven by
 // `InputModule`'s `definition()` — no annotations required here.
 //
-// `@objc(WhiskerInputView)` pins the Obj-C class name so the codegen
-// plugin's `NSClassFromString` lookup finds it whether the
-// SwiftPM-target-prefixed form (`whisker_input.WhiskerInputView`) or the
-// bare form is used.
+// `@objc(WhiskerInputView)` pins the Obj-C class name to the bare,
+// SwiftPM-target-unprefixed form, matching the sibling view modules.
 //
 // ## Single-line vs multiline
 //
@@ -28,7 +26,6 @@ import Foundation
 import UIKit
 import WhiskerModule
 
-@objc(WhiskerInputView)
 /// A container `UIView` that invokes `onDetach` when it leaves its
 /// window, so `WhiskerInputView` can resign first responder on teardown
 /// and a removed input never lingers as the keyboard target.
@@ -45,6 +42,7 @@ private final class DetachAwareView: UIView {
     }
 }
 
+@objc(WhiskerInputView)
 public final class WhiskerInputView: WhiskerUI<UIView> {
 
     // MARK: - Hosted controls

--- a/packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/CanvasVisitor.kt
+++ b/packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/CanvasVisitor.kt
@@ -21,7 +21,6 @@ import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Path
-import android.graphics.PorterDuff
 
 internal class CanvasVisitor(
     private val canvas: Canvas,
@@ -203,11 +202,6 @@ internal class CanvasVisitor(
 
     private fun resolveStrokeColor(): Int? =
         if (strokeIsTint) tintArgb else currentStrokeArgb
-
-    /** Consumes the otherwise-unused `PorterDuff` import so lint is
-     *  happy. */
-    @Suppress("unused")
-    private val _porterDuffUsage = PorterDuff.Mode.SRC
 
     /**
      * Multiply the colour's alpha channel by the current group opacity.


### PR DESCRIPTION
The Kotlin/Swift comment sweep (#382) verified comments against code and found these code-side issues; fixes were kept out of the comment-only PR.

## 1. `@objc(WhiskerInputView)` was on the wrong class (InputView.swift)

The attribute sat directly above the private `DetachAwareView` — evidently the helper class was later inserted between the attribute and `WhiskerInputView`, the class it names. The ObjC runtime therefore exposed `DetachAwareView` under the public view's name. Moved onto `WhiskerInputView`, restoring parity with whisker-image / whisker-video / whisker-webview.

**Severity note (downgraded from the sweep report):** investigation found no live `NSClassFromString` lookup — registration passes the class object (`def.view!.viewClass`), and the codegen explicitly states no name pinning is needed. So this was a vestigial attribute on the wrong declaration, not an observed breakage; the fix restores intent. Removing the attribute from all four view files entirely is the candidate end state, but that deserves a device pass — left as follow-up.

## 2. Dead pre-API-29 caret-color branch (WhiskerInputView.kt)

The `else` branch reflectively fetched `TextView.mCursorDrawableRes`, called `setAccessible(true)`, and then did nothing. Completing the hack is not worth shipping: the field is on Android's non-SDK greylist from API 28, making it an untestable, OS-update-fragile path for a cosmetic feature. Removed; pre-Q devices keep the theme caret color, and the limitation is now stated in one comment instead of implied by dead code.

## 3. Dead `_porterDuffUsage` field (CanvasVisitor.kt)

Existed only to consume the `PorterDuff` import. Both removed (no other usage in the file).

## Verification

Kotlin/Swift have no standalone compile gate (`swift build` of a module package fails on the Lynx xcframework having no macOS slice — pre-existing; these sources compile only inside an app's xcodebuild/gradle build). Changes are minimal and mechanical; the next CI run and device build are the compile check. Recommend a giga/example smoke on input focus + caret + svg rendering after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)