### PR TITLE
Tear down the previous app tree when run() is called again (#396)

### DIFF
--- a/crates/whisker-dev-runtime/src/hot_reload.rs
+++ b/crates/whisker-dev-runtime/src/hot_reload.rs
@@ -97,6 +97,14 @@ pub fn take_pending_patch() -> Option<JumpTable> {
 /// on connection failure so a dev server starting later still gets
 /// picked up.
 pub fn start_receiver() {
+    // Once per process: the receiver thread + its WebSocket outlive any
+    // single bootstrap, so a re-`run()` (Android Activity recreation)
+    // must not spawn a second thread racing the same dev server.
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static STARTED: AtomicBool = AtomicBool::new(false);
+    if STARTED.swap(true, Ordering::AcqRel) {
+        return;
+    }
     let addr = std::env::var("WHISKER_DEV_ADDR")
         .ok()
         .filter(|a| !a.is_empty())

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -56,7 +56,7 @@ use whisker_runtime::reactive::{
 };
 use whisker_runtime::view::{
     DynRenderer, Element, append_child, create_element, flush as renderer_flush, install_renderer,
-    set_inline_styles, set_root,
+    set_inline_styles, set_root, uninstall_renderer,
 };
 
 thread_local! {
@@ -66,6 +66,16 @@ thread_local! {
     /// the callback runs synchronously, so this is flipped back to
     /// `false` before `tick()` returns.
     static PENDING: Cell<bool> = const { Cell::new(false) };
+
+    /// The current bootstrap's app-root owner. Retained so a
+    /// re-`run()` in the same process — Android recreates the Activity
+    /// (hence the WhiskerView, the engine, and this bootstrap) after a
+    /// back-out finishes it while the process lives on — can tear the
+    /// previous app tree down before building the next one. Without
+    /// this the second tree stacks on top of the first in the shared
+    /// thread-local runtime and never paints (issue #396).
+    static APP_ROOT_OWNER: std::cell::RefCell<Option<whisker_runtime::reactive::Owner>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 /// Bootstrap the runtime. Called from the FFI export the
@@ -125,6 +135,26 @@ extern "C" fn init_callback(user_data: *mut c_void) {
     if user_data.is_null() {
         return;
     }
+    // Re-`run()` in a live process (Android Activity recreation): tear
+    // the previous app tree down before building the next. Disposing
+    // the app-root owner cascades the run owner and every element /
+    // signal / on_cleanup below it — including the `BackGuard`s and
+    // other registrations tree #1 held. Process-global module
+    // singletons (safe-area insets, the back registry, …) are minted
+    // under their OWN detached roots, so they survive untouched.
+    //
+    // Uninstall the renderer FIRST: the previous BridgeRenderer points
+    // at the now-freed engine #1 (the old WhiskerView's `destroy()`
+    // called `whisker_bridge_engine_release`, which `delete`s it), so
+    // the element releases the dispose fans out must not reach the
+    // native side. With no renderer installed they no-op, and the
+    // fresh engine #2 renderer is installed further down.
+    APP_ROOT_OWNER.with(|slot| {
+        if let Some(prev) = slot.borrow_mut().take() {
+            uninstall_renderer(None);
+            prev.dispose();
+        }
+    });
     let mut ctx: Box<InitCtx> = unsafe { Box::from_raw(user_data as *mut InitCtx) };
 
     let renderer = match unsafe { BridgeRenderer::from_raw(ctx.engine) } {
@@ -201,9 +231,11 @@ extern "C" fn init_callback(user_data: *mut c_void) {
     // owner to attach to; without one it silently no-ops and any
     // descendant's `use_context::<T>().expect(...)` panics across this
     // `extern "C"` boundary (aborting on Android, blank-screening on
-    // iOS). This root owner is never disposed — the disposable child
-    // "run owner" below is what a full remount tears down.
+    // iOS). Disposed only by a re-`run()` in the same process (see the
+    // teardown at the top of this fn); a full remount tears down the
+    // disposable child "run owner" below instead.
     let root_owner = whisker_runtime::reactive::Owner::detached_root();
+    APP_ROOT_OWNER.with(|slot| *slot.borrow_mut() = Some(root_owner));
     root_owner.with(|| {
         // Lynx requires the shell root to be a `page` element and keeps
         // it FIXED for the app's lifetime (it can't be swapped — see
@@ -247,6 +279,14 @@ fn start_hot_reload_receiver() {}
 // so a current-thread reactor would never advance registered IO.
 #[cfg(feature = "tokio")]
 fn init_tokio_runtime() {
+    // Once per process: the runtime + its entered context outlive any
+    // single bootstrap, so a re-`run()` (Android Activity recreation)
+    // must not build and leak a second one.
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static STARTED: AtomicBool = AtomicBool::new(false);
+    if STARTED.swap(true, Ordering::Relaxed) {
+        return;
+    }
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all() // IO (mio: epoll on Android / kqueue on iOS) + timer
         .worker_threads(2) // conservative for mobile; tune later if needed

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -143,15 +143,21 @@ extern "C" fn init_callback(user_data: *mut c_void) {
     // singletons (safe-area insets, the back registry, …) are minted
     // under their OWN detached roots, so they survive untouched.
     //
-    // Uninstall the renderer FIRST: the previous BridgeRenderer points
-    // at the now-freed engine #1 (the old WhiskerView's `destroy()`
-    // called `whisker_bridge_engine_release`, which `delete`s it), so
-    // the element releases the dispose fans out must not reach the
-    // native side. With no renderer installed they no-op, and the
-    // fresh engine #2 renderer is installed further down.
+    // Clear every process-global wiring that pointed at engine #1
+    // FIRST. The old WhiskerView's `destroy()` called
+    // `whisker_bridge_engine_release`, which `delete`s the engine, so
+    // the renderer, the host-wake callback, and the main-thread
+    // dispatcher all dangle. Any call through them during the dispose
+    // (element releases; an `on_cleanup` writing a signal, which wakes
+    // the host; a background async completion marshalling onto the main
+    // thread) would be a use-after-free. Nulled, they no-op; engine #2's
+    // wirings install further down.
     APP_ROOT_OWNER.with(|slot| {
         if let Some(prev) = slot.borrow_mut().take() {
             uninstall_renderer(None);
+            whisker_runtime::host_wake::set_request_frame_callback(None, std::ptr::null_mut());
+            whisker_runtime::main_thread::set_main_thread_dispatcher(None, std::ptr::null_mut());
+            whisker_runtime::main_thread::set_drive_callback(None);
             prev.dispose();
         }
     });


### PR DESCRIPTION
Fixes #396.

## Root cause (device-diagnosed)

Android finishes the Activity on a back-out even for a launcher-started root (confirmed on API 36 — the "API 31+ keeps launcher roots" behavior does **not** apply here), while keeping the process alive. It then recreates the Activity → a new WhiskerView → a new Lynx engine → a second call to `run()`. The diagnosis traces showed:

- `init_callback #2` runs on the **same TASM thread** (`ThreadId(3)`) as #1 → same thread-local reactive runtime.
- `app_fn` runs and `set_root + flush` execute fully — yet the screen is blank.

So the second app tree stacks on top of the first in the shared runtime and never paints. A minimal on-device probe that disposed the previous app-root owner before building the second tree **restored a live, interactive screen** — confirming the mechanism is runtime pollution, not a renderer/flush plumbing gap.

## Fix

- **Retain the app-root owner; dispose it at the top of a re-`run()`.** Cascades the run owner and all of tree #1 — elements, signals, `on_cleanup`-registered `BackGuard`s — while process-global module singletons (safe-area insets, the `whisker::back` registry) survive, because those are minted under their own detached roots.
- **A wholesale runtime reset was ruled out on device:** it frees those singletons' arena nodes while their handles are still cached in thread-locals, aborting across the FFI boundary (`non-unwinding panic. aborting`).
- **Clear all four engine-bound wirings before the dispose** — renderer, host-wake callback, main-thread dispatcher, drive. The old WhiskerView already freed engine #1 (`whisker_bridge_engine_release` `delete`s it), so element releases, an `on_cleanup` waking the host, or a background async marshalling onto the main thread during the dispose would each be a use-after-free. Nulled, they no-op; engine #2's wirings install immediately after.
- **`init_tokio_runtime` / `start_receiver` are now once-per-process.** Their threads outlive any single bootstrap; a re-run must not leak a second tokio runtime or spawn a second hot-reload receiver racing the dev server.

Harmless on iOS, where `run()` is called once per process — `APP_ROOT_OWNER` holds the single owner and the teardown never triggers.

## Known residual (not gating; filed as #398)

The four-wiring clear closes the **dispose-phase** window. A narrower, **pre-existing** window remains: between `onDestroy` (engine freed) and the next Activity's bootstrap, the wirings dangle at the freed engine, so a background async completion calling `run_on_main_thread` while the app is backgrounded with no new Activity is still a UAF. The correct close is clearing the wirings in `WhiskerView.destroy()` before the engine is freed — tracked in #398.

## Verification

- Device (router example, API 36): two back-out / relaunch cycles resume to a live, interactive Home; zero aborts across cycles (previously blank; a wholesale reset aborted).
- `cargo build --workspace` clean; `cargo test` green across whisker-driver / whisker-dev-runtime / whisker-runtime / whisker-router; clippy 0; `xcodebuild -scheme WhiskerRuntime` BUILD SUCCEEDED.
- Rust-only — reaches apps with the next crates release (no SDK/SPM bump).

The broader class this touches (any Activity recreation in a live process — low-memory recreation, some config changes) is now handled by the same teardown, not just the back path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)