### PR TITLE
test(host): cover box paint basics across all hosts

### DIFF
--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -201,6 +201,15 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
         ),
+        "wpt/css/CSS2/borders/border-top-003.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json"
+        ),
+        "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"
+        ),
+        "wpt/css/CSS2/borders/border-bottom-003.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-bottom-003.json"
+        ),
         "wpt/css/CSS2/borders/border-left-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-left-003.json"
         ),

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -6,15 +6,36 @@
       "id": "wpt.css2.backgrounds.background-color-129",
       "feature": "background-color",
       "fixture": "wpt/css/CSS2/backgrounds/background-color-129.json",
-      "required_hosts": ["desktop", "android", "ios"],
+      "required_hosts": ["desktop", "web", "android", "ios"],
       "checkpoints": ["semantic-projection", "pixel"]
     },
     {
       "id": "wpt.css-backgrounds.border-radius-sum-of-radii-001.test1",
       "feature": "border-radius",
       "fixture": "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json",
-      "required_hosts": ["desktop", "android", "ios"],
+      "required_hosts": ["desktop", "web", "android", "ios"],
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel"]
+    },
+    {
+      "id": "wpt.css2.borders.border-top-003",
+      "feature": "border-top",
+      "fixture": "wpt/css/CSS2/borders/border-top-003.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel"]
+    },
+    {
+      "id": "wpt.css2.borders.border-right-003",
+      "feature": "border-right",
+      "fixture": "wpt/css/CSS2/borders/border-right-003.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel"]
+    },
+    {
+      "id": "wpt.css2.borders.border-bottom-003",
+      "feature": "border-bottom",
+      "fixture": "wpt/css/CSS2/borders/border-bottom-003.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel"]
     },
     {
       "id": "wpt.css2.borders.border-left-003",

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-bottom-003.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-bottom-003.json
@@ -1,0 +1,48 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-bottom-003",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-bottom-003.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "The border-bottom shorthand sets the color of a solid bottom border, producing a blue line.",
+    "adaptation": "The CSS medium bottom border is isolated as a 3 by 96 logical-pixel strip and compared with an explicit blue reference box; instructional document content and margins are omitted."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 96.0, "height": 3.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 96.0, 3.0],
+        "background": { "kind": "named", "value": "transparent" },
+        "border": {
+          "widths": [0.0, 0.0, 3.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "blue" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["none", "none", "solid", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      { "type": "checkpoint", "name": "paint.box" }
+    ]
+  },
+  "reference": {
+    "commands": [
+      { "type": "attach_surface", "width": 96.0, "height": 3.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 96.0, 3.0],
+        "background": { "kind": "named", "value": "blue" }
+      },
+      { "type": "checkpoint", "name": "paint.box" }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json
@@ -1,0 +1,48 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-right-003",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-right-003.xht",
+    "reference_path": "css/CSS2/borders/border-right-003-ref.xht",
+    "license": "BSD-3-Clause",
+    "assertion": "The border-right shorthand sets the color of a solid right border, producing a short vertical blue line.",
+    "adaptation": "The 5px by 1in right border and its reference are represented as 5 by 96 logical-pixel boxes; instructional document content and margins are omitted."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 5.0, "height": 96.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 5.0, 96.0],
+        "background": { "kind": "named", "value": "transparent" },
+        "border": {
+          "widths": [0.0, 5.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "blue" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["none", "solid", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      { "type": "checkpoint", "name": "paint.box" }
+    ]
+  },
+  "reference": {
+    "commands": [
+      { "type": "attach_surface", "width": 5.0, "height": 96.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 5.0, 96.0],
+        "background": { "kind": "named", "value": "blue" }
+      },
+      { "type": "checkpoint", "name": "paint.box" }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json
@@ -1,0 +1,48 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-003",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-003.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "The border-top shorthand sets the color of a solid top border, producing a blue line.",
+    "adaptation": "The CSS medium top border is represented as a 3 by 96 logical-pixel strip and compared with an explicit blue reference box; instructional document content and margins are omitted."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 96.0, "height": 3.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 96.0, 3.0],
+        "background": { "kind": "named", "value": "transparent" },
+        "border": {
+          "widths": [3.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "blue" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["solid", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      { "type": "checkpoint", "name": "paint.box" }
+    ]
+  },
+  "reference": {
+    "commands": [
+      { "type": "attach_surface", "width": 96.0, "height": 3.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 96.0, 3.0],
+        "background": { "kind": "named", "value": "blue" }
+      },
+      { "type": "checkpoint", "name": "paint.box" }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- adapt WPT border-top/right/bottom solid-border cases into the shared Host fixture format
- require Desktop, Web, Android, and iOS for background color, radius normalization, and every physical solid-border edge
- embed the new shared fixtures in the production Web Host conformance runner

## Verification
- `cargo test -p whisker-host-conformance`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`
- `cargo fmt --all --check`
- `git diff --check`