### PR TITLE
feat(elements): implement RFC0004 module registry

### DIFF
--- a/crates/whisker-driver/src/element_ref.rs
+++ b/crates/whisker-driver/src/element_ref.rs
@@ -478,7 +478,7 @@ macro_rules! generic_element_methods {
 /// Imperative handle to any mounted element — the generic Lynx UI
 /// methods that work regardless of tag. Allocate with
 /// [`ElementHandle::new`], bind via `view(ref: handle.r())` (or `text`,
-/// `page`, …) in `render!`, then call the methods below.
+/// `scroll_view`, …) in `render!`, then call the methods below.
 ///
 /// `Copy` (the inner `ElementRef` is an arena handle), so it can be
 /// captured by value into multiple event closures.

--- a/crates/whisker-driver/src/lynx/bootstrap.rs
+++ b/crates/whisker-driver/src/lynx/bootstrap.rs
@@ -7,7 +7,7 @@
 //!
 //! #[whisker::main]
 //! fn app() -> Element {
-//!     render! { page { text { "Hello" } } }
+//!     render! { view { text(value: "Hello") } }
 //! }
 //! ```
 //!
@@ -22,8 +22,8 @@
 //! 3. We invoke `app()`. The user's body runs `render!`, which
 //!    populates the Lynx element tree and returns an `Element`
 //!    for the root.
-//! 4. We call `view::set_root(root)` and `view::flush()` to commit
-//!    the initial frame.
+//! 4. We attach that root beneath the Lynx-required shell `page`, then
+//!    call `view::set_root(page)` and `view::flush()` to commit the frame.
 //!
 //! ## What happens on tick
 //!

--- a/crates/whisker-protocol/src/element.rs
+++ b/crates/whisker-protocol/src/element.rs
@@ -1,0 +1,255 @@
+//! Element schemas negotiated before a surface presents its first frame.
+
+use crate::ElementTypeId;
+
+/// Host-independent element contract before a surface assigns compact IDs.
+///
+/// Generated module metadata and built-in primitives both enter bootstrap in
+/// this form. The resulting surface registry turns each schema into an
+/// [`ElementRegistration`] with an immutable [`ElementTypeId`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ElementSchema {
+    /// Stable, versionless package-qualified name.
+    pub canonical_name: String,
+    /// Element-specific content channel.
+    pub content: ElementContentKind,
+    /// Host mount target for ordinary scene children.
+    pub child_mount: ElementChildMount,
+    /// Intrinsic measurement behavior.
+    pub measurement: ElementMeasurement,
+    /// Whether the Host content receives resolved inherited text style.
+    pub consumes_text_style: bool,
+}
+
+impl ElementSchema {
+    /// Validates schema invariants independent of a particular Host backend.
+    pub fn validate(&self) -> Result<(), ElementRegistrationError> {
+        validate_contract(
+            &self.canonical_name,
+            self.content,
+            self.child_mount,
+            self.measurement,
+            self.consumes_text_style,
+        )
+    }
+
+    /// Binds this schema to a compact ID allocated for one registry epoch.
+    pub fn bind(self, element_type: ElementTypeId) -> ElementRegistration {
+        ElementRegistration {
+            element_type,
+            canonical_name: self.canonical_name,
+            content: self.content,
+            child_mount: self.child_mount,
+            measurement: self.measurement,
+            consumes_text_style: self.consumes_text_style,
+        }
+    }
+}
+
+/// Host content owned by one element type.
+///
+/// Common box presentation is deliberately absent from this enum. Layout,
+/// background, borders, clipping, opacity, transforms, and stacking are
+/// handled by the Host renderer for every registered element.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ElementContentKind {
+    /// The element contributes only common box presentation and children.
+    None,
+    /// Plain shaped text supplied by [`Operation::SetText`](crate::Operation::SetText).
+    Text,
+    /// Replaced image content.
+    Image,
+    /// A platform-native editable text control.
+    EditableText,
+    /// Other platform-native or external-surface content.
+    Native,
+    /// A platform scroll container with a separate content mount target.
+    ScrollContainer,
+}
+
+/// Where ordinary Whisker children are mounted in the Host projection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ElementChildMount {
+    /// The element is a leaf and rejects ordinary scene children.
+    None,
+    /// Children mount in the common presentation container.
+    Presentation,
+    /// Children mount in the content container owned by a scroll element.
+    ScrollContent,
+}
+
+/// Intrinsic measurement provider selected by an element schema.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ElementMeasurement {
+    /// Taffy derives size from style and children without Host measurement.
+    None,
+    /// The common Host text shaper supplies intrinsic metrics.
+    Text,
+    /// Rust-side resource metadata or a replaced-content provider supplies size.
+    ReplacedContent,
+    /// An element-specific Host measurer supplies intrinsic metrics.
+    Host,
+}
+
+/// One element contract bound to a compact type ID for a surface registry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ElementRegistration {
+    /// Compact identifier carried by frame and measurement packets.
+    pub element_type: ElementTypeId,
+    /// Stable, versionless package-qualified name.
+    pub canonical_name: String,
+    /// Element-specific content channel.
+    pub content: ElementContentKind,
+    /// Host mount target for ordinary scene children.
+    pub child_mount: ElementChildMount,
+    /// Intrinsic measurement behavior.
+    pub measurement: ElementMeasurement,
+    /// Whether the Host content receives resolved inherited text style.
+    pub consumes_text_style: bool,
+}
+
+impl ElementRegistration {
+    /// Validates schema invariants independent of a particular Host backend.
+    pub fn validate(&self) -> Result<(), ElementRegistrationError> {
+        validate_contract(
+            &self.canonical_name,
+            self.content,
+            self.child_mount,
+            self.measurement,
+            self.consumes_text_style,
+        )
+    }
+
+    /// Returns the Host-independent schema represented by this registration.
+    pub fn schema(&self) -> ElementSchema {
+        ElementSchema {
+            canonical_name: self.canonical_name.clone(),
+            content: self.content,
+            child_mount: self.child_mount,
+            measurement: self.measurement,
+            consumes_text_style: self.consumes_text_style,
+        }
+    }
+}
+
+fn validate_contract(
+    canonical_name: &str,
+    content: ElementContentKind,
+    child_mount: ElementChildMount,
+    measurement: ElementMeasurement,
+    consumes_text_style: bool,
+) -> Result<(), ElementRegistrationError> {
+    if canonical_name.trim().is_empty() {
+        return Err(ElementRegistrationError::EmptyCanonicalName);
+    }
+    if content == ElementContentKind::Text {
+        if child_mount != ElementChildMount::None {
+            return Err(ElementRegistrationError::TextMustBeLeaf);
+        }
+        if measurement != ElementMeasurement::Text {
+            return Err(ElementRegistrationError::TextMeasurementMismatch);
+        }
+        if !consumes_text_style {
+            return Err(ElementRegistrationError::TextStyleRequired);
+        }
+    }
+    if child_mount == ElementChildMount::ScrollContent
+        && content != ElementContentKind::ScrollContainer
+    {
+        return Err(ElementRegistrationError::ScrollMountWithoutContainer);
+    }
+    if content == ElementContentKind::ScrollContainer
+        && child_mount != ElementChildMount::ScrollContent
+    {
+        return Err(ElementRegistrationError::ScrollContainerWithoutMount);
+    }
+    Ok(())
+}
+
+/// Invalid Host-independent element registration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ElementRegistrationError {
+    /// The package-qualified element name was empty.
+    EmptyCanonicalName,
+    /// Text content cannot contain ordinary scene children.
+    TextMustBeLeaf,
+    /// Text content did not select common text measurement.
+    TextMeasurementMismatch,
+    /// Text content did not request the resolved text-style channel.
+    TextStyleRequired,
+    /// A scroll-content mount target was declared by non-scroll content.
+    ScrollMountWithoutContainer,
+    /// Scroll content did not provide its required child mount target.
+    ScrollContainerWithoutMount,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text() -> ElementRegistration {
+        ElementRegistration {
+            element_type: ElementTypeId::new(1).unwrap(),
+            canonical_name: "whisker.ui/Text".into(),
+            content: ElementContentKind::Text,
+            child_mount: ElementChildMount::None,
+            measurement: ElementMeasurement::Text,
+            consumes_text_style: true,
+        }
+    }
+
+    #[test]
+    fn schema_binding_assigns_only_the_registry_id() {
+        let registration = text();
+        let schema = registration.schema();
+        assert_eq!(schema.validate(), Ok(()));
+        assert_eq!(
+            schema.bind(ElementTypeId::new(42).unwrap()),
+            ElementRegistration {
+                element_type: ElementTypeId::new(42).unwrap(),
+                ..registration
+            }
+        );
+    }
+
+    #[test]
+    fn valid_text_and_scroll_contracts_are_accepted() {
+        assert_eq!(text().validate(), Ok(()));
+        assert_eq!(
+            ElementRegistration {
+                element_type: ElementTypeId::new(2).unwrap(),
+                canonical_name: "whisker.ui/ScrollView".into(),
+                content: ElementContentKind::ScrollContainer,
+                child_mount: ElementChildMount::ScrollContent,
+                measurement: ElementMeasurement::None,
+                consumes_text_style: false,
+            }
+            .validate(),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn invalid_category_combinations_are_rejected() {
+        let mut registration = text();
+        registration.child_mount = ElementChildMount::Presentation;
+        assert_eq!(
+            registration.validate(),
+            Err(ElementRegistrationError::TextMustBeLeaf)
+        );
+
+        let mut registration = text();
+        registration.measurement = ElementMeasurement::None;
+        assert_eq!(
+            registration.validate(),
+            Err(ElementRegistrationError::TextMeasurementMismatch)
+        );
+
+        let mut registration = text();
+        registration.consumes_text_style = false;
+        assert_eq!(
+            registration.validate(),
+            Err(ElementRegistrationError::TextStyleRequired)
+        );
+    }
+}

--- a/crates/whisker-protocol/src/lib.rs
+++ b/crates/whisker-protocol/src/lib.rs
@@ -14,12 +14,17 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+mod element;
 mod frame;
 mod id;
 mod input;
 mod measurement;
 mod validation;
 
+pub use element::{
+    ElementChildMount, ElementContentKind, ElementMeasurement, ElementRegistration,
+    ElementRegistrationError, ElementSchema,
+};
 pub use frame::{
     BorderLineStyle, BoxClip, BoxPaint, FrameHeader, FrameMode, FramePacket, HitTestBehavior,
     LayoutGeometry, LayoutRect, Operation, OverflowClip, PROTOCOL_MAJOR, PROTOCOL_MINOR,

--- a/crates/whisker-protocol/src/measurement.rs
+++ b/crates/whisker-protocol/src/measurement.rs
@@ -18,7 +18,7 @@ pub enum MeasurementKind {
     NativeControl,
     /// A child surface whose content determines its containing box.
     EmbeddedSurface,
-    /// A versioned element-specific measurement implemented by a module.
+    /// An element-specific measurement implemented by a module.
     Custom {
         /// Module-defined payload schema version.
         version: u16,

--- a/crates/whisker-runtime/src/element.rs
+++ b/crates/whisker-runtime/src/element.rs
@@ -6,6 +6,7 @@
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ElementTag {
+    /// Legacy Lynx shell root. Not a public Whisker element registration.
     Page = 1,
     View = 2,
     Text = 3,

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -272,7 +272,7 @@ pub trait DynRenderer {
         EventDispatchPlan::default()
     }
 
-    fn set_root(&self, page: Element);
+    fn set_root(&self, root: Element);
     fn flush(&self);
 
     /// Opaque platform pointer the C bridge associates with this
@@ -978,8 +978,8 @@ pub fn dispatch_event(target_sign: i32, event_name: &str, body: WhiskerValue) ->
     plan.consumed
 }
 
-pub fn set_root(page: Element) {
-    with_renderer(|r| r.set_root(page), ())
+pub fn set_root(root: Element) {
+    with_renderer(|renderer| renderer.set_root(root), ())
 }
 
 pub fn flush() {

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -146,8 +146,8 @@ impl DynRenderer for RecordingRenderer {
             name: name.into(),
         });
     }
-    fn set_root(&self, page: Element) {
-        self.ops.borrow_mut().push(Op::SetRoot { id: page.id() });
+    fn set_root(&self, root: Element) {
+        self.ops.borrow_mut().push(Op::SetRoot { id: root.id() });
     }
     fn flush(&self) {
         self.ops.borrow_mut().push(Op::Flush);

--- a/crates/whisker/src/element_registry.rs
+++ b/crates/whisker/src/element_registry.rs
@@ -1,0 +1,396 @@
+//! Bootstrap-time normalization of built-in and module-provided elements.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+use crate::ElementTag;
+use whisker_engine::whisker_protocol::{
+    ElementRegistration, ElementRegistrationError, ElementSchema, ElementTypeId,
+};
+
+type SchemaKey = String;
+
+/// Authoring syntax generated for one element provider.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ElementAuthoringBinding {
+    /// A standard `render!` tag implemented through the provider path.
+    Builtin(ElementTag),
+    /// A generated module component or compatibility element name.
+    Named(String),
+}
+
+/// Generated bootstrap metadata for one UI-providing module definition.
+///
+/// Service-only modules do not emit this value and continue through the
+/// existing function, event, and observer registration path. This is an owned
+/// description rather than a public factory trait so build-generated metadata
+/// can be normalized before a target Host binds its implementation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ElementProviderMetadata {
+    /// Host-independent element contract.
+    pub schema: ElementSchema,
+    /// Authoring syntax that resolves to this contract.
+    pub authoring: ElementAuthoringBinding,
+}
+
+/// Generated Rust-side definition for one element-provider module.
+///
+/// A module owns its element schemas and authoring bindings as one bootstrap
+/// unit. Host packages bind target-specific factories to the resulting
+/// canonical names before the first frame.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ElementModuleDefinition {
+    /// Stable package/module identity used in bootstrap diagnostics.
+    pub module_name: String,
+    /// Visual elements exported by this module.
+    pub elements: Vec<ElementProviderMetadata>,
+}
+
+impl ElementModuleDefinition {
+    /// Creates an element-provider module definition.
+    pub fn new(
+        module_name: impl Into<String>,
+        elements: impl IntoIterator<Item = ElementProviderMetadata>,
+    ) -> Self {
+        Self {
+            module_name: module_name.into(),
+            elements: elements.into_iter().collect(),
+        }
+    }
+}
+
+impl ElementProviderMetadata {
+    /// Describes one standard element implemented through the provider path.
+    pub fn builtin(tag: ElementTag, schema: ElementSchema) -> Self {
+        Self {
+            schema,
+            authoring: ElementAuthoringBinding::Builtin(tag),
+        }
+    }
+
+    /// Describes one generated module element name.
+    pub fn named(name: impl Into<String>, schema: ElementSchema) -> Self {
+        Self {
+            schema,
+            authoring: ElementAuthoringBinding::Named(name.into()),
+        }
+    }
+}
+
+/// Immutable element contracts and authoring bindings for one registry epoch.
+///
+/// Compact IDs are assigned when an [`ElementRegistryBuilder`] is built. They
+/// are therefore independent of [`ElementTag`] discriminants and are never
+/// supplied by a module schema.
+#[derive(Clone, Debug)]
+pub struct ElementRegistry {
+    registrations: Vec<ElementRegistration>,
+    builtins: HashMap<ElementTag, usize>,
+    names: HashMap<String, usize>,
+}
+
+impl ElementRegistry {
+    /// Starts an empty registry definition.
+    pub fn builder() -> ElementRegistryBuilder {
+        ElementRegistryBuilder::default()
+    }
+
+    /// Starts a registry definition containing the standard Whisker elements.
+    ///
+    /// Callers can append module schemas and authoring-name bindings before
+    /// building the immutable surface registry.
+    pub fn standard_builder() -> ElementRegistryBuilder {
+        Self::builder().register_module(crate::standard_ui_module_definition())
+    }
+
+    /// Returns the standard Whisker element registry.
+    pub fn standard() -> Self {
+        Self::standard_builder()
+            .build()
+            .expect("standard element schemas are valid and uniquely bound")
+    }
+
+    /// Returns the normalized contracts in compact-ID order.
+    pub fn registrations(&self) -> &[ElementRegistration] {
+        &self.registrations
+    }
+
+    /// Resolves one built-in authoring tag to its normalized contract.
+    pub fn registration_for_builtin(&self, tag: ElementTag) -> Option<&ElementRegistration> {
+        self.builtins
+            .get(&tag)
+            .and_then(|index| self.registrations.get(*index))
+    }
+
+    /// Resolves one generated or compatibility authoring name.
+    pub fn registration_for_name(&self, name: &str) -> Option<&ElementRegistration> {
+        self.names
+            .get(name)
+            .and_then(|index| self.registrations.get(*index))
+    }
+}
+
+/// Mutable bootstrap description used to construct an [`ElementRegistry`].
+#[derive(Clone, Debug, Default)]
+pub struct ElementRegistryBuilder {
+    schemas: Vec<ElementSchema>,
+    builtin_bindings: Vec<(ElementTag, SchemaKey)>,
+    name_bindings: Vec<(String, SchemaKey)>,
+}
+
+impl ElementRegistryBuilder {
+    /// Adds every generated element exported by one module definition.
+    pub fn register_module(self, definition: ElementModuleDefinition) -> Self {
+        self.register_providers(definition.elements)
+    }
+
+    /// Adds a sequence of generated element-provider modules.
+    pub fn register_modules(
+        mut self,
+        definitions: impl IntoIterator<Item = ElementModuleDefinition>,
+    ) -> Self {
+        for definition in definitions {
+            self = self.register_module(definition);
+        }
+        self
+    }
+
+    /// Adds generated metadata for one UI-providing module.
+    pub fn register_provider(mut self, provider: ElementProviderMetadata) -> Self {
+        let canonical_name = provider.schema.canonical_name.clone();
+        self.schemas.push(provider.schema);
+        match provider.authoring {
+            ElementAuthoringBinding::Builtin(tag) => {
+                self.builtin_bindings.push((tag, canonical_name));
+            }
+            ElementAuthoringBinding::Named(name) => {
+                self.name_bindings.push((name, canonical_name));
+            }
+        }
+        self
+    }
+
+    /// Adds every UI provider emitted by generated application metadata.
+    pub fn register_providers(
+        mut self,
+        providers: impl IntoIterator<Item = ElementProviderMetadata>,
+    ) -> Self {
+        for provider in providers {
+            self = self.register_provider(provider);
+        }
+        self
+    }
+
+    /// Adds a Host-independent schema to the registry epoch.
+    ///
+    /// Prefer [`Self::register_provider`] for generated module metadata. This
+    /// lower-level method supports schemas whose authoring binding is supplied
+    /// separately or which are retained only for Host negotiation.
+    pub fn register(mut self, schema: ElementSchema) -> Self {
+        self.schemas.push(schema);
+        self
+    }
+
+    /// Maps a built-in authoring tag to a schema's canonical key.
+    pub fn bind_builtin(mut self, tag: ElementTag, canonical_name: impl Into<String>) -> Self {
+        self.builtin_bindings.push((tag, canonical_name.into()));
+        self
+    }
+
+    /// Maps a generated or compatibility authoring name to a schema key.
+    pub fn bind_name(mut self, name: impl Into<String>, canonical_name: impl Into<String>) -> Self {
+        self.name_bindings
+            .push((name.into(), canonical_name.into()));
+        self
+    }
+
+    /// Validates schemas and bindings, then assigns compact IDs for the epoch.
+    pub fn build(self) -> Result<ElementRegistry, ElementRegistryError> {
+        let mut registrations = Vec::with_capacity(self.schemas.len());
+        let mut schemas = HashMap::with_capacity(self.schemas.len());
+        for (index, schema) in self.schemas.into_iter().enumerate() {
+            schema
+                .validate()
+                .map_err(|error| ElementRegistryError::InvalidSchema {
+                    canonical_name: schema.canonical_name.clone(),
+                    error,
+                })?;
+            let key = schema.canonical_name.clone();
+            if schemas.contains_key(&key) {
+                return Err(ElementRegistryError::DuplicateCanonicalKey {
+                    canonical_name: key,
+                });
+            }
+            let raw_id = u32::try_from(index)
+                .ok()
+                .and_then(|value| value.checked_add(1))
+                .and_then(ElementTypeId::new)
+                .ok_or(ElementRegistryError::ElementTypeIdExhausted)?;
+            schemas.insert(key, registrations.len());
+            registrations.push(schema.bind(raw_id));
+        }
+
+        let mut builtins = HashMap::with_capacity(self.builtin_bindings.len());
+        for (tag, key) in self.builtin_bindings {
+            if tag == ElementTag::RawText {
+                return Err(ElementRegistryError::VirtualBuiltinBinding { tag });
+            }
+            let index = schemas.get(&key).copied().ok_or_else(|| {
+                ElementRegistryError::UnknownSchemaBinding {
+                    canonical_name: key.clone(),
+                }
+            })?;
+            if builtins.insert(tag, index).is_some() {
+                return Err(ElementRegistryError::DuplicateBuiltinBinding { tag });
+            }
+        }
+
+        let mut names = HashMap::with_capacity(self.name_bindings.len());
+        for (name, key) in self.name_bindings {
+            if name.trim().is_empty() {
+                return Err(ElementRegistryError::EmptyAuthoringName);
+            }
+            let index = schemas.get(&key).copied().ok_or_else(|| {
+                ElementRegistryError::UnknownSchemaBinding {
+                    canonical_name: key.clone(),
+                }
+            })?;
+            if names.insert(name.clone(), index).is_some() {
+                return Err(ElementRegistryError::DuplicateAuthoringName { name });
+            }
+        }
+
+        Ok(ElementRegistry {
+            registrations,
+            builtins,
+            names,
+        })
+    }
+}
+
+/// Bootstrap failure while normalizing an element registry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ElementRegistryError {
+    /// A schema violated a Host-independent contract invariant.
+    InvalidSchema {
+        /// Canonical name retained for diagnostics.
+        canonical_name: String,
+        /// Rejected contract combination.
+        error: ElementRegistrationError,
+    },
+    /// Two schemas declared the same canonical name.
+    DuplicateCanonicalKey {
+        /// Conflicting package-qualified name.
+        canonical_name: String,
+    },
+    /// A binding referred to a schema absent from this registry definition.
+    UnknownSchemaBinding {
+        /// Missing package-qualified name.
+        canonical_name: String,
+    },
+    /// A built-in tag was bound more than once.
+    DuplicateBuiltinBinding {
+        /// Conflicting authoring tag.
+        tag: ElementTag,
+    },
+    /// Virtual raw text cannot have a Host element schema.
+    VirtualBuiltinBinding {
+        /// Rejected virtual tag.
+        tag: ElementTag,
+    },
+    /// A generated or compatibility authoring name was empty.
+    EmptyAuthoringName,
+    /// A generated or compatibility authoring name was bound more than once.
+    DuplicateAuthoringName {
+        /// Conflicting authoring name.
+        name: String,
+    },
+    /// The registry cannot allocate another non-zero compact element ID.
+    ElementTypeIdExhausted,
+}
+
+impl fmt::Display for ElementRegistryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Whisker element registry error: {self:?}")
+    }
+}
+
+impl Error for ElementRegistryError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_engine::whisker_protocol::{
+        ElementChildMount, ElementContentKind, ElementMeasurement,
+    };
+
+    fn custom_schema(name: &str) -> ElementSchema {
+        ElementSchema {
+            canonical_name: name.into(),
+            content: ElementContentKind::None,
+            child_mount: ElementChildMount::Presentation,
+            measurement: ElementMeasurement::None,
+            consumes_text_style: false,
+        }
+    }
+
+    #[test]
+    fn standard_and_module_schemas_share_one_id_allocator() {
+        let registry = ElementRegistry::standard_builder()
+            .register_module(ElementModuleDefinition::new(
+                "example.maps",
+                [ElementProviderMetadata::named(
+                    "map",
+                    custom_schema("example.maps/Map"),
+                )],
+            ))
+            .build()
+            .unwrap();
+
+        assert_eq!(registry.registrations().len(), 4);
+        assert_eq!(
+            registry.registration_for_name("map").unwrap().element_type,
+            ElementTypeId::new(4).unwrap()
+        );
+        assert!(
+            registry
+                .registration_for_builtin(ElementTag::Page)
+                .is_none()
+        );
+        assert_ne!(
+            registry
+                .registration_for_builtin(ElementTag::ScrollView)
+                .unwrap()
+                .element_type
+                .get(),
+            ElementTag::ScrollView as u32
+        );
+    }
+
+    #[test]
+    fn duplicate_canonical_keys_fail_before_a_surface_starts() {
+        let result = ElementRegistry::builder()
+            .register(custom_schema("example/Map"))
+            .register(custom_schema("example/Map"))
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(ElementRegistryError::DuplicateCanonicalKey { .. })
+        ));
+    }
+
+    #[test]
+    fn authoring_bindings_must_resolve_uniquely() {
+        let result = ElementRegistry::builder()
+            .register(custom_schema("example/Map"))
+            .bind_name("map", "example/Map")
+            .bind_name("map", "example/Map")
+            .build();
+        assert_eq!(
+            result.unwrap_err(),
+            ElementRegistryError::DuplicateAuthoringName { name: "map".into() }
+        );
+    }
+}

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -17,9 +17,9 @@
 //! }
 //! ```
 //!
-//! Whisker owns the root `page` element: it wraps whatever your app
-//! returns in a full-screen flex column, so app code just returns a
-//! `view` (give it `flex-grow: 1` to fill the screen).
+//! The legacy Lynx Host owns its required root `page` element and wraps
+//! whatever your app returns. Other Hosts mount the returned root element
+//! directly, so `page` is not part of Whisker's public element API.
 //!
 //! ## What's in this crate
 //!
@@ -165,20 +165,30 @@ pub use whisker_runtime::{RuntimeDispatcher, runtime_dispatcher};
 #[doc(hidden)]
 pub use whisker_runtime::tasks::run_until_stalled;
 mod control_flow;
+mod element_registry;
 mod runtime_instance;
+mod standard_ui;
 mod style;
 mod surface_runtime;
 
 pub mod attrs;
 
+pub use element_registry::{
+    ElementAuthoringBinding, ElementModuleDefinition, ElementProviderMetadata, ElementRegistry,
+    ElementRegistryBuilder, ElementRegistryError,
+};
 pub use runtime_instance::{
     RuntimeDrive, RuntimeDriveError, RuntimeEventError, RuntimeInstance, RuntimeLifecycle,
     RuntimeLifecycleError,
 };
+pub use standard_ui::{
+    SCROLL_VIEW_ELEMENT_NAME, TEXT_ELEMENT_NAME, VIEW_ELEMENT_NAME, standard_element_providers,
+    standard_ui_module_definition,
+};
 pub use style::{Style, apply_style};
 pub use surface_runtime::{
     InputDispatch, RuntimeBindingError, RuntimeFrame, RuntimeFrameError, RuntimeInputError,
-    RuntimeLayoutError, RuntimePresentError, SurfaceRuntime,
+    RuntimeLayoutError, RuntimePresentError, SurfaceRuntime, standard_element_registrations,
 };
 
 pub use control_flow::{ForEach, ForEachProps, Show, ShowProps};
@@ -835,32 +845,6 @@ pub mod __tags {
         #[doc(hidden)]
         fn __h(self) -> Element {
             self.__element()
-        }
-    }
-
-    /// `<page>` — top-level container Lynx mounts as the root of an
-    /// app. **Whisker-internal:** `page` is no longer a `render!`
-    /// built-in tag. The framework creates exactly one root `page`
-    /// during bootstrap (a full-screen flex column) and mounts whatever
-    /// your app returns as its child, so app code never writes `page` —
-    /// return a `view` (with `flex-grow: 1` to fill the screen) instead.
-    ///
-    /// Lynx keeps this root `page` fixed for the app's lifetime; it
-    /// cannot be hot-reloaded, which is why whisker owns it rather than
-    /// the user.
-    #[allow(non_camel_case_types)]
-    pub struct page {
-        handle: Element,
-    }
-    #[allow(non_snake_case)]
-    pub fn __page_ctor() -> page {
-        page {
-            handle: create_element(ElementTag::Page),
-        }
-    }
-    impl ElementBuilder for page {
-        fn __element(&self) -> Element {
-            self.handle
         }
     }
 
@@ -1883,7 +1867,7 @@ pub mod __hot {
 ///   numeric extension traits (`8.px()`, `45.deg()`, …), and the
 ///   `css!` macro.
 /// - **Built-in element tags** — `view`, `text`, `scroll_view`,
-///   `list`, `page`, `raw_text`, `fragment` (re-exported from the
+///   `list`, `raw_text`, `fragment` (re-exported from the
 ///   hidden [`__tags`] module so rust-analyzer
 ///   completes `vie|` → `view` inside `render!`).
 /// - **Typed attribute enums** — [`AccessibilityTrait`](crate::attrs::AccessibilityTrait),
@@ -1934,7 +1918,7 @@ pub mod prelude {
     // kwarg, so RA's macro-expansion completion path sees the
     // method-call shape regardless of what `view` resolves to.
     #[doc(hidden)]
-    pub use crate::__tags::{fragment, list, page, raw_text, scroll_view, text, view};
+    pub use crate::__tags::{fragment, list, raw_text, scroll_view, text, view};
     // A separate list-item builder is intentionally absent — the `list` render-props
     // builder auto-wraps every item internally.
 }

--- a/crates/whisker/src/standard_ui.rs
+++ b/crates/whisker/src/standard_ui.rs
@@ -1,0 +1,89 @@
+//! Rust-side definition of Whisker's built-in primitive element module.
+
+use crate::{ElementModuleDefinition, ElementProviderMetadata, ElementTag};
+use whisker_engine::whisker_protocol::{
+    ElementChildMount, ElementContentKind, ElementMeasurement, ElementSchema,
+};
+
+/// Canonical key for the standard presentation container.
+pub const VIEW_ELEMENT_NAME: &str = "whisker.ui/View";
+/// Canonical key for the standard plain-text element.
+pub const TEXT_ELEMENT_NAME: &str = "whisker.ui/Text";
+/// Canonical key for the standard scroll container.
+pub const SCROLL_VIEW_ELEMENT_NAME: &str = "whisker.ui/ScrollView";
+
+/// Returns the providers exported by the built-in UI package.
+///
+/// Hosts consume these providers exactly like application-selected external
+/// element modules; there is no separately maintained tag-to-schema table.
+pub fn standard_element_providers() -> Vec<ElementProviderMetadata> {
+    vec![view(), text(), scroll_view()]
+}
+
+/// Returns the Rust-side module definition for `whisker.ui`.
+pub fn standard_ui_module_definition() -> ElementModuleDefinition {
+    ElementModuleDefinition::new("whisker.ui", standard_element_providers())
+}
+
+fn view() -> ElementProviderMetadata {
+    ElementProviderMetadata::builtin(
+        ElementTag::View,
+        ElementSchema {
+            canonical_name: VIEW_ELEMENT_NAME.into(),
+            content: ElementContentKind::None,
+            child_mount: ElementChildMount::Presentation,
+            measurement: ElementMeasurement::None,
+            consumes_text_style: false,
+        },
+    )
+}
+
+fn text() -> ElementProviderMetadata {
+    ElementProviderMetadata::builtin(
+        ElementTag::Text,
+        ElementSchema {
+            canonical_name: TEXT_ELEMENT_NAME.into(),
+            content: ElementContentKind::Text,
+            child_mount: ElementChildMount::None,
+            measurement: ElementMeasurement::Text,
+            consumes_text_style: true,
+        },
+    )
+}
+
+fn scroll_view() -> ElementProviderMetadata {
+    ElementProviderMetadata::builtin(
+        ElementTag::ScrollView,
+        ElementSchema {
+            canonical_name: SCROLL_VIEW_ELEMENT_NAME.into(),
+            content: ElementContentKind::ScrollContainer,
+            child_mount: ElementChildMount::ScrollContent,
+            measurement: ElementMeasurement::None,
+            consumes_text_style: false,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_ui_is_an_ordinary_element_provider_module() {
+        let definition = standard_ui_module_definition();
+        assert_eq!(definition.module_name, "whisker.ui");
+        assert_eq!(definition.elements.len(), 3);
+        assert_eq!(
+            definition.elements[0].schema.canonical_name,
+            "whisker.ui/View"
+        );
+        assert_eq!(
+            definition.elements[1].schema.canonical_name,
+            "whisker.ui/Text"
+        );
+        assert_eq!(
+            definition.elements[2].schema.canonical_name,
+            "whisker.ui/ScrollView"
+        );
+    }
+}

--- a/crates/whisker/src/surface_runtime.rs
+++ b/crates/whisker/src/surface_runtime.rs
@@ -6,13 +6,14 @@ use std::error::Error;
 use std::fmt;
 use std::rc::Rc;
 
+use crate::ElementRegistry;
 use crate::runtime::element::ElementTag;
 use crate::runtime::value::WhiskerValue;
 use crate::runtime::view::{BindType, DynRenderer, Element};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::whisker_protocol::{
-    ElementTypeId, HitTestBehavior, InputEvent, InputEventError, MeasurementReady, NodeId,
-    ProtocolValue, SurfaceId,
+    ElementChildMount, ElementContentKind, ElementRegistration, HitTestBehavior, InputEvent,
+    InputEventError, MeasurementReady, NodeId, ProtocolValue, SurfaceId,
 };
 use whisker_engine::whisker_style::{
     InheritedStyle, ResolvedNodeStyle, SpecifiedStyle, StyleEnvironment, StyleResolutionError,
@@ -35,6 +36,18 @@ pub enum RuntimeBindingError {
     UnsupportedCustomElement {
         /// Requested element name.
         name: String,
+    },
+    /// A built-in authoring tag has no negotiated element registration.
+    MissingElementRegistration {
+        /// Tag that could not be mapped to a compact element type.
+        tag: ElementTag,
+    },
+    /// A leaf element was given an ordinary scene child.
+    ChildrenNotAllowed {
+        /// Parent element whose schema declares no child mount target.
+        parent: Element,
+        /// Child rejected before entering the retained scene.
+        child: Element,
     },
     /// A compatibility-only CSS string reached the typed renderer.
     UnsupportedRawStyle {
@@ -241,13 +254,35 @@ pub struct SurfaceRuntime {
     state: Rc<RefCell<BindingState>>,
 }
 
+/// Returns the built-in element contracts used by a default surface.
+///
+/// Hosts normally obtain the same values from
+/// [`SurfaceRuntime::element_registrations`]. This helper is useful for
+/// Host-only conformance tests that intentionally do not mount a runtime.
+pub fn standard_element_registrations() -> Vec<ElementRegistration> {
+    ElementRegistry::standard().registrations().to_vec()
+}
+
 impl SurfaceRuntime {
     /// Creates an empty renderer-backed surface for one style environment.
     pub fn new(surface: SurfaceId, environment: StyleEnvironment) -> Self {
+        Self::with_element_registry(surface, environment, ElementRegistry::standard())
+    }
+
+    /// Creates a surface with a registry normalized during application bootstrap.
+    ///
+    /// Built-in and module-provided elements in this registry share the same
+    /// compact-ID allocation and retained scene path.
+    pub fn with_element_registry(
+        surface: SurfaceId,
+        environment: StyleEnvironment,
+        registry: ElementRegistry,
+    ) -> Self {
         Self {
             state: Rc::new(RefCell::new(BindingState {
                 surface: SurfaceEngine::new(surface),
                 environment,
+                registry,
                 next_element: 0,
                 elements: HashMap::new(),
                 node_elements: HashMap::new(),
@@ -265,6 +300,15 @@ impl SurfaceRuntime {
     /// Returns the semantic surface identifier.
     pub fn surface(&self) -> SurfaceId {
         self.state.borrow().surface.surface()
+    }
+
+    /// Returns the element contracts negotiated by this surface runtime.
+    ///
+    /// A Host binds this snapshot before accepting the first frame. Built-in
+    /// and future module-provided elements use the same registration values;
+    /// `ElementTag` discriminants are not wire element IDs.
+    pub fn element_registrations(&self) -> Vec<ElementRegistration> {
+        self.state.borrow().registry.registrations().to_vec()
     }
 
     /// Returns the root selected by the runtime, when available.
@@ -423,7 +467,7 @@ impl SurfaceRuntime {
 
 #[derive(Clone)]
 struct BoundElement {
-    tag: ElementTag,
+    kind: BoundElementKind,
     node: Option<NodeId>,
     parent: Option<Element>,
     children: Vec<Element>,
@@ -432,6 +476,38 @@ struct BoundElement {
     text: Option<PlainTextInput>,
     raw_text: String,
     listeners: HashMap<String, Vec<RuntimeListener>>,
+}
+
+#[derive(Clone)]
+enum BoundElementKind {
+    RawText,
+    Registered {
+        content: ElementContentKind,
+        child_mount: ElementChildMount,
+    },
+}
+
+impl BoundElementKind {
+    fn is_raw_text(&self) -> bool {
+        matches!(self, Self::RawText)
+    }
+
+    fn is_text(&self) -> bool {
+        matches!(
+            self,
+            Self::Registered {
+                content: ElementContentKind::Text,
+                ..
+            }
+        )
+    }
+
+    fn child_mount(&self) -> Option<ElementChildMount> {
+        match self {
+            Self::RawText => None,
+            Self::Registered { child_mount, .. } => Some(*child_mount),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -445,6 +521,7 @@ type PlannedListener = (NodeId, Rc<dyn Fn(WhiskerValue) + 'static>);
 struct BindingState {
     surface: SurfaceEngine,
     environment: StyleEnvironment,
+    registry: ElementRegistry,
     next_element: u32,
     elements: HashMap<Element, BoundElement>,
     node_elements: HashMap<NodeId, Element>,
@@ -551,27 +628,61 @@ impl BindingState {
     }
 
     fn allocate(&mut self, tag: ElementTag) -> Result<Element, RuntimeBindingError> {
+        if tag == ElementTag::RawText {
+            return self.allocate_registration(None);
+        }
+        let registration = self
+            .registry
+            .registration_for_builtin(tag)
+            .cloned()
+            .ok_or(RuntimeBindingError::MissingElementRegistration { tag })?;
+        self.allocate_registration(Some(registration))
+    }
+
+    fn allocate_named(&mut self, name: &str) -> Result<Element, RuntimeBindingError> {
+        let registration = self
+            .registry
+            .registration_for_name(name)
+            .cloned()
+            .ok_or_else(|| RuntimeBindingError::UnsupportedCustomElement {
+                name: name.to_owned(),
+            })?;
+        self.allocate_registration(Some(registration))
+    }
+
+    fn allocate_registration(
+        &mut self,
+        registration: Option<ElementRegistration>,
+    ) -> Result<Element, RuntimeBindingError> {
         if self.next_element == u32::MAX {
             return Err(RuntimeBindingError::ElementIdExhausted);
         }
         let handle = Element::from_raw(self.next_element);
         self.next_element += 1;
-        let (node, resolved, text) = if tag == ElementTag::RawText {
-            (None, None, None)
-        } else {
+        let (kind, node, resolved, text) = if let Some(registration) = registration {
             let resolved = resolve_style(&SpecifiedStyle::new(), None, self.environment)?;
-            let element_type =
-                ElementTypeId::new(tag as u32).expect("built-in element tags are non-zero");
-            let node = self
-                .surface
-                .create_node(element_type, resolved.computed().layout().clone())?;
-            let text = (tag == ElementTag::Text).then(|| PlainTextInput::new(""));
-            (Some(node), Some(resolved), text)
+            let node = self.surface.create_node(
+                registration.element_type,
+                resolved.computed().layout().clone(),
+            )?;
+            let text =
+                (registration.content == ElementContentKind::Text).then(|| PlainTextInput::new(""));
+            (
+                BoundElementKind::Registered {
+                    content: registration.content,
+                    child_mount: registration.child_mount,
+                },
+                Some(node),
+                Some(resolved),
+                text,
+            )
+        } else {
+            (BoundElementKind::RawText, None, None, None)
         };
         self.elements.insert(
             handle,
             BoundElement {
-                tag,
+                kind,
                 node,
                 parent: None,
                 children: Vec::new(),
@@ -702,7 +813,7 @@ impl BindingState {
     }
 
     fn refresh_text(&mut self, text_element: Element) -> Result<(), RuntimeBindingError> {
-        if self.element(text_element)?.tag != ElementTag::Text {
+        if !self.element(text_element)?.kind.is_text() {
             return Err(RuntimeBindingError::InvalidRawTextParent {
                 element: text_element,
                 parent: text_element,
@@ -712,7 +823,7 @@ impl BindingState {
         let mut value = String::new();
         for child in children {
             let child = self.element(child)?;
-            if child.tag == ElementTag::RawText {
+            if child.kind.is_raw_text() {
                 value.push_str(&child.raw_text);
             }
         }
@@ -738,11 +849,16 @@ impl BindingState {
                 parent,
             });
         }
-        if child_entry.tag == ElementTag::RawText && parent_entry.tag != ElementTag::Text {
+        if child_entry.kind.is_raw_text() && !parent_entry.kind.is_text() {
             return Err(RuntimeBindingError::InvalidRawTextParent {
                 element: child,
                 parent,
             });
+        }
+        if !child_entry.kind.is_raw_text()
+            && parent_entry.kind.child_mount() == Some(ElementChildMount::None)
+        {
+            return Err(RuntimeBindingError::ChildrenNotAllowed { parent, child });
         }
         let position = match before {
             Some(reference) => self
@@ -805,15 +921,15 @@ impl BindingState {
         name: &str,
         value: &str,
     ) -> Result<(), RuntimeBindingError> {
-        let tag = self.element(element)?.tag;
-        if tag == ElementTag::RawText && name == "text" {
+        let kind = self.element(element)?.kind.clone();
+        if kind.is_raw_text() && name == "text" {
             self.element_mut(element)?.raw_text = value.to_owned();
             if let Some(parent) = self.element(element)?.parent {
                 self.refresh_text(parent)?;
             }
             return Ok(());
         }
-        if tag == ElementTag::Text && name == "text-maxline" {
+        if kind.is_text() && name == "text-maxline" {
             let max_lines = value.parse::<i32>().ok().and_then(|value| {
                 if value > 0 {
                     u32::try_from(value).ok()
@@ -946,10 +1062,13 @@ impl DynRenderer for SurfaceRuntime {
 
     fn create_element_by_name(&self, tag_name: &str) -> Element {
         let mut state = self.state.borrow_mut();
-        state.record(Err(RuntimeBindingError::UnsupportedCustomElement {
-            name: tag_name.to_owned(),
-        }));
-        Element::from_raw(u32::MAX)
+        match state.allocate_named(tag_name) {
+            Ok(element) => element,
+            Err(error) => {
+                state.record(Err(error));
+                Element::from_raw(u32::MAX)
+            }
+        }
     }
 
     fn release_element(&self, handle: Element) {
@@ -1058,15 +1177,15 @@ impl DynRenderer for SurfaceRuntime {
         state.record(result);
     }
 
-    fn set_root(&self, page: Element) {
+    fn set_root(&self, root: Element) {
         let mut state = self.state.borrow_mut();
-        let result = match state.element(page) {
+        let result = match state.element(root) {
             Ok(entry) => match entry.node {
                 Some(node) => {
                     state.root = Some(node);
                     Ok(())
                 }
-                None => Err(RuntimeBindingError::InvalidRoot { element: page }),
+                None => Err(RuntimeBindingError::InvalidRoot { element: root }),
             },
             Err(error) => Err(error),
         };

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -1,15 +1,19 @@
 use std::convert::Infallible;
 
-use whisker::SurfaceRuntime;
 use whisker::css::{BorderStyle, Overflow};
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
-use whisker::runtime::view::{set_root, with_installed_renderer};
+use whisker::runtime::view::{create_element_by_name, set_root, with_installed_renderer};
+use whisker::{
+    ElementModuleDefinition, ElementProviderMetadata, ElementRegistry, ElementTag,
+    RuntimeBindingError, SurfaceRuntime,
+};
 use whisker_engine::RecordingRenderer;
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::whisker_protocol::{
-    MeasuredSize, MeasurementMetrics, MeasurementPayload, MeasurementRequest, MeasurementResponse,
-    Operation, PaintColor, PreparedContentId, SurfaceId,
+    ElementChildMount, ElementContentKind, ElementMeasurement, ElementSchema, MeasuredSize,
+    MeasurementMetrics, MeasurementPayload, MeasurementRequest, MeasurementResponse, Operation,
+    PaintColor, PreparedContentId, SurfaceId,
 };
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{HostLayoutOptions, MeasurementHost};
@@ -310,6 +314,124 @@ fn render_box_paint_and_clip_reach_the_frame_sink() {
                     blue: 230,
                     alpha: 1.0,
                 }
+    ));
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn frame_element_type_comes_from_the_surface_registry() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(10).expect("test surface"),
+        StyleEnvironment::new(100.0, 100.0, 1.0, 14.0),
+    );
+    let scroll_type = surface
+        .element_registrations()
+        .into_iter()
+        .find(|registration| registration.canonical_name == "whisker.ui/ScrollView")
+        .expect("standard ScrollView registration")
+        .element_type;
+    assert_ne!(
+        scroll_type.get(),
+        ElementTag::ScrollView as u32,
+        "wire IDs must not depend on authoring-tag discriminants"
+    );
+
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| render! { scroll_view() });
+        set_root(root);
+    });
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(100.0, 100.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            HostLayoutOptions::default(),
+        )
+        .expect("ScrollView frame");
+
+    assert!(renderer.frames()[0].packet.operations.iter().any(
+        |operation| matches!(operation, Operation::CreateNode { element_type, .. } if *element_type == scroll_type)
+    ));
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn module_element_uses_the_same_retained_frame_path_as_builtins() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let registry = ElementRegistry::standard_builder()
+        .register_module(ElementModuleDefinition::new(
+            "example.maps",
+            [ElementProviderMetadata::named(
+                "map",
+                ElementSchema {
+                    canonical_name: "example.maps/Map".into(),
+                    content: ElementContentKind::None,
+                    child_mount: ElementChildMount::Presentation,
+                    measurement: ElementMeasurement::None,
+                    consumes_text_style: false,
+                },
+            )],
+        ))
+        .build()
+        .expect("valid module element registry");
+    let map_type = registry
+        .registration_for_name("map")
+        .expect("map authoring binding")
+        .element_type;
+    let surface = SurfaceRuntime::with_element_registry(
+        SurfaceId::new(12).expect("test surface"),
+        StyleEnvironment::new(100.0, 100.0, 1.0, 14.0),
+        registry,
+    );
+
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| create_element_by_name("map"));
+        set_root(root);
+    });
+    assert_eq!(surface.binding_error(), None);
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(100.0, 100.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            HostLayoutOptions::default(),
+        )
+        .expect("module element frame");
+
+    assert!(renderer.frames()[0].packet.operations.iter().any(
+        |operation| matches!(operation, Operation::CreateNode { element_type, .. } if *element_type == map_type)
+    ));
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn text_leaf_contract_is_enforced_before_frame_generation() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(11).expect("test surface"),
+        StyleEnvironment::new(100.0, 100.0, 1.0, 14.0),
+    );
+
+    with_installed_renderer(surface.renderer(), || {
+        owner.with(|| render! { text { view() } });
+    });
+
+    assert!(matches!(
+        surface.binding_error(),
+        Some(RuntimeBindingError::ChildrenNotAllowed { .. })
     ));
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }

--- a/docs/rfcs/0001-runtime-modules-and-build-plugins.md
+++ b/docs/rfcs/0001-runtime-modules-and-build-plugins.md
@@ -44,11 +44,15 @@ The current terms describe particular implementations:
   mutations.
 
 Those mechanisms are useful, but they are too narrow for the architecture
-after removing Lynx. Rendering, layout, motion, storage, routing, and the
-application entry point should be composable through the same runtime model.
-Likewise, Android, iOS, Web, and Desktop projects should be reproducibly
-assembled by build-time components instead of accumulating platform-specific
-special cases in the CLI.
+after removing Lynx. Native services, Host renderers, and Host-backed element
+types need one typed extension model. Internal scene mechanisms do not all
+need runtime replacement: style resolution, Taffy layout, frame generation,
+measurement coordination, and event propagation remain tightly coordinated
+Whisker core subsystems as refined by
+[RFC 0004](0004-native-modules-and-host-elements.md). Likewise, Android, iOS,
+Web, and Desktop projects should be reproducibly assembled by build-time
+components instead of accumulating platform-specific special cases in the
+CLI.
 
 The model must also avoid two misleading equivalences:
 
@@ -61,7 +65,9 @@ The model must also avoid two misleading equivalences:
   manager.
 - Make their identity, versioning, dependency resolution, and lifecycle
   explicit.
-- Allow core facilities such as a renderer to be ordinary typed modules.
+- Allow stable target and extension boundaries such as a Host renderer,
+  native service, or element provider to be ordinary typed modules without
+  requiring internal frame algorithms to become modules.
 - Allow a generated Xcode, Gradle, Web, or Desktop project to be the
   deterministic result of plugin composition.
 - Make the generated project contain all runtime providers, host code,
@@ -138,8 +144,12 @@ per-frame IPC in the Desktop architecture.
 
 The minimal runtime mechanism that makes modules possible: registry,
 interface resolution, instance handles, lifecycle dispatch, callback/event
-dispatch, memory ownership across transports, and frame transaction
-coordination. The kernel contains no renderer or platform policy.
+dispatch, memory ownership across transports, and surface transaction
+coordination. The module kernel contains no target renderer policy. “Whisker
+core” is broader than this module kernel: it also contains the scene, style,
+layout, measurement, scheduling, and event-routing mechanisms that must agree
+on one UI revision. Those mechanisms may use internal Rust traits and crates
+without becoming replaceable runtime modules.
 
 ### Project IR
 
@@ -246,6 +256,14 @@ Code becomes a module when it needs runtime discovery, replacement,
 capability resolution, managed lifecycle, or a stable boundary. Pure functions
 and internal implementation details remain ordinary library code.
 
+The initial public module boundary is intentionally narrower than the set of
+all possible runtime interfaces. Service modules expose addable native
+capabilities. Element-provider modules expose Host-backed element types.
+Built-in UI elements use the same element-provider contract as third-party
+elements, while Taffy layout, common style resolution, frame generation, and
+event propagation remain core. RFC 0004 defines that division and the
+Expo-like native authoring API.
+
 ### Consumers resolve interfaces
 
 Application code and framework modules depend on interface contracts:
@@ -283,14 +301,14 @@ optional typed handle. `Many` injects every compatible provider in a stable,
 deterministic order and is used for extension collections such as element or
 style-extension providers.
 
-For example, a scene runtime can require one renderer and collect multiple UI
+For example, Whisker core can resolve one renderer and collect multiple UI
 element providers without any UI module naming or depending on that renderer:
 
 ```text
-Application --requires exactly one--> SceneV1
+Application -------------------------> Whisker Core Scene API
 
-Scene Runtime --requires exactly one--> RendererV1
-Scene Runtime --requires many---------> ElementProviderV1
+Core bootstrap --requires exactly one--> RendererV1
+Core bootstrap --requires many---------> ElementProviderV1
 
 View Module ----provides--------------> ElementProviderV1
 Text Module ----provides--------------> ElementProviderV1
@@ -323,7 +341,7 @@ B --emits through sink----------> A
 ```
 
 This rule is particularly important for a renderer returning frame and input
-events to the scene runtime.
+events to the core scene through the sink supplied at surface attachment.
 
 ### Runtime dependencies are not package or plugin dependencies
 
@@ -733,13 +751,17 @@ The implementation must preserve these rules:
 12. Standalone and embedded startup create the same kind of `RuntimeInstance`;
     they differ only in whether a generated or existing Host owns the root
     `WhiskerView` container.
+13. A Rust crate or internal interface is not made a runtime module merely to
+    achieve source-code decomposition or test substitution.
+14. Built-in and third-party Host elements register through the same public
+    element-provider boundary, but neither may replace core scene semantics.
 
 ## Mapping from the current implementation
 
 | Current concept | Direction under this RFC |
 |---|---|
 | `PlatformModule` and `module!` | Raw dynamic transport; official APIs move to generated typed interface handles |
-| Kotlin/Swift `ModuleDefinition` | One source of Host provider descriptors and bindings |
+| Kotlin/Swift `ModuleDefinition` | Expo-like Host implementation DSL bound to generated service/element schemas under RFC 0004 |
 | `whisker-plugin::Plugin` | Seed for the versioned Build Plugin API |
 | `GenerateContext` with iOS/Android IR | Seed for a broader versioned Project IR including Web/Desktop and runtime composition |
 | `PluginRequest`/`PluginResponse` JSON | One possible transport for the Build Plugin API |

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -29,9 +29,12 @@ changes since the last accepted scene revision, so Whisker does not send the
 whole screen every frame.
 
 The renderer is an ordinary runtime module implementing
-`whisker.renderer@1`. UI modules are ordinary modules that contribute element
-types. Individual `View`, `Text`, or custom-view instances are scene nodes, not
-module instances.
+`whisker.renderer@1`. UI modules contribute element types through the narrow
+provider contract refined by
+[RFC 0004](0004-native-modules-and-host-elements.md). The scene coordinator,
+style resolution, Taffy layout, frame generation, measurement transaction,
+and event propagation remain Whisker core. Individual `View`, `Text`, or
+custom-view instances are scene nodes, not module instances.
 
 ## Motivation
 
@@ -434,18 +437,18 @@ An element instance is a scene node identified by `NodeId`. Thousands of nodes
 may be created from one registered element type. Nodes follow scene lifecycle,
 not module-registry lifecycle.
 
-### Module dependency graph
+### Composition graph
 
 UI modules do not require a concrete renderer and do not call `present`,
-`measure_batch`, or Host factories. The Scene Runtime is the coordinator that
-requires both sides:
+`measure_batch`, or Host factories. Whisker core is the coordinator that binds
+both sides. It may use the module registry to resolve providers without making
+the scene engine itself a third-party-replaceable module:
 
 ```text
-Application Module
+Application
     |
-    | requires exactly one SceneV1
     v
-Scene Runtime Module
+Whisker Core Scene
     |
     | requires exactly one RendererV1
     +---------------------------> DOM / Android / iOS Renderer
@@ -457,17 +460,12 @@ Scene Runtime Module
     `---------------------------> Video Module
 ```
 
-Conceptually, the Scene Runtime declares:
+Conceptually, core requests these provider collections during bootstrap:
 
 ```rust,ignore
-ModuleDescriptor {
-    id: "whisker.scene",
-    provides: [interface("whisker.scene", "1")],
-    requires: [
-        exactly_one("whisker.renderer", "^1"),
-        many("whisker.element-provider", "^1"),
-    ],
-    lifecycle: LifecycleScope::Surface,
+ProviderRequirements {
+    renderer: exactly_one("whisker.renderer", "^1"),
+    elements: many("whisker.element-provider", "^1"),
 }
 ```
 
@@ -483,24 +481,23 @@ ModuleDescriptor {
 }
 ```
 
-The registry starts the renderer and element providers before the Scene
-Runtime, then starts the Application module. The Scene Runtime collects the
-schemas, validates duplicate canonical element keys, and passes registrations
-to the resolved renderer. Shutdown occurs in reverse order.
+The registry starts the renderer and element providers before core starts the
+Application. Core collects the schemas, validates duplicate canonical element
+keys, and passes registrations to the resolved renderer. Shutdown occurs in
+reverse order.
 
-The renderer does not resolve the Scene Runtime to send events back. During
-`attach_surface`, the Scene Runtime passes a typed `RendererEventSink`. This
-keeps the registry graph directed and avoids a `Scene -> Renderer -> Scene`
-cycle:
+The renderer does not resolve core to send events back. During
+`attach_surface`, core passes a typed `RendererEventSink`. This keeps the
+registry graph directed and avoids a `Core -> Renderer -> Core` cycle:
 
 ```text
-Scene --requires RendererV1---------> Renderer
-Scene --passes RendererEventSink----> Renderer
-Scene <-------events through sink---- Renderer
+Core --requires RendererV1---------> Renderer
+Core --passes RendererEventSink----> Renderer
+Core <-------events through sink---- Renderer
 ```
 
 Likewise, the renderer does not resolve `ElementProvider` modules itself. It
-receives normalized `ElementRegistration` values from the Scene Runtime. This
+receives normalized `ElementRegistration` values from core. This
 keeps provider discovery, duplicate detection, and schema policy in Rust while
 the renderer remains responsible for binding schemas to Host factories.
 
@@ -794,6 +791,7 @@ Paint and content
   SetBoxPaint(node, background, borders, radii)
   SetShadow(node, shadow)
   SetText(node, text_run)
+  SetTextStyle(node, resolved_text_style)
   SetImage(node, resource)
   SetProperty(node, property_id, typed_value)
   ClearProperty(node, property_id)
@@ -839,33 +837,32 @@ packet operations while unchanged. An idle application requests no frames.
 
 An element provider defines what an element *is*; it does not implement common
 style resolution, limited text-property inheritance, layout, or paint
-properties. The Scene Runtime connects independent style and layout services
-with element providers and the renderer:
+properties. Whisker core connects its style and layout subsystems with element
+providers and the renderer:
 
 ```text
 ElementProvider modules -------+
-Style Engine ------------------+--> Scene Runtime --> FramePacket --> Renderer
+Style Engine ------------------+--> Whisker Core --> FramePacket --> Renderer
 Layout Engine -----------------+
 ```
 
-Element schemas declare semantic traits used by the common style system:
+Element schemas declare closed semantic categories used by the common style
+system. The public module DSL uses domain terms rather than Rust traits:
 
 ```rust,ignore
-enum ElementTrait {
-    Box,
-    Container,
-    TextContent,
-    Replaced,
-    ScrollContainer,
-    HitTestable,
-    Accessible,
+ElementDefinition {
+    presentation: Presentation::Box,
+    children: Children::None,
+    content: Content::Text,
+    measurement: Measurement::Text,
+    consumes_text_style: true,
 }
 ```
 
-The final trait set belongs to RFC 0003. The boundary is fixed here: a `View`
-can declare `Box + Container`, `Text` can declare `Box + TextContent`, and
-`Image` or `Video` can declare `Box + Replaced`; the common Style Engine uses
-those declarations to determine property applicability.
+The schema compiler may normalize these declarations to internal capability
+bits. Those bits are not exposed as `Traits` in Swift, Kotlin, JavaScript, or
+the public Rust module-definition surface. RFC 0004 owns the closed categories
+and their mapping to common presentation and element content.
 
 Common typed style properties such as width, padding, background, opacity,
 transform, border, and clip are not repeated in each element schema. An
@@ -894,7 +891,7 @@ Conceptually, `View` declares:
 
 ```rust,ignore
 ElementSchema {
-    key: "whisker.ui/View@1",
+    key: "whisker.ui/View",
     children: ChildrenPolicy::Multiple,
     measure: MeasurePolicy::None,
     properties: &[ACCESSIBILITY_LABEL, POINTER_EVENTS, FOCUSABLE],
@@ -911,7 +908,7 @@ scene node:
 
 ```text
 whisker.ui.primitives module instance
-  `- element type whisker.ui/View@1
+  `- element type whisker.ui/View
        |- NodeId 41
        |- NodeId 42
        `- NodeId 43
@@ -946,7 +943,7 @@ whisker-video package
 |- Rust declarative component API
 |- Rust typed ElementHandle, props, events, and commands
 |- runtime module providing an ElementProvider
-|- versioned whisker.video/Video@1 element schema
+|- canonical whisker.video/Video element schema
 |- Android Host element factory
 |- iOS Host element factory
 |- JavaScript Host element factory
@@ -1009,7 +1006,8 @@ module and plugin declarations.
 ### Module-author contract
 
 A module author declares a canonical element key and typed properties, events,
-commands, measurement policy, child policy, and traits. The exact macro syntax
+commands, presentation/content category, measurement policy, and child policy.
+The exact macro syntax
 is deliberately not fixed by this RFC; conceptually the declaration produces:
 
 - the Rust component builder and props;
@@ -1024,9 +1022,10 @@ An illustrative generated schema is:
 
 ```rust,ignore
 ElementSchema {
-    key: "whisker.video/Video@1",
-    traits: &[BOX, REPLACED, ACCESSIBLE, MEDIA],
+    key: "whisker.video/Video",
+    presentation: Presentation::Box,
     children: ChildrenPolicy::None,
+    content: Content::Native,
     measure: MeasurePolicy::FixedAspectRatioOrHostIntrinsic,
     properties: &[
         VIDEO_SOURCE,
@@ -1050,8 +1049,8 @@ ElementSchema {
 
 Source, autoplay, muted, looping, controls, and playback rate are
 element-specific properties. Width, height, aspect ratio, object fit, opacity,
-transform, border radius, and clip are common styles supplied by the traits and
-the Style Engine.
+transform, border radius, and clip are common styles supplied by the closed
+semantic channels and the Style Engine.
 
 ### Typed updates, events, and commands
 
@@ -1091,12 +1090,14 @@ Every supported target provides a factory conforming to the generated element
 binding. At the information level it implements:
 
 ```rust,ignore
+trait HostElementMeasurer {
+    fn measure(&mut self, request: &MeasurementRequest) -> MeasurementResponse;
+}
+
 trait HostElementFactory {
     fn create(&mut self, context: ElementContext) -> HostElement;
     fn apply_properties(&mut self, element: &mut HostElement, patch: PropertyPatch);
     fn invoke_command(&mut self, element: &mut HostElement, command: Command);
-    fn measure(&mut self, element: &HostElement, request: MeasureRequest)
-        -> MeasureResponse;
     fn destroy(&mut self, element: HostElement);
 }
 ```
@@ -1104,12 +1105,16 @@ trait HostElementFactory {
 This is a cross-language behavioral shape, not a Rust trait that Kotlin,
 Swift, or JavaScript literally implements. Binding generation supplies native
 typed payloads and verifies the common schema so authors do not manually keep
-wire IDs synchronized.
+wire IDs synchronized. Measurement is separate because layout can need an
+answer before the first `CreateNode` has created a live Host element. The
+measurer receives all content, property, resolved-text-style, constraint, and
+environment inputs in the request and may share prepared resources with the
+later factory through `PreparedContentId`.
 
 The same element key can map to different concrete objects:
 
 ```text
-whisker.video/Video@1
+whisker.video/Video
   Android -> PlayerView / Media3 player
   iOS     -> AVPlayerLayer-backed UIView
   Web     -> HTMLVideoElement
@@ -1126,14 +1131,14 @@ and generated registration to be included in Project IR. At runtime:
 
 ```text
 Video module
-  -> provides ElementSchema("whisker.video/Video@1")
+  -> provides ElementSchema("whisker.video/Video")
 
-Scene Runtime
+Whisker Core
   -> collects and normalizes the schema
   -> Renderer.register_elements(...)
 
 Host Renderer
-  -> looks up embedded Host factory by canonical key and major version
+  -> looks up embedded Host factory by canonical key
   -> verifies supported properties, events, commands, and measurement
   -> assigns compact ElementTypeId::VIDEO
 ```
@@ -1193,7 +1198,7 @@ composition fails. It must not silently emit an empty view or ignore commands:
 
 ```text
 cannot compose target `web`:
-  whisker.video/Video@1 is selected
+  whisker.video/Video is selected
   available Host providers: android, ios
   missing Host provider: web
 ```
@@ -1239,7 +1244,7 @@ None             Rust constraints determine size; no Host query
 HostIntrinsic    Host measures under Rust-provided constraints
 FixedAspectRatio Rust layout uses provider metadata
 DeferredResource size may become known after a resource event
-Custom           versioned element-specific measurement payload
+Custom           typed element-specific measurement payload
 ```
 
 The request also carries a semantic provider category independent of the
@@ -1626,7 +1631,7 @@ how server-emitted presentation relates to Rust-resolved interactive styling.
 | Lynx frame/tick | Host `Frame` event feeding the Rust scheduler |
 | `bounding_client_rect` Host query | Read Rust layout for ordinary geometry; explicit Host query only where necessary |
 | Lynx element methods | Typed element commands ordered in the frame protocol |
-| Native `ModuleDefinition.View` / `Prop` | Host element factory and versioned element schema registration |
+| Native `ModuleDefinition.View` / `Prop` | Host element factory and canonical element schema registration |
 | Lynx CSS animation and imperative extension | Rust motion updating typed property slots before packet generation |
 | Lynx text/layout | Taffy layout plus batched Host intrinsic measurement |
 
@@ -1658,7 +1663,7 @@ how server-emitted presentation relates to Rust-resolved interactive styling.
 9. Complete Desktop capability coverage for hierarchical accessibility, group
    compositing, filters, path clipping, and external surfaces without leaking
    Desktop render types into the common protocol.
-10. Migrate custom UI modules to versioned element schemas, generated Host
+10. Migrate custom UI modules to canonical element schemas, generated Host
    factories, and typed commands.
 11. Remove the separate legacy Lynx production path, C++ bridge, fork artifacts,
    and obsolete distribution paths after Host conformance and visual parity are
@@ -1680,9 +1685,9 @@ how server-emitted presentation relates to Rust-resolved interactive styling.
    boundary. Neither crosses native-process IPC.
 10. Host-dependent measurement is batched, keyed, cached, and epoch-validated.
 11. Renderer and protocol behavior can be tested with a Rust-only provider.
-12. The Scene Runtime, not UI modules, requires and coordinates the renderer.
+12. Whisker core, not UI modules, requires and coordinates the renderer.
 13. Renderer callbacks use the event sink passed during binding and do not
-    create a reverse registry dependency on the Scene Runtime.
+    create a reverse registry dependency on core.
 14. A third-party UI element uses the same schema registration, frame,
     measurement, event, and command paths as a built-in element.
 15. A Host `WhiskerView` is a surface/bootstrap container, not a scene element
@@ -1708,8 +1713,8 @@ The following must be resolved before this RFC becomes `Accepted`:
 - whether accessibility uses frame operations or a separately versioned but
   transaction-linked semantics packet;
 - command cancellation and result ordering when an element is deleted;
-- the final standard `ElementTrait` and typed custom-property contracts, which
-  RFC 0003 must define consistently with this boundary;
+- the final normalized element-category encoding and typed custom-property
+  contracts, consistently with RFC 0004's public domain vocabulary;
 - debug symbol-table format for compact element, property, event, and command
   IDs;
 - hydration and event attachment requirements for a future SSR DOM renderer;

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -300,21 +300,22 @@ The common style registry declares, for each property:
 - stable property ID and wire type;
 - accepted Rust value types and normalization;
 - initial value;
-- applicable `ElementTrait`s;
+- applicable closed element categories;
 - percentage and environment resolution rules;
 - interpolation support;
 - invalidation impacts;
 - backend capability requirements.
 
-An `ElementSchema` declares traits such as `Box`, `Container`, `TextContent`,
-`Replaced`, or `ScrollContainer`. It does not repeat every common style
+An `ElementSchema` declares presentation, children, content, measurement, and
+text-style-consumer categories as defined by RFC 0004. Its public module DSL
+does not expose a Rust `Trait` list, and it does not repeat every common style
 property. Invalid property/element combinations should be compile-time errors
 when statically known and deterministic runtime diagnostics otherwise.
 The seven inherited text properties are valid on containers because they also
 define the inherited context for descendants, even when that container does
 not paint text itself.
 
-Element-specific behavior stays in the versioned element schema. For example,
+Element-specific behavior stays in the canonical element schema. For example,
 `Video` uses common width, border, opacity, transform, and clip styles, while
 `src`, `autoplay`, `muted`, and playback commands are element properties. A
 third-party module that needs a truly custom visual parameter declares a typed
@@ -647,27 +648,26 @@ deliberately unsupported. Such exclusions require rationale in the coverage
 table. The goal is full useful Lynx visual capability, not implementation of a
 general-purpose web browser.
 
-## Rust module boundaries
+## Rust subsystem boundaries
 
-The implementation may be split into Rust-only crates while each remains an
-ordinary Whisker runtime module where runtime lifecycle or replaceability is
-needed:
+The implementation may be split into Rust-only crates. They remain internal
+subsystems by default rather than ordinary Whisker runtime modules:
 
 ```text
 whisker-style
   stable typed values, property IDs, declaration storage
   composition, applicability, inheritance, computed values, invalidation
 
-whisker-layout module
+whisker-layout
   retained Taffy tree, measurement requests, layout results
 
-whisker-motion module
+whisker-motion
   time, interpolation, springs, gestures, presentation updates
 
-whisker-engine module
+whisker-engine
   coordinates style/layout/motion and emits renderer operations
 
-whisker-renderer module
+whisker-renderer
   versioned Host boundary defined by RFC 0002
 ```
 
@@ -676,12 +676,16 @@ schema types, not on `whisker-engine`, a concrete layout engine, or a renderer.
 Style resolution is a deterministic Rust subsystem of `whisker-style`; the
 retained `whisker-engine` owns per-node state and decides when to invoke it.
 It does not require a separate `whisker-style-engine` crate or runtime module.
-At runtime, the Scene Runtime resolves replaceable providers through versioned
-module interfaces and coordinates them. A Rust-only crate can implement one of
-these interfaces and still be a `whisker-module` under RFC 0001.
+Whisker core coordinates these mechanisms directly. The module registry is
+used at stable extension boundaries such as the selected Host renderer,
+native services, and element providers; it is not inserted between core
+style, layout, motion, scene, and event algorithms. RFC 0004 defines this
+division.
 
-The exact crate split is not normative. The ownership boundaries, typed
-interfaces, and ability to substitute Rust-only recording/test providers are.
+The exact crate split is not normative. The ownership boundaries, internal
+typed interfaces, and ability to substitute Rust-only recording/test
+implementations are. Test substitution does not by itself imply a public
+runtime-provider compatibility promise.
 
 ## Test strategy
 
@@ -787,7 +791,7 @@ typed replacements for properties used by maintained Whisker packages.
     applies values sampled by Rust.
 11. Internal style interning or generated Web classes are unobservable
     optimizations.
-12. Third-party UI modules use common styles plus typed versioned element
+12. Third-party UI modules use common styles plus typed canonical element
     properties; they do not extend a global CSS language.
 13. Lynx compatibility is measured by semantic feature coverage, not CSS text
     compatibility.

--- a/docs/rfcs/0004-native-modules-and-host-elements.md
+++ b/docs/rfcs/0004-native-modules-and-host-elements.md
@@ -1,0 +1,943 @@
+# RFC 0004: Native Modules and Host Elements
+
+- Status: Draft
+- Authors: Whisker maintainers
+- Created: 2026-08-21
+- Discussion: TBD
+- Tracking issue: TBD
+- Depends on: [RFC 0001](0001-runtime-modules-and-build-plugins.md),
+  [RFC 0002](0002-renderer-interface-and-frame-protocol.md),
+  [RFC 0003](0003-typed-inline-style-layout-and-paint.md)
+- Supersedes: None
+
+## Summary
+
+Whisker modules are the public extension mechanism for native services and
+Host-backed elements. They are not the decomposition mechanism for every
+internal Rust subsystem.
+
+Whisker core owns the mechanisms that must agree to produce one coherent
+scene: reactive execution, the logical element tree, typed style resolution,
+Taffy layout, intrinsic-measurement transactions, frame scheduling and
+generation, and event routing. Built-in UI elements such as `View`, `Text`,
+`Image`, `TextInput`, and `ScrollView` are nevertheless registered through the
+same element-provider contract as a third-party element such as `GoogleMap`.
+Core does not reserve hard-coded element IDs or a privileged registration path
+for its built-ins.
+
+Lynx's shell-only `Page` tag is not a Whisker element contract. The legacy Lynx
+bootstrap may keep creating it as a private Host wrapper, but it is not present
+in the normalized registry and is never exposed by `ModuleDefinition.View`.
+
+Every visual element has two logical Host-side parts:
+
+```text
+HostNode
+|- common presentation
+|    layout, background, border, shadow, clip, opacity, transform,
+|    stacking, hit testing, semantics
+`- element-specific content
+     empty box, shaped text, image, native input, native map, video, ...
+```
+
+The common Host renderer implements presentation once. An element provider
+implements only its content, properties, commands, events, and optional
+intrinsic measurement. This prevents the number of implementations from
+growing as `element types x style properties` while allowing built-in and
+third-party elements to use the same registration, frame, measurement, event,
+and lifecycle paths.
+
+The split is logical, not a requirement to allocate two platform views. A Host
+may fuse presentation and content into one object when the observable result
+is identical. It creates a wrapper or extra compositing layer when clipping,
+shadows, native-view composition, accessibility, or event semantics require
+one.
+
+## Motivation
+
+The previous module direction was broad enough to imply that style, layout,
+motion, scene coordination, rendering, and other internal mechanisms should
+all become replaceable runtime modules. That is aesthetically uniform but
+puts versioned interfaces, lifecycle resolution, and possible indirection
+between algorithms that must be tightly coordinated on every frame. It also
+suggests a replaceability guarantee that Whisker is not ready to maintain.
+
+At the other extreme, implementing `View`, `Text`, and every future custom
+element directly in core makes native extension difficult and recreates a
+different bridge for each platform. The desired boundary is narrower:
+
+- core owns scene-wide mechanisms and semantic policy;
+- a module exposes an addable native service or element type;
+- a build plugin/CNG contribution makes its target implementation available;
+- the Host renderer applies common presentation and delegates only
+  element-specific content behavior.
+
+This must support Android Views, UIViews, DOM, and the Rust Desktop Host without
+making any one of them the semantic reference implementation.
+
+## Goals
+
+- Keep Whisker core small in responsibility and free from target UI classes.
+- Keep the public module API simple enough for application and library authors.
+- Register built-in and custom elements through one canonical contract.
+- Preserve the Expo-like native `ModuleDefinition` authoring shape.
+- Avoid exposing Rust implementation vocabulary such as `Trait` in the
+  Swift/Kotlin/JavaScript module definition DSL.
+- Apply common styles to every eligible element without reimplementing them in
+  every element provider.
+- Deliver resolved text styles, including inherited `font_size`, to native
+  elements that render or edit text.
+- Support synchronous and deferred intrinsic measurement without making the
+  Host authoritative for layout.
+- Keep frame, measurement, and event traffic typed, numeric, batched, and
+  testable with mock peers.
+- Apply the same semantic contract to Web and Desktop even when there is no
+  language FFI boundary.
+
+## Non-goals
+
+- Turning every Rust crate, algorithm, or internal trait into a module.
+- Allowing an element provider to replace Taffy, the style resolver, scene
+  invalidation, frame ordering, or event propagation.
+- Letting third-party modules add arbitrary properties to the common CSS
+  registry or participate in a general cascade.
+- Requiring one native object per logical node or requiring one wrapper around
+  every native object.
+- Reproducing Lynx's dynamic property-name dispatch or React Native's legacy
+  serialized bridge.
+- Guaranteeing that every native element supports every compositing
+  combination on every target. Unsupported required combinations must be
+  diagnosed rather than silently approximated.
+- Defining a rich inline-text tree in version 1. Version 1 `Text` is a leaf
+  text-content element; rich runs require a separate content model.
+
+## Architectural boundary
+
+### Whisker core
+
+“Small core” means a narrow and stable responsibility, not the smallest
+possible crate or line count. The following remain core because splitting
+them behind independently replaceable runtime interfaces would weaken scene
+correctness or add work to the frame hot path:
+
+- runtime/event-loop integration and reactive scheduling;
+- the retained logical tree, stable `NodeId`s, and node generations;
+- element-schema registry and applicability validation;
+- typed style composition, limited inheritance, and computed values;
+- Taffy tree ownership and layout;
+- measurement batching, cache keys, pending-result validation, and relayout;
+- dirty classification and frame transaction generation;
+- frame request coalescing and revision ownership;
+- logical hit testing, capture/bubble propagation, and listener lifetime;
+- focus, IME, accessibility, and scroll-state coordination contracts;
+- protocol validation and recovery.
+
+These responsibilities may be split into ordinary Rust crates. They are not
+runtime modules merely because they are separate crates. Internal Rust traits
+remain useful for tests and implementation boundaries without promising
+third-party replacement compatibility.
+
+### Whisker modules
+
+A module is appropriate when functionality is addable, omittable,
+target-backed, independently versioned, or supplied by an application/library
+author. The initial public categories are:
+
+1. **service modules**, such as haptics, notifications, secure storage, and
+   sensors;
+2. **element-provider modules**, such as `TextInput`, `GoogleMap`, a video
+   player, or the built-in primitive element package.
+
+A package may provide both categories. A map package, for example, can expose
+a `GoogleMap` element and a detached geocoding service. A scene node uses the
+element command/event path; an operation with no scene lifetime uses a service
+interface.
+
+The Host renderer remains the singular target projection selected at
+bootstrap. It is a module boundary because the Host implementation is selected
+per target, but it is not decomposed into one renderer per element.
+
+## Element contract
+
+### Registration and identity
+
+An element has one versionless canonical key, for example `whisker.ui/Text`
+or `whisker.google-maps/GoogleMap`. Build composition embeds a matching Host
+factory. During surface bootstrap, core:
+
+1. collects element schemas from selected modules;
+2. rejects duplicate canonical keys;
+3. assigns an immutable compact `ElementTypeId` for the registry epoch;
+4. asks the Host renderer to bind each normalized registration to an embedded
+   factory;
+5. validates properties, events, commands, measurement, and target
+   capabilities before the first frame.
+
+`FramePacket::CreateNode` carries the compact `ElementTypeId`. Element names
+and module names are not repeated in per-node operations. `SetText` does not
+implicitly decide that a node is a `Text`; type identity is established only
+by `CreateNode`.
+
+Built-in and custom element IDs use this same negotiation. Core must not
+assume that `View == 1` or dispatch `Text` through a separate protocol.
+
+### Public description, not public traits
+
+The author-facing definition uses UI-domain terms:
+
+```rust,ignore
+ElementDefinition {
+    presentation: Presentation::Box,
+    children: Children::None,
+    content: Content::EditableText,
+    measurement: Measurement::Host {
+        pending: PendingPolicy::RetainPrevious,
+    },
+    consumes_text_style: true,
+    properties: [...],
+    events: [...],
+    commands: [...],
+}
+```
+
+The Expo-like Swift/Kotlin DSL spells these concepts as `View`, `Children`,
+`Content`, `Measurement`, and `TextStyle`. It does not expose a `Traits`
+directive. The schema compiler may normalize the declaration to internal
+capability bits such as box presentation, text content, replaced content,
+scroll container, focusability, or accessibility. Those bits are an internal
+validation and dispatch representation, not public Rust terminology.
+
+The initial policies are deliberately closed:
+
+- `Presentation::Box` means common box/layout/paint semantics are available;
+- `Children::{None, Multiple(ChildMount)}` decides ordinary scene-child
+  containment and its Host mount target;
+- `Content::{None, Text, EditableText, Image, Native, ScrollContainer}`
+  chooses the element-specific semantic channel;
+- `Measurement::{None, Text, ReplacedContent, Host}` chooses intrinsic
+  sizing behavior;
+- `consumes_text_style` opts into receiving the resolved text-style snapshot.
+
+New categories require a protocol/RFC change. A module-specific prop does not
+create a new common style category.
+
+### Children and content are different
+
+Whether an element contains logical children is independent of what it draws:
+
+| Element | Children / mount target | Content | Intrinsic measurement |
+|---|---|---|---|
+| `View` | multiple / presentation | none | none |
+| `Text` v1 | none | text | text |
+| `Image` | none | image | known metadata or replaced content |
+| `TextInput` | none | editable text/native | Host |
+| `ScrollView` | multiple / scroll content | scroll container | none for viewport |
+| `GoogleMap` | none | native | normally none |
+
+Version 1 forbids ordinary flex children inside `Text`. Inline text is not a
+tree of rectangular flex items: iOS and Android flatten styled ranges into an
+attributed string/spannable representation. Rich text therefore needs a later
+`TextRun` content model rather than pretending normal `View` children can be
+laid out inline.
+
+An intrinsic Host measure function is initially valid only for a leaf element.
+A container derives its size from Taffy and its children. A future container
+whose native content participates in sizing needs an explicit, cycle-safe
+contract; it is not enabled by setting a flag.
+
+### Child mount targets
+
+`Children::Multiple` requires a stable Host child mount target. The common
+`View` target is its presentation container. `ScrollView` returns the native
+scroll content container, not its viewport wrapper. The common renderer uses
+that target for `InsertChild`, `MoveChild`, and `RemoveChild`; the element
+provider does not receive one callback per common child style.
+
+A third-party native element may contain Whisker children only if its generated
+schema declares a supported `ChildMount` and its Host factory returns the
+matching target. The contract defines whether element content is below,
+between, or above logical children and how coordinates map into the target.
+Arbitrary native content plus arbitrary children is unsupported by default;
+otherwise paint order, clipping, hit testing, and accessibility would be
+platform-dependent. A leaf provider such as `GoogleMap` simply has no child
+mount target.
+
+## Common presentation and element content
+
+### Responsibility split
+
+The common renderer consumes these operations for every box-presented node:
+
+- `SetLayout` and stacking order;
+- `SetBoxPaint` for backgrounds, borders, and radii;
+- shadow, clip, opacity, transform, visibility, and hit-test state;
+- common accessibility geometry and semantics.
+
+The registered element factory consumes only content-specific operations:
+
+- `SetText` or `SetImage` for a matching content category;
+- `SetTextStyle` for an element that declares `TextStyle` consumption;
+- generated `SetProperty(PropertyId, TypedValue)` patches;
+- generated commands and node-scoped events;
+- an optional resolved `TextStyleSnapshot`;
+- optional intrinsic measurement requests.
+
+Consequently, `background_color` works on `Text`, `TextInput`, `Image`, and
+`GoogleMap` even though those factories do not implement background painting.
+The common presentation implementation paints the background behind their
+content. The element factory should normally make its own default background
+and border transparent so there is only one owner.
+
+### Logical wrapper and physical realization
+
+The observable model is always presentation plus content, but the Host chooses
+the cheapest correct realization per node and revision:
+
+```text
+fused
+  one UIView/View/DOM element/GPU node owns presentation and content
+
+wrapped
+  presentation container or layer
+    `- native content object
+
+external surface
+  presentation/compositor node
+    `- platform surface or texture with explicit composition constraints
+```
+
+Fusion is allowed only while it preserves paint order, clipping, shadows,
+transform origin, opacity grouping, z-order, hit testing, focus,
+accessibility, and native-content behavior. In version 1 the realization is
+stable for the node lifetime. A Host may fuse only when its factory and common
+presenter can implement every supported dynamic presentation state for that
+element without later reparenting it. Native controls and external surfaces
+therefore normally start wrapped. A later protocol may permit state-preserving
+fused/wrapped migration, but version 1 never risks losing focus, IME,
+selection, scroll position, or native resource state to save a wrapper.
+
+Wrapper elision is an optimization after correctness. A schema and current
+presentation state form a conservative materialization key. A node with only
+layout effects can often be flattened; a node with background, border, clip,
+native ID/ref, accessibility, pointer handling, or an external surface is a
+materialization barrier unless the Host proves exact fusion.
+
+A physical presentation wrapper is accessibility-neutral unless the logical
+node's resolved semantics require it to be the accessible object. The Host
+must expose one logical accessibility node, not duplicate wrapper and content
+nodes. The same rule applies to focus and hit testing: the wrapper may
+translate coordinates and route events, but it must not create an extra
+application-visible target.
+
+### Platform examples
+
+#### iOS
+
+- `View`: a presentation `UIView`/`CALayer`; no separate content object when
+  fusion is exact.
+- `Text`: a presentation layer plus transparent CoreText/TextKit content. A
+  simple case may fuse into a Whisker-owned text view/layer.
+- `TextInput`: a presentation container around a transparent
+  `UITextField`/`UITextView`. UIKit retains IME, caret, selection, and native
+  editing behavior; Whisker owns the outer box. Native background, border,
+  and content insets are disabled or explicitly represented so they do not
+  silently add a second CSS box.
+- `ScrollView`: an outer presentation node, `UIScrollView`, and content
+  container. The native scroll object owns scrolling physics; Taffy owns the
+  viewport and content geometry.
+- `GoogleMap`: a presentation container around `GMSMapView`. Whisker paint is
+  behind or around the map; rounded clipping is applied by a compatible layer
+  or declared unsupported when the map surface cannot be composed correctly.
+
+#### Android
+
+- `View`: a Whisker presentation `View`/`ViewGroup`, fused when possible.
+- `Text`: common presentation plus a transparent text-layout/content object.
+- `TextInput`: common presentation plus transparent `EditText`; Android owns
+  IME, cursor, selection, and platform autofill. Default native background and
+  padding are disabled or explicitly represented by the element contract.
+- `ScrollView`: common presentation, native scroll container, and content
+  `ViewGroup`. Gesture arbitration is integrated with Whisker's event router.
+- `GoogleMap`: common presentation around a Maps SDK view or surface, subject
+  to the backend's z-order and clipping capabilities.
+
+#### Web
+
+The DOM Host uses the same logical split. It may use one element where CSS and
+content semantics match, or a presentation wrapper plus an `input`, `img`,
+`video`, map element, canvas, or custom element. Taffy remains authoritative;
+browser APIs supply measurement and paint primitives but must not create a
+browser-layout-to-Taffy feedback loop.
+
+The provider may be implemented in Rust with `web-sys` or in JavaScript with
+generated bindings. `web-sys` is an implementation detail, not part of the
+module contract and not something to remove solely to make the architecture
+look uniform. A JavaScript Host can reduce WASM crossings and improve direct
+ecosystem integration, while a Rust provider can be smaller and simpler when
+only selected `web-sys` features are linked.
+
+#### Desktop
+
+The Desktop Host implements the same semantic contract directly in Rust.
+Common presentation lowers to retained GPU primitives and text lowers to
+shaped glyph content. There is no serialization or language FFI merely to
+preserve the abstraction.
+
+A native child control or map-like provider is an external surface. Its
+support depends on explicit compositor capabilities for clipping, transforms,
+opacity, z-order, input, and accessibility. A target that cannot meet the
+declared minimum fails composition or reports the unsupported combination; it
+must not paint a plausible but incorrect result.
+
+## Style delivery
+
+### Closed common registry
+
+RFC 0003's common property registry is closed and owned by core. Each property
+is mapped once to a semantic channel:
+
+| Channel | Examples | Consumer |
+|---|---|---|
+| layout | width, padding, flex, position | core/Taffy |
+| box paint | background, border, radius, shadow | common Host presentation |
+| composite | opacity, transform, clip, z-order | common Host presentation |
+| text | font size/family/weight, line height, color | text-style consumer |
+| replaced content | object fit/position | image/video content consumer |
+| scroll | overflow/scroll behavior | core + scroll content consumer |
+| semantics | accessibility, focusability, pointer behavior | core + Host adapter |
+
+The element schema selects categories; it does not list or implement every
+common property. Applicability is generated from the property table and the
+normalized element categories. This makes the implementation approximately
+`properties + element schemas`, not `properties x elements`.
+
+A third-party visual setting such as `map_type`, `camera`, or
+`shows_user_location` is a generated element prop. It does not become a CSS
+property and does not inherit.
+
+### Resolved text style
+
+An element with `TextStyle` receives a typed, resolved snapshot, never raw CSS:
+
+```rust,ignore
+struct TextStyleSnapshot {
+    revision: u64,
+    font_families: FontFallbackList,
+    font_size: LogicalPx,
+    font_weight: u16,
+    font_style: FontStyle,
+    line_height: ResolvedLineHeight,
+    letter_spacing: LogicalPx,
+    color: Color,
+    locale: LocaleId,
+    direction: TextDirection,
+}
+```
+
+This includes inherited values. A custom `TextInput` therefore receives
+`font_size` through its generated `TextStyle` callback even though it did not
+declare `font_size` as a prop. The same snapshot revision and shaping inputs
+are included in its measurement key. A font change invalidates intrinsic
+measurement before the new presentation is accepted.
+
+Element props and common styles remain separate namespaces. A module must not
+declare a second `font-size` prop to receive common text style.
+
+## Expo-like `ModuleDefinition`
+
+The existing authoring shape is retained and extended progressively. The
+exact syntax remains language-idiomatic, but conceptually an iOS definition
+can read:
+
+```swift
+public func definition() -> ModuleDefinition {
+  Name("WhiskerTextInput")
+
+  AsyncFunction("requestPermission") { /* service API */ }
+
+  View(TextInputElementBinding.self, TextInputView.self) {
+    Children(.none)
+    Content(.editableText)
+    Measurement(.host, pending: .retainPrevious)
+
+    TextStyle { view, style in
+      view.font = resolveFont(style)
+      view.textColor = style.color.uiColor
+    }
+
+    Prop(TextInputProps.value) { view, value, revision in
+      view.reconcileValue(value, revision: revision)
+    }
+
+    Events(TextInputEvents.change, TextInputEvents.selectionChange)
+    Command(TextInputCommands.focus) { view in view.focus() }
+  }
+}
+```
+
+Kotlin has the same declarations with Kotlin naming and types. Service-only
+modules retain the existing `Name`, `Function`, `AsyncFunction`, module event,
+and observer-lifecycle definition shape and do not emit element-provider
+metadata. They do not need a `View` block. Simple elements omit directives
+whose generated binding already supplies defaults.
+
+The declarations map as follows:
+
+- module-level `Function`/`AsyncFunction` -> typed native service interface;
+- `View` -> Host factory for one generated element schema;
+- `Prop` -> numeric `PropertyId` patch;
+- `Command` or view-local function -> numeric `CommandId` and optional
+  `ResultId`;
+- `Events` in a `View` -> node-scoped typed event IDs;
+- module-level events -> service subscription lifecycle;
+- `TextStyle` -> common resolved text-style channel;
+- `Measurement` -> the element's intrinsic measurement provider.
+
+### One schema source of truth
+
+Swift, Kotlin, JavaScript, and Rust declarations must not independently assign
+names, numbers, optionality, or payload shapes. A platform-neutral schema
+source produces:
+
+- `ElementSchema` and canonical name;
+- stable property, event, and command IDs;
+- Rust builders and typed handles;
+- Swift, Kotlin, JavaScript, and Desktop Rust binding types;
+- FramePacket encoders/decoders and debug symbols;
+- build-registration metadata.
+
+The native `ModuleDefinition` binds implementation callbacks to generated
+symbols. It is not a second schema source. Build composition fails if a target
+factory is missing a required callback or was generated from an incompatible
+schema. Whether the source syntax is a Rust macro or a small IDL remains an
+implementation question; generated artifacts and validation are normative.
+
+The current string-name/`WhiskerValue` path may remain temporarily for service
+compatibility and diagnostics. Frame, measure, input, and frequent element
+updates use numeric typed batches, not a dynamic call for each property.
+
+## Intrinsic measurement
+
+### Provider contract
+
+Measurement occurs before the first `CreateNode` packet can be mounted, so it
+must not require an already-created Host view. An element factory may expose a
+separate lightweight measurer:
+
+```rust,ignore
+trait HostElementMeasurer {
+    fn measure(
+        &mut self,
+        request: &MeasurementRequest,
+    ) -> MeasurementResponse;
+}
+
+trait HostElementFactory {
+    fn create(&mut self, context: ElementContext) -> HostElement;
+    fn apply_content(&mut self, element: &mut HostElement, patch: ContentPatch);
+    fn invoke_command(&mut self, element: &mut HostElement, command: Command);
+    fn destroy(&mut self, element: HostElement);
+}
+```
+
+These are information-level interfaces. A Host can share a text shaper,
+control prototype, immutable resource metadata, or prepared content between
+the measurer and factory. It must not create and leak a mounted native view
+just to answer layout.
+
+The request describes the content box constraints and contains all inputs
+that can affect intrinsic size: element type, content and relevant props,
+resolved text style, locale, direction, scale, resource metadata, content
+revision, style revision, and environment epoch. The provider returns content
+size, baselines, overflow, and optionally a `PreparedContentId`. Core adds
+padding/border and applies width/height/min/max/aspect rules through Taffy.
+
+### Synchronous and pending results
+
+Requests are batched. Each answer is one of:
+
+```text
+Ready(key, metrics, prepared_content?)
+Pending(key, request_id, provisional?)
+Unsupported(key, reason)
+```
+
+The element declaration chooses the pending behavior:
+
+- `Block`: withhold the new subtree until the initial answer is ready;
+- `Placeholder(size)`: lay out using a declared provisional size;
+- `RetainPrevious`: preserve the previous accepted size during an update.
+
+An asynchronous resource completion emits `MeasurementReady`, wakes the
+runtime, reruns the smallest affected Taffy subtree, and prepares another
+frame. Completion is accepted only when request ID, measurement key, node
+generation, content/style revisions, and environment epoch still match.
+Deleted nodes cancel outstanding requests. The engine bounds immediate
+measure/layout rounds and diagnoses oscillation for unchanged inputs.
+
+The same resolved style snapshot used in measurement must be used to present
+the accepted content. A `PreparedContentId` can bind a shaped glyph object,
+decoded image metadata, or native layout object to that exact result and avoid
+doing expensive work twice.
+
+### Element policies
+
+- `Text`: Host text shaping and line breaking; synchronous on primary Hosts.
+- `TextInput`: Host control/text metrics; may use a lightweight prototype or
+  platform text API rather than the live view.
+- bundled image with known dimensions: `ReplacedContent` metadata; no Host FFI
+  is needed.
+- network/custom image: explicit dimensions or aspect ratio are preferred.
+  A module may opt into pending intrinsic size with an explicit placeholder
+  policy.
+- `GoogleMap`, `WebView`, and video: normally have no useful intrinsic size;
+  they require explicit, flex, or parent-constrained geometry. Resource
+  readiness does not redefine their viewport unless the schema says so.
+- a measuring container: unsupported in version 1 to prevent Host/Taffy child
+  feedback cycles.
+
+## Events, native state, and commands
+
+Host events are node-scoped, typed, and include the node generation. Core owns
+logical capture/bubble propagation and listener lifetimes. A native control
+may perform platform gesture recognition, scrolling, text editing, or
+accessibility actions locally, then report the corresponding typed state/event
+through the surface event sink.
+
+Host callbacks never synchronously re-enter arbitrary Rust application code
+from inside `present`. They enqueue an event and request/wake the runtime.
+Native objects are created, mutated, and destroyed on the Host UI thread.
+Background resource work posts completion back to that boundary.
+
+### TextInput reconciliation
+
+IME composition, selection, caret movement, and rapid typing cannot be
+round-tripped as naive controlled-value assignments. Every Host editing event
+carries a monotonically increasing `host_state_revision`. A Rust value update
+back to the Host identifies the revision on which it was based. The Host:
+
+- ignores an update older than its accepted editing revision;
+- applies a newer authoritative value without corrupting active composition;
+- reports composition and selection changes explicitly;
+- clears pending state when the node generation changes or is deleted.
+
+The exact conflict policy is part of the generated editable-text contract, not
+a generic `Prop("value")` convention. This prevents stale frames from
+overwriting characters entered after Rust began producing them.
+
+### Scroll state and gesture arbitration
+
+`ScrollView` has a bounded viewport box and a distinct content extent. Taffy
+lays out its content with an unbounded constraint only in the configured
+scroll axis; the cross axis remains constrained. A scroll viewport without a
+bounded size is a diagnostic.
+
+The native scroll control owns transient offset, velocity, inertia, overscroll,
+and platform gesture arbitration. It reports versioned scroll state to core so
+hit testing, queries, events, sticky behavior, and accessibility observe a
+coherent offset. Programmatic scroll is an ordered node command. Long lists
+require a separate virtualized collection element; `ScrollView` does not imply
+virtualization and must not eagerly materialize an unbounded data set by
+accident.
+
+## Performance contract
+
+The module abstraction must not restore a bridge-shaped hot path:
+
+- registry and canonical-name resolution happen at bootstrap;
+- hot operations use compact element/property/event/command IDs;
+- one changed frame crosses the Host boundary as one transaction;
+- intrinsic requests and Host events are batched where latency permits;
+- strings and variable payloads live in packet tables rather than one object
+  allocation per property;
+- Desktop passes borrowed typed data directly in Rust;
+- WASM presents a borrowed linear-memory view for the duration of the call;
+- native bindings may use generated C-compatible tables/JNI arrays without
+  JSON or per-property reflection;
+- wrapper elision and lazy Host content creation are permitted behind the
+  semantic model;
+- a module callback is not invoked for every common style property.
+
+Synchronous calls are allowed where correctness requires a result before
+commit, especially text measurement, but they must be batched and must not
+perform network or unbounded work. A provider that cannot meet this requirement
+uses `Pending`.
+
+## Lifecycle and failure
+
+A module instance normally has Application or Process scope. An element
+factory registration has surface availability; an element instance has node
+scope. They are not the same lifetime.
+
+Deleting a node must:
+
+- detach it from presentation and content hierarchies;
+- release or pool its Host objects;
+- remove native observers and event subscriptions;
+- cancel or invalidate pending measurements and command results;
+- release prepared content and external surfaces;
+- resign focus/IME and pointer capture safely;
+- prevent stale callbacks from targeting a reused ID.
+
+Unsupported targets fail during build composition. A schema/factory mismatch
+fails during bootstrap. An unsupported style/content combination discovered
+at runtime rejects the frame or emits a structured capability error according
+to whether the capability was declared optional. Silent no-op behavior is not
+allowed for required semantics.
+
+## Prior-art and failure-mode review
+
+This section is normative where it records a Whisker decision. It compares the
+design against problems already exposed by Lynx and React Native rather than
+claiming API compatibility with either project.
+
+### React Native Fabric
+
+React Native's current renderer separates render, commit/layout, and UI-thread
+mounting. Host-dependent `Text` and `TextInput` measurement participates in
+layout, while atomic Host mutations are applied on the UI thread. Whisker keeps
+the same important separation: the Rust scene and Taffy result are prepared
+before one Host transaction, and native objects are mutated only by the Host
+UI thread. See [Render, Commit, and Mount](https://reactnative.dev/architecture/render-pipeline)
+and the [Threading Model](https://reactnative.dev/architecture/threading-model).
+
+Fabric Native Components use a typed specification and Codegen for props,
+events, and commands. This validates the requirement for one schema source of
+truth and generated native bindings. Independent hand-maintained Swift/Kotlin
+IDs would repeat the mismatch class Fabric removed. See the
+[Fabric Native Components introduction](https://reactnative.dev/docs/next/fabric-native-components-introduction)
+and [native commands](https://reactnative.dev/docs/next/the-new-architecture/fabric-component-native-commands).
+
+React Native's legacy serialized bridge became a bottleneck for frequent and
+large updates. Whisker therefore does not use the friendly dynamic
+`ModuleDefinition` dispatch as its frame transport. The public DSL generates a
+typed registry and the hot path stays numeric and batched. See React Native's
+[New Architecture rationale](https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here).
+
+Fabric flattens layout-only views during tree diffing. That demonstrates both
+the performance value of avoiding unconditional wrappers and the need to make
+flattening sensitive to paint and interaction props. Whisker's logical
+presentation/content split permits conservative fusion, but background,
+opacity, clipping, native refs, accessibility, and events are materialization
+barriers unless exact equivalence is proven. See
+[View Flattening](https://reactnative.dev/architecture/view-flattening).
+
+React Native treats nested text as an inline attributed-text context rather
+than ordinary flex children. Whisker v1 therefore makes `Text` a leaf and does
+not hide inline layout behind `Children::Multiple`. See React Native's
+[Text container model](https://reactnative.dev/docs/text).
+
+React Native requires network images to have dimensions instead of changing
+layout after download, explicitly avoiding layout shift. Whisker permits
+deferred intrinsic image sizing only as an opt-in schema policy with a declared
+placeholder/retain/block behavior; explicit dimensions or aspect ratio remain
+the default. See React Native's [Images guide](https://reactnative.dev/docs/images).
+
+React Native's `ScrollView` requires bounded height and renders every child,
+which makes it unsuitable as an implicit virtualized list. Whisker records
+both constraints in the element contract instead of leaving them as usage
+folklore. See the [ScrollView guide](https://reactnative.dev/docs/scrollview).
+
+React Native editing events include an event count and expose Host-owned
+selection/composition behavior. Whisker goes further by making Host state
+revision part of the editable-text reconciliation contract. See the
+[TextInput event API](https://reactnative.dev/docs/next/textinput).
+
+### Lynx
+
+Lynx custom elements separate the native UI object from a `ShadowNode` measure
+provider. Its documentation limits custom intrinsic measurement to leaf
+components and can pass prepared extra data from measure/layout to UI. Whisker
+adopts the same safety constraints as a Host-independent measurer plus optional
+`PreparedContentId`, while keeping Taffy and validation in Rust. See
+[Lynx Custom Element](https://lynxjs.org/next/guide/custom-native-component.html).
+
+Lynx's custom element API has distinct registration, property, event, method,
+layout, and measurement hooks. That supports Whisker's separation of schema,
+factory, commands/events, and measure provider. Whisker deliberately replaces
+runtime string dispatch with generated IDs in frequent paths.
+
+Lynx supports event work on both main and background scripting threads and
+warns that excessive main-thread handlers make the main thread busy. Whisker
+does not initially expose arbitrary priority execution from module callbacks:
+Host controls run locally, callbacks enqueue typed events, and Rust application
+work runs at an explicit runtime boundary. Expensive work is delegated to
+ordinary Rust background execution and wakes the Host loop when complete. See
+[Lynx Event Handling](https://lynxjs.org/guide/interaction/event-handling).
+
+### Risk audit
+
+| Risk | Severity | RFC decision / required check |
+|---|---:|---|
+| element x style implementation explosion | blocker | common presentation owns box/composite styles; schemas select fixed channels |
+| wrapper hierarchy cost | high | logical wrapper only; conservative fusion/flattening with materialization barriers |
+| dynamic wrapper insertion loses control state | high | realization is stable for a node lifetime in v1; native controls/external surfaces start wrapped |
+| native surface cannot clip/transform correctly | high | explicit external-surface capability matrix; reject unsupported required combinations |
+| measure needs a view that does not exist yet | blocker | separate pre-mount measurer; no live Host element parameter |
+| async measure returns stale data | high | key + request ID + node generation + content/style/environment revisions |
+| measure/layout feedback oscillates | high | leaf-only v1, bounded rounds, identical-input oscillation diagnostic |
+| measurement and paint shape text differently | high | one resolved snapshot and optional prepared-content identity |
+| Text treated as an ordinary container | high | leaf `Text` v1; future rich-text content protocol |
+| controlled TextInput loses keystrokes/IME state | blocker | Host state revision and explicit composition/selection reconciliation |
+| ScrollView has circular/unbounded geometry | high | bounded viewport, one unbounded content axis, separate offset state |
+| native control steals pointer/focus semantics | high | explicit gesture/focus ownership and typed state events; conformance tests |
+| platform implementations drift | high | one generated schema and shared scenario IDs across Hosts |
+| dynamic module API leaks into frame hot path | high | numeric typed packets; dynamic API limited to compatibility/cold service paths |
+| third-party CSS extensions break global semantics | medium | closed common registry; custom visuals are typed element props |
+| background work re-enters UI/runtime unsafely | high | enqueue/wake boundary; Host UI objects remain UI-thread-affine |
+| node deletion leaks native resources/callbacks | high | generation checks and normative teardown checklist |
+| Web browser layout becomes second authority | high | Taffy authoritative; batch measure reads separately from DOM writes |
+| built-ins gain hidden privileges over modules | medium | same registry, IDs, frame ops, events, lifecycle, and conformance harness |
+
+### Review conclusion
+
+The architecture is feasible, and its central presentation/content split is a
+sound way to avoid combinatorial styling implementations. It is not safe if
+“same treatment” is interpreted as “same capabilities”: containers, leaf
+content, editable controls, scroll containers, text, replaced content, and
+external surfaces need distinct closed semantic channels.
+
+The following changes are required by this review and are incorporated above:
+
+1. intrinsic measurement is pre-mount and separate from the live Host factory;
+2. custom measurement is leaf-only in version 1;
+3. `Text` is leaf-only until an explicit inline-run protocol exists;
+4. TextInput uses revisioned Host state rather than naive controlled props;
+5. ScrollView has a bounded viewport/content-extent contract and does not
+   imply virtualization;
+6. wrapper elision is semantics-aware and external surfaces negotiate
+   composition capabilities;
+7. one generated schema, not parallel native declarations, owns wire identity;
+8. common style remains closed and element-specific visuals remain props.
+
+With those constraints, no architectural blocker was found. The largest
+implementation risks are native external-surface composition, IME correctness,
+and keeping measurement/presentation text snapshots identical. These require
+target conformance tests before a Host can claim support; they do not require a
+different top-level architecture.
+
+## Test strategy
+
+### Rust core tests
+
+- built-in and third-party schemas normalize through the same registry;
+- duplicate keys and generated-ID mismatches fail bootstrap;
+- property applicability is derived from closed channels;
+- `CreateNode` type IDs, property IDs, event IDs, and command IDs are stable
+  within a registry epoch;
+- measurement batching, cache keys, pending policy, stale completion, and
+  oscillation limits;
+- resolved text style is identical between measure and frame content;
+- TextInput and scroll Host-state revisions reject stale updates;
+- node deletion invalidates every pending handle and callback;
+- recording Host tests verify no per-style module dispatch occurs.
+
+### Host-only tests
+
+Each Host has a standalone scenario runner that mocks frame packets,
+measurement requests, and the Rust event sink. Shared scenarios cover:
+
+- background/border/clip/opacity on View, Text, TextInput, Image, and a mock
+  custom native element;
+- wrapper fusion and forced materialization producing equivalent pixels,
+  geometry, focus, hit testing, and accessibility;
+- font-size inheritance delivered to Text and TextInput measurement/content;
+- Ready/Pending measurement and prepared-content reuse;
+- native input composition, selection, stale value frames, focus, and teardown;
+- ScrollView bounds, offset events, gesture arbitration, and command ordering;
+- an external-surface mock for z-order, transform, opacity, and clip capability
+  failures;
+- event capture/bubble and deletion during callbacks;
+- schema mismatch diagnostics before the first frame.
+
+The scenario IDs are shared across Android, iOS, Web, and Desktop. WPT-derived
+box/style cases remain useful for common presentation; element-specific native
+state cases are Whisker-owned because WPT does not define UIKit/Android control
+behavior.
+
+### Full-stack tests
+
+A smaller matrix runs `render!` through core, real measurement, FramePacket,
+Host presentation, and returned events. It proves wiring, while the larger
+Host-only and Rust-only suites localize failures and allow target development
+without the other side running.
+
+## Migration
+
+The first implementation slice represents the built-in primitives as the
+ordinary `whisker.ui` `ElementModuleDefinition`. Desktop and Web composition
+then pair every Rust provider with a target factory by the versionless
+canonical key. The same `DesktopElementModule` / `WebElementModule` value is
+used for built-in and application-selected providers; a missing, duplicate, or
+unmatched factory fails bootstrap before mounting application UI. `Page` is
+not part of this module.
+
+This slice covers the active RFC0004 Desktop and Web Hosts. Android and iOS
+continue to use the Lynx module registrar until their RFC0004 Host renderers
+and generated binding-symbol ingestion exist; their current Swift/Kotlin
+`ModuleDefinition.View` blocks must not be treated as a second schema source.
+
+1. Add the normalized element schema and generated symbol source without
+   changing current built-in rendering.
+2. Extend native `ModuleDefinition` with generated `View`, `Children`,
+   `Content`, `Measurement`, `TextStyle`, typed prop/event, and command
+   bindings.
+3. Register built-in `View` and `Text` through the provider path and remove
+   hard-coded tag-to-ID conversion.
+4. Split common Host presentation from content factories and add View/Text
+   parity tests.
+5. Change the conceptual/live factory measurement API to the pre-mount
+   measurer and preserve the current protocol's prepared-content path.
+6. Add `Image`, `TextInput`, and `ScrollView` one at a time with their
+   measurement/state contracts and shared Host scenarios.
+7. Add a mock third-party native element, then a Google Maps proof of concept
+   including CNG dependencies and capability failures.
+8. Move frame and frequent element updates off raw name/`WhiskerValue`
+   dispatch; retain a documented dynamic service escape hatch if still useful.
+9. Add conservative wrapper fusion only after the non-fused implementation
+   passes the same semantics and visual tests.
+
+No Lynx migration adapter or `SurfaceEngine` compatibility layer is introduced
+solely to preserve the old architecture. Until built-ins use the module path,
+the temporary hard-coded path is removed directly rather than standardized.
+
+## Invariants
+
+1. Core owns one logical scene, style resolution, Taffy layout, frame
+   revisions, measurement coordination, and event propagation.
+2. Internal crate or Rust-trait boundaries are not automatically modules.
+3. Built-in and third-party elements use the same registry and wire protocol.
+4. Public `ModuleDefinition` does not expose Rust `Trait` terminology.
+5. Every visual element has common box presentation independent of its content.
+6. Element providers do not implement background, border, layout, or common
+   compositing property resolution.
+7. Physical wrappers are optional only when observable semantics are equal.
+8. Common style is closed; module-specific behavior uses typed props.
+9. Text-style consumers receive resolved inherited values, including
+   `font_size`, through a dedicated typed channel.
+10. Measurement can run before Host element creation and is leaf-only in v1.
+11. Measurement and presentation use matching style/content revisions.
+12. Host UI mutation is UI-thread-affine; callbacks enqueue rather than
+    re-entering application code during presentation.
+13. Frame, measurement, and frequent event traffic is typed and batched.
+14. Unsupported required target or composition behavior fails visibly.
+15. Node generation protects every event, command, measure, and Host resource
+    from stale reuse.
+
+## Open questions
+
+The following remain open before this RFC becomes `Accepted`:
+
+- whether the canonical schema source is a Rust macro, a standalone IDL, or a
+  generated combination with one normative normalized representation;
+- exact Swift and Kotlin DSL names and which directives can be inferred;
+- the minimum external-surface composition profile required of every Host;
+- the rich-text run/tree protocol and inline attachment model;
+- exact editable-text conflict behavior during active marked-text composition;
+- the common scroll-state record, nested scrolling contract, and gesture
+  priority model;
+- criteria and state-transfer protocol for any future in-place wrapper
+  realization change;
+- the initial cross-platform accessibility role/action schema;
+- whether any custom container measurement use case justifies a cycle-safe
+  version 2 contract.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -49,3 +49,4 @@ are specified independently inside each RFC.
 | [0001](0001-runtime-modules-and-build-plugins.md) | Runtime Modules and Build-time Plugins | Draft |
 | [0002](0002-renderer-interface-and-frame-protocol.md) | Renderer Interface and Frame Protocol | Draft |
 | [0003](0003-typed-inline-style-layout-and-paint.md) | Typed Inline Style, Layout, and Paint | Draft |
+| [0004](0004-native-modules-and-host-elements.md) | Native Modules and Host Elements | Draft |

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -1,0 +1,425 @@
+//! Desktop binding for negotiated element schemas.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+use whisker::ElementProviderMetadata;
+use whisker_protocol::{
+    ElementChildMount, ElementContentKind, ElementMeasurement, ElementRegistration,
+    ElementRegistrationError, ElementTypeId, NodeId, TextContent,
+};
+
+/// One Desktop element module's Rust schema and target factory.
+///
+/// Keeping both halves in one value prevents application composition from
+/// selecting an element schema without embedding its Desktop implementation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DesktopElementModule {
+    provider: ElementProviderMetadata,
+    factory: DesktopElementFactory,
+}
+
+impl DesktopElementModule {
+    /// Joins a Rust provider to its Desktop Host factory.
+    pub fn new(provider: ElementProviderMetadata, factory: DesktopElementFactory) -> Self {
+        Self { provider, factory }
+    }
+
+    /// Returns the Rust provider metadata.
+    pub fn provider(&self) -> &ElementProviderMetadata {
+        &self.provider
+    }
+
+    /// Returns the target-specific Desktop factory.
+    pub fn factory(&self) -> &DesktopElementFactory {
+        &self.factory
+    }
+}
+
+/// Target-specific Desktop factory embedded for one element module.
+///
+/// The canonical name joins this Host definition to the Rust-side
+/// [`whisker::ElementProviderMetadata`]. Constructors intentionally expose only
+/// the content factories implemented by the current Desktop Host.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DesktopElementFactory {
+    canonical_name: String,
+    kind: DesktopElementFactoryKind,
+}
+
+impl DesktopElementFactory {
+    /// Creates a common-presentation-only element factory.
+    pub fn presentation(canonical_name: impl Into<String>) -> Self {
+        Self::new(canonical_name, DesktopElementFactoryKind::Presentation)
+    }
+
+    /// Creates a native Desktop text-content factory.
+    pub fn text(canonical_name: impl Into<String>) -> Self {
+        Self::new(canonical_name, DesktopElementFactoryKind::Text)
+    }
+
+    /// Creates a Desktop scroll-container factory.
+    pub fn scroll_container(canonical_name: impl Into<String>) -> Self {
+        Self::new(canonical_name, DesktopElementFactoryKind::ScrollContainer)
+    }
+
+    fn new(canonical_name: impl Into<String>, kind: DesktopElementFactoryKind) -> Self {
+        Self {
+            canonical_name: canonical_name.into(),
+            kind,
+        }
+    }
+
+    fn content(&self) -> ElementContentKind {
+        match self.kind {
+            DesktopElementFactoryKind::Presentation => ElementContentKind::None,
+            DesktopElementFactoryKind::Text => ElementContentKind::Text,
+            DesktopElementFactoryKind::ScrollContainer => ElementContentKind::ScrollContainer,
+        }
+    }
+
+    fn create(&self) -> DesktopElementContent {
+        match self.kind {
+            DesktopElementFactoryKind::Presentation => DesktopElementContent::Empty,
+            DesktopElementFactoryKind::Text => DesktopElementContent::Text(None),
+            DesktopElementFactoryKind::ScrollContainer => DesktopElementContent::ScrollContainer,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DesktopElementFactoryKind {
+    Presentation,
+    Text,
+    ScrollContainer,
+}
+
+/// Returns the standard UI package as ordinary Desktop element modules.
+pub fn standard_desktop_element_modules() -> Vec<DesktopElementModule> {
+    whisker::standard_element_providers()
+        .into_iter()
+        .map(|provider| {
+            let factory = match provider.schema.canonical_name.as_str() {
+                whisker::VIEW_ELEMENT_NAME => {
+                    DesktopElementFactory::presentation(whisker::VIEW_ELEMENT_NAME)
+                }
+                whisker::TEXT_ELEMENT_NAME => {
+                    DesktopElementFactory::text(whisker::TEXT_ELEMENT_NAME)
+                }
+                whisker::SCROLL_VIEW_ELEMENT_NAME => {
+                    DesktopElementFactory::scroll_container(whisker::SCROLL_VIEW_ELEMENT_NAME)
+                }
+                canonical_name => panic!("standard UI factory missing for {canonical_name}"),
+            };
+            DesktopElementModule::new(provider, factory)
+        })
+        .collect()
+}
+
+/// Returns only the Desktop factories from the standard UI package.
+pub fn standard_desktop_element_factories() -> Vec<DesktopElementFactory> {
+    standard_desktop_element_modules()
+        .into_iter()
+        .map(|module| module.factory)
+        .collect()
+}
+
+/// Element-specific state retained beside common Desktop presentation.
+#[derive(Clone, Debug)]
+pub(crate) enum DesktopElementContent {
+    Empty,
+    Text(Option<TextContent>),
+    ScrollContainer,
+}
+
+impl DesktopElementContent {
+    pub(crate) fn text(&self) -> Option<&TextContent> {
+        match self {
+            Self::Text(content) => content.as_ref(),
+            Self::Empty | Self::ScrollContainer => None,
+        }
+    }
+
+    pub(crate) fn set_text(
+        &mut self,
+        node: NodeId,
+        content: TextContent,
+    ) -> Result<(), DesktopElementError> {
+        match self {
+            Self::Text(current) => {
+                *current = Some(content);
+                Ok(())
+            }
+            Self::Empty | Self::ScrollContainer => {
+                Err(DesktopElementError::UnexpectedText { node })
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DesktopElementBinding {
+    factory: DesktopElementFactory,
+    child_mount: ElementChildMount,
+    measurement: ElementMeasurement,
+}
+
+/// Immutable element factories bound before the first Desktop frame.
+///
+/// Common presentation never dispatches through this registry. It is consulted
+/// only when a node is created or receives an element-specific content
+/// operation, keeping style and layout updates on the existing dense path.
+#[derive(Clone, Debug)]
+pub(crate) struct DesktopElementRegistry {
+    bindings: HashMap<ElementTypeId, DesktopElementBinding>,
+}
+
+impl DesktopElementRegistry {
+    pub(crate) fn bind(
+        registrations: &[ElementRegistration],
+        factories: &[DesktopElementFactory],
+    ) -> Result<Self, DesktopElementError> {
+        let mut bindings = HashMap::with_capacity(registrations.len());
+        let mut canonical = HashMap::with_capacity(registrations.len());
+        let mut factories_by_name = HashMap::with_capacity(factories.len());
+        for factory in factories {
+            if factories_by_name
+                .insert(factory.canonical_name.clone(), factory.clone())
+                .is_some()
+            {
+                return Err(DesktopElementError::DuplicateFactory {
+                    canonical_name: factory.canonical_name.clone(),
+                });
+            }
+        }
+        for registration in registrations {
+            registration
+                .validate()
+                .map_err(|error| DesktopElementError::InvalidRegistration {
+                    element_type: registration.element_type,
+                    error,
+                })?;
+            if bindings.contains_key(&registration.element_type) {
+                return Err(DesktopElementError::DuplicateElementType {
+                    element_type: registration.element_type,
+                });
+            }
+            let identity = registration.canonical_name.clone();
+            if canonical
+                .insert(identity, registration.element_type)
+                .is_some()
+            {
+                return Err(DesktopElementError::DuplicateCanonicalElement {
+                    element_type: registration.element_type,
+                });
+            }
+            let factory = factories_by_name
+                .remove(&registration.canonical_name)
+                .ok_or_else(|| DesktopElementError::MissingFactory {
+                    canonical_name: registration.canonical_name.clone(),
+                })?;
+            if registration.content != factory.content() {
+                return Err(DesktopElementError::FactoryMismatch {
+                    canonical_name: registration.canonical_name.clone(),
+                    schema_content: registration.content,
+                    factory_content: factory.content(),
+                });
+            }
+            bindings.insert(
+                registration.element_type,
+                DesktopElementBinding {
+                    factory,
+                    child_mount: registration.child_mount,
+                    measurement: registration.measurement,
+                },
+            );
+        }
+        if let Some(canonical_name) = factories_by_name.into_keys().next() {
+            return Err(DesktopElementError::UnknownFactory { canonical_name });
+        }
+        Ok(Self { bindings })
+    }
+
+    pub(crate) fn create(
+        &self,
+        element_type: ElementTypeId,
+    ) -> Result<DesktopElementContent, DesktopElementError> {
+        Ok(self.binding(element_type)?.factory.create())
+    }
+
+    pub(crate) fn child_mount(
+        &self,
+        element_type: ElementTypeId,
+    ) -> Result<ElementChildMount, DesktopElementError> {
+        Ok(self.binding(element_type)?.child_mount)
+    }
+
+    pub(crate) fn measurement(
+        &self,
+        element_type: ElementTypeId,
+    ) -> Result<ElementMeasurement, DesktopElementError> {
+        Ok(self.binding(element_type)?.measurement)
+    }
+
+    fn binding(
+        &self,
+        element_type: ElementTypeId,
+    ) -> Result<DesktopElementBinding, DesktopElementError> {
+        self.bindings
+            .get(&element_type)
+            .cloned()
+            .ok_or(DesktopElementError::UnknownElementType { element_type })
+    }
+}
+
+/// Desktop element registration or content-dispatch failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum DesktopElementError {
+    InvalidRegistration {
+        element_type: ElementTypeId,
+        error: ElementRegistrationError,
+    },
+    DuplicateElementType {
+        element_type: ElementTypeId,
+    },
+    DuplicateCanonicalElement {
+        element_type: ElementTypeId,
+    },
+    DuplicateFactory {
+        canonical_name: String,
+    },
+    MissingFactory {
+        canonical_name: String,
+    },
+    UnknownFactory {
+        canonical_name: String,
+    },
+    FactoryMismatch {
+        canonical_name: String,
+        schema_content: ElementContentKind,
+        factory_content: ElementContentKind,
+    },
+    UnknownElementType {
+        element_type: ElementTypeId,
+    },
+    ChildrenNotAllowed {
+        parent: NodeId,
+    },
+    UnexpectedText {
+        node: NodeId,
+    },
+    UnsupportedProperty {
+        node: NodeId,
+    },
+    UnsupportedCommand {
+        node: NodeId,
+    },
+}
+
+impl fmt::Display for DesktopElementError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Desktop element error: {self:?}")
+    }
+}
+
+impl Error for DesktopElementError {}
+
+#[cfg(test)]
+mod tests {
+    use whisker::{
+        ElementProviderMetadata, ElementRegistry, SurfaceRuntime, standard_element_registrations,
+    };
+    use whisker_protocol::{ElementMeasurement, ElementSchema, SurfaceId};
+    use whisker_style::StyleEnvironment;
+
+    use super::*;
+
+    #[test]
+    fn standard_view_text_and_scroll_bind_through_one_registry() {
+        let registrations = standard_element_registrations();
+        let factories = standard_desktop_element_factories();
+        let registry = DesktopElementRegistry::bind(&registrations, &factories).unwrap();
+        for registration in &registrations {
+            let content = registry.create(registration.element_type).unwrap();
+            assert_eq!(
+                matches!(content, DesktopElementContent::Text(_)),
+                registration.content == ElementContentKind::Text
+            );
+            assert_eq!(
+                registry.child_mount(registration.element_type).unwrap(),
+                registration.child_mount
+            );
+            assert_eq!(
+                registry.measurement(registration.element_type).unwrap(),
+                registration.measurement
+            );
+        }
+
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(1).unwrap(),
+            StyleEnvironment::new(100.0, 100.0, 1.0, 14.0),
+        );
+        assert_eq!(surface.element_registrations(), registrations);
+        assert!(registrations.iter().any(|registration| {
+            registration.content == ElementContentKind::Text
+                && registration.measurement == ElementMeasurement::Text
+        }));
+    }
+
+    #[test]
+    fn duplicate_and_unsupported_registrations_fail_before_a_frame() {
+        let mut registrations = standard_element_registrations();
+        registrations.push(registrations[0].clone());
+        assert!(matches!(
+            DesktopElementRegistry::bind(&registrations, &standard_desktop_element_factories()),
+            Err(DesktopElementError::DuplicateElementType { .. })
+        ));
+
+        let mut unsupported = standard_element_registrations()[0].clone();
+        unsupported.content = ElementContentKind::Native;
+        assert!(matches!(
+            DesktopElementRegistry::bind(
+                &[unsupported],
+                &[DesktopElementFactory::presentation("whisker.ui/View")]
+            ),
+            Err(DesktopElementError::FactoryMismatch { .. })
+        ));
+
+        assert!(matches!(
+            DesktopElementRegistry::bind(&standard_element_registrations(), &[]),
+            Err(DesktopElementError::MissingFactory { .. })
+        ));
+    }
+
+    #[test]
+    fn module_provider_binds_by_versionless_canonical_name() {
+        let module = DesktopElementModule::new(
+            ElementProviderMetadata::named(
+                "badge",
+                ElementSchema {
+                    canonical_name: "whisker.test/Badge".into(),
+                    content: ElementContentKind::None,
+                    child_mount: ElementChildMount::Presentation,
+                    measurement: ElementMeasurement::None,
+                    consumes_text_style: false,
+                },
+            ),
+            DesktopElementFactory::presentation("whisker.test/Badge"),
+        );
+        let elements = ElementRegistry::standard_builder()
+            .register_provider(module.provider().clone())
+            .build()
+            .unwrap();
+        let badge = elements.registration_for_name("badge").unwrap();
+        let mut factories = standard_desktop_element_factories();
+        factories.push(module.factory().clone());
+        let desktop = DesktopElementRegistry::bind(elements.registrations(), &factories).unwrap();
+
+        assert!(matches!(
+            desktop.create(badge.element_type),
+            Ok(DesktopElementContent::Empty)
+        ));
+        assert_eq!(badge.canonical_name, "whisker.test/Badge");
+    }
+}

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -14,9 +14,10 @@ use std::fmt;
 
 use whisker::RuntimeInstance;
 use whisker_engine::HostLayoutOptions;
-use whisker_protocol::SurfaceId;
+use whisker_protocol::{ElementRegistration, SurfaceId};
 use whisker_style::StyleEnvironment;
 
+mod element;
 mod gpu;
 mod paint;
 mod scene;
@@ -27,6 +28,11 @@ mod text;
 #[path = "../tests/host_conformance/mod.rs"]
 mod host_conformance_tests;
 
+use element::DesktopElementRegistry;
+pub use element::{
+    DesktopElementFactory, DesktopElementModule, standard_desktop_element_factories,
+    standard_desktop_element_modules,
+};
 use surface::DesktopSurface;
 use text::NativeTextHost;
 
@@ -86,12 +92,16 @@ impl DesktopHost {
         target: impl Into<wgpu::SurfaceTarget<'static>>,
         physical_size: [u32; 2],
         surface: SurfaceId,
+        elements: &[ElementRegistration],
+        element_factories: &[DesktopElementFactory],
     ) -> Result<Self, DesktopHostError> {
-        let surface = DesktopSurface::new(target, physical_size, surface)
+        let elements = DesktopElementRegistry::bind(elements, element_factories)
+            .map_err(|error| DesktopHostError(format!("bind Desktop elements: {error}")))?;
+        let surface = DesktopSurface::new(target, physical_size, surface, elements.clone())
             .await
             .map_err(|error| DesktopHostError(format!("initialize Desktop renderer: {error}")))?;
         Ok(Self {
-            measurements: NativeTextHost::new(),
+            measurements: NativeTextHost::new(elements),
             surface,
         })
     }

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -1,14 +1,18 @@
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
 
 use whisker_engine::FrameSink;
 use whisker_protocol::{
-    ApplyResult, BoxClip, BoxPaint, FrameMode, FramePacket, LayoutGeometry, LayoutRect, NodeId,
-    Operation, OverflowClip, PaintColor, SceneProjection, SurfaceId, TextContent, ValidationError,
-    Visibility,
+    ApplyResult, BoxClip, BoxPaint, ElementChildMount, ElementTypeId, FrameMode, FramePacket,
+    LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip, PaintColor, SceneProjection,
+    SurfaceId, TextContent, ValidationError, Visibility,
 };
 
+use crate::element::{DesktopElementContent, DesktopElementError, DesktopElementRegistry};
+
 #[derive(Clone, Debug)]
-struct RenderNode {
+struct CommonPresentation {
     parent: Option<NodeId>,
     children: Vec<NodeId>,
     layout: LayoutGeometry,
@@ -17,10 +21,9 @@ struct RenderNode {
     opacity: f32,
     visibility: Visibility,
     z_order: i32,
-    text: Option<TextContent>,
 }
 
-impl Default for RenderNode {
+impl Default for CommonPresentation {
     fn default() -> Self {
         Self {
             parent: None,
@@ -34,9 +37,15 @@ impl Default for RenderNode {
             opacity: 1.0,
             visibility: Visibility::Visible,
             z_order: 0,
-            text: None,
         }
     }
+}
+
+#[derive(Clone, Debug)]
+struct RenderNode {
+    element_type: ElementTypeId,
+    presentation: CommonPresentation,
+    content: DesktopElementContent,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -93,13 +102,15 @@ pub(crate) enum PaintCommand<'a> {
 #[derive(Debug)]
 pub(crate) struct DesktopScene {
     validation: SceneProjection,
+    elements: DesktopElementRegistry,
     nodes: HashMap<NodeId, RenderNode>,
 }
 
 impl DesktopScene {
-    pub(crate) fn new(surface: SurfaceId) -> Self {
+    pub(crate) fn new(surface: SurfaceId, elements: DesktopElementRegistry) -> Self {
         Self {
             validation: SceneProjection::new(surface),
+            elements,
             nodes: HashMap::new(),
         }
     }
@@ -108,7 +119,12 @@ impl DesktopScene {
         let mut roots = self
             .nodes
             .iter()
-            .filter_map(|(id, node)| node.parent.is_none().then_some((*id, node.z_order)))
+            .filter_map(|(id, node)| {
+                node.presentation
+                    .parent
+                    .is_none()
+                    .then_some((*id, node.presentation.z_order))
+            })
             .collect::<Vec<_>>();
         roots.sort_by_key(|(id, z)| (*z, id.get()));
         let mut commands = Vec::new();
@@ -128,15 +144,16 @@ impl DesktopScene {
         commands: &mut Vec<PaintCommand<'a>>,
     ) {
         let node = self.nodes.get(&id).expect("retained child remains live");
+        let presentation = &node.presentation;
         let border = LayoutRect {
-            x: parent_x + node.layout.border_box.x,
-            y: parent_y + node.layout.border_box.y,
-            width: node.layout.border_box.width,
-            height: node.layout.border_box.height,
+            x: parent_x + presentation.layout.border_box.x,
+            y: parent_y + presentation.layout.border_box.y,
+            width: presentation.layout.border_box.width,
+            height: presentation.layout.border_box.height,
         };
-        let opacity = ancestor_opacity * node.opacity;
-        if node.visibility == Visibility::Visible {
-            if let Some(paint) = &node.paint {
+        let opacity = ancestor_opacity * presentation.opacity;
+        if presentation.visibility == Visibility::Visible {
+            if let Some(paint) = &presentation.paint {
                 commands.push(PaintCommand::Box {
                     rect: border,
                     paint,
@@ -148,17 +165,17 @@ impl DesktopScene {
 
         let descendant_clip = ancestor_clip.intersect(
             border,
-            node.clip.horizontal == OverflowClip::Hidden,
-            node.clip.vertical == OverflowClip::Hidden,
+            presentation.clip.horizontal == OverflowClip::Hidden,
+            presentation.clip.vertical == OverflowClip::Hidden,
         );
-        if node.visibility == Visibility::Visible
-            && let Some(content) = &node.text
+        if presentation.visibility == Visibility::Visible
+            && let Some(content) = node.content.text()
         {
             let content_rect = LayoutRect {
-                x: border.x + node.layout.content_box.x,
-                y: border.y + node.layout.content_box.y,
-                width: node.layout.content_box.width,
-                height: node.layout.content_box.height,
+                x: border.x + presentation.layout.content_box.x,
+                y: border.y + presentation.layout.content_box.y,
+                width: presentation.layout.content_box.width,
+                height: presentation.layout.content_box.height,
             };
             commands.push(PaintCommand::Text {
                 node: id,
@@ -170,6 +187,7 @@ impl DesktopScene {
         }
 
         let mut children = node
+            .presentation
             .children
             .iter()
             .enumerate()
@@ -178,6 +196,7 @@ impl DesktopScene {
                     .nodes
                     .get(child)
                     .expect("retained child remains live")
+                    .presentation
                     .z_order;
                 (*child, z, index)
             })
@@ -195,14 +214,83 @@ impl DesktopScene {
         }
     }
 
+    fn validate_element_operations(&self, packet: &FramePacket) -> Result<(), DesktopElementError> {
+        let mut types = if packet.header.mode == FrameMode::Snapshot {
+            HashMap::new()
+        } else {
+            self.nodes
+                .iter()
+                .map(|(node, state)| (*node, state.element_type))
+                .collect()
+        };
+        for operation in &packet.operations {
+            match operation {
+                Operation::CreateNode { node, element_type } => {
+                    self.elements.create(*element_type)?;
+                    types.insert(*node, *element_type);
+                }
+                Operation::InsertChild { parent, .. } => {
+                    if let Some(element_type) = types.get(parent).copied()
+                        && self.elements.child_mount(element_type)? == ElementChildMount::None
+                    {
+                        return Err(DesktopElementError::ChildrenNotAllowed { parent: *parent });
+                    }
+                }
+                Operation::SetText { node, content } => {
+                    if let Some(element_type) = types.get(node).copied() {
+                        self.elements
+                            .create(element_type)?
+                            .set_text(*node, content.clone())?;
+                    }
+                }
+                Operation::SetProperty { node, .. } | Operation::ClearProperty { node, .. } => {
+                    if types.contains_key(node) {
+                        return Err(DesktopElementError::UnsupportedProperty { node: *node });
+                    }
+                }
+                Operation::InvokeCommand { node, .. } => {
+                    if types.contains_key(node) {
+                        return Err(DesktopElementError::UnsupportedCommand { node: *node });
+                    }
+                }
+                Operation::DeleteNode { .. }
+                | Operation::RemoveChild { .. }
+                | Operation::MoveChild { .. }
+                | Operation::SetLayout { .. }
+                | Operation::SetBoxPaint { .. }
+                | Operation::SetClip { .. }
+                | Operation::SetTransform { .. }
+                | Operation::SetOpacity { .. }
+                | Operation::SetVisibility { .. }
+                | Operation::SetZOrder { .. }
+                | Operation::SetEventMask { .. }
+                | Operation::SetHitTest { .. }
+                | Operation::SetPointerCapture { .. }
+                | Operation::ReleasePointerCapture { .. } => {}
+            }
+        }
+        Ok(())
+    }
+
     fn apply_operations(&mut self, packet: &FramePacket) {
         if packet.header.mode == FrameMode::Snapshot {
             self.nodes.clear();
         }
         for operation in &packet.operations {
             match operation {
-                Operation::CreateNode { node, .. } => {
-                    self.nodes.insert(*node, RenderNode::default());
+                Operation::CreateNode { node, element_type } => {
+                    let content = self
+                        .elements
+                        .create(*element_type)
+                        .expect("element operations were validated before commit");
+                    self.nodes.insert(
+                        *node,
+                        RenderNode {
+                            element_type: *element_type,
+                            presentation: CommonPresentation::default(),
+                            content,
+                        },
+                    );
                 }
                 Operation::DeleteNode { node } => self.delete_subtree(*node),
                 Operation::InsertChild {
@@ -210,18 +298,28 @@ impl DesktopScene {
                     child,
                     index,
                 } => {
-                    self.nodes.get_mut(child).expect("validated child").parent = Some(*parent);
+                    self.nodes
+                        .get_mut(child)
+                        .expect("validated child")
+                        .presentation
+                        .parent = Some(*parent);
                     self.nodes
                         .get_mut(parent)
                         .expect("validated parent")
+                        .presentation
                         .children
                         .insert(*index as usize, *child);
                 }
                 Operation::RemoveChild { parent, child } => {
-                    self.nodes.get_mut(child).expect("validated child").parent = None;
+                    self.nodes
+                        .get_mut(child)
+                        .expect("validated child")
+                        .presentation
+                        .parent = None;
                     self.nodes
                         .get_mut(parent)
                         .expect("validated parent")
+                        .presentation
                         .children
                         .retain(|candidate| candidate != child);
                 }
@@ -234,6 +332,7 @@ impl DesktopScene {
                         .nodes
                         .get_mut(parent)
                         .expect("validated parent")
+                        .presentation
                         .children;
                     let old = children
                         .iter()
@@ -243,25 +342,54 @@ impl DesktopScene {
                     children.insert(*index as usize, *child);
                 }
                 Operation::SetLayout { node, geometry } => {
-                    self.nodes.get_mut(node).expect("validated node").layout = *geometry;
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .presentation
+                        .layout = *geometry;
                 }
                 Operation::SetBoxPaint { node, paint } => {
-                    self.nodes.get_mut(node).expect("validated node").paint = Some(paint.clone());
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .presentation
+                        .paint = Some(paint.clone());
                 }
                 Operation::SetClip { node, clip } => {
-                    self.nodes.get_mut(node).expect("validated node").clip = *clip;
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .presentation
+                        .clip = *clip;
                 }
                 Operation::SetOpacity { node, opacity } => {
-                    self.nodes.get_mut(node).expect("validated node").opacity = *opacity;
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .presentation
+                        .opacity = *opacity;
                 }
                 Operation::SetVisibility { node, visibility } => {
-                    self.nodes.get_mut(node).expect("validated node").visibility = *visibility;
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .presentation
+                        .visibility = *visibility;
                 }
                 Operation::SetZOrder { node, z_order } => {
-                    self.nodes.get_mut(node).expect("validated node").z_order = *z_order;
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .presentation
+                        .z_order = *z_order;
                 }
                 Operation::SetText { node, content } => {
-                    self.nodes.get_mut(node).expect("validated node").text = Some(content.clone());
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .content
+                        .set_text(*node, content.clone())
+                        .expect("element content operation was validated before commit");
                 }
                 Operation::SetTransform { .. }
                 | Operation::SetProperty { .. }
@@ -279,30 +407,73 @@ impl DesktopScene {
         let Some(removed) = self.nodes.remove(&node) else {
             return;
         };
-        if let Some(parent) = removed.parent
+        if let Some(parent) = removed.presentation.parent
             && let Some(parent) = self.nodes.get_mut(&parent)
         {
-            parent.children.retain(|candidate| *candidate != node);
+            parent
+                .presentation
+                .children
+                .retain(|candidate| *candidate != node);
         }
-        for child in removed.children {
+        for child in removed.presentation.children {
             self.delete_subtree(child);
         }
     }
 }
 
 impl FrameSink for DesktopScene {
-    type Error = ValidationError;
+    type Error = DesktopPresentError;
 
     fn present(&mut self, packet: &FramePacket) -> Result<ApplyResult, Self::Error> {
+        if packet.header.mode == FrameMode::Delta
+            && (self.validation.scene_epoch() != Some(packet.header.scene_epoch)
+                || self.validation.revision() != packet.header.base_revision)
+        {
+            return self.validation.apply(packet).map_err(Into::into);
+        }
+        // Element validation is read-only. The reference projection then
+        // validates and commits the complete protocol transaction atomically,
+        // allowing the retained Desktop tree to update in place without a
+        // whole-scene clone on each delta.
+        self.validate_element_operations(packet)?;
         let result = self.validation.apply(packet)?;
         if matches!(result, ApplyResult::Accepted { .. }) {
-            // The reference projection has validated the complete transaction,
-            // so every lookup and index below is now infallible. Applying in
-            // place avoids cloning the retained Host tree on every delta while
-            // preserving atomic rejection for malformed packets.
             self.apply_operations(packet);
         }
         Ok(result)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum DesktopPresentError {
+    Protocol(ValidationError),
+    Element(DesktopElementError),
+}
+
+impl fmt::Display for DesktopPresentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Desktop frame rejection: {self:?}")
+    }
+}
+
+impl Error for DesktopPresentError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Protocol(error) => Some(error),
+            Self::Element(error) => Some(error),
+        }
+    }
+}
+
+impl From<ValidationError> for DesktopPresentError {
+    fn from(error: ValidationError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+impl From<DesktopElementError> for DesktopPresentError {
+    fn from(error: DesktopElementError) -> Self {
+        Self::Element(error)
     }
 }
 
@@ -316,11 +487,31 @@ pub(crate) fn is_transparent(color: &PaintColor) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use whisker::standard_element_registrations;
     use whisker_protocol::{
-        ElementTypeId, FrameHeader, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+        ElementContentKind, FrameHeader, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
         MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap, PaintCorners, PaintEdges,
         PaintLengthPercentage, ProtocolVersion, TextMeasurePayload, TextMeasureStyle, TextPaint,
     };
+
+    fn element_type(content: ElementContentKind) -> ElementTypeId {
+        standard_element_registrations()
+            .into_iter()
+            .find(|registration| registration.content == content)
+            .expect("standard content registration")
+            .element_type
+    }
+
+    fn scene(surface: SurfaceId) -> DesktopScene {
+        DesktopScene::new(
+            surface,
+            DesktopElementRegistry::bind(
+                &standard_element_registrations(),
+                &crate::element::standard_desktop_element_factories(),
+            )
+            .unwrap(),
+        )
+    }
 
     fn id(value: u64) -> NodeId {
         NodeId::new(value).unwrap()
@@ -417,8 +608,9 @@ mod tests {
     fn accepted_projection_lowers_content_geometry_clip_and_opacity() {
         let root = id(1);
         let child = id(2);
-        let element_type = ElementTypeId::new(1).unwrap();
-        let mut scene = DesktopScene::new(SurfaceId::new(1).unwrap());
+        let box_type = element_type(ElementContentKind::None);
+        let text_type = element_type(ElementContentKind::Text);
+        let mut scene = scene(SurfaceId::new(1).unwrap());
         let snapshot = packet(
             FrameMode::Snapshot,
             0,
@@ -426,11 +618,11 @@ mod tests {
             vec![
                 Operation::CreateNode {
                     node: root,
-                    element_type,
+                    element_type: box_type,
                 },
                 Operation::CreateNode {
                     node: child,
-                    element_type,
+                    element_type: text_type,
                 },
                 Operation::InsertChild {
                     parent: root,
@@ -494,8 +686,8 @@ mod tests {
     #[test]
     fn rejected_delta_does_not_partially_change_desktop_state() {
         let root = id(1);
-        let element_type = ElementTypeId::new(1).unwrap();
-        let mut scene = DesktopScene::new(SurfaceId::new(1).unwrap());
+        let element_type = element_type(ElementContentKind::None);
+        let mut scene = scene(SurfaceId::new(1).unwrap());
         scene
             .present(&packet(
                 FrameMode::Snapshot,
@@ -535,11 +727,150 @@ mod tests {
                     geometry: invalid
                 }],
             )),
-            Err(ValidationError::NonFiniteNumber)
+            Err(DesktopPresentError::Protocol(
+                ValidationError::NonFiniteNumber
+            ))
         );
         assert_eq!(scene.paint_commands().len(), before_len);
         assert!(
             matches!(scene.paint_commands()[0], PaintCommand::Box { rect, .. } if rect.width == 10.0)
+        );
+    }
+
+    #[test]
+    fn unknown_element_type_rejects_the_whole_frame() {
+        let root = id(1);
+        let mut scene = scene(SurfaceId::new(1).unwrap());
+        let unknown = ElementTypeId::new(900).unwrap();
+
+        assert_eq!(
+            scene.present(&packet(
+                FrameMode::Snapshot,
+                0,
+                1,
+                vec![Operation::CreateNode {
+                    node: root,
+                    element_type: unknown,
+                }],
+            )),
+            Err(DesktopPresentError::Element(
+                DesktopElementError::UnknownElementType {
+                    element_type: unknown,
+                }
+            ))
+        );
+
+        assert_eq!(
+            scene.present(&packet(
+                FrameMode::Snapshot,
+                0,
+                1,
+                vec![Operation::CreateNode {
+                    node: root,
+                    element_type: element_type(ElementContentKind::None),
+                }],
+            )),
+            Ok(ApplyResult::Accepted { revision: 1 })
+        );
+    }
+
+    #[test]
+    fn text_content_operation_is_dispatched_by_registered_element_type() {
+        let root = id(1);
+        let mut scene = scene(SurfaceId::new(1).unwrap());
+
+        assert_eq!(
+            scene.present(&packet(
+                FrameMode::Snapshot,
+                0,
+                1,
+                vec![
+                    Operation::CreateNode {
+                        node: root,
+                        element_type: element_type(ElementContentKind::None),
+                    },
+                    Operation::SetText {
+                        node: root,
+                        content: text(),
+                    },
+                ],
+            )),
+            Err(DesktopPresentError::Element(
+                DesktopElementError::UnexpectedText { node: root }
+            ))
+        );
+
+        assert_eq!(
+            scene.present(&packet(
+                FrameMode::Snapshot,
+                0,
+                1,
+                vec![
+                    Operation::CreateNode {
+                        node: root,
+                        element_type: element_type(ElementContentKind::Text),
+                    },
+                    Operation::SetText {
+                        node: root,
+                        content: text(),
+                    },
+                    Operation::SetBoxPaint {
+                        node: root,
+                        paint: paint(PaintColor::Named("green".into())),
+                    },
+                ],
+            )),
+            Ok(ApplyResult::Accepted { revision: 1 })
+        );
+        assert!(matches!(
+            scene.paint_commands().as_slice(),
+            [PaintCommand::Box { .. }, PaintCommand::Text { node, .. }] if *node == root
+        ));
+    }
+
+    #[test]
+    fn leaf_element_rejects_scene_children_without_partial_commit() {
+        let parent = id(1);
+        let child = id(2);
+        let mut scene = scene(SurfaceId::new(1).unwrap());
+
+        assert_eq!(
+            scene.present(&packet(
+                FrameMode::Snapshot,
+                0,
+                1,
+                vec![
+                    Operation::CreateNode {
+                        node: parent,
+                        element_type: element_type(ElementContentKind::Text),
+                    },
+                    Operation::CreateNode {
+                        node: child,
+                        element_type: element_type(ElementContentKind::None),
+                    },
+                    Operation::InsertChild {
+                        parent,
+                        child,
+                        index: 0,
+                    },
+                ],
+            )),
+            Err(DesktopPresentError::Element(
+                DesktopElementError::ChildrenNotAllowed { parent }
+            ))
+        );
+
+        assert_eq!(
+            scene.present(&packet(
+                FrameMode::Snapshot,
+                0,
+                1,
+                vec![Operation::CreateNode {
+                    node: parent,
+                    element_type: element_type(ElementContentKind::Text),
+                }],
+            )),
+            Ok(ApplyResult::Accepted { revision: 1 })
         );
     }
 }

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -1,8 +1,9 @@
 use whisker_engine::FrameSink;
-use whisker_protocol::{ApplyResult, FramePacket, SurfaceId, ValidationError};
+use whisker_protocol::{ApplyResult, FramePacket, SurfaceId};
 
+use crate::element::DesktopElementRegistry;
 use crate::gpu::{GpuError, GpuRenderer};
-use crate::scene::DesktopScene;
+use crate::scene::{DesktopPresentError, DesktopScene};
 use crate::text::NativeTextHost;
 
 /// The complete Host-owned projection and presentation state for one native
@@ -17,9 +18,10 @@ impl DesktopSurface {
         target: impl Into<wgpu::SurfaceTarget<'static>>,
         physical_size: [u32; 2],
         surface: SurfaceId,
+        elements: DesktopElementRegistry,
     ) -> Result<Self, GpuError> {
         Ok(Self {
-            scene: DesktopScene::new(surface),
+            scene: DesktopScene::new(surface, elements),
             gpu: GpuRenderer::new(target, physical_size).await?,
         })
     }
@@ -40,7 +42,7 @@ impl DesktopSurface {
 }
 
 impl FrameSink for DesktopSurface {
-    type Error = ValidationError;
+    type Error = DesktopPresentError;
 
     fn present(&mut self, packet: &FramePacket) -> Result<ApplyResult, Self::Error> {
         self.scene.present(packet)

--- a/platforms/desktop/src/text.rs
+++ b/platforms/desktop/src/text.rs
@@ -6,25 +6,29 @@ use glyphon::{
 };
 use whisker_engine::MeasurementHost;
 use whisker_protocol::{
-    AvailableSpace, LayoutRect, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
-    MeasureTextWrap, MeasuredSize, MeasurementMetrics, MeasurementPayload, MeasurementRequest,
-    MeasurementResponse, PreparedContentId, SurfaceId, TextMeasurePayload,
+    AvailableSpace, ElementMeasurement, LayoutRect, MeasureFontFamily, MeasureFontStyle,
+    MeasureLineHeight, MeasureTextWrap, MeasuredSize, MeasurementMetrics, MeasurementPayload,
+    MeasurementRequest, MeasurementResponse, PreparedContentId, SurfaceId, TextMeasurePayload,
     UnsupportedMeasurementReason,
 };
+
+use crate::element::DesktopElementRegistry;
 
 pub(crate) struct PreparedText {
     pub(crate) buffer: Buffer,
 }
 
 pub(crate) struct NativeTextHost {
+    elements: DesktopElementRegistry,
     pub(crate) font_system: FontSystem,
     pub(crate) swash_cache: SwashCache,
     pub(crate) prepared: HashMap<PreparedContentId, PreparedText>,
 }
 
 impl NativeTextHost {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(elements: DesktopElementRegistry) -> Self {
         Self {
+            elements,
             font_system: FontSystem::new(),
             swash_cache: SwashCache::new(),
             prepared: HashMap::new(),
@@ -143,8 +147,11 @@ impl MeasurementHost for NativeTextHost {
         responses: &mut Vec<MeasurementResponse>,
     ) -> Result<(), Self::Error> {
         for request in requests {
-            let response = match &request.payload {
-                MeasurementPayload::Text(payload) => {
+            let response = match (
+                self.elements.measurement(request.element_type),
+                &request.payload,
+            ) {
+                (Ok(ElementMeasurement::Text), MeasurementPayload::Text(payload)) => {
                     let (prepared, mut metrics) = self.prepare_text(payload, request);
                     let id = PreparedContentId::new(request.key.get())
                         .expect("measurement keys are always non-zero");
@@ -156,7 +163,12 @@ impl MeasurementHost for NativeTextHost {
                         metrics,
                     }
                 }
-                _ => MeasurementResponse::Unsupported {
+                (Err(_), _) => MeasurementResponse::Unsupported {
+                    key: request.key,
+                    environment_epoch: request.environment_epoch,
+                    reason: UnsupportedMeasurementReason::Element,
+                },
+                (Ok(_), _) => MeasurementResponse::Unsupported {
                     key: request.key,
                     environment_epoch: request.environment_epoch,
                     reason: UnsupportedMeasurementReason::Kind,
@@ -171,15 +183,33 @@ impl MeasurementHost for NativeTextHost {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use whisker::standard_element_registrations;
     use whisker_protocol::{
-        ElementTypeId, MeasureConstraints, MeasurementKey, NodeId, ReplacedContentMeasurePayload,
+        ElementContentKind, ElementTypeId, MeasureConstraints, MeasurementKey, NodeId,
+        ReplacedContentMeasurePayload,
     };
+
+    fn registry() -> DesktopElementRegistry {
+        DesktopElementRegistry::bind(
+            &standard_element_registrations(),
+            &crate::element::standard_desktop_element_factories(),
+        )
+        .unwrap()
+    }
+
+    fn text_element_type() -> ElementTypeId {
+        standard_element_registrations()
+            .into_iter()
+            .find(|registration| registration.content == ElementContentKind::Text)
+            .unwrap()
+            .element_type
+    }
 
     fn request(key: u64, payload: MeasurementPayload) -> MeasurementRequest {
         MeasurementRequest {
             key: MeasurementKey::new(key).unwrap(),
             node: NodeId::new(1).unwrap(),
-            element_type: ElementTypeId::new(1).unwrap(),
+            element_type: text_element_type(),
             environment_epoch: 3,
             constraints: MeasureConstraints {
                 known_dimensions: [None, None],
@@ -207,7 +237,7 @@ mod tests {
             max_lines: Some(2),
             overflow: whisker_protocol::MeasureTextOverflow::Clip,
         };
-        let mut host = NativeTextHost::new();
+        let mut host = NativeTextHost::new(registry());
         let mut responses = Vec::new();
         host.measure_batch(
             SurfaceId::new(1).unwrap(),
@@ -250,8 +280,10 @@ mod tests {
             max_lines: None,
             overflow: whisker_protocol::MeasureTextOverflow::Ellipsis,
         };
-        let mut host = NativeTextHost::new();
+        let mut host = NativeTextHost::new(registry());
         let mut responses = Vec::new();
+        let mut unknown_element = request(9, MeasurementPayload::Text(empty.clone()));
+        unknown_element.element_type = ElementTypeId::new(900).unwrap();
         host.measure_batch(
             SurfaceId::new(1).unwrap(),
             &[
@@ -260,11 +292,12 @@ mod tests {
                     8,
                     MeasurementPayload::ReplacedContent(ReplacedContentMeasurePayload::default()),
                 ),
+                unknown_element,
             ],
             &mut responses,
         )
         .unwrap();
-        assert_eq!(responses.len(), 2);
+        assert_eq!(responses.len(), 3);
         assert!(matches!(
             &responses[0],
             MeasurementResponse::Ready { metrics, .. }
@@ -274,6 +307,13 @@ mod tests {
             &responses[1],
             MeasurementResponse::Unsupported {
                 reason: UnsupportedMeasurementReason::Kind,
+                ..
+            }
+        ));
+        assert!(matches!(
+            &responses[2],
+            MeasurementResponse::Unsupported {
+                reason: UnsupportedMeasurementReason::Element,
                 ..
             }
         ));

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -1,22 +1,23 @@
 use serde::Deserialize;
-use whisker::SurfaceRuntime;
 use whisker::css::BorderStyle;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
 use whisker::runtime::view::{set_root, with_installed_renderer};
+use whisker::{SurfaceRuntime, standard_element_registrations};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementHost};
 use whisker_protocol::{
-    AvailableSpace, BorderLineStyle, BoxPaint, ElementTypeId, FrameHeader, FrameMode, FramePacket,
-    InputEvent, InputEventKind, InputPoint, LayoutGeometry, LayoutRect, MeasureConstraints,
-    MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextDirection,
-    MeasureTextOverflow, MeasureTextWrap, MeasurementKey, MeasurementPayload, MeasurementRequest,
-    MeasurementResponse, NodeId, Operation, PaintColor, PaintCorners, PaintEdges,
-    PaintLengthPercentage, PointerId, PointerInput, PointerKind, ProtocolValue, ProtocolVersion,
-    SurfaceId, TextMeasurePayload, TextMeasureStyle,
+    AvailableSpace, BorderLineStyle, BoxPaint, ElementContentKind, ElementTypeId, FrameHeader,
+    FrameMode, FramePacket, InputEvent, InputEventKind, InputPoint, LayoutGeometry, LayoutRect,
+    MeasureConstraints, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+    MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap, MeasurementKey, MeasurementPayload,
+    MeasurementRequest, MeasurementResponse, NodeId, Operation, PaintColor, PaintCorners,
+    PaintEdges, PaintLengthPercentage, PointerId, PointerInput, PointerKind, ProtocolValue,
+    ProtocolVersion, SurfaceId, TextMeasurePayload, TextMeasureStyle,
 };
 use whisker_style::StyleEnvironment;
 
+use crate::element::{DesktopElementRegistry, standard_desktop_element_factories};
 use crate::gpu::render_box_primitives_offscreen;
 use crate::paint::box_paint::{BoxPrimitive, BoxPrimitiveKind, lower_box};
 use crate::scene::{DesktopScene, PaintCommand};
@@ -244,6 +245,25 @@ struct Checkpoint {
     primitives: Vec<BoxPrimitive>,
 }
 
+fn standard_element_type(content: ElementContentKind) -> ElementTypeId {
+    standard_element_registrations()
+        .into_iter()
+        .find(|registration| registration.content == content)
+        .expect("standard content registration")
+        .element_type
+}
+
+fn desktop_scene(surface: SurfaceId) -> DesktopScene {
+    DesktopScene::new(
+        surface,
+        DesktopElementRegistry::bind(
+            &standard_element_registrations(),
+            &standard_desktop_element_factories(),
+        )
+        .unwrap(),
+    )
+}
+
 impl Driver {
     fn new() -> Self {
         Self {
@@ -251,7 +271,13 @@ impl Driver {
             scene: None,
             logical_size: [0.0; 2],
             scale: 1.0,
-            text: NativeTextHost::new(),
+            text: NativeTextHost::new(
+                DesktopElementRegistry::bind(
+                    &standard_element_registrations(),
+                    &standard_desktop_element_factories(),
+                )
+                .unwrap(),
+            ),
             measurement_responses: Vec::new(),
             input: RecordingInputSink::default(),
         }
@@ -269,7 +295,7 @@ impl Driver {
                     assert!(*width > 0.0 && *height > 0.0 && *scale > 0.0);
                     let surface = SurfaceId::new(1).unwrap();
                     self.surface = Some(surface);
-                    self.scene = Some(DesktopScene::new(surface));
+                    self.scene = Some(desktop_scene(surface));
                     self.logical_size = [*width, *height];
                     self.scale = *scale;
                 }
@@ -363,7 +389,7 @@ impl Driver {
             operations: vec![
                 Operation::CreateNode {
                     node,
-                    element_type: ElementTypeId::new(1).unwrap(),
+                    element_type: standard_element_type(ElementContentKind::None),
                 },
                 Operation::SetLayout {
                     node,
@@ -416,7 +442,7 @@ impl Driver {
         let request = MeasurementRequest {
             key: MeasurementKey::new(key).expect("scenario measurement key is non-zero"),
             node: NodeId::new(key).expect("scenario node key is non-zero"),
-            element_type: ElementTypeId::new(1).unwrap(),
+            element_type: standard_element_type(ElementContentKind::Text),
             environment_epoch: 1,
             constraints: MeasureConstraints {
                 known_dimensions: [None, None],
@@ -794,8 +820,16 @@ fn render_taffy_protocol_and_desktop_box_paint_compose() {
         root
     });
 
-    let mut measurement = NativeTextHost::new();
-    let mut scene = DesktopScene::new(surface_id);
+    let registrations = surface.element_registrations();
+    let mut measurement = NativeTextHost::new(
+        DesktopElementRegistry::bind(&registrations, &standard_desktop_element_factories())
+            .unwrap(),
+    );
+    let mut scene = DesktopScene::new(
+        surface_id,
+        DesktopElementRegistry::bind(&registrations, &standard_desktop_element_factories())
+            .unwrap(),
+    );
     let frame = surface
         .render_frame(
             LayoutSize::new(100.0, 100.0),

--- a/platforms/linux/src/app.rs
+++ b/platforms/linux/src/app.rs
@@ -4,8 +4,11 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use whisker::runtime::RuntimeWakeHandle;
-use whisker::{Element, RuntimeInstance, SurfaceRuntime};
-use whisker_desktop::{DesktopFrameContext, DesktopHost};
+use whisker::{Element, ElementRegistry, RuntimeInstance, SurfaceRuntime};
+use whisker_desktop::{
+    DesktopElementFactory, DesktopElementModule, DesktopFrameContext, DesktopHost,
+    standard_desktop_element_modules,
+};
 use whisker_protocol::SurfaceId;
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
@@ -23,6 +26,9 @@ pub struct LinuxAppConfig {
     pub width: f64,
     /// Initial logical height in points.
     pub height: f64,
+    /// Element modules selected for this target.
+    pub element_modules: Vec<DesktopElementModule>,
+    element_factories: Vec<DesktopElementFactory>,
 }
 
 impl LinuxAppConfig {
@@ -32,7 +38,15 @@ impl LinuxAppConfig {
             title: title.into(),
             width: 1024.0,
             height: 720.0,
+            element_modules: Vec::new(),
+            element_factories: Vec::new(),
         }
+    }
+
+    /// Adds one Rust element definition with its matching Desktop factory.
+    pub fn with_element_module(mut self, module: DesktopElementModule) -> Self {
+        self.element_modules.push(module);
+        self
     }
 }
 
@@ -49,12 +63,26 @@ impl fmt::Display for LinuxHostError {
 impl Error for LinuxHostError {}
 
 /// Runs a standalone Whisker application in a native Linux window.
-pub fn run(config: LinuxAppConfig, application: fn() -> Element) -> Result<(), LinuxHostError> {
+pub fn run(mut config: LinuxAppConfig, application: fn() -> Element) -> Result<(), LinuxHostError> {
+    let mut element_modules = standard_desktop_element_modules();
+    element_modules.append(&mut config.element_modules);
+    let elements = ElementRegistry::builder()
+        .register_providers(
+            element_modules
+                .iter()
+                .map(|module| module.provider().clone()),
+        )
+        .build()
+        .map_err(|error| LinuxHostError(format!("build element registry: {error}")))?;
+    config.element_factories = element_modules
+        .iter()
+        .map(|module| module.factory().clone())
+        .collect();
     let event_loop = EventLoop::<HostEvent>::with_user_event()
         .build()
         .map_err(|error| LinuxHostError(format!("create Linux event loop: {error}")))?;
     let proxy = event_loop.create_proxy();
-    let mut application = LinuxApplication::new(config, application, proxy);
+    let mut application = LinuxApplication::new(config, elements, application, proxy);
     event_loop
         .run_app(&mut application)
         .map_err(|error| LinuxHostError(format!("run Linux event loop: {error}")))
@@ -67,6 +95,7 @@ enum HostEvent {
 
 struct LinuxApplication {
     config: LinuxAppConfig,
+    elements: ElementRegistry,
     application: fn() -> Element,
     proxy: EventLoopProxy<HostEvent>,
     window: Option<Arc<Window>>,
@@ -82,11 +111,13 @@ struct LinuxApplication {
 impl LinuxApplication {
     fn new(
         config: LinuxAppConfig,
+        elements: ElementRegistry,
         application: fn() -> Element,
         proxy: EventLoopProxy<HostEvent>,
     ) -> Self {
         Self {
             config,
+            elements,
             application,
             proxy,
             window: None,
@@ -116,24 +147,28 @@ impl LinuxApplication {
         let scale = window.scale_factor() as f32;
         let logical = self.viewport.to_logical::<f32>(window.scale_factor());
         let surface_id = SurfaceId::new(1).expect("the standalone surface id is non-zero");
-        let surface = SurfaceRuntime::new(
+        let surface = SurfaceRuntime::with_element_registry(
             surface_id,
             StyleEnvironment::new(logical.width, logical.height, scale, 14.0),
+            self.elements.clone(),
         );
+        let element_registrations = surface.element_registrations();
         let wake_proxy = self.proxy.clone();
         let wake = RuntimeWakeHandle::new(move || {
             let _ = wake_proxy.send_event(HostEvent::RequestFrame);
         });
-        let mut runtime = RuntimeInstance::new(surface, wake);
-        runtime
-            .mount(self.application)
-            .map_err(|error| LinuxHostError(format!("mount Whisker application: {error}")))?;
         let host = pollster::block_on(DesktopHost::new(
             window.clone(),
             [self.viewport.width, self.viewport.height],
             surface_id,
+            &element_registrations,
+            &self.config.element_factories,
         ))
         .map_err(|error| LinuxHostError(error.to_string()))?;
+        let mut runtime = RuntimeInstance::new(surface, wake);
+        runtime
+            .mount(self.application)
+            .map_err(|error| LinuxHostError(format!("mount Whisker application: {error}")))?;
         self.host = Some(host);
         self.runtime = Some(runtime);
         self.window = Some(window);

--- a/platforms/macos/src/app.rs
+++ b/platforms/macos/src/app.rs
@@ -4,8 +4,11 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use whisker::runtime::RuntimeWakeHandle;
-use whisker::{Element, RuntimeInstance, SurfaceRuntime};
-use whisker_desktop::{DesktopFrameContext, DesktopHost};
+use whisker::{Element, ElementRegistry, RuntimeInstance, SurfaceRuntime};
+use whisker_desktop::{
+    DesktopElementFactory, DesktopElementModule, DesktopFrameContext, DesktopHost,
+    standard_desktop_element_modules,
+};
 use whisker_protocol::SurfaceId;
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
@@ -23,6 +26,9 @@ pub struct MacosAppConfig {
     pub width: f64,
     /// Initial logical height in points.
     pub height: f64,
+    /// Element modules selected for this target.
+    pub element_modules: Vec<DesktopElementModule>,
+    element_factories: Vec<DesktopElementFactory>,
 }
 
 impl MacosAppConfig {
@@ -32,7 +38,15 @@ impl MacosAppConfig {
             title: title.into(),
             width: 1024.0,
             height: 720.0,
+            element_modules: Vec::new(),
+            element_factories: Vec::new(),
         }
+    }
+
+    /// Adds one Rust element definition with its matching Desktop factory.
+    pub fn with_element_module(mut self, module: DesktopElementModule) -> Self {
+        self.element_modules.push(module);
+        self
     }
 }
 
@@ -49,12 +63,26 @@ impl fmt::Display for MacosHostError {
 impl Error for MacosHostError {}
 
 /// Runs a standalone Whisker application in a native macOS window.
-pub fn run(config: MacosAppConfig, application: fn() -> Element) -> Result<(), MacosHostError> {
+pub fn run(mut config: MacosAppConfig, application: fn() -> Element) -> Result<(), MacosHostError> {
+    let mut element_modules = standard_desktop_element_modules();
+    element_modules.append(&mut config.element_modules);
+    let elements = ElementRegistry::builder()
+        .register_providers(
+            element_modules
+                .iter()
+                .map(|module| module.provider().clone()),
+        )
+        .build()
+        .map_err(|error| MacosHostError(format!("build element registry: {error}")))?;
+    config.element_factories = element_modules
+        .iter()
+        .map(|module| module.factory().clone())
+        .collect();
     let event_loop = EventLoop::<HostEvent>::with_user_event()
         .build()
         .map_err(|error| MacosHostError(format!("create macOS event loop: {error}")))?;
     let proxy = event_loop.create_proxy();
-    let mut application = MacosApplication::new(config, application, proxy);
+    let mut application = MacosApplication::new(config, elements, application, proxy);
     event_loop
         .run_app(&mut application)
         .map_err(|error| MacosHostError(format!("run macOS event loop: {error}")))
@@ -67,6 +95,7 @@ enum HostEvent {
 
 struct MacosApplication {
     config: MacosAppConfig,
+    elements: ElementRegistry,
     application: fn() -> Element,
     proxy: EventLoopProxy<HostEvent>,
     window: Option<Arc<Window>>,
@@ -82,11 +111,13 @@ struct MacosApplication {
 impl MacosApplication {
     fn new(
         config: MacosAppConfig,
+        elements: ElementRegistry,
         application: fn() -> Element,
         proxy: EventLoopProxy<HostEvent>,
     ) -> Self {
         Self {
             config,
+            elements,
             application,
             proxy,
             window: None,
@@ -116,24 +147,28 @@ impl MacosApplication {
         let scale = window.scale_factor() as f32;
         let logical = self.viewport.to_logical::<f32>(window.scale_factor());
         let surface_id = SurfaceId::new(1).expect("the standalone surface id is non-zero");
-        let surface = SurfaceRuntime::new(
+        let surface = SurfaceRuntime::with_element_registry(
             surface_id,
             StyleEnvironment::new(logical.width, logical.height, scale, 14.0),
+            self.elements.clone(),
         );
+        let element_registrations = surface.element_registrations();
         let wake_proxy = self.proxy.clone();
         let wake = RuntimeWakeHandle::new(move || {
             let _ = wake_proxy.send_event(HostEvent::RequestFrame);
         });
-        let mut runtime = RuntimeInstance::new(surface, wake);
-        runtime
-            .mount(self.application)
-            .map_err(|error| MacosHostError(format!("mount Whisker application: {error}")))?;
         let host = pollster::block_on(DesktopHost::new(
             window.clone(),
             [self.viewport.width, self.viewport.height],
             surface_id,
+            &element_registrations,
+            &self.config.element_factories,
         ))
         .map_err(|error| MacosHostError(error.to_string()))?;
+        let mut runtime = RuntimeInstance::new(surface, wake);
+        runtime
+            .mount(self.application)
+            .map_err(|error| MacosHostError(format!("mount Whisker application: {error}")))?;
         self.host = Some(host);
         self.runtime = Some(runtime);
         self.window = Some(window);

--- a/platforms/web/src/lib.rs
+++ b/platforms/web/src/lib.rs
@@ -14,14 +14,14 @@ use std::fmt;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
 use whisker::runtime::RuntimeWakeHandle;
-use whisker::{Element, RuntimeInstance, SurfaceRuntime};
+use whisker::{Element, ElementProviderMetadata, ElementRegistry, RuntimeInstance, SurfaceRuntime};
 use whisker_engine::{FrameSink, HostLayoutOptions, MeasurementHost};
 use whisker_protocol::{
-    ApplyResult, AvailableSpace, BorderLineStyle, FrameMode, FramePacket, MeasureFontFamily,
-    MeasureFontStyle, MeasureLineHeight, MeasureTextDirection, MeasureTextWrap, MeasuredSize,
-    MeasurementMetrics, MeasurementPayload, MeasurementRequest, MeasurementResponse, NodeId,
-    Operation, OverflowClip, PaintColor, PaintLengthPercentage, PreparedContentId, SceneProjection,
-    SurfaceId,
+    ApplyResult, AvailableSpace, BorderLineStyle, ElementContentKind, ElementRegistration,
+    ElementTypeId, FrameMode, FramePacket, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+    MeasureTextDirection, MeasureTextWrap, MeasuredSize, MeasurementMetrics, MeasurementPayload,
+    MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintColor,
+    PaintLengthPercentage, PreparedContentId, SceneProjection, SurfaceId,
 };
 use whisker_style::StyleEnvironment;
 
@@ -37,6 +37,8 @@ pub struct WebAppConfig {
     pub title: String,
     /// DOM element id used as the surface root.
     pub root_id: String,
+    /// Element modules selected for this target.
+    pub element_modules: Vec<WebElementModule>,
 }
 
 impl WebAppConfig {
@@ -45,8 +47,82 @@ impl WebAppConfig {
         Self {
             title: title.into(),
             root_id: "whisker-root".to_string(),
+            element_modules: Vec::new(),
         }
     }
+
+    /// Adds one Rust element definition with its matching DOM factory.
+    pub fn with_element_module(mut self, module: WebElementModule) -> Self {
+        self.element_modules.push(module);
+        self
+    }
+}
+
+/// One Web element module's Rust schema and target factory.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebElementModule {
+    provider: ElementProviderMetadata,
+    factory: WebElementFactory,
+}
+
+impl WebElementModule {
+    /// Joins a Rust provider to its DOM Host factory.
+    pub fn new(provider: ElementProviderMetadata, factory: WebElementFactory) -> Self {
+        Self { provider, factory }
+    }
+
+    /// Returns the Rust provider metadata.
+    pub fn provider(&self) -> &ElementProviderMetadata {
+        &self.provider
+    }
+
+    /// Returns the target-specific DOM factory.
+    pub fn factory(&self) -> &WebElementFactory {
+        &self.factory
+    }
+}
+
+/// DOM factory embedded for one element-provider module.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WebElementFactory {
+    canonical_name: String,
+    tag_name: String,
+}
+
+impl WebElementFactory {
+    /// Creates a DOM factory joined to a Rust schema by canonical name.
+    pub fn new(canonical_name: impl Into<String>, tag_name: impl Into<String>) -> Self {
+        Self {
+            canonical_name: canonical_name.into(),
+            tag_name: tag_name.into(),
+        }
+    }
+}
+
+/// Returns the standard UI package as ordinary Web element modules.
+pub fn standard_web_element_modules() -> Vec<WebElementModule> {
+    whisker::standard_element_providers()
+        .into_iter()
+        .map(|provider| {
+            let factory = match provider.schema.canonical_name.as_str() {
+                whisker::VIEW_ELEMENT_NAME
+                | whisker::TEXT_ELEMENT_NAME
+                | whisker::SCROLL_VIEW_ELEMENT_NAME => {
+                    WebElementFactory::new(provider.schema.canonical_name.clone(), "div")
+                }
+                canonical_name => panic!("standard UI DOM factory missing for {canonical_name}"),
+            };
+            WebElementModule::new(provider, factory)
+        })
+        .collect()
+}
+
+/// Returns only the DOM factories from the standard UI package.
+pub fn standard_web_element_factories() -> Vec<WebElementFactory> {
+    standard_web_element_modules()
+        .into_iter()
+        .map(|module| module.factory)
+        .collect()
 }
 
 /// Failure while creating or driving the browser Host.
@@ -107,7 +183,13 @@ struct WebApplication {
 }
 
 impl WebApplication {
-    fn new(config: WebAppConfig) -> Result<Self, WebHostError> {
+    fn new(mut config: WebAppConfig) -> Result<Self, WebHostError> {
+        let mut element_modules = standard_web_element_modules();
+        element_modules.append(&mut config.element_modules);
+        let elements = ElementRegistry::builder()
+            .register_providers(element_modules.iter().map(|module| module.provider.clone()))
+            .build()
+            .map_err(|error| WebHostError(format!("build element registry: {error}")))?;
         let window = browser_window()?;
         let document = window
             .document()
@@ -123,15 +205,27 @@ impl WebApplication {
 
         let viewport = viewport(&window)?;
         let surface_id = SurfaceId::new(1).expect("the browser surface id is non-zero");
-        let surface = SurfaceRuntime::new(
+        let registrations = elements.registrations().to_vec();
+        let element_factories = element_modules
+            .iter()
+            .map(|module| module.factory.clone())
+            .collect::<Vec<_>>();
+        let surface = SurfaceRuntime::with_element_registry(
             surface_id,
             StyleEnvironment::new(viewport.0, viewport.1, viewport.2, 16.0),
+            elements,
         );
         let wake = RuntimeWakeHandle::new(request_frame);
         Ok(Self {
             runtime: RuntimeInstance::new(surface, wake),
             measurements: DomMeasurementHost::new(document.clone()),
-            frames: DomFrameSink::new(document, root, surface_id),
+            frames: DomFrameSink::new(
+                document,
+                root,
+                surface_id,
+                &registrations,
+                &element_factories,
+            )?,
             viewport,
             viewport_epoch: 1,
             environment_epoch: 1,
@@ -300,29 +394,148 @@ struct DomFrameSink {
     document: web_sys::Document,
     root: web_sys::Element,
     projection: SceneProjection,
+    elements: DomElementRegistry,
     nodes: HashMap<NodeId, web_sys::Element>,
+    node_types: HashMap<NodeId, ElementTypeId>,
     parents: HashMap<NodeId, NodeId>,
     layouts: HashMap<NodeId, whisker_protocol::LayoutGeometry>,
     text_nodes: HashMap<NodeId, web_sys::Element>,
 }
 
+#[derive(Clone, Debug)]
+struct DomElementRegistry {
+    bindings: HashMap<ElementTypeId, DomElementBinding>,
+}
+
+#[derive(Clone, Debug)]
+struct DomElementBinding {
+    content: ElementContentKind,
+    tag_name: String,
+}
+
+impl DomElementRegistry {
+    fn bind(
+        registrations: &[ElementRegistration],
+        factories: &[WebElementFactory],
+    ) -> Result<Self, WebHostError> {
+        let mut bindings = HashMap::with_capacity(registrations.len());
+        let mut canonical = HashMap::with_capacity(registrations.len());
+        let mut factories_by_name = HashMap::with_capacity(factories.len());
+        for factory in factories {
+            if factory.tag_name.trim().is_empty() {
+                return Err(WebHostError(format!(
+                    "DOM factory {} has an empty tag name",
+                    factory.canonical_name
+                )));
+            }
+            if factories_by_name
+                .insert(factory.canonical_name.clone(), factory.clone())
+                .is_some()
+            {
+                return Err(WebHostError(format!(
+                    "duplicate DOM factory {}",
+                    factory.canonical_name
+                )));
+            }
+        }
+        for registration in registrations {
+            registration.validate().map_err(|error| {
+                WebHostError(format!(
+                    "invalid DOM element {}: {error:?}",
+                    registration.canonical_name
+                ))
+            })?;
+            if bindings.contains_key(&registration.element_type) {
+                return Err(WebHostError(format!(
+                    "duplicate DOM element type {}",
+                    registration.element_type.get()
+                )));
+            }
+            if canonical
+                .insert(
+                    registration.canonical_name.clone(),
+                    registration.element_type,
+                )
+                .is_some()
+            {
+                return Err(WebHostError(format!(
+                    "duplicate DOM element {}",
+                    registration.canonical_name
+                )));
+            }
+            match registration.content {
+                ElementContentKind::None
+                | ElementContentKind::Text
+                | ElementContentKind::ScrollContainer => {}
+                ElementContentKind::Image
+                | ElementContentKind::EditableText
+                | ElementContentKind::Native => {
+                    return Err(WebHostError(format!(
+                        "DOM Host does not implement {} content {:?}",
+                        registration.canonical_name, registration.content
+                    )));
+                }
+            }
+            let factory = factories_by_name
+                .remove(&registration.canonical_name)
+                .ok_or_else(|| {
+                    WebHostError(format!(
+                        "missing DOM factory {}",
+                        registration.canonical_name
+                    ))
+                })?;
+            bindings.insert(
+                registration.element_type,
+                DomElementBinding {
+                    content: registration.content,
+                    tag_name: factory.tag_name,
+                },
+            );
+        }
+        if let Some(canonical_name) = factories_by_name.into_keys().next() {
+            return Err(WebHostError(format!(
+                "DOM factory {canonical_name} has no Rust element schema"
+            )));
+        }
+        Ok(Self { bindings })
+    }
+
+    fn binding(&self, element_type: ElementTypeId) -> Result<&DomElementBinding, WebHostError> {
+        self.bindings.get(&element_type).ok_or_else(|| {
+            WebHostError(format!(
+                "DOM Host received unknown element type {}",
+                element_type.get()
+            ))
+        })
+    }
+}
+
 impl DomFrameSink {
-    fn new(document: web_sys::Document, root: web_sys::Element, surface: SurfaceId) -> Self {
-        Self {
+    fn new(
+        document: web_sys::Document,
+        root: web_sys::Element,
+        surface: SurfaceId,
+        registrations: &[ElementRegistration],
+        factories: &[WebElementFactory],
+    ) -> Result<Self, WebHostError> {
+        Ok(Self {
             document,
             root,
             projection: SceneProjection::new(surface),
+            elements: DomElementRegistry::bind(registrations, factories)?,
             nodes: HashMap::new(),
+            node_types: HashMap::new(),
             parents: HashMap::new(),
             layouts: HashMap::new(),
             text_nodes: HashMap::new(),
-        }
+        })
     }
 
     fn apply(&mut self, packet: &FramePacket) -> Result<(), WebHostError> {
         if packet.header.mode == FrameMode::Snapshot {
             self.root.set_inner_html("");
             self.nodes.clear();
+            self.node_types.clear();
             self.parents.clear();
             self.layouts.clear();
             self.text_nodes.clear();
@@ -335,20 +548,25 @@ impl DomFrameSink {
 
     fn apply_operation(&mut self, operation: &Operation) -> Result<(), WebHostError> {
         match operation {
-            Operation::CreateNode { node, .. } => {
+            Operation::CreateNode { node, element_type } => {
+                let binding = self.elements.binding(*element_type)?.clone();
                 let element = self
                     .document
-                    .create_element("div")
+                    .create_element(&binding.tag_name)
                     .map_err(|error| js_error("create Whisker DOM node", error))?;
                 element
                     .set_attribute("data-whisker-node", &node.get().to_string())
                     .map_err(|error| js_error("mark Whisker DOM node", error))?;
+                element
+                    .set_attribute("data-whisker-content", content_name(binding.content))
+                    .map_err(|error| js_error("mark Whisker DOM element content", error))?;
                 set_style(&element, "position", "absolute")?;
                 set_style(&element, "box-sizing", "border-box")?;
                 self.root
                     .append_child(&element)
                     .map_err(|error| js_error("attach Whisker DOM node", error))?;
                 self.nodes.insert(*node, element);
+                self.node_types.insert(*node, *element_type);
             }
             Operation::DeleteNode { node } => self.delete_subtree(*node),
             Operation::InsertChild {
@@ -479,6 +697,15 @@ impl DomFrameSink {
                 set_style(&self.node(*node)?, "z-index", &z_order.to_string())?;
             }
             Operation::SetText { node, content } => {
+                let element_type = self.node_types.get(node).copied().ok_or_else(|| {
+                    WebHostError(format!("DOM projection is missing node {}", node.get()))
+                })?;
+                if self.elements.binding(element_type)?.content != ElementContentKind::Text {
+                    return Err(WebHostError(format!(
+                        "DOM Host received text for non-text node {}",
+                        node.get()
+                    )));
+                }
                 let text = if let Some(text) = self.text_nodes.get(node) {
                     text.clone()
                 } else {
@@ -548,10 +775,22 @@ impl DomFrameSink {
         }
         for node in deleted {
             self.nodes.remove(&node);
+            self.node_types.remove(&node);
             self.parents.remove(&node);
             self.layouts.remove(&node);
             self.text_nodes.remove(&node);
         }
+    }
+}
+
+fn content_name(content: ElementContentKind) -> &'static str {
+    match content {
+        ElementContentKind::None => "none",
+        ElementContentKind::Text => "text",
+        ElementContentKind::ScrollContainer => "scroll-container",
+        ElementContentKind::Image => "image",
+        ElementContentKind::EditableText => "editable-text",
+        ElementContentKind::Native => "native",
     }
 }
 
@@ -698,4 +937,56 @@ fn js_error(context: &str, value: wasm_bindgen::JsValue) -> WebHostError {
         "{context}: {}",
         value.as_string().unwrap_or_else(|| format!("{value:?}"))
     ))
+}
+
+#[cfg(test)]
+mod element_registry_tests {
+    use super::*;
+    use whisker::{ElementProviderMetadata, ElementRegistry};
+    use whisker_protocol::{ElementChildMount, ElementMeasurement, ElementSchema};
+
+    #[test]
+    fn standard_and_module_factories_use_the_same_dom_binding_path() {
+        let mut modules = standard_web_element_modules();
+        modules.push(WebElementModule::new(
+            ElementProviderMetadata::named(
+                "badge",
+                ElementSchema {
+                    canonical_name: "whisker.test/Badge".into(),
+                    content: ElementContentKind::None,
+                    child_mount: ElementChildMount::Presentation,
+                    measurement: ElementMeasurement::None,
+                    consumes_text_style: false,
+                },
+            ),
+            WebElementFactory::new("whisker.test/Badge", "span"),
+        ));
+        let elements = ElementRegistry::builder()
+            .register_providers(modules.iter().map(|module| module.provider().clone()))
+            .build()
+            .unwrap();
+        let factories = modules
+            .iter()
+            .map(|module| module.factory().clone())
+            .collect::<Vec<_>>();
+
+        let registry = DomElementRegistry::bind(elements.registrations(), &factories).unwrap();
+        let badge = elements.registration_for_name("badge").unwrap();
+        assert_eq!(
+            registry.binding(badge.element_type).unwrap().tag_name,
+            "span"
+        );
+    }
+
+    #[test]
+    fn missing_or_unmatched_dom_factories_fail_bootstrap() {
+        let registrations = ElementRegistry::standard().registrations().to_vec();
+        let missing = DomElementRegistry::bind(&registrations, &[]).unwrap_err();
+        assert!(missing.0.contains("missing DOM factory"));
+
+        let mut factories = standard_web_element_factories();
+        factories.push(WebElementFactory::new("whisker.test/Unknown", "div"));
+        let unknown = DomElementRegistry::bind(&registrations, &factories).unwrap_err();
+        assert!(unknown.0.contains("has no Rust element schema"));
+    }
 }

--- a/platforms/windows/src/app.rs
+++ b/platforms/windows/src/app.rs
@@ -4,8 +4,11 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use whisker::runtime::RuntimeWakeHandle;
-use whisker::{Element, RuntimeInstance, SurfaceRuntime};
-use whisker_desktop::{DesktopFrameContext, DesktopHost};
+use whisker::{Element, ElementRegistry, RuntimeInstance, SurfaceRuntime};
+use whisker_desktop::{
+    DesktopElementFactory, DesktopElementModule, DesktopFrameContext, DesktopHost,
+    standard_desktop_element_modules,
+};
 use whisker_protocol::SurfaceId;
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
@@ -23,6 +26,9 @@ pub struct WindowsAppConfig {
     pub width: f64,
     /// Initial logical height in points.
     pub height: f64,
+    /// Element modules selected for this target.
+    pub element_modules: Vec<DesktopElementModule>,
+    element_factories: Vec<DesktopElementFactory>,
 }
 
 impl WindowsAppConfig {
@@ -32,7 +38,15 @@ impl WindowsAppConfig {
             title: title.into(),
             width: 1024.0,
             height: 720.0,
+            element_modules: Vec::new(),
+            element_factories: Vec::new(),
         }
+    }
+
+    /// Adds one Rust element definition with its matching Desktop factory.
+    pub fn with_element_module(mut self, module: DesktopElementModule) -> Self {
+        self.element_modules.push(module);
+        self
     }
 }
 
@@ -49,12 +63,29 @@ impl fmt::Display for WindowsHostError {
 impl Error for WindowsHostError {}
 
 /// Runs a standalone Whisker application in a native Windows window.
-pub fn run(config: WindowsAppConfig, application: fn() -> Element) -> Result<(), WindowsHostError> {
+pub fn run(
+    mut config: WindowsAppConfig,
+    application: fn() -> Element,
+) -> Result<(), WindowsHostError> {
+    let mut element_modules = standard_desktop_element_modules();
+    element_modules.append(&mut config.element_modules);
+    let elements = ElementRegistry::builder()
+        .register_providers(
+            element_modules
+                .iter()
+                .map(|module| module.provider().clone()),
+        )
+        .build()
+        .map_err(|error| WindowsHostError(format!("build element registry: {error}")))?;
+    config.element_factories = element_modules
+        .iter()
+        .map(|module| module.factory().clone())
+        .collect();
     let event_loop = EventLoop::<HostEvent>::with_user_event()
         .build()
         .map_err(|error| WindowsHostError(format!("create Windows event loop: {error}")))?;
     let proxy = event_loop.create_proxy();
-    let mut application = WindowsApplication::new(config, application, proxy);
+    let mut application = WindowsApplication::new(config, elements, application, proxy);
     event_loop
         .run_app(&mut application)
         .map_err(|error| WindowsHostError(format!("run Windows event loop: {error}")))
@@ -67,6 +98,7 @@ enum HostEvent {
 
 struct WindowsApplication {
     config: WindowsAppConfig,
+    elements: ElementRegistry,
     application: fn() -> Element,
     proxy: EventLoopProxy<HostEvent>,
     window: Option<Arc<Window>>,
@@ -82,11 +114,13 @@ struct WindowsApplication {
 impl WindowsApplication {
     fn new(
         config: WindowsAppConfig,
+        elements: ElementRegistry,
         application: fn() -> Element,
         proxy: EventLoopProxy<HostEvent>,
     ) -> Self {
         Self {
             config,
+            elements,
             application,
             proxy,
             window: None,
@@ -116,24 +150,28 @@ impl WindowsApplication {
         let scale = window.scale_factor() as f32;
         let logical = self.viewport.to_logical::<f32>(window.scale_factor());
         let surface_id = SurfaceId::new(1).expect("the standalone surface id is non-zero");
-        let surface = SurfaceRuntime::new(
+        let surface = SurfaceRuntime::with_element_registry(
             surface_id,
             StyleEnvironment::new(logical.width, logical.height, scale, 14.0),
+            self.elements.clone(),
         );
+        let element_registrations = surface.element_registrations();
         let wake_proxy = self.proxy.clone();
         let wake = RuntimeWakeHandle::new(move || {
             let _ = wake_proxy.send_event(HostEvent::RequestFrame);
         });
-        let mut runtime = RuntimeInstance::new(surface, wake);
-        runtime
-            .mount(self.application)
-            .map_err(|error| WindowsHostError(format!("mount Whisker application: {error}")))?;
         let host = pollster::block_on(DesktopHost::new(
             window.clone(),
             [self.viewport.width, self.viewport.height],
             surface_id,
+            &element_registrations,
+            &self.config.element_factories,
         ))
         .map_err(|error| WindowsHostError(error.to_string()))?;
+        let mut runtime = RuntimeInstance::new(surface, wake);
+        runtime
+            .mount(self.application)
+            .map_err(|error| WindowsHostError(format!("mount Whisker application: {error}")))?;
         self.host = Some(host);
         self.runtime = Some(runtime);
         self.window = Some(window);


### PR DESCRIPTION
## Summary

- add RFC0004 and normalized element schema/registry primitives
- register `View`, `Text`, and `ScrollView` as the ordinary versionless `whisker.ui` element module; keep `Page` out of the module
- bind Rust providers to Desktop and Web Host factories through the same module composition path used by application-selected elements
- reject missing, duplicate, unmatched, and incompatible Host factories before the first frame
- preserve the existing service-only module registration path

This is an implementation slice on top of #407. Android and iOS remain on their Lynx Host path until RFC0004 native Host renderers and generated binding ingestion are implemented.

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p whisker -p whisker-desktop -p whisker-web` after rebasing onto the latest `next-architecture`
- `cargo check -p whisker-web --target wasm32-unknown-unknown`
- generated `examples/host-smoke` macOS Host builds and remains active in its event loop
- generated Web Host builds with Trunk and renders 8 Whisker DOM nodes with all four expected labels and no console warnings/errors
