### PR TITLE
Add semantic style declaration storage

### DIFF
--- a/crates/whisker-css/src/css.rs
+++ b/crates/whisker-css/src/css.rs
@@ -10,8 +10,34 @@
 
 use core::fmt;
 
+use crate::style_value::ToStyleValue;
 use crate::to_css::ToCss;
-use whisker_style::{StyleProperty, StylePropertyId};
+use whisker_style::{SpecifiedStyle, StyleProperty, StylePropertyId, StyleValue};
+
+/// A declaration still requiring the temporary Lynx CSS compatibility path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UnmigratedStyleValue {
+    property: &'static str,
+}
+
+impl UnmigratedStyleValue {
+    /// Returns the compatibility property that has no semantic value yet.
+    pub const fn property(self) -> &'static str {
+        self.property
+    }
+}
+
+impl fmt::Display for UnmigratedStyleValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "style property `{}` still requires Lynx CSS compatibility",
+            self.property
+        )
+    }
+}
+
+impl std::error::Error for UnmigratedStyleValue {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum PropertyKey {
@@ -40,7 +66,8 @@ impl PropertyKey {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CssProp {
     property: PropertyKey,
-    value: String,
+    style_value: Option<StyleValue>,
+    lynx_value: String,
 }
 
 impl CssProp {
@@ -49,14 +76,28 @@ impl CssProp {
     pub(crate) fn new(property: StyleProperty, value: String) -> Self {
         Self {
             property: PropertyKey::Known(property),
-            value,
+            style_value: None,
+            lynx_value: value,
+        }
+    }
+
+    pub(crate) fn typed(
+        property: StyleProperty,
+        style_value: StyleValue,
+        lynx_value: String,
+    ) -> Self {
+        Self {
+            property: PropertyKey::Known(property),
+            style_value: Some(style_value),
+            lynx_value,
         }
     }
 
     fn legacy(name: &'static str, value: String) -> Self {
         Self {
             property: PropertyKey::from_name(name),
-            value,
+            style_value: None,
+            lynx_value: value,
         }
     }
 
@@ -79,9 +120,15 @@ impl CssProp {
         self.property().map(StyleProperty::id)
     }
 
+    /// The semantic value, or `None` while this declaration still uses the
+    /// compatibility-only Lynx CSS representation.
+    pub fn style_value(&self) -> Option<&StyleValue> {
+        self.style_value.as_ref()
+    }
+
     /// The serialized CSS value (`"8px"`, `"rgb(26, 26, 46)"`).
     pub fn value(&self) -> &str {
-        &self.value
+        &self.lynx_value
     }
 }
 
@@ -89,7 +136,7 @@ impl ToCss for CssProp {
     fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
         dest.write_str(self.name())?;
         dest.write_str(": ")?;
-        dest.write_str(&self.value)?;
+        dest.write_str(&self.lynx_value)?;
         dest.write_char(';')
     }
 }
@@ -127,6 +174,30 @@ impl Css {
     pub(crate) fn push(mut self, property: StyleProperty, value: impl ToCss) -> Self {
         self.props
             .push(CssProp::new(property, value.to_css_string()));
+        self
+    }
+
+    /// Pushes a semantic value while retaining its temporary Lynx spelling.
+    pub(crate) fn push_typed<T>(mut self, property: StyleProperty, value: T) -> Self
+    where
+        T: ToCss + ToStyleValue,
+    {
+        let lynx_value = value.to_css_string();
+        self.props
+            .push(CssProp::typed(property, value.to_style_value(), lynx_value));
+        self
+    }
+
+    /// Pushes an already-normalized semantic value and its migration-only Lynx
+    /// spelling.
+    pub(crate) fn push_semantic(
+        mut self,
+        property: StyleProperty,
+        style_value: StyleValue,
+        lynx_value: impl Into<String>,
+    ) -> Self {
+        self.props
+            .push(CssProp::typed(property, style_value, lynx_value.into()));
         self
     }
 
@@ -191,6 +262,28 @@ impl Css {
         self.props.extend(other.props);
         self
     }
+
+    /// Converts this authoring fragment to renderer-independent typed storage.
+    ///
+    /// Migration-only declarations fail with the first property that still
+    /// depends on Lynx CSS text. No CSS parsing is performed.
+    pub fn to_specified_style(&self) -> Result<SpecifiedStyle, UnmigratedStyleValue> {
+        let mut style = SpecifiedStyle::new();
+        for property in &self.props {
+            let Some(value) = property.style_value.clone() else {
+                return Err(UnmigratedStyleValue {
+                    property: property.name(),
+                });
+            };
+            let Some(property_id) = property.property() else {
+                return Err(UnmigratedStyleValue {
+                    property: property.name(),
+                });
+            };
+            style = style.push(property_id, value);
+        }
+        Ok(style)
+    }
 }
 
 impl ToCss for Css {
@@ -227,6 +320,7 @@ impl From<&Css> for String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Length;
 
     #[test]
     fn empty_style_serializes_to_empty_string() {
@@ -325,6 +419,7 @@ mod tests {
         assert_eq!(prop.name(), "color");
         assert_eq!(prop.property(), Some(StyleProperty::Color));
         assert_eq!(prop.property_id(), Some(StyleProperty::Color.id()));
+        assert_eq!(prop.style_value(), None);
         assert_eq!(prop.value(), "red");
         assert_eq!(prop.to_css_string(), "color: red;");
     }
@@ -345,6 +440,41 @@ mod tests {
             .raw("color", "blue");
         assert_eq!(s.resolved().len(), 1);
         assert_eq!(s.to_css_string(), "color: blue;");
+    }
+
+    #[test]
+    fn typed_push_keeps_semantics_separate_from_lynx_text() {
+        let s = Css::new().push_typed(StyleProperty::PaddingTop, Length::Px(8.0));
+        let prop = s.entries().next().unwrap();
+        assert_eq!(
+            prop.style_value(),
+            Some(&StyleValue::Length(whisker_style::LengthValue::Dimension {
+                value: whisker_style::StyleNumber::new(8.0),
+                unit: whisker_style::LengthUnit::Px,
+            }))
+        );
+        assert_eq!(prop.value(), "8px");
+    }
+
+    #[test]
+    fn typed_fragment_converts_without_parsing_css() {
+        let css = Css::new().padding_top(Length::Px(8.0));
+        let style = css.to_specified_style().unwrap();
+        assert_eq!(style.len(), 1);
+        assert_eq!(style.resolved()[0].property(), StyleProperty::PaddingTop);
+    }
+
+    #[test]
+    fn compatibility_fragment_reports_the_blocking_property() {
+        let error = Css::new()
+            .raw("future-property", "value")
+            .to_specified_style()
+            .unwrap_err();
+        assert_eq!(error.property(), "future-property");
+        assert_eq!(
+            error.to_string(),
+            "style property `future-property` still requires Lynx CSS compatibility"
+        );
     }
 
     struct Token(&'static str);

--- a/crates/whisker-css/src/lib.rs
+++ b/crates/whisker-css/src/lib.rs
@@ -49,6 +49,7 @@ pub mod ext;
 pub mod keyword;
 pub mod prop;
 pub mod shorthand;
+mod style_value;
 mod to_css;
 pub mod value;
 
@@ -58,7 +59,7 @@ pub mod value;
 // the macros crate directly.
 pub use whisker_macros::css;
 
-pub use crate::css::{Css, CssProp};
+pub use crate::css::{Css, CssProp, UnmigratedStyleValue};
 pub use crate::data_type::{
     Angle, CalcExpr, Color, ColorStop, CssString, FitContent, Gradient, Length, LengthPercentage,
     LinearDirection, MaxContent, NamedColor, Number, Percentage, RadialShape, StopPosition, Time,

--- a/crates/whisker-css/src/prop/animation.rs
+++ b/crates/whisker-css/src/prop/animation.rs
@@ -12,7 +12,12 @@ impl Css {
     /// <https://lynxjs.org/api/css/properties/animation-name>
     pub fn animation_name(self, name: impl Into<String>) -> Self {
         // Names are CSS identifiers, written bare.
-        self.push_raw(crate::StyleProperty::AnimationName, name)
+        let name = name.into();
+        self.push_semantic(
+            crate::StyleProperty::AnimationName,
+            whisker_style::StyleValue::Text(name.clone()),
+            name,
+        )
     }
 
     /// Sets `animation-duration`.

--- a/crates/whisker-css/src/prop/background.rs
+++ b/crates/whisker-css/src/prop/background.rs
@@ -37,13 +37,13 @@ impl Css {
     /// Sets `background-position-x` — horizontal component only.
     /// <https://lynxjs.org/api/css/properties/background-position-x>
     pub fn background_position_x(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::BackgroundPositionX, v.into())
+        self.push_typed(crate::StyleProperty::BackgroundPositionX, v.into())
     }
 
     /// Sets `background-position-y` — vertical component only.
     /// <https://lynxjs.org/api/css/properties/background-position-y>
     pub fn background_position_y(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::BackgroundPositionY, v.into())
+        self.push_typed(crate::StyleProperty::BackgroundPositionY, v.into())
     }
 
     /// Sets `background-size`.

--- a/crates/whisker-css/src/prop/border.rs
+++ b/crates/whisker-css/src/prop/border.rs
@@ -10,25 +10,25 @@ impl Css {
     /// Sets `border-top-width`.
     /// <https://lynxjs.org/api/css/properties/border-top-width>
     pub fn border_top_width(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::BorderTopWidth, v.into())
+        self.push_typed(crate::StyleProperty::BorderTopWidth, v.into())
     }
 
     /// Sets `border-right-width`.
     /// <https://lynxjs.org/api/css/properties/border-right-width>
     pub fn border_right_width(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::BorderRightWidth, v.into())
+        self.push_typed(crate::StyleProperty::BorderRightWidth, v.into())
     }
 
     /// Sets `border-bottom-width`.
     /// <https://lynxjs.org/api/css/properties/border-bottom-width>
     pub fn border_bottom_width(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::BorderBottomWidth, v.into())
+        self.push_typed(crate::StyleProperty::BorderBottomWidth, v.into())
     }
 
     /// Sets `border-left-width`.
     /// <https://lynxjs.org/api/css/properties/border-left-width>
     pub fn border_left_width(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::BorderLeftWidth, v.into())
+        self.push_typed(crate::StyleProperty::BorderLeftWidth, v.into())
     }
 
     // ---------- border-style longhands ----------

--- a/crates/whisker-css/src/prop/box_model.rs
+++ b/crates/whisker-css/src/prop/box_model.rs
@@ -70,25 +70,25 @@ impl Css {
     /// Sets `padding-top`. Negative values are clamped to zero by Lynx.
     /// <https://lynxjs.org/api/css/properties/padding-top>
     pub fn padding_top(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::PaddingTop, v.into())
+        self.push_typed(crate::StyleProperty::PaddingTop, v.into())
     }
 
     /// Sets `padding-right`. Negative values are clamped to zero by Lynx.
     /// <https://lynxjs.org/api/css/properties/padding-right>
     pub fn padding_right(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::PaddingRight, v.into())
+        self.push_typed(crate::StyleProperty::PaddingRight, v.into())
     }
 
     /// Sets `padding-bottom`. Negative values are clamped to zero by Lynx.
     /// <https://lynxjs.org/api/css/properties/padding-bottom>
     pub fn padding_bottom(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::PaddingBottom, v.into())
+        self.push_typed(crate::StyleProperty::PaddingBottom, v.into())
     }
 
     /// Sets `padding-left`. Negative values are clamped to zero by Lynx.
     /// <https://lynxjs.org/api/css/properties/padding-left>
     pub fn padding_left(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::PaddingLeft, v.into())
+        self.push_typed(crate::StyleProperty::PaddingLeft, v.into())
     }
 
     // ---------- Margin longhand ----------
@@ -123,20 +123,20 @@ impl Css {
     /// <https://lynxjs.org/api/css/properties/gap>
     pub fn gap(self, v: impl Into<LengthPercentage>) -> Self {
         let v = v.into();
-        self.push(crate::StyleProperty::RowGap, v.clone())
-            .push(crate::StyleProperty::ColumnGap, v)
+        self.push_typed(crate::StyleProperty::RowGap, v.clone())
+            .push_typed(crate::StyleProperty::ColumnGap, v)
     }
 
     /// Sets `row-gap` — inline gap between rows in flex/grid layouts.
     /// <https://lynxjs.org/api/css/properties/row-gap>
     pub fn row_gap(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::RowGap, v.into())
+        self.push_typed(crate::StyleProperty::RowGap, v.into())
     }
 
     /// Sets `column-gap` — gap between columns in flex/grid layouts.
     /// <https://lynxjs.org/api/css/properties/column-gap>
     pub fn column_gap(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::ColumnGap, v.into())
+        self.push_typed(crate::StyleProperty::ColumnGap, v.into())
     }
 }
 

--- a/crates/whisker-css/src/prop/effects.rs
+++ b/crates/whisker-css/src/prop/effects.rs
@@ -9,8 +9,9 @@ impl Css {
     /// Sets `opacity`. Lynx clamps to `0.0..=1.0`. Default: `1`.
     /// <https://lynxjs.org/api/css/properties/opacity>
     pub fn opacity(self, v: f32) -> Self {
-        self.push_raw(
+        self.push_semantic(
             crate::StyleProperty::Opacity,
+            whisker_style::StyleValue::Number(whisker_style::StyleNumber::new(v)),
             crate::to_css::number_to_string(v),
         )
     }
@@ -131,7 +132,7 @@ impl Css {
     /// Sets `outline-width`.
     /// <https://lynxjs.org/api/css/properties/outline-width>
     pub fn outline_width(self, v: Length) -> Self {
-        self.push(crate::StyleProperty::OutlineWidth, v)
+        self.push_typed(crate::StyleProperty::OutlineWidth, v)
     }
 
     /// Sets `outline-color`.
@@ -149,14 +150,14 @@ impl Css {
     /// Sets `outline-offset`.
     /// <https://lynxjs.org/api/css/properties/outline-offset>
     pub fn outline_offset(self, v: Length) -> Self {
-        self.push(crate::StyleProperty::OutlineOffset, v)
+        self.push_typed(crate::StyleProperty::OutlineOffset, v)
     }
 
     /// Sets `-x-caret-width`. Lynx accepts a length controlling the
     /// rendered caret thickness. Lynx 4.0 renamed the unprefixed
     /// `caret-width` (unlike `caret-color`, which kept its name).
     pub fn caret_width(self, v: Length) -> Self {
-        self.push(crate::StyleProperty::XCaretWidth, v)
+        self.push_typed(crate::StyleProperty::XCaretWidth, v)
     }
 
     /// Sets `-x-handle-color` — Lynx-only selection-handle color.
@@ -168,14 +169,15 @@ impl Css {
     /// Sets `-x-handle-size` — Lynx-only selection-handle size.
     /// <https://lynxjs.org/api/css/properties/-x-handle-size>
     pub fn x_handle_size(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::XHandleSize, v.into())
+        self.push_typed(crate::StyleProperty::XHandleSize, v.into())
     }
 
     /// Sets `-x-auto-font-size` — Lynx-only auto font-size flag.
     /// <https://lynxjs.org/api/css/properties/-x-auto-font-size>
     pub fn x_auto_font_size(self, enabled: bool) -> Self {
-        self.push_raw(
+        self.push_semantic(
             crate::StyleProperty::XAutoFontSize,
+            whisker_style::StyleValue::Bool(enabled),
             if enabled { "true" } else { "false" },
         )
     }

--- a/crates/whisker-css/src/prop/flex.rs
+++ b/crates/whisker-css/src/prop/flex.rs
@@ -23,8 +23,9 @@ impl Css {
     /// clamped to zero.
     /// <https://lynxjs.org/api/css/properties/flex-grow>
     pub fn flex_grow(self, v: f32) -> Self {
-        self.push_raw(
+        self.push_semantic(
             crate::StyleProperty::FlexGrow,
+            whisker_style::StyleValue::Number(whisker_style::StyleNumber::new(v)),
             crate::to_css::number_to_string(v),
         )
     }
@@ -33,8 +34,9 @@ impl Css {
     /// clamped to zero.
     /// <https://lynxjs.org/api/css/properties/flex-shrink>
     pub fn flex_shrink(self, v: f32) -> Self {
-        self.push_raw(
+        self.push_semantic(
             crate::StyleProperty::FlexShrink,
+            whisker_style::StyleValue::Number(whisker_style::StyleNumber::new(v)),
             crate::to_css::number_to_string(v),
         )
     }
@@ -72,7 +74,11 @@ impl Css {
     /// Sets `order` — controls layout order among flex/grid siblings.
     /// <https://lynxjs.org/api/css/properties/order>
     pub fn order(self, v: i32) -> Self {
-        self.push_raw(crate::StyleProperty::Order, v.to_string())
+        self.push_semantic(
+            crate::StyleProperty::Order,
+            whisker_style::StyleValue::Integer(i64::from(v)),
+            v.to_string(),
+        )
     }
 }
 

--- a/crates/whisker-css/src/prop/grid.rs
+++ b/crates/whisker-css/src/prop/grid.rs
@@ -63,13 +63,13 @@ impl Css {
     /// Sets `grid-row-gap` (legacy alias for `row-gap`).
     /// <https://lynxjs.org/api/css/properties/grid-row-gap>
     pub fn grid_row_gap(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::GridRowGap, v.into())
+        self.push_typed(crate::StyleProperty::GridRowGap, v.into())
     }
 
     /// Sets `grid-column-gap` (legacy alias for `column-gap`).
     /// <https://lynxjs.org/api/css/properties/grid-column-gap>
     pub fn grid_column_gap(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::GridColumnGap, v.into())
+        self.push_typed(crate::StyleProperty::GridColumnGap, v.into())
     }
 }
 

--- a/crates/whisker-css/src/prop/linear.rs
+++ b/crates/whisker-css/src/prop/linear.rs
@@ -39,8 +39,9 @@ impl Css {
     /// Sets `linear-weight` — relative size weight along the main axis.
     /// <https://lynxjs.org/api/css/properties/linear-weight>
     pub fn linear_weight(self, v: f32) -> Self {
-        self.push_raw(
+        self.push_semantic(
             crate::StyleProperty::LinearWeight,
+            whisker_style::StyleValue::Number(whisker_style::StyleNumber::new(v)),
             crate::to_css::number_to_string(v),
         )
     }
@@ -48,8 +49,9 @@ impl Css {
     /// Sets `linear-weight-sum` — denominator for weight calculations.
     /// <https://lynxjs.org/api/css/properties/linear-weight-sum>
     pub fn linear_weight_sum(self, v: f32) -> Self {
-        self.push_raw(
+        self.push_semantic(
             crate::StyleProperty::LinearWeightSum,
+            whisker_style::StyleValue::Number(whisker_style::StyleNumber::new(v)),
             crate::to_css::number_to_string(v),
         )
     }

--- a/crates/whisker-css/src/prop/position.rs
+++ b/crates/whisker-css/src/prop/position.rs
@@ -17,43 +17,43 @@ impl Css {
     /// Sets `top` offset (positioned elements).
     /// <https://lynxjs.org/api/css/properties/top>
     pub fn top(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::Top, v.into())
+        self.push_typed(crate::StyleProperty::Top, v.into())
     }
 
     /// Sets `right` offset (positioned elements).
     /// <https://lynxjs.org/api/css/properties/right>
     pub fn right(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::Right, v.into())
+        self.push_typed(crate::StyleProperty::Right, v.into())
     }
 
     /// Sets `bottom` offset (positioned elements).
     /// <https://lynxjs.org/api/css/properties/bottom>
     pub fn bottom(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::Bottom, v.into())
+        self.push_typed(crate::StyleProperty::Bottom, v.into())
     }
 
     /// Sets `left` offset (positioned elements).
     /// <https://lynxjs.org/api/css/properties/left>
     pub fn left(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::Left, v.into())
+        self.push_typed(crate::StyleProperty::Left, v.into())
     }
 
     /// Sets `inset-inline-start` — logical start edge.
     /// <https://lynxjs.org/api/css/properties/inset-inline-start>
     pub fn inset_inline_start(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::InsetInlineStart, v.into())
+        self.push_typed(crate::StyleProperty::InsetInlineStart, v.into())
     }
 
     /// Sets `inset-inline-end` — logical end edge.
     /// <https://lynxjs.org/api/css/properties/inset-inline-end>
     pub fn inset_inline_end(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::InsetInlineEnd, v.into())
+        self.push_typed(crate::StyleProperty::InsetInlineEnd, v.into())
     }
 
     /// Sets `z-index`. Lynx default: `auto` (no stacking context promotion).
     /// <https://lynxjs.org/api/css/properties/z-index>
     pub fn z_index(self, v: i32) -> Self {
-        self.push(crate::StyleProperty::ZIndex, Integer(v))
+        self.push_typed(crate::StyleProperty::ZIndex, Integer(v))
     }
 }
 

--- a/crates/whisker-css/src/prop/text.rs
+++ b/crates/whisker-css/src/prop/text.rs
@@ -36,7 +36,7 @@ impl Css {
     /// Sets `text-decoration-thickness`.
     /// <https://lynxjs.org/api/css/properties/text-decoration-thickness>
     pub fn text_decoration_thickness(self, v: Length) -> Self {
-        self.push(crate::StyleProperty::TextDecorationThickness, v)
+        self.push_typed(crate::StyleProperty::TextDecorationThickness, v)
     }
 
     /// Sets `text-overflow`.
@@ -54,7 +54,7 @@ impl Css {
     /// Sets `text-indent` — first-line indentation.
     /// <https://lynxjs.org/api/css/properties/text-indent>
     pub fn text_indent(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::TextIndent, v.into())
+        self.push_typed(crate::StyleProperty::TextIndent, v.into())
     }
 
     /// Sets `vertical-align`.
@@ -90,13 +90,17 @@ impl Css {
     /// Sets `-webkit-line-clamp` — limit the visible line count.
     /// <https://lynxjs.org/api/css/properties/-webkit-line-clamp>
     pub fn webkit_line_clamp(self, v: u32) -> Self {
-        self.push_raw(crate::StyleProperty::WebkitLineClamp, v.to_string())
+        self.push_semantic(
+            crate::StyleProperty::WebkitLineClamp,
+            whisker_style::StyleValue::Integer(i64::from(v)),
+            v.to_string(),
+        )
     }
 
     /// Sets `text-stroke-width`.
     /// <https://lynxjs.org/api/css/properties/text-stroke-width>
     pub fn text_stroke_width(self, v: Length) -> Self {
-        self.push(crate::StyleProperty::TextStrokeWidth, v)
+        self.push_typed(crate::StyleProperty::TextStrokeWidth, v)
     }
 
     /// Sets `text-stroke-color`.

--- a/crates/whisker-css/src/prop/transform.rs
+++ b/crates/whisker-css/src/prop/transform.rs
@@ -33,7 +33,7 @@ impl Css {
     /// Sets `perspective` — distance from the viewer to the z=0 plane.
     /// <https://lynxjs.org/api/css/properties/perspective>
     pub fn perspective(self, v: Length) -> Self {
-        self.push(crate::StyleProperty::Perspective, v)
+        self.push_typed(crate::StyleProperty::Perspective, v)
     }
 
     /// Sets `perspective-origin`.

--- a/crates/whisker-css/src/prop/typography.rs
+++ b/crates/whisker-css/src/prop/typography.rs
@@ -13,13 +13,13 @@ impl Css {
     pub fn font_family(self, v: impl Into<String>) -> Self {
         // Lynx accepts either bare identifiers or quoted strings; quoting
         // unconditionally is always safe.
-        self.push(crate::StyleProperty::FontFamily, CssString::new(v))
+        self.push_typed(crate::StyleProperty::FontFamily, CssString::new(v))
     }
 
     /// Sets `font-size`. Lynx default: `14px`.
     /// <https://lynxjs.org/api/css/properties/font-size>
     pub fn font_size(self, v: impl Into<LengthPercentage>) -> Self {
-        self.push(crate::StyleProperty::FontSize, v.into())
+        self.push_typed(crate::StyleProperty::FontSize, v.into())
     }
 
     /// Sets `font-style`. Lynx default: `normal`.
@@ -44,7 +44,7 @@ impl Css {
     /// Sets `letter-spacing`. Accepts `<length>`.
     /// <https://lynxjs.org/api/css/properties/letter-spacing>
     pub fn letter_spacing(self, v: Length) -> Self {
-        self.push(crate::StyleProperty::LetterSpacing, v)
+        self.push_typed(crate::StyleProperty::LetterSpacing, v)
     }
 
     /// Sets `line-height`. Lynx default: `normal`.

--- a/crates/whisker-css/src/style_value.rs
+++ b/crates/whisker-css/src/style_value.rs
@@ -1,0 +1,162 @@
+//! Conversion from the compatibility authoring types to semantic style values.
+
+use whisker_style::{
+    CalcExpression, LengthPercentageValue, LengthUnit, LengthValue, StyleNumber, StyleValue,
+};
+
+use crate::{CalcExpr, CssString, Integer, Length, LengthPercentage, Number, Percentage};
+
+pub(crate) trait ToStyleValue {
+    fn to_style_value(&self) -> StyleValue;
+}
+
+impl ToStyleValue for Length {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::Length(to_length(*self))
+    }
+}
+
+impl ToStyleValue for Percentage {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::LengthPercentage(LengthPercentageValue::Percentage(StyleNumber::new(self.0)))
+    }
+}
+
+impl ToStyleValue for LengthPercentage {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::LengthPercentage(to_length_percentage(self))
+    }
+}
+
+impl ToStyleValue for Number {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::Number(StyleNumber::new(self.0))
+    }
+}
+
+impl ToStyleValue for Integer {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::Integer(i64::from(self.0))
+    }
+}
+
+impl ToStyleValue for CssString {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::Text(self.0.clone())
+    }
+}
+
+fn to_length(value: Length) -> LengthValue {
+    let (value, unit) = match value {
+        Length::Zero => return LengthValue::Zero,
+        Length::Px(value) => (value, LengthUnit::Px),
+        Length::Rpx(value) => (value, LengthUnit::Rpx),
+        Length::Ppx(value) => (value, LengthUnit::Ppx),
+        Length::Em(value) => (value, LengthUnit::Em),
+        Length::Rem(value) => (value, LengthUnit::Rem),
+        Length::Vh(value) => (value, LengthUnit::Vh),
+        Length::Vw(value) => (value, LengthUnit::Vw),
+    };
+    LengthValue::Dimension {
+        value: StyleNumber::new(value),
+        unit,
+    }
+}
+
+fn to_length_percentage(value: &LengthPercentage) -> LengthPercentageValue {
+    match value {
+        LengthPercentage::Length(value) => LengthPercentageValue::Length(to_length(*value)),
+        LengthPercentage::Percentage(value) => {
+            LengthPercentageValue::Percentage(StyleNumber::new(value.0))
+        }
+        LengthPercentage::Calc(value) => {
+            LengthPercentageValue::Calc(Box::new(to_calc_expression(value)))
+        }
+    }
+}
+
+fn to_calc_expression(value: &CalcExpr) -> CalcExpression {
+    match value {
+        CalcExpr::Value(value) => CalcExpression::Value(Box::new(to_length_percentage(value))),
+        CalcExpr::Number(value) => CalcExpression::Number(StyleNumber::new(*value)),
+        CalcExpr::Add(left, right) => CalcExpression::Add(
+            Box::new(to_calc_expression(left)),
+            Box::new(to_calc_expression(right)),
+        ),
+        CalcExpr::Sub(left, right) => CalcExpression::Sub(
+            Box::new(to_calc_expression(left)),
+            Box::new(to_calc_expression(right)),
+        ),
+        CalcExpr::Mul(left, right) => CalcExpression::Mul(
+            Box::new(to_calc_expression(left)),
+            Box::new(to_calc_expression(right)),
+        ),
+        CalcExpr::Div(left, right) => CalcExpression::Div(
+            Box::new(to_calc_expression(left)),
+            Box::new(to_calc_expression(right)),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_length_unit_converts_semantically() {
+        let cases = [
+            (Length::Zero, LengthValue::Zero),
+            (Length::Px(1.0), dimension(1.0, LengthUnit::Px)),
+            (Length::Rpx(2.0), dimension(2.0, LengthUnit::Rpx)),
+            (Length::Ppx(3.0), dimension(3.0, LengthUnit::Ppx)),
+            (Length::Em(4.0), dimension(4.0, LengthUnit::Em)),
+            (Length::Rem(5.0), dimension(5.0, LengthUnit::Rem)),
+            (Length::Vh(6.0), dimension(6.0, LengthUnit::Vh)),
+            (Length::Vw(7.0), dimension(7.0, LengthUnit::Vw)),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(input.to_style_value(), StyleValue::Length(expected));
+        }
+    }
+
+    #[test]
+    fn scalar_authoring_types_keep_semantics() {
+        assert_eq!(
+            Number(1.5).to_style_value(),
+            StyleValue::Number(StyleNumber::new(1.5))
+        );
+        assert_eq!(Integer(-2).to_style_value(), StyleValue::Integer(-2));
+        assert_eq!(
+            CssString::new("hello").to_style_value(),
+            StyleValue::Text("hello".into())
+        );
+        assert_eq!(
+            Percentage(25.0).to_style_value(),
+            StyleValue::LengthPercentage(LengthPercentageValue::Percentage(StyleNumber::new(25.0)))
+        );
+    }
+
+    #[test]
+    fn every_calc_operator_converts_as_a_tree() {
+        let leaf = || CalcExpr::value(Length::Px(1.0));
+        for expression in [
+            leaf().add(leaf()),
+            leaf().sub(leaf()),
+            leaf().mul(CalcExpr::number(2.0)),
+            leaf().div(CalcExpr::number(2.0)),
+        ] {
+            let value = LengthPercentage::calc(expression).to_style_value();
+            assert!(matches!(
+                value,
+                StyleValue::LengthPercentage(LengthPercentageValue::Calc(_))
+            ));
+        }
+    }
+
+    fn dimension(value: f32, unit: LengthUnit) -> LengthValue {
+        LengthValue::Dimension {
+            value: StyleNumber::new(value),
+            unit,
+        }
+    }
+}

--- a/crates/whisker-style/src/declaration.rs
+++ b/crates/whisker-style/src/declaration.rs
@@ -1,0 +1,171 @@
+//! Typed declaration storage and deterministic fragment composition.
+
+use std::collections::HashSet;
+
+use crate::{StyleProperty, StyleValue};
+
+/// One typed inline-style declaration.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct StyleDeclaration {
+    property: StyleProperty,
+    value: StyleValue,
+}
+
+impl StyleDeclaration {
+    /// Creates a declaration for a registered common property.
+    pub const fn new(property: StyleProperty, value: StyleValue) -> Self {
+        Self { property, value }
+    }
+
+    /// Returns the stable property identity.
+    pub const fn property(&self) -> StyleProperty {
+        self.property
+    }
+
+    /// Returns the semantic value.
+    pub const fn value(&self) -> &StyleValue {
+        &self.value
+    }
+
+    /// Splits the declaration into its property and value.
+    pub fn into_parts(self) -> (StyleProperty, StyleValue) {
+        (self.property, self.value)
+    }
+}
+
+/// An ordered set of explicitly specified inline-style declarations.
+///
+/// Repeated properties remain in insertion history and resolve with the last
+/// declaration winning. This makes fragment composition deterministic without
+/// selectors, specificity, or a global cascade.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct SpecifiedStyle {
+    declarations: Vec<StyleDeclaration>,
+}
+
+impl SpecifiedStyle {
+    /// Creates an empty style.
+    pub const fn new() -> Self {
+        Self {
+            declarations: Vec::new(),
+        }
+    }
+
+    /// Appends a declaration.
+    pub fn push(mut self, property: StyleProperty, value: StyleValue) -> Self {
+        self.declarations
+            .push(StyleDeclaration::new(property, value));
+        self
+    }
+
+    /// Appends another fragment so its declarations override earlier writes.
+    pub fn merge(mut self, other: Self) -> Self {
+        self.declarations.extend(other.declarations);
+        self
+    }
+
+    /// Returns whether the fragment has no declarations.
+    pub fn is_empty(&self) -> bool {
+        self.declarations.is_empty()
+    }
+
+    /// Returns the number of declarations including overridden writes.
+    pub fn len(&self) -> usize {
+        self.declarations.len()
+    }
+
+    /// Iterates over insertion history.
+    pub fn declarations(&self) -> impl Iterator<Item = &StyleDeclaration> {
+        self.declarations.iter()
+    }
+
+    /// Iterates over the last declaration for each property in final-write
+    /// order.
+    pub fn resolved(&self) -> Vec<&StyleDeclaration> {
+        let mut seen = HashSet::new();
+        let mut resolved = Vec::new();
+        for declaration in self.declarations.iter().rev() {
+            if seen.insert(declaration.property) {
+                resolved.push(declaration);
+            }
+        }
+        resolved.reverse();
+        resolved
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LengthValue, StyleNumber};
+
+    #[test]
+    fn declaration_accessors_and_parts_preserve_types() {
+        let declaration = StyleDeclaration::new(
+            StyleProperty::Opacity,
+            StyleValue::Number(StyleNumber::new(0.5)),
+        );
+        assert_eq!(declaration.property(), StyleProperty::Opacity);
+        assert_eq!(
+            declaration.value(),
+            &StyleValue::Number(StyleNumber::new(0.5))
+        );
+        assert_eq!(
+            declaration.into_parts(),
+            (
+                StyleProperty::Opacity,
+                StyleValue::Number(StyleNumber::new(0.5))
+            )
+        );
+    }
+
+    #[test]
+    fn empty_style_reports_empty() {
+        let style = SpecifiedStyle::new();
+        assert!(style.is_empty());
+        assert_eq!(style.len(), 0);
+        assert_eq!(style.declarations().count(), 0);
+        assert!(style.resolved().is_empty());
+    }
+
+    #[test]
+    fn resolution_is_last_wins_in_final_write_order() {
+        let style = SpecifiedStyle::new()
+            .push(
+                StyleProperty::Opacity,
+                StyleValue::Number(StyleNumber::new(0.2)),
+            )
+            .push(StyleProperty::Width, StyleValue::Length(LengthValue::Zero))
+            .push(
+                StyleProperty::Opacity,
+                StyleValue::Number(StyleNumber::new(0.8)),
+            );
+        assert_eq!(style.len(), 3);
+        let resolved = style.resolved();
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].property(), StyleProperty::Width);
+        assert_eq!(resolved[1].property(), StyleProperty::Opacity);
+        assert_eq!(
+            resolved[1].value(),
+            &StyleValue::Number(StyleNumber::new(0.8))
+        );
+    }
+
+    #[test]
+    fn merge_appends_the_overriding_fragment() {
+        let base = SpecifiedStyle::new().push(
+            StyleProperty::Opacity,
+            StyleValue::Number(StyleNumber::new(0.1)),
+        );
+        let overlay = SpecifiedStyle::new().push(
+            StyleProperty::Opacity,
+            StyleValue::Number(StyleNumber::new(0.9)),
+        );
+        let merged = base.merge(overlay);
+        assert_eq!(merged.declarations().count(), 2);
+        assert_eq!(
+            merged.resolved()[0].value(),
+            &StyleValue::Number(StyleNumber::new(0.9))
+        );
+    }
+}

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -7,6 +7,12 @@
 
 #![warn(missing_docs)]
 
+mod declaration;
 mod property;
+mod value;
 
+pub use declaration::{SpecifiedStyle, StyleDeclaration};
 pub use property::{PropertyMetadata, PropertyOrigin, StyleProperty, StylePropertyId};
+pub use value::{
+    CalcExpression, LengthPercentageValue, LengthUnit, LengthValue, StyleNumber, StyleValue,
+};

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -1,0 +1,142 @@
+//! Renderer-independent values stored in specified style declarations.
+
+/// An `f32` with equality and hashing defined by its IEEE-754 bit pattern.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StyleNumber(u32);
+
+impl StyleNumber {
+    /// Stores a number without changing its representation.
+    pub const fn new(value: f32) -> Self {
+        Self(value.to_bits())
+    }
+
+    /// Returns the stored number.
+    pub const fn get(self) -> f32 {
+        f32::from_bits(self.0)
+    }
+}
+
+/// A unit accepted by Whisker's length model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum LengthUnit {
+    /// Logical pixels: iOS points and Android density-independent pixels.
+    Px,
+    /// Responsive pixels relative to a 750-unit viewport width.
+    Rpx,
+    /// Physical device pixels.
+    Ppx,
+    /// Units relative to the element's computed font size.
+    Em,
+    /// Units relative to the root computed font size.
+    Rem,
+    /// Percent of viewport height.
+    Vh,
+    /// Percent of viewport width.
+    Vw,
+}
+
+/// A semantic length that does not require CSS parsing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum LengthValue {
+    /// Unitless zero.
+    Zero,
+    /// A number paired with an explicit unit.
+    Dimension {
+        /// Numeric magnitude.
+        value: StyleNumber,
+        /// Length unit.
+        unit: LengthUnit,
+    },
+}
+
+/// A semantic length-or-percentage value.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum LengthPercentageValue {
+    /// Absolute or environment-relative length.
+    Length(LengthValue),
+    /// Percentage number before the `%` suffix.
+    Percentage(StyleNumber),
+    /// Typed arithmetic expression.
+    Calc(Box<CalcExpression>),
+}
+
+/// A typed arithmetic expression used by length-percentage values.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum CalcExpression {
+    /// Length-percentage operand.
+    Value(Box<LengthPercentageValue>),
+    /// Unitless numeric operand.
+    Number(StyleNumber),
+    /// Addition.
+    Add(Box<Self>, Box<Self>),
+    /// Subtraction.
+    Sub(Box<Self>, Box<Self>),
+    /// Multiplication.
+    Mul(Box<Self>, Box<Self>),
+    /// Division.
+    Div(Box<Self>, Box<Self>),
+}
+
+/// An owned value in a specified inline-style declaration.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum StyleValue {
+    /// Boolean value.
+    Bool(bool),
+    /// Signed integer value.
+    Integer(i64),
+    /// Unitless real number.
+    Number(StyleNumber),
+    /// UTF-8 text whose interpretation is defined by its property schema.
+    Text(String),
+    /// Length value.
+    Length(LengthValue),
+    /// Length, percentage, or typed `calc` expression.
+    LengthPercentage(LengthPercentageValue),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn style_number_preserves_bits_and_hashes() {
+        let number = StyleNumber::new(-0.0);
+        assert_eq!(number.get().to_bits(), (-0.0_f32).to_bits());
+        let mut values = HashSet::new();
+        assert!(values.insert(number));
+        assert!(!values.insert(number));
+    }
+
+    #[test]
+    fn semantic_values_clone_and_compare_without_text() {
+        let length = LengthValue::Dimension {
+            value: StyleNumber::new(12.5),
+            unit: LengthUnit::Px,
+        };
+        let calc = CalcExpression::Add(
+            Box::new(CalcExpression::Value(Box::new(
+                LengthPercentageValue::Length(length),
+            ))),
+            Box::new(CalcExpression::Value(Box::new(
+                LengthPercentageValue::Percentage(StyleNumber::new(50.0)),
+            ))),
+        );
+        let value = StyleValue::LengthPercentage(LengthPercentageValue::Calc(Box::new(calc)));
+        assert_eq!(value.clone(), value);
+        assert_ne!(value, StyleValue::Text("calc(12.5px + 50%)".into()));
+    }
+
+    #[test]
+    fn scalar_variants_remain_distinct() {
+        assert_ne!(StyleValue::Bool(true), StyleValue::Integer(1));
+        assert_ne!(
+            StyleValue::Number(StyleNumber::new(1.0)),
+            StyleValue::Text("1".into())
+        );
+        assert_eq!(
+            StyleValue::Length(LengthValue::Zero),
+            StyleValue::Length(LengthValue::Zero)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Continues phase 3 of #411 by adding the first renderer-independent semantic values and declaration storage to `whisker-style`. Existing `css!` and function-call `render!` syntax are unchanged, and `whisker-css` still emits identical Lynx CSS during migration.

This slice deliberately starts with values required by layout and high-frequency scalar updates. It does not pretend unmigrated values are typed: `whisker-css` retains those only in its compatibility path and reports them when typed extraction is requested.

## Included

- bit-stable `StyleNumber` suitable for equality, hashing, dirty comparison, and retained storage
- semantic length units and unitless zero
- semantic length-percentage values
- recursive typed `calc` trees preserving add/subtract/multiply/divide structure
- boolean, signed integer, number, text, length, and length-percentage `StyleValue` variants
- `StyleDeclaration` and `SpecifiedStyle` in `whisker-style`
- deterministic insertion history, merge, and last-write-wins resolution without selectors or CSS parsing
- authoring-type conversion in `whisker-css` for Length, Percentage, LengthPercentage, CalcExpr, Number, Integer, and CssString
- 43 existing builder paths now retaining semantic data, including padding, positions, gaps, border widths, font size/family/spacing, opacity, flex factors, ordering, z-index, and related Lynx extensions
- `CssProp::style_value()` for inspecting migration state
- `Css::to_specified_style()` for extracting pure typed storage
- explicit `UnmigratedStyleValue` diagnostics instead of parsing compatibility CSS text

## Boundary

`whisker-style` contains no CSS serializer and no legacy CSS-string variant. Unmigrated CSS text remains solely in `whisker-css`. A typed declaration keeps semantic data and a temporary cached Lynx spelling in the facade until the Lynx backend is removed.

## Explicitly deferred

- size keywords, margin auto, colors, keyword enums, gradients, transforms, animation/transition structures, borders, backgrounds, and other compound values
- requiring every maintained style to pass `to_specified_style()`
- property-specific schema validation and applicability
- inheritance and computed-style resolution
- protocol encoding
- deletion of the compatibility text cache and public `raw()`

## Stack

This Draft PR targets #413. Further phase-3 slices can extend `StyleValue` by semantic family while keeping each step reviewable and the app-facing DSL stable.

## Coverage

`whisker-style` remains at and is CI-gated for:

- lines: 100%
- functions: 100%
- regions: 100%

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p whisker-style -p whisker-css`
- `cargo clippy -p whisker-style -p whisker-css --all-targets -- -D warnings`
- `cargo llvm-cov -p whisker-style --summary-only --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100`
- `cargo check --workspace --all-targets`
- `git diff --check`
