### PR TITLE
Carry the real error message through UI-method rejections

### DIFF
--- a/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
+++ b/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
@@ -304,9 +304,8 @@ public final class WhiskerWebViewView: WhiskerUI<UIView> {
         }
         wv.evaluateJavaScript(script) { value, error in
             if let error = error {
-                // WebKit buries the actual JS exception text in
-                // userInfo; localizedDescription is just "a JavaScript
-                // exception occurred".
+                // The JS exception text rides in userInfo, not
+                // localizedDescription.
                 let ns = error as NSError
                 let detail = ns.userInfo["WKJavaScriptExceptionMessage"] as? String
                     ?? error.localizedDescription

--- a/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
+++ b/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
@@ -304,7 +304,13 @@ public final class WhiskerWebViewView: WhiskerUI<UIView> {
         }
         wv.evaluateJavaScript(script) { value, error in
             if let error = error {
-                promise.reject("evaluateJavaScript failed: \(error.localizedDescription)")
+                // WebKit buries the actual JS exception text in
+                // userInfo; localizedDescription is just "a JavaScript
+                // exception occurred".
+                let ns = error as NSError
+                let detail = ns.userInfo["WKJavaScriptExceptionMessage"] as? String
+                    ?? error.localizedDescription
+                promise.reject("evaluateJavaScript failed: \(detail)")
                 return
             }
             guard let value = value else {

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -202,13 +202,9 @@ internal class WhiskerDSLMethodInvoker(
         val asyncComponent = asyncByName[methodName]
         if (asyncComponent != null) {
             // The promise owns the Lynx callback — late-callable by
-            // design — and fires it once with SUCCESS; errors travel as
-            // `WhiskerValue.Err` inside the result, mirroring the sync
-            // path below.
+            // design.
             val args = decodeArgs(params).map { whiskerValueOf(it) }
-            val promise = WhiskerPromise({ value ->
-                callback.invoke(LynxUIMethodConstants.SUCCESS, value.toJavaObject())
-            })
+            val promise = WhiskerPromise({ value -> settle(callback, value) })
             try {
                 asyncComponent.handler(ui, args, promise)
             } catch (t: Throwable) {
@@ -235,7 +231,21 @@ internal class WhiskerDSLMethodInvoker(
             )
             return
         }
-        callback.invoke(LynxUIMethodConstants.SUCCESS, result.toJavaObject())
+        settle(callback, result)
+    }
+
+    /** Route a handler result onto the Lynx callback. [WhiskerValue.Err]
+     *  goes out as a non-zero code with the message as the string
+     *  payload — an error delivered as a success-coded value flattens
+     *  into a plain map in the lepus round-trip, and the bridge adapter
+     *  can only recover the message from the error-code path. */
+    private fun settle(callback: Callback, value: WhiskerValue) {
+        when (value) {
+            is WhiskerValue.Err ->
+                callback.invoke(LynxUIMethodConstants.UNKNOWN, value.message)
+            else ->
+                callback.invoke(LynxUIMethodConstants.SUCCESS, value.toJavaObject())
+        }
     }
 
     private fun decodeArgs(params: ReadableMap?): List<Any?> {

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -201,8 +201,6 @@ internal class WhiskerDSLMethodInvoker(
     ) {
         val asyncComponent = asyncByName[methodName]
         if (asyncComponent != null) {
-            // The promise owns the Lynx callback — late-callable by
-            // design.
             val args = decodeArgs(params).map { whiskerValueOf(it) }
             val promise = WhiskerPromise({ value -> settle(callback, value) })
             try {
@@ -234,11 +232,9 @@ internal class WhiskerDSLMethodInvoker(
         settle(callback, result)
     }
 
-    /** Route a handler result onto the Lynx callback. [WhiskerValue.Err]
-     *  goes out as a non-zero code with the message as the string
-     *  payload — an error delivered as a success-coded value flattens
-     *  into a plain map in the lepus round-trip, and the bridge adapter
-     *  can only recover the message from the error-code path. */
+    /** [WhiskerValue.Err] rides the error-code channel — a
+     *  success-coded error flattens into a plain map in the lepus
+     *  round-trip and the message is lost. */
     private fun settle(callback: Callback, value: WhiskerValue) {
         when (value) {
             is WhiskerValue.Err ->

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
@@ -191,10 +191,8 @@ internal enum WhiskerLynxInstaller {
     // ---- AsyncFunction installation --------------------------------------
 
     /// Same selector shapes as [`installFunction`], but the handler
-    /// receives a [`WhiskerPromise`] wrapping the Lynx callback, so it
-    /// can deliver the result from a later completion. Lynx's UI-method
-    /// callback is late-callable by design (its own `boundingClientRect`
-    /// resolves it asynchronously).
+    /// receives a [`WhiskerPromise`] wrapping the (late-callable) Lynx
+    /// callback, so it can deliver the result from a later completion.
     static func installAsyncFunction(
         _ comp: WhiskerAsyncFunctionComponent, on viewClass: AnyClass
     ) {
@@ -229,12 +227,9 @@ internal enum WhiskerLynxInstaller {
 
     // ---- Helpers ---------------------------------------------------------
 
-    /// Route a handler result onto the Lynx UI-method callback.
-    /// `.error` goes out as a non-zero code (UNKNOWN = 1) with the
-    /// message as the string payload — an error delivered as a
-    /// success-coded value flattens into a plain map in the ObjC→lepus
-    /// round-trip, and the bridge adapter can only recover the message
-    /// from the error-code path.
+    /// `.error` rides the error-code channel (UNKNOWN = 1) — a
+    /// success-coded error flattens into a plain map in the lepus
+    /// round-trip and the message is lost.
     private static func settle(_ cb: LynxUIMethodCallbackBlockShim?, with value: WhiskerValue) {
         if case .error(let message) = value {
             cb?(1, message as NSString)

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
@@ -174,11 +174,7 @@ internal enum WhiskerLynxInstaller {
         let handler = comp.handler
         let methodBlock: @convention(block) (AnyObject, NSDictionary?, LynxUIMethodCallbackBlockShim?) -> Void = { view, params, cb in
             let args = WhiskerValue.fromNSDictionary(params)
-            let result = handler(view, args)
-            // Lynx kUIMethodSuccess = 0; reported unconditionally —
-            // dispatch failures surface as a `WhiskerValue.error`
-            // inside `result` rather than a failure code.
-            cb?(0, WhiskerValue.toAnyObject(result) as AnyObject?)
+            settle(cb, with: handler(view, args))
         }
         let methodIMP = imp_implementationWithBlock(methodBlock)
         addInstanceMethod(
@@ -198,9 +194,7 @@ internal enum WhiskerLynxInstaller {
     /// receives a [`WhiskerPromise`] wrapping the Lynx callback, so it
     /// can deliver the result from a later completion. Lynx's UI-method
     /// callback is late-callable by design (its own `boundingClientRect`
-    /// resolves it asynchronously); errors travel as
-    /// `WhiskerValue.error` inside a success-coded result, mirroring the
-    /// sync Function path.
+    /// resolves it asynchronously).
     static func installAsyncFunction(
         _ comp: WhiskerAsyncFunctionComponent, on viewClass: AnyClass
     ) {
@@ -221,7 +215,7 @@ internal enum WhiskerLynxInstaller {
         let methodBlock: @convention(block) (AnyObject, NSDictionary?, LynxUIMethodCallbackBlockShim?) -> Void = { view, params, cb in
             let args = WhiskerValue.fromNSDictionary(params)
             let promise = WhiskerPromise(onSettle: { value in
-                cb?(0, WhiskerValue.toAnyObject(value) as AnyObject?)
+                settle(cb, with: value)
             })
             handler(view, args, promise)
         }
@@ -234,6 +228,20 @@ internal enum WhiskerLynxInstaller {
     }
 
     // ---- Helpers ---------------------------------------------------------
+
+    /// Route a handler result onto the Lynx UI-method callback.
+    /// `.error` goes out as a non-zero code (UNKNOWN = 1) with the
+    /// message as the string payload — an error delivered as a
+    /// success-coded value flattens into a plain map in the ObjC→lepus
+    /// round-trip, and the bridge adapter can only recover the message
+    /// from the error-code path.
+    private static func settle(_ cb: LynxUIMethodCallbackBlockShim?, with value: WhiskerValue) {
+        if case .error(let message) = value {
+            cb?(1, message as NSString)
+        } else {
+            cb?(0, WhiskerValue.toAnyObject(value) as AnyObject?)
+        }
+    }
 
     private static func addInstanceMethod(
         on cls: AnyClass,


### PR DESCRIPTION
Fixes finding (a) from the iOS retest of #385: a rejected promise reached Rust as `Err(DispatchFailed)` (right variant) with a serde artifact for a message (`invalid type: map, expected a string`) — the actual JS error text was lost.

## Root cause

The registrars delivered errors as **success-coded `.error` / `Err` values**. The ObjC/lepus round-trip flattens those into plain maps, so `element_method_async_adapter`'s error mapping (which only fires on a non-zero code) never ran, and `invoke_typed` fell into the success decode path with a map where a string was expected.

## Fix

Route handler errors onto the Lynx UI-method callback's **error-code channel**: code `UNKNOWN` (1) + the message as the string payload. Verified against the sources on both ends before implementing:

- the fork passes the code through verbatim (`callback(code, &result, user_data)` in `lynx_native_renderer.cc` @ v3.8.0-whisker.13), and
- the bridge adapter already maps non-zero codes to `WhiskerValue::Error("UI method failed (code N): <string payload>")` (`whisker_bridge_common.cc`).

Applied to both the sync `Function` path and the `AsyncFunction` path, on both platforms — error-valued results now surface their message everywhere, and the Kotlin/Swift `settle` helpers keep the two paths from diverging again.

Also: the webview's iOS reject now surfaces `WKJavaScriptExceptionMessage` from the error's userInfo — `localizedDescription` is just "a JavaScript exception occurred"; the actual JS text ("boom") rides in userInfo.

## Verification

- `xcodebuild -scheme WhiskerRuntime` BUILD SUCCEEDED locally; CI's swift-build job re-checks.
- Kotlin has no local compile gate (same as previous native PRs); CI/device is the gate.
- Behavior change ships with the **next SDK (Maven) + SwiftPM release**; the iOS throw-case E2E should then report `Err(DispatchFailed { message: "UI method failed (code 1): evaluateJavaScript failed: boom" })`-shaped output. Suggest batching that release with the fix for finding (b) (iOS bool→0.0 collapse, recorded separately — likely a fork-side ObjC→lepus issue, since `PubValueToCapi` already handles bools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)