### PR TITLE
Give apps the Android back button, and give it back to Android

### DIFF
--- a/crates/whisker-driver/src/back.rs
+++ b/crates/whisker-driver/src/back.rs
@@ -129,12 +129,26 @@ pub fn set_exit_impl(f: impl Fn() + 'static) {
     EXIT_IMPL.with(|e| *e.borrow_mut() = Some(Rc::new(f)));
 }
 
-/// Framework wiring: whether an active handler exists right now.
-/// Reads the registry's revision signal, so calling inside an
-/// `effect` re-runs it on register / unregister.
+/// Framework wiring: whether an active (non-paused) handler exists
+/// right now — the dispatch / preview-suppression predicate. Reads
+/// the registry's revision signal, so calling inside an `effect`
+/// re-runs it on register / unregister.
 pub fn has_active_handler() -> bool {
     let _ = revision_signal().get();
     HANDLERS.with(|h| h.borrow().iter().any(Entry::is_active))
+}
+
+/// Framework wiring: whether ANY registration exists, paused or not —
+/// the platform enabled-state predicate. Pause is deliberately
+/// ignored here: a pop's survivor stays paused until its settle
+/// animation finishes, and an enabled state computed through the
+/// pause filter would fall to the OS default in exactly that window,
+/// exiting past a guarded root. A paused-but-registered guard keeps
+/// the platform callback enabled; [`dispatch`]'s pause filter still
+/// routes the action to the pop instead of the buried handler.
+pub fn has_any_handler() -> bool {
+    let _ = revision_signal().get();
+    HANDLERS.with(|h| !h.borrow().is_empty())
 }
 
 /// Framework wiring: deliver one back action to the most recent
@@ -204,6 +218,16 @@ mod tests {
         owner.resume();
         assert!(dispatch());
         assert_eq!(hits.get(), 1);
+    }
+
+    #[test]
+    fn paused_owner_still_counts_for_the_enabled_predicate() {
+        reset();
+        let owner = Owner::new(None);
+        let _guard = owner.with(|| on_back(|| {}));
+        owner.pause();
+        assert!(!has_active_handler());
+        assert!(has_any_handler());
     }
 
     #[test]

--- a/crates/whisker-driver/src/back.rs
+++ b/crates/whisker-driver/src/back.rs
@@ -1,0 +1,232 @@
+//! Process-global back-interception registry — Whisker's analogue of
+//! React Native's `BackHandler`.
+//!
+//! [`on_back`] registers a handler for the platform back action
+//! (Android's hardware button / back gesture). While a registration is
+//! *active* — its [`BackGuard`] alive and its owning scope not paused —
+//! the back action is delivered to the most recent active handler
+//! instead of popping the navigation stack, and the platform's
+//! interactive back preview is suppressed for that screen. With no
+//! active handler and nothing left to pop, the platform default runs
+//! (the app exits or moves to the background).
+//!
+//! Registration means consumption: there is no boolean return to
+//! decline an event, because Android's predictive back requires the
+//! interception decision *before* the gesture starts. Scope the guard
+//! to the screen instead — a registration made inside a component is
+//! tied to that component's scope, so a screen buried in the back
+//! stack (paused) stops intercepting until it is on top again.
+//!
+//! Delivery is wired by the platform gesture component
+//! (`whisker-router`'s `AndroidPredictiveBack`); without a router
+//! mounted the registry is inert and the platform default applies.
+//! Main-thread only, like [`crate::focus`].
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use whisker_runtime::reactive::{Owner, RwSignal};
+
+struct Entry {
+    id: u64,
+    owner: Option<Owner>,
+    handler: Rc<dyn Fn()>,
+}
+
+impl Entry {
+    fn is_active(&self) -> bool {
+        self.owner.is_none_or(|o| !o.is_paused())
+    }
+}
+
+thread_local! {
+    static HANDLERS: RefCell<Vec<Entry>> = const { RefCell::new(Vec::new()) };
+    static NEXT_ID: Cell<u64> = const { Cell::new(0) };
+    static EXIT_IMPL: RefCell<Option<Rc<dyn Fn()>>> = const { RefCell::new(None) };
+    static REVISION: Cell<Option<RwSignal<u64>>> = const { Cell::new(None) };
+}
+
+/// Registry-change signal, minted lazily under a detached root so its
+/// lifetime is the process, not whichever scope touches it first.
+fn revision_signal() -> RwSignal<u64> {
+    REVISION.with(|slot| {
+        if let Some(sig) = slot.get() {
+            return sig;
+        }
+        let sig = Owner::detached_root().with(|| RwSignal::new(0_u64));
+        slot.set(Some(sig));
+        sig
+    })
+}
+
+fn bump_revision() {
+    let sig = revision_signal();
+    sig.set(sig.get_untracked() + 1);
+}
+
+/// Keeps its [`on_back`] registration alive. Dropping the guard
+/// unregisters the handler; hold it in the registering component's
+/// state so unmount unregisters automatically.
+#[must_use = "the handler is unregistered when the guard drops"]
+pub struct BackGuard {
+    id: u64,
+}
+
+impl Drop for BackGuard {
+    fn drop(&mut self) {
+        HANDLERS.with(|h| h.borrow_mut().retain(|e| e.id != self.id));
+        bump_revision();
+    }
+}
+
+/// Intercept the platform back action while the returned guard lives.
+///
+/// The handler fires instead of a stack pop or an app exit whenever
+/// back is triggered with this registration active. Registrations
+/// stack: the most recent active one wins, so a screen pushed on top
+/// of a guarded screen can install its own. A registration made
+/// inside a component deactivates while that component's scope is
+/// paused (e.g. buried in the router's back stack).
+///
+/// ```ignore
+/// // Root screen: confirm before leaving the app.
+/// let show_exit_dialog = RwSignal::new(false);
+/// let _guard = back::on_back(move || show_exit_dialog.set(true));
+/// // The dialog's "exit" button then calls `back::exit_app()`.
+/// ```
+pub fn on_back(handler: impl Fn() + 'static) -> BackGuard {
+    let id = NEXT_ID.with(|n| {
+        let id = n.get();
+        n.set(id + 1);
+        id
+    });
+    HANDLERS.with(|h| {
+        h.borrow_mut().push(Entry {
+            id,
+            owner: Owner::current(),
+            handler: Rc::new(handler),
+        })
+    });
+    bump_revision();
+    BackGuard { id }
+}
+
+/// Trigger the platform's default back-out-of-the-app behavior
+/// (Android: finish or move the task to the background, matching what
+/// an unhandled back press would have done). Call from an [`on_back`]
+/// handler once the user confirms leaving. No-op where no platform
+/// exit is wired (iOS, or no router mounted).
+pub fn exit_app() {
+    let f = EXIT_IMPL.with(|e| e.borrow().clone());
+    if let Some(f) = f {
+        f();
+    }
+}
+
+/// Framework wiring: install the platform exit implementation
+/// [`exit_app`] calls. Registered by the platform gesture component.
+pub fn set_exit_impl(f: impl Fn() + 'static) {
+    EXIT_IMPL.with(|e| *e.borrow_mut() = Some(Rc::new(f)));
+}
+
+/// Framework wiring: whether an active handler exists right now.
+/// Reads the registry's revision signal, so calling inside an
+/// `effect` re-runs it on register / unregister.
+pub fn has_active_handler() -> bool {
+    let _ = revision_signal().get();
+    HANDLERS.with(|h| h.borrow().iter().any(Entry::is_active))
+}
+
+/// Framework wiring: deliver one back action to the most recent
+/// active handler. Returns `false` when no handler consumed it and
+/// the caller should fall back to its own behavior (pop / default).
+pub fn dispatch() -> bool {
+    let handler = HANDLERS.with(|h| {
+        h.borrow()
+            .iter()
+            .rev()
+            .find(|e| e.is_active())
+            .map(|e| e.handler.clone())
+    });
+    match handler {
+        Some(f) => {
+            f();
+            true
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reset() {
+        HANDLERS.with(|h| h.borrow_mut().clear());
+        EXIT_IMPL.with(|e| *e.borrow_mut() = None);
+    }
+
+    #[test]
+    fn dispatch_runs_the_most_recent_handler_and_reports_consumption() {
+        reset();
+        let hits: Rc<RefCell<Vec<&str>>> = Rc::new(RefCell::new(Vec::new()));
+        let (h1, h2) = (hits.clone(), hits.clone());
+        let _a = on_back(move || h1.borrow_mut().push("a"));
+        let _b = on_back(move || h2.borrow_mut().push("b"));
+        assert!(dispatch());
+        assert_eq!(*hits.borrow(), vec!["b"]);
+    }
+
+    #[test]
+    fn dropping_the_guard_unregisters() {
+        reset();
+        let hits = Rc::new(Cell::new(0));
+        let h = hits.clone();
+        let guard = on_back(move || h.set(h.get() + 1));
+        assert!(has_active_handler());
+        drop(guard);
+        assert!(!has_active_handler());
+        assert!(!dispatch());
+        assert_eq!(hits.get(), 0);
+    }
+
+    #[test]
+    fn paused_owner_deactivates_its_handler() {
+        reset();
+        let owner = Owner::new(None);
+        let hits = Rc::new(Cell::new(0));
+        let h = hits.clone();
+        let _guard = owner.with(|| on_back(move || h.set(h.get() + 1)));
+        assert!(has_active_handler());
+        owner.pause();
+        assert!(!has_active_handler());
+        assert!(!dispatch());
+        owner.resume();
+        assert!(dispatch());
+        assert_eq!(hits.get(), 1);
+    }
+
+    #[test]
+    fn paused_top_falls_through_to_the_next_active_handler() {
+        reset();
+        let hits: Rc<RefCell<Vec<&str>>> = Rc::new(RefCell::new(Vec::new()));
+        let (h1, h2) = (hits.clone(), hits.clone());
+        let _under = on_back(move || h1.borrow_mut().push("under"));
+        let top_owner = Owner::new(None);
+        let _top = top_owner.with(|| on_back(move || h2.borrow_mut().push("top")));
+        top_owner.pause();
+        assert!(dispatch());
+        assert_eq!(*hits.borrow(), vec!["under"]);
+    }
+
+    #[test]
+    fn exit_app_routes_through_the_installed_impl() {
+        reset();
+        let hits = Rc::new(Cell::new(0));
+        let h = hits.clone();
+        exit_app();
+        set_exit_impl(move || h.set(h.get() + 1));
+        exit_app();
+        assert_eq!(hits.get(), 1);
+    }
+}

--- a/crates/whisker-driver/src/lib.rs
+++ b/crates/whisker-driver/src/lib.rs
@@ -19,6 +19,7 @@
 //!   `whisker_runtime::view` thread-local, plus event-propagation
 //!   replay and list-provider trampolines.
 
+pub mod back;
 pub mod element_ref;
 pub mod focus;
 pub mod lynx;

--- a/crates/whisker-runtime/src/reactive/owner.rs
+++ b/crates/whisker-runtime/src/reactive/owner.rs
@@ -335,6 +335,14 @@ impl Owner {
     pub fn is_paused(self) -> bool {
         with_runtime(|rt| rt.owners.get(self).map(|o| o.paused).unwrap_or(false))
     }
+
+    /// The owner currently at the top of the scope stack, if any —
+    /// the scope that new signals, effects, and cleanups would
+    /// register against. Lets registries capture the scope of the
+    /// code that called them (see `whisker-driver`'s `back` module).
+    pub fn current() -> Option<Owner> {
+        with_runtime(|rt| rt.current_owner())
+    }
 }
 
 /// Register a callback to run when the current owner is disposed.

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -95,6 +95,12 @@ pub use whisker_driver::module::PlatformModule;
 /// restore the specific field that was focused.
 pub use whisker_driver::focus;
 
+/// Platform back-action interception (Whisker's analogue of React
+/// Native's `BackHandler`): [`back::on_back`] captures the Android
+/// back button / gesture while its guard lives, [`back::exit_app`]
+/// triggers the platform's default leave-the-app behavior.
+pub use whisker_driver::back;
+
 /// The universal tagged-union value model. Crosses the native
 /// boundary as both module args/returns and event payloads, so it
 /// lives at the crate root rather than buried under

--- a/packages/whisker-router/android/src/main/kotlin/rs/whisker/router/PredictiveBackModule.kt
+++ b/packages/whisker-router/android/src/main/kotlin/rs/whisker/router/PredictiveBackModule.kt
@@ -63,6 +63,14 @@ public class PredictiveBackModule : Module() {
      * tearing it down and the next `OnStartObserving` re-registering.
      */
     private var callback: OnBackPressedCallback? = null
+
+    /**
+     * Whether the Rust side currently wants back consumed (`setBackEnabled`).
+     * Cached here because the callback registers deferred; while disabled,
+     * the dispatcher falls through to the OS default (exit / background)
+     * and the system's leave-the-app predictive animation.
+     */
+    private var backEnabled: Boolean = false
     /**
      * Pending registration listener. Set when `OnStartObserving` fires
      * before the WhiskerView attaches to its window — fires once the host
@@ -90,6 +98,25 @@ public class PredictiveBackModule : Module() {
         // screen. Rust caches the result rather than calling per frame.
         Function("getDeviceCornerRadius") { _ ->
             WhiskerValue.Float(deviceCornerRadiusDp())
+        }
+
+        Function("setBackEnabled") { args ->
+            backEnabled = args.getOrNull(0)?.asBool() ?: false
+            callback?.isEnabled = backEnabled
+            WhiskerValue.Null
+        }
+
+        // The platform's default leave-the-app behavior: re-dispatch
+        // back with our own callback disabled so the dispatcher falls
+        // through (finish on API < 31, task-to-background on 31+).
+        Function("exitApp") { _ ->
+            val activity = appContext.currentActivity as? ComponentActivity
+            if (activity != null) {
+                callback?.isEnabled = false
+                activity.onBackPressedDispatcher.onBackPressed()
+                callback?.isEnabled = backEnabled
+            }
+            WhiskerValue.Null
         }
     }
 
@@ -150,7 +177,7 @@ public class PredictiveBackModule : Module() {
     private fun tryRegisterCallback(): Boolean {
         if (callback != null) return true
         val activity = appContext.currentActivity as? ComponentActivity ?: return false
-        val cb = object : OnBackPressedCallback(true) {
+        val cb = object : OnBackPressedCallback(backEnabled) {
             override fun handleOnBackStarted(backEvent: BackEventCompat) {
                 sendEvent("backStarted", edgePayload(backEvent))
             }

--- a/packages/whisker-router/src/render/gesture.rs
+++ b/packages/whisker-router/src/render/gesture.rs
@@ -58,6 +58,8 @@ const PB_EV_CANCELLED: &str = "backCancelled";
 const PB_EV_INVOKED: &str = "backInvoked";
 /// Module method returning the device display corner radius (dp).
 const PB_M_DEVICE_CORNER_RADIUS: &str = "getDeviceCornerRadius";
+const PB_M_SET_BACK_ENABLED: &str = "setBackEnabled";
+const PB_M_EXIT_APP: &str = "exitApp";
 /// Predictive-back event payload keys.
 const PB_K_TOUCH_Y: &str = "touchY";
 const PB_K_PROGRESS: &str = "progress";
@@ -195,6 +197,11 @@ fn install(container: Element, nav: RouterHandle) {
 /// **predictive-back** pose mode, and return the bridge. `None` means no
 /// gesture should begin.
 pub(crate) fn begin(nav: &RouterHandle, edge: SwipeEdge) -> Option<StackBridge> {
+    // An active `whisker::back::on_back` handler owns the back action;
+    // no interactive preview on either platform.
+    if whisker::back::has_active_handler() {
+        return None;
+    }
     let bridge = nav.active_stack_bridge()?;
     // Edge-swipe back is opt-in by *mounting* a gesture component
     // (`SwipeBack` / `AndroidPredictiveBack`); it is NOT gated on the
@@ -355,6 +362,29 @@ pub fn android_predictive_back() -> Element {
     let nav = use_navigator();
     let module = pb_module();
 
+    if cfg!(target_os = "android") {
+        whisker::back::set_exit_impl(|| {
+            let _ = pb_module().invoke(PB_M_EXIT_APP, std::vec![]);
+        });
+        // Mirror "something here will consume back" into the Kotlin
+        // callback's enabled state; when false, the OS default (exit /
+        // background) runs instead of a swallowed press.
+        let nav_for_enabled = nav.clone();
+        let last_sent: Rc<std::cell::Cell<Option<bool>>> = Rc::new(std::cell::Cell::new(None));
+        whisker::runtime::reactive::effect(move || {
+            let _ = nav_for_enabled.state().get();
+            let can_pop = nav_for_enabled.active_stack_bridge().is_some();
+            let enabled = can_pop || whisker::back::has_active_handler();
+            if last_sent.get() != Some(enabled) {
+                last_sent.set(Some(enabled));
+                let _ = pb_module().invoke(
+                    PB_M_SET_BACK_ENABLED,
+                    std::vec![WhiskerValue::Bool(enabled)],
+                );
+            }
+        });
+    }
+
     // The in-flight bridge for the current predictive-back gesture. Shared
     // across the four event listeners. The native `PredictiveBack` module
     // fires on the Android UI thread — the same thread as Whisker's main
@@ -427,11 +457,14 @@ pub fn android_predictive_back() -> Element {
                 // Interactive path (API 34+): a gesture was in flight, so
                 // commit it (animate the top off, then `back()`).
                 Some(bridge) => settle(nav, &bridge, /* commit = */ true, None),
-                // No preview (API < 34, or a discrete press): just pop.
-                // `back()` routes through `with_navigator`, which handles
-                // the keyboard (targeted blur of the focused field).
+                // No preview (API < 34, a discrete press, or an app-level
+                // handler suppressed it): the handler gets first claim,
+                // then `back()` (which handles the keyboard's targeted
+                // blur via `with_navigator`).
                 None => {
-                    let _ = nav.back();
+                    if !whisker::back::dispatch() {
+                        let _ = nav.back();
+                    }
                 }
             }
         })

--- a/packages/whisker-router/src/render/gesture.rs
+++ b/packages/whisker-router/src/render/gesture.rs
@@ -374,7 +374,11 @@ pub fn android_predictive_back() -> Element {
         whisker::runtime::reactive::effect(move || {
             let _ = nav_for_enabled.state().get();
             let can_pop = nav_for_enabled.active_stack_bridge().is_some();
-            let enabled = can_pop || whisker::back::has_active_handler();
+            // `has_any_handler`, not `has_active_handler`: a pop's
+            // survivor stays paused until its settle finishes, and the
+            // pause-filtered predicate would disable back past a
+            // guarded root for that whole window.
+            let enabled = can_pop || whisker::back::has_any_handler();
             if last_sent.get() != Some(enabled) {
                 last_sent.set(Some(enabled));
                 let _ = pb_module().invoke(

--- a/packages/whisker-router/src/render/handle.rs
+++ b/packages/whisker-router/src/render/handle.rs
@@ -204,7 +204,6 @@ impl RouterHandle {
     /// The raw state signal (test only). Production code reads via
     /// [`slice_at`](Self::slice_at) / [`current`](Self::current) and mutates
     /// via the verbs.
-    #[cfg(test)]
     pub(crate) fn state(&self) -> RwSignal<RouteState> {
         self.inner.state
     }


### PR DESCRIPTION
Two back-button problems, one wiring:

1. **Back with nothing to pop did nothing.** The router's `OnBackPressedCallback` registered permanently enabled, consuming every press at the dispatcher — the OS default (finish on API < 31, task-to-background on 31+) never ran. Normal apps exit; whisker apps sat there.
2. **Apps could not intercept back at all** — no exit-confirmation dialog, no screen-level guards.

## `whisker::back` (new core API)

```rust
// A screen that wants to own the back action while it is on top:
let _guard = back::on_back(move || show_exit_dialog.set(true));
// The dialog's "leave" button:
back::exit_app();
```

- **Home = core** (`whisker-driver::back`, re-exported as `whisker::back`), mirroring RN's `BackHandler`-in-core and this repo's focus-registry layering; the router is the wiring, not the owner. Without a router mounted the registry is inert (and back already falls through today in that case).
- **Registration means consumption** — no boolean return. Android's predictive back needs the interception decision *before* the gesture starts, which is also why RN's return-`true` API fights `enableOnBackInvokedCallback`. Scoping comes from the guard's lifetime instead, plus **pause-awareness at dispatch**: a handler registered inside a screen stops receiving the action while that screen's scope is paused (whisker keeps back-stack screens mounted-but-paused, so without this a buried screen's guard would fire). Most recent active handler wins.
- An active handler **suppresses the interactive preview** on both platforms (Android predictive card, iOS edge swipe) — inherent to interception, same trade-off as native/RN.

## Router / platform wiring

- The Kotlin callback's `isEnabled` mirrors `router can pop || a handler is REGISTERED` (pushed from a Rust effect on state/registry changes; cached across the deferred registration; initial `false`). Disabled ⇒ the dispatcher falls through to the **true OS default**, including the system's leave-the-app predictive animation on 33+.
- The enabled predicate deliberately ignores pause (`has_any_handler`, distinct from dispatch's `has_active_handler`): a pop's survivor stays paused until its settle animation finishes, and a pause-filtered enabled state would fall to the OS default in exactly that window — exiting past a guarded root. A paused-but-registered guard keeps the callback enabled; dispatch's pause filter still routes the action to the pop instead of the buried handler.
- `exitApp` re-dispatches with our callback disabled instead of calling `finish()` — the app leaves exactly as an unhandled press would have (RN's `invokeDefaultOnBackPressed` semantics).
- `Owner::current()` (whisker-runtime) and un-gating the router's `state()` accessor support the above. Hot-reload remount of the gesture component re-installs the exit impl (last-write-wins) and a fresh effect whose first run re-pushes the enabled state — considered, no special handling needed.

## Verification

- 6 new registry unit tests (LIFO, guard drop, pause deactivation/fall-through at dispatch, paused-still-counts for enabled, exit hook); whisker-runtime / whisker-driver / whisker-router suites green, clippy 0, `cargo build --workspace` clean.
- Kotlin compiles only in CI/device builds (no local gate). **Device E2E pending** — needs the next SDK release; recommend batching with #388 and the #389 fix so one Android local-inject + post-release iOS round covers everything. E2E cases: empty-stack back exits the app (and shows the 33+ leave-the-app preview); `on_back` dialog on the root screen; a guard on a pushed screen deactivating after pop; **pop back to a guarded root and press back both during and after the settle animation — the guard must hold in both**; `exit_app()` leaving the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)