### PR TITLE
Add the Host-independent frame protocol model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,16 @@ jobs:
           cargo llvm-cov --workspace --lcov --output-path lcov.info
           cargo llvm-cov report --summary-only | tee coverage-summary.txt
 
+      - name: Enforce coverage for the new Rust renderer foundation
+        # Legacy crates are raised incrementally as they move onto the new
+        # engine. New Host-independent foundation crates start at the strict
+        # gate and must keep line, function, and region coverage at 100%.
+        run: |
+          cargo llvm-cov -p whisker-protocol --summary-only \
+            --fail-under-lines 100 \
+            --fail-under-functions 100 \
+            --fail-under-regions 100
+
       - name: Render Markdown summary
         # cargo-llvm-cov's summary is a wide fixed-width table; wrap it
         # in a Markdown fenced block so both the Job Summary and PR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4487,6 +4487,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-protocol"
+version = "0.12.0"
+
+[[package]]
 name = "whisker-router"
 version = "0.12.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "packages/whisker-asset-macros",
     "crates/whisker-css",
     "crates/whisker-plugin",
+    "crates/whisker-protocol",
     "crates/whisker-runtime",
     "crates/whisker-subsecond",
     "examples/anim-smoke",
@@ -103,6 +104,7 @@ whisker-asset = { path = "packages/whisker-asset", version = "0.12.0" }
 whisker-asset-macros = { path = "packages/whisker-asset-macros", version = "0.12.0" }
 whisker-css = { path = "crates/whisker-css", version = "0.12.0" }
 whisker-plugin = { path = "crates/whisker-plugin", version = "0.12.0" }
+whisker-protocol = { path = "crates/whisker-protocol", version = "0.12.0" }
 whisker-runtime = { path = "crates/whisker-runtime", version = "0.12.0" }
 whisker-router = { path = "packages/whisker-router", version = "0.12.0" }
 whisker-router-macros = { path = "packages/whisker-router-macros", version = "0.12.0" }

--- a/crates/whisker-protocol/Cargo.toml
+++ b/crates/whisker-protocol/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "whisker-protocol"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Host-independent scene frame model and validator for Whisker."
+
+[dependencies]

--- a/crates/whisker-protocol/src/frame.rs
+++ b/crates/whisker-protocol/src/frame.rs
@@ -291,3 +291,119 @@ impl Operation {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(value: u64) -> NodeId {
+        NodeId::new(value).expect("test node")
+    }
+
+    #[test]
+    fn target_node_covers_every_operation_group() {
+        let target = node(1);
+        let child = node(2);
+        let element_type = ElementTypeId::new(1).expect("test element type");
+        let property = PropertyId::new(1).expect("test property");
+        let pointer = PointerId::new(1).expect("test pointer");
+        let command = CommandId::new(1).expect("test command");
+
+        let operations = [
+            Operation::CreateNode {
+                node: target,
+                element_type,
+            },
+            Operation::DeleteNode { node: target },
+            Operation::InsertChild {
+                parent: target,
+                child,
+                index: 0,
+            },
+            Operation::RemoveChild {
+                parent: target,
+                child,
+            },
+            Operation::MoveChild {
+                parent: target,
+                child,
+                index: 0,
+            },
+            Operation::SetLayout {
+                node: target,
+                rect: LayoutRect::default(),
+            },
+            Operation::SetTransform {
+                node: target,
+                transform: Transform::IDENTITY,
+            },
+            Operation::SetOpacity {
+                node: target,
+                opacity: 1.0,
+            },
+            Operation::SetVisibility {
+                node: target,
+                visibility: Visibility::Visible,
+            },
+            Operation::SetZOrder {
+                node: target,
+                z_order: 0,
+            },
+            Operation::SetProperty {
+                node: target,
+                property,
+                value: ProtocolValue::Null,
+            },
+            Operation::ClearProperty {
+                node: target,
+                property,
+            },
+            Operation::SetEventMask {
+                node: target,
+                event_mask: 0,
+            },
+            Operation::SetHitTest {
+                node: target,
+                behavior: HitTestBehavior::Auto,
+            },
+            Operation::SetPointerCapture {
+                node: target,
+                pointer,
+            },
+            Operation::ReleasePointerCapture {
+                node: target,
+                pointer,
+            },
+            Operation::InvokeCommand {
+                node: target,
+                command,
+                arguments: ProtocolValue::Null,
+                result: None,
+            },
+        ];
+
+        assert_eq!(operations[0].target_node(), None);
+        for operation in &operations[1..] {
+            assert_eq!(operation.target_node(), Some(target));
+        }
+    }
+
+    #[test]
+    fn semantic_values_represent_every_owned_value_shape() {
+        let values = [
+            ProtocolValue::Null,
+            ProtocolValue::Bool(true),
+            ProtocolValue::I64(-1),
+            ProtocolValue::F64(0.5),
+            ProtocolValue::String("value".into()),
+            ProtocolValue::Bytes(vec![1, 2]),
+            ProtocolValue::Array(vec![ProtocolValue::Null]),
+            ProtocolValue::Object(vec![("key".into(), ProtocolValue::Bool(false))]),
+        ];
+
+        assert_eq!(values.len(), 8);
+        assert_ne!(Visibility::Visible, Visibility::Hidden);
+        assert_ne!(HitTestBehavior::None, HitTestBehavior::BoxOnly);
+        assert_ne!(HitTestBehavior::Auto, HitTestBehavior::DescendantsOnly);
+    }
+}

--- a/crates/whisker-protocol/src/frame.rs
+++ b/crates/whisker-protocol/src/frame.rs
@@ -1,0 +1,293 @@
+//! Owned semantic frame values.
+
+use crate::{CommandId, ElementTypeId, NodeId, PointerId, PropertyId, ResultId, SurfaceId};
+
+/// Protocol major version implemented by this semantic model.
+pub const PROTOCOL_MAJOR: u16 = 1;
+
+/// Protocol minor version implemented by this semantic model.
+pub const PROTOCOL_MINOR: u16 = 0;
+
+/// A negotiated frame protocol version.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ProtocolVersion {
+    /// Breaking protocol generation.
+    pub major: u16,
+    /// Backward-compatible feature generation within one major version.
+    pub minor: u16,
+}
+
+impl ProtocolVersion {
+    /// Version supported by this crate.
+    pub const CURRENT: Self = Self {
+        major: PROTOCOL_MAJOR,
+        minor: PROTOCOL_MINOR,
+    };
+}
+
+/// Whether a packet replaces or advances the receiver projection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum FrameMode {
+    /// Replaces all nodes and starts the declared scene epoch.
+    Snapshot,
+    /// Advances the existing scene from `base_revision`.
+    Delta,
+}
+
+/// Metadata that orders a frame within one surface and scene epoch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FrameHeader {
+    /// Protocol version used by the packet.
+    pub version: ProtocolVersion,
+    /// Destination surface.
+    pub surface: SurfaceId,
+    /// Generation in which node identifiers remain unique.
+    pub scene_epoch: u32,
+    /// Monotonically increasing diagnostic frame identifier.
+    pub frame_id: u64,
+    /// Revision the receiver must currently have for a delta.
+    pub base_revision: u64,
+    /// Revision accepted after the complete packet succeeds.
+    pub target_revision: u64,
+    /// Viewport/environment generation used to compute geometry.
+    pub viewport_epoch: u32,
+    /// Snapshot or incremental transaction.
+    pub mode: FrameMode,
+}
+
+/// One owned frame transaction before packed wire encoding.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FramePacket {
+    /// Transaction metadata.
+    pub header: FrameHeader,
+    /// Operations applied in order after complete validation succeeds.
+    pub operations: Vec<Operation>,
+}
+
+/// Backend-independent rectangle in logical pixels.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct LayoutRect {
+    /// Horizontal offset from the parent content origin.
+    pub x: f32,
+    /// Vertical offset from the parent content origin.
+    pub y: f32,
+    /// Border-box width.
+    pub width: f32,
+    /// Border-box height.
+    pub height: f32,
+}
+
+/// A column-major 4-by-4 transform matrix.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Transform(pub [f32; 16]);
+
+impl Transform {
+    /// Identity transform.
+    pub const IDENTITY: Self = Self([
+        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+    ]);
+}
+
+/// Whether a node participates in presentation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Visibility {
+    /// The node is presented normally.
+    Visible,
+    /// The node retains scene state but is not presented.
+    Hidden,
+}
+
+/// How Host hit testing treats a node and its descendants.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum HitTestBehavior {
+    /// The node and descendants use their normal hit-test rules.
+    Auto,
+    /// Neither the node nor its descendants receives pointer input.
+    None,
+    /// The node may receive input but its descendants do not.
+    BoxOnly,
+    /// Descendants may receive input but the node itself does not.
+    DescendantsOnly,
+}
+
+/// An owned typed value in the semantic model.
+///
+/// The packed protocol will store repeated and variable-sized values in
+/// tables. This recursive owned form exists for engine tests and does not
+/// prescribe a per-property wire allocation.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProtocolValue {
+    /// Absence of a value where a schema permits it.
+    Null,
+    /// Boolean value.
+    Bool(bool),
+    /// Signed integer value.
+    I64(i64),
+    /// Floating-point value.
+    F64(f64),
+    /// UTF-8 string value.
+    String(String),
+    /// Opaque binary value interpreted by its declared schema.
+    Bytes(Vec<u8>),
+    /// Ordered homogeneous or heterogeneous values.
+    Array(Vec<Self>),
+    /// Ordered named fields.
+    Object(Vec<(String, Self)>),
+}
+
+/// A semantic mutation within a [`FramePacket`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum Operation {
+    /// Creates an unattached node.
+    CreateNode {
+        /// New node identifier.
+        node: NodeId,
+        /// Negotiated element type.
+        element_type: ElementTypeId,
+    },
+    /// Deletes a node and its complete attached subtree.
+    DeleteNode {
+        /// Subtree root to delete.
+        node: NodeId,
+    },
+    /// Attaches an unattached child at an index.
+    InsertChild {
+        /// Destination parent.
+        parent: NodeId,
+        /// Unattached child.
+        child: NodeId,
+        /// Position in the resulting child list.
+        index: u32,
+    },
+    /// Detaches a direct child without deleting it.
+    RemoveChild {
+        /// Current parent.
+        parent: NodeId,
+        /// Direct child to detach.
+        child: NodeId,
+    },
+    /// Reorders a direct child within its current parent.
+    MoveChild {
+        /// Current parent.
+        parent: NodeId,
+        /// Direct child to move.
+        child: NodeId,
+        /// Position after removing the child from its old position.
+        index: u32,
+    },
+    /// Sets resolved box geometry.
+    SetLayout {
+        /// Target node.
+        node: NodeId,
+        /// Resolved logical-pixel rectangle.
+        rect: LayoutRect,
+    },
+    /// Sets the resolved transform matrix.
+    SetTransform {
+        /// Target node.
+        node: NodeId,
+        /// Resolved transform.
+        transform: Transform,
+    },
+    /// Sets resolved opacity.
+    SetOpacity {
+        /// Target node.
+        node: NodeId,
+        /// Opacity in the inclusive range `0.0..=1.0`.
+        opacity: f32,
+    },
+    /// Sets whether a node is presented.
+    SetVisibility {
+        /// Target node.
+        node: NodeId,
+        /// Resolved visibility.
+        visibility: Visibility,
+    },
+    /// Sets resolved sibling stacking order.
+    SetZOrder {
+        /// Target node.
+        node: NodeId,
+        /// Backend-independent stacking order.
+        z_order: i32,
+    },
+    /// Sets a typed common or element-specific property.
+    SetProperty {
+        /// Target node.
+        node: NodeId,
+        /// Negotiated property identifier.
+        property: PropertyId,
+        /// Typed property payload.
+        value: ProtocolValue,
+    },
+    /// Restores a property to its schema-defined absence/default state.
+    ClearProperty {
+        /// Target node.
+        node: NodeId,
+        /// Negotiated property identifier.
+        property: PropertyId,
+    },
+    /// Replaces the event subscription bitset for a node.
+    SetEventMask {
+        /// Target node.
+        node: NodeId,
+        /// Negotiated event bits.
+        event_mask: u64,
+    },
+    /// Sets Host hit-test participation.
+    SetHitTest {
+        /// Target node.
+        node: NodeId,
+        /// Resolved behavior.
+        behavior: HitTestBehavior,
+    },
+    /// Captures a pointer stream for a node.
+    SetPointerCapture {
+        /// Target node.
+        node: NodeId,
+        /// Pointer to capture.
+        pointer: PointerId,
+    },
+    /// Releases a pointer stream previously captured by a node.
+    ReleasePointerCapture {
+        /// Target node.
+        node: NodeId,
+        /// Pointer to release.
+        pointer: PointerId,
+    },
+    /// Invokes an element command after preceding mutations.
+    InvokeCommand {
+        /// Target node.
+        node: NodeId,
+        /// Negotiated command identifier.
+        command: CommandId,
+        /// Typed command arguments.
+        arguments: ProtocolValue,
+        /// Optional asynchronous result correlation.
+        result: Option<ResultId>,
+    },
+}
+
+impl Operation {
+    /// Returns the node that must exist when this operation executes.
+    pub fn target_node(&self) -> Option<NodeId> {
+        match self {
+            Self::CreateNode { .. } => None,
+            Self::DeleteNode { node }
+            | Self::SetLayout { node, .. }
+            | Self::SetTransform { node, .. }
+            | Self::SetOpacity { node, .. }
+            | Self::SetVisibility { node, .. }
+            | Self::SetZOrder { node, .. }
+            | Self::SetProperty { node, .. }
+            | Self::ClearProperty { node, .. }
+            | Self::SetEventMask { node, .. }
+            | Self::SetHitTest { node, .. }
+            | Self::SetPointerCapture { node, .. }
+            | Self::ReleasePointerCapture { node, .. }
+            | Self::InvokeCommand { node, .. } => Some(*node),
+            Self::InsertChild { parent, .. }
+            | Self::RemoveChild { parent, .. }
+            | Self::MoveChild { parent, .. } => Some(*parent),
+        }
+    }
+}

--- a/crates/whisker-protocol/src/id.rs
+++ b/crates/whisker-protocol/src/id.rs
@@ -1,0 +1,74 @@
+//! Stable identifiers carried by the semantic frame protocol.
+
+macro_rules! define_id {
+    ($name:ident, $repr:ty, $summary:literal) => {
+        #[doc = $summary]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name($repr);
+
+        impl $name {
+            /// Creates an identifier, returning `None` for the reserved zero value.
+            pub const fn new(value: $repr) -> Option<Self> {
+                if value == 0 { None } else { Some(Self(value)) }
+            }
+
+            /// Returns the integer carried by this identifier.
+            pub const fn get(self) -> $repr {
+                self.0
+            }
+        }
+    };
+}
+
+define_id!(
+    SurfaceId,
+    u64,
+    "Identifies one independently presented surface"
+);
+define_id!(
+    NodeId,
+    u64,
+    "Identifies one scene node within a scene epoch"
+);
+define_id!(
+    ElementTypeId,
+    u32,
+    "Identifies an element schema negotiated when a surface attaches"
+);
+define_id!(
+    PropertyId,
+    u32,
+    "Identifies a typed common-style or element-specific property"
+);
+define_id!(
+    CommandId,
+    u32,
+    "Identifies a command declared by an element schema"
+);
+define_id!(
+    ResultId,
+    u64,
+    "Correlates an asynchronous command result with its invocation"
+);
+define_id!(
+    PointerId,
+    u64,
+    "Identifies one Host pointer stream for capture operations"
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_is_reserved_for_every_id_width() {
+        assert_eq!(NodeId::new(0), None);
+        assert_eq!(PropertyId::new(0), None);
+    }
+
+    #[test]
+    fn id_round_trips_its_integer() {
+        let id = NodeId::new(42).expect("non-zero ID");
+        assert_eq!(id.get(), 42);
+    }
+}

--- a/crates/whisker-protocol/src/lib.rs
+++ b/crates/whisker-protocol/src/lib.rs
@@ -1,0 +1,26 @@
+//! Host-independent frame protocol model for Whisker
+//!
+//! This crate defines the owned, semantic representation of a scene frame and
+//! validates its revision and tree invariants. It deliberately does not define
+//! the packed wire encoding or a platform renderer ABI yet: those layers can
+//! evolve without coupling the Rust scene engine to Android, UIKit, or DOM
+//! types.
+//!
+//! [`SceneProjection`] is a small reference receiver used by tests, recording
+//! renderers, and future Host conformance fixtures. Applying a [`FramePacket`]
+//! is transactional: malformed operations leave the accepted projection and
+//! revision unchanged.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+mod frame;
+mod id;
+mod validation;
+
+pub use frame::{
+    FrameHeader, FrameMode, FramePacket, HitTestBehavior, LayoutRect, Operation, PROTOCOL_MAJOR,
+    PROTOCOL_MINOR, ProtocolValue, ProtocolVersion, Transform, Visibility,
+};
+pub use id::{CommandId, ElementTypeId, NodeId, PointerId, PropertyId, ResultId, SurfaceId};
+pub use validation::{ApplyResult, NodeProjection, SceneProjection, ValidationError};

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -323,10 +323,15 @@ impl SceneProjection {
                     return Err(ValidationError::DuplicateResultId { result: *result });
                 }
             }
-            operation => {
-                if let Some(node) = operation.target_node() {
-                    self.require_node(node)?;
-                }
+            Operation::SetVisibility { node, .. }
+            | Operation::SetZOrder { node, .. }
+            | Operation::SetProperty { node, .. }
+            | Operation::ClearProperty { node, .. }
+            | Operation::SetEventMask { node, .. }
+            | Operation::SetHitTest { node, .. }
+            | Operation::SetPointerCapture { node, .. }
+            | Operation::ReleasePointerCapture { node, .. } => {
+                self.require_node(*node)?;
             }
         }
         Ok(())
@@ -344,7 +349,7 @@ impl SceneProjection {
         child: NodeId,
         index: u32,
     ) -> Result<(), ValidationError> {
-        self.require_node(parent)?;
+        let len = self.require_node(parent)?.children.len();
         let child_state = self.require_node(child)?;
         if let Some(existing) = child_state.parent {
             return Err(ValidationError::ChildAlreadyAttached {
@@ -356,7 +361,6 @@ impl SceneProjection {
             return Err(ValidationError::TreeCycle { parent, child });
         }
 
-        let len = self.require_node(parent)?.children.len();
         let index = usize::try_from(index).expect("u32 always fits supported Rust targets");
         if index > len {
             return Err(ValidationError::ChildIndexOutOfBounds {
@@ -473,7 +477,10 @@ impl SceneProjection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ElementTypeId, FrameHeader, LayoutRect, Operation, ProtocolVersion, ResultId};
+    use crate::{
+        CommandId, ElementTypeId, FrameHeader, HitTestBehavior, LayoutRect, Operation, PointerId,
+        PropertyId, ProtocolValue, ProtocolVersion, ResultId, Transform, Visibility,
+    };
 
     fn surface() -> SurfaceId {
         SurfaceId::new(1).expect("test surface")
@@ -540,12 +547,31 @@ mod tests {
         (scene, root, child)
     }
 
+    fn apply_next(
+        scene: &mut SceneProjection,
+        operations: Vec<Operation>,
+    ) -> Result<ApplyResult, ValidationError> {
+        let revision = scene.revision();
+        scene.apply(&packet(
+            FrameMode::Delta,
+            scene.scene_epoch().expect("initialized scene"),
+            revision,
+            revision + 1,
+            operations,
+        ))
+    }
+
     #[test]
     fn snapshot_builds_a_retained_tree() {
         let (scene, root, child) = initial_tree();
         assert_eq!(scene.scene_epoch(), Some(1));
         assert_eq!(scene.revision(), 1);
         assert_eq!(scene.node_count(), 2);
+        assert_eq!(scene.surface(), surface());
+        assert_eq!(
+            scene.node(root).expect("root").element_type(),
+            element_type()
+        );
         assert_eq!(scene.node(root).expect("root").children(), &[child]);
         assert_eq!(scene.node(child).expect("child").parent(), Some(root));
     }
@@ -718,6 +744,443 @@ mod tests {
             .apply(&packet(FrameMode::Snapshot, 1, 0, 1, Vec::new()))
             .expect_err("snapshot must rotate its epoch");
         assert_eq!(error, ValidationError::SnapshotReusedEpoch { epoch: 1 });
+        assert_eq!(scene.revision(), 1);
+    }
+
+    #[test]
+    fn replacement_snapshot_accepts_a_new_epoch_and_discards_old_nodes() {
+        let (mut scene, old_root, _) = initial_tree();
+        let new_root = node(9);
+        let result = scene
+            .apply(&packet(
+                FrameMode::Snapshot,
+                2,
+                0,
+                1,
+                vec![Operation::CreateNode {
+                    node: new_root,
+                    element_type: element_type(),
+                }],
+            ))
+            .expect("new epoch snapshot");
+
+        assert_eq!(result, ApplyResult::Accepted { revision: 1 });
+        assert_eq!(scene.scene_epoch(), Some(2));
+        assert!(scene.node(old_root).is_none());
+        assert!(scene.node(new_root).is_some());
+    }
+
+    #[test]
+    fn header_validation_reports_every_malformed_case() {
+        let cases = [
+            (
+                {
+                    let mut value = packet(FrameMode::Snapshot, 1, 0, 1, Vec::new());
+                    value.header.version.major += 1;
+                    value
+                },
+                ValidationError::UnsupportedProtocolMajor { received: 2 },
+            ),
+            (
+                {
+                    let mut value = packet(FrameMode::Snapshot, 1, 0, 1, Vec::new());
+                    value.header.surface = SurfaceId::new(2).expect("other surface");
+                    value
+                },
+                ValidationError::SurfaceMismatch {
+                    expected: surface(),
+                    received: SurfaceId::new(2).expect("other surface"),
+                },
+            ),
+            (
+                packet(FrameMode::Snapshot, 1, 2, 3, Vec::new()),
+                ValidationError::SnapshotBaseRevision { received: 2 },
+            ),
+            (
+                packet(FrameMode::Snapshot, 1, 0, 0, Vec::new()),
+                ValidationError::RevisionDidNotAdvance { base: 0, target: 0 },
+            ),
+        ];
+
+        for (packet, expected) in cases {
+            let mut scene = SceneProjection::new(surface());
+            let error = scene.apply(&packet).expect_err("malformed header");
+            assert_eq!(error, expected);
+            assert!(error.to_string().starts_with("invalid Whisker frame:"));
+            let as_error: &dyn Error = &error;
+            assert!(as_error.source().is_none());
+            assert_eq!(scene.revision(), 0);
+        }
+    }
+
+    #[test]
+    fn scene_epoch_drift_requests_a_snapshot() {
+        let (mut scene, _, _) = initial_tree();
+        let result = scene
+            .apply(&packet(FrameMode::Delta, 2, 1, 2, Vec::new()))
+            .expect("epoch drift is recoverable");
+        assert_eq!(result, ApplyResult::NeedSnapshot { host_revision: 1 });
+        assert_eq!(scene.scene_epoch(), Some(1));
+    }
+
+    #[test]
+    fn all_non_structural_operations_accept_valid_values() {
+        let (mut scene, root, _) = initial_tree();
+        let property = PropertyId::new(1).expect("test property");
+        let pointer = PointerId::new(1).expect("test pointer");
+        let command = CommandId::new(1).expect("test command");
+        let result = ResultId::new(1).expect("test result");
+
+        let outcome = apply_next(
+            &mut scene,
+            vec![
+                Operation::SetLayout {
+                    node: root,
+                    rect: LayoutRect {
+                        x: -1.0,
+                        y: 2.0,
+                        width: 30.0,
+                        height: 40.0,
+                    },
+                },
+                Operation::SetTransform {
+                    node: root,
+                    transform: Transform::IDENTITY,
+                },
+                Operation::SetOpacity {
+                    node: root,
+                    opacity: 0.0,
+                },
+                Operation::SetOpacity {
+                    node: root,
+                    opacity: 1.0,
+                },
+                Operation::SetVisibility {
+                    node: root,
+                    visibility: Visibility::Hidden,
+                },
+                Operation::SetZOrder {
+                    node: root,
+                    z_order: -2,
+                },
+                Operation::SetProperty {
+                    node: root,
+                    property,
+                    value: ProtocolValue::Object(vec![(
+                        "enabled".into(),
+                        ProtocolValue::Bool(true),
+                    )]),
+                },
+                Operation::ClearProperty {
+                    node: root,
+                    property,
+                },
+                Operation::SetEventMask {
+                    node: root,
+                    event_mask: 3,
+                },
+                Operation::SetHitTest {
+                    node: root,
+                    behavior: HitTestBehavior::BoxOnly,
+                },
+                Operation::SetPointerCapture {
+                    node: root,
+                    pointer,
+                },
+                Operation::ReleasePointerCapture {
+                    node: root,
+                    pointer,
+                },
+                Operation::InvokeCommand {
+                    node: root,
+                    command,
+                    arguments: ProtocolValue::Array(Vec::new()),
+                    result: None,
+                },
+                Operation::InvokeCommand {
+                    node: root,
+                    command,
+                    arguments: ProtocolValue::Null,
+                    result: Some(result),
+                },
+            ],
+        )
+        .expect("all valid operations");
+
+        assert_eq!(outcome, ApplyResult::Accepted { revision: 2 });
+    }
+
+    #[test]
+    fn structural_operations_support_detach_reinsert_and_move() {
+        let (mut scene, root, child) = initial_tree();
+        let sibling = node(3);
+        apply_next(
+            &mut scene,
+            vec![
+                Operation::CreateNode {
+                    node: sibling,
+                    element_type: element_type(),
+                },
+                Operation::InsertChild {
+                    parent: root,
+                    child: sibling,
+                    index: 1,
+                },
+                Operation::MoveChild {
+                    parent: root,
+                    child: sibling,
+                    index: 0,
+                },
+                Operation::RemoveChild {
+                    parent: root,
+                    child,
+                },
+                Operation::InsertChild {
+                    parent: root,
+                    child,
+                    index: 1,
+                },
+            ],
+        )
+        .expect("valid structural transaction");
+
+        assert_eq!(
+            scene.node(root).expect("root").children(),
+            &[sibling, child]
+        );
+        assert_eq!(scene.node(child).expect("child").parent(), Some(root));
+    }
+
+    #[test]
+    fn unattached_root_can_be_deleted() {
+        let (mut scene, root, _) = initial_tree();
+        apply_next(&mut scene, vec![Operation::DeleteNode { node: root }])
+            .expect("delete unattached scene root");
+        assert_eq!(scene.node_count(), 0);
+    }
+
+    #[test]
+    fn unknown_node_is_rejected_by_specialized_and_generic_operations() {
+        let (mut scene, _, _) = initial_tree();
+        let missing = node(99);
+        let property = PropertyId::new(1).expect("test property");
+        let operations = [
+            Operation::DeleteNode { node: missing },
+            Operation::SetLayout {
+                node: missing,
+                rect: LayoutRect::default(),
+            },
+            Operation::SetTransform {
+                node: missing,
+                transform: Transform::IDENTITY,
+            },
+            Operation::SetOpacity {
+                node: missing,
+                opacity: 1.0,
+            },
+            Operation::SetProperty {
+                node: missing,
+                property,
+                value: ProtocolValue::Null,
+            },
+            Operation::InvokeCommand {
+                node: missing,
+                command: CommandId::new(1).expect("test command"),
+                arguments: ProtocolValue::Null,
+                result: None,
+            },
+        ];
+
+        for operation in operations {
+            let error = apply_next(&mut scene, vec![operation]).expect_err("unknown node");
+            assert_eq!(error, ValidationError::UnknownNode { node: missing });
+            assert_eq!(scene.revision(), 1);
+        }
+    }
+
+    #[test]
+    fn insert_reports_unknown_attached_and_index_errors() {
+        let (mut scene, root, child) = initial_tree();
+        let missing = node(99);
+        let unattached = node(3);
+        apply_next(
+            &mut scene,
+            vec![Operation::CreateNode {
+                node: unattached,
+                element_type: element_type(),
+            }],
+        )
+        .expect("create unattached node");
+
+        let cases = [
+            (
+                Operation::InsertChild {
+                    parent: missing,
+                    child: unattached,
+                    index: 0,
+                },
+                ValidationError::UnknownNode { node: missing },
+            ),
+            (
+                Operation::InsertChild {
+                    parent: root,
+                    child: missing,
+                    index: 0,
+                },
+                ValidationError::UnknownNode { node: missing },
+            ),
+            (
+                Operation::InsertChild {
+                    parent: root,
+                    child,
+                    index: 0,
+                },
+                ValidationError::ChildAlreadyAttached {
+                    child,
+                    parent: root,
+                },
+            ),
+            (
+                Operation::InsertChild {
+                    parent: root,
+                    child: unattached,
+                    index: 2,
+                },
+                ValidationError::ChildIndexOutOfBounds {
+                    parent: root,
+                    index: 2,
+                    len: 1,
+                },
+            ),
+            (
+                Operation::InsertChild {
+                    parent: unattached,
+                    child: unattached,
+                    index: 0,
+                },
+                ValidationError::TreeCycle {
+                    parent: unattached,
+                    child: unattached,
+                },
+            ),
+        ];
+
+        for (operation, expected) in cases {
+            let error = apply_next(&mut scene, vec![operation]).expect_err("invalid insertion");
+            assert_eq!(error, expected);
+            assert_eq!(scene.revision(), 2);
+        }
+    }
+
+    #[test]
+    fn remove_and_move_report_relationship_and_index_errors() {
+        let (mut scene, root, child) = initial_tree();
+        let sibling = node(3);
+        let missing = node(99);
+        apply_next(
+            &mut scene,
+            vec![Operation::CreateNode {
+                node: sibling,
+                element_type: element_type(),
+            }],
+        )
+        .expect("create sibling");
+
+        let not_child = ValidationError::NotDirectChild {
+            parent: root,
+            child: sibling,
+        };
+        for operation in [
+            Operation::RemoveChild {
+                parent: root,
+                child: sibling,
+            },
+            Operation::MoveChild {
+                parent: root,
+                child: sibling,
+                index: 0,
+            },
+        ] {
+            assert_eq!(
+                apply_next(&mut scene, vec![operation]).expect_err("not a child"),
+                not_child
+            );
+        }
+
+        for operation in [
+            Operation::RemoveChild {
+                parent: missing,
+                child,
+            },
+            Operation::MoveChild {
+                parent: root,
+                child: missing,
+                index: 0,
+            },
+        ] {
+            assert_eq!(
+                apply_next(&mut scene, vec![operation]).expect_err("unknown relationship node"),
+                ValidationError::UnknownNode { node: missing }
+            );
+        }
+
+        let error = apply_next(
+            &mut scene,
+            vec![Operation::MoveChild {
+                parent: root,
+                child,
+                index: 1,
+            }],
+        )
+        .expect_err("index is checked after removal");
+        assert_eq!(
+            error,
+            ValidationError::ChildIndexOutOfBounds {
+                parent: root,
+                index: 1,
+                len: 0,
+            }
+        );
+        assert_eq!(scene.node(root).expect("root").children(), &[child]);
+    }
+
+    #[test]
+    fn numeric_validation_rejects_transform_and_opacity_edges() {
+        let (mut scene, root, _) = initial_tree();
+        let mut invalid_transform = Transform::IDENTITY;
+        invalid_transform.0[15] = f32::INFINITY;
+        let transform_error = apply_next(
+            &mut scene,
+            vec![Operation::SetTransform {
+                node: root,
+                transform: invalid_transform,
+            }],
+        )
+        .expect_err("infinite transform");
+        assert_eq!(transform_error, ValidationError::NonFiniteNumber);
+
+        let range_error = apply_next(
+            &mut scene,
+            vec![Operation::SetOpacity {
+                node: root,
+                opacity: -0.1,
+            }],
+        )
+        .expect_err("out-of-range opacity");
+        assert_eq!(
+            range_error,
+            ValidationError::InvalidOpacity { opacity: -0.1 }
+        );
+
+        let nan_error = apply_next(
+            &mut scene,
+            vec![Operation::SetOpacity {
+                node: root,
+                opacity: f32::NAN,
+            }],
+        )
+        .expect_err("NaN opacity");
+        assert_eq!(format!("{nan_error:?}"), "InvalidOpacity { opacity: NaN }");
         assert_eq!(scene.revision(), 1);
     }
 }

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -1,0 +1,723 @@
+//! Transactional reference validation for semantic frame packets.
+
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::fmt;
+
+use crate::{
+    ElementTypeId, FrameMode, FramePacket, NodeId, Operation, PROTOCOL_MAJOR, ResultId, SurfaceId,
+};
+
+/// Minimal retained state for one node in a reference projection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeProjection {
+    element_type: ElementTypeId,
+    parent: Option<NodeId>,
+    children: Vec<NodeId>,
+}
+
+impl NodeProjection {
+    /// Returns the negotiated type used to create this node.
+    pub const fn element_type(&self) -> ElementTypeId {
+        self.element_type
+    }
+
+    /// Returns the current logical parent, if attached.
+    pub const fn parent(&self) -> Option<NodeId> {
+        self.parent
+    }
+
+    /// Returns children in presentation order.
+    pub fn children(&self) -> &[NodeId] {
+        &self.children
+    }
+}
+
+/// Result of attempting to apply a well-formed packet to a projection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApplyResult {
+    /// The complete transaction was accepted.
+    Accepted {
+        /// Newly accepted scene revision.
+        revision: u64,
+    },
+    /// A delta did not continue the receiver state and a snapshot is needed.
+    NeedSnapshot {
+        /// Revision currently held by the receiver.
+        host_revision: u64,
+    },
+}
+
+/// A malformed frame transaction.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ValidationError {
+    /// Packet uses a protocol major this implementation cannot interpret.
+    UnsupportedProtocolMajor {
+        /// Received major version.
+        received: u16,
+    },
+    /// Packet targets a different surface.
+    SurfaceMismatch {
+        /// Surface owned by the projection.
+        expected: SurfaceId,
+        /// Surface declared by the packet.
+        received: SurfaceId,
+    },
+    /// Snapshot did not start from the empty revision.
+    SnapshotBaseRevision {
+        /// Invalid base revision.
+        received: u64,
+    },
+    /// Target revision did not advance beyond its base.
+    RevisionDidNotAdvance {
+        /// Packet base revision.
+        base: u64,
+        /// Packet target revision.
+        target: u64,
+    },
+    /// Snapshot reused the currently accepted scene epoch.
+    SnapshotReusedEpoch {
+        /// Reused scene epoch.
+        epoch: u32,
+    },
+    /// Node identifier was created more than once in one epoch.
+    DuplicateNode {
+        /// Duplicate identifier.
+        node: NodeId,
+    },
+    /// An operation referenced a node that does not exist at that point.
+    UnknownNode {
+        /// Missing identifier.
+        node: NodeId,
+    },
+    /// Insert attempted to attach a child that already has a parent.
+    ChildAlreadyAttached {
+        /// Child identifier.
+        child: NodeId,
+        /// Existing parent.
+        parent: NodeId,
+    },
+    /// A parent/child relationship did not match the operation.
+    NotDirectChild {
+        /// Expected parent.
+        parent: NodeId,
+        /// Node that was not its direct child.
+        child: NodeId,
+    },
+    /// Child position exceeds the resulting child-list length.
+    ChildIndexOutOfBounds {
+        /// Parent whose list was addressed.
+        parent: NodeId,
+        /// Requested position.
+        index: u32,
+        /// Maximum accepted insertion position.
+        len: usize,
+    },
+    /// Insertion would make a node its own ancestor.
+    TreeCycle {
+        /// Parent requested by the operation.
+        parent: NodeId,
+        /// Child whose subtree already contains the parent.
+        child: NodeId,
+    },
+    /// Opacity was non-finite or outside `0.0..=1.0`.
+    InvalidOpacity {
+        /// Invalid opacity.
+        opacity: f32,
+    },
+    /// A geometry or transform component was NaN or infinite.
+    NonFiniteNumber,
+    /// One packet reused a command result identifier.
+    DuplicateResultId {
+        /// Duplicate result correlation.
+        result: ResultId,
+    },
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid Whisker frame: {self:?}")
+    }
+}
+
+impl Error for ValidationError {}
+
+/// Reference retained-tree receiver for one surface.
+///
+/// This type validates semantic packets before a packed encoder or Host
+/// backend exists. It intentionally stores only structure: renderers may keep
+/// richer property state alongside the same accepted revision.
+#[derive(Clone, Debug)]
+pub struct SceneProjection {
+    surface: SurfaceId,
+    scene_epoch: Option<u32>,
+    revision: u64,
+    nodes: HashMap<NodeId, NodeProjection>,
+    allocated_nodes: HashSet<NodeId>,
+}
+
+impl SceneProjection {
+    /// Creates an empty receiver for a surface.
+    pub fn new(surface: SurfaceId) -> Self {
+        Self {
+            surface,
+            scene_epoch: None,
+            revision: 0,
+            nodes: HashMap::new(),
+            allocated_nodes: HashSet::new(),
+        }
+    }
+
+    /// Returns the surface accepted by this receiver.
+    pub const fn surface(&self) -> SurfaceId {
+        self.surface
+    }
+
+    /// Returns the current scene epoch after the first snapshot.
+    pub const fn scene_epoch(&self) -> Option<u32> {
+        self.scene_epoch
+    }
+
+    /// Returns the last accepted revision.
+    pub const fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    /// Returns the number of retained nodes.
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Returns retained structural state for a node.
+    pub fn node(&self, node: NodeId) -> Option<&NodeProjection> {
+        self.nodes.get(&node)
+    }
+
+    /// Validates and atomically applies a packet.
+    ///
+    /// Revision or epoch drift on a delta returns [`ApplyResult::NeedSnapshot`]
+    /// without classifying the sender as malformed. Every
+    /// [`ValidationError`] also leaves this projection unchanged.
+    pub fn apply(&mut self, packet: &FramePacket) -> Result<ApplyResult, ValidationError> {
+        self.validate_header(packet)?;
+
+        if packet.header.mode == FrameMode::Delta
+            && (self.scene_epoch != Some(packet.header.scene_epoch)
+                || self.revision != packet.header.base_revision)
+        {
+            return Ok(ApplyResult::NeedSnapshot {
+                host_revision: self.revision,
+            });
+        }
+
+        let mut next = if packet.header.mode == FrameMode::Snapshot {
+            Self::new(self.surface)
+        } else {
+            self.clone()
+        };
+        next.scene_epoch = Some(packet.header.scene_epoch);
+
+        let mut result_ids = HashSet::new();
+        for operation in &packet.operations {
+            next.apply_operation(operation, &mut result_ids)?;
+        }
+
+        next.revision = packet.header.target_revision;
+        *self = next;
+        Ok(ApplyResult::Accepted {
+            revision: self.revision,
+        })
+    }
+
+    fn validate_header(&self, packet: &FramePacket) -> Result<(), ValidationError> {
+        let header = packet.header;
+        if header.version.major != PROTOCOL_MAJOR {
+            return Err(ValidationError::UnsupportedProtocolMajor {
+                received: header.version.major,
+            });
+        }
+        if header.surface != self.surface {
+            return Err(ValidationError::SurfaceMismatch {
+                expected: self.surface,
+                received: header.surface,
+            });
+        }
+        if header.target_revision <= header.base_revision {
+            return Err(ValidationError::RevisionDidNotAdvance {
+                base: header.base_revision,
+                target: header.target_revision,
+            });
+        }
+        if header.mode == FrameMode::Snapshot {
+            if header.base_revision != 0 {
+                return Err(ValidationError::SnapshotBaseRevision {
+                    received: header.base_revision,
+                });
+            }
+            if self.scene_epoch == Some(header.scene_epoch) {
+                return Err(ValidationError::SnapshotReusedEpoch {
+                    epoch: header.scene_epoch,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_operation(
+        &mut self,
+        operation: &Operation,
+        result_ids: &mut HashSet<ResultId>,
+    ) -> Result<(), ValidationError> {
+        match operation {
+            Operation::CreateNode { node, element_type } => {
+                if !self.allocated_nodes.insert(*node) {
+                    return Err(ValidationError::DuplicateNode { node: *node });
+                }
+                self.nodes.insert(
+                    *node,
+                    NodeProjection {
+                        element_type: *element_type,
+                        parent: None,
+                        children: Vec::new(),
+                    },
+                );
+            }
+            Operation::DeleteNode { node } => self.delete_subtree(*node)?,
+            Operation::InsertChild {
+                parent,
+                child,
+                index,
+            } => self.insert_child(*parent, *child, *index)?,
+            Operation::RemoveChild { parent, child } => self.remove_child(*parent, *child)?,
+            Operation::MoveChild {
+                parent,
+                child,
+                index,
+            } => self.move_child(*parent, *child, *index)?,
+            Operation::SetLayout { node, rect } => {
+                self.require_node(*node)?;
+                if ![rect.x, rect.y, rect.width, rect.height]
+                    .into_iter()
+                    .all(f32::is_finite)
+                {
+                    return Err(ValidationError::NonFiniteNumber);
+                }
+            }
+            Operation::SetTransform { node, transform } => {
+                self.require_node(*node)?;
+                if !transform.0.into_iter().all(f32::is_finite) {
+                    return Err(ValidationError::NonFiniteNumber);
+                }
+            }
+            Operation::SetOpacity { node, opacity } => {
+                self.require_node(*node)?;
+                if !opacity.is_finite() || !(0.0..=1.0).contains(opacity) {
+                    return Err(ValidationError::InvalidOpacity { opacity: *opacity });
+                }
+            }
+            Operation::InvokeCommand { node, result, .. } => {
+                self.require_node(*node)?;
+                if let Some(result) = result
+                    && !result_ids.insert(*result)
+                {
+                    return Err(ValidationError::DuplicateResultId { result: *result });
+                }
+            }
+            operation => {
+                if let Some(node) = operation.target_node() {
+                    self.require_node(node)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn require_node(&self, node: NodeId) -> Result<&NodeProjection, ValidationError> {
+        self.nodes
+            .get(&node)
+            .ok_or(ValidationError::UnknownNode { node })
+    }
+
+    fn insert_child(
+        &mut self,
+        parent: NodeId,
+        child: NodeId,
+        index: u32,
+    ) -> Result<(), ValidationError> {
+        self.require_node(parent)?;
+        let child_state = self.require_node(child)?;
+        if let Some(existing) = child_state.parent {
+            return Err(ValidationError::ChildAlreadyAttached {
+                child,
+                parent: existing,
+            });
+        }
+        if parent == child || self.is_descendant(child, parent) {
+            return Err(ValidationError::TreeCycle { parent, child });
+        }
+
+        let len = self.require_node(parent)?.children.len();
+        let index = usize::try_from(index).expect("u32 always fits supported Rust targets");
+        if index > len {
+            return Err(ValidationError::ChildIndexOutOfBounds {
+                parent,
+                index: index as u32,
+                len,
+            });
+        }
+
+        self.nodes
+            .get_mut(&parent)
+            .expect("parent checked above")
+            .children
+            .insert(index, child);
+        self.nodes
+            .get_mut(&child)
+            .expect("child checked above")
+            .parent = Some(parent);
+        Ok(())
+    }
+
+    fn remove_child(&mut self, parent: NodeId, child: NodeId) -> Result<(), ValidationError> {
+        self.require_direct_child(parent, child)?;
+        let children = &mut self
+            .nodes
+            .get_mut(&parent)
+            .expect("parent checked above")
+            .children;
+        let position = children
+            .iter()
+            .position(|candidate| *candidate == child)
+            .expect("parent link and child list agree");
+        children.remove(position);
+        self.nodes
+            .get_mut(&child)
+            .expect("child checked above")
+            .parent = None;
+        Ok(())
+    }
+
+    fn move_child(
+        &mut self,
+        parent: NodeId,
+        child: NodeId,
+        index: u32,
+    ) -> Result<(), ValidationError> {
+        self.require_direct_child(parent, child)?;
+        let children = &mut self
+            .nodes
+            .get_mut(&parent)
+            .expect("parent checked above")
+            .children;
+        let old_index = children
+            .iter()
+            .position(|candidate| *candidate == child)
+            .expect("parent link and child list agree");
+        children.remove(old_index);
+
+        let index = usize::try_from(index).expect("u32 always fits supported Rust targets");
+        if index > children.len() {
+            return Err(ValidationError::ChildIndexOutOfBounds {
+                parent,
+                index: index as u32,
+                len: children.len(),
+            });
+        }
+        children.insert(index, child);
+        Ok(())
+    }
+
+    fn require_direct_child(&self, parent: NodeId, child: NodeId) -> Result<(), ValidationError> {
+        self.require_node(parent)?;
+        let child_state = self.require_node(child)?;
+        if child_state.parent != Some(parent) {
+            return Err(ValidationError::NotDirectChild { parent, child });
+        }
+        Ok(())
+    }
+
+    fn is_descendant(&self, ancestor: NodeId, candidate: NodeId) -> bool {
+        let mut cursor = Some(candidate);
+        while let Some(node) = cursor {
+            if node == ancestor {
+                return true;
+            }
+            cursor = self.nodes.get(&node).and_then(|entry| entry.parent);
+        }
+        false
+    }
+
+    fn delete_subtree(&mut self, node: NodeId) -> Result<(), ValidationError> {
+        let state = self.require_node(node)?.clone();
+        if let Some(parent) = state.parent {
+            let siblings = &mut self
+                .nodes
+                .get_mut(&parent)
+                .expect("attached parent exists")
+                .children;
+            siblings.retain(|candidate| *candidate != node);
+        }
+
+        let mut pending = vec![node];
+        while let Some(current) = pending.pop() {
+            let state = self
+                .nodes
+                .remove(&current)
+                .expect("subtree children exist while parent exists");
+            pending.extend(state.children);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ElementTypeId, FrameHeader, LayoutRect, Operation, ProtocolVersion, ResultId};
+
+    fn surface() -> SurfaceId {
+        SurfaceId::new(1).expect("test surface")
+    }
+
+    fn node(value: u64) -> NodeId {
+        NodeId::new(value).expect("test node")
+    }
+
+    fn element_type() -> ElementTypeId {
+        ElementTypeId::new(1).expect("test element type")
+    }
+
+    fn packet(
+        mode: FrameMode,
+        epoch: u32,
+        base: u64,
+        target: u64,
+        operations: Vec<Operation>,
+    ) -> FramePacket {
+        FramePacket {
+            header: FrameHeader {
+                version: ProtocolVersion::CURRENT,
+                surface: surface(),
+                scene_epoch: epoch,
+                frame_id: target,
+                base_revision: base,
+                target_revision: target,
+                viewport_epoch: 1,
+                mode,
+            },
+            operations,
+        }
+    }
+
+    fn initial_tree() -> (SceneProjection, NodeId, NodeId) {
+        let root = node(1);
+        let child = node(2);
+        let mut scene = SceneProjection::new(surface());
+        let result = scene
+            .apply(&packet(
+                FrameMode::Snapshot,
+                1,
+                0,
+                1,
+                vec![
+                    Operation::CreateNode {
+                        node: root,
+                        element_type: element_type(),
+                    },
+                    Operation::CreateNode {
+                        node: child,
+                        element_type: element_type(),
+                    },
+                    Operation::InsertChild {
+                        parent: root,
+                        child,
+                        index: 0,
+                    },
+                ],
+            ))
+            .expect("valid snapshot");
+        assert_eq!(result, ApplyResult::Accepted { revision: 1 });
+        (scene, root, child)
+    }
+
+    #[test]
+    fn snapshot_builds_a_retained_tree() {
+        let (scene, root, child) = initial_tree();
+        assert_eq!(scene.scene_epoch(), Some(1));
+        assert_eq!(scene.revision(), 1);
+        assert_eq!(scene.node_count(), 2);
+        assert_eq!(scene.node(root).expect("root").children(), &[child]);
+        assert_eq!(scene.node(child).expect("child").parent(), Some(root));
+    }
+
+    #[test]
+    fn revision_drift_requests_a_snapshot_without_mutation() {
+        let (mut scene, root, _) = initial_tree();
+        let result = scene
+            .apply(&packet(
+                FrameMode::Delta,
+                1,
+                7,
+                8,
+                vec![Operation::SetOpacity {
+                    node: root,
+                    opacity: 0.5,
+                }],
+            ))
+            .expect("revision drift is recoverable");
+        assert_eq!(result, ApplyResult::NeedSnapshot { host_revision: 1 });
+        assert_eq!(scene.revision(), 1);
+        assert_eq!(scene.node_count(), 2);
+    }
+
+    #[test]
+    fn malformed_operation_rolls_back_the_complete_packet() {
+        let (mut scene, root, child) = initial_tree();
+        let new_child = node(3);
+        let error = scene
+            .apply(&packet(
+                FrameMode::Delta,
+                1,
+                1,
+                2,
+                vec![
+                    Operation::CreateNode {
+                        node: new_child,
+                        element_type: element_type(),
+                    },
+                    Operation::InsertChild {
+                        parent: root,
+                        child: new_child,
+                        index: 1,
+                    },
+                    Operation::SetLayout {
+                        node: child,
+                        rect: LayoutRect {
+                            width: f32::NAN,
+                            ..LayoutRect::default()
+                        },
+                    },
+                ],
+            ))
+            .expect_err("NaN must reject the transaction");
+        assert_eq!(error, ValidationError::NonFiniteNumber);
+        assert_eq!(scene.revision(), 1);
+        assert_eq!(scene.node_count(), 2);
+        assert_eq!(scene.node(root).expect("root").children(), &[child]);
+        assert_eq!(scene.node(new_child), None);
+    }
+
+    #[test]
+    fn deleting_a_node_invalidates_its_subtree() {
+        let (mut scene, root, child) = initial_tree();
+        let grandchild = node(3);
+        scene
+            .apply(&packet(
+                FrameMode::Delta,
+                1,
+                1,
+                2,
+                vec![
+                    Operation::CreateNode {
+                        node: grandchild,
+                        element_type: element_type(),
+                    },
+                    Operation::InsertChild {
+                        parent: child,
+                        child: grandchild,
+                        index: 0,
+                    },
+                    Operation::DeleteNode { node: child },
+                ],
+            ))
+            .expect("valid subtree deletion");
+        assert_eq!(scene.node_count(), 1);
+        assert!(scene.node(child).is_none());
+        assert!(scene.node(grandchild).is_none());
+        assert!(scene.node(root).expect("root").children().is_empty());
+    }
+
+    #[test]
+    fn deleted_node_id_cannot_be_reused_in_the_same_epoch() {
+        let (mut scene, _, child) = initial_tree();
+        scene
+            .apply(&packet(
+                FrameMode::Delta,
+                1,
+                1,
+                2,
+                vec![Operation::DeleteNode { node: child }],
+            ))
+            .expect("valid deletion");
+
+        let error = scene
+            .apply(&packet(
+                FrameMode::Delta,
+                1,
+                2,
+                3,
+                vec![Operation::CreateNode {
+                    node: child,
+                    element_type: element_type(),
+                }],
+            ))
+            .expect_err("retired ID must remain unavailable");
+        assert_eq!(error, ValidationError::DuplicateNode { node: child });
+        assert_eq!(scene.revision(), 2);
+        assert!(scene.node(child).is_none());
+    }
+
+    #[test]
+    fn insertion_rejects_a_cycle() {
+        let (mut scene, root, child) = initial_tree();
+        let error = scene
+            .apply(&packet(
+                FrameMode::Delta,
+                1,
+                1,
+                2,
+                vec![Operation::InsertChild {
+                    parent: child,
+                    child: root,
+                    index: 0,
+                }],
+            ))
+            .expect_err("cycle must be rejected");
+        assert_eq!(
+            error,
+            ValidationError::TreeCycle {
+                parent: child,
+                child: root
+            }
+        );
+        assert_eq!(scene.node(root).expect("root").children(), &[child]);
+    }
+
+    #[test]
+    fn command_result_ids_are_unique_within_a_packet() {
+        let (mut scene, root, _) = initial_tree();
+        let result = ResultId::new(9).expect("test result ID");
+        let command = crate::CommandId::new(1).expect("test command");
+        let invoke = || Operation::InvokeCommand {
+            node: root,
+            command,
+            arguments: crate::ProtocolValue::Null,
+            result: Some(result),
+        };
+        let error = scene
+            .apply(&packet(FrameMode::Delta, 1, 1, 2, vec![invoke(), invoke()]))
+            .expect_err("duplicate result must be rejected");
+        assert_eq!(error, ValidationError::DuplicateResultId { result });
+        assert_eq!(scene.revision(), 1);
+    }
+
+    #[test]
+    fn replacement_snapshot_requires_a_new_epoch() {
+        let (mut scene, _, _) = initial_tree();
+        let error = scene
+            .apply(&packet(FrameMode::Snapshot, 1, 0, 1, Vec::new()))
+            .expect_err("snapshot must rotate its epoch");
+        assert_eq!(error, ValidationError::SnapshotReusedEpoch { epoch: 1 });
+        assert_eq!(scene.revision(), 1);
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,10 @@ runs on iOS and Android by driving Lynx's element tree directly.
                                         (WebSocket receiver,
                                          subsecond::apply_patch)
 
+   whisker-protocol
+   (Host-independent frame model + transactional reference validator;
+    migration foundation, not yet wired into the production Lynx path)
+
    subsecond  (= whisker-subsecond, [lib] name = "subsecond")
      pulled into whisker / whisker-driver / whisker-dev-runtime
      when `hot-reload` is on.
@@ -86,6 +90,7 @@ runs on iOS and Android by driving Lynx's element tree directly.
 | `whisker-build` | Lynx artifact fetch, cargo cross-compile, AAR/xcframework packaging. | `whisker-dev-server` |
 | `whisker-cng` | Continuous Native Generation: pure renderer of `gen/{android,ios}/` from Config, fingerprint-gated. No CLI surface, no side effects. | `whisker-cli` |
 | `whisker-plugin` | CNG plugin surface: `Plugin` trait, IR types, JSON envelope, subprocess runner shared by the engine and 3rd-party plugin binaries. | `whisker-cng`, 3rd-party plugins |
+| `whisker-protocol` | Host-independent semantic frame types, stable IDs, and transactional retained-tree validation. It is currently a migration foundation and is not yet used by the production Lynx path. | future scene engine and renderer providers |
 | `whisker-subsecond` | Whisker's fork of DioxusLabs `subsecond` — anchors the ASLR-slide lookup on `whisker_aslr_anchor` (emitted by `#[whisker::main]`) instead of `main`. `[lib] name = "subsecond"` keeps `use subsecond::*`. | `whisker`, `whisker-driver`, `whisker-dev-runtime` |
 
 ### Modules and the router (`packages/*`)


### PR DESCRIPTION
## Summary

Introduces the first implementation slice of RFC 0002: a pure-Rust whisker-protocol crate containing stable semantic IDs, an owned FramePacket model, structural operations, and a transactional retained-tree reference validator.

This intentionally does not choose a packed byte encoding, FFI ABI, Host binding, or production renderer yet. It establishes the invariants that those implementations must share.

## Included

- non-zero stable IDs for surfaces, nodes, element types, properties, commands, pointers, and results
- versioned snapshot and delta frame headers
- semantic tree, geometry, compositing, property, interaction, and command operations
- recoverable NeedSnapshot result for revision or epoch drift
- atomic packet validation using a cloned reference projection
- parent/child, bounds, cycle, finite-number, opacity, and result-ID validation
- subtree invalidation on deletion
- tombstones preventing NodeId reuse within one scene epoch
- current-architecture documentation for the new, not-yet-wired crate

## Explicitly deferred

- packed opcode and value-table encoding
- RendererV1 ABI and Host bindings
- element/property schema validation
- retained scene producer and RecordingRenderer
- typed style resolution and Taffy
- integration with the current DynRenderer or Lynx adapter

## Stack

This implementation is stacked on RFC 0003 in #409, which is stacked on RFC 0002 in #408. It can be retargeted to next-architecture after the RFC stack merges.

## Validation

- cargo fmt --all -- --check
- cargo test -p whisker-protocol
- cargo clippy -p whisker-protocol --all-targets -- -D warnings
- git diff --check