### PR TITLE
Add retained Rust layout engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         # engine. New Host-independent foundation crates start at the strict
         # gate and must keep line, function, and region coverage at 100%.
         run: |
-          for package in whisker-protocol whisker-engine whisker-style; do
+          for package in whisker-protocol whisker-engine whisker-style whisker-layout; do
             cargo llvm-cov -p "$package" --summary-only \
               --fail-under-lines 100 \
               --fail-under-functions 100 \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "asset-demo"
 version = "0.1.0"
 dependencies = [
@@ -3530,6 +3536,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "taffy"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c034e05f6ee85a12daa63863c2245797715075c70649947aa0da54f3f2ab1d0f"
+dependencies = [
+ "arrayvec",
+ "serde",
+ "slotmap",
+ "smallvec",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4440,6 +4458,15 @@ name = "whisker-keyboard"
 version = "0.12.0"
 dependencies = [
  "whisker",
+]
+
+[[package]]
+name = "whisker-layout"
+version = "0.12.0"
+dependencies = [
+ "taffy",
+ "whisker-protocol",
+ "whisker-style",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/whisker-driver",
     "crates/whisker-driver-sys",
     "crates/whisker-engine",
+    "crates/whisker-layout",
     "crates/whisker-macros",
     "crates/whisker-macro-syntax",
     "crates/whisker-fmt",
@@ -100,6 +101,7 @@ whisker-dev-server = { path = "crates/whisker-dev-server", version = "0.12.0" }
 whisker-driver = { path = "crates/whisker-driver", version = "0.12.0" }
 whisker-driver-sys = { path = "crates/whisker-driver-sys", version = "0.12.0" }
 whisker-engine = { path = "crates/whisker-engine", version = "0.12.0" }
+whisker-layout = { path = "crates/whisker-layout", version = "0.12.0" }
 whisker-macros = { path = "crates/whisker-macros", version = "0.12.0" }
 whisker-macro-syntax = { path = "crates/whisker-macro-syntax", version = "0.12.0" }
 whisker-fmt = { path = "crates/whisker-fmt", version = "0.12.0" }

--- a/crates/whisker-layout/Cargo.toml
+++ b/crates/whisker-layout/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "whisker-layout"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Retained, renderer-independent layout engine for Whisker."
+
+[dependencies]
+taffy = { version = "0.13", default-features = false, features = ["std", "taffy_tree", "flexbox", "grid", "block_layout", "content_size"] }
+whisker-protocol.workspace = true
+whisker-style.workspace = true

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -1,0 +1,1358 @@
+//! Retained, renderer-independent layout for Whisker scenes.
+//!
+//! The public API deliberately contains no Taffy types. The implementation
+//! keeps Taffy private so layout inputs and snapshots remain Whisker-owned,
+//! versionable contracts.
+
+#![warn(missing_docs)]
+
+use std::{collections::BTreeMap, error::Error, fmt};
+
+use taffy::{
+    AlignContent, AlignItems, AvailableSpace as TaffyAvailableSpace, BoxSizing, Dimension,
+    Direction, Display, FlexDirection, FlexWrap, LengthPercentage, LengthPercentageAuto, Position,
+    Rect, Size, Style, TaffyTree,
+};
+use whisker_protocol::{LayoutRect, NodeId};
+use whisker_style::{
+    AlignContentValue, AlignItemsValue, AlignSelfValue, BoxSizingValue, ComputedFlexBasis,
+    ComputedLayoutStyle, ComputedLengthPercentage, ComputedLengthPercentageAuto, ComputedSizeValue,
+    DirectionValue, DisplayValue, FlexDirectionValue, FlexWrapValue, JustifyContentValue,
+    PositionValue, PropertyImpactSet,
+};
+
+/// A width and height in logical pixels.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct LayoutSize {
+    /// Horizontal extent.
+    pub width: f32,
+    /// Vertical extent.
+    pub height: f32,
+}
+
+impl LayoutSize {
+    /// Creates a logical-pixel size.
+    pub const fn new(width: f32, height: f32) -> Self {
+        Self { width, height }
+    }
+
+    fn is_valid(self) -> bool {
+        self.width.is_finite() && self.height.is_finite() && self.width >= 0.0 && self.height >= 0.0
+    }
+}
+
+/// The constraint presented to an intrinsic measurer on one axis.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AvailableSpace {
+    /// A finite logical-pixel constraint.
+    Definite(f32),
+    /// Measure the smallest unbreakable content size.
+    MinContent,
+    /// Measure the unconstrained content size.
+    MaxContent,
+}
+
+/// Inputs supplied when measuring an intrinsically sized leaf.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MeasureRequest {
+    /// Dimensions already fixed by the layout algorithm.
+    pub known_dimensions: [Option<f32>; 2],
+    /// Width and height constraints.
+    pub available_space: [AvailableSpace; 2],
+}
+
+/// Supplies intrinsic leaf sizes, normally by asking the Host text or media backend.
+pub trait IntrinsicMeasurer {
+    /// Measures `node` under the supplied constraints.
+    fn measure(&mut self, node: NodeId, request: MeasureRequest) -> LayoutSize;
+}
+
+impl<F> IntrinsicMeasurer for F
+where
+    F: FnMut(NodeId, MeasureRequest) -> LayoutSize,
+{
+    fn measure(&mut self, node: NodeId, request: MeasureRequest) -> LayoutSize {
+        self(node, request)
+    }
+}
+
+/// A deterministic immutable result of one layout pass.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LayoutSnapshot {
+    boxes: BTreeMap<NodeId, LayoutRect>,
+}
+
+impl LayoutSnapshot {
+    /// Returns the border box for a node relative to its parent content origin.
+    pub fn get(&self, node: NodeId) -> Option<&LayoutRect> {
+        self.boxes.get(&node)
+    }
+
+    /// Iterates in stable node-ID order.
+    pub fn iter(&self) -> impl Iterator<Item = (NodeId, &LayoutRect)> {
+        self.boxes.iter().map(|(node, rect)| (*node, rect))
+    }
+
+    /// Returns the number of laid-out nodes.
+    pub fn len(&self) -> usize {
+        self.boxes.len()
+    }
+
+    /// Returns whether the snapshot contains no nodes.
+    pub fn is_empty(&self) -> bool {
+        self.boxes.is_empty()
+    }
+}
+
+/// A computed style feature not yet representable by the private backend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnsupportedLayoutFeature {
+    /// An affine value has both non-zero length and percentage components.
+    MixedLengthPercentage,
+    /// `max-content` as a size value.
+    MaxContent,
+    /// `min-content` as a size value.
+    MinContent,
+    /// `fit-content` as a size value.
+    FitContent,
+    /// `content` as a flex basis.
+    ContentFlexBasis,
+    /// Viewport-fixed positioning.
+    FixedPosition,
+    /// Scroll-sticky positioning.
+    StickyPosition,
+}
+
+/// Failure while mutating or computing a retained layout tree.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LayoutError {
+    /// The external node ID is already live.
+    DuplicateNode(NodeId),
+    /// The external node ID is not live.
+    UnknownNode(NodeId),
+    /// A child occurs more than once in a replacement list.
+    DuplicateChild {
+        /// The node receiving children.
+        parent: NodeId,
+        /// The repeated child.
+        child: NodeId,
+    },
+    /// A child is still attached to another parent.
+    ChildAlreadyAttached {
+        /// The requested child.
+        child: NodeId,
+        /// Its current parent.
+        parent: NodeId,
+    },
+    /// The requested relation would create a cycle.
+    TreeCycle {
+        /// The requested parent.
+        parent: NodeId,
+        /// The child that would close the cycle.
+        child: NodeId,
+    },
+    /// The compute root is currently attached below another node.
+    RootHasParent {
+        /// The requested compute root.
+        root: NodeId,
+        /// Its current parent.
+        parent: NodeId,
+    },
+    /// A reparent insertion index exceeds the resulting child-list length.
+    ChildIndexOutOfBounds {
+        /// The destination parent.
+        parent: NodeId,
+        /// The requested insertion index.
+        index: usize,
+        /// The largest accepted insertion index.
+        max_index: usize,
+    },
+    /// The viewport is negative or non-finite.
+    InvalidViewport,
+    /// An intrinsic measurer returned a negative or non-finite size.
+    InvalidMeasurement(NodeId),
+    /// The style uses a feature that cannot yet be represented faithfully.
+    UnsupportedStyle(UnsupportedLayoutFeature),
+}
+
+impl fmt::Display for LayoutError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+impl Error for LayoutError {}
+
+#[derive(Clone, Debug)]
+struct RetainedNode {
+    backend: taffy::NodeId,
+    style: ComputedLayoutStyle,
+    parent: Option<NodeId>,
+    children: Vec<NodeId>,
+    measurable: bool,
+}
+
+/// A retained tree that converts Whisker computed styles into layout snapshots.
+#[derive(Clone, Debug)]
+pub struct LayoutTree {
+    backend: TaffyTree<NodeId>,
+    nodes: BTreeMap<NodeId, RetainedNode>,
+}
+
+impl Default for LayoutTree {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LayoutTree {
+    /// Creates an empty tree. Fractional logical coordinates are preserved.
+    pub fn new() -> Self {
+        let mut backend = TaffyTree::new();
+        backend.disable_rounding();
+        Self {
+            backend,
+            nodes: BTreeMap::new(),
+        }
+    }
+
+    /// Returns the number of live nodes.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Returns whether the tree contains no nodes.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// Returns whether an external node ID is live.
+    pub fn contains(&self, node: NodeId) -> bool {
+        self.nodes.contains_key(&node)
+    }
+
+    /// Creates an unattached, initially non-measurable node.
+    pub fn create_node(
+        &mut self,
+        node: NodeId,
+        style: ComputedLayoutStyle,
+    ) -> Result<(), LayoutError> {
+        if self.contains(node) {
+            return Err(LayoutError::DuplicateNode(node));
+        }
+        let converted = convert_style(&style)?;
+        let backend = self
+            .backend
+            .new_leaf(converted)
+            .expect("valid private style");
+        self.nodes.insert(
+            node,
+            RetainedNode {
+                backend,
+                style,
+                parent: None,
+                children: Vec::new(),
+                measurable: false,
+            },
+        );
+        Ok(())
+    }
+
+    /// Replaces a node's style and reports the resulting invalidation.
+    pub fn update_style(
+        &mut self,
+        node: NodeId,
+        style: ComputedLayoutStyle,
+    ) -> Result<PropertyImpactSet, LayoutError> {
+        let retained = self
+            .nodes
+            .get(&node)
+            .ok_or(LayoutError::UnknownNode(node))?;
+        let impact = style.changes_from(&retained.style);
+        if impact.is_empty() {
+            return Ok(impact);
+        }
+        let converted = convert_style(&style)?;
+        let backend_node = retained.backend;
+        let parent = retained.parent;
+        self.backend
+            .set_style(backend_node, converted)
+            .expect("retained backend node");
+        self.nodes.get_mut(&node).expect("checked above").style = style;
+        if let Some(parent) = parent {
+            self.sync_backend_children(parent);
+        }
+        Ok(impact)
+    }
+
+    /// Marks or unmarks a leaf as requiring intrinsic Host measurement.
+    pub fn set_measurable(&mut self, node: NodeId, measurable: bool) -> Result<(), LayoutError> {
+        let retained = self
+            .nodes
+            .get(&node)
+            .ok_or(LayoutError::UnknownNode(node))?;
+        if retained.measurable == measurable {
+            return Ok(());
+        }
+        let backend = retained.backend;
+        self.backend
+            .set_node_context(backend, measurable.then_some(node))
+            .expect("retained backend node");
+        self.nodes.get_mut(&node).expect("checked above").measurable = measurable;
+        Ok(())
+    }
+
+    /// Invalidates cached intrinsic measurement for a node and its ancestors.
+    pub fn invalidate_measurement(&mut self, node: NodeId) -> Result<(), LayoutError> {
+        let retained = self
+            .nodes
+            .get(&node)
+            .ok_or(LayoutError::UnknownNode(node))?;
+        self.backend
+            .mark_dirty(retained.backend)
+            .expect("retained backend node");
+        Ok(())
+    }
+
+    /// Atomically replaces a parent's ordered child list.
+    ///
+    /// A node attached elsewhere must first be detached by replacing its old
+    /// parent's children. This keeps scene mutations explicit and deterministic.
+    pub fn set_children(&mut self, parent: NodeId, children: &[NodeId]) -> Result<(), LayoutError> {
+        let old_children = self
+            .nodes
+            .get(&parent)
+            .ok_or(LayoutError::UnknownNode(parent))?
+            .children
+            .clone();
+        let mut seen = std::collections::BTreeSet::new();
+        for &child in children {
+            let retained = self
+                .nodes
+                .get(&child)
+                .ok_or(LayoutError::UnknownNode(child))?;
+            if !seen.insert(child) {
+                return Err(LayoutError::DuplicateChild { parent, child });
+            }
+            if child == parent || self.is_ancestor(child, parent) {
+                return Err(LayoutError::TreeCycle { parent, child });
+            }
+            if let Some(attached) = retained.parent
+                && attached != parent
+            {
+                return Err(LayoutError::ChildAlreadyAttached {
+                    child,
+                    parent: attached,
+                });
+            }
+        }
+        if old_children == children {
+            return Ok(());
+        }
+        for child in old_children {
+            self.nodes.get_mut(&child).expect("retained child").parent = None;
+        }
+        self.nodes.get_mut(&parent).expect("checked above").children = children.to_vec();
+        for &child in children {
+            self.nodes.get_mut(&child).expect("checked above").parent = Some(parent);
+        }
+        self.sync_backend_children(parent);
+        Ok(())
+    }
+
+    /// Moves a live node to `index` in a destination parent's child list.
+    ///
+    /// This is the atomic retained-tree operation for moves emitted by the
+    /// scene engine. It also reorders a child within its existing parent.
+    pub fn reparent(
+        &mut self,
+        child: NodeId,
+        parent: NodeId,
+        index: usize,
+    ) -> Result<(), LayoutError> {
+        let old_parent = self
+            .nodes
+            .get(&child)
+            .ok_or(LayoutError::UnknownNode(child))?
+            .parent;
+        let destination = self
+            .nodes
+            .get(&parent)
+            .ok_or(LayoutError::UnknownNode(parent))?;
+        if child == parent || self.is_ancestor(child, parent) {
+            return Err(LayoutError::TreeCycle { parent, child });
+        }
+        let max_index = destination.children.len() - usize::from(old_parent == Some(parent));
+        if index > max_index {
+            return Err(LayoutError::ChildIndexOutOfBounds {
+                parent,
+                index,
+                max_index,
+            });
+        }
+
+        if let Some(old_parent) = old_parent {
+            self.nodes
+                .get_mut(&old_parent)
+                .expect("retained old parent")
+                .children
+                .retain(|node| *node != child);
+            if old_parent != parent {
+                self.sync_backend_children(old_parent);
+            }
+        }
+        self.nodes
+            .get_mut(&parent)
+            .expect("retained destination")
+            .children
+            .insert(index, child);
+        self.nodes.get_mut(&child).expect("retained child").parent = Some(parent);
+        self.sync_backend_children(parent);
+        Ok(())
+    }
+
+    /// Removes a node and its entire retained subtree.
+    pub fn remove_subtree(&mut self, node: NodeId) -> Result<(), LayoutError> {
+        let parent = self
+            .nodes
+            .get(&node)
+            .ok_or(LayoutError::UnknownNode(node))?
+            .parent;
+        if let Some(parent) = parent {
+            let parent_node = self.nodes.get_mut(&parent).expect("retained parent");
+            parent_node.children.retain(|child| *child != node);
+            self.sync_backend_children(parent);
+        }
+        let mut postorder = Vec::new();
+        self.collect_postorder(node, &mut postorder);
+        for removed in postorder {
+            let retained = self.nodes.remove(&removed).expect("collected live node");
+            self.backend
+                .remove(retained.backend)
+                .expect("retained backend node");
+        }
+        Ok(())
+    }
+
+    /// Computes a root subtree against a finite viewport and returns its snapshot.
+    pub fn compute(
+        &mut self,
+        root: NodeId,
+        viewport: LayoutSize,
+        measurer: &mut dyn IntrinsicMeasurer,
+    ) -> Result<LayoutSnapshot, LayoutError> {
+        if !viewport.is_valid() {
+            return Err(LayoutError::InvalidViewport);
+        }
+        let retained = self
+            .nodes
+            .get(&root)
+            .ok_or(LayoutError::UnknownNode(root))?;
+        if let Some(parent) = retained.parent {
+            return Err(LayoutError::RootHasParent { root, parent });
+        }
+        let backend_root = retained.backend;
+        let mut invalid_measurement = None;
+        self.backend
+            .compute_layout_with_measure(
+                backend_root,
+                Size {
+                    width: TaffyAvailableSpace::Definite(viewport.width),
+                    height: TaffyAvailableSpace::Definite(viewport.height),
+                },
+                |known, available, _, context, _| {
+                    let Some(node) = context.copied() else {
+                        return Size::ZERO;
+                    };
+                    let measured = measurer.measure(
+                        node,
+                        MeasureRequest {
+                            known_dimensions: [known.width, known.height],
+                            available_space: [
+                                from_taffy_available(available.width),
+                                from_taffy_available(available.height),
+                            ],
+                        },
+                    );
+                    if !measured.is_valid() {
+                        invalid_measurement.get_or_insert(node);
+                        Size::ZERO
+                    } else {
+                        Size {
+                            width: measured.width,
+                            height: measured.height,
+                        }
+                    }
+                },
+            )
+            .expect("retained backend root");
+        if let Some(node) = invalid_measurement {
+            self.backend
+                .mark_dirty(backend_root)
+                .expect("retained backend root");
+            return Err(LayoutError::InvalidMeasurement(node));
+        }
+        let mut snapshot = LayoutSnapshot::default();
+        self.collect_snapshot(root, &mut snapshot);
+        Ok(snapshot)
+    }
+
+    fn is_ancestor(&self, candidate: NodeId, mut node: NodeId) -> bool {
+        while let Some(parent) = self.nodes.get(&node).and_then(|entry| entry.parent) {
+            if parent == candidate {
+                return true;
+            }
+            node = parent;
+        }
+        false
+    }
+
+    fn sync_backend_children(&mut self, parent: NodeId) {
+        let retained = self.nodes.get(&parent).expect("retained parent");
+        let backend_parent = retained.backend;
+        let mut children = retained.children.clone();
+        children.sort_by_key(|child| self.nodes.get(child).expect("retained child").style.order);
+        let backend_children = children
+            .iter()
+            .map(|child| self.nodes.get(child).expect("retained child").backend)
+            .collect::<Vec<_>>();
+        self.backend
+            .set_children(backend_parent, &backend_children)
+            .expect("retained backend nodes");
+    }
+
+    fn collect_postorder(&self, node: NodeId, output: &mut Vec<NodeId>) {
+        for child in &self.nodes.get(&node).expect("live node").children {
+            self.collect_postorder(*child, output);
+        }
+        output.push(node);
+    }
+
+    fn collect_snapshot(&self, node: NodeId, snapshot: &mut LayoutSnapshot) {
+        let retained = self.nodes.get(&node).expect("retained snapshot node");
+        let layout = self
+            .backend
+            .layout(retained.backend)
+            .expect("retained backend node");
+        snapshot.boxes.insert(
+            node,
+            LayoutRect {
+                x: layout.location.x,
+                y: layout.location.y,
+                width: layout.size.width,
+                height: layout.size.height,
+            },
+        );
+        for child in &retained.children {
+            self.collect_snapshot(*child, snapshot);
+        }
+    }
+}
+
+fn from_taffy_available(value: TaffyAvailableSpace) -> AvailableSpace {
+    match value {
+        TaffyAvailableSpace::Definite(value) => AvailableSpace::Definite(value),
+        TaffyAvailableSpace::MinContent => AvailableSpace::MinContent,
+        TaffyAvailableSpace::MaxContent => AvailableSpace::MaxContent,
+    }
+}
+
+fn convert_style(input: &ComputedLayoutStyle) -> Result<Style, LayoutError> {
+    Ok(Style {
+        display: match input.display {
+            DisplayValue::None => Display::None,
+            DisplayValue::Flex | DisplayValue::Linear => Display::Flex,
+            DisplayValue::Grid => Display::Grid,
+            DisplayValue::Relative => Display::Block,
+        },
+        position: match input.position {
+            PositionValue::Relative => Position::Relative,
+            PositionValue::Absolute => Position::Absolute,
+            PositionValue::Fixed => return unsupported(UnsupportedLayoutFeature::FixedPosition),
+            PositionValue::Sticky => return unsupported(UnsupportedLayoutFeature::StickyPosition),
+        },
+        direction: match input.direction {
+            DirectionValue::Ltr => Direction::Ltr,
+            DirectionValue::Rtl => Direction::Rtl,
+        },
+        box_sizing: match input.box_sizing {
+            BoxSizingValue::ContentBox => BoxSizing::ContentBox,
+            BoxSizingValue::BorderBox => BoxSizing::BorderBox,
+        },
+        size: Size {
+            width: dimension(input.size.width)?,
+            height: dimension(input.size.height)?,
+        },
+        min_size: Size {
+            width: dimension(input.min_size.width)?,
+            height: dimension(input.min_size.height)?,
+        },
+        max_size: Size {
+            width: dimension(input.max_size.width)?,
+            height: dimension(input.max_size.height)?,
+        },
+        margin: Rect {
+            top: length_auto(input.margin.top)?,
+            right: length_auto(input.margin.right)?,
+            bottom: length_auto(input.margin.bottom)?,
+            left: length_auto(input.margin.left)?,
+        },
+        padding: Rect {
+            top: length(input.padding.top, true)?,
+            right: length(input.padding.right, true)?,
+            bottom: length(input.padding.bottom, true)?,
+            left: length(input.padding.left, true)?,
+        },
+        inset: Rect {
+            top: length_auto(input.inset.top)?,
+            right: length_auto(input.inset.right)?,
+            bottom: length_auto(input.inset.bottom)?,
+            left: length_auto(input.inset.left)?,
+        },
+        flex_direction: match input.flex_direction {
+            FlexDirectionValue::Row => FlexDirection::Row,
+            FlexDirectionValue::RowReverse => FlexDirection::RowReverse,
+            FlexDirectionValue::Column => FlexDirection::Column,
+            FlexDirectionValue::ColumnReverse => FlexDirection::ColumnReverse,
+        },
+        flex_wrap: match input.flex_wrap {
+            FlexWrapValue::NoWrap => FlexWrap::NoWrap,
+            FlexWrapValue::Wrap => FlexWrap::Wrap,
+            FlexWrapValue::WrapReverse => FlexWrap::WrapReverse,
+        },
+        flex_grow: input.flex_grow.get(),
+        flex_shrink: input.flex_shrink.get(),
+        flex_basis: match input.flex_basis {
+            ComputedFlexBasis::Auto => Dimension::auto(),
+            ComputedFlexBasis::Content => {
+                return unsupported(UnsupportedLayoutFeature::ContentFlexBasis);
+            }
+            ComputedFlexBasis::Value(value) => dimension_value(value)?,
+        },
+        justify_content: Some(justify(input.justify_content)),
+        align_items: Some(align_items(input.align_items)),
+        align_self: match input.align_self {
+            AlignSelfValue::Auto => None,
+            AlignSelfValue::Stretch => Some(AlignItems::STRETCH),
+            AlignSelfValue::FlexStart => Some(AlignItems::FLEX_START),
+            AlignSelfValue::FlexEnd => Some(AlignItems::FLEX_END),
+            AlignSelfValue::Center => Some(AlignItems::CENTER),
+            AlignSelfValue::Baseline => Some(AlignItems::BASELINE),
+            AlignSelfValue::Start => Some(AlignItems::START),
+            AlignSelfValue::End => Some(AlignItems::END),
+        },
+        align_content: Some(align_content(input.align_content)),
+        gap: Size {
+            width: length(input.gap.width, false)?,
+            height: length(input.gap.height, false)?,
+        },
+        aspect_ratio: input.aspect_ratio.map(|ratio| ratio.get()),
+        ..Style::default()
+    })
+}
+
+fn unsupported<T>(feature: UnsupportedLayoutFeature) -> Result<T, LayoutError> {
+    Err(LayoutError::UnsupportedStyle(feature))
+}
+
+fn dimension(value: ComputedSizeValue) -> Result<Dimension, LayoutError> {
+    match value {
+        ComputedSizeValue::Auto | ComputedSizeValue::None => Ok(Dimension::auto()),
+        ComputedSizeValue::Value(value) => dimension_value(value),
+        ComputedSizeValue::MaxContent => unsupported(UnsupportedLayoutFeature::MaxContent),
+        ComputedSizeValue::MinContent => unsupported(UnsupportedLayoutFeature::MinContent),
+        ComputedSizeValue::FitContent(_) => unsupported(UnsupportedLayoutFeature::FitContent),
+    }
+}
+
+fn dimension_value(value: ComputedLengthPercentage) -> Result<Dimension, LayoutError> {
+    scalar(value).map(|value| match value {
+        Scalar::Length(value) => Dimension::length(value),
+        Scalar::Percent(value) => Dimension::percent(value),
+    })
+}
+
+fn length_auto(value: ComputedLengthPercentageAuto) -> Result<LengthPercentageAuto, LayoutError> {
+    match value {
+        ComputedLengthPercentageAuto::Auto => Ok(LengthPercentageAuto::auto()),
+        ComputedLengthPercentageAuto::Value(value) => scalar(value).map(|value| match value {
+            Scalar::Length(value) => LengthPercentageAuto::length(value),
+            Scalar::Percent(value) => LengthPercentageAuto::percent(value),
+        }),
+    }
+}
+
+fn length(
+    value: ComputedLengthPercentage,
+    clamp_negative: bool,
+) -> Result<LengthPercentage, LayoutError> {
+    scalar(value).map(|value| match value {
+        Scalar::Length(value) => LengthPercentage::length(if clamp_negative {
+            value.max(0.0)
+        } else {
+            value
+        }),
+        Scalar::Percent(value) => LengthPercentage::percent(if clamp_negative {
+            value.max(0.0)
+        } else {
+            value
+        }),
+    })
+}
+
+enum Scalar {
+    Length(f32),
+    Percent(f32),
+}
+
+fn scalar(value: ComputedLengthPercentage) -> Result<Scalar, LayoutError> {
+    match (value.length(), value.fraction()) {
+        (length, 0.0) => Ok(Scalar::Length(length)),
+        (0.0, fraction) => Ok(Scalar::Percent(fraction)),
+        _ => unsupported(UnsupportedLayoutFeature::MixedLengthPercentage),
+    }
+}
+
+fn align_items(value: AlignItemsValue) -> AlignItems {
+    match value {
+        AlignItemsValue::Stretch => AlignItems::STRETCH,
+        AlignItemsValue::FlexStart => AlignItems::FLEX_START,
+        AlignItemsValue::FlexEnd => AlignItems::FLEX_END,
+        AlignItemsValue::Center => AlignItems::CENTER,
+        AlignItemsValue::Baseline => AlignItems::BASELINE,
+        AlignItemsValue::Start => AlignItems::START,
+        AlignItemsValue::End => AlignItems::END,
+    }
+}
+
+fn align_content(value: AlignContentValue) -> AlignContent {
+    match value {
+        AlignContentValue::Stretch => AlignContent::STRETCH,
+        AlignContentValue::FlexStart => AlignContent::FLEX_START,
+        AlignContentValue::FlexEnd => AlignContent::FLEX_END,
+        AlignContentValue::Center => AlignContent::CENTER,
+        AlignContentValue::SpaceBetween => AlignContent::SPACE_BETWEEN,
+        AlignContentValue::SpaceAround => AlignContent::SPACE_AROUND,
+        AlignContentValue::SpaceEvenly => AlignContent::SPACE_EVENLY,
+    }
+}
+
+fn justify(value: JustifyContentValue) -> AlignContent {
+    match value {
+        JustifyContentValue::Stretch => AlignContent::STRETCH,
+        JustifyContentValue::FlexStart => AlignContent::FLEX_START,
+        JustifyContentValue::FlexEnd => AlignContent::FLEX_END,
+        JustifyContentValue::Center => AlignContent::CENTER,
+        JustifyContentValue::SpaceBetween => AlignContent::SPACE_BETWEEN,
+        JustifyContentValue::SpaceAround => AlignContent::SPACE_AROUND,
+        JustifyContentValue::SpaceEvenly => AlignContent::SPACE_EVENLY,
+        JustifyContentValue::Start => AlignContent::START,
+        JustifyContentValue::End => AlignContent::END,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_style::{Axes, Edges, StyleNumber};
+
+    const MIXED: ComputedLengthPercentage = ComputedLengthPercentage::new(1.0, 0.5);
+
+    fn id(value: u64) -> NodeId {
+        NodeId::new(value).expect("non-zero test ID")
+    }
+
+    fn sized(width: f32, height: f32) -> ComputedLayoutStyle {
+        ComputedLayoutStyle {
+            size: Axes {
+                width: ComputedSizeValue::Value(ComputedLengthPercentage::new(width, 0.0)),
+                height: ComputedSizeValue::Value(ComputedLengthPercentage::new(height, 0.0)),
+            },
+            ..ComputedLayoutStyle::default()
+        }
+    }
+
+    fn zero_measure(_: NodeId, _: MeasureRequest) -> LayoutSize {
+        LayoutSize::default()
+    }
+
+    fn assert_unsupported(style: ComputedLayoutStyle, feature: UnsupportedLayoutFeature) {
+        assert_eq!(
+            convert_style(&style),
+            Err(LayoutError::UnsupportedStyle(feature))
+        );
+    }
+
+    #[test]
+    fn retained_tree_measures_orders_and_snapshots_fractional_layout() {
+        let root = id(1);
+        let first = id(2);
+        let second = id(3);
+        let mut tree = LayoutTree::new();
+        let mut root_style = sized(100.5, 40.5);
+        root_style.padding.left = ComputedLengthPercentage::new(0.25, 0.0);
+        tree.create_node(root, root_style).unwrap();
+
+        let first_style = ComputedLayoutStyle {
+            order: 1,
+            ..ComputedLayoutStyle::default()
+        };
+        let second_style = ComputedLayoutStyle {
+            order: -1,
+            ..ComputedLayoutStyle::default()
+        };
+        tree.create_node(first, first_style).unwrap();
+        tree.create_node(second, second_style).unwrap();
+        tree.set_measurable(first, true).unwrap();
+        tree.set_measurable(second, true).unwrap();
+        tree.set_children(root, &[first, second]).unwrap();
+
+        let mut requests = Vec::new();
+        let snapshot = tree
+            .compute(root, LayoutSize::new(200.0, 100.0), &mut |node, request| {
+                requests.push((node, request));
+                LayoutSize::new(10.0, 5.0)
+            })
+            .unwrap();
+
+        assert_eq!(tree.len(), 3);
+        assert!(!tree.is_empty());
+        assert!(tree.contains(first));
+        assert_eq!(snapshot.len(), 3);
+        assert!(!snapshot.is_empty());
+        assert_eq!(
+            snapshot.iter().map(|(node, _)| node).collect::<Vec<_>>(),
+            [root, first, second]
+        );
+        assert_eq!(snapshot.get(root).unwrap().width, 100.5);
+        assert_eq!(snapshot.get(second).unwrap().x, 0.25);
+        assert_eq!(snapshot.get(first).unwrap().x, 10.25);
+        assert!(requests.len() >= 2);
+        assert!(requests.iter().any(|(node, _)| *node == first));
+        assert!(requests.iter().any(|(node, _)| *node == second));
+        assert!(
+            requests
+                .iter()
+                .any(|(_, request)| request.known_dimensions == [None, None])
+        );
+
+        let cloned = tree.clone();
+        assert_eq!(cloned.len(), tree.len());
+    }
+
+    #[test]
+    fn measurement_cache_invalidation_and_validation_are_explicit() {
+        use std::cell::Cell;
+
+        let root = id(1);
+        let mut tree = LayoutTree::default();
+        tree.create_node(root, ComputedLayoutStyle::default())
+            .unwrap();
+        tree.set_measurable(root, true).unwrap();
+        tree.set_measurable(root, true).unwrap();
+
+        let calls = Cell::new(0);
+        let mut measure = |_: NodeId, _: MeasureRequest| {
+            calls.set(calls.get() + 1);
+            LayoutSize::new(12.0, 8.0)
+        };
+        tree.compute(root, LayoutSize::new(100.0, 100.0), &mut measure)
+            .unwrap();
+        tree.compute(root, LayoutSize::new(100.0, 100.0), &mut measure)
+            .unwrap();
+        assert_eq!(calls.get(), 1);
+        tree.invalidate_measurement(root).unwrap();
+        tree.compute(root, LayoutSize::new(100.0, 100.0), &mut measure)
+            .unwrap();
+        assert_eq!(calls.get(), 2);
+
+        tree.invalidate_measurement(root).unwrap();
+        assert_eq!(
+            tree.compute(root, LayoutSize::new(100.0, 100.0), &mut |_, _| {
+                LayoutSize::new(f32::NAN, 1.0)
+            }),
+            Err(LayoutError::InvalidMeasurement(root))
+        );
+        tree.compute(root, LayoutSize::new(100.0, 100.0), &mut measure)
+            .unwrap();
+        assert_eq!(calls.get(), 3);
+        tree.set_measurable(root, false).unwrap();
+        tree.set_measurable(root, false).unwrap();
+        let snapshot = tree
+            .compute(root, LayoutSize::new(100.0, 100.0), &mut zero_measure)
+            .unwrap();
+        assert_eq!(snapshot.get(root).unwrap().width, 0.0);
+    }
+
+    #[test]
+    fn mutations_enforce_tree_invariants_and_remove_subtrees() {
+        let root = id(1);
+        let child = id(2);
+        let grandchild = id(3);
+        let other = id(4);
+        let unknown = id(99);
+        let mut tree = LayoutTree::new();
+        for node in [root, child, grandchild, other] {
+            tree.create_node(node, ComputedLayoutStyle::default())
+                .unwrap();
+        }
+        assert_eq!(
+            tree.create_node(root, ComputedLayoutStyle::default()),
+            Err(LayoutError::DuplicateNode(root))
+        );
+        assert_eq!(
+            tree.set_children(unknown, &[]),
+            Err(LayoutError::UnknownNode(unknown))
+        );
+        assert_eq!(
+            tree.set_children(root, &[unknown]),
+            Err(LayoutError::UnknownNode(unknown))
+        );
+        assert_eq!(
+            tree.set_children(root, &[child, child]),
+            Err(LayoutError::DuplicateChild {
+                parent: root,
+                child
+            })
+        );
+
+        tree.set_children(root, &[child]).unwrap();
+        tree.set_children(root, &[child]).unwrap();
+        tree.set_children(root, &[]).unwrap();
+        tree.set_children(root, &[child]).unwrap();
+        tree.set_children(child, &[grandchild]).unwrap();
+        assert_eq!(
+            tree.set_children(child, &[child]),
+            Err(LayoutError::TreeCycle {
+                parent: child,
+                child
+            })
+        );
+        assert_eq!(
+            tree.set_children(child, &[root]),
+            Err(LayoutError::TreeCycle {
+                parent: child,
+                child: root
+            })
+        );
+        assert_eq!(
+            tree.set_children(other, &[grandchild]),
+            Err(LayoutError::ChildAlreadyAttached {
+                child: grandchild,
+                parent: child
+            })
+        );
+        assert_eq!(
+            tree.compute(child, LayoutSize::new(10.0, 10.0), &mut zero_measure),
+            Err(LayoutError::RootHasParent {
+                root: child,
+                parent: root
+            })
+        );
+
+        tree.remove_subtree(child).unwrap();
+        assert_eq!(tree.len(), 2);
+        assert!(!tree.contains(child));
+        assert!(!tree.contains(grandchild));
+        assert_eq!(
+            tree.remove_subtree(unknown),
+            Err(LayoutError::UnknownNode(unknown))
+        );
+        tree.remove_subtree(root).unwrap();
+        tree.remove_subtree(other).unwrap();
+        assert!(tree.is_empty());
+    }
+
+    #[test]
+    fn mutation_unknowns_and_viewport_validation_are_reported() {
+        let unknown = id(8);
+        let mut tree = LayoutTree::new();
+        assert_eq!(
+            tree.update_style(unknown, ComputedLayoutStyle::default()),
+            Err(LayoutError::UnknownNode(unknown))
+        );
+        assert_eq!(
+            tree.set_measurable(unknown, true),
+            Err(LayoutError::UnknownNode(unknown))
+        );
+        assert_eq!(
+            tree.invalidate_measurement(unknown),
+            Err(LayoutError::UnknownNode(unknown))
+        );
+        assert_eq!(
+            tree.compute(unknown, LayoutSize::new(1.0, 1.0), &mut zero_measure),
+            Err(LayoutError::UnknownNode(unknown))
+        );
+
+        let root = id(1);
+        tree.create_node(root, ComputedLayoutStyle::default())
+            .unwrap();
+        for viewport in [
+            LayoutSize::new(-1.0, 1.0),
+            LayoutSize::new(1.0, -1.0),
+            LayoutSize::new(f32::INFINITY, 1.0),
+            LayoutSize::new(1.0, f32::NAN),
+        ] {
+            assert_eq!(
+                tree.compute(root, viewport, &mut zero_measure),
+                Err(LayoutError::InvalidViewport)
+            );
+        }
+        assert_eq!(LayoutSize::default(), LayoutSize::new(0.0, 0.0));
+        assert_eq!(
+            format!("{}", LayoutError::InvalidViewport),
+            "InvalidViewport"
+        );
+        let error: &dyn Error = &LayoutError::InvalidViewport;
+        assert!(error.source().is_none());
+    }
+
+    #[test]
+    fn reparent_moves_attached_and_unattached_nodes_atomically() {
+        let first_parent = id(1);
+        let second_parent = id(2);
+        let first = id(3);
+        let moved = id(4);
+        let unattached = id(5);
+        let unknown = id(99);
+        let mut tree = LayoutTree::new();
+        for node in [first_parent, second_parent, first, moved, unattached] {
+            tree.create_node(node, ComputedLayoutStyle::default())
+                .unwrap();
+        }
+        tree.set_children(first_parent, &[first, moved]).unwrap();
+
+        tree.reparent(moved, first_parent, 0).unwrap();
+        assert_eq!(tree.nodes[&first_parent].children, [moved, first]);
+        tree.reparent(moved, second_parent, 0).unwrap();
+        assert_eq!(tree.nodes[&first_parent].children, [first]);
+        assert_eq!(tree.nodes[&second_parent].children, [moved]);
+        tree.reparent(unattached, second_parent, 1).unwrap();
+        assert_eq!(tree.nodes[&second_parent].children, [moved, unattached]);
+
+        assert_eq!(
+            tree.reparent(unknown, second_parent, 0),
+            Err(LayoutError::UnknownNode(unknown))
+        );
+        assert_eq!(
+            tree.reparent(first, unknown, 0),
+            Err(LayoutError::UnknownNode(unknown))
+        );
+        assert_eq!(
+            tree.reparent(first_parent, first, 0),
+            Err(LayoutError::TreeCycle {
+                parent: first,
+                child: first_parent
+            })
+        );
+        assert_eq!(
+            tree.reparent(second_parent, second_parent, 0),
+            Err(LayoutError::TreeCycle {
+                parent: second_parent,
+                child: second_parent
+            })
+        );
+        assert_eq!(
+            tree.reparent(first, first_parent, 2),
+            Err(LayoutError::ChildIndexOutOfBounds {
+                parent: first_parent,
+                index: 2,
+                max_index: 0
+            })
+        );
+        assert_eq!(tree.nodes[&first_parent].children, [first]);
+    }
+
+    #[test]
+    fn updates_report_impacts_and_resort_siblings() {
+        let root = id(1);
+        let left = id(2);
+        let right = id(3);
+        let mut tree = LayoutTree::new();
+        tree.create_node(root, sized(30.0, 10.0)).unwrap();
+        tree.create_node(left, sized(10.0, 10.0)).unwrap();
+        tree.create_node(right, sized(10.0, 10.0)).unwrap();
+        tree.set_children(root, &[left, right]).unwrap();
+        let mut resized_root = sized(31.0, 10.0);
+        resized_root.display = DisplayValue::Linear;
+        assert!(
+            tree.update_style(root, resized_root)
+                .unwrap()
+                .contains(PropertyImpactSet::LAYOUT)
+        );
+        assert!(
+            tree.update_style(left, sized(10.0, 10.0))
+                .unwrap()
+                .is_empty()
+        );
+
+        let mut reordered = sized(10.0, 10.0);
+        reordered.order = -1;
+        assert!(
+            tree.update_style(right, reordered)
+                .unwrap()
+                .contains(PropertyImpactSet::LAYOUT)
+        );
+        let snapshot = tree
+            .compute(root, LayoutSize::new(30.0, 10.0), &mut zero_measure)
+            .unwrap();
+        assert_eq!(snapshot.get(right).unwrap().x, 0.0);
+        assert_eq!(snapshot.get(left).unwrap().x, 10.0);
+
+        let mut unsupported = sized(10.0, 10.0);
+        unsupported.position = PositionValue::Fixed;
+        assert_eq!(
+            tree.update_style(left, unsupported),
+            Err(LayoutError::UnsupportedStyle(
+                UnsupportedLayoutFeature::FixedPosition
+            ))
+        );
+        assert_eq!(snapshot.get(id(44)), None);
+    }
+
+    #[test]
+    fn all_supported_style_spellings_convert() {
+        let mut style = ComputedLayoutStyle {
+            display: DisplayValue::None,
+            position: PositionValue::Absolute,
+            direction: DirectionValue::Rtl,
+            box_sizing: BoxSizingValue::ContentBox,
+            size: Axes {
+                width: ComputedSizeValue::Value(ComputedLengthPercentage::new(0.0, 0.5)),
+                height: ComputedSizeValue::Auto,
+            },
+            min_size: Axes {
+                width: ComputedSizeValue::None,
+                height: ComputedSizeValue::Value(ComputedLengthPercentage::new(2.0, 0.0)),
+            },
+            max_size: Axes {
+                width: ComputedSizeValue::None,
+                height: ComputedSizeValue::None,
+            },
+            margin: Edges {
+                top: ComputedLengthPercentageAuto::Auto,
+                right: ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(0.0, 0.1)),
+                bottom: ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(
+                    2.0, 0.0,
+                )),
+                left: ComputedLengthPercentageAuto::Auto,
+            },
+            padding: Edges {
+                top: ComputedLengthPercentage::new(-2.0, 0.0),
+                right: ComputedLengthPercentage::new(0.0, -0.2),
+                bottom: ComputedLengthPercentage::ZERO,
+                left: ComputedLengthPercentage::ZERO,
+            },
+            inset: Edges {
+                top: ComputedLengthPercentageAuto::Auto,
+                right: ComputedLengthPercentageAuto::Auto,
+                bottom: ComputedLengthPercentageAuto::Auto,
+                left: ComputedLengthPercentageAuto::Auto,
+            },
+            flex_direction: FlexDirectionValue::RowReverse,
+            flex_wrap: FlexWrapValue::WrapReverse,
+            flex_grow: StyleNumber::new(2.0),
+            flex_shrink: StyleNumber::new(3.0),
+            flex_basis: ComputedFlexBasis::Value(ComputedLengthPercentage::new(3.0, 0.0)),
+            justify_content: JustifyContentValue::Start,
+            align_items: AlignItemsValue::Start,
+            align_self: AlignSelfValue::Auto,
+            align_content: AlignContentValue::SpaceEvenly,
+            gap: Axes {
+                width: ComputedLengthPercentage::new(-1.0, 0.0),
+                height: ComputedLengthPercentage::new(0.0, -0.1),
+            },
+            aspect_ratio: Some(StyleNumber::new(1.5)),
+            order: 7,
+        };
+        let converted = convert_style(&style).unwrap();
+        assert_eq!(converted.display, Display::None);
+        assert_eq!(converted.position, Position::Absolute);
+        assert_eq!(converted.direction, Direction::Rtl);
+        assert_eq!(converted.box_sizing, BoxSizing::ContentBox);
+        assert_eq!(converted.size.width.value(), 0.5);
+        assert_eq!(converted.aspect_ratio, Some(1.5));
+
+        for display in [
+            DisplayValue::Flex,
+            DisplayValue::Grid,
+            DisplayValue::Linear,
+            DisplayValue::Relative,
+        ] {
+            style.display = display;
+            convert_style(&style).unwrap();
+        }
+        for direction in [
+            FlexDirectionValue::Row,
+            FlexDirectionValue::Column,
+            FlexDirectionValue::ColumnReverse,
+        ] {
+            style.flex_direction = direction;
+            convert_style(&style).unwrap();
+        }
+        for wrap in [FlexWrapValue::NoWrap, FlexWrapValue::Wrap] {
+            style.flex_wrap = wrap;
+            convert_style(&style).unwrap();
+        }
+        for value in [
+            AlignItemsValue::Stretch,
+            AlignItemsValue::FlexStart,
+            AlignItemsValue::FlexEnd,
+            AlignItemsValue::Center,
+            AlignItemsValue::Baseline,
+            AlignItemsValue::End,
+        ] {
+            style.align_items = value;
+            convert_style(&style).unwrap();
+        }
+        for value in [
+            AlignSelfValue::Stretch,
+            AlignSelfValue::FlexStart,
+            AlignSelfValue::FlexEnd,
+            AlignSelfValue::Center,
+            AlignSelfValue::Baseline,
+            AlignSelfValue::Start,
+            AlignSelfValue::End,
+        ] {
+            style.align_self = value;
+            convert_style(&style).unwrap();
+        }
+        for value in [
+            AlignContentValue::Stretch,
+            AlignContentValue::FlexStart,
+            AlignContentValue::FlexEnd,
+            AlignContentValue::Center,
+            AlignContentValue::SpaceBetween,
+            AlignContentValue::SpaceAround,
+        ] {
+            style.align_content = value;
+            convert_style(&style).unwrap();
+        }
+        for value in [
+            JustifyContentValue::Stretch,
+            JustifyContentValue::FlexStart,
+            JustifyContentValue::FlexEnd,
+            JustifyContentValue::Center,
+            JustifyContentValue::SpaceBetween,
+            JustifyContentValue::SpaceAround,
+            JustifyContentValue::SpaceEvenly,
+            JustifyContentValue::End,
+        ] {
+            style.justify_content = value;
+            convert_style(&style).unwrap();
+        }
+        style.position = PositionValue::Relative;
+        style.direction = DirectionValue::Ltr;
+        style.box_sizing = BoxSizingValue::BorderBox;
+        style.flex_basis = ComputedFlexBasis::Auto;
+        style.aspect_ratio = None;
+        convert_style(&style).unwrap();
+    }
+
+    #[test]
+    fn unsupported_style_features_are_never_silently_lowered() {
+        let mut style = ComputedLayoutStyle {
+            position: PositionValue::Fixed,
+            ..ComputedLayoutStyle::default()
+        };
+        assert_unsupported(style.clone(), UnsupportedLayoutFeature::FixedPosition);
+        style.position = PositionValue::Sticky;
+        assert_unsupported(style.clone(), UnsupportedLayoutFeature::StickyPosition);
+        style.position = PositionValue::Relative;
+
+        style.size.width = ComputedSizeValue::MaxContent;
+        assert_unsupported(style.clone(), UnsupportedLayoutFeature::MaxContent);
+        style.size.width = ComputedSizeValue::MinContent;
+        assert_unsupported(style.clone(), UnsupportedLayoutFeature::MinContent);
+        style.size.width = ComputedSizeValue::FitContent(None);
+        assert_unsupported(style.clone(), UnsupportedLayoutFeature::FitContent);
+        style.size.width = ComputedSizeValue::Auto;
+
+        style.flex_basis = ComputedFlexBasis::Content;
+        assert_unsupported(style.clone(), UnsupportedLayoutFeature::ContentFlexBasis);
+        style.flex_basis = ComputedFlexBasis::Value(MIXED);
+        assert_unsupported(
+            style.clone(),
+            UnsupportedLayoutFeature::MixedLengthPercentage,
+        );
+        style.flex_basis = ComputedFlexBasis::Auto;
+        style.gap.width = ComputedLengthPercentage::new(1.0, 0.5);
+        assert_unsupported(style, UnsupportedLayoutFeature::MixedLengthPercentage);
+
+        let node = id(1);
+        let mut tree = LayoutTree::new();
+        let unsupported = ComputedLayoutStyle {
+            position: PositionValue::Fixed,
+            ..ComputedLayoutStyle::default()
+        };
+        assert_eq!(
+            tree.create_node(node, unsupported),
+            Err(LayoutError::UnsupportedStyle(
+                UnsupportedLayoutFeature::FixedPosition
+            ))
+        );
+        assert!(!tree.contains(node));
+    }
+
+    #[test]
+    fn every_style_field_propagates_mixed_value_rejection() {
+        let size_setters: [fn(&mut ComputedLayoutStyle); 5] = [
+            |style| style.size.height = ComputedSizeValue::Value(MIXED),
+            |style| style.min_size.width = ComputedSizeValue::Value(MIXED),
+            |style| style.min_size.height = ComputedSizeValue::Value(MIXED),
+            |style| style.max_size.width = ComputedSizeValue::Value(MIXED),
+            |style| style.max_size.height = ComputedSizeValue::Value(MIXED),
+        ];
+        let auto_setters: [fn(&mut ComputedLayoutStyle); 8] = [
+            |style| style.margin.top = ComputedLengthPercentageAuto::Value(MIXED),
+            |style| style.margin.right = ComputedLengthPercentageAuto::Value(MIXED),
+            |style| style.margin.bottom = ComputedLengthPercentageAuto::Value(MIXED),
+            |style| style.margin.left = ComputedLengthPercentageAuto::Value(MIXED),
+            |style| style.inset.top = ComputedLengthPercentageAuto::Value(MIXED),
+            |style| style.inset.right = ComputedLengthPercentageAuto::Value(MIXED),
+            |style| style.inset.bottom = ComputedLengthPercentageAuto::Value(MIXED),
+            |style| style.inset.left = ComputedLengthPercentageAuto::Value(MIXED),
+        ];
+        let length_setters: [fn(&mut ComputedLayoutStyle); 5] = [
+            |style| style.padding.top = MIXED,
+            |style| style.padding.right = MIXED,
+            |style| style.padding.bottom = MIXED,
+            |style| style.padding.left = MIXED,
+            |style| style.gap.height = MIXED,
+        ];
+        for setter in size_setters
+            .into_iter()
+            .chain(auto_setters)
+            .chain(length_setters)
+        {
+            let mut style = ComputedLayoutStyle::default();
+            setter(&mut style);
+            assert_unsupported(style, UnsupportedLayoutFeature::MixedLengthPercentage);
+        }
+    }
+
+    #[test]
+    fn available_space_translation_covers_intrinsic_constraints() {
+        let request = MeasureRequest {
+            known_dimensions: [None, None],
+            available_space: [AvailableSpace::MaxContent, AvailableSpace::MinContent],
+        };
+        let mut measure = zero_measure;
+        assert_eq!(
+            IntrinsicMeasurer::measure(&mut measure, id(1), request),
+            LayoutSize::default()
+        );
+        assert_eq!(
+            from_taffy_available(TaffyAvailableSpace::Definite(3.0)),
+            AvailableSpace::Definite(3.0)
+        );
+        assert_eq!(
+            from_taffy_available(TaffyAvailableSpace::MinContent),
+            AvailableSpace::MinContent
+        );
+        assert_eq!(
+            from_taffy_available(TaffyAvailableSpace::MaxContent),
+            AvailableSpace::MaxContent
+        );
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,6 +49,10 @@ runs on iOS and Android by driving Lynx's element tree directly.
    (Host-independent retained scene + incremental frame journal;
     migration foundation, not yet wired into render! or Lynx)
 
+   whisker-layout ──────────► whisker-style + whisker-protocol
+   (Host-independent retained Taffy tree + intrinsic-measurement boundary;
+    migration foundation, not yet wired into whisker-engine)
+
    subsecond  (= whisker-subsecond, [lib] name = "subsecond")
      pulled into whisker / whisker-driver / whisker-dev-runtime
      when `hot-reload` is on.
@@ -103,6 +107,7 @@ runs on iOS and Android by driving Lynx's element tree directly.
 | `whisker-plugin` | CNG plugin surface: `Plugin` trait, IR types, JSON envelope, subprocess runner shared by the engine and 3rd-party plugin binaries. | `whisker-cng`, 3rd-party plugins |
 | `whisker-protocol` | Host-independent semantic frame types, stable IDs, and transactional retained-tree validation. It is currently a migration foundation and is not yet used by the production Lynx path. | future scene engine and renderer providers |
 | `whisker-engine` | Host-independent retained scene, coalescing mutation journal, snapshot/delta production, and frame acceptance/recovery lifecycle. It is currently a migration foundation and is not yet connected to `render!`. | future scene runtime |
+| `whisker-layout` | Host-independent retained box layout. It privately owns Taffy, accepts `ComputedLayoutStyle` and stable `NodeId`s, calls an abstract intrinsic measurer, and returns deterministic logical-pixel snapshots. It is not yet connected to `whisker-engine`. | future scene runtime |
 | `whisker-subsecond` | Whisker's fork of DioxusLabs `subsecond` — anchors the ASLR-slide lookup on `whisker_aslr_anchor` (emitted by `#[whisker::main]`) instead of `main`. `[lib] name = "subsecond"` keeps `use subsecond::*`. | `whisker`, `whisker-driver`, `whisker-dev-runtime` |
 
 ### Modules and the router (`packages/*`)

--- a/docs/rfcs/0001-runtime-modules-and-build-plugins.md
+++ b/docs/rfcs/0001-runtime-modules-and-build-plugins.md
@@ -127,9 +127,11 @@ providers and zero or more plugins.
 ### Host
 
 The platform environment to which the Whisker runtime is connected:
-Kotlin/Java on Android, Swift/Objective-C on iOS, and JavaScript on Web and the
-initial Desktop WebView backend. A Host implementation can provide module
-interfaces, but `Host` is not a second module type.
+Kotlin/Java on Android, Swift/Objective-C on iOS, JavaScript in the browser on
+Web, and native Rust/GPUI on Desktop. A Host implementation can provide module
+interfaces, but `Host` is not a second module type. Desktop has one
+Whisker-visible Host: the native Rust process containing GPUI and the WASM
+runtime; there is no JavaScript or WebView Host in the Desktop architecture.
 
 ### Kernel
 
@@ -365,7 +367,7 @@ The initial lifecycle scopes are:
 |---|---|---|---|
 | Process | Once per process | Process shutdown | diagnostics sink |
 | Application | Once per Whisker application | application shutdown | router root |
-| Window | Once per native/WebView window | window close | window commands |
+| Window | Once per native or browser window | window close | window commands |
 | Surface | Once per rendered surface | surface close | renderer |
 | Owner | Bound to a reactive owner | owner disposal | scoped resource |
 
@@ -658,10 +660,13 @@ package and release version for convenience without becoming the same entity.
 ### Example: renderer
 
 A DOM renderer package can provide a `whisker.renderer@1` module implemented by
-JavaScript and a build plugin that adds the Host bootstrap, WASM loader, DOM
-entry point, and generated module registry to Web and Desktop projects. A Rust
-recording renderer used in unit tests can provide the same interface without a
-plugin or Host code.
+JavaScript and a build plugin that adds the browser Host bootstrap, WASM loader,
+DOM entry point, and generated module registry to Web projects. A separate
+GPUI renderer package provides the same interface from native Rust and has a
+build plugin that contributes the GPUI dependency, native window entry point,
+embedded WASM runtime, and generated module registry to Desktop projects. A
+Rust recording renderer used in unit tests can provide the same interface
+without a plugin or Host code.
 
 This is how renderer selection becomes ordinary module resolution while the
 target-specific project assembly remains a plugin responsibility.
@@ -698,13 +703,14 @@ produce the same input.
 | Android | Native Rust | Kotlin/Java | Gradle project |
 | iOS | Native Rust | Swift/Objective-C | Xcode project |
 | Web | Rust/WASM | JavaScript | Web project/bundle |
-| Desktop v1 | Rust/WASM in system WebView | WebView JavaScript | Desktop launcher plus Web assets |
+| Desktop v1 | Rust/WASM in an in-process WASM runtime | Native Rust/GPUI | Native Desktop project and application bundle |
 
-Desktop v1 has one Whisker-visible Host: JavaScript. Native launcher code may
-be generated to create the WebView and load assets, but it is not a second
-runtime Host or module registry. If native Desktop capabilities are introduced
-later, their internal bridge remains behind the JavaScript Host unless a later
-RFC deliberately changes this model.
+Desktop v1 has one Whisker-visible Host: native Rust. The generated launcher
+creates the GPUI application and window, instantiates the Whisker WASM runtime,
+and registers native module providers. GPUI and those providers are parts of
+the same Host and module registry, not a second rendering process. Calls across
+the WASM boundary may be synchronous because they remain in-process; a normal
+frame does not use WebView, JavaScript, Tauri commands, or process IPC.
 
 ## Invariants
 

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -17,7 +17,8 @@ projects the resulting retained scene onto a platform Host:
 - Android Views through Kotlin/Java;
 - UIViews through Swift/Objective-C;
 - DOM nodes through JavaScript on Web;
-- DOM nodes through JavaScript inside the system WebView on Desktop v1.
+- a retained Whisker scene lowered to GPUI paint, text, input, and
+  accessibility primitives by native Rust on Desktop.
 
 The Host supplies frame callbacks, native text and intrinsic measurement,
 input, viewport changes, resource readiness, and concrete element factories.
@@ -61,9 +62,11 @@ Removing Lynx requires a boundary that:
 - Make full-tree initialization and incremental updates use the same protocol.
 - Distinguish runtime modules, element types, and element instances.
 - Support Rust-only recording, test, headless, and future SSR renderers.
-- Keep Web and Desktop animation within one JavaScript animation-frame callback
-  without asynchronous native IPC.
-- Permit custom native/DOM views while retaining a single Host per platform.
+- Keep Web animation within one JavaScript animation-frame callback and
+  Desktop animation within one GPUI frame callback, without asynchronous
+  native-process IPC.
+- Permit custom native, DOM, and GPUI-backed elements while retaining a single
+  Host per platform.
 - Use the same `#[whisker::main]` Application descriptor and surface runtime
   for a generated standalone root and an optional embedded Host container.
 
@@ -79,8 +82,8 @@ Removing Lynx requires a boundary that:
   the application.
 - Preserving Lynx element handles, raw inline-style strings, or the current
   imperative animation extension.
-- Introducing a second native Host for Desktop. Desktop v1 has a JavaScript
-  Host inside its WebView.
+- Defining a DOM or WebView fallback renderer for Desktop. Desktop v1 uses the
+  native Rust/GPUI Host.
 - Making every element instance a Whisker module.
 - Changing Whisker's existing function-call-style `render!` syntax. The new
   scene and renderer pipeline remains behind the current authoring API.
@@ -107,7 +110,8 @@ Removing Lynx requires a boundary that:
 
 ### The Host owns
 
-- concrete Android View, UIView, or DOM object allocation and destruction;
+- concrete Android View, UIView, DOM object, or GPUI presentation-resource
+  allocation and destruction;
 - applying geometry, paint, clipping, transforms, content, and accessibility
   changes to those objects;
 - native text shaping, line breaking, glyph metrics, and intrinsic measurement;
@@ -130,12 +134,79 @@ the corresponding Android, UIKit, or DOM clip.
 | Android | Native Rust | Kotlin/Java | Android Views |
 | iOS | Native Rust | Swift/Objective-C | UIViews |
 | Web | Rust/WASM | JavaScript | DOM |
-| Desktop v1 | Rust/WASM in WebView | WebView JavaScript | DOM |
+| Desktop v1 | Rust/WASM in an in-process WASM runtime | Native Rust/GPUI | GPUI Scene rendered by Metal, DirectX, or wgpu |
 
-The Desktop launcher creates a system WebView and loads the application. It is
-generated build infrastructure, not a second Whisker Host. In particular, a
-normal Desktop frame does not travel from WASM to JavaScript, through IPC to a
-native Rust process, and back.
+The Desktop launcher creates a native GPUI application and embeds the Whisker
+WASM runtime in the same process. Native Rust is the sole Whisker-visible Host.
+The GPUI renderer provider receives the same versioned renderer operations as
+other providers, stores their retained semantic state, and lowers that state
+through GPUI only while GPUI is in its layout, prepaint, or paint phase. A
+normal Desktop frame crosses an in-process WASM ABI but does not cross
+JavaScript, WebView IPC, a Tauri command channel, or a process boundary.
+
+### Desktop GPUI integration boundary
+
+Desktop does not construct one declarative GPUI element for every Whisker
+node. It mounts one custom `WhiskerView` element. GPUI lays out that outer
+element in its containing window; Whisker's retained Taffy tree remains
+authoritative for every node inside it.
+
+The adapter maps Whisker presentation operations onto GPUI's public low-level
+surface:
+
+```text
+Whisker box/shadow     -> Window::paint_quad / paint_*_shadows
+Whisker path           -> Window::paint_path
+Whisker text layout    -> GPUI TextSystem shaped/wrapped line
+Whisker text paint     -> ShapedLine/WrappedLine::paint
+Whisker image          -> Window::paint_image
+Whisker clip/layer     -> Window::with_content_mask / paint_layer
+Whisker pointer input  -> root GPUI listener -> Whisker hit testing
+Whisker keyboard/IME   -> GPUI focus and InputHandler -> Whisker event routing
+```
+
+Incoming renderer packets cannot call GPUI paint methods immediately because
+GPUI restricts them to its paint lifecycle. The Desktop provider first applies
+the packet to a retained adapter scene and marks the GPUI window dirty. During
+the next GPUI frame, the custom element reads that retained state in
+`request_layout`, `prepaint`, and `paint` order and emits GPUI primitives.
+
+The first implementation may require narrow upstream additions or a pinned
+patch for hierarchical accessibility subtrees, group opacity/compositing, and
+cross-platform external surfaces. Those additions must remain low-level GPUI
+capabilities; Whisker must not depend on GPUI's declarative `div` component
+tree or make GPUI layout authoritative for the inner surface.
+
+### GPUI dependency policy
+
+Desktop v1 depends on GPUI as a pinned external library. Web must not compile,
+link, or bundle GPUI. GPUI's current Cargo features do not isolate only the
+window, scene, renderer, and text paths: the core crate also has unconditional
+image, SVG, HTTP, Taffy, and application-framework dependencies. Link-time
+dead-code elimination helps the installed artifact but does not remove build
+cost or make those boundaries independently versioned.
+
+At the time of this RFC revision, the released `gpui` crate and the current
+Zed repository do not expose the same package boundaries: the repository has
+separate `gpui_platform`, `gpui_macos`, `gpui_windows`, `gpui_linux`, and
+renderer crates that are not yet available as one coordinated crates.io
+release. The prototype must therefore pin an exact Zed git revision. A release
+must either consume coordinated published versions or keep the exact revision
+and patch set reproducible in Project IR and lockfiles.
+
+The initial implementation therefore uses the upstream crates with unused
+features such as inspector and screen capture disabled. It does not copy the
+Metal, DirectX, or wgpu renderers into Whisker. If measured release artifacts
+make the dependency unacceptable, the preferred follow-up is to contribute or
+maintain feature boundaries that separate GPUI core facilities; a source copy
+of selected renderer files is a last resort because shader, atlas, Scene, text,
+and platform APIs evolve together.
+
+For planning rather than as a protocol guarantee, a stripped minimal GPUI
+Desktop executable should be budgeted at roughly 15--30 MiB per architecture.
+An embedded WASM engine is a separate cost. Release builds must record actual
+per-target size, compile time, and enabled dependency features so this choice
+can be revisited with evidence.
 
 ## Runtime concepts
 
@@ -148,7 +219,8 @@ handle. No module-name or method-name lookup occurs while constructing a frame.
 ### Surface
 
 A `Surface` is one independently presented root: an Android Activity content
-root, iOS window/root view, browser document root, or Desktop WebView document.
+root, iOS window/root view, browser document root, or GPUI window/embedded
+element region on Desktop.
 Every node, frame, measurement request, and input event belongs to exactly one
 surface.
 
@@ -173,7 +245,7 @@ The platform shape is:
 Android   WhiskerView : Host ViewGroup
 iOS       WhiskerView : Host UIView
 Web       DOM custom element (for example `whisker-view`) or JavaScript object
-Desktop   system-WebView-backed container, with JavaScript as the Host
+Desktop   GPUI custom Element backed by one Whisker Surface
 ```
 
 `WhiskerView` is a Host SDK/bootstrap primitive, not a scene element and not a
@@ -490,10 +562,10 @@ Rust
 `Frame` is a scheduling callback, not permission for the Host to calculate
 animation values. Motion state remains in Rust.
 
-### Web and Desktop timing
+### Web timing
 
-On Web and Desktop, JavaScript calls into WASM from a
-`requestAnimationFrame` callback. Rust advances motion and calls
+On Web, JavaScript calls into WASM from a `requestAnimationFrame` callback.
+Rust advances motion and calls
 `Renderer::present`; the generated binding invokes JavaScript synchronously,
 and JavaScript applies the DOM patch before the same animation-frame callback
 returns:
@@ -507,9 +579,29 @@ JavaScript rAF
   <- return
 ```
 
-There is no Tauri command or native-process IPC on this path. DOM measurement
-can still trigger expensive browser layout, so reads are batched and cached,
-but it is not forced to be asynchronous by the Desktop architecture.
+DOM measurement can still trigger expensive browser layout, so reads are
+batched and cached.
+
+### Desktop timing
+
+On Desktop, GPUI's frame callback enters the in-process Whisker WASM runtime.
+Rust advances motion, produces renderer operations, and returns to the native
+adapter before GPUI performs prepaint and paint for the `WhiskerView` element:
+
+```text
+GPUI frame callback
+  -> WASM frame entry
+       -> Rust motion/reactivity/style/layout
+       -> in-process Host present(packet)
+            -> update retained GPUI adapter scene
+  -> WhiskerView prepaint/paint
+       -> GPUI low-level paint operations
+  <- submit GPUI Scene
+```
+
+The WASM ABI is synchronous on this path. It is an isolation/versioning
+boundary, not asynchronous IPC. GPUI text shaping and intrinsic measurement
+may therefore be queried synchronously and cached during the frame.
 
 ## Frame packet
 
@@ -732,7 +824,7 @@ The Host binding maps `VIEW` to its registered standard factory:
 Android -> standard Whisker ViewGroup
 iOS     -> UIView
 Web     -> div
-Desktop -> div in the WebView DOM
+Desktop -> retained box lowered to GPUI quad/shadow/path primitives
 ```
 
 ## Custom UI modules
@@ -749,6 +841,7 @@ whisker-video package
 |- Android Host element factory
 |- iOS Host element factory
 |- JavaScript Host element factory
+|- Desktop Rust/GPUI Host element factory
 |- generated bindings and registration metadata
 `- optional build plugin for dependencies, permissions, and lifecycle hooks
 ```
@@ -815,7 +908,7 @@ is deliberately not fixed by this RFC; conceptually the declaration produces:
 - typed event and command payloads;
 - `ElementSchema` and stable symbolic property/event/command IDs;
 - FramePacket encoders and decoders;
-- Kotlin, Swift, and TypeScript binding inputs;
+- Kotlin, Swift, TypeScript, and Desktop Rust binding inputs;
 - module and debug-symbol descriptors.
 
 An illustrative generated schema is:
@@ -911,7 +1004,7 @@ whisker.video/Video@1
   Android -> PlayerView / Media3 player
   iOS     -> AVPlayerLayer-backed UIView
   Web     -> HTMLVideoElement
-  Desktop -> HTMLVideoElement in the WebView
+  Desktop -> native media provider presented through a GPUI external surface
 ```
 
 Factories register through the one Host renderer registry. They do not create
@@ -956,9 +1049,14 @@ iOS
   HostSourceModule(WhiskerVideo)
   HostElementFactory(VideoElementFactory)
 
-Web / Desktop
+Web
   JavaScriptProvider(whisker-video/host)
   HostElementFactory(VideoElementFactory)
+
+Desktop
+  NativeRustProvider(whisker_video_gpui)
+  NativeMediaDependency(...)
+  GpuiElementFactory(VideoElementFactory)
 ```
 
 Generic target plugins can handle ordinary source inclusion, binding
@@ -1005,7 +1103,7 @@ Application start
   -> start Video module and register schema once
 
 CreateNode(Video)
-  -> create AVPlayer / Media3 player / HTMLVideoElement
+  -> create AVPlayer / Media3 player / HTMLVideoElement / Desktop media player
 
 DeleteNode(Video)
   -> detach observers, stop playback, release per-node resources
@@ -1055,9 +1153,11 @@ Unsupported { key, reason }
 ```
 
 Android, iOS, Web, and Desktop v1 are expected to provide synchronous `Ready`
-results for ordinary text measurement. Web/Desktop may do synchronous work in
-JavaScript during the WASM frame callback; they are not forced through native
-IPC. Requests are batched to avoid interleaved DOM reads and writes.
+results for ordinary text measurement. Web may do synchronous browser text
+measurement during the WASM frame callback; requests are batched to avoid
+interleaved DOM reads and writes. Desktop uses GPUI's platform text system in
+the native Host and returns shaped/wrapped metrics across the in-process WASM
+ABI. Neither path requires native-process IPC.
 
 Asynchronous `Pending` is reserved for resources and custom providers that
 cannot answer immediately. The Host later emits `MeasurementReady`; Rust
@@ -1239,10 +1339,15 @@ how server-emitted presentation relates to Rust-resolved interactive styling.
    property slots and one transaction per frame.
 5. Implement standard element factories, measurement, events, and packet
    application for Android and iOS.
-6. Implement the JavaScript DOM provider shared by Web and Desktop v1.
-7. Migrate custom UI modules to versioned element schemas, generated Host
+6. Implement the JavaScript DOM provider for Web.
+7. Implement the native Rust GPUI provider for Desktop using one custom
+   `WhiskerView` element and GPUI's low-level paint/text/input APIs.
+8. Add the narrow GPUI capability extensions required for hierarchical
+   accessibility, group compositing, and external surfaces, preferably
+   upstream rather than by copying renderer code.
+9. Migrate custom UI modules to versioned element schemas, generated Host
    factories, and typed commands.
-8. Remove the temporary Lynx renderer, C++ bridge, fork artifacts, and obsolete
+10. Remove the temporary Lynx renderer, C++ bridge, fork artifacts, and obsolete
    distribution paths after conformance and visual parity are reached.
 
 ## Invariants
@@ -1256,7 +1361,9 @@ how server-emitted presentation relates to Rust-resolved interactive styling.
 6. A frame packet is an ordered transaction, not a bag of independent calls.
 7. Element instances are scene nodes, not module instances.
 8. Custom UI modules use registered element types and the same frame protocol.
-9. Ordinary Web/Desktop frames do not cross native IPC.
+9. Ordinary Web frames use an in-callback WASM/JavaScript call and ordinary
+   Desktop frames use an in-process WASM/native-Rust call; neither crosses
+   native-process IPC.
 10. Host-dependent measurement is batched, keyed, cached, and epoch-validated.
 11. Renderer and protocol behavior can be tested with a Rust-only provider.
 12. The Scene Runtime, not UI modules, requires and coordinates the renderer.
@@ -1292,6 +1399,10 @@ The following must be resolved before this RFC becomes `Accepted`:
 - debug symbol-table format for compact element, property, event, and command
   IDs;
 - hydration and event attachment requirements for a future SSR DOM renderer.
+- the GPUI version pin and the exact upstream API additions required by the
+  Desktop conformance suite;
+- the Desktop WASM engine and ABI implementation, including its independent
+  binary-size and startup-time budget;
 - the binary ABI and generated Host representation of an
   `ApplicationDescriptor`, including collision-free selection when several
   independently built applications are linked into one Host;

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -431,11 +431,15 @@ batched, cached, and tagged with the scene and environment epochs as required
 by RFC 0002.
 
 Android and iOS may answer synchronously within the renderer binding when safe.
-Web and Desktop v1 call JavaScript from WASM in the same event-loop turn; they
-do not cross native desktop IPC. If a font, image, or custom control is not
-ready, the Host returns a pending result. Rust may present a provisional layout
-and relayout when the resource epoch changes. The scheduler coalesces that
-correction into the next frame and prevents stale responses from applying.
+Web calls its JavaScript Host from WASM in the same event-loop turn and batches
+browser text measurement. Desktop calls the native Rust/GPUI Host through an
+in-process WASM import; the Host uses GPUI's platform text system and returns a
+measurement derived from the same shaped/wrapped line object that it later
+paints. Neither path requires native-process IPC. If a font, image, or custom
+control is not ready, the Host returns a pending result. Rust may present a
+provisional layout and relayout when the resource epoch changes. The scheduler
+coalesces that correction into the next frame and prevents stale responses
+from applying.
 
 Exact prevention of visible correction for unavailable fonts is impossible on
 any backend. Applications can preload fonts, reserve explicit dimensions, or
@@ -473,13 +477,13 @@ Animation is owned by Rust. There is no Android animator, Core Animation, Web
 Animation, or CSS Animation offload in the semantic model.
 
 `whisker-motion` owns timelines, easing, keyframes, springs, decay, gesture
-handoff, interruption, and cancellation. On each Host VSync or
-`requestAnimationFrame` callback it samples active values, writes changed typed
-property slots, runs required layout at most once, and emits at most one frame
-packet for the surface.
+handoff, interruption, and cancellation. On each Host VSync,
+`requestAnimationFrame`, or GPUI frame callback it samples active values,
+writes changed typed property slots, runs required layout at most once, and
+emits at most one frame packet for the surface.
 
 ```text
-Host VSync/rAF
+Host VSync/rAF/GPUI frame
   -> Rust scheduler
   -> sample motion and gesture state
   -> update typed property slots
@@ -505,12 +509,12 @@ capabilities may be convenience constructors over `whisker-motion`. They do
 not require CSS parsing and must obey the same interruption and gesture
 handoff semantics as direct motion APIs.
 
-## Web and Desktop
+## Web Host and DOM renderer
 
-The Web renderer and Desktop v1 renderer share the JavaScript DOM backend.
-Desktop runs Whisker Rust as WASM inside the system WebView, so its frame path
-is the same synchronous WASM-to-JavaScript path as Web and does not involve a
-Tauri-style command IPC round trip.
+Web uses a Whisker-owned JavaScript Host and DOM renderer. It does not use GPUI
+or `gpui_web`. Whisker Rust runs as WASM in the browser; JavaScript enters WASM
+from `requestAnimationFrame`, and the renderer applies the returned typed DOM
+deltas before that callback returns.
 
 The DOM backend may cache normalized style applications, intern repeated
 values, use generated classes for immutable repeated paint data, and apply
@@ -523,6 +527,31 @@ influence. The backend should use a shadow root, reset boundary, or equivalent
 generated rules so external selectors and inherited page CSS cannot change
 Whisker's computed semantics. Host-owned focus, IME, accessibility, and native
 text behavior remain available through that boundary.
+
+## Desktop GPUI Host
+
+Desktop uses native Rust/GPUI rather than the Web Host or DOM renderer. The
+generated native shell embeds the Whisker WASM runtime in-process and mounts
+one custom GPUI `WhiskerView` element. GPUI may lay out that outer element, but
+Whisker's retained Taffy tree remains authoritative for all inner nodes.
+
+The Desktop renderer stores accepted Whisker scene state and lowers it during
+GPUI's lifecycle through low-level paint, shaped text, image, clip, hit-test,
+focus, IME, and accessibility APIs. It must not rebuild the Whisker tree as a
+declarative GPUI `div` tree or allow GPUI's inner layout to compete with
+Whisker layout.
+
+GPUI's Scene is an implementation detail of the Desktop Host, not the common
+Whisker frame protocol. Common operations remain semantic enough for Android
+Views, UIViews, and DOM; only the Desktop provider lowers them further into
+quads, shadows, paths, glyph/image sprites, and external surfaces.
+
+GPUI does not presently expose every Lynx-targeted paint capability through a
+stable low-level API. The Desktop capability profile must therefore track
+group opacity/compositing, general transforms, rounded or path clips, filters,
+blend modes, hierarchical accessibility, and external media surfaces. Missing
+required capabilities are explicit conformance gaps, not permission to change
+style semantics.
 
 ## SSR and hydration
 
@@ -650,9 +679,13 @@ testing. Visual snapshots supplement but do not replace semantic assertions.
    renderer operations.
 6. Route signal and `whisker-motion` writes through the shared property slots
    and incremental dirty classifier.
-7. Implement and conform Android, iOS, and JavaScript DOM application paths.
-8. Add the optional SSR serializer and hydration contract in a follow-up RFC.
-9. Remove raw CSS string inputs, Lynx inline-style serialization, Lynx style
+7. Implement and conform Android, iOS, the JavaScript DOM Web path, and the
+   native Rust/GPUI Desktop path independently.
+8. Add GPUI lowering conformance for paint, text, clipping, compositing,
+   accessibility, and external surfaces without making GPUI Scene part of the
+   common protocol.
+9. Add the optional SSR serializer and hydration contract in a follow-up RFC.
+10. Remove raw CSS string inputs, Lynx inline-style serialization, Lynx style
    ownership, and temporary migration adapters.
 
 Steps may overlap, but raw-string removal must not land without diagnostics and
@@ -691,6 +724,8 @@ The following must be resolved before this RFC becomes `Accepted`:
 - the baseline and multi-line text measurement representation;
 - the minimum filter, blend, shadow, and clip capability required of all
   interactive renderers;
+- which missing GPUI low-level paint/compositing capabilities must be added
+  upstream before Desktop can satisfy that minimum profile;
 - scrolling ownership for platform-native and fully Rust-coordinated modes;
 - the fallback font-metrics policy for SSR and pre-font-load Web layout;
 - which Lynx style features are deliberately excluded as browser-oriented

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -388,6 +388,22 @@ Lynx property that Taffy cannot represent requires an explicit engine
 extension, preprocessing rule, or documented unsupported status; it must not
 silently acquire target-dependent browser behavior.
 
+The first retained implementation lives in the Rust-only `whisker-layout`
+crate. Its public boundary consists of Whisker-owned `NodeId`,
+`ComputedLayoutStyle`, viewport/measurement values, and `LayoutSnapshot`;
+Taffy types remain private. The tree supports create, subtree removal,
+reparent/reorder, style replacement, intrinsic-measure invalidation, and
+viewport computation. Fractional logical coordinates are preserved so that
+physical-pixel snapping remains a renderer concern.
+
+This first slice explicitly rejects, rather than approximates, backend gaps:
+mixed non-zero length-plus-percentage values, intrinsic size keywords,
+`flex-basis: content`, and fixed/sticky positioning. `linear` currently lowers
+to flex and `relative` to block as migration-compatible layout modes. These
+statuses are implementation milestones, not reductions of the RFC's Lynx
+coverage goal; each rejection must later be replaced by a faithful Taffy
+extension/preprocessing rule or remain recorded in the coverage registry.
+
 ## Text and intrinsic measurement
 
 The Host owns shaping, fallback font selection, line breaking, glyph metrics,
@@ -627,7 +643,9 @@ testing. Visual snapshots supplement but do not replace semantic assertions.
    `InheritedStyle`, Taffy-independent computed box/flex values, and Rust-only
    resolution tests.
 4. Map computed layout values into a retained Taffy tree and connect RFC
-   0002's measurement batches.
+   0002's measurement batches. The retained tree and synchronous measurement
+   abstraction are implemented; engine integration, pending/batched Host
+   measurement, and the explicitly diagnosed backend gaps remain.
 5. Resolve paint, clip, stacking, transforms, text, and semantics into typed
    renderer operations.
 6. Route signal and `whisker-motion` writes through the shared property slots


### PR DESCRIPTION
## Summary

- add the Rust-only `whisker-layout` crate with a private retained Taffy tree
- expose Whisker-owned node, viewport, intrinsic-measurement, and layout-snapshot contracts without leaking Taffy types
- support node creation, child replacement, atomic reparent/reorder, subtree removal, style updates, measurement invalidation, and viewport computation
- preserve fractional logical coordinates and apply stable `order` sorting before backend layout
- diagnose unsupported backend gaps instead of silently changing semantics
- add the crate to the strict 100% line/function/region coverage gate and record implementation status in RFC 0003

## Current lowering and diagnosed gaps

- `linear` lowers to flex and `relative` lowers to block
- mixed non-zero length-plus-percentage values are rejected until a faithful calc resolver exists
- intrinsic size keywords and `flex-basis: content` are rejected
- fixed and sticky positioning are rejected pending engine-level implementations

## Verification

- `cargo test --workspace`
- `cargo clippy -p whisker-layout --all-targets -- -D warnings`
- `cargo doc -p whisker-layout --no-deps`
- `cargo llvm-cov -p whisker-layout --summary-only --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100`
- `git diff --check`

`whisker-layout` coverage: 100% lines, functions, and regions.

Stacked on #416. Tracks phase 5 of #411.
