### PR TITLE
fmt: reach nested macros, converge with rustfmt, and respect authored layout

### DIFF
--- a/crates/whisker-fmt/src/ir.rs
+++ b/crates/whisker-fmt/src/ir.rs
@@ -53,9 +53,15 @@ pub(crate) struct IrTag {
 
 pub(crate) struct IrKwarg {
     pub name: String,
+    /// Source span of the kwarg's name (routes!'s synthesized kwargs use
+    /// the value token's span), locating the kwarg for comment placement.
+    pub name_span: Option<Span>,
     /// `None` = partial (mid-typing: no `:` yet, or the value failed to
     /// parse) — printed as the bare name, no value.
     pub value: Option<IrValue>,
+    /// Source span of the value, bounding the kwarg's line for trailing-
+    /// comment attachment.
+    pub value_span: Option<Span>,
 }
 
 pub(crate) enum IrValue {
@@ -101,15 +107,18 @@ fn adapt_render_node(node: &whisker_macro_syntax::render::Node) -> IrNode {
 }
 
 fn adapt_render_kwargs(kwargs: &[whisker_macro_syntax::render::Kwarg]) -> Vec<IrKwarg> {
+    use syn::spanned::Spanned;
     kwargs
         .iter()
         .map(|kw| IrKwarg {
             name: kw.name.to_string(),
+            name_span: Some(kw.name.span()),
             value: if kw.partial {
                 None
             } else {
                 Some(IrValue::Expr(Box::new(kw.value.clone())))
             },
+            value_span: (!kw.partial).then(|| kw.value.span()),
         })
         .collect()
 }
@@ -143,23 +152,30 @@ fn adapt_routes_node(node: &whisker_macro_syntax::routes::RoutesNode) -> IrNode 
             transition,
             children,
         } => {
+            use syn::spanned::Spanned;
             let mut kwargs = Vec::new();
             if let Some(p) = path {
                 kwargs.push(IrKwarg {
                     name: "path".to_string(),
+                    name_span: Some(p.span()),
                     value: Some(IrValue::Literal(format!("{:?}", p.value()))),
+                    value_span: Some(p.span()),
                 });
             }
             if let Some(c) = component {
                 kwargs.push(IrKwarg {
                     name: "component".to_string(),
+                    name_span: Some(c.span()),
                     value: Some(IrValue::Literal(c.to_string())),
+                    value_span: Some(c.span()),
                 });
             }
             if let Some(t) = transition {
                 kwargs.push(IrKwarg {
                     name: "transition".to_string(),
+                    name_span: Some(t.span()),
                     value: Some(IrValue::Expr(Box::new(t.clone()))),
+                    value_span: Some(t.span()),
                 });
             }
             IrNode::Tag(IrTag {

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -1343,9 +1343,9 @@ mod comment_tests {
     #[test]
     fn wallet_faithful_reduction_formats_and_preserves_comments() {
         let input = "fn d() -> Element {\n    render! {\n        view(style: css!(\n            flex_grow: 1.0,\n            background_color: BG,\n        )) {\n        view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false\n    )\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n        }\n        }\n    }\n}\n";
-        // The css!'s trailing comma is a keep-vertical hint, so it stays
-        // broken and the enclosing kwarg list wraps around it.
-        let expected = "fn d() -> Element {\n    render! {\n        view(\n            style: css!(\n                flex_grow: 1.0,\n                background_color: BG,\n            ),\n        ) {\n            view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false)\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n            }\n        }\n    }\n}\n";
+        // The css!'s trailing comma keeps IT vertical, and last-argument
+        // overflow keeps it combined on the view's own line.
+        let expected = "fn d() -> Element {\n    render! {\n        view(style: css!(\n            flex_grow: 1.0,\n            background_color: BG,\n        )) {\n            view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false)\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n            }\n        }\n    }\n}\n";
         let out = fmt(input);
         assert_ne!(out, input, "must not fall back:\n{out}");
         assert_eq!(out, expected, "got:\n{out}");
@@ -1663,6 +1663,33 @@ mod coverage_tests {
         let out = fmt(input);
         assert!(out.contains("a: css!(x: 1)"), "got:\n{out}");
         assert!(out.contains("b: css!(y: 2)"), "got:\n{out}");
+    }
+
+    // ---- last-argument overflow (combine) ---------------------------------
+
+    #[test]
+    fn multiline_last_kwarg_combines_on_open_line() {
+        let input = "fn ui() -> Element {\n    render! {\n        view(style: css!(\n            flex_grow: 1.0,\n            background_color: BG,\n        )) {\n            text(value: \"hi\")\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn single_line_kwargs_before_multiline_last_stay_on_open_line() {
+        let input = "fn ui() -> Element {\n    render! {\n        view(key: 1, style: css!(\n            flex_grow: 1.0,\n        ))\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn outer_trailing_comma_beats_combine() {
+        let input = "fn ui() -> Element {\n    render! {\n        view(\n            style: css!(\n                flex_grow: 1.0,\n            ),\n        )\n    }\n}\n";
+        assert_eq!(
+            fmt(input),
+            input,
+            "authored outer trailing comma pins the wrap"
+        );
+        assert_idempotent(input);
     }
 
     // ---- comments anchored to kwargs --------------------------------------

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -1665,6 +1665,45 @@ mod coverage_tests {
         assert!(out.contains("b: css!(y: 2)"), "got:\n{out}");
     }
 
+    // ---- blank-line preservation ------------------------------------------
+
+    #[test]
+    fn blank_line_between_siblings_preserved() {
+        let input = "fn ui() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n\n            text(value: \"b\")\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn multiple_blank_lines_collapse_to_one() {
+        let input = "fn ui() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n\n\n\n            text(value: \"b\")\n        }\n    }\n}\n";
+        let expected = "fn ui() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n\n            text(value: \"b\")\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), expected);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn blank_line_before_section_comment_preserved() {
+        let input = "fn ui() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n\n            // section\n            text(value: \"b\")\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn blank_lines_at_block_edges_dropped() {
+        let input = "fn ui() -> Element {\n    render! {\n        view {\n\n            text(value: \"a\")\n\n        }\n    }\n}\n";
+        let expected = "fn ui() -> Element {\n    render! {\n        view {\n            text(value: \"a\")\n        }\n    }\n}\n";
+        assert_eq!(fmt(input), expected);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn blank_line_between_css_field_groups_preserved() {
+        let input = "fn s() -> Css {\n    css! {\n        color: red,\n        padding: px(8),\n\n        margin_top: px(4),\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
     // ---- inline-when-fits statement macros --------------------------------
 
     #[test]

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -1264,7 +1264,9 @@ mod comment_tests {
     #[test]
     fn wallet_faithful_reduction_formats_and_preserves_comments() {
         let input = "fn d() -> Element {\n    render! {\n        view(style: css!(\n            flex_grow: 1.0,\n            background_color: BG,\n        )) {\n        view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false\n    )\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n        }\n        }\n    }\n}\n";
-        let expected = "fn d() -> Element {\n    render! {\n        view(style: css!(flex_grow: 1.0, background_color: BG)) {\n            view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false)\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n            }\n        }\n    }\n}\n";
+        // The css!'s trailing comma is a keep-vertical hint, so it stays
+        // broken and the enclosing kwarg list wraps around it.
+        let expected = "fn d() -> Element {\n    render! {\n        view(\n            style: css!(\n                flex_grow: 1.0,\n                background_color: BG,\n            ),\n        ) {\n            view {\n                // \u{2500}\u{2500} Recent \u{2500}\u{2500}\n                Tx(icon: cart, name: \"Groceries\", positive: false)\n                Tx(icon: coffee, name: \"Coffee\", positive: false)\n            }\n        }\n    }\n}\n";
         let out = fmt(input);
         assert_ne!(out, input, "must not fall back:\n{out}");
         assert_eq!(out, expected, "got:\n{out}");
@@ -1577,6 +1579,55 @@ mod coverage_tests {
         let out = fmt(input);
         assert!(out.contains("a: css!(x: 1)"), "got:\n{out}");
         assert!(out.contains("b: css!(y: 2)"), "got:\n{out}");
+    }
+
+    // ---- trailing-comma keep-vertical hint --------------------------------
+
+    #[test]
+    fn trailing_comma_keeps_kwargs_vertical() {
+        let input = "fn ui() -> Element {\n    render! {\n        LabeledField(\n            label: \"Name\",\n            value: v,\n        )\n    }\n}\n";
+        assert_eq!(
+            fmt(input),
+            input,
+            "trailing comma must keep the list vertical"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn no_trailing_comma_joins_kwargs_when_they_fit() {
+        let input = "fn ui() -> Element {\n    render! {\n        LabeledField(\n            label: \"Name\",\n            value: v\n        )\n    }\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains("LabeledField(label: \"Name\", value: v)"),
+            "no hint, fits → joined:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn trailing_comma_keeps_css_fields_vertical() {
+        let input =
+            "fn s() -> Css {\n    css! {\n        color: red,\n        padding: px(8),\n    }\n}\n";
+        assert_eq!(fmt(input), input, "trailing comma must keep css! vertical");
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn trailing_comma_keeps_nested_css_vertical() {
+        let input = "fn ui() -> Element {\n    render! {\n        view(\n            style: css!(\n                flex_grow: 1.0,\n                background_color: BG,\n            ),\n        )\n    }\n}\n";
+        assert_eq!(fmt(input), input, "nested css! trailing comma must hold");
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn comma_inside_string_is_not_a_keep_vertical_hint() {
+        let input = "fn ui() -> Element {\n    render! {\n        text(\n            value: \"a, b,\"\n        )\n    }\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains("text(value: \"a, b,\")"),
+            "a comma inside a string is no hint:\n{out}"
+        );
     }
 
     // ---- macros nested inside closures / arbitrary exprs ------------------

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -1665,6 +1665,40 @@ mod coverage_tests {
         assert!(out.contains("b: css!(y: 2)"), "got:\n{out}");
     }
 
+    // ---- comments anchored to kwargs --------------------------------------
+
+    #[test]
+    fn own_line_comment_between_kwargs_stays_on_its_kwarg() {
+        let input = "fn ui() -> Element {\n    render! {\n        ConnectionTab(\n            icon: home_icon,\n            active: home_active,\n            // Only Home's own root switches connections.\n            at_root: home_at_root,\n        )\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn trailing_comment_on_kwarg_line_stays_there() {
+        let input = "fn ui() -> Element {\n    render! {\n        TabButton(\n            icon: home_icon,\n            active: home_active, // updated per nav\n            label: home_label,\n        )\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn comments_before_first_and_after_last_kwarg_stay_inside_parens() {
+        let input = "fn ui() -> Element {\n    render! {\n        TabButton(\n            // leading\n            icon: home_icon,\n            active: home_active,\n            // last\n        )\n    }\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn kwarg_comments_reflow_from_messy_input() {
+        let input = "fn ui() -> Element {\n    render! {\n        TabButton(icon: home_icon,\n            // anchor\n            active: home_active) { text(value: \"x\") }\n    }\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains("            // anchor\n            active: home_active,\n"),
+            "comment must stay anchored to its kwarg:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
     // ---- blank-line preservation ------------------------------------------
 
     #[test]

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -549,6 +549,14 @@ fn macro_body_edit(
                 }
                 let comments = comments::collect_grammar_comments(body_src, &spans, &body_map);
                 let expr_map = build_expr_map(&spans, &body_map, exprfmt);
+                let inline_budget = inline_body_budget(
+                    group.delimiter(),
+                    rust_src,
+                    line_start,
+                    group_start,
+                    close_byte,
+                    opts,
+                );
                 let s = printer::print_css(
                     &input,
                     &body_map,
@@ -558,6 +566,7 @@ fn macro_body_edit(
                     exprfmt,
                     &comments,
                     body_len,
+                    inline_budget,
                 );
                 (s, comments)
             }
@@ -566,14 +575,23 @@ fn macro_body_edit(
         _ => return Ok(None),
     };
 
-    // The printer emits the body already indented to `base_indent + 1`,
-    // so only the surrounding newlines and closing indent are added
-    // here. Every delimiter form breaks onto its own lines, matching
-    // rustfmt's treatment of multi-item macros.
+    // A single-line body stays on the macro's own line when the whole
+    // line (prefix, delimiters, and whatever follows the macro) fits
+    // `max_width`; otherwise the body breaks onto its own lines. The
+    // printer already indented a multi-line body to `base_indent + 1`.
     let closing_indent = opts.indent_prefix(base_indent);
-    let replacement = match group.delimiter() {
-        Delimiter::Brace => format!("\n{formatted}\n{closing_indent}"),
-        _ => format!("\n{formatted}\n{closing_indent}"),
+    let replacement = if let Some(inline) = inline_replacement(
+        &formatted,
+        group.delimiter(),
+        rust_src,
+        line_start,
+        group_start,
+        close_byte,
+        opts,
+    ) {
+        inline
+    } else {
+        format!("\n{formatted}\n{closing_indent}")
     };
 
     if body_src == replacement {
@@ -597,6 +615,66 @@ fn macro_body_edit(
         close_byte,
         replacement,
     }))
+}
+
+/// Char budget a single-line BODY (delimiter padding excluded) may use
+/// and still keep the macro's whole original line — the text before the
+/// opening delimiter through the text after the closing one — within
+/// `max_width`.
+fn inline_body_budget(
+    delimiter: Delimiter,
+    rust_src: &str,
+    line_start: usize,
+    group_start: usize,
+    close_byte: usize,
+    opts: &FmtOptions,
+) -> usize {
+    let prefix = rust_src[line_start..group_start].chars().count();
+    let after_close = close_byte + 1;
+    let line_end = rust_src[after_close..]
+        .find('\n')
+        .map(|n| after_close + n)
+        .unwrap_or(rust_src.len());
+    let suffix = rust_src[after_close..line_end].trim_end().chars().count();
+    let pads = if delimiter == Delimiter::Brace { 2 } else { 0 };
+    opts.max_width.saturating_sub(prefix + 2 + pads + suffix)
+}
+
+/// The inline (single-line) body replacement, or `None` when the body
+/// must break: it is multi-line or over [`inline_body_budget`]. Brace
+/// bodies get rustfmt's `name! { … }` interior padding; paren/bracket
+/// bodies none.
+#[allow(clippy::too_many_arguments)]
+fn inline_replacement(
+    formatted: &str,
+    delimiter: Delimiter,
+    rust_src: &str,
+    line_start: usize,
+    group_start: usize,
+    close_byte: usize,
+    opts: &FmtOptions,
+) -> Option<String> {
+    if formatted.contains('\n') {
+        return None;
+    }
+    let body = formatted.trim_start();
+    let budget = inline_body_budget(
+        delimiter,
+        rust_src,
+        line_start,
+        group_start,
+        close_byte,
+        opts,
+    );
+    if body.chars().count() > budget {
+        return None;
+    }
+    let pad = if delimiter == Delimiter::Brace {
+        " "
+    } else {
+        ""
+    };
+    Some(format!("{pad}{body}{pad}"))
 }
 
 // ---- comment-preservation fail-safe helpers -----------------------------
@@ -801,7 +879,8 @@ mod tests {
     fn trailing_block_comment_preserved_and_reflowed() {
         let input = "fn ui() -> Element {\n    render! { view(style:\"x\") /* keep me */ }\n}\n";
         let out = reformat_macros(input, &opts(4, 100)).unwrap();
-        let expected = "fn ui() -> Element {\n    render! {\n        view(style: \"x\") /* keep me */\n    }\n}\n";
+        let expected =
+            "fn ui() -> Element {\n    render! { view(style: \"x\") /* keep me */ }\n}\n";
         assert_eq!(out, expected, "got:\n{out}");
     }
 
@@ -932,7 +1011,7 @@ mod tests {
         let input = "fn ui() -> Element {\n    render! { view(child: render!{text(value:\"nested\")}) }\n}\n";
         let out = reformat_macros(input, &opts(4, 100)).unwrap();
         assert!(
-            out.contains("render! {text(value: \"nested\")}"),
+            out.contains("render! { text(value: \"nested\") }"),
             "nested render! must be reformatted:\n{out}"
         );
     }
@@ -1398,12 +1477,17 @@ mod coverage_tests {
 
     #[test]
     fn render_bare_tag_no_parens_no_children() {
-        // Parens are omitted, but `macro_body_edit` wraps every macro
-        // body onto its own lines however short, so `view` still breaks.
+        // A bare tag stays bare (no parens invented) and a body this
+        // short stays on the macro's own line.
         let input = "fn ui() -> Element {\n    render! { view }\n}\n";
-        let out = fmt(input);
-        let expected = "fn ui() -> Element {\n    render! {\n        view\n    }\n}\n";
-        assert_eq!(out, expected, "got:\n{out}");
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn render_empty_parens_preserved() {
+        let input = "fn ui() -> Element {\n    render! { FreeQuotaBanner() }\n}\n";
+        assert_eq!(fmt(input), input, "authored empty () must survive");
         assert_idempotent(input);
     }
 
@@ -1581,6 +1665,57 @@ mod coverage_tests {
         assert!(out.contains("b: css!(y: 2)"), "got:\n{out}");
     }
 
+    // ---- inline-when-fits statement macros --------------------------------
+
+    #[test]
+    fn statement_css_stays_inline_when_it_fits() {
+        let input = "fn s() {\n    let a = css!(color: red, padding: px(8));\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn statement_css_trailing_comma_stays_vertical() {
+        let input = "fn s() {\n    let a = css!(\n        color: red,\n        padding: px(8),\n    );\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn over_budget_statement_css_goes_one_field_per_line() {
+        // Whole line doesn't fit → each field on its own line; never the
+        // broken-delimiter + one-joined-line middle form.
+        let input = "fn s() {\n    let label_column_style = css!(\n        flex_direction: FlexDirection::Column, flex_grow: 1.0, margin_right: px(16.0)\n    );\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains(
+                "css!(\n        flex_direction: FlexDirection::Column,\n        flex_grow: 1.0,\n        margin_right: px(16.0),\n    );"
+            ),
+            "must go one field per line:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn paren_broken_single_line_css_body_reinlines() {
+        // The shape an older whisker fmt used to emit: delimiters broken
+        // but fields joined. It must collapse back to one line.
+        let input = "fn s() {\n    let a = css!(\n        color: red, padding: px(8)\n    );\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains("let a = css!(color: red, padding: px(8));"),
+            "fits on one line, must re-inline:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn tiny_render_body_stays_on_one_line() {
+        let input = "fn ui() -> Element {\n    return render! { view() };\n}\n";
+        assert_eq!(fmt(input), input);
+        assert_idempotent(input);
+    }
+
     // ---- trailing-comma keep-vertical hint --------------------------------
 
     #[test]
@@ -1637,10 +1772,25 @@ mod coverage_tests {
         let input = "fn ui() -> Element {\n    render! { view(child: move || render! { text(value:\"hi\") }) }\n}\n";
         let out = fmt(input);
         assert!(
-            out.contains(
-                "child: move || render! {\n                text(value: \"hi\")\n            },"
-            ),
+            out.contains("child: move || render! { text(value: \"hi\") }"),
             "closure-wrapped render! body must be reformatted:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn closure_wrapped_render_in_kwarg_wraps_when_too_wide() {
+        let input = "fn ui() -> Element {\n    render! { view(child: move || render! { text(value:\"a-value-plenty-wide-enough-to-overflow-the-line-budget-here\") }) }\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains("child: move || render! {\n"),
+            "over-budget closure-wrapped render! must break:\n{out}"
+        );
+        assert!(
+            out.contains(
+                "text(value: \"a-value-plenty-wide-enough-to-overflow-the-line-budget-here\")"
+            ),
+            "inner body must be reformatted:\n{out}"
         );
         assert_idempotent(input);
     }

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -1798,8 +1798,8 @@ mod coverage_tests {
 
     #[test]
     fn paren_broken_single_line_css_body_reinlines() {
-        // The shape an older whisker fmt used to emit: delimiters broken
-        // but fields joined. It must collapse back to one line.
+        // Delimiters broken around one joined line that fits: collapses
+        // back to a single line.
         let input = "fn s() {\n    let a = css!(\n        color: red, padding: px(8)\n    );\n}\n";
         let out = fmt(input);
         assert!(

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -62,18 +62,46 @@ use std::process::Command;
 /// The rustfmt binary independently reads `rustfmt.toml`; pass
 /// `opts.edition` through so both passes agree on the edition.
 pub fn format_source(src: &str, opts: &FmtOptions) -> Result<String> {
-    let base = run_rustfmt(src, opts, None)?;
     let exprfmt = ExprFormatter::new(opts);
-    reformat_macros_inner(&base, opts, Some(&exprfmt))
+    format_converged(src, opts, None, &exprfmt)
 }
 
 /// Like [`format_source`] but tells rustfmt to resolve `rustfmt.toml`
 /// from `config_dir` (its `--config-path`). Used by the CLI so each
 /// file's nearest `rustfmt.toml` governs.
 pub fn format_source_in_dir(src: &str, opts: &FmtOptions, config_dir: &Path) -> Result<String> {
-    let base = run_rustfmt(src, opts, Some(config_dir))?;
     let exprfmt = ExprFormatter::new_in_dir(opts, config_dir);
-    reformat_macros_inner(&base, opts, Some(&exprfmt))
+    format_converged(src, opts, Some(config_dir), &exprfmt)
+}
+
+/// Run rustfmt + the macro pass repeatedly until the output is a fixed
+/// point, capped at 3 rounds. The two passes are individually idempotent
+/// but their COMPOSITION need not be: the macro pass can emit a shape
+/// (e.g. a multi-line `move || css!(…)` closure body) that the next
+/// round's rustfmt rewrites again (into `move || { css!(…) }`), which
+/// then IS stable.
+fn format_converged(
+    src: &str,
+    opts: &FmtOptions,
+    config_dir: Option<&Path>,
+    exprfmt: &ExprFormatter,
+) -> Result<String> {
+    let round = |input: &str| -> Result<String> {
+        let base = run_rustfmt(input, opts, config_dir)?;
+        reformat_macros_inner(&base, opts, Some(exprfmt))
+    };
+    let mut cur = round(src)?;
+    if cur == src {
+        return Ok(cur);
+    }
+    for _ in 0..2 {
+        let next = round(&cur)?;
+        if next == cur {
+            break;
+        }
+        cur = next;
+    }
+    Ok(cur)
 }
 
 /// `--check` helper: returns `Ok(None)` if the source is already

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -473,6 +473,7 @@ fn macro_body_edit(
                     opts,
                     base_indent,
                     &expr_map,
+                    exprfmt,
                     &comments,
                     body_len,
                 );
@@ -499,6 +500,7 @@ fn macro_body_edit(
                     opts,
                     base_indent,
                     &expr_map,
+                    exprfmt,
                     &comments,
                     body_len,
                 );
@@ -525,6 +527,7 @@ fn macro_body_edit(
                     opts,
                     base_indent,
                     &expr_map,
+                    exprfmt,
                     &comments,
                     body_len,
                 );
@@ -1546,6 +1549,72 @@ mod coverage_tests {
         let out = fmt(input);
         assert!(out.contains("a: css!(x: 1)"), "got:\n{out}");
         assert!(out.contains("b: css!(y: 2)"), "got:\n{out}");
+    }
+
+    // ---- macros nested inside closures / arbitrary exprs ------------------
+
+    #[test]
+    fn closure_wrapped_render_in_kwarg_reformats() {
+        let input = "fn ui() -> Element {\n    render! { view(child: move || render! { text(value:\"hi\") }) }\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains(
+                "child: move || render! {\n                text(value: \"hi\")\n            },"
+            ),
+            "closure-wrapped render! body must be reformatted:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn closure_wrapped_render_with_comment_survives_and_reformats() {
+        let input = "fn ui() -> Element {\n    render! { view(child: move || render! {\n        // note\n        text(value:\"hi\")\n    }) }\n}\n";
+        let out = fmt(input);
+        assert!(out.contains("// note"), "comment must survive:\n{out}");
+        assert!(
+            out.contains("text(value: \"hi\")"),
+            "body around the comment must still reformat:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn comment_bearing_routes_kwarg_value_reformats() {
+        let input = "fn ui() -> Element {\n    render! {\n        Router(routes: routes! {\n            // home\n            Stack { Route(path: \"a\", component: A) }\n        })\n    }\n}\n";
+        let out = fmt(input);
+        assert!(out.contains("// home"), "comment must survive:\n{out}");
+        assert!(
+            out.contains("Stack {\n"),
+            "comment-bearing routes! must still reformat:\n{out}"
+        );
+        assert!(
+            out.contains("Route(path: \"a\", component: A)\n"),
+            "route must land on its own line:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn url_string_in_nested_css_not_frozen() {
+        let input = "fn ui() -> Element {\n    render! { view(style: css!(background_image:\"https://x.com/a.png\",flex_grow:1.0)) }\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains("css!(background_image: \"https://x.com/a.png\", flex_grow: 1.0)"),
+            "a // inside a string must not freeze the nested css!:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn closure_wrapped_render_respects_max_width_at_real_depth() {
+        let input = "fn ui() -> Element {\n    render! { view { Show(fallback: move || render! { text(value: \"a-quite-long-fallback-value-here\", style: css!(font_size: 24.0.px(), font_weight: FontWeight::Bold)) }) } }\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains("text(\n"),
+            "inner kwargs must wrap at their real depth:\n{out}"
+        );
+        assert_no_line_over(&out, 100);
+        assert_idempotent(input);
     }
 
     // ---- width boundary ---------------------------------------------------

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -585,7 +585,20 @@ impl Printer<'_> {
             .tag_span
             .and_then(|s| self.map.byte_range(s))
             .and_then(|(start, _)| self.map.kwarg_paren_range(start));
-        if !tag.kwargs.is_empty() {
+        // A pending comment inside the parens anchors to its kwarg, so
+        // the list must print one kwarg per line with interleaved
+        // flushes instead of going through `delimited_list`.
+        let kwarg_comments = paren_range
+            .map(|(open, close)| {
+                self.comments
+                    .get(self.next.get())
+                    .map(|c| c.start > open && c.start < close)
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false);
+        if !tag.kwargs.is_empty() && kwarg_comments {
+            self.kwargs_with_comments(tag, level, paren_range, out);
+        } else if !tag.kwargs.is_empty() {
             let parts: Vec<String> = tag
                 .kwargs
                 .iter()
@@ -660,6 +673,52 @@ impl Printer<'_> {
             if let Some(close) = inner_close {
                 self.prev_end.set(Some(close + 1));
             }
+        }
+    }
+
+    /// One kwarg per line with comments flushed in place: own-line
+    /// comments at the kwarg indent, trailing comments after the comma
+    /// of the kwarg whose line they share.
+    fn kwargs_with_comments(
+        &self,
+        tag: &IrTag,
+        level: usize,
+        paren_range: Option<(usize, usize)>,
+        out: &mut String,
+    ) {
+        out.push_str("(\n");
+        let kw_level = level + 1;
+        let indent = self.indent(kw_level);
+        self.prev_end.set(None);
+        for kw in &tag.kwargs {
+            if let Some((s, _)) = kw.name_span.and_then(|sp| self.map.byte_range(sp)) {
+                self.flush(s, kw_level, out);
+                self.maybe_blank_line(s, out);
+            }
+            out.push_str(&indent);
+            out.push_str(&reindent(&self.ir_kwarg(kw, level), &indent));
+            out.push(',');
+            let end = kw
+                .value_span
+                .or(kw.name_span)
+                .and_then(|sp| self.map.byte_range(sp))
+                .map(|(_, e)| e);
+            if let Some(end) = end {
+                self.prev_end.set(Some(end));
+                if let Some(idx) = self.pending_trailing_on_line(end) {
+                    let before = self.comments[idx].start + 1;
+                    self.flush(before, kw_level, out);
+                }
+            }
+            out.push('\n');
+        }
+        if let Some((_, close)) = paren_range {
+            self.flush(close, kw_level, out);
+        }
+        out.push_str(&self.indent(level));
+        out.push(')');
+        if let Some((_, close)) = paren_range {
+            self.prev_end.set(Some(close + 1));
         }
     }
 

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -323,10 +323,19 @@ impl Printer<'_> {
                     .iter()
                     .map(|kw| self.css_kwarg(kw, level))
                     .collect();
+                let force_wrap = full_map.trailing_comma_in(1, full_src.len().saturating_sub(1));
                 // `output_level = 0`: a relative, column-0-anchored
                 // fragment — see `delimited_list`'s doc.
-                let list =
-                    self.delimited_list(level, 0, name.len() + bang.len(), &parts, open, close, 0);
+                let list = self.delimited_list(
+                    level,
+                    0,
+                    name.len() + bang.len(),
+                    &parts,
+                    open,
+                    close,
+                    0,
+                    force_wrap,
+                );
                 Some(format!("{name}{bang}{list}"))
             }
             "render" => {
@@ -405,6 +414,10 @@ impl Printer<'_> {
     /// group's own line that isn't one of `parts` (e.g. a tag name
     /// before the opening delimiter, or a trailing ` {` before a child
     /// block).
+    ///
+    /// `force_wrap` is the author's keep-vertical hint (a trailing comma
+    /// in the source list): the wrapped form is used even when the
+    /// inline form would fit.
     #[allow(clippy::too_many_arguments)]
     fn delimited_list(
         &self,
@@ -415,10 +428,12 @@ impl Printer<'_> {
         open: char,
         close: char,
         suffix_width: usize,
+        force_wrap: bool,
     ) -> String {
         let inline = parts.join(", ");
         let delimited = format!("{open}{inline}{close}");
-        let fits = !inline.contains('\n')
+        let fits = !force_wrap
+            && !inline.contains('\n')
             && self.opts.indent_width(check_level) + prefix_width + delimited.len() + suffix_width
                 <= self.opts.max_width;
         if fits {
@@ -544,6 +559,12 @@ impl Printer<'_> {
                 .map(|kw| self.ir_kwarg(kw, level))
                 .collect();
             let suffix = ir_brace_width(&tag.children, tag.always_block);
+            let force_wrap = tag
+                .tag_span
+                .and_then(|s| self.map.byte_range(s))
+                .and_then(|(start, _)| self.map.kwarg_paren_range(start))
+                .map(|(open, close)| self.map.trailing_comma_in(open + 1, close))
+                .unwrap_or(false);
             out.push_str(&self.delimited_list(
                 level,
                 level,
@@ -552,6 +573,7 @@ impl Printer<'_> {
                 '(',
                 ')',
                 suffix,
+                force_wrap,
             ));
         }
 
@@ -628,16 +650,18 @@ impl Printer<'_> {
         let has_comments = !self.comments.is_empty();
 
         // Inline form only when there are NO comments to place (comments
-        // imply line breaks).
+        // imply line breaks) and the author left no keep-vertical hint
+        // (a trailing comma after the last field).
         if !has_comments {
             let parts: Vec<String> = input
                 .kwargs
                 .iter()
                 .map(|kw| self.css_kwarg(kw, level))
                 .collect();
+            let force_wrap = self.map.trailing_comma_in(0, body_len);
             let inline = parts.join(", ");
             let inline_width = self.opts.indent_width(level) + inline.len();
-            if !inline.contains('\n') && inline_width <= self.opts.max_width {
+            if !force_wrap && !inline.contains('\n') && inline_width <= self.opts.max_width {
                 let indent = self.indent(level);
                 return format!("{indent}{inline}");
             }

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -455,6 +455,33 @@ impl Printer<'_> {
         if fits {
             return delimited;
         }
+        // Combine a multi-line LAST item (nested macro, closure) with the
+        // earlier single-line items on the open line — rustfmt's
+        // last-argument overflow — instead of wrapping the whole list.
+        if !force_wrap
+            && parts.last().is_some_and(|p| p.contains('\n'))
+            && parts[..parts.len() - 1].iter().all(|p| !p.contains('\n'))
+        {
+            let last = parts.last().unwrap();
+            let head = if parts.len() > 1 {
+                format!("{}, ", parts[..parts.len() - 1].join(", "))
+            } else {
+                String::new()
+            };
+            let first_line = last.lines().next().unwrap_or("");
+            let last_line = last.lines().last().unwrap_or("");
+            let first_width = self.opts.indent_width(check_level)
+                + prefix_width
+                + 1
+                + head.chars().count()
+                + first_line.chars().count();
+            let close_width =
+                self.opts.indent_width(output_level) + last_line.chars().count() + 1 + suffix_width;
+            if first_width <= self.opts.max_width && close_width <= self.opts.max_width {
+                let re = reindent(last, &self.indent(output_level));
+                return format!("{open}{head}{re}{close}");
+            }
+        }
         let body = self.wrap_one_per_line(output_level + 1, parts);
         format!("{open}\n{body}\n{}{close}", self.indent(output_level))
     }

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -34,11 +34,11 @@
 //! and is easy to keep idempotent.
 
 use crate::comments::GrammarComment;
-use crate::expr_fmt::ExprMap;
+use crate::expr_fmt::{ExprFormatter, ExprMap};
 use crate::ir::{IrKwarg, IrNode, IrTag, IrValue};
 use crate::options::FmtOptions;
 use crate::source_map::SourceMap;
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::ToTokens;
 use std::cell::Cell;
 use syn::Expr;
@@ -65,6 +65,7 @@ pub(crate) fn print_render(
     opts: &FmtOptions,
     base_indent: usize,
     expr_map: &ExprMap,
+    exprfmt: Option<&ExprFormatter>,
     comments: &[GrammarComment],
     body_len: usize,
 ) -> String {
@@ -72,6 +73,7 @@ pub(crate) fn print_render(
         map,
         opts,
         expr_map,
+        exprfmt,
         comments,
         next: Cell::new(0),
     };
@@ -100,12 +102,14 @@ pub(crate) fn print_render(
 }
 
 /// Pretty-print a parsed `css!` body.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn print_css(
     input: &CssInput,
     map: &SourceMap,
     opts: &FmtOptions,
     base_indent: usize,
     expr_map: &ExprMap,
+    exprfmt: Option<&ExprFormatter>,
     comments: &[GrammarComment],
     body_len: usize,
 ) -> String {
@@ -113,6 +117,7 @@ pub(crate) fn print_css(
         map,
         opts,
         expr_map,
+        exprfmt,
         comments,
         next: Cell::new(0),
     };
@@ -128,6 +133,7 @@ pub(crate) fn print_routes(
     opts: &FmtOptions,
     base_indent: usize,
     expr_map: &ExprMap,
+    exprfmt: Option<&ExprFormatter>,
     comments: &[GrammarComment],
     body_len: usize,
 ) -> String {
@@ -135,6 +141,7 @@ pub(crate) fn print_routes(
         map,
         opts,
         expr_map,
+        exprfmt,
         comments,
         next: Cell::new(0),
     };
@@ -175,6 +182,10 @@ struct Printer<'a> {
     map: &'a SourceMap<'a>,
     opts: &'a FmtOptions,
     expr_map: &'a ExprMap,
+    /// Threaded through so a re-entrant macro pass over an expr fragment
+    /// ([`Printer::fragment_macro_src`]) formats ITS embedded exprs with
+    /// the same rustfmt settings as the enclosing body.
+    exprfmt: Option<&'a ExprFormatter>,
     comments: &'a [GrammarComment],
     /// Index of the next unconsumed comment.
     next: Cell<usize>,
@@ -204,17 +215,57 @@ impl Printer<'_> {
         if let Some(nested) = self.nested_macro_src(expr, level) {
             return nested;
         }
-        if let Some(formatted) = self.expr_map.get(span) {
-            return formatted.to_string();
-        }
-        if let Some(s) = self.map.slice(span) {
+        let fragment = if let Some(formatted) = self.expr_map.get(span) {
+            formatted.to_string()
+        } else if let Some(s) = self.map.slice(span) {
             // Continuation lines must be dedented to column 0 (the
             // [`ExprMap`] contract) or the later [`reindent`] compounds
             // the indentation on every pass.
             dedent_continuation(s.trim())
         } else {
-            expr.to_token_stream().to_string()
+            return expr.to_token_stream().to_string();
+        };
+        if contains_target_macro(expr.to_token_stream()) {
+            if let Some(s) = self.fragment_macro_src(&fragment, level) {
+                return s;
+            }
         }
+        fragment
+    }
+
+    /// Re-enter the whole macro pass over an expr fragment that contains
+    /// a `render!`/`css!`/`routes!` call somewhere INSIDE it (nested in a
+    /// closure, a method chain, …) where [`Printer::nested_macro_src`]'s
+    /// direct-`Expr::Macro` fast path can't reach. The fragment is
+    /// wrapped in a synthetic fn at `level`'s indent — so nested bodies
+    /// measure width at their real depth — reformatted by
+    /// [`crate::reformat_macros_pass`] (comment fail-safes included),
+    /// then unwrapped back to a column-0-anchored fragment.
+    fn fragment_macro_src(&self, fragment: &str, level: usize) -> Option<String> {
+        const HEAD: &str = "fn __wsk_frag() {\nlet _x =\n";
+        const TAIL: &str = ";\n}\n";
+        let indent = self.indent(level);
+        let mut synthetic = String::from(HEAD);
+        for (i, line) in fragment.split('\n').enumerate() {
+            if i > 0 {
+                synthetic.push('\n');
+            }
+            if !line.is_empty() {
+                synthetic.push_str(&indent);
+                synthetic.push_str(line);
+            }
+        }
+        synthetic.push_str(TAIL);
+        let out = crate::reformat_macros_pass(&synthetic, self.opts, self.exprfmt, true).ok()?;
+        let inner = out.strip_prefix(HEAD)?.strip_suffix(TAIL)?;
+        let mut result = String::new();
+        for (i, line) in inner.split('\n').enumerate() {
+            if i > 0 {
+                result.push('\n');
+            }
+            result.push_str(line.strip_prefix(indent.as_str()).unwrap_or(line));
+        }
+        Some(result)
     }
 
     /// If `expr` is a `css!( … )` / `render!{ … }` / `routes!{ … }` macro
@@ -231,12 +282,11 @@ impl Printer<'_> {
     /// exact: the true depth depends on the outer wrap decision, which
     /// depends circularly on this one.
     ///
-    /// Returns `None` — falling back to the [`ExprMap`] / verbatim path
-    /// in [`Printer::expr_src`] — when `expr` isn't one of those macros,
-    /// its body doesn't parse or is empty, or its source contains `//`
-    /// or `/*`. Grammar-comment recovery runs once over the OUTER body,
-    /// before this nested printer exists, so a nested call carrying a
-    /// comment is left untouched rather than risk dropping it.
+    /// Returns `None` — falling back to [`Printer::fragment_macro_src`]'s
+    /// re-entrant pass in [`Printer::expr_src`] — when `expr` isn't one
+    /// of those macros, its body doesn't parse or is empty, or its source
+    /// carries a comment (this fast path has no comment reattachment; the
+    /// fragment pass does).
     fn nested_macro_src(&self, expr: &Expr, level: usize) -> Option<String> {
         let Expr::Macro(em) = expr else {
             return None;
@@ -254,7 +304,10 @@ impl Printer<'_> {
             syn::MacroDelimiter::Bracket(bk) => ('[', ']', bk.span),
         };
         let full_src = self.map.slice(delim_span.join())?;
-        if full_src.contains("//") || full_src.contains("/*") {
+        // String-aware comment scan: a `//` inside a string literal
+        // (`"https://…"`) must not force the fallback.
+        let full_map = SourceMap::new(full_src);
+        if !crate::comments::collect_grammar_comments(full_src, &[], &full_map).is_empty() {
             return None;
         }
         // rustfmt spaces a brace-delimited macro's `{` but not `(`/`[`.
@@ -279,7 +332,16 @@ impl Printer<'_> {
             "render" => {
                 let root = whisker_macro_syntax::render::parse_root(em.mac.tokens.clone()).ok()?;
                 let ir_root = crate::ir::adapt_render_root(&root);
-                let body = print_render(&ir_root, self.map, self.opts, 0, self.expr_map, &[], 0);
+                let body = print_render(
+                    &ir_root,
+                    self.map,
+                    self.opts,
+                    0,
+                    self.expr_map,
+                    self.exprfmt,
+                    &[],
+                    0,
+                );
                 Some(nested_wrap(&name, bang, open, close, &body))
             }
             "routes" => {
@@ -289,7 +351,16 @@ impl Printer<'_> {
                     return None;
                 }
                 let roots = crate::ir::adapt_routes_roots(&input);
-                let body = print_routes(&roots, self.map, self.opts, 0, self.expr_map, &[], 0);
+                let body = print_routes(
+                    &roots,
+                    self.map,
+                    self.opts,
+                    0,
+                    self.expr_map,
+                    self.exprfmt,
+                    &[],
+                    0,
+                );
                 Some(nested_wrap(&name, bang, open, close, &body))
             }
             _ => None,
@@ -702,6 +773,28 @@ fn reindent(fragment: &str, prefix: &str) -> String {
 fn span_of(expr: &syn::Expr) -> Span {
     use syn::spanned::Spanned;
     expr.span()
+}
+
+/// `true` if the token stream contains a `render!`/`css!`/`routes!`
+/// invocation (`IDENT ! GROUP`) at any nesting depth.
+fn contains_target_macro(tokens: TokenStream) -> bool {
+    let trees: Vec<TokenTree> = tokens.into_iter().collect();
+    for (i, tree) in trees.iter().enumerate() {
+        match tree {
+            TokenTree::Ident(ident)
+                if matches!(ident.to_string().as_str(), "render" | "css" | "routes")
+                    && matches!(trees.get(i + 1), Some(TokenTree::Punct(p)) if p.as_char() == '!')
+                    && matches!(trees.get(i + 2), Some(TokenTree::Group(_))) =>
+            {
+                return true;
+            }
+            TokenTree::Group(group) if contains_target_macro(group.stream()) => {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 /// Wrap a nested `render!`/`routes!` macro's already-printed `body` with

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -102,6 +102,12 @@ pub(crate) fn print_render(
 }
 
 /// Pretty-print a parsed `css!` body.
+///
+/// `inline_budget` is the char count the joined field list may have and
+/// still fit the macro's ORIGINAL line (prefix, delimiters and trailing
+/// text included) — the caller inlines a single-line result there. Over
+/// budget the body goes one field per line: there is no middle form
+/// with broken delimiters around one joined line.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn print_css(
     input: &CssInput,
@@ -112,6 +118,7 @@ pub(crate) fn print_css(
     exprfmt: Option<&ExprFormatter>,
     comments: &[GrammarComment],
     body_len: usize,
+    inline_budget: usize,
 ) -> String {
     let p = Printer {
         map,
@@ -121,7 +128,7 @@ pub(crate) fn print_css(
         comments,
         next: Cell::new(0),
     };
-    p.css(input, base_indent + 1, body_len)
+    p.css(input, base_indent + 1, body_len, inline_budget)
 }
 
 /// Pretty-print an adapted `routes!` root list
@@ -552,6 +559,10 @@ impl Printer<'_> {
         out.push_str(&indent);
         out.push_str(&tag.tag);
 
+        let paren_range = tag
+            .tag_span
+            .and_then(|s| self.map.byte_range(s))
+            .and_then(|(start, _)| self.map.kwarg_paren_range(start));
         if !tag.kwargs.is_empty() {
             let parts: Vec<String> = tag
                 .kwargs
@@ -559,10 +570,7 @@ impl Printer<'_> {
                 .map(|kw| self.ir_kwarg(kw, level))
                 .collect();
             let suffix = ir_brace_width(&tag.children, tag.always_block);
-            let force_wrap = tag
-                .tag_span
-                .and_then(|s| self.map.byte_range(s))
-                .and_then(|(start, _)| self.map.kwarg_paren_range(start))
+            let force_wrap = paren_range
                 .map(|(open, close)| self.map.trailing_comma_in(open + 1, close))
                 .unwrap_or(false);
             out.push_str(&self.delimited_list(
@@ -575,6 +583,9 @@ impl Printer<'_> {
                 suffix,
                 force_wrap,
             ));
+        } else if paren_range.is_some() {
+            // The author's empty `()` is preserved, not stripped.
+            out.push_str("()");
         }
 
         // Resolve this node's block byte bounds so comments are placed
@@ -642,7 +653,7 @@ impl Printer<'_> {
 
     // ---- css! ----------------------------------------------------------
 
-    fn css(&self, input: &CssInput, level: usize, body_len: usize) -> String {
+    fn css(&self, input: &CssInput, level: usize, body_len: usize, inline_budget: usize) -> String {
         if input.kwargs.is_empty() {
             return String::new();
         }
@@ -650,8 +661,9 @@ impl Printer<'_> {
         let has_comments = !self.comments.is_empty();
 
         // Inline form only when there are NO comments to place (comments
-        // imply line breaks) and the author left no keep-vertical hint
-        // (a trailing comma after the last field).
+        // imply line breaks), the author left no keep-vertical hint (a
+        // trailing comma after the last field), and the joined list fits
+        // the macro's original line (`inline_budget`).
         if !has_comments {
             let parts: Vec<String> = input
                 .kwargs
@@ -660,8 +672,7 @@ impl Printer<'_> {
                 .collect();
             let force_wrap = self.map.trailing_comma_in(0, body_len);
             let inline = parts.join(", ");
-            let inline_width = self.opts.indent_width(level) + inline.len();
-            if !force_wrap && !inline.contains('\n') && inline_width <= self.opts.max_width {
+            if !force_wrap && !inline.contains('\n') && inline.chars().count() <= inline_budget {
                 let indent = self.indent(level);
                 return format!("{indent}{inline}");
             }
@@ -831,7 +842,8 @@ fn nested_wrap(name: &str, bang: &str, open: char, close: char, body: &str) -> S
     if body.contains('\n') {
         format!("{name}{bang}{open}\n{body}\n{close}")
     } else {
-        format!("{name}{bang}{open}{}{close}", body.trim_start())
+        let pad = if open == '{' { " " } else { "" };
+        format!("{name}{bang}{open}{pad}{}{pad}{close}", body.trim_start())
     }
 }
 

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -76,6 +76,7 @@ pub(crate) fn print_render(
         exprfmt,
         comments,
         next: Cell::new(0),
+        prev_end: Cell::new(None),
     };
     let mut out = String::new();
     if let Some(start) = p.ir_node_start_byte(root) {
@@ -127,6 +128,7 @@ pub(crate) fn print_css(
         exprfmt,
         comments,
         next: Cell::new(0),
+        prev_end: Cell::new(None),
     };
     p.css(input, base_indent + 1, body_len, inline_budget)
 }
@@ -151,15 +153,18 @@ pub(crate) fn print_routes(
         exprfmt,
         comments,
         next: Cell::new(0),
+        prev_end: Cell::new(None),
     };
     let mut out = String::new();
     let level = base_indent + 1;
     for (i, node) in roots.iter().enumerate() {
         if let Some(start) = p.ir_node_start_byte(node) {
             p.flush(start, level, &mut out);
+            p.maybe_blank_line(start, &mut out);
         }
         p.ir_node(node, level, &mut out);
         if let Some((_, end)) = p.ir_node_extent(node) {
+            p.prev_end.set(Some(end));
             if let Some(idx) = p.pending_trailing_on_line(end) {
                 let before = p.comments[idx].start + 1;
                 p.flush(before, level, &mut out);
@@ -196,6 +201,10 @@ struct Printer<'a> {
     comments: &'a [GrammarComment],
     /// Index of the next unconsumed comment.
     next: Cell<usize>,
+    /// Source byte just past the previously emitted item (sibling or
+    /// comment), for carrying authored blank lines between items.
+    /// `None` suppresses the blank-line check (block start).
+    prev_end: Cell<Option<usize>>,
 }
 
 impl Printer<'_> {
@@ -454,6 +463,17 @@ impl Printer<'_> {
         self.opts.indent_prefix(level)
     }
 
+    /// Emit ONE blank line when the source had one or more between the
+    /// previously emitted item ([`Printer::prev_end`]) and the item
+    /// starting at `next_start`.
+    fn maybe_blank_line(&self, next_start: usize, out: &mut String) {
+        if let Some(prev) = self.prev_end.get() {
+            if self.map.has_blank_line_between(prev, next_start) {
+                out.push('\n');
+            }
+        }
+    }
+
     // ---- comment reattachment ------------------------------------------
 
     /// Emit every not-yet-consumed comment whose `start < before`, at the
@@ -469,6 +489,7 @@ impl Printer<'_> {
         while idx < self.comments.len() && self.comments[idx].start < before {
             let c = &self.comments[idx];
             if c.own_line {
+                self.maybe_blank_line(c.start, out);
                 out.push_str(&indent);
                 out.push_str(&reindent(&c.text, &indent));
                 out.push('\n');
@@ -485,6 +506,7 @@ impl Printer<'_> {
                     out.push('\n');
                 }
             }
+            self.prev_end.set(Some(c.end));
             idx += 1;
         }
         self.next.set(idx);
@@ -612,12 +634,17 @@ impl Printer<'_> {
         if !tag.children.is_empty() || tag.always_block || has_block_comments {
             out.push_str(" {\n");
             let child_level = level + 1;
+            // Blank lines at the block's edges are dropped: the check is
+            // disarmed until the first child/comment sets a new anchor.
+            self.prev_end.set(None);
             for child in &tag.children {
                 if let Some(cs) = self.ir_node_start_byte(child) {
                     self.flush(cs, child_level, out);
+                    self.maybe_blank_line(cs, out);
                 }
                 self.ir_node(child, child_level, out);
                 if let Some((_, child_end)) = self.ir_node_extent(child) {
+                    self.prev_end.set(Some(child_end));
                     if let Some(idx) = self.pending_trailing_on_line(child_end) {
                         let before = self.comments[idx].start + 1;
                         self.flush(before, child_level, out);
@@ -630,6 +657,9 @@ impl Printer<'_> {
             }
             out.push_str(&indent);
             out.push('}');
+            if let Some(close) = inner_close {
+                self.prev_end.set(Some(close + 1));
+            }
         }
     }
 
@@ -678,10 +708,14 @@ impl Printer<'_> {
             }
             let indent = self.indent(level);
             let mut out = String::new();
-            for part in &parts {
+            for (kw, part) in input.kwargs.iter().zip(&parts) {
+                if let Some((s, _)) = self.map.byte_range(kw.name.span()) {
+                    self.maybe_blank_line(s, &mut out);
+                }
                 out.push_str(&indent);
                 out.push_str(&reindent(part, &indent));
                 out.push_str(",\n");
+                self.prev_end.set(Some(css_field_end(self.map, kw)));
             }
             out.pop();
             return out;
@@ -695,22 +729,13 @@ impl Printer<'_> {
             let start = self.map.byte_range(kw.name.span()).map(|(s, _)| s);
             if let Some(s) = start {
                 self.flush(s, level, &mut out);
+                self.maybe_blank_line(s, &mut out);
             }
             out.push_str(&indent);
             out.push_str(&reindent(&self.css_kwarg(kw, level), &indent));
             out.push(',');
-            let field_end = self
-                .map
-                .byte_range(kw.name.span())
-                .map(|(_, e)| e)
-                .unwrap_or(0);
-            // Use the value's end if present for a tighter line bound.
-            let line_end = kw
-                .value
-                .as_ref()
-                .and_then(|e| self.map.byte_range(span_of(e)))
-                .map(|(_, e)| e)
-                .unwrap_or(field_end);
+            let line_end = css_field_end(self.map, kw);
+            self.prev_end.set(Some(line_end));
             if let Some(idx) = self.pending_trailing_on_line(line_end) {
                 let before = self.comments[idx].start + 1;
                 self.flush(before, level, &mut out);
@@ -735,6 +760,17 @@ impl Printer<'_> {
             None => name,
         }
     }
+}
+
+/// Byte just past a css field in the source: the value's end when
+/// present, else the name's.
+fn css_field_end(map: &SourceMap, kw: &whisker_macro_syntax::CssKwarg) -> usize {
+    kw.value
+        .as_ref()
+        .and_then(|e| map.byte_range(span_of(e)))
+        .map(|(_, e)| e)
+        .or_else(|| map.byte_range(kw.name.span()).map(|(_, e)| e))
+        .unwrap_or(0)
 }
 
 /// Width contribution of a ` { … }` children block when deciding

--- a/crates/whisker-fmt/src/source_map.rs
+++ b/crates/whisker-fmt/src/source_map.rs
@@ -156,6 +156,22 @@ impl<'a> SourceMap<'a> {
         last == Some(b',')
     }
 
+    /// `true` if `[lo, hi)` spans at least one BLANK line — i.e. two or
+    /// more newlines. Used to carry (at most one) authored blank line
+    /// between emitted siblings into the output.
+    pub(crate) fn has_blank_line_between(&self, lo: usize, hi: usize) -> bool {
+        let lo = lo.min(self.src.len());
+        let hi = hi.min(self.src.len());
+        if hi <= lo {
+            return false;
+        }
+        self.src.as_bytes()[lo..hi]
+            .iter()
+            .filter(|&&b| b == b'\n')
+            .count()
+            >= 2
+    }
+
     /// Advance past whitespace and comments (line + nested block) from
     /// `i`, returning the index of the next significant byte.
     fn skip_trivia(&self, mut i: usize) -> usize {

--- a/crates/whisker-fmt/src/source_map.rs
+++ b/crates/whisker-fmt/src/source_map.rs
@@ -109,6 +109,53 @@ impl<'a> SourceMap<'a> {
         (None, after_parens)
     }
 
+    /// Byte range of a node's kwarg `( … )` group starting at byte
+    /// `start` (the first byte of its tag ident): `(open, close)` are the
+    /// indices of `(` and `)` themselves. `None` when the tag has no
+    /// paren group.
+    pub(crate) fn kwarg_paren_range(&self, start: usize) -> Option<(usize, usize)> {
+        let bytes = self.src.as_bytes();
+        let len = bytes.len();
+        let mut i = start;
+        while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+            i += 1;
+        }
+        i = self.skip_trivia(i);
+        if i < len && bytes[i] == b'(' {
+            let after = self.skip_balanced(i, b'(', b')');
+            return Some((i, after - 1));
+        }
+        None
+    }
+
+    /// `true` if the last significant byte in `[lo, hi)` — ignoring
+    /// whitespace, comments and string/char literal interiors — is a
+    /// `,`. This is the author's keep-vertical hint: a trailing comma
+    /// means the list must not be joined onto one line.
+    pub(crate) fn trailing_comma_in(&self, lo: usize, hi: usize) -> bool {
+        let bytes = self.src.as_bytes();
+        let hi = hi.min(bytes.len());
+        let mut i = lo;
+        let mut last: Option<u8> = None;
+        while i < hi {
+            let b = bytes[i];
+            if b == b'"' || b == b'\'' {
+                last = Some(b);
+                i = self.skip_string(i, b);
+                continue;
+            }
+            if i + 1 < hi && b == b'/' && (bytes[i + 1] == b'/' || bytes[i + 1] == b'*') {
+                i = self.skip_trivia(i);
+                continue;
+            }
+            if !b.is_ascii_whitespace() {
+                last = Some(b);
+            }
+            i += 1;
+        }
+        last == Some(b',')
+    }
+
     /// Advance past whitespace and comments (line + nested block) from
     /// `i`, returning the index of the next significant byte.
     fn skip_trivia(&self, mut i: usize) -> usize {

--- a/crates/whisker-fmt/tests/integration.rs
+++ b/crates/whisker-fmt/tests/integration.rs
@@ -190,6 +190,41 @@ fn full_pipeline_nested_routes_in_render_idempotent() {
 }
 
 #[test]
+fn statement_macro_in_closure_converges_in_one_call() {
+    if !rustfmt_available() {
+        return;
+    }
+    // The macro pass emits a multi-line `move || css!(…)`; a later
+    // rustfmt round rewrites the closure body into a block. One
+    // format_source call must already return that stable form.
+    let src = "fn ui() -> Element {\n    let style = computed(move || css!(flex_direction: FlexDirection::Column, gap: px(12.0), margin_bottom: px(16.0), padding_left: px(20.0)));\n    render! { view(style: style) }\n}\n";
+    let once = format_source(src, &opts(4, 100)).unwrap();
+    let twice = format_source(&once, &opts(4, 100)).unwrap();
+    assert_eq!(
+        once, twice,
+        "must converge within one call:\n--once--\n{once}\n--twice--\n{twice}"
+    );
+}
+
+#[test]
+fn closure_wrapped_render_kwarg_converges_in_one_call() {
+    if !rustfmt_available() {
+        return;
+    }
+    let src = "fn ui() -> Element {\n    render! { view { ForEach(each: move || rows(), key: |i: &usize| i.to_string(), children: move |_: usize| render! { view(style: row_style) }) } }\n}\n";
+    let once = format_source(src, &opts(4, 100)).unwrap();
+    let twice = format_source(&once, &opts(4, 100)).unwrap();
+    assert_eq!(
+        once, twice,
+        "must converge within one call:\n--once--\n{once}\n--twice--\n{twice}"
+    );
+    assert!(
+        once.contains("render! {\n"),
+        "closure-wrapped render! must format:\n{once}"
+    );
+}
+
+#[test]
 fn full_pipeline_composite_podcast_like_tree() {
     if !rustfmt_available() {
         return;


### PR DESCRIPTION
## Summary

Fixes all nine failure classes found by the full-app `whisker fmt` census over giga (107 files). One commit per class:

1. **Re-entrant fragment pass** — `render!`/`css!`/`routes!` nested inside closures or any embedded expr (`Show(fallback: …)`, `ForEach(children: …)`, `computed(|| css!(…))`) now format; previously the walker never reached them. The nested fast path's `//` freeze guard is now string-aware, so `https://` URLs no longer freeze a call, and genuinely comment-bearing calls format through the fragment pass with the existing comment fail-safes.
2. **Fixed-point convergence** — rustfmt and the macro pass are individually idempotent but their composition wasn't; `format_source` now iterates to a fixed point (max 3 rounds), so one invocation is stable.
3. **Trailing-comma keep-vertical hint** — a list ending in a trailing comma stays one item per line; commas inside strings/comments don't count.
4. **Inline-when-fits** — a single-line body stays on the macro's own line when the whole line fits (`return render! { view() };` stays 1 line). css! is now strictly inline-or-one-field-per-line; the broken-delimiter + one-joined-line middle form is gone. Authored empty `()` survives.
5. **Blank-line preservation** — up to one authored blank line between siblings, before own-line comments, and between css! fields; block edges drop blanks.
6. **Kwarg-anchored comments** — a comment inside a tag's parens stays on its kwarg instead of relocating after the element.
7. **Last-argument overflow (combine)** — the ubiquitous `view(style: css!(…)) {` shape survives instead of wrapping every kwarg; an authored outer trailing comma still pins the full wrap.

## Verification

- giga (107 files): pass 1 changes 21 files, **pass 2 changes zero** (one-shot convergence); 0 comments lost, 0 blank lines lost, `cargo check` passes on the formatted tree; over-width line counts improve in every affected file except one known ExprMap column-shift case.
- The comment-frozen `routes!` in giga's `lib.rs` now repairs deliberately broken indentation.
- `--stdin` (rust-analyzer path) verified converged; `--check` exit codes verified for dirty/clean inputs.
- whisker-fmt: 139 unit + 14 integration tests (28 new); whisker-cli: 95 tests; fmt/clippy clean.

Known remaining limitation (out of scope): the ExprMap column-shift — embedded exprs are rustfmt'd in a shallow synthetic wrapper and can exceed `max_width` after reindenting to a deep column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)