### PR TITLE
Fix the two back-handling regressions the batch E2E caught

### DIFF
--- a/packages/whisker-router/src/render/gesture.rs
+++ b/packages/whisker-router/src/render/gesture.rs
@@ -372,8 +372,14 @@ pub fn android_predictive_back() -> Element {
         let nav_for_enabled = nav.clone();
         let last_sent: Rc<std::cell::Cell<Option<bool>>> = Rc::new(std::cell::Cell::new(None));
         whisker::runtime::reactive::effect(move || {
-            let _ = nav_for_enabled.state().get();
-            let can_pop = nav_for_enabled.active_stack_bridge().is_some();
+            // Derived from the state itself, not the gesture bridges:
+            // `Stack` re-registers its bridge during reconcile AFTER the
+            // state write, so a bridge-based read here is one navigation
+            // stale (first push → back exits the app).
+            let state = nav_for_enabled.state().get();
+            let can_pop = state.active_chain().iter().any(
+                |node| matches!(node, crate::core::RouteState::Stack(s) if s.history.len() > 1),
+            );
             // `has_any_handler`, not `has_active_handler`: a pop's
             // survivor stays paused until its settle finishes, and the
             // pause-filtered predicate would disable back past a

--- a/packages/whisker-router/src/render/node.rs
+++ b/packages/whisker-router/src/render/node.rs
@@ -365,16 +365,39 @@ fn reconcile_stack(
                 let drive = w.ctrl.clone();
                 w.ctrl.set_value(0.0);
                 set_pose(&w, &drive, Role::Top, Direction::Push);
-                {
+                let under_owner = {
                     let l = live.borrow();
-                    if let Some(under) = l.last() {
+                    l.last().map(|under| {
                         under.owner.resume(); // animate it while covered
                         set_pose(under, &drive, Role::Under, Direction::Push);
-                    }
-                }
+                        under.owner
+                    })
+                };
                 if w.transition.is_instant() {
                     drive.set_value(1.0);
+                    if let Some(owner) = under_owner {
+                        owner.pause();
+                    }
                 } else {
+                    // The steady-state settle skips wrappers whose pose is
+                    // still animating and no reconcile re-runs after the
+                    // slide, so the covered under has to be frozen from the
+                    // run's own completion. One-shot: `on_finish` callbacks
+                    // persist across a controller's later runs, and firing
+                    // again on a pop's reverse would pause the screen that
+                    // pop just revealed.
+                    if let Some(owner) = under_owner {
+                        let mut done = false;
+                        drive.on_finish(move |finished| {
+                            if done {
+                                return;
+                            }
+                            done = true;
+                            if finished {
+                                owner.pause();
+                            }
+                        });
+                    }
                     drive.forward();
                 }
                 live.borrow_mut().push(w);

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -487,6 +487,70 @@ fn settle_animations() {
 }
 
 #[test]
+fn push_pauses_the_covered_under_once_the_slide_finishes() {
+    whisker::runtime::reactive::__reset_for_tests();
+    whisker_animation::__reset_for_tests();
+    let owner = Owner::new(None);
+    owner.with(|| {
+        let h = slide_stack_handle();
+        let _slot = mount_node(&h, NodePath::root());
+        flush();
+
+        h.navigate("/detail/1").unwrap();
+        flush();
+        settle_animations();
+
+        let under_owner = h
+            .active_stack_bridge()
+            .and_then(|b| b.under_owner)
+            .expect("under owner present after push");
+        assert!(
+            under_owner.is_paused(),
+            "the covered under must be frozen after the push settles — an \
+             unfrozen under keeps its back-handler registrations active"
+        );
+
+        // Popping revives it: the revealed screen must not stay paused.
+        assert!(h.back().is_ok());
+        flush();
+        settle_animations();
+        assert!(
+            !under_owner.is_paused(),
+            "the pop's survivor must be resumed"
+        );
+    });
+}
+
+#[test]
+fn can_pop_is_derivable_from_state_before_any_reconcile() {
+    // The platform enabled effect computes can-pop from the state
+    // signal; the gesture bridges update one reconcile later and must
+    // not be its source.
+    whisker::runtime::reactive::__reset_for_tests();
+    whisker_animation::__reset_for_tests();
+    let owner = Owner::new(None);
+    owner.with(|| {
+        let h = slide_stack_handle();
+        let _slot = mount_node(&h, NodePath::root());
+        flush();
+
+        let can_pop = |h: &RouterHandle| {
+            h.state().get_untracked().active_chain().iter().any(
+                |node| matches!(node, crate::core::RouteState::Stack(s) if s.history.len() > 1),
+            )
+        };
+        assert!(!can_pop(&h), "root: nothing to pop");
+        h.navigate("/detail/1").unwrap();
+        assert!(
+            can_pop(&h),
+            "immediately after the state write, before any flush/reconcile"
+        );
+        assert!(h.back().is_ok());
+        assert!(!can_pop(&h), "back at root");
+    });
+}
+
+#[test]
 fn pop_settles_survivor_to_active_pose() {
     whisker::runtime::reactive::__reset_for_tests();
     whisker_animation::__reset_for_tests();


### PR DESCRIPTION
Round 2 of the batch-E2E findings — both #392 regressions, root-caused from the device traces:

## 1. Enabled state one navigation stale (back exited the app from the first pushed screen)

The effect subscribed to the route-state signal but computed can-pop from `active_stack_bridge()` — the gesture bridges, which `Stack` re-registers during reconcile **after** the state write. The E2E trace showed the effect re-running with a one-generation-old value (`can_pop=false` after the first push). Now derived from the state itself (`active_chain()` has a `Stack` with history > 1), which is synchronous with the subscribed read.

## 2. A pushed-under was never frozen (a guarded root made every pushed screen unpoppable)

`reconcile_stack`'s steady-state settle intends to pause buried entries but skips wrappers whose pose is still animating — and no reconcile re-runs when the push slide finishes, so the covered screen's scope stayed unpaused forever. Its `on_back` registration therefore stayed active, and `dispatch()`/`begin()` routed every back (and iOS edge swipe) to the buried guard instead of the pop.

Fix: freeze the under from the push run's own completion. One-shot by hand, because `on_finish` callbacks persist across a controller's later runs — a naive registration would re-fire on a pop's reverse and pause the screen that pop just revealed. Instant transitions pause synchronously. Cancelled/interrupted runs (`finished == false`) leave the state to the next reconcile, matching today's behavior.

This also closes a broader gap the E2E exposed: pushed-under screens kept running their effects while covered.

## Verification

Two new harness tests: `push_pauses_the_covered_under_once_the_slide_finishes` (+ resume on pop) and `can_pop_is_derivable_from_state_before_any_reconcile`. Full whisker-router suite green (45), clippy 0, `cargo build --workspace` clean. Rust-only — reaches the E2E examples via the workspace immediately (no SDK release needed); device re-verification round follows.

The third E2E finding (blank screen resuming after the back/exit path) is tracked separately — it is in the Kotlin/activity-lifecycle layer, not this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)