### PR TITLE
fmt: keep DSL slot values in expression form through the expr pass

### DIFF
--- a/crates/whisker-fmt/src/expr_fmt.rs
+++ b/crates/whisker-fmt/src/expr_fmt.rs
@@ -138,9 +138,18 @@ impl ExprFormatter {
     }
 
     /// Format every expr (given as `(span, source_slice)` pairs) of ONE
-    /// macro body with a single rustfmt spawn, returning a map from span
-    /// to formatted text. Exprs that fail to format are simply absent
-    /// from the map (the printer then falls back to verbatim).
+    /// macro body, returning a map from span to formatted text. Exprs
+    /// that fail to format are simply absent from the map (the printer
+    /// then falls back to verbatim).
+    ///
+    /// Most exprs share ONE rustfmt spawn. `if` expressions are the
+    /// exception: bare in the wrapper's tail position they format as
+    /// control flow (always broken), so they're parenthesized — and
+    /// `single_line_if_else_max_width` measures the EXPRESSION's own
+    /// width, so each one's allowance is `max_width` minus its source
+    /// column (capped by an explicit user setting). One extra spawn per
+    /// distinct allowance keeps an if single-line exactly when its real
+    /// line has room.
     ///
     /// `exprs` carries the body-relative span of each expr (for keying)
     /// alongside its verbatim source slice (the text we format).
@@ -150,46 +159,99 @@ impl ExprFormatter {
             return map;
         }
 
-        let mut synthetic = String::new();
-        for (i, (_, src)) in exprs.iter().enumerate() {
-            synthetic.push_str(&format!("fn __wsk_e{i}() {{\n"));
-            synthetic.push_str(src);
-            // Guarantee the body ends on its own line so the closing
-            // brace is on a fresh line (slicing relies on this).
-            if !src.ends_with('\n') {
-                synthetic.push('\n');
+        let user_cap = self
+            .opts
+            .single_line_if_else_max_width
+            .unwrap_or(self.opts.max_width);
+        let mut batches: Vec<(Option<usize>, Vec<usize>)> = Vec::new();
+        let mut by_allowance: HashMap<usize, usize> = HashMap::new();
+        let mut plain: Vec<usize> = Vec::new();
+        for (i, (span, src)) in exprs.iter().enumerate() {
+            if src.trim_start().starts_with("if ") {
+                let allowed = self
+                    .opts
+                    .max_width
+                    .saturating_sub(span.start().column)
+                    .min(user_cap);
+                let bi = *by_allowance.entry(allowed).or_insert_with(|| {
+                    batches.push((Some(allowed), Vec::new()));
+                    batches.len() - 1
+                });
+                batches[bi].1.push(i);
+            } else {
+                plain.push(i);
             }
-            synthetic.push_str("}\n");
+        }
+        if !plain.is_empty() {
+            batches.push((None, plain));
         }
 
-        let formatted_file =
-            match crate::run_rustfmt(&synthetic, &self.opts, self.config_dir.as_deref()) {
+        let unit = self.opts.indent_unit();
+        for (if_allowance, indices) in &batches {
+            let mut synthetic = String::new();
+            for &i in indices {
+                synthetic.push_str(&format!("fn __wsk_e{i}() {{\n"));
+                if if_allowance.is_some() {
+                    synthetic.push('(');
+                }
+                synthetic.push_str(&exprs[i].1);
+                if if_allowance.is_some() {
+                    synthetic.push(')');
+                }
+                // Guarantee the body ends on its own line so the closing
+                // brace is on a fresh line (slicing relies on this).
+                if !synthetic.ends_with('\n') {
+                    synthetic.push('\n');
+                }
+                synthetic.push_str("}\n");
+            }
+            let extra: Vec<(&str, String)> = match if_allowance {
+                Some(v) => vec![("single_line_if_else_max_width", v.to_string())],
+                None => vec![],
+            };
+            let formatted = match crate::run_rustfmt(
+                &synthetic,
+                &self.opts,
+                self.config_dir.as_deref(),
+                &extra,
+            ) {
                 Ok(s) => s,
                 // No rustfmt, or the batch failed as a whole → verbatim.
-                Err(_) => return map,
+                Err(_) => continue,
             };
-
-        let bodies = match extract_bodies(&formatted_file, exprs.len()) {
-            Some(b) => b,
-            None => return map,
-        };
-
-        let unit = self.opts.indent_unit();
-        for (i, (span, _)) in exprs.iter().enumerate() {
-            if let Some(body) = bodies.get(i).and_then(|b| b.as_deref()) {
-                let dedented = dedent_one_level(body, &unit);
-                map.insert(*span, dedented);
+            let Some(found) = extract_bodies(&formatted) else {
+                continue;
+            };
+            for &i in indices {
+                if let Some(body) = found.get(&i) {
+                    let mut dedented = dedent_one_level(body, &unit);
+                    if if_allowance.is_some() {
+                        dedented = strip_outer_parens(&dedented);
+                    }
+                    map.insert(exprs[i].0, dedented);
+                }
             }
         }
         map
     }
 }
 
-/// Re-parse the rustfmt output, locate every `__wsk_eN` fn (in order),
-/// and return its raw body text (between the `{` and `}` braces, newline
-/// boundaries trimmed). Returns `None` if the output can't be parsed or
-/// any wrapper fn is missing — so the caller falls back wholesale.
-fn extract_bodies(formatted_file: &str, count: usize) -> Option<Vec<Option<String>>> {
+/// Undo the wrapper's added `( … )` around an `if` expression. The text
+/// is left alone when the parens aren't the outermost characters.
+fn strip_outer_parens(s: &str) -> String {
+    let t = s.trim();
+    match t.strip_prefix('(').and_then(|r| r.strip_suffix(')')) {
+        Some(inner) => inner.to_string(),
+        None => s.to_string(),
+    }
+}
+
+/// Re-parse the rustfmt output, locate every `__wsk_eN` fn, and return
+/// its raw body text (between the `{` and `}` braces, newline boundaries
+/// trimmed) keyed by N. Returns `None` if the output can't be parsed —
+/// so the caller falls back wholesale; an individually missing fn is
+/// simply absent from the map.
+fn extract_bodies(formatted_file: &str) -> Option<HashMap<usize, String>> {
     let parsed: syn::File = syn::parse_file(formatted_file).ok()?;
     let map = crate::source_map::SourceMap::new(formatted_file);
 
@@ -219,12 +281,7 @@ fn extract_bodies(formatted_file: &str, count: usize) -> Option<Vec<Option<Strin
         let inner = inner.strip_suffix('\n').unwrap_or(inner);
         found.insert(idx, inner.to_string());
     }
-
-    let mut bodies = Vec::with_capacity(count);
-    for i in 0..count {
-        bodies.push(Some(found.remove(&i)?));
-    }
-    Some(bodies)
+    Some(found)
 }
 
 /// Strip exactly one indentation level (`unit`) from the front of every
@@ -260,6 +317,7 @@ mod tests {
             tab_spaces: 4,
             hard_tabs: false,
             edition: Some("2021".to_string()),
+            single_line_if_else_max_width: None,
         }
     }
 
@@ -278,14 +336,15 @@ mod tests {
     #[test]
     fn extract_single_body() {
         let file = "fn __wsk_e0() {\n    foo(a, b)\n}\n";
-        let bodies = extract_bodies(file, 1).unwrap();
-        assert_eq!(bodies[0].as_deref(), Some("    foo(a, b)"));
+        let bodies = extract_bodies(file).unwrap();
+        assert_eq!(bodies.get(&0).map(String::as_str), Some("    foo(a, b)"));
     }
 
     #[test]
-    fn extract_requires_all() {
+    fn extract_missing_index_absent() {
         let file = "fn __wsk_e0() {\n    a\n}\n";
-        assert!(extract_bodies(file, 2).is_none());
+        let bodies = extract_bodies(file).unwrap();
+        assert!(!bodies.contains_key(&1));
     }
 
     #[test]

--- a/crates/whisker-fmt/src/lib.rs
+++ b/crates/whisker-fmt/src/lib.rs
@@ -87,7 +87,7 @@ fn format_converged(
     exprfmt: &ExprFormatter,
 ) -> Result<String> {
     let round = |input: &str| -> Result<String> {
-        let base = run_rustfmt(input, opts, config_dir)?;
+        let base = run_rustfmt(input, opts, config_dir, &[])?;
         reformat_macros_inner(&base, opts, Some(exprfmt))
     };
     let mut cur = round(src)?;
@@ -172,8 +172,15 @@ pub fn rustfmt_available() -> bool {
 
 /// Run the rustfmt binary over `src`, returning its stdout. rustfmt is
 /// run with cwd = `config_dir` (when given) so it resolves the right
-/// `rustfmt.toml`; otherwise it runs in the current dir.
-fn run_rustfmt(src: &str, opts: &FmtOptions, config_dir: Option<&Path>) -> Result<String> {
+/// `rustfmt.toml`; otherwise it runs in the current dir. `extra_config`
+/// key=value pairs are passed via `--config`, overriding the config
+/// file — the embedded-expr pass uses this for its slot-specific keys.
+fn run_rustfmt(
+    src: &str,
+    opts: &FmtOptions,
+    config_dir: Option<&Path>,
+    extra_config: &[(&str, String)],
+) -> Result<String> {
     use std::io::Write;
     use std::process::Stdio;
 
@@ -181,6 +188,13 @@ fn run_rustfmt(src: &str, opts: &FmtOptions, config_dir: Option<&Path>) -> Resul
     cmd.arg("--emit").arg("stdout");
     if let Some(ed) = &opts.edition {
         cmd.arg("--edition").arg(ed);
+    }
+    if !extra_config.is_empty() {
+        let joined: Vec<String> = extra_config
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+        cmd.arg("--config").arg(joined.join(","));
     }
     if let Some(dir) = config_dir {
         // `--config-path` must be the config FILE, not `dir`: the config
@@ -802,6 +816,7 @@ mod tests {
             tab_spaces: tab,
             hard_tabs: false,
             edition: None,
+            single_line_if_else_max_width: None,
         }
     }
 
@@ -1194,6 +1209,7 @@ mod comment_tests {
             tab_spaces: 4,
             hard_tabs: false,
             edition: None,
+            single_line_if_else_max_width: None,
         }
     }
 
@@ -1383,6 +1399,7 @@ mod coverage_tests {
             tab_spaces: tab,
             hard_tabs: false,
             edition: None,
+            single_line_if_else_max_width: None,
         }
     }
 
@@ -1663,6 +1680,43 @@ mod coverage_tests {
         let out = fmt(input);
         assert!(out.contains("a: css!(x: 1)"), "got:\n{out}");
         assert!(out.contains("b: css!(y: 2)"), "got:\n{out}");
+    }
+
+    // ---- closure-body unblocking ------------------------------------------
+
+    #[test]
+    fn blockified_closure_macro_body_unblocks() {
+        let input = "fn ui() -> Element {\n    render! {\n        view(child: move || {\n            render! { text(value: \"hi\") }\n        })\n    }\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains("child: move || render! { text(value: \"hi\") }"),
+            "sole-macro closure body must unblock:\n{out}"
+        );
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn closure_with_extra_statement_keeps_block() {
+        let input = "fn ui() -> Element {\n    render! {\n        view(child: move || {\n            log_render();\n            render! { text(value: \"hi\") }\n        })\n    }\n}\n";
+        let out = fmt(input);
+        assert!(
+            out.contains("move || {"),
+            "multi-statement closure body must keep its block:\n{out}"
+        );
+        assert!(out.contains("log_render();"), "got:\n{out}");
+        assert_idempotent(input);
+    }
+
+    #[test]
+    fn closure_with_leading_comment_keeps_block() {
+        let input = "fn ui() -> Element {\n    render! {\n        view(child: move || {\n            // c\n            render! { text(value: \"hi\") }\n        })\n    }\n}\n";
+        let out = fmt(input);
+        assert!(out.contains("// c"), "comment must survive:\n{out}");
+        assert!(
+            out.contains("move || {"),
+            "comment-bearing closure body must keep its block:\n{out}"
+        );
+        assert_idempotent(input);
     }
 
     // ---- last-argument overflow (combine) ---------------------------------

--- a/crates/whisker-fmt/src/options.rs
+++ b/crates/whisker-fmt/src/options.rs
@@ -9,6 +9,14 @@
 //! | `tab_spaces` | `tab_spaces`     | 4       |
 //! | `hard_tabs`  | `hard_tabs`      | false   |
 //! | `edition`    | (CLI `--edition`)| 2015    |
+//! | `single_line_if_else_max_width` | same | `None` |
+//!
+//! `single_line_if_else_max_width` is the one key with a whisker twist:
+//! when the user leaves it unset, the EMBEDDED-EXPR pass widens it to
+//! `max_width` so an `if c { a } else { b }` kwarg value stays on one
+//! line like any other DSL slot value; the base Rust pass keeps
+//! rustfmt's own default. An explicit `rustfmt.toml` value wins in both
+//! passes.
 //!
 //! The rustfmt *binary* reads `rustfmt.toml` itself for the base Rust
 //! pass, so any key it understands is honored. The subset captured here
@@ -33,6 +41,9 @@ pub struct FmtOptions {
     /// though `syn` is edition-agnostic for our purposes). `None` lets
     /// rustfmt pick its own default.
     pub edition: Option<String>,
+    /// `single_line_if_else_max_width` — `None` = unset by the user; the
+    /// embedded-expr pass then widens it to `max_width` (see module doc).
+    pub single_line_if_else_max_width: Option<usize>,
 }
 
 impl Default for FmtOptions {
@@ -42,6 +53,7 @@ impl Default for FmtOptions {
             tab_spaces: 4,
             hard_tabs: false,
             edition: None,
+            single_line_if_else_max_width: None,
         }
     }
 }
@@ -101,6 +113,11 @@ impl FmtOptions {
                 }
                 "edition" => {
                     opts.edition = Some(value.to_string());
+                }
+                "single_line_if_else_max_width" => {
+                    if let Ok(v) = value.parse() {
+                        opts.single_line_if_else_max_width = Some(v);
+                    }
                 }
                 _ => {}
             }

--- a/crates/whisker-fmt/src/printer.rs
+++ b/crates/whisker-fmt/src/printer.rs
@@ -231,7 +231,7 @@ impl Printer<'_> {
         if let Some(nested) = self.nested_macro_src(expr, level) {
             return nested;
         }
-        let fragment = if let Some(formatted) = self.expr_map.get(span) {
+        let mut fragment = if let Some(formatted) = self.expr_map.get(span) {
             formatted.to_string()
         } else if let Some(s) = self.map.slice(span) {
             // Continuation lines must be dedented to column 0 (the
@@ -242,8 +242,13 @@ impl Printer<'_> {
             return expr.to_token_stream().to_string();
         };
         if contains_target_macro(expr.to_token_stream()) {
+            // Unblock BEFORE the re-entrant pass so the macro body is
+            // measured at the depth it will actually print at.
+            if let Some(s) = unblock_macro_closure(&fragment, &self.opts.indent_unit()) {
+                fragment = s;
+            }
             if let Some(s) = self.fragment_macro_src(&fragment, level) {
-                return s;
+                fragment = s;
             }
         }
         fragment
@@ -930,6 +935,50 @@ fn reindent(fragment: &str, prefix: &str) -> String {
 fn span_of(expr: &syn::Expr) -> Span {
     use syn::spanned::Spanned;
     expr.span()
+}
+
+/// Rewrite a closure whose block body is EXACTLY one `render!`/`css!`/
+/// `routes!` call — `|args| { mac! { … } }` — to `|args| mac! { … }`.
+/// rustfmt blocks such closure bodies in the embedded-expr pass, but a
+/// macro-body slot is whisker-fmt's to lay out and the unblocked form
+/// is the DSL idiom. Returns `None` (leave the fragment alone) unless
+/// the pattern matches exactly: a comment or second statement in the
+/// block keeps the block.
+fn unblock_macro_closure(fragment: &str, unit: &str) -> Option<String> {
+    let mut lines = fragment.lines();
+    let header = lines.next()?.strip_suffix(" {")?;
+    if !header.trim_end().ends_with('|') {
+        return None;
+    }
+    let rest: Vec<&str> = lines.collect();
+    let (&last, middle) = rest.split_last()?;
+    if last != "}" || middle.is_empty() {
+        return None;
+    }
+    let mut body = String::new();
+    for (i, line) in middle.iter().enumerate() {
+        if i > 0 {
+            body.push('\n');
+        }
+        body.push_str(line.strip_prefix(unit).unwrap_or(line));
+    }
+    for name in ["render!", "css!", "routes!"] {
+        if body.trim_start().starts_with(name) {
+            let ts: TokenStream = body.parse().ok()?;
+            let trees: Vec<TokenTree> = ts.into_iter().collect();
+            let sole_macro = matches!(
+                trees.as_slice(),
+                [TokenTree::Ident(_), TokenTree::Punct(p), TokenTree::Group(_)]
+                    if p.as_char() == '!'
+            );
+            if !sole_macro {
+                return None;
+            }
+            let candidate = format!("{header} {body}");
+            return syn::parse_str::<Expr>(&candidate).ok().map(|_| candidate);
+        }
+    }
+    None
 }
 
 /// `true` if the token stream contains a `render!`/`css!`/`routes!`

--- a/crates/whisker-fmt/tests/integration.rs
+++ b/crates/whisker-fmt/tests/integration.rs
@@ -11,6 +11,7 @@ fn opts(tab: usize, width: usize) -> FmtOptions {
         tab_spaces: tab,
         hard_tabs: false,
         edition: Some("2021".to_string()),
+        single_line_if_else_max_width: None,
     }
 }
 
@@ -222,6 +223,68 @@ fn closure_wrapped_render_kwarg_converges_in_one_call() {
         once.contains("render! {\n"),
         "closure-wrapped render! must format:\n{once}"
     );
+}
+
+#[test]
+fn closure_wrapped_render_stays_unblocked_through_rustfmt() {
+    if !rustfmt_available() {
+        return;
+    }
+    // rustfmt blocks a multi-line `|…| render! {…}` closure body in the
+    // embedded-expr pass; inside a macro body the slot is whisker-fmt's,
+    // so the sole-macro body must come back unblocked.
+    let src = "fn ui() -> Element {\n    render! {\n        ForEach(\n            each: move || rows(),\n            key: |i: &usize| i.to_string(),\n            children: move |_: usize| render! {\n                view(style: row_style, on_tap: move |_| handle_row_tap_for(row_identifier))\n            },\n        )\n    }\n}\n";
+    let once = format_source(src, &opts(4, 100)).unwrap();
+    assert!(
+        once.contains("children: move |_: usize| render! {\n"),
+        "closure body must stay unblocked:\n{once}"
+    );
+    assert!(
+        !once.contains("|_: usize| {"),
+        "closure body must not be blockified:\n{once}"
+    );
+    let twice = format_source(&once, &opts(4, 100)).unwrap();
+    assert_eq!(once, twice, "not idempotent:\n--once--\n{once}");
+}
+
+#[test]
+fn single_line_if_else_slot_value_stays_inline() {
+    if !rustfmt_available() {
+        return;
+    }
+    // 52 chars — over rustfmt's default single_line_if_else_max_width
+    // of 50, which the embedded-expr pass widens to max_width.
+    let src = "fn s() -> Css {\n    css! {\n        opacity: if dimming_is_enabled_now.get() { 0.5 } else { 1.0 },\n        color: red,\n    }\n}\n";
+    let once = format_source(src, &opts(4, 100)).unwrap();
+    assert!(
+        once.contains("opacity: if dimming_is_enabled_now.get() { 0.5 } else { 1.0 },"),
+        "slot if-else must stay on one line:\n{once}"
+    );
+    let twice = format_source(&once, &opts(4, 100)).unwrap();
+    assert_eq!(once, twice, "not idempotent:\n--once--\n{once}");
+}
+
+#[test]
+fn deep_if_else_slot_value_expands_when_line_lacks_room() {
+    if !rustfmt_available() {
+        return;
+    }
+    // A 78-char if at column 25: the expression alone fits max_width,
+    // but its line doesn't — the per-column allowance must break it.
+    let src = "fn s() -> Css {\n    css! {\n        justify_content: if value.get() { JustifyContent::FlexEnd } else { JustifyContent::FlexStart },\n        color: red,\n    }\n}\n";
+    let once = format_source(src, &opts(4, 100)).unwrap();
+    for line in once.lines() {
+        assert!(
+            line.chars().count() <= 100,
+            "line exceeds max_width:\n{line}\nfull output:\n{once}"
+        );
+    }
+    assert!(
+        once.contains("justify_content: if value.get() {\n"),
+        "over-allowance if must break:\n{once}"
+    );
+    let twice = format_source(&once, &opts(4, 100)).unwrap();
+    assert_eq!(once, twice, "not idempotent:\n--once--\n{once}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #400: resolves the two remaining "rustfmt-conformance" artifacts inside macro-body slots that the giga census filed under class 9.

- **Closure blockification** — a closure whose body is exactly one `render!`/`css!`/`routes!` call came back as `move || { render! {…} }` from the embedded-expr pass (rustfmt blocks multi-line closure bodies). The sole-macro body is now unblocked to the DSL idiom `move || render! {…}`. A comment or a second statement in the block keeps the block, and the unblocked candidate must re-parse as an expression before it's used.
- **5-line if-else expansion** — an if-else kwarg value always broke past rustfmt's 50-char `single_line_if_else_max_width`, and bare tail position in the synthetic wrapper formatted it as control flow regardless of config. Each `if` expression is now parenthesized (expression position) and formatted with a per-column allowance — `max_width` minus its source column, capped by an explicit `rustfmt.toml` setting — one rustfmt spawn per distinct allowance. It stays on one line exactly when its real line has room, so this adds no over-width lines (the option measures the expression's own width, verified against rustfmt).

Both changes apply only inside macro bodies, which the base rustfmt pass never touches — statement-position Rust keeps rustfmt's own layout, so `whisker fmt` still agrees with plain rustfmt on non-DSL code.

## Verification

- giga: converges in one run (pass 2 changes zero files); 0 comments lost; blockified closure+`render!` patterns drop to 0; shallow if-else values stay on one line (`opacity: if open { 1.0 } else { 0.0 },`) while deep ones break; over-width totals match the #400 baseline (the only remaining excess is the pre-existing ExprMap column-shift case). `cargo check` passes on the formatted tree.
- whisker-fmt: 142 unit + 17 integration tests (7 new); whisker-cli tests pass; fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)