### PR TITLE
feat(host): render resolved conic gradients

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 2 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 3 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -22,7 +22,10 @@ enum {
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
   WHISKER_OP_BACKGROUND_LAYERS
 };
-enum { WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1 };
+enum {
+  WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
+  WHISKER_BACKGROUND_CONIC = 2
+};
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -56,6 +59,11 @@ typedef struct {
   const WhiskerMobileGradientStop *stops;
   size_t stop_count;
 } WhiskerMobileRadialGradient;
+typedef struct {
+  WhiskerMobileLengthPercentage center_x, center_y;
+  const WhiskerMobileGradientStop *stops;
+  size_t stop_count;
+} WhiskerMobileConicGradient;
 typedef struct {
   WhiskerStringRef text;
   float font_size;
@@ -91,6 +99,7 @@ _Static_assert(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift")
 _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
 _Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGradient ABI drift");
+_Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGradient ABI drift");
 
 typedef struct {
   uint32_t id;

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -264,15 +264,22 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
             case WHISKER_OP_BACKGROUND_LAYERS: {
                 const WhiskerMobileGradientStop* stops = op->payload;
                 const WhiskerMobileRadialGradient* radial = NULL;
+                const WhiskerMobileConicGradient* conic = NULL;
                 size_t stop_count = op->payload_count;
                 size_t prefix_count = 0;
-                if (op->flags == 1) {
+                if (op->flags == WHISKER_BACKGROUND_RADIAL) {
                     if (op->payload == NULL || op->payload_count != 1) { ok = false; break; }
                     radial = op->payload;
                     stops = radial->stops;
                     stop_count = radial->stop_count;
                     prefix_count = 8;
-                } else if (op->flags != 0) {
+                } else if (op->flags == WHISKER_BACKGROUND_CONIC) {
+                    if (op->payload == NULL || op->payload_count != 1) { ok = false; break; }
+                    conic = op->payload;
+                    stops = conic->stops;
+                    stop_count = conic->stop_count;
+                    prefix_count = 4;
+                } else if (op->flags != WHISKER_BACKGROUND_LINEAR) {
                     ok = false; break;
                 }
                 if ((stops == NULL && stop_count != 0) || stop_count > (INT32_MAX - prefix_count) / 7) {
@@ -287,6 +294,14 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                         &radial->center_x, &radial->center_y, &radial->radius_x, &radial->radius_y
                     };
                     for (size_t j = 0; j < 4; ++j) {
+                        values[cursor++] = coordinates[j]->length;
+                        values[cursor++] = coordinates[j]->fraction;
+                    }
+                } else if (conic != NULL) {
+                    const WhiskerMobileLengthPercentage* coordinates[] = {
+                        &conic->center_x, &conic->center_y
+                    };
+                    for (size_t j = 0; j < 2; ++j) {
                         values[cursor++] = coordinates[j]->length;
                         values[cursor++] = coordinates[j]->fraction;
                     }

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 2;
+pub const MOBILE_ABI_MINOR: u16 = 3;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -48,6 +48,7 @@ pub const OP_BACKGROUND_LAYERS: u32 = 21;
 
 pub const BACKGROUND_LINEAR: u32 = 0;
 pub const BACKGROUND_RADIAL: u32 = 1;
+pub const BACKGROUND_CONIC: u32 = 2;
 
 pub const MEASURE_TEXT: u32 = 1;
 pub const MEASURE_REPLACED_CONTENT: u32 = 2;
@@ -122,6 +123,16 @@ pub struct MobileRadialGradient {
     pub center_y: MobileLengthPercentage,
     pub radius_x: MobileLengthPercentage,
     pub radius_y: MobileLengthPercentage,
+    pub stops: *const MobileGradientStop,
+    pub stop_count: usize,
+}
+
+/// One non-repeating conic gradient with explicit fractional stops.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileConicGradient {
+    pub center_x: MobileLengthPercentage,
+    pub center_y: MobileLengthPercentage,
     pub stops: *const MobileGradientStop,
     pub stop_count: usize,
 }
@@ -454,6 +465,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
             assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 48);
+            assert_eq!(std::mem::size_of::<MobileConicGradient>(), 32);
             assert_eq!(std::mem::align_of::<MobileFrame>(), 8);
             assert_eq!(std::mem::align_of::<MobileMeasureRequest>(), 8);
         }

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -350,6 +350,9 @@ pub struct SceneNodeFixture {
     /// Optional explicit, non-repeating radial-gradient background image.
     #[serde(default)]
     pub radial_gradient: Option<RadialGradientFixture>,
+    /// Optional explicit, non-repeating conic-gradient background image.
+    #[serde(default)]
+    pub conic_gradient: Option<ConicGradientFixture>,
 }
 
 /// One resolved linear-gradient image used by a retained scene node.
@@ -384,6 +387,18 @@ pub struct RadialGradientFixture {
     /// Horizontal and vertical radii in logical pixels.
     pub radii: [f32; 2],
     /// Ordered, explicitly resolved color stops.
+    pub stops: Vec<GradientStopFixture>,
+}
+
+/// One resolved non-repeating conic-gradient image.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ConicGradientFixture {
+    /// Starting angle in clockwise degrees from the positive vertical axis.
+    pub from_degrees: f32,
+    /// Center x/y in logical pixels relative to the positioning box.
+    pub center: [f32; 2],
+    /// Ordered, explicitly resolved color stops expressed as turns.
     pub stops: Vec<GradientStopFixture>,
 }
 
@@ -857,7 +872,24 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                             .iter()
                             .all(|stop| valid_color(&stop.color) && stop.position.is_finite())
                 })
-                && !(node.linear_gradient.is_some() && node.radial_gradient.is_some())
+                && node.conic_gradient.as_ref().is_none_or(|gradient| {
+                    gradient.from_degrees.is_finite()
+                        && gradient.center.iter().all(|value| value.is_finite())
+                        && gradient.stops.len() >= 2
+                        && gradient
+                            .stops
+                            .iter()
+                            .all(|stop| valid_color(&stop.color) && stop.position.is_finite())
+                })
+                && [
+                    node.linear_gradient.is_some(),
+                    node.radial_gradient.is_some(),
+                    node.conic_gradient.is_some(),
+                ]
+                .into_iter()
+                .filter(|present| *present)
+                .count()
+                    <= 1
         })
         && nodes.iter().all(|node| {
             let mut seen = std::collections::BTreeSet::new();

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -28,11 +28,14 @@ pub enum RenderCapability {
     /// One resolved, non-repeating explicit radial-gradient background image
     /// using the initial layer geometry and explicit color-stop positions.
     RadialGradients,
+    /// One resolved, non-repeating conic-gradient background image using the
+    /// initial layer geometry and explicit fractional color-stop positions.
+    ConicGradients,
 }
 
 impl RenderCapability {
     /// Every optional capability in stable declaration order.
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::EllipticalBorderRadius,
         Self::BackgroundLayers,
         Self::VisualEffects,
@@ -43,6 +46,7 @@ impl RenderCapability {
         Self::ResourceLifecycle,
         Self::LinearGradients,
         Self::RadialGradients,
+        Self::ConicGradients,
     ];
 
     /// Stable diagnostic spelling shared by Host errors and checklists.
@@ -58,6 +62,7 @@ impl RenderCapability {
             Self::ResourceLifecycle => "resource-lifecycle",
             Self::LinearGradients => "linear-gradients",
             Self::RadialGradients => "radial-gradients",
+            Self::ConicGradients => "conic-gradients",
         }
     }
 
@@ -227,6 +232,9 @@ fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 2
         Operation::SetBackgroundLayers { layers, .. } if is_basic_radial_gradient(layers) => {
             Some(RenderCapability::RadialGradients)
         }
+        Operation::SetBackgroundLayers { layers, .. } if is_basic_conic_gradient(layers) => {
+            Some(RenderCapability::ConicGradients)
+        }
         Operation::SetBackgroundLayers { .. } => Some(RenderCapability::BackgroundLayers),
         Operation::SetVisualEffects { .. } => Some(RenderCapability::VisualEffects),
         Operation::SetText { content, .. } if content.paint.uses_extended_features() => {
@@ -274,6 +282,29 @@ fn is_basic_radial_gradient(layers: &[crate::BackgroundLayer]) -> bool {
             shape: crate::RadialGradientShape::Ellipse,
             extent: crate::RadialGradientExtent::Explicit,
             radii: Some(_),
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| {
+            stop.position.is_some_and(|position| position.length == 0.0)
+        })
+    ) && layer.position == Default::default()
+        && layer.size == crate::BackgroundSize::Auto
+        && layer.repeat_x == crate::ImageRepeat::Repeat
+        && layer.repeat_y == crate::ImageRepeat::Repeat
+        && layer.origin == crate::PaintBox::Padding
+        && layer.clip == crate::PaintBox::Border
+        && layer.attachment == crate::BackgroundAttachment::Scroll
+        && layer.blend_mode == crate::BlendMode::Normal
+}
+
+fn is_basic_conic_gradient(layers: &[crate::BackgroundLayer]) -> bool {
+    let [layer] = layers else {
+        return false;
+    };
+    matches!(
+        &layer.image,
+        crate::PaintImage::ConicGradient {
             repeating: false,
             stops,
             ..
@@ -377,6 +408,21 @@ mod tests {
         })
     }
 
+    fn conic_layer(repeating: bool, first_stop_length: f32) -> BackgroundLayer {
+        let mut stops = basic_gradient_stops();
+        stops[0].position.as_mut().unwrap().length = first_stop_length;
+        background_layer(PaintImage::ConicGradient {
+            from_degrees: 90.0,
+            center: PaintPosition::default(),
+            repeating,
+            stops,
+        })
+    }
+
+    fn basic_conic_layer() -> BackgroundLayer {
+        conic_layer(false, 0.0)
+    }
+
     #[test]
     fn discovers_elliptical_radius_without_classifying_base_box_paint() {
         let node = NodeId::new(1).unwrap();
@@ -456,6 +502,52 @@ mod tests {
     }
 
     #[test]
+    fn conic_gradient_capability_is_limited_to_the_resolved_host_subset() {
+        let node = NodeId::new(1).unwrap();
+        assert_eq!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: vec![basic_conic_layer()],
+            }])
+            .required_capabilities(),
+            vec![RenderCapability::ConicGradients]
+        );
+
+        assert_eq!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: vec![conic_layer(true, 0.0)],
+            }])
+            .required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
+        );
+
+        assert_eq!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: vec![conic_layer(false, 1.0)],
+            }])
+            .required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
+        );
+
+        assert_eq!(
+            packet(vec![
+                Operation::SetBackgroundLayers {
+                    node,
+                    layers: vec![basic_conic_layer()],
+                },
+                Operation::SetBackgroundLayers {
+                    node,
+                    layers: vec![basic_conic_layer()],
+                },
+            ])
+            .required_capabilities(),
+            vec![RenderCapability::ConicGradients]
+        );
+    }
+
+    #[test]
     fn profiles_and_packets_cover_every_optional_capability() {
         assert_eq!(
             RenderCapability::ALL.map(RenderCapability::as_str),
@@ -470,6 +562,7 @@ mod tests {
                 "resource-lifecycle",
                 "linear-gradients",
                 "radial-gradients",
+                "conic-gradients",
             ]
         );
 
@@ -538,6 +631,10 @@ mod tests {
                 node,
                 layers: vec![basic_linear_layer()],
             },
+            Operation::SetBackgroundLayers {
+                node,
+                layers: vec![basic_conic_layer()],
+            },
             Operation::SetVisualEffects {
                 node,
                 effects: VisualEffects::default(),
@@ -583,6 +680,7 @@ mod tests {
             vec![
                 RenderCapability::EllipticalBorderRadius,
                 RenderCapability::LinearGradients,
+                RenderCapability::ConicGradients,
                 RenderCapability::VisualEffects,
                 RenderCapability::TextEffects,
                 RenderCapability::TextTypography,

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -660,6 +660,10 @@ impl FrameSink for MobileFrameSink {
                     capability: whisker_engine::whisker_protocol::RenderCapability::RadialGradients,
                     support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_engine::whisker_protocol::CapabilityEntry {
+                    capability: whisker_engine::whisker_protocol::RenderCapability::ConicGradients,
+                    support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("mobile capability profile is unique")
@@ -697,6 +701,7 @@ struct MobileFrameOwned {
     _paints: Vec<Box<MobileBoxPaint>>,
     _gradient_stops: Vec<Box<[MobileGradientStop]>>,
     _radial_gradients: Vec<Box<MobileRadialGradient>>,
+    _conic_gradients: Vec<Box<MobileConicGradient>>,
     _texts: Vec<Box<MobileText>>,
     _transforms: Vec<Box<[f32; 16]>>,
     _values: Vec<Box<WhiskerValueRaw>>,
@@ -711,6 +716,7 @@ impl MobileFrameOwned {
         let mut paints = Vec::<Box<MobileBoxPaint>>::new();
         let mut gradient_stops = Vec::<Box<[MobileGradientStop]>>::new();
         let mut radial_gradients = Vec::<Box<MobileRadialGradient>>::new();
+        let mut conic_gradients = Vec::<Box<MobileConicGradient>>::new();
         let mut texts = Vec::<Box<MobileText>>::new();
         let mut transforms = Vec::<Box<[f32; 16]>>::new();
         let mut values = Vec::<Box<WhiskerValueRaw>>::new();
@@ -834,6 +840,30 @@ impl MobileFrameOwned {
                                 raw.flags = BACKGROUND_RADIAL;
                                 raw.payload_count = 1;
                                 raw.payload = radial_gradients.last().unwrap().as_ref() as *const _
+                                    as *const c_void;
+                            }
+                            PaintImage::ConicGradient {
+                                from_degrees,
+                                center,
+                                repeating: false,
+                                stops,
+                            } if stops.iter().all(|stop| {
+                                stop.position.is_some_and(|position| position.length == 0.0)
+                            }) =>
+                            {
+                                let stops = mobile_gradient_stops(stops, &mut strings)?;
+                                gradient_stops.push(stops);
+                                let stops = gradient_stops.last().unwrap();
+                                conic_gradients.push(Box::new(MobileConicGradient {
+                                    center_x: mobile_coordinate(center.x),
+                                    center_y: mobile_coordinate(center.y),
+                                    stops: stops.as_ptr(),
+                                    stop_count: stops.len(),
+                                }));
+                                raw.flags = BACKGROUND_CONIC;
+                                raw.scalar = *from_degrees;
+                                raw.payload_count = 1;
+                                raw.payload = conic_gradients.last().unwrap().as_ref() as *const _
                                     as *const c_void;
                             }
                             _ => return Err(MobileFrameError),
@@ -991,6 +1021,7 @@ impl MobileFrameOwned {
             _paints: paints,
             _gradient_stops: gradient_stops,
             _radial_gradients: radial_gradients,
+            _conic_gradients: conic_gradients,
             _texts: texts,
             _transforms: transforms,
             _values: values,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
@@ -9,6 +9,7 @@ import android.graphics.Path
 import android.graphics.RectF
 import android.graphics.RadialGradient
 import android.graphics.Shader
+import android.graphics.SweepGradient
 import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.sin
@@ -39,10 +40,18 @@ internal data class HostRadialGradient(
     val stops: List<HostGradientStop>,
 )
 
+internal data class HostConicGradient(
+    val fromDegrees: Float,
+    val centerX: HostPaintCoordinate,
+    val centerY: HostPaintCoordinate,
+    val stops: List<HostGradientStop>,
+)
+
 /** Retained projection of the currently supported SetBackgroundLayers subset. */
 internal data class HostBackgroundLayers(
     val linearGradient: HostLinearGradient?,
     val radialGradient: HostRadialGradient? = null,
+    val conicGradient: HostConicGradient? = null,
 )
 
 internal fun drawBackgroundLayers(
@@ -58,6 +67,10 @@ internal fun drawBackgroundLayers(
     }
     layers?.radialGradient?.let { gradient ->
         drawRadialGradient(canvas, clip, box, gradient, paint)
+        return
+    }
+    layers?.conicGradient?.let { gradient ->
+        drawConicGradient(canvas, clip, box, gradient, paint)
     }
 }
 
@@ -147,6 +160,39 @@ private fun drawRadialGradient(
     ).apply {
         setLocalMatrix(Matrix().apply {
             setScale(1f, radiusY / radiusX, centerX, centerY)
+        })
+    }
+    canvas.drawPath(clip, paint)
+    paint.shader = null
+}
+
+private fun drawConicGradient(
+    canvas: Canvas,
+    clip: Path,
+    box: RectF,
+    gradient: HostConicGradient,
+    paint: Paint,
+) {
+    if (gradient.stops.size < 2) return
+    val centerX = box.left + gradient.centerX.resolve(box.width())
+    val centerY = box.top + gradient.centerY.resolve(box.height())
+    var previousPosition = 0f
+    val positions = gradient.stops.mapIndexed { index, stop ->
+        stop.fraction.coerceIn(0f, 1f)
+            .coerceAtLeast(if (index == 0) 0f else previousPosition)
+            .also { previousPosition = it }
+    }.toFloatArray()
+    paint.color = Color.WHITE
+    paint.shader = SweepGradient(
+        centerX,
+        centerY,
+        gradient.stops.map(HostGradientStop::color).toIntArray(),
+        positions,
+    ).apply {
+        // Android starts a sweep at +x. CSS/protocol starts at the positive
+        // vertical axis, with both advancing clockwise in screen space.
+        setLocalMatrix(Matrix().apply {
+            setRotate(gradient.fromDegrees - 90f, centerX, centerY)
         })
     }
     canvas.drawPath(clip, paint)

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -11,6 +11,7 @@ import rs.whisker.runtime.WhiskerTextContent
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.paint.HostBoxPaint
 import rs.whisker.runtime.paint.HostBackgroundLayers
+import rs.whisker.runtime.paint.HostConicGradient
 import rs.whisker.runtime.paint.HostGradientStop
 import rs.whisker.runtime.paint.HostLinearGradient
 import rs.whisker.runtime.paint.HostPaintCoordinate
@@ -361,13 +362,17 @@ internal class HostScene(
         } else {
             val density = root.resources.displayMetrics.density
             val names = requireNotNull(operation.names)
-            val stopOffset = if (operation.flags == 1) 8 else 0
+            val stopOffset = when (operation.flags) {
+                1 -> 8
+                2 -> 4
+                else -> 0
+            }
             val stops = decodeGradientStops(numbers, stopOffset, names, density)
+            fun coordinate(offset: Int) = HostPaintCoordinate(
+                length = numbers[offset] * density,
+                fraction = numbers[offset + 1],
+            )
             node.backgroundLayers = if (operation.flags == 1) {
-                fun coordinate(offset: Int) = HostPaintCoordinate(
-                    length = numbers[offset] * density,
-                    fraction = numbers[offset + 1],
-                )
                 HostBackgroundLayers(
                     linearGradient = null,
                     radialGradient = HostRadialGradient(
@@ -375,6 +380,16 @@ internal class HostScene(
                         centerY = coordinate(2),
                         radiusX = coordinate(4),
                         radiusY = coordinate(6),
+                        stops = stops,
+                    ),
+                )
+            } else if (operation.flags == 2) {
+                HostBackgroundLayers(
+                    linearGradient = null,
+                    conicGradient = HostConicGradient(
+                        fromDegrees = operation.scalar,
+                        centerX = coordinate(0),
+                        centerY = coordinate(2),
                         stops = stops,
                     ),
                 )
@@ -415,7 +430,7 @@ internal class HostScene(
         existing: Set<Long>,
     ): Boolean {
         if (
-            operation.node !in existing || operation.flags !in 0..1 ||
+            operation.node !in existing || operation.flags !in 0..2 ||
             !operation.scalar.isFinite()
         ) {
             return false
@@ -423,7 +438,11 @@ internal class HostScene(
         val numbers = operation.numbers ?: FloatArray(0)
         val names = operation.names ?: emptyArray()
         if (numbers.isEmpty()) return operation.flags == 0 && names.isEmpty()
-        val stopOffset = if (operation.flags == 1) 8 else 0
+        val stopOffset = when (operation.flags) {
+            1 -> 8
+            2 -> 4
+            else -> 0
+        }
         if (
             numbers.size < stopOffset + 14 || (numbers.size - stopOffset) % 7 != 0 ||
             names.size != (numbers.size - stopOffset) / 7

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -368,7 +368,11 @@ fn linear_gradient_color(draw_index: u32, position: vec2<f32>) -> vec4<f32> {
     }
     let line = gradient.start_end.zw - gradient.start_end.xy;
     var progress = dot(position - gradient.start_end.xy, line) / max(dot(line, line), 0.0001);
-    if gradient.kind == 2u {
+    if gradient.kind == 3u {
+        let delta = position - gradient.start_end.xy;
+        let clockwise_turns = atan2(delta.x, -delta.y) / (2.0 * 3.141592653589793);
+        progress = fract(clockwise_turns - gradient.start_end.z);
+    } else if gradient.kind == 2u {
         let normalized = (position - gradient.start_end.xy)
             / max(gradient.start_end.zw, vec2<f32>(0.0001));
         progress = length(normalized);
@@ -644,8 +648,7 @@ struct LinearGradientStopGpu {
 pub(crate) struct LinearGradientDraw {
     start_end: [f32; 4],
     stops: Vec<LinearGradientStopGpu>,
-    repeating: bool,
-    radial: bool,
+    kind: u32,
 }
 
 struct BoxGpuPipeline {
@@ -828,11 +831,7 @@ impl BoxGpuPipeline {
                     start_end: gradient.start_end,
                     stop_offset,
                     stop_count: gradient.stops.len() as u32,
-                    kind: if gradient.radial {
-                        2
-                    } else {
-                        u32::from(gradient.repeating)
-                    },
+                    kind: gradient.kind,
                     padding: 0,
                 }
             })
@@ -945,8 +944,7 @@ pub(crate) fn linear_gradient_draw(
                 color: gpu_color(&stop.color, opacity),
             })
             .collect(),
-        repeating,
-        radial: false,
+        kind: u32::from(repeating),
     }
 }
 
@@ -978,8 +976,32 @@ pub(crate) fn radial_gradient_draw(
                 color: gpu_color(&stop.color, opacity),
             })
             .collect(),
-        repeating: false,
-        radial: true,
+        kind: 2,
+    }
+}
+
+pub(crate) fn conic_gradient_draw(
+    positioning_rect: LayoutRect,
+    from_degrees: f32,
+    center: whisker_protocol::PaintPosition,
+    stops: &[GradientStop],
+    opacity: f32,
+) -> LinearGradientDraw {
+    let center = [
+        positioning_rect.x + center.x.length + center.x.fraction * positioning_rect.width,
+        positioning_rect.y + center.y.length + center.y.fraction * positioning_rect.height,
+    ];
+    LinearGradientDraw {
+        start_end: [center[0], center[1], from_degrees / 360.0, 0.0],
+        stops: stops
+            .iter()
+            .map(|stop| LinearGradientStopGpu {
+                position: stop.position.map_or(0.0, |position| position.fraction),
+                padding: [0.0; 3],
+                color: gpu_color(&stop.color, opacity),
+            })
+            .collect(),
+        kind: 3,
     }
 }
 
@@ -1168,6 +1190,18 @@ impl GpuRenderer {
                                 positioning_rect,
                                 *center,
                                 *radii,
+                                stops,
+                                *opacity,
+                            ),
+                            PaintImage::ConicGradient {
+                                from_degrees,
+                                center,
+                                repeating: false,
+                                stops,
+                            } => conic_gradient_draw(
+                                positioning_rect,
+                                *from_degrees,
+                                *center,
                                 stops,
                                 *opacity,
                             ),

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -777,6 +777,10 @@ impl FrameSink for DesktopScene {
                     capability: whisker_protocol::RenderCapability::RadialGradients,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::ConicGradients,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("Desktop capability profile is unique")
@@ -858,6 +862,15 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
             stops,
             ..
         } if stops.iter().all(|stop| stop.position.is_some())
+    ) || matches!(
+        &layer.image,
+        PaintImage::ConicGradient {
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| {
+            stop.position.is_some_and(|position| position.length == 0.0)
+        })
     )) && layer.position == Default::default()
         && layer.size == BackgroundSize::Auto
         && layer.repeat_x == ImageRepeat::Repeat

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -6,10 +6,10 @@ use whisker::{SurfaceRuntime, standard_element_registrations};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LinearGradientFixture,
-    LoadedCase, OverflowClipFixture, PixelRelationFixture, PixelRelationKind, PixelSampleFixture,
-    PointerEventFixture, RadialGradientFixture, Scenario, ScenarioSide, SceneNodeFixture,
-    VisibilityFixture, load_required,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, ConicGradientFixture, Host,
+    LinearGradientFixture, LoadedCase, OverflowClipFixture, PixelRelationFixture,
+    PixelRelationKind, PixelSampleFixture, PointerEventFixture, RadialGradientFixture, Scenario,
+    ScenarioSide, SceneNodeFixture, VisibilityFixture, load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
@@ -27,7 +27,7 @@ use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
 use crate::element::{DesktopElementRegistry, built_in_element_factories};
 use crate::gpu::{
-    LinearGradientDraw, linear_gradient_draw, radial_gradient_draw,
+    LinearGradientDraw, conic_gradient_draw, linear_gradient_draw, radial_gradient_draw,
     render_box_primitives_offscreen, render_clipped_box_primitives_offscreen,
 };
 use crate::paint::box_paint::{
@@ -118,6 +118,44 @@ fn radial_gradient_protocol(value: &RadialGradientFixture) -> BackgroundLayer {
                     fraction: 0.0,
                 },
             )),
+            repeating: false,
+            stops: value
+                .stops
+                .iter()
+                .map(|stop| GradientStop {
+                    color: color_protocol(&stop.color),
+                    position: Some(PaintCoordinate {
+                        length: 0.0,
+                        fraction: stop.position,
+                    }),
+                })
+                .collect(),
+        },
+        position: PaintPosition::default(),
+        size: BackgroundSize::Auto,
+        repeat_x: ImageRepeat::Repeat,
+        repeat_y: ImageRepeat::Repeat,
+        origin: PaintBox::Padding,
+        clip: PaintBox::Border,
+        attachment: BackgroundAttachment::Scroll,
+        blend_mode: BlendMode::Normal,
+    }
+}
+
+fn conic_gradient_protocol(value: &ConicGradientFixture) -> BackgroundLayer {
+    BackgroundLayer {
+        image: PaintImage::ConicGradient {
+            from_degrees: value.from_degrees,
+            center: PaintPosition {
+                x: PaintCoordinate {
+                    length: value.center[0],
+                    fraction: 0.0,
+                },
+                y: PaintCoordinate {
+                    length: value.center[1],
+                    fraction: 0.0,
+                },
+            },
             repeating: false,
             stops: value
                 .stops
@@ -426,6 +464,12 @@ impl Driver {
                     layers: vec![radial_gradient_protocol(gradient)],
                 });
             }
+            if let Some(gradient) = &fixture.conic_gradient {
+                operations.push(Operation::SetBackgroundLayers {
+                    node,
+                    layers: vec![conic_gradient_protocol(gradient)],
+                });
+            }
             operations.push(Operation::SetClip {
                 node,
                 clip: BoxClip {
@@ -530,6 +574,18 @@ impl Driver {
                         } => {
                             radial_gradient_draw(positioning_rect, *center, *radii, stops, opacity)
                         }
+                        PaintImage::ConicGradient {
+                            from_degrees,
+                            center,
+                            repeating: false,
+                            stops,
+                        } => conic_gradient_draw(
+                            positioning_rect,
+                            *from_degrees,
+                            *center,
+                            stops,
+                            opacity,
+                        ),
                         _ => continue,
                     };
                     primitives.push((

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 2 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 3 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -17,7 +17,10 @@ enum {
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
   WHISKER_OP_BACKGROUND_LAYERS
 };
-enum { WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1 };
+enum {
+  WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
+  WHISKER_BACKGROUND_CONIC = 2
+};
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -49,6 +52,11 @@ typedef struct {
   size_t stop_count;
 } WhiskerMobileRadialGradient;
 typedef struct {
+  WhiskerMobileLengthPercentage center_x, center_y;
+  const WhiskerMobileGradientStop *stops;
+  size_t stop_count;
+} WhiskerMobileConicGradient;
+typedef struct {
   WhiskerStringRef text; float font_size; uint16_t font_weight;
   uint8_t font_style, wrap; uint32_t max_lines; float line_height, letter_spacing;
   WhiskerMobileColor color; uint64_t prepared_content;
@@ -69,6 +77,7 @@ _Static_assert(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift")
 _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
 _Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGradient ABI drift");
+_Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGradient ABI drift");
 typedef struct {
   uint32_t id; uint8_t value_kind, optional_kind, _pad[2]; WhiskerStringRef name;
 } WhiskerMobileMemberRegistration;

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -25,20 +25,36 @@ struct HostRadialGradient {
     let stops: [HostLinearGradientStop]
 }
 
+struct HostConicGradient {
+    let fromDegrees: CGFloat
+    let centerX: WhiskerMobileLengthPercentage
+    let centerY: WhiskerMobileLengthPercentage
+    let stops: [HostLinearGradientStop]
+}
+
 private enum HostBackgroundImage {
     case linear(HostLinearGradient)
     case radial(HostRadialGradient)
+    case conic(HostConicGradient)
 }
 
 final class HostBackgroundPainter {
     private var image: HostBackgroundImage?
+    private var conicCache: (size: CGSize, scale: CGFloat, image: CGImage)?
 
     func update(linearGradient: HostLinearGradient?) {
         image = linearGradient.map(HostBackgroundImage.linear)
+        conicCache = nil
     }
 
     func update(radialGradient: HostRadialGradient) {
         image = .radial(radialGradient)
+        conicCache = nil
+    }
+
+    func update(conicGradient: HostConicGradient) {
+        image = .conic(conicGradient)
+        conicCache = nil
     }
 
     func draw(in bounds: CGRect, clippedBy clipPath: CGPath) {
@@ -49,6 +65,8 @@ final class HostBackgroundPainter {
             drawLinear(gradient, in: bounds, clippedBy: clipPath, context: context)
         case let .radial(gradient):
             drawRadial(gradient, in: bounds, clippedBy: clipPath, context: context)
+        case let .conic(gradient):
+            drawConic(gradient, in: bounds, clippedBy: clipPath, context: context)
         }
     }
 
@@ -144,6 +162,36 @@ final class HostBackgroundPainter {
         )
         context.restoreGState()
     }
+
+    private func drawConic(
+        _ conicGradient: HostConicGradient,
+        in bounds: CGRect,
+        clippedBy clipPath: CGPath,
+        context: CGContext
+    ) {
+        let stops = normalizedConicStops(conicGradient.stops)
+        guard stops.count >= 2 else { return }
+        let scale = max(hypot(context.ctm.a, context.ctm.c), 1)
+        let image: CGImage
+        if let cache = conicCache, cache.size == bounds.size, cache.scale == scale {
+            image = cache.image
+        } else {
+            guard let rendered = rasterizeConic(
+                conicGradient,
+                stops: stops,
+                size: bounds.size,
+                scale: scale
+            ) else { return }
+            conicCache = (bounds.size, scale, rendered)
+            image = rendered
+        }
+
+        context.saveGState()
+        context.addPath(clipPath)
+        context.clip()
+        UIImage(cgImage: image, scale: scale, orientation: .up).draw(in: bounds)
+        context.restoreGState()
+    }
 }
 
 private struct ResolvedGradient {
@@ -197,6 +245,135 @@ private func makeGradient(
         count: resolved.count
     ) else { return nil }
     return ResolvedGradient(value: value, domainStart: domainStart, domainEnd: domainEnd)
+}
+
+private func normalizedConicStops(
+    _ input: [HostLinearGradientStop]
+) -> [(color: UIColor, position: CGFloat)] {
+    guard input.count >= 2 else { return [] }
+    var previous = -CGFloat.infinity
+    let ordered = input.map { stop -> (color: UIColor, position: CGFloat) in
+        let position = max(previous, CGFloat(stop.position.fraction))
+        previous = position
+        return (stop.color, position)
+    }
+    var result = [(color: color(at: 0, in: ordered), position: CGFloat(0))]
+    result.append(contentsOf: ordered.filter { (0...1).contains($0.position) })
+    result.append((color: color(at: 1, in: ordered), position: 1))
+    return result
+}
+
+/// Evaluates the resolved, non-repeating stop list at one turn fraction.
+private func color(
+    at position: CGFloat,
+    in stops: [(color: UIColor, position: CGFloat)]
+) -> UIColor {
+    guard let first = stops.first, position > first.position else {
+        return stops.first?.color ?? .clear
+    }
+    for (left, right) in zip(stops, stops.dropFirst()) where position <= right.position {
+        let distance = right.position - left.position
+        guard distance > 0 else { return right.color }
+        return interpolate(left.color, right.color, amount: (position - left.position) / distance)
+    }
+    return stops.last?.color ?? .clear
+}
+
+private func rasterizeConic(
+    _ gradient: HostConicGradient,
+    stops: [(color: UIColor, position: CGFloat)],
+    size: CGSize,
+    scale: CGFloat
+) -> CGImage? {
+    let width = max(Int(ceil(size.width * scale)), 1)
+    let height = max(Int(ceil(size.height * scale)), 1)
+    let centerX = resolve(gradient.centerX, extent: size.width) * scale
+    let centerY = resolve(gradient.centerY, extent: size.height) * scale
+    let startTurn = gradient.fromDegrees / 360
+    let rasterStops = stops.map { (color: rgba($0.color), position: $0.position) }
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    for y in 0..<height {
+        for x in 0..<width {
+            let dx = CGFloat(x) + 0.5 - centerX
+            let dy = CGFloat(y) + 0.5 - centerY
+            let turn = (atan2(dx, -dy) / (2 * .pi) - startTurn).truncatingRemainder(
+                dividingBy: 1
+            )
+            let components = conicColor(
+                at: turn < 0 ? turn + 1 : turn,
+                in: rasterStops
+            )
+            let alpha = max(0, min(1, components.alpha))
+            let offset = (y * width + x) * 4
+            pixels[offset] = byte(components.red * alpha)
+            pixels[offset + 1] = byte(components.green * alpha)
+            pixels[offset + 2] = byte(components.blue * alpha)
+            pixels[offset + 3] = byte(alpha)
+        }
+    }
+    guard let bitmap = CGContext(
+        data: &pixels,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ) else { return nil }
+    return bitmap.makeImage()
+}
+
+private struct RGBA {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+}
+
+private func rgba(_ color: UIColor) -> RGBA {
+    let components = rgbaComponents(color)
+    return RGBA(
+        red: components[0],
+        green: components[1],
+        blue: components[2],
+        alpha: components[3]
+    )
+}
+
+private func conicColor(
+    at position: CGFloat,
+    in stops: [(color: RGBA, position: CGFloat)]
+) -> RGBA {
+    guard let first = stops.first, position > first.position else {
+        return stops.first?.color ?? RGBA(red: 0, green: 0, blue: 0, alpha: 0)
+    }
+    for (left, right) in zip(stops, stops.dropFirst()) where position <= right.position {
+        let distance = right.position - left.position
+        guard distance > 0 else { return right.color }
+        let amount = (position - left.position) / distance
+        return RGBA(
+            red: left.color.red + (right.color.red - left.color.red) * amount,
+            green: left.color.green + (right.color.green - left.color.green) * amount,
+            blue: left.color.blue + (right.color.blue - left.color.blue) * amount,
+            alpha: left.color.alpha + (right.color.alpha - left.color.alpha) * amount
+        )
+    }
+    return stops.last?.color ?? RGBA(red: 0, green: 0, blue: 0, alpha: 0)
+}
+
+private func byte(_ value: CGFloat) -> UInt8 {
+    UInt8((max(0, min(1, value)) * 255).rounded())
+}
+
+private func interpolate(_ left: UIColor, _ right: UIColor, amount: CGFloat) -> UIColor {
+    let lhs = rgbaComponents(left)
+    let rhs = rgbaComponents(right)
+    return UIColor(
+        red: lhs[0] + (rhs[0] - lhs[0]) * amount,
+        green: lhs[1] + (rhs[1] - lhs[1]) * amount,
+        blue: lhs[2] + (rhs[2] - lhs[2]) * amount,
+        alpha: lhs[3] + (rhs[3] - lhs[3]) * amount
+    )
 }
 
 private func rgbaComponents(_ color: UIColor) -> [CGFloat] {

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -69,6 +69,10 @@ final class HostBoxPainter {
         backgroundPainter.update(radialGradient: radialGradient)
     }
 
+    func updateBackgroundLayers(_ conicGradient: HostConicGradient) {
+        backgroundPainter.update(conicGradient: conicGradient)
+    }
+
     func overflowClipPath(
         in bounds: CGRect,
         visibleBounds: CGRect,

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -164,6 +164,21 @@ final class HostScene {
                           ) else {
                         return false
                     }
+                case UInt32(WHISKER_BACKGROUND_CONIC):
+                    guard operation.payload_count == 1,
+                          let conic = operation.payload?.assumingMemoryBound(
+                              to: WhiskerMobileConicGradient.self
+                          ).pointee,
+                          conic.center_x.isFinite, conic.center_y.isFinite,
+                          (2...4_096).contains(conic.stop_count),
+                          let stops = conic.stops,
+                          validGradientStops(
+                              UnsafeRawPointer(stops),
+                              count: conic.stop_count,
+                              requiresFractionOnly: true
+                          ) else {
+                        return false
+                    }
                 default:
                     return false
                 }
@@ -257,6 +272,20 @@ final class HostScene {
                     centerY: radial.center_y,
                     radiusX: radial.radius_x,
                     radiusY: radial.radius_y,
+                    stops: stops
+                ))
+            } else if operation.flags == UInt32(WHISKER_BACKGROUND_CONIC) {
+                guard let conic = operation.payload?.assumingMemoryBound(
+                    to: WhiskerMobileConicGradient.self
+                ).pointee, let stopPointer = conic.stops else { return false }
+                let stops = UnsafeBufferPointer(
+                    start: stopPointer,
+                    count: conic.stop_count
+                ).map(HostLinearGradientStop.init)
+                node.boxPainter.updateBackgroundLayers(HostConicGradient(
+                    fromDegrees: CGFloat(operation.scalar),
+                    centerX: conic.center_x,
+                    centerY: conic.center_y,
                     stops: stops
                 ))
             } else {
@@ -448,14 +477,19 @@ private func hostRect(_ value: WhiskerMobileRect) -> CGRect {
     )
 }
 
-private func validGradientStops(_ payload: UnsafeRawPointer, count: Int) -> Bool {
+private func validGradientStops(
+    _ payload: UnsafeRawPointer,
+    count: Int,
+    requiresFractionOnly: Bool = false
+) -> Bool {
     guard (2...4_096).contains(count) else { return false }
     let stops = UnsafeBufferPointer(
         start: payload.assumingMemoryBound(to: WhiskerMobileGradientStop.self),
         count: count
     )
     return stops.allSatisfy { stop in
-        stop.position.isFinite && stop.color.kind <= 1 && stop.color.alpha.isFinite &&
+        stop.position.isFinite && (!requiresFractionOnly || stop.position.length == 0) &&
+            stop.color.kind <= 1 && stop.color.alpha.isFinite &&
             (0...1).contains(stop.color.alpha)
     }
 }

--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -15,15 +15,12 @@ pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
     let [layer] = layers else {
         return false;
     };
-    let supported_image = matches!(
-        &layer.image,
+    let supported_image = match &layer.image {
         PaintImage::LinearGradient {
             repeating: false,
             stops,
             ..
-        } if stops.iter().all(|stop| stop.position.is_some())
-    ) || matches!(
-        &layer.image,
+        } => stops.iter().all(|stop| stop.position.is_some()),
         PaintImage::RadialGradient {
             shape: RadialGradientShape::Ellipse,
             extent: RadialGradientExtent::Explicit,
@@ -31,8 +28,16 @@ pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
             repeating: false,
             stops,
             ..
-        } if stops.iter().all(|stop| stop.position.is_some())
-    );
+        } => stops.iter().all(|stop| stop.position.is_some()),
+        PaintImage::ConicGradient {
+            repeating: false,
+            stops,
+            ..
+        } => stops
+            .iter()
+            .all(|stop| stop.position.is_some_and(|position| position.length == 0.0)),
+        _ => false,
+    };
     supported_image
         && layer.position == Default::default()
         && layer.size == BackgroundSize::Auto
@@ -50,7 +55,7 @@ pub(crate) fn apply(
 ) -> Result<(), WebError> {
     if !supports(layers) {
         return Err(WebError(
-            "DOM Host only implements one non-repeating linear or explicit elliptical radial gradient with explicit stops and CSS initial layer values"
+            "DOM Host only implements one non-repeating linear, explicit elliptical radial, or conic gradient with explicit stops and CSS initial layer values"
                 .into(),
         ));
     }
@@ -118,6 +123,12 @@ fn background_image(layer: &BackgroundLayer) -> Result<String, WebError> {
             repeating: false,
             stops,
         } => radial_gradient(*center, *radii, stops),
+        PaintImage::ConicGradient {
+            from_degrees,
+            center,
+            repeating: false,
+            stops,
+        } => conic_gradient(*from_degrees, *center, stops),
         _ => Err(WebError("unsupported DOM background image".into())),
     }
 }
@@ -150,6 +161,23 @@ fn radial_gradient(
     ))
 }
 
+fn conic_gradient(
+    from_degrees: f32,
+    center: PaintPosition,
+    stops: &[GradientStop],
+) -> Result<String, WebError> {
+    let stops = stops
+        .iter()
+        .map(conic_gradient_stop)
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    Ok(format!(
+        "conic-gradient(from {from_degrees}deg at {} {}, {stops})",
+        coordinate(center.x),
+        coordinate(center.y),
+    ))
+}
+
 fn gradient_stop(stop: &GradientStop) -> Result<String, WebError> {
     let position = stop
         .position
@@ -158,6 +186,18 @@ fn gradient_stop(stop: &GradientStop) -> Result<String, WebError> {
         "{} {}",
         css_color(&stop.color),
         coordinate(position)
+    ))
+}
+
+fn conic_gradient_stop(stop: &GradientStop) -> Result<String, WebError> {
+    let position = stop
+        .position
+        .filter(|position| position.length == 0.0)
+        .ok_or_else(|| WebError("DOM conic-gradient requires resolved turn stops".into()))?;
+    Ok(format!(
+        "{} {}turn",
+        css_color(&stop.color),
+        position.fraction
     ))
 }
 

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -458,6 +458,10 @@ impl FrameSink for DomFrameSink {
                     capability: whisker_protocol::RenderCapability::RadialGradients,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::ConicGradients,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("Web capability profile is unique")

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -3,8 +3,8 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use whisker::ElementRegistry;
 use whisker_engine::FrameSink;
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, CornerRadiusFixture,
-    LinearGradientFixture, Manifest, OverflowClipFixture, PixelSampleFixture,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, ConicGradientFixture,
+    CornerRadiusFixture, LinearGradientFixture, Manifest, OverflowClipFixture, PixelSampleFixture,
     RadialGradientFixture, SCHEMA_VERSION, Scenario, ScenarioSide, SceneNodeFixture,
     VisibilityFixture,
 };
@@ -109,6 +109,11 @@ impl Driver {
                                             node.radial_gradient
                                                 .as_ref()
                                                 .map(|_| "paint.background-layers.radial-gradient")
+                                        })
+                                        .or_else(|| {
+                                            node.conic_gradient
+                                                .as_ref()
+                                                .map(|_| "paint.background-layers.conic-gradient")
                                         })
                                 })
                             })
@@ -223,6 +228,13 @@ impl Driver {
                     &fixture_radial_gradient_css(gradient),
                 );
                 assert_initial_background_layer_is_projected(&style);
+            } else if let Some(gradient) = &fixture_node.conic_gradient {
+                assert_style(
+                    &style,
+                    "background-image",
+                    &fixture_conic_gradient_css(gradient),
+                );
+                assert_initial_background_layer_is_projected(&style);
             } else {
                 assert_eq!(style.get_property_value("background-image").unwrap(), "");
             }
@@ -267,6 +279,7 @@ impl Driver {
                     node.id.to_string() == id.as_str()
                         && (node.linear_gradient.is_some()
                             || node.radial_gradient.is_some()
+                            || node.conic_gradient.is_some()
                             || !fixture_color_is_transparent(&node.background))
                 })
             });
@@ -282,7 +295,9 @@ impl Driver {
                         .find(|node| node.opacity.is_some())
                         .or_else(|| {
                             expected.iter().find(|node| {
-                                node.linear_gradient.is_some() || node.radial_gradient.is_some()
+                                node.linear_gradient.is_some()
+                                    || node.radial_gradient.is_some()
+                                    || node.conic_gradient.is_some()
                             })
                         })
                         .expect("sRGBA sample requires an opacity or gradient source node")
@@ -300,7 +315,9 @@ impl Driver {
                         .find(|node| node.background == *expected_color)
                         .or_else(|| {
                             expected.iter().find(|node| {
-                                node.linear_gradient.is_some() || node.radial_gradient.is_some()
+                                node.linear_gradient.is_some()
+                                    || node.radial_gradient.is_some()
+                                    || node.conic_gradient.is_some()
                             })
                         })
                         .unwrap_or_else(|| {
@@ -369,6 +386,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-images/radial-gradient-container-relative-units-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-images/radial-gradient-container-relative-units-001.json"
+        ),
+        "wpt/css/css-images/conic-gradient-angle.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-images/conic-gradient-angle.json"
         ),
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
@@ -563,6 +583,11 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
                 node,
                 layers: vec![radial_gradient_layer(gradient)],
             });
+        } else if let Some(gradient) = &fixture_node.conic_gradient {
+            operations.push(Operation::SetBackgroundLayers {
+                node,
+                layers: vec![conic_gradient_layer(gradient)],
+            });
         }
     }
     for (node_index, fixture_node) in nodes.iter().enumerate() {
@@ -657,6 +682,44 @@ fn radial_gradient_layer(gradient: &RadialGradientFixture) -> BackgroundLayer {
                     fraction: 0.0,
                 },
             )),
+            repeating: false,
+            stops: gradient
+                .stops
+                .iter()
+                .map(|stop| GradientStop {
+                    color: color(&stop.color),
+                    position: Some(PaintCoordinate {
+                        length: 0.0,
+                        fraction: stop.position,
+                    }),
+                })
+                .collect(),
+        },
+        position: PaintPosition::default(),
+        size: BackgroundSize::Auto,
+        repeat_x: ImageRepeat::Repeat,
+        repeat_y: ImageRepeat::Repeat,
+        origin: PaintBox::Padding,
+        clip: PaintBox::Border,
+        attachment: BackgroundAttachment::Scroll,
+        blend_mode: BlendMode::Normal,
+    }
+}
+
+fn conic_gradient_layer(gradient: &ConicGradientFixture) -> BackgroundLayer {
+    BackgroundLayer {
+        image: PaintImage::ConicGradient {
+            from_degrees: gradient.from_degrees,
+            center: PaintPosition {
+                x: PaintCoordinate {
+                    length: gradient.center[0],
+                    fraction: 0.0,
+                },
+                y: PaintCoordinate {
+                    length: gradient.center[1],
+                    fraction: 0.0,
+                },
+            },
             repeating: false,
             stops: gradient
                 .stops
@@ -912,6 +975,19 @@ fn fixture_radial_gradient_css(gradient: &RadialGradientFixture) -> String {
     format!(
         "radial-gradient(ellipse {}px {}px at {}px {}px, {stops})",
         gradient.radii[0], gradient.radii[1], gradient.center[0], gradient.center[1]
+    )
+}
+
+fn fixture_conic_gradient_css(gradient: &ConicGradientFixture) -> String {
+    let stops = gradient
+        .stops
+        .iter()
+        .map(|stop| format!("{} {}turn", fixture_color_css(&stop.color), stop.position))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "conic-gradient(from {}deg at {}px {}px, {stops})",
+        gradient.from_degrees, gradient.center[0], gradient.center[1]
     )
 }
 

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -24,6 +24,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-images.conic-gradient-angle",
+      "feature": "background-image-conic-gradient",
+      "fixture": "wpt/css/css-images/conic-gradient-angle.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.border-radius-sum-of-radii-001.test1",
       "feature": "border-radius",
       "fixture": "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -138,7 +138,8 @@ private class Driver(
                     check(
                         command.getString("name") == "paint.box" ||
                             command.getString("name") == "paint.background-layers.linear-gradient" ||
-                            command.getString("name") == "paint.background-layers.radial-gradient",
+                            command.getString("name") == "paint.background-layers.radial-gradient" ||
+                            command.getString("name") == "paint.background-layers.conic-gradient",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -269,6 +270,19 @@ private class Driver(
                     ),
                 )
             }
+            node.optJSONObject("conic_gradient")?.let { gradient ->
+                val (numbers, names) = conicGradient(gradient)
+                check(
+                    stage(
+                        tag = 21,
+                        flags = 2,
+                        node = id,
+                        scalar = gradient.getDouble("from_degrees").toFloat(),
+                        numbers = numbers,
+                        names = names,
+                    ),
+                )
+            }
         }
         check(view.commitFrameFromNative())
     }
@@ -380,6 +394,22 @@ private class Driver(
             center.getDouble(1).toFloat(), 0f,
             radii.getDouble(0).toFloat(), 0f,
             radii.getDouble(1).toFloat(), 0f,
+        )
+        gradient.getJSONArray("stops").objects().forEach { stop ->
+            appendColor(stop.getJSONObject("color"), numbers, names)
+            numbers += 0f
+            numbers += stop.getDouble("position").toFloat()
+        }
+        return numbers.toFloatArray() to names.toTypedArray()
+    }
+
+    private fun conicGradient(gradient: JSONObject): Pair<FloatArray, Array<String>> {
+        val numbers = ArrayList<Float>()
+        val names = ArrayList<String>()
+        val center = gradient.getJSONArray("center")
+        numbers += listOf(
+            center.getDouble(0).toFloat(), 0f,
+            center.getDouble(1).toFloat(), 0f,
         )
         gradient.getJSONArray("stops").objects().forEach { stop ->
             appendColor(stop.getJSONObject("color"), numbers, names)

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -83,7 +83,8 @@ private final class Driver {
                 let name = try string(command, "name")
                 guard name == "paint.box" ||
                     name == "paint.background-layers.linear-gradient" ||
-                    name == "paint.background-layers.radial-gradient" else {
+                    name == "paint.background-layers.radial-gradient" ||
+                    name == "paint.background-layers.conic-gradient" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -173,6 +174,9 @@ private final class Driver {
             } else if let gradient = fixture.radialGradient {
                 gradientOffsets.append(gradientStops.count)
                 gradientStops.append(contentsOf: gradient.stops)
+            } else if let gradient = fixture.conicGradient {
+                gradientOffsets.append(gradientStops.count)
+                gradientStops.append(contentsOf: gradient.stops)
             } else {
                 gradientOffsets.append(nil)
             }
@@ -181,31 +185,47 @@ private final class Driver {
             repeating: WhiskerMobileRadialGradient(),
             count: fixtures.count
         )
+        var conicPayloads = [WhiskerMobileConicGradient](
+            repeating: WhiskerMobileConicGradient(),
+            count: fixtures.count
+        )
         try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
             try paints.withUnsafeMutableBufferPointer { paintBuffer in
                 try transforms.withUnsafeMutableBufferPointer { transformBuffer in
                     try gradientStops.withUnsafeMutableBufferPointer { gradientBuffer in
                         for (index, fixture) in fixtures.enumerated() {
-                            guard let radial = fixture.radialGradient,
-                                  let offset = gradientOffsets[index] else { continue }
-                            radialPayloads[index].center_x = WhiskerMobileLengthPercentage(
-                                length: radial.center[0], fraction: 0
-                            )
-                            radialPayloads[index].center_y = WhiskerMobileLengthPercentage(
-                                length: radial.center[1], fraction: 0
-                            )
-                            radialPayloads[index].radius_x = WhiskerMobileLengthPercentage(
-                                length: radial.radii[0], fraction: 0
-                            )
-                            radialPayloads[index].radius_y = WhiskerMobileLengthPercentage(
-                                length: radial.radii[1], fraction: 0
-                            )
-                            radialPayloads[index].stops = UnsafePointer(
+                            guard let offset = gradientOffsets[index] else { continue }
+                            let stops = UnsafePointer(
                                 gradientBuffer.baseAddress!.advanced(by: offset)
                             )
-                            radialPayloads[index].stop_count = radial.stops.count
+                            if let radial = fixture.radialGradient {
+                                radialPayloads[index].center_x = WhiskerMobileLengthPercentage(
+                                    length: radial.center[0], fraction: 0
+                                )
+                                radialPayloads[index].center_y = WhiskerMobileLengthPercentage(
+                                    length: radial.center[1], fraction: 0
+                                )
+                                radialPayloads[index].radius_x = WhiskerMobileLengthPercentage(
+                                    length: radial.radii[0], fraction: 0
+                                )
+                                radialPayloads[index].radius_y = WhiskerMobileLengthPercentage(
+                                    length: radial.radii[1], fraction: 0
+                                )
+                                radialPayloads[index].stops = stops
+                                radialPayloads[index].stop_count = radial.stops.count
+                            } else if let conic = fixture.conicGradient {
+                                conicPayloads[index].center_x = WhiskerMobileLengthPercentage(
+                                    length: conic.center[0], fraction: 0
+                                )
+                                conicPayloads[index].center_y = WhiskerMobileLengthPercentage(
+                                    length: conic.center[1], fraction: 0
+                                )
+                                conicPayloads[index].stops = stops
+                                conicPayloads[index].stop_count = conic.stops.count
+                            }
                         }
                         try radialPayloads.withUnsafeMutableBufferPointer { radialBuffer in
+                            try conicPayloads.withUnsafeMutableBufferPointer { conicBuffer in
                             var operations = fixtures.map {
                                 operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
                             }
@@ -296,6 +316,17 @@ private final class Driver {
                                         ),
                                         count: 1
                                     ))
+                                } else if let conic = fixture.conicGradient {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS),
+                                        node: fixture.id,
+                                        flags: UInt32(WHISKER_BACKGROUND_CONIC),
+                                        scalar: conic.fromDegrees,
+                                        payload: UnsafeRawPointer(
+                                            conicBuffer.baseAddress!.advanced(by: index)
+                                        ),
+                                        count: 1
+                                    ))
                                 }
                             }
                             try operations.withUnsafeMutableBufferPointer { buffer in
@@ -318,6 +349,7 @@ private final class Driver {
                                       response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
                                     throw Failure("UIKit Host rejected scene fixture frame")
                                 }
+                            }
                             }
                         }
                     }
@@ -371,6 +403,7 @@ private struct SceneFixtureNode {
     let zOrder: Int32?
     let linearGradient: SceneLinearGradient?
     let radialGradient: SceneRadialGradient?
+    let conicGradient: SceneConicGradient?
 }
 
 private struct SceneLinearGradient {
@@ -381,6 +414,12 @@ private struct SceneLinearGradient {
 private struct SceneRadialGradient {
     let center: [Float]
     let radii: [Float]
+    let stops: [WhiskerMobileGradientStop]
+}
+
+private struct SceneConicGradient {
+    let fromDegrees: Float
+    let center: [Float]
     let stops: [WhiskerMobileGradientStop]
 }
 
@@ -505,6 +544,29 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     } else {
         radialGradient = nil
     }
+    let conicGradient: SceneConicGradient?
+    if let gradient = fixture["conic_gradient"] as? [String: Any] {
+        let center = try numberArray(gradient, "center").map(Float.init)
+        let stops = try objectArray(gradient, "stops").map { stop -> WhiskerMobileGradientStop in
+            var raw = WhiskerMobileGradientStop()
+            raw.color = try color(try object(stop, "color"))
+            raw.position = WhiskerMobileLengthPercentage(
+                length: 0,
+                fraction: Float(try number(stop, "position"))
+            )
+            return raw
+        }
+        guard center.count == 2, stops.count >= 2 else {
+            throw Failure("conic gradient needs a center and at least two stops")
+        }
+        conicGradient = SceneConicGradient(
+            fromDegrees: Float(try number(gradient, "from_degrees")),
+            center: center,
+            stops: stops
+        )
+    } else {
+        conicGradient = nil
+    }
     return SceneFixtureNode(
         id: id,
         parent: parent,
@@ -516,7 +578,8 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         visible: visible,
         zOrder: zOrder,
         linearGradient: linearGradient,
-        radialGradient: radialGradient
+        radialGradient: radialGradient,
+        conicGradient: conicGradient
     )
 }
 

--- a/tests/host-conformance/wpt/css/css-images/conic-gradient-angle.json
+++ b/tests/host-conformance/wpt/css/css-images/conic-gradient-angle.json
@@ -1,0 +1,54 @@
+{
+  "schema": 1,
+  "id": "wpt.css-images.conic-gradient-angle",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-images/conic-gradient-angle.html",
+    "reference_path": "css/css-images/reference/200x200-blue-black-green-red.html",
+    "license": "BSD-3-Clause",
+    "assertion": "A conic gradient with a 90 degree starting angle paints the four quadrants in the reference order.",
+    "adaptation": "CSS parsing and stop-list expansion remain Rust responsibilities. The Host receives the WPT gradient as an explicit SetBackgroundLayers conic image; the box is reduced to 100 logical pixels and interior quadrant samples avoid antialiased boundaries."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 100.0],
+            "background": { "kind": "srgba", "red": 255, "green": 255, "blue": 255, "alpha": 0.0 },
+            "conic_gradient": {
+              "from_degrees": 90.0,
+              "center": [50.0, 50.0],
+              "stops": [
+                { "color": { "kind": "named", "value": "red" }, "position": 0.0 },
+                { "color": { "kind": "named", "value": "red" }, "position": 0.25 },
+                { "color": { "kind": "named", "value": "green" }, "position": 0.25 },
+                { "color": { "kind": "named", "value": "green" }, "position": 0.5 },
+                { "color": { "kind": "named", "value": "blue" }, "position": 0.5 },
+                { "color": { "kind": "named", "value": "blue" }, "position": 0.75 },
+                { "color": { "kind": "named", "value": "black" }, "position": 0.75 },
+                { "color": { "kind": "named", "value": "black" }, "position": 1.0 }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.conic-gradient",
+        "samples": [
+          { "point": [25.0, 25.0], "color": { "kind": "named", "value": "blue" }, "tolerance": 5 },
+          { "point": [75.0, 25.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [25.0, 75.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [75.0, 75.0], "color": { "kind": "named", "value": "red" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared WPT-derived conic-gradient angle fixture and four-Host conformance coverage
- negotiate a narrow `ConicGradients` capability without advertising complete background-layer support
- render resolved non-repeating conic gradients in Desktop/wgpu, Web, Android, and iOS
- extend the mobile ABI to 2.3 with a typed conic-gradient payload and matching C/JNI bridge

## Host implementation
- Desktop: shared gradient stop buffer plus CSS-clockwise conic evaluation in WGSL
- Web: native `conic-gradient()` projection
- Android: `SweepGradient` with CSS angle correction
- iOS: cached Core Graphics raster preserving explicit hard stops

## Validation
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`
- strict protocol line/function/region coverage: 100%
- Rust clippy across changed packages with `-D warnings`
- mobile ABI layout tests and Android C bridge NDK syntax check

The supported subset remains one non-repeating conic layer with initial layer geometry and explicit fractional stops; unsupported layer combinations continue to fail before retained-state mutation.