### PR TITLE
feat(host): preserve elliptical border radii

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 1, WHISKER_MOBILE_ABI_MINOR = 0 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 0 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -42,7 +42,8 @@ typedef struct {
   WhiskerMobileLengthPercentage widths[4];
   WhiskerMobileColor colors[4];
   uint32_t styles[4];
-  WhiskerMobileLengthPercentage radii[4];
+  WhiskerMobileLengthPercentage radii_horizontal[4];
+  WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileBoxPaint;
 typedef struct {
   WhiskerStringRef text;
@@ -127,7 +128,7 @@ _Static_assert(sizeof(WhiskerMobileBootstrap) == 24, "WhiskerMobileBootstrap ABI
 _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 160, "WhiskerMobileMeasureRequest ABI drift");
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileText) == 80, "WhiskerMobileText ABI drift");
-_Static_assert(sizeof(WhiskerMobileBoxPaint) == 240, "WhiskerMobileBoxPaint ABI drift");
+_Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 
 typedef void (*WhiskerMobileRequestFrameCallback)(void*);
 typedef bool (*WhiskerMobileBootstrapCallback)(void*, const WhiskerMobileBootstrap*);

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -230,7 +230,7 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
     for (size_t i = 0; i < frame->operation_count && ok; ++i) {
         const WhiskerMobileOperation* op = &frame->operations[i];
         jfloatArray numbers = NULL; jstring text = NULL; jobjectArray names = NULL; jobject value = NULL;
-        float storage[48]; size_t count = 0;
+        float storage[64]; size_t count = 0;
         switch (op->tag) {
             case WHISKER_OP_LAYOUT: {
                 const WhiskerMobileLayoutGeometry* p = op->payload;
@@ -243,7 +243,8 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 append_color(storage, &count, &p->background);
                 for (int j=0;j<4;++j) { storage[count++]=p->widths[j].length; storage[count++]=p->widths[j].fraction; }
                 for (int j=0;j<4;++j) append_color(storage, &count, &p->colors[j]);
-                for (int j=0;j<4;++j) { storage[count++]=p->radii[j].length; storage[count++]=p->radii[j].fraction; }
+                for (int j=0;j<4;++j) { storage[count++]=p->radii_horizontal[j].length; storage[count++]=p->radii_horizontal[j].fraction; }
+                for (int j=0;j<4;++j) { storage[count++]=p->radii_vertical[j].length; storage[count++]=p->radii_vertical[j].fraction; }
                 for (int j=0;j<4;++j) storage[count++]=(float)p->styles[j];
                 numbers = floats(env, storage, count); names = color_names(env, p); break;
             }

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -14,7 +14,7 @@ pub use ffi::{
     WhiskerValueRaw, WhiskerValueType, WhiskerValueUnion,
 };
 
-pub const MOBILE_ABI_MAJOR: u16 = 1;
+pub const MOBILE_ABI_MAJOR: u16 = 2;
 pub const MOBILE_ABI_MINOR: u16 = 0;
 
 pub const APPLY_ACCEPTED: u8 = 0;
@@ -98,7 +98,8 @@ pub struct MobileBoxPaint {
     pub widths: [MobileLengthPercentage; 4],
     pub colors: [MobileColor; 4],
     pub styles: [u32; 4],
-    pub radii: [MobileLengthPercentage; 4],
+    pub radii_horizontal: [MobileLengthPercentage; 4],
+    pub radii_vertical: [MobileLengthPercentage; 4],
 }
 
 #[repr(C)]
@@ -426,7 +427,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileMeasureRequest>(), 160);
             assert_eq!(std::mem::size_of::<MobileMeasureResponse>(), 64);
             assert_eq!(std::mem::size_of::<MobileText>(), 80);
-            assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 240);
+            assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::align_of::<MobileFrame>(), 8);
             assert_eq!(std::mem::align_of::<MobileMeasureRequest>(), 8);
         }

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -301,8 +301,40 @@ pub struct BorderFixture {
     pub colors: [ColorFixture; 4],
     /// Line styles.
     pub styles: [BorderStyleFixture; 4],
-    /// Circular radii in top-left, top-right, bottom-right, bottom-left order.
-    pub radii: [f32; 4],
+    /// Corner radii in top-left, top-right, bottom-right, bottom-left order.
+    pub radii: [CornerRadiusFixture; 4],
+}
+
+/// One circular or elliptical CSS border radius.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum CornerRadiusFixture {
+    /// A single value applies to both axes.
+    Circular(f32),
+    /// Independent horizontal and vertical values.
+    Elliptical([f32; 2]),
+}
+
+impl CornerRadiusFixture {
+    /// Horizontal radius in logical pixels.
+    pub fn horizontal(self) -> f32 {
+        match self {
+            Self::Circular(value) | Self::Elliptical([value, _]) => value,
+        }
+    }
+
+    /// Vertical radius in logical pixels.
+    pub fn vertical(self) -> f32 {
+        match self {
+            Self::Circular(value) | Self::Elliptical([_, value]) => value,
+        }
+    }
+
+    fn is_valid(self) -> bool {
+        [self.horizontal(), self.vertical()]
+            .into_iter()
+            .all(|value| value.is_finite() && value >= 0.0)
+    }
 }
 
 /// Complete CSS border line-style vocabulary.
@@ -659,8 +691,8 @@ fn valid_border(border: &BorderFixture) -> bool {
     border
         .widths
         .iter()
-        .chain(border.radii.iter())
         .all(|value| value.is_finite() && *value >= 0.0)
+        && border.radii.iter().all(|radius| radius.is_valid())
         && border.colors.iter().all(valid_color)
 }
 

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -154,6 +154,10 @@ pub enum Command {
         /// reference document.
         #[serde(default)]
         samples: Vec<PixelSampleFixture>,
+        /// Optional relative luminance assertions for CSS rendering whose
+        /// exact colors are intentionally Host-defined.
+        #[serde(default)]
+        relations: Vec<PixelRelationFixture>,
     },
     /// Sends a text measurement request to the production Host measurer.
     MeasureText {
@@ -260,6 +264,31 @@ pub struct PixelSampleFixture {
     /// Maximum per-channel difference accepted by native rasterizers.
     #[serde(default)]
     pub tolerance: u8,
+}
+
+/// One relative luminance assertion between two logical pixels.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PixelRelationFixture {
+    /// First logical x/y coordinate.
+    pub first: [f32; 2],
+    /// Second logical x/y coordinate.
+    pub second: [f32; 2],
+    /// Required ordering of the first sample relative to the second.
+    pub relation: PixelRelationKind,
+    /// Minimum luminance distance on an 8-bit scale.
+    #[serde(default)]
+    pub minimum_difference: u8,
+}
+
+/// Relative luminance ordering used by platform-defined CSS shading.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PixelRelationKind {
+    /// The first pixel must be lighter than the second.
+    Lighter,
+    /// The first pixel must be darker than the second.
+    Darker,
 }
 
 /// Physical border semantics in top, right, bottom, left order.
@@ -424,6 +453,7 @@ fn validate_manifest(manifest: &Manifest) -> Result<(), FixtureError> {
                     | "semantic-projection"
                     | "pixel"
                     | "pixel-samples"
+                    | "pixel-relations"
                     | "measurement"
                     | "input"
             ) {
@@ -485,6 +515,22 @@ fn validate_scenario(
             scenario.id
         )));
     }
+    if entry
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint == "pixel-relations")
+        && !scenario.test.commands.iter().any(|command| {
+            matches!(
+                command,
+                Command::Checkpoint { relations, .. } if !relations.is_empty()
+            )
+        })
+    {
+        return Err(FixtureError(format!(
+            "scenario {} declares pixel-relations without relation assertions",
+            scenario.id
+        )));
+    }
     if let Some(reference) = &scenario.reference {
         validate_side(&scenario.id, "reference", reference)?;
     }
@@ -538,15 +584,25 @@ fn validate_side(id: &str, label: &str, side: &ScenarioSide) -> Result<(), Fixtu
                 && rect[3] >= 0.0
                 && valid_color(background)
                 && border.as_ref().is_none_or(valid_border) => {}
-            Command::Checkpoint { name, samples }
-                if !name.trim().is_empty()
-                    && samples.iter().all(|sample| {
-                        sample
-                            .point
-                            .iter()
-                            .all(|value| value.is_finite() && *value >= 0.0)
-                            && valid_color(&sample.color)
-                    }) => {}
+            Command::Checkpoint {
+                name,
+                samples,
+                relations,
+            } if !name.trim().is_empty()
+                && samples.iter().all(|sample| {
+                    sample
+                        .point
+                        .iter()
+                        .all(|value| value.is_finite() && *value >= 0.0)
+                        && valid_color(&sample.color)
+                })
+                && relations.iter().all(|relation| {
+                    relation
+                        .first
+                        .iter()
+                        .chain(relation.second.iter())
+                        .all(|value| value.is_finite() && *value >= 0.0)
+                }) => {}
             Command::MeasureText {
                 key,
                 font_size,

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -753,17 +753,6 @@ impl MobileFrameOwned {
                     raw.payload = layouts.last().unwrap().as_ref() as *const _ as *const c_void;
                 }
                 Operation::SetBoxPaint { node, paint } => {
-                    if [
-                        paint.border_radii.top_left,
-                        paint.border_radii.top_right,
-                        paint.border_radii.bottom_right,
-                        paint.border_radii.bottom_left,
-                    ]
-                    .into_iter()
-                    .any(|radius| !radius.is_circular())
-                    {
-                        return Err(MobileFrameError);
-                    }
                     raw.tag = OP_PAINT;
                     raw.node = node.get();
                     paints.push(Box::new(mobile_paint(paint, &mut strings)));
@@ -966,11 +955,17 @@ fn mobile_paint(
             border_style(value.border_styles.bottom),
             border_style(value.border_styles.left),
         ],
-        radii: [
+        radii_horizontal: [
             mobile_length(value.border_radii.top_left.horizontal),
             mobile_length(value.border_radii.top_right.horizontal),
             mobile_length(value.border_radii.bottom_right.horizontal),
             mobile_length(value.border_radii.bottom_left.horizontal),
+        ],
+        radii_vertical: [
+            mobile_length(value.border_radii.top_left.vertical),
+            mobile_length(value.border_radii.top_right.vertical),
+            mobile_length(value.border_radii.bottom_right.vertical),
+            mobile_length(value.border_radii.bottom_left.vertical),
         ],
     }
 }
@@ -1066,5 +1061,23 @@ mod tests {
     fn hsla_is_lowered_without_host_string_parsing() {
         assert_eq!(hsl_to_rgb(0.0, 1.0, 0.5), (255, 0, 0));
         assert_eq!(hsl_to_rgb(120.0, 1.0, 0.5), (0, 255, 0));
+    }
+
+    #[test]
+    fn mobile_box_paint_preserves_elliptical_radii() {
+        let mut paint = whisker_engine::whisker_protocol::BoxPaint::default();
+        paint.border_radii.top_left = whisker_engine::whisker_protocol::PaintCornerRadius {
+            horizontal: PaintLengthPercentage {
+                length: 40.0,
+                fraction: 0.0,
+            },
+            vertical: PaintLengthPercentage {
+                length: 10.0,
+                fraction: 0.0,
+            },
+        };
+        let raw = mobile_paint(&paint, &mut Vec::new());
+        assert_eq!(raw.radii_horizontal[0].length, 40.0);
+        assert_eq!(raw.radii_vertical[0].length, 10.0);
     }
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -159,7 +159,7 @@ private class WhiskerBoxDrawable(
             paint.color = borderColors[side]
             when (borderStyles[side]) {
                 BORDER_STYLE_SOLID -> canvas.drawPath(sidePaths[side], paint)
-                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED -> {
+                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE -> {
                     canvas.clipPath(sidePaths[side])
                     drawPatternedEdge(
                         canvas,
@@ -194,14 +194,14 @@ private class WhiskerBoxDrawable(
             paint.color = borderColors[side]
             when (borderStyles[side]) {
                 BORDER_STYLE_SOLID -> canvas.drawRect(edges[side], paint)
-                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED ->
+                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE ->
                     drawPatternedEdge(canvas, edges[side], side, widths[side], borderStyles[side])
             }
         }
     }
 
     private fun paintsSide(side: Int): Boolean = when (borderStyles[side]) {
-        BORDER_STYLE_SOLID, BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED -> true
+        BORDER_STYLE_SOLID, BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE -> true
         else -> false
     }
 
@@ -220,6 +220,10 @@ private class WhiskerBoxDrawable(
         style: Int,
     ) {
         if (width <= 0f || edge.isEmpty) return
+        if (style == BORDER_STYLE_DOUBLE) {
+            drawDoubleEdge(canvas, edge, side, width)
+            return
+        }
         val horizontal = side == 0 || side == 2
         val start = if (horizontal) edge.left else edge.top
         val end = if (horizontal) edge.right else edge.bottom
@@ -252,6 +256,37 @@ private class WhiskerBoxDrawable(
             }
         }
         canvas.restoreToCount(save)
+    }
+
+    private fun drawDoubleEdge(
+        canvas: Canvas,
+        edge: RectF,
+        side: Int,
+        width: Float,
+    ) {
+        val band = width / 3f
+        val outer: RectF
+        val inner: RectF
+        when (side) {
+            0 -> {
+                outer = RectF(edge.left, edge.top, edge.right, edge.top + band)
+                inner = RectF(edge.left, edge.bottom - band, edge.right, edge.bottom)
+            }
+            1 -> {
+                outer = RectF(edge.right - band, edge.top, edge.right, edge.bottom)
+                inner = RectF(edge.left, edge.top, edge.left + band, edge.bottom)
+            }
+            2 -> {
+                outer = RectF(edge.left, edge.bottom - band, edge.right, edge.bottom)
+                inner = RectF(edge.left, edge.top, edge.right, edge.top + band)
+            }
+            else -> {
+                outer = RectF(edge.left, edge.top, edge.left + band, edge.bottom)
+                inner = RectF(edge.right - band, edge.top, edge.right, edge.bottom)
+            }
+        }
+        canvas.drawRect(outer, paint)
+        canvas.drawRect(inner, paint)
     }
 
     private fun normalizedRadii(width: Float, height: Float): FloatArray {
@@ -290,3 +325,4 @@ private class WhiskerBoxDrawable(
 private const val BORDER_STYLE_SOLID = 2
 private const val BORDER_STYLE_DASHED = 3
 private const val BORDER_STYLE_DOTTED = 4
+private const val BORDER_STYLE_DOUBLE = 5

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -24,7 +24,7 @@ internal fun applyBoxPaint(
     density: Float,
 ) {
     val values = paint.values
-    require(values.size >= 45)
+    require(values.size >= BOX_PAINT_PACKED_SIZE)
     val background = if (values[0] == 0f) {
         parseNamedColor(paint.names[0])
     } else {
@@ -45,11 +45,13 @@ internal fun applyBoxPaint(
         }
     }
     val radii = FloatArray(8) { index ->
-        val offset = 33 + (index / 2) * 2
-        val axis = if (index % 2 == 0) logicalWidth else logicalHeight
+        val corner = index / 2
+        val horizontal = index % 2 == 0
+        val offset = (if (horizontal) RADII_HORIZONTAL_OFFSET else RADII_VERTICAL_OFFSET) + corner * 2
+        val axis = if (horizontal) logicalWidth else logicalHeight
         resolveLength(values[offset], values[offset + 1], axis) * density
     }
-    val borderStyles = IntArray(4) { index -> values[41 + index].toInt() }
+    val borderStyles = IntArray(4) { index -> values[BORDER_STYLES_OFFSET + index].toInt() }
     val uniformSolidBorder = borderStyles.all { it == BORDER_STYLE_SOLID } &&
         borderWidths.all { it == borderWidths[0] } &&
         borderColors.all { it == borderColors[0] }
@@ -420,3 +422,7 @@ private const val BORDER_STYLE_RIDGE = 7
 private const val BORDER_STYLE_INSET = 8
 private const val BORDER_STYLE_OUTSET = 9
 private const val RELIEF_SHADE_FACTOR = 0.4f
+private const val RADII_HORIZONTAL_OFFSET = 33
+private const val RADII_VERTICAL_OFFSET = 41
+private const val BORDER_STYLES_OFFSET = 49
+private const val BOX_PAINT_PACKED_SIZE = 53

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -1,6 +1,7 @@
 package rs.whisker.runtime.paint
 
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.ColorFilter
 import android.graphics.Paint
 import android.graphics.Path
@@ -169,6 +170,17 @@ private class WhiskerBoxDrawable(
                         borderStyles[side],
                     )
                 }
+                BORDER_STYLE_GROOVE, BORDER_STYLE_RIDGE,
+                BORDER_STYLE_INSET, BORDER_STYLE_OUTSET -> {
+                    canvas.clipPath(sidePaths[side])
+                    drawReliefEdge(
+                        canvas,
+                        edgeRect(box, side, widths[side]),
+                        side,
+                        borderStyles[side],
+                        borderColors[side],
+                    )
+                }
             }
             canvas.restoreToCount(save)
         }
@@ -196,12 +208,22 @@ private class WhiskerBoxDrawable(
                 BORDER_STYLE_SOLID -> canvas.drawRect(edges[side], paint)
                 BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE ->
                     drawPatternedEdge(canvas, edges[side], side, widths[side], borderStyles[side])
+                BORDER_STYLE_GROOVE, BORDER_STYLE_RIDGE,
+                BORDER_STYLE_INSET, BORDER_STYLE_OUTSET ->
+                    drawReliefEdge(
+                        canvas,
+                        edges[side],
+                        side,
+                        borderStyles[side],
+                        borderColors[side],
+                    )
             }
         }
     }
 
     private fun paintsSide(side: Int): Boolean = when (borderStyles[side]) {
-        BORDER_STYLE_SOLID, BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE -> true
+        BORDER_STYLE_SOLID, BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE,
+        BORDER_STYLE_GROOVE, BORDER_STYLE_RIDGE, BORDER_STYLE_INSET, BORDER_STYLE_OUTSET -> true
         else -> false
     }
 
@@ -289,6 +311,73 @@ private class WhiskerBoxDrawable(
         canvas.drawRect(inner, paint)
     }
 
+    private fun drawReliefEdge(
+        canvas: Canvas,
+        edge: RectF,
+        side: Int,
+        style: Int,
+        color: Int,
+    ) {
+        if (edge.isEmpty) return
+        val topOrLeft = side == 0 || side == 3
+        when (style) {
+            BORDER_STYLE_INSET -> {
+                paint.color = shadedColor(color, lighter = !topOrLeft)
+                canvas.drawRect(edge, paint)
+            }
+            BORDER_STYLE_OUTSET -> {
+                paint.color = shadedColor(color, lighter = topOrLeft)
+                canvas.drawRect(edge, paint)
+            }
+            BORDER_STYLE_GROOVE, BORDER_STYLE_RIDGE -> {
+                val (outer, inner) = splitEdge(edge, side)
+                val outerIsLighter = if (style == BORDER_STYLE_GROOVE) !topOrLeft else topOrLeft
+                paint.color = shadedColor(color, lighter = outerIsLighter)
+                canvas.drawRect(outer, paint)
+                paint.color = shadedColor(color, lighter = !outerIsLighter)
+                canvas.drawRect(inner, paint)
+            }
+        }
+    }
+
+    /** Splits a border across its depth, preserving CSS outer-to-inner order. */
+    private fun splitEdge(edge: RectF, side: Int): Pair<RectF, RectF> = when (side) {
+        0 -> {
+            val middle = edge.centerY()
+            RectF(edge.left, edge.top, edge.right, middle) to
+                RectF(edge.left, middle, edge.right, edge.bottom)
+        }
+        1 -> {
+            val middle = edge.centerX()
+            RectF(middle, edge.top, edge.right, edge.bottom) to
+                RectF(edge.left, edge.top, middle, edge.bottom)
+        }
+        2 -> {
+            val middle = edge.centerY()
+            RectF(edge.left, middle, edge.right, edge.bottom) to
+                RectF(edge.left, edge.top, edge.right, middle)
+        }
+        else -> {
+            val middle = edge.centerX()
+            RectF(edge.left, edge.top, middle, edge.bottom) to
+                RectF(middle, edge.top, edge.right, edge.bottom)
+        }
+    }
+
+    private fun shadedColor(color: Int, lighter: Boolean): Int {
+        fun shade(channel: Int): Int = if (lighter) {
+            channel + ((255 - channel) * RELIEF_SHADE_FACTOR).toInt()
+        } else {
+            (channel * (1f - RELIEF_SHADE_FACTOR)).toInt()
+        }
+        return Color.argb(
+            Color.alpha(color),
+            shade(Color.red(color)),
+            shade(Color.green(color)),
+            shade(Color.blue(color)),
+        )
+    }
+
     private fun normalizedRadii(width: Float, height: Float): FloatArray {
         val result = cornerRadii.map { it.coerceAtLeast(0f) }.toFloatArray()
         val denominators = floatArrayOf(
@@ -326,3 +415,8 @@ private const val BORDER_STYLE_SOLID = 2
 private const val BORDER_STYLE_DASHED = 3
 private const val BORDER_STYLE_DOTTED = 4
 private const val BORDER_STYLE_DOUBLE = 5
+private const val BORDER_STYLE_GROOVE = 6
+private const val BORDER_STYLE_RIDGE = 7
+private const val BORDER_STYLE_INSET = 8
+private const val BORDER_STYLE_OUTSET = 9
+private const val RELIEF_SHADE_FACTOR = 0.4f

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -136,7 +136,7 @@ internal class HostScene(
             5 -> if (stagedParents[operation.child] != operation.parent) return false
             6 -> if (operation.node !in existing || operation.numbers?.size ?: 0 < 8) return false
             7 -> if (
-                operation.node !in existing || operation.numbers?.size ?: 0 < 45 ||
+                operation.node !in existing || operation.numbers?.size ?: 0 < 53 ||
                 operation.names?.size ?: 0 < 5
             ) return false
             8, 10, 11, 12, 15, 16 -> if (operation.node !in existing) return false

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -6,8 +6,9 @@ use whisker::{SurfaceRuntime, standard_element_registrations};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LoadedCase, PixelSampleFixture,
-    PointerEventFixture, Scenario, ScenarioSide, load_required,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LoadedCase,
+    PixelRelationFixture, PixelRelationKind, PixelSampleFixture, PointerEventFixture, Scenario,
+    ScenarioSide, load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BorderLineStyle, BoxPaint, ElementTypeId, FrameHeader, FrameMode, FramePacket,
@@ -98,6 +99,7 @@ struct Checkpoint {
     logical_size: [u32; 2],
     primitives: Vec<BoxPrimitive>,
     samples: Vec<PixelSampleFixture>,
+    relations: Vec<PixelRelationFixture>,
 }
 
 fn standard_element_type(name: &str) -> ElementTypeId {
@@ -160,7 +162,11 @@ impl Driver {
                     background,
                     border,
                 } => self.present_box(*revision, *rect, background, border.as_ref()),
-                Command::Checkpoint { name, samples } => {
+                Command::Checkpoint {
+                    name,
+                    samples,
+                    relations,
+                } => {
                     assert_eq!(name, "paint.box", "unsupported Desktop checkpoint");
                     checkpoints.push(Checkpoint {
                         logical_size: [
@@ -169,6 +175,7 @@ impl Driver {
                         ],
                         primitives: self.box_primitives(),
                         samples: samples.clone(),
+                        relations: relations.clone(),
                     });
                 }
                 Command::MeasureText {
@@ -531,11 +538,11 @@ fn run_reftest(scenario: &Scenario) {
     );
 }
 
-fn run_pixel_samples(scenario: &Scenario) {
+fn run_pixel_assertions(scenario: &Scenario) {
     let checkpoints = Driver::new().execute(&scenario.test);
     for checkpoint in checkpoints
         .iter()
-        .filter(|checkpoint| !checkpoint.samples.is_empty())
+        .filter(|checkpoint| !checkpoint.samples.is_empty() || !checkpoint.relations.is_empty())
     {
         let pixels = pollster::block_on(render_box_primitives_offscreen(
             &checkpoint.primitives,
@@ -567,7 +574,49 @@ fn run_pixel_samples(scenario: &Scenario) {
                 scenario.id
             );
         }
+        for relation in &checkpoint.relations {
+            let first = pixel_at(
+                &pixels,
+                checkpoint.logical_size,
+                relation.first,
+                &scenario.id,
+            );
+            let second = pixel_at(
+                &pixels,
+                checkpoint.logical_size,
+                relation.second,
+                &scenario.id,
+            );
+            let first_luminance = luminance(first);
+            let second_luminance = luminance(second);
+            let minimum = u32::from(relation.minimum_difference);
+            let matches = match relation.relation {
+                PixelRelationKind::Lighter => first_luminance >= second_luminance + minimum,
+                PixelRelationKind::Darker => first_luminance + minimum <= second_luminance,
+            };
+            assert!(
+                matches,
+                "{} relation {:?}: {first:?} ({first_luminance}) vs {second:?} ({second_luminance})",
+                scenario.id, relation.relation
+            );
+        }
     }
+}
+
+fn pixel_at(pixels: &[u8], size: [u32; 2], point: [f32; 2], id: &str) -> [u8; 4] {
+    let [width, height] = size;
+    let x = point[0].floor() as u32;
+    let y = point[1].floor() as u32;
+    assert!(
+        x < width && y < height,
+        "{id} sample is outside the surface"
+    );
+    let offset = ((y * width + x) * 4) as usize;
+    pixels[offset..offset + 4].try_into().unwrap()
+}
+
+fn luminance([red, green, blue, _]: [u8; 4]) -> u32 {
+    (u32::from(red) * 299 + u32::from(green) * 587 + u32::from(blue) * 114) / 1000
 }
 
 #[test]
@@ -585,7 +634,7 @@ fn every_manifest_case_required_by_desktop_executes() {
             );
             run_reftest(&scenario);
         } else {
-            run_pixel_samples(&scenario);
+            run_pixel_assertions(&scenario);
         }
     }
 }

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -460,11 +460,15 @@ fn box_paint(background: &ColorFixture, border: Option<&BorderFixture>) -> BoxPa
         length,
         fraction: 0.0,
     });
-    let radii = border.radii.map(|length| {
-        PaintCornerRadius::circular(PaintLengthPercentage {
-            length,
+    let radii = border.radii.map(|radius| PaintCornerRadius {
+        horizontal: PaintLengthPercentage {
+            length: radius.horizontal(),
             fraction: 0.0,
-        })
+        },
+        vertical: PaintLengthPercentage {
+            length: radius.vertical(),
+            fraction: 0.0,
+        },
     });
     BoxPaint {
         background_color: color_protocol(background),

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 1, WHISKER_MOBILE_ABI_MINOR = 0 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 0 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -34,7 +34,8 @@ typedef struct {
   WhiskerMobileLengthPercentage widths[4];
   WhiskerMobileColor colors[4];
   uint32_t styles[4];
-  WhiskerMobileLengthPercentage radii[4];
+  WhiskerMobileLengthPercentage radii_horizontal[4];
+  WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileBoxPaint;
 typedef struct {
   WhiskerStringRef text; float font_size; uint16_t font_weight;
@@ -89,5 +90,5 @@ _Static_assert(sizeof(WhiskerMobileBootstrap) == 24, "WhiskerMobileBootstrap ABI
 _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 160, "WhiskerMobileMeasureRequest ABI drift");
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileText) == 80, "WhiskerMobileText ABI drift");
-_Static_assert(sizeof(WhiskerMobileBoxPaint) == 240, "WhiskerMobileBoxPaint ABI drift");
+_Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 #endif

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -92,6 +92,15 @@ final class HostBoxPainter {
             colors[index].setFill()
             if styles[index] == borderStyleSolid {
                 region.fill()
+            } else if isReliefBorderStyle(styles[index]) {
+                drawReliefBorder(
+                    in: edgeRect(bounds: bounds, side: index, width: widths[index]),
+                    side: index,
+                    width: widths[index],
+                    style: styles[index],
+                    color: colors[index],
+                    context: context
+                )
             } else {
                 drawPatternedBorder(
                     in: edgeRect(bounds: bounds, side: index, width: widths[index]),
@@ -181,6 +190,61 @@ final class HostBoxPainter {
         }
         context.fill(outer)
         context.fill(inner)
+    }
+
+    private func drawReliefBorder(
+        in edge: CGRect,
+        side: Int,
+        width: CGFloat,
+        style: UInt32,
+        color: UIColor,
+        context: CGContext
+    ) {
+        let topOrLeft = side == 0 || side == 3
+        if style == borderStyleInset || style == borderStyleOutset {
+            let lighter = style == borderStyleInset ? !topOrLeft : topOrLeft
+            shadedBorderColor(color, lighter: lighter).setFill()
+            context.fill(edge)
+            return
+        }
+
+        let outerLighter: Bool
+        if style == borderStyleGroove {
+            outerLighter = !topOrLeft
+        } else {
+            outerLighter = topOrLeft
+        }
+        let (outer, inner) = reliefBands(in: edge, side: side, width: width)
+        shadedBorderColor(color, lighter: outerLighter).setFill()
+        context.fill(outer)
+        shadedBorderColor(color, lighter: !outerLighter).setFill()
+        context.fill(inner)
+    }
+
+    private func reliefBands(in edge: CGRect, side: Int, width: CGFloat) -> (CGRect, CGRect) {
+        let band = width / 2
+        switch side {
+        case 0:
+            return (
+                CGRect(x: edge.minX, y: edge.minY, width: edge.width, height: band),
+                CGRect(x: edge.minX, y: edge.maxY - band, width: edge.width, height: band)
+            )
+        case 1:
+            return (
+                CGRect(x: edge.maxX - band, y: edge.minY, width: band, height: edge.height),
+                CGRect(x: edge.minX, y: edge.minY, width: band, height: edge.height)
+            )
+        case 2:
+            return (
+                CGRect(x: edge.minX, y: edge.maxY - band, width: edge.width, height: band),
+                CGRect(x: edge.minX, y: edge.minY, width: edge.width, height: band)
+            )
+        default:
+            return (
+                CGRect(x: edge.minX, y: edge.minY, width: band, height: edge.height),
+                CGRect(x: edge.maxX - band, y: edge.minY, width: band, height: edge.height)
+            )
+        }
     }
 }
 
@@ -272,8 +336,36 @@ private let borderStyleSolid: UInt32 = 2
 private let borderStyleDashed: UInt32 = 3
 private let borderStyleDotted: UInt32 = 4
 private let borderStyleDouble: UInt32 = 5
+private let borderStyleGroove: UInt32 = 6
+private let borderStyleRidge: UInt32 = 7
+private let borderStyleInset: UInt32 = 8
+private let borderStyleOutset: UInt32 = 9
 
 private func paintsBorderStyle(_ style: UInt32) -> Bool {
     style == borderStyleSolid || style == borderStyleDashed || style == borderStyleDotted ||
-        style == borderStyleDouble
+        style == borderStyleDouble || isReliefBorderStyle(style)
+}
+
+private func isReliefBorderStyle(_ style: UInt32) -> Bool {
+    style == borderStyleGroove || style == borderStyleRidge || style == borderStyleInset ||
+        style == borderStyleOutset
+}
+
+private func shadedBorderColor(_ color: UIColor, lighter: Bool) -> UIColor {
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return color }
+    let amount: CGFloat = 0.45
+    if lighter {
+        red += (1 - red) * amount
+        green += (1 - green) * amount
+        blue += (1 - blue) * amount
+    } else {
+        red *= 1 - amount
+        green *= 1 - amount
+        blue *= 1 - amount
+    }
+    return UIColor(red: red, green: green, blue: blue, alpha: alpha)
 }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -123,6 +123,10 @@ final class HostBoxPainter {
         context: CGContext
     ) {
         guard width > 0, !edge.isEmpty else { return }
+        if style == borderStyleDouble {
+            drawDoubleBorder(in: edge, side: side, width: width, context: context)
+            return
+        }
         let horizontal = side == 0 || side == 2
         let start = horizontal ? edge.minX : edge.minY
         let end = horizontal ? edge.maxX : edge.maxY
@@ -150,6 +154,33 @@ final class HostBoxPainter {
                 position += width * 2
             }
         }
+    }
+
+    private func drawDoubleBorder(
+        in edge: CGRect,
+        side: Int,
+        width: CGFloat,
+        context: CGContext
+    ) {
+        let band = width / 3
+        let outer: CGRect
+        let inner: CGRect
+        switch side {
+        case 0:
+            outer = CGRect(x: edge.minX, y: edge.minY, width: edge.width, height: band)
+            inner = CGRect(x: edge.minX, y: edge.maxY - band, width: edge.width, height: band)
+        case 1:
+            outer = CGRect(x: edge.maxX - band, y: edge.minY, width: band, height: edge.height)
+            inner = CGRect(x: edge.minX, y: edge.minY, width: band, height: edge.height)
+        case 2:
+            outer = CGRect(x: edge.minX, y: edge.maxY - band, width: edge.width, height: band)
+            inner = CGRect(x: edge.minX, y: edge.minY, width: edge.width, height: band)
+        default:
+            outer = CGRect(x: edge.minX, y: edge.minY, width: band, height: edge.height)
+            inner = CGRect(x: edge.maxX - band, y: edge.minY, width: band, height: edge.height)
+        }
+        context.fill(outer)
+        context.fill(inner)
     }
 }
 
@@ -240,7 +271,9 @@ private func roundedPath(in rect: CGRect, radii: [CGSize]) -> UIBezierPath {
 private let borderStyleSolid: UInt32 = 2
 private let borderStyleDashed: UInt32 = 3
 private let borderStyleDotted: UInt32 = 4
+private let borderStyleDouble: UInt32 = 5
 
 private func paintsBorderStyle(_ style: UInt32) -> Bool {
-    style == borderStyleSolid || style == borderStyleDashed || style == borderStyleDotted
+    style == borderStyleSolid || style == borderStyleDashed || style == borderStyleDotted ||
+        style == borderStyleDouble
 }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -6,14 +6,16 @@ struct HostBoxPaint {
     let widths: [WhiskerMobileLengthPercentage]
     let colors: [UIColor]
     let styles: [UInt32]
-    let radii: [WhiskerMobileLengthPercentage]
+    let radiiHorizontal: [WhiskerMobileLengthPercentage]
+    let radiiVertical: [WhiskerMobileLengthPercentage]
 
     init(_ raw: WhiskerMobileBoxPaint) {
         background = parsePaintColor(raw.background)
         widths = tupleArray(raw.widths)
         colors = tupleArray(raw.colors).map(parsePaintColor)
         styles = tupleArray(raw.styles)
-        radii = tupleArray(raw.radii)
+        radiiHorizontal = tupleArray(raw.radii_horizontal)
+        radiiVertical = tupleArray(raw.radii_vertical)
     }
 }
 
@@ -35,10 +37,10 @@ final class HostBoxPainter {
         ]
         borderColors = paint.colors
         borderStyles = paint.styles
-        cornerRadii = paint.radii.map { value in
+        cornerRadii = paint.radiiHorizontal.indices.map { index in
             CGSize(
-                width: resolve(value, axis: bounds.width),
-                height: resolve(value, axis: bounds.height)
+                width: resolve(paint.radiiHorizontal[index], axis: bounds.width),
+                height: resolve(paint.radiiVertical[index], axis: bounds.height)
             )
         }
     }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -222,6 +222,18 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/CSS2/borders/border-top-style-006.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-006.json"
         ),
+        "wpt/css/CSS2/borders/border-top-style-007.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-007.json"
+        ),
+        "wpt/css/CSS2/borders/border-top-style-008.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-008.json"
+        ),
+        "wpt/css/CSS2/borders/border-top-style-009.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-009.json"
+        ),
+        "wpt/css/CSS2/borders/border-top-style-010.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-010.json"
+        ),
         "core/text-measure-basic.json" => {
             include_str!("../../../../tests/host-conformance/core/text-measure-basic.json")
         }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -219,6 +219,9 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/CSS2/borders/border-top-style-004.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-004.json"
         ),
+        "wpt/css/CSS2/borders/border-top-style-006.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-006.json"
+        ),
         "core/text-measure-basic.json" => {
             include_str!("../../../../tests/host-conformance/core/text-measure-basic.json")
         }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -3,8 +3,8 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use whisker::ElementRegistry;
 use whisker_engine::FrameSink;
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, Manifest, SCHEMA_VERSION, Scenario,
-    ScenarioSide,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, CornerRadiusFixture, Manifest,
+    SCHEMA_VERSION, Scenario, ScenarioSide,
 };
 use whisker_protocol::{
     BorderLineStyle, BoxPaint, FrameHeader, FrameMode, FramePacket, LayoutGeometry, LayoutRect,
@@ -123,7 +123,11 @@ impl Driver {
         );
 
         let (widths, styles, radii) = expected.border.as_ref().map_or(
-            ([0.0; 4], [BorderStyleFixture::None; 4], [0.0; 4]),
+            (
+                [0.0; 4],
+                [BorderStyleFixture::None; 4],
+                [CornerRadiusFixture::Circular(0.0); 4],
+            ),
             |border| (border.widths, border.styles, border.radii),
         );
         for (index, side) in ["top", "right", "bottom", "left"].iter().enumerate() {
@@ -150,11 +154,12 @@ impl Driver {
             .iter()
             .enumerate()
         {
-            let radius = fixture_px(radii[index]);
+            let horizontal = fixture_px(radii[index].horizontal());
+            let vertical = fixture_px(radii[index].vertical());
             assert_style(
                 &style,
                 &format!("border-{corner}-radius"),
-                &format!("{radius} {radius}"),
+                &format!("{horizontal} {vertical}"),
             );
         }
     }
@@ -200,6 +205,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
+        ),
+        "wpt/css/css-backgrounds/border-radius-004.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-004.json"
         ),
         "wpt/css/CSS2/borders/border-top-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json"
@@ -310,11 +318,15 @@ fn box_paint(
         length,
         fraction: 0.0,
     });
-    let radii = border.radii.map(|length| {
-        PaintCornerRadius::circular(PaintLengthPercentage {
-            length,
+    let radii = border.radii.map(|radius| PaintCornerRadius {
+        horizontal: PaintLengthPercentage {
+            length: radius.horizontal(),
             fraction: 0.0,
-        })
+        },
+        vertical: PaintLengthPercentage {
+            length: radius.vertical(),
+            fraction: 0.0,
+        },
     });
     BoxPaint {
         background_color: color(background),

--- a/tests/host-conformance/README.md
+++ b/tests/host-conformance/README.md
@@ -42,6 +42,11 @@ Android, and iOS assert those samples against production raster output. Web
 asserts the equivalent CSS projection and leaves dash/dot distribution to the
 browser, while sharing the same scenario and semantic values.
 
+The same checkpoint may use relative luminance `relations` when CSS requires
+a lighter or darker rendering but deliberately leaves the exact derived color
+to the user agent. Native rasterizers compare the requested pixels while Web
+continues to verify the corresponding semantic CSS value.
+
 From the repository root, run one Host with:
 
 ```sh

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -17,6 +17,13 @@
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel"]
     },
     {
+      "id": "wpt.css-backgrounds.border-radius-004",
+      "feature": "border-radius",
+      "fixture": "wpt/css/css-backgrounds/border-radius-004.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-top-003",
       "feature": "border-top",
       "fixture": "wpt/css/CSS2/borders/border-top-003.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -59,6 +59,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css2.borders.border-top-style-006",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-006.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "host.measure.text.basic",
       "feature": "text-measurement",
       "fixture": "core/text-measure-basic.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -66,6 +66,34 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css2.borders.border-top-style-007",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-007.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
+      "id": "wpt.css2.borders.border-top-style-008",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-008.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
+      "id": "wpt.css2.borders.border-top-style-009",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-009.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
+      "id": "wpt.css2.borders.border-top-style-010",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-010.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
       "id": "host.measure.text.basic",
       "feature": "text-measurement",
       "fixture": "core/text-measure-basic.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -162,7 +162,7 @@ private class Driver(
     )
 
     private fun paint(command: JSONObject): Pair<FloatArray, Array<String>> {
-        val numbers = ArrayList<Float>(41)
+        val numbers = ArrayList<Float>(53)
         val names = ArrayList<String>(5)
         appendColor(command.getJSONObject("background"), numbers, names)
         val border = command.optJSONObject("border")
@@ -176,11 +176,28 @@ private class Driver(
                 names,
             )
         }
-        val radii = border?.getJSONArray("radii")?.floats() ?: FloatArray(4)
-        radii.forEach { radius -> numbers += listOf(radius, 0f) }
+        val radii = border?.getJSONArray("radii")
+        val radiiHorizontal = FloatArray(4)
+        val radiiVertical = FloatArray(4)
+        repeat(4) { index ->
+            when (val radius = radii?.get(index)) {
+                is Number -> {
+                    radiiHorizontal[index] = radius.toFloat()
+                    radiiVertical[index] = radius.toFloat()
+                }
+                is JSONArray -> {
+                    radiiHorizontal[index] = radius.getDouble(0).toFloat()
+                    radiiVertical[index] = radius.getDouble(1).toFloat()
+                }
+                null -> Unit
+                else -> error("unsupported border radius: $radius")
+            }
+        }
+        radiiHorizontal.forEach { radius -> numbers += listOf(radius, 0f) }
+        radiiVertical.forEach { radius -> numbers += listOf(radius, 0f) }
         val styles = border?.getJSONArray("styles")?.strings() ?: Array(4) { "none" }
         styles.forEach { style -> numbers += borderStyle(style).toFloat() }
-        check(numbers.size == 45)
+        check(numbers.size == 53)
         check(names.size == 5)
         return numbers.toFloatArray() to names.toTypedArray()
     }
@@ -286,7 +303,9 @@ private fun luminance(color: Int): Int =
 
 private fun fixtureColor(value: JSONObject): Int =
     if (value.getString("kind") == "named") {
-        android.graphics.Color.parseColor(value.getString("value"))
+        val name = value.getString("value")
+        if (name == "transparent") android.graphics.Color.TRANSPARENT
+        else android.graphics.Color.parseColor(name)
     } else {
         android.graphics.Color.argb(
             (value.getDouble("alpha") * 255.0).roundToInt(),

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -113,6 +113,14 @@ private class Driver(
                             context.resources.displayMetrics.density,
                         )
                     }
+                    command.optJSONArray("relations")?.let { relations ->
+                        assertPixelRelations(
+                            id,
+                            checkNotNull(checkpoint),
+                            relations,
+                            context.resources.displayMetrics.density,
+                        )
+                    }
                 }
                 else -> error("unsupported Android paint command: ${command.getString("type")}")
             }
@@ -243,6 +251,38 @@ private fun assertPixelSamples(id: String, bitmap: Bitmap, samples: JSONArray, d
         assertTrue("$id sample ($x, $y) differs by $difference", difference <= tolerance)
     }
 }
+
+private fun assertPixelRelations(id: String, bitmap: Bitmap, relations: JSONArray, density: Float) {
+    relations.objects().forEach { relation ->
+        val first = pixelAt(bitmap, relation.getJSONArray("first"), density)
+        val second = pixelAt(bitmap, relation.getJSONArray("second"), density)
+        val firstLuminance = luminance(first)
+        val secondLuminance = luminance(second)
+        val minimum = relation.optInt("minimum_difference", 0)
+        val matches = when (val kind = relation.getString("relation")) {
+            "lighter" -> firstLuminance >= secondLuminance + minimum
+            "darker" -> firstLuminance + minimum <= secondLuminance
+            else -> error("unknown pixel relation: $kind")
+        }
+        assertTrue(
+            "$id ${relation.getString("relation")}: " +
+                "$first ($firstLuminance) vs $second ($secondLuminance)",
+            matches,
+        )
+    }
+}
+
+private fun pixelAt(bitmap: Bitmap, point: JSONArray, density: Float): Int {
+    val x = (point.getDouble(0) * density).toInt()
+    val y = (point.getDouble(1) * density).toInt()
+    check(x in 0 until bitmap.width && y in 0 until bitmap.height)
+    return bitmap.getPixel(x, y)
+}
+
+private fun luminance(color: Int): Int =
+    (android.graphics.Color.red(color) * 299 +
+        android.graphics.Color.green(color) * 587 +
+        android.graphics.Color.blue(color) * 114) / 1000
 
 private fun fixtureColor(value: JSONObject): Int =
     if (value.getString("kind") == "named") {

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -210,15 +210,32 @@ private func boxPaint(_ command: [String: Any]) throws -> WhiskerMobileBoxPaint 
     let widths = try numberArray(border, "widths").map(length)
     let colors = try objectArray(border, "colors").map(color)
     let styles = try stringArray(border, "styles").map(borderStyle)
-    let radii = try numberArray(border, "radii").map(length)
+    let radii = try radiusPairs(border)
     guard widths.count == 4, colors.count == 4, styles.count == 4, radii.count == 4 else {
         throw Failure("border arrays need four values")
     }
     value.widths = (widths[0], widths[1], widths[2], widths[3])
     value.colors = (colors[0], colors[1], colors[2], colors[3])
     value.styles = (styles[0], styles[1], styles[2], styles[3])
-    value.radii = (radii[0], radii[1], radii[2], radii[3])
+    let horizontal = radii.map { length($0.0) }
+    let vertical = radii.map { length($0.1) }
+    value.radii_horizontal = (horizontal[0], horizontal[1], horizontal[2], horizontal[3])
+    value.radii_vertical = (vertical[0], vertical[1], vertical[2], vertical[3])
     return value
+}
+
+private func radiusPairs(_ border: [String: Any]) throws -> [(Double, Double)] {
+    guard let values = border["radii"] as? [Any] else { throw Failure("missing or invalid radii") }
+    return try values.map { value in
+        if let number = value as? NSNumber {
+            let radius = number.doubleValue
+            return (radius, radius)
+        }
+        if let pair = value as? [NSNumber], pair.count == 2 {
+            return (pair[0].doubleValue, pair[1].doubleValue)
+        }
+        throw Failure("radius must be a number or horizontal/vertical pair")
+    }
 }
 
 private func color(_ fixture: [String: Any]) throws -> WhiskerMobileColor {

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -85,6 +85,9 @@ private final class Driver {
                 if let samples = command["samples"] as? [[String: Any]] {
                     try assertPixelSamples(id: id, pixels: pixels, samples: samples)
                 }
+                if let relations = command["relations"] as? [[String: Any]] {
+                    try assertPixelRelations(id: id, pixels: pixels, relations: relations)
+                }
             default:
                 throw Failure("unsupported UIKit paint command")
             }
@@ -226,6 +229,7 @@ private func color(_ fixture: [String: Any]) throws -> WhiskerMobileColor {
         case "aqua": rgba = (0, 255, 255, 1)
         case "black": rgba = (0, 0, 0, 1)
         case "blue": rgba = (0, 0, 255, 1)
+        case "green": rgba = (0, 128, 0, 1)
         case "transparent": rgba = (0, 0, 0, 0)
         case "white": rgba = (255, 255, 255, 1)
         default: throw Failure("unsupported fixture named color")
@@ -331,4 +335,47 @@ private func assertPixelSamples(
         let difference = largestDifference(actual, expected)
         XCTAssertLessThanOrEqual(difference, tolerance, "\(id) sample (\(x), \(y))")
     }
+}
+
+private func assertPixelRelations(
+    id: String,
+    pixels: Pixels,
+    relations: [[String: Any]]
+) throws {
+    for relation in relations {
+        let firstPoint = try numberArray(relation, "first")
+        let secondPoint = try numberArray(relation, "second")
+        guard firstPoint.count == 2, secondPoint.count == 2 else {
+            throw Failure("pixel relation needs two coordinates per point")
+        }
+        let first = try pixel(at: firstPoint, in: pixels)
+        let second = try pixel(at: secondPoint, in: pixels)
+        let firstLuminance = luminance(first)
+        let secondLuminance = luminance(second)
+        let minimum = UInt32(try number(relation, "minimum_difference"))
+        let matches: Bool
+        switch try string(relation, "relation") {
+        case "lighter": matches = firstLuminance >= secondLuminance + minimum
+        case "darker": matches = firstLuminance + minimum <= secondLuminance
+        default: throw Failure("unknown pixel relation")
+        }
+        XCTAssertTrue(
+            matches,
+            "\(id) relation: \(first) (\(firstLuminance)) vs \(second) (\(secondLuminance))"
+        )
+    }
+}
+
+private func pixel(at point: [Double], in pixels: Pixels) throws -> [UInt8] {
+    let x = Int(point[0].rounded(.down))
+    let y = Int(point[1].rounded(.down))
+    guard x >= 0, x < pixels.width, y >= 0, y < pixels.height else {
+        throw Failure("pixel relation is outside the surface")
+    }
+    let offset = (y * pixels.width + x) * 4
+    return Array(pixels.bytes[offset..<(offset + 4)])
+}
+
+private func luminance(_ color: [UInt8]) -> UInt32 {
+    (UInt32(color[0]) * 299 + UInt32(color[1]) * 587 + UInt32(color[2]) * 114) / 1000
 }

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -91,6 +91,10 @@
         "samples": {
           "type": "array",
           "items": { "$ref": "#/$defs/pixelSample" }
+        },
+        "relations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pixelRelation" }
         }
       }
     },
@@ -108,6 +112,23 @@
         "color": { "$ref": "#/$defs/color" },
         "tolerance": { "type": "integer", "minimum": 0, "maximum": 255 }
       }
+    },
+    "pixelRelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["first", "second", "relation"],
+      "properties": {
+        "first": { "$ref": "#/$defs/point" },
+        "second": { "$ref": "#/$defs/point" },
+        "relation": { "enum": ["lighter", "darker"] },
+        "minimum_difference": { "type": "integer", "minimum": 0, "maximum": 255 }
+      }
+    },
+    "point": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0 }
     },
     "measureText": {
       "type": "object",

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -240,8 +240,24 @@
             ]
           }
         },
-        "radii": { "$ref": "#/$defs/quadNumber" }
+        "radii": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": { "$ref": "#/$defs/cornerRadius" }
+        }
       }
+    },
+    "cornerRadius": {
+      "oneOf": [
+        { "type": "number", "minimum": 0 },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "number", "minimum": 0 }
+        }
+      ]
     },
     "quadNumber": {
       "type": "array",

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-006.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-006.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-006",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-006.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A double border-top renders two solid lines separated by a transparent gap.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection plus logical-pixel samples in the outer line, center gap, inner line, and white box background. The specified 9px width divides into three equal bands."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 20.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 20.0],
+        "background": { "kind": "named", "value": "white" },
+        "border": {
+          "widths": [9.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["double", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 1.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [50.0, 4.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 },
+          { "point": [50.0, 7.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [50.0, 15.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-007.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-007.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-007",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-007.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A groove border uses two shades of its border color to appear carved into the canvas.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection, an unchanged green background sample, and a relative luminance assertion requiring the outer half of the top border to be darker than its inner half. Exact shade colors remain Host-defined."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 24.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 24.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [12.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["groove", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ],
+        "relations": [
+          { "first": [50.0, 2.0], "second": [50.0, 9.0], "relation": "darker", "minimum_difference": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-008.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-008.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-008",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-008.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A ridge border uses two shades of its border color to appear raised from the canvas.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection, an unchanged green background sample, and a relative luminance assertion requiring the outer half of the top border to be lighter than its inner half. Exact shade colors remain Host-defined."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 24.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 24.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [12.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["ridge", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ],
+        "relations": [
+          { "first": [50.0, 2.0], "second": [50.0, 9.0], "relation": "lighter", "minimum_difference": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-009.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-009.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-009",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-009.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "An inset top border is darker than its border color to make the box appear embedded in the canvas.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection and a relative luminance assertion comparing the shaded top border with the unchanged green box background. Exact shade colors remain Host-defined."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 24.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 24.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [12.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["inset", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ],
+        "relations": [
+          { "first": [50.0, 6.0], "second": [50.0, 18.0], "relation": "darker", "minimum_difference": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-010.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-010.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-010",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-010.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "An outset top border is lighter than its border color to make the box appear raised from the canvas.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection and a relative luminance assertion comparing the shaded top border with the unchanged green box background. Exact shade colors remain Host-defined."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 24.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 24.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [12.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["outset", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ],
+        "relations": [
+          { "first": [50.0, 6.0], "second": [50.0, 18.0], "relation": "lighter", "minimum_difference": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-004.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-004.json
@@ -1,0 +1,44 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-004",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-004.xht",
+    "reference_path": "css/css-backgrounds/border-radius-004-ref.xht",
+    "license": "BSD-3-Clause",
+    "assertion": "The slash syntax preserves independent horizontal and vertical border radii.",
+    "adaptation": "The WPT 200 by 100 box is represented as a 100 by 60 Host frame with proportionally similar 40 by 10 elliptical radii. Interior and exterior pixel samples distinguish the ellipse from both a circular radius and an unclipped box."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 60.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [0.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["none", "none", "none", "none"],
+          "radii": [[40.0, 10.0], [40.0, 10.0], [40.0, 10.0], [40.0, 10.0]]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [12.0, 5.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [2.0, 2.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}


### PR DESCRIPTION
## Summary
- add a WPT-derived fixture that distinguishes elliptical radii from circular and square corners
- preserve independent horizontal and vertical radii through the mobile ABI (v2)
- implement the expanded ABI in Android JNI/Kotlin and iOS Swift
- verify existing Desktop/WGPU and Web/DOM independent-axis projections

## Verification
- `cargo test -p whisker-host-conformance`
- `cargo test -p whisker-driver mobile_abi_layouts_are_stable_on_64_bit_hosts --lib`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`

## Stack
This PR is stacked on #430 and #431. Merge those first; GitHub will then reduce this PR to the elliptical-radius commit.