### PR TITLE
Resolve the fixed inherited text style context

### DIFF
--- a/crates/whisker-css/src/css.rs
+++ b/crates/whisker-css/src/css.rs
@@ -320,7 +320,7 @@ impl From<&Css> for String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Length;
+    use crate::{Color, FontStyle, FontWeight, Length, LineHeight, NamedColor};
 
     #[test]
     fn empty_style_serializes_to_empty_string() {
@@ -474,6 +474,34 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "style property `future-property` still requires Lynx CSS compatibility"
+        );
+    }
+
+    #[test]
+    fn inherited_text_fragment_resolves_entirely_in_rust() {
+        let css = Css::new()
+            .font_family("Inter")
+            .font_size(Length::Px(20.0))
+            .font_weight(FontWeight::Bold)
+            .font_style(FontStyle::Italic)
+            .line_height(LineHeight::Number(1.5))
+            .letter_spacing(Length::Px(1.0))
+            .color(Color::Named(NamedColor::Red));
+        let specified = css.to_specified_style().unwrap();
+        let resolved = whisker_style::resolve_text_style(
+            &specified,
+            None,
+            whisker_style::StyleEnvironment::default(),
+        )
+        .unwrap();
+        let text = resolved.inherited_for_children();
+        assert_eq!(text.font_size(), 20.0);
+        assert_eq!(text.font_weight(), whisker_style::FontWeightValue::BOLD);
+        assert_eq!(text.font_style(), whisker_style::FontStyleValue::Italic);
+        assert_eq!(text.letter_spacing(), 1.0);
+        assert_eq!(
+            text.line_height(),
+            whisker_style::ComputedLineHeight::LogicalPixels(whisker_style::StyleNumber::new(30.0))
         );
     }
 

--- a/crates/whisker-css/src/prop/background.rs
+++ b/crates/whisker-css/src/prop/background.rs
@@ -73,7 +73,7 @@ impl Css {
     /// Sets `color` — the foreground color used by text and SVG strokes.
     /// <https://lynxjs.org/api/css/properties/color>
     pub fn color(self, v: Color) -> Self {
-        self.push(crate::StyleProperty::Color, v)
+        self.push_typed(crate::StyleProperty::Color, v)
     }
 }
 

--- a/crates/whisker-css/src/prop/typography.rs
+++ b/crates/whisker-css/src/prop/typography.rs
@@ -3,6 +3,7 @@
 use crate::css::Css;
 use crate::data_type::{CssString, Length, LengthPercentage};
 use crate::keyword::{FontStyle, FontVariant, FontWeight};
+use crate::to_css::ToCss;
 use crate::value::LineHeight;
 
 impl Css {
@@ -13,7 +14,14 @@ impl Css {
     pub fn font_family(self, v: impl Into<String>) -> Self {
         // Lynx accepts either bare identifiers or quoted strings; quoting
         // unconditionally is always safe.
-        self.push_typed(crate::StyleProperty::FontFamily, CssString::new(v))
+        let name = v.into();
+        self.push_semantic(
+            crate::StyleProperty::FontFamily,
+            whisker_style::StyleValue::FontFamily(whisker_style::FontFamilyValue::Named(
+                name.clone(),
+            )),
+            CssString::new(name).to_css_string(),
+        )
     }
 
     /// Sets `font-size`. Lynx default: `14px`.
@@ -25,14 +33,14 @@ impl Css {
     /// Sets `font-style`. Lynx default: `normal`.
     /// <https://lynxjs.org/api/css/properties/font-style>
     pub fn font_style(self, v: FontStyle) -> Self {
-        self.push(crate::StyleProperty::FontStyle, v)
+        self.push_typed(crate::StyleProperty::FontStyle, v)
     }
 
     /// Sets `font-weight`. Lynx default: `normal`. `bolder`/`lighter`
     /// are not supported.
     /// <https://lynxjs.org/api/css/properties/font-weight>
     pub fn font_weight(self, v: FontWeight) -> Self {
-        self.push(crate::StyleProperty::FontWeight, v)
+        self.push_typed(crate::StyleProperty::FontWeight, v)
     }
 
     /// Sets `font-variant`.
@@ -50,7 +58,7 @@ impl Css {
     /// Sets `line-height`. Lynx default: `normal`.
     /// <https://lynxjs.org/api/css/properties/line-height>
     pub fn line_height(self, v: impl Into<LineHeight>) -> Self {
-        self.push(crate::StyleProperty::LineHeight, v.into())
+        self.push_typed(crate::StyleProperty::LineHeight, v.into())
     }
 }
 

--- a/crates/whisker-css/src/style_value.rs
+++ b/crates/whisker-css/src/style_value.rs
@@ -1,10 +1,14 @@
 //! Conversion from the compatibility authoring types to semantic style values.
 
 use whisker_style::{
-    CalcExpression, LengthPercentageValue, LengthUnit, LengthValue, StyleNumber, StyleValue,
+    CalcExpression, ColorValue, FontStyleValue, FontWeightValue, LengthPercentageValue, LengthUnit,
+    LengthValue, LineHeightValue, StyleNumber, StyleValue,
 };
 
-use crate::{CalcExpr, CssString, Integer, Length, LengthPercentage, Number, Percentage};
+use crate::{
+    Angle, CalcExpr, Color, CssString, FontStyle, FontWeight, Integer, Length, LengthPercentage,
+    LineHeight, Number, Percentage,
+};
 
 pub(crate) trait ToStyleValue {
     fn to_style_value(&self) -> StyleValue;
@@ -43,6 +47,75 @@ impl ToStyleValue for Integer {
 impl ToStyleValue for CssString {
     fn to_style_value(&self) -> StyleValue {
         StyleValue::Text(self.0.clone())
+    }
+}
+
+impl ToStyleValue for FontStyle {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::FontStyle(match self {
+            Self::Normal => FontStyleValue::Normal,
+            Self::Italic => FontStyleValue::Italic,
+            Self::Oblique => FontStyleValue::Oblique,
+        })
+    }
+}
+
+impl ToStyleValue for FontWeight {
+    fn to_style_value(&self) -> StyleValue {
+        let value = match self {
+            Self::Normal => FontWeightValue::NORMAL,
+            Self::Bold => FontWeightValue::BOLD,
+            Self::Numeric(value) => FontWeightValue::from_raw(*value),
+        };
+        StyleValue::FontWeight(value)
+    }
+}
+
+impl ToStyleValue for LineHeight {
+    fn to_style_value(&self) -> StyleValue {
+        let value = match self {
+            Self::Normal => LineHeightValue::Normal,
+            Self::Number(value) => LineHeightValue::Number(StyleNumber::new(*value)),
+            Self::LengthPercentage(value) => {
+                LineHeightValue::LengthPercentage(to_length_percentage(value))
+            }
+        };
+        StyleValue::LineHeight(value)
+    }
+}
+
+impl ToStyleValue for Color {
+    fn to_style_value(&self) -> StyleValue {
+        let value = match self {
+            Self::Named(value) => ColorValue::Named(value.name().into()),
+            Self::Transparent => ColorValue::Rgba {
+                red: 0,
+                green: 0,
+                blue: 0,
+                alpha: StyleNumber::new(0.0),
+            },
+            Self::Rgba(red, green, blue, alpha) => ColorValue::Rgba {
+                red: *red,
+                green: *green,
+                blue: *blue,
+                alpha: StyleNumber::new(*alpha),
+            },
+            Self::Hsla { h, s, l, a } => ColorValue::Hsla {
+                hue_degrees: StyleNumber::new(angle_degrees(*h)),
+                saturation: StyleNumber::new(*s),
+                lightness: StyleNumber::new(*l),
+                alpha: StyleNumber::new(*a),
+            },
+        };
+        StyleValue::Color(value)
+    }
+}
+
+fn angle_degrees(value: Angle) -> f32 {
+    match value {
+        Angle::Deg(value) => value,
+        Angle::Rad(value) => value.to_degrees(),
+        Angle::Turn(value) => value * 360.0,
     }
 }
 
@@ -150,6 +223,85 @@ mod tests {
                 value,
                 StyleValue::LengthPercentage(LengthPercentageValue::Calc(_))
             ));
+        }
+    }
+
+    #[test]
+    fn inherited_authoring_values_convert_without_css_parsing() {
+        for (input, expected) in [
+            (FontStyle::Normal, FontStyleValue::Normal),
+            (FontStyle::Italic, FontStyleValue::Italic),
+            (FontStyle::Oblique, FontStyleValue::Oblique),
+        ] {
+            assert_eq!(input.to_style_value(), StyleValue::FontStyle(expected));
+        }
+        for (input, expected) in [
+            (FontWeight::Normal, FontWeightValue::NORMAL),
+            (FontWeight::Bold, FontWeightValue::BOLD),
+            (FontWeight::Numeric(650), FontWeightValue::from_raw(650)),
+        ] {
+            assert_eq!(input.to_style_value(), StyleValue::FontWeight(expected));
+        }
+        assert_eq!(
+            LineHeight::Normal.to_style_value(),
+            StyleValue::LineHeight(LineHeightValue::Normal)
+        );
+        assert_eq!(
+            LineHeight::Number(1.5).to_style_value(),
+            StyleValue::LineHeight(LineHeightValue::Number(StyleNumber::new(1.5)))
+        );
+        assert_eq!(
+            LineHeight::LengthPercentage(Length::Px(20.0).into()).to_style_value(),
+            StyleValue::LineHeight(LineHeightValue::LengthPercentage(
+                LengthPercentageValue::Length(dimension(20.0, LengthUnit::Px))
+            ))
+        );
+    }
+
+    #[test]
+    fn every_color_form_becomes_a_typed_color_value() {
+        assert_eq!(
+            Color::Named(crate::NamedColor::Red).to_style_value(),
+            StyleValue::Color(ColorValue::Named("red".into()))
+        );
+        assert_eq!(
+            Color::Transparent.to_style_value(),
+            StyleValue::Color(ColorValue::Rgba {
+                red: 0,
+                green: 0,
+                blue: 0,
+                alpha: StyleNumber::new(0.0),
+            })
+        );
+        assert_eq!(
+            Color::rgba(1, 2, 3, 0.5).to_style_value(),
+            StyleValue::Color(ColorValue::Rgba {
+                red: 1,
+                green: 2,
+                blue: 3,
+                alpha: StyleNumber::new(0.5),
+            })
+        );
+        for (angle, degrees) in [
+            (Angle::Deg(90.0), 90.0),
+            (Angle::Rad(core::f32::consts::FRAC_PI_2), 90.0),
+            (Angle::Turn(0.25), 90.0),
+        ] {
+            assert_eq!(
+                Color::Hsla {
+                    h: angle,
+                    s: 50.0,
+                    l: 25.0,
+                    a: 0.75,
+                }
+                .to_style_value(),
+                StyleValue::Color(ColorValue::Hsla {
+                    hue_degrees: StyleNumber::new(degrees),
+                    saturation: StyleNumber::new(50.0),
+                    lightness: StyleNumber::new(25.0),
+                    alpha: StyleNumber::new(0.75),
+                })
+            );
         }
     }
 

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -9,10 +9,17 @@
 
 mod declaration;
 mod property;
+mod resolution;
 mod value;
 
 pub use declaration::{SpecifiedStyle, StyleDeclaration};
 pub use property::{PropertyMetadata, PropertyOrigin, StyleProperty, StylePropertyId};
+pub use resolution::{
+    ComputedLineHeight, ComputedStyle, InheritedPropertySet, InheritedStyle, InheritedStyleChange,
+    PropertyImpactSet, ResolvedNodeStyle, StyleEnvironment, StyleResolutionError,
+    resolve_text_style,
+};
 pub use value::{
-    CalcExpression, LengthPercentageValue, LengthUnit, LengthValue, StyleNumber, StyleValue,
+    CalcExpression, ColorValue, FontFamilyValue, FontStyleValue, FontWeightValue,
+    LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, StyleNumber, StyleValue,
 };

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -1,0 +1,1361 @@
+//! Deterministic resolution for Whisker's fixed inherited text context.
+
+use core::fmt;
+
+use crate::{
+    CalcExpression, ColorValue, FontFamilyValue, FontStyleValue, FontWeightValue,
+    LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, SpecifiedStyle, StyleNumber,
+    StyleProperty, StyleValue,
+};
+
+const RPX_REFERENCE_WIDTH: f32 = 750.0;
+
+/// Environment values needed to resolve relative style units.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StyleEnvironment {
+    viewport_width: StyleNumber,
+    viewport_height: StyleNumber,
+    scale_factor: StyleNumber,
+    root_font_size: StyleNumber,
+}
+
+impl StyleEnvironment {
+    /// Creates an environment using logical-pixel viewport dimensions.
+    pub const fn new(
+        viewport_width: f32,
+        viewport_height: f32,
+        scale_factor: f32,
+        root_font_size: f32,
+    ) -> Self {
+        Self {
+            viewport_width: StyleNumber::new(viewport_width),
+            viewport_height: StyleNumber::new(viewport_height),
+            scale_factor: StyleNumber::new(scale_factor),
+            root_font_size: StyleNumber::new(root_font_size),
+        }
+    }
+
+    /// Returns the logical viewport width.
+    pub const fn viewport_width(self) -> f32 {
+        self.viewport_width.get()
+    }
+
+    /// Returns the logical viewport height.
+    pub const fn viewport_height(self) -> f32 {
+        self.viewport_height.get()
+    }
+
+    /// Returns physical pixels per logical pixel.
+    pub const fn scale_factor(self) -> f32 {
+        self.scale_factor.get()
+    }
+
+    /// Returns the root font size in logical pixels.
+    pub const fn root_font_size(self) -> f32 {
+        self.root_font_size.get()
+    }
+
+    fn validate(self) -> Result<(), StyleResolutionError> {
+        if !self.viewport_width().is_finite()
+            || self.viewport_width() < 0.0
+            || !self.viewport_height().is_finite()
+            || self.viewport_height() < 0.0
+            || !self.scale_factor().is_finite()
+            || self.scale_factor() <= 0.0
+            || !self.root_font_size().is_finite()
+            || self.root_font_size() < 0.0
+        {
+            return Err(StyleResolutionError::InvalidEnvironment);
+        }
+        Ok(())
+    }
+}
+
+impl Default for StyleEnvironment {
+    fn default() -> Self {
+        Self::new(0.0, 0.0, 1.0, 14.0)
+    }
+}
+
+/// A computed line height ready for text measurement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ComputedLineHeight {
+    /// Let the platform text shaper use its normal metric.
+    Normal,
+    /// An explicit logical-pixel line height.
+    LogicalPixels(StyleNumber),
+}
+
+/// The seven computed text values inherited by descendant nodes.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct InheritedStyle {
+    font_family: FontFamilyValue,
+    font_size: StyleNumber,
+    font_weight: FontWeightValue,
+    font_style: FontStyleValue,
+    line_height: ComputedLineHeight,
+    letter_spacing: StyleNumber,
+    color: ColorValue,
+}
+
+impl InheritedStyle {
+    fn initial(environment: StyleEnvironment) -> Self {
+        Self {
+            font_family: FontFamilyValue::System,
+            font_size: StyleNumber::new(environment.root_font_size()),
+            font_weight: FontWeightValue::NORMAL,
+            font_style: FontStyleValue::Normal,
+            line_height: ComputedLineHeight::Normal,
+            letter_spacing: StyleNumber::new(0.0),
+            color: ColorValue::Rgba {
+                red: 0,
+                green: 0,
+                blue: 0,
+                alpha: StyleNumber::new(1.0),
+            },
+        }
+    }
+
+    /// Returns the selected font family.
+    pub const fn font_family(&self) -> &FontFamilyValue {
+        &self.font_family
+    }
+
+    /// Returns the computed logical-pixel font size.
+    pub const fn font_size(&self) -> f32 {
+        self.font_size.get()
+    }
+
+    /// Returns the numeric font weight.
+    pub const fn font_weight(&self) -> FontWeightValue {
+        self.font_weight
+    }
+
+    /// Returns the selected font face style.
+    pub const fn font_style(&self) -> FontStyleValue {
+        self.font_style
+    }
+
+    /// Returns the computed line height.
+    pub const fn line_height(&self) -> ComputedLineHeight {
+        self.line_height
+    }
+
+    /// Returns computed logical-pixel letter spacing.
+    pub const fn letter_spacing(&self) -> f32 {
+        self.letter_spacing.get()
+    }
+
+    /// Returns the text color.
+    pub const fn color(&self) -> &ColorValue {
+        &self.color
+    }
+
+    /// Classifies inherited changes and their downstream work.
+    pub fn changes_from(&self, previous: &Self) -> InheritedStyleChange {
+        let mut properties = InheritedPropertySet::EMPTY;
+        let mut impacts = PropertyImpactSet::EMPTY;
+        if self.font_family != previous.font_family {
+            properties |= InheritedPropertySet::FONT_FAMILY;
+            impacts |= PropertyImpactSet::TEXT_METRICS;
+        }
+        if self.font_size != previous.font_size {
+            properties |= InheritedPropertySet::FONT_SIZE;
+            impacts |= PropertyImpactSet::TEXT_METRICS;
+        }
+        if self.font_weight != previous.font_weight {
+            properties |= InheritedPropertySet::FONT_WEIGHT;
+            impacts |= PropertyImpactSet::TEXT_METRICS;
+        }
+        if self.font_style != previous.font_style {
+            properties |= InheritedPropertySet::FONT_STYLE;
+            impacts |= PropertyImpactSet::TEXT_METRICS;
+        }
+        if self.line_height != previous.line_height {
+            properties |= InheritedPropertySet::LINE_HEIGHT;
+            impacts |= PropertyImpactSet::TEXT_METRICS;
+        }
+        if self.letter_spacing != previous.letter_spacing {
+            properties |= InheritedPropertySet::LETTER_SPACING;
+            impacts |= PropertyImpactSet::TEXT_METRICS;
+        }
+        if self.color != previous.color {
+            properties |= InheritedPropertySet::COLOR;
+            impacts |= PropertyImpactSet::PAINT;
+        }
+        InheritedStyleChange {
+            properties,
+            impacts,
+        }
+    }
+}
+
+/// The currently implemented computed-style slice.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedStyle {
+    inherited_text: InheritedStyle,
+}
+
+impl ComputedStyle {
+    /// Returns computed text values for this node.
+    pub const fn inherited_text(&self) -> &InheritedStyle {
+        &self.inherited_text
+    }
+}
+
+/// Result of resolving one node's specified style.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ResolvedNodeStyle {
+    computed: ComputedStyle,
+}
+
+impl ResolvedNodeStyle {
+    /// Returns the node's computed style.
+    pub const fn computed(&self) -> &ComputedStyle {
+        &self.computed
+    }
+
+    /// Returns the fixed text context to pass to every child.
+    pub const fn inherited_for_children(&self) -> &InheritedStyle {
+        self.computed.inherited_text()
+    }
+}
+
+/// Failure to turn a typed declaration into a valid computed value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StyleResolutionError {
+    /// One or more environment inputs are non-finite or outside their range.
+    InvalidEnvironment,
+    /// A property received the wrong semantic variant or an invalid number.
+    InvalidPropertyValue(StyleProperty),
+    /// A typed `calc` expression has incompatible dimensions or divides by zero.
+    InvalidCalculation(StyleProperty),
+}
+
+impl fmt::Display for StyleResolutionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEnvironment => formatter.write_str("invalid style environment"),
+            Self::InvalidPropertyValue(property) => {
+                write!(formatter, "invalid value for `{}`", property.css_name())
+            }
+            Self::InvalidCalculation(property) => {
+                write!(
+                    formatter,
+                    "invalid calculation for `{}`",
+                    property.css_name()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for StyleResolutionError {}
+
+/// Bit set identifying which inherited values changed.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct InheritedPropertySet(u8);
+
+impl InheritedPropertySet {
+    /// No inherited property.
+    pub const EMPTY: Self = Self(0);
+    /// `font-family`.
+    pub const FONT_FAMILY: Self = Self(1 << 0);
+    /// `font-size`.
+    pub const FONT_SIZE: Self = Self(1 << 1);
+    /// `font-weight`.
+    pub const FONT_WEIGHT: Self = Self(1 << 2);
+    /// `font-style`.
+    pub const FONT_STYLE: Self = Self(1 << 3);
+    /// `line-height`.
+    pub const LINE_HEIGHT: Self = Self(1 << 4);
+    /// `letter-spacing`.
+    pub const LETTER_SPACING: Self = Self(1 << 5);
+    /// `color`.
+    pub const COLOR: Self = Self(1 << 6);
+
+    /// Returns whether this set contains every bit from `other`.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Returns whether no properties are present.
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl core::ops::BitOrAssign for InheritedPropertySet {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// Work categories invalidated by a computed style change.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct PropertyImpactSet(u8);
+
+impl PropertyImpactSet {
+    /// No downstream work.
+    pub const EMPTY: Self = Self(0);
+    /// Intrinsic measurement must be refreshed.
+    pub const INTRINSIC_MEASURE: Self = Self(1 << 0);
+    /// Box layout must run again.
+    pub const LAYOUT: Self = Self(1 << 1);
+    /// Paint output changed.
+    pub const PAINT: Self = Self(1 << 2);
+    /// All work caused by a text metric change.
+    pub const TEXT_METRICS: Self = Self(Self::INTRINSIC_MEASURE.0 | Self::LAYOUT.0 | Self::PAINT.0);
+
+    /// Returns whether this set contains every bit from `other`.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Returns whether no impacts are present.
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl core::ops::BitOrAssign for PropertyImpactSet {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// Inherited-property delta used to invalidate descendant style contexts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct InheritedStyleChange {
+    properties: InheritedPropertySet,
+    impacts: PropertyImpactSet,
+}
+
+impl InheritedStyleChange {
+    /// Returns the inherited values that changed.
+    pub const fn properties(self) -> InheritedPropertySet {
+        self.properties
+    }
+
+    /// Returns downstream work required by the change.
+    pub const fn impacts(self) -> PropertyImpactSet {
+        self.impacts
+    }
+
+    /// Returns whether this delta contains no changes.
+    pub const fn is_empty(self) -> bool {
+        self.properties.is_empty()
+    }
+}
+
+/// Resolves the fixed inherited text context for one scene node.
+pub fn resolve_text_style(
+    specified: &SpecifiedStyle,
+    parent: Option<&InheritedStyle>,
+    environment: StyleEnvironment,
+) -> Result<ResolvedNodeStyle, StyleResolutionError> {
+    environment.validate()?;
+    let initial = InheritedStyle::initial(environment);
+    let base = parent.unwrap_or(&initial);
+    let declarations = InheritedDeclarations::from_specified(specified);
+
+    let font_size = match declarations.font_size {
+        Some(value) => {
+            let value = expect_length_percentage(StyleProperty::FontSize, value)?;
+            let pixels = resolve_length_percentage(
+                value,
+                base.font_size(),
+                base.font_size(),
+                environment,
+                StyleProperty::FontSize,
+            )?;
+            if pixels < 0.0 {
+                return Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::FontSize,
+                ));
+            }
+            StyleNumber::new(pixels)
+        }
+        None => base.font_size,
+    };
+
+    let font_family = match declarations.font_family {
+        Some(StyleValue::FontFamily(FontFamilyValue::Named(name))) if name.is_empty() => {
+            return Err(StyleResolutionError::InvalidPropertyValue(
+                StyleProperty::FontFamily,
+            ));
+        }
+        Some(StyleValue::FontFamily(value)) => value.clone(),
+        Some(_) => return Err(wrong_type(StyleProperty::FontFamily)),
+        None => base.font_family.clone(),
+    };
+    let font_weight = match declarations.font_weight {
+        Some(StyleValue::FontWeight(value)) if FontWeightValue::new(value.get()).is_some() => {
+            *value
+        }
+        Some(StyleValue::FontWeight(_)) => {
+            return Err(StyleResolutionError::InvalidPropertyValue(
+                StyleProperty::FontWeight,
+            ));
+        }
+        Some(_) => return Err(wrong_type(StyleProperty::FontWeight)),
+        None => base.font_weight,
+    };
+    let font_style = match declarations.font_style {
+        Some(StyleValue::FontStyle(value)) => *value,
+        Some(_) => return Err(wrong_type(StyleProperty::FontStyle)),
+        None => base.font_style,
+    };
+    let line_height = match declarations.line_height {
+        Some(StyleValue::LineHeight(LineHeightValue::Normal)) => ComputedLineHeight::Normal,
+        Some(StyleValue::LineHeight(LineHeightValue::Number(value))) => {
+            let multiplier = finite(*value, StyleProperty::LineHeight)?;
+            let pixels = multiplier * font_size.get();
+            if multiplier < 0.0 || !pixels.is_finite() {
+                return Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::LineHeight,
+                ));
+            }
+            ComputedLineHeight::LogicalPixels(StyleNumber::new(pixels))
+        }
+        Some(StyleValue::LineHeight(LineHeightValue::LengthPercentage(value))) => {
+            let pixels = resolve_length_percentage(
+                value,
+                font_size.get(),
+                font_size.get(),
+                environment,
+                StyleProperty::LineHeight,
+            )?;
+            if pixels < 0.0 {
+                return Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::LineHeight,
+                ));
+            }
+            ComputedLineHeight::LogicalPixels(StyleNumber::new(pixels))
+        }
+        Some(_) => return Err(wrong_type(StyleProperty::LineHeight)),
+        None => base.line_height,
+    };
+    let letter_spacing = match declarations.letter_spacing {
+        Some(StyleValue::Length(value)) => StyleNumber::new(resolve_length(
+            *value,
+            font_size.get(),
+            environment,
+            StyleProperty::LetterSpacing,
+        )?),
+        Some(_) => return Err(wrong_type(StyleProperty::LetterSpacing)),
+        None => base.letter_spacing,
+    };
+    let color = match declarations.color {
+        Some(StyleValue::Color(value)) => normalize_color(value)?,
+        Some(_) => return Err(wrong_type(StyleProperty::Color)),
+        None => base.color.clone(),
+    };
+
+    Ok(ResolvedNodeStyle {
+        computed: ComputedStyle {
+            inherited_text: InheritedStyle {
+                font_family,
+                font_size,
+                font_weight,
+                font_style,
+                line_height,
+                letter_spacing,
+                color,
+            },
+        },
+    })
+}
+
+#[derive(Default)]
+struct InheritedDeclarations<'a> {
+    font_family: Option<&'a StyleValue>,
+    font_size: Option<&'a StyleValue>,
+    font_weight: Option<&'a StyleValue>,
+    font_style: Option<&'a StyleValue>,
+    line_height: Option<&'a StyleValue>,
+    letter_spacing: Option<&'a StyleValue>,
+    color: Option<&'a StyleValue>,
+}
+
+impl<'a> InheritedDeclarations<'a> {
+    fn from_specified(specified: &'a SpecifiedStyle) -> Self {
+        let mut values = Self::default();
+        for declaration in specified.resolved() {
+            let slot = match declaration.property() {
+                StyleProperty::FontFamily => &mut values.font_family,
+                StyleProperty::FontSize => &mut values.font_size,
+                StyleProperty::FontWeight => &mut values.font_weight,
+                StyleProperty::FontStyle => &mut values.font_style,
+                StyleProperty::LineHeight => &mut values.line_height,
+                StyleProperty::LetterSpacing => &mut values.letter_spacing,
+                StyleProperty::Color => &mut values.color,
+                _ => continue,
+            };
+            *slot = Some(declaration.value());
+        }
+        values
+    }
+}
+
+fn expect_length_percentage(
+    property: StyleProperty,
+    value: &StyleValue,
+) -> Result<&LengthPercentageValue, StyleResolutionError> {
+    match value {
+        StyleValue::LengthPercentage(value) => Ok(value),
+        _ => Err(wrong_type(property)),
+    }
+}
+
+fn wrong_type(property: StyleProperty) -> StyleResolutionError {
+    StyleResolutionError::InvalidPropertyValue(property)
+}
+
+fn finite(value: StyleNumber, property: StyleProperty) -> Result<f32, StyleResolutionError> {
+    let value = value.get();
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(StyleResolutionError::InvalidPropertyValue(property))
+    }
+}
+
+fn resolve_length(
+    value: LengthValue,
+    em_basis: f32,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<f32, StyleResolutionError> {
+    let (number, multiplier) = match value {
+        LengthValue::Zero => return Ok(0.0),
+        LengthValue::Dimension { value, unit } => {
+            let multiplier = match unit {
+                LengthUnit::Px => 1.0,
+                LengthUnit::Rpx => environment.viewport_width() / RPX_REFERENCE_WIDTH,
+                LengthUnit::Ppx => 1.0 / environment.scale_factor(),
+                LengthUnit::Em => em_basis,
+                LengthUnit::Rem => environment.root_font_size(),
+                LengthUnit::Vh => environment.viewport_height() / 100.0,
+                LengthUnit::Vw => environment.viewport_width() / 100.0,
+            };
+            (finite(value, property)?, multiplier)
+        }
+    };
+    let resolved = number * multiplier;
+    if resolved.is_finite() {
+        Ok(resolved)
+    } else {
+        Err(StyleResolutionError::InvalidPropertyValue(property))
+    }
+}
+
+fn resolve_length_percentage(
+    value: &LengthPercentageValue,
+    percentage_basis: f32,
+    em_basis: f32,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<f32, StyleResolutionError> {
+    let resolved = match value {
+        LengthPercentageValue::Length(value) => {
+            resolve_length(*value, em_basis, environment, property)?
+        }
+        LengthPercentageValue::Percentage(value) => {
+            finite(*value, property)? * percentage_basis / 100.0
+        }
+        LengthPercentageValue::Calc(expression) => {
+            match evaluate_calc(
+                expression,
+                percentage_basis,
+                em_basis,
+                environment,
+                property,
+            )? {
+                Quantity::Length(value) => value,
+                Quantity::Number(_) => {
+                    return Err(StyleResolutionError::InvalidCalculation(property));
+                }
+            }
+        }
+    };
+    if resolved.is_finite() {
+        Ok(resolved)
+    } else {
+        Err(StyleResolutionError::InvalidPropertyValue(property))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Quantity {
+    Number(f32),
+    Length(f32),
+}
+
+fn evaluate_calc(
+    expression: &CalcExpression,
+    percentage_basis: f32,
+    em_basis: f32,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<Quantity, StyleResolutionError> {
+    let invalid = || StyleResolutionError::InvalidCalculation(property);
+    match expression {
+        CalcExpression::Value(value) => {
+            resolve_length_percentage(value, percentage_basis, em_basis, environment, property)
+                .map(Quantity::Length)
+        }
+        CalcExpression::Number(value) => finite(*value, property).map(Quantity::Number),
+        CalcExpression::Add(left, right) => {
+            match (
+                evaluate_calc(left, percentage_basis, em_basis, environment, property)?,
+                evaluate_calc(right, percentage_basis, em_basis, environment, property)?,
+            ) {
+                (Quantity::Number(left), Quantity::Number(right)) => {
+                    Ok(Quantity::Number(left + right))
+                }
+                (Quantity::Length(left), Quantity::Length(right)) => {
+                    Ok(Quantity::Length(left + right))
+                }
+                _ => Err(invalid()),
+            }
+        }
+        CalcExpression::Sub(left, right) => {
+            match (
+                evaluate_calc(left, percentage_basis, em_basis, environment, property)?,
+                evaluate_calc(right, percentage_basis, em_basis, environment, property)?,
+            ) {
+                (Quantity::Number(left), Quantity::Number(right)) => {
+                    Ok(Quantity::Number(left - right))
+                }
+                (Quantity::Length(left), Quantity::Length(right)) => {
+                    Ok(Quantity::Length(left - right))
+                }
+                _ => Err(invalid()),
+            }
+        }
+        CalcExpression::Mul(left, right) => {
+            match (
+                evaluate_calc(left, percentage_basis, em_basis, environment, property)?,
+                evaluate_calc(right, percentage_basis, em_basis, environment, property)?,
+            ) {
+                (Quantity::Number(left), Quantity::Number(right)) => {
+                    Ok(Quantity::Number(left * right))
+                }
+                (Quantity::Number(number), Quantity::Length(length))
+                | (Quantity::Length(length), Quantity::Number(number)) => {
+                    Ok(Quantity::Length(number * length))
+                }
+                (Quantity::Length(_), Quantity::Length(_)) => Err(invalid()),
+            }
+        }
+        CalcExpression::Div(left, right) => {
+            let left = evaluate_calc(left, percentage_basis, em_basis, environment, property)?;
+            let right = evaluate_calc(right, percentage_basis, em_basis, environment, property)?;
+            match (left, right) {
+                (_, Quantity::Number(0.0)) | (_, Quantity::Length(0.0)) => Err(invalid()),
+                (Quantity::Number(left), Quantity::Number(right)) => {
+                    Ok(Quantity::Number(left / right))
+                }
+                (Quantity::Length(left), Quantity::Number(right)) => {
+                    Ok(Quantity::Length(left / right))
+                }
+                (Quantity::Length(left), Quantity::Length(right)) => {
+                    Ok(Quantity::Number(left / right))
+                }
+                (Quantity::Number(_), Quantity::Length(_)) => Err(invalid()),
+            }
+        }
+    }
+}
+
+fn normalize_color(value: &ColorValue) -> Result<ColorValue, StyleResolutionError> {
+    let invalid = || StyleResolutionError::InvalidPropertyValue(StyleProperty::Color);
+    match value {
+        ColorValue::Named(name) if name.is_empty() => Err(invalid()),
+        ColorValue::Named(name) => Ok(ColorValue::Named(name.clone())),
+        ColorValue::Rgba {
+            red,
+            green,
+            blue,
+            alpha,
+        } => {
+            let alpha = finite(*alpha, StyleProperty::Color)?;
+            if !(0.0..=1.0).contains(&alpha) {
+                return Err(invalid());
+            }
+            Ok(ColorValue::Rgba {
+                red: *red,
+                green: *green,
+                blue: *blue,
+                alpha: StyleNumber::new(alpha),
+            })
+        }
+        ColorValue::Hsla {
+            hue_degrees,
+            saturation,
+            lightness,
+            alpha,
+        } => {
+            let hue = finite(*hue_degrees, StyleProperty::Color)?.rem_euclid(360.0);
+            let saturation = finite(*saturation, StyleProperty::Color)?;
+            let lightness = finite(*lightness, StyleProperty::Color)?;
+            let alpha = finite(*alpha, StyleProperty::Color)?;
+            if !(0.0..=100.0).contains(&saturation)
+                || !(0.0..=100.0).contains(&lightness)
+                || !(0.0..=1.0).contains(&alpha)
+            {
+                return Err(invalid());
+            }
+            Ok(ColorValue::Hsla {
+                hue_degrees: StyleNumber::new(hue),
+                saturation: StyleNumber::new(saturation),
+                lightness: StyleNumber::new(lightness),
+                alpha: StyleNumber::new(alpha),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn number(value: f32) -> StyleNumber {
+        StyleNumber::new(value)
+    }
+
+    fn px(value: f32) -> LengthValue {
+        LengthValue::Dimension {
+            value: number(value),
+            unit: LengthUnit::Px,
+        }
+    }
+
+    fn length(value: f32, unit: LengthUnit) -> LengthPercentageValue {
+        LengthPercentageValue::Length(LengthValue::Dimension {
+            value: number(value),
+            unit,
+        })
+    }
+
+    fn declaration(property: StyleProperty, value: StyleValue) -> SpecifiedStyle {
+        SpecifiedStyle::new().push(property, value)
+    }
+
+    fn inherited(style: &ResolvedNodeStyle) -> &InheritedStyle {
+        assert_eq!(
+            style.computed().inherited_text(),
+            style.inherited_for_children()
+        );
+        style.inherited_for_children()
+    }
+
+    #[test]
+    fn root_uses_documented_initial_text_context() {
+        let environment = StyleEnvironment::default();
+        assert_eq!(environment.viewport_width(), 0.0);
+        assert_eq!(environment.viewport_height(), 0.0);
+        assert_eq!(environment.scale_factor(), 1.0);
+        assert_eq!(environment.root_font_size(), 14.0);
+
+        let resolved = resolve_text_style(&SpecifiedStyle::new(), None, environment).unwrap();
+        let text = inherited(&resolved);
+        assert_eq!(text.font_family(), &FontFamilyValue::System);
+        assert_eq!(text.font_size(), 14.0);
+        assert_eq!(text.font_weight(), FontWeightValue::NORMAL);
+        assert_eq!(text.font_style(), FontStyleValue::Normal);
+        assert_eq!(text.line_height(), ComputedLineHeight::Normal);
+        assert_eq!(text.letter_spacing(), 0.0);
+        assert_eq!(
+            text.color(),
+            &ColorValue::Rgba {
+                red: 0,
+                green: 0,
+                blue: 0,
+                alpha: number(1.0),
+            }
+        );
+    }
+
+    #[test]
+    fn child_inherits_parent_and_explicit_values_stop_inheritance() {
+        let environment = StyleEnvironment::new(750.0, 800.0, 2.0, 16.0);
+        let parent_specified = SpecifiedStyle::new()
+            .push(
+                StyleProperty::FontFamily,
+                StyleValue::FontFamily(FontFamilyValue::Named("Inter".into())),
+            )
+            .push(
+                StyleProperty::FontSize,
+                StyleValue::LengthPercentage(length(20.0, LengthUnit::Px)),
+            )
+            .push(
+                StyleProperty::FontWeight,
+                StyleValue::FontWeight(FontWeightValue::BOLD),
+            )
+            .push(
+                StyleProperty::FontStyle,
+                StyleValue::FontStyle(FontStyleValue::Italic),
+            )
+            .push(
+                StyleProperty::LineHeight,
+                StyleValue::LineHeight(LineHeightValue::Number(number(1.5))),
+            )
+            .push(StyleProperty::LetterSpacing, StyleValue::Length(px(2.0)))
+            .push(
+                StyleProperty::Color,
+                StyleValue::Color(ColorValue::Named("red".into())),
+            );
+        let parent = resolve_text_style(&parent_specified, None, environment).unwrap();
+        let child = resolve_text_style(
+            &declaration(
+                StyleProperty::FontSize,
+                StyleValue::LengthPercentage(LengthPercentageValue::Percentage(number(50.0))),
+            ),
+            Some(parent.inherited_for_children()),
+            environment,
+        )
+        .unwrap();
+        let child = inherited(&child);
+        assert_eq!(child.font_family(), &FontFamilyValue::Named("Inter".into()));
+        assert_eq!(child.font_size(), 10.0);
+        assert_eq!(child.font_weight(), FontWeightValue::BOLD);
+        assert_eq!(child.font_style(), FontStyleValue::Italic);
+        assert_eq!(
+            child.line_height(),
+            ComputedLineHeight::LogicalPixels(number(30.0))
+        );
+        assert_eq!(child.letter_spacing(), 2.0);
+        assert_eq!(child.color(), &ColorValue::Named("red".into()));
+    }
+
+    #[test]
+    fn declaration_order_and_unrelated_properties_do_not_change_resolution() {
+        let specified = SpecifiedStyle::new()
+            .push(StyleProperty::Opacity, StyleValue::Number(number(0.5)))
+            .push(
+                StyleProperty::FontSize,
+                StyleValue::LengthPercentage(length(10.0, LengthUnit::Px)),
+            )
+            .push(
+                StyleProperty::FontSize,
+                StyleValue::LengthPercentage(length(12.0, LengthUnit::Px)),
+            );
+        assert_eq!(
+            inherited(&resolve_text_style(&specified, None, StyleEnvironment::default()).unwrap())
+                .font_size(),
+            12.0
+        );
+    }
+
+    #[test]
+    fn relative_units_use_the_correct_environment_basis() {
+        let environment = StyleEnvironment::new(750.0, 400.0, 2.0, 10.0);
+        let cases = [
+            (LengthValue::Zero, 0.0),
+            (px(3.0), 3.0),
+            (
+                LengthValue::Dimension {
+                    value: number(3.0),
+                    unit: LengthUnit::Rpx,
+                },
+                3.0,
+            ),
+            (
+                LengthValue::Dimension {
+                    value: number(4.0),
+                    unit: LengthUnit::Ppx,
+                },
+                2.0,
+            ),
+            (
+                LengthValue::Dimension {
+                    value: number(2.0),
+                    unit: LengthUnit::Em,
+                },
+                12.0,
+            ),
+            (
+                LengthValue::Dimension {
+                    value: number(2.0),
+                    unit: LengthUnit::Rem,
+                },
+                20.0,
+            ),
+            (
+                LengthValue::Dimension {
+                    value: number(2.0),
+                    unit: LengthUnit::Vh,
+                },
+                8.0,
+            ),
+            (
+                LengthValue::Dimension {
+                    value: number(2.0),
+                    unit: LengthUnit::Vw,
+                },
+                15.0,
+            ),
+        ];
+        for (value, expected) in cases {
+            assert_eq!(
+                resolve_length(value, 6.0, environment, StyleProperty::LetterSpacing).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn line_height_resolves_normal_number_and_relative_length() {
+        let environment = StyleEnvironment::default();
+        let number_style = declaration(
+            StyleProperty::LineHeight,
+            StyleValue::LineHeight(LineHeightValue::Number(number(2.0))),
+        );
+        assert_eq!(
+            inherited(&resolve_text_style(&number_style, None, environment).unwrap()).line_height(),
+            ComputedLineHeight::LogicalPixels(number(28.0))
+        );
+        let length_style = declaration(
+            StyleProperty::LineHeight,
+            StyleValue::LineHeight(LineHeightValue::LengthPercentage(
+                LengthPercentageValue::Percentage(number(150.0)),
+            )),
+        );
+        assert_eq!(
+            inherited(&resolve_text_style(&length_style, None, environment).unwrap()).line_height(),
+            ComputedLineHeight::LogicalPixels(number(21.0))
+        );
+        let normal_style = declaration(
+            StyleProperty::LineHeight,
+            StyleValue::LineHeight(LineHeightValue::Normal),
+        );
+        let parent = resolve_text_style(&number_style, None, environment).unwrap();
+        let normal = resolve_text_style(
+            &normal_style,
+            Some(parent.inherited_for_children()),
+            environment,
+        )
+        .unwrap();
+        assert_eq!(inherited(&normal).line_height(), ComputedLineHeight::Normal);
+    }
+
+    #[test]
+    fn calc_supports_valid_dimension_arithmetic() {
+        let environment = StyleEnvironment::default();
+        let leaf = || CalcExpression::Value(Box::new(LengthPercentageValue::Length(px(10.0))));
+        let scalar = |value| CalcExpression::Number(number(value));
+        let cases = [
+            (
+                CalcExpression::Add(Box::new(leaf()), Box::new(leaf())),
+                20.0,
+            ),
+            (CalcExpression::Sub(Box::new(leaf()), Box::new(leaf())), 0.0),
+            (
+                CalcExpression::Mul(Box::new(scalar(2.0)), Box::new(leaf())),
+                20.0,
+            ),
+            (
+                CalcExpression::Mul(Box::new(leaf()), Box::new(scalar(3.0))),
+                30.0,
+            ),
+            (
+                CalcExpression::Div(Box::new(leaf()), Box::new(scalar(2.0))),
+                5.0,
+            ),
+        ];
+        for (expression, expected) in cases {
+            assert_eq!(
+                resolve_length_percentage(
+                    &LengthPercentageValue::Calc(Box::new(expression)),
+                    14.0,
+                    14.0,
+                    environment,
+                    StyleProperty::FontSize,
+                )
+                .unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn calc_evaluates_scalar_branches_and_rejects_invalid_dimensions() {
+        let environment = StyleEnvironment::default();
+        let scalar = |value| CalcExpression::Number(number(value));
+        let length = || CalcExpression::Value(Box::new(LengthPercentageValue::Length(px(4.0))));
+        for expression in [
+            CalcExpression::Add(Box::new(scalar(1.0)), Box::new(scalar(2.0))),
+            CalcExpression::Sub(Box::new(scalar(3.0)), Box::new(scalar(1.0))),
+            CalcExpression::Mul(Box::new(scalar(2.0)), Box::new(scalar(3.0))),
+            CalcExpression::Div(Box::new(scalar(6.0)), Box::new(scalar(2.0))),
+            CalcExpression::Div(Box::new(length()), Box::new(length())),
+        ] {
+            evaluate_calc(
+                &expression,
+                10.0,
+                10.0,
+                environment,
+                StyleProperty::FontSize,
+            )
+            .unwrap();
+        }
+        for expression in [
+            CalcExpression::Add(Box::new(scalar(1.0)), Box::new(length())),
+            CalcExpression::Sub(Box::new(length()), Box::new(scalar(1.0))),
+            CalcExpression::Mul(Box::new(length()), Box::new(length())),
+            CalcExpression::Div(Box::new(scalar(1.0)), Box::new(length())),
+            CalcExpression::Div(Box::new(length()), Box::new(scalar(0.0))),
+            CalcExpression::Div(
+                Box::new(scalar(1.0)),
+                Box::new(CalcExpression::Value(Box::new(
+                    LengthPercentageValue::Length(LengthValue::Zero),
+                ))),
+            ),
+        ] {
+            assert_eq!(
+                evaluate_calc(
+                    &expression,
+                    10.0,
+                    10.0,
+                    environment,
+                    StyleProperty::FontSize
+                )
+                .unwrap_err(),
+                StyleResolutionError::InvalidCalculation(StyleProperty::FontSize)
+            );
+        }
+        let scalar_result = LengthPercentageValue::Calc(Box::new(scalar(2.0)));
+        assert_eq!(
+            resolve_length_percentage(
+                &scalar_result,
+                10.0,
+                10.0,
+                environment,
+                StyleProperty::FontSize
+            )
+            .unwrap_err(),
+            StyleResolutionError::InvalidCalculation(StyleProperty::FontSize)
+        );
+    }
+
+    #[test]
+    fn invalid_environment_values_are_rejected() {
+        for environment in [
+            StyleEnvironment::new(f32::NAN, 0.0, 1.0, 14.0),
+            StyleEnvironment::new(-1.0, 0.0, 1.0, 14.0),
+            StyleEnvironment::new(0.0, f32::INFINITY, 1.0, 14.0),
+            StyleEnvironment::new(0.0, -1.0, 1.0, 14.0),
+            StyleEnvironment::new(0.0, 0.0, f32::NAN, 14.0),
+            StyleEnvironment::new(0.0, 0.0, 0.0, 14.0),
+            StyleEnvironment::new(0.0, 0.0, 1.0, f32::INFINITY),
+            StyleEnvironment::new(0.0, 0.0, 1.0, -1.0),
+        ] {
+            assert_eq!(
+                resolve_text_style(&SpecifiedStyle::new(), None, environment).unwrap_err(),
+                StyleResolutionError::InvalidEnvironment
+            );
+        }
+    }
+
+    #[test]
+    fn wrong_semantic_variants_are_reported_per_property() {
+        for property in [
+            StyleProperty::FontFamily,
+            StyleProperty::FontSize,
+            StyleProperty::FontWeight,
+            StyleProperty::FontStyle,
+            StyleProperty::LineHeight,
+            StyleProperty::LetterSpacing,
+            StyleProperty::Color,
+        ] {
+            let error = resolve_text_style(
+                &declaration(property, StyleValue::Bool(true)),
+                None,
+                StyleEnvironment::default(),
+            )
+            .unwrap_err();
+            assert_eq!(error, StyleResolutionError::InvalidPropertyValue(property));
+            assert_eq!(
+                error.to_string(),
+                format!("invalid value for `{}`", property.css_name())
+            );
+        }
+        assert_eq!(
+            StyleResolutionError::InvalidEnvironment.to_string(),
+            "invalid style environment"
+        );
+        assert_eq!(
+            StyleResolutionError::InvalidCalculation(StyleProperty::FontSize).to_string(),
+            "invalid calculation for `font-size`"
+        );
+    }
+
+    #[test]
+    fn invalid_typed_values_are_rejected() {
+        let cases = [
+            declaration(
+                StyleProperty::FontFamily,
+                StyleValue::FontFamily(FontFamilyValue::Named(String::new())),
+            ),
+            declaration(
+                StyleProperty::FontWeight,
+                StyleValue::FontWeight(FontWeightValue::from_raw(0)),
+            ),
+            declaration(
+                StyleProperty::FontSize,
+                StyleValue::LengthPercentage(length(-1.0, LengthUnit::Px)),
+            ),
+            declaration(
+                StyleProperty::LineHeight,
+                StyleValue::LineHeight(LineHeightValue::Number(number(-1.0))),
+            ),
+            declaration(
+                StyleProperty::LineHeight,
+                StyleValue::LineHeight(LineHeightValue::Number(number(f32::NAN))),
+            ),
+            declaration(
+                StyleProperty::LineHeight,
+                StyleValue::LineHeight(LineHeightValue::LengthPercentage(length(
+                    -1.0,
+                    LengthUnit::Px,
+                ))),
+            ),
+        ];
+        for style in cases {
+            resolve_text_style(&style, None, StyleEnvironment::default()).unwrap_err();
+        }
+        assert_eq!(
+            expect_length_percentage(
+                StyleProperty::FontSize,
+                &StyleValue::Length(LengthValue::Zero)
+            )
+            .unwrap_err(),
+            StyleResolutionError::InvalidPropertyValue(StyleProperty::FontSize)
+        );
+    }
+
+    #[test]
+    fn non_finite_lengths_and_overflow_are_rejected() {
+        let environment = StyleEnvironment::default();
+        assert!(
+            resolve_length(
+                px(f32::NAN),
+                14.0,
+                environment,
+                StyleProperty::LetterSpacing
+            )
+            .is_err()
+        );
+        assert!(
+            resolve_length(
+                LengthValue::Dimension {
+                    value: number(f32::MAX),
+                    unit: LengthUnit::Vw,
+                },
+                14.0,
+                StyleEnvironment::new(f32::MAX, 1.0, 1.0, 14.0),
+                StyleProperty::LetterSpacing
+            )
+            .is_err()
+        );
+        let overflowing = LengthPercentageValue::Percentage(number(f32::MAX));
+        assert!(
+            resolve_length_percentage(
+                &overflowing,
+                f32::MAX,
+                14.0,
+                environment,
+                StyleProperty::FontSize
+            )
+            .is_err()
+        );
+
+        let invalid_calc = LengthPercentageValue::Calc(Box::new(CalcExpression::Add(
+            Box::new(CalcExpression::Number(number(1.0))),
+            Box::new(CalcExpression::Value(Box::new(
+                LengthPercentageValue::Length(px(1.0)),
+            ))),
+        )));
+        for (property, value) in [
+            (
+                StyleProperty::FontSize,
+                StyleValue::LengthPercentage(invalid_calc.clone()),
+            ),
+            (
+                StyleProperty::LineHeight,
+                StyleValue::LineHeight(LineHeightValue::LengthPercentage(
+                    LengthPercentageValue::Percentage(number(f32::NAN)),
+                )),
+            ),
+            (
+                StyleProperty::LetterSpacing,
+                StyleValue::Length(px(f32::NAN)),
+            ),
+        ] {
+            assert!(
+                resolve_text_style(
+                    &declaration(property, value),
+                    None,
+                    StyleEnvironment::default()
+                )
+                .is_err()
+            );
+        }
+        assert_eq!(
+            resolve_length_percentage(
+                &invalid_calc,
+                14.0,
+                14.0,
+                environment,
+                StyleProperty::FontSize,
+            )
+            .unwrap_err(),
+            StyleResolutionError::InvalidCalculation(StyleProperty::FontSize)
+        );
+
+        let invalid_leaf = || CalcExpression::Number(number(f32::NAN));
+        let valid_leaf = || CalcExpression::Number(number(1.0));
+        for expression in [
+            CalcExpression::Add(Box::new(invalid_leaf()), Box::new(valid_leaf())),
+            CalcExpression::Add(Box::new(valid_leaf()), Box::new(invalid_leaf())),
+            CalcExpression::Sub(Box::new(invalid_leaf()), Box::new(valid_leaf())),
+            CalcExpression::Sub(Box::new(valid_leaf()), Box::new(invalid_leaf())),
+            CalcExpression::Mul(Box::new(invalid_leaf()), Box::new(valid_leaf())),
+            CalcExpression::Mul(Box::new(valid_leaf()), Box::new(invalid_leaf())),
+            CalcExpression::Div(Box::new(invalid_leaf()), Box::new(valid_leaf())),
+            CalcExpression::Div(Box::new(valid_leaf()), Box::new(invalid_leaf())),
+        ] {
+            evaluate_calc(
+                &expression,
+                14.0,
+                14.0,
+                environment,
+                StyleProperty::FontSize,
+            )
+            .unwrap_err();
+        }
+        evaluate_calc(
+            &CalcExpression::Value(Box::new(LengthPercentageValue::Length(px(f32::NAN)))),
+            14.0,
+            14.0,
+            environment,
+            StyleProperty::FontSize,
+        )
+        .unwrap_err();
+        resolve_text_style(
+            &declaration(
+                StyleProperty::Color,
+                StyleValue::Color(ColorValue::Named(String::new())),
+            ),
+            None,
+            environment,
+        )
+        .unwrap_err();
+    }
+
+    #[test]
+    fn colors_are_normalized_and_validated() {
+        assert_eq!(
+            normalize_color(&ColorValue::Named("blue".into())).unwrap(),
+            ColorValue::Named("blue".into())
+        );
+        assert!(normalize_color(&ColorValue::Named(String::new())).is_err());
+        let rgba = ColorValue::Rgba {
+            red: 1,
+            green: 2,
+            blue: 3,
+            alpha: number(0.5),
+        };
+        assert_eq!(normalize_color(&rgba).unwrap(), rgba);
+        for alpha in [f32::NAN, -0.1, 1.1] {
+            assert!(
+                normalize_color(&ColorValue::Rgba {
+                    red: 0,
+                    green: 0,
+                    blue: 0,
+                    alpha: number(alpha),
+                })
+                .is_err()
+            );
+        }
+        let hsla = ColorValue::Hsla {
+            hue_degrees: number(-30.0),
+            saturation: number(50.0),
+            lightness: number(25.0),
+            alpha: number(1.0),
+        };
+        assert_eq!(
+            normalize_color(&hsla).unwrap(),
+            ColorValue::Hsla {
+                hue_degrees: number(330.0),
+                saturation: number(50.0),
+                lightness: number(25.0),
+                alpha: number(1.0),
+            }
+        );
+        for (hue, saturation, lightness, alpha) in [
+            (f32::NAN, 0.0, 0.0, 1.0),
+            (0.0, f32::NAN, 0.0, 1.0),
+            (0.0, -1.0, 0.0, 1.0),
+            (0.0, 101.0, 0.0, 1.0),
+            (0.0, 0.0, f32::NAN, 1.0),
+            (0.0, 0.0, -1.0, 1.0),
+            (0.0, 0.0, 101.0, 1.0),
+            (0.0, 0.0, 0.0, f32::NAN),
+            (0.0, 0.0, 0.0, -0.1),
+            (0.0, 0.0, 0.0, 1.1),
+        ] {
+            assert!(
+                normalize_color(&ColorValue::Hsla {
+                    hue_degrees: number(hue),
+                    saturation: number(saturation),
+                    lightness: number(lightness),
+                    alpha: number(alpha),
+                })
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn inherited_change_classification_distinguishes_metrics_and_color() {
+        let initial =
+            resolve_text_style(&SpecifiedStyle::new(), None, StyleEnvironment::default()).unwrap();
+        let initial = initial.inherited_for_children();
+        let unchanged = initial.changes_from(initial);
+        assert!(unchanged.is_empty());
+        assert!(unchanged.properties().is_empty());
+        assert!(unchanged.impacts().is_empty());
+
+        let changed = InheritedStyle {
+            font_family: FontFamilyValue::Named("Inter".into()),
+            font_size: number(20.0),
+            font_weight: FontWeightValue::BOLD,
+            font_style: FontStyleValue::Oblique,
+            line_height: ComputedLineHeight::LogicalPixels(number(24.0)),
+            letter_spacing: number(1.0),
+            color: ColorValue::Named("red".into()),
+        };
+        let change = changed.changes_from(initial);
+        for property in [
+            InheritedPropertySet::FONT_FAMILY,
+            InheritedPropertySet::FONT_SIZE,
+            InheritedPropertySet::FONT_WEIGHT,
+            InheritedPropertySet::FONT_STYLE,
+            InheritedPropertySet::LINE_HEIGHT,
+            InheritedPropertySet::LETTER_SPACING,
+            InheritedPropertySet::COLOR,
+        ] {
+            assert!(change.properties().contains(property));
+        }
+        for impact in [
+            PropertyImpactSet::INTRINSIC_MEASURE,
+            PropertyImpactSet::LAYOUT,
+            PropertyImpactSet::PAINT,
+        ] {
+            assert!(change.impacts().contains(impact));
+        }
+    }
+}

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -77,6 +77,99 @@ pub enum CalcExpression {
     Div(Box<Self>, Box<Self>),
 }
 
+/// A font family selected by application code or by the platform default.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum FontFamilyValue {
+    /// The platform's default application font.
+    System,
+    /// One explicitly named font family.
+    Named(String),
+}
+
+/// The face style used to render text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum FontStyleValue {
+    /// An upright face.
+    Normal,
+    /// An italic face.
+    Italic,
+    /// An oblique or synthesized slanted face.
+    Oblique,
+}
+
+/// A numeric font weight in the CSS-compatible `1..=1000` range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FontWeightValue(u16);
+
+impl FontWeightValue {
+    /// The normal font weight.
+    pub const NORMAL: Self = Self(400);
+
+    /// The bold font weight.
+    pub const BOLD: Self = Self(700);
+
+    /// Creates a font weight when it is in the supported range.
+    pub const fn new(value: u16) -> Option<Self> {
+        if value >= 1 && value <= 1000 {
+            Some(Self(value))
+        } else {
+            None
+        }
+    }
+
+    /// Preserves an authoring value for later resolver validation.
+    ///
+    /// Prefer [`Self::new`] outside compatibility adapters.
+    pub const fn from_raw(value: u16) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric weight.
+    pub const fn get(self) -> u16 {
+        self.0
+    }
+}
+
+/// A semantic color that does not require parsing CSS text.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ColorValue {
+    /// A named color accepted by Whisker's typed authoring API.
+    Named(String),
+    /// An sRGB color with a floating-point alpha channel.
+    Rgba {
+        /// Red channel.
+        red: u8,
+        /// Green channel.
+        green: u8,
+        /// Blue channel.
+        blue: u8,
+        /// Alpha in the range `0.0..=1.0`.
+        alpha: StyleNumber,
+    },
+    /// An HSL color, normalized to degrees and percentages.
+    Hsla {
+        /// Hue in degrees.
+        hue_degrees: StyleNumber,
+        /// Saturation percentage.
+        saturation: StyleNumber,
+        /// Lightness percentage.
+        lightness: StyleNumber,
+        /// Alpha in the range `0.0..=1.0`.
+        alpha: StyleNumber,
+    },
+}
+
+/// A specified line height before environment and font-size resolution.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum LineHeightValue {
+    /// Let the platform text shaper select its normal line height.
+    Normal,
+    /// A multiplier of the node's computed font size.
+    Number(StyleNumber),
+    /// An explicit length or percentage of the node's computed font size.
+    LengthPercentage(LengthPercentageValue),
+}
+
 /// An owned value in a specified inline-style declaration.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StyleValue {
@@ -92,6 +185,16 @@ pub enum StyleValue {
     Length(LengthValue),
     /// Length, percentage, or typed `calc` expression.
     LengthPercentage(LengthPercentageValue),
+    /// Font family.
+    FontFamily(FontFamilyValue),
+    /// Font face style.
+    FontStyle(FontStyleValue),
+    /// Numeric font weight.
+    FontWeight(FontWeightValue),
+    /// Text color.
+    Color(ColorValue),
+    /// Line height.
+    LineHeight(LineHeightValue),
 }
 
 #[cfg(test)]
@@ -137,6 +240,32 @@ mod tests {
         assert_eq!(
             StyleValue::Length(LengthValue::Zero),
             StyleValue::Length(LengthValue::Zero)
+        );
+    }
+
+    #[test]
+    fn font_weight_accepts_only_the_supported_range() {
+        assert_eq!(FontWeightValue::new(1).unwrap().get(), 1);
+        assert_eq!(FontWeightValue::new(1000).unwrap().get(), 1000);
+        assert_eq!(FontWeightValue::new(0), None);
+        assert_eq!(FontWeightValue::new(1001), None);
+        assert_eq!(FontWeightValue::NORMAL.get(), 400);
+        assert_eq!(FontWeightValue::BOLD.get(), 700);
+    }
+
+    #[test]
+    fn typography_variants_are_semantically_distinct() {
+        assert_ne!(
+            StyleValue::FontFamily(FontFamilyValue::System),
+            StyleValue::Text("system-ui".into())
+        );
+        assert_ne!(
+            StyleValue::FontStyle(FontStyleValue::Italic),
+            StyleValue::FontWeight(FontWeightValue::BOLD)
+        );
+        assert_ne!(
+            StyleValue::Color(ColorValue::Named("red".into())),
+            StyleValue::LineHeight(LineHeightValue::Normal)
         );
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,7 @@ runs on iOS and Android by driving Lynx's element tree directly.
 | `whisker` | Umbrella. Users `use whisker::prelude::*`; almost everything is a re-export surfaced through one import root. | user crates |
 | `whisker-config` | `Config` metadata types users build in `whisker.rs`. Intentionally tiny. | `whisker`, `whisker-cli`, `whisker-cng` |
 | `whisker-runtime` | The reactive runtime (signals/effects/computed/owners/scheduler), the element tree, events, async tasks, and the renderer that wires effects to Lynx handles. Renderer-agnostic. | `whisker`, `whisker-driver` |
-| `whisker-style` | Renderer-independent typed inline-style model and stable common-property registry. It will own declaration composition, fixed inheritance, and computed-style resolution as the migration advances. | `whisker-css`, future UI modules and `whisker-engine` |
+| `whisker-style` | Renderer-independent typed inline-style model and stable common-property registry. It owns declaration composition and the first computed-style slice: fixed inheritance and environment resolution for seven text properties. | `whisker-css`, future UI modules and `whisker-engine` |
 | `whisker-css` | Compatibility authoring facade for the existing `css!` API plus the temporary Lynx CSS serializer. It constructs and re-exports `whisker-style` identities rather than owning renderer semantics. | `whisker` |
 | `whisker-driver-sys` | Raw `extern "C"` decls matching the C++ bridge (`bridge/…`), plus the bridge sources themselves. Unsafe-only. | `whisker-driver` |
 | `whisker-driver` | Safe Rust wrappers over the bridge + the Lynx backend; exposes the host shims (`run`/`tick`) the iOS/Android shells call into. Bootstraps `subsecond` under `hot-reload`. | `whisker` |

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -32,11 +32,11 @@ a general CSS cascade. Reuse and conditional styling use ordinary Rust values,
 functions, composition, components, and signals. A small fixed set of text
 properties inherit from parent nodes when a child does not specify them.
 
-The Rust Style Engine resolves typed input into layout, paint, compositing,
-text, and semantics data. Taffy computes layout. Rust motion updates the same
-typed property slots. The renderer protocol sends only changed resolved
-properties and geometry; the Host implements native text shaping and concrete
-painting with Android Views, UIViews, or DOM nodes.
+The Rust `whisker-style` subsystem resolves typed input into layout, paint,
+compositing, text, and semantics data. Taffy computes layout. Rust motion
+updates the same typed property slots. The renderer protocol sends only
+changed resolved properties and geometry; the Host implements native text
+shaping and concrete painting with Android Views, UIViews, or DOM nodes.
 
 Supporting the styling surface of Lynx means covering its useful visual
 properties and values, not preserving CSS text syntax or browser cascade
@@ -257,6 +257,12 @@ Only the following properties inherit in version 1:
 - `letter_spacing`;
 - `color`.
 
+The initial inherited context is platform system font, `14px`, weight `400`,
+`normal` font style, platform-normal line height, zero letter spacing, and
+opaque black. A surface may provide a different root font size through its
+`StyleEnvironment`; `rem` and an otherwise unspecified root `font_size` use
+that value.
+
 For each property, resolution is:
 
 ```text
@@ -345,9 +351,10 @@ allows the Host to reinterpret a change with different layout semantics.
 
 ## Layout
 
-Taffy is authoritative for box layout on Android, iOS, Web, and Desktop. The
-Style Engine converts `ComputedStyle` into Taffy input and maintains a retained
-Taffy node for each layout-participating scene node.
+Taffy is authoritative for box layout on Android, iOS, Web, and Desktop.
+`whisker-style` produces renderer-independent `ComputedStyle`; `whisker-layout`
+converts its layout slice into Taffy input and maintains a retained Taffy node
+for each layout-participating scene node.
 
 ```text
 ComputedStyle + child structure + intrinsic measurements
@@ -558,7 +565,7 @@ whisker-style
   stable typed values, property IDs, declaration storage
   composition, applicability, inheritance, computed values, invalidation
 
-whisker-layout-engine module
+whisker-layout module
   retained Taffy tree, measurement requests, layout results
 
 whisker-motion module
@@ -654,7 +661,7 @@ The following must be resolved before this RFC becomes `Accepted`:
 - whether the public typed declaration value keeps the name `Css` or becomes
   `Style` while `css!` remains the macro name;
 - the exact fragment composition helpers and constant-style support;
-- the initial values and element applicability of every inherited property;
+- the element applicability of every inherited property;
 - the baseline and multi-line text measurement representation;
 - the minimum filter, blend, shadow, and clip capability required of all
   interactive renderers;


### PR DESCRIPTION
## Summary

- add renderer-independent semantic values for font family/style/weight, line height, and color
- resolve the seven RFC 0003 inherited text properties using explicit value -> parent computed value -> engine initial value
- resolve font-relative, root-relative, viewport, physical-pixel, percentage, and typed `calc` values to logical pixels
- classify inherited deltas into descendant property changes and text-measure/layout/paint impacts
- migrate the existing `css!` authoring builders for all seven properties without parsing CSS text
- record the initial inherited context and standardize the future Taffy crate name as `whisker-layout`

## Scope

This is the first `ComputedStyle` slice. It deliberately does not connect `whisker-engine`, add element applicability, or create the retained Taffy tree; those remain follow-up changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo llvm-cov -p whisker-style --summary-only --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100`
- `git diff --check`

`whisker-style` coverage: 100% lines, functions, and regions.

Stacked on #414.
