### PR TITLE
Point apps at Lynx 4.0.1-whisker.2, Android SDK 0.1.19, iOS SwiftPM 0.1.9

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,7 +49,7 @@ use std::process::Command;
 /// Keep in lockstep with the `Package.swift` at the repo root and the
 /// `v<version>` git tag published for SwiftPM to resolve.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
-pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.8";
+pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.9";
 
 use crate::capture::{CaptureShims, capture_env_vars_for_triple};
 

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -64,7 +64,7 @@ pub struct PlatformSync {
 /// latter can be hard-breaking, because a per-app `WhiskerDriver`
 /// bridge built against a newer capi ABI refuses to attach to the Lynx
 /// an older SDK pulls in.
-const WHISKER_SDK_VERSION: &str = "0.1.18";
+const WHISKER_SDK_VERSION: &str = "0.1.19";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/packages/whisker-asset/Package.swift
+++ b/packages/whisker-asset/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WhiskerAsset", targets: ["WhiskerAsset"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-haptics/Package.swift
+++ b/packages/whisker-haptics/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerHaptics", targets: ["WhiskerHaptics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
         // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
         // via Core Image, animated GIF via `AnimatedImageView`, in-
         // memory `NSCache` + disk cache out of the box. WebP requires

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-keyboard/Package.swift
+++ b/packages/whisker-keyboard/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "WhiskerKeyboard", targets: ["WhiskerKeyboard"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "WhiskerLocalStore", targets: ["WhiskerLocalStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
         // PoC — an external SwiftPM dependency. swift-collections is
         // Apple-maintained, header-only Swift, small enough that
         // resolving it is fast even on a cold cache. Use is minimal

--- a/packages/whisker-paths/Package.swift
+++ b/packages/whisker-paths/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerPaths", targets: ["WhiskerPaths"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-status-bar/Package.swift
+++ b/packages/whisker-status-bar/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .library(name: "WhiskerStatusBar", targets: ["WhiskerStatusBar"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "WhiskerSvg", targets: ["WhiskerSvg"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // it there, and the package identity (the crate's dir name)
         // is unique, so the app aggregator references it via
         // `.package(path: …)` without the `ios`-dir-name collision.
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-web-browser/Package.swift
+++ b/packages/whisker-web-browser/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "WhiskerWebBrowser", targets: ["WhiskerWebBrowser"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.8"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
     ],
     targets: [
         .target(

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v4.0.1-whisker.1").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v4.0.1-whisker.2").removePrefix("v")
 
 dependencies {
     if (whiskerSdkRelease) {

--- a/platforms/android/whisker-runtime/build.gradle.kts
+++ b/platforms/android/whisker-runtime/build.gradle.kts
@@ -20,7 +20,7 @@
 // `whiskerSdkRelease` Gradle property toggles the dep form: unset
 // (default) → flatDir-friendly `:LynxAndroid@aar`; `true` → Maven
 // coords pinned to `lynxFork`. The CI publish workflow sets
-// `-PwhiskerSdkRelease=true -PlynxFork=v4.0.1-whisker.1`; local CLI
+// `-PwhiskerSdkRelease=true -PlynxFork=v4.0.1-whisker.2`; local CLI
 // flows leave both unset and use flatDir as before.
 
 plugins {
@@ -70,7 +70,7 @@ android {
 }
 
 val whiskerSdkRelease = providers.gradleProperty("whiskerSdkRelease").orNull == "true"
-val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v4.0.1-whisker.1").removePrefix("v")
+val lynxFork = providers.gradleProperty("lynxFork").getOrElse("v4.0.1-whisker.2").removePrefix("v")
 
 dependencies {
     api(project(":module"))

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -87,23 +87,23 @@ let package = Package(
         // build.rs still stages them out of `target/lynx-headers`.
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/Lynx-4.0.1-whisker.1.xcframework.zip",
-            checksum: "e5161bf110a1d22869412689b89362798fd35e53dad9467980e9390918261c1d"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.2/Lynx-4.0.1-whisker.2.xcframework.zip",
+            checksum: "71a6ae0fcdae9b0ed33734bf954cc9c5971011d0e247f6b785ec81dcd132cd51"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/LynxBase-4.0.1-whisker.1.xcframework.zip",
-            checksum: "875c389e2a33ad846ae43a29bcb1dad131d8b1e75ab36a2d41f39355e68cd25e"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.2/LynxBase-4.0.1-whisker.2.xcframework.zip",
+            checksum: "269d768cd268e952d74e6d53fa7af1d3cd3eb909bacc8a4ffb461eb4ac3e2263"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/LynxServiceAPI-4.0.1-whisker.1.xcframework.zip",
-            checksum: "9347769f21d9c41e0274cdb555698d7489f67ab9ed26fe2146688061f55a9b24"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.2/LynxServiceAPI-4.0.1-whisker.2.xcframework.zip",
+            checksum: "20d974529ebf8c2358f8f799922b7d0b854eccd5e182bca275bb2298c06e5b9c"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/PrimJS-4.0.1-whisker.1.xcframework.zip",
-            checksum: "76502d535310b42d7c15d9dcb8e802622d17f8541bcee5a8dcf8863b59d8f45b"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.2/PrimJS-4.0.1-whisker.2.xcframework.zip",
+            checksum: "3993b821603dea83152abe281152ec07bcb0cbea90841776dc5f80f2fd02187e"
         ),
 
         // Minimal module-author surface, kept apart from the larger


### PR DESCRIPTION
Release-pin roll per [.agents/skills/release-whisker](.agents/skills/release-whisker/SKILL.md), carrying three device-facing fixes in one release train:

- **Lynx `v4.0.1-whisker.2`** ([whiskerrs/lynx#30](https://github.com/whiskerrs/lynx/pull/30)): the UI-method result callback keeps `@YES`/`@NO` as bools (fixes #389). URLs + all four xcframework checksums (from the release's swiftpm-manifest) + the gradle `lynxFork` defaults; Maven AAR verified reachable.
- **`WHISKER_SDK_VERSION` 0.1.18 → 0.1.19** (tag `sdk-v0.1.19` to follow): carries #388's error-code rejection path and #392's `setBackEnabled`/`exitApp`.
- **`WHISKER_IOS_SPM_VERSION` 0.1.8 → 0.1.9** + all 15 module pins (`spm_pin_consistency` green; `publish-ios` will validate and tag).

Gates run locally: `cargo build --workspace` clean; `xcodebuild -scheme WhiskerRuntime` BUILD SUCCEEDED against the new Lynx binaries (which also proves the URLs/checksums resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)