### PR TITLE
feat(host): render dashed and dotted borders

### DIFF
--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -150,6 +150,10 @@ pub enum Command {
     Checkpoint {
         /// Checkpoint contract name.
         name: String,
+        /// Optional logical-pixel samples for visual tests without a WPT
+        /// reference document.
+        #[serde(default)]
+        samples: Vec<PixelSampleFixture>,
     },
     /// Sends a text measurement request to the production Host measurer.
     MeasureText {
@@ -243,6 +247,19 @@ pub enum ColorFixture {
         /// Alpha channel in `[0, 1]`.
         alpha: f32,
     },
+}
+
+/// One logical-pixel color assertion captured at a paint checkpoint.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PixelSampleFixture {
+    /// Logical x/y coordinate within the attached surface.
+    pub point: [f32; 2],
+    /// Expected unpremultiplied sRGB color.
+    pub color: ColorFixture,
+    /// Maximum per-channel difference accepted by native rasterizers.
+    #[serde(default)]
+    pub tolerance: u8,
 }
 
 /// Physical border semantics in top, right, bottom, left order.
@@ -403,7 +420,12 @@ fn validate_manifest(manifest: &Manifest) -> Result<(), FixtureError> {
         for checkpoint in &case.checkpoints {
             if !matches!(
                 checkpoint.as_str(),
-                "rust-layout-protocol" | "semantic-projection" | "pixel" | "measurement" | "input"
+                "rust-layout-protocol"
+                    | "semantic-projection"
+                    | "pixel"
+                    | "pixel-samples"
+                    | "measurement"
+                    | "input"
             ) {
                 return Err(FixtureError(format!(
                     "case {} names unknown checkpoint {checkpoint}",
@@ -447,6 +469,22 @@ fn validate_scenario(
         )));
     }
     validate_side(&scenario.id, "test", &scenario.test)?;
+    if entry
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint == "pixel-samples")
+        && !scenario.test.commands.iter().any(|command| {
+            matches!(
+                command,
+                Command::Checkpoint { samples, .. } if !samples.is_empty()
+            )
+        })
+    {
+        return Err(FixtureError(format!(
+            "scenario {} declares pixel-samples without sample assertions",
+            scenario.id
+        )));
+    }
     if let Some(reference) = &scenario.reference {
         validate_side(&scenario.id, "reference", reference)?;
     }
@@ -500,7 +538,15 @@ fn validate_side(id: &str, label: &str, side: &ScenarioSide) -> Result<(), Fixtu
                 && rect[3] >= 0.0
                 && valid_color(background)
                 && border.as_ref().is_none_or(valid_border) => {}
-            Command::Checkpoint { name } if !name.trim().is_empty() => {}
+            Command::Checkpoint { name, samples }
+                if !name.trim().is_empty()
+                    && samples.iter().all(|sample| {
+                        sample
+                            .point
+                            .iter()
+                            .all(|value| value.is_finite() && *value >= 0.0)
+                            && valid_color(&sample.color)
+                    }) => {}
             Command::MeasureText {
                 key,
                 font_size,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -91,6 +91,7 @@ private class WhiskerBoxDrawable(
         val right = borderWidths[1].coerceIn(0f, box.width())
         val bottom = borderWidths[2].coerceIn(0f, box.height())
         val left = borderWidths[3].coerceIn(0f, box.width())
+        val widths = floatArrayOf(top, right, bottom, left)
         if (top == 0f && right == 0f && bottom == 0f && left == 0f) return
 
         if (radii.all { it == 0f }) {
@@ -147,7 +148,7 @@ private class WhiskerBoxDrawable(
             },
         )
         repeat(4) { side ->
-            if (!paintsSolidSide(side) || borderWidths[side] <= 0f) return@repeat
+            if (!paintsSide(side) || borderWidths[side] <= 0f) return@repeat
             val save = canvas.save()
             @Suppress("DEPRECATION")
             canvas.clipPath(outer)
@@ -156,7 +157,19 @@ private class WhiskerBoxDrawable(
                 canvas.clipPath(innerPath, android.graphics.Region.Op.DIFFERENCE)
             }
             paint.color = borderColors[side]
-            canvas.drawPath(sidePaths[side], paint)
+            when (borderStyles[side]) {
+                BORDER_STYLE_SOLID -> canvas.drawPath(sidePaths[side], paint)
+                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED -> {
+                    canvas.clipPath(sidePaths[side])
+                    drawPatternedEdge(
+                        canvas,
+                        edgeRect(box, side, widths[side]),
+                        side,
+                        borderWidths[side],
+                        borderStyles[side],
+                    )
+                }
+            }
             canvas.restoreToCount(save)
         }
     }
@@ -177,13 +190,69 @@ private class WhiskerBoxDrawable(
             RectF(box.left, box.top, box.left + left, box.bottom),
         )
         repeat(4) { side ->
-            if (!paintsSolidSide(side) || widths[side] <= 0f) return@repeat
+            if (!paintsSide(side) || widths[side] <= 0f) return@repeat
             paint.color = borderColors[side]
-            canvas.drawRect(edges[side], paint)
+            when (borderStyles[side]) {
+                BORDER_STYLE_SOLID -> canvas.drawRect(edges[side], paint)
+                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED ->
+                    drawPatternedEdge(canvas, edges[side], side, widths[side], borderStyles[side])
+            }
         }
     }
 
-    private fun paintsSolidSide(side: Int): Boolean = borderStyles[side] == BORDER_STYLE_SOLID
+    private fun paintsSide(side: Int): Boolean = when (borderStyles[side]) {
+        BORDER_STYLE_SOLID, BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED -> true
+        else -> false
+    }
+
+    private fun edgeRect(box: RectF, side: Int, width: Float): RectF = when (side) {
+        0 -> RectF(box.left, box.top, box.right, box.top + width)
+        1 -> RectF(box.right - width, box.top, box.right, box.bottom)
+        2 -> RectF(box.left, box.bottom - width, box.right, box.bottom)
+        else -> RectF(box.left, box.top, box.left + width, box.bottom)
+    }
+
+    private fun drawPatternedEdge(
+        canvas: Canvas,
+        edge: RectF,
+        side: Int,
+        width: Float,
+        style: Int,
+    ) {
+        if (width <= 0f || edge.isEmpty) return
+        val horizontal = side == 0 || side == 2
+        val start = if (horizontal) edge.left else edge.top
+        val end = if (horizontal) edge.right else edge.bottom
+        val center = if (horizontal) edge.centerY() else edge.centerX()
+        val save = canvas.save()
+        canvas.clipRect(edge)
+        if (style == BORDER_STYLE_DASHED) {
+            val dash = width * 3f
+            val period = width * 4f
+            var position = start
+            while (position < end) {
+                val dashEnd = min(position + dash, end)
+                if (horizontal) {
+                    canvas.drawRect(position, edge.top, dashEnd, edge.bottom, paint)
+                } else {
+                    canvas.drawRect(edge.left, position, edge.right, dashEnd, paint)
+                }
+                position += period
+            }
+        } else {
+            val radius = width / 2f
+            var position = start + width
+            while (position - radius < end) {
+                if (horizontal) {
+                    canvas.drawCircle(position, center, radius, paint)
+                } else {
+                    canvas.drawCircle(center, position, radius, paint)
+                }
+                position += width * 2f
+            }
+        }
+        canvas.restoreToCount(save)
+    }
 
     private fun normalizedRadii(width: Float, height: Float): FloatArray {
         val result = cornerRadii.map { it.coerceAtLeast(0f) }.toFloatArray()
@@ -219,3 +288,5 @@ private class WhiskerBoxDrawable(
 }
 
 private const val BORDER_STYLE_SOLID = 2
+private const val BORDER_STYLE_DASHED = 3
+private const val BORDER_STYLE_DOTTED = 4

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -6,7 +6,7 @@ use whisker::{SurfaceRuntime, standard_element_registrations};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LoadedCase,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LoadedCase, PixelSampleFixture,
     PointerEventFixture, Scenario, ScenarioSide, load_required,
 };
 use whisker_protocol::{
@@ -23,6 +23,7 @@ use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 use crate::element::{DesktopElementRegistry, built_in_element_factories};
 use crate::gpu::render_box_primitives_offscreen;
 use crate::paint::box_paint::{BoxPrimitive, BoxPrimitiveKind, lower_box};
+use crate::paint::color::srgba;
 use crate::scene::{DesktopScene, PaintCommand};
 use crate::text::NativeTextHost;
 
@@ -96,6 +97,7 @@ impl RecordingInputSink {
 struct Checkpoint {
     logical_size: [u32; 2],
     primitives: Vec<BoxPrimitive>,
+    samples: Vec<PixelSampleFixture>,
 }
 
 fn standard_element_type(name: &str) -> ElementTypeId {
@@ -158,7 +160,7 @@ impl Driver {
                     background,
                     border,
                 } => self.present_box(*revision, *rect, background, border.as_ref()),
-                Command::Checkpoint { name } => {
+                Command::Checkpoint { name, samples } => {
                     assert_eq!(name, "paint.box", "unsupported Desktop checkpoint");
                     checkpoints.push(Checkpoint {
                         logical_size: [
@@ -166,6 +168,7 @@ impl Driver {
                             self.logical_size[1].round() as u32,
                         ],
                         primitives: self.box_primitives(),
+                        samples: samples.clone(),
                     });
                 }
                 Command::MeasureText {
@@ -528,6 +531,45 @@ fn run_reftest(scenario: &Scenario) {
     );
 }
 
+fn run_pixel_samples(scenario: &Scenario) {
+    let checkpoints = Driver::new().execute(&scenario.test);
+    for checkpoint in checkpoints
+        .iter()
+        .filter(|checkpoint| !checkpoint.samples.is_empty())
+    {
+        let pixels = pollster::block_on(render_box_primitives_offscreen(
+            &checkpoint.primitives,
+            checkpoint.logical_size,
+        ))
+        .expect("Desktop pixel-sample checkpoint");
+        let [width, height] = checkpoint.logical_size;
+        for sample in &checkpoint.samples {
+            let x = sample.point[0].floor() as u32;
+            let y = sample.point[1].floor() as u32;
+            assert!(
+                x < width && y < height,
+                "{} sample is outside the surface",
+                scenario.id
+            );
+            let offset = ((y * width + x) * 4) as usize;
+            let actual: [u8; 4] = pixels[offset..offset + 4].try_into().unwrap();
+            let expected = srgba(&color_protocol(&sample.color), 1.0)
+                .map(|channel| (channel * 255.0).round() as u8);
+            let difference = actual
+                .into_iter()
+                .zip(expected)
+                .map(|(actual, expected)| actual.abs_diff(expected))
+                .max()
+                .unwrap_or(0);
+            assert!(
+                difference <= sample.tolerance,
+                "{} sample ({x}, {y}) differs by {difference}: {actual:?} != {expected:?}",
+                scenario.id
+            );
+        }
+    }
+}
+
 #[test]
 fn every_manifest_case_required_by_desktop_executes() {
     let root =
@@ -543,7 +585,7 @@ fn every_manifest_case_required_by_desktop_executes() {
             );
             run_reftest(&scenario);
         } else {
-            Driver::new().execute(&scenario.test);
+            run_pixel_samples(&scenario);
         }
     }
 }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -47,15 +47,15 @@ final class HostBoxPainter {
         let path = roundedPath(in: bounds, radii: cornerRadii)
         fillColor.setFill()
         path.fill()
-        drawSolidBorders(in: bounds, clippedBy: path)
+        drawBorders(in: bounds, clippedBy: path)
     }
 
-    private func drawSolidBorders(in bounds: CGRect, clippedBy outerPath: UIBezierPath) {
+    private func drawBorders(in bounds: CGRect, clippedBy outerPath: UIBezierPath) {
         guard let context = UIGraphicsGetCurrentContext() else { return }
         let widths = Array((borderWidths + [0, 0, 0, 0]).prefix(4)).map { max(0, $0) }
         let colors = Array((borderColors + [.clear, .clear, .clear, .clear]).prefix(4))
         let styles = Array((borderStyles + [0, 0, 0, 0]).prefix(4))
-        guard zip(widths, styles).contains(where: { $0.0 > 0 && $0.1 == borderStyleSolid }) else {
+        guard zip(widths, styles).contains(where: { $0.0 > 0 && paintsBorderStyle($0.1) }) else {
             return
         }
 
@@ -81,15 +81,75 @@ final class HostBoxPainter {
         context.saveGState()
         context.addPath(outerPath.cgPath)
         context.clip()
-        for index in 0..<4 where widths[index] > 0 && styles[index] == borderStyleSolid {
+        for index in 0..<4 where widths[index] > 0 && paintsBorderStyle(styles[index]) {
             let region = UIBezierPath()
             region.move(to: regions[index][0])
             for point in regions[index].dropFirst() { region.addLine(to: point) }
             region.close()
+            context.saveGState()
+            context.addPath(region.cgPath)
+            context.clip()
             colors[index].setFill()
-            region.fill()
+            if styles[index] == borderStyleSolid {
+                region.fill()
+            } else {
+                drawPatternedBorder(
+                    in: edgeRect(bounds: bounds, side: index, width: widths[index]),
+                    side: index,
+                    width: widths[index],
+                    style: styles[index],
+                    context: context
+                )
+            }
+            context.restoreGState()
         }
         context.restoreGState()
+    }
+
+    private func edgeRect(bounds: CGRect, side: Int, width: CGFloat) -> CGRect {
+        switch side {
+        case 0: return CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width, height: width)
+        case 1: return CGRect(x: bounds.maxX - width, y: bounds.minY, width: width, height: bounds.height)
+        case 2: return CGRect(x: bounds.minX, y: bounds.maxY - width, width: bounds.width, height: width)
+        default: return CGRect(x: bounds.minX, y: bounds.minY, width: width, height: bounds.height)
+        }
+    }
+
+    private func drawPatternedBorder(
+        in edge: CGRect,
+        side: Int,
+        width: CGFloat,
+        style: UInt32,
+        context: CGContext
+    ) {
+        guard width > 0, !edge.isEmpty else { return }
+        let horizontal = side == 0 || side == 2
+        let start = horizontal ? edge.minX : edge.minY
+        let end = horizontal ? edge.maxX : edge.maxY
+        let center = horizontal ? edge.midY : edge.midX
+        if style == borderStyleDashed {
+            let dash = width * 3
+            let period = width * 4
+            var position = start
+            while position < end {
+                let dashEnd = min(position + dash, end)
+                let rect = horizontal
+                    ? CGRect(x: position, y: edge.minY, width: dashEnd - position, height: edge.height)
+                    : CGRect(x: edge.minX, y: position, width: edge.width, height: dashEnd - position)
+                context.fill(rect)
+                position += period
+            }
+        } else {
+            let radius = width / 2
+            var position = start + width
+            while position - radius < end {
+                let rect = horizontal
+                    ? CGRect(x: position - radius, y: center - radius, width: width, height: width)
+                    : CGRect(x: center - radius, y: position - radius, width: width, height: width)
+                context.fillEllipse(in: rect)
+                position += width * 2
+            }
+        }
     }
 }
 
@@ -178,3 +238,9 @@ private func roundedPath(in rect: CGRect, radii: [CGSize]) -> UIBezierPath {
 }
 
 private let borderStyleSolid: UInt32 = 2
+private let borderStyleDashed: UInt32 = 3
+private let borderStyleDotted: UInt32 = 4
+
+private func paintsBorderStyle(_ style: UInt32) -> Bool {
+    style == borderStyleSolid || style == borderStyleDashed || style == borderStyleDotted
+}

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -83,7 +83,7 @@ impl Driver {
                         border: border.clone(),
                     });
                 }
-                Command::Checkpoint { name } => {
+                Command::Checkpoint { name, .. } => {
                     assert_eq!(name, "paint.box");
                     self.assert_box_is_projected();
                 }
@@ -212,6 +212,12 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/CSS2/borders/border-left-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-left-003.json"
+        ),
+        "wpt/css/CSS2/borders/border-top-style-003.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-003.json"
+        ),
+        "wpt/css/CSS2/borders/border-top-style-004.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-004.json"
         ),
         "core/text-measure-basic.json" => {
             include_str!("../../../../tests/host-conformance/core/text-measure-basic.json")

--- a/tests/host-conformance/README.md
+++ b/tests/host-conformance/README.md
@@ -35,6 +35,13 @@ bitmaps on an emulator. iOS compiles the generated production
 `WhiskerView.swift`, injects the mobile C ABI frame, and compares UIKit layer
 captures in a Simulator.
 
+Manual visual WPT adaptations may attach logical-pixel `samples` to a paint
+checkpoint instead of inventing an exact reference image for behavior whose
+fine geometry is intentionally implementation-defined by CSS. Desktop,
+Android, and iOS assert those samples against production raster output. Web
+asserts the equivalent CSS projection and leaves dash/dot distribution to the
+browser, while sharing the same scenario and semantic values.
+
 From the repository root, run one Host with:
 
 ```sh

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -45,6 +45,20 @@
       "checkpoints": ["semantic-projection", "pixel"]
     },
     {
+      "id": "wpt.css2.borders.border-top-style-003",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-003.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css2.borders.border-top-style-004",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-004.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "host.measure.text.basic",
       "feature": "text-measurement",
       "fixture": "core/text-measure-basic.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -26,7 +26,7 @@ class HostConformanceTest {
     }
 
     @Test
-    fun everySharedPaintReftestUsesTheProductionAndroidView() {
+    fun everySharedPaintScenarioUsesTheProductionAndroidView() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()
             .runOnMainSync {
@@ -37,15 +37,21 @@ class HostConformanceTest {
                     val scenario = JSONObject(asset(entry.getString("fixture")))
                     check(scenario.getInt("schema") == 1)
                     check(scenario.getString("id") == entry.getString("id"))
-                    val reference = scenario.optJSONObject("reference") ?: return@forEach
-                    val test = Driver(context).execute(scenario.getJSONObject("test"))
-                    val expected = Driver(context).execute(reference)
-                    assertEquals(scenario.getString("id"), expected.width, test.width)
-                    assertEquals(scenario.getString("id"), expected.height, test.height)
-                    assertPixelsClose(scenario.getString("id"), test, expected)
+                    val testSide = scenario.getJSONObject("test")
+                    if (testSide.getJSONArray("commands").objects().none {
+                            it.getString("type") == "present_box"
+                        }) return@forEach
+                    val id = scenario.getString("id")
+                    val test = Driver(context, id).execute(testSide)
+                    scenario.optJSONObject("reference")?.let { reference ->
+                        val expected = Driver(context, id).execute(reference)
+                        assertEquals(id, expected.width, test.width)
+                        assertEquals(id, expected.height, test.height)
+                        assertPixelsClose(id, test, expected)
+                    }
                     count += 1
                 }
-                assertTrue("at least one shared paint reftest", count > 0)
+                assertTrue("at least one shared paint scenario", count > 0)
             }
     }
 
@@ -59,7 +65,10 @@ class HostConformanceTest {
             .use { it.readText() }
 }
 
-private class Driver(private val context: android.content.Context) {
+private class Driver(
+    private val context: android.content.Context,
+    private val id: String,
+) {
     private val view = WhiskerView(context)
     private var logicalWidth = 0f
     private var logicalHeight = 0f
@@ -96,6 +105,14 @@ private class Driver(private val context: android.content.Context) {
                 "checkpoint" -> {
                     check(command.getString("name") == "paint.box")
                     checkpoint = capture()
+                    command.optJSONArray("samples")?.let { samples ->
+                        assertPixelSamples(
+                            id,
+                            checkNotNull(checkpoint),
+                            samples,
+                            context.resources.displayMetrics.density,
+                        )
+                    }
                 }
                 else -> error("unsupported Android paint command: ${command.getString("type")}")
             }
@@ -207,6 +224,37 @@ private fun JSONArray.floats(): FloatArray =
 
 private fun JSONArray.strings(): Array<String> =
     Array(length()) { index -> getString(index) }
+
+private fun assertPixelSamples(id: String, bitmap: Bitmap, samples: JSONArray, density: Float) {
+    samples.objects().forEach { sample ->
+        val point = sample.getJSONArray("point")
+        val x = (point.getDouble(0) * density).toInt()
+        val y = (point.getDouble(1) * density).toInt()
+        check(x in 0 until bitmap.width && y in 0 until bitmap.height)
+        val actual = bitmap.getPixel(x, y)
+        val expected = fixtureColor(sample.getJSONObject("color"))
+        val tolerance = sample.optInt("tolerance", 0)
+        val difference = listOf(
+            android.graphics.Color.alpha(actual) to android.graphics.Color.alpha(expected),
+            android.graphics.Color.red(actual) to android.graphics.Color.red(expected),
+            android.graphics.Color.green(actual) to android.graphics.Color.green(expected),
+            android.graphics.Color.blue(actual) to android.graphics.Color.blue(expected),
+        ).maxOf { (left, right) -> abs(left - right) }
+        assertTrue("$id sample ($x, $y) differs by $difference", difference <= tolerance)
+    }
+}
+
+private fun fixtureColor(value: JSONObject): Int =
+    if (value.getString("kind") == "named") {
+        android.graphics.Color.parseColor(value.getString("value"))
+    } else {
+        android.graphics.Color.argb(
+            (value.getDouble("alpha") * 255.0).roundToInt(),
+            value.getInt("red"),
+            value.getInt("green"),
+            value.getInt("blue"),
+        )
+    }
 
 private fun assertPixelsClose(id: String, actual: Bitmap, expected: Bitmap) {
     val actualPixels = IntArray(actual.width * actual.height)

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -13,7 +13,7 @@ final class HostConformanceTests: XCTestCase {
         BuiltInElementModule().registerWithWhisker()
     }
 
-    func testEverySharedPaintReftestUsesProductionUIKitHost() throws {
+    func testEverySharedPaintScenarioUsesProductionUIKitHost() throws {
         let manifest = try json(at: fixtureRoot.appendingPathComponent("manifest.json"))
         let cases = try XCTUnwrap(manifest["cases"] as? [[String: Any]])
         var count = 0
@@ -24,17 +24,22 @@ final class HostConformanceTests: XCTestCase {
                   try string(scenario, "id") == string(entry, "id") else {
                 throw Failure("manifest and iOS fixture disagree")
             }
-            guard let reference = scenario["reference"] as? [String: Any] else { continue }
-            let test = try Driver().execute(try object(scenario, "test"))
-            let expected = try Driver().execute(reference)
             let id = try string(scenario, "id")
-            XCTAssertEqual(test.width, expected.width)
-            XCTAssertEqual(test.height, expected.height)
-            XCTAssertLessThanOrEqual(
-                largestDifference(test.bytes, expected.bytes),
-                1,
-                id
-            )
+            let testSide = try object(scenario, "test")
+            guard try array(testSide, "commands").contains(where: {
+                try string($0, "type") == "present_box"
+            }) else { continue }
+            let test = try Driver(id: id).execute(testSide)
+            if let reference = scenario["reference"] as? [String: Any] {
+                let expected = try Driver(id: id).execute(reference)
+                XCTAssertEqual(test.width, expected.width)
+                XCTAssertEqual(test.height, expected.height)
+                XCTAssertLessThanOrEqual(
+                    largestDifference(test.bytes, expected.bytes),
+                    1,
+                    id
+                )
+            }
             count += 1
         }
         XCTAssertGreaterThan(count, 0)
@@ -43,11 +48,13 @@ final class HostConformanceTests: XCTestCase {
 
 @MainActor
 private final class Driver {
+    private let id: String
     private let view = WhiskerView(frame: .zero)
     private var logicalSize = CGSize.zero
     private var checkpoint: Pixels?
 
-    init() throws {
+    init(id: String) throws {
+        self.id = id
         let registration = WhiskerElementRegistration(
             elementType: 1,
             name: WhiskerBuiltInElements.viewName,
@@ -73,7 +80,11 @@ private final class Driver {
                 guard try string(command, "name") == "paint.box" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
-                checkpoint = try capture()
+                let pixels = try capture()
+                checkpoint = pixels
+                if let samples = command["samples"] as? [[String: Any]] {
+                    try assertPixelSamples(id: id, pixels: pixels, samples: samples)
+                }
             default:
                 throw Failure("unsupported UIKit paint command")
             }
@@ -216,6 +227,7 @@ private func color(_ fixture: [String: Any]) throws -> WhiskerMobileColor {
         case "black": rgba = (0, 0, 0, 1)
         case "blue": rgba = (0, 0, 255, 1)
         case "transparent": rgba = (0, 0, 0, 0)
+        case "white": rgba = (255, 255, 255, 1)
         default: throw Failure("unsupported fixture named color")
         }
     } else {
@@ -291,4 +303,32 @@ private func unwrap<T>(_ value: T?, _ context: String) throws -> T {
 
 private func largestDifference(_ left: [UInt8], _ right: [UInt8]) -> UInt8 {
     zip(left, right).map { $0 > $1 ? $0 - $1 : $1 - $0 }.max() ?? 0
+}
+
+private func assertPixelSamples(
+    id: String,
+    pixels: Pixels,
+    samples: [[String: Any]]
+) throws {
+    for sample in samples {
+        let point = try numberArray(sample, "point")
+        guard point.count == 2 else { throw Failure("pixel sample needs two coordinates") }
+        let x = Int(point[0].rounded(.down))
+        let y = Int(point[1].rounded(.down))
+        guard x >= 0, x < pixels.width, y >= 0, y < pixels.height else {
+            throw Failure("pixel sample is outside the surface")
+        }
+        let offset = (y * pixels.width + x) * 4
+        let actual = Array(pixels.bytes[offset..<(offset + 4)])
+        let expectedColor = try color(try object(sample, "color"))
+        let expected = [
+            expectedColor.red,
+            expectedColor.green,
+            expectedColor.blue,
+            UInt8((expectedColor.alpha * 255).rounded())
+        ]
+        let tolerance = UInt8((sample["tolerance"] as? NSNumber)?.uint8Value ?? 0)
+        let difference = largestDifference(actual, expected)
+        XCTAssertLessThanOrEqual(difference, tolerance, "\(id) sample (\(x), \(y))")
+    }
 }

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -87,7 +87,26 @@
       "required": ["type", "name"],
       "properties": {
         "type": { "const": "checkpoint" },
-        "name": { "type": "string", "minLength": 1 }
+        "name": { "type": "string", "minLength": 1 },
+        "samples": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pixelSample" }
+        }
+      }
+    },
+    "pixelSample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["point", "color"],
+      "properties": {
+        "point": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "number", "minimum": 0 }
+        },
+        "color": { "$ref": "#/$defs/color" },
+        "tolerance": { "type": "integer", "minimum": 0, "maximum": 255 }
       }
     },
     "measureText": {

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-003.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-003.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-003",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-003.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A dotted border-top renders separated round dots with the specified border width.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection plus logical-pixel samples inside two dots, one gap, and the white box background. Exact dot distribution outside those samples remains Host-defined as allowed by CSS."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 20.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 20.0],
+        "background": { "kind": "named", "value": "white" },
+        "border": {
+          "widths": [10.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["dotted", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [10.0, 5.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [20.0, 5.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 },
+          { "point": [30.0, 5.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [10.0, 15.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-004.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-004.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-004",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-004.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A dashed border-top renders separated dash segments with the specified border width.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection plus logical-pixel samples inside two dashes, one gap, and the white box background. Exact dash distribution outside those samples remains Host-defined as allowed by CSS."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 20.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 20.0],
+        "background": { "kind": "named", "value": "white" },
+        "border": {
+          "widths": [3.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["dashed", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [4.0, 1.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [10.0, 1.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 },
+          { "point": [14.0, 1.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [4.0, 10.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- adapt the WPT dotted and dashed `border-top-style` visual cases into shared Host fixtures
- extend paint checkpoints with optional logical-pixel samples for manual WPT cases without exact reference images
- assert sample pixels through production wgpu, Android Canvas, and UIKit paths while Web verifies the equivalent DOM/CSS projection
- implement dashed and dotted border painting in the Android and iOS Host runtimes

## Design note
CSS leaves the exact dash/dot distribution implementation-defined. The shared samples assert representative painted segments, gaps, and background without requiring browser-identical phase or anti-aliasing.

## Verification
- `cargo test -p whisker-host-conformance`
- `cargo clippy -p whisker-host-conformance -p whisker-desktop --all-targets --features whisker-desktop/host-conformance -- -D warnings`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`
- `cargo fmt --all --check`
- `git diff --check`