### PR TITLE
Let evaluate_javascript return the page's value

### DIFF
--- a/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WebViewModule.kt
+++ b/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WebViewModule.kt
@@ -96,16 +96,22 @@ class WebViewModule : Module() {
                 WhiskerValue.Null
             }
 
-            // One Function serves both `invoke` (ignores the return) and
-            // `invoke_typed` (awaits `{ "value": "<result>" }`).
-            //
-            // TODO: Android result-returning element methods need
-            // invoke_async wiring in lynx_native_renderer.cc, compiled
-            // iOS-only in Lynx 3.8.0-whisker.1 (memory note
-            // `whisker_element_method_results_need_async`).
+            // Fire-and-forget; the result-returning form is the
+            // AsyncFunction below.
             Function("evaluateJavaScript") { view: WhiskerWebView, args ->
                 val script = args.getOrNull(0)?.asString() ?: ""
                 view.evaluateJs(script)
+            }
+
+            // Async so the WebView's ValueCallback can carry the JS
+            // result back through the promise.
+            AsyncFunction("evaluateJavaScriptWithResult") { view: WhiskerWebView, args, promise ->
+                val script = args.getOrNull(0)?.asString()
+                if (script == null) {
+                    promise.reject("evaluateJavaScriptWithResult: missing script argument")
+                } else {
+                    view.evaluateJsWithResult(script, promise)
+                }
             }
 
             Function("canGoBack") { view: WhiskerWebView, _ ->

--- a/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WhiskerWebView.kt
+++ b/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WhiskerWebView.kt
@@ -52,6 +52,7 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import rs.whisker.runtime.WhiskerContext
 import rs.whisker.runtime.WhiskerCustomEvent
+import rs.whisker.runtime.WhiskerPromise
 import rs.whisker.runtime.WhiskerUI
 import rs.whisker.runtime.WhiskerValue
 
@@ -431,6 +432,21 @@ open class WhiskerWebView(context: WhiskerContext) :
             result = jsonDecodeString(raw)
         }
         return WhiskerValue.Map(mapOf("value" to WhiskerValue.Str(result)))
+    }
+
+    /** Evaluate JavaScript and resolve [promise] from the WebView's
+     *  callback with the JSON-encoded result string (`"null"` when the
+     *  script yields no value — including on a JS exception, which
+     *  Android's `evaluateJavascript` does not report). */
+    fun evaluateJsWithResult(script: String, promise: WhiskerPromise) {
+        val wv = view
+        if (wv == null) {
+            promise.resolve(WhiskerValue.Str("null"))
+            return
+        }
+        wv.evaluateJavascript(script) { jsonEncodedResult ->
+            promise.resolve(WhiskerValue.Str(jsonEncodedResult ?: "null"))
+        }
     }
 
     fun queryCanGoBack(): WhiskerValue =

--- a/packages/whisker-webview/ios/Sources/WhiskerWebview/WebViewModule.swift
+++ b/packages/whisker-webview/ios/Sources/WhiskerWebview/WebViewModule.swift
@@ -100,6 +100,15 @@ public final class WebViewModule: Module {
                     return view.evaluateJavaScript(script)
                 }
 
+                // Async so the WKWebView completion can carry the JS
+                // result back through the promise.
+                AsyncFunction("evaluateJavaScriptWithResult") { (view: WhiskerWebViewView, args: [WhiskerValue], promise: WhiskerPromise) in
+                    guard let script = args.first?.asString else {
+                        return promise.reject("evaluateJavaScriptWithResult: missing script argument")
+                    }
+                    view.evaluateJavaScript(script, resolving: promise)
+                }
+
                 Function("canGoBack") { (view: WhiskerWebViewView, _: [WhiskerValue]) -> WhiskerValue in
                     return view.canGoBackResult()
                 }

--- a/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
+++ b/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
@@ -281,22 +281,49 @@ public final class WhiskerWebViewView: WhiskerUI<UIView> {
         webView?.evaluateJavaScript("window.whisker._receive(\(jsString))", completionHandler: nil)
     }
 
-    /// Evaluate arbitrary JavaScript for its side effects.
-    ///
-    /// The returned `value` is ALWAYS the empty string. Lynx's `Function`
-    /// dispatch is synchronous while `evaluateJavaScript` is async, and its
-    /// completion block fires on the main queue — so waiting for the result
-    /// on a semaphore from the main thread would deadlock.
-    ///
-    /// TODO: replace with a continuation once the `AsyncFunction` DSL entry
-    /// ships; until then, callers that need the JS return value must use the
-    /// Lynx result-method mechanism directly.
+    /// Evaluate arbitrary JavaScript for its side effects. The returned
+    /// `value` is always the empty string — the completion fires after
+    /// this synchronous dispatch returns; use
+    /// [`evaluateJavaScript(_:resolving:)`] for the result.
     public func evaluateJavaScript(_ script: String) -> WhiskerValue {
         guard let wv = webView else {
             return .map(["value": .string("")])
         }
         wv.evaluateJavaScript(script, completionHandler: nil)
         return .map(["value": .string("")])
+    }
+
+    /// Evaluate JavaScript and settle `promise` from the completion:
+    /// the result as a JSON-encoded string (`"null"` when the script
+    /// yields no value), matching Android's `evaluateJavascript`
+    /// callback convention; a JS exception rejects.
+    public func evaluateJavaScript(_ script: String, resolving promise: WhiskerPromise) {
+        guard let wv = webView else {
+            promise.resolve(.string("null"))
+            return
+        }
+        wv.evaluateJavaScript(script) { value, error in
+            if let error = error {
+                promise.reject("evaluateJavaScript failed: \(error.localizedDescription)")
+                return
+            }
+            guard let value = value else {
+                promise.resolve(.string("null"))
+                return
+            }
+            // The precheck matters: `JSONSerialization.data` raises an
+            // (uncatchable) NSException for non-JSON top-level objects.
+            guard JSONSerialization.isValidJSONObject(value)
+                || value is NSString || value is NSNumber || value is NSNull,
+                let data = try? JSONSerialization.data(
+                    withJSONObject: value, options: .fragmentsAllowed),
+                let json = String(data: data, encoding: .utf8)
+            else {
+                promise.reject("evaluateJavaScript: result is not JSON-encodable")
+                return
+            }
+            promise.resolve(.string(json))
+        }
     }
 
     public func canGoBackResult() -> WhiskerValue {

--- a/packages/whisker-webview/src/lib.rs
+++ b/packages/whisker-webview/src/lib.rs
@@ -126,8 +126,8 @@
 //! - [`WebViewRef::stop_loading`] — abort the in-flight load.
 //! - [`WebViewRef::post_message`] — push a string to the page.
 //! - [`WebViewRef::evaluate_javascript`] — run script (fire-and-forget).
-//!   To read a value back, `postMessage` it from the script and handle
-//!   it in `on_message`.
+//! - [`WebViewRef::evaluate_javascript_with_result`] — async: run script
+//!   and get its completion value back as a JSON-encoded string.
 //! - [`WebViewRef::can_go_back`] / [`WebViewRef::can_go_forward`] —
 //!   async history-availability checks.
 //!
@@ -386,18 +386,34 @@ impl WebViewRef {
     }
 
     /// Run JavaScript in the page, fire-and-forget. No-op if unmounted.
-    ///
-    /// To get a value BACK from the page, have the script post it to the
-    /// host and read it via [`on_message`](web_view): e.g.
-    /// `evaluate_javascript("window.whisker.postMessage(document.title)")`
-    /// and handle it in `on_message`. There is no result-returning
-    /// variant: the native JS eval is asynchronous and the sync `Function`
-    /// dispatch it goes through cannot carry a result back.
+    /// Use [`evaluate_javascript_with_result`](Self::evaluate_javascript_with_result)
+    /// when you need the script's value.
     pub fn evaluate_javascript(&self, script: &str) {
         let _ = self.r.invoke(
             "evaluateJavaScript",
             WhiskerValue::args([WhiskerValue::String(script.to_string())]),
         );
+    }
+
+    /// Async: run JavaScript and get its completion value back as a
+    /// JSON-encoded string (`"null"` when the script yields no value).
+    ///
+    /// ```ignore
+    /// let title = webview.evaluate_javascript_with_result("document.title").await?;
+    /// // title == "\"My Page\"" — JSON-encoded, so decode as needed.
+    /// ```
+    ///
+    /// Platform asymmetry: a script that throws rejects with
+    /// [`RefError::DispatchFailed`] on iOS, but resolves `"null"` on
+    /// Android — `WebView.evaluateJavascript` cannot observe JS
+    /// exceptions.
+    pub async fn evaluate_javascript_with_result(&self, script: &str) -> Result<String, RefError> {
+        self.r
+            .invoke_typed::<String>(
+                "evaluateJavaScriptWithResult",
+                WhiskerValue::args([WhiskerValue::String(script.to_string())]),
+            )
+            .await
     }
 
     /// Async: can the view navigate back in history right now?

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -70,6 +70,7 @@ private fun registerViewBearing(viewBlock: WhiskerViewComponent) {
 
     val propComponents = viewBlock.components.filterIsInstance<WhiskerPropComponent>()
     val funcComponents = viewBlock.components.filterIsInstance<WhiskerFunctionComponent>()
+    val asyncComponents = viewBlock.components.filterIsInstance<WhiskerAsyncFunctionComponent>()
 
     if (propComponents.isNotEmpty()) {
         PropsUpdater.registerSetter(
@@ -77,10 +78,10 @@ private fun registerViewBearing(viewBlock: WhiskerViewComponent) {
             WhiskerDSLPropsSetter(propComponents),
         )
     }
-    if (funcComponents.isNotEmpty()) {
+    if (funcComponents.isNotEmpty() || asyncComponents.isNotEmpty()) {
         LynxUIMethodsExecutor.registerMethodInvoker(
             viewClass,
-            WhiskerDSLMethodInvoker(funcComponents),
+            WhiskerDSLMethodInvoker(funcComponents, asyncComponents),
         )
     }
 }
@@ -184,10 +185,13 @@ internal class WhiskerDSLPropsSetter(
  */
 internal class WhiskerDSLMethodInvoker(
     private val functions: List<WhiskerFunctionComponent>,
+    private val asyncFunctions: List<WhiskerAsyncFunctionComponent> = emptyList(),
 ) : LynxUIMethodInvoker<LynxBaseUI> {
 
     private val byName: Map<String, WhiskerFunctionComponent> =
         functions.associateBy { it.name }
+    private val asyncByName: Map<String, WhiskerAsyncFunctionComponent> =
+        asyncFunctions.associateBy { it.name }
 
     override fun invoke(
         ui: LynxBaseUI,
@@ -195,6 +199,24 @@ internal class WhiskerDSLMethodInvoker(
         params: ReadableMap?,
         callback: Callback,
     ) {
+        val asyncComponent = asyncByName[methodName]
+        if (asyncComponent != null) {
+            // The promise owns the Lynx callback — late-callable by
+            // design — and fires it once with SUCCESS; errors travel as
+            // `WhiskerValue.Err` inside the result, mirroring the sync
+            // path below.
+            val args = decodeArgs(params).map { whiskerValueOf(it) }
+            val promise = WhiskerPromise({ value ->
+                callback.invoke(LynxUIMethodConstants.SUCCESS, value.toJavaObject())
+            })
+            try {
+                asyncComponent.handler(ui, args, promise)
+            } catch (t: Throwable) {
+                promise.reject("exception while invoking `$methodName`: ${t.message}")
+            }
+            return
+        }
+
         val component = byName[methodName]
         if (component == null) {
             callback.invoke(

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerPromise.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerPromise.kt
@@ -5,23 +5,29 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * The resolver handed to an `AsyncFunction` handler (Android).
  *
- * Wraps the C bridge's completion callback + opaque `user_data` (the
- * Rust `oneshot::Sender` boxed by `PlatformModule::invoke_async`),
- * carried across JNI as raw `Long` pointers, so a module can deliver
- * its result *later* — e.g. from a RevenueCat / coroutine completion —
- * instead of returning synchronously.
+ * Wraps the completion path of an async dispatch — the C bridge's
+ * callback + opaque `user_data` (carried across JNI as raw `Long`
+ * pointers) for module-level calls, or the Lynx UI-method callback for
+ * view-bound calls — so a module can deliver its result *later*, e.g.
+ * from a RevenueCat / coroutine completion, instead of returning
+ * synchronously.
  *
  * Mirrors Expo's `Promise` (`resolve` / `reject`). One-shot: the first
  * `resolve`/`reject` wins and fires the callback exactly once; further
  * calls are ignored, matching the Rust side whose `async_trampoline`
  * consumes the boxed sender on the first callback.
- *
- * Constructed only by [WhiskerModuleRegistry.invokeDispatchAsync].
  */
 public class WhiskerPromise internal constructor(
-    private val callbackPtr: Long,
-    private val userDataPtr: Long,
+    private val onSettle: (WhiskerValue) -> Unit,
 ) {
+    /** Module-dispatch form — constructed by
+     *  [WhiskerModuleRegistry.invokeDispatchAsync]. */
+    internal constructor(callbackPtr: Long, userDataPtr: Long) : this({ value ->
+        if (callbackPtr != 0L) {
+            WhiskerModuleRegistry.nativeResolveAsync(callbackPtr, userDataPtr, value)
+        }
+    })
+
     private val settled = AtomicBoolean(false)
 
     /** Resolve the call with [value] (`WhiskerValue.Null` for "no result"). */
@@ -36,8 +42,7 @@ public class WhiskerPromise internal constructor(
     }
 
     private fun fire(value: WhiskerValue) {
-        if (callbackPtr == 0L) return
         if (!settled.compareAndSet(false, true)) return
-        WhiskerModuleRegistry.nativeResolveAsync(callbackPtr, userDataPtr, value)
+        onSettle(value)
     }
 }

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
@@ -63,6 +63,8 @@ extension Module {
                 WhiskerLynxInstaller.installProp(prop, on: viewClass)
             case let fn as WhiskerFunctionComponent:
                 WhiskerLynxInstaller.installFunction(fn, on: viewClass)
+            case let afn as WhiskerAsyncFunctionComponent:
+                WhiskerLynxInstaller.installAsyncFunction(afn, on: viewClass)
             case is WhiskerEventsComponent:
                 // Declaration-only metadata; dispatch goes through
                 // `WhiskerCustomEvent.dispatch(from:name:params:)`.
@@ -186,6 +188,47 @@ internal enum WhiskerLynxInstaller {
             // `v@:@@?` = void return, (self id, SEL, params id, block).
             // `@` also works for argument-position blocks (same ABI);
             // `@?` gives clearer crash diagnostics on a shape mismatch.
+            typeEncoding: "v@:@@?"
+        )
+    }
+
+    // ---- AsyncFunction installation --------------------------------------
+
+    /// Same selector shapes as [`installFunction`], but the handler
+    /// receives a [`WhiskerPromise`] wrapping the Lynx callback, so it
+    /// can deliver the result from a later completion. Lynx's UI-method
+    /// callback is late-callable by design (its own `boundingClientRect`
+    /// resolves it asynchronously); errors travel as
+    /// `WhiskerValue.error` inside a success-coded result, mirroring the
+    /// sync Function path.
+    static func installAsyncFunction(
+        _ comp: WhiskerAsyncFunctionComponent, on viewClass: AnyClass
+    ) {
+        let methodName = comp.name
+        let configSelName = "__lynx_ui_method_config__" + methodName
+        let configBlock: @convention(block) (AnyClass) -> NSString = { _ in
+            return methodName as NSString
+        }
+        addClassMethod(
+            on: viewClass,
+            selector: NSSelectorFromString(configSelName),
+            imp: imp_implementationWithBlock(configBlock),
+            typeEncoding: "@@:"
+        )
+
+        let methodSel = NSSelectorFromString(methodName + ":withResult:")
+        let handler = comp.handler
+        let methodBlock: @convention(block) (AnyObject, NSDictionary?, LynxUIMethodCallbackBlockShim?) -> Void = { view, params, cb in
+            let args = WhiskerValue.fromNSDictionary(params)
+            let promise = WhiskerPromise(onSettle: { value in
+                cb?(0, WhiskerValue.toAnyObject(value) as AnyObject?)
+            })
+            handler(view, args, promise)
+        }
+        addInstanceMethod(
+            on: viewClass,
+            selector: methodSel,
+            imp: imp_implementationWithBlock(methodBlock),
             typeEncoding: "v@:@@?"
         )
     }

--- a/platforms/ios/Sources/WhiskerModule/WhiskerPromise.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerPromise.swift
@@ -1,9 +1,10 @@
 // The resolver handed to an `AsyncFunction` handler (iOS).
 //
-// Wraps the C bridge's completion `callback` + opaque `user_data` (the
-// Rust `oneshot::Sender` boxed by `PlatformModule::invoke_async`), so a
-// module can deliver its result *later* — e.g. from a StoreKit purchase
-// or `URLSession` completion — instead of returning synchronously.
+// Wraps the completion path of an async dispatch — the C bridge's
+// `callback` + opaque `user_data` for module-level calls, or the Lynx
+// UI-method callback for view-bound calls — so a module can deliver
+// its result *later* (e.g. from a StoreKit purchase or `URLSession`
+// completion) instead of returning synchronously.
 //
 // Mirrors Expo's `Promise` (`resolve` / `reject`). One-shot: the first
 // `resolve`/`reject` wins and fires the callback exactly once; further
@@ -14,17 +15,29 @@
 import Foundation
 
 public final class WhiskerPromise {
-    private let callback: WhiskerModuleCallback
-    private let userData: UnsafeMutableRawPointer?
+    private let onSettle: (WhiskerValue) -> Void
     private let lock = NSLock()
     private var settled = false
 
-    /// `callback` is the bridge's `WhiskerModuleCallback`; `userData` the
-    /// opaque pointer the async dispatch was handed. Constructed only by
-    /// the module-dispatch layer.
+    /// Module-dispatch form: `callback` is the bridge's
+    /// `WhiskerModuleCallback`; `userData` the opaque pointer the async
+    /// dispatch was handed.
     init(callback: WhiskerModuleCallback, userData: UnsafeMutableRawPointer?) {
-        self.callback = callback
-        self.userData = userData
+        // Same encode → hand-to-bridge → release sequence the event
+        // center uses (`WhiskerModuleEventCenter.dispatchSend`): the
+        // callback copies the value out before returning, so releasing
+        // right after is safe.
+        self.onSettle = { value in
+            var raw = value.toRaw()
+            callback(userData, &raw)
+            whisker_bridge_value_release(&raw)
+        }
+    }
+
+    /// Closure form — constructed by the Lynx UI-method dispatch layer
+    /// (`WhiskerLynxInstaller.installAsyncFunction`).
+    init(onSettle: @escaping (WhiskerValue) -> Void) {
+        self.onSettle = onSettle
     }
 
     /// Resolve the call with `value` (`.null` for "no result").
@@ -47,12 +60,6 @@ public final class WhiskerPromise {
         settled = true
         lock.unlock()
 
-        // Same encode → hand-to-bridge → release sequence the event
-        // center uses (`WhiskerModuleEventCenter.dispatchSend`): the
-        // callback copies the value out before returning, so releasing
-        // right after is safe.
-        var raw = value.toRaw()
-        callback(userData, &raw)
-        whisker_bridge_value_release(&raw)
+        onSettle(value)
     }
 }


### PR DESCRIPTION
Fixes the webview finding from the comment sweep (#382): `evaluateJavaScript`'s result never reached Rust on either platform — the native JS eval completes in a callback, but view-bound methods only had the sync `Function` form, so iOS documented fire-and-return-`""` and Android silently returned a placeholder.

## Mechanism

Lynx's UI-method callback is **late-callable by design** (its own `boundingClientRect` resolves it asynchronously), so the missing piece was routing view-bound `AsyncFunction`s onto it:

- **`WhiskerPromise` (both platforms)** generalises from the module-bridge callback to any settle target (new closure-form constructor; the bridge-pointer form delegates to it). One-shot semantics unchanged.
- **Registrars** (`WhiskerModuleRegistrar.swift` / `.kt`): view-bound `AsyncFunction` components now install as Lynx UI methods whose handler receives a promise wrapping the Lynx callback — resolvable from a later completion. Errors travel as error-valued results with a success code, mirroring the existing sync `Function` path, which `invoke_typed` already maps to `RefError::DispatchFailed`.
- **whisker-webview**: new `evaluateJavaScriptWithResult` on both native sides + `WebViewRef::evaluate_javascript_with_result` in Rust. The existing fire-and-forget `evaluate_javascript` is untouched.

## Contract

Resolves a **JSON-encoded string** (`"null"` when the script yields no value) — Android's `evaluateJavascript` callback convention, matched on iOS via `JSONSerialization` with `.fragmentsAllowed` (guarded by `isValidJSONObject`/fragment checks, since `JSONSerialization.data` raises an uncatchable NSException on non-JSON top-level objects).

Platform asymmetry, documented on the Rust API: a throwing script **rejects on iOS** (`WKWebView` reports the error) but **resolves `"null"` on Android** — `WebView.evaluateJavascript` cannot observe JS exceptions.

## Stale-claim casualty

The Kotlin module carried a TODO claiming Android result-returning element methods need iOS-only fork wiring. The bridge source says otherwise — `lynx_ui_invoke_method_async` is exported by liblynx.so on Android since fork v3.7.0-whisker.5 and compiled into WhiskerDriver on iOS, same dispatch both platforms. TODO removed.

## Verification

- Rust: `cargo test -p whisker-webview` green, clippy 0, fmt clean.
- Kotlin/Swift: no local compile gate; CI's `swift build (WhiskerRuntime)` covers the platforms/ios changes, gradle/device build covers the rest.
- **Needs a device E2E pass before this ships in a release** (both platforms: `evaluate_javascript_with_result("1+1")` → `"2"`, `document.title` → JSON string, a throwing script → iOS `Err` / Android `"null"`). Happy to write the giga-style E2E handoff instructions on request. Note the platforms/ half reaches apps via the next SDK release (Android Maven / iOS SPM tag), the packages/ half via the next crates release — both halves must ship together for the new method to work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)