### PR TITLE
Repair the release pins the batch E2E caught

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,23 +74,23 @@ let package = Package(
         // `swiftpm-manifest-<ver>.txt` published alongside each release.
         .binaryTarget(
             name: "Lynx",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/Lynx-4.0.1-whisker.1.xcframework.zip",
-            checksum: "e5161bf110a1d22869412689b89362798fd35e53dad9467980e9390918261c1d"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.2/Lynx-4.0.1-whisker.2.xcframework.zip",
+            checksum: "71a6ae0fcdae9b0ed33734bf954cc9c5971011d0e247f6b785ec81dcd132cd51"
         ),
         .binaryTarget(
             name: "LynxBase",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/LynxBase-4.0.1-whisker.1.xcframework.zip",
-            checksum: "875c389e2a33ad846ae43a29bcb1dad131d8b1e75ab36a2d41f39355e68cd25e"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.2/LynxBase-4.0.1-whisker.2.xcframework.zip",
+            checksum: "269d768cd268e952d74e6d53fa7af1d3cd3eb909bacc8a4ffb461eb4ac3e2263"
         ),
         .binaryTarget(
             name: "LynxServiceAPI",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/LynxServiceAPI-4.0.1-whisker.1.xcframework.zip",
-            checksum: "9347769f21d9c41e0274cdb555698d7489f67ab9ed26fe2146688061f55a9b24"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.2/LynxServiceAPI-4.0.1-whisker.2.xcframework.zip",
+            checksum: "20d974529ebf8c2358f8f799922b7d0b854eccd5e182bca275bb2298c06e5b9c"
         ),
         .binaryTarget(
             name: "PrimJS",
-            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.1/PrimJS-4.0.1-whisker.1.xcframework.zip",
-            checksum: "76502d535310b42d7c15d9dcb8e802622d17f8541bcee5a8dcf8863b59d8f45b"
+            url: "https://github.com/whiskerrs/lynx/releases/download/v4.0.1-whisker.2/PrimJS-4.0.1-whisker.2.xcframework.zip",
+            checksum: "3993b821603dea83152abe281152ec07bcb0cbea90841776dc5f80f2fd02187e"
         ),
 
         // Header-only mirror of `WhiskerDriver`'s public C ABI. Source

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -49,7 +49,7 @@ use std::process::Command;
 /// Keep in lockstep with the `Package.swift` at the repo root and the
 /// `v<version>` git tag published for SwiftPM to resolve.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
-pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.9";
+pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.10";
 
 use crate::capture::{CaptureShims, capture_env_vars_for_triple};
 

--- a/crates/whisker-build/tests/spm_pin_consistency.rs
+++ b/crates/whisker-build/tests/spm_pin_consistency.rs
@@ -61,3 +61,44 @@ fn module_package_swift_pins_match_whisker_ios_spm_version() {
         bad.join("\n"),
     );
 }
+
+/// The root `/Package.swift` is what REMOTE SwiftPM consumers resolve
+/// when they depend on the `whisker` package tag; `platforms/ios/
+/// Package.swift` is the in-repo development manifest. A Lynx roll
+/// that bumps only the latter ships a release whose apps silently keep
+/// the previous Lynx (the 0.1.9 incident).
+#[test]
+fn root_package_swift_lynx_pins_match_the_platform_manifest() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let root_manifest = workspace_root.join("Package.swift");
+    let platform_manifest = workspace_root.join("platforms/ios/Package.swift");
+    let (Ok(root), Ok(platform)) = (
+        std::fs::read_to_string(&root_manifest),
+        std::fs::read_to_string(&platform_manifest),
+    ) else {
+        return; // published-crate layout; nothing to check
+    };
+
+    let lynx_lines = |s: &str| -> Vec<String> {
+        s.lines()
+            .map(str::trim)
+            .filter(|l| {
+                (l.contains("whiskerrs/lynx/releases/download") || l.contains("checksum:"))
+                    && !l.starts_with("//")
+            })
+            .map(str::to_string)
+            .collect()
+    };
+    let (root_pins, platform_pins) = (lynx_lines(&root), lynx_lines(&platform));
+    assert!(
+        !platform_pins.is_empty(),
+        "no Lynx binaryTarget pins found in {} — update this test's matcher",
+        platform_manifest.display(),
+    );
+    assert_eq!(
+        root_pins, platform_pins,
+        "Lynx binaryTarget pins differ between /Package.swift (what remote \
+         SwiftPM consumers get) and platforms/ios/Package.swift — roll both \
+         in the same change",
+    );
+}

--- a/packages/whisker-asset/Package.swift
+++ b/packages/whisker-asset/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WhiskerAsset", targets: ["WhiskerAsset"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-asset/build.gradle.kts
+++ b/packages/whisker-asset/build.gradle.kts
@@ -53,6 +53,6 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 }

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-audio/build.gradle.kts
+++ b/packages/whisker-audio/build.gradle.kts
@@ -43,8 +43,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 
     // AndroidX Media3 — modern Player API. We use ExoPlayer (the
     // engine) directly without PlayerView (the visual chrome),

--- a/packages/whisker-haptics/Package.swift
+++ b/packages/whisker-haptics/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerHaptics", targets: ["WhiskerHaptics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-haptics/build.gradle.kts
+++ b/packages/whisker-haptics/build.gradle.kts
@@ -42,8 +42,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.6")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
     // No extra native dep: `Vibrator`/`VibratorManager` are platform
     // APIs — see `src/lib.rs`'s doc comment.
 }

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
         // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
         // via Core Image, animated GIF via `AnimatedImageView`, in-
         // memory `NSCache` + disk cache out of the box. WebP requires

--- a/packages/whisker-image/build.gradle.kts
+++ b/packages/whisker-image/build.gradle.kts
@@ -48,8 +48,8 @@ ksp {
 dependencies {
     // 0.1.15 for the module-level `AsyncFunction` the `prefetch`
     // entry point needs; the view-only packages still build on 0.1.0.
-    implementation("rs.whisker:whisker-module-android:0.1.15")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 
     // Coil 2.7 — Kotlin-first, coroutine-native image loader. Base
     // artifact covers PNG / JPEG / static WebP (Android 14+ native

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-input/build.gradle.kts
+++ b/packages/whisker-input/build.gradle.kts
@@ -46,6 +46,6 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 }

--- a/packages/whisker-keyboard/Package.swift
+++ b/packages/whisker-keyboard/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "WhiskerKeyboard", targets: ["WhiskerKeyboard"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-keyboard/build.gradle.kts
+++ b/packages/whisker-keyboard/build.gradle.kts
@@ -49,8 +49,8 @@ dependencies {
     // 0.1.6 is the first SDK release carrying `WhiskerInsetsDispatcher`
     // (the shared decor-view inset multiplexer this module subscribes
     // to). Requires cutting `sdk-v0.1.6`; see the module refactor commit.
-    implementation("rs.whisker:whisker-module-android:0.1.6")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 
     // `WindowInsetsCompat.Type.ime()` + `ViewCompat.setOnApplyWindowInsetsListener`
     // — the AndroidX wrappers that expose the IME inset uniformly across

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "WhiskerLocalStore", targets: ["WhiskerLocalStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
         // PoC — an external SwiftPM dependency. swift-collections is
         // Apple-maintained, header-only Swift, small enough that
         // resolving it is fast even on a cold cache. Use is minimal

--- a/packages/whisker-local-store/build.gradle.kts
+++ b/packages/whisker-local-store/build.gradle.kts
@@ -40,13 +40,13 @@ ksp {
 }
 
 dependencies {
-    // Phase J — single Whisker runtime dep. `ksp("rs.whisker:ksp:0.1.0")`
+    // Phase J — single Whisker runtime dep. `ksp("rs.whisker:ksp:0.1.19")`
     // stays separate (it is a build-time processor, not on the
     // runtime classpath). Phase M (Issue #59) dropped the
     // `:annotations` JAR: the KSP processor finds Module subclasses
     // by inheritance, so no marker annotation is needed.
-    implementation("rs.whisker:whisker-module-android:0.1.0")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 
     // Phase 7-Φ.G PoC — an external Maven dependency. AndroidX
     // Collection is small + pure-Kotlin (no native libs), so it

--- a/packages/whisker-paths/Package.swift
+++ b/packages/whisker-paths/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerPaths", targets: ["WhiskerPaths"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-paths/build.gradle.kts
+++ b/packages/whisker-paths/build.gradle.kts
@@ -41,6 +41,6 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 }

--- a/packages/whisker-router/build.gradle.kts
+++ b/packages/whisker-router/build.gradle.kts
@@ -54,11 +54,11 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
     // androidx.activity.OnBackPressedDispatcher / -Callback for
     // PredictiveBackModule. 1.8+ is the floor that wires
     // OnBackPressedDispatcher into the platform's OnBackInvoked
     // path on API 33+ — older androidx routes the legacy path.
     implementation("androidx.activity:activity:1.8.2")
-    ksp("rs.whisker:ksp:0.1.0")
+    ksp("rs.whisker:ksp:0.1.19")
 }

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-safe-area/build.gradle.kts
+++ b/packages/whisker-safe-area/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
     // 0.1.6 is the first SDK release carrying `WhiskerInsetsDispatcher`
     // (the shared decor-view inset multiplexer this module subscribes
     // to). Requires cutting `sdk-v0.1.6`; see the module refactor commit.
-    implementation("rs.whisker:whisker-module-android:0.1.6")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 
     // `WindowInsetsCompat` + `ViewCompat.setOnApplyWindowInsetsListener`
     // — the AndroidX wrappers that paper over the API-30 introduction

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-secure-store/build.gradle.kts
+++ b/packages/whisker-secure-store/build.gradle.kts
@@ -43,8 +43,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 
     // Google Tink — AES-256-GCM payload crypto with an Android
     // Keystore-wrapped keyset. Google's recommended replacement for the

--- a/packages/whisker-status-bar/Package.swift
+++ b/packages/whisker-status-bar/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .library(name: "WhiskerStatusBar", targets: ["WhiskerStatusBar"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-status-bar/build.gradle.kts
+++ b/packages/whisker-status-bar/build.gradle.kts
@@ -40,8 +40,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.6")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
     // `WindowInsetsControllerCompat` / `WindowCompat` live in
     // androidx.core — the runtime already depends on it transitively,
     // but declare it so this module builds standalone too.

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "WhiskerSvg", targets: ["WhiskerSvg"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-svg/build.gradle.kts
+++ b/packages/whisker-svg/build.gradle.kts
@@ -48,8 +48,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 
     testImplementation("junit:junit:4.13.2")
 }

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // it there, and the package identity (the crate's dir name)
         // is unique, so the app aggregator references it via
         // `.package(path: …)` without the `ios`-dir-name collision.
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-video/build.gradle.kts
+++ b/packages/whisker-video/build.gradle.kts
@@ -38,13 +38,13 @@ ksp {
 }
 
 dependencies {
-    // Phase J — single Whisker runtime dep. `ksp("rs.whisker:ksp:0.1.0")`
+    // Phase J — single Whisker runtime dep. `ksp("rs.whisker:ksp:0.1.19")`
     // stays separate (it is a build-time processor, not on the
     // runtime classpath). Phase M (Issue #59) dropped the
     // `:annotations` JAR: the KSP processor finds Module subclasses
     // by inheritance now, so no marker annotation is needed.
-    implementation("rs.whisker:whisker-module-android:0.1.0")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 
     // AndroidX Media3 — modern replacement for the deprecated
     // android.widget.VideoView / MediaPlayer pair. ExoPlayer is

--- a/packages/whisker-web-browser/Package.swift
+++ b/packages/whisker-web-browser/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "WhiskerWebBrowser", targets: ["WhiskerWebBrowser"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-web-browser/build.gradle.kts
+++ b/packages/whisker-web-browser/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     // `0.1.7` — needs `WhiskerAppContext.DeepLinkListener`/
     // `addDeepLinkListener`/`removeDeepLinkListener`, added in this
     // same change and published by the `sdk-v0.1.7` release.
-    implementation("rs.whisker:whisker-module-android:0.1.7")
-    ksp("rs.whisker:ksp:0.1.7")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
     implementation("androidx.browser:browser:1.8.0")
 }

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.9"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.10"),
     ],
     targets: [
         .target(

--- a/packages/whisker-webview/build.gradle.kts
+++ b/packages/whisker-webview/build.gradle.kts
@@ -48,8 +48,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.0")
-    ksp("rs.whisker:ksp:0.1.0")
+    implementation("rs.whisker:whisker-module-android:0.1.19")
+    ksp("rs.whisker:ksp:0.1.19")
 
     // AndroidX WebKit compat — provides WebViewCompat.addDocumentStartJavaScript
     // (API 24+) for reliable document-start JS injection without a race against


### PR DESCRIPTION
Round 1 of the batch-E2E findings (#389's fix verified correct but undelivered; module gradle pins fossilized):

- **Root `/Package.swift` → Lynx `4.0.1-whisker.2`.** The root manifest is what remote SwiftPM consumers resolve at a `v0.1.N` tag; #393 rolled only `platforms/ios/Package.swift`, so the published 0.1.9 still shipped `whisker.1` — the E2E proved the bool fix works by overriding the checkout, and that apps never received it. New test `root_package_swift_lynx_pins_match_the_platform_manifest` fails the build on any future drift.
- **`WHISKER_IOS_SPM_VERSION` 0.1.9 → 0.1.10** + all 15 module pins; `publish-ios 0.1.10` follows after merge. 0.1.9 stays abandoned per the release skill's never-move-a-tag rule.
- **All `packages/*/build.gradle.kts` SDK pins → 0.1.19** (were 0.1.0–0.1.15; 17× `ksp:0.1.0`). whisker-webview's Android module has been uncompilable standalone since #385 (`WhiskerPromise` arrived in sdk-v0.1.15); app builds masked it via dependency-resolution upgrade, the E2E's clean build did not.

No new `sdk-v` tag — the SDK AARs themselves are unchanged. Gates: `spm_pin_consistency` (both tests) green, `cargo build --workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)