### PR TITLE
Point apps at Android SDK 0.1.18 and iOS SwiftPM 0.1.8

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,7 +49,7 @@ use std::process::Command;
 /// Keep in lockstep with the `Package.swift` at the repo root and the
 /// `v<version>` git tag published for SwiftPM to resolve.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
-pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.7";
+pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.8";
 
 use crate::capture::{CaptureShims, capture_env_vars_for_triple};
 

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -64,7 +64,7 @@ pub struct PlatformSync {
 /// latter can be hard-breaking, because a per-app `WhiskerDriver`
 /// bridge built against a newer capi ABI refuses to attach to the Lynx
 /// an older SDK pulls in.
-const WHISKER_SDK_VERSION: &str = "0.1.17";
+const WHISKER_SDK_VERSION: &str = "0.1.18";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/packages/whisker-asset/Package.swift
+++ b/packages/whisker-asset/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WhiskerAsset", targets: ["WhiskerAsset"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-haptics/Package.swift
+++ b/packages/whisker-haptics/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerHaptics", targets: ["WhiskerHaptics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
         // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
         // via Core Image, animated GIF via `AnimatedImageView`, in-
         // memory `NSCache` + disk cache out of the box. WebP requires

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-keyboard/Package.swift
+++ b/packages/whisker-keyboard/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "WhiskerKeyboard", targets: ["WhiskerKeyboard"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "WhiskerLocalStore", targets: ["WhiskerLocalStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
         // PoC — an external SwiftPM dependency. swift-collections is
         // Apple-maintained, header-only Swift, small enough that
         // resolving it is fast even on a cold cache. Use is minimal

--- a/packages/whisker-paths/Package.swift
+++ b/packages/whisker-paths/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerPaths", targets: ["WhiskerPaths"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-status-bar/Package.swift
+++ b/packages/whisker-status-bar/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .library(name: "WhiskerStatusBar", targets: ["WhiskerStatusBar"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "WhiskerSvg", targets: ["WhiskerSvg"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // it there, and the package identity (the crate's dir name)
         // is unique, so the app aggregator references it via
         // `.package(path: …)` without the `ios`-dir-name collision.
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-web-browser/Package.swift
+++ b/packages/whisker-web-browser/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "WhiskerWebBrowser", targets: ["WhiskerWebBrowser"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.7"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Release-pin bump for #385 per [.agents/skills/release-whisker](.agents/skills/release-whisker/SKILL.md): both platform artifacts carry the view-bound AsyncFunction dispatch that `evaluateJavaScriptWithResult` needs.

- `WHISKER_SDK_VERSION` 0.1.17 → 0.1.18 (tag `sdk-v0.1.18` to follow)
- `WHISKER_IOS_SPM_VERSION` 0.1.7 → 0.1.8 + all 15 module `Package.swift` `exact:` pins (`spm_pin_consistency` test green); the `publish-ios` workflow will validate and tag after merge

Local gates: `cargo build --workspace` clean, `xcodebuild -scheme WhiskerRuntime` BUILD SUCCEEDED on the merged #385 sources. Apps pick the pins up with the next crates release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)