### PR TITLE
feat(host): render repeated background tiles

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 2 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 3 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -22,7 +22,10 @@ enum {
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
   WHISKER_OP_BACKGROUND_LAYERS
 };
-enum { WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1 };
+enum {
+  WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
+  WHISKER_BACKGROUND_CONIC = 2
+};
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -56,6 +59,11 @@ typedef struct {
   const WhiskerMobileGradientStop *stops;
   size_t stop_count;
 } WhiskerMobileRadialGradient;
+typedef struct {
+  WhiskerMobileLengthPercentage center_x, center_y;
+  const WhiskerMobileGradientStop *stops;
+  size_t stop_count;
+} WhiskerMobileConicGradient;
 typedef struct {
   WhiskerStringRef text;
   float font_size;
@@ -91,6 +99,7 @@ _Static_assert(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift")
 _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
 _Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGradient ABI drift");
+_Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGradient ABI drift");
 
 typedef struct {
   uint32_t id;

--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 0 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 1 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -19,7 +19,8 @@ enum {
   WHISKER_OP_TRANSFORM, WHISKER_OP_OPACITY, WHISKER_OP_VISIBILITY,
   WHISKER_OP_Z_ORDER, WHISKER_OP_TEXT, WHISKER_OP_PROPERTY,
   WHISKER_OP_CLEAR_PROPERTY, WHISKER_OP_EVENT_MASK, WHISKER_OP_HIT_TEST,
-  WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND
+  WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
+  WHISKER_OP_BACKGROUND_LAYERS
 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
@@ -45,6 +46,10 @@ typedef struct {
   WhiskerMobileLengthPercentage radii_horizontal[4];
   WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileBoxPaint;
+typedef struct {
+  WhiskerMobileColor color;
+  WhiskerMobileLengthPercentage position;
+} WhiskerMobileGradientStop;
 typedef struct {
   WhiskerStringRef text;
   float font_size;
@@ -78,6 +83,7 @@ typedef struct { uint8_t status, _pad[7]; uint64_t revision; } WhiskerMobileAppl
 _Static_assert(sizeof(WhiskerMobileOperation) == 72, "WhiskerMobileOperation ABI drift");
 _Static_assert(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift");
 _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResponse ABI drift");
+_Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
 
 typedef struct {
   uint32_t id;

--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 1, WHISKER_MOBILE_ABI_MINOR = 0 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 0 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -42,7 +42,8 @@ typedef struct {
   WhiskerMobileLengthPercentage widths[4];
   WhiskerMobileColor colors[4];
   uint32_t styles[4];
-  WhiskerMobileLengthPercentage radii[4];
+  WhiskerMobileLengthPercentage radii_horizontal[4];
+  WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileBoxPaint;
 typedef struct {
   WhiskerStringRef text;
@@ -127,7 +128,7 @@ _Static_assert(sizeof(WhiskerMobileBootstrap) == 24, "WhiskerMobileBootstrap ABI
 _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 160, "WhiskerMobileMeasureRequest ABI drift");
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileText) == 80, "WhiskerMobileText ABI drift");
-_Static_assert(sizeof(WhiskerMobileBoxPaint) == 240, "WhiskerMobileBoxPaint ABI drift");
+_Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 
 typedef void (*WhiskerMobileRequestFrameCallback)(void*);
 typedef bool (*WhiskerMobileBootstrapCallback)(void*, const WhiskerMobileBootstrap*);

--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 1 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 2 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -22,6 +22,7 @@ enum {
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
   WHISKER_OP_BACKGROUND_LAYERS
 };
+enum { WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -50,6 +51,11 @@ typedef struct {
   WhiskerMobileColor color;
   WhiskerMobileLengthPercentage position;
 } WhiskerMobileGradientStop;
+typedef struct {
+  WhiskerMobileLengthPercentage center_x, center_y, radius_x, radius_y;
+  const WhiskerMobileGradientStop *stops;
+  size_t stop_count;
+} WhiskerMobileRadialGradient;
 typedef struct {
   WhiskerStringRef text;
   float font_size;
@@ -84,6 +90,7 @@ _Static_assert(sizeof(WhiskerMobileOperation) == 72, "WhiskerMobileOperation ABI
 _Static_assert(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift");
 _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
+_Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGradient ABI drift");
 
 typedef struct {
   uint32_t id;

--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 3 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 4 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -26,6 +26,14 @@ enum {
   WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
   WHISKER_BACKGROUND_CONIC = 2
 };
+enum { WHISKER_BACKGROUND_SIZE_AUTO = 0, WHISKER_BACKGROUND_SIZE_EXPLICIT = 1 };
+enum { WHISKER_BACKGROUND_REPEAT = 0, WHISKER_BACKGROUND_NO_REPEAT = 1 };
+enum {
+  WHISKER_BACKGROUND_BOX_BORDER = 0, WHISKER_BACKGROUND_BOX_PADDING = 1,
+  WHISKER_BACKGROUND_BOX_CONTENT = 2
+};
+enum { WHISKER_BACKGROUND_ATTACHMENT_SCROLL = 0 };
+enum { WHISKER_BACKGROUND_BLEND_NORMAL = 0 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -65,6 +73,18 @@ typedef struct {
   size_t stop_count;
 } WhiskerMobileConicGradient;
 typedef struct {
+  uint32_t kind;
+  float scalar;
+  const void *payload;
+  size_t payload_count;
+} WhiskerMobileBackgroundImage;
+typedef struct {
+  WhiskerMobileBackgroundImage image;
+  WhiskerMobileLengthPercentage position_x, position_y;
+  WhiskerMobileLengthPercentage size_width, size_height;
+  uint32_t size_kind, repeat_x, repeat_y, origin, clip, attachment, blend_mode;
+} WhiskerMobileBackgroundLayer;
+typedef struct {
   WhiskerStringRef text;
   float font_size;
   uint16_t font_weight;
@@ -100,6 +120,8 @@ _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResp
 _Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
 _Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGradient ABI drift");
 _Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGradient ABI drift");
+_Static_assert(sizeof(WhiskerMobileBackgroundImage) == 24, "WhiskerMobileBackgroundImage ABI drift");
+_Static_assert(sizeof(WhiskerMobileBackgroundLayer) == 88, "WhiskerMobileBackgroundLayer ABI drift");
 
 typedef struct {
   uint32_t id;

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -230,7 +230,7 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
     for (size_t i = 0; i < frame->operation_count && ok; ++i) {
         const WhiskerMobileOperation* op = &frame->operations[i];
         jfloatArray numbers = NULL; jstring text = NULL; jobjectArray names = NULL; jobject value = NULL;
-        float storage[48]; size_t count = 0;
+        float storage[64]; size_t count = 0;
         switch (op->tag) {
             case WHISKER_OP_LAYOUT: {
                 const WhiskerMobileLayoutGeometry* p = op->payload;
@@ -243,7 +243,8 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 append_color(storage, &count, &p->background);
                 for (int j=0;j<4;++j) { storage[count++]=p->widths[j].length; storage[count++]=p->widths[j].fraction; }
                 for (int j=0;j<4;++j) append_color(storage, &count, &p->colors[j]);
-                for (int j=0;j<4;++j) { storage[count++]=p->radii[j].length; storage[count++]=p->radii[j].fraction; }
+                for (int j=0;j<4;++j) { storage[count++]=p->radii_horizontal[j].length; storage[count++]=p->radii_horizontal[j].fraction; }
+                for (int j=0;j<4;++j) { storage[count++]=p->radii_vertical[j].length; storage[count++]=p->radii_vertical[j].fraction; }
                 for (int j=0;j<4;++j) storage[count++]=(float)p->styles[j];
                 numbers = floats(env, storage, count); names = color_names(env, p); break;
             }

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -243,6 +243,8 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
     for (size_t i = 0; i < frame->operation_count && ok; ++i) {
         const WhiskerMobileOperation* op = &frame->operations[i];
         jfloatArray numbers = NULL; jstring text = NULL; jobjectArray names = NULL; jobject value = NULL;
+        uint32_t staged_flags = op->flags;
+        float staged_scalar = op->scalar;
         float storage[64]; size_t count = 0;
         switch (op->tag) {
             case WHISKER_OP_LAYOUT: {
@@ -262,26 +264,40 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 numbers = floats(env, storage, count); names = color_names(env, p); break;
             }
             case WHISKER_OP_BACKGROUND_LAYERS: {
-                const WhiskerMobileGradientStop* stops = op->payload;
+                if (op->payload == NULL) {
+                    if (op->payload_count != 0) ok = false;
+                    staged_flags = WHISKER_BACKGROUND_LINEAR;
+                    staged_scalar = 0.0f;
+                    break;
+                }
+                if (op->payload_count != 1) { ok = false; break; }
+                const WhiskerMobileBackgroundLayer* layer = op->payload;
+                const WhiskerMobileGradientStop* stops = layer->image.payload;
                 const WhiskerMobileRadialGradient* radial = NULL;
                 const WhiskerMobileConicGradient* conic = NULL;
-                size_t stop_count = op->payload_count;
-                size_t prefix_count = 0;
-                if (op->flags == WHISKER_BACKGROUND_RADIAL) {
-                    if (op->payload == NULL || op->payload_count != 1) { ok = false; break; }
-                    radial = op->payload;
+                size_t stop_count = layer->image.payload_count;
+                size_t image_prefix_count = 0;
+                if (layer->image.kind == WHISKER_BACKGROUND_RADIAL) {
+                    if (layer->image.payload == NULL || layer->image.payload_count != 1) {
+                        ok = false; break;
+                    }
+                    radial = layer->image.payload;
                     stops = radial->stops;
                     stop_count = radial->stop_count;
-                    prefix_count = 8;
-                } else if (op->flags == WHISKER_BACKGROUND_CONIC) {
-                    if (op->payload == NULL || op->payload_count != 1) { ok = false; break; }
-                    conic = op->payload;
+                    image_prefix_count = 8;
+                } else if (layer->image.kind == WHISKER_BACKGROUND_CONIC) {
+                    if (layer->image.payload == NULL || layer->image.payload_count != 1) {
+                        ok = false; break;
+                    }
+                    conic = layer->image.payload;
                     stops = conic->stops;
                     stop_count = conic->stop_count;
-                    prefix_count = 4;
-                } else if (op->flags != WHISKER_BACKGROUND_LINEAR) {
+                    image_prefix_count = 4;
+                } else if (layer->image.kind != WHISKER_BACKGROUND_LINEAR) {
                     ok = false; break;
                 }
+                const size_t geometry_count = 15;
+                size_t prefix_count = geometry_count + image_prefix_count;
                 if ((stops == NULL && stop_count != 0) || stop_count > (INT32_MAX - prefix_count) / 7) {
                     ok = false; break;
                 }
@@ -289,6 +305,21 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 float* values = malloc((value_count > 0 ? value_count : 1) * sizeof(float));
                 if (values == NULL) { ok = false; break; }
                 size_t cursor = 0;
+                const WhiskerMobileLengthPercentage* geometry[] = {
+                    &layer->position_x, &layer->position_y,
+                    &layer->size_width, &layer->size_height
+                };
+                for (size_t j = 0; j < 4; ++j) {
+                    values[cursor++] = geometry[j]->length;
+                    values[cursor++] = geometry[j]->fraction;
+                }
+                values[cursor++] = (float)layer->size_kind;
+                values[cursor++] = (float)layer->repeat_x;
+                values[cursor++] = (float)layer->repeat_y;
+                values[cursor++] = (float)layer->origin;
+                values[cursor++] = (float)layer->clip;
+                values[cursor++] = (float)layer->attachment;
+                values[cursor++] = (float)layer->blend_mode;
                 if (radial != NULL) {
                     const WhiskerMobileLengthPercentage* coordinates[] = {
                         &radial->center_x, &radial->center_y, &radial->radius_x, &radial->radius_y
@@ -313,6 +344,8 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 }
                 numbers = floats(env, values, value_count);
                 names = gradient_stop_names(env, stops, stop_count);
+                staged_flags = layer->image.kind;
+                staged_scalar = layer->image.scalar;
                 free(values);
                 break;
             }
@@ -332,8 +365,8 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
         }
         if (!ok) break;
         ok = (*env)->CallBooleanMethod(env, view, g_stage_operation,
-            (jint)op->tag,(jint)op->flags,(jlong)op->node,(jlong)op->parent,(jlong)op->child,
-            (jint)op->index,(jint)op->member,(jint)op->integer,(jfloat)op->scalar,(jlong)op->wide,
+            (jint)op->tag,(jint)staged_flags,(jlong)op->node,(jlong)op->parent,(jlong)op->child,
+            (jint)op->index,(jint)op->member,(jint)op->integer,(jfloat)staged_scalar,(jlong)op->wide,
             numbers,text,names,value) == JNI_TRUE && !clear_exception(env);
         if (numbers) (*env)->DeleteLocalRef(env, numbers); if (text) (*env)->DeleteLocalRef(env, text);
         if (names) (*env)->DeleteLocalRef(env, names); if (value) (*env)->DeleteLocalRef(env, value);

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -262,21 +262,42 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 numbers = floats(env, storage, count); names = color_names(env, p); break;
             }
             case WHISKER_OP_BACKGROUND_LAYERS: {
-                const WhiskerMobileGradientStop* p = op->payload;
-                if ((p == NULL && op->payload_count != 0) || op->payload_count > INT32_MAX / 7) {
+                const WhiskerMobileGradientStop* stops = op->payload;
+                const WhiskerMobileRadialGradient* radial = NULL;
+                size_t stop_count = op->payload_count;
+                size_t prefix_count = 0;
+                if (op->flags == 1) {
+                    if (op->payload == NULL || op->payload_count != 1) { ok = false; break; }
+                    radial = op->payload;
+                    stops = radial->stops;
+                    stop_count = radial->stop_count;
+                    prefix_count = 8;
+                } else if (op->flags != 0) {
                     ok = false; break;
                 }
-                size_t value_count = op->payload_count * 7;
+                if ((stops == NULL && stop_count != 0) || stop_count > (INT32_MAX - prefix_count) / 7) {
+                    ok = false; break;
+                }
+                size_t value_count = prefix_count + stop_count * 7;
                 float* values = malloc((value_count > 0 ? value_count : 1) * sizeof(float));
                 if (values == NULL) { ok = false; break; }
                 size_t cursor = 0;
-                for (size_t j = 0; j < op->payload_count; ++j) {
-                    append_color(values, &cursor, &p[j].color);
-                    values[cursor++] = p[j].position.length;
-                    values[cursor++] = p[j].position.fraction;
+                if (radial != NULL) {
+                    const WhiskerMobileLengthPercentage* coordinates[] = {
+                        &radial->center_x, &radial->center_y, &radial->radius_x, &radial->radius_y
+                    };
+                    for (size_t j = 0; j < 4; ++j) {
+                        values[cursor++] = coordinates[j]->length;
+                        values[cursor++] = coordinates[j]->fraction;
+                    }
+                }
+                for (size_t j = 0; j < stop_count; ++j) {
+                    append_color(values, &cursor, &stops[j].color);
+                    values[cursor++] = stops[j].position.length;
+                    values[cursor++] = stops[j].position.fraction;
                 }
                 numbers = floats(env, values, value_count);
-                names = gradient_stop_names(env, p, op->payload_count);
+                names = gradient_stop_names(env, stops, stop_count);
                 free(values);
                 break;
             }

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -264,15 +264,22 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
             case WHISKER_OP_BACKGROUND_LAYERS: {
                 const WhiskerMobileGradientStop* stops = op->payload;
                 const WhiskerMobileRadialGradient* radial = NULL;
+                const WhiskerMobileConicGradient* conic = NULL;
                 size_t stop_count = op->payload_count;
                 size_t prefix_count = 0;
-                if (op->flags == 1) {
+                if (op->flags == WHISKER_BACKGROUND_RADIAL) {
                     if (op->payload == NULL || op->payload_count != 1) { ok = false; break; }
                     radial = op->payload;
                     stops = radial->stops;
                     stop_count = radial->stop_count;
                     prefix_count = 8;
-                } else if (op->flags != 0) {
+                } else if (op->flags == WHISKER_BACKGROUND_CONIC) {
+                    if (op->payload == NULL || op->payload_count != 1) { ok = false; break; }
+                    conic = op->payload;
+                    stops = conic->stops;
+                    stop_count = conic->stop_count;
+                    prefix_count = 4;
+                } else if (op->flags != WHISKER_BACKGROUND_LINEAR) {
                     ok = false; break;
                 }
                 if ((stops == NULL && stop_count != 0) || stop_count > (INT32_MAX - prefix_count) / 7) {
@@ -287,6 +294,14 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                         &radial->center_x, &radial->center_y, &radial->radius_x, &radial->radius_y
                     };
                     for (size_t j = 0; j < 4; ++j) {
+                        values[cursor++] = coordinates[j]->length;
+                        values[cursor++] = coordinates[j]->fraction;
+                    }
+                } else if (conic != NULL) {
+                    const WhiskerMobileLengthPercentage* coordinates[] = {
+                        &conic->center_x, &conic->center_y
+                    };
+                    for (size_t j = 0; j < 2; ++j) {
                         values[cursor++] = coordinates[j]->length;
                         values[cursor++] = coordinates[j]->fraction;
                     }

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -201,6 +201,19 @@ static jobjectArray color_names(JNIEnv* env, const WhiskerMobileBoxPaint* paint)
     (*env)->DeleteLocalRef(env, cls); return result;
 }
 
+static jobjectArray gradient_stop_names(JNIEnv* env, const WhiskerMobileGradientStop* stops,
+                                        size_t count) {
+    jclass cls = (*env)->FindClass(env, "java/lang/String");
+    jobjectArray result = (*env)->NewObjectArray(env, (jsize)count, cls, NULL);
+    for (size_t i = 0; i < count; ++i) {
+        jstring name = new_string(env, stops[i].color.name.ptr, stops[i].color.name.len);
+        (*env)->SetObjectArrayElement(env, result, (jsize)i, name);
+        if (name) (*env)->DeleteLocalRef(env, name);
+    }
+    (*env)->DeleteLocalRef(env, cls);
+    return result;
+}
+
 static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMobileApplyResponse* response) {
     if (frame == NULL || response == NULL || frame->abi_major != WHISKER_MOBILE_ABI_MAJOR) return false;
     bool attached; JNIEnv* env = whisker_env(&attached); jobject view = env != NULL ? local_view(env, data) : NULL;
@@ -247,6 +260,25 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 for (int j=0;j<4;++j) { storage[count++]=p->radii_vertical[j].length; storage[count++]=p->radii_vertical[j].fraction; }
                 for (int j=0;j<4;++j) storage[count++]=(float)p->styles[j];
                 numbers = floats(env, storage, count); names = color_names(env, p); break;
+            }
+            case WHISKER_OP_BACKGROUND_LAYERS: {
+                const WhiskerMobileGradientStop* p = op->payload;
+                if ((p == NULL && op->payload_count != 0) || op->payload_count > INT32_MAX / 7) {
+                    ok = false; break;
+                }
+                size_t value_count = op->payload_count * 7;
+                float* values = malloc((value_count > 0 ? value_count : 1) * sizeof(float));
+                if (values == NULL) { ok = false; break; }
+                size_t cursor = 0;
+                for (size_t j = 0; j < op->payload_count; ++j) {
+                    append_color(values, &cursor, &p[j].color);
+                    values[cursor++] = p[j].position.length;
+                    values[cursor++] = p[j].position.fraction;
+                }
+                numbers = floats(env, values, value_count);
+                names = gradient_stop_names(env, p, op->payload_count);
+                free(values);
+                break;
             }
             case WHISKER_OP_TRANSFORM: numbers = floats(env, op->payload, op->payload_count); break;
             case WHISKER_OP_TEXT: {

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 0;
+pub const MOBILE_ABI_MINOR: u16 = 1;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -44,6 +44,7 @@ pub const OP_HIT_TEST: u32 = 17;
 pub const OP_CAPTURE: u32 = 18;
 pub const OP_RELEASE_CAPTURE: u32 = 19;
 pub const OP_COMMAND: u32 = 20;
+pub const OP_BACKGROUND_LAYERS: u32 = 21;
 
 pub const MEASURE_TEXT: u32 = 1;
 pub const MEASURE_REPLACED_CONTENT: u32 = 2;
@@ -100,6 +101,14 @@ pub struct MobileBoxPaint {
     pub styles: [u32; 4],
     pub radii_horizontal: [MobileLengthPercentage; 4],
     pub radii_vertical: [MobileLengthPercentage; 4],
+}
+
+/// One explicit color stop in the additive linear-gradient ABI subset.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileGradientStop {
+    pub color: MobileColor,
+    pub position: MobileLengthPercentage,
 }
 
 #[repr(C)]
@@ -428,6 +437,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileMeasureResponse>(), 64);
             assert_eq!(std::mem::size_of::<MobileText>(), 80);
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
+            assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
             assert_eq!(std::mem::align_of::<MobileFrame>(), 8);
             assert_eq!(std::mem::align_of::<MobileMeasureRequest>(), 8);
         }

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 1;
+pub const MOBILE_ABI_MINOR: u16 = 2;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -45,6 +45,9 @@ pub const OP_CAPTURE: u32 = 18;
 pub const OP_RELEASE_CAPTURE: u32 = 19;
 pub const OP_COMMAND: u32 = 20;
 pub const OP_BACKGROUND_LAYERS: u32 = 21;
+
+pub const BACKGROUND_LINEAR: u32 = 0;
+pub const BACKGROUND_RADIAL: u32 = 1;
 
 pub const MEASURE_TEXT: u32 = 1;
 pub const MEASURE_REPLACED_CONTENT: u32 = 2;
@@ -103,12 +106,24 @@ pub struct MobileBoxPaint {
     pub radii_vertical: [MobileLengthPercentage; 4],
 }
 
-/// One explicit color stop in the additive linear-gradient ABI subset.
+/// One explicit color stop shared by the additive gradient ABI subsets.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MobileGradientStop {
     pub color: MobileColor,
     pub position: MobileLengthPercentage,
+}
+
+/// One explicit, non-repeating elliptical radial gradient.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileRadialGradient {
+    pub center_x: MobileLengthPercentage,
+    pub center_y: MobileLengthPercentage,
+    pub radius_x: MobileLengthPercentage,
+    pub radius_y: MobileLengthPercentage,
+    pub stops: *const MobileGradientStop,
+    pub stop_count: usize,
 }
 
 #[repr(C)]
@@ -438,6 +453,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileText>(), 80);
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
+            assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 48);
             assert_eq!(std::mem::align_of::<MobileFrame>(), 8);
             assert_eq!(std::mem::align_of::<MobileMeasureRequest>(), 8);
         }

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 2;
+pub const MOBILE_ABI_MINOR: u16 = 3;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -48,6 +48,7 @@ pub const OP_BACKGROUND_LAYERS: u32 = 21;
 
 pub const BACKGROUND_LINEAR: u32 = 0;
 pub const BACKGROUND_RADIAL: u32 = 1;
+pub const BACKGROUND_CONIC: u32 = 2;
 
 pub const MEASURE_TEXT: u32 = 1;
 pub const MEASURE_REPLACED_CONTENT: u32 = 2;
@@ -122,6 +123,16 @@ pub struct MobileRadialGradient {
     pub center_y: MobileLengthPercentage,
     pub radius_x: MobileLengthPercentage,
     pub radius_y: MobileLengthPercentage,
+    pub stops: *const MobileGradientStop,
+    pub stop_count: usize,
+}
+
+/// One non-repeating conic gradient with explicit fractional stops.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileConicGradient {
+    pub center_x: MobileLengthPercentage,
+    pub center_y: MobileLengthPercentage,
     pub stops: *const MobileGradientStop,
     pub stop_count: usize,
 }
@@ -454,6 +465,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
             assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 48);
+            assert_eq!(std::mem::size_of::<MobileConicGradient>(), 32);
             assert_eq!(std::mem::align_of::<MobileFrame>(), 8);
             assert_eq!(std::mem::align_of::<MobileMeasureRequest>(), 8);
         }

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 3;
+pub const MOBILE_ABI_MINOR: u16 = 4;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -49,6 +49,19 @@ pub const OP_BACKGROUND_LAYERS: u32 = 21;
 pub const BACKGROUND_LINEAR: u32 = 0;
 pub const BACKGROUND_RADIAL: u32 = 1;
 pub const BACKGROUND_CONIC: u32 = 2;
+
+pub const BACKGROUND_SIZE_AUTO: u32 = 0;
+pub const BACKGROUND_SIZE_EXPLICIT: u32 = 1;
+
+pub const BACKGROUND_REPEAT_REPEAT: u32 = 0;
+pub const BACKGROUND_REPEAT_NO_REPEAT: u32 = 1;
+
+pub const BACKGROUND_BOX_BORDER: u32 = 0;
+pub const BACKGROUND_BOX_PADDING: u32 = 1;
+pub const BACKGROUND_BOX_CONTENT: u32 = 2;
+
+pub const BACKGROUND_ATTACHMENT_SCROLL: u32 = 0;
+pub const BACKGROUND_BLEND_NORMAL: u32 = 0;
 
 pub const MEASURE_TEXT: u32 = 1;
 pub const MEASURE_REPLACED_CONTENT: u32 = 2;
@@ -135,6 +148,34 @@ pub struct MobileConicGradient {
     pub center_y: MobileLengthPercentage,
     pub stops: *const MobileGradientStop,
     pub stop_count: usize,
+}
+
+/// One typed gradient image nested in [`MobileBackgroundLayer`].
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileBackgroundImage {
+    pub kind: u32,
+    pub scalar: f32,
+    pub payload: *const c_void,
+    pub payload_count: usize,
+}
+
+/// One retained background layer with explicit geometry and a typed image.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileBackgroundLayer {
+    pub image: MobileBackgroundImage,
+    pub position_x: MobileLengthPercentage,
+    pub position_y: MobileLengthPercentage,
+    pub size_width: MobileLengthPercentage,
+    pub size_height: MobileLengthPercentage,
+    pub size_kind: u32,
+    pub repeat_x: u32,
+    pub repeat_y: u32,
+    pub origin: u32,
+    pub clip: u32,
+    pub attachment: u32,
+    pub blend_mode: u32,
 }
 
 #[repr(C)]
@@ -466,6 +507,8 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
             assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 48);
             assert_eq!(std::mem::size_of::<MobileConicGradient>(), 32);
+            assert_eq!(std::mem::size_of::<MobileBackgroundImage>(), 24);
+            assert_eq!(std::mem::size_of::<MobileBackgroundLayer>(), 88);
             assert_eq!(std::mem::align_of::<MobileFrame>(), 8);
             assert_eq!(std::mem::align_of::<MobileMeasureRequest>(), 8);
         }

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -14,7 +14,7 @@ pub use ffi::{
     WhiskerValueRaw, WhiskerValueType, WhiskerValueUnion,
 };
 
-pub const MOBILE_ABI_MAJOR: u16 = 1;
+pub const MOBILE_ABI_MAJOR: u16 = 2;
 pub const MOBILE_ABI_MINOR: u16 = 0;
 
 pub const APPLY_ACCEPTED: u8 = 0;
@@ -98,7 +98,8 @@ pub struct MobileBoxPaint {
     pub widths: [MobileLengthPercentage; 4],
     pub colors: [MobileColor; 4],
     pub styles: [u32; 4],
-    pub radii: [MobileLengthPercentage; 4],
+    pub radii_horizontal: [MobileLengthPercentage; 4],
+    pub radii_vertical: [MobileLengthPercentage; 4],
 }
 
 #[repr(C)]
@@ -426,7 +427,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileMeasureRequest>(), 160);
             assert_eq!(std::mem::size_of::<MobileMeasureResponse>(), 64);
             assert_eq!(std::mem::size_of::<MobileText>(), 80);
-            assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 240);
+            assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::align_of::<MobileFrame>(), 8);
             assert_eq!(std::mem::align_of::<MobileMeasureRequest>(), 8);
         }

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -333,6 +333,25 @@ pub struct SceneNodeFixture {
     /// Optional column-major 4-by-4 transform matrix.
     #[serde(default)]
     pub transform: Option<[f32; 16]>,
+    /// Optional resolved group opacity in `[0, 1]`.
+    #[serde(default)]
+    pub opacity: Option<f32>,
+    /// Optional resolved paint visibility.
+    #[serde(default)]
+    pub visibility: Option<VisibilityFixture>,
+    /// Optional resolved sibling stacking order.
+    #[serde(default)]
+    pub z_order: Option<i32>,
+}
+
+/// Paint visibility delivered by `SetVisibility`.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VisibilityFixture {
+    /// Paint the node and its descendants.
+    Visible,
+    /// Suppress the node subtree while preserving layout.
+    Hidden,
 }
 
 /// Independent horizontal and vertical descendant clipping.
@@ -772,6 +791,9 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                 && node
                     .transform
                     .is_none_or(|transform| transform.into_iter().all(f32::is_finite))
+                && node
+                    .opacity
+                    .is_none_or(|opacity| opacity.is_finite() && (0.0..=1.0).contains(&opacity))
         })
         && nodes.iter().all(|node| {
             let mut seen = std::collections::BTreeSet::new();

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -347,6 +347,9 @@ pub struct SceneNodeFixture {
     /// values so every Host receives the same protocol operation.
     #[serde(default)]
     pub linear_gradient: Option<LinearGradientFixture>,
+    /// Optional explicit, non-repeating radial-gradient background image.
+    #[serde(default)]
+    pub radial_gradient: Option<RadialGradientFixture>,
 }
 
 /// One resolved linear-gradient image used by a retained scene node.
@@ -370,6 +373,18 @@ pub struct GradientStopFixture {
     pub color: ColorFixture,
     /// Position as a fraction of the gradient line.
     pub position: f32,
+}
+
+/// One resolved explicit elliptical radial-gradient image.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct RadialGradientFixture {
+    /// Center x/y in logical pixels relative to the positioning box.
+    pub center: [f32; 2],
+    /// Horizontal and vertical radii in logical pixels.
+    pub radii: [f32; 2],
+    /// Ordered, explicitly resolved color stops.
+    pub stops: Vec<GradientStopFixture>,
 }
 
 /// Paint visibility delivered by `SetVisibility`.
@@ -830,6 +845,19 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                             .iter()
                             .all(|stop| valid_color(&stop.color) && stop.position.is_finite())
                 })
+                && node.radial_gradient.as_ref().is_none_or(|gradient| {
+                    gradient.center.iter().all(|value| value.is_finite())
+                        && gradient
+                            .radii
+                            .iter()
+                            .all(|value| value.is_finite() && *value > 0.0)
+                        && gradient.stops.len() >= 2
+                        && gradient
+                            .stops
+                            .iter()
+                            .all(|stop| valid_color(&stop.color) && stop.position.is_finite())
+                })
+                && !(node.linear_gradient.is_some() && node.radial_gradient.is_some())
         })
         && nodes.iter().all(|node| {
             let mut seen = std::collections::BTreeSet::new();

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -330,6 +330,9 @@ pub struct SceneNodeFixture {
     /// Descendant overflow clipping semantics.
     #[serde(default)]
     pub clip: BoxClipFixture,
+    /// Optional column-major 4-by-4 transform matrix.
+    #[serde(default)]
+    pub transform: Option<[f32; 16]>,
 }
 
 /// Independent horizontal and vertical descendant clipping.
@@ -766,6 +769,9 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                 && node.rect[3] >= 0.0
                 && valid_color(&node.background)
                 && node.border.as_ref().is_none_or(valid_border)
+                && node
+                    .transform
+                    .is_none_or(|transform| transform.into_iter().all(f32::is_finite))
         })
         && nodes.iter().all(|node| {
             let mut seen = std::collections::BTreeSet::new();

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -350,6 +350,9 @@ pub struct SceneNodeFixture {
     /// Optional explicit, non-repeating radial-gradient background image.
     #[serde(default)]
     pub radial_gradient: Option<RadialGradientFixture>,
+    /// Optional explicit, non-repeating conic-gradient background image.
+    #[serde(default)]
+    pub conic_gradient: Option<ConicGradientFixture>,
 }
 
 /// One resolved linear-gradient image used by a retained scene node.
@@ -384,6 +387,18 @@ pub struct RadialGradientFixture {
     /// Horizontal and vertical radii in logical pixels.
     pub radii: [f32; 2],
     /// Ordered, explicitly resolved color stops.
+    pub stops: Vec<GradientStopFixture>,
+}
+
+/// One resolved non-repeating conic-gradient image.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ConicGradientFixture {
+    /// Starting angle in clockwise degrees from the positive vertical axis.
+    pub from_degrees: f32,
+    /// Center x/y in logical pixels relative to the positioning box.
+    pub center: [f32; 2],
+    /// Ordered, explicitly resolved color stops expressed as turns.
     pub stops: Vec<GradientStopFixture>,
 }
 
@@ -857,7 +872,24 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                             .iter()
                             .all(|stop| valid_color(&stop.color) && stop.position.is_finite())
                 })
-                && !(node.linear_gradient.is_some() && node.radial_gradient.is_some())
+                && node.conic_gradient.as_ref().is_none_or(|gradient| {
+                    gradient.from_degrees.is_finite()
+                        && gradient.center.iter().all(|value| value.is_finite())
+                        && gradient.stops.len() >= 2
+                        && gradient
+                            .stops
+                            .iter()
+                            .all(|stop| valid_color(&stop.color) && stop.position.is_finite())
+                })
+                && [
+                    node.linear_gradient.is_some(),
+                    node.radial_gradient.is_some(),
+                    node.conic_gradient.is_some(),
+                ]
+                .into_iter()
+                .filter(|present| *present)
+                .count()
+                    <= 1
         })
         && nodes.iter().all(|node| {
             let mut seen = std::collections::BTreeSet::new();

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -301,8 +301,40 @@ pub struct BorderFixture {
     pub colors: [ColorFixture; 4],
     /// Line styles.
     pub styles: [BorderStyleFixture; 4],
-    /// Circular radii in top-left, top-right, bottom-right, bottom-left order.
-    pub radii: [f32; 4],
+    /// Corner radii in top-left, top-right, bottom-right, bottom-left order.
+    pub radii: [CornerRadiusFixture; 4],
+}
+
+/// One circular or elliptical CSS border radius.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum CornerRadiusFixture {
+    /// A single value applies to both axes.
+    Circular(f32),
+    /// Independent horizontal and vertical values.
+    Elliptical([f32; 2]),
+}
+
+impl CornerRadiusFixture {
+    /// Horizontal radius in logical pixels.
+    pub fn horizontal(self) -> f32 {
+        match self {
+            Self::Circular(value) | Self::Elliptical([value, _]) => value,
+        }
+    }
+
+    /// Vertical radius in logical pixels.
+    pub fn vertical(self) -> f32 {
+        match self {
+            Self::Circular(value) | Self::Elliptical([_, value]) => value,
+        }
+    }
+
+    fn is_valid(self) -> bool {
+        [self.horizontal(), self.vertical()]
+            .into_iter()
+            .all(|value| value.is_finite() && value >= 0.0)
+    }
 }
 
 /// Complete CSS border line-style vocabulary.
@@ -659,8 +691,8 @@ fn valid_border(border: &BorderFixture) -> bool {
     border
         .widths
         .iter()
-        .chain(border.radii.iter())
         .all(|value| value.is_finite() && *value >= 0.0)
+        && border.radii.iter().all(|radius| radius.is_valid())
         && border.colors.iter().all(valid_color)
 }
 

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -146,6 +146,13 @@ pub enum Command {
         #[serde(default)]
         border: Option<BorderFixture>,
     },
+    /// Presents a retained tree of semantic boxes through the production Host path.
+    PresentScene {
+        /// Frame target revision.
+        revision: u64,
+        /// Nodes ordered independently of their parent relationships.
+        nodes: Vec<SceneNodeFixture>,
+    },
     /// Captures one named presentation checkpoint.
     Checkpoint {
         /// Checkpoint contract name.
@@ -303,6 +310,49 @@ pub struct BorderFixture {
     pub styles: [BorderStyleFixture; 4],
     /// Corner radii in top-left, top-right, bottom-right, bottom-left order.
     pub radii: [CornerRadiusFixture; 4],
+}
+
+/// One node in a retained Host scene fixture.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SceneNodeFixture {
+    /// Stable non-zero node identifier.
+    pub id: u64,
+    /// Optional parent node identifier.
+    pub parent: Option<u64>,
+    /// Parent-relative x, y, width, and height in logical pixels.
+    pub rect: [f32; 4],
+    /// Box background color.
+    pub background: ColorFixture,
+    /// Optional border semantics.
+    #[serde(default)]
+    pub border: Option<BorderFixture>,
+    /// Descendant overflow clipping semantics.
+    #[serde(default)]
+    pub clip: BoxClipFixture,
+}
+
+/// Independent horizontal and vertical descendant clipping.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BoxClipFixture {
+    /// Horizontal overflow behavior.
+    #[serde(default)]
+    pub horizontal: OverflowClipFixture,
+    /// Vertical overflow behavior.
+    #[serde(default)]
+    pub vertical: OverflowClipFixture,
+}
+
+/// One Host-protocol overflow axis.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OverflowClipFixture {
+    /// Descendants remain visible outside this axis.
+    #[default]
+    Visible,
+    /// Descendants are clipped to this axis.
+    Hidden,
 }
 
 /// One circular or elliptical CSS border radius.
@@ -616,6 +666,8 @@ fn validate_side(id: &str, label: &str, side: &ScenarioSide) -> Result<(), Fixtu
                 && rect[3] >= 0.0
                 && valid_color(background)
                 && border.as_ref().is_none_or(valid_border) => {}
+            Command::PresentScene { revision, nodes }
+                if *revision > 0 && valid_scene_nodes(nodes) => {}
             Command::Checkpoint {
                 name,
                 samples,
@@ -694,6 +746,41 @@ fn valid_border(border: &BorderFixture) -> bool {
         .all(|value| value.is_finite() && *value >= 0.0)
         && border.radii.iter().all(|radius| radius.is_valid())
         && border.colors.iter().all(valid_color)
+}
+
+fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
+    if nodes.is_empty() {
+        return false;
+    }
+    let ids = nodes
+        .iter()
+        .map(|node| node.id)
+        .collect::<std::collections::BTreeSet<_>>();
+    ids.len() == nodes.len()
+        && !ids.contains(&0)
+        && nodes.iter().all(|node| {
+            node.parent
+                .is_none_or(|parent| parent != node.id && ids.contains(&parent))
+                && node.rect.iter().all(|value| value.is_finite())
+                && node.rect[2] >= 0.0
+                && node.rect[3] >= 0.0
+                && valid_color(&node.background)
+                && node.border.as_ref().is_none_or(valid_border)
+        })
+        && nodes.iter().all(|node| {
+            let mut seen = std::collections::BTreeSet::new();
+            let mut current = Some(node.id);
+            while let Some(id) = current {
+                if !seen.insert(id) {
+                    return false;
+                }
+                current = nodes
+                    .iter()
+                    .find(|candidate| candidate.id == id)
+                    .and_then(|candidate| candidate.parent);
+            }
+            true
+        })
 }
 
 #[cfg(test)]

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -342,6 +342,34 @@ pub struct SceneNodeFixture {
     /// Optional resolved sibling stacking order.
     #[serde(default)]
     pub z_order: Option<i32>,
+    /// Optional resolved linear-gradient background image. The fixture DSL
+    /// supplies the remaining `BackgroundLayer` fields as their CSS initial
+    /// values so every Host receives the same protocol operation.
+    #[serde(default)]
+    pub linear_gradient: Option<LinearGradientFixture>,
+}
+
+/// One resolved linear-gradient image used by a retained scene node.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LinearGradientFixture {
+    /// Direction in clockwise degrees from the positive vertical axis.
+    pub angle_degrees: f32,
+    /// Whether the gradient repeats beyond its final stop.
+    #[serde(default)]
+    pub repeating: bool,
+    /// Ordered, explicitly resolved color stops.
+    pub stops: Vec<GradientStopFixture>,
+}
+
+/// One resolved stop on a fixture gradient line.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct GradientStopFixture {
+    /// Stop color.
+    pub color: ColorFixture,
+    /// Position as a fraction of the gradient line.
+    pub position: f32,
 }
 
 /// Paint visibility delivered by `SetVisibility`.
@@ -794,6 +822,14 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                 && node
                     .opacity
                     .is_none_or(|opacity| opacity.is_finite() && (0.0..=1.0).contains(&opacity))
+                && node.linear_gradient.as_ref().is_none_or(|gradient| {
+                    gradient.angle_degrees.is_finite()
+                        && gradient.stops.len() >= 2
+                        && gradient
+                            .stops
+                            .iter()
+                            .all(|stop| valid_color(&stop.color) && stop.position.is_finite())
+                })
         })
         && nodes.iter().all(|node| {
             let mut seen = std::collections::BTreeSet::new();

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -342,6 +342,9 @@ pub struct SceneNodeFixture {
     /// Optional resolved sibling stacking order.
     #[serde(default)]
     pub z_order: Option<i32>,
+    /// Resolved geometry shared by the optional background image below.
+    #[serde(default)]
+    pub background_layer: BackgroundLayerFixture,
     /// Optional resolved linear-gradient background image. The fixture DSL
     /// supplies the remaining `BackgroundLayer` fields as their CSS initial
     /// values so every Host receives the same protocol operation.
@@ -400,6 +403,88 @@ pub struct ConicGradientFixture {
     pub center: [f32; 2],
     /// Ordered, explicitly resolved color stops expressed as turns.
     pub stops: Vec<GradientStopFixture>,
+}
+
+/// Resolved geometry for the one background image supported by the fixture DSL.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BackgroundLayerFixture {
+    /// X/y position as a length plus a fraction of the positioning area.
+    #[serde(default)]
+    pub position: [LengthPercentageFixture; 2],
+    /// Explicit width/height, or `None` for the CSS `auto` initial value.
+    #[serde(default)]
+    pub size: Option<[LengthPercentageFixture; 2]>,
+    /// Horizontal image repetition.
+    #[serde(default)]
+    pub repeat_x: ImageRepeatFixture,
+    /// Vertical image repetition.
+    #[serde(default)]
+    pub repeat_y: ImageRepeatFixture,
+    /// Background positioning box.
+    #[serde(default = "default_background_origin")]
+    pub origin: BackgroundBoxFixture,
+    /// Background painting clip box.
+    #[serde(default = "default_background_clip")]
+    pub clip: BackgroundBoxFixture,
+}
+
+impl Default for BackgroundLayerFixture {
+    fn default() -> Self {
+        Self {
+            position: Default::default(),
+            size: None,
+            repeat_x: ImageRepeatFixture::Repeat,
+            repeat_y: ImageRepeatFixture::Repeat,
+            origin: default_background_origin(),
+            clip: default_background_clip(),
+        }
+    }
+}
+
+/// One resolved CSS length-percentage pair.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LengthPercentageFixture {
+    /// Absolute logical-pixel component.
+    pub length: f32,
+    /// Fractional component where `1` is 100 percent.
+    pub fraction: f32,
+}
+
+/// Background tiling rule on one axis.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageRepeatFixture {
+    /// Tile and crop the final tile.
+    #[default]
+    Repeat,
+    /// Paint one image only.
+    NoRepeat,
+    /// Distribute whole tiles with spacing.
+    Space,
+    /// Resize tiles so a whole number fits.
+    Round,
+}
+
+/// CSS boxes currently meaningful for background geometry fixtures.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundBoxFixture {
+    /// Border box.
+    Border,
+    /// Padding box.
+    Padding,
+    /// Content box.
+    Content,
+}
+
+const fn default_background_origin() -> BackgroundBoxFixture {
+    BackgroundBoxFixture::Padding
+}
+
+const fn default_background_clip() -> BackgroundBoxFixture {
+    BackgroundBoxFixture::Border
 }
 
 /// Paint visibility delivered by `SetVisibility`.
@@ -852,6 +937,15 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                 && node
                     .opacity
                     .is_none_or(|opacity| opacity.is_finite() && (0.0..=1.0).contains(&opacity))
+                && node
+                    .background_layer
+                    .position
+                    .iter()
+                    .all(LengthPercentageFixture::is_finite)
+                && node
+                    .background_layer
+                    .size
+                    .is_none_or(|size| size.iter().all(LengthPercentageFixture::is_finite))
                 && node.linear_gradient.as_ref().is_none_or(|gradient| {
                     gradient.angle_degrees.is_finite()
                         && gradient.stops.len() >= 2
@@ -905,6 +999,12 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
             }
             true
         })
+}
+
+impl LengthPercentageFixture {
+    fn is_finite(&self) -> bool {
+        self.length.is_finite() && self.fraction.is_finite()
+    }
 }
 
 #[cfg(test)]

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -154,6 +154,10 @@ pub enum Command {
         /// reference document.
         #[serde(default)]
         samples: Vec<PixelSampleFixture>,
+        /// Optional relative luminance assertions for CSS rendering whose
+        /// exact colors are intentionally Host-defined.
+        #[serde(default)]
+        relations: Vec<PixelRelationFixture>,
     },
     /// Sends a text measurement request to the production Host measurer.
     MeasureText {
@@ -260,6 +264,31 @@ pub struct PixelSampleFixture {
     /// Maximum per-channel difference accepted by native rasterizers.
     #[serde(default)]
     pub tolerance: u8,
+}
+
+/// One relative luminance assertion between two logical pixels.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PixelRelationFixture {
+    /// First logical x/y coordinate.
+    pub first: [f32; 2],
+    /// Second logical x/y coordinate.
+    pub second: [f32; 2],
+    /// Required ordering of the first sample relative to the second.
+    pub relation: PixelRelationKind,
+    /// Minimum luminance distance on an 8-bit scale.
+    #[serde(default)]
+    pub minimum_difference: u8,
+}
+
+/// Relative luminance ordering used by platform-defined CSS shading.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PixelRelationKind {
+    /// The first pixel must be lighter than the second.
+    Lighter,
+    /// The first pixel must be darker than the second.
+    Darker,
 }
 
 /// Physical border semantics in top, right, bottom, left order.
@@ -424,6 +453,7 @@ fn validate_manifest(manifest: &Manifest) -> Result<(), FixtureError> {
                     | "semantic-projection"
                     | "pixel"
                     | "pixel-samples"
+                    | "pixel-relations"
                     | "measurement"
                     | "input"
             ) {
@@ -485,6 +515,22 @@ fn validate_scenario(
             scenario.id
         )));
     }
+    if entry
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint == "pixel-relations")
+        && !scenario.test.commands.iter().any(|command| {
+            matches!(
+                command,
+                Command::Checkpoint { relations, .. } if !relations.is_empty()
+            )
+        })
+    {
+        return Err(FixtureError(format!(
+            "scenario {} declares pixel-relations without relation assertions",
+            scenario.id
+        )));
+    }
     if let Some(reference) = &scenario.reference {
         validate_side(&scenario.id, "reference", reference)?;
     }
@@ -538,15 +584,25 @@ fn validate_side(id: &str, label: &str, side: &ScenarioSide) -> Result<(), Fixtu
                 && rect[3] >= 0.0
                 && valid_color(background)
                 && border.as_ref().is_none_or(valid_border) => {}
-            Command::Checkpoint { name, samples }
-                if !name.trim().is_empty()
-                    && samples.iter().all(|sample| {
-                        sample
-                            .point
-                            .iter()
-                            .all(|value| value.is_finite() && *value >= 0.0)
-                            && valid_color(&sample.color)
-                    }) => {}
+            Command::Checkpoint {
+                name,
+                samples,
+                relations,
+            } if !name.trim().is_empty()
+                && samples.iter().all(|sample| {
+                    sample
+                        .point
+                        .iter()
+                        .all(|value| value.is_finite() && *value >= 0.0)
+                        && valid_color(&sample.color)
+                })
+                && relations.iter().all(|relation| {
+                    relation
+                        .first
+                        .iter()
+                        .chain(relation.second.iter())
+                        .all(|value| value.is_finite() && *value >= 0.0)
+                }) => {}
             Command::MeasureText {
                 key,
                 font_size,

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -261,7 +261,7 @@ fn background_capabilities(layers: &[crate::BackgroundLayer]) -> [Option<RenderC
         if has_initial_background_geometry(layer) {
             return [Some(image), None];
         }
-        if has_explicit_no_repeat_geometry(layer) {
+        if has_explicit_background_geometry(layer) {
             return [Some(image), Some(RenderCapability::BackgroundGeometry)];
         }
         return [Some(RenderCapability::BackgroundLayers), None];
@@ -318,7 +318,7 @@ fn has_initial_background_geometry(layer: &crate::BackgroundLayer) -> bool {
         && has_initial_background_environment(layer)
 }
 
-fn has_explicit_no_repeat_geometry(layer: &crate::BackgroundLayer) -> bool {
+fn has_explicit_background_geometry(layer: &crate::BackgroundLayer) -> bool {
     [
         layer.position.x.length,
         layer.position.x.fraction,
@@ -334,8 +334,14 @@ fn has_explicit_no_repeat_geometry(layer: &crate::BackgroundLayer) -> bool {
                 height: Some(height)
             } if width.is_valid() && height.is_valid()
         )
-        && layer.repeat_x == crate::ImageRepeat::NoRepeat
-        && layer.repeat_y == crate::ImageRepeat::NoRepeat
+        && matches!(
+            layer.repeat_x,
+            crate::ImageRepeat::Repeat | crate::ImageRepeat::NoRepeat
+        )
+        && matches!(
+            layer.repeat_y,
+            crate::ImageRepeat::Repeat | crate::ImageRepeat::NoRepeat
+        )
         && matches!(
             layer.origin,
             crate::PaintBox::Border | crate::PaintBox::Padding
@@ -628,6 +634,32 @@ mod tests {
                 RenderCapability::BackgroundGeometry,
             ]
         );
+
+        for (repeat_x, repeat_y) in [
+            (ImageRepeat::Repeat, ImageRepeat::NoRepeat),
+            (ImageRepeat::NoRepeat, ImageRepeat::Repeat),
+            (ImageRepeat::Repeat, ImageRepeat::Repeat),
+        ] {
+            let mut layer = explicit_no_repeat(basic_linear_layer());
+            layer.repeat_x = repeat_x;
+            layer.repeat_y = repeat_y;
+            assert_eq!(
+                packet(vec![operation(layer)]).required_capabilities(),
+                vec![
+                    RenderCapability::LinearGradients,
+                    RenderCapability::BackgroundGeometry,
+                ]
+            );
+        }
+
+        for unsupported_repeat in [ImageRepeat::Space, ImageRepeat::Round] {
+            let mut layer = explicit_no_repeat(basic_linear_layer());
+            layer.repeat_x = unsupported_repeat;
+            assert_eq!(
+                packet(vec![operation(layer)]).required_capabilities(),
+                vec![RenderCapability::BackgroundLayers]
+            );
+        }
 
         let mut positioned = explicit_no_repeat(basic_linear_layer());
         positioned.position = PaintPosition {

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -28,11 +28,14 @@ pub enum RenderCapability {
     /// One resolved, non-repeating explicit radial-gradient background image
     /// using the initial layer geometry and explicit color-stop positions.
     RadialGradients,
+    /// One resolved, non-repeating conic-gradient background image using the
+    /// initial layer geometry and explicit fractional color-stop positions.
+    ConicGradients,
 }
 
 impl RenderCapability {
     /// Every optional capability in stable declaration order.
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::EllipticalBorderRadius,
         Self::BackgroundLayers,
         Self::VisualEffects,
@@ -43,6 +46,7 @@ impl RenderCapability {
         Self::ResourceLifecycle,
         Self::LinearGradients,
         Self::RadialGradients,
+        Self::ConicGradients,
     ];
 
     /// Stable diagnostic spelling shared by Host errors and checklists.
@@ -58,6 +62,7 @@ impl RenderCapability {
             Self::ResourceLifecycle => "resource-lifecycle",
             Self::LinearGradients => "linear-gradients",
             Self::RadialGradients => "radial-gradients",
+            Self::ConicGradients => "conic-gradients",
         }
     }
 
@@ -227,6 +232,9 @@ fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 2
         Operation::SetBackgroundLayers { layers, .. } if is_basic_radial_gradient(layers) => {
             Some(RenderCapability::RadialGradients)
         }
+        Operation::SetBackgroundLayers { layers, .. } if is_basic_conic_gradient(layers) => {
+            Some(RenderCapability::ConicGradients)
+        }
         Operation::SetBackgroundLayers { .. } => Some(RenderCapability::BackgroundLayers),
         Operation::SetVisualEffects { .. } => Some(RenderCapability::VisualEffects),
         Operation::SetText { content, .. } if content.paint.uses_extended_features() => {
@@ -274,6 +282,29 @@ fn is_basic_radial_gradient(layers: &[crate::BackgroundLayer]) -> bool {
             shape: crate::RadialGradientShape::Ellipse,
             extent: crate::RadialGradientExtent::Explicit,
             radii: Some(_),
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| {
+            stop.position.is_some_and(|position| position.length == 0.0)
+        })
+    ) && layer.position == Default::default()
+        && layer.size == crate::BackgroundSize::Auto
+        && layer.repeat_x == crate::ImageRepeat::Repeat
+        && layer.repeat_y == crate::ImageRepeat::Repeat
+        && layer.origin == crate::PaintBox::Padding
+        && layer.clip == crate::PaintBox::Border
+        && layer.attachment == crate::BackgroundAttachment::Scroll
+        && layer.blend_mode == crate::BlendMode::Normal
+}
+
+fn is_basic_conic_gradient(layers: &[crate::BackgroundLayer]) -> bool {
+    let [layer] = layers else {
+        return false;
+    };
+    matches!(
+        &layer.image,
+        crate::PaintImage::ConicGradient {
             repeating: false,
             stops,
             ..
@@ -377,6 +408,21 @@ mod tests {
         })
     }
 
+    fn conic_layer(repeating: bool, first_stop_length: f32) -> BackgroundLayer {
+        let mut stops = basic_gradient_stops();
+        stops[0].position.as_mut().unwrap().length = first_stop_length;
+        background_layer(PaintImage::ConicGradient {
+            from_degrees: 90.0,
+            center: PaintPosition::default(),
+            repeating,
+            stops,
+        })
+    }
+
+    fn basic_conic_layer() -> BackgroundLayer {
+        conic_layer(false, 0.0)
+    }
+
     #[test]
     fn discovers_elliptical_radius_without_classifying_base_box_paint() {
         let node = NodeId::new(1).unwrap();
@@ -456,6 +502,52 @@ mod tests {
     }
 
     #[test]
+    fn conic_gradient_capability_is_limited_to_the_resolved_host_subset() {
+        let node = NodeId::new(1).unwrap();
+        assert_eq!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: vec![basic_conic_layer()],
+            }])
+            .required_capabilities(),
+            vec![RenderCapability::ConicGradients]
+        );
+
+        assert_eq!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: vec![conic_layer(true, 0.0)],
+            }])
+            .required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
+        );
+
+        assert_eq!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: vec![conic_layer(false, 1.0)],
+            }])
+            .required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
+        );
+
+        assert_eq!(
+            packet(vec![
+                Operation::SetBackgroundLayers {
+                    node,
+                    layers: vec![basic_conic_layer()],
+                },
+                Operation::SetBackgroundLayers {
+                    node,
+                    layers: vec![basic_conic_layer()],
+                },
+            ])
+            .required_capabilities(),
+            vec![RenderCapability::ConicGradients]
+        );
+    }
+
+    #[test]
     fn profiles_and_packets_cover_every_optional_capability() {
         assert_eq!(
             RenderCapability::ALL.map(RenderCapability::as_str),
@@ -470,6 +562,7 @@ mod tests {
                 "resource-lifecycle",
                 "linear-gradients",
                 "radial-gradients",
+                "conic-gradients",
             ]
         );
 
@@ -538,6 +631,10 @@ mod tests {
                 node,
                 layers: vec![basic_linear_layer()],
             },
+            Operation::SetBackgroundLayers {
+                node,
+                layers: vec![basic_conic_layer()],
+            },
             Operation::SetVisualEffects {
                 node,
                 effects: VisualEffects::default(),
@@ -583,6 +680,7 @@ mod tests {
             vec![
                 RenderCapability::EllipticalBorderRadius,
                 RenderCapability::LinearGradients,
+                RenderCapability::ConicGradients,
                 RenderCapability::VisualEffects,
                 RenderCapability::TextEffects,
                 RenderCapability::TextTypography,

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -333,32 +333,32 @@ mod tests {
         }
     }
 
+    fn basic_gradient_stops() -> Vec<GradientStop> {
+        vec![
+            GradientStop {
+                color: PaintColor::Named("black".into()),
+                position: Some(PaintCoordinate::default()),
+            },
+            GradientStop {
+                color: PaintColor::Named("white".into()),
+                position: Some(PaintCoordinate {
+                    length: 0.0,
+                    fraction: 1.0,
+                }),
+            },
+        ]
+    }
+
     fn basic_linear_layer() -> BackgroundLayer {
         background_layer(PaintImage::LinearGradient {
             angle_degrees: 90.0,
             repeating: false,
-            stops: vec![
-                GradientStop {
-                    color: PaintColor::Named("black".into()),
-                    position: Some(PaintCoordinate::default()),
-                },
-                GradientStop {
-                    color: PaintColor::Named("white".into()),
-                    position: Some(PaintCoordinate {
-                        length: 0.0,
-                        fraction: 1.0,
-                    }),
-                },
-            ],
+            stops: basic_gradient_stops(),
         })
     }
 
     fn basic_radial_layer() -> BackgroundLayer {
-        let mut layer = basic_linear_layer();
-        let PaintImage::LinearGradient { stops, .. } = layer.image else {
-            unreachable!()
-        };
-        layer.image = PaintImage::RadialGradient {
+        background_layer(PaintImage::RadialGradient {
             shape: crate::RadialGradientShape::Ellipse,
             extent: crate::RadialGradientExtent::Explicit,
             center: PaintPosition::default(),
@@ -373,9 +373,8 @@ mod tests {
                 },
             )),
             repeating: false,
-            stops,
-        };
-        layer
+            stops: basic_gradient_stops(),
+        })
     }
 
     #[test]

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -336,7 +336,16 @@ fn has_explicit_no_repeat_geometry(layer: &crate::BackgroundLayer) -> bool {
         )
         && layer.repeat_x == crate::ImageRepeat::NoRepeat
         && layer.repeat_y == crate::ImageRepeat::NoRepeat
-        && has_initial_background_environment(layer)
+        && matches!(
+            layer.origin,
+            crate::PaintBox::Border | crate::PaintBox::Padding
+        )
+        && matches!(
+            layer.clip,
+            crate::PaintBox::Border | crate::PaintBox::Padding
+        )
+        && layer.attachment == crate::BackgroundAttachment::Scroll
+        && layer.blend_mode == crate::BlendMode::Normal
 }
 
 fn has_initial_background_environment(layer: &crate::BackgroundLayer) -> bool {
@@ -643,6 +652,36 @@ mod tests {
         non_finite_position.position.x.fraction = f32::NAN;
         assert_eq!(
             packet(vec![operation(non_finite_position)]).required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
+        );
+
+        for (origin, clip) in [
+            (PaintBox::Border, PaintBox::Border),
+            (PaintBox::Border, PaintBox::Padding),
+            (PaintBox::Padding, PaintBox::Padding),
+        ] {
+            let mut layer = explicit_no_repeat(basic_linear_layer());
+            layer.origin = origin;
+            layer.clip = clip;
+            assert_eq!(
+                packet(vec![operation(layer)]).required_capabilities(),
+                vec![
+                    RenderCapability::LinearGradients,
+                    RenderCapability::BackgroundGeometry,
+                ]
+            );
+        }
+
+        let mut unsupported_box = explicit_no_repeat(basic_linear_layer());
+        unsupported_box.origin = PaintBox::Content;
+        assert_eq!(
+            packet(vec![operation(unsupported_box)]).required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
+        );
+        let mut unsupported_clip = explicit_no_repeat(basic_linear_layer());
+        unsupported_clip.clip = PaintBox::Content;
+        assert_eq!(
+            packet(vec![operation(unsupported_clip)]).required_capabilities(),
             vec![RenderCapability::BackgroundLayers]
         );
 

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -659,6 +659,13 @@ mod tests {
                 packet(vec![operation(layer)]).required_capabilities(),
                 vec![RenderCapability::BackgroundLayers]
             );
+
+            let mut layer = explicit_no_repeat(basic_linear_layer());
+            layer.repeat_y = unsupported_repeat;
+            assert_eq!(
+                packet(vec![operation(layer)]).required_capabilities(),
+                vec![RenderCapability::BackgroundLayers]
+            );
         }
 
         let mut positioned = explicit_no_repeat(basic_linear_layer());

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -31,11 +31,14 @@ pub enum RenderCapability {
     /// One resolved, non-repeating conic-gradient background image using the
     /// initial layer geometry and explicit fractional color-stop positions.
     ConicGradients,
+    /// Explicit two-axis background image sizing and no-repeat geometry for a
+    /// single otherwise supported background image.
+    BackgroundGeometry,
 }
 
 impl RenderCapability {
     /// Every optional capability in stable declaration order.
-    pub const ALL: [Self; 11] = [
+    pub const ALL: [Self; 12] = [
         Self::EllipticalBorderRadius,
         Self::BackgroundLayers,
         Self::VisualEffects,
@@ -47,6 +50,7 @@ impl RenderCapability {
         Self::LinearGradients,
         Self::RadialGradients,
         Self::ConicGradients,
+        Self::BackgroundGeometry,
     ];
 
     /// Stable diagnostic spelling shared by Host errors and checklists.
@@ -63,6 +67,7 @@ impl RenderCapability {
             Self::LinearGradients => "linear-gradients",
             Self::RadialGradients => "radial-gradients",
             Self::ConicGradients => "conic-gradients",
+            Self::BackgroundGeometry => "background-geometry",
         }
     }
 
@@ -212,6 +217,9 @@ impl FramePacket {
 }
 
 fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 2] {
+    if let Operation::SetBackgroundLayers { layers, .. } = operation {
+        return background_capabilities(layers);
+    }
     let first = match operation {
         Operation::SetBoxPaint { paint, .. }
             if [
@@ -225,17 +233,6 @@ fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 2
         {
             Some(RenderCapability::EllipticalBorderRadius)
         }
-        Operation::SetBackgroundLayers { layers, .. } if layers.is_empty() => None,
-        Operation::SetBackgroundLayers { layers, .. } if is_basic_linear_gradient(layers) => {
-            Some(RenderCapability::LinearGradients)
-        }
-        Operation::SetBackgroundLayers { layers, .. } if is_basic_radial_gradient(layers) => {
-            Some(RenderCapability::RadialGradients)
-        }
-        Operation::SetBackgroundLayers { layers, .. } if is_basic_conic_gradient(layers) => {
-            Some(RenderCapability::ConicGradients)
-        }
-        Operation::SetBackgroundLayers { .. } => Some(RenderCapability::BackgroundLayers),
         Operation::SetVisualEffects { .. } => Some(RenderCapability::VisualEffects),
         Operation::SetText { content, .. } if content.paint.uses_extended_features() => {
             Some(RenderCapability::TextEffects)
@@ -253,30 +250,37 @@ fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 2
     [first, second]
 }
 
-fn is_basic_linear_gradient(layers: &[crate::BackgroundLayer]) -> bool {
-    let [layer] = layers else { return false };
-    matches!(
+fn background_capabilities(layers: &[crate::BackgroundLayer]) -> [Option<RenderCapability>; 2] {
+    let [] = layers else {
+        let [layer] = layers else {
+            return [Some(RenderCapability::BackgroundLayers), None];
+        };
+        let Some(image) = gradient_image_capability(layer) else {
+            return [Some(RenderCapability::BackgroundLayers), None];
+        };
+        if has_initial_background_geometry(layer) {
+            return [Some(image), None];
+        }
+        if has_explicit_no_repeat_geometry(layer) {
+            return [Some(image), Some(RenderCapability::BackgroundGeometry)];
+        }
+        return [Some(RenderCapability::BackgroundLayers), None];
+    };
+    [None, None]
+}
+
+fn gradient_image_capability(layer: &crate::BackgroundLayer) -> Option<RenderCapability> {
+    if matches!(
         &layer.image,
         crate::PaintImage::LinearGradient {
             repeating: false,
             stops,
             ..
         } if stops.iter().all(|stop| stop.position.is_some())
-    ) && layer.position == Default::default()
-        && layer.size == crate::BackgroundSize::Auto
-        && layer.repeat_x == crate::ImageRepeat::Repeat
-        && layer.repeat_y == crate::ImageRepeat::Repeat
-        && layer.origin == crate::PaintBox::Padding
-        && layer.clip == crate::PaintBox::Border
-        && layer.attachment == crate::BackgroundAttachment::Scroll
-        && layer.blend_mode == crate::BlendMode::Normal
-}
-
-fn is_basic_radial_gradient(layers: &[crate::BackgroundLayer]) -> bool {
-    let [layer] = layers else {
-        return false;
-    };
-    matches!(
+    ) {
+        return Some(RenderCapability::LinearGradients);
+    }
+    if matches!(
         &layer.image,
         crate::PaintImage::RadialGradient {
             shape: crate::RadialGradientShape::Ellipse,
@@ -288,21 +292,10 @@ fn is_basic_radial_gradient(layers: &[crate::BackgroundLayer]) -> bool {
         } if stops.iter().all(|stop| {
             stop.position.is_some_and(|position| position.length == 0.0)
         })
-    ) && layer.position == Default::default()
-        && layer.size == crate::BackgroundSize::Auto
-        && layer.repeat_x == crate::ImageRepeat::Repeat
-        && layer.repeat_y == crate::ImageRepeat::Repeat
-        && layer.origin == crate::PaintBox::Padding
-        && layer.clip == crate::PaintBox::Border
-        && layer.attachment == crate::BackgroundAttachment::Scroll
-        && layer.blend_mode == crate::BlendMode::Normal
-}
-
-fn is_basic_conic_gradient(layers: &[crate::BackgroundLayer]) -> bool {
-    let [layer] = layers else {
-        return false;
-    };
-    matches!(
+    ) {
+        return Some(RenderCapability::RadialGradients);
+    }
+    if matches!(
         &layer.image,
         crate::PaintImage::ConicGradient {
             repeating: false,
@@ -311,11 +304,36 @@ fn is_basic_conic_gradient(layers: &[crate::BackgroundLayer]) -> bool {
         } if stops.iter().all(|stop| {
             stop.position.is_some_and(|position| position.length == 0.0)
         })
-    ) && layer.position == Default::default()
+    ) {
+        return Some(RenderCapability::ConicGradients);
+    }
+    None
+}
+
+fn has_initial_background_geometry(layer: &crate::BackgroundLayer) -> bool {
+    layer.position == Default::default()
         && layer.size == crate::BackgroundSize::Auto
         && layer.repeat_x == crate::ImageRepeat::Repeat
         && layer.repeat_y == crate::ImageRepeat::Repeat
-        && layer.origin == crate::PaintBox::Padding
+        && has_initial_background_environment(layer)
+}
+
+fn has_explicit_no_repeat_geometry(layer: &crate::BackgroundLayer) -> bool {
+    layer.position == Default::default()
+        && matches!(
+            layer.size,
+            crate::BackgroundSize::Explicit {
+                width: Some(width),
+                height: Some(height)
+            } if width.is_valid() && height.is_valid()
+        )
+        && layer.repeat_x == crate::ImageRepeat::NoRepeat
+        && layer.repeat_y == crate::ImageRepeat::NoRepeat
+        && has_initial_background_environment(layer)
+}
+
+fn has_initial_background_environment(layer: &crate::BackgroundLayer) -> bool {
+    layer.origin == crate::PaintBox::Padding
         && layer.clip == crate::PaintBox::Border
         && layer.attachment == crate::BackgroundAttachment::Scroll
         && layer.blend_mode == crate::BlendMode::Normal
@@ -421,6 +439,22 @@ mod tests {
 
     fn basic_conic_layer() -> BackgroundLayer {
         conic_layer(false, 0.0)
+    }
+
+    fn explicit_no_repeat(mut layer: BackgroundLayer) -> BackgroundLayer {
+        layer.size = BackgroundSize::Explicit {
+            width: Some(PaintLengthPercentage {
+                length: 45.0,
+                fraction: 0.0,
+            }),
+            height: Some(PaintLengthPercentage {
+                length: 45.0,
+                fraction: 0.0,
+            }),
+        };
+        layer.repeat_x = ImageRepeat::NoRepeat;
+        layer.repeat_y = ImageRepeat::NoRepeat;
+        layer
     }
 
     #[test]
@@ -548,6 +582,76 @@ mod tests {
     }
 
     #[test]
+    fn background_geometry_is_additive_to_the_supported_image_capability() {
+        let node = NodeId::new(1).unwrap();
+        let operation = |layer| Operation::SetBackgroundLayers {
+            node,
+            layers: vec![layer],
+        };
+        assert_eq!(
+            packet(vec![operation(explicit_no_repeat(basic_linear_layer()))])
+                .required_capabilities(),
+            vec![
+                RenderCapability::LinearGradients,
+                RenderCapability::BackgroundGeometry,
+            ]
+        );
+        assert_eq!(
+            packet(vec![operation(explicit_no_repeat(basic_radial_layer()))])
+                .required_capabilities(),
+            vec![
+                RenderCapability::RadialGradients,
+                RenderCapability::BackgroundGeometry,
+            ]
+        );
+        assert_eq!(
+            packet(vec![operation(explicit_no_repeat(basic_conic_layer()))])
+                .required_capabilities(),
+            vec![
+                RenderCapability::ConicGradients,
+                RenderCapability::BackgroundGeometry,
+            ]
+        );
+
+        let mut incomplete_size = explicit_no_repeat(basic_linear_layer());
+        incomplete_size.size = BackgroundSize::Explicit {
+            width: Some(PaintLengthPercentage::default()),
+            height: None,
+        };
+        assert_eq!(
+            packet(vec![operation(incomplete_size)]).required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
+        );
+
+        let mut negative_size = explicit_no_repeat(basic_linear_layer());
+        negative_size.size = BackgroundSize::Explicit {
+            width: Some(PaintLengthPercentage {
+                length: -1.0,
+                fraction: 0.0,
+            }),
+            height: Some(PaintLengthPercentage::default()),
+        };
+        assert_eq!(
+            packet(vec![operation(negative_size)]).required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
+        );
+
+        let image_only = RenderCapabilities::new(
+            ProtocolVersion::CURRENT,
+            vec![CapabilityEntry {
+                capability: RenderCapability::LinearGradients,
+                support: CapabilitySupport::Native,
+            }],
+        )
+        .unwrap();
+        let packet = packet(vec![operation(explicit_no_repeat(basic_linear_layer()))]);
+        assert_eq!(
+            image_only.first_unsupported(&packet),
+            Some(RenderCapability::BackgroundGeometry)
+        );
+    }
+
+    #[test]
     fn profiles_and_packets_cover_every_optional_capability() {
         assert_eq!(
             RenderCapability::ALL.map(RenderCapability::as_str),
@@ -563,6 +667,7 @@ mod tests {
                 "linear-gradients",
                 "radial-gradients",
                 "conic-gradients",
+                "background-geometry",
             ]
         );
 
@@ -635,6 +740,10 @@ mod tests {
                 node,
                 layers: vec![basic_conic_layer()],
             },
+            Operation::SetBackgroundLayers {
+                node,
+                layers: vec![explicit_no_repeat(basic_linear_layer())],
+            },
             Operation::SetVisualEffects {
                 node,
                 effects: VisualEffects::default(),
@@ -681,6 +790,7 @@ mod tests {
                 RenderCapability::EllipticalBorderRadius,
                 RenderCapability::LinearGradients,
                 RenderCapability::ConicGradients,
+                RenderCapability::BackgroundGeometry,
                 RenderCapability::VisualEffects,
                 RenderCapability::TextEffects,
                 RenderCapability::TextTypography,

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -25,11 +25,14 @@ pub enum RenderCapability {
     /// One resolved, non-repeating linear-gradient background image using the
     /// initial layer geometry and explicit color-stop positions.
     LinearGradients,
+    /// One resolved, non-repeating explicit radial-gradient background image
+    /// using the initial layer geometry and explicit color-stop positions.
+    RadialGradients,
 }
 
 impl RenderCapability {
     /// Every optional capability in stable declaration order.
-    pub const ALL: [Self; 9] = [
+    pub const ALL: [Self; 10] = [
         Self::EllipticalBorderRadius,
         Self::BackgroundLayers,
         Self::VisualEffects,
@@ -39,6 +42,7 @@ impl RenderCapability {
         Self::Cursor,
         Self::ResourceLifecycle,
         Self::LinearGradients,
+        Self::RadialGradients,
     ];
 
     /// Stable diagnostic spelling shared by Host errors and checklists.
@@ -53,6 +57,7 @@ impl RenderCapability {
             Self::Cursor => "cursor",
             Self::ResourceLifecycle => "resource-lifecycle",
             Self::LinearGradients => "linear-gradients",
+            Self::RadialGradients => "radial-gradients",
         }
     }
 
@@ -219,6 +224,9 @@ fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 2
         Operation::SetBackgroundLayers { layers, .. } if is_basic_linear_gradient(layers) => {
             Some(RenderCapability::LinearGradients)
         }
+        Operation::SetBackgroundLayers { layers, .. } if is_basic_radial_gradient(layers) => {
+            Some(RenderCapability::RadialGradients)
+        }
         Operation::SetBackgroundLayers { .. } => Some(RenderCapability::BackgroundLayers),
         Operation::SetVisualEffects { .. } => Some(RenderCapability::VisualEffects),
         Operation::SetText { content, .. } if content.paint.uses_extended_features() => {
@@ -246,6 +254,32 @@ fn is_basic_linear_gradient(layers: &[crate::BackgroundLayer]) -> bool {
             stops,
             ..
         } if stops.iter().all(|stop| stop.position.is_some())
+    ) && layer.position == Default::default()
+        && layer.size == crate::BackgroundSize::Auto
+        && layer.repeat_x == crate::ImageRepeat::Repeat
+        && layer.repeat_y == crate::ImageRepeat::Repeat
+        && layer.origin == crate::PaintBox::Padding
+        && layer.clip == crate::PaintBox::Border
+        && layer.attachment == crate::BackgroundAttachment::Scroll
+        && layer.blend_mode == crate::BlendMode::Normal
+}
+
+fn is_basic_radial_gradient(layers: &[crate::BackgroundLayer]) -> bool {
+    let [layer] = layers else {
+        return false;
+    };
+    matches!(
+        &layer.image,
+        crate::PaintImage::RadialGradient {
+            shape: crate::RadialGradientShape::Ellipse,
+            extent: crate::RadialGradientExtent::Explicit,
+            radii: Some(_),
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| {
+            stop.position.is_some_and(|position| position.length == 0.0)
+        })
     ) && layer.position == Default::default()
         && layer.size == crate::BackgroundSize::Auto
         && layer.repeat_x == crate::ImageRepeat::Repeat
@@ -319,6 +353,31 @@ mod tests {
         })
     }
 
+    fn basic_radial_layer() -> BackgroundLayer {
+        let mut layer = basic_linear_layer();
+        let PaintImage::LinearGradient { stops, .. } = layer.image else {
+            unreachable!()
+        };
+        layer.image = PaintImage::RadialGradient {
+            shape: crate::RadialGradientShape::Ellipse,
+            extent: crate::RadialGradientExtent::Explicit,
+            center: PaintPosition::default(),
+            radii: Some((
+                PaintLengthPercentage {
+                    length: 10.0,
+                    fraction: 0.0,
+                },
+                PaintLengthPercentage {
+                    length: 20.0,
+                    fraction: 0.0,
+                },
+            )),
+            repeating: false,
+            stops,
+        };
+        layer
+    }
+
     #[test]
     fn discovers_elliptical_radius_without_classifying_base_box_paint() {
         let node = NodeId::new(1).unwrap();
@@ -379,6 +438,14 @@ mod tests {
             .required_capabilities(),
             vec![RenderCapability::BackgroundLayers]
         );
+        assert_eq!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: vec![basic_radial_layer()],
+            }])
+            .required_capabilities(),
+            vec![RenderCapability::RadialGradients]
+        );
         assert!(
             packet(vec![Operation::SetBackgroundLayers {
                 node,
@@ -403,6 +470,7 @@ mod tests {
                 "cursor",
                 "resource-lifecycle",
                 "linear-gradients",
+                "radial-gradients",
             ]
         );
 

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -319,7 +319,14 @@ fn has_initial_background_geometry(layer: &crate::BackgroundLayer) -> bool {
 }
 
 fn has_explicit_no_repeat_geometry(layer: &crate::BackgroundLayer) -> bool {
-    layer.position == Default::default()
+    [
+        layer.position.x.length,
+        layer.position.x.fraction,
+        layer.position.y.length,
+        layer.position.y.fraction,
+    ]
+    .into_iter()
+    .all(f32::is_finite)
         && matches!(
             layer.size,
             crate::BackgroundSize::Explicit {
@@ -611,6 +618,32 @@ mod tests {
                 RenderCapability::ConicGradients,
                 RenderCapability::BackgroundGeometry,
             ]
+        );
+
+        let mut positioned = explicit_no_repeat(basic_linear_layer());
+        positioned.position = PaintPosition {
+            x: PaintCoordinate {
+                length: 50.0,
+                fraction: 0.0,
+            },
+            y: PaintCoordinate {
+                length: 0.0,
+                fraction: 0.5,
+            },
+        };
+        assert_eq!(
+            packet(vec![operation(positioned)]).required_capabilities(),
+            vec![
+                RenderCapability::LinearGradients,
+                RenderCapability::BackgroundGeometry,
+            ]
+        );
+
+        let mut non_finite_position = explicit_no_repeat(basic_linear_layer());
+        non_finite_position.position.x.fraction = f32::NAN;
+        assert_eq!(
+            packet(vec![operation(non_finite_position)]).required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
         );
 
         let mut incomplete_size = explicit_no_repeat(basic_linear_layer());

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -22,11 +22,14 @@ pub enum RenderCapability {
     Cursor,
     /// Resource load, readiness, failure, and release messages.
     ResourceLifecycle,
+    /// One resolved, non-repeating linear-gradient background image using the
+    /// initial layer geometry and explicit color-stop positions.
+    LinearGradients,
 }
 
 impl RenderCapability {
     /// Every optional capability in stable declaration order.
-    pub const ALL: [Self; 8] = [
+    pub const ALL: [Self; 9] = [
         Self::EllipticalBorderRadius,
         Self::BackgroundLayers,
         Self::VisualEffects,
@@ -35,6 +38,7 @@ impl RenderCapability {
         Self::ImageContent,
         Self::Cursor,
         Self::ResourceLifecycle,
+        Self::LinearGradients,
     ];
 
     /// Stable diagnostic spelling shared by Host errors and checklists.
@@ -48,6 +52,7 @@ impl RenderCapability {
             Self::ImageContent => "image-content",
             Self::Cursor => "cursor",
             Self::ResourceLifecycle => "resource-lifecycle",
+            Self::LinearGradients => "linear-gradients",
         }
     }
 
@@ -130,9 +135,13 @@ impl RenderCapabilities {
     /// Resource lifecycle is deliberately omitted because it uses a separate
     /// service boundary rather than [`crate::FramePacket`].
     pub fn all_frame_native() -> Self {
+        let native = RenderCapability::ALL
+            .into_iter()
+            .filter(|capability| *capability != RenderCapability::ResourceLifecycle)
+            .fold(0, |bits, capability| bits | capability.bit());
         Self {
             protocol: ProtocolVersion::CURRENT,
-            native: RenderCapability::ResourceLifecycle.bit() - 1,
+            native,
             emulated: 0,
         }
     }
@@ -206,6 +215,10 @@ fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 2
         {
             Some(RenderCapability::EllipticalBorderRadius)
         }
+        Operation::SetBackgroundLayers { layers, .. } if layers.is_empty() => None,
+        Operation::SetBackgroundLayers { layers, .. } if is_basic_linear_gradient(layers) => {
+            Some(RenderCapability::LinearGradients)
+        }
         Operation::SetBackgroundLayers { .. } => Some(RenderCapability::BackgroundLayers),
         Operation::SetVisualEffects { .. } => Some(RenderCapability::VisualEffects),
         Operation::SetText { content, .. } if content.paint.uses_extended_features() => {
@@ -224,15 +237,36 @@ fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 2
     [first, second]
 }
 
+fn is_basic_linear_gradient(layers: &[crate::BackgroundLayer]) -> bool {
+    let [layer] = layers else { return false };
+    matches!(
+        &layer.image,
+        crate::PaintImage::LinearGradient {
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| stop.position.is_some())
+    ) && layer.position == Default::default()
+        && layer.size == crate::BackgroundSize::Auto
+        && layer.repeat_x == crate::ImageRepeat::Repeat
+        && layer.repeat_y == crate::ImageRepeat::Repeat
+        && layer.origin == crate::PaintBox::Padding
+        && layer.clip == crate::PaintBox::Border
+        && layer.attachment == crate::BackgroundAttachment::Scroll
+        && layer.blend_mode == crate::BlendMode::Normal
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        BoxPaint, Cursor, ElementTypeId, FontFeature, FontOpticalSizing, FontTag, FrameHeader,
-        FrameMode, ImageContent, MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap,
-        NodeId, ObjectFit, PaintCornerRadius, PaintLengthPercentage, PaintPosition, ResourceId,
-        SurfaceId, TextContent, TextDecorationLines, TextMeasurePayload, TextMeasureStyle,
-        TextPaint, VisualEffects,
+        BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BoxPaint, Cursor,
+        ElementTypeId, FontFeature, FontOpticalSizing, FontTag, FrameHeader, FrameMode,
+        GradientStop, ImageContent, ImageRepeat, MeasureTextDirection, MeasureTextOverflow,
+        MeasureTextWrap, NodeId, ObjectFit, PaintBox, PaintColor, PaintCoordinate,
+        PaintCornerRadius, PaintImage, PaintLengthPercentage, PaintPosition, ResourceId, SurfaceId,
+        TextContent, TextDecorationLines, TextMeasurePayload, TextMeasureStyle, TextPaint,
+        VisualEffects,
     };
 
     fn packet(operations: Vec<Operation>) -> FramePacket {
@@ -249,6 +283,40 @@ mod tests {
             },
             operations,
         }
+    }
+
+    fn background_layer(image: PaintImage) -> BackgroundLayer {
+        BackgroundLayer {
+            image,
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Padding,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
+        }
+    }
+
+    fn basic_linear_layer() -> BackgroundLayer {
+        background_layer(PaintImage::LinearGradient {
+            angle_degrees: 90.0,
+            repeating: false,
+            stops: vec![
+                GradientStop {
+                    color: PaintColor::Named("black".into()),
+                    position: Some(PaintCoordinate::default()),
+                },
+                GradientStop {
+                    color: PaintColor::Named("white".into()),
+                    position: Some(PaintCoordinate {
+                        length: 0.0,
+                        fraction: 1.0,
+                    }),
+                },
+            ],
+        })
     }
 
     #[test]
@@ -293,6 +361,35 @@ mod tests {
     }
 
     #[test]
+    fn linear_gradient_capability_does_not_claim_the_complete_layer_protocol() {
+        let node = NodeId::new(1).unwrap();
+        assert_eq!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: vec![basic_linear_layer()],
+            }])
+            .required_capabilities(),
+            vec![RenderCapability::LinearGradients]
+        );
+        assert_eq!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: vec![basic_linear_layer(), basic_linear_layer()],
+            }])
+            .required_capabilities(),
+            vec![RenderCapability::BackgroundLayers]
+        );
+        assert!(
+            packet(vec![Operation::SetBackgroundLayers {
+                node,
+                layers: Vec::new(),
+            }])
+            .required_capabilities()
+            .is_empty()
+        );
+    }
+
+    #[test]
     fn profiles_and_packets_cover_every_optional_capability() {
         assert_eq!(
             RenderCapability::ALL.map(RenderCapability::as_str),
@@ -305,6 +402,7 @@ mod tests {
                 "image-content",
                 "cursor",
                 "resource-lifecycle",
+                "linear-gradients",
             ]
         );
 
@@ -371,7 +469,7 @@ mod tests {
             Operation::SetBoxPaint { node, paint },
             Operation::SetBackgroundLayers {
                 node,
-                layers: Vec::new(),
+                layers: vec![basic_linear_layer()],
             },
             Operation::SetVisualEffects {
                 node,
@@ -407,7 +505,9 @@ mod tests {
             },
             Operation::SetBackgroundLayers {
                 node,
-                layers: Vec::new(),
+                layers: vec![background_layer(PaintImage::Resource(
+                    ResourceId::new(2).unwrap(),
+                ))],
             },
         ];
         let packet = packet(operations);
@@ -415,12 +515,13 @@ mod tests {
             packet.required_capabilities(),
             vec![
                 RenderCapability::EllipticalBorderRadius,
-                RenderCapability::BackgroundLayers,
+                RenderCapability::LinearGradients,
                 RenderCapability::VisualEffects,
                 RenderCapability::TextEffects,
                 RenderCapability::TextTypography,
                 RenderCapability::ImageContent,
                 RenderCapability::Cursor,
+                RenderCapability::BackgroundLayers,
             ]
         );
         assert_eq!(
@@ -437,7 +538,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             elliptical_only.first_unsupported(&packet),
-            Some(RenderCapability::BackgroundLayers)
+            Some(RenderCapability::LinearGradients)
         );
         assert_eq!(
             RenderCapabilities::all_frame_native().first_unsupported(&packet),

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -7,12 +7,12 @@ use whisker_driver::module::{
     InvokeModuleCallback, MobileModuleHost, ObserveModuleCallback, with_mobile_module_host,
 };
 use whisker_engine::whisker_protocol::{
-    ApplyResult, AvailableSpace, BorderLineStyle, ChildPolicy, ElementMeasurement,
-    ElementRegistration, ElementValueKind, FrameMode, FramePacket, MeasureFontFamily,
-    MeasureFontStyle, MeasureLineHeight, MeasureTextWrap, MeasuredSize, MeasurementMetrics,
-    MeasurementPayload, MeasurementRequest, MeasurementRequestId, MeasurementResponse, NodeId,
-    Operation, PaintColor, PaintLengthPercentage, PreparedContentId, SurfaceId,
-    UnsupportedMeasurementReason,
+    ApplyResult, AvailableSpace, BackgroundAttachment, BackgroundSize, BlendMode, BorderLineStyle,
+    ChildPolicy, ElementMeasurement, ElementRegistration, ElementValueKind, FrameMode, FramePacket,
+    ImageRepeat, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextWrap,
+    MeasuredSize, MeasurementMetrics, MeasurementPayload, MeasurementRequest, MeasurementRequestId,
+    MeasurementResponse, NodeId, Operation, PaintBox, PaintColor, PaintImage,
+    PaintLengthPercentage, PreparedContentId, SurfaceId, UnsupportedMeasurementReason,
 };
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{FrameSink, LayoutOptions, MeasurementProvider};
@@ -643,7 +643,21 @@ struct MobileFrameSink {
 impl FrameSink for MobileFrameSink {
     type Error = MobileFrameError;
     fn capabilities(&self) -> whisker_engine::whisker_protocol::RenderCapabilities {
-        whisker_engine::whisker_protocol::RenderCapabilities::base()
+        whisker_engine::whisker_protocol::RenderCapabilities::new(
+            whisker_engine::whisker_protocol::ProtocolVersion::CURRENT,
+            [
+                whisker_engine::whisker_protocol::CapabilityEntry {
+                    capability:
+                        whisker_engine::whisker_protocol::RenderCapability::EllipticalBorderRadius,
+                    support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
+                },
+                whisker_engine::whisker_protocol::CapabilityEntry {
+                    capability: whisker_engine::whisker_protocol::RenderCapability::LinearGradients,
+                    support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
+                },
+            ],
+        )
+        .expect("mobile capability profile is unique")
     }
     fn present(&mut self, packet: &FramePacket) -> Result<ApplyResult, Self::Error> {
         let capabilities = self.capabilities();
@@ -676,6 +690,7 @@ struct MobileFrameOwned {
     _arena: RawValueArena,
     _layouts: Vec<Box<MobileLayoutGeometry>>,
     _paints: Vec<Box<MobileBoxPaint>>,
+    _gradient_stops: Vec<Box<[MobileGradientStop]>>,
     _texts: Vec<Box<MobileText>>,
     _transforms: Vec<Box<[f32; 16]>>,
     _values: Vec<Box<WhiskerValueRaw>>,
@@ -688,6 +703,7 @@ impl MobileFrameOwned {
         let mut arena = RawValueArena::default();
         let mut layouts = Vec::<Box<MobileLayoutGeometry>>::new();
         let mut paints = Vec::<Box<MobileBoxPaint>>::new();
+        let mut gradient_stops = Vec::<Box<[MobileGradientStop]>>::new();
         let mut texts = Vec::<Box<MobileText>>::new();
         let mut transforms = Vec::<Box<[f32; 16]>>::new();
         let mut values = Vec::<Box<WhiskerValueRaw>>::new();
@@ -757,6 +773,52 @@ impl MobileFrameOwned {
                     raw.node = node.get();
                     paints.push(Box::new(mobile_paint(paint, &mut strings)));
                     raw.payload = paints.last().unwrap().as_ref() as *const _ as *const c_void;
+                }
+                Operation::SetBackgroundLayers { node, layers } => {
+                    raw.tag = OP_BACKGROUND_LAYERS;
+                    raw.node = node.get();
+                    if !layers.is_empty() {
+                        let [layer] = layers.as_slice() else {
+                            return Err(MobileFrameError);
+                        };
+                        if layer.position != Default::default()
+                            || layer.size != BackgroundSize::Auto
+                            || layer.repeat_x != ImageRepeat::Repeat
+                            || layer.repeat_y != ImageRepeat::Repeat
+                            || layer.origin != PaintBox::Padding
+                            || layer.clip != PaintBox::Border
+                            || layer.attachment != BackgroundAttachment::Scroll
+                            || layer.blend_mode != BlendMode::Normal
+                        {
+                            return Err(MobileFrameError);
+                        }
+                        let PaintImage::LinearGradient {
+                            angle_degrees,
+                            repeating: false,
+                            stops,
+                        } = &layer.image
+                        else {
+                            return Err(MobileFrameError);
+                        };
+                        let stops = stops
+                            .iter()
+                            .map(|stop| {
+                                let position = stop.position.ok_or(MobileFrameError)?;
+                                Ok(MobileGradientStop {
+                                    color: mobile_color(&stop.color, &mut strings),
+                                    position: MobileLengthPercentage {
+                                        length: position.length,
+                                        fraction: position.fraction,
+                                    },
+                                })
+                            })
+                            .collect::<Result<Vec<_>, MobileFrameError>>()?
+                            .into_boxed_slice();
+                        raw.scalar = *angle_degrees;
+                        raw.payload_count = stops.len();
+                        gradient_stops.push(stops);
+                        raw.payload = gradient_stops.last().unwrap().as_ptr().cast();
+                    }
                 }
                 Operation::SetClip { node, clip } => {
                     raw.tag = OP_CLIP;
@@ -877,8 +939,7 @@ impl MobileFrameOwned {
                     values.push(Box::new(arena.encode(arguments)));
                     raw.payload = values.last().unwrap().as_ref() as *const _ as *const c_void;
                 }
-                Operation::SetBackgroundLayers { .. }
-                | Operation::SetVisualEffects { .. }
+                Operation::SetVisualEffects { .. }
                 | Operation::SetImage { .. }
                 | Operation::SetCursor { .. } => return Err(MobileFrameError),
             }
@@ -908,6 +969,7 @@ impl MobileFrameOwned {
             _arena: arena,
             _layouts: layouts,
             _paints: paints,
+            _gradient_stops: gradient_stops,
             _texts: texts,
             _transforms: transforms,
             _values: values,

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -660,6 +660,10 @@ impl FrameSink for MobileFrameSink {
                     capability: whisker_engine::whisker_protocol::RenderCapability::RadialGradients,
                     support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_engine::whisker_protocol::CapabilityEntry {
+                    capability: whisker_engine::whisker_protocol::RenderCapability::ConicGradients,
+                    support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("mobile capability profile is unique")
@@ -697,6 +701,7 @@ struct MobileFrameOwned {
     _paints: Vec<Box<MobileBoxPaint>>,
     _gradient_stops: Vec<Box<[MobileGradientStop]>>,
     _radial_gradients: Vec<Box<MobileRadialGradient>>,
+    _conic_gradients: Vec<Box<MobileConicGradient>>,
     _texts: Vec<Box<MobileText>>,
     _transforms: Vec<Box<[f32; 16]>>,
     _values: Vec<Box<WhiskerValueRaw>>,
@@ -711,6 +716,7 @@ impl MobileFrameOwned {
         let mut paints = Vec::<Box<MobileBoxPaint>>::new();
         let mut gradient_stops = Vec::<Box<[MobileGradientStop]>>::new();
         let mut radial_gradients = Vec::<Box<MobileRadialGradient>>::new();
+        let mut conic_gradients = Vec::<Box<MobileConicGradient>>::new();
         let mut texts = Vec::<Box<MobileText>>::new();
         let mut transforms = Vec::<Box<[f32; 16]>>::new();
         let mut values = Vec::<Box<WhiskerValueRaw>>::new();
@@ -834,6 +840,30 @@ impl MobileFrameOwned {
                                 raw.flags = BACKGROUND_RADIAL;
                                 raw.payload_count = 1;
                                 raw.payload = radial_gradients.last().unwrap().as_ref() as *const _
+                                    as *const c_void;
+                            }
+                            PaintImage::ConicGradient {
+                                from_degrees,
+                                center,
+                                repeating: false,
+                                stops,
+                            } if stops.iter().all(|stop| {
+                                stop.position.is_some_and(|position| position.length == 0.0)
+                            }) =>
+                            {
+                                let stops = mobile_gradient_stops(stops, &mut strings)?;
+                                gradient_stops.push(stops);
+                                let stops = gradient_stops.last().unwrap();
+                                conic_gradients.push(Box::new(MobileConicGradient {
+                                    center_x: mobile_coordinate(center.x),
+                                    center_y: mobile_coordinate(center.y),
+                                    stops: stops.as_ptr(),
+                                    stop_count: stops.len(),
+                                }));
+                                raw.flags = BACKGROUND_CONIC;
+                                raw.scalar = *from_degrees;
+                                raw.payload_count = 1;
+                                raw.payload = conic_gradients.last().unwrap().as_ref() as *const _
                                     as *const c_void;
                             }
                             _ => return Err(MobileFrameError),
@@ -991,6 +1021,7 @@ impl MobileFrameOwned {
             _paints: paints,
             _gradient_stops: gradient_stops,
             _radial_gradients: radial_gradients,
+            _conic_gradients: conic_gradients,
             _texts: texts,
             _transforms: transforms,
             _values: values,

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -801,8 +801,7 @@ impl MobileFrameOwned {
                         let [layer] = layers.as_slice() else {
                             return Err(MobileFrameError);
                         };
-                        if layer.position != Default::default()
-                            || layer.origin != PaintBox::Padding
+                        if layer.origin != PaintBox::Padding
                             || layer.clip != PaintBox::Border
                             || layer.attachment != BackgroundAttachment::Scroll
                             || layer.blend_mode != BlendMode::Normal
@@ -815,7 +814,7 @@ impl MobileFrameOwned {
                                     BackgroundSize::Auto,
                                     ImageRepeat::Repeat,
                                     ImageRepeat::Repeat,
-                                ) => (
+                                ) if layer.position == Default::default() => (
                                     BACKGROUND_SIZE_AUTO,
                                     MobileLengthPercentage::default(),
                                     MobileLengthPercentage::default(),

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -801,9 +801,7 @@ impl MobileFrameOwned {
                         let [layer] = layers.as_slice() else {
                             return Err(MobileFrameError);
                         };
-                        if layer.origin != PaintBox::Padding
-                            || layer.clip != PaintBox::Border
-                            || layer.attachment != BackgroundAttachment::Scroll
+                        if layer.attachment != BackgroundAttachment::Scroll
                             || layer.blend_mode != BlendMode::Normal
                         {
                             return Err(MobileFrameError);
@@ -814,13 +812,18 @@ impl MobileFrameOwned {
                                     BackgroundSize::Auto,
                                     ImageRepeat::Repeat,
                                     ImageRepeat::Repeat,
-                                ) if layer.position == Default::default() => (
-                                    BACKGROUND_SIZE_AUTO,
-                                    MobileLengthPercentage::default(),
-                                    MobileLengthPercentage::default(),
-                                    BACKGROUND_REPEAT_REPEAT,
-                                    BACKGROUND_REPEAT_REPEAT,
-                                ),
+                                ) if layer.position == Default::default()
+                                    && layer.origin == PaintBox::Padding
+                                    && layer.clip == PaintBox::Border =>
+                                {
+                                    (
+                                        BACKGROUND_SIZE_AUTO,
+                                        MobileLengthPercentage::default(),
+                                        MobileLengthPercentage::default(),
+                                        BACKGROUND_REPEAT_REPEAT,
+                                        BACKGROUND_REPEAT_REPEAT,
+                                    )
+                                }
                                 (
                                     BackgroundSize::Explicit {
                                         width: Some(width),
@@ -837,6 +840,16 @@ impl MobileFrameOwned {
                                 ),
                                 _ => return Err(MobileFrameError),
                             };
+                        let origin = match layer.origin {
+                            PaintBox::Border => BACKGROUND_BOX_BORDER,
+                            PaintBox::Padding => BACKGROUND_BOX_PADDING,
+                            _ => return Err(MobileFrameError),
+                        };
+                        let clip = match layer.clip {
+                            PaintBox::Border => BACKGROUND_BOX_BORDER,
+                            PaintBox::Padding => BACKGROUND_BOX_PADDING,
+                            _ => return Err(MobileFrameError),
+                        };
                         let image = match &layer.image {
                             PaintImage::LinearGradient {
                                 angle_degrees,
@@ -917,8 +930,8 @@ impl MobileFrameOwned {
                             size_kind,
                             repeat_x,
                             repeat_y,
-                            origin: BACKGROUND_BOX_PADDING,
-                            clip: BACKGROUND_BOX_BORDER,
+                            origin,
+                            clip,
                             attachment: BACKGROUND_ATTACHMENT_SCROLL,
                             blend_mode: BACKGROUND_BLEND_NORMAL,
                         }));

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -664,6 +664,11 @@ impl FrameSink for MobileFrameSink {
                     capability: whisker_engine::whisker_protocol::RenderCapability::ConicGradients,
                     support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_engine::whisker_protocol::CapabilityEntry {
+                    capability:
+                        whisker_engine::whisker_protocol::RenderCapability::BackgroundGeometry,
+                    support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("mobile capability profile is unique")
@@ -702,6 +707,7 @@ struct MobileFrameOwned {
     _gradient_stops: Vec<Box<[MobileGradientStop]>>,
     _radial_gradients: Vec<Box<MobileRadialGradient>>,
     _conic_gradients: Vec<Box<MobileConicGradient>>,
+    _background_layers: Vec<Box<MobileBackgroundLayer>>,
     _texts: Vec<Box<MobileText>>,
     _transforms: Vec<Box<[f32; 16]>>,
     _values: Vec<Box<WhiskerValueRaw>>,
@@ -717,6 +723,7 @@ impl MobileFrameOwned {
         let mut gradient_stops = Vec::<Box<[MobileGradientStop]>>::new();
         let mut radial_gradients = Vec::<Box<MobileRadialGradient>>::new();
         let mut conic_gradients = Vec::<Box<MobileConicGradient>>::new();
+        let mut background_layers = Vec::<Box<MobileBackgroundLayer>>::new();
         let mut texts = Vec::<Box<MobileText>>::new();
         let mut transforms = Vec::<Box<[f32; 16]>>::new();
         let mut values = Vec::<Box<WhiskerValueRaw>>::new();
@@ -795,9 +802,6 @@ impl MobileFrameOwned {
                             return Err(MobileFrameError);
                         };
                         if layer.position != Default::default()
-                            || layer.size != BackgroundSize::Auto
-                            || layer.repeat_x != ImageRepeat::Repeat
-                            || layer.repeat_y != ImageRepeat::Repeat
                             || layer.origin != PaintBox::Padding
                             || layer.clip != PaintBox::Border
                             || layer.attachment != BackgroundAttachment::Scroll
@@ -805,18 +809,50 @@ impl MobileFrameOwned {
                         {
                             return Err(MobileFrameError);
                         }
-                        match &layer.image {
+                        let (size_kind, size_width, size_height, repeat_x, repeat_y) =
+                            match (layer.size, layer.repeat_x, layer.repeat_y) {
+                                (
+                                    BackgroundSize::Auto,
+                                    ImageRepeat::Repeat,
+                                    ImageRepeat::Repeat,
+                                ) => (
+                                    BACKGROUND_SIZE_AUTO,
+                                    MobileLengthPercentage::default(),
+                                    MobileLengthPercentage::default(),
+                                    BACKGROUND_REPEAT_REPEAT,
+                                    BACKGROUND_REPEAT_REPEAT,
+                                ),
+                                (
+                                    BackgroundSize::Explicit {
+                                        width: Some(width),
+                                        height: Some(height),
+                                    },
+                                    ImageRepeat::NoRepeat,
+                                    ImageRepeat::NoRepeat,
+                                ) => (
+                                    BACKGROUND_SIZE_EXPLICIT,
+                                    mobile_length(width),
+                                    mobile_length(height),
+                                    BACKGROUND_REPEAT_NO_REPEAT,
+                                    BACKGROUND_REPEAT_NO_REPEAT,
+                                ),
+                                _ => return Err(MobileFrameError),
+                            };
+                        let image = match &layer.image {
                             PaintImage::LinearGradient {
                                 angle_degrees,
                                 repeating: false,
                                 stops,
                             } => {
                                 let stops = mobile_gradient_stops(stops, &mut strings)?;
-                                raw.flags = BACKGROUND_LINEAR;
-                                raw.scalar = *angle_degrees;
-                                raw.payload_count = stops.len();
                                 gradient_stops.push(stops);
-                                raw.payload = gradient_stops.last().unwrap().as_ptr().cast();
+                                let stops = gradient_stops.last().unwrap();
+                                MobileBackgroundImage {
+                                    kind: BACKGROUND_LINEAR,
+                                    scalar: *angle_degrees,
+                                    payload: stops.as_ptr().cast(),
+                                    payload_count: stops.len(),
+                                }
                             }
                             PaintImage::RadialGradient {
                                 shape: RadialGradientShape::Ellipse,
@@ -837,10 +873,13 @@ impl MobileFrameOwned {
                                     stops: stops.as_ptr(),
                                     stop_count: stops.len(),
                                 }));
-                                raw.flags = BACKGROUND_RADIAL;
-                                raw.payload_count = 1;
-                                raw.payload = radial_gradients.last().unwrap().as_ref() as *const _
-                                    as *const c_void;
+                                MobileBackgroundImage {
+                                    kind: BACKGROUND_RADIAL,
+                                    scalar: 0.0,
+                                    payload: radial_gradients.last().unwrap().as_ref() as *const _
+                                        as *const c_void,
+                                    payload_count: 1,
+                                }
                             }
                             PaintImage::ConicGradient {
                                 from_degrees,
@@ -860,14 +899,33 @@ impl MobileFrameOwned {
                                     stops: stops.as_ptr(),
                                     stop_count: stops.len(),
                                 }));
-                                raw.flags = BACKGROUND_CONIC;
-                                raw.scalar = *from_degrees;
-                                raw.payload_count = 1;
-                                raw.payload = conic_gradients.last().unwrap().as_ref() as *const _
-                                    as *const c_void;
+                                MobileBackgroundImage {
+                                    kind: BACKGROUND_CONIC,
+                                    scalar: *from_degrees,
+                                    payload: conic_gradients.last().unwrap().as_ref() as *const _
+                                        as *const c_void,
+                                    payload_count: 1,
+                                }
                             }
                             _ => return Err(MobileFrameError),
-                        }
+                        };
+                        background_layers.push(Box::new(MobileBackgroundLayer {
+                            image,
+                            position_x: mobile_coordinate(layer.position.x),
+                            position_y: mobile_coordinate(layer.position.y),
+                            size_width,
+                            size_height,
+                            size_kind,
+                            repeat_x,
+                            repeat_y,
+                            origin: BACKGROUND_BOX_PADDING,
+                            clip: BACKGROUND_BOX_BORDER,
+                            attachment: BACKGROUND_ATTACHMENT_SCROLL,
+                            blend_mode: BACKGROUND_BLEND_NORMAL,
+                        }));
+                        raw.payload =
+                            background_layers.last().unwrap().as_ref() as *const _ as *const c_void;
+                        raw.payload_count = 1;
                     }
                 }
                 Operation::SetClip { node, clip } => {
@@ -1022,6 +1080,7 @@ impl MobileFrameOwned {
             _gradient_stops: gradient_stops,
             _radial_gradients: radial_gradients,
             _conic_gradients: conic_gradients,
+            _background_layers: background_layers,
             _texts: texts,
             _transforms: transforms,
             _values: values,

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -829,14 +829,14 @@ impl MobileFrameOwned {
                                         width: Some(width),
                                         height: Some(height),
                                     },
-                                    ImageRepeat::NoRepeat,
-                                    ImageRepeat::NoRepeat,
+                                    repeat_x @ (ImageRepeat::Repeat | ImageRepeat::NoRepeat),
+                                    repeat_y @ (ImageRepeat::Repeat | ImageRepeat::NoRepeat),
                                 ) => (
                                     BACKGROUND_SIZE_EXPLICIT,
                                     mobile_length(width),
                                     mobile_length(height),
-                                    BACKGROUND_REPEAT_NO_REPEAT,
-                                    BACKGROUND_REPEAT_NO_REPEAT,
+                                    mobile_background_repeat(repeat_x),
+                                    mobile_background_repeat(repeat_y),
                                 ),
                                 _ => return Err(MobileFrameError),
                             };
@@ -1122,6 +1122,16 @@ fn mobile_length(value: PaintLengthPercentage) -> MobileLengthPercentage {
     MobileLengthPercentage {
         length: value.length,
         fraction: value.fraction,
+    }
+}
+
+fn mobile_background_repeat(value: ImageRepeat) -> u32 {
+    match value {
+        ImageRepeat::Repeat => BACKGROUND_REPEAT_REPEAT,
+        ImageRepeat::NoRepeat => BACKGROUND_REPEAT_NO_REPEAT,
+        ImageRepeat::Space | ImageRepeat::Round => {
+            unreachable!("unsupported repeat modes are rejected before ABI lowering")
+        }
     }
 }
 fn mobile_gradient_stops(

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -753,17 +753,6 @@ impl MobileFrameOwned {
                     raw.payload = layouts.last().unwrap().as_ref() as *const _ as *const c_void;
                 }
                 Operation::SetBoxPaint { node, paint } => {
-                    if [
-                        paint.border_radii.top_left,
-                        paint.border_radii.top_right,
-                        paint.border_radii.bottom_right,
-                        paint.border_radii.bottom_left,
-                    ]
-                    .into_iter()
-                    .any(|radius| !radius.is_circular())
-                    {
-                        return Err(MobileFrameError);
-                    }
                     raw.tag = OP_PAINT;
                     raw.node = node.get();
                     paints.push(Box::new(mobile_paint(paint, &mut strings)));
@@ -966,11 +955,17 @@ fn mobile_paint(
             border_style(value.border_styles.bottom),
             border_style(value.border_styles.left),
         ],
-        radii: [
+        radii_horizontal: [
             mobile_length(value.border_radii.top_left.horizontal),
             mobile_length(value.border_radii.top_right.horizontal),
             mobile_length(value.border_radii.bottom_right.horizontal),
             mobile_length(value.border_radii.bottom_left.horizontal),
+        ],
+        radii_vertical: [
+            mobile_length(value.border_radii.top_left.vertical),
+            mobile_length(value.border_radii.top_right.vertical),
+            mobile_length(value.border_radii.bottom_right.vertical),
+            mobile_length(value.border_radii.bottom_left.vertical),
         ],
     }
 }
@@ -1066,5 +1061,23 @@ mod tests {
     fn hsla_is_lowered_without_host_string_parsing() {
         assert_eq!(hsl_to_rgb(0.0, 1.0, 0.5), (255, 0, 0));
         assert_eq!(hsl_to_rgb(120.0, 1.0, 0.5), (0, 255, 0));
+    }
+
+    #[test]
+    fn mobile_box_paint_preserves_elliptical_radii() {
+        let mut paint = whisker_engine::whisker_protocol::BoxPaint::default();
+        paint.border_radii.top_left = whisker_engine::whisker_protocol::PaintCornerRadius {
+            horizontal: PaintLengthPercentage {
+                length: 40.0,
+                fraction: 0.0,
+            },
+            vertical: PaintLengthPercentage {
+                length: 10.0,
+                fraction: 0.0,
+            },
+        };
+        let raw = mobile_paint(&paint, &mut Vec::new());
+        assert_eq!(raw.radii_horizontal[0].length, 40.0);
+        assert_eq!(raw.radii_vertical[0].length, 10.0);
     }
 }

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -12,7 +12,8 @@ use whisker_engine::whisker_protocol::{
     ImageRepeat, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextWrap,
     MeasuredSize, MeasurementMetrics, MeasurementPayload, MeasurementRequest, MeasurementRequestId,
     MeasurementResponse, NodeId, Operation, PaintBox, PaintColor, PaintImage,
-    PaintLengthPercentage, PreparedContentId, SurfaceId, UnsupportedMeasurementReason,
+    PaintLengthPercentage, PreparedContentId, RadialGradientExtent, RadialGradientShape, SurfaceId,
+    UnsupportedMeasurementReason,
 };
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{FrameSink, LayoutOptions, MeasurementProvider};
@@ -655,6 +656,10 @@ impl FrameSink for MobileFrameSink {
                     capability: whisker_engine::whisker_protocol::RenderCapability::LinearGradients,
                     support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_engine::whisker_protocol::CapabilityEntry {
+                    capability: whisker_engine::whisker_protocol::RenderCapability::RadialGradients,
+                    support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("mobile capability profile is unique")
@@ -691,6 +696,7 @@ struct MobileFrameOwned {
     _layouts: Vec<Box<MobileLayoutGeometry>>,
     _paints: Vec<Box<MobileBoxPaint>>,
     _gradient_stops: Vec<Box<[MobileGradientStop]>>,
+    _radial_gradients: Vec<Box<MobileRadialGradient>>,
     _texts: Vec<Box<MobileText>>,
     _transforms: Vec<Box<[f32; 16]>>,
     _values: Vec<Box<WhiskerValueRaw>>,
@@ -704,6 +710,7 @@ impl MobileFrameOwned {
         let mut layouts = Vec::<Box<MobileLayoutGeometry>>::new();
         let mut paints = Vec::<Box<MobileBoxPaint>>::new();
         let mut gradient_stops = Vec::<Box<[MobileGradientStop]>>::new();
+        let mut radial_gradients = Vec::<Box<MobileRadialGradient>>::new();
         let mut texts = Vec::<Box<MobileText>>::new();
         let mut transforms = Vec::<Box<[f32; 16]>>::new();
         let mut values = Vec::<Box<WhiskerValueRaw>>::new();
@@ -792,32 +799,45 @@ impl MobileFrameOwned {
                         {
                             return Err(MobileFrameError);
                         }
-                        let PaintImage::LinearGradient {
-                            angle_degrees,
-                            repeating: false,
-                            stops,
-                        } = &layer.image
-                        else {
-                            return Err(MobileFrameError);
-                        };
-                        let stops = stops
-                            .iter()
-                            .map(|stop| {
-                                let position = stop.position.ok_or(MobileFrameError)?;
-                                Ok(MobileGradientStop {
-                                    color: mobile_color(&stop.color, &mut strings),
-                                    position: MobileLengthPercentage {
-                                        length: position.length,
-                                        fraction: position.fraction,
-                                    },
-                                })
-                            })
-                            .collect::<Result<Vec<_>, MobileFrameError>>()?
-                            .into_boxed_slice();
-                        raw.scalar = *angle_degrees;
-                        raw.payload_count = stops.len();
-                        gradient_stops.push(stops);
-                        raw.payload = gradient_stops.last().unwrap().as_ptr().cast();
+                        match &layer.image {
+                            PaintImage::LinearGradient {
+                                angle_degrees,
+                                repeating: false,
+                                stops,
+                            } => {
+                                let stops = mobile_gradient_stops(stops, &mut strings)?;
+                                raw.flags = BACKGROUND_LINEAR;
+                                raw.scalar = *angle_degrees;
+                                raw.payload_count = stops.len();
+                                gradient_stops.push(stops);
+                                raw.payload = gradient_stops.last().unwrap().as_ptr().cast();
+                            }
+                            PaintImage::RadialGradient {
+                                shape: RadialGradientShape::Ellipse,
+                                extent: RadialGradientExtent::Explicit,
+                                center,
+                                radii: Some((radius_x, radius_y)),
+                                repeating: false,
+                                stops,
+                            } => {
+                                let stops = mobile_gradient_stops(stops, &mut strings)?;
+                                gradient_stops.push(stops);
+                                let stops = gradient_stops.last().unwrap();
+                                radial_gradients.push(Box::new(MobileRadialGradient {
+                                    center_x: mobile_coordinate(center.x),
+                                    center_y: mobile_coordinate(center.y),
+                                    radius_x: mobile_length(*radius_x),
+                                    radius_y: mobile_length(*radius_y),
+                                    stops: stops.as_ptr(),
+                                    stop_count: stops.len(),
+                                }));
+                                raw.flags = BACKGROUND_RADIAL;
+                                raw.payload_count = 1;
+                                raw.payload = radial_gradients.last().unwrap().as_ref() as *const _
+                                    as *const c_void;
+                            }
+                            _ => return Err(MobileFrameError),
+                        }
                     }
                 }
                 Operation::SetClip { node, clip } => {
@@ -970,6 +990,7 @@ impl MobileFrameOwned {
             _layouts: layouts,
             _paints: paints,
             _gradient_stops: gradient_stops,
+            _radial_gradients: radial_gradients,
             _texts: texts,
             _transforms: transforms,
             _values: values,
@@ -987,11 +1008,38 @@ fn mobile_rect(value: whisker_engine::whisker_protocol::LayoutRect) -> MobileRec
         height: value.height,
     }
 }
+fn mobile_coordinate(
+    value: whisker_engine::whisker_protocol::PaintCoordinate,
+) -> MobileLengthPercentage {
+    MobileLengthPercentage {
+        length: value.length,
+        fraction: value.fraction,
+    }
+}
 fn mobile_length(value: PaintLengthPercentage) -> MobileLengthPercentage {
     MobileLengthPercentage {
         length: value.length,
         fraction: value.fraction,
     }
+}
+fn mobile_gradient_stops(
+    stops: &[whisker_engine::whisker_protocol::GradientStop],
+    strings: &mut Vec<CString>,
+) -> Result<Box<[MobileGradientStop]>, MobileFrameError> {
+    if !(2..=4_096).contains(&stops.len()) {
+        return Err(MobileFrameError);
+    }
+    stops
+        .iter()
+        .map(|stop| {
+            let position = stop.position.ok_or(MobileFrameError)?;
+            Ok(MobileGradientStop {
+                color: mobile_color(&stop.color, strings),
+                position: mobile_coordinate(position),
+            })
+        })
+        .collect::<Result<Vec<_>, MobileFrameError>>()
+        .map(Vec::into_boxed_slice)
 }
 fn mobile_paint(
     value: &whisker_engine::whisker_protocol::BoxPaint,

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
@@ -2,6 +2,7 @@ package rs.whisker.runtime
 
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
@@ -43,14 +44,29 @@ public open class WhiskerContainerView(context: Context) : ViewGroup(context) {
         }
         val visible = canvas.clipBounds
         val save = canvas.save()
-        canvas.clipRect(
-            if (clipDescendantsHorizontally) 0f else visible.left.toFloat(),
-            if (clipDescendantsVertically) 0f else visible.top.toFloat(),
-            if (clipDescendantsHorizontally) width.toFloat() else visible.right.toFloat(),
-            if (clipDescendantsVertically) height.toFloat() else visible.bottom.toFloat(),
+        clipDescendants(
+            canvas,
+            horizontal = clipDescendantsHorizontally,
+            vertical = clipDescendantsVertically,
+            visible = visible,
         )
         super.dispatchDraw(canvas)
         canvas.restoreToCount(save)
+    }
+
+    /** Hook for the runtime wrapper to project rounded overflow geometry. */
+    protected open fun clipDescendants(
+        canvas: Canvas,
+        horizontal: Boolean,
+        vertical: Boolean,
+        visible: Rect,
+    ) {
+        canvas.clipRect(
+            if (horizontal) 0f else visible.left.toFloat(),
+            if (vertical) 0f else visible.top.toFloat(),
+            if (horizontal) width.toFloat() else visible.right.toFloat(),
+            if (vertical) height.toFloat() else visible.bottom.toFloat(),
+        )
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
@@ -1,6 +1,7 @@
 package rs.whisker.runtime
 
 import android.content.Context
+import android.graphics.Canvas
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
@@ -16,9 +17,40 @@ import kotlin.math.max
  * the retained scene.
  */
 public open class WhiskerContainerView(context: Context) : ViewGroup(context) {
+    private var clipDescendantsHorizontally: Boolean = false
+    private var clipDescendantsVertically: Boolean = false
+
     init {
         clipChildren = false
         clipToPadding = false
+    }
+
+    /** Applies protocol overflow clipping to descendants without clipping this View's background. */
+    public fun setDescendantClip(horizontal: Boolean, vertical: Boolean) {
+        if (
+            clipDescendantsHorizontally == horizontal &&
+            clipDescendantsVertically == vertical
+        ) return
+        clipDescendantsHorizontally = horizontal
+        clipDescendantsVertically = vertical
+        invalidate()
+    }
+
+    override fun dispatchDraw(canvas: Canvas) {
+        if (!clipDescendantsHorizontally && !clipDescendantsVertically) {
+            super.dispatchDraw(canvas)
+            return
+        }
+        val visible = canvas.clipBounds
+        val save = canvas.save()
+        canvas.clipRect(
+            if (clipDescendantsHorizontally) 0f else visible.left.toFloat(),
+            if (clipDescendantsVertically) 0f else visible.top.toFloat(),
+            if (clipDescendantsHorizontally) width.toFloat() else visible.right.toFloat(),
+            if (clipDescendantsVertically) height.toFloat() else visible.bottom.toFloat(),
+        )
+        super.dispatchDraw(canvas)
+        canvas.restoreToCount(save)
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
@@ -1,7 +1,8 @@
 package rs.whisker.runtime.paint
 
-import android.graphics.RectF
 import android.graphics.Path
+import android.graphics.RectF
+import kotlin.math.floor
 
 internal enum class HostBackgroundRepeat {
     Repeat,
@@ -49,6 +50,44 @@ internal data class HostBackgroundGeometry(
         return RectF(left, top, left + width, top + height)
     }
 
-    val clipsToSingleImage: Boolean
-        get() = repeatX == HostBackgroundRepeat.NoRepeat && repeatY == HostBackgroundRepeat.NoRepeat
+    fun forEachImageBox(
+        positioningBox: RectF,
+        paintingBox: RectF,
+        draw: (RectF) -> Unit,
+    ) {
+        val base = imageBox(positioningBox)
+        if (base.isEmpty || paintingBox.isEmpty) return
+        val firstX = firstTileOrigin(base.left, base.width(), paintingBox.left, repeatX)
+        val firstY = firstTileOrigin(base.top, base.height(), paintingBox.top, repeatY)
+        var tileCount = 0
+        var y = firstY
+        do {
+            var x = firstX
+            do {
+                draw(RectF(x, y, x + base.width(), y + base.height()))
+                tileCount += 1
+                // Bound adversarial sub-pixel tiles so paint cannot monopolize
+                // the Host UI thread. Normal viewport-sized CSS tiling remains
+                // well below this ceiling.
+                if (tileCount >= MAX_BACKGROUND_TILES) return
+                x += base.width()
+            } while (repeatX == HostBackgroundRepeat.Repeat && x < paintingBox.right)
+            y += base.height()
+        } while (repeatY == HostBackgroundRepeat.Repeat && y < paintingBox.bottom)
+    }
+
+    private fun firstTileOrigin(
+        base: Float,
+        tileSize: Float,
+        paintStart: Float,
+        repeat: HostBackgroundRepeat,
+    ): Float = if (repeat == HostBackgroundRepeat.Repeat) {
+        base + floor((paintStart - base) / tileSize) * tileSize
+    } else {
+        base
+    }
+
+    private companion object {
+        const val MAX_BACKGROUND_TILES = 16_384
+    }
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
@@ -1,10 +1,31 @@
 package rs.whisker.runtime.paint
 
 import android.graphics.RectF
+import android.graphics.Path
 
 internal enum class HostBackgroundRepeat {
     Repeat,
     NoRepeat,
+}
+
+internal enum class HostBackgroundBox {
+    Border,
+    Padding,
+}
+
+internal data class HostBackgroundPaintBox(
+    val rect: RectF,
+    val clip: Path,
+)
+
+internal data class HostBackgroundPaintBoxes(
+    val border: HostBackgroundPaintBox,
+    val padding: HostBackgroundPaintBox,
+) {
+    fun select(box: HostBackgroundBox): HostBackgroundPaintBox = when (box) {
+        HostBackgroundBox.Border -> border
+        HostBackgroundBox.Padding -> padding
+    }
 }
 
 /** Retained geometry for one background image layer. */
@@ -15,6 +36,8 @@ internal data class HostBackgroundGeometry(
     val sizeHeight: HostPaintCoordinate? = null,
     val repeatX: HostBackgroundRepeat = HostBackgroundRepeat.Repeat,
     val repeatY: HostBackgroundRepeat = HostBackgroundRepeat.Repeat,
+    val origin: HostBackgroundBox = HostBackgroundBox.Padding,
+    val clip: HostBackgroundBox = HostBackgroundBox.Border,
 ) {
     fun imageBox(positioningBox: RectF): RectF {
         val width = sizeWidth?.resolve(positioningBox.width()) ?: positioningBox.width()

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
@@ -1,0 +1,29 @@
+package rs.whisker.runtime.paint
+
+import android.graphics.RectF
+
+internal enum class HostBackgroundRepeat {
+    Repeat,
+    NoRepeat,
+}
+
+/** Retained geometry for one background image layer. */
+internal data class HostBackgroundGeometry(
+    val positionX: HostPaintCoordinate = HostPaintCoordinate(0f, 0f),
+    val positionY: HostPaintCoordinate = HostPaintCoordinate(0f, 0f),
+    val sizeWidth: HostPaintCoordinate? = null,
+    val sizeHeight: HostPaintCoordinate? = null,
+    val repeatX: HostBackgroundRepeat = HostBackgroundRepeat.Repeat,
+    val repeatY: HostBackgroundRepeat = HostBackgroundRepeat.Repeat,
+) {
+    fun imageBox(positioningBox: RectF): RectF {
+        val width = sizeWidth?.resolve(positioningBox.width()) ?: positioningBox.width()
+        val height = sizeHeight?.resolve(positioningBox.height()) ?: positioningBox.height()
+        val left = positioningBox.left + positionX.resolve(positioningBox.width())
+        val top = positioningBox.top + positionY.resolve(positioningBox.height())
+        return RectF(left, top, left + width, top + height)
+    }
+
+    val clipsToSingleImage: Boolean
+        get() = repeatX == HostBackgroundRepeat.NoRepeat && repeatY == HostBackgroundRepeat.NoRepeat
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
@@ -19,8 +19,10 @@ internal data class HostBackgroundGeometry(
     fun imageBox(positioningBox: RectF): RectF {
         val width = sizeWidth?.resolve(positioningBox.width()) ?: positioningBox.width()
         val height = sizeHeight?.resolve(positioningBox.height()) ?: positioningBox.height()
-        val left = positioningBox.left + positionX.resolve(positioningBox.width())
-        val top = positioningBox.top + positionY.resolve(positioningBox.height())
+        val left = positioningBox.left +
+            positionX.length + positionX.fraction * (positioningBox.width() - width)
+        val top = positioningBox.top +
+            positionY.length + positionY.fraction * (positioningBox.height() - height)
         return RectF(left, top, left + width, top + height)
     }
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
@@ -3,9 +3,11 @@ package rs.whisker.runtime.paint
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.LinearGradient
+import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.RectF
+import android.graphics.RadialGradient
 import android.graphics.Shader
 import kotlin.math.abs
 import kotlin.math.cos
@@ -22,9 +24,25 @@ internal data class HostLinearGradient(
     val stops: List<HostGradientStop>,
 )
 
+internal data class HostPaintCoordinate(
+    val length: Float,
+    val fraction: Float,
+) {
+    fun resolve(axis: Float): Float = length + fraction * axis
+}
+
+internal data class HostRadialGradient(
+    val centerX: HostPaintCoordinate,
+    val centerY: HostPaintCoordinate,
+    val radiusX: HostPaintCoordinate,
+    val radiusY: HostPaintCoordinate,
+    val stops: List<HostGradientStop>,
+)
+
 /** Retained projection of the currently supported SetBackgroundLayers subset. */
 internal data class HostBackgroundLayers(
     val linearGradient: HostLinearGradient?,
+    val radialGradient: HostRadialGradient? = null,
 )
 
 internal fun drawBackgroundLayers(
@@ -34,7 +52,22 @@ internal fun drawBackgroundLayers(
     layers: HostBackgroundLayers?,
     paint: Paint,
 ) {
-    val gradient = layers?.linearGradient ?: return
+    layers?.linearGradient?.let { gradient ->
+        drawLinearGradient(canvas, clip, box, gradient, paint)
+        return
+    }
+    layers?.radialGradient?.let { gradient ->
+        drawRadialGradient(canvas, clip, box, gradient, paint)
+    }
+}
+
+private fun drawLinearGradient(
+    canvas: Canvas,
+    clip: Path,
+    box: RectF,
+    gradient: HostLinearGradient,
+    paint: Paint,
+) {
     if (gradient.stops.size < 2) return
     val radians = Math.toRadians(gradient.angleDegrees.toDouble())
     val directionX = sin(radians).toFloat()
@@ -79,6 +112,43 @@ internal fun drawBackgroundLayers(
         positions,
         Shader.TileMode.CLAMP,
     )
+    canvas.drawPath(clip, paint)
+    paint.shader = null
+}
+
+private fun drawRadialGradient(
+    canvas: Canvas,
+    clip: Path,
+    box: RectF,
+    gradient: HostRadialGradient,
+    paint: Paint,
+) {
+    if (gradient.stops.size < 2) return
+    val centerX = box.left + gradient.centerX.resolve(box.width())
+    val centerY = box.top + gradient.centerY.resolve(box.height())
+    val radiusX = gradient.radiusX.resolve(box.width())
+    val radiusY = gradient.radiusY.resolve(box.height())
+    if (radiusX <= 0f || radiusY <= 0f) return
+    var previousPosition = 0f
+    val positions = gradient.stops.mapIndexed { index, stop ->
+        val resolved = (stop.length / radiusX + stop.fraction).coerceIn(0f, 1f)
+        resolved.coerceAtLeast(if (index == 0) 0f else previousPosition).also {
+            previousPosition = it
+        }
+    }.toFloatArray()
+    paint.color = Color.WHITE
+    paint.shader = RadialGradient(
+        centerX,
+        centerY,
+        radiusX,
+        gradient.stops.map(HostGradientStop::color).toIntArray(),
+        positions,
+        Shader.TileMode.CLAMP,
+    ).apply {
+        setLocalMatrix(Matrix().apply {
+            setScale(1f, radiusY / radiusX, centerX, centerY)
+        })
+    }
     canvas.drawPath(clip, paint)
     paint.shader = null
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
@@ -57,36 +57,34 @@ internal data class HostBackgroundLayers(
 
 internal fun drawBackgroundLayers(
     canvas: Canvas,
-    clip: Path,
-    box: RectF,
+    boxes: HostBackgroundPaintBoxes,
     layers: HostBackgroundLayers?,
     paint: Paint,
 ) {
     val geometry = layers?.geometry ?: return
-    val imageBox = geometry.imageBox(box)
+    val imageBox = geometry.imageBox(boxes.select(geometry.origin).rect)
     if (imageBox.isEmpty) return
-    val saveCount = if (geometry.clipsToSingleImage) {
-        canvas.save().also {
-            canvas.clipPath(clip)
+    val paintClip = boxes.select(geometry.clip).clip
+    val saveCount = canvas.save().also {
+        canvas.clipPath(paintClip)
+        if (geometry.clipsToSingleImage) {
             canvas.clipRect(imageBox)
         }
-    } else {
-        null
     }
     try {
         layers.linearGradient?.let { gradient ->
-            drawLinearGradient(canvas, clip, imageBox, gradient, paint)
+            drawLinearGradient(canvas, paintClip, imageBox, gradient, paint)
             return
         }
         layers.radialGradient?.let { gradient ->
-            drawRadialGradient(canvas, clip, imageBox, gradient, paint)
+            drawRadialGradient(canvas, paintClip, imageBox, gradient, paint)
             return
         }
         layers.conicGradient?.let { gradient ->
-            drawConicGradient(canvas, clip, imageBox, gradient, paint)
+            drawConicGradient(canvas, paintClip, imageBox, gradient, paint)
         }
     } finally {
-        saveCount?.let(canvas::restoreToCount)
+        canvas.restoreToCount(saveCount)
     }
 }
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
@@ -1,0 +1,84 @@
+package rs.whisker.runtime.paint
+
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import android.graphics.Shader
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+
+internal data class HostGradientStop(
+    val color: Int,
+    val length: Float,
+    val fraction: Float,
+)
+
+internal data class HostLinearGradient(
+    val angleDegrees: Float,
+    val stops: List<HostGradientStop>,
+)
+
+/** Retained projection of the currently supported SetBackgroundLayers subset. */
+internal data class HostBackgroundLayers(
+    val linearGradient: HostLinearGradient?,
+)
+
+internal fun drawBackgroundLayers(
+    canvas: Canvas,
+    clip: Path,
+    box: RectF,
+    layers: HostBackgroundLayers?,
+    paint: Paint,
+) {
+    val gradient = layers?.linearGradient ?: return
+    if (gradient.stops.size < 2) return
+    val radians = Math.toRadians(gradient.angleDegrees.toDouble())
+    val directionX = sin(radians).toFloat()
+    val directionY = -cos(radians).toFloat()
+    val halfLength = (abs(directionX) * box.width() + abs(directionY) * box.height()) / 2f
+    val centerX = box.centerX()
+    val centerY = box.centerY()
+    val gradientLength = halfLength * 2f
+    var previousPosition = Float.NEGATIVE_INFINITY
+    val resolved = gradient.stops.map { stop ->
+        val position = if (gradientLength > 0f) {
+            stop.length / gradientLength + stop.fraction
+        } else {
+            stop.fraction
+        }
+        Pair(stop.color, position.coerceAtLeast(previousPosition).also {
+            previousPosition = it
+        })
+    }.toMutableList()
+    val domainStart = minOf(0f, resolved.first().second)
+    val domainEnd = maxOf(1f, resolved.last().second)
+    val domainLength = domainEnd - domainStart
+    if (domainLength <= 0f) return
+    if (resolved.first().second > domainStart) {
+        resolved.add(0, Pair(resolved.first().first, domainStart))
+    }
+    if (resolved.last().second < domainEnd) {
+        resolved.add(Pair(resolved.last().first, domainEnd))
+    }
+    val positions = resolved.map { (_, position) ->
+        (position - domainStart) / domainLength
+    }.toFloatArray()
+    // Shader colors are modulated by the Paint color/alpha left by the box
+    // background, which may itself be transparent.
+    paint.color = Color.WHITE
+    paint.shader = LinearGradient(
+        centerX + directionX * gradientLength * (domainStart - 0.5f),
+        centerY + directionY * gradientLength * (domainStart - 0.5f),
+        centerX + directionX * gradientLength * (domainEnd - 0.5f),
+        centerY + directionY * gradientLength * (domainEnd - 0.5f),
+        resolved.map { it.first }.toIntArray(),
+        positions,
+        Shader.TileMode.CLAMP,
+    )
+    canvas.drawPath(clip, paint)
+    paint.shader = null
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
@@ -52,6 +52,7 @@ internal data class HostBackgroundLayers(
     val linearGradient: HostLinearGradient?,
     val radialGradient: HostRadialGradient? = null,
     val conicGradient: HostConicGradient? = null,
+    val geometry: HostBackgroundGeometry = HostBackgroundGeometry(),
 )
 
 internal fun drawBackgroundLayers(
@@ -61,16 +62,31 @@ internal fun drawBackgroundLayers(
     layers: HostBackgroundLayers?,
     paint: Paint,
 ) {
-    layers?.linearGradient?.let { gradient ->
-        drawLinearGradient(canvas, clip, box, gradient, paint)
-        return
+    val geometry = layers?.geometry ?: return
+    val imageBox = geometry.imageBox(box)
+    if (imageBox.isEmpty) return
+    val saveCount = if (geometry.clipsToSingleImage) {
+        canvas.save().also {
+            canvas.clipPath(clip)
+            canvas.clipRect(imageBox)
+        }
+    } else {
+        null
     }
-    layers?.radialGradient?.let { gradient ->
-        drawRadialGradient(canvas, clip, box, gradient, paint)
-        return
-    }
-    layers?.conicGradient?.let { gradient ->
-        drawConicGradient(canvas, clip, box, gradient, paint)
+    try {
+        layers.linearGradient?.let { gradient ->
+            drawLinearGradient(canvas, clip, imageBox, gradient, paint)
+            return
+        }
+        layers.radialGradient?.let { gradient ->
+            drawRadialGradient(canvas, clip, imageBox, gradient, paint)
+            return
+        }
+        layers.conicGradient?.let { gradient ->
+            drawConicGradient(canvas, clip, imageBox, gradient, paint)
+        }
+    } finally {
+        saveCount?.let(canvas::restoreToCount)
     }
 }
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
@@ -62,29 +62,42 @@ internal fun drawBackgroundLayers(
     paint: Paint,
 ) {
     val geometry = layers?.geometry ?: return
-    val imageBox = geometry.imageBox(boxes.select(geometry.origin).rect)
-    if (imageBox.isEmpty) return
-    val paintClip = boxes.select(geometry.clip).clip
+    val positioningBox = boxes.select(geometry.origin).rect
+    val painting = boxes.select(geometry.clip)
     val saveCount = canvas.save().also {
-        canvas.clipPath(paintClip)
-        if (geometry.clipsToSingleImage) {
-            canvas.clipRect(imageBox)
-        }
+        canvas.clipPath(painting.clip)
     }
     try {
-        layers.linearGradient?.let { gradient ->
-            drawLinearGradient(canvas, paintClip, imageBox, gradient, paint)
-            return
-        }
-        layers.radialGradient?.let { gradient ->
-            drawRadialGradient(canvas, paintClip, imageBox, gradient, paint)
-            return
-        }
-        layers.conicGradient?.let { gradient ->
-            drawConicGradient(canvas, paintClip, imageBox, gradient, paint)
+        geometry.forEachImageBox(positioningBox, painting.rect) { imageBox ->
+            val tileSaveCount = canvas.save().also { canvas.clipRect(imageBox) }
+            try {
+                drawBackgroundImage(canvas, painting.clip, imageBox, layers, paint)
+            } finally {
+                canvas.restoreToCount(tileSaveCount)
+            }
         }
     } finally {
         canvas.restoreToCount(saveCount)
+    }
+}
+
+private fun drawBackgroundImage(
+    canvas: Canvas,
+    clip: Path,
+    imageBox: RectF,
+    layers: HostBackgroundLayers,
+    paint: Paint,
+) {
+    layers.linearGradient?.let { gradient ->
+        drawLinearGradient(canvas, clip, imageBox, gradient, paint)
+        return
+    }
+    layers.radialGradient?.let { gradient ->
+        drawRadialGradient(canvas, clip, imageBox, gradient, paint)
+        return
+    }
+    layers.conicGradient?.let { gradient ->
+        drawConicGradient(canvas, clip, imageBox, gradient, paint)
     }
 }
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
@@ -9,6 +9,7 @@ import android.graphics.Path
 import android.graphics.RectF
 import android.graphics.RadialGradient
 import android.graphics.Shader
+import android.graphics.SweepGradient
 import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.sin
@@ -39,10 +40,18 @@ internal data class HostRadialGradient(
     val stops: List<HostGradientStop>,
 )
 
+internal data class HostConicGradient(
+    val fromDegrees: Float,
+    val centerX: HostPaintCoordinate,
+    val centerY: HostPaintCoordinate,
+    val stops: List<HostGradientStop>,
+)
+
 /** Retained projection of the currently supported SetBackgroundLayers subset. */
 internal data class HostBackgroundLayers(
     val linearGradient: HostLinearGradient?,
     val radialGradient: HostRadialGradient? = null,
+    val conicGradient: HostConicGradient? = null,
 )
 
 internal fun drawBackgroundLayers(
@@ -58,6 +67,10 @@ internal fun drawBackgroundLayers(
     }
     layers?.radialGradient?.let { gradient ->
         drawRadialGradient(canvas, clip, box, gradient, paint)
+        return
+    }
+    layers?.conicGradient?.let { gradient ->
+        drawConicGradient(canvas, clip, box, gradient, paint)
     }
 }
 
@@ -147,6 +160,39 @@ private fun drawRadialGradient(
     ).apply {
         setLocalMatrix(Matrix().apply {
             setScale(1f, radiusY / radiusX, centerX, centerY)
+        })
+    }
+    canvas.drawPath(clip, paint)
+    paint.shader = null
+}
+
+private fun drawConicGradient(
+    canvas: Canvas,
+    clip: Path,
+    box: RectF,
+    gradient: HostConicGradient,
+    paint: Paint,
+) {
+    if (gradient.stops.size < 2) return
+    val centerX = box.left + gradient.centerX.resolve(box.width())
+    val centerY = box.top + gradient.centerY.resolve(box.height())
+    var previousPosition = 0f
+    val positions = gradient.stops.mapIndexed { index, stop ->
+        stop.fraction.coerceIn(0f, 1f)
+            .coerceAtLeast(if (index == 0) 0f else previousPosition)
+            .also { previousPosition = it }
+    }.toFloatArray()
+    paint.color = Color.WHITE
+    paint.shader = SweepGradient(
+        centerX,
+        centerY,
+        gradient.stops.map(HostGradientStop::color).toIntArray(),
+        positions,
+    ).apply {
+        // Android starts a sweep at +x. CSS/protocol starts at the positive
+        // vertical axis, with both advancing clockwise in screen space.
+        setLocalMatrix(Matrix().apply {
+            setRotate(gradient.fromDegrees - 90f, centerX, centerY)
         })
     }
     canvas.drawPath(clip, paint)

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -159,7 +159,7 @@ private class WhiskerBoxDrawable(
             paint.color = borderColors[side]
             when (borderStyles[side]) {
                 BORDER_STYLE_SOLID -> canvas.drawPath(sidePaths[side], paint)
-                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED -> {
+                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE -> {
                     canvas.clipPath(sidePaths[side])
                     drawPatternedEdge(
                         canvas,
@@ -194,14 +194,14 @@ private class WhiskerBoxDrawable(
             paint.color = borderColors[side]
             when (borderStyles[side]) {
                 BORDER_STYLE_SOLID -> canvas.drawRect(edges[side], paint)
-                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED ->
+                BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE ->
                     drawPatternedEdge(canvas, edges[side], side, widths[side], borderStyles[side])
             }
         }
     }
 
     private fun paintsSide(side: Int): Boolean = when (borderStyles[side]) {
-        BORDER_STYLE_SOLID, BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED -> true
+        BORDER_STYLE_SOLID, BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE -> true
         else -> false
     }
 
@@ -220,6 +220,10 @@ private class WhiskerBoxDrawable(
         style: Int,
     ) {
         if (width <= 0f || edge.isEmpty) return
+        if (style == BORDER_STYLE_DOUBLE) {
+            drawDoubleEdge(canvas, edge, side, width)
+            return
+        }
         val horizontal = side == 0 || side == 2
         val start = if (horizontal) edge.left else edge.top
         val end = if (horizontal) edge.right else edge.bottom
@@ -252,6 +256,37 @@ private class WhiskerBoxDrawable(
             }
         }
         canvas.restoreToCount(save)
+    }
+
+    private fun drawDoubleEdge(
+        canvas: Canvas,
+        edge: RectF,
+        side: Int,
+        width: Float,
+    ) {
+        val band = width / 3f
+        val outer: RectF
+        val inner: RectF
+        when (side) {
+            0 -> {
+                outer = RectF(edge.left, edge.top, edge.right, edge.top + band)
+                inner = RectF(edge.left, edge.bottom - band, edge.right, edge.bottom)
+            }
+            1 -> {
+                outer = RectF(edge.right - band, edge.top, edge.right, edge.bottom)
+                inner = RectF(edge.left, edge.top, edge.left + band, edge.bottom)
+            }
+            2 -> {
+                outer = RectF(edge.left, edge.bottom - band, edge.right, edge.bottom)
+                inner = RectF(edge.left, edge.top, edge.right, edge.top + band)
+            }
+            else -> {
+                outer = RectF(edge.left, edge.top, edge.left + band, edge.bottom)
+                inner = RectF(edge.right - band, edge.top, edge.right, edge.bottom)
+            }
+        }
+        canvas.drawRect(outer, paint)
+        canvas.drawRect(inner, paint)
     }
 
     private fun normalizedRadii(width: Float, height: Float): FloatArray {
@@ -290,3 +325,4 @@ private class WhiskerBoxDrawable(
 private const val BORDER_STYLE_SOLID = 2
 private const val BORDER_STYLE_DASHED = 3
 private const val BORDER_STYLE_DOTTED = 4
+private const val BORDER_STYLE_DOUBLE = 5

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -24,7 +24,7 @@ internal fun applyBoxPaint(
     density: Float,
 ) {
     val values = paint.values
-    require(values.size >= 45)
+    require(values.size >= BOX_PAINT_PACKED_SIZE)
     val background = if (values[0] == 0f) {
         parseNamedColor(paint.names[0])
     } else {
@@ -45,11 +45,13 @@ internal fun applyBoxPaint(
         }
     }
     val radii = FloatArray(8) { index ->
-        val offset = 33 + (index / 2) * 2
-        val axis = if (index % 2 == 0) logicalWidth else logicalHeight
+        val corner = index / 2
+        val horizontal = index % 2 == 0
+        val offset = (if (horizontal) RADII_HORIZONTAL_OFFSET else RADII_VERTICAL_OFFSET) + corner * 2
+        val axis = if (horizontal) logicalWidth else logicalHeight
         resolveLength(values[offset], values[offset + 1], axis) * density
     }
-    val borderStyles = IntArray(4) { index -> values[41 + index].toInt() }
+    val borderStyles = IntArray(4) { index -> values[BORDER_STYLES_OFFSET + index].toInt() }
     val uniformSolidBorder = borderStyles.all { it == BORDER_STYLE_SOLID } &&
         borderWidths.all { it == borderWidths[0] } &&
         borderColors.all { it == borderColors[0] }
@@ -420,3 +422,7 @@ private const val BORDER_STYLE_RIDGE = 7
 private const val BORDER_STYLE_INSET = 8
 private const val BORDER_STYLE_OUTSET = 9
 private const val RELIEF_SHADE_FACTOR = 0.4f
+private const val RADII_HORIZONTAL_OFFSET = 33
+private const val RADII_VERTICAL_OFFSET = 41
+private const val BORDER_STYLES_OFFSET = 49
+private const val BOX_PAINT_PACKED_SIZE = 53

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -15,6 +15,14 @@ import kotlin.math.min
 /** Packed Android projection of one protocol `SetBoxPaint` payload. */
 internal data class HostBoxPaint(val values: FloatArray, val names: Array<String>)
 
+/** Resolved physical geometry shared by box paint and overflow clipping. */
+internal data class ResolvedBoxGeometry(
+    val width: Float,
+    val height: Float,
+    val borderWidths: FloatArray,
+    val cornerRadii: FloatArray,
+)
+
 /** Applies renderer-independent box paint to the common Host node wrapper. */
 internal fun applyBoxPaint(
     node: View,
@@ -22,7 +30,7 @@ internal fun applyBoxPaint(
     logicalWidth: Float,
     logicalHeight: Float,
     density: Float,
-) {
+): ResolvedBoxGeometry {
     val values = paint.values
     require(values.size >= BOX_PAINT_PACKED_SIZE)
     val background = if (values[0] == 0f) {
@@ -51,6 +59,9 @@ internal fun applyBoxPaint(
         val axis = if (horizontal) logicalWidth else logicalHeight
         resolveLength(values[offset], values[offset + 1], axis) * density
     }
+    val physicalWidth = logicalWidth * density
+    val physicalHeight = logicalHeight * density
+    val normalizedRadii = normalizeRadii(radii, physicalWidth, physicalHeight)
     val borderStyles = IntArray(4) { index -> values[BORDER_STYLES_OFFSET + index].toInt() }
     val uniformSolidBorder = borderStyles.all { it == BORDER_STYLE_SOLID } &&
         borderWidths.all { it == borderWidths[0] } &&
@@ -62,11 +73,17 @@ internal fun applyBoxPaint(
             if (borderWidths[0] > 0f) {
                 setStroke(borderWidths[0].toInt().coerceAtLeast(1), borderColors[0])
             }
-            cornerRadii = radii
+            cornerRadii = normalizedRadii
         }
     } else {
-        WhiskerBoxDrawable(background, borderWidths, borderColors, borderStyles, radii)
+        WhiskerBoxDrawable(background, borderWidths, borderColors, borderStyles, normalizedRadii)
     }
+    return ResolvedBoxGeometry(
+        width = physicalWidth,
+        height = physicalHeight,
+        borderWidths = borderWidths,
+        cornerRadii = normalizedRadii,
+    )
 }
 
 private fun resolveLength(length: Float, fraction: Float, axis: Float): Float =
@@ -85,7 +102,7 @@ private class WhiskerBoxDrawable(
     override fun draw(canvas: Canvas) {
         val box = RectF(bounds)
         if (box.isEmpty) return
-        val radii = normalizedRadii(box.width(), box.height())
+        val radii = normalizeRadii(cornerRadii, box.width(), box.height())
         val outer = roundedPath(box, radii)
         paint.color = fillColor
         canvas.drawPath(outer, paint)
@@ -380,23 +397,6 @@ private class WhiskerBoxDrawable(
         )
     }
 
-    private fun normalizedRadii(width: Float, height: Float): FloatArray {
-        val result = cornerRadii.map { it.coerceAtLeast(0f) }.toFloatArray()
-        val denominators = floatArrayOf(
-            result[0] + result[2],
-            result[6] + result[4],
-            result[1] + result[7],
-            result[3] + result[5],
-        )
-        val limits = floatArrayOf(width, width, height, height)
-        var scale = 1f
-        repeat(4) { index ->
-            if (denominators[index] > 0f) scale = min(scale, limits[index] / denominators[index])
-        }
-        if (scale < 1f) repeat(result.size) { result[it] *= scale }
-        return result
-    }
-
     private fun roundedPath(rect: RectF, radii: FloatArray): Path = Path().apply {
         addRoundRect(rect, radii, Path.Direction.CW)
     }
@@ -411,6 +411,23 @@ private class WhiskerBoxDrawable(
     override fun setColorFilter(colorFilter: ColorFilter?) {
         paint.colorFilter = colorFilter
     }
+}
+
+internal fun normalizeRadii(radii: FloatArray, width: Float, height: Float): FloatArray {
+    val result = radii.map { it.coerceAtLeast(0f) }.toFloatArray()
+    val denominators = floatArrayOf(
+        result[0] + result[2],
+        result[6] + result[4],
+        result[1] + result[7],
+        result[3] + result[5],
+    )
+    val limits = floatArrayOf(width, width, height, height)
+    var scale = 1f
+    repeat(4) { index ->
+        if (denominators[index] > 0f) scale = min(scale, limits[index] / denominators[index])
+    }
+    if (scale < 1f) repeat(result.size) { result[it] *= scale }
+    return result
 }
 
 private const val BORDER_STYLE_SOLID = 2

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -30,6 +30,7 @@ internal fun applyBoxPaint(
     logicalWidth: Float,
     logicalHeight: Float,
     density: Float,
+    backgroundLayers: HostBackgroundLayers? = null,
 ): ResolvedBoxGeometry {
     val values = paint.values
     require(values.size >= BOX_PAINT_PACKED_SIZE)
@@ -63,7 +64,8 @@ internal fun applyBoxPaint(
     val physicalHeight = logicalHeight * density
     val normalizedRadii = normalizeRadii(radii, physicalWidth, physicalHeight)
     val borderStyles = IntArray(4) { index -> values[BORDER_STYLES_OFFSET + index].toInt() }
-    val uniformSolidBorder = borderStyles.all { it == BORDER_STYLE_SOLID } &&
+    val uniformSolidBorder = backgroundLayers == null &&
+        borderStyles.all { it == BORDER_STYLE_SOLID } &&
         borderWidths.all { it == borderWidths[0] } &&
         borderColors.all { it == borderColors[0] }
     node.background = if (uniformSolidBorder) {
@@ -76,7 +78,14 @@ internal fun applyBoxPaint(
             cornerRadii = normalizedRadii
         }
     } else {
-        WhiskerBoxDrawable(background, borderWidths, borderColors, borderStyles, normalizedRadii)
+        WhiskerBoxDrawable(
+            background,
+            borderWidths,
+            borderColors,
+            borderStyles,
+            normalizedRadii,
+            backgroundLayers,
+        )
     }
     return ResolvedBoxGeometry(
         width = physicalWidth,
@@ -96,6 +105,7 @@ private class WhiskerBoxDrawable(
     private val borderColors: IntArray,
     private val borderStyles: IntArray,
     private val cornerRadii: FloatArray,
+    private val backgroundLayers: HostBackgroundLayers?,
 ) : Drawable() {
     private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
 
@@ -104,13 +114,20 @@ private class WhiskerBoxDrawable(
         if (box.isEmpty) return
         val radii = normalizeRadii(cornerRadii, box.width(), box.height())
         val outer = roundedPath(box, radii)
-        paint.color = fillColor
-        canvas.drawPath(outer, paint)
-
         val top = borderWidths[0].coerceIn(0f, box.height())
         val right = borderWidths[1].coerceIn(0f, box.width())
         val bottom = borderWidths[2].coerceIn(0f, box.height())
         val left = borderWidths[3].coerceIn(0f, box.width())
+        val paddingBox = RectF(
+            box.left + left,
+            box.top + top,
+            box.right - right,
+            box.bottom - bottom,
+        )
+        paint.color = fillColor
+        canvas.drawPath(outer, paint)
+        drawBackgroundLayers(canvas, outer, paddingBox, backgroundLayers, paint)
+
         val widths = floatArrayOf(top, right, bottom, left)
         if (top == 0f && right == 0f && bottom == 0f && left == 0f) return
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -124,22 +124,9 @@ private class WhiskerBoxDrawable(
             box.right - right,
             box.bottom - bottom,
         )
-        paint.color = fillColor
-        canvas.drawPath(outer, paint)
-        drawBackgroundLayers(canvas, outer, paddingBox, backgroundLayers, paint)
-
-        val widths = floatArrayOf(top, right, bottom, left)
-        if (top == 0f && right == 0f && bottom == 0f && left == 0f) return
-
-        if (radii.all { it == 0f }) {
-            drawRectangularEdges(canvas, box, top, right, bottom, left)
-            return
-        }
-
-        val inner = RectF(box.left + left, box.top + top, box.right - right, box.bottom - bottom)
-        val innerPath = if (inner.width() > 0f && inner.height() > 0f) {
+        val paddingPath = if (paddingBox.width() > 0f && paddingBox.height() > 0f) {
             roundedPath(
-                inner,
+                paddingBox,
                 floatArrayOf(
                     (radii[0] - left).coerceAtLeast(0f),
                     (radii[1] - top).coerceAtLeast(0f),
@@ -152,8 +139,30 @@ private class WhiskerBoxDrawable(
                 ),
             )
         } else {
-            null
+            Path()
         }
+        paint.color = fillColor
+        canvas.drawPath(outer, paint)
+        drawBackgroundLayers(
+            canvas,
+            HostBackgroundPaintBoxes(
+                border = HostBackgroundPaintBox(box, outer),
+                padding = HostBackgroundPaintBox(paddingBox, paddingPath),
+            ),
+            backgroundLayers,
+            paint,
+        )
+
+        val widths = floatArrayOf(top, right, bottom, left)
+        if (top == 0f && right == 0f && bottom == 0f && left == 0f) return
+
+        if (radii.all { it == 0f }) {
+            drawRectangularEdges(canvas, box, top, right, bottom, left)
+            return
+        }
+
+        val inner = paddingBox
+        val innerPath = if (paddingPath.isEmpty) null else paddingPath
         val sidePaths = arrayOf(
             Path().apply {
                 moveTo(box.left, box.top)

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -1,6 +1,7 @@
 package rs.whisker.runtime.paint
 
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.ColorFilter
 import android.graphics.Paint
 import android.graphics.Path
@@ -169,6 +170,17 @@ private class WhiskerBoxDrawable(
                         borderStyles[side],
                     )
                 }
+                BORDER_STYLE_GROOVE, BORDER_STYLE_RIDGE,
+                BORDER_STYLE_INSET, BORDER_STYLE_OUTSET -> {
+                    canvas.clipPath(sidePaths[side])
+                    drawReliefEdge(
+                        canvas,
+                        edgeRect(box, side, widths[side]),
+                        side,
+                        borderStyles[side],
+                        borderColors[side],
+                    )
+                }
             }
             canvas.restoreToCount(save)
         }
@@ -196,12 +208,22 @@ private class WhiskerBoxDrawable(
                 BORDER_STYLE_SOLID -> canvas.drawRect(edges[side], paint)
                 BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE ->
                     drawPatternedEdge(canvas, edges[side], side, widths[side], borderStyles[side])
+                BORDER_STYLE_GROOVE, BORDER_STYLE_RIDGE,
+                BORDER_STYLE_INSET, BORDER_STYLE_OUTSET ->
+                    drawReliefEdge(
+                        canvas,
+                        edges[side],
+                        side,
+                        borderStyles[side],
+                        borderColors[side],
+                    )
             }
         }
     }
 
     private fun paintsSide(side: Int): Boolean = when (borderStyles[side]) {
-        BORDER_STYLE_SOLID, BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE -> true
+        BORDER_STYLE_SOLID, BORDER_STYLE_DASHED, BORDER_STYLE_DOTTED, BORDER_STYLE_DOUBLE,
+        BORDER_STYLE_GROOVE, BORDER_STYLE_RIDGE, BORDER_STYLE_INSET, BORDER_STYLE_OUTSET -> true
         else -> false
     }
 
@@ -289,6 +311,73 @@ private class WhiskerBoxDrawable(
         canvas.drawRect(inner, paint)
     }
 
+    private fun drawReliefEdge(
+        canvas: Canvas,
+        edge: RectF,
+        side: Int,
+        style: Int,
+        color: Int,
+    ) {
+        if (edge.isEmpty) return
+        val topOrLeft = side == 0 || side == 3
+        when (style) {
+            BORDER_STYLE_INSET -> {
+                paint.color = shadedColor(color, lighter = !topOrLeft)
+                canvas.drawRect(edge, paint)
+            }
+            BORDER_STYLE_OUTSET -> {
+                paint.color = shadedColor(color, lighter = topOrLeft)
+                canvas.drawRect(edge, paint)
+            }
+            BORDER_STYLE_GROOVE, BORDER_STYLE_RIDGE -> {
+                val (outer, inner) = splitEdge(edge, side)
+                val outerIsLighter = if (style == BORDER_STYLE_GROOVE) !topOrLeft else topOrLeft
+                paint.color = shadedColor(color, lighter = outerIsLighter)
+                canvas.drawRect(outer, paint)
+                paint.color = shadedColor(color, lighter = !outerIsLighter)
+                canvas.drawRect(inner, paint)
+            }
+        }
+    }
+
+    /** Splits a border across its depth, preserving CSS outer-to-inner order. */
+    private fun splitEdge(edge: RectF, side: Int): Pair<RectF, RectF> = when (side) {
+        0 -> {
+            val middle = edge.centerY()
+            RectF(edge.left, edge.top, edge.right, middle) to
+                RectF(edge.left, middle, edge.right, edge.bottom)
+        }
+        1 -> {
+            val middle = edge.centerX()
+            RectF(middle, edge.top, edge.right, edge.bottom) to
+                RectF(edge.left, edge.top, middle, edge.bottom)
+        }
+        2 -> {
+            val middle = edge.centerY()
+            RectF(edge.left, middle, edge.right, edge.bottom) to
+                RectF(edge.left, edge.top, edge.right, middle)
+        }
+        else -> {
+            val middle = edge.centerX()
+            RectF(edge.left, edge.top, middle, edge.bottom) to
+                RectF(middle, edge.top, edge.right, edge.bottom)
+        }
+    }
+
+    private fun shadedColor(color: Int, lighter: Boolean): Int {
+        fun shade(channel: Int): Int = if (lighter) {
+            channel + ((255 - channel) * RELIEF_SHADE_FACTOR).toInt()
+        } else {
+            (channel * (1f - RELIEF_SHADE_FACTOR)).toInt()
+        }
+        return Color.argb(
+            Color.alpha(color),
+            shade(Color.red(color)),
+            shade(Color.green(color)),
+            shade(Color.blue(color)),
+        )
+    }
+
     private fun normalizedRadii(width: Float, height: Float): FloatArray {
         val result = cornerRadii.map { it.coerceAtLeast(0f) }.toFloatArray()
         val denominators = floatArrayOf(
@@ -326,3 +415,8 @@ private const val BORDER_STYLE_SOLID = 2
 private const val BORDER_STYLE_DASHED = 3
 private const val BORDER_STYLE_DOTTED = 4
 private const val BORDER_STYLE_DOUBLE = 5
+private const val BORDER_STYLE_GROOVE = 6
+private const val BORDER_STYLE_RIDGE = 7
+private const val BORDER_STYLE_INSET = 8
+private const val BORDER_STYLE_OUTSET = 9
+private const val RELIEF_SHADE_FACTOR = 0.4f

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/PaintColor.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/PaintColor.kt
@@ -12,6 +12,9 @@ internal fun rgba(red: Float, green: Float, blue: Float, alpha: Float): Int = Co
 internal fun parseNamedColor(name: String): Int =
     when (name.lowercase()) {
         "gold" -> Color.rgb(255, 215, 0)
+        // Android's named `green` is #00ff00, while CSS defines `green` as
+        // #008000. Keep Host paint color resolution aligned with CSS/WPT.
+        "green" -> Color.rgb(0, 128, 0)
         "transparent" -> Color.TRANSPARENT
         else -> runCatching { Color.parseColor(name) }.getOrDefault(Color.TRANSPARENT)
     }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/PaintColor.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/PaintColor.kt
@@ -10,4 +10,8 @@ internal fun rgba(red: Float, green: Float, blue: Float, alpha: Float): Int = Co
 )
 
 internal fun parseNamedColor(name: String): Int =
-    runCatching { Color.parseColor(name) }.getOrDefault(Color.TRANSPARENT)
+    when (name.lowercase()) {
+        "gold" -> Color.rgb(255, 215, 0)
+        "transparent" -> Color.TRANSPARENT
+        else -> runCatching { Color.parseColor(name) }.getOrDefault(Color.TRANSPARENT)
+    }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -3,9 +3,14 @@ package rs.whisker.runtime.scene
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Matrix
+import android.graphics.Path
+import android.graphics.Rect
+import android.graphics.RectF
 import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerMountedElement
 import rs.whisker.runtime.paint.HostBoxPaint
+import rs.whisker.runtime.paint.ResolvedBoxGeometry
+import rs.whisker.runtime.paint.normalizeRadii
 
 /** Mutable logical geometry attached to one Host scene node. */
 internal data class HostGeometry(
@@ -33,6 +38,40 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
 
     private val localTransform = Matrix()
     private var hasLocalTransform = false
+    private var overflowClipRect = RectF()
+    private var overflowClipPath: Path? = null
+
+    fun setOverflowClipGeometry(geometry: ResolvedBoxGeometry) {
+        val top = geometry.borderWidths[0].coerceIn(0f, geometry.height)
+        val right = geometry.borderWidths[1].coerceIn(0f, geometry.width)
+        val bottom = geometry.borderWidths[2].coerceIn(0f, geometry.height)
+        val left = geometry.borderWidths[3].coerceIn(0f, geometry.width)
+        overflowClipRect = RectF(left, top, geometry.width - right, geometry.height - bottom)
+        if (overflowClipRect.isEmpty) {
+            overflowClipPath = Path()
+            invalidate()
+            return
+        }
+        val outer = geometry.cornerRadii
+        val inner = normalizeRadii(
+            floatArrayOf(
+                (outer[0] - left).coerceAtLeast(0f),
+                (outer[1] - top).coerceAtLeast(0f),
+                (outer[2] - right).coerceAtLeast(0f),
+                (outer[3] - top).coerceAtLeast(0f),
+                (outer[4] - right).coerceAtLeast(0f),
+                (outer[5] - bottom).coerceAtLeast(0f),
+                (outer[6] - left).coerceAtLeast(0f),
+                (outer[7] - bottom).coerceAtLeast(0f),
+            ),
+            overflowClipRect.width(),
+            overflowClipRect.height(),
+        )
+        overflowClipPath = Path().apply {
+            addRoundRect(overflowClipRect, inner, Path.Direction.CW)
+        }
+        invalidate()
+    }
 
     /** Applies a protocol transform around the local border-box origin. */
     fun setLocalTransform(values: FloatArray, density: Float) {
@@ -59,6 +98,29 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
         canvas.concat(localTransform)
         super.draw(canvas)
         canvas.restoreToCount(save)
+    }
+
+    override fun clipDescendants(
+        canvas: Canvas,
+        horizontal: Boolean,
+        vertical: Boolean,
+        visible: Rect,
+    ) {
+        val path = overflowClipPath
+        if (path == null) {
+            super.clipDescendants(canvas, horizontal, vertical, visible)
+            return
+        }
+        if (horizontal && vertical) {
+            canvas.clipPath(path)
+            return
+        }
+        canvas.clipRect(
+            if (horizontal) overflowClipRect.left else visible.left.toFloat(),
+            if (vertical) overflowClipRect.top else visible.top.toFloat(),
+            if (horizontal) overflowClipRect.right else visible.right.toFloat(),
+            if (vertical) overflowClipRect.bottom else visible.bottom.toFloat(),
+        )
     }
 }
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -1,6 +1,8 @@
 package rs.whisker.runtime.scene
 
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Matrix
 import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerMountedElement
 import rs.whisker.runtime.paint.HostBoxPaint
@@ -27,4 +29,43 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
     val geometry = HostGeometry()
     var paint: HostBoxPaint? = null
     var mountedElement: WhiskerMountedElement? = null
+
+    private val localTransform = Matrix()
+    private var hasLocalTransform = false
+
+    /** Applies a protocol transform around the local border-box origin. */
+    fun setLocalTransform(values: FloatArray, density: Float) {
+        require(isSupported2dTransform(values))
+        (parent as? android.view.View)?.invalidate()
+        localTransform.setValues(
+            floatArrayOf(
+                values[0], values[4], values[12] * density,
+                values[1], values[5], values[13] * density,
+                values[3], values[7], values[15],
+            ),
+        )
+        hasLocalTransform = !localTransform.isIdentity
+        invalidate()
+        (parent as? android.view.View)?.invalidate()
+    }
+
+    override fun draw(canvas: Canvas) {
+        if (!hasLocalTransform) {
+            super.draw(canvas)
+            return
+        }
+        val save = canvas.save()
+        canvas.concat(localTransform)
+        super.draw(canvas)
+        canvas.restoreToCount(save)
+    }
 }
+
+/** True only for finite 2D affine matrices embedded in a column-major 4x4 matrix. */
+internal fun isSupported2dTransform(values: FloatArray): Boolean =
+    values.size == 16 && values.all(Float::isFinite) &&
+        values[2] == 0f && values[3] == 0f &&
+        values[6] == 0f && values[7] == 0f &&
+        values[8] == 0f && values[9] == 0f &&
+        values[10] == 1f && values[11] == 0f &&
+        values[14] == 0f && values[15] == 1f

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -29,6 +29,7 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
     val geometry = HostGeometry()
     var paint: HostBoxPaint? = null
     var mountedElement: WhiskerMountedElement? = null
+    var zOrder: Int = 0
 
     private val localTransform = Matrix()
     private var hasLocalTransform = false

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -9,6 +9,7 @@ import android.graphics.RectF
 import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerMountedElement
 import rs.whisker.runtime.paint.HostBoxPaint
+import rs.whisker.runtime.paint.HostBackgroundLayers
 import rs.whisker.runtime.paint.ResolvedBoxGeometry
 import rs.whisker.runtime.paint.normalizeRadii
 
@@ -33,6 +34,7 @@ internal data class HostGeometry(
 internal class HostNode(context: Context, val element: String) : WhiskerContainerView(context) {
     val geometry = HostGeometry()
     var paint: HostBoxPaint? = null
+    var backgroundLayers: HostBackgroundLayers? = null
     var mountedElement: WhiskerMountedElement? = null
     var zOrder: Int = 0
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -10,6 +10,7 @@ import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerTextContent
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.paint.HostBackgroundGeometry
+import rs.whisker.runtime.paint.HostBackgroundBox
 import rs.whisker.runtime.paint.HostBoxPaint
 import rs.whisker.runtime.paint.HostBackgroundLayers
 import rs.whisker.runtime.paint.HostBackgroundRepeat
@@ -390,6 +391,8 @@ internal class HostScene(
                 },
                 repeatX = backgroundRepeat(numbers[9]),
                 repeatY = backgroundRepeat(numbers[10]),
+                origin = backgroundBox(numbers[11]),
+                clip = backgroundBox(numbers[12]),
             )
             node.backgroundLayers = if (operation.flags == BACKGROUND_RADIAL) {
                 HostBackgroundLayers(
@@ -454,6 +457,13 @@ internal class HostScene(
             HostBackgroundRepeat.NoRepeat
         }
 
+    private fun backgroundBox(value: Float): HostBackgroundBox =
+        if (value == BACKGROUND_BOX_BORDER.toFloat()) {
+            HostBackgroundBox.Border
+        } else {
+            HostBackgroundBox.Padding
+        }
+
     private fun validBackgroundLayers(
         operation: HostSceneOperation,
         existing: Set<Long>,
@@ -504,8 +514,13 @@ internal class HostScene(
                 )
         return supportedGeometry &&
             (sizeKind == BACKGROUND_SIZE_EXPLICIT.toFloat() || (0..3).all { numbers[it] == 0f }) &&
-            numbers[11] == BACKGROUND_BOX_PADDING.toFloat() &&
-            numbers[12] == BACKGROUND_BOX_BORDER.toFloat() &&
+            if (sizeKind == BACKGROUND_SIZE_EXPLICIT.toFloat()) {
+                numbers[11] in BACKGROUND_BOX_BORDER.toFloat()..BACKGROUND_BOX_PADDING.toFloat() &&
+                    numbers[12] in BACKGROUND_BOX_BORDER.toFloat()..BACKGROUND_BOX_PADDING.toFloat()
+            } else {
+                numbers[11] == BACKGROUND_BOX_PADDING.toFloat() &&
+                    numbers[12] == BACKGROUND_BOX_BORDER.toFloat()
+            } &&
             numbers[13] == BACKGROUND_ATTACHMENT_SCROLL.toFloat() &&
             numbers[14] == BACKGROUND_BLEND_NORMAL.toFloat()
     }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -74,6 +74,9 @@ internal class HostScene(
             if (stagedSnapshot) clear()
             stagedOperations.forEach(::applyOperation)
             attachRoots()
+            if (stagedOperations.any { it.tag in 1..5 || it.tag == 12 }) {
+                refreshZOrderProjection()
+            }
             sceneEpoch = stagedSceneEpoch
             revision = stagedTargetRevision
             true
@@ -139,11 +142,16 @@ internal class HostScene(
                 operation.node !in existing || operation.numbers?.size ?: 0 < 53 ||
                 operation.names?.size ?: 0 < 5
             ) return false
-            8, 10, 11, 12, 15, 16 -> if (operation.node !in existing) return false
+            8, 12, 15, 16 -> if (operation.node !in existing) return false
             9 -> if (
                 operation.node !in existing ||
                 !isSupported2dTransform(operation.numbers ?: return false)
             ) return false
+            10 -> if (
+                operation.node !in existing || !operation.scalar.isFinite() ||
+                operation.scalar !in 0f..1f
+            ) return false
+            11 -> if (operation.node !in existing || operation.integer !in 0..1) return false
             13 -> if (
                 operation.node !in existing || operation.text == null ||
                 operation.numbers?.size ?: 0 < 8 || operation.names?.isEmpty() != false
@@ -196,7 +204,7 @@ internal class HostScene(
             10 -> (nodes[id] ?: return).alpha = operation.scalar
             11 -> (nodes[id] ?: return).visibility =
                 if (operation.integer != 0) View.VISIBLE else View.INVISIBLE
-            12 -> (nodes[id] ?: return).translationZ = operation.integer.toFloat()
+            12 -> (nodes[id] ?: return).zOrder = operation.integer
             13 -> applyText(
                 nodes[id] ?: return,
                 requireNotNull(operation.text),
@@ -216,6 +224,15 @@ internal class HostScene(
                 (node.parent as? ViewGroup)?.removeView(node)
                 root.addView(node)
             }
+        }
+    }
+
+    /** Preserves exact signed i32 ordering while projecting onto Android's Float Z axis. */
+    private fun refreshZOrderProjection() {
+        nodes.entries.groupBy { parents[it.key] }.values.forEach { siblings ->
+            val ranks = siblings.map { it.value.zOrder }.distinct().sorted()
+                .withIndex().associate { (rank, value) -> value to rank.toFloat() }
+            siblings.forEach { (_, node) -> node.translationZ = requireNotNull(ranks[node.zOrder]) }
         }
     }
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -140,6 +140,10 @@ internal class HostScene(
                 operation.names?.size ?: 0 < 5
             ) return false
             8, 10, 11, 12, 15, 16 -> if (operation.node !in existing) return false
+            9 -> if (
+                operation.node !in existing ||
+                !isSupported2dTransform(operation.numbers ?: return false)
+            ) return false
             13 -> if (
                 operation.node !in existing || operation.text == null ||
                 operation.numbers?.size ?: 0 < 8 || operation.names?.isEmpty() != false
@@ -184,6 +188,10 @@ internal class HostScene(
             8 -> (nodes[id] ?: return).setDescendantClip(
                 horizontal = operation.flags and 1 != 0,
                 vertical = operation.flags and 2 != 0,
+            )
+            9 -> (nodes[id] ?: return).setLocalTransform(
+                requireNotNull(operation.numbers),
+                root.resources.displayMetrics.density,
             )
             10 -> (nodes[id] ?: return).alpha = operation.scalar
             11 -> (nodes[id] ?: return).visibility =

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -181,7 +181,10 @@ internal class HostScene(
                 nodes[id] ?: return,
                 HostBoxPaint(requireNotNull(operation.numbers), requireNotNull(operation.names)),
             )
-            8 -> (nodes[id] ?: return).clipChildren = operation.flags and 3 != 0
+            8 -> (nodes[id] ?: return).setDescendantClip(
+                horizontal = operation.flags and 1 != 0,
+                vertical = operation.flags and 2 != 0,
+            )
             10 -> (nodes[id] ?: return).alpha = operation.scalar
             11 -> (nodes[id] ?: return).visibility =
                 if (operation.integer != 0) View.VISIBLE else View.INVISIBLE

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -136,7 +136,7 @@ internal class HostScene(
             5 -> if (stagedParents[operation.child] != operation.parent) return false
             6 -> if (operation.node !in existing || operation.numbers?.size ?: 0 < 8) return false
             7 -> if (
-                operation.node !in existing || operation.numbers?.size ?: 0 < 45 ||
+                operation.node !in existing || operation.numbers?.size ?: 0 < 53 ||
                 operation.names?.size ?: 0 < 5
             ) return false
             8, 10, 11, 12, 15, 16 -> if (operation.node !in existing) return false

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -11,6 +11,7 @@ import rs.whisker.runtime.WhiskerTextContent
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.paint.HostBoxPaint
 import rs.whisker.runtime.paint.HostBackgroundLayers
+import rs.whisker.runtime.paint.HostConicGradient
 import rs.whisker.runtime.paint.HostGradientStop
 import rs.whisker.runtime.paint.HostLinearGradient
 import rs.whisker.runtime.paint.HostPaintCoordinate
@@ -361,13 +362,17 @@ internal class HostScene(
         } else {
             val density = root.resources.displayMetrics.density
             val names = requireNotNull(operation.names)
-            val stopOffset = if (operation.flags == 1) 8 else 0
+            val stopOffset = when (operation.flags) {
+                1 -> 8
+                2 -> 4
+                else -> 0
+            }
             val stops = decodeGradientStops(numbers, stopOffset, names, density)
+            fun coordinate(offset: Int) = HostPaintCoordinate(
+                length = numbers[offset] * density,
+                fraction = numbers[offset + 1],
+            )
             node.backgroundLayers = if (operation.flags == 1) {
-                fun coordinate(offset: Int) = HostPaintCoordinate(
-                    length = numbers[offset] * density,
-                    fraction = numbers[offset + 1],
-                )
                 HostBackgroundLayers(
                     linearGradient = null,
                     radialGradient = HostRadialGradient(
@@ -375,6 +380,16 @@ internal class HostScene(
                         centerY = coordinate(2),
                         radiusX = coordinate(4),
                         radiusY = coordinate(6),
+                        stops = stops,
+                    ),
+                )
+            } else if (operation.flags == 2) {
+                HostBackgroundLayers(
+                    linearGradient = null,
+                    conicGradient = HostConicGradient(
+                        fromDegrees = operation.scalar,
+                        centerX = coordinate(0),
+                        centerY = coordinate(2),
                         stops = stops,
                     ),
                 )
@@ -415,7 +430,7 @@ internal class HostScene(
         existing: Set<Long>,
     ): Boolean {
         if (
-            operation.node !in existing || operation.flags !in 0..1 ||
+            operation.node !in existing || operation.flags !in 0..2 ||
             !operation.scalar.isFinite()
         ) {
             return false
@@ -423,7 +438,11 @@ internal class HostScene(
         val numbers = operation.numbers ?: FloatArray(0)
         val names = operation.names ?: emptyArray()
         if (numbers.isEmpty()) return operation.flags == 0 && names.isEmpty()
-        val stopOffset = if (operation.flags == 1) 8 else 0
+        val stopOffset = when (operation.flags) {
+            1 -> 8
+            2 -> 4
+            else -> 0
+        }
         if (
             numbers.size < stopOffset + 14 || (numbers.size - stopOffset) % 7 != 0 ||
             names.size != (numbers.size - stopOffset) / 7

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -13,6 +13,8 @@ import rs.whisker.runtime.paint.HostBoxPaint
 import rs.whisker.runtime.paint.HostBackgroundLayers
 import rs.whisker.runtime.paint.HostGradientStop
 import rs.whisker.runtime.paint.HostLinearGradient
+import rs.whisker.runtime.paint.HostPaintCoordinate
+import rs.whisker.runtime.paint.HostRadialGradient
 import rs.whisker.runtime.paint.applyBoxPaint
 import rs.whisker.runtime.paint.parseNamedColor
 import rs.whisker.runtime.paint.rgba
@@ -359,44 +361,78 @@ internal class HostScene(
         } else {
             val density = root.resources.displayMetrics.density
             val names = requireNotNull(operation.names)
-            val stops = List(numbers.size / 7) { index ->
-                val offset = index * 7
-                HostGradientStop(
-                    color = if (numbers[offset] == 0f) {
-                        parseNamedColor(names[index])
-                    } else {
-                        rgba(
-                            numbers[offset + 1],
-                            numbers[offset + 2],
-                            numbers[offset + 3],
-                            numbers[offset + 4],
-                        )
-                    },
-                    length = numbers[offset + 5] * density,
-                    fraction = numbers[offset + 6],
+            val stopOffset = if (operation.flags == 1) 8 else 0
+            val stops = decodeGradientStops(numbers, stopOffset, names, density)
+            node.backgroundLayers = if (operation.flags == 1) {
+                fun coordinate(offset: Int) = HostPaintCoordinate(
+                    length = numbers[offset] * density,
+                    fraction = numbers[offset + 1],
+                )
+                HostBackgroundLayers(
+                    linearGradient = null,
+                    radialGradient = HostRadialGradient(
+                        centerX = coordinate(0),
+                        centerY = coordinate(2),
+                        radiusX = coordinate(4),
+                        radiusY = coordinate(6),
+                        stops = stops,
+                    ),
+                )
+            } else {
+                HostBackgroundLayers(
+                    linearGradient = HostLinearGradient(operation.scalar, stops),
                 )
             }
-            node.backgroundLayers = HostBackgroundLayers(
-                linearGradient = HostLinearGradient(operation.scalar, stops),
-            )
         }
         node.paint?.let { applyPaint(node, it) }
+    }
+
+    private fun decodeGradientStops(
+        numbers: FloatArray,
+        start: Int,
+        names: Array<String>,
+        density: Float,
+    ): List<HostGradientStop> = List((numbers.size - start) / 7) { index ->
+        val offset = start + index * 7
+        HostGradientStop(
+            color = if (numbers[offset] == 0f) {
+                parseNamedColor(names[index])
+            } else {
+                rgba(
+                    numbers[offset + 1],
+                    numbers[offset + 2],
+                    numbers[offset + 3],
+                    numbers[offset + 4],
+                )
+            },
+            length = numbers[offset + 5] * density,
+            fraction = numbers[offset + 6],
+        )
     }
 
     private fun validBackgroundLayers(
         operation: HostSceneOperation,
         existing: Set<Long>,
     ): Boolean {
-        if (operation.node !in existing || operation.flags != 0 || !operation.scalar.isFinite()) {
+        if (
+            operation.node !in existing || operation.flags !in 0..1 ||
+            !operation.scalar.isFinite()
+        ) {
             return false
         }
         val numbers = operation.numbers ?: FloatArray(0)
         val names = operation.names ?: emptyArray()
-        if (numbers.isEmpty()) return names.isEmpty()
-        if (numbers.size < 14 || numbers.size % 7 != 0 || names.size != numbers.size / 7) {
+        if (numbers.isEmpty()) return operation.flags == 0 && names.isEmpty()
+        val stopOffset = if (operation.flags == 1) 8 else 0
+        if (
+            numbers.size < stopOffset + 14 || (numbers.size - stopOffset) % 7 != 0 ||
+            names.size != (numbers.size - stopOffset) / 7
+        ) {
             return false
         }
         return numbers.indices.all { index -> numbers[index].isFinite() } &&
-            (numbers.indices step 7).all { offset -> numbers[offset] == 0f || numbers[offset] == 1f }
+            (stopOffset until numbers.size step 7).all { offset ->
+                numbers[offset] == 0f || numbers[offset] == 1f
+            }
     }
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -503,7 +503,7 @@ internal class HostScene(
                         repeatY == BACKGROUND_NO_REPEAT.toFloat()
                 )
         return supportedGeometry &&
-            (0..3).all { numbers[it] == 0f } &&
+            (sizeKind == BACKGROUND_SIZE_EXPLICIT.toFloat() || (0..3).all { numbers[it] == 0f }) &&
             numbers[11] == BACKGROUND_BOX_PADDING.toFloat() &&
             numbers[12] == BACKGROUND_BOX_BORDER.toFloat() &&
             numbers[13] == BACKGROUND_ATTACHMENT_SCROLL.toFloat() &&

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -9,8 +9,10 @@ import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerTextContent
 import rs.whisker.runtime.WhiskerValue
+import rs.whisker.runtime.paint.HostBackgroundGeometry
 import rs.whisker.runtime.paint.HostBoxPaint
 import rs.whisker.runtime.paint.HostBackgroundLayers
+import rs.whisker.runtime.paint.HostBackgroundRepeat
 import rs.whisker.runtime.paint.HostConicGradient
 import rs.whisker.runtime.paint.HostGradientStop
 import rs.whisker.runtime.paint.HostLinearGradient
@@ -362,9 +364,10 @@ internal class HostScene(
         } else {
             val density = root.resources.displayMetrics.density
             val names = requireNotNull(operation.names)
-            val stopOffset = when (operation.flags) {
-                1 -> 8
-                2 -> 4
+            val imageOffset = BACKGROUND_GEOMETRY_PACKED_SIZE
+            val stopOffset = imageOffset + when (operation.flags) {
+                BACKGROUND_RADIAL -> 8
+                BACKGROUND_CONIC -> 4
                 else -> 0
             }
             val stops = decodeGradientStops(numbers, stopOffset, names, density)
@@ -372,30 +375,49 @@ internal class HostScene(
                 length = numbers[offset] * density,
                 fraction = numbers[offset + 1],
             )
-            node.backgroundLayers = if (operation.flags == 1) {
+            val geometry = HostBackgroundGeometry(
+                positionX = coordinate(0),
+                positionY = coordinate(2),
+                sizeWidth = if (numbers[8] == BACKGROUND_SIZE_EXPLICIT.toFloat()) {
+                    coordinate(4)
+                } else {
+                    null
+                },
+                sizeHeight = if (numbers[8] == BACKGROUND_SIZE_EXPLICIT.toFloat()) {
+                    coordinate(6)
+                } else {
+                    null
+                },
+                repeatX = backgroundRepeat(numbers[9]),
+                repeatY = backgroundRepeat(numbers[10]),
+            )
+            node.backgroundLayers = if (operation.flags == BACKGROUND_RADIAL) {
                 HostBackgroundLayers(
                     linearGradient = null,
                     radialGradient = HostRadialGradient(
-                        centerX = coordinate(0),
-                        centerY = coordinate(2),
-                        radiusX = coordinate(4),
-                        radiusY = coordinate(6),
+                        centerX = coordinate(imageOffset),
+                        centerY = coordinate(imageOffset + 2),
+                        radiusX = coordinate(imageOffset + 4),
+                        radiusY = coordinate(imageOffset + 6),
                         stops = stops,
                     ),
+                    geometry = geometry,
                 )
-            } else if (operation.flags == 2) {
+            } else if (operation.flags == BACKGROUND_CONIC) {
                 HostBackgroundLayers(
                     linearGradient = null,
                     conicGradient = HostConicGradient(
                         fromDegrees = operation.scalar,
-                        centerX = coordinate(0),
-                        centerY = coordinate(2),
+                        centerX = coordinate(imageOffset),
+                        centerY = coordinate(imageOffset + 2),
                         stops = stops,
                     ),
+                    geometry = geometry,
                 )
             } else {
                 HostBackgroundLayers(
                     linearGradient = HostLinearGradient(operation.scalar, stops),
+                    geometry = geometry,
                 )
             }
         }
@@ -425,22 +447,32 @@ internal class HostScene(
         )
     }
 
+    private fun backgroundRepeat(value: Float): HostBackgroundRepeat =
+        if (value == BACKGROUND_REPEAT.toFloat()) {
+            HostBackgroundRepeat.Repeat
+        } else {
+            HostBackgroundRepeat.NoRepeat
+        }
+
     private fun validBackgroundLayers(
         operation: HostSceneOperation,
         existing: Set<Long>,
     ): Boolean {
         if (
-            operation.node !in existing || operation.flags !in 0..2 ||
+            operation.node !in existing || operation.flags !in BACKGROUND_LINEAR..BACKGROUND_CONIC ||
             !operation.scalar.isFinite()
         ) {
             return false
         }
         val numbers = operation.numbers ?: FloatArray(0)
         val names = operation.names ?: emptyArray()
-        if (numbers.isEmpty()) return operation.flags == 0 && names.isEmpty()
-        val stopOffset = when (operation.flags) {
-            1 -> 8
-            2 -> 4
+        if (numbers.isEmpty()) return operation.flags == BACKGROUND_LINEAR && names.isEmpty()
+        if (numbers.size < BACKGROUND_GEOMETRY_PACKED_SIZE || !validBackgroundGeometry(numbers)) {
+            return false
+        }
+        val stopOffset = BACKGROUND_GEOMETRY_PACKED_SIZE + when (operation.flags) {
+            BACKGROUND_RADIAL -> 8
+            BACKGROUND_CONIC -> 4
             else -> 0
         }
         if (
@@ -453,5 +485,43 @@ internal class HostScene(
             (stopOffset until numbers.size step 7).all { offset ->
                 numbers[offset] == 0f || numbers[offset] == 1f
             }
+    }
+
+    private fun validBackgroundGeometry(numbers: FloatArray): Boolean {
+        val sizeKind = numbers[8]
+        val repeatX = numbers[9]
+        val repeatY = numbers[10]
+        val supportedGeometry =
+            (
+                sizeKind == BACKGROUND_SIZE_AUTO.toFloat() &&
+                    repeatX == BACKGROUND_REPEAT.toFloat() &&
+                    repeatY == BACKGROUND_REPEAT.toFloat()
+            ) ||
+                (
+                    sizeKind == BACKGROUND_SIZE_EXPLICIT.toFloat() &&
+                        repeatX == BACKGROUND_NO_REPEAT.toFloat() &&
+                        repeatY == BACKGROUND_NO_REPEAT.toFloat()
+                )
+        return supportedGeometry &&
+            (0..3).all { numbers[it] == 0f } &&
+            numbers[11] == BACKGROUND_BOX_PADDING.toFloat() &&
+            numbers[12] == BACKGROUND_BOX_BORDER.toFloat() &&
+            numbers[13] == BACKGROUND_ATTACHMENT_SCROLL.toFloat() &&
+            numbers[14] == BACKGROUND_BLEND_NORMAL.toFloat()
+    }
+
+    private companion object {
+        const val BACKGROUND_GEOMETRY_PACKED_SIZE = 15
+        const val BACKGROUND_LINEAR = 0
+        const val BACKGROUND_RADIAL = 1
+        const val BACKGROUND_CONIC = 2
+        const val BACKGROUND_SIZE_AUTO = 0
+        const val BACKGROUND_SIZE_EXPLICIT = 1
+        const val BACKGROUND_REPEAT = 0
+        const val BACKGROUND_NO_REPEAT = 1
+        const val BACKGROUND_BOX_BORDER = 0
+        const val BACKGROUND_BOX_PADDING = 1
+        const val BACKGROUND_ATTACHMENT_SCROLL = 0
+        const val BACKGROUND_BLEND_NORMAL = 0
     }
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -336,12 +336,13 @@ internal class HostScene(
 
     private fun applyPaint(node: HostNode, paint: HostBoxPaint) {
         node.paint = paint
-        applyBoxPaint(
+        val geometry = applyBoxPaint(
             node,
             paint,
             node.geometry.width,
             node.geometry.height,
             root.resources.displayMetrics.density,
         )
+        node.setOverflowClipGeometry(geometry)
     }
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -509,14 +509,13 @@ internal class HostScene(
             ) ||
                 (
                     sizeKind == BACKGROUND_SIZE_EXPLICIT.toFloat() &&
-                        repeatX == BACKGROUND_NO_REPEAT.toFloat() &&
-                        repeatY == BACKGROUND_NO_REPEAT.toFloat()
+                        validBackgroundRepeat(repeatX) &&
+                        validBackgroundRepeat(repeatY)
                 )
         return supportedGeometry &&
             (sizeKind == BACKGROUND_SIZE_EXPLICIT.toFloat() || (0..3).all { numbers[it] == 0f }) &&
             if (sizeKind == BACKGROUND_SIZE_EXPLICIT.toFloat()) {
-                numbers[11] in BACKGROUND_BOX_BORDER.toFloat()..BACKGROUND_BOX_PADDING.toFloat() &&
-                    numbers[12] in BACKGROUND_BOX_BORDER.toFloat()..BACKGROUND_BOX_PADDING.toFloat()
+                validBackgroundBox(numbers[11]) && validBackgroundBox(numbers[12])
             } else {
                 numbers[11] == BACKGROUND_BOX_PADDING.toFloat() &&
                     numbers[12] == BACKGROUND_BOX_BORDER.toFloat()
@@ -524,6 +523,12 @@ internal class HostScene(
             numbers[13] == BACKGROUND_ATTACHMENT_SCROLL.toFloat() &&
             numbers[14] == BACKGROUND_BLEND_NORMAL.toFloat()
     }
+
+    private fun validBackgroundRepeat(value: Float): Boolean =
+        value == BACKGROUND_REPEAT.toFloat() || value == BACKGROUND_NO_REPEAT.toFloat()
+
+    private fun validBackgroundBox(value: Float): Boolean =
+        value == BACKGROUND_BOX_BORDER.toFloat() || value == BACKGROUND_BOX_PADDING.toFloat()
 
     private companion object {
         const val BACKGROUND_GEOMETRY_PACKED_SIZE = 15

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -10,6 +10,9 @@ import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerTextContent
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.paint.HostBoxPaint
+import rs.whisker.runtime.paint.HostBackgroundLayers
+import rs.whisker.runtime.paint.HostGradientStop
+import rs.whisker.runtime.paint.HostLinearGradient
 import rs.whisker.runtime.paint.applyBoxPaint
 import rs.whisker.runtime.paint.parseNamedColor
 import rs.whisker.runtime.paint.rgba
@@ -157,6 +160,7 @@ internal class HostScene(
                 operation.numbers?.size ?: 0 < 8 || operation.names?.isEmpty() != false
             ) return false
             14 -> if (operation.node !in existing || operation.value == null) return false
+            21 -> if (!validBackgroundLayers(operation, existing)) return false
             else -> return false
         }
         return true
@@ -215,6 +219,7 @@ internal class HostScene(
                 ?.setProperty(operation.member, requireNotNull(operation.value))
             15 -> (nodes[id] ?: return).mountedElement?.clearProperty(operation.member)
             16 -> (nodes[id] ?: return).mountedElement?.setEventMask(operation.wide)
+            21 -> applyBackgroundLayers(nodes[id] ?: return, operation)
         }
     }
 
@@ -342,7 +347,56 @@ internal class HostScene(
             node.geometry.width,
             node.geometry.height,
             root.resources.displayMetrics.density,
+            node.backgroundLayers,
         )
         node.setOverflowClipGeometry(geometry)
+    }
+
+    private fun applyBackgroundLayers(node: HostNode, operation: HostSceneOperation) {
+        val numbers = operation.numbers ?: FloatArray(0)
+        if (numbers.isEmpty()) {
+            node.backgroundLayers = null
+        } else {
+            val density = root.resources.displayMetrics.density
+            val names = requireNotNull(operation.names)
+            val stops = List(numbers.size / 7) { index ->
+                val offset = index * 7
+                HostGradientStop(
+                    color = if (numbers[offset] == 0f) {
+                        parseNamedColor(names[index])
+                    } else {
+                        rgba(
+                            numbers[offset + 1],
+                            numbers[offset + 2],
+                            numbers[offset + 3],
+                            numbers[offset + 4],
+                        )
+                    },
+                    length = numbers[offset + 5] * density,
+                    fraction = numbers[offset + 6],
+                )
+            }
+            node.backgroundLayers = HostBackgroundLayers(
+                linearGradient = HostLinearGradient(operation.scalar, stops),
+            )
+        }
+        node.paint?.let { applyPaint(node, it) }
+    }
+
+    private fun validBackgroundLayers(
+        operation: HostSceneOperation,
+        existing: Set<Long>,
+    ): Boolean {
+        if (operation.node !in existing || operation.flags != 0 || !operation.scalar.isFinite()) {
+            return false
+        }
+        val numbers = operation.numbers ?: FloatArray(0)
+        val names = operation.names ?: emptyArray()
+        if (numbers.isEmpty()) return names.isEmpty()
+        if (numbers.size < 14 || numbers.size % 7 != 0 || names.size != numbers.size / 7) {
+            return false
+        }
+        return numbers.indices.all { index -> numbers[index].isFinite() } &&
+            (numbers.indices step 7).all { offset -> numbers[offset] == 0f || numbers[offset] == 1f }
     }
 }

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -910,6 +910,7 @@ impl GpuRenderer {
     }
 }
 
+#[cfg(test)]
 fn push_quad(vertices: &mut Vec<BoxVertex>, primitive: BoxPrimitive) {
     push_transformed_quad(vertices, primitive, Transform::IDENTITY);
 }

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -16,10 +16,12 @@ use wgpu::{
     TextureViewDescriptor, VertexAttribute, VertexBufferLayout, VertexFormat, VertexState,
     VertexStepMode,
 };
-use whisker_protocol::{NodeId, Transform};
+use whisker_protocol::{GradientStop, LayoutRect, NodeId, PaintImage, Transform};
 
-use crate::paint::box_paint::{BoxPrimitive, lower_box};
-use crate::paint::color::text_color;
+use crate::paint::box_paint::{
+    BoxPrimitive, BoxPrimitiveKind, linear_gradient_primitive, lower_box, resolve_box_geometry,
+};
+use crate::paint::color::{gpu_color, text_color};
 use crate::scene::{LogicalClip, PaintCommand, ShapeClipStack};
 use crate::text::NativeTextHost;
 
@@ -51,6 +53,25 @@ var<storage, read> shape_clip_records: array<ShapeClipRecord>;
 
 @group(1) @binding(1)
 var<storage, read> shape_clip_spans: array<ShapeClipSpan>;
+
+struct LinearGradientDraw {
+    start_end: vec4<f32>,
+    stop_offset: u32,
+    stop_count: u32,
+    repeating: u32,
+    _padding: u32,
+};
+
+struct LinearGradientStop {
+    position_and_padding: vec4<f32>,
+    color: vec4<f32>,
+};
+
+@group(1) @binding(2)
+var<storage, read> linear_gradient_draws: array<LinearGradientDraw>;
+
+@group(1) @binding(3)
+var<storage, read> linear_gradient_stops: array<LinearGradientStop>;
 
 struct VertexInput {
     @location(0) position: vec2<f32>,
@@ -340,6 +361,48 @@ fn styled_color(color: vec4<f32>, style: f32, side: f32, depth: f32) -> vec4<f32
     return color;
 }
 
+fn linear_gradient_color(draw_index: u32, position: vec2<f32>) -> vec4<f32> {
+    let gradient = linear_gradient_draws[draw_index];
+    if gradient.stop_count == 0u {
+        return vec4<f32>(0.0);
+    }
+    let line = gradient.start_end.zw - gradient.start_end.xy;
+    var progress = dot(position - gradient.start_end.xy, line) / max(dot(line, line), 0.0001);
+    if gradient.repeating != 0u {
+        progress = fract(progress);
+    }
+    let first = linear_gradient_stops[gradient.stop_offset];
+    if progress <= first.position_and_padding.x {
+        return first.color;
+    }
+    var previous = first;
+    for (var index = 1u; index < gradient.stop_count; index++) {
+        let current = linear_gradient_stops[gradient.stop_offset + index];
+        if progress <= current.position_and_padding.x {
+            let amount = clamp(
+                (progress - previous.position_and_padding.x)
+                    / max(current.position_and_padding.x - previous.position_and_padding.x, 0.0001),
+                0.0,
+                1.0,
+            );
+            let alpha = mix(previous.color.a, current.color.a, amount);
+            let premultiplied = mix(
+                previous.color.rgb * previous.color.a,
+                current.color.rgb * current.color.a,
+                amount,
+            );
+            let rgb = select(
+                vec3<f32>(0.0),
+                premultiplied / max(alpha, 0.0001),
+                alpha > 0.0001,
+            );
+            return vec4<f32>(rgb, alpha);
+        }
+        previous = current;
+    }
+    return previous.color;
+}
+
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let span = shape_clip_spans[input.draw_index];
@@ -372,6 +435,10 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         input.outer_radii_y,
     );
     let outer_coverage = shape_coverage(outer_distance);
+    if input.mode < -1.5 {
+        let color = linear_gradient_color(input.draw_index, input.logical_position);
+        return vec4<f32>(color.rgb, color.a * outer_coverage * clip_coverage);
+    }
     if input.mode < 0.0 {
         return vec4<f32>(input.color.rgb, input.color.a * outer_coverage * clip_coverage);
     }
@@ -551,6 +618,31 @@ struct ShapeClipSpanGpu {
     padding: [u32; 2],
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct LinearGradientDrawGpu {
+    start_end: [f32; 4],
+    stop_offset: u32,
+    stop_count: u32,
+    repeating: u32,
+    padding: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct LinearGradientStopGpu {
+    position: f32,
+    padding: [f32; 3],
+    color: [f32; 4],
+}
+
+#[derive(Clone)]
+pub(crate) struct LinearGradientDraw {
+    start_end: [f32; 4],
+    stops: Vec<LinearGradientStopGpu>,
+    repeating: bool,
+}
+
 struct BoxGpuPipeline {
     pipeline: RenderPipeline,
     viewport_buffer: Buffer,
@@ -605,6 +697,26 @@ impl BoxGpuPipeline {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: true },
@@ -698,6 +810,32 @@ impl BoxGpuPipeline {
         } else {
             spans
         };
+        let mut gradient_stops = Vec::new();
+        let gradient_draws = draws
+            .iter()
+            .map(|draw| {
+                let Some(gradient) = draw.gradient() else {
+                    return LinearGradientDrawGpu::zeroed();
+                };
+                let stop_offset = gradient_stops.len() as u32;
+                gradient_stops.extend_from_slice(&gradient.stops);
+                LinearGradientDrawGpu {
+                    start_end: gradient.start_end,
+                    stop_offset,
+                    stop_count: gradient.stops.len() as u32,
+                    repeating: u32::from(gradient.repeating),
+                    padding: 0,
+                }
+            })
+            .collect::<Vec<_>>();
+        if gradient_stops.is_empty() {
+            gradient_stops.push(LinearGradientStopGpu::zeroed());
+        }
+        let gradient_draws = if gradient_draws.is_empty() {
+            vec![LinearGradientDrawGpu::zeroed()]
+        } else {
+            gradient_draws
+        };
         let record_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("whisker Desktop shape clip records"),
             contents: bytemuck::cast_slice(&records),
@@ -706,6 +844,16 @@ impl BoxGpuPipeline {
         let span_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("whisker Desktop shape clip spans"),
             contents: bytemuck::cast_slice(&spans),
+            usage: BufferUsages::STORAGE,
+        });
+        let gradient_draw_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("whisker Desktop linear gradient draws"),
+            contents: bytemuck::cast_slice(&gradient_draws),
+            usage: BufferUsages::STORAGE,
+        });
+        let gradient_stop_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("whisker Desktop linear gradient stops"),
+            contents: bytemuck::cast_slice(&gradient_stops),
             usage: BufferUsages::STORAGE,
         });
         device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -720,6 +868,14 @@ impl BoxGpuPipeline {
                     binding: 1,
                     resource: span_buffer.as_entire_binding(),
                 },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: gradient_draw_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: gradient_stop_buffer.as_entire_binding(),
+                },
             ],
         })
     }
@@ -730,11 +886,77 @@ enum DrawCommand {
         vertices: Range<u32>,
         clip: LogicalClip,
         shape_clips: ShapeClipStack,
+        gradient: Option<LinearGradientDraw>,
     },
     Text {
         index: usize,
         node: NodeId,
     },
+}
+
+impl DrawCommand {
+    fn gradient(&self) -> Option<&LinearGradientDraw> {
+        match self {
+            Self::Quads { gradient, .. } => gradient.as_ref(),
+            Self::Text { .. } => None,
+        }
+    }
+}
+
+pub(crate) fn linear_gradient_draw(
+    positioning_rect: LayoutRect,
+    angle_degrees: f32,
+    repeating: bool,
+    stops: &[GradientStop],
+    opacity: f32,
+) -> LinearGradientDraw {
+    let angle = angle_degrees.to_radians();
+    let direction = [angle.sin(), -angle.cos()];
+    let center = [
+        positioning_rect.x + positioning_rect.width * 0.5,
+        positioning_rect.y + positioning_rect.height * 0.5,
+    ];
+    let half_length = direction[0].abs() * positioning_rect.width * 0.5
+        + direction[1].abs() * positioning_rect.height * 0.5;
+    let line_length = (half_length * 2.0).max(0.0001);
+    LinearGradientDraw {
+        start_end: [
+            center[0] - direction[0] * half_length,
+            center[1] - direction[1] * half_length,
+            center[0] + direction[0] * half_length,
+            center[1] + direction[1] * half_length,
+        ],
+        stops: stops
+            .iter()
+            .map(|stop| LinearGradientStopGpu {
+                position: stop.position.map_or(0.0, |position| {
+                    position.fraction + position.length / line_length
+                }),
+                padding: [0.0; 3],
+                color: gpu_color(&stop.color, opacity),
+            })
+            .collect(),
+        repeating,
+    }
+}
+
+fn push_quad_draw(
+    vertices: &mut Vec<BoxVertex>,
+    draws: &mut Vec<DrawCommand>,
+    primitive: BoxPrimitive,
+    transform: Transform,
+    clip: LogicalClip,
+    shape_clips: &ShapeClipStack,
+    gradient: Option<LinearGradientDraw>,
+) {
+    let start = vertices.len() as u32;
+    push_transformed_quad(vertices, primitive, transform);
+    draws.push(DrawCommand::Quads {
+        vertices: start..vertices.len() as u32,
+        clip,
+        shape_clips: shape_clips.clone(),
+        gradient,
+    });
 }
 
 pub(crate) struct GpuRenderer {
@@ -853,22 +1075,72 @@ impl GpuRenderer {
                 PaintCommand::Box {
                     rect,
                     paint,
+                    background_layers,
                     clip,
                     shape_clips,
                     transform,
                     opacity,
                 } => {
-                    let start = vertices.len() as u32;
+                    let default_paint = whisker_protocol::BoxPaint::default();
+                    let paint = paint.unwrap_or(&default_paint);
+                    let mut box_primitives = Vec::new();
                     lower_box(*rect, paint, *opacity, |primitive| {
-                        push_transformed_quad(&mut vertices, primitive, *transform);
+                        box_primitives.push(primitive)
                     });
-                    let end = vertices.len() as u32;
-                    if start != end {
-                        draws.push(DrawCommand::Quads {
-                            vertices: start..end,
-                            clip: *clip,
-                            shape_clips: shape_clips.clone(),
-                        });
+                    for primitive in box_primitives
+                        .iter()
+                        .copied()
+                        .filter(|primitive| primitive.kind == BoxPrimitiveKind::Fill)
+                    {
+                        push_quad_draw(
+                            &mut vertices,
+                            &mut draws,
+                            primitive,
+                            *transform,
+                            *clip,
+                            shape_clips,
+                            None,
+                        );
+                    }
+                    let positioning_rect = resolve_box_geometry(*rect, paint).inner_rect;
+                    for layer in background_layers.iter().rev() {
+                        let PaintImage::LinearGradient {
+                            angle_degrees,
+                            repeating,
+                            stops,
+                        } = &layer.image
+                        else {
+                            continue;
+                        };
+                        push_quad_draw(
+                            &mut vertices,
+                            &mut draws,
+                            linear_gradient_primitive(*rect, paint),
+                            *transform,
+                            *clip,
+                            shape_clips,
+                            Some(linear_gradient_draw(
+                                positioning_rect,
+                                *angle_degrees,
+                                *repeating,
+                                stops,
+                                *opacity,
+                            )),
+                        );
+                    }
+                    for primitive in box_primitives
+                        .into_iter()
+                        .filter(|primitive| primitive.kind == BoxPrimitiveKind::Border)
+                    {
+                        push_quad_draw(
+                            &mut vertices,
+                            &mut draws,
+                            primitive,
+                            *transform,
+                            *clip,
+                            shape_clips,
+                            None,
+                        );
                     }
                 }
                 PaintCommand::Text {
@@ -1154,6 +1426,7 @@ pub(crate) async fn render_box_primitives_offscreen(
                 LogicalClip::default(),
                 Transform::IDENTITY,
                 ShapeClipStack::default(),
+                None,
             )
         })
         .collect::<Vec<_>>();
@@ -1162,7 +1435,13 @@ pub(crate) async fn render_box_primitives_offscreen(
 
 #[cfg(all(test, feature = "host-conformance"))]
 pub(crate) async fn render_clipped_box_primitives_offscreen(
-    primitives: &[(BoxPrimitive, LogicalClip, Transform, ShapeClipStack)],
+    primitives: &[(
+        BoxPrimitive,
+        LogicalClip,
+        Transform,
+        ShapeClipStack,
+        Option<LinearGradientDraw>,
+    )],
     logical_size: [u32; 2],
 ) -> Result<Vec<u8>, GpuError> {
     let [width, height] = logical_size;
@@ -1191,13 +1470,14 @@ pub(crate) async fn render_clipped_box_primitives_offscreen(
 
     let mut vertices = Vec::new();
     let mut draws = Vec::new();
-    for (primitive, clip, transform, shape_clips) in primitives {
+    for (primitive, clip, transform, shape_clips, gradient) in primitives {
         let start = vertices.len() as u32;
         push_transformed_quad(&mut vertices, *primitive, *transform);
         draws.push(DrawCommand::Quads {
             vertices: start..vertices.len() as u32,
             clip: *clip,
             shape_clips: shape_clips.clone(),
+            gradient: gradient.clone(),
         });
     }
     let vertex_buffer = (!vertices.is_empty()).then(|| {

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -368,7 +368,11 @@ fn linear_gradient_color(draw_index: u32, position: vec2<f32>) -> vec4<f32> {
     }
     let line = gradient.start_end.zw - gradient.start_end.xy;
     var progress = dot(position - gradient.start_end.xy, line) / max(dot(line, line), 0.0001);
-    if gradient.kind == 2u {
+    if gradient.kind == 3u {
+        let delta = position - gradient.start_end.xy;
+        let clockwise_turns = atan2(delta.x, -delta.y) / (2.0 * 3.141592653589793);
+        progress = fract(clockwise_turns - gradient.start_end.z);
+    } else if gradient.kind == 2u {
         let normalized = (position - gradient.start_end.xy)
             / max(gradient.start_end.zw, vec2<f32>(0.0001));
         progress = length(normalized);
@@ -644,8 +648,7 @@ struct LinearGradientStopGpu {
 pub(crate) struct LinearGradientDraw {
     start_end: [f32; 4],
     stops: Vec<LinearGradientStopGpu>,
-    repeating: bool,
-    radial: bool,
+    kind: u32,
 }
 
 struct BoxGpuPipeline {
@@ -828,11 +831,7 @@ impl BoxGpuPipeline {
                     start_end: gradient.start_end,
                     stop_offset,
                     stop_count: gradient.stops.len() as u32,
-                    kind: if gradient.radial {
-                        2
-                    } else {
-                        u32::from(gradient.repeating)
-                    },
+                    kind: gradient.kind,
                     padding: 0,
                 }
             })
@@ -945,8 +944,7 @@ pub(crate) fn linear_gradient_draw(
                 color: gpu_color(&stop.color, opacity),
             })
             .collect(),
-        repeating,
-        radial: false,
+        kind: u32::from(repeating),
     }
 }
 
@@ -978,8 +976,32 @@ pub(crate) fn radial_gradient_draw(
                 color: gpu_color(&stop.color, opacity),
             })
             .collect(),
-        repeating: false,
-        radial: true,
+        kind: 2,
+    }
+}
+
+pub(crate) fn conic_gradient_draw(
+    positioning_rect: LayoutRect,
+    from_degrees: f32,
+    center: whisker_protocol::PaintPosition,
+    stops: &[GradientStop],
+    opacity: f32,
+) -> LinearGradientDraw {
+    let center = [
+        positioning_rect.x + center.x.length + center.x.fraction * positioning_rect.width,
+        positioning_rect.y + center.y.length + center.y.fraction * positioning_rect.height,
+    ];
+    LinearGradientDraw {
+        start_end: [center[0], center[1], from_degrees / 360.0, 0.0],
+        stops: stops
+            .iter()
+            .map(|stop| LinearGradientStopGpu {
+                position: stop.position.map_or(0.0, |position| position.fraction),
+                padding: [0.0; 3],
+                color: gpu_color(&stop.color, opacity),
+            })
+            .collect(),
+        kind: 3,
     }
 }
 
@@ -1168,6 +1190,18 @@ impl GpuRenderer {
                                 positioning_rect,
                                 *center,
                                 *radii,
+                                stops,
+                                *opacity,
+                            ),
+                            PaintImage::ConicGradient {
+                                from_degrees,
+                                center,
+                                repeating: false,
+                                stops,
+                            } => conic_gradient_draw(
+                                positioning_rect,
+                                *from_degrees,
+                                *center,
                                 stops,
                                 *opacity,
                             ),

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -20,17 +20,37 @@ use whisker_protocol::{NodeId, Transform};
 
 use crate::paint::box_paint::{BoxPrimitive, lower_box};
 use crate::paint::color::text_color;
-use crate::scene::{LogicalClip, PaintCommand};
+use crate::scene::{LogicalClip, PaintCommand, ShapeClipStack};
 use crate::text::NativeTextHost;
 
 const BOX_SHADER: &str = r#"
 struct Viewport {
     logical_size: vec2<f32>,
-    _padding: vec2<f32>,
+    physical_size: vec2<f32>,
 };
 
 @group(0) @binding(0)
 var<uniform> viewport: Viewport;
+
+struct ShapeClipRecord {
+    rect: vec4<f32>,
+    radii_x: vec4<f32>,
+    radii_y: vec4<f32>,
+    inverse_transform: mat4x4<f32>,
+    axes: vec4<u32>,
+};
+
+struct ShapeClipSpan {
+    offset: u32,
+    count: u32,
+    _padding: vec2<u32>,
+};
+
+@group(1) @binding(0)
+var<storage, read> shape_clip_records: array<ShapeClipRecord>;
+
+@group(1) @binding(1)
+var<storage, read> shape_clip_spans: array<ShapeClipSpan>;
 
 struct VertexInput {
     @location(0) position: vec2<f32>,
@@ -68,10 +88,11 @@ struct VertexOutput {
     @location(12) border_bottom_color: vec4<f32>,
     @location(13) border_left_color: vec4<f32>,
     @location(14) @interpolate(flat) border_styles: vec4<f32>,
+    @location(15) @interpolate(flat) draw_index: u32,
 };
 
 @vertex
-fn vs_main(input: VertexInput) -> VertexOutput {
+fn vs_main(input: VertexInput, @builtin(instance_index) draw_index: u32) -> VertexOutput {
     let transformed = input.transformed_position;
     var output: VertexOutput;
     output.position = vec4<f32>(
@@ -95,6 +116,7 @@ fn vs_main(input: VertexInput) -> VertexOutput {
     output.border_bottom_color = input.border_bottom_color;
     output.border_left_color = input.border_left_color;
     output.border_styles = input.border_styles;
+    output.draw_index = draw_index;
     return output;
 }
 
@@ -320,6 +342,29 @@ fn styled_color(color: vec4<f32>, style: f32, side: f32, depth: f32) -> vec4<f32
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let span = shape_clip_spans[input.draw_index];
+    var clip_coverage = 1.0;
+    let world_position = input.position.xy * viewport.logical_size / viewport.physical_size;
+    for (var index = 0u; index < span.count; index++) {
+        let clip = shape_clip_records[span.offset + index];
+        let local_h = clip.inverse_transform * vec4<f32>(world_position, 0.0, 1.0);
+        let local = local_h.xy / local_h.w;
+        var distance = -1e20;
+        if clip.axes.x != 0u && clip.axes.y != 0u {
+            distance = rounded_rect_distance(local, clip.rect, clip.radii_x, clip.radii_y);
+        } else {
+            if clip.axes.x != 0u {
+                distance = max(clip.rect.x - local.x, local.x - clip.rect.x - clip.rect.z);
+            }
+            if clip.axes.y != 0u {
+                distance = max(
+                    distance,
+                    max(clip.rect.y - local.y, local.y - clip.rect.y - clip.rect.w),
+                );
+            }
+        }
+        clip_coverage *= shape_coverage(distance);
+    }
     let outer_distance = rounded_rect_distance(
         input.logical_position,
         input.outer_rect,
@@ -328,7 +373,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     );
     let outer_coverage = shape_coverage(outer_distance);
     if input.mode < 0.0 {
-        return vec4<f32>(input.color.rgb, input.color.a * outer_coverage);
+        return vec4<f32>(input.color.rgb, input.color.a * outer_coverage * clip_coverage);
     }
 
     var inner_coverage = 0.0;
@@ -355,7 +400,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let style_coverage = patterned_coverage(style, path_position, width, depth)
         * double_coverage(style, depth);
     let coverage = max(outer_coverage - inner_coverage, 0.0) * style_coverage;
-    return vec4<f32>(color.rgb, color.a * coverage);
+    return vec4<f32>(color.rgb, color.a * coverage * clip_coverage);
 }
 "#;
 
@@ -485,20 +530,39 @@ impl BoxVertex {
 #[derive(Clone, Copy, Pod, Zeroable)]
 struct ViewportUniform {
     logical_size: [f32; 2],
-    padding: [f32; 2],
+    physical_size: [f32; 2],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct ShapeClipRecordGpu {
+    rect: [f32; 4],
+    radii_x: [f32; 4],
+    radii_y: [f32; 4],
+    inverse_transform: [f32; 16],
+    axes: [u32; 4],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct ShapeClipSpanGpu {
+    offset: u32,
+    count: u32,
+    padding: [u32; 2],
 }
 
 struct BoxGpuPipeline {
     pipeline: RenderPipeline,
     viewport_buffer: Buffer,
     viewport_bind_group: wgpu::BindGroup,
+    shape_clip_layout: wgpu::BindGroupLayout,
 }
 
 impl BoxGpuPipeline {
     fn new(device: &Device, format: TextureFormat) -> Self {
         let viewport_uniform = ViewportUniform {
             logical_size: [1.0, 1.0],
-            padding: [0.0; 2],
+            physical_size: [1.0, 1.0],
         };
         let viewport_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("whisker Desktop logical viewport"),
@@ -509,7 +573,7 @@ impl BoxGpuPipeline {
             label: Some("whisker Desktop viewport layout"),
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: false,
@@ -526,13 +590,38 @@ impl BoxGpuPipeline {
                 resource: viewport_buffer.as_entire_binding(),
             }],
         });
+        let shape_clip_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("whisker Desktop shape clip layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
         let shader = device.create_shader_module(ShaderModuleDescriptor {
             label: Some("whisker Desktop box shader"),
             source: ShaderSource::Wgsl(BOX_SHADER.into()),
         });
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("whisker Desktop box pipeline layout"),
-            bind_group_layouts: &[&viewport_layout],
+            bind_group_layouts: &[&viewport_layout, &shape_clip_layout],
             push_constant_ranges: &[],
         });
         let pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
@@ -564,18 +653,75 @@ impl BoxGpuPipeline {
             pipeline,
             viewport_buffer,
             viewport_bind_group,
+            shape_clip_layout,
         }
     }
 
-    fn update_viewport(&self, queue: &Queue, logical_size: [f32; 2]) {
+    fn update_viewport(&self, queue: &Queue, logical_size: [f32; 2], physical_size: [f32; 2]) {
         queue.write_buffer(
             &self.viewport_buffer,
             0,
             bytemuck::bytes_of(&ViewportUniform {
                 logical_size,
-                padding: [0.0; 2],
+                physical_size,
             }),
         );
+    }
+
+    fn shape_clip_bind_group(&self, device: &Device, draws: &[DrawCommand]) -> wgpu::BindGroup {
+        let mut records = Vec::new();
+        let spans = draws
+            .iter()
+            .map(|draw| {
+                let offset = records.len() as u32;
+                if let DrawCommand::Quads { shape_clips, .. } = draw {
+                    records.extend(shape_clips.iter().map(|clip| ShapeClipRecordGpu {
+                        rect: [clip.rect.x, clip.rect.y, clip.rect.width, clip.rect.height],
+                        radii_x: clip.radii.horizontal,
+                        radii_y: clip.radii.vertical,
+                        inverse_transform: clip.inverse_transform.0,
+                        axes: [u32::from(clip.horizontal), u32::from(clip.vertical), 0, 0],
+                    }));
+                }
+                ShapeClipSpanGpu {
+                    offset,
+                    count: records.len() as u32 - offset,
+                    padding: [0; 2],
+                }
+            })
+            .collect::<Vec<_>>();
+        if records.is_empty() {
+            records.push(ShapeClipRecordGpu::zeroed());
+        }
+        let spans = if spans.is_empty() {
+            vec![ShapeClipSpanGpu::zeroed()]
+        } else {
+            spans
+        };
+        let record_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("whisker Desktop shape clip records"),
+            contents: bytemuck::cast_slice(&records),
+            usage: BufferUsages::STORAGE,
+        });
+        let span_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("whisker Desktop shape clip spans"),
+            contents: bytemuck::cast_slice(&spans),
+            usage: BufferUsages::STORAGE,
+        });
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("whisker Desktop shape clips"),
+            layout: &self.shape_clip_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: record_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: span_buffer.as_entire_binding(),
+                },
+            ],
+        })
     }
 }
 
@@ -583,6 +729,7 @@ enum DrawCommand {
     Quads {
         vertices: Range<u32>,
         clip: LogicalClip,
+        shape_clips: ShapeClipStack,
     },
     Text {
         index: usize,
@@ -686,7 +833,11 @@ impl GpuRenderer {
         if self.config.width == 0 || self.config.height == 0 {
             return Ok(());
         }
-        self.box_gpu.update_viewport(&self.queue, logical_size);
+        self.box_gpu.update_viewport(
+            &self.queue,
+            logical_size,
+            [self.config.width as f32, self.config.height as f32],
+        );
         self.text_viewport.update(
             &self.queue,
             Resolution {
@@ -703,6 +854,7 @@ impl GpuRenderer {
                     rect,
                     paint,
                     clip,
+                    shape_clips,
                     transform,
                     opacity,
                 } => {
@@ -715,14 +867,19 @@ impl GpuRenderer {
                         draws.push(DrawCommand::Quads {
                             vertices: start..end,
                             clip: *clip,
+                            shape_clips: shape_clips.clone(),
                         });
                     }
                 }
                 PaintCommand::Text {
-                    node, transform, ..
+                    node,
+                    transform,
+                    shape_clips,
+                    ..
                 } => {
-                    // Glyph transforms are implemented with the SetText paint slice.
-                    let _ = transform;
+                    // Glyph transforms and shape clips are implemented with the
+                    // SetText paint slice; retain both states on the command now.
+                    let _ = (transform, shape_clips);
                     draws.push(DrawCommand::Text { index, node: *node })
                 }
             }
@@ -801,6 +958,7 @@ impl GpuRenderer {
                     usage: BufferUsages::VERTEX,
                 })
         });
+        let shape_clip_bind_group = self.box_gpu.shape_clip_bind_group(&self.device, &draws);
 
         let frame = match self.surface.get_current_texture() {
             Ok(frame) => frame,
@@ -836,9 +994,9 @@ impl GpuRenderer {
             });
         }
 
-        for draw in draws {
+        for (draw_index, draw) in draws.into_iter().enumerate() {
             match draw {
-                DrawCommand::Quads { vertices, clip } => {
+                DrawCommand::Quads { vertices, clip, .. } => {
                     let Some((x, y, width, height)) = self.scissor(clip, scale) else {
                         continue;
                     };
@@ -859,6 +1017,7 @@ impl GpuRenderer {
                     pass.set_scissor_rect(x, y, width, height);
                     pass.set_pipeline(&self.box_gpu.pipeline);
                     pass.set_bind_group(0, &self.box_gpu.viewport_bind_group, &[]);
+                    pass.set_bind_group(1, &shape_clip_bind_group, &[]);
                     pass.set_vertex_buffer(
                         0,
                         vertex_buffer
@@ -866,7 +1025,7 @@ impl GpuRenderer {
                             .expect("quad draw has vertices")
                             .slice(..),
                     );
-                    pass.draw(vertices, 0..1);
+                    pass.draw(vertices, draw_index as u32..draw_index as u32 + 1);
                 }
                 DrawCommand::Text { node, .. } => {
                     if !prepared_text_nodes.contains(&node) {
@@ -989,14 +1148,21 @@ pub(crate) async fn render_box_primitives_offscreen(
     let clipped = primitives
         .iter()
         .copied()
-        .map(|primitive| (primitive, LogicalClip::default(), Transform::IDENTITY))
+        .map(|primitive| {
+            (
+                primitive,
+                LogicalClip::default(),
+                Transform::IDENTITY,
+                ShapeClipStack::default(),
+            )
+        })
         .collect::<Vec<_>>();
     render_clipped_box_primitives_offscreen(&clipped, logical_size).await
 }
 
 #[cfg(all(test, feature = "host-conformance"))]
 pub(crate) async fn render_clipped_box_primitives_offscreen(
-    primitives: &[(BoxPrimitive, LogicalClip, Transform)],
+    primitives: &[(BoxPrimitive, LogicalClip, Transform, ShapeClipStack)],
     logical_size: [u32; 2],
 ) -> Result<Vec<u8>, GpuError> {
     let [width, height] = logical_size;
@@ -1017,14 +1183,22 @@ pub(crate) async fn render_clipped_box_primitives_offscreen(
         .map_err(|error| GpuError(format!("create offscreen Desktop GPU device: {error}")))?;
     let format = TextureFormat::Rgba8Unorm;
     let box_gpu = BoxGpuPipeline::new(&device, format);
-    box_gpu.update_viewport(&queue, [width as f32, height as f32]);
+    box_gpu.update_viewport(
+        &queue,
+        [width as f32, height as f32],
+        [width as f32, height as f32],
+    );
 
     let mut vertices = Vec::new();
     let mut draws = Vec::new();
-    for (primitive, clip, transform) in primitives {
+    for (primitive, clip, transform, shape_clips) in primitives {
         let start = vertices.len() as u32;
         push_transformed_quad(&mut vertices, *primitive, *transform);
-        draws.push((start..vertices.len() as u32, *clip));
+        draws.push(DrawCommand::Quads {
+            vertices: start..vertices.len() as u32,
+            clip: *clip,
+            shape_clips: shape_clips.clone(),
+        });
     }
     let vertex_buffer = (!vertices.is_empty()).then(|| {
         device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -1061,6 +1235,7 @@ pub(crate) async fn render_clipped_box_primitives_offscreen(
     let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor {
         label: Some("whisker Desktop conformance encoder"),
     });
+    let shape_clip_bind_group = box_gpu.shape_clip_bind_group(&device, &draws);
     {
         encoder.begin_render_pass(&RenderPassDescriptor {
             label: Some("whisker Desktop conformance clear"),
@@ -1078,7 +1253,15 @@ pub(crate) async fn render_clipped_box_primitives_offscreen(
         });
     }
     if let Some(vertex_buffer) = &vertex_buffer {
-        for (range, clip) in draws {
+        for (draw_index, draw) in draws.into_iter().enumerate() {
+            let DrawCommand::Quads {
+                vertices: range,
+                clip,
+                ..
+            } = draw
+            else {
+                unreachable!();
+            };
             let Some((x, y, clip_width, clip_height)) = offscreen_scissor(clip, width, height)
             else {
                 continue;
@@ -1100,8 +1283,9 @@ pub(crate) async fn render_clipped_box_primitives_offscreen(
             pass.set_scissor_rect(x, y, clip_width, clip_height);
             pass.set_pipeline(&box_gpu.pipeline);
             pass.set_bind_group(0, &box_gpu.viewport_bind_group, &[]);
+            pass.set_bind_group(1, &shape_clip_bind_group, &[]);
             pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-            pass.draw(range, 0..1);
+            pass.draw(range, draw_index as u32..draw_index as u32 + 1);
         }
     }
     encoder.copy_texture_to_buffer(

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -16,10 +16,10 @@ use wgpu::{
     TextureViewDescriptor, VertexAttribute, VertexBufferLayout, VertexFormat, VertexState,
     VertexStepMode,
 };
-use whisker_protocol::{GradientStop, LayoutRect, NodeId, PaintImage, Transform};
+use whisker_protocol::{GradientStop, LayoutRect, NodeId, PaintBox, PaintImage, Transform};
 
 use crate::paint::box_paint::{
-    BoxPrimitive, BoxPrimitiveKind, linear_gradient_primitive, lower_box, resolve_box_geometry,
+    BoxPrimitive, BoxPrimitiveKind, background_gradient_primitive, lower_box, resolve_box_geometry,
 };
 use crate::paint::color::{gpu_color, text_color};
 use crate::scene::{LogicalClip, PaintCommand, ShapeClipStack};
@@ -1267,8 +1267,13 @@ impl GpuRenderer {
                             None,
                         );
                     }
-                    let positioning_rect = resolve_box_geometry(*rect, paint).inner_rect;
+                    let box_geometry = resolve_box_geometry(*rect, paint);
                     for layer in background_layers.iter().rev() {
+                        let positioning_rect = match layer.origin {
+                            PaintBox::Border => box_geometry.outer_rect,
+                            PaintBox::Padding => box_geometry.inner_rect,
+                            _ => continue,
+                        };
                         let Some(gradient) =
                             background_gradient_draw(positioning_rect, layer, *opacity)
                         else {
@@ -1277,7 +1282,7 @@ impl GpuRenderer {
                         push_quad_draw(
                             &mut vertices,
                             &mut draws,
-                            linear_gradient_primitive(*rect, paint),
+                            background_gradient_primitive(*rect, paint, layer.clip),
                             *transform,
                             *clip,
                             shape_clips,

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -58,7 +58,7 @@ struct LinearGradientDraw {
     start_end: vec4<f32>,
     stop_offset: u32,
     stop_count: u32,
-    repeating: u32,
+    kind: u32,
     _padding: u32,
 };
 
@@ -368,7 +368,11 @@ fn linear_gradient_color(draw_index: u32, position: vec2<f32>) -> vec4<f32> {
     }
     let line = gradient.start_end.zw - gradient.start_end.xy;
     var progress = dot(position - gradient.start_end.xy, line) / max(dot(line, line), 0.0001);
-    if gradient.repeating != 0u {
+    if gradient.kind == 2u {
+        let normalized = (position - gradient.start_end.xy)
+            / max(gradient.start_end.zw, vec2<f32>(0.0001));
+        progress = length(normalized);
+    } else if gradient.kind == 1u {
         progress = fract(progress);
     }
     let first = linear_gradient_stops[gradient.stop_offset];
@@ -624,7 +628,7 @@ struct LinearGradientDrawGpu {
     start_end: [f32; 4],
     stop_offset: u32,
     stop_count: u32,
-    repeating: u32,
+    kind: u32,
     padding: u32,
 }
 
@@ -641,6 +645,7 @@ pub(crate) struct LinearGradientDraw {
     start_end: [f32; 4],
     stops: Vec<LinearGradientStopGpu>,
     repeating: bool,
+    radial: bool,
 }
 
 struct BoxGpuPipeline {
@@ -823,7 +828,11 @@ impl BoxGpuPipeline {
                     start_end: gradient.start_end,
                     stop_offset,
                     stop_count: gradient.stops.len() as u32,
-                    repeating: u32::from(gradient.repeating),
+                    kind: if gradient.radial {
+                        2
+                    } else {
+                        u32::from(gradient.repeating)
+                    },
                     padding: 0,
                 }
             })
@@ -937,6 +946,40 @@ pub(crate) fn linear_gradient_draw(
             })
             .collect(),
         repeating,
+        radial: false,
+    }
+}
+
+pub(crate) fn radial_gradient_draw(
+    positioning_rect: LayoutRect,
+    center: whisker_protocol::PaintPosition,
+    radii: (
+        whisker_protocol::PaintLengthPercentage,
+        whisker_protocol::PaintLengthPercentage,
+    ),
+    stops: &[GradientStop],
+    opacity: f32,
+) -> LinearGradientDraw {
+    let center = [
+        positioning_rect.x + center.x.length + center.x.fraction * positioning_rect.width,
+        positioning_rect.y + center.y.length + center.y.fraction * positioning_rect.height,
+    ];
+    let radii = [
+        radii.0.length + radii.0.fraction * positioning_rect.width,
+        radii.1.length + radii.1.fraction * positioning_rect.height,
+    ];
+    LinearGradientDraw {
+        start_end: [center[0], center[1], radii[0], radii[1]],
+        stops: stops
+            .iter()
+            .map(|stop| LinearGradientStopGpu {
+                position: stop.position.map_or(0.0, |position| position.fraction),
+                padding: [0.0; 3],
+                color: gpu_color(&stop.color, opacity),
+            })
+            .collect(),
+        repeating: false,
+        radial: true,
     }
 }
 
@@ -1104,13 +1147,31 @@ impl GpuRenderer {
                     }
                     let positioning_rect = resolve_box_geometry(*rect, paint).inner_rect;
                     for layer in background_layers.iter().rev() {
-                        let PaintImage::LinearGradient {
-                            angle_degrees,
-                            repeating,
-                            stops,
-                        } = &layer.image
-                        else {
-                            continue;
+                        let gradient = match &layer.image {
+                            PaintImage::LinearGradient {
+                                angle_degrees,
+                                repeating,
+                                stops,
+                            } => linear_gradient_draw(
+                                positioning_rect,
+                                *angle_degrees,
+                                *repeating,
+                                stops,
+                                *opacity,
+                            ),
+                            PaintImage::RadialGradient {
+                                center,
+                                radii: Some(radii),
+                                stops,
+                                ..
+                            } => radial_gradient_draw(
+                                positioning_rect,
+                                *center,
+                                *radii,
+                                stops,
+                                *opacity,
+                            ),
+                            _ => continue,
                         };
                         push_quad_draw(
                             &mut vertices,
@@ -1119,13 +1180,7 @@ impl GpuRenderer {
                             *transform,
                             *clip,
                             shape_clips,
-                            Some(linear_gradient_draw(
-                                positioning_rect,
-                                *angle_degrees,
-                                *repeating,
-                                stops,
-                                *opacity,
-                            )),
+                            Some(gradient),
                         );
                     }
                     for primitive in box_primitives

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -56,10 +56,11 @@ var<storage, read> shape_clip_spans: array<ShapeClipSpan>;
 
 struct LinearGradientDraw {
     start_end: vec4<f32>,
+    tile_rect: vec4<f32>,
     stop_offset: u32,
     stop_count: u32,
     kind: u32,
-    _padding: u32,
+    geometry_flags: u32,
 };
 
 struct LinearGradientStop {
@@ -366,6 +367,11 @@ fn linear_gradient_color(draw_index: u32, position: vec2<f32>) -> vec4<f32> {
     if gradient.stop_count == 0u {
         return vec4<f32>(0.0);
     }
+    if (gradient.geometry_flags & 1u) != 0u
+        && (any(position < gradient.tile_rect.xy)
+            || any(position >= gradient.tile_rect.xy + gradient.tile_rect.zw)) {
+        return vec4<f32>(0.0);
+    }
     let line = gradient.start_end.zw - gradient.start_end.xy;
     var progress = dot(position - gradient.start_end.xy, line) / max(dot(line, line), 0.0001);
     if gradient.kind == 3u {
@@ -630,10 +636,11 @@ struct ShapeClipSpanGpu {
 #[derive(Clone, Copy, Pod, Zeroable)]
 struct LinearGradientDrawGpu {
     start_end: [f32; 4],
+    tile_rect: [f32; 4],
     stop_offset: u32,
     stop_count: u32,
     kind: u32,
-    padding: u32,
+    geometry_flags: u32,
 }
 
 #[repr(C)]
@@ -647,8 +654,10 @@ struct LinearGradientStopGpu {
 #[derive(Clone)]
 pub(crate) struct LinearGradientDraw {
     start_end: [f32; 4],
+    tile_rect: [f32; 4],
     stops: Vec<LinearGradientStopGpu>,
     kind: u32,
+    no_repeat: bool,
 }
 
 struct BoxGpuPipeline {
@@ -829,10 +838,11 @@ impl BoxGpuPipeline {
                 gradient_stops.extend_from_slice(&gradient.stops);
                 LinearGradientDrawGpu {
                     start_end: gradient.start_end,
+                    tile_rect: gradient.tile_rect,
                     stop_offset,
                     stop_count: gradient.stops.len() as u32,
                     kind: gradient.kind,
-                    padding: 0,
+                    geometry_flags: u32::from(gradient.no_repeat),
                 }
             })
             .collect::<Vec<_>>();
@@ -934,6 +944,12 @@ pub(crate) fn linear_gradient_draw(
             center[0] + direction[0] * half_length,
             center[1] + direction[1] * half_length,
         ],
+        tile_rect: [
+            positioning_rect.x,
+            positioning_rect.y,
+            positioning_rect.width,
+            positioning_rect.height,
+        ],
         stops: stops
             .iter()
             .map(|stop| LinearGradientStopGpu {
@@ -945,6 +961,7 @@ pub(crate) fn linear_gradient_draw(
             })
             .collect(),
         kind: u32::from(repeating),
+        no_repeat: false,
     }
 }
 
@@ -968,6 +985,12 @@ pub(crate) fn radial_gradient_draw(
     ];
     LinearGradientDraw {
         start_end: [center[0], center[1], radii[0], radii[1]],
+        tile_rect: [
+            positioning_rect.x,
+            positioning_rect.y,
+            positioning_rect.width,
+            positioning_rect.height,
+        ],
         stops: stops
             .iter()
             .map(|stop| LinearGradientStopGpu {
@@ -977,6 +1000,7 @@ pub(crate) fn radial_gradient_draw(
             })
             .collect(),
         kind: 2,
+        no_repeat: false,
     }
 }
 
@@ -993,6 +1017,12 @@ pub(crate) fn conic_gradient_draw(
     ];
     LinearGradientDraw {
         start_end: [center[0], center[1], from_degrees / 360.0, 0.0],
+        tile_rect: [
+            positioning_rect.x,
+            positioning_rect.y,
+            positioning_rect.width,
+            positioning_rect.height,
+        ],
         stops: stops
             .iter()
             .map(|stop| LinearGradientStopGpu {
@@ -1002,7 +1032,77 @@ pub(crate) fn conic_gradient_draw(
             })
             .collect(),
         kind: 3,
+        no_repeat: false,
     }
+}
+
+fn background_tile_rect(
+    positioning_rect: LayoutRect,
+    layer: &whisker_protocol::BackgroundLayer,
+) -> Option<(LayoutRect, bool)> {
+    use whisker_protocol::{BackgroundSize, ImageRepeat};
+
+    match layer.size {
+        BackgroundSize::Auto
+            if layer.repeat_x == ImageRepeat::Repeat && layer.repeat_y == ImageRepeat::Repeat =>
+        {
+            Some((positioning_rect, false))
+        }
+        BackgroundSize::Explicit {
+            width: Some(width),
+            height: Some(height),
+        } if layer.repeat_x == ImageRepeat::NoRepeat && layer.repeat_y == ImageRepeat::NoRepeat => {
+            let width = width.length + width.fraction * positioning_rect.width;
+            let height = height.length + height.fraction * positioning_rect.height;
+            if width < 0.0 || height < 0.0 {
+                return None;
+            }
+            Some((
+                LayoutRect {
+                    x: positioning_rect.x
+                        + layer.position.x.length
+                        + layer.position.x.fraction * (positioning_rect.width - width),
+                    y: positioning_rect.y
+                        + layer.position.y.length
+                        + layer.position.y.fraction * (positioning_rect.height - height),
+                    width,
+                    height,
+                },
+                true,
+            ))
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn background_gradient_draw(
+    positioning_rect: LayoutRect,
+    layer: &whisker_protocol::BackgroundLayer,
+    opacity: f32,
+) -> Option<LinearGradientDraw> {
+    let (tile_rect, no_repeat) = background_tile_rect(positioning_rect, layer)?;
+    let mut gradient = match &layer.image {
+        PaintImage::LinearGradient {
+            angle_degrees,
+            repeating,
+            stops,
+        } => linear_gradient_draw(tile_rect, *angle_degrees, *repeating, stops, opacity),
+        PaintImage::RadialGradient {
+            center,
+            radii: Some(radii),
+            stops,
+            ..
+        } => radial_gradient_draw(tile_rect, *center, *radii, stops, opacity),
+        PaintImage::ConicGradient {
+            from_degrees,
+            center,
+            repeating: false,
+            stops,
+        } => conic_gradient_draw(tile_rect, *from_degrees, *center, stops, opacity),
+        _ => return None,
+    };
+    gradient.no_repeat = no_repeat;
+    Some(gradient)
 }
 
 fn push_quad_draw(
@@ -1169,43 +1269,10 @@ impl GpuRenderer {
                     }
                     let positioning_rect = resolve_box_geometry(*rect, paint).inner_rect;
                     for layer in background_layers.iter().rev() {
-                        let gradient = match &layer.image {
-                            PaintImage::LinearGradient {
-                                angle_degrees,
-                                repeating,
-                                stops,
-                            } => linear_gradient_draw(
-                                positioning_rect,
-                                *angle_degrees,
-                                *repeating,
-                                stops,
-                                *opacity,
-                            ),
-                            PaintImage::RadialGradient {
-                                center,
-                                radii: Some(radii),
-                                stops,
-                                ..
-                            } => radial_gradient_draw(
-                                positioning_rect,
-                                *center,
-                                *radii,
-                                stops,
-                                *opacity,
-                            ),
-                            PaintImage::ConicGradient {
-                                from_degrees,
-                                center,
-                                repeating: false,
-                                stops,
-                            } => conic_gradient_draw(
-                                positioning_rect,
-                                *from_degrees,
-                                *center,
-                                stops,
-                                *opacity,
-                            ),
-                            _ => continue,
+                        let Some(gradient) =
+                            background_gradient_draw(positioning_rect, layer, *opacity)
+                        else {
+                            continue;
                         };
                         push_quad_draw(
                             &mut vertices,

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -367,19 +367,33 @@ fn linear_gradient_color(draw_index: u32, position: vec2<f32>) -> vec4<f32> {
     if gradient.stop_count == 0u {
         return vec4<f32>(0.0);
     }
-    if (gradient.geometry_flags & 1u) != 0u
-        && (any(position < gradient.tile_rect.xy)
-            || any(position >= gradient.tile_rect.xy + gradient.tile_rect.zw)) {
+    let no_repeat_x = (gradient.geometry_flags & 1u) != 0u;
+    let no_repeat_y = (gradient.geometry_flags & 2u) != 0u;
+    let tile_end = gradient.tile_rect.xy + gradient.tile_rect.zw;
+    if (no_repeat_x && (position.x < gradient.tile_rect.x || position.x >= tile_end.x))
+        || (no_repeat_y && (position.y < gradient.tile_rect.y || position.y >= tile_end.y)) {
         return vec4<f32>(0.0);
     }
+    var sample_position = position;
+    if !no_repeat_x {
+        sample_position.x = gradient.tile_rect.x
+            + fract((position.x - gradient.tile_rect.x) / max(gradient.tile_rect.z, 0.0001))
+                * gradient.tile_rect.z;
+    }
+    if !no_repeat_y {
+        sample_position.y = gradient.tile_rect.y
+            + fract((position.y - gradient.tile_rect.y) / max(gradient.tile_rect.w, 0.0001))
+                * gradient.tile_rect.w;
+    }
     let line = gradient.start_end.zw - gradient.start_end.xy;
-    var progress = dot(position - gradient.start_end.xy, line) / max(dot(line, line), 0.0001);
+    var progress = dot(sample_position - gradient.start_end.xy, line)
+        / max(dot(line, line), 0.0001);
     if gradient.kind == 3u {
-        let delta = position - gradient.start_end.xy;
+        let delta = sample_position - gradient.start_end.xy;
         let clockwise_turns = atan2(delta.x, -delta.y) / (2.0 * 3.141592653589793);
         progress = fract(clockwise_turns - gradient.start_end.z);
     } else if gradient.kind == 2u {
-        let normalized = (position - gradient.start_end.xy)
+        let normalized = (sample_position - gradient.start_end.xy)
             / max(gradient.start_end.zw, vec2<f32>(0.0001));
         progress = length(normalized);
     } else if gradient.kind == 1u {
@@ -657,7 +671,7 @@ pub(crate) struct LinearGradientDraw {
     tile_rect: [f32; 4],
     stops: Vec<LinearGradientStopGpu>,
     kind: u32,
-    no_repeat: bool,
+    geometry_flags: u32,
 }
 
 struct BoxGpuPipeline {
@@ -842,7 +856,7 @@ impl BoxGpuPipeline {
                     stop_offset,
                     stop_count: gradient.stops.len() as u32,
                     kind: gradient.kind,
-                    geometry_flags: u32::from(gradient.no_repeat),
+                    geometry_flags: gradient.geometry_flags,
                 }
             })
             .collect::<Vec<_>>();
@@ -961,7 +975,7 @@ pub(crate) fn linear_gradient_draw(
             })
             .collect(),
         kind: u32::from(repeating),
-        no_repeat: false,
+        geometry_flags: 0,
     }
 }
 
@@ -1000,7 +1014,7 @@ pub(crate) fn radial_gradient_draw(
             })
             .collect(),
         kind: 2,
-        no_repeat: false,
+        geometry_flags: 0,
     }
 }
 
@@ -1032,26 +1046,28 @@ pub(crate) fn conic_gradient_draw(
             })
             .collect(),
         kind: 3,
-        no_repeat: false,
+        geometry_flags: 0,
     }
 }
 
 fn background_tile_rect(
     positioning_rect: LayoutRect,
     layer: &whisker_protocol::BackgroundLayer,
-) -> Option<(LayoutRect, bool)> {
+) -> Option<(LayoutRect, u32)> {
     use whisker_protocol::{BackgroundSize, ImageRepeat};
 
     match layer.size {
         BackgroundSize::Auto
             if layer.repeat_x == ImageRepeat::Repeat && layer.repeat_y == ImageRepeat::Repeat =>
         {
-            Some((positioning_rect, false))
+            Some((positioning_rect, 0))
         }
         BackgroundSize::Explicit {
             width: Some(width),
             height: Some(height),
-        } if layer.repeat_x == ImageRepeat::NoRepeat && layer.repeat_y == ImageRepeat::NoRepeat => {
+        } if matches!(layer.repeat_x, ImageRepeat::Repeat | ImageRepeat::NoRepeat)
+            && matches!(layer.repeat_y, ImageRepeat::Repeat | ImageRepeat::NoRepeat) =>
+        {
             let width = width.length + width.fraction * positioning_rect.width;
             let height = height.length + height.fraction * positioning_rect.height;
             if width < 0.0 || height < 0.0 {
@@ -1068,7 +1084,8 @@ fn background_tile_rect(
                     width,
                     height,
                 },
-                true,
+                u32::from(layer.repeat_x == ImageRepeat::NoRepeat)
+                    | (u32::from(layer.repeat_y == ImageRepeat::NoRepeat) << 1),
             ))
         }
         _ => None,
@@ -1080,7 +1097,7 @@ pub(crate) fn background_gradient_draw(
     layer: &whisker_protocol::BackgroundLayer,
     opacity: f32,
 ) -> Option<LinearGradientDraw> {
-    let (tile_rect, no_repeat) = background_tile_rect(positioning_rect, layer)?;
+    let (tile_rect, geometry_flags) = background_tile_rect(positioning_rect, layer)?;
     let mut gradient = match &layer.image {
         PaintImage::LinearGradient {
             angle_degrees,
@@ -1101,7 +1118,7 @@ pub(crate) fn background_gradient_draw(
         } => conic_gradient_draw(tile_rect, *from_degrees, *center, stops, opacity),
         _ => return None,
     };
-    gradient.no_repeat = no_repeat;
+    gradient.geometry_flags = geometry_flags;
     Some(gradient)
 }
 

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -947,6 +947,19 @@ pub(crate) async fn render_box_primitives_offscreen(
     primitives: &[BoxPrimitive],
     logical_size: [u32; 2],
 ) -> Result<Vec<u8>, GpuError> {
+    let clipped = primitives
+        .iter()
+        .copied()
+        .map(|primitive| (primitive, LogicalClip::default()))
+        .collect::<Vec<_>>();
+    render_clipped_box_primitives_offscreen(&clipped, logical_size).await
+}
+
+#[cfg(all(test, feature = "host-conformance"))]
+pub(crate) async fn render_clipped_box_primitives_offscreen(
+    primitives: &[(BoxPrimitive, LogicalClip)],
+    logical_size: [u32; 2],
+) -> Result<Vec<u8>, GpuError> {
     let [width, height] = logical_size;
     if width == 0 || height == 0 {
         return Err(GpuError(
@@ -968,8 +981,11 @@ pub(crate) async fn render_box_primitives_offscreen(
     box_gpu.update_viewport(&queue, [width as f32, height as f32]);
 
     let mut vertices = Vec::new();
-    for primitive in primitives {
+    let mut draws = Vec::new();
+    for (primitive, clip) in primitives {
+        let start = vertices.len() as u32;
         push_quad(&mut vertices, *primitive);
+        draws.push((start..vertices.len() as u32, *clip));
     }
     let vertex_buffer = (!vertices.is_empty()).then(|| {
         device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -1007,8 +1023,8 @@ pub(crate) async fn render_box_primitives_offscreen(
         label: Some("whisker Desktop conformance encoder"),
     });
     {
-        let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
-            label: Some("whisker Desktop conformance boxes"),
+        encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("whisker Desktop conformance clear"),
             color_attachments: &[Some(RenderPassColorAttachment {
                 view: &view,
                 resolve_target: None,
@@ -1021,11 +1037,32 @@ pub(crate) async fn render_box_primitives_offscreen(
             timestamp_writes: None,
             occlusion_query_set: None,
         });
-        if let Some(vertex_buffer) = &vertex_buffer {
+    }
+    if let Some(vertex_buffer) = &vertex_buffer {
+        for (range, clip) in draws {
+            let Some((x, y, clip_width, clip_height)) = offscreen_scissor(clip, width, height)
+            else {
+                continue;
+            };
+            let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+                label: Some("whisker Desktop conformance boxes"),
+                color_attachments: &[Some(RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: Operations {
+                        load: LoadOp::Load,
+                        store: StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_scissor_rect(x, y, clip_width, clip_height);
             pass.set_pipeline(&box_gpu.pipeline);
             pass.set_bind_group(0, &box_gpu.viewport_bind_group, &[]);
             pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-            pass.draw(0..vertices.len() as u32, 0..1);
+            pass.draw(range, 0..1);
         }
     }
     encoder.copy_texture_to_buffer(
@@ -1072,6 +1109,23 @@ pub(crate) async fn render_box_primitives_offscreen(
     drop(mapped);
     readback.unmap();
     Ok(pixels)
+}
+
+#[cfg(all(test, feature = "host-conformance"))]
+fn offscreen_scissor(clip: LogicalClip, width: u32, height: u32) -> Option<(u32, u32, u32, u32)> {
+    let left = clip.left.unwrap_or(0.0).floor().max(0.0) as u32;
+    let top = clip.top.unwrap_or(0.0).floor().max(0.0) as u32;
+    let right = clip
+        .right
+        .unwrap_or(width as f32)
+        .ceil()
+        .clamp(0.0, width as f32) as u32;
+    let bottom = clip
+        .bottom
+        .unwrap_or(height as f32)
+        .ceil()
+        .clamp(0.0, height as f32) as u32;
+    (right > left && bottom > top).then_some((left, top, right - left, bottom - top))
 }
 
 #[cfg(test)]

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -16,7 +16,7 @@ use wgpu::{
     TextureViewDescriptor, VertexAttribute, VertexBufferLayout, VertexFormat, VertexState,
     VertexStepMode,
 };
-use whisker_protocol::NodeId;
+use whisker_protocol::{NodeId, Transform};
 
 use crate::paint::box_paint::{BoxPrimitive, lower_box};
 use crate::paint::color::text_color;
@@ -48,6 +48,7 @@ struct VertexInput {
     @location(12) border_bottom_color: vec4<f32>,
     @location(13) border_left_color: vec4<f32>,
     @location(14) border_styles: vec4<f32>,
+    @location(15) transformed_position: vec4<f32>,
 };
 
 struct VertexOutput {
@@ -71,9 +72,14 @@ struct VertexOutput {
 
 @vertex
 fn vs_main(input: VertexInput) -> VertexOutput {
-    let normalized = input.position / viewport.logical_size;
+    let transformed = input.transformed_position;
     var output: VertexOutput;
-    output.position = vec4<f32>(normalized.x * 2.0 - 1.0, 1.0 - normalized.y * 2.0, 0.0, 1.0);
+    output.position = vec4<f32>(
+        transformed.x / viewport.logical_size.x * 2.0 - transformed.w,
+        transformed.w - transformed.y / viewport.logical_size.y * 2.0,
+        transformed.z,
+        transformed.w,
+    );
     output.color = input.color;
     output.logical_position = input.position;
     output.outer_rect = input.outer_rect;
@@ -379,10 +385,11 @@ struct BoxVertex {
     mode: f32,
     border_colors: [[f32; 4]; 4],
     border_styles: [f32; 4],
+    transformed_position: [f32; 4],
 }
 
 impl BoxVertex {
-    const ATTRIBUTES: [VertexAttribute; 15] = [
+    const ATTRIBUTES: [VertexAttribute; 16] = [
         VertexAttribute {
             format: VertexFormat::Float32x2,
             offset: 0,
@@ -457,6 +464,11 @@ impl BoxVertex {
             format: VertexFormat::Float32x4,
             offset: std::mem::size_of::<[f32; 51]>() as u64,
             shader_location: 14,
+        },
+        VertexAttribute {
+            format: VertexFormat::Float32x4,
+            offset: std::mem::size_of::<[f32; 55]>() as u64,
+            shader_location: 15,
         },
     ];
 
@@ -688,11 +700,12 @@ impl GpuRenderer {
                     rect,
                     paint,
                     clip,
+                    transform,
                     opacity,
                 } => {
                     let start = vertices.len() as u32;
                     lower_box(*rect, paint, *opacity, |primitive| {
-                        push_quad(&mut vertices, primitive);
+                        push_transformed_quad(&mut vertices, primitive, *transform);
                     });
                     let end = vertices.len() as u32;
                     if start != end {
@@ -702,7 +715,11 @@ impl GpuRenderer {
                         });
                     }
                 }
-                PaintCommand::Text { node, .. } => {
+                PaintCommand::Text {
+                    node, transform, ..
+                } => {
+                    // Glyph transforms are implemented with the SetText paint slice.
+                    let _ = transform;
                     draws.push(DrawCommand::Text { index, node: *node })
                 }
             }
@@ -894,6 +911,14 @@ impl GpuRenderer {
 }
 
 fn push_quad(vertices: &mut Vec<BoxVertex>, primitive: BoxPrimitive) {
+    push_transformed_quad(vertices, primitive, Transform::IDENTITY);
+}
+
+fn push_transformed_quad(
+    vertices: &mut Vec<BoxVertex>,
+    primitive: BoxPrimitive,
+    transform: Transform,
+) {
     let rect = primitive.outer_rect;
     let left = rect.x;
     let top = rect.y;
@@ -925,8 +950,18 @@ fn push_quad(vertices: &mut Vec<BoxVertex>, primitive: BoxPrimitive) {
             mode: primitive.kind.shader_mode(),
             border_colors: primitive.border_colors,
             border_styles: primitive.border_styles,
+            transformed_position: transform_point(transform, position),
         });
     }
+}
+
+fn transform_point(transform: Transform, [x, y]: [f32; 2]) -> [f32; 4] {
+    [
+        transform.0[0] * x + transform.0[4] * y + transform.0[12],
+        transform.0[1] * x + transform.0[5] * y + transform.0[13],
+        transform.0[2] * x + transform.0[6] * y + transform.0[14],
+        transform.0[3] * x + transform.0[7] * y + transform.0[15],
+    ]
 }
 
 fn text_bounds(clip: LogicalClip, width: u32, height: u32, scale: f32) -> TextBounds {
@@ -950,14 +985,14 @@ pub(crate) async fn render_box_primitives_offscreen(
     let clipped = primitives
         .iter()
         .copied()
-        .map(|primitive| (primitive, LogicalClip::default()))
+        .map(|primitive| (primitive, LogicalClip::default(), Transform::IDENTITY))
         .collect::<Vec<_>>();
     render_clipped_box_primitives_offscreen(&clipped, logical_size).await
 }
 
 #[cfg(all(test, feature = "host-conformance"))]
 pub(crate) async fn render_clipped_box_primitives_offscreen(
-    primitives: &[(BoxPrimitive, LogicalClip)],
+    primitives: &[(BoxPrimitive, LogicalClip, Transform)],
     logical_size: [u32; 2],
 ) -> Result<Vec<u8>, GpuError> {
     let [width, height] = logical_size;
@@ -982,9 +1017,9 @@ pub(crate) async fn render_clipped_box_primitives_offscreen(
 
     let mut vertices = Vec::new();
     let mut draws = Vec::new();
-    for (primitive, clip) in primitives {
+    for (primitive, clip, transform) in primitives {
         let start = vertices.len() as u32;
-        push_quad(&mut vertices, *primitive);
+        push_transformed_quad(&mut vertices, *primitive, *transform);
         draws.push((start..vertices.len() as u32, *clip));
     }
     let vertex_buffer = (!vertices.is_empty()).then(|| {

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -626,9 +626,12 @@ impl GpuRenderer {
             .formats
             .iter()
             .copied()
-            .find(TextureFormat::is_srgb)
-            .or_else(|| capabilities.formats.first().copied())
-            .ok_or_else(|| GpuError("Desktop GPU surface exposes no texture format".into()))?;
+            .find(|format| !format.is_srgb())
+            .ok_or_else(|| {
+                GpuError(
+                    "Desktop GPU surface exposes no non-sRGB format for CSS compositing".into(),
+                )
+            })?;
         let present_mode = capabilities
             .present_modes
             .iter()
@@ -1012,7 +1015,7 @@ pub(crate) async fn render_clipped_box_primitives_offscreen(
         .request_device(&DeviceDescriptor::default())
         .await
         .map_err(|error| GpuError(format!("create offscreen Desktop GPU device: {error}")))?;
-    let format = TextureFormat::Rgba8UnormSrgb;
+    let format = TextureFormat::Rgba8Unorm;
     let box_gpu = BoxGpuPipeline::new(&device, format);
     box_gpu.update_viewport(&queue, [width as f32, height as f32]);
 
@@ -1174,7 +1177,7 @@ mod tests {
     };
 
     use crate::paint::box_paint::{ResolvedRadii, resolve_box_geometry, resolve_radii};
-    use crate::paint::color::{srgb_to_linear, srgba};
+    use crate::paint::color::srgba;
 
     fn radius(length: f32, fraction: f32) -> PaintCornerRadius {
         PaintCornerRadius::circular(PaintLengthPercentage { length, fraction })
@@ -1407,8 +1410,6 @@ mod tests {
             srgba(&PaintColor::Named("not-a-css-color".into()), 1.0),
             [0.0; 4]
         );
-        assert!((srgb_to_linear(0.02) - 0.02 / 12.92).abs() < f32::EPSILON);
-        assert!(srgb_to_linear(1.0) > 0.99);
     }
 
     #[test]

--- a/platforms/desktop/src/paint/box.rs
+++ b/platforms/desktop/src/paint/box.rs
@@ -3,7 +3,7 @@ use whisker_protocol::{
     PaintLengthPercentage,
 };
 
-use super::color::linear_color;
+use super::color::gpu_color;
 use crate::scene::is_transparent;
 
 /// One box fill or complete border ring ready for GPU vertex expansion.
@@ -50,7 +50,7 @@ pub(crate) fn lower_box(
         return;
     }
     if !is_transparent(&paint.background_color) {
-        let color = linear_color(&paint.background_color, opacity);
+        let color = gpu_color(&paint.background_color, opacity);
         if color[3] > 0.0 {
             emit(geometry.primitive(color, [[0.0; 4]; 4], [0.0; 4], BoxPrimitiveKind::Fill));
         }
@@ -117,7 +117,7 @@ fn paints_line(style: BorderLineStyle) -> bool {
 
 fn border_color(style: BorderLineStyle, width: f32, color: &PaintColor, opacity: f32) -> [f32; 4] {
     if paints_line(style) && width > 0.0 {
-        linear_color(color, opacity)
+        gpu_color(color, opacity)
     } else {
         [0.0; 4]
     }

--- a/platforms/desktop/src/paint/box.rs
+++ b/platforms/desktop/src/paint/box.rs
@@ -26,6 +26,7 @@ pub(crate) struct BoxPrimitive {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BoxPrimitiveKind {
     Fill,
+    LinearGradient,
     Border,
 }
 
@@ -33,9 +34,21 @@ impl BoxPrimitiveKind {
     pub(crate) const fn shader_mode(self) -> f32 {
         match self {
             Self::Fill => -1.0,
+            Self::LinearGradient => -2.0,
             Self::Border => 1.0,
         }
     }
+}
+
+/// Builds the border-box quad used by a background image layer. The shader
+/// evaluates the gradient against its independently resolved positioning box.
+pub(crate) fn linear_gradient_primitive(rect: LayoutRect, paint: &BoxPaint) -> BoxPrimitive {
+    resolve_box_geometry(rect, paint).primitive(
+        [0.0; 4],
+        [[0.0; 4]; 4],
+        [0.0; 4],
+        BoxPrimitiveKind::LinearGradient,
+    )
 }
 
 /// Lowers one semantic box without allocating or dynamically dispatching.

--- a/platforms/desktop/src/paint/box.rs
+++ b/platforms/desktop/src/paint/box.rs
@@ -1,5 +1,5 @@
 use whisker_protocol::{
-    BorderLineStyle, BoxPaint, LayoutRect, PaintColor, PaintCornerRadius, PaintCorners,
+    BorderLineStyle, BoxPaint, LayoutRect, PaintBox, PaintColor, PaintCornerRadius, PaintCorners,
     PaintLengthPercentage,
 };
 
@@ -40,10 +40,26 @@ impl BoxPrimitiveKind {
     }
 }
 
-/// Builds the border-box quad used by a background image layer. The shader
-/// evaluates the gradient against its independently resolved positioning box.
-pub(crate) fn linear_gradient_primitive(rect: LayoutRect, paint: &BoxPaint) -> BoxPrimitive {
-    resolve_box_geometry(rect, paint).primitive(
+/// Builds the quad used by a background image layer. The shader evaluates the
+/// gradient against its independently resolved positioning box.
+pub(crate) fn background_gradient_primitive(
+    rect: LayoutRect,
+    paint: &BoxPaint,
+    clip: PaintBox,
+) -> BoxPrimitive {
+    let geometry = resolve_box_geometry(rect, paint);
+    let geometry = match clip {
+        PaintBox::Border => geometry,
+        PaintBox::Padding => BoxGeometry {
+            outer_rect: geometry.inner_rect,
+            outer_radii: geometry.inner_radii,
+            inner_rect: geometry.inner_rect,
+            inner_radii: geometry.inner_radii,
+            border_widths: [0.0; 4],
+        },
+        _ => geometry,
+    };
+    geometry.primitive(
         [0.0; 4],
         [[0.0; 4]; 4],
         [0.0; 4],

--- a/platforms/desktop/src/paint/color.rs
+++ b/platforms/desktop/src/paint/color.rs
@@ -11,14 +11,13 @@ pub(crate) fn text_color(color: &PaintColor, opacity: f32) -> TextColor {
     )
 }
 
-pub(super) fn linear_color(color: &PaintColor, opacity: f32) -> [f32; 4] {
-    let [red, green, blue, alpha] = srgba(color, opacity);
-    [
-        srgb_to_linear(red),
-        srgb_to_linear(green),
-        srgb_to_linear(blue),
-        alpha,
-    ]
+/// CSS presentation color for an unorm render target.
+///
+/// CSS source-over compositing is defined in the sRGB color space. Keeping the
+/// swapchain unorm avoids the implicit linear-light blend performed by an sRGB
+/// GPU attachment.
+pub(super) fn gpu_color(color: &PaintColor, opacity: f32) -> [f32; 4] {
+    srgba(color, opacity)
 }
 
 pub(crate) fn srgba(color: &PaintColor, opacity: f32) -> [f32; 4] {
@@ -74,14 +73,6 @@ fn hsl_to_srgba(hue: f32, saturation: f32, lightness: f32, alpha: f32) -> [f32; 
     ]
 }
 
-pub(crate) fn srgb_to_linear(value: f32) -> f32 {
-    if value <= 0.04045 {
-        value / 12.92
-    } else {
-        ((value + 0.055) / 1.055).powf(2.4)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -105,7 +96,6 @@ mod tests {
             srgba(&PaintColor::Named("not-a-css-color".into()), 1.0),
             [0.0; 4]
         );
-        assert!((srgb_to_linear(0.02) - 0.02 / 12.92).abs() < f32::EPSILON);
-        assert!(srgb_to_linear(1.0) > 0.99);
+        assert_eq!(gpu_color(&hsl, 0.5), [0.0, 1.0, 0.0, 0.4]);
     }
 }

--- a/platforms/desktop/src/paint/color.rs
+++ b/platforms/desktop/src/paint/color.rs
@@ -16,7 +16,7 @@ pub(crate) fn text_color(color: &PaintColor, opacity: f32) -> TextColor {
 /// CSS source-over compositing is defined in the sRGB color space. Keeping the
 /// swapchain unorm avoids the implicit linear-light blend performed by an sRGB
 /// GPU attachment.
-pub(super) fn gpu_color(color: &PaintColor, opacity: f32) -> [f32; 4] {
+pub(crate) fn gpu_color(color: &PaintColor, opacity: f32) -> [f32; 4] {
     srgba(color, opacity)
 }
 

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
+use std::sync::Arc;
 
 use whisker_engine::FrameSink;
 use whisker_protocol::{
@@ -10,6 +11,7 @@ use whisker_protocol::{
 };
 
 use crate::element::{DesktopElementContent, DesktopElementError, DesktopElementRegistry};
+use crate::paint::box_paint::{ResolvedRadii, resolve_box_geometry};
 
 #[derive(Clone, Debug)]
 struct CommonPresentation {
@@ -93,10 +95,43 @@ impl LogicalClip {
 }
 
 #[derive(Clone, Copy, Debug)]
+pub(crate) struct ShapeClip {
+    pub(crate) rect: LayoutRect,
+    pub(crate) radii: ResolvedRadii,
+    pub(crate) inverse_transform: Transform,
+    pub(crate) horizontal: bool,
+    pub(crate) vertical: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ShapeClipStack(Option<Arc<ShapeClipNode>>);
+
+#[derive(Debug)]
+struct ShapeClipNode {
+    parent: ShapeClipStack,
+    clip: ShapeClip,
+}
+
+impl ShapeClipStack {
+    fn push(&self, clip: ShapeClip) -> Self {
+        Self(Some(Arc::new(ShapeClipNode {
+            parent: self.clone(),
+            clip,
+        })))
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = ShapeClip> + '_ {
+        std::iter::successors(self.0.as_deref(), |node| node.parent.0.as_deref())
+            .map(|node| node.clip)
+    }
+}
+
+#[derive(Clone, Debug)]
 struct PresentationContext {
     origin: [f32; 2],
     transform: Transform,
     clip: LogicalClip,
+    shape_clips: ShapeClipStack,
     opacity: f32,
 }
 
@@ -106,6 +141,7 @@ impl Default for PresentationContext {
             origin: [0.0; 2],
             transform: Transform::IDENTITY,
             clip: LogicalClip::default(),
+            shape_clips: ShapeClipStack::default(),
             opacity: 1.0,
         }
     }
@@ -137,12 +173,94 @@ fn transform_around(transform: Transform, x: f32, y: f32) -> Transform {
     )
 }
 
+fn inverse_transform(transform: Transform) -> Option<Transform> {
+    let mut rows = [[0.0_f32; 8]; 4];
+    for (row, values) in rows.iter_mut().enumerate() {
+        for (column, value) in values.iter_mut().take(4).enumerate() {
+            *value = transform.0[column * 4 + row];
+        }
+        values[4 + row] = 1.0;
+    }
+    for column in 0..4 {
+        let pivot = (column..4).max_by(|left, right| {
+            rows[*left][column]
+                .abs()
+                .total_cmp(&rows[*right][column].abs())
+        })?;
+        if rows[pivot][column].abs() <= f32::EPSILON {
+            return None;
+        }
+        rows.swap(column, pivot);
+        let scale = rows[column][column];
+        for value in &mut rows[column] {
+            *value /= scale;
+        }
+        let pivot_row = rows[column];
+        for (row, values) in rows.iter_mut().enumerate() {
+            if row == column {
+                continue;
+            }
+            let factor = values[column];
+            for index in 0..8 {
+                values[index] -= factor * pivot_row[index];
+            }
+        }
+    }
+    let mut inverse = [0.0; 16];
+    for (row, values) in rows.iter().enumerate() {
+        for column in 0..4 {
+            inverse[column * 4 + row] = values[4 + column];
+        }
+    }
+    Some(Transform(inverse))
+}
+
+fn transform_rect_aabb(rect: LayoutRect, transform: Transform) -> Option<LayoutRect> {
+    let mut minimum = [f32::INFINITY; 2];
+    let mut maximum = [f32::NEG_INFINITY; 2];
+    for [x, y] in [
+        [rect.x, rect.y],
+        [rect.x + rect.width, rect.y],
+        [rect.x + rect.width, rect.y + rect.height],
+        [rect.x, rect.y + rect.height],
+    ] {
+        let transformed_x = transform.0[0] * x + transform.0[4] * y + transform.0[12];
+        let transformed_y = transform.0[1] * x + transform.0[5] * y + transform.0[13];
+        let transformed_w = transform.0[3] * x + transform.0[7] * y + transform.0[15];
+        if transformed_w.abs() <= f32::EPSILON {
+            return None;
+        }
+        let point = [transformed_x / transformed_w, transformed_y / transformed_w];
+        if !point.into_iter().all(f32::is_finite) {
+            return None;
+        }
+        for axis in 0..2 {
+            minimum[axis] = minimum[axis].min(point[axis]);
+            maximum[axis] = maximum[axis].max(point[axis]);
+        }
+    }
+    Some(LayoutRect {
+        x: minimum[0],
+        y: minimum[1],
+        width: maximum[0] - minimum[0],
+        height: maximum[1] - minimum[1],
+    })
+}
+
+fn preserves_screen_axes(transform: Transform) -> bool {
+    transform.0[1].abs() <= f32::EPSILON
+        && transform.0[4].abs() <= f32::EPSILON
+        && transform.0[3].abs() <= f32::EPSILON
+        && transform.0[7].abs() <= f32::EPSILON
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum PaintCommand<'a> {
     Box {
         rect: LayoutRect,
         paint: &'a BoxPaint,
         clip: LogicalClip,
+        shape_clips: ShapeClipStack,
         transform: Transform,
         opacity: f32,
     },
@@ -151,6 +269,7 @@ pub(crate) enum PaintCommand<'a> {
         rect: LayoutRect,
         content: &'a TextContent,
         clip: LogicalClip,
+        shape_clips: ShapeClipStack,
         transform: Transform,
         opacity: f32,
     },
@@ -224,16 +343,49 @@ impl DesktopScene {
                 rect: border,
                 paint,
                 clip: context.clip,
+                shape_clips: context.shape_clips.clone(),
                 transform,
                 opacity,
             });
         }
 
-        let descendant_clip = context.clip.intersect(
-            border,
-            presentation.clip.horizontal == OverflowClip::Hidden,
-            presentation.clip.vertical == OverflowClip::Hidden,
-        );
+        let clip_horizontal = presentation.clip.horizontal == OverflowClip::Hidden;
+        let clip_vertical = presentation.clip.vertical == OverflowClip::Hidden;
+        let mut descendant_clip = context.clip;
+        let mut descendant_shape_clips = context.shape_clips.clone();
+        if clip_horizontal || clip_vertical {
+            let geometry = presentation.paint.as_ref().map_or_else(
+                || crate::paint::box_paint::BoxGeometry {
+                    outer_rect: border,
+                    outer_radii: ResolvedRadii {
+                        horizontal: [0.0; 4],
+                        vertical: [0.0; 4],
+                    },
+                    inner_rect: border,
+                    inner_radii: ResolvedRadii {
+                        horizontal: [0.0; 4],
+                        vertical: [0.0; 4],
+                    },
+                    border_widths: [0.0; 4],
+                },
+                |paint| resolve_box_geometry(border, paint),
+            );
+            descendant_shape_clips = descendant_shape_clips.push(ShapeClip {
+                rect: geometry.inner_rect,
+                radii: geometry.inner_radii,
+                inverse_transform: inverse_transform(transform).unwrap_or(Transform::IDENTITY),
+                horizontal: clip_horizontal,
+                vertical: clip_vertical,
+            });
+            if let Some(bounds) = transform_rect_aabb(geometry.inner_rect, transform) {
+                let axis_aligned = preserves_screen_axes(transform);
+                descendant_clip = descendant_clip.intersect(
+                    bounds,
+                    clip_horizontal && (clip_vertical || axis_aligned),
+                    clip_vertical && (clip_horizontal || axis_aligned),
+                );
+            }
+        }
         if let Some(content) = node.content.text() {
             let content_rect = LayoutRect {
                 x: border.x + presentation.layout.content_box.x,
@@ -246,6 +398,7 @@ impl DesktopScene {
                 rect: content_rect,
                 content,
                 clip: descendant_clip.intersect(content_rect, true, true),
+                shape_clips: descendant_shape_clips.clone(),
                 transform,
                 opacity,
             });
@@ -274,6 +427,7 @@ impl DesktopScene {
                     origin: [border.x, border.y],
                     transform,
                     clip: descendant_clip,
+                    shape_clips: descendant_shape_clips.clone(),
                     opacity,
                 },
                 commands,

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -6,7 +6,7 @@ use whisker_engine::FrameSink;
 use whisker_protocol::{
     ApplyResult, BoxClip, BoxPaint, ElementTypeId, FrameMode, FramePacket, LayoutGeometry,
     LayoutRect, NodeId, Operation, OverflowClip, PaintColor, SceneProjection, SurfaceId,
-    TextContent, ValidationError, Visibility, WhiskerValue,
+    TextContent, Transform, ValidationError, Visibility, WhiskerValue,
 };
 
 use crate::element::{DesktopElementContent, DesktopElementError, DesktopElementRegistry};
@@ -18,6 +18,7 @@ struct CommonPresentation {
     layout: LayoutGeometry,
     paint: Option<BoxPaint>,
     clip: BoxClip,
+    transform: Transform,
     opacity: f32,
     visibility: Visibility,
     z_order: i32,
@@ -34,6 +35,7 @@ impl Default for CommonPresentation {
                 horizontal: OverflowClip::Visible,
                 vertical: OverflowClip::Visible,
             },
+            transform: Transform::IDENTITY,
             opacity: 1.0,
             visibility: Visibility::Visible,
             z_order: 0,
@@ -90,12 +92,39 @@ impl LogicalClip {
     }
 }
 
+fn multiply_transform(left: Transform, right: Transform) -> Transform {
+    let mut result = [0.0; 16];
+    for column in 0..4 {
+        for row in 0..4 {
+            result[column * 4 + row] = (0..4)
+                .map(|index| left.0[index * 4 + row] * right.0[column * 4 + index])
+                .sum();
+        }
+    }
+    Transform(result)
+}
+
+fn translation(x: f32, y: f32) -> Transform {
+    let mut result = Transform::IDENTITY;
+    result.0[12] = x;
+    result.0[13] = y;
+    result
+}
+
+fn transform_around(transform: Transform, x: f32, y: f32) -> Transform {
+    multiply_transform(
+        multiply_transform(translation(x, y), transform),
+        translation(-x, -y),
+    )
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum PaintCommand<'a> {
     Box {
         rect: LayoutRect,
         paint: &'a BoxPaint,
         clip: LogicalClip,
+        transform: Transform,
         opacity: f32,
     },
     Text {
@@ -103,6 +132,7 @@ pub(crate) enum PaintCommand<'a> {
         rect: LayoutRect,
         content: &'a TextContent,
         clip: LogicalClip,
+        transform: Transform,
         opacity: f32,
     },
 }
@@ -143,7 +173,15 @@ impl DesktopScene {
         roots.sort_by_key(|(id, z)| (*z, id.get()));
         let mut commands = Vec::new();
         for (root, _) in roots {
-            self.collect_commands(root, 0.0, 0.0, LogicalClip::default(), 1.0, &mut commands);
+            self.collect_commands(
+                root,
+                0.0,
+                0.0,
+                Transform::IDENTITY,
+                LogicalClip::default(),
+                1.0,
+                &mut commands,
+            );
         }
         commands
     }
@@ -153,6 +191,7 @@ impl DesktopScene {
         id: NodeId,
         parent_x: f32,
         parent_y: f32,
+        ancestor_transform: Transform,
         ancestor_clip: LogicalClip,
         ancestor_opacity: f32,
         commands: &mut Vec<PaintCommand<'a>>,
@@ -166,12 +205,17 @@ impl DesktopScene {
             height: presentation.layout.border_box.height,
         };
         let opacity = ancestor_opacity * presentation.opacity;
+        let transform = multiply_transform(
+            ancestor_transform,
+            transform_around(presentation.transform, border.x, border.y),
+        );
         if presentation.visibility == Visibility::Visible {
             if let Some(paint) = &presentation.paint {
                 commands.push(PaintCommand::Box {
                     rect: border,
                     paint,
                     clip: ancestor_clip,
+                    transform,
                     opacity,
                 });
             }
@@ -196,6 +240,7 @@ impl DesktopScene {
                 rect: content_rect,
                 content,
                 clip: descendant_clip.intersect(content_rect, true, true),
+                transform,
                 opacity,
             });
         }
@@ -221,6 +266,7 @@ impl DesktopScene {
                 child,
                 border.x,
                 border.y,
+                transform,
                 descendant_clip,
                 opacity,
                 commands,
@@ -419,6 +465,13 @@ impl DesktopScene {
                         .presentation
                         .clip = *clip;
                 }
+                Operation::SetTransform { node, transform } => {
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .presentation
+                        .transform = *transform;
+                }
                 Operation::SetOpacity { node, opacity } => {
                     self.nodes
                         .get_mut(node)
@@ -500,8 +553,7 @@ impl DesktopScene {
                         }
                     }
                 }
-                Operation::SetTransform { .. }
-                | Operation::SetHitTest { .. }
+                Operation::SetHitTest { .. }
                 | Operation::SetPointerCapture { .. }
                 | Operation::ReleasePointerCapture { .. } => {}
                 Operation::SetBackgroundLayers { .. }

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -205,6 +205,9 @@ impl DesktopScene {
     ) {
         let node = self.nodes.get(&id).expect("retained child remains live");
         let presentation = &node.presentation;
+        if presentation.visibility == Visibility::Hidden {
+            return;
+        }
         let border = LayoutRect {
             x: context.origin[0] + presentation.layout.border_box.x,
             y: context.origin[1] + presentation.layout.border_box.y,
@@ -216,16 +219,14 @@ impl DesktopScene {
             context.transform,
             transform_around(presentation.transform, border.x, border.y),
         );
-        if presentation.visibility == Visibility::Visible {
-            if let Some(paint) = &presentation.paint {
-                commands.push(PaintCommand::Box {
-                    rect: border,
-                    paint,
-                    clip: context.clip,
-                    transform,
-                    opacity,
-                });
-            }
+        if let Some(paint) = &presentation.paint {
+            commands.push(PaintCommand::Box {
+                rect: border,
+                paint,
+                clip: context.clip,
+                transform,
+                opacity,
+            });
         }
 
         let descendant_clip = context.clip.intersect(
@@ -233,9 +234,7 @@ impl DesktopScene {
             presentation.clip.horizontal == OverflowClip::Hidden,
             presentation.clip.vertical == OverflowClip::Hidden,
         );
-        if presentation.visibility == Visibility::Visible
-            && let Some(content) = node.content.text()
-        {
+        if let Some(content) = node.content.text() {
             let content_rect = LayoutRect {
                 x: border.x + presentation.layout.content_box.x,
                 y: border.y + presentation.layout.content_box.y,

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -889,7 +889,6 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
             && layer.repeat_y == ImageRepeat::NoRepeat);
     supported_image
         && supported_geometry
-        && layer.position == Default::default()
         && layer.origin == PaintBox::Padding
         && layer.clip == PaintBox::Border
         && layer.attachment == BackgroundAttachment::Scroll

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -882,16 +882,17 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
         && layer.repeat_y == ImageRepeat::Repeat
         && layer.origin == PaintBox::Padding
         && layer.clip == PaintBox::Border;
-    let explicit_geometry = matches!(
-        layer.size,
-        BackgroundSize::Explicit {
-            width: Some(_),
-            height: Some(_)
-        }
-    ) && layer.repeat_x == ImageRepeat::NoRepeat
-        && layer.repeat_y == ImageRepeat::NoRepeat
-        && matches!(layer.origin, PaintBox::Border | PaintBox::Padding)
-        && matches!(layer.clip, PaintBox::Border | PaintBox::Padding);
+    let explicit_geometry =
+        matches!(
+            layer.size,
+            BackgroundSize::Explicit {
+                width: Some(_),
+                height: Some(_)
+            }
+        ) && matches!(layer.repeat_x, ImageRepeat::Repeat | ImageRepeat::NoRepeat)
+            && matches!(layer.repeat_y, ImageRepeat::Repeat | ImageRepeat::NoRepeat)
+            && matches!(layer.origin, PaintBox::Border | PaintBox::Padding)
+            && matches!(layer.clip, PaintBox::Border | PaintBox::Padding);
     supported_image
         && (initial_geometry || explicit_geometry)
         && layer.attachment == BackgroundAttachment::Scroll

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -876,21 +876,24 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
             stop.position.is_some_and(|position| position.length == 0.0)
         })
     );
-    let supported_geometry = (layer.size == BackgroundSize::Auto
+    let initial_geometry = layer.position == Default::default()
+        && layer.size == BackgroundSize::Auto
         && layer.repeat_x == ImageRepeat::Repeat
-        && layer.repeat_y == ImageRepeat::Repeat)
-        || (matches!(
-            layer.size,
-            BackgroundSize::Explicit {
-                width: Some(_),
-                height: Some(_)
-            }
-        ) && layer.repeat_x == ImageRepeat::NoRepeat
-            && layer.repeat_y == ImageRepeat::NoRepeat);
-    supported_image
-        && supported_geometry
+        && layer.repeat_y == ImageRepeat::Repeat
         && layer.origin == PaintBox::Padding
-        && layer.clip == PaintBox::Border
+        && layer.clip == PaintBox::Border;
+    let explicit_geometry = matches!(
+        layer.size,
+        BackgroundSize::Explicit {
+            width: Some(_),
+            height: Some(_)
+        }
+    ) && layer.repeat_x == ImageRepeat::NoRepeat
+        && layer.repeat_y == ImageRepeat::NoRepeat
+        && matches!(layer.origin, PaintBox::Border | PaintBox::Padding)
+        && matches!(layer.clip, PaintBox::Border | PaintBox::Padding);
+    supported_image
+        && (initial_geometry || explicit_geometry)
         && layer.attachment == BackgroundAttachment::Scroll
         && layer.blend_mode == BlendMode::Normal
 }

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -92,6 +92,25 @@ impl LogicalClip {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+struct PresentationContext {
+    origin: [f32; 2],
+    transform: Transform,
+    clip: LogicalClip,
+    opacity: f32,
+}
+
+impl Default for PresentationContext {
+    fn default() -> Self {
+        Self {
+            origin: [0.0; 2],
+            transform: Transform::IDENTITY,
+            clip: LogicalClip::default(),
+            opacity: 1.0,
+        }
+    }
+}
+
 fn multiply_transform(left: Transform, right: Transform) -> Transform {
     let mut result = [0.0; 16];
     for column in 0..4 {
@@ -173,15 +192,7 @@ impl DesktopScene {
         roots.sort_by_key(|(id, z)| (*z, id.get()));
         let mut commands = Vec::new();
         for (root, _) in roots {
-            self.collect_commands(
-                root,
-                0.0,
-                0.0,
-                Transform::IDENTITY,
-                LogicalClip::default(),
-                1.0,
-                &mut commands,
-            );
+            self.collect_commands(root, PresentationContext::default(), &mut commands);
         }
         commands
     }
@@ -189,24 +200,20 @@ impl DesktopScene {
     fn collect_commands<'a>(
         &'a self,
         id: NodeId,
-        parent_x: f32,
-        parent_y: f32,
-        ancestor_transform: Transform,
-        ancestor_clip: LogicalClip,
-        ancestor_opacity: f32,
+        context: PresentationContext,
         commands: &mut Vec<PaintCommand<'a>>,
     ) {
         let node = self.nodes.get(&id).expect("retained child remains live");
         let presentation = &node.presentation;
         let border = LayoutRect {
-            x: parent_x + presentation.layout.border_box.x,
-            y: parent_y + presentation.layout.border_box.y,
+            x: context.origin[0] + presentation.layout.border_box.x,
+            y: context.origin[1] + presentation.layout.border_box.y,
             width: presentation.layout.border_box.width,
             height: presentation.layout.border_box.height,
         };
-        let opacity = ancestor_opacity * presentation.opacity;
+        let opacity = context.opacity * presentation.opacity;
         let transform = multiply_transform(
-            ancestor_transform,
+            context.transform,
             transform_around(presentation.transform, border.x, border.y),
         );
         if presentation.visibility == Visibility::Visible {
@@ -214,14 +221,14 @@ impl DesktopScene {
                 commands.push(PaintCommand::Box {
                     rect: border,
                     paint,
-                    clip: ancestor_clip,
+                    clip: context.clip,
                     transform,
                     opacity,
                 });
             }
         }
 
-        let descendant_clip = ancestor_clip.intersect(
+        let descendant_clip = context.clip.intersect(
             border,
             presentation.clip.horizontal == OverflowClip::Hidden,
             presentation.clip.vertical == OverflowClip::Hidden,
@@ -264,11 +271,12 @@ impl DesktopScene {
         for (child, _, _) in children {
             self.collect_commands(
                 child,
-                border.x,
-                border.y,
-                transform,
-                descendant_clip,
-                opacity,
+                PresentationContext {
+                    origin: [border.x, border.y],
+                    transform,
+                    clip: descendant_clip,
+                    opacity,
+                },
                 commands,
             );
         }

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 
 use whisker_engine::FrameSink;
 use whisker_protocol::{
-    ApplyResult, BoxClip, BoxPaint, ElementTypeId, FrameMode, FramePacket, LayoutGeometry,
-    LayoutRect, NodeId, Operation, OverflowClip, PaintColor, SceneProjection, SurfaceId,
+    ApplyResult, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BoxClip,
+    BoxPaint, ElementTypeId, FrameMode, FramePacket, ImageRepeat, LayoutGeometry, LayoutRect,
+    NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintImage, SceneProjection, SurfaceId,
     TextContent, Transform, ValidationError, Visibility, WhiskerValue,
 };
 
@@ -19,6 +20,7 @@ struct CommonPresentation {
     children: Vec<NodeId>,
     layout: LayoutGeometry,
     paint: Option<BoxPaint>,
+    background_layers: Vec<BackgroundLayer>,
     clip: BoxClip,
     transform: Transform,
     opacity: f32,
@@ -33,6 +35,7 @@ impl Default for CommonPresentation {
             children: Vec::new(),
             layout: LayoutGeometry::default(),
             paint: None,
+            background_layers: Vec::new(),
             clip: BoxClip {
                 horizontal: OverflowClip::Visible,
                 vertical: OverflowClip::Visible,
@@ -258,7 +261,8 @@ fn preserves_screen_axes(transform: Transform) -> bool {
 pub(crate) enum PaintCommand<'a> {
     Box {
         rect: LayoutRect,
-        paint: &'a BoxPaint,
+        paint: Option<&'a BoxPaint>,
+        background_layers: &'a [BackgroundLayer],
         clip: LogicalClip,
         shape_clips: ShapeClipStack,
         transform: Transform,
@@ -338,10 +342,11 @@ impl DesktopScene {
             context.transform,
             transform_around(presentation.transform, border.x, border.y),
         );
-        if let Some(paint) = &presentation.paint {
+        if presentation.paint.is_some() || !presentation.background_layers.is_empty() {
             commands.push(PaintCommand::Box {
                 rect: border,
-                paint,
+                paint: presentation.paint.as_ref(),
+                background_layers: &presentation.background_layers,
                 clip: context.clip,
                 shape_clips: context.shape_clips.clone(),
                 transform,
@@ -503,8 +508,10 @@ impl DesktopScene {
                             .validate_command(element_type, *node, *command, arguments)?;
                     }
                 }
-                Operation::SetBackgroundLayers { .. } => {
-                    return Err(DesktopPresentError::Unsupported("background-layers"));
+                Operation::SetBackgroundLayers { layers, .. } => {
+                    if !layers.iter().all(supports_linear_gradient_layer) {
+                        return Err(DesktopPresentError::Unsupported("background-layers"));
+                    }
                 }
                 Operation::SetVisualEffects { .. } => {
                     return Err(DesktopPresentError::Unsupported("visual-effects"));
@@ -619,6 +626,13 @@ impl DesktopScene {
                         .presentation
                         .paint = Some(paint.clone());
                 }
+                Operation::SetBackgroundLayers { node, layers } => {
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .presentation
+                        .background_layers = layers.clone();
+                }
                 Operation::SetClip { node, clip } => {
                     self.nodes
                         .get_mut(node)
@@ -717,8 +731,7 @@ impl DesktopScene {
                 Operation::SetHitTest { .. }
                 | Operation::SetPointerCapture { .. }
                 | Operation::ReleasePointerCapture { .. } => {}
-                Operation::SetBackgroundLayers { .. }
-                | Operation::SetVisualEffects { .. }
+                Operation::SetVisualEffects { .. }
                 | Operation::SetImage { .. }
                 | Operation::SetCursor { .. } => {
                     unreachable!("unsupported operations are rejected before commit")
@@ -751,10 +764,16 @@ impl FrameSink for DesktopScene {
     fn capabilities(&self) -> whisker_protocol::RenderCapabilities {
         whisker_protocol::RenderCapabilities::new(
             whisker_protocol::ProtocolVersion::CURRENT,
-            [whisker_protocol::CapabilityEntry {
-                capability: whisker_protocol::RenderCapability::EllipticalBorderRadius,
-                support: whisker_protocol::CapabilitySupport::Native,
-            }],
+            [
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::EllipticalBorderRadius,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::LinearGradients,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
+            ],
         )
         .expect("Desktop capability profile is unique")
     }
@@ -815,6 +834,24 @@ impl From<DesktopElementError> for DesktopPresentError {
     fn from(error: DesktopElementError) -> Self {
         Self::Element(error)
     }
+}
+
+fn supports_linear_gradient_layer(layer: &BackgroundLayer) -> bool {
+    matches!(
+        &layer.image,
+        PaintImage::LinearGradient {
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| stop.position.is_some())
+    ) && layer.position == Default::default()
+        && layer.size == BackgroundSize::Auto
+        && layer.repeat_x == ImageRepeat::Repeat
+        && layer.repeat_y == ImageRepeat::Repeat
+        && layer.origin == PaintBox::Padding
+        && layer.clip == PaintBox::Border
+        && layer.attachment == BackgroundAttachment::Scroll
+        && layer.blend_mode == BlendMode::Normal
 }
 
 pub(crate) fn is_transparent(color: &PaintColor) -> bool {

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -7,8 +7,8 @@ use whisker_engine::FrameSink;
 use whisker_protocol::{
     ApplyResult, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BoxClip,
     BoxPaint, ElementTypeId, FrameMode, FramePacket, ImageRepeat, LayoutGeometry, LayoutRect,
-    NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintImage, SceneProjection, SurfaceId,
-    TextContent, Transform, ValidationError, Visibility, WhiskerValue,
+    NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintImage, RadialGradientExtent,
+    SceneProjection, SurfaceId, TextContent, Transform, ValidationError, Visibility, WhiskerValue,
 };
 
 use crate::element::{DesktopElementContent, DesktopElementError, DesktopElementRegistry};
@@ -509,7 +509,7 @@ impl DesktopScene {
                     }
                 }
                 Operation::SetBackgroundLayers { layers, .. } => {
-                    if !layers.iter().all(supports_linear_gradient_layer) {
+                    if !layers.iter().all(supports_basic_background_layer) {
                         return Err(DesktopPresentError::Unsupported("background-layers"));
                     }
                 }
@@ -773,6 +773,10 @@ impl FrameSink for DesktopScene {
                     capability: whisker_protocol::RenderCapability::LinearGradients,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::RadialGradients,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("Desktop capability profile is unique")
@@ -836,15 +840,25 @@ impl From<DesktopElementError> for DesktopPresentError {
     }
 }
 
-fn supports_linear_gradient_layer(layer: &BackgroundLayer) -> bool {
-    matches!(
+fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
+    (matches!(
         &layer.image,
         PaintImage::LinearGradient {
             repeating: false,
             stops,
             ..
         } if stops.iter().all(|stop| stop.position.is_some())
-    ) && layer.position == Default::default()
+    ) || matches!(
+        &layer.image,
+        PaintImage::RadialGradient {
+            shape: whisker_protocol::RadialGradientShape::Ellipse,
+            extent: RadialGradientExtent::Explicit,
+            radii: Some(_),
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| stop.position.is_some())
+    )) && layer.position == Default::default()
         && layer.size == BackgroundSize::Auto
         && layer.repeat_x == ImageRepeat::Repeat
         && layer.repeat_y == ImageRepeat::Repeat

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -777,6 +777,10 @@ impl FrameSink for DesktopScene {
                     capability: whisker_protocol::RenderCapability::RadialGradients,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::ConicGradients,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("Desktop capability profile is unique")
@@ -858,6 +862,15 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
             stops,
             ..
         } if stops.iter().all(|stop| stop.position.is_some())
+    ) || matches!(
+        &layer.image,
+        PaintImage::ConicGradient {
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| {
+            stop.position.is_some_and(|position| position.length == 0.0)
+        })
     )) && layer.position == Default::default()
         && layer.size == BackgroundSize::Auto
         && layer.repeat_x == ImageRepeat::Repeat

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -781,6 +781,10 @@ impl FrameSink for DesktopScene {
                     capability: whisker_protocol::RenderCapability::ConicGradients,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::BackgroundGeometry,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("Desktop capability profile is unique")
@@ -845,7 +849,7 @@ impl From<DesktopElementError> for DesktopPresentError {
 }
 
 fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
-    (matches!(
+    let supported_image = matches!(
         &layer.image,
         PaintImage::LinearGradient {
             repeating: false,
@@ -871,10 +875,21 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
         } if stops.iter().all(|stop| {
             stop.position.is_some_and(|position| position.length == 0.0)
         })
-    )) && layer.position == Default::default()
-        && layer.size == BackgroundSize::Auto
+    );
+    let supported_geometry = (layer.size == BackgroundSize::Auto
         && layer.repeat_x == ImageRepeat::Repeat
-        && layer.repeat_y == ImageRepeat::Repeat
+        && layer.repeat_y == ImageRepeat::Repeat)
+        || (matches!(
+            layer.size,
+            BackgroundSize::Explicit {
+                width: Some(_),
+                height: Some(_)
+            }
+        ) && layer.repeat_x == ImageRepeat::NoRepeat
+            && layer.repeat_y == ImageRepeat::NoRepeat);
+    supported_image
+        && supported_geometry
+        && layer.position == Default::default()
         && layer.origin == PaintBox::Padding
         && layer.clip == PaintBox::Border
         && layer.attachment == BackgroundAttachment::Scroll

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -7,25 +7,25 @@ use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
     BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LoadedCase,
-    PixelRelationFixture, PixelRelationKind, PixelSampleFixture, PointerEventFixture, Scenario,
-    ScenarioSide, load_required,
+    OverflowClipFixture, PixelRelationFixture, PixelRelationKind, PixelSampleFixture,
+    PointerEventFixture, Scenario, ScenarioSide, SceneNodeFixture, load_required,
 };
 use whisker_protocol::{
-    AvailableSpace, BorderLineStyle, BoxPaint, ElementTypeId, FrameHeader, FrameMode, FramePacket,
-    InputEvent, InputEventKind, InputPoint, LayoutGeometry, LayoutRect, MeasureConstraints,
-    MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextDirection,
-    MeasureTextOverflow, MeasureTextWrap, MeasurementKey, MeasurementPayload, MeasurementRequest,
-    MeasurementResponse, NodeId, Operation, PaintColor, PaintCornerRadius, PaintCorners,
-    PaintEdges, PaintLengthPercentage, PointerId, PointerInput, PointerKind, ProtocolVersion,
-    SurfaceId, TextMeasurePayload, TextMeasureStyle, WhiskerValue,
+    AvailableSpace, BorderLineStyle, BoxClip, BoxPaint, ElementTypeId, FrameHeader, FrameMode,
+    FramePacket, InputEvent, InputEventKind, InputPoint, LayoutGeometry, LayoutRect,
+    MeasureConstraints, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+    MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap, MeasurementKey, MeasurementPayload,
+    MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintColor,
+    PaintCornerRadius, PaintCorners, PaintEdges, PaintLengthPercentage, PointerId, PointerInput,
+    PointerKind, ProtocolVersion, SurfaceId, TextMeasurePayload, TextMeasureStyle, WhiskerValue,
 };
 use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
 use crate::element::{DesktopElementRegistry, built_in_element_factories};
-use crate::gpu::render_box_primitives_offscreen;
+use crate::gpu::{render_box_primitives_offscreen, render_clipped_box_primitives_offscreen};
 use crate::paint::box_paint::{BoxPrimitive, BoxPrimitiveKind, lower_box};
 use crate::paint::color::srgba;
-use crate::scene::{DesktopScene, PaintCommand};
+use crate::scene::{DesktopScene, LogicalClip, PaintCommand};
 use crate::text::NativeTextHost;
 
 const CAPABILITIES: &str = include_str!("../../../../tests/host-conformance/capabilities.json");
@@ -97,7 +97,7 @@ impl RecordingInputSink {
 
 struct Checkpoint {
     logical_size: [u32; 2],
-    primitives: Vec<BoxPrimitive>,
+    primitives: Vec<(BoxPrimitive, LogicalClip)>,
     samples: Vec<PixelSampleFixture>,
     relations: Vec<PixelRelationFixture>,
 }
@@ -162,6 +162,7 @@ impl Driver {
                     background,
                     border,
                 } => self.present_box(*revision, *rect, background, border.as_ref()),
+                Command::PresentScene { revision, nodes } => self.present_scene(*revision, nodes),
                 Command::Checkpoint {
                     name,
                     samples,
@@ -173,7 +174,7 @@ impl Driver {
                             self.logical_size[0].round() as u32,
                             self.logical_size[1].round() as u32,
                         ],
-                        primitives: self.box_primitives(),
+                        primitives: self.clipped_box_primitives(),
                         samples: samples.clone(),
                         relations: relations.clone(),
                     });
@@ -287,19 +288,81 @@ impl Driver {
         }
     }
 
-    fn box_primitives(&self) -> Vec<BoxPrimitive> {
+    fn present_scene(&mut self, revision: u64, nodes: &[SceneNodeFixture]) {
+        let surface = self.surface.expect("attach_surface precedes present_scene");
+        let element_type = standard_element_type(whisker::VIEW_ELEMENT_NAME);
+        let mut operations = Vec::new();
+        for fixture in nodes {
+            operations.push(Operation::CreateNode {
+                node: NodeId::new(fixture.id).expect("validated fixture node id"),
+                element_type,
+            });
+        }
+        let mut child_counts = std::collections::BTreeMap::<u64, u32>::new();
+        for fixture in nodes.iter().filter(|fixture| fixture.parent.is_some()) {
+            let parent = fixture.parent.unwrap();
+            let index = child_counts.entry(parent).or_default();
+            operations.push(Operation::InsertChild {
+                parent: NodeId::new(parent).unwrap(),
+                child: NodeId::new(fixture.id).unwrap(),
+                index: *index,
+            });
+            *index += 1;
+        }
+        for fixture in nodes {
+            let node = NodeId::new(fixture.id).unwrap();
+            operations.push(Operation::SetLayout {
+                node,
+                geometry: LayoutGeometry {
+                    border_box: layout_rect(fixture.rect),
+                    content_box: LayoutRect::default(),
+                },
+            });
+            operations.push(Operation::SetBoxPaint {
+                node,
+                paint: box_paint(&fixture.background, fixture.border.as_ref()),
+            });
+            operations.push(Operation::SetClip {
+                node,
+                clip: BoxClip {
+                    horizontal: overflow_clip_protocol(fixture.clip.horizontal),
+                    vertical: overflow_clip_protocol(fixture.clip.vertical),
+                },
+            });
+        }
+        self.scene
+            .as_mut()
+            .expect("attached Desktop scene")
+            .present(&FramePacket {
+                header: FrameHeader {
+                    version: ProtocolVersion::CURRENT,
+                    surface,
+                    scene_epoch: 1,
+                    frame_id: revision,
+                    base_revision: 0,
+                    target_revision: revision,
+                    viewport_epoch: 1,
+                    mode: FrameMode::Snapshot,
+                },
+                operations,
+            })
+            .expect("canonical Host scene fixture is valid");
+    }
+
+    fn clipped_box_primitives(&self) -> Vec<(BoxPrimitive, LogicalClip)> {
         let scene = self.scene.as_ref().expect("checkpoint follows attach");
         let mut primitives = Vec::new();
         for command in scene.paint_commands() {
             if let PaintCommand::Box {
                 rect,
                 paint,
+                clip,
                 opacity,
                 ..
             } = command
             {
                 lower_box(rect, paint, opacity, |primitive| {
-                    primitives.push(primitive);
+                    primitives.push((primitive, clip));
                 });
             }
         }
@@ -425,6 +488,13 @@ fn layout_rect([x, y, width, height]: [f32; 4]) -> LayoutRect {
     }
 }
 
+fn overflow_clip_protocol(value: OverflowClipFixture) -> OverflowClip {
+    match value {
+        OverflowClipFixture::Visible => OverflowClip::Visible,
+        OverflowClipFixture::Hidden => OverflowClip::Hidden,
+    }
+}
+
 fn box_paint(background: &ColorFixture, border: Option<&BorderFixture>) -> BoxPaint {
     let zero = PaintLengthPercentage::default();
     let Some(border) = border else {
@@ -517,12 +587,12 @@ fn run_reftest(scenario: &Scenario) {
     assert_eq!(reference.len(), 1, "one reference checkpoint");
     assert_eq!(test[0].logical_size, reference[0].logical_size);
 
-    let test_pixels = pollster::block_on(render_box_primitives_offscreen(
+    let test_pixels = pollster::block_on(render_clipped_box_primitives_offscreen(
         &test[0].primitives,
         test[0].logical_size,
     ))
     .expect("Desktop test pixel checkpoint");
-    let reference_pixels = pollster::block_on(render_box_primitives_offscreen(
+    let reference_pixels = pollster::block_on(render_clipped_box_primitives_offscreen(
         &reference[0].primitives,
         reference[0].logical_size,
     ))
@@ -548,7 +618,7 @@ fn run_pixel_assertions(scenario: &Scenario) {
         .iter()
         .filter(|checkpoint| !checkpoint.samples.is_empty() || !checkpoint.relations.is_empty())
     {
-        let pixels = pollster::block_on(render_box_primitives_offscreen(
+        let pixels = pollster::block_on(render_clipped_box_primitives_offscreen(
             &checkpoint.primitives,
             checkpoint.logical_size,
         ))

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -27,7 +27,7 @@ use crate::element::{DesktopElementRegistry, built_in_element_factories};
 use crate::gpu::{render_box_primitives_offscreen, render_clipped_box_primitives_offscreen};
 use crate::paint::box_paint::{BoxPrimitive, BoxPrimitiveKind, lower_box};
 use crate::paint::color::srgba;
-use crate::scene::{DesktopScene, LogicalClip, PaintCommand};
+use crate::scene::{DesktopScene, LogicalClip, PaintCommand, ShapeClipStack};
 use crate::text::NativeTextHost;
 
 const CAPABILITIES: &str = include_str!("../../../../tests/host-conformance/capabilities.json");
@@ -99,7 +99,7 @@ impl RecordingInputSink {
 
 struct Checkpoint {
     logical_size: [u32; 2],
-    primitives: Vec<(BoxPrimitive, LogicalClip, Transform)>,
+    primitives: Vec<(BoxPrimitive, LogicalClip, Transform, ShapeClipStack)>,
     samples: Vec<PixelSampleFixture>,
     relations: Vec<PixelRelationFixture>,
 }
@@ -372,7 +372,9 @@ impl Driver {
             .expect("canonical Host scene fixture is valid");
     }
 
-    fn clipped_box_primitives(&self) -> Vec<(BoxPrimitive, LogicalClip, Transform)> {
+    fn clipped_box_primitives(
+        &self,
+    ) -> Vec<(BoxPrimitive, LogicalClip, Transform, ShapeClipStack)> {
         let scene = self.scene.as_ref().expect("checkpoint follows attach");
         let mut primitives = Vec::new();
         for command in scene.paint_commands() {
@@ -380,13 +382,14 @@ impl Driver {
                 rect,
                 paint,
                 clip,
+                shape_clips,
                 transform,
                 opacity,
                 ..
             } = command
             {
                 lower_box(rect, paint, opacity, |primitive| {
-                    primitives.push((primitive, clip, transform));
+                    primitives.push((primitive, clip, transform, shape_clips.clone()));
                 });
             }
         }

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -32,7 +32,7 @@ use crate::gpu::{
     render_clipped_box_primitives_offscreen,
 };
 use crate::paint::box_paint::{
-    BoxPrimitive, BoxPrimitiveKind, linear_gradient_primitive, lower_box, resolve_box_geometry,
+    BoxPrimitive, BoxPrimitiveKind, background_gradient_primitive, lower_box, resolve_box_geometry,
 };
 use crate::paint::color::srgba;
 use crate::scene::{DesktopScene, LogicalClip, PaintCommand, ShapeClipStack};
@@ -617,14 +617,19 @@ impl Driver {
                         .filter(|primitive| primitive.kind == BoxPrimitiveKind::Fill)
                         .map(|primitive| (primitive, clip, transform, shape_clips.clone(), None)),
                 );
-                let positioning_rect = resolve_box_geometry(rect, paint).inner_rect;
+                let box_geometry = resolve_box_geometry(rect, paint);
                 for layer in background_layers.iter().rev() {
+                    let positioning_rect = match layer.origin {
+                        PaintBox::Border => box_geometry.outer_rect,
+                        PaintBox::Padding => box_geometry.inner_rect,
+                        _ => continue,
+                    };
                     let Some(gradient) = background_gradient_draw(positioning_rect, layer, opacity)
                     else {
                         continue;
                     };
                     primitives.push((
-                        linear_gradient_primitive(rect, paint),
+                        background_gradient_primitive(rect, paint, layer.clip),
                         clip,
                         transform,
                         shape_clips.clone(),

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -6,8 +6,9 @@ use whisker::{SurfaceRuntime, standard_element_registrations};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LoadedCase, PixelSampleFixture,
-    PointerEventFixture, Scenario, ScenarioSide, load_required,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LoadedCase,
+    PixelRelationFixture, PixelRelationKind, PixelSampleFixture, PointerEventFixture, Scenario,
+    ScenarioSide, load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BorderLineStyle, BoxPaint, ElementTypeId, FrameHeader, FrameMode, FramePacket,
@@ -98,6 +99,7 @@ struct Checkpoint {
     logical_size: [u32; 2],
     primitives: Vec<BoxPrimitive>,
     samples: Vec<PixelSampleFixture>,
+    relations: Vec<PixelRelationFixture>,
 }
 
 fn standard_element_type(name: &str) -> ElementTypeId {
@@ -160,7 +162,11 @@ impl Driver {
                     background,
                     border,
                 } => self.present_box(*revision, *rect, background, border.as_ref()),
-                Command::Checkpoint { name, samples } => {
+                Command::Checkpoint {
+                    name,
+                    samples,
+                    relations,
+                } => {
                     assert_eq!(name, "paint.box", "unsupported Desktop checkpoint");
                     checkpoints.push(Checkpoint {
                         logical_size: [
@@ -169,6 +175,7 @@ impl Driver {
                         ],
                         primitives: self.box_primitives(),
                         samples: samples.clone(),
+                        relations: relations.clone(),
                     });
                 }
                 Command::MeasureText {
@@ -531,11 +538,11 @@ fn run_reftest(scenario: &Scenario) {
     );
 }
 
-fn run_pixel_samples(scenario: &Scenario) {
+fn run_pixel_assertions(scenario: &Scenario) {
     let checkpoints = Driver::new().execute(&scenario.test);
     for checkpoint in checkpoints
         .iter()
-        .filter(|checkpoint| !checkpoint.samples.is_empty())
+        .filter(|checkpoint| !checkpoint.samples.is_empty() || !checkpoint.relations.is_empty())
     {
         let pixels = pollster::block_on(render_box_primitives_offscreen(
             &checkpoint.primitives,
@@ -567,7 +574,49 @@ fn run_pixel_samples(scenario: &Scenario) {
                 scenario.id
             );
         }
+        for relation in &checkpoint.relations {
+            let first = pixel_at(
+                &pixels,
+                checkpoint.logical_size,
+                relation.first,
+                &scenario.id,
+            );
+            let second = pixel_at(
+                &pixels,
+                checkpoint.logical_size,
+                relation.second,
+                &scenario.id,
+            );
+            let first_luminance = luminance(first);
+            let second_luminance = luminance(second);
+            let minimum = u32::from(relation.minimum_difference);
+            let matches = match relation.relation {
+                PixelRelationKind::Lighter => first_luminance >= second_luminance + minimum,
+                PixelRelationKind::Darker => first_luminance + minimum <= second_luminance,
+            };
+            assert!(
+                matches,
+                "{} relation {:?}: {first:?} ({first_luminance}) vs {second:?} ({second_luminance})",
+                scenario.id, relation.relation
+            );
+        }
     }
+}
+
+fn pixel_at(pixels: &[u8], size: [u32; 2], point: [f32; 2], id: &str) -> [u8; 4] {
+    let [width, height] = size;
+    let x = point[0].floor() as u32;
+    let y = point[1].floor() as u32;
+    assert!(
+        x < width && y < height,
+        "{id} sample is outside the surface"
+    );
+    let offset = ((y * width + x) * 4) as usize;
+    pixels[offset..offset + 4].try_into().unwrap()
+}
+
+fn luminance([red, green, blue, _]: [u8; 4]) -> u32 {
+    (u32::from(red) * 299 + u32::from(green) * 587 + u32::from(blue) * 114) / 1000
 }
 
 #[test]
@@ -585,7 +634,7 @@ fn every_manifest_case_required_by_desktop_executes() {
             );
             run_reftest(&scenario);
         } else {
-            run_pixel_samples(&scenario);
+            run_pixel_assertions(&scenario);
         }
     }
 }

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -6,10 +6,10 @@ use whisker::{SurfaceRuntime, standard_element_registrations};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LinearGradientFixture,
-    LoadedCase, OverflowClipFixture, PixelRelationFixture, PixelRelationKind, PixelSampleFixture,
-    PointerEventFixture, RadialGradientFixture, Scenario, ScenarioSide, SceneNodeFixture,
-    VisibilityFixture, load_required,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, ConicGradientFixture, Host,
+    LinearGradientFixture, LoadedCase, OverflowClipFixture, PixelRelationFixture,
+    PixelRelationKind, PixelSampleFixture, PointerEventFixture, RadialGradientFixture, Scenario,
+    ScenarioSide, SceneNodeFixture, VisibilityFixture, load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
@@ -27,7 +27,7 @@ use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
 use crate::element::{DesktopElementRegistry, built_in_element_factories};
 use crate::gpu::{
-    LinearGradientDraw, linear_gradient_draw, radial_gradient_draw,
+    LinearGradientDraw, conic_gradient_draw, linear_gradient_draw, radial_gradient_draw,
     render_box_primitives_offscreen, render_clipped_box_primitives_offscreen,
 };
 use crate::paint::box_paint::{
@@ -118,6 +118,44 @@ fn radial_gradient_protocol(value: &RadialGradientFixture) -> BackgroundLayer {
                     fraction: 0.0,
                 },
             )),
+            repeating: false,
+            stops: value
+                .stops
+                .iter()
+                .map(|stop| GradientStop {
+                    color: color_protocol(&stop.color),
+                    position: Some(PaintCoordinate {
+                        length: 0.0,
+                        fraction: stop.position,
+                    }),
+                })
+                .collect(),
+        },
+        position: PaintPosition::default(),
+        size: BackgroundSize::Auto,
+        repeat_x: ImageRepeat::Repeat,
+        repeat_y: ImageRepeat::Repeat,
+        origin: PaintBox::Padding,
+        clip: PaintBox::Border,
+        attachment: BackgroundAttachment::Scroll,
+        blend_mode: BlendMode::Normal,
+    }
+}
+
+fn conic_gradient_protocol(value: &ConicGradientFixture) -> BackgroundLayer {
+    BackgroundLayer {
+        image: PaintImage::ConicGradient {
+            from_degrees: value.from_degrees,
+            center: PaintPosition {
+                x: PaintCoordinate {
+                    length: value.center[0],
+                    fraction: 0.0,
+                },
+                y: PaintCoordinate {
+                    length: value.center[1],
+                    fraction: 0.0,
+                },
+            },
             repeating: false,
             stops: value
                 .stops
@@ -426,6 +464,12 @@ impl Driver {
                     layers: vec![radial_gradient_protocol(gradient)],
                 });
             }
+            if let Some(gradient) = &fixture.conic_gradient {
+                operations.push(Operation::SetBackgroundLayers {
+                    node,
+                    layers: vec![conic_gradient_protocol(gradient)],
+                });
+            }
             operations.push(Operation::SetClip {
                 node,
                 clip: BoxClip {
@@ -530,6 +574,18 @@ impl Driver {
                         } => {
                             radial_gradient_draw(positioning_rect, *center, *radii, stops, opacity)
                         }
+                        PaintImage::ConicGradient {
+                            from_degrees,
+                            center,
+                            repeating: false,
+                            stops,
+                        } => conic_gradient_draw(
+                            positioning_rect,
+                            *from_degrees,
+                            *center,
+                            stops,
+                            opacity,
+                        ),
                         _ => continue,
                     };
                     primitives.push((

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -17,7 +17,8 @@ use whisker_protocol::{
     MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap, MeasurementKey, MeasurementPayload,
     MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintColor,
     PaintCornerRadius, PaintCorners, PaintEdges, PaintLengthPercentage, PointerId, PointerInput,
-    PointerKind, ProtocolVersion, SurfaceId, TextMeasurePayload, TextMeasureStyle, WhiskerValue,
+    PointerKind, ProtocolVersion, SurfaceId, TextMeasurePayload, TextMeasureStyle, Transform,
+    WhiskerValue,
 };
 use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
@@ -97,7 +98,7 @@ impl RecordingInputSink {
 
 struct Checkpoint {
     logical_size: [u32; 2],
-    primitives: Vec<(BoxPrimitive, LogicalClip)>,
+    primitives: Vec<(BoxPrimitive, LogicalClip, Transform)>,
     samples: Vec<PixelSampleFixture>,
     relations: Vec<PixelRelationFixture>,
 }
@@ -329,6 +330,12 @@ impl Driver {
                     vertical: overflow_clip_protocol(fixture.clip.vertical),
                 },
             });
+            if let Some(transform) = fixture.transform {
+                operations.push(Operation::SetTransform {
+                    node,
+                    transform: Transform(transform),
+                });
+            }
         }
         self.scene
             .as_mut()
@@ -349,7 +356,7 @@ impl Driver {
             .expect("canonical Host scene fixture is valid");
     }
 
-    fn clipped_box_primitives(&self) -> Vec<(BoxPrimitive, LogicalClip)> {
+    fn clipped_box_primitives(&self) -> Vec<(BoxPrimitive, LogicalClip, Transform)> {
         let scene = self.scene.as_ref().expect("checkpoint follows attach");
         let mut primitives = Vec::new();
         for command in scene.paint_commands() {
@@ -357,12 +364,13 @@ impl Driver {
                 rect,
                 paint,
                 clip,
+                transform,
                 opacity,
                 ..
             } = command
             {
                 lower_box(rect, paint, opacity, |primitive| {
-                    primitives.push((primitive, clip));
+                    primitives.push((primitive, clip, transform));
                 });
             }
         }

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -460,11 +460,15 @@ fn box_paint(background: &ColorFixture, border: Option<&BorderFixture>) -> BoxPa
         length,
         fraction: 0.0,
     });
-    let radii = border.radii.map(|length| {
-        PaintCornerRadius::circular(PaintLengthPercentage {
-            length,
+    let radii = border.radii.map(|radius| PaintCornerRadius {
+        horizontal: PaintLengthPercentage {
+            length: radius.horizontal(),
             fraction: 0.0,
-        })
+        },
+        vertical: PaintLengthPercentage {
+            length: radius.vertical(),
+            fraction: 0.0,
+        },
     });
     BoxPaint {
         background_color: color_protocol(background),

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -6,26 +6,32 @@ use whisker::{SurfaceRuntime, standard_element_registrations};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LoadedCase,
-    OverflowClipFixture, PixelRelationFixture, PixelRelationKind, PixelSampleFixture,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LinearGradientFixture,
+    LoadedCase, OverflowClipFixture, PixelRelationFixture, PixelRelationKind, PixelSampleFixture,
     PointerEventFixture, Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture,
     load_required,
 };
 use whisker_protocol::{
-    AvailableSpace, BorderLineStyle, BoxClip, BoxPaint, ElementTypeId, FrameHeader, FrameMode,
-    FramePacket, InputEvent, InputEventKind, InputPoint, LayoutGeometry, LayoutRect,
+    AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
+    BorderLineStyle, BoxClip, BoxPaint, ElementTypeId, FrameHeader, FrameMode, FramePacket,
+    GradientStop, ImageRepeat, InputEvent, InputEventKind, InputPoint, LayoutGeometry, LayoutRect,
     MeasureConstraints, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
     MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap, MeasurementKey, MeasurementPayload,
-    MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintColor,
-    PaintCornerRadius, PaintCorners, PaintEdges, PaintLengthPercentage, PointerId, PointerInput,
-    PointerKind, ProtocolVersion, SurfaceId, TextMeasurePayload, TextMeasureStyle, Transform,
-    Visibility, WhiskerValue,
+    MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
+    PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
+    PaintLengthPercentage, PaintPosition, PointerId, PointerInput, PointerKind, ProtocolVersion,
+    SurfaceId, TextMeasurePayload, TextMeasureStyle, Transform, Visibility, WhiskerValue,
 };
 use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
 use crate::element::{DesktopElementRegistry, built_in_element_factories};
-use crate::gpu::{render_box_primitives_offscreen, render_clipped_box_primitives_offscreen};
-use crate::paint::box_paint::{BoxPrimitive, BoxPrimitiveKind, lower_box};
+use crate::gpu::{
+    LinearGradientDraw, linear_gradient_draw, render_box_primitives_offscreen,
+    render_clipped_box_primitives_offscreen,
+};
+use crate::paint::box_paint::{
+    BoxPrimitive, BoxPrimitiveKind, linear_gradient_primitive, lower_box, resolve_box_geometry,
+};
 use crate::paint::color::srgba;
 use crate::scene::{DesktopScene, LogicalClip, PaintCommand, ShapeClipStack};
 use crate::text::NativeTextHost;
@@ -55,6 +61,34 @@ fn color_protocol(value: &ColorFixture) -> PaintColor {
             blue: *blue,
             alpha: *alpha,
         },
+    }
+}
+
+fn linear_gradient_protocol(value: &LinearGradientFixture) -> BackgroundLayer {
+    BackgroundLayer {
+        image: PaintImage::LinearGradient {
+            angle_degrees: value.angle_degrees,
+            repeating: value.repeating,
+            stops: value
+                .stops
+                .iter()
+                .map(|stop| GradientStop {
+                    color: color_protocol(&stop.color),
+                    position: Some(PaintCoordinate {
+                        length: 0.0,
+                        fraction: stop.position,
+                    }),
+                })
+                .collect(),
+        },
+        position: PaintPosition::default(),
+        size: BackgroundSize::Auto,
+        repeat_x: ImageRepeat::Repeat,
+        repeat_y: ImageRepeat::Repeat,
+        origin: PaintBox::Padding,
+        clip: PaintBox::Border,
+        attachment: BackgroundAttachment::Scroll,
+        blend_mode: BlendMode::Normal,
     }
 }
 
@@ -99,7 +133,13 @@ impl RecordingInputSink {
 
 struct Checkpoint {
     logical_size: [u32; 2],
-    primitives: Vec<(BoxPrimitive, LogicalClip, Transform, ShapeClipStack)>,
+    primitives: Vec<(
+        BoxPrimitive,
+        LogicalClip,
+        Transform,
+        ShapeClipStack,
+        Option<LinearGradientDraw>,
+    )>,
     samples: Vec<PixelSampleFixture>,
     relations: Vec<PixelRelationFixture>,
 }
@@ -170,7 +210,7 @@ impl Driver {
                     samples,
                     relations,
                 } => {
-                    assert_eq!(name, "paint.box", "unsupported Desktop checkpoint");
+                    assert!(name.starts_with("paint."), "unsupported Desktop checkpoint");
                     checkpoints.push(Checkpoint {
                         logical_size: [
                             self.logical_size[0].round() as u32,
@@ -284,7 +324,7 @@ impl Driver {
                 },
             ] => {
                 assert_eq!(*actual_rect, layout_rect(rect));
-                assert_eq!(*actual_paint, &expected_paint);
+                assert_eq!(*actual_paint, Some(&expected_paint));
             }
             _ => panic!("one projected Desktop box command"),
         }
@@ -324,6 +364,12 @@ impl Driver {
                 node,
                 paint: box_paint(&fixture.background, fixture.border.as_ref()),
             });
+            if let Some(gradient) = &fixture.linear_gradient {
+                operations.push(Operation::SetBackgroundLayers {
+                    node,
+                    layers: vec![linear_gradient_protocol(gradient)],
+                });
+            }
             operations.push(Operation::SetClip {
                 node,
                 clip: BoxClip {
@@ -374,13 +420,20 @@ impl Driver {
 
     fn clipped_box_primitives(
         &self,
-    ) -> Vec<(BoxPrimitive, LogicalClip, Transform, ShapeClipStack)> {
+    ) -> Vec<(
+        BoxPrimitive,
+        LogicalClip,
+        Transform,
+        ShapeClipStack,
+        Option<LinearGradientDraw>,
+    )> {
         let scene = self.scene.as_ref().expect("checkpoint follows attach");
         let mut primitives = Vec::new();
         for command in scene.paint_commands() {
             if let PaintCommand::Box {
                 rect,
                 paint,
+                background_layers,
                 clip,
                 shape_clips,
                 transform,
@@ -388,9 +441,47 @@ impl Driver {
                 ..
             } = command
             {
-                lower_box(rect, paint, opacity, |primitive| {
-                    primitives.push((primitive, clip, transform, shape_clips.clone()));
-                });
+                let default_paint = BoxPaint::default();
+                let paint = paint.unwrap_or(&default_paint);
+                let mut boxes = Vec::new();
+                lower_box(rect, paint, opacity, |primitive| boxes.push(primitive));
+                primitives.extend(
+                    boxes
+                        .iter()
+                        .copied()
+                        .filter(|primitive| primitive.kind == BoxPrimitiveKind::Fill)
+                        .map(|primitive| (primitive, clip, transform, shape_clips.clone(), None)),
+                );
+                let positioning_rect = resolve_box_geometry(rect, paint).inner_rect;
+                for layer in background_layers.iter().rev() {
+                    let PaintImage::LinearGradient {
+                        angle_degrees,
+                        repeating,
+                        stops,
+                    } = &layer.image
+                    else {
+                        continue;
+                    };
+                    primitives.push((
+                        linear_gradient_primitive(rect, paint),
+                        clip,
+                        transform,
+                        shape_clips.clone(),
+                        Some(linear_gradient_draw(
+                            positioning_rect,
+                            *angle_degrees,
+                            *repeating,
+                            stops,
+                            opacity,
+                        )),
+                    ));
+                }
+                primitives.extend(
+                    boxes
+                        .into_iter()
+                        .filter(|primitive| primitive.kind == BoxPrimitiveKind::Border)
+                        .map(|primitive| (primitive, clip, transform, shape_clips.clone(), None)),
+                );
             }
         }
         primitives
@@ -807,9 +898,14 @@ fn render_taffy_protocol_and_desktop_box_paint_compose() {
         {
             assert_close(rect.width, 100.0, "Taffy border-box width");
             assert_close(rect.height, 100.0, "Taffy border-box height");
-            lower_box(rect, paint, opacity, |primitive| {
-                primitives.push(primitive);
-            });
+            lower_box(
+                rect,
+                paint.expect("render! emits box paint"),
+                opacity,
+                |primitive| {
+                    primitives.push(primitive);
+                },
+            );
         }
     }
     assert_eq!(primitives.len(), 2);

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -6,10 +6,11 @@ use whisker::{SurfaceRuntime, standard_element_registrations};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, ConicGradientFixture, Host,
-    LinearGradientFixture, LoadedCase, OverflowClipFixture, PixelRelationFixture,
-    PixelRelationKind, PixelSampleFixture, PointerEventFixture, RadialGradientFixture, Scenario,
-    ScenarioSide, SceneNodeFixture, VisibilityFixture, load_required,
+    BackgroundBoxFixture, BackgroundLayerFixture, BorderFixture, BorderStyleFixture, ColorFixture,
+    Command, ConicGradientFixture, Host, ImageRepeatFixture, LinearGradientFixture, LoadedCase,
+    OverflowClipFixture, PixelRelationFixture, PixelRelationKind, PixelSampleFixture,
+    PointerEventFixture, RadialGradientFixture, Scenario, ScenarioSide, SceneNodeFixture,
+    VisibilityFixture, load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
@@ -27,8 +28,8 @@ use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
 use crate::element::{DesktopElementRegistry, built_in_element_factories};
 use crate::gpu::{
-    LinearGradientDraw, conic_gradient_draw, linear_gradient_draw, radial_gradient_draw,
-    render_box_primitives_offscreen, render_clipped_box_primitives_offscreen,
+    LinearGradientDraw, background_gradient_draw, render_box_primitives_offscreen,
+    render_clipped_box_primitives_offscreen,
 };
 use crate::paint::box_paint::{
     BoxPrimitive, BoxPrimitiveKind, linear_gradient_primitive, lower_box, resolve_box_geometry,
@@ -65,119 +66,177 @@ fn color_protocol(value: &ColorFixture) -> PaintColor {
     }
 }
 
-fn linear_gradient_protocol(value: &LinearGradientFixture) -> BackgroundLayer {
-    BackgroundLayer {
-        image: PaintImage::LinearGradient {
-            angle_degrees: value.angle_degrees,
-            repeating: value.repeating,
-            stops: value
-                .stops
-                .iter()
-                .map(|stop| GradientStop {
-                    color: color_protocol(&stop.color),
-                    position: Some(PaintCoordinate {
-                        length: 0.0,
-                        fraction: stop.position,
-                    }),
-                })
-                .collect(),
-        },
-        position: PaintPosition::default(),
-        size: BackgroundSize::Auto,
-        repeat_x: ImageRepeat::Repeat,
-        repeat_y: ImageRepeat::Repeat,
-        origin: PaintBox::Padding,
-        clip: PaintBox::Border,
-        attachment: BackgroundAttachment::Scroll,
-        blend_mode: BlendMode::Normal,
-    }
+fn apply_background_geometry(
+    mut layer: BackgroundLayer,
+    value: &BackgroundLayerFixture,
+) -> BackgroundLayer {
+    let length = |value: whisker_host_conformance::LengthPercentageFixture| PaintLengthPercentage {
+        length: value.length,
+        fraction: value.fraction,
+    };
+    let coordinate = |value: whisker_host_conformance::LengthPercentageFixture| PaintCoordinate {
+        length: value.length,
+        fraction: value.fraction,
+    };
+    let repeat = |value| match value {
+        ImageRepeatFixture::Repeat => ImageRepeat::Repeat,
+        ImageRepeatFixture::NoRepeat => ImageRepeat::NoRepeat,
+        ImageRepeatFixture::Space => ImageRepeat::Space,
+        ImageRepeatFixture::Round => ImageRepeat::Round,
+    };
+    let paint_box = |value| match value {
+        BackgroundBoxFixture::Border => PaintBox::Border,
+        BackgroundBoxFixture::Padding => PaintBox::Padding,
+        BackgroundBoxFixture::Content => PaintBox::Content,
+    };
+    layer.position = PaintPosition {
+        x: coordinate(value.position[0]),
+        y: coordinate(value.position[1]),
+    };
+    layer.size = value
+        .size
+        .map_or(BackgroundSize::Auto, |size| BackgroundSize::Explicit {
+            width: Some(length(size[0])),
+            height: Some(length(size[1])),
+        });
+    layer.repeat_x = repeat(value.repeat_x);
+    layer.repeat_y = repeat(value.repeat_y);
+    layer.origin = paint_box(value.origin);
+    layer.clip = paint_box(value.clip);
+    layer
 }
 
-fn radial_gradient_protocol(value: &RadialGradientFixture) -> BackgroundLayer {
-    BackgroundLayer {
-        image: PaintImage::RadialGradient {
-            shape: RadialGradientShape::Ellipse,
-            extent: RadialGradientExtent::Explicit,
-            center: PaintPosition {
-                x: PaintCoordinate {
-                    length: value.center[0],
-                    fraction: 0.0,
-                },
-                y: PaintCoordinate {
-                    length: value.center[1],
-                    fraction: 0.0,
-                },
+fn linear_gradient_protocol(
+    value: &LinearGradientFixture,
+    geometry: &BackgroundLayerFixture,
+) -> BackgroundLayer {
+    apply_background_geometry(
+        BackgroundLayer {
+            image: PaintImage::LinearGradient {
+                angle_degrees: value.angle_degrees,
+                repeating: value.repeating,
+                stops: value
+                    .stops
+                    .iter()
+                    .map(|stop| GradientStop {
+                        color: color_protocol(&stop.color),
+                        position: Some(PaintCoordinate {
+                            length: 0.0,
+                            fraction: stop.position,
+                        }),
+                    })
+                    .collect(),
             },
-            radii: Some((
-                PaintLengthPercentage {
-                    length: value.radii[0],
-                    fraction: 0.0,
-                },
-                PaintLengthPercentage {
-                    length: value.radii[1],
-                    fraction: 0.0,
-                },
-            )),
-            repeating: false,
-            stops: value
-                .stops
-                .iter()
-                .map(|stop| GradientStop {
-                    color: color_protocol(&stop.color),
-                    position: Some(PaintCoordinate {
-                        length: 0.0,
-                        fraction: stop.position,
-                    }),
-                })
-                .collect(),
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Padding,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
         },
-        position: PaintPosition::default(),
-        size: BackgroundSize::Auto,
-        repeat_x: ImageRepeat::Repeat,
-        repeat_y: ImageRepeat::Repeat,
-        origin: PaintBox::Padding,
-        clip: PaintBox::Border,
-        attachment: BackgroundAttachment::Scroll,
-        blend_mode: BlendMode::Normal,
-    }
+        geometry,
+    )
 }
 
-fn conic_gradient_protocol(value: &ConicGradientFixture) -> BackgroundLayer {
-    BackgroundLayer {
-        image: PaintImage::ConicGradient {
-            from_degrees: value.from_degrees,
-            center: PaintPosition {
-                x: PaintCoordinate {
-                    length: value.center[0],
-                    fraction: 0.0,
+fn radial_gradient_protocol(
+    value: &RadialGradientFixture,
+    geometry: &BackgroundLayerFixture,
+) -> BackgroundLayer {
+    apply_background_geometry(
+        BackgroundLayer {
+            image: PaintImage::RadialGradient {
+                shape: RadialGradientShape::Ellipse,
+                extent: RadialGradientExtent::Explicit,
+                center: PaintPosition {
+                    x: PaintCoordinate {
+                        length: value.center[0],
+                        fraction: 0.0,
+                    },
+                    y: PaintCoordinate {
+                        length: value.center[1],
+                        fraction: 0.0,
+                    },
                 },
-                y: PaintCoordinate {
-                    length: value.center[1],
-                    fraction: 0.0,
-                },
+                radii: Some((
+                    PaintLengthPercentage {
+                        length: value.radii[0],
+                        fraction: 0.0,
+                    },
+                    PaintLengthPercentage {
+                        length: value.radii[1],
+                        fraction: 0.0,
+                    },
+                )),
+                repeating: false,
+                stops: value
+                    .stops
+                    .iter()
+                    .map(|stop| GradientStop {
+                        color: color_protocol(&stop.color),
+                        position: Some(PaintCoordinate {
+                            length: 0.0,
+                            fraction: stop.position,
+                        }),
+                    })
+                    .collect(),
             },
-            repeating: false,
-            stops: value
-                .stops
-                .iter()
-                .map(|stop| GradientStop {
-                    color: color_protocol(&stop.color),
-                    position: Some(PaintCoordinate {
-                        length: 0.0,
-                        fraction: stop.position,
-                    }),
-                })
-                .collect(),
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Padding,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
         },
-        position: PaintPosition::default(),
-        size: BackgroundSize::Auto,
-        repeat_x: ImageRepeat::Repeat,
-        repeat_y: ImageRepeat::Repeat,
-        origin: PaintBox::Padding,
-        clip: PaintBox::Border,
-        attachment: BackgroundAttachment::Scroll,
-        blend_mode: BlendMode::Normal,
-    }
+        geometry,
+    )
+}
+
+fn conic_gradient_protocol(
+    value: &ConicGradientFixture,
+    geometry: &BackgroundLayerFixture,
+) -> BackgroundLayer {
+    apply_background_geometry(
+        BackgroundLayer {
+            image: PaintImage::ConicGradient {
+                from_degrees: value.from_degrees,
+                center: PaintPosition {
+                    x: PaintCoordinate {
+                        length: value.center[0],
+                        fraction: 0.0,
+                    },
+                    y: PaintCoordinate {
+                        length: value.center[1],
+                        fraction: 0.0,
+                    },
+                },
+                repeating: false,
+                stops: value
+                    .stops
+                    .iter()
+                    .map(|stop| GradientStop {
+                        color: color_protocol(&stop.color),
+                        position: Some(PaintCoordinate {
+                            length: 0.0,
+                            fraction: stop.position,
+                        }),
+                    })
+                    .collect(),
+            },
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Padding,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
+        },
+        geometry,
+    )
 }
 
 const fn border_style_protocol(value: BorderStyleFixture) -> BorderLineStyle {
@@ -455,19 +514,25 @@ impl Driver {
             if let Some(gradient) = &fixture.linear_gradient {
                 operations.push(Operation::SetBackgroundLayers {
                     node,
-                    layers: vec![linear_gradient_protocol(gradient)],
+                    layers: vec![linear_gradient_protocol(
+                        gradient,
+                        &fixture.background_layer,
+                    )],
                 });
             }
             if let Some(gradient) = &fixture.radial_gradient {
                 operations.push(Operation::SetBackgroundLayers {
                     node,
-                    layers: vec![radial_gradient_protocol(gradient)],
+                    layers: vec![radial_gradient_protocol(
+                        gradient,
+                        &fixture.background_layer,
+                    )],
                 });
             }
             if let Some(gradient) = &fixture.conic_gradient {
                 operations.push(Operation::SetBackgroundLayers {
                     node,
-                    layers: vec![conic_gradient_protocol(gradient)],
+                    layers: vec![conic_gradient_protocol(gradient, &fixture.background_layer)],
                 });
             }
             operations.push(Operation::SetClip {
@@ -554,39 +619,9 @@ impl Driver {
                 );
                 let positioning_rect = resolve_box_geometry(rect, paint).inner_rect;
                 for layer in background_layers.iter().rev() {
-                    let gradient = match &layer.image {
-                        PaintImage::LinearGradient {
-                            angle_degrees,
-                            repeating,
-                            stops,
-                        } => linear_gradient_draw(
-                            positioning_rect,
-                            *angle_degrees,
-                            *repeating,
-                            stops,
-                            opacity,
-                        ),
-                        PaintImage::RadialGradient {
-                            center,
-                            radii: Some(radii),
-                            stops,
-                            ..
-                        } => {
-                            radial_gradient_draw(positioning_rect, *center, *radii, stops, opacity)
-                        }
-                        PaintImage::ConicGradient {
-                            from_degrees,
-                            center,
-                            repeating: false,
-                            stops,
-                        } => conic_gradient_draw(
-                            positioning_rect,
-                            *from_degrees,
-                            *center,
-                            stops,
-                            opacity,
-                        ),
-                        _ => continue,
+                    let Some(gradient) = background_gradient_draw(positioning_rect, layer, opacity)
+                    else {
+                        continue;
                     };
                     primitives.push((
                         linear_gradient_primitive(rect, paint),

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -8,7 +8,8 @@ use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
     BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LoadedCase,
     OverflowClipFixture, PixelRelationFixture, PixelRelationKind, PixelSampleFixture,
-    PointerEventFixture, Scenario, ScenarioSide, SceneNodeFixture, load_required,
+    PointerEventFixture, Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture,
+    load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BorderLineStyle, BoxClip, BoxPaint, ElementTypeId, FrameHeader, FrameMode,
@@ -18,7 +19,7 @@ use whisker_protocol::{
     MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintColor,
     PaintCornerRadius, PaintCorners, PaintEdges, PaintLengthPercentage, PointerId, PointerInput,
     PointerKind, ProtocolVersion, SurfaceId, TextMeasurePayload, TextMeasureStyle, Transform,
-    WhiskerValue,
+    Visibility, WhiskerValue,
 };
 use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
@@ -335,6 +336,21 @@ impl Driver {
                     node,
                     transform: Transform(transform),
                 });
+            }
+            if let Some(opacity) = fixture.opacity {
+                operations.push(Operation::SetOpacity { node, opacity });
+            }
+            if let Some(visibility) = fixture.visibility {
+                operations.push(Operation::SetVisibility {
+                    node,
+                    visibility: match visibility {
+                        VisibilityFixture::Visible => Visibility::Visible,
+                        VisibilityFixture::Hidden => Visibility::Hidden,
+                    },
+                });
+            }
+            if let Some(z_order) = fixture.z_order {
+                operations.push(Operation::SetZOrder { node, z_order });
             }
         }
         self.scene

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -8,8 +8,8 @@ use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
     BorderFixture, BorderStyleFixture, ColorFixture, Command, Host, LinearGradientFixture,
     LoadedCase, OverflowClipFixture, PixelRelationFixture, PixelRelationKind, PixelSampleFixture,
-    PointerEventFixture, Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture,
-    load_required,
+    PointerEventFixture, RadialGradientFixture, Scenario, ScenarioSide, SceneNodeFixture,
+    VisibilityFixture, load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
@@ -20,14 +20,15 @@ use whisker_protocol::{
     MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
     PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
     PaintLengthPercentage, PaintPosition, PointerId, PointerInput, PointerKind, ProtocolVersion,
-    SurfaceId, TextMeasurePayload, TextMeasureStyle, Transform, Visibility, WhiskerValue,
+    RadialGradientExtent, RadialGradientShape, SurfaceId, TextMeasurePayload, TextMeasureStyle,
+    Transform, Visibility, WhiskerValue,
 };
 use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
 use crate::element::{DesktopElementRegistry, built_in_element_factories};
 use crate::gpu::{
-    LinearGradientDraw, linear_gradient_draw, render_box_primitives_offscreen,
-    render_clipped_box_primitives_offscreen,
+    LinearGradientDraw, linear_gradient_draw, radial_gradient_draw,
+    render_box_primitives_offscreen, render_clipped_box_primitives_offscreen,
 };
 use crate::paint::box_paint::{
     BoxPrimitive, BoxPrimitiveKind, linear_gradient_primitive, lower_box, resolve_box_geometry,
@@ -69,6 +70,55 @@ fn linear_gradient_protocol(value: &LinearGradientFixture) -> BackgroundLayer {
         image: PaintImage::LinearGradient {
             angle_degrees: value.angle_degrees,
             repeating: value.repeating,
+            stops: value
+                .stops
+                .iter()
+                .map(|stop| GradientStop {
+                    color: color_protocol(&stop.color),
+                    position: Some(PaintCoordinate {
+                        length: 0.0,
+                        fraction: stop.position,
+                    }),
+                })
+                .collect(),
+        },
+        position: PaintPosition::default(),
+        size: BackgroundSize::Auto,
+        repeat_x: ImageRepeat::Repeat,
+        repeat_y: ImageRepeat::Repeat,
+        origin: PaintBox::Padding,
+        clip: PaintBox::Border,
+        attachment: BackgroundAttachment::Scroll,
+        blend_mode: BlendMode::Normal,
+    }
+}
+
+fn radial_gradient_protocol(value: &RadialGradientFixture) -> BackgroundLayer {
+    BackgroundLayer {
+        image: PaintImage::RadialGradient {
+            shape: RadialGradientShape::Ellipse,
+            extent: RadialGradientExtent::Explicit,
+            center: PaintPosition {
+                x: PaintCoordinate {
+                    length: value.center[0],
+                    fraction: 0.0,
+                },
+                y: PaintCoordinate {
+                    length: value.center[1],
+                    fraction: 0.0,
+                },
+            },
+            radii: Some((
+                PaintLengthPercentage {
+                    length: value.radii[0],
+                    fraction: 0.0,
+                },
+                PaintLengthPercentage {
+                    length: value.radii[1],
+                    fraction: 0.0,
+                },
+            )),
+            repeating: false,
             stops: value
                 .stops
                 .iter()
@@ -370,6 +420,12 @@ impl Driver {
                     layers: vec![linear_gradient_protocol(gradient)],
                 });
             }
+            if let Some(gradient) = &fixture.radial_gradient {
+                operations.push(Operation::SetBackgroundLayers {
+                    node,
+                    layers: vec![radial_gradient_protocol(gradient)],
+                });
+            }
             operations.push(Operation::SetClip {
                 node,
                 clip: BoxClip {
@@ -454,26 +510,34 @@ impl Driver {
                 );
                 let positioning_rect = resolve_box_geometry(rect, paint).inner_rect;
                 for layer in background_layers.iter().rev() {
-                    let PaintImage::LinearGradient {
-                        angle_degrees,
-                        repeating,
-                        stops,
-                    } = &layer.image
-                    else {
-                        continue;
+                    let gradient = match &layer.image {
+                        PaintImage::LinearGradient {
+                            angle_degrees,
+                            repeating,
+                            stops,
+                        } => linear_gradient_draw(
+                            positioning_rect,
+                            *angle_degrees,
+                            *repeating,
+                            stops,
+                            opacity,
+                        ),
+                        PaintImage::RadialGradient {
+                            center,
+                            radii: Some(radii),
+                            stops,
+                            ..
+                        } => {
+                            radial_gradient_draw(positioning_rect, *center, *radii, stops, opacity)
+                        }
+                        _ => continue,
                     };
                     primitives.push((
                         linear_gradient_primitive(rect, paint),
                         clip,
                         transform,
                         shape_clips.clone(),
-                        Some(linear_gradient_draw(
-                            positioning_rect,
-                            *angle_degrees,
-                            *repeating,
-                            stops,
-                            opacity,
-                        )),
+                        Some(gradient),
                     ));
                 }
                 primitives.extend(

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 0 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 1 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -14,7 +14,8 @@ enum {
   WHISKER_OP_TRANSFORM, WHISKER_OP_OPACITY, WHISKER_OP_VISIBILITY,
   WHISKER_OP_Z_ORDER, WHISKER_OP_TEXT, WHISKER_OP_PROPERTY,
   WHISKER_OP_CLEAR_PROPERTY, WHISKER_OP_EVENT_MASK, WHISKER_OP_HIT_TEST,
-  WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND
+  WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
+  WHISKER_OP_BACKGROUND_LAYERS
 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
@@ -38,6 +39,10 @@ typedef struct {
   WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileBoxPaint;
 typedef struct {
+  WhiskerMobileColor color;
+  WhiskerMobileLengthPercentage position;
+} WhiskerMobileGradientStop;
+typedef struct {
   WhiskerStringRef text; float font_size; uint16_t font_weight;
   uint8_t font_style, wrap; uint32_t max_lines; float line_height, letter_spacing;
   WhiskerMobileColor color; uint64_t prepared_content;
@@ -56,6 +61,7 @@ typedef struct { uint8_t status, _pad[7]; uint64_t revision; } WhiskerMobileAppl
 _Static_assert(sizeof(WhiskerMobileOperation) == 72, "WhiskerMobileOperation ABI drift");
 _Static_assert(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift");
 _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResponse ABI drift");
+_Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
 typedef struct {
   uint32_t id; uint8_t value_kind, optional_kind, _pad[2]; WhiskerStringRef name;
 } WhiskerMobileMemberRegistration;

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 3 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 4 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -21,6 +21,14 @@ enum {
   WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
   WHISKER_BACKGROUND_CONIC = 2
 };
+enum { WHISKER_BACKGROUND_SIZE_AUTO = 0, WHISKER_BACKGROUND_SIZE_EXPLICIT = 1 };
+enum { WHISKER_BACKGROUND_REPEAT = 0, WHISKER_BACKGROUND_NO_REPEAT = 1 };
+enum {
+  WHISKER_BACKGROUND_BOX_BORDER = 0, WHISKER_BACKGROUND_BOX_PADDING = 1,
+  WHISKER_BACKGROUND_BOX_CONTENT = 2
+};
+enum { WHISKER_BACKGROUND_ATTACHMENT_SCROLL = 0 };
+enum { WHISKER_BACKGROUND_BLEND_NORMAL = 0 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -57,6 +65,15 @@ typedef struct {
   size_t stop_count;
 } WhiskerMobileConicGradient;
 typedef struct {
+  uint32_t kind; float scalar; const void *payload; size_t payload_count;
+} WhiskerMobileBackgroundImage;
+typedef struct {
+  WhiskerMobileBackgroundImage image;
+  WhiskerMobileLengthPercentage position_x, position_y;
+  WhiskerMobileLengthPercentage size_width, size_height;
+  uint32_t size_kind, repeat_x, repeat_y, origin, clip, attachment, blend_mode;
+} WhiskerMobileBackgroundLayer;
+typedef struct {
   WhiskerStringRef text; float font_size; uint16_t font_weight;
   uint8_t font_style, wrap; uint32_t max_lines; float line_height, letter_spacing;
   WhiskerMobileColor color; uint64_t prepared_content;
@@ -78,6 +95,8 @@ _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResp
 _Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
 _Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGradient ABI drift");
 _Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGradient ABI drift");
+_Static_assert(sizeof(WhiskerMobileBackgroundImage) == 24, "WhiskerMobileBackgroundImage ABI drift");
+_Static_assert(sizeof(WhiskerMobileBackgroundLayer) == 88, "WhiskerMobileBackgroundLayer ABI drift");
 typedef struct {
   uint32_t id; uint8_t value_kind, optional_kind, _pad[2]; WhiskerStringRef name;
 } WhiskerMobileMemberRegistration;

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 2 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 3 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -17,7 +17,10 @@ enum {
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
   WHISKER_OP_BACKGROUND_LAYERS
 };
-enum { WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1 };
+enum {
+  WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
+  WHISKER_BACKGROUND_CONIC = 2
+};
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -49,6 +52,11 @@ typedef struct {
   size_t stop_count;
 } WhiskerMobileRadialGradient;
 typedef struct {
+  WhiskerMobileLengthPercentage center_x, center_y;
+  const WhiskerMobileGradientStop *stops;
+  size_t stop_count;
+} WhiskerMobileConicGradient;
+typedef struct {
   WhiskerStringRef text; float font_size; uint16_t font_weight;
   uint8_t font_style, wrap; uint32_t max_lines; float line_height, letter_spacing;
   WhiskerMobileColor color; uint64_t prepared_content;
@@ -69,6 +77,7 @@ _Static_assert(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift")
 _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
 _Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGradient ABI drift");
+_Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGradient ABI drift");
 typedef struct {
   uint32_t id; uint8_t value_kind, optional_kind, _pad[2]; WhiskerStringRef name;
 } WhiskerMobileMemberRegistration;

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 1, WHISKER_MOBILE_ABI_MINOR = 0 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 0 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -34,7 +34,8 @@ typedef struct {
   WhiskerMobileLengthPercentage widths[4];
   WhiskerMobileColor colors[4];
   uint32_t styles[4];
-  WhiskerMobileLengthPercentage radii[4];
+  WhiskerMobileLengthPercentage radii_horizontal[4];
+  WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileBoxPaint;
 typedef struct {
   WhiskerStringRef text; float font_size; uint16_t font_weight;
@@ -89,5 +90,5 @@ _Static_assert(sizeof(WhiskerMobileBootstrap) == 24, "WhiskerMobileBootstrap ABI
 _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 160, "WhiskerMobileMeasureRequest ABI drift");
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileText) == 80, "WhiskerMobileText ABI drift");
-_Static_assert(sizeof(WhiskerMobileBoxPaint) == 240, "WhiskerMobileBoxPaint ABI drift");
+_Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 #endif

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 1 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 2 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -17,6 +17,7 @@ enum {
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
   WHISKER_OP_BACKGROUND_LAYERS
 };
+enum { WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -43,6 +44,11 @@ typedef struct {
   WhiskerMobileLengthPercentage position;
 } WhiskerMobileGradientStop;
 typedef struct {
+  WhiskerMobileLengthPercentage center_x, center_y, radius_x, radius_y;
+  const WhiskerMobileGradientStop *stops;
+  size_t stop_count;
+} WhiskerMobileRadialGradient;
+typedef struct {
   WhiskerStringRef text; float font_size; uint16_t font_weight;
   uint8_t font_style, wrap; uint32_t max_lines; float line_height, letter_spacing;
   WhiskerMobileColor color; uint64_t prepared_content;
@@ -62,6 +68,7 @@ _Static_assert(sizeof(WhiskerMobileOperation) == 72, "WhiskerMobileOperation ABI
 _Static_assert(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift");
 _Static_assert(sizeof(WhiskerMobileApplyResponse) == 16, "WhiskerMobileApplyResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileGradientStop) == 40, "WhiskerMobileGradientStop ABI drift");
+_Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGradient ABI drift");
 typedef struct {
   uint32_t id; uint8_t value_kind, optional_kind, _pad[2]; WhiskerStringRef name;
 } WhiskerMobileMemberRegistration;

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -32,6 +32,43 @@ struct HostConicGradient {
     let stops: [HostLinearGradientStop]
 }
 
+enum HostBackgroundRepeat {
+    case `repeat`
+    case noRepeat
+}
+
+struct HostBackgroundGeometry {
+    let positionX: WhiskerMobileLengthPercentage
+    let positionY: WhiskerMobileLengthPercentage
+    let sizeWidth: WhiskerMobileLengthPercentage?
+    let sizeHeight: WhiskerMobileLengthPercentage?
+    let repeatX: HostBackgroundRepeat
+    let repeatY: HostBackgroundRepeat
+
+    static let initial = HostBackgroundGeometry(
+        positionX: WhiskerMobileLengthPercentage(),
+        positionY: WhiskerMobileLengthPercentage(),
+        sizeWidth: nil,
+        sizeHeight: nil,
+        repeatX: .repeat,
+        repeatY: .repeat
+    )
+
+    func imageBounds(in positioningBox: CGRect) -> CGRect {
+        guard let sizeWidth, let sizeHeight else { return positioningBox }
+        return CGRect(
+            x: positioningBox.minX + resolve(positionX, extent: positioningBox.width),
+            y: positioningBox.minY + resolve(positionY, extent: positioningBox.height),
+            width: resolve(sizeWidth, extent: positioningBox.width),
+            height: resolve(sizeHeight, extent: positioningBox.height)
+        )
+    }
+
+    var clipsToSingleImage: Bool {
+        repeatX == .noRepeat && repeatY == .noRepeat
+    }
+}
+
 private enum HostBackgroundImage {
     case linear(HostLinearGradient)
     case radial(HostRadialGradient)
@@ -40,40 +77,54 @@ private enum HostBackgroundImage {
 
 final class HostBackgroundPainter {
     private var image: HostBackgroundImage?
+    private var geometry = HostBackgroundGeometry.initial
     private var conicCache: (size: CGSize, scale: CGFloat, image: CGImage)?
 
-    func update(linearGradient: HostLinearGradient?) {
+    func update(
+        linearGradient: HostLinearGradient?,
+        geometry: HostBackgroundGeometry = .initial
+    ) {
         image = linearGradient.map(HostBackgroundImage.linear)
+        self.geometry = geometry
         conicCache = nil
     }
 
-    func update(radialGradient: HostRadialGradient) {
+    func update(radialGradient: HostRadialGradient, geometry: HostBackgroundGeometry) {
         image = .radial(radialGradient)
+        self.geometry = geometry
         conicCache = nil
     }
 
-    func update(conicGradient: HostConicGradient) {
+    func update(conicGradient: HostConicGradient, geometry: HostBackgroundGeometry) {
         image = .conic(conicGradient)
+        self.geometry = geometry
         conicCache = nil
     }
 
     func draw(in bounds: CGRect, clippedBy clipPath: CGPath) {
-        guard let image, bounds.width > 0, bounds.height > 0,
+        let imageBounds = geometry.imageBounds(in: bounds)
+        guard let image, imageBounds.width > 0, imageBounds.height > 0,
               let context = UIGraphicsGetCurrentContext() else { return }
+        context.saveGState()
+        context.addPath(clipPath)
+        context.clip()
+        if geometry.clipsToSingleImage {
+            context.clip(to: imageBounds)
+        }
+        defer { context.restoreGState() }
         switch image {
         case let .linear(gradient):
-            drawLinear(gradient, in: bounds, clippedBy: clipPath, context: context)
+            drawLinear(gradient, in: imageBounds, context: context)
         case let .radial(gradient):
-            drawRadial(gradient, in: bounds, clippedBy: clipPath, context: context)
+            drawRadial(gradient, in: imageBounds, context: context)
         case let .conic(gradient):
-            drawConic(gradient, in: bounds, clippedBy: clipPath, context: context)
+            drawConic(gradient, in: imageBounds, context: context)
         }
     }
 
     private func drawLinear(
         _ linearGradient: HostLinearGradient,
         in bounds: CGRect,
-        clippedBy clipPath: CGPath,
         context: CGContext
     ) {
         let radians = linearGradient.angleDegrees * .pi / 180
@@ -118,22 +169,17 @@ final class HostBackgroundPainter {
             x: center.x + direction.dx * lineLength * (domainEnd - 0.5),
             y: center.y + direction.dy * lineLength * (domainEnd - 0.5)
         )
-        context.saveGState()
-        context.addPath(clipPath)
-        context.clip()
         context.drawLinearGradient(
             gradient,
             start: start,
             end: end,
             options: [.drawsBeforeStartLocation, .drawsAfterEndLocation]
         )
-        context.restoreGState()
     }
 
     private func drawRadial(
         _ radialGradient: HostRadialGradient,
         in bounds: CGRect,
-        clippedBy clipPath: CGPath,
         context: CGContext
     ) {
         let center = CGPoint(
@@ -147,8 +193,6 @@ final class HostBackgroundPainter {
         guard let gradient = makeGradient(resolved) else { return }
 
         context.saveGState()
-        context.addPath(clipPath)
-        context.clip()
         context.translateBy(x: center.x, y: center.y)
         context.scaleBy(x: 1, y: radiusY / radiusX)
         context.translateBy(x: -center.x, y: -center.y)
@@ -166,7 +210,6 @@ final class HostBackgroundPainter {
     private func drawConic(
         _ conicGradient: HostConicGradient,
         in bounds: CGRect,
-        clippedBy clipPath: CGPath,
         context: CGContext
     ) {
         let stops = normalizedConicStops(conicGradient.stops)
@@ -186,11 +229,7 @@ final class HostBackgroundPainter {
             image = rendered
         }
 
-        context.saveGState()
-        context.addPath(clipPath)
-        context.clip()
         UIImage(cgImage: image, scale: scale, orientation: .up).draw(in: bounds)
-        context.restoreGState()
     }
 }
 

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -17,16 +17,47 @@ struct HostLinearGradient {
     let stops: [HostLinearGradientStop]
 }
 
+struct HostRadialGradient {
+    let centerX: WhiskerMobileLengthPercentage
+    let centerY: WhiskerMobileLengthPercentage
+    let radiusX: WhiskerMobileLengthPercentage
+    let radiusY: WhiskerMobileLengthPercentage
+    let stops: [HostLinearGradientStop]
+}
+
+private enum HostBackgroundImage {
+    case linear(HostLinearGradient)
+    case radial(HostRadialGradient)
+}
+
 final class HostBackgroundPainter {
-    private var linearGradient: HostLinearGradient?
+    private var image: HostBackgroundImage?
 
     func update(linearGradient: HostLinearGradient?) {
-        self.linearGradient = linearGradient
+        image = linearGradient.map(HostBackgroundImage.linear)
+    }
+
+    func update(radialGradient: HostRadialGradient) {
+        image = .radial(radialGradient)
     }
 
     func draw(in bounds: CGRect, clippedBy clipPath: CGPath) {
-        guard let linearGradient, bounds.width > 0, bounds.height > 0,
+        guard let image, bounds.width > 0, bounds.height > 0,
               let context = UIGraphicsGetCurrentContext() else { return }
+        switch image {
+        case let .linear(gradient):
+            drawLinear(gradient, in: bounds, clippedBy: clipPath, context: context)
+        case let .radial(gradient):
+            drawRadial(gradient, in: bounds, clippedBy: clipPath, context: context)
+        }
+    }
+
+    private func drawLinear(
+        _ linearGradient: HostLinearGradient,
+        in bounds: CGRect,
+        clippedBy clipPath: CGPath,
+        context: CGContext
+    ) {
         let radians = linearGradient.angleDegrees * .pi / 180
         let direction = CGVector(dx: sin(radians), dy: -cos(radians))
         let lineLength = abs(bounds.width * direction.dx) + abs(bounds.height * direction.dy)
@@ -80,6 +111,92 @@ final class HostBackgroundPainter {
         )
         context.restoreGState()
     }
+
+    private func drawRadial(
+        _ radialGradient: HostRadialGradient,
+        in bounds: CGRect,
+        clippedBy clipPath: CGPath,
+        context: CGContext
+    ) {
+        let center = CGPoint(
+            x: resolve(radialGradient.centerX, extent: bounds.width) + bounds.minX,
+            y: resolve(radialGradient.centerY, extent: bounds.height) + bounds.minY
+        )
+        let radiusX = resolve(radialGradient.radiusX, extent: bounds.width)
+        let radiusY = resolve(radialGradient.radiusY, extent: bounds.height)
+        guard radiusX > 0, radiusY > 0 else { return }
+        let resolved = resolveStops(radialGradient.stops, lineLength: radiusX)
+        guard let gradient = makeGradient(resolved) else { return }
+
+        context.saveGState()
+        context.addPath(clipPath)
+        context.clip()
+        context.translateBy(x: center.x, y: center.y)
+        context.scaleBy(x: 1, y: radiusY / radiusX)
+        context.translateBy(x: -center.x, y: -center.y)
+        context.drawRadialGradient(
+            gradient.value,
+            startCenter: center,
+            startRadius: radiusX * gradient.domainStart,
+            endCenter: center,
+            endRadius: radiusX * gradient.domainEnd,
+            options: [.drawsBeforeStartLocation, .drawsAfterEndLocation]
+        )
+        context.restoreGState()
+    }
+}
+
+private struct ResolvedGradient {
+    let value: CGGradient
+    let domainStart: CGFloat
+    let domainEnd: CGFloat
+}
+
+private func resolve(
+    _ value: WhiskerMobileLengthPercentage,
+    extent: CGFloat
+) -> CGFloat {
+    CGFloat(value.length) + CGFloat(value.fraction) * extent
+}
+
+private func resolveStops(
+    _ stops: [HostLinearGradientStop],
+    lineLength: CGFloat
+) -> [(color: UIColor, position: CGFloat)] {
+    stops.map { stop in
+        (
+            color: stop.color,
+            position: CGFloat(stop.position.length) / lineLength +
+                CGFloat(stop.position.fraction)
+        )
+    }
+}
+
+private func makeGradient(
+    _ input: [(color: UIColor, position: CGFloat)]
+) -> ResolvedGradient? {
+    guard input.count >= 2 else { return nil }
+    var resolved = input
+    let domainStart = min(0, resolved[0].position)
+    let domainEnd = max(1, resolved[resolved.count - 1].position)
+    let domainLength = domainEnd - domainStart
+    guard domainLength > 0 else { return nil }
+    if resolved[0].position > domainStart {
+        resolved.insert((resolved[0].color, domainStart), at: 0)
+    }
+    if resolved[resolved.count - 1].position < domainEnd {
+        resolved.append((resolved[resolved.count - 1].color, domainEnd))
+    }
+    let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+    let components = resolved.flatMap { rgbaComponents($0.color) }
+    let locations = resolved.map { ($0.position - domainStart) / domainLength }
+    guard let value = CGGradient(
+        colorSpace: colorSpace,
+        colorComponents: components,
+        locations: locations,
+        count: resolved.count
+    ) else { return nil }
+    return ResolvedGradient(value: value, domainStart: domainStart, domainEnd: domainEnd)
 }
 
 private func rgbaComponents(_ color: UIColor) -> [CGFloat] {

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -56,11 +56,15 @@ struct HostBackgroundGeometry {
 
     func imageBounds(in positioningBox: CGRect) -> CGRect {
         guard let sizeWidth, let sizeHeight else { return positioningBox }
+        let width = resolve(sizeWidth, extent: positioningBox.width)
+        let height = resolve(sizeHeight, extent: positioningBox.height)
         return CGRect(
-            x: positioningBox.minX + resolve(positionX, extent: positioningBox.width),
-            y: positioningBox.minY + resolve(positionY, extent: positioningBox.height),
-            width: resolve(sizeWidth, extent: positioningBox.width),
-            height: resolve(sizeHeight, extent: positioningBox.height)
+            x: positioningBox.minX + CGFloat(positionX.length) +
+                CGFloat(positionX.fraction) * (positioningBox.width - width),
+            y: positioningBox.minY + CGFloat(positionY.length) +
+                CGFloat(positionY.fraction) * (positioningBox.height - height),
+            width: width,
+            height: height
         )
     }
 
@@ -109,7 +113,25 @@ final class HostBackgroundPainter {
         context.addPath(clipPath)
         context.clip()
         if geometry.clipsToSingleImage {
-            context.clip(to: imageBounds)
+            var imageClip = imageBounds
+            let deviceScale = max(
+                hypot(context.ctm.a, context.ctm.c),
+                hypot(context.ctm.b, context.ctm.d),
+                1
+            )
+            // A rect clip includes coverage from the device pixel touching its
+            // leading edge. Move that edge to the next pixel center so a
+            // no-repeat image cannot bleed into the preceding CSS pixel.
+            let leadingEdgeInset = backgroundLeadingEdgeInset(deviceScale: deviceScale)
+            if imageClip.minX > bounds.minX {
+                imageClip.origin.x += leadingEdgeInset
+                imageClip.size.width = max(0, imageClip.width - leadingEdgeInset)
+            }
+            if imageClip.minY > bounds.minY {
+                imageClip.origin.y += leadingEdgeInset
+                imageClip.size.height = max(0, imageClip.height - leadingEdgeInset)
+            }
+            context.clip(to: imageClip)
         }
         defer { context.restoreGState() }
         switch image {
@@ -231,6 +253,10 @@ final class HostBackgroundPainter {
 
         UIImage(cgImage: image, scale: scale, orientation: .up).draw(in: bounds)
     }
+}
+
+func backgroundLeadingEdgeInset(deviceScale: CGFloat) -> CGFloat {
+    0.5 / max(deviceScale, 1)
 }
 
 private struct ResolvedGradient {

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -77,8 +77,27 @@ struct HostBackgroundGeometry {
         )
     }
 
-    var clipsToSingleImage: Bool {
-        repeatX == .noRepeat && repeatY == .noRepeat
+    func tileRects(in positioningBox: CGRect, covering paintBounds: CGRect) -> [CGRect] {
+        let image = imageBounds(in: positioningBox)
+        let xOrigins = backgroundTileOrigins(
+            base: image.minX,
+            tileSize: image.width,
+            coverage: paintBounds.minX..<paintBounds.maxX,
+            repeatMode: repeatX
+        )
+        let yOrigins = backgroundTileOrigins(
+            base: image.minY,
+            tileSize: image.height,
+            coverage: paintBounds.minY..<paintBounds.maxY,
+            repeatMode: repeatY
+        )
+        guard !yOrigins.isEmpty,
+              xOrigins.count <= 65_536 / yOrigins.count else { return [] }
+        return xOrigins.flatMap { x in
+            yOrigins.map { y in
+                CGRect(x: x, y: y, width: image.width, height: image.height)
+            }
+        }
     }
 }
 
@@ -128,35 +147,37 @@ final class HostBackgroundPainter {
         context.saveGState()
         context.addPath(clipPath)
         context.clip()
-        if geometry.clipsToSingleImage {
-            var imageClip = imageBounds
-            let deviceScale = max(
-                hypot(context.ctm.a, context.ctm.c),
-                hypot(context.ctm.b, context.ctm.d),
-                1
-            )
-            // A rect clip includes coverage from the device pixel touching its
-            // leading edge. Move that edge to the next pixel center so a
-            // no-repeat image cannot bleed into the preceding CSS pixel.
-            let leadingEdgeInset = backgroundLeadingEdgeInset(deviceScale: deviceScale)
-            if imageClip.minX > positioningBox.minX {
-                imageClip.origin.x += leadingEdgeInset
-                imageClip.size.width = max(0, imageClip.width - leadingEdgeInset)
-            }
-            if imageClip.minY > positioningBox.minY {
-                imageClip.origin.y += leadingEdgeInset
-                imageClip.size.height = max(0, imageClip.height - leadingEdgeInset)
-            }
-            context.clip(to: imageClip)
-        }
         defer { context.restoreGState() }
-        switch image {
-        case let .linear(gradient):
-            drawLinear(gradient, in: imageBounds, context: context)
-        case let .radial(gradient):
-            drawRadial(gradient, in: imageBounds, context: context)
-        case let .conic(gradient):
-            drawConic(gradient, in: imageBounds, context: context)
+        let deviceScale = max(
+            hypot(context.ctm.a, context.ctm.c),
+            hypot(context.ctm.b, context.ctm.d),
+            1
+        )
+        let leadingEdgeInset = backgroundLeadingEdgeInset(deviceScale: deviceScale)
+        for tile in geometry.tileRects(
+            in: positioningBox,
+            covering: clipPath.boundingBoxOfPath
+        ) {
+            var tileClip = tile
+            if geometry.repeatX == .noRepeat && tileClip.minX > positioningBox.minX {
+                tileClip.origin.x += leadingEdgeInset
+                tileClip.size.width = max(0, tileClip.width - leadingEdgeInset)
+            }
+            if geometry.repeatY == .noRepeat && tileClip.minY > positioningBox.minY {
+                tileClip.origin.y += leadingEdgeInset
+                tileClip.size.height = max(0, tileClip.height - leadingEdgeInset)
+            }
+            context.saveGState()
+            context.clip(to: tileClip)
+            switch image {
+            case let .linear(gradient):
+                drawLinear(gradient, in: tile, context: context)
+            case let .radial(gradient):
+                drawRadial(gradient, in: tile, context: context)
+            case let .conic(gradient):
+                drawConic(gradient, in: tile, context: context)
+            }
+            context.restoreGState()
         }
     }
 
@@ -273,6 +294,21 @@ final class HostBackgroundPainter {
 
 func backgroundLeadingEdgeInset(deviceScale: CGFloat) -> CGFloat {
     0.5 / max(deviceScale, 1)
+}
+
+func backgroundTileOrigins(
+    base: CGFloat,
+    tileSize: CGFloat,
+    coverage: Range<CGFloat>,
+    repeatMode: HostBackgroundRepeat
+) -> [CGFloat] {
+    guard tileSize > 0, coverage.lowerBound < coverage.upperBound else { return [] }
+    guard repeatMode == .repeat else { return [base] }
+    let first = base + floor((coverage.lowerBound - base) / tileSize) * tileSize
+    let rawCount = ceil((coverage.upperBound - first) / tileSize)
+    guard rawCount.isFinite, rawCount > 0, rawCount <= 65_536 else { return [] }
+    let count = Int(rawCount)
+    return (0..<count).map { first + CGFloat($0) * tileSize }
 }
 
 private struct ResolvedGradient {

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -25,20 +25,36 @@ struct HostRadialGradient {
     let stops: [HostLinearGradientStop]
 }
 
+struct HostConicGradient {
+    let fromDegrees: CGFloat
+    let centerX: WhiskerMobileLengthPercentage
+    let centerY: WhiskerMobileLengthPercentage
+    let stops: [HostLinearGradientStop]
+}
+
 private enum HostBackgroundImage {
     case linear(HostLinearGradient)
     case radial(HostRadialGradient)
+    case conic(HostConicGradient)
 }
 
 final class HostBackgroundPainter {
     private var image: HostBackgroundImage?
+    private var conicCache: (size: CGSize, scale: CGFloat, image: CGImage)?
 
     func update(linearGradient: HostLinearGradient?) {
         image = linearGradient.map(HostBackgroundImage.linear)
+        conicCache = nil
     }
 
     func update(radialGradient: HostRadialGradient) {
         image = .radial(radialGradient)
+        conicCache = nil
+    }
+
+    func update(conicGradient: HostConicGradient) {
+        image = .conic(conicGradient)
+        conicCache = nil
     }
 
     func draw(in bounds: CGRect, clippedBy clipPath: CGPath) {
@@ -49,6 +65,8 @@ final class HostBackgroundPainter {
             drawLinear(gradient, in: bounds, clippedBy: clipPath, context: context)
         case let .radial(gradient):
             drawRadial(gradient, in: bounds, clippedBy: clipPath, context: context)
+        case let .conic(gradient):
+            drawConic(gradient, in: bounds, clippedBy: clipPath, context: context)
         }
     }
 
@@ -144,6 +162,36 @@ final class HostBackgroundPainter {
         )
         context.restoreGState()
     }
+
+    private func drawConic(
+        _ conicGradient: HostConicGradient,
+        in bounds: CGRect,
+        clippedBy clipPath: CGPath,
+        context: CGContext
+    ) {
+        let stops = normalizedConicStops(conicGradient.stops)
+        guard stops.count >= 2 else { return }
+        let scale = max(hypot(context.ctm.a, context.ctm.c), 1)
+        let image: CGImage
+        if let cache = conicCache, cache.size == bounds.size, cache.scale == scale {
+            image = cache.image
+        } else {
+            guard let rendered = rasterizeConic(
+                conicGradient,
+                stops: stops,
+                size: bounds.size,
+                scale: scale
+            ) else { return }
+            conicCache = (bounds.size, scale, rendered)
+            image = rendered
+        }
+
+        context.saveGState()
+        context.addPath(clipPath)
+        context.clip()
+        UIImage(cgImage: image, scale: scale, orientation: .up).draw(in: bounds)
+        context.restoreGState()
+    }
 }
 
 private struct ResolvedGradient {
@@ -197,6 +245,135 @@ private func makeGradient(
         count: resolved.count
     ) else { return nil }
     return ResolvedGradient(value: value, domainStart: domainStart, domainEnd: domainEnd)
+}
+
+private func normalizedConicStops(
+    _ input: [HostLinearGradientStop]
+) -> [(color: UIColor, position: CGFloat)] {
+    guard input.count >= 2 else { return [] }
+    var previous = -CGFloat.infinity
+    let ordered = input.map { stop -> (color: UIColor, position: CGFloat) in
+        let position = max(previous, CGFloat(stop.position.fraction))
+        previous = position
+        return (stop.color, position)
+    }
+    var result = [(color: color(at: 0, in: ordered), position: CGFloat(0))]
+    result.append(contentsOf: ordered.filter { (0...1).contains($0.position) })
+    result.append((color: color(at: 1, in: ordered), position: 1))
+    return result
+}
+
+/// Evaluates the resolved, non-repeating stop list at one turn fraction.
+private func color(
+    at position: CGFloat,
+    in stops: [(color: UIColor, position: CGFloat)]
+) -> UIColor {
+    guard let first = stops.first, position > first.position else {
+        return stops.first?.color ?? .clear
+    }
+    for (left, right) in zip(stops, stops.dropFirst()) where position <= right.position {
+        let distance = right.position - left.position
+        guard distance > 0 else { return right.color }
+        return interpolate(left.color, right.color, amount: (position - left.position) / distance)
+    }
+    return stops.last?.color ?? .clear
+}
+
+private func rasterizeConic(
+    _ gradient: HostConicGradient,
+    stops: [(color: UIColor, position: CGFloat)],
+    size: CGSize,
+    scale: CGFloat
+) -> CGImage? {
+    let width = max(Int(ceil(size.width * scale)), 1)
+    let height = max(Int(ceil(size.height * scale)), 1)
+    let centerX = resolve(gradient.centerX, extent: size.width) * scale
+    let centerY = resolve(gradient.centerY, extent: size.height) * scale
+    let startTurn = gradient.fromDegrees / 360
+    let rasterStops = stops.map { (color: rgba($0.color), position: $0.position) }
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    for y in 0..<height {
+        for x in 0..<width {
+            let dx = CGFloat(x) + 0.5 - centerX
+            let dy = CGFloat(y) + 0.5 - centerY
+            let turn = (atan2(dx, -dy) / (2 * .pi) - startTurn).truncatingRemainder(
+                dividingBy: 1
+            )
+            let components = conicColor(
+                at: turn < 0 ? turn + 1 : turn,
+                in: rasterStops
+            )
+            let alpha = max(0, min(1, components.alpha))
+            let offset = (y * width + x) * 4
+            pixels[offset] = byte(components.red * alpha)
+            pixels[offset + 1] = byte(components.green * alpha)
+            pixels[offset + 2] = byte(components.blue * alpha)
+            pixels[offset + 3] = byte(alpha)
+        }
+    }
+    guard let bitmap = CGContext(
+        data: &pixels,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ) else { return nil }
+    return bitmap.makeImage()
+}
+
+private struct RGBA {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+}
+
+private func rgba(_ color: UIColor) -> RGBA {
+    let components = rgbaComponents(color)
+    return RGBA(
+        red: components[0],
+        green: components[1],
+        blue: components[2],
+        alpha: components[3]
+    )
+}
+
+private func conicColor(
+    at position: CGFloat,
+    in stops: [(color: RGBA, position: CGFloat)]
+) -> RGBA {
+    guard let first = stops.first, position > first.position else {
+        return stops.first?.color ?? RGBA(red: 0, green: 0, blue: 0, alpha: 0)
+    }
+    for (left, right) in zip(stops, stops.dropFirst()) where position <= right.position {
+        let distance = right.position - left.position
+        guard distance > 0 else { return right.color }
+        let amount = (position - left.position) / distance
+        return RGBA(
+            red: left.color.red + (right.color.red - left.color.red) * amount,
+            green: left.color.green + (right.color.green - left.color.green) * amount,
+            blue: left.color.blue + (right.color.blue - left.color.blue) * amount,
+            alpha: left.color.alpha + (right.color.alpha - left.color.alpha) * amount
+        )
+    }
+    return stops.last?.color ?? RGBA(red: 0, green: 0, blue: 0, alpha: 0)
+}
+
+private func byte(_ value: CGFloat) -> UInt8 {
+    UInt8((max(0, min(1, value)) * 255).rounded())
+}
+
+private func interpolate(_ left: UIColor, _ right: UIColor, amount: CGFloat) -> UIColor {
+    let lhs = rgbaComponents(left)
+    let rhs = rgbaComponents(right)
+    return UIColor(
+        red: lhs[0] + (rhs[0] - lhs[0]) * amount,
+        green: lhs[1] + (rhs[1] - lhs[1]) * amount,
+        blue: lhs[2] + (rhs[2] - lhs[2]) * amount,
+        alpha: lhs[3] + (rhs[3] - lhs[3]) * amount
+    )
 }
 
 private func rgbaComponents(_ color: UIColor) -> [CGFloat] {

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -37,6 +37,11 @@ enum HostBackgroundRepeat {
     case noRepeat
 }
 
+enum HostBackgroundBox {
+    case border
+    case padding
+}
+
 struct HostBackgroundGeometry {
     let positionX: WhiskerMobileLengthPercentage
     let positionY: WhiskerMobileLengthPercentage
@@ -44,6 +49,8 @@ struct HostBackgroundGeometry {
     let sizeHeight: WhiskerMobileLengthPercentage?
     let repeatX: HostBackgroundRepeat
     let repeatY: HostBackgroundRepeat
+    let origin: HostBackgroundBox
+    let clip: HostBackgroundBox
 
     static let initial = HostBackgroundGeometry(
         positionX: WhiskerMobileLengthPercentage(),
@@ -51,7 +58,9 @@ struct HostBackgroundGeometry {
         sizeWidth: nil,
         sizeHeight: nil,
         repeatX: .repeat,
-        repeatY: .repeat
+        repeatY: .repeat,
+        origin: .padding,
+        clip: .border
     )
 
     func imageBounds(in positioningBox: CGRect) -> CGRect {
@@ -105,8 +114,15 @@ final class HostBackgroundPainter {
         conicCache = nil
     }
 
-    func draw(in bounds: CGRect, clippedBy clipPath: CGPath) {
-        let imageBounds = geometry.imageBounds(in: bounds)
+    func draw(
+        borderBox: CGRect,
+        paddingBox: CGRect,
+        borderClip: CGPath,
+        paddingClip: CGPath
+    ) {
+        let positioningBox = geometry.origin == .border ? borderBox : paddingBox
+        let clipPath = geometry.clip == .border ? borderClip : paddingClip
+        let imageBounds = geometry.imageBounds(in: positioningBox)
         guard let image, imageBounds.width > 0, imageBounds.height > 0,
               let context = UIGraphicsGetCurrentContext() else { return }
         context.saveGState()
@@ -123,11 +139,11 @@ final class HostBackgroundPainter {
             // leading edge. Move that edge to the next pixel center so a
             // no-repeat image cannot bleed into the preceding CSS pixel.
             let leadingEdgeInset = backgroundLeadingEdgeInset(deviceScale: deviceScale)
-            if imageClip.minX > bounds.minX {
+            if imageClip.minX > positioningBox.minX {
                 imageClip.origin.x += leadingEdgeInset
                 imageClip.size.width = max(0, imageClip.width - leadingEdgeInset)
             }
-            if imageClip.minY > bounds.minY {
+            if imageClip.minY > positioningBox.minY {
                 imageClip.origin.y += leadingEdgeInset
                 imageClip.size.height = max(0, imageClip.height - leadingEdgeInset)
             }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -1,0 +1,94 @@
+import CoreGraphics
+import UIKit
+import WhiskerModule
+
+struct HostLinearGradientStop {
+    let color: UIColor
+    let position: WhiskerMobileLengthPercentage
+
+    init(_ raw: WhiskerMobileGradientStop) {
+        color = parsePaintColor(raw.color)
+        position = raw.position
+    }
+}
+
+struct HostLinearGradient {
+    let angleDegrees: CGFloat
+    let stops: [HostLinearGradientStop]
+}
+
+final class HostBackgroundPainter {
+    private var linearGradient: HostLinearGradient?
+
+    func update(linearGradient: HostLinearGradient?) {
+        self.linearGradient = linearGradient
+    }
+
+    func draw(in bounds: CGRect, clippedBy clipPath: CGPath) {
+        guard let linearGradient, bounds.width > 0, bounds.height > 0,
+              let context = UIGraphicsGetCurrentContext() else { return }
+        let radians = linearGradient.angleDegrees * .pi / 180
+        let direction = CGVector(dx: sin(radians), dy: -cos(radians))
+        let lineLength = abs(bounds.width * direction.dx) + abs(bounds.height * direction.dy)
+        guard lineLength > 0 else { return }
+
+        var resolved = linearGradient.stops.map { stop in
+            (
+                color: stop.color,
+                position: CGFloat(stop.position.length) / lineLength +
+                    CGFloat(stop.position.fraction)
+            )
+        }
+        guard resolved.count >= 2 else { return }
+        let domainStart = min(0, resolved[0].position)
+        let domainEnd = max(1, resolved[resolved.count - 1].position)
+        let domainLength = domainEnd - domainStart
+        guard domainLength > 0 else { return }
+        if resolved[0].position > domainStart {
+            resolved.insert((resolved[0].color, domainStart), at: 0)
+        }
+        if resolved[resolved.count - 1].position < domainEnd {
+            resolved.append((resolved[resolved.count - 1].color, domainEnd))
+        }
+
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let components = resolved.flatMap { rgbaComponents($0.color) }
+        let locations = resolved.map { ($0.position - domainStart) / domainLength }
+        guard let gradient = CGGradient(
+            colorSpace: colorSpace,
+            colorComponents: components,
+            locations: locations,
+            count: resolved.count
+        ) else { return }
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        let start = CGPoint(
+            x: center.x + direction.dx * lineLength * (domainStart - 0.5),
+            y: center.y + direction.dy * lineLength * (domainStart - 0.5)
+        )
+        let end = CGPoint(
+            x: center.x + direction.dx * lineLength * (domainEnd - 0.5),
+            y: center.y + direction.dy * lineLength * (domainEnd - 0.5)
+        )
+        context.saveGState()
+        context.addPath(clipPath)
+        context.clip()
+        context.drawLinearGradient(
+            gradient,
+            start: start,
+            end: end,
+            options: [.drawsBeforeStartLocation, .drawsAfterEndLocation]
+        )
+        context.restoreGState()
+    }
+}
+
+private func rgbaComponents(_ color: UIColor) -> [CGFloat] {
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+        return [0, 0, 0, 0]
+    }
+    return [red, green, blue, alpha]
+}

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -65,6 +65,10 @@ final class HostBoxPainter {
         backgroundPainter.update(linearGradient: linearGradient)
     }
 
+    func updateBackgroundLayers(_ radialGradient: HostRadialGradient) {
+        backgroundPainter.update(radialGradient: radialGradient)
+    }
+
     func overflowClipPath(
         in bounds: CGRect,
         visibleBounds: CGRect,

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -55,9 +55,34 @@ final class HostBoxPainter {
             width: max(0, bounds.width - min(widths[3], bounds.width) - min(widths[1], bounds.width)),
             height: max(0, bounds.height - min(widths[0], bounds.height) - min(widths[2], bounds.height))
         )
+        let outerRadii = normalizedRadii(cornerRadii, in: bounds)
+        let paddingRadii = [
+            CGSize(
+                width: max(0, outerRadii[0].width - widths[3]),
+                height: max(0, outerRadii[0].height - widths[0])
+            ),
+            CGSize(
+                width: max(0, outerRadii[1].width - widths[1]),
+                height: max(0, outerRadii[1].height - widths[0])
+            ),
+            CGSize(
+                width: max(0, outerRadii[2].width - widths[1]),
+                height: max(0, outerRadii[2].height - widths[2])
+            ),
+            CGSize(
+                width: max(0, outerRadii[3].width - widths[3]),
+                height: max(0, outerRadii[3].height - widths[2])
+            )
+        ]
+        let paddingPath = roundedPath(in: paddingBox, radii: paddingRadii)
         fillColor.setFill()
         path.fill()
-        backgroundPainter.draw(in: paddingBox, clippedBy: path.cgPath)
+        backgroundPainter.draw(
+            borderBox: bounds,
+            paddingBox: paddingBox,
+            borderClip: path.cgPath,
+            paddingClip: paddingPath.cgPath
+        )
         drawBorders(in: bounds, clippedBy: path)
     }
 

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -20,6 +20,7 @@ struct HostBoxPaint {
 }
 
 final class HostBoxPainter {
+    private let backgroundPainter = HostBackgroundPainter()
     private var fillColor = UIColor.clear
     /// CSS order: top, right, bottom, left.
     private var borderWidths = [CGFloat](repeating: 0, count: 4)
@@ -47,9 +48,21 @@ final class HostBoxPainter {
 
     func draw(in bounds: CGRect) {
         let path = roundedPath(in: bounds, radii: cornerRadii)
+        let widths = Array((borderWidths + [0, 0, 0, 0]).prefix(4)).map { max(0, $0) }
+        let paddingBox = CGRect(
+            x: bounds.minX + min(widths[3], bounds.width),
+            y: bounds.minY + min(widths[0], bounds.height),
+            width: max(0, bounds.width - min(widths[3], bounds.width) - min(widths[1], bounds.width)),
+            height: max(0, bounds.height - min(widths[0], bounds.height) - min(widths[2], bounds.height))
+        )
         fillColor.setFill()
         path.fill()
+        backgroundPainter.draw(in: paddingBox, clippedBy: path.cgPath)
         drawBorders(in: bounds, clippedBy: path)
+    }
+
+    func updateBackgroundLayers(_ linearGradient: HostLinearGradient?) {
+        backgroundPainter.update(linearGradient: linearGradient)
     }
 
     func overflowClipPath(

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -92,6 +92,15 @@ final class HostBoxPainter {
             colors[index].setFill()
             if styles[index] == borderStyleSolid {
                 region.fill()
+            } else if isReliefBorderStyle(styles[index]) {
+                drawReliefBorder(
+                    in: edgeRect(bounds: bounds, side: index, width: widths[index]),
+                    side: index,
+                    width: widths[index],
+                    style: styles[index],
+                    color: colors[index],
+                    context: context
+                )
             } else {
                 drawPatternedBorder(
                     in: edgeRect(bounds: bounds, side: index, width: widths[index]),
@@ -181,6 +190,61 @@ final class HostBoxPainter {
         }
         context.fill(outer)
         context.fill(inner)
+    }
+
+    private func drawReliefBorder(
+        in edge: CGRect,
+        side: Int,
+        width: CGFloat,
+        style: UInt32,
+        color: UIColor,
+        context: CGContext
+    ) {
+        let topOrLeft = side == 0 || side == 3
+        if style == borderStyleInset || style == borderStyleOutset {
+            let lighter = style == borderStyleInset ? !topOrLeft : topOrLeft
+            shadedBorderColor(color, lighter: lighter).setFill()
+            context.fill(edge)
+            return
+        }
+
+        let outerLighter: Bool
+        if style == borderStyleGroove {
+            outerLighter = !topOrLeft
+        } else {
+            outerLighter = topOrLeft
+        }
+        let (outer, inner) = reliefBands(in: edge, side: side, width: width)
+        shadedBorderColor(color, lighter: outerLighter).setFill()
+        context.fill(outer)
+        shadedBorderColor(color, lighter: !outerLighter).setFill()
+        context.fill(inner)
+    }
+
+    private func reliefBands(in edge: CGRect, side: Int, width: CGFloat) -> (CGRect, CGRect) {
+        let band = width / 2
+        switch side {
+        case 0:
+            return (
+                CGRect(x: edge.minX, y: edge.minY, width: edge.width, height: band),
+                CGRect(x: edge.minX, y: edge.maxY - band, width: edge.width, height: band)
+            )
+        case 1:
+            return (
+                CGRect(x: edge.maxX - band, y: edge.minY, width: band, height: edge.height),
+                CGRect(x: edge.minX, y: edge.minY, width: band, height: edge.height)
+            )
+        case 2:
+            return (
+                CGRect(x: edge.minX, y: edge.maxY - band, width: edge.width, height: band),
+                CGRect(x: edge.minX, y: edge.minY, width: edge.width, height: band)
+            )
+        default:
+            return (
+                CGRect(x: edge.minX, y: edge.minY, width: band, height: edge.height),
+                CGRect(x: edge.maxX - band, y: edge.minY, width: band, height: edge.height)
+            )
+        }
     }
 }
 
@@ -272,8 +336,36 @@ private let borderStyleSolid: UInt32 = 2
 private let borderStyleDashed: UInt32 = 3
 private let borderStyleDotted: UInt32 = 4
 private let borderStyleDouble: UInt32 = 5
+private let borderStyleGroove: UInt32 = 6
+private let borderStyleRidge: UInt32 = 7
+private let borderStyleInset: UInt32 = 8
+private let borderStyleOutset: UInt32 = 9
 
 private func paintsBorderStyle(_ style: UInt32) -> Bool {
     style == borderStyleSolid || style == borderStyleDashed || style == borderStyleDotted ||
-        style == borderStyleDouble
+        style == borderStyleDouble || isReliefBorderStyle(style)
+}
+
+private func isReliefBorderStyle(_ style: UInt32) -> Bool {
+    style == borderStyleGroove || style == borderStyleRidge || style == borderStyleInset ||
+        style == borderStyleOutset
+}
+
+private func shadedBorderColor(_ color: UIColor, lighter: Bool) -> UIColor {
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return color }
+    let amount: CGFloat = 0.45
+    if lighter {
+        red += (1 - red) * amount
+        green += (1 - green) * amount
+        blue += (1 - blue) * amount
+    } else {
+        red *= 1 - amount
+        green *= 1 - amount
+        blue *= 1 - amount
+    }
+    return UIColor(red: red, green: green, blue: blue, alpha: alpha)
 }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -69,6 +69,10 @@ final class HostBoxPainter {
         backgroundPainter.update(radialGradient: radialGradient)
     }
 
+    func updateBackgroundLayers(_ conicGradient: HostConicGradient) {
+        backgroundPainter.update(conicGradient: conicGradient)
+    }
+
     func overflowClipPath(
         in bounds: CGRect,
         visibleBounds: CGRect,

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -61,16 +61,25 @@ final class HostBoxPainter {
         drawBorders(in: bounds, clippedBy: path)
     }
 
-    func updateBackgroundLayers(_ linearGradient: HostLinearGradient?) {
-        backgroundPainter.update(linearGradient: linearGradient)
+    func updateBackgroundLayers(
+        _ linearGradient: HostLinearGradient?,
+        geometry: HostBackgroundGeometry = .initial
+    ) {
+        backgroundPainter.update(linearGradient: linearGradient, geometry: geometry)
     }
 
-    func updateBackgroundLayers(_ radialGradient: HostRadialGradient) {
-        backgroundPainter.update(radialGradient: radialGradient)
+    func updateBackgroundLayers(
+        _ radialGradient: HostRadialGradient,
+        geometry: HostBackgroundGeometry = .initial
+    ) {
+        backgroundPainter.update(radialGradient: radialGradient, geometry: geometry)
     }
 
-    func updateBackgroundLayers(_ conicGradient: HostConicGradient) {
-        backgroundPainter.update(conicGradient: conicGradient)
+    func updateBackgroundLayers(
+        _ conicGradient: HostConicGradient,
+        geometry: HostBackgroundGeometry = .initial
+    ) {
+        backgroundPainter.update(conicGradient: conicGradient, geometry: geometry)
     }
 
     func overflowClipPath(

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -52,6 +52,76 @@ final class HostBoxPainter {
         drawBorders(in: bounds, clippedBy: path)
     }
 
+    func overflowClipPath(
+        in bounds: CGRect,
+        visibleBounds: CGRect,
+        horizontal: Bool,
+        vertical: Bool
+    ) -> CGPath {
+        let widths = Array((borderWidths + [0, 0, 0, 0]).prefix(4)).map { max(0, $0) }
+        let top = min(widths[0], bounds.height)
+        let right = min(widths[1], bounds.width)
+        let bottom = min(widths[2], bounds.height)
+        let left = min(widths[3], bounds.width)
+        let innerRect = CGRect(
+            x: bounds.minX + left,
+            y: bounds.minY + top,
+            width: max(0, bounds.width - left - right),
+            height: max(0, bounds.height - top - bottom)
+        )
+        guard horizontal || vertical else { return UIBezierPath(rect: visibleBounds).cgPath }
+        let outer = normalizedRadii(cornerRadii, in: bounds)
+        let inner = [
+            CGSize(
+                width: max(0, outer[0].width - left),
+                height: max(0, outer[0].height - top)
+            ),
+            CGSize(
+                width: max(0, outer[1].width - right),
+                height: max(0, outer[1].height - top)
+            ),
+            CGSize(
+                width: max(0, outer[2].width - right),
+                height: max(0, outer[2].height - bottom)
+            ),
+            CGSize(
+                width: max(0, outer[3].width - left),
+                height: max(0, outer[3].height - bottom)
+            )
+        ]
+        let path = CGMutablePath()
+        path.addPath(roundedPath(in: innerRect, radii: inner).cgPath)
+        if !vertical {
+            path.addRect(CGRect(
+                x: innerRect.minX,
+                y: visibleBounds.minY,
+                width: innerRect.width,
+                height: max(0, innerRect.minY - visibleBounds.minY)
+            ))
+            path.addRect(CGRect(
+                x: innerRect.minX,
+                y: innerRect.maxY,
+                width: innerRect.width,
+                height: max(0, visibleBounds.maxY - innerRect.maxY)
+            ))
+        }
+        if !horizontal {
+            path.addRect(CGRect(
+                x: visibleBounds.minX,
+                y: innerRect.minY,
+                width: max(0, innerRect.minX - visibleBounds.minX),
+                height: innerRect.height
+            ))
+            path.addRect(CGRect(
+                x: innerRect.maxX,
+                y: innerRect.minY,
+                width: max(0, visibleBounds.maxX - innerRect.maxX),
+                height: innerRect.height
+            ))
+        }
+        return path
+    }
+
     private func drawBorders(in bounds: CGRect, clippedBy outerPath: UIBezierPath) {
         guard let context = UIGraphicsGetCurrentContext() else { return }
         let widths = Array((borderWidths + [0, 0, 0, 0]).prefix(4)).map { max(0, $0) }
@@ -259,25 +329,7 @@ private func resolve(_ value: WhiskerMobileLengthPercentage, axis: CGFloat) -> C
 }
 
 private func roundedPath(in rect: CGRect, radii: [CGSize]) -> UIBezierPath {
-    var normalized = Array((radii + [.zero, .zero, .zero, .zero]).prefix(4)).map {
-        CGSize(width: max($0.width, 0), height: max($0.height, 0))
-    }
-    let horizontalTop = normalized[0].width + normalized[1].width
-    let horizontalBottom = normalized[3].width + normalized[2].width
-    let verticalLeft = normalized[0].height + normalized[3].height
-    let verticalRight = normalized[1].height + normalized[2].height
-    let scale = [
-        CGFloat(1),
-        horizontalTop > 0 ? rect.width / horizontalTop : 1,
-        horizontalBottom > 0 ? rect.width / horizontalBottom : 1,
-        verticalLeft > 0 ? rect.height / verticalLeft : 1,
-        verticalRight > 0 ? rect.height / verticalRight : 1
-    ].min() ?? 1
-    if scale < 1 {
-        normalized = normalized.map {
-            CGSize(width: $0.width * scale, height: $0.height * scale)
-        }
-    }
+    let normalized = normalizedRadii(radii, in: rect)
 
     let k: CGFloat = 0.552_284_749_830_793_6
     let path = UIBezierPath()
@@ -332,6 +384,29 @@ private func roundedPath(in rect: CGRect, radii: [CGSize]) -> UIBezierPath {
     )
     path.close()
     return path
+}
+
+private func normalizedRadii(_ radii: [CGSize], in rect: CGRect) -> [CGSize] {
+    var normalized = Array((radii + [.zero, .zero, .zero, .zero]).prefix(4)).map {
+        CGSize(width: max($0.width, 0), height: max($0.height, 0))
+    }
+    let horizontalTop = normalized[0].width + normalized[1].width
+    let horizontalBottom = normalized[3].width + normalized[2].width
+    let verticalLeft = normalized[0].height + normalized[3].height
+    let verticalRight = normalized[1].height + normalized[2].height
+    let scale = [
+        CGFloat(1),
+        horizontalTop > 0 ? rect.width / horizontalTop : 1,
+        horizontalBottom > 0 ? rect.width / horizontalBottom : 1,
+        verticalLeft > 0 ? rect.height / verticalLeft : 1,
+        verticalRight > 0 ? rect.height / verticalRight : 1
+    ].min() ?? 1
+    if scale < 1 {
+        normalized = normalized.map {
+            CGSize(width: $0.width * scale, height: $0.height * scale)
+        }
+    }
+    return normalized
 }
 
 private let borderStyleSolid: UInt32 = 2

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -123,6 +123,10 @@ final class HostBoxPainter {
         context: CGContext
     ) {
         guard width > 0, !edge.isEmpty else { return }
+        if style == borderStyleDouble {
+            drawDoubleBorder(in: edge, side: side, width: width, context: context)
+            return
+        }
         let horizontal = side == 0 || side == 2
         let start = horizontal ? edge.minX : edge.minY
         let end = horizontal ? edge.maxX : edge.maxY
@@ -150,6 +154,33 @@ final class HostBoxPainter {
                 position += width * 2
             }
         }
+    }
+
+    private func drawDoubleBorder(
+        in edge: CGRect,
+        side: Int,
+        width: CGFloat,
+        context: CGContext
+    ) {
+        let band = width / 3
+        let outer: CGRect
+        let inner: CGRect
+        switch side {
+        case 0:
+            outer = CGRect(x: edge.minX, y: edge.minY, width: edge.width, height: band)
+            inner = CGRect(x: edge.minX, y: edge.maxY - band, width: edge.width, height: band)
+        case 1:
+            outer = CGRect(x: edge.maxX - band, y: edge.minY, width: band, height: edge.height)
+            inner = CGRect(x: edge.minX, y: edge.minY, width: band, height: edge.height)
+        case 2:
+            outer = CGRect(x: edge.minX, y: edge.maxY - band, width: edge.width, height: band)
+            inner = CGRect(x: edge.minX, y: edge.minY, width: edge.width, height: band)
+        default:
+            outer = CGRect(x: edge.minX, y: edge.minY, width: band, height: edge.height)
+            inner = CGRect(x: edge.maxX - band, y: edge.minY, width: band, height: edge.height)
+        }
+        context.fill(outer)
+        context.fill(inner)
     }
 }
 
@@ -240,7 +271,9 @@ private func roundedPath(in rect: CGRect, radii: [CGSize]) -> UIBezierPath {
 private let borderStyleSolid: UInt32 = 2
 private let borderStyleDashed: UInt32 = 3
 private let borderStyleDotted: UInt32 = 4
+private let borderStyleDouble: UInt32 = 5
 
 private func paintsBorderStyle(_ style: UInt32) -> Bool {
-    style == borderStyleSolid || style == borderStyleDashed || style == borderStyleDotted
+    style == borderStyleSolid || style == borderStyleDashed || style == borderStyleDotted ||
+        style == borderStyleDouble
 }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -6,14 +6,16 @@ struct HostBoxPaint {
     let widths: [WhiskerMobileLengthPercentage]
     let colors: [UIColor]
     let styles: [UInt32]
-    let radii: [WhiskerMobileLengthPercentage]
+    let radiiHorizontal: [WhiskerMobileLengthPercentage]
+    let radiiVertical: [WhiskerMobileLengthPercentage]
 
     init(_ raw: WhiskerMobileBoxPaint) {
         background = parsePaintColor(raw.background)
         widths = tupleArray(raw.widths)
         colors = tupleArray(raw.colors).map(parsePaintColor)
         styles = tupleArray(raw.styles)
-        radii = tupleArray(raw.radii)
+        radiiHorizontal = tupleArray(raw.radii_horizontal)
+        radiiVertical = tupleArray(raw.radii_vertical)
     }
 }
 
@@ -35,10 +37,10 @@ final class HostBoxPainter {
         ]
         borderColors = paint.colors
         borderStyles = paint.styles
-        cornerRadii = paint.radii.map { value in
+        cornerRadii = paint.radiiHorizontal.indices.map { index in
             CGSize(
-                width: resolve(value, axis: bounds.width),
-                height: resolve(value, axis: bounds.height)
+                width: resolve(paint.radiiHorizontal[index], axis: bounds.width),
+                height: resolve(paint.radiiVertical[index], axis: bounds.height)
             )
         }
     }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/PaintColor.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/PaintColor.swift
@@ -15,6 +15,7 @@ func parsePaintColor(_ value: WhiskerMobileColor) -> UIColor {
     case "white": return .white
     case "red": return .red
     case "green": return .green
+    case "gold": return UIColor(red: 1, green: 215 / 255, blue: 0, alpha: 1)
     case "blue": return .blue
     default: return .clear
     }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/PaintColor.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/PaintColor.swift
@@ -14,7 +14,8 @@ func parsePaintColor(_ value: WhiskerMobileColor) -> UIColor {
     case "black": return .black
     case "white": return .white
     case "red": return .red
-    case "green": return .green
+    // UIKit's `.green` is #00ff00; CSS named `green` is #008000.
+    case "green": return UIColor(red: 0, green: 128 / 255, blue: 0, alpha: 1)
     case "gold": return UIColor(red: 1, green: 215 / 255, blue: 0, alpha: 1)
     case "blue": return .blue
     default: return .clear

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -11,6 +11,9 @@ final class WhiskerNodeView: UIView {
     var paint: HostBoxPaint?
     let boxPainter = HostBoxPainter()
     var mountedElement: WhiskerMountedElement?
+    private let overflowMask = CALayer()
+    private var clipsOverflowHorizontally = false
+    private var clipsOverflowVertically = false
 
     init(element: String) {
         self.element = element
@@ -20,15 +23,55 @@ final class WhiskerNodeView: UIView {
 
     required init?(coder: NSCoder) { nil }
 
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        updateOverflowMask()
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         if let mountedElement {
             mountedElement.view.frame = contentFrame
         }
+        updateOverflowMask()
         setNeedsDisplay()
     }
 
     override func draw(_ rect: CGRect) {
         boxPainter.draw(in: bounds)
+    }
+
+    func setOverflowClip(horizontal: Bool, vertical: Bool) {
+        clipsOverflowHorizontally = horizontal
+        clipsOverflowVertically = vertical
+        clipsToBounds = false
+        updateOverflowMask()
+    }
+
+    private func updateOverflowMask() {
+        guard clipsOverflowHorizontally || clipsOverflowVertically else {
+            layer.mask = nil
+            return
+        }
+        // A layer mask participates in composition after this view's own box
+        // has been painted, so the box remains intact while overflowing
+        // descendants are constrained only on the requested axes. Visible
+        // axes extend through the complete Host surface; the surface itself is
+        // the final composition boundary.
+        let compositionBounds = hostCompositionBounds()
+        overflowMask.frame = CGRect(
+            x: clipsOverflowHorizontally ? bounds.minX : compositionBounds.minX,
+            y: clipsOverflowVertically ? bounds.minY : compositionBounds.minY,
+            width: clipsOverflowHorizontally ? bounds.width : compositionBounds.width,
+            height: clipsOverflowVertically ? bounds.height : compositionBounds.height
+        )
+        overflowMask.backgroundColor = UIColor.white.cgColor
+        layer.mask = overflowMask
+    }
+
+    private func hostCompositionBounds() -> CGRect {
+        var host: UIView = self
+        while let parent = host.superview { host = parent }
+        return convert(host.bounds, from: host)
     }
 }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -11,7 +11,8 @@ final class WhiskerNodeView: UIView {
     var paint: HostBoxPaint?
     let boxPainter = HostBoxPainter()
     var mountedElement: WhiskerMountedElement?
-    private let overflowMask = CALayer()
+    private let defaultChildrenHost = WhiskerChildrenHostView(frame: .zero)
+    private let overflowMask = CAShapeLayer()
     private var clipsOverflowHorizontally = false
     private var clipsOverflowVertically = false
 
@@ -20,6 +21,10 @@ final class WhiskerNodeView: UIView {
         super.init(frame: .zero)
         isOpaque = false
         layer.anchorPoint = .zero
+        defaultChildrenHost.isOpaque = false
+        defaultChildrenHost.backgroundColor = .clear
+        defaultChildrenHost.clipsToBounds = false
+        addSubview(defaultChildrenHost)
     }
 
     required init?(coder: NSCoder) { nil }
@@ -34,6 +39,7 @@ final class WhiskerNodeView: UIView {
         if let mountedElement {
             mountedElement.view.frame = contentFrame
         }
+        defaultChildrenHost.frame = bounds
         updateOverflowMask()
         setNeedsDisplay()
     }
@@ -48,6 +54,8 @@ final class WhiskerNodeView: UIView {
         // independent by positioning the zero-anchor layer directly.
         bounds = CGRect(origin: .zero, size: frame.size)
         layer.position = frame.origin
+        defaultChildrenHost.frame = bounds
+        updateOverflowMask()
     }
 
     func setPresentationTransform(_ values: UnsafeBufferPointer<Float>) {
@@ -79,30 +87,66 @@ final class WhiskerNodeView: UIView {
         updateOverflowMask()
     }
 
+    func sceneChildrenHost() -> UIView {
+        mountedElement?.childrenHost() ?? defaultChildrenHost
+    }
+
+    func mountedContentDidInstall() {
+        bringSubviewToFront(defaultChildrenHost)
+        updateOverflowMask()
+    }
+
+    func boxPaintDidChange() {
+        updateOverflowMask()
+    }
+
     private func updateOverflowMask() {
         guard clipsOverflowHorizontally || clipsOverflowVertically else {
-            layer.mask = nil
+            sceneChildrenHost().layer.mask = nil
             return
         }
-        // A layer mask participates in composition after this view's own box
-        // has been painted, so the box remains intact while overflowing
-        // descendants are constrained only on the requested axes. Visible
-        // axes extend through the complete Host surface; the surface itself is
-        // the final composition boundary.
         let compositionBounds = hostCompositionBounds()
-        overflowMask.frame = CGRect(
-            x: clipsOverflowHorizontally ? bounds.minX : compositionBounds.minX,
-            y: clipsOverflowVertically ? bounds.minY : compositionBounds.minY,
-            width: clipsOverflowHorizontally ? bounds.width : compositionBounds.width,
-            height: clipsOverflowVertically ? bounds.height : compositionBounds.height
+        let nodePath = boxPainter.overflowClipPath(
+            in: bounds,
+            visibleBounds: compositionBounds,
+            horizontal: clipsOverflowHorizontally,
+            vertical: clipsOverflowVertically
         )
-        overflowMask.backgroundColor = UIColor.white.cgColor
-        layer.mask = overflowMask
+        let host = sceneChildrenHost()
+        let origin = host.convert(CGPoint.zero, from: self)
+        let xUnit = host.convert(CGPoint(x: 1, y: 0), from: self)
+        let yUnit = host.convert(CGPoint(x: 0, y: 1), from: self)
+        var conversion = CGAffineTransform(
+            a: xUnit.x - origin.x,
+            b: xUnit.y - origin.y,
+            c: yUnit.x - origin.x,
+            d: yUnit.y - origin.y,
+            tx: origin.x,
+            ty: origin.y
+        )
+        guard let convertedPath = nodePath.copy(using: &conversion) else { return }
+        let maskFrame = convertedPath.boundingBoxOfPath
+        var maskTranslation = CGAffineTransform(
+            translationX: -maskFrame.minX,
+            y: -maskFrame.minY
+        )
+        overflowMask.frame = maskFrame
+        overflowMask.path = convertedPath.copy(using: &maskTranslation)
+        overflowMask.backgroundColor = UIColor.clear.cgColor
+        overflowMask.fillColor = UIColor.white.cgColor
+        host.layer.mask = overflowMask
     }
 
     private func hostCompositionBounds() -> CGRect {
         var host: UIView = self
         while let parent = host.superview { host = parent }
         return convert(host.bounds, from: host)
+    }
+}
+
+private final class WhiskerChildrenHostView: UIView {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let result = super.hitTest(point, with: event)
+        return result === self ? nil : result
     }
 }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -19,6 +19,7 @@ final class WhiskerNodeView: UIView {
         self.element = element
         super.init(frame: .zero)
         isOpaque = false
+        layer.anchorPoint = .zero
     }
 
     required init?(coder: NSCoder) { nil }
@@ -39,6 +40,36 @@ final class WhiskerNodeView: UIView {
 
     override func draw(_ rect: CGRect) {
         boxPainter.draw(in: bounds)
+    }
+
+    func setLayoutFrame(_ frame: CGRect) {
+        // `UIView.frame` is undefined while a non-identity transform is
+        // installed. Keep layout geometry and presentation transform
+        // independent by positioning the zero-anchor layer directly.
+        bounds = CGRect(origin: .zero, size: frame.size)
+        layer.position = frame.origin
+    }
+
+    func setPresentationTransform(_ values: UnsafeBufferPointer<Float>) {
+        precondition(values.count == 16)
+        var transform = CATransform3DIdentity
+        transform.m11 = CGFloat(values[0])
+        transform.m12 = CGFloat(values[1])
+        transform.m13 = CGFloat(values[2])
+        transform.m14 = CGFloat(values[3])
+        transform.m21 = CGFloat(values[4])
+        transform.m22 = CGFloat(values[5])
+        transform.m23 = CGFloat(values[6])
+        transform.m24 = CGFloat(values[7])
+        transform.m31 = CGFloat(values[8])
+        transform.m32 = CGFloat(values[9])
+        transform.m33 = CGFloat(values[10])
+        transform.m34 = CGFloat(values[11])
+        transform.m41 = CGFloat(values[12])
+        transform.m42 = CGFloat(values[13])
+        transform.m43 = CGFloat(values[14])
+        transform.m44 = CGFloat(values[15])
+        layer.transform = transform
     }
 
     func setOverflowClip(horizontal: Bool, vertical: Bool) {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -506,7 +506,7 @@ private func validGradientStops(
 }
 
 private func validBackgroundGeometry(_ layer: WhiskerMobileBackgroundLayer) -> Bool {
-    guard layer.position_x.isZero, layer.position_y.isZero,
+    guard layer.position_x.isFinite, layer.position_y.isFinite,
           layer.origin == UInt32(WHISKER_BACKGROUND_BOX_PADDING),
           layer.clip == UInt32(WHISKER_BACKGROUND_BOX_BORDER),
           layer.attachment == UInt32(WHISKER_BACKGROUND_ATTACHMENT_SCROLL),
@@ -514,7 +514,8 @@ private func validBackgroundGeometry(_ layer: WhiskerMobileBackgroundLayer) -> B
         return false
     }
     if layer.size_kind == UInt32(WHISKER_BACKGROUND_SIZE_AUTO) {
-        return layer.size_width.isZero && layer.size_height.isZero &&
+        return layer.position_x.isZero && layer.position_y.isZero &&
+            layer.size_width.isZero && layer.size_height.isZero &&
             layer.repeat_x == UInt32(WHISKER_BACKGROUND_REPEAT) &&
             layer.repeat_y == UInt32(WHISKER_BACKGROUND_REPEAT)
     }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -135,6 +135,24 @@ final class HostScene {
                     count: 16
                 )
                 guard values.allSatisfy(\.isFinite) else { return false }
+            case UInt32(WHISKER_OP_BACKGROUND_LAYERS):
+                guard existing.contains(operation.node), operation.scalar.isFinite,
+                      operation.flags == 0 else { return false }
+                if operation.payload_count == 0 {
+                    guard operation.payload == nil else { return false }
+                    continue
+                }
+                guard operation.payload_count >= 2, operation.payload_count <= 4_096,
+                      let payload = operation.payload else { return false }
+                let stops = UnsafeBufferPointer(
+                    start: payload.assumingMemoryBound(to: WhiskerMobileGradientStop.self),
+                    count: operation.payload_count
+                )
+                guard stops.allSatisfy({ stop in
+                    stop.position.length.isFinite && stop.position.fraction.isFinite &&
+                        stop.color.kind <= 1 && stop.color.alpha.isFinite &&
+                        (0...1).contains(stop.color.alpha)
+                }) else { return false }
             case UInt32(WHISKER_OP_OPACITY):
                 guard existing.contains(operation.node), operation.scalar.isFinite,
                       (0...1).contains(operation.scalar) else { return false }
@@ -198,6 +216,22 @@ final class HostScene {
                 start: payload.assumingMemoryBound(to: Float.self),
                 count: 16
             ))
+        case UInt32(WHISKER_OP_BACKGROUND_LAYERS):
+            guard let node = nodes[id] else { return false }
+            if operation.payload_count == 0 {
+                node.boxPainter.updateBackgroundLayers(nil)
+            } else {
+                guard let payload = operation.payload else { return false }
+                let stops = UnsafeBufferPointer(
+                    start: payload.assumingMemoryBound(to: WhiskerMobileGradientStop.self),
+                    count: operation.payload_count
+                ).map(HostLinearGradientStop.init)
+                node.boxPainter.updateBackgroundLayers(HostLinearGradient(
+                    angleDegrees: CGFloat(operation.scalar),
+                    stops: stops
+                ))
+            }
+            node.setNeedsDisplay()
         case UInt32(WHISKER_OP_OPACITY):
             nodes[id]?.alpha = CGFloat(operation.scalar)
         case UInt32(WHISKER_OP_VISIBILITY):

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -136,23 +136,37 @@ final class HostScene {
                 )
                 guard values.allSatisfy(\.isFinite) else { return false }
             case UInt32(WHISKER_OP_BACKGROUND_LAYERS):
-                guard existing.contains(operation.node), operation.scalar.isFinite,
-                      operation.flags == 0 else { return false }
-                if operation.payload_count == 0 {
-                    guard operation.payload == nil else { return false }
-                    continue
+                guard existing.contains(operation.node), operation.scalar.isFinite else {
+                    return false
                 }
-                guard operation.payload_count >= 2, operation.payload_count <= 4_096,
-                      let payload = operation.payload else { return false }
-                let stops = UnsafeBufferPointer(
-                    start: payload.assumingMemoryBound(to: WhiskerMobileGradientStop.self),
-                    count: operation.payload_count
-                )
-                guard stops.allSatisfy({ stop in
-                    stop.position.length.isFinite && stop.position.fraction.isFinite &&
-                        stop.color.kind <= 1 && stop.color.alpha.isFinite &&
-                        (0...1).contains(stop.color.alpha)
-                }) else { return false }
+                switch operation.flags {
+                case UInt32(WHISKER_BACKGROUND_LINEAR):
+                    if operation.payload_count == 0 {
+                        guard operation.payload == nil else { return false }
+                        continue
+                    }
+                    guard let payload = operation.payload,
+                          validGradientStops(payload, count: operation.payload_count) else {
+                        return false
+                    }
+                case UInt32(WHISKER_BACKGROUND_RADIAL):
+                    guard operation.payload_count == 1,
+                          let radial = operation.payload?.assumingMemoryBound(
+                              to: WhiskerMobileRadialGradient.self
+                          ).pointee,
+                          radial.center_x.isFinite, radial.center_y.isFinite,
+                          radial.radius_x.isFinite, radial.radius_y.isFinite,
+                          (2...4_096).contains(radial.stop_count),
+                          let stops = radial.stops,
+                          validGradientStops(
+                              UnsafeRawPointer(stops),
+                              count: radial.stop_count
+                          ) else {
+                        return false
+                    }
+                default:
+                    return false
+                }
             case UInt32(WHISKER_OP_OPACITY):
                 guard existing.contains(operation.node), operation.scalar.isFinite,
                       (0...1).contains(operation.scalar) else { return false }
@@ -220,7 +234,7 @@ final class HostScene {
             guard let node = nodes[id] else { return false }
             if operation.payload_count == 0 {
                 node.boxPainter.updateBackgroundLayers(nil)
-            } else {
+            } else if operation.flags == UInt32(WHISKER_BACKGROUND_LINEAR) {
                 guard let payload = operation.payload else { return false }
                 let stops = UnsafeBufferPointer(
                     start: payload.assumingMemoryBound(to: WhiskerMobileGradientStop.self),
@@ -230,6 +244,23 @@ final class HostScene {
                     angleDegrees: CGFloat(operation.scalar),
                     stops: stops
                 ))
+            } else if operation.flags == UInt32(WHISKER_BACKGROUND_RADIAL) {
+                guard let radial = operation.payload?.assumingMemoryBound(
+                    to: WhiskerMobileRadialGradient.self
+                ).pointee, let stopPointer = radial.stops else { return false }
+                let stops = UnsafeBufferPointer(
+                    start: stopPointer,
+                    count: radial.stop_count
+                ).map(HostLinearGradientStop.init)
+                node.boxPainter.updateBackgroundLayers(HostRadialGradient(
+                    centerX: radial.center_x,
+                    centerY: radial.center_y,
+                    radiusX: radial.radius_x,
+                    radiusY: radial.radius_y,
+                    stops: stops
+                ))
+            } else {
+                return false
             }
             node.setNeedsDisplay()
         case UInt32(WHISKER_OP_OPACITY):
@@ -415,4 +446,20 @@ private func hostRect(_ value: WhiskerMobileRect) -> CGRect {
         width: CGFloat(value.width),
         height: CGFloat(value.height)
     )
+}
+
+private func validGradientStops(_ payload: UnsafeRawPointer, count: Int) -> Bool {
+    guard (2...4_096).contains(count) else { return false }
+    let stops = UnsafeBufferPointer(
+        start: payload.assumingMemoryBound(to: WhiskerMobileGradientStop.self),
+        count: count
+    )
+    return stops.allSatisfy { stop in
+        stop.position.isFinite && stop.color.kind <= 1 && stop.color.alpha.isFinite &&
+            (0...1).contains(stop.color.alpha)
+    }
+}
+
+private extension WhiskerMobileLengthPercentage {
+    var isFinite: Bool { length.isFinite && fraction.isFinite }
 }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -7,7 +7,9 @@ final class HostScene {
     private let logicalBounds: () -> CGRect
     private let emitElementEvent: (UInt64, String, WhiskerValue) -> Void
     private var nodes: [UInt64: WhiskerNodeView] = [:]
+    private var nodeOrder: [UInt64] = []
     private var parents: [UInt64: UInt64] = [:]
+    private var zOrders: [UInt64: Int32] = [:]
     private var sceneEpoch: UInt32 = 0
     private var revision: UInt64 = 0
     private var applyingFrame = false
@@ -66,6 +68,7 @@ final class HostScene {
             return true
         }
         attachRoots()
+        refreshZOrderProjection()
         sceneEpoch = frame.scene_epoch
         revision = frame.target_revision
         response.status = UInt8(WHISKER_APPLY_ACCEPTED)
@@ -81,7 +84,9 @@ final class HostScene {
         nodes.values.forEach { $0.mountedElement?.dispose() }
         nodes.values.forEach { $0.removeFromSuperview() }
         nodes.removeAll()
+        nodeOrder.removeAll()
         parents.removeAll()
+        zOrders.removeAll()
     }
 
     private func validate(_ operations: [WhiskerMobileOperation], snapshot: Bool) -> Bool {
@@ -130,8 +135,13 @@ final class HostScene {
                     count: 16
                 )
                 guard values.allSatisfy(\.isFinite) else { return false }
-            case UInt32(WHISKER_OP_CLIP), UInt32(WHISKER_OP_OPACITY),
-                 UInt32(WHISKER_OP_VISIBILITY), UInt32(WHISKER_OP_Z_ORDER),
+            case UInt32(WHISKER_OP_OPACITY):
+                guard existing.contains(operation.node), operation.scalar.isFinite,
+                      (0...1).contains(operation.scalar) else { return false }
+            case UInt32(WHISKER_OP_VISIBILITY):
+                guard existing.contains(operation.node),
+                      operation.integer == 0 || operation.integer == 1 else { return false }
+            case UInt32(WHISKER_OP_CLIP), UInt32(WHISKER_OP_Z_ORDER),
                  UInt32(WHISKER_OP_CLEAR_PROPERTY), UInt32(WHISKER_OP_EVENT_MASK):
                 guard existing.contains(operation.node) else { return false }
             default:
@@ -159,6 +169,7 @@ final class HostScene {
             mounted.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             node.addSubview(mounted.view)
             nodes[id] = node
+            nodeOrder.append(id)
         case UInt32(WHISKER_OP_DELETE):
             deleteNode(id)
         case UInt32(WHISKER_OP_INSERT), UInt32(WHISKER_OP_MOVE):
@@ -191,7 +202,7 @@ final class HostScene {
         case UInt32(WHISKER_OP_VISIBILITY):
             nodes[id]?.isHidden = operation.integer == 0
         case UInt32(WHISKER_OP_Z_ORDER):
-            nodes[id]?.layer.zPosition = CGFloat(operation.integer)
+            zOrders[id] = operation.integer
         case UInt32(WHISKER_OP_TEXT):
             guard let payload = operation.payload?
                 .assumingMemoryBound(to: WhiskerMobileText.self).pointee
@@ -216,7 +227,8 @@ final class HostScene {
     }
 
     private func attachRoots() {
-        for (id, node) in nodes where parents[id] == nil && node.superview !== root {
+        for id in nodeOrder where parents[id] == nil {
+            guard let node = nodes[id], node.superview !== root else { continue }
             node.removeFromSuperview()
             root.addSubview(node)
         }
@@ -253,9 +265,54 @@ final class HostScene {
             nodes.removeValue(forKey: $0)?.mountedElement?.dispose()
             parents.removeValue(forKey: $0)
         }
+        let removed = Set(descendants).union([id])
+        nodeOrder.removeAll { removed.contains($0) }
+        removed.forEach { zOrders.removeValue(forKey: $0) }
         parents.removeValue(forKey: id)
         node.mountedElement?.dispose()
         node.removeFromSuperview()
+    }
+
+    private func normalizeZOrder(parent parentID: UInt64?) {
+        let creationOrder = Dictionary(uniqueKeysWithValues: nodeOrder.enumerated().map { ($1, $0) })
+        let host: UIView?
+        if let parentID, let parent = nodes[parentID] {
+            host = parent.mountedElement?.childrenHost() ?? parent
+        } else {
+            host = root
+        }
+        let idsByView = Dictionary(uniqueKeysWithValues: nodes.map { (ObjectIdentifier($1), $0) })
+        let siblingPairs: [(UInt64, Int)] = (host?.subviews ?? []).enumerated()
+            .compactMap { index, view in
+                guard let id = idsByView[ObjectIdentifier(view)] else { return nil }
+                return (id, index)
+            }
+        let siblingOrder = Dictionary(uniqueKeysWithValues: siblingPairs)
+        let siblings = nodeOrder.filter { id in
+            nodes[id] != nil && parents[id] == parentID
+        }.sorted { left, right in
+            let leftZ = zOrders[left] ?? 0
+            let rightZ = zOrders[right] ?? 0
+            if leftZ != rightZ { return leftZ < rightZ }
+            return siblingOrder[left, default: creationOrder[left, default: 0]] <
+                siblingOrder[right, default: creationOrder[right, default: 0]]
+        }
+        for id in siblings {
+            guard let node = nodes[id] else { continue }
+            // `CALayer.render(in:)`, used by deterministic Host capture as
+            // well as some UIKit snapshot paths, preserves sublayer order but
+            // does not reliably sort extreme signed zPosition values. Project
+            // protocol z-order into stable UIView sibling order instead.
+            node.layer.zPosition = 0
+            if node.superview === host { host?.bringSubviewToFront(node) }
+        }
+    }
+
+    private func refreshZOrderProjection() {
+        normalizeZOrder(parent: nil)
+        for parentID in Set(parents.values).sorted() where nodes[parentID] != nil {
+            normalizeZOrder(parent: parentID)
+        }
     }
 
     private func isDescendant(_ candidate: UInt64, of ancestor: UInt64) -> Bool {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -168,6 +168,7 @@ final class HostScene {
             mounted.view.frame = node.bounds
             mounted.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             node.addSubview(mounted.view)
+            node.mountedContentDidInstall()
             nodes[id] = node
             nodeOrder.append(id)
         case UInt32(WHISKER_OP_DELETE):
@@ -245,11 +246,8 @@ final class HostScene {
         )
         child.removeFromSuperview()
         parents[childID] = parentID
-        if let childrenHost = mounted.childrenHost() {
-            childrenHost.insertSubview(child, at: min(max(index, 0), childrenHost.subviews.count))
-        } else {
-            parent.insertSubview(child, at: min(max(index + 1, 1), parent.subviews.count))
-        }
+        let childrenHost = parent.sceneChildrenHost()
+        childrenHost.insertSubview(child, at: min(max(index, 0), childrenHost.subviews.count))
     }
 
     private func detachChild(parent parentID: UInt64, child childID: UInt64) {
@@ -277,7 +275,7 @@ final class HostScene {
         let creationOrder = Dictionary(uniqueKeysWithValues: nodeOrder.enumerated().map { ($1, $0) })
         let host: UIView?
         if let parentID, let parent = nodes[parentID] {
-            host = parent.mountedElement?.childrenHost() ?? parent
+            host = parent.sceneChildrenHost()
         } else {
             host = root
         }
@@ -371,6 +369,7 @@ final class HostScene {
     private func applyPaint(_ node: WhiskerNodeView, _ paint: HostBoxPaint) {
         node.paint = paint
         node.boxPainter.update(paint, bounds: node.bounds)
+        node.boxPaintDidChange()
         node.setNeedsLayout()
     }
 }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -507,8 +507,6 @@ private func validGradientStops(
 
 private func validBackgroundGeometry(_ layer: WhiskerMobileBackgroundLayer) -> Bool {
     guard layer.position_x.isFinite, layer.position_y.isFinite,
-          layer.origin == UInt32(WHISKER_BACKGROUND_BOX_PADDING),
-          layer.clip == UInt32(WHISKER_BACKGROUND_BOX_BORDER),
           layer.attachment == UInt32(WHISKER_BACKGROUND_ATTACHMENT_SCROLL),
           layer.blend_mode == UInt32(WHISKER_BACKGROUND_BLEND_NORMAL) else {
         return false
@@ -517,12 +515,18 @@ private func validBackgroundGeometry(_ layer: WhiskerMobileBackgroundLayer) -> B
         return layer.position_x.isZero && layer.position_y.isZero &&
             layer.size_width.isZero && layer.size_height.isZero &&
             layer.repeat_x == UInt32(WHISKER_BACKGROUND_REPEAT) &&
-            layer.repeat_y == UInt32(WHISKER_BACKGROUND_REPEAT)
+            layer.repeat_y == UInt32(WHISKER_BACKGROUND_REPEAT) &&
+            layer.origin == UInt32(WHISKER_BACKGROUND_BOX_PADDING) &&
+            layer.clip == UInt32(WHISKER_BACKGROUND_BOX_BORDER)
     }
     return layer.size_kind == UInt32(WHISKER_BACKGROUND_SIZE_EXPLICIT) &&
         layer.size_width.isNonNegativeFinite && layer.size_height.isNonNegativeFinite &&
         layer.repeat_x == UInt32(WHISKER_BACKGROUND_NO_REPEAT) &&
-        layer.repeat_y == UInt32(WHISKER_BACKGROUND_NO_REPEAT)
+        layer.repeat_y == UInt32(WHISKER_BACKGROUND_NO_REPEAT) &&
+        [UInt32(WHISKER_BACKGROUND_BOX_BORDER), UInt32(WHISKER_BACKGROUND_BOX_PADDING)]
+            .contains(layer.origin) &&
+        [UInt32(WHISKER_BACKGROUND_BOX_BORDER), UInt32(WHISKER_BACKGROUND_BOX_PADDING)]
+            .contains(layer.clip)
 }
 
 private func hostBackgroundGeometry(
@@ -536,7 +540,9 @@ private func hostBackgroundGeometry(
         sizeWidth: explicit ? layer.size_width : nil,
         sizeHeight: explicit ? layer.size_height : nil,
         repeatX: layer.repeat_x == UInt32(WHISKER_BACKGROUND_NO_REPEAT) ? .noRepeat : .repeat,
-        repeatY: layer.repeat_y == UInt32(WHISKER_BACKGROUND_NO_REPEAT) ? .noRepeat : .repeat
+        repeatY: layer.repeat_y == UInt32(WHISKER_BACKGROUND_NO_REPEAT) ? .noRepeat : .repeat,
+        origin: layer.origin == UInt32(WHISKER_BACKGROUND_BOX_BORDER) ? .border : .padding,
+        clip: layer.clip == UInt32(WHISKER_BACKGROUND_BOX_BORDER) ? .border : .padding
     )
 }
 

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -136,22 +136,27 @@ final class HostScene {
                 )
                 guard values.allSatisfy(\.isFinite) else { return false }
             case UInt32(WHISKER_OP_BACKGROUND_LAYERS):
-                guard existing.contains(operation.node), operation.scalar.isFinite else {
+                guard existing.contains(operation.node) else { return false }
+                if operation.payload_count == 0 {
+                    guard operation.payload == nil else { return false }
+                    continue
+                }
+                guard operation.payload_count == 1,
+                      let layer = operation.payload?.assumingMemoryBound(
+                          to: WhiskerMobileBackgroundLayer.self
+                      ).pointee,
+                      validBackgroundGeometry(layer), layer.image.scalar.isFinite else {
                     return false
                 }
-                switch operation.flags {
+                switch layer.image.kind {
                 case UInt32(WHISKER_BACKGROUND_LINEAR):
-                    if operation.payload_count == 0 {
-                        guard operation.payload == nil else { return false }
-                        continue
-                    }
-                    guard let payload = operation.payload,
-                          validGradientStops(payload, count: operation.payload_count) else {
+                    guard let payload = layer.image.payload,
+                          validGradientStops(payload, count: layer.image.payload_count) else {
                         return false
                     }
                 case UInt32(WHISKER_BACKGROUND_RADIAL):
-                    guard operation.payload_count == 1,
-                          let radial = operation.payload?.assumingMemoryBound(
+                    guard layer.image.payload_count == 1,
+                          let radial = layer.image.payload?.assumingMemoryBound(
                               to: WhiskerMobileRadialGradient.self
                           ).pointee,
                           radial.center_x.isFinite, radial.center_y.isFinite,
@@ -165,8 +170,8 @@ final class HostScene {
                         return false
                     }
                 case UInt32(WHISKER_BACKGROUND_CONIC):
-                    guard operation.payload_count == 1,
-                          let conic = operation.payload?.assumingMemoryBound(
+                    guard layer.image.payload_count == 1,
+                          let conic = layer.image.payload?.assumingMemoryBound(
                               to: WhiskerMobileConicGradient.self
                           ).pointee,
                           conic.center_x.isFinite, conic.center_y.isFinite,
@@ -249,18 +254,24 @@ final class HostScene {
             guard let node = nodes[id] else { return false }
             if operation.payload_count == 0 {
                 node.boxPainter.updateBackgroundLayers(nil)
-            } else if operation.flags == UInt32(WHISKER_BACKGROUND_LINEAR) {
-                guard let payload = operation.payload else { return false }
+                node.setNeedsDisplay()
+                return true
+            }
+            guard let layer = operation.payload?.assumingMemoryBound(
+                to: WhiskerMobileBackgroundLayer.self
+            ).pointee, let geometry = hostBackgroundGeometry(layer) else { return false }
+            if layer.image.kind == UInt32(WHISKER_BACKGROUND_LINEAR) {
+                guard let payload = layer.image.payload else { return false }
                 let stops = UnsafeBufferPointer(
                     start: payload.assumingMemoryBound(to: WhiskerMobileGradientStop.self),
-                    count: operation.payload_count
+                    count: layer.image.payload_count
                 ).map(HostLinearGradientStop.init)
                 node.boxPainter.updateBackgroundLayers(HostLinearGradient(
-                    angleDegrees: CGFloat(operation.scalar),
+                    angleDegrees: CGFloat(layer.image.scalar),
                     stops: stops
-                ))
-            } else if operation.flags == UInt32(WHISKER_BACKGROUND_RADIAL) {
-                guard let radial = operation.payload?.assumingMemoryBound(
+                ), geometry: geometry)
+            } else if layer.image.kind == UInt32(WHISKER_BACKGROUND_RADIAL) {
+                guard let radial = layer.image.payload?.assumingMemoryBound(
                     to: WhiskerMobileRadialGradient.self
                 ).pointee, let stopPointer = radial.stops else { return false }
                 let stops = UnsafeBufferPointer(
@@ -273,9 +284,9 @@ final class HostScene {
                     radiusX: radial.radius_x,
                     radiusY: radial.radius_y,
                     stops: stops
-                ))
-            } else if operation.flags == UInt32(WHISKER_BACKGROUND_CONIC) {
-                guard let conic = operation.payload?.assumingMemoryBound(
+                ), geometry: geometry)
+            } else if layer.image.kind == UInt32(WHISKER_BACKGROUND_CONIC) {
+                guard let conic = layer.image.payload?.assumingMemoryBound(
                     to: WhiskerMobileConicGradient.self
                 ).pointee, let stopPointer = conic.stops else { return false }
                 let stops = UnsafeBufferPointer(
@@ -283,11 +294,11 @@ final class HostScene {
                     count: conic.stop_count
                 ).map(HostLinearGradientStop.init)
                 node.boxPainter.updateBackgroundLayers(HostConicGradient(
-                    fromDegrees: CGFloat(operation.scalar),
+                    fromDegrees: CGFloat(layer.image.scalar),
                     centerX: conic.center_x,
                     centerY: conic.center_y,
                     stops: stops
-                ))
+                ), geometry: geometry)
             } else {
                 return false
             }
@@ -494,6 +505,44 @@ private func validGradientStops(
     }
 }
 
+private func validBackgroundGeometry(_ layer: WhiskerMobileBackgroundLayer) -> Bool {
+    guard layer.position_x.isZero, layer.position_y.isZero,
+          layer.origin == UInt32(WHISKER_BACKGROUND_BOX_PADDING),
+          layer.clip == UInt32(WHISKER_BACKGROUND_BOX_BORDER),
+          layer.attachment == UInt32(WHISKER_BACKGROUND_ATTACHMENT_SCROLL),
+          layer.blend_mode == UInt32(WHISKER_BACKGROUND_BLEND_NORMAL) else {
+        return false
+    }
+    if layer.size_kind == UInt32(WHISKER_BACKGROUND_SIZE_AUTO) {
+        return layer.size_width.isZero && layer.size_height.isZero &&
+            layer.repeat_x == UInt32(WHISKER_BACKGROUND_REPEAT) &&
+            layer.repeat_y == UInt32(WHISKER_BACKGROUND_REPEAT)
+    }
+    return layer.size_kind == UInt32(WHISKER_BACKGROUND_SIZE_EXPLICIT) &&
+        layer.size_width.isNonNegativeFinite && layer.size_height.isNonNegativeFinite &&
+        layer.repeat_x == UInt32(WHISKER_BACKGROUND_NO_REPEAT) &&
+        layer.repeat_y == UInt32(WHISKER_BACKGROUND_NO_REPEAT)
+}
+
+private func hostBackgroundGeometry(
+    _ layer: WhiskerMobileBackgroundLayer
+) -> HostBackgroundGeometry? {
+    guard validBackgroundGeometry(layer) else { return nil }
+    let explicit = layer.size_kind == UInt32(WHISKER_BACKGROUND_SIZE_EXPLICIT)
+    return HostBackgroundGeometry(
+        positionX: layer.position_x,
+        positionY: layer.position_y,
+        sizeWidth: explicit ? layer.size_width : nil,
+        sizeHeight: explicit ? layer.size_height : nil,
+        repeatX: layer.repeat_x == UInt32(WHISKER_BACKGROUND_NO_REPEAT) ? .noRepeat : .repeat,
+        repeatY: layer.repeat_y == UInt32(WHISKER_BACKGROUND_NO_REPEAT) ? .noRepeat : .repeat
+    )
+}
+
 private extension WhiskerMobileLengthPercentage {
     var isFinite: Bool { length.isFinite && fraction.isFinite }
+    var isZero: Bool { length == 0 && fraction == 0 }
+    var isNonNegativeFinite: Bool {
+        isFinite && length >= 0 && fraction >= 0
+    }
 }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -164,6 +164,21 @@ final class HostScene {
                           ) else {
                         return false
                     }
+                case UInt32(WHISKER_BACKGROUND_CONIC):
+                    guard operation.payload_count == 1,
+                          let conic = operation.payload?.assumingMemoryBound(
+                              to: WhiskerMobileConicGradient.self
+                          ).pointee,
+                          conic.center_x.isFinite, conic.center_y.isFinite,
+                          (2...4_096).contains(conic.stop_count),
+                          let stops = conic.stops,
+                          validGradientStops(
+                              UnsafeRawPointer(stops),
+                              count: conic.stop_count,
+                              requiresFractionOnly: true
+                          ) else {
+                        return false
+                    }
                 default:
                     return false
                 }
@@ -257,6 +272,20 @@ final class HostScene {
                     centerY: radial.center_y,
                     radiusX: radial.radius_x,
                     radiusY: radial.radius_y,
+                    stops: stops
+                ))
+            } else if operation.flags == UInt32(WHISKER_BACKGROUND_CONIC) {
+                guard let conic = operation.payload?.assumingMemoryBound(
+                    to: WhiskerMobileConicGradient.self
+                ).pointee, let stopPointer = conic.stops else { return false }
+                let stops = UnsafeBufferPointer(
+                    start: stopPointer,
+                    count: conic.stop_count
+                ).map(HostLinearGradientStop.init)
+                node.boxPainter.updateBackgroundLayers(HostConicGradient(
+                    fromDegrees: CGFloat(operation.scalar),
+                    centerX: conic.center_x,
+                    centerY: conic.center_y,
                     stops: stops
                 ))
             } else {
@@ -448,14 +477,19 @@ private func hostRect(_ value: WhiskerMobileRect) -> CGRect {
     )
 }
 
-private func validGradientStops(_ payload: UnsafeRawPointer, count: Int) -> Bool {
+private func validGradientStops(
+    _ payload: UnsafeRawPointer,
+    count: Int,
+    requiresFractionOnly: Bool = false
+) -> Bool {
     guard (2...4_096).contains(count) else { return false }
     let stops = UnsafeBufferPointer(
         start: payload.assumingMemoryBound(to: WhiskerMobileGradientStop.self),
         count: count
     )
     return stops.allSatisfy { stop in
-        stop.position.isFinite && stop.color.kind <= 1 && stop.color.alpha.isFinite &&
+        stop.position.isFinite && (!requiresFractionOnly || stop.position.length == 0) &&
+            stop.color.kind <= 1 && stop.color.alpha.isFinite &&
             (0...1).contains(stop.color.alpha)
     }
 }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -519,10 +519,13 @@ private func validBackgroundGeometry(_ layer: WhiskerMobileBackgroundLayer) -> B
             layer.origin == UInt32(WHISKER_BACKGROUND_BOX_PADDING) &&
             layer.clip == UInt32(WHISKER_BACKGROUND_BOX_BORDER)
     }
+    let supportedRepeats = [
+        UInt32(WHISKER_BACKGROUND_REPEAT),
+        UInt32(WHISKER_BACKGROUND_NO_REPEAT)
+    ]
     return layer.size_kind == UInt32(WHISKER_BACKGROUND_SIZE_EXPLICIT) &&
         layer.size_width.isNonNegativeFinite && layer.size_height.isNonNegativeFinite &&
-        layer.repeat_x == UInt32(WHISKER_BACKGROUND_NO_REPEAT) &&
-        layer.repeat_y == UInt32(WHISKER_BACKGROUND_NO_REPEAT) &&
+        supportedRepeats.contains(layer.repeat_x) && supportedRepeats.contains(layer.repeat_y) &&
         [UInt32(WHISKER_BACKGROUND_BOX_BORDER), UInt32(WHISKER_BACKGROUND_BOX_PADDING)]
             .contains(layer.origin) &&
         [UInt32(WHISKER_BACKGROUND_BOX_BORDER), UInt32(WHISKER_BACKGROUND_BOX_PADDING)]

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -122,6 +122,14 @@ final class HostScene {
             case UInt32(WHISKER_OP_LAYOUT), UInt32(WHISKER_OP_PAINT),
                  UInt32(WHISKER_OP_TEXT), UInt32(WHISKER_OP_PROPERTY):
                 guard existing.contains(operation.node), operation.payload != nil else { return false }
+            case UInt32(WHISKER_OP_TRANSFORM):
+                guard existing.contains(operation.node), operation.payload != nil,
+                      operation.payload_count == 16 else { return false }
+                let values = UnsafeBufferPointer(
+                    start: operation.payload?.assumingMemoryBound(to: Float.self),
+                    count: 16
+                )
+                guard values.allSatisfy(\.isFinite) else { return false }
             case UInt32(WHISKER_OP_CLIP), UInt32(WHISKER_OP_OPACITY),
                  UInt32(WHISKER_OP_VISIBILITY), UInt32(WHISKER_OP_Z_ORDER),
                  UInt32(WHISKER_OP_CLEAR_PROPERTY), UInt32(WHISKER_OP_EVENT_MASK):
@@ -172,6 +180,12 @@ final class HostScene {
                 horizontal: operation.flags & 1 != 0,
                 vertical: operation.flags & 2 != 0
             )
+        case UInt32(WHISKER_OP_TRANSFORM):
+            guard let payload = operation.payload else { return false }
+            nodes[id]?.setPresentationTransform(UnsafeBufferPointer(
+                start: payload.assumingMemoryBound(to: Float.self),
+                count: 16
+            ))
         case UInt32(WHISKER_OP_OPACITY):
             nodes[id]?.alpha = CGFloat(operation.scalar)
         case UInt32(WHISKER_OP_VISIBILITY):
@@ -269,7 +283,7 @@ final class HostScene {
             frame.origin.x += logicalBounds().origin.x
             frame.origin.y += logicalBounds().origin.y
         }
-        node.frame = frame
+        node.setLayoutFrame(frame)
         node.contentFrame = hostRect(geometry.content)
         node.superview?.setNeedsLayout()
         node.superview?.superview?.setNeedsLayout()

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -168,7 +168,10 @@ final class HostScene {
             else { return false }
             applyPaint(nodes[id], payload)
         case UInt32(WHISKER_OP_CLIP):
-            nodes[id]?.clipsToBounds = operation.flags & 3 != 0
+            nodes[id]?.setOverflowClip(
+                horizontal: operation.flags & 1 != 0,
+                vertical: operation.flags & 2 != 0
+            )
         case UInt32(WHISKER_OP_OPACITY):
             nodes[id]?.alpha = CGFloat(operation.scalar)
         case UInt32(WHISKER_OP_VISIBILITY):
@@ -202,9 +205,6 @@ final class HostScene {
         for (id, node) in nodes where parents[id] == nil && node.superview !== root {
             node.removeFromSuperview()
             root.addSubview(node)
-        }
-        for (id, node) in nodes where parents[id] == nil {
-            node.frame.origin = logicalBounds().origin
         }
     }
 
@@ -265,6 +265,9 @@ final class HostScene {
            parent.mountedElement?.childrenHost() != nil {
             frame.origin.x -= parent.contentFrame.origin.x
             frame.origin.y -= parent.contentFrame.origin.y
+        } else if parents[id] == nil {
+            frame.origin.x += logicalBounds().origin.x
+            frame.origin.y += logicalBounds().origin.y
         }
         node.frame = frame
         node.contentFrame = hostRect(geometry.content)

--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -1,0 +1,131 @@
+use whisker_protocol::{
+    BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, GradientStop, ImageRepeat,
+    PaintBox, PaintCoordinate, PaintImage,
+};
+
+use super::color::css_color;
+use crate::{WebError, set_style};
+
+/// Whether every layer belongs to the subset currently implemented by the DOM Host.
+pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
+    layers.iter().all(|layer| {
+        matches!(
+            &layer.image,
+            PaintImage::LinearGradient {
+                repeating: false,
+                stops,
+                ..
+            } if stops.iter().all(|stop| stop.position.is_some())
+        ) && layer.position == Default::default()
+            && layer.size == BackgroundSize::Auto
+            && layer.repeat_x == ImageRepeat::Repeat
+            && layer.repeat_y == ImageRepeat::Repeat
+            && layer.origin == PaintBox::Padding
+            && layer.clip == PaintBox::Border
+            && layer.attachment == BackgroundAttachment::Scroll
+            && layer.blend_mode == BlendMode::Normal
+    })
+}
+
+pub(crate) fn apply(
+    element: &web_sys::Element,
+    layers: &[BackgroundLayer],
+) -> Result<(), WebError> {
+    if !supports(layers) {
+        return Err(WebError(
+            "DOM Host only implements non-repeating linear-gradient background layers with explicit stops and CSS initial layer values"
+                .into(),
+        ));
+    }
+
+    let images = if layers.is_empty() {
+        "none".to_owned()
+    } else {
+        layers
+            .iter()
+            .map(linear_gradient)
+            .collect::<Result<Vec<_>, _>>()?
+            .join(", ")
+    };
+    let layer_count = layers.len().max(1);
+    set_style(element, "background-image", &images)?;
+    set_style(
+        element,
+        "background-position",
+        &initial_list("0px 0px", layer_count),
+    )?;
+    set_style(
+        element,
+        "background-size",
+        &initial_list("auto", layer_count),
+    )?;
+    set_style(
+        element,
+        "background-repeat",
+        &initial_list("repeat", layer_count),
+    )?;
+    set_style(
+        element,
+        "background-origin",
+        &initial_list("padding-box", layer_count),
+    )?;
+    set_style(
+        element,
+        "background-clip",
+        &initial_list("border-box", layer_count),
+    )?;
+    set_style(
+        element,
+        "background-attachment",
+        &initial_list("scroll", layer_count),
+    )?;
+    set_style(
+        element,
+        "background-blend-mode",
+        &initial_list("normal", layer_count),
+    )
+}
+
+fn linear_gradient(layer: &BackgroundLayer) -> Result<String, WebError> {
+    let PaintImage::LinearGradient {
+        angle_degrees,
+        repeating: false,
+        stops,
+    } = &layer.image
+    else {
+        return Err(WebError("unsupported DOM background image".into()));
+    };
+    let stops = stops
+        .iter()
+        .map(gradient_stop)
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    Ok(format!("linear-gradient({angle_degrees}deg, {stops})"))
+}
+
+fn gradient_stop(stop: &GradientStop) -> Result<String, WebError> {
+    let position = stop
+        .position
+        .ok_or_else(|| WebError("DOM linear-gradient requires resolved stop positions".into()))?;
+    Ok(format!(
+        "{} {}",
+        css_color(&stop.color),
+        coordinate(position)
+    ))
+}
+
+fn coordinate(value: PaintCoordinate) -> String {
+    if value.length == 0.0 {
+        format!("{}%", value.fraction * 100.0)
+    } else if value.fraction == 0.0 {
+        format!("{}px", value.length)
+    } else {
+        format!("calc({}px + {}%)", value.length, value.fraction * 100.0)
+    }
+}
+
+fn initial_list(value: &str, count: usize) -> String {
+    std::iter::repeat_n(value, count)
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -50,10 +50,13 @@ pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
         }
     ) && layer.repeat_x == ImageRepeat::NoRepeat
         && layer.repeat_y == ImageRepeat::NoRepeat;
+    let supported_geometry =
+        (initial_geometry && layer.origin == PaintBox::Padding && layer.clip == PaintBox::Border)
+            || (explicit_no_repeat_geometry
+                && matches!(layer.origin, PaintBox::Border | PaintBox::Padding)
+                && matches!(layer.clip, PaintBox::Border | PaintBox::Padding));
     supported_image
-        && (initial_geometry || explicit_no_repeat_geometry)
-        && layer.origin == PaintBox::Padding
-        && layer.clip == PaintBox::Border
+        && supported_geometry
         && layer.attachment == BackgroundAttachment::Scroll
         && layer.blend_mode == BlendMode::Normal
 }
@@ -64,7 +67,7 @@ pub(crate) fn apply(
 ) -> Result<(), WebError> {
     if !supports(layers) {
         return Err(WebError(
-            "DOM Host only implements one supported gradient with explicit stops, initial position and boxes, two-axis auto or explicit size, and repeat/no-repeat"
+            "DOM Host only implements one supported gradient with explicit stops, supported border/padding boxes, two-axis auto or explicit size, and repeat/no-repeat"
                 .into(),
         ));
     }
@@ -87,12 +90,18 @@ pub(crate) fn apply(
     let repeat = layers
         .first()
         .map_or_else(|| "repeat".into(), background_repeat);
+    let origin = layers
+        .first()
+        .map_or("padding-box", |layer| background_box(layer.origin));
+    let clip = layers
+        .first()
+        .map_or("border-box", |layer| background_box(layer.clip));
     set_style(element, "background-image", &images)?;
     set_style(element, "background-position", &position)?;
     set_style(element, "background-size", &size)?;
     set_style(element, "background-repeat", &repeat)?;
-    set_style(element, "background-origin", "padding-box")?;
-    set_style(element, "background-clip", "border-box")?;
+    set_style(element, "background-origin", origin)?;
+    set_style(element, "background-clip", clip)?;
     set_style(element, "background-attachment", "scroll")?;
     set_style(element, "background-blend-mode", "normal")
 }
@@ -237,5 +246,13 @@ fn background_repeat(layer: &BackgroundLayer) -> String {
         (ImageRepeat::Repeat, ImageRepeat::Repeat) => "repeat".into(),
         (ImageRepeat::NoRepeat, ImageRepeat::NoRepeat) => "no-repeat".into(),
         _ => unreachable!("unsupported background repeat passed preflight"),
+    }
+}
+
+fn background_box(value: PaintBox) -> &'static str {
+    match value {
+        PaintBox::Border => "border-box",
+        PaintBox::Padding => "padding-box",
+        _ => unreachable!("unsupported background box passed preflight"),
     }
 }

--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -38,7 +38,8 @@ pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
             .all(|stop| stop.position.is_some_and(|position| position.length == 0.0)),
         _ => false,
     };
-    let initial_geometry = layer.size == BackgroundSize::Auto
+    let initial_geometry = layer.position == Default::default()
+        && layer.size == BackgroundSize::Auto
         && layer.repeat_x == ImageRepeat::Repeat
         && layer.repeat_y == ImageRepeat::Repeat;
     let explicit_no_repeat_geometry = matches!(
@@ -50,7 +51,6 @@ pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
     ) && layer.repeat_x == ImageRepeat::NoRepeat
         && layer.repeat_y == ImageRepeat::NoRepeat;
     supported_image
-        && layer.position == Default::default()
         && (initial_geometry || explicit_no_repeat_geometry)
         && layer.origin == PaintBox::Padding
         && layer.clip == PaintBox::Border

--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -15,15 +15,12 @@ pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
     let [layer] = layers else {
         return false;
     };
-    let supported_image = matches!(
-        &layer.image,
+    let supported_image = match &layer.image {
         PaintImage::LinearGradient {
             repeating: false,
             stops,
             ..
-        } if stops.iter().all(|stop| stop.position.is_some())
-    ) || matches!(
-        &layer.image,
+        } => stops.iter().all(|stop| stop.position.is_some()),
         PaintImage::RadialGradient {
             shape: RadialGradientShape::Ellipse,
             extent: RadialGradientExtent::Explicit,
@@ -31,8 +28,16 @@ pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
             repeating: false,
             stops,
             ..
-        } if stops.iter().all(|stop| stop.position.is_some())
-    );
+        } => stops.iter().all(|stop| stop.position.is_some()),
+        PaintImage::ConicGradient {
+            repeating: false,
+            stops,
+            ..
+        } => stops
+            .iter()
+            .all(|stop| stop.position.is_some_and(|position| position.length == 0.0)),
+        _ => false,
+    };
     supported_image
         && layer.position == Default::default()
         && layer.size == BackgroundSize::Auto
@@ -50,7 +55,7 @@ pub(crate) fn apply(
 ) -> Result<(), WebError> {
     if !supports(layers) {
         return Err(WebError(
-            "DOM Host only implements one non-repeating linear or explicit elliptical radial gradient with explicit stops and CSS initial layer values"
+            "DOM Host only implements one non-repeating linear, explicit elliptical radial, or conic gradient with explicit stops and CSS initial layer values"
                 .into(),
         ));
     }
@@ -118,6 +123,12 @@ fn background_image(layer: &BackgroundLayer) -> Result<String, WebError> {
             repeating: false,
             stops,
         } => radial_gradient(*center, *radii, stops),
+        PaintImage::ConicGradient {
+            from_degrees,
+            center,
+            repeating: false,
+            stops,
+        } => conic_gradient(*from_degrees, *center, stops),
         _ => Err(WebError("unsupported DOM background image".into())),
     }
 }
@@ -150,6 +161,23 @@ fn radial_gradient(
     ))
 }
 
+fn conic_gradient(
+    from_degrees: f32,
+    center: PaintPosition,
+    stops: &[GradientStop],
+) -> Result<String, WebError> {
+    let stops = stops
+        .iter()
+        .map(conic_gradient_stop)
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    Ok(format!(
+        "conic-gradient(from {from_degrees}deg at {} {}, {stops})",
+        coordinate(center.x),
+        coordinate(center.y),
+    ))
+}
+
 fn gradient_stop(stop: &GradientStop) -> Result<String, WebError> {
     let position = stop
         .position
@@ -158,6 +186,18 @@ fn gradient_stop(stop: &GradientStop) -> Result<String, WebError> {
         "{} {}",
         css_color(&stop.color),
         coordinate(position)
+    ))
+}
+
+fn conic_gradient_stop(stop: &GradientStop) -> Result<String, WebError> {
+    let position = stop
+        .position
+        .filter(|position| position.length == 0.0)
+        .ok_or_else(|| WebError("DOM conic-gradient requires resolved turn stops".into()))?;
+    Ok(format!(
+        "{} {}turn",
+        css_color(&stop.color),
+        position.fraction
     ))
 }
 

--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -1,6 +1,7 @@
 use whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, GradientStop, ImageRepeat,
-    PaintBox, PaintCoordinate, PaintImage,
+    PaintBox, PaintCoordinate, PaintImage, PaintLengthPercentage, PaintPosition,
+    RadialGradientExtent, RadialGradientShape,
 };
 
 use super::color::css_color;
@@ -8,23 +9,39 @@ use crate::{WebError, set_style};
 
 /// Whether every layer belongs to the subset currently implemented by the DOM Host.
 pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
-    layers.iter().all(|layer| {
-        matches!(
-            &layer.image,
-            PaintImage::LinearGradient {
-                repeating: false,
-                stops,
-                ..
-            } if stops.iter().all(|stop| stop.position.is_some())
-        ) && layer.position == Default::default()
-            && layer.size == BackgroundSize::Auto
-            && layer.repeat_x == ImageRepeat::Repeat
-            && layer.repeat_y == ImageRepeat::Repeat
-            && layer.origin == PaintBox::Padding
-            && layer.clip == PaintBox::Border
-            && layer.attachment == BackgroundAttachment::Scroll
-            && layer.blend_mode == BlendMode::Normal
-    })
+    if layers.is_empty() {
+        return true;
+    }
+    let [layer] = layers else {
+        return false;
+    };
+    let supported_image = matches!(
+        &layer.image,
+        PaintImage::LinearGradient {
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| stop.position.is_some())
+    ) || matches!(
+        &layer.image,
+        PaintImage::RadialGradient {
+            shape: RadialGradientShape::Ellipse,
+            extent: RadialGradientExtent::Explicit,
+            radii: Some(_),
+            repeating: false,
+            stops,
+            ..
+        } if stops.iter().all(|stop| stop.position.is_some())
+    );
+    supported_image
+        && layer.position == Default::default()
+        && layer.size == BackgroundSize::Auto
+        && layer.repeat_x == ImageRepeat::Repeat
+        && layer.repeat_y == ImageRepeat::Repeat
+        && layer.origin == PaintBox::Padding
+        && layer.clip == PaintBox::Border
+        && layer.attachment == BackgroundAttachment::Scroll
+        && layer.blend_mode == BlendMode::Normal
 }
 
 pub(crate) fn apply(
@@ -33,7 +50,7 @@ pub(crate) fn apply(
 ) -> Result<(), WebError> {
     if !supports(layers) {
         return Err(WebError(
-            "DOM Host only implements non-repeating linear-gradient background layers with explicit stops and CSS initial layer values"
+            "DOM Host only implements one non-repeating linear or explicit elliptical radial gradient with explicit stops and CSS initial layer values"
                 .into(),
         ));
     }
@@ -43,7 +60,7 @@ pub(crate) fn apply(
     } else {
         layers
             .iter()
-            .map(linear_gradient)
+            .map(background_image)
             .collect::<Result<Vec<_>, _>>()?
             .join(", ")
     };
@@ -86,21 +103,51 @@ pub(crate) fn apply(
     )
 }
 
-fn linear_gradient(layer: &BackgroundLayer) -> Result<String, WebError> {
-    let PaintImage::LinearGradient {
-        angle_degrees,
-        repeating: false,
-        stops,
-    } = &layer.image
-    else {
-        return Err(WebError("unsupported DOM background image".into()));
-    };
+fn background_image(layer: &BackgroundLayer) -> Result<String, WebError> {
+    match &layer.image {
+        PaintImage::LinearGradient {
+            angle_degrees,
+            repeating: false,
+            stops,
+        } => linear_gradient(*angle_degrees, stops),
+        PaintImage::RadialGradient {
+            shape: RadialGradientShape::Ellipse,
+            extent: RadialGradientExtent::Explicit,
+            center,
+            radii: Some(radii),
+            repeating: false,
+            stops,
+        } => radial_gradient(*center, *radii, stops),
+        _ => Err(WebError("unsupported DOM background image".into())),
+    }
+}
+
+fn linear_gradient(angle_degrees: f32, stops: &[GradientStop]) -> Result<String, WebError> {
     let stops = stops
         .iter()
         .map(gradient_stop)
         .collect::<Result<Vec<_>, _>>()?
         .join(", ");
     Ok(format!("linear-gradient({angle_degrees}deg, {stops})"))
+}
+
+fn radial_gradient(
+    center: PaintPosition,
+    radii: (PaintLengthPercentage, PaintLengthPercentage),
+    stops: &[GradientStop],
+) -> Result<String, WebError> {
+    let stops = stops
+        .iter()
+        .map(gradient_stop)
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    Ok(format!(
+        "radial-gradient(ellipse {} {} at {} {}, {stops})",
+        length_percentage(radii.0),
+        length_percentage(radii.1),
+        coordinate(center.x),
+        coordinate(center.y),
+    ))
 }
 
 fn gradient_stop(stop: &GradientStop) -> Result<String, WebError> {
@@ -115,6 +162,16 @@ fn gradient_stop(stop: &GradientStop) -> Result<String, WebError> {
 }
 
 fn coordinate(value: PaintCoordinate) -> String {
+    if value.length == 0.0 {
+        format!("{}%", value.fraction * 100.0)
+    } else if value.fraction == 0.0 {
+        format!("{}px", value.length)
+    } else {
+        format!("calc({}px + {}%)", value.length, value.fraction * 100.0)
+    }
+}
+
+fn length_percentage(value: PaintLengthPercentage) -> String {
     if value.length == 0.0 {
         format!("{}%", value.fraction * 100.0)
     } else if value.fraction == 0.0 {

--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -38,11 +38,20 @@ pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
             .all(|stop| stop.position.is_some_and(|position| position.length == 0.0)),
         _ => false,
     };
+    let initial_geometry = layer.size == BackgroundSize::Auto
+        && layer.repeat_x == ImageRepeat::Repeat
+        && layer.repeat_y == ImageRepeat::Repeat;
+    let explicit_no_repeat_geometry = matches!(
+        layer.size,
+        BackgroundSize::Explicit {
+            width: Some(_),
+            height: Some(_),
+        }
+    ) && layer.repeat_x == ImageRepeat::NoRepeat
+        && layer.repeat_y == ImageRepeat::NoRepeat;
     supported_image
         && layer.position == Default::default()
-        && layer.size == BackgroundSize::Auto
-        && layer.repeat_x == ImageRepeat::Repeat
-        && layer.repeat_y == ImageRepeat::Repeat
+        && (initial_geometry || explicit_no_repeat_geometry)
         && layer.origin == PaintBox::Padding
         && layer.clip == PaintBox::Border
         && layer.attachment == BackgroundAttachment::Scroll
@@ -55,7 +64,7 @@ pub(crate) fn apply(
 ) -> Result<(), WebError> {
     if !supports(layers) {
         return Err(WebError(
-            "DOM Host only implements one non-repeating linear, explicit elliptical radial, or conic gradient with explicit stops and CSS initial layer values"
+            "DOM Host only implements one supported gradient with explicit stops, initial position and boxes, two-axis auto or explicit size, and repeat/no-repeat"
                 .into(),
         ));
     }
@@ -69,43 +78,23 @@ pub(crate) fn apply(
             .collect::<Result<Vec<_>, _>>()?
             .join(", ")
     };
-    let layer_count = layers.len().max(1);
+    let position = layers
+        .first()
+        .map_or_else(|| "0px 0px".into(), background_position);
+    let size = layers
+        .first()
+        .map_or_else(|| "auto".into(), background_size);
+    let repeat = layers
+        .first()
+        .map_or_else(|| "repeat".into(), background_repeat);
     set_style(element, "background-image", &images)?;
-    set_style(
-        element,
-        "background-position",
-        &initial_list("0px 0px", layer_count),
-    )?;
-    set_style(
-        element,
-        "background-size",
-        &initial_list("auto", layer_count),
-    )?;
-    set_style(
-        element,
-        "background-repeat",
-        &initial_list("repeat", layer_count),
-    )?;
-    set_style(
-        element,
-        "background-origin",
-        &initial_list("padding-box", layer_count),
-    )?;
-    set_style(
-        element,
-        "background-clip",
-        &initial_list("border-box", layer_count),
-    )?;
-    set_style(
-        element,
-        "background-attachment",
-        &initial_list("scroll", layer_count),
-    )?;
-    set_style(
-        element,
-        "background-blend-mode",
-        &initial_list("normal", layer_count),
-    )
+    set_style(element, "background-position", &position)?;
+    set_style(element, "background-size", &size)?;
+    set_style(element, "background-repeat", &repeat)?;
+    set_style(element, "background-origin", "padding-box")?;
+    set_style(element, "background-clip", "border-box")?;
+    set_style(element, "background-attachment", "scroll")?;
+    set_style(element, "background-blend-mode", "normal")
 }
 
 fn background_image(layer: &BackgroundLayer) -> Result<String, WebError> {
@@ -221,8 +210,32 @@ fn length_percentage(value: PaintLengthPercentage) -> String {
     }
 }
 
-fn initial_list(value: &str, count: usize) -> String {
-    std::iter::repeat_n(value, count)
-        .collect::<Vec<_>>()
-        .join(", ")
+fn background_position(layer: &BackgroundLayer) -> String {
+    if layer.position == Default::default() {
+        return "0px 0px".into();
+    }
+    format!(
+        "{} {}",
+        coordinate(layer.position.x),
+        coordinate(layer.position.y)
+    )
+}
+
+fn background_size(layer: &BackgroundLayer) -> String {
+    match layer.size {
+        BackgroundSize::Auto => "auto".into(),
+        BackgroundSize::Explicit {
+            width: Some(width),
+            height: Some(height),
+        } => format!("{} {}", length_percentage(width), length_percentage(height)),
+        _ => unreachable!("unsupported background size passed preflight"),
+    }
+}
+
+fn background_repeat(layer: &BackgroundLayer) -> String {
+    match (layer.repeat_x, layer.repeat_y) {
+        (ImageRepeat::Repeat, ImageRepeat::Repeat) => "repeat".into(),
+        (ImageRepeat::NoRepeat, ImageRepeat::NoRepeat) => "no-repeat".into(),
+        _ => unreachable!("unsupported background repeat passed preflight"),
+    }
 }

--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -42,17 +42,18 @@ pub(crate) fn supports(layers: &[BackgroundLayer]) -> bool {
         && layer.size == BackgroundSize::Auto
         && layer.repeat_x == ImageRepeat::Repeat
         && layer.repeat_y == ImageRepeat::Repeat;
-    let explicit_no_repeat_geometry = matches!(
-        layer.size,
-        BackgroundSize::Explicit {
-            width: Some(_),
-            height: Some(_),
-        }
-    ) && layer.repeat_x == ImageRepeat::NoRepeat
-        && layer.repeat_y == ImageRepeat::NoRepeat;
+    let explicit_geometry =
+        matches!(
+            layer.size,
+            BackgroundSize::Explicit {
+                width: Some(_),
+                height: Some(_),
+            }
+        ) && matches!(layer.repeat_x, ImageRepeat::Repeat | ImageRepeat::NoRepeat)
+            && matches!(layer.repeat_y, ImageRepeat::Repeat | ImageRepeat::NoRepeat);
     let supported_geometry =
         (initial_geometry && layer.origin == PaintBox::Padding && layer.clip == PaintBox::Border)
-            || (explicit_no_repeat_geometry
+            || (explicit_geometry
                 && matches!(layer.origin, PaintBox::Border | PaintBox::Padding)
                 && matches!(layer.clip, PaintBox::Border | PaintBox::Padding));
     supported_image
@@ -245,6 +246,8 @@ fn background_repeat(layer: &BackgroundLayer) -> String {
     match (layer.repeat_x, layer.repeat_y) {
         (ImageRepeat::Repeat, ImageRepeat::Repeat) => "repeat".into(),
         (ImageRepeat::NoRepeat, ImageRepeat::NoRepeat) => "no-repeat".into(),
+        (ImageRepeat::Repeat, ImageRepeat::NoRepeat) => "repeat no-repeat".into(),
+        (ImageRepeat::NoRepeat, ImageRepeat::Repeat) => "no-repeat repeat".into(),
         _ => unreachable!("unsupported background repeat passed preflight"),
     }
 }

--- a/platforms/web/src/paint/clip.rs
+++ b/platforms/web/src/paint/clip.rs
@@ -20,11 +20,10 @@ pub(crate) fn apply(
 }
 
 fn overflow(value: OverflowClip, scroll_content: bool) -> &'static str {
-    if value == OverflowClip::Hidden {
-        "hidden"
-    } else if scroll_content {
-        "auto"
-    } else {
-        "visible"
+    match (value, scroll_content) {
+        (OverflowClip::Hidden, true) => "hidden",
+        (OverflowClip::Visible, true) => "auto",
+        (OverflowClip::Hidden, false) => "clip",
+        (OverflowClip::Visible, false) => "visible",
     }
 }

--- a/platforms/web/src/paint/mod.rs
+++ b/platforms/web/src/paint/mod.rs
@@ -1,5 +1,6 @@
 //! Projection of semantic paint operations into browser CSSOM values.
 
+pub(crate) mod background_layers;
 #[path = "box.rs"]
 pub(crate) mod box_paint;
 pub(crate) mod clip;

--- a/platforms/web/src/paint/transform.rs
+++ b/platforms/web/src/paint/transform.rs
@@ -9,5 +9,6 @@ pub(crate) fn apply(element: &web_sys::Element, transform: Transform) -> Result<
         .map(ToString::to_string)
         .collect::<Vec<_>>()
         .join(",");
+    set_style(element, "transform-origin", "0 0")?;
     set_style(element, "transform", &format!("matrix3d({value})"))
 }

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -454,6 +454,10 @@ impl FrameSink for DomFrameSink {
                     capability: whisker_protocol::RenderCapability::LinearGradients,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::RadialGradients,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("Web capability profile is unique")

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -458,6 +458,10 @@ impl FrameSink for DomFrameSink {
                     capability: whisker_protocol::RenderCapability::RadialGradients,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::ConicGradients,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("Web capability profile is unique")

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -462,6 +462,10 @@ impl FrameSink for DomFrameSink {
                     capability: whisker_protocol::RenderCapability::ConicGradients,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::BackgroundGeometry,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
             ],
         )
         .expect("Web capability profile is unique")

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -70,7 +70,11 @@ impl DomFrameSink {
             .operations
             .iter()
             .find_map(|operation| match operation {
-                Operation::SetBackgroundLayers { .. } => Some("background-layers"),
+                Operation::SetBackgroundLayers { layers, .. }
+                    if !paint::background_layers::supports(layers) =>
+                {
+                    Some("background-layers payload")
+                }
                 Operation::SetVisualEffects { .. } => Some("visual-effects"),
                 Operation::SetImage { .. } => Some("image-content"),
                 Operation::SetCursor { .. } => Some("cursor"),
@@ -230,6 +234,9 @@ impl DomFrameSink {
                 let element = self.node(*node)?;
                 paint::box_paint::apply(&element, paint)?;
             }
+            Operation::SetBackgroundLayers { node, layers } => {
+                paint::background_layers::apply(&self.node(*node)?, layers)?;
+            }
             Operation::SetClip { node, clip } => {
                 let element = self.node(*node)?;
                 let element_type = *self
@@ -378,8 +385,7 @@ impl DomFrameSink {
                     .map_err(|error| js_error("invoke native DOM command", error))?;
             }
             Operation::SetPointerCapture { .. } | Operation::ReleasePointerCapture { .. } => {}
-            Operation::SetBackgroundLayers { .. }
-            | Operation::SetVisualEffects { .. }
+            Operation::SetVisualEffects { .. }
             | Operation::SetImage { .. }
             | Operation::SetCursor { .. } => {
                 unreachable!("unsupported operations are rejected before DOM mutation")
@@ -439,10 +445,16 @@ impl FrameSink for DomFrameSink {
     fn capabilities(&self) -> whisker_protocol::RenderCapabilities {
         whisker_protocol::RenderCapabilities::new(
             whisker_protocol::ProtocolVersion::CURRENT,
-            [whisker_protocol::CapabilityEntry {
-                capability: whisker_protocol::RenderCapability::EllipticalBorderRadius,
-                support: whisker_protocol::CapabilitySupport::Native,
-            }],
+            [
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::EllipticalBorderRadius,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::LinearGradients,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
+            ],
         )
         .expect("Web capability profile is unique")
     }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -222,6 +222,18 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/CSS2/borders/border-top-style-006.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-006.json"
         ),
+        "wpt/css/CSS2/borders/border-top-style-007.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-007.json"
+        ),
+        "wpt/css/CSS2/borders/border-top-style-008.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-008.json"
+        ),
+        "wpt/css/CSS2/borders/border-top-style-009.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-009.json"
+        ),
+        "wpt/css/CSS2/borders/border-top-style-010.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-010.json"
+        ),
         "core/text-measure-basic.json" => {
             include_str!("../../../../tests/host-conformance/core/text-measure-basic.json")
         }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -5,12 +5,12 @@ use whisker_engine::FrameSink;
 use whisker_host_conformance::{
     BorderFixture, BorderStyleFixture, ColorFixture, Command, CornerRadiusFixture, Manifest,
     OverflowClipFixture, PixelSampleFixture, SCHEMA_VERSION, Scenario, ScenarioSide,
-    SceneNodeFixture,
+    SceneNodeFixture, VisibilityFixture,
 };
 use whisker_protocol::{
     BorderLineStyle, BoxClip, BoxPaint, FrameHeader, FrameMode, FramePacket, LayoutGeometry,
     LayoutRect, NodeId, Operation, OverflowClip, PaintColor, PaintCornerRadius, PaintCorners,
-    PaintEdges, PaintLengthPercentage, ProtocolVersion, SurfaceId, Transform,
+    PaintEdges, PaintLengthPercentage, ProtocolVersion, SurfaceId, Transform, Visibility,
 };
 
 use crate::module_api::built_in_element_factories;
@@ -212,6 +212,21 @@ impl Driver {
                 assert_eq!(style.get_property_value("transform").unwrap(), "");
                 assert_eq!(style.get_property_value("transform-origin").unwrap(), "");
             }
+            if let Some(opacity) = fixture_node.opacity {
+                assert_style(&style, "opacity", &opacity.to_string());
+            } else {
+                assert_eq!(style.get_property_value("opacity").unwrap(), "");
+            }
+            if let Some(visibility) = fixture_node.visibility {
+                assert_style(&style, "visibility", fixture_visibility_css(visibility));
+            } else {
+                assert_eq!(style.get_property_value("visibility").unwrap(), "");
+            }
+            if let Some(z_order) = fixture_node.z_order {
+                assert_style(&style, "z-index", &z_order.to_string());
+            } else {
+                assert_eq!(style.get_property_value("z-index").unwrap(), "");
+            }
 
             let actual_parent = node.parent_element().unwrap();
             match fixture_node.parent {
@@ -235,22 +250,44 @@ impl Driver {
         let document = web_sys::window().unwrap().document().unwrap();
         let bounds = self.root.get_bounding_client_rect();
         for sample in samples {
-            let hit = document
-                .element_from_point(
+            let hit_nodes = document
+                .elements_from_point(
                     (bounds.left() + f64::from(sample.point[0])) as f32,
                     (bounds.top() + f64::from(sample.point[1])) as f32,
                 )
-                .expect("fixture sample lies inside the browser viewport");
-            let hit_node = hit.get_attribute("data-whisker-node");
+                .iter()
+                .filter_map(|value| {
+                    value
+                        .dyn_into::<web_sys::Element>()
+                        .ok()?
+                        .get_attribute("data-whisker-node")
+                })
+                .collect::<Vec<_>>();
+            let opaque_hit = hit_nodes.iter().find(|id| {
+                expected.iter().any(|node| {
+                    node.id.to_string() == id.as_str()
+                        && !fixture_color_is_transparent(&node.background)
+                })
+            });
             match &sample.color {
                 ColorFixture::Named { value } if value == "transparent" => assert!(
-                    hit_node.as_deref().is_none_or(|id| {
-                        expected.iter().any(|node| {
-                            node.id.to_string() == id && node.background == sample.color
-                        })
-                    }),
-                    "transparent sample unexpectedly hit an opaque scene node {hit_node:?}"
+                    opaque_hit.is_none(),
+                    "transparent sample unexpectedly hit opaque scene stack {hit_nodes:?}"
                 ),
+                ColorFixture::Srgba { .. } => {
+                    let expected_node = expected
+                        .iter()
+                        .rev()
+                        .find(|node| node.opacity.is_some())
+                        .expect("composited sRGBA sample requires an opacity node")
+                        .id
+                        .to_string();
+                    assert_eq!(
+                        opaque_hit.map(String::as_str),
+                        Some(expected_node.as_str()),
+                        "composited sample did not hit the opacity source node"
+                    );
+                }
                 expected_color => {
                     let expected_node = expected
                         .iter()
@@ -261,7 +298,7 @@ impl Driver {
                         .id
                         .to_string();
                     assert_eq!(
-                        hit_node.as_deref(),
+                        opaque_hit.map(String::as_str),
                         Some(expected_node.as_str()),
                         "paint sample did not hit the expected transformed scene node"
                     );
@@ -337,6 +374,15 @@ fn fixture(path: &str) -> &'static str {
         "core/transform-parent-composition.json" => include_str!(
             "../../../../tests/host-conformance/core/transform-parent-composition.json"
         ),
+        "wpt/css/css-color/t32-opacity-basic-0.6-a.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-color/t32-opacity-basic-0.6-a.json"
+        ),
+        "wpt/css/CSS2/visufx/visibility-004.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/visufx/visibility-004.json"
+        ),
+        "wpt/css/CSS2/zindex/z-index-003.json" => {
+            include_str!("../../../../tests/host-conformance/wpt/css/CSS2/zindex/z-index-003.json")
+        }
         "wpt/css/CSS2/borders/border-top-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json"
         ),
@@ -471,6 +517,18 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
                 node,
                 transform: Transform(transform),
             });
+        }
+        if let Some(opacity) = fixture_node.opacity {
+            operations.push(Operation::SetOpacity { node, opacity });
+        }
+        if let Some(visibility) = fixture_node.visibility {
+            operations.push(Operation::SetVisibility {
+                node,
+                visibility: protocol_visibility(visibility),
+            });
+        }
+        if let Some(z_order) = fixture_node.z_order {
+            operations.push(Operation::SetZOrder { node, z_order });
         }
     }
     for (node_index, fixture_node) in nodes.iter().enumerate() {
@@ -658,6 +716,13 @@ fn fixture_color_css(value: &ColorFixture) -> String {
     }
 }
 
+fn fixture_color_is_transparent(value: &ColorFixture) -> bool {
+    match value {
+        ColorFixture::Named { value } => value == "transparent",
+        ColorFixture::Srgba { alpha, .. } => *alpha == 0.0,
+    }
+}
+
 fn fixture_border_style_css(value: BorderStyleFixture) -> &'static str {
     match value {
         BorderStyleFixture::None => "none",
@@ -687,4 +752,18 @@ fn fixture_transform_css(transform: [f32; 16]) -> String {
         .collect::<Vec<_>>()
         .join(",");
     format!("matrix3d({values})")
+}
+
+fn protocol_visibility(value: VisibilityFixture) -> Visibility {
+    match value {
+        VisibilityFixture::Visible => Visibility::Visible,
+        VisibilityFixture::Hidden => Visibility::Hidden,
+    }
+}
+
+fn fixture_visibility_css(value: VisibilityFixture) -> &'static str {
+    match value {
+        VisibilityFixture::Visible => "visible",
+        VisibilityFixture::Hidden => "hidden",
+    }
 }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -219,6 +219,9 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/CSS2/borders/border-top-style-004.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-004.json"
         ),
+        "wpt/css/CSS2/borders/border-top-style-006.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-style-006.json"
+        ),
         "core/text-measure-basic.json" => {
             include_str!("../../../../tests/host-conformance/core/text-measure-basic.json")
         }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -3,8 +3,8 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use whisker::ElementRegistry;
 use whisker_engine::FrameSink;
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, CornerRadiusFixture,
-    LinearGradientFixture, Manifest, OverflowClipFixture, PixelSampleFixture,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, ConicGradientFixture,
+    CornerRadiusFixture, LinearGradientFixture, Manifest, OverflowClipFixture, PixelSampleFixture,
     RadialGradientFixture, SCHEMA_VERSION, Scenario, ScenarioSide, SceneNodeFixture,
     VisibilityFixture,
 };
@@ -109,6 +109,11 @@ impl Driver {
                                             node.radial_gradient
                                                 .as_ref()
                                                 .map(|_| "paint.background-layers.radial-gradient")
+                                        })
+                                        .or_else(|| {
+                                            node.conic_gradient
+                                                .as_ref()
+                                                .map(|_| "paint.background-layers.conic-gradient")
                                         })
                                 })
                             })
@@ -223,6 +228,13 @@ impl Driver {
                     &fixture_radial_gradient_css(gradient),
                 );
                 assert_initial_background_layer_is_projected(&style);
+            } else if let Some(gradient) = &fixture_node.conic_gradient {
+                assert_style(
+                    &style,
+                    "background-image",
+                    &fixture_conic_gradient_css(gradient),
+                );
+                assert_initial_background_layer_is_projected(&style);
             } else {
                 assert_eq!(style.get_property_value("background-image").unwrap(), "");
             }
@@ -267,6 +279,7 @@ impl Driver {
                     node.id.to_string() == id.as_str()
                         && (node.linear_gradient.is_some()
                             || node.radial_gradient.is_some()
+                            || node.conic_gradient.is_some()
                             || !fixture_color_is_transparent(&node.background))
                 })
             });
@@ -282,7 +295,9 @@ impl Driver {
                         .find(|node| node.opacity.is_some())
                         .or_else(|| {
                             expected.iter().find(|node| {
-                                node.linear_gradient.is_some() || node.radial_gradient.is_some()
+                                node.linear_gradient.is_some()
+                                    || node.radial_gradient.is_some()
+                                    || node.conic_gradient.is_some()
                             })
                         })
                         .expect("sRGBA sample requires an opacity or gradient source node")
@@ -300,7 +315,9 @@ impl Driver {
                         .find(|node| node.background == *expected_color)
                         .or_else(|| {
                             expected.iter().find(|node| {
-                                node.linear_gradient.is_some() || node.radial_gradient.is_some()
+                                node.linear_gradient.is_some()
+                                    || node.radial_gradient.is_some()
+                                    || node.conic_gradient.is_some()
                             })
                         })
                         .unwrap_or_else(|| {
@@ -369,6 +386,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-images/radial-gradient-container-relative-units-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-images/radial-gradient-container-relative-units-001.json"
+        ),
+        "wpt/css/css-images/conic-gradient-angle.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-images/conic-gradient-angle.json"
         ),
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
@@ -563,6 +583,11 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
                 node,
                 layers: vec![radial_gradient_layer(gradient)],
             });
+        } else if let Some(gradient) = &fixture_node.conic_gradient {
+            operations.push(Operation::SetBackgroundLayers {
+                node,
+                layers: vec![conic_gradient_layer(gradient)],
+            });
         }
     }
     for (node_index, fixture_node) in nodes.iter().enumerate() {
@@ -657,6 +682,44 @@ fn radial_gradient_layer(gradient: &RadialGradientFixture) -> BackgroundLayer {
                     fraction: 0.0,
                 },
             )),
+            repeating: false,
+            stops: gradient
+                .stops
+                .iter()
+                .map(|stop| GradientStop {
+                    color: color(&stop.color),
+                    position: Some(PaintCoordinate {
+                        length: 0.0,
+                        fraction: stop.position,
+                    }),
+                })
+                .collect(),
+        },
+        position: PaintPosition::default(),
+        size: BackgroundSize::Auto,
+        repeat_x: ImageRepeat::Repeat,
+        repeat_y: ImageRepeat::Repeat,
+        origin: PaintBox::Padding,
+        clip: PaintBox::Border,
+        attachment: BackgroundAttachment::Scroll,
+        blend_mode: BlendMode::Normal,
+    }
+}
+
+fn conic_gradient_layer(gradient: &ConicGradientFixture) -> BackgroundLayer {
+    BackgroundLayer {
+        image: PaintImage::ConicGradient {
+            from_degrees: gradient.from_degrees,
+            center: PaintPosition {
+                x: PaintCoordinate {
+                    length: gradient.center[0],
+                    fraction: 0.0,
+                },
+                y: PaintCoordinate {
+                    length: gradient.center[1],
+                    fraction: 0.0,
+                },
+            },
             repeating: false,
             stops: gradient
                 .stops
@@ -912,6 +975,19 @@ fn fixture_radial_gradient_css(gradient: &RadialGradientFixture) -> String {
     format!(
         "radial-gradient(ellipse {}px {}px at {}px {}px, {stops})",
         gradient.radii[0], gradient.radii[1], gradient.center[0], gradient.center[1]
+    )
+}
+
+fn fixture_conic_gradient_css(gradient: &ConicGradientFixture) -> String {
+    let stops = gradient
+        .stops
+        .iter()
+        .map(|stop| format!("{} {}turn", fixture_color_css(&stop.color), stop.position))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "conic-gradient(from {}deg at {}px {}px, {stops})",
+        gradient.from_degrees, gradient.center[0], gradient.center[1]
     )
 }
 

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -3,10 +3,11 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use whisker::ElementRegistry;
 use whisker_engine::FrameSink;
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, ConicGradientFixture,
-    CornerRadiusFixture, LinearGradientFixture, Manifest, OverflowClipFixture, PixelSampleFixture,
-    RadialGradientFixture, SCHEMA_VERSION, Scenario, ScenarioSide, SceneNodeFixture,
-    VisibilityFixture,
+    BackgroundBoxFixture, BackgroundLayerFixture, BorderFixture, BorderStyleFixture, ColorFixture,
+    Command, ConicGradientFixture, CornerRadiusFixture, ImageRepeatFixture,
+    LengthPercentageFixture, LinearGradientFixture, Manifest, OverflowClipFixture,
+    PixelSampleFixture, RadialGradientFixture, SCHEMA_VERSION, Scenario, ScenarioSide,
+    SceneNodeFixture, VisibilityFixture,
 };
 use whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
@@ -101,21 +102,29 @@ impl Driver {
                             .expected_scene
                             .as_ref()
                             .and_then(|nodes| {
-                                nodes.iter().find_map(|node| {
-                                    node.linear_gradient
-                                        .as_ref()
-                                        .map(|_| "paint.background-layers.linear-gradient")
-                                        .or_else(|| {
-                                            node.radial_gradient
+                                nodes
+                                    .iter()
+                                    .any(|node| {
+                                        node.background_layer != BackgroundLayerFixture::default()
+                                    })
+                                    .then_some("paint.background-layers.explicit-size-no-repeat")
+                                    .or_else(|| {
+                                        nodes.iter().find_map(|node| {
+                                            node.linear_gradient
                                                 .as_ref()
-                                                .map(|_| "paint.background-layers.radial-gradient")
+                                                .map(|_| "paint.background-layers.linear-gradient")
+                                                .or_else(|| {
+                                                    node.radial_gradient.as_ref().map(|_| {
+                                                        "paint.background-layers.radial-gradient"
+                                                    })
+                                                })
+                                                .or_else(|| {
+                                                    node.conic_gradient.as_ref().map(|_| {
+                                                        "paint.background-layers.conic-gradient"
+                                                    })
+                                                })
                                         })
-                                        .or_else(|| {
-                                            node.conic_gradient
-                                                .as_ref()
-                                                .map(|_| "paint.background-layers.conic-gradient")
-                                        })
-                                })
+                                    })
                             })
                             .unwrap_or("paint.box");
                         assert_eq!(name, expected_checkpoint);
@@ -220,21 +229,21 @@ impl Driver {
                     "background-image",
                     &fixture_linear_gradient_css(gradient),
                 );
-                assert_initial_background_layer_is_projected(&style);
+                assert_background_layer_is_projected(&style, fixture_node.background_layer);
             } else if let Some(gradient) = &fixture_node.radial_gradient {
                 assert_style(
                     &style,
                     "background-image",
                     &fixture_radial_gradient_css(gradient),
                 );
-                assert_initial_background_layer_is_projected(&style);
+                assert_background_layer_is_projected(&style, fixture_node.background_layer);
             } else if let Some(gradient) = &fixture_node.conic_gradient {
                 assert_style(
                     &style,
                     "background-image",
                     &fixture_conic_gradient_css(gradient),
                 );
-                assert_initial_background_layer_is_projected(&style);
+                assert_background_layer_is_projected(&style, fixture_node.background_layer);
             } else {
                 assert_eq!(style.get_property_value("background-image").unwrap(), "");
             }
@@ -276,11 +285,7 @@ impl Driver {
                 .collect::<Vec<_>>();
             let opaque_hit = hit_nodes.iter().find(|id| {
                 expected.iter().any(|node| {
-                    node.id.to_string() == id.as_str()
-                        && (node.linear_gradient.is_some()
-                            || node.radial_gradient.is_some()
-                            || node.conic_gradient.is_some()
-                            || !fixture_color_is_transparent(&node.background))
+                    node.id.to_string() == id.as_str() && fixture_node_paints_at(node, sample.point)
                 })
             });
             match &sample.color {
@@ -389,6 +394,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-images/conic-gradient-angle.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-images/conic-gradient-angle.json"
+        ),
+        "wpt/css/css-backgrounds/background-size-009.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/background-size-009.json"
         ),
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
@@ -576,17 +584,26 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
         if let Some(gradient) = &fixture_node.linear_gradient {
             operations.push(Operation::SetBackgroundLayers {
                 node,
-                layers: vec![linear_gradient_layer(gradient)],
+                layers: vec![with_background_geometry(
+                    linear_gradient_layer(gradient),
+                    fixture_node.background_layer,
+                )],
             });
         } else if let Some(gradient) = &fixture_node.radial_gradient {
             operations.push(Operation::SetBackgroundLayers {
                 node,
-                layers: vec![radial_gradient_layer(gradient)],
+                layers: vec![with_background_geometry(
+                    radial_gradient_layer(gradient),
+                    fixture_node.background_layer,
+                )],
             });
         } else if let Some(gradient) = &fixture_node.conic_gradient {
             operations.push(Operation::SetBackgroundLayers {
                 node,
-                layers: vec![conic_gradient_layer(gradient)],
+                layers: vec![with_background_geometry(
+                    conic_gradient_layer(gradient),
+                    fixture_node.background_layer,
+                )],
             });
         }
     }
@@ -741,6 +758,58 @@ fn conic_gradient_layer(gradient: &ConicGradientFixture) -> BackgroundLayer {
         clip: PaintBox::Border,
         attachment: BackgroundAttachment::Scroll,
         blend_mode: BlendMode::Normal,
+    }
+}
+
+fn with_background_geometry(
+    mut layer: BackgroundLayer,
+    geometry: BackgroundLayerFixture,
+) -> BackgroundLayer {
+    layer.position = PaintPosition {
+        x: paint_coordinate(geometry.position[0]),
+        y: paint_coordinate(geometry.position[1]),
+    };
+    layer.size = geometry
+        .size
+        .map_or(BackgroundSize::Auto, |size| BackgroundSize::Explicit {
+            width: Some(paint_length_percentage(size[0])),
+            height: Some(paint_length_percentage(size[1])),
+        });
+    layer.repeat_x = image_repeat(geometry.repeat_x);
+    layer.repeat_y = image_repeat(geometry.repeat_y);
+    layer.origin = background_box(geometry.origin);
+    layer.clip = background_box(geometry.clip);
+    layer
+}
+
+fn paint_coordinate(value: LengthPercentageFixture) -> PaintCoordinate {
+    PaintCoordinate {
+        length: value.length,
+        fraction: value.fraction,
+    }
+}
+
+fn paint_length_percentage(value: LengthPercentageFixture) -> PaintLengthPercentage {
+    PaintLengthPercentage {
+        length: value.length,
+        fraction: value.fraction,
+    }
+}
+
+fn image_repeat(value: ImageRepeatFixture) -> ImageRepeat {
+    match value {
+        ImageRepeatFixture::Repeat => ImageRepeat::Repeat,
+        ImageRepeatFixture::NoRepeat => ImageRepeat::NoRepeat,
+        ImageRepeatFixture::Space => ImageRepeat::Space,
+        ImageRepeatFixture::Round => ImageRepeat::Round,
+    }
+}
+
+fn background_box(value: BackgroundBoxFixture) -> PaintBox {
+    match value {
+        BackgroundBoxFixture::Border => PaintBox::Border,
+        BackgroundBoxFixture::Padding => PaintBox::Padding,
+        BackgroundBoxFixture::Content => PaintBox::Content,
     }
 }
 
@@ -991,14 +1060,91 @@ fn fixture_conic_gradient_css(gradient: &ConicGradientFixture) -> String {
     )
 }
 
-fn assert_initial_background_layer_is_projected(style: &web_sys::CssStyleDeclaration) {
+fn assert_background_layer_is_projected(
+    style: &web_sys::CssStyleDeclaration,
+    layer: BackgroundLayerFixture,
+) {
     assert_style(style, "background-position", "0px 0px");
-    assert_style(style, "background-size", "auto");
-    assert_style(style, "background-repeat", "repeat");
-    assert_style(style, "background-origin", "padding-box");
-    assert_style(style, "background-clip", "border-box");
+    assert_style(style, "background-size", &fixture_background_size(layer));
+    assert_style(style, "background-repeat", fixture_background_repeat(layer));
+    assert_style(
+        style,
+        "background-origin",
+        fixture_background_box(layer.origin),
+    );
+    assert_style(style, "background-clip", fixture_background_box(layer.clip));
     assert_style(style, "background-attachment", "scroll");
     assert_style(style, "background-blend-mode", "normal");
+}
+
+fn fixture_background_size(layer: BackgroundLayerFixture) -> String {
+    layer.size.map_or_else(
+        || "auto".into(),
+        |size| {
+            format!(
+                "{} {}",
+                fixture_length_percentage(size[0]),
+                fixture_length_percentage(size[1])
+            )
+        },
+    )
+}
+
+fn fixture_background_repeat(layer: BackgroundLayerFixture) -> &'static str {
+    match (layer.repeat_x, layer.repeat_y) {
+        (ImageRepeatFixture::Repeat, ImageRepeatFixture::Repeat) => "repeat",
+        (ImageRepeatFixture::NoRepeat, ImageRepeatFixture::NoRepeat) => "no-repeat",
+        (ImageRepeatFixture::Repeat, ImageRepeatFixture::NoRepeat) => "repeat no-repeat",
+        (ImageRepeatFixture::NoRepeat, ImageRepeatFixture::Repeat) => "no-repeat repeat",
+        (ImageRepeatFixture::Space, _) | (_, ImageRepeatFixture::Space) => "space",
+        (ImageRepeatFixture::Round, _) | (_, ImageRepeatFixture::Round) => "round",
+    }
+}
+
+fn fixture_background_box(value: BackgroundBoxFixture) -> &'static str {
+    match value {
+        BackgroundBoxFixture::Border => "border-box",
+        BackgroundBoxFixture::Padding => "padding-box",
+        BackgroundBoxFixture::Content => "content-box",
+    }
+}
+
+fn fixture_length_percentage(value: LengthPercentageFixture) -> String {
+    if value.length == 0.0 {
+        format!("{}%", value.fraction * 100.0)
+    } else if value.fraction == 0.0 {
+        format!("{}px", value.length)
+    } else {
+        format!("calc({}px + {}%)", value.length, value.fraction * 100.0)
+    }
+}
+
+fn fixture_node_paints_at(node: &SceneNodeFixture, point: [f32; 2]) -> bool {
+    if !fixture_color_is_transparent(&node.background) {
+        return true;
+    }
+    if node.linear_gradient.is_none()
+        && node.radial_gradient.is_none()
+        && node.conic_gradient.is_none()
+    {
+        return false;
+    }
+    let layer = node.background_layer;
+    let size = layer.size.map_or([node.rect[2], node.rect[3]], |size| {
+        [
+            size[0].length + size[0].fraction * node.rect[2],
+            size[1].length + size[1].fraction * node.rect[3],
+        ]
+    });
+    let position = [
+        node.rect[0] + layer.position[0].length + layer.position[0].fraction * node.rect[2],
+        node.rect[1] + layer.position[1].length + layer.position[1].fraction * node.rect[3],
+    ];
+    let paints_x = layer.repeat_x != ImageRepeatFixture::NoRepeat
+        || (position[0]..position[0] + size[0]).contains(&point[0]);
+    let paints_y = layer.repeat_y != ImageRepeatFixture::NoRepeat
+        || (position[1]..position[1] + size[1]).contains(&point[1]);
+    paints_x && paints_y
 }
 
 fn fixture_border_style_css(value: BorderStyleFixture) -> &'static str {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -3,14 +3,16 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use whisker::ElementRegistry;
 use whisker_engine::FrameSink;
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, CornerRadiusFixture, Manifest,
-    OverflowClipFixture, PixelSampleFixture, SCHEMA_VERSION, Scenario, ScenarioSide,
-    SceneNodeFixture, VisibilityFixture,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, CornerRadiusFixture,
+    LinearGradientFixture, Manifest, OverflowClipFixture, PixelSampleFixture, SCHEMA_VERSION,
+    Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture,
 };
 use whisker_protocol::{
-    BorderLineStyle, BoxClip, BoxPaint, FrameHeader, FrameMode, FramePacket, LayoutGeometry,
-    LayoutRect, NodeId, Operation, OverflowClip, PaintColor, PaintCornerRadius, PaintCorners,
-    PaintEdges, PaintLengthPercentage, ProtocolVersion, SurfaceId, Transform, Visibility,
+    BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
+    BoxPaint, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat, LayoutGeometry,
+    LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate,
+    PaintCornerRadius, PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition,
+    ProtocolVersion, SurfaceId, Transform, Visibility,
 };
 
 use crate::module_api::built_in_element_factories;
@@ -93,10 +95,21 @@ impl Driver {
                     self.expected_box = None;
                 }
                 Command::Checkpoint { name, samples, .. } => {
-                    assert_eq!(name, "paint.box");
                     if self.expected_scene.is_some() {
+                        let has_gradient = self.expected_scene.as_ref().is_some_and(|nodes| {
+                            nodes.iter().any(|node| node.linear_gradient.is_some())
+                        });
+                        assert_eq!(
+                            name,
+                            if has_gradient {
+                                "paint.background-layers.linear-gradient"
+                            } else {
+                                "paint.box"
+                            }
+                        );
                         self.assert_scene_is_projected(samples);
                     } else {
+                        assert_eq!(name, "paint.box");
                         self.assert_box_is_projected();
                     }
                 }
@@ -189,6 +202,22 @@ impl Driver {
             } else {
                 assert_eq!(style.get_property_value("z-index").unwrap(), "");
             }
+            if let Some(gradient) = &fixture_node.linear_gradient {
+                assert_style(
+                    &style,
+                    "background-image",
+                    &fixture_linear_gradient_css(gradient),
+                );
+                assert_style(&style, "background-position", "0px 0px");
+                assert_style(&style, "background-size", "auto");
+                assert_style(&style, "background-repeat", "repeat");
+                assert_style(&style, "background-origin", "padding-box");
+                assert_style(&style, "background-clip", "border-box");
+                assert_style(&style, "background-attachment", "scroll");
+                assert_style(&style, "background-blend-mode", "normal");
+            } else {
+                assert_eq!(style.get_property_value("background-image").unwrap(), "");
+            }
 
             let actual_parent = node.parent_element().unwrap();
             match fixture_node.parent {
@@ -228,7 +257,8 @@ impl Driver {
             let opaque_hit = hit_nodes.iter().find(|id| {
                 expected.iter().any(|node| {
                     node.id.to_string() == id.as_str()
-                        && !fixture_color_is_transparent(&node.background)
+                        && (node.linear_gradient.is_some()
+                            || !fixture_color_is_transparent(&node.background))
                 })
             });
             match &sample.color {
@@ -241,7 +271,8 @@ impl Driver {
                         .iter()
                         .rev()
                         .find(|node| node.opacity.is_some())
-                        .expect("composited sRGBA sample requires an opacity node")
+                        .or_else(|| expected.iter().find(|node| node.linear_gradient.is_some()))
+                        .expect("sRGBA sample requires an opacity or gradient source node")
                         .id
                         .to_string();
                     assert_eq!(
@@ -254,6 +285,7 @@ impl Driver {
                     let expected_node = expected
                         .iter()
                         .find(|node| node.background == *expected_color)
+                        .or_else(|| expected.iter().find(|node| node.linear_gradient.is_some()))
                         .unwrap_or_else(|| {
                             panic!("sample color {expected_color:?} has no matching scene node")
                         })
@@ -314,6 +346,9 @@ fn fixture(path: &str) -> &'static str {
     match path {
         "wpt/css/CSS2/backgrounds/background-color-129.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/backgrounds/background-color-129.json"
+        ),
+        "wpt/css/css-images/linear-gradient-1.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-images/linear-gradient-1.json"
         ),
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
@@ -498,6 +533,12 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
         if let Some(z_order) = fixture_node.z_order {
             operations.push(Operation::SetZOrder { node, z_order });
         }
+        if let Some(gradient) = &fixture_node.linear_gradient {
+            operations.push(Operation::SetBackgroundLayers {
+                node,
+                layers: vec![linear_gradient_layer(gradient)],
+            });
+        }
     }
     for (node_index, fixture_node) in nodes.iter().enumerate() {
         if let Some(parent) = fixture_node.parent {
@@ -535,6 +576,34 @@ fn overflow_clip(value: OverflowClipFixture) -> OverflowClip {
     match value {
         OverflowClipFixture::Visible => OverflowClip::Visible,
         OverflowClipFixture::Hidden => OverflowClip::Hidden,
+    }
+}
+
+fn linear_gradient_layer(gradient: &LinearGradientFixture) -> BackgroundLayer {
+    BackgroundLayer {
+        image: PaintImage::LinearGradient {
+            angle_degrees: gradient.angle_degrees,
+            repeating: gradient.repeating,
+            stops: gradient
+                .stops
+                .iter()
+                .map(|stop| GradientStop {
+                    color: color(&stop.color),
+                    position: Some(PaintCoordinate {
+                        length: 0.0,
+                        fraction: stop.position,
+                    }),
+                })
+                .collect(),
+        },
+        position: PaintPosition::default(),
+        size: BackgroundSize::Auto,
+        repeat_x: ImageRepeat::Repeat,
+        repeat_y: ImageRepeat::Repeat,
+        origin: PaintBox::Padding,
+        clip: PaintBox::Border,
+        attachment: BackgroundAttachment::Scroll,
+        blend_mode: BlendMode::Normal,
     }
 }
 
@@ -735,6 +804,22 @@ fn fixture_color_is_transparent(value: &ColorFixture) -> bool {
         ColorFixture::Named { value } => value == "transparent",
         ColorFixture::Srgba { alpha, .. } => *alpha == 0.0,
     }
+}
+
+fn fixture_linear_gradient_css(gradient: &LinearGradientFixture) -> String {
+    let stops = gradient
+        .stops
+        .iter()
+        .map(|stop| {
+            format!(
+                "{} {}%",
+                fixture_color_css(&stop.color),
+                stop.position * 100.0
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("linear-gradient({}deg, {stops})", gradient.angle_degrees)
 }
 
 fn fixture_border_style_css(value: BorderStyleFixture) -> &'static str {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -105,9 +105,21 @@ impl Driver {
                                 nodes
                                     .iter()
                                     .any(|node| {
-                                        node.background_layer != BackgroundLayerFixture::default()
+                                        node.background_layer.position
+                                            != [LengthPercentageFixture::default(); 2]
                                     })
-                                    .then_some("paint.background-layers.explicit-size-no-repeat")
+                                    .then_some("paint.background-layers.position-length-percentage")
+                                    .or_else(|| {
+                                        nodes
+                                            .iter()
+                                            .any(|node| {
+                                                node.background_layer
+                                                    != BackgroundLayerFixture::default()
+                                            })
+                                            .then_some(
+                                                "paint.background-layers.explicit-size-no-repeat",
+                                            )
+                                    })
                                     .or_else(|| {
                                         nodes.iter().find_map(|node| {
                                             node.linear_gradient
@@ -397,6 +409,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/background-size-009.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/background-size-009.json"
+        ),
+        "wpt/css/css-backgrounds/background-position-three-four-values.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/background-position-three-four-values.json"
         ),
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
@@ -1064,7 +1079,11 @@ fn assert_background_layer_is_projected(
     style: &web_sys::CssStyleDeclaration,
     layer: BackgroundLayerFixture,
 ) {
-    assert_style(style, "background-position", "0px 0px");
+    assert_style(
+        style,
+        "background-position",
+        &fixture_background_position(layer),
+    );
     assert_style(style, "background-size", &fixture_background_size(layer));
     assert_style(style, "background-repeat", fixture_background_repeat(layer));
     assert_style(
@@ -1075,6 +1094,18 @@ fn assert_background_layer_is_projected(
     assert_style(style, "background-clip", fixture_background_box(layer.clip));
     assert_style(style, "background-attachment", "scroll");
     assert_style(style, "background-blend-mode", "normal");
+}
+
+fn fixture_background_position(layer: BackgroundLayerFixture) -> String {
+    if layer.position == [LengthPercentageFixture::default(); 2] {
+        "0px 0px".into()
+    } else {
+        format!(
+            "{} {}",
+            fixture_coordinate(layer.position[0]),
+            fixture_coordinate(layer.position[1])
+        )
+    }
 }
 
 fn fixture_background_size(layer: BackgroundLayerFixture) -> String {
@@ -1119,6 +1150,10 @@ fn fixture_length_percentage(value: LengthPercentageFixture) -> String {
     }
 }
 
+fn fixture_coordinate(value: LengthPercentageFixture) -> String {
+    fixture_length_percentage(value)
+}
+
 fn fixture_node_paints_at(node: &SceneNodeFixture, point: [f32; 2]) -> bool {
     if !fixture_color_is_transparent(&node.background) {
         return true;
@@ -1137,8 +1172,12 @@ fn fixture_node_paints_at(node: &SceneNodeFixture, point: [f32; 2]) -> bool {
         ]
     });
     let position = [
-        node.rect[0] + layer.position[0].length + layer.position[0].fraction * node.rect[2],
-        node.rect[1] + layer.position[1].length + layer.position[1].fraction * node.rect[3],
+        node.rect[0]
+            + layer.position[0].length
+            + layer.position[0].fraction * (node.rect[2] - size[0]),
+        node.rect[1]
+            + layer.position[1].length
+            + layer.position[1].fraction * (node.rect[3] - size[1]),
     ];
     let paints_x = layer.repeat_x != ImageRepeatFixture::NoRepeat
         || (position[0]..position[0] + size[0]).contains(&point[0]);

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -135,46 +135,7 @@ impl Driver {
             &fixture_color_css(&expected.background),
         );
 
-        let (widths, styles, radii) = expected.border.as_ref().map_or(
-            (
-                [0.0; 4],
-                [BorderStyleFixture::None; 4],
-                [CornerRadiusFixture::Circular(0.0); 4],
-            ),
-            |border| (border.widths, border.styles, border.radii),
-        );
-        for (index, side) in ["top", "right", "bottom", "left"].iter().enumerate() {
-            assert_style(
-                &style,
-                &format!("border-{side}-width"),
-                &fixture_px(widths[index]),
-            );
-            assert_style(
-                &style,
-                &format!("border-{side}-color"),
-                &expected.border.as_ref().map_or_else(
-                    || "rgba(0, 0, 0, 1)".to_owned(),
-                    |border| fixture_color_css(&border.colors[index]),
-                ),
-            );
-            assert_style(
-                &style,
-                &format!("border-{side}-style"),
-                fixture_border_style_css(styles[index]),
-            );
-        }
-        for (index, corner) in ["top-left", "top-right", "bottom-right", "bottom-left"]
-            .iter()
-            .enumerate()
-        {
-            let horizontal = fixture_px(radii[index].horizontal());
-            let vertical = fixture_px(radii[index].vertical());
-            assert_style(
-                &style,
-                &format!("border-{corner}-radius"),
-                &format!("{horizontal} {vertical}"),
-            );
-        }
+        assert_border_is_projected(&style, expected.border.as_ref());
     }
 
     fn assert_scene_is_projected(&self, samples: &[PixelSampleFixture]) {
@@ -195,6 +156,7 @@ impl Driver {
                 "background-color",
                 &fixture_color_css(&fixture_node.background),
             );
+            assert_border_is_projected(&style, fixture_node.border.as_ref());
             assert_style(
                 &style,
                 "overflow-x",
@@ -358,6 +320,12 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/border-radius-004.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-004.json"
+        ),
+        "wpt/css/css-backgrounds/border-radius-overflow-hidden.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-overflow-hidden.json"
+        ),
+        "wpt/css/css-backgrounds/border-radius-clipping-with-transform-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-clipping-with-transform-001.json"
         ),
         "wpt/css/css-overflow/clip-002.json" => {
             include_str!("../../../../tests/host-conformance/wpt/css/css-overflow/clip-002.json")
@@ -698,6 +666,52 @@ fn assert_style(style: &web_sys::CssStyleDeclaration, property: &str, expected: 
         actual, expected,
         "production DOM projection for {property} did not match the fixture"
     );
+}
+
+fn assert_border_is_projected(
+    style: &web_sys::CssStyleDeclaration,
+    border: Option<&BorderFixture>,
+) {
+    let (widths, styles, radii) = border.map_or(
+        (
+            [0.0; 4],
+            [BorderStyleFixture::None; 4],
+            [CornerRadiusFixture::Circular(0.0); 4],
+        ),
+        |border| (border.widths, border.styles, border.radii),
+    );
+    for (index, side) in ["top", "right", "bottom", "left"].iter().enumerate() {
+        assert_style(
+            style,
+            &format!("border-{side}-width"),
+            &fixture_px(widths[index]),
+        );
+        assert_style(
+            style,
+            &format!("border-{side}-color"),
+            &border.map_or_else(
+                || "rgba(0, 0, 0, 1)".to_owned(),
+                |border| fixture_color_css(&border.colors[index]),
+            ),
+        );
+        assert_style(
+            style,
+            &format!("border-{side}-style"),
+            fixture_border_style_css(styles[index]),
+        );
+    }
+    for (index, corner) in ["top-left", "top-right", "bottom-right", "bottom-left"]
+        .iter()
+        .enumerate()
+    {
+        let horizontal = fixture_px(radii[index].horizontal());
+        let vertical = fixture_px(radii[index].vertical());
+        assert_style(
+            style,
+            &format!("border-{corner}-radius"),
+            &format!("{horizontal} {vertical}"),
+        );
+    }
 }
 
 fn fixture_px(value: f32) -> String {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -105,10 +105,30 @@ impl Driver {
                                 nodes
                                     .iter()
                                     .any(|node| {
-                                        node.background_layer.position
-                                            != [LengthPercentageFixture::default(); 2]
+                                        node.background_layer.clip
+                                            == BackgroundBoxFixture::Padding
                                     })
-                                    .then_some("paint.background-layers.position-length-percentage")
+                                    .then_some("paint.background-layers.clip-padding-box")
+                                    .or_else(|| {
+                                        nodes
+                                            .iter()
+                                            .any(|node| {
+                                                node.background_layer.origin
+                                                    == BackgroundBoxFixture::Border
+                                            })
+                                            .then_some("paint.background-layers.origin-border-box")
+                                    })
+                                    .or_else(|| {
+                                        nodes
+                                            .iter()
+                                            .any(|node| {
+                                                node.background_layer.position
+                                                    != [LengthPercentageFixture::default(); 2]
+                                            })
+                                            .then_some(
+                                                "paint.background-layers.position-length-percentage",
+                                            )
+                                    })
                                     .or_else(|| {
                                         nodes
                                             .iter()
@@ -412,6 +432,12 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/background-position-three-four-values.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/background-position-three-four-values.json"
+        ),
+        "wpt/css/css-backgrounds/css3-background-origin-border-box.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/css3-background-origin-border-box.json"
+        ),
+        "wpt/css/css-backgrounds/clip-padding-box-with-size.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/clip-padding-box-with-size.json"
         ),
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
@@ -1165,25 +1191,57 @@ fn fixture_node_paints_at(node: &SceneNodeFixture, point: [f32; 2]) -> bool {
         return false;
     }
     let layer = node.background_layer;
-    let size = layer.size.map_or([node.rect[2], node.rect[3]], |size| {
-        [
-            size[0].length + size[0].fraction * node.rect[2],
-            size[1].length + size[1].fraction * node.rect[3],
-        ]
-    });
+    let border_widths = node
+        .border
+        .as_ref()
+        .map_or([0.0; 4], |border| border.widths);
+    let positioning_area = fixture_background_area(node.rect, border_widths, layer.origin);
+    let clip_area = fixture_background_area(node.rect, border_widths, layer.clip);
+    if !fixture_rect_contains(clip_area, point) {
+        return false;
+    }
+    let size = layer
+        .size
+        .map_or([positioning_area[2], positioning_area[3]], |size| {
+            [
+                size[0].length + size[0].fraction * positioning_area[2],
+                size[1].length + size[1].fraction * positioning_area[3],
+            ]
+        });
     let position = [
-        node.rect[0]
+        positioning_area[0]
             + layer.position[0].length
-            + layer.position[0].fraction * (node.rect[2] - size[0]),
-        node.rect[1]
+            + layer.position[0].fraction * (positioning_area[2] - size[0]),
+        positioning_area[1]
             + layer.position[1].length
-            + layer.position[1].fraction * (node.rect[3] - size[1]),
+            + layer.position[1].fraction * (positioning_area[3] - size[1]),
     ];
     let paints_x = layer.repeat_x != ImageRepeatFixture::NoRepeat
         || (position[0]..position[0] + size[0]).contains(&point[0]);
     let paints_y = layer.repeat_y != ImageRepeatFixture::NoRepeat
         || (position[1]..position[1] + size[1]).contains(&point[1]);
     paints_x && paints_y
+}
+
+fn fixture_background_area(
+    border_box: [f32; 4],
+    border_widths: [f32; 4],
+    background_box: BackgroundBoxFixture,
+) -> [f32; 4] {
+    match background_box {
+        BackgroundBoxFixture::Border => border_box,
+        BackgroundBoxFixture::Padding | BackgroundBoxFixture::Content => [
+            border_box[0] + border_widths[3],
+            border_box[1] + border_widths[0],
+            border_box[2] - border_widths[1] - border_widths[3],
+            border_box[3] - border_widths[0] - border_widths[2],
+        ],
+    }
+}
+
+fn fixture_rect_contains(rect: [f32; 4], point: [f32; 2]) -> bool {
+    (rect[0]..rect[0] + rect[2]).contains(&point[0])
+        && (rect[1]..rect[1] + rect[3]).contains(&point[1])
 }
 
 fn fixture_border_style_css(value: BorderStyleFixture) -> &'static str {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -4,15 +4,16 @@ use whisker::ElementRegistry;
 use whisker_engine::FrameSink;
 use whisker_host_conformance::{
     BorderFixture, BorderStyleFixture, ColorFixture, Command, CornerRadiusFixture,
-    LinearGradientFixture, Manifest, OverflowClipFixture, PixelSampleFixture, SCHEMA_VERSION,
-    Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture,
+    LinearGradientFixture, Manifest, OverflowClipFixture, PixelSampleFixture,
+    RadialGradientFixture, SCHEMA_VERSION, Scenario, ScenarioSide, SceneNodeFixture,
+    VisibilityFixture,
 };
 use whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
     BoxPaint, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat, LayoutGeometry,
     LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate,
     PaintCornerRadius, PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition,
-    ProtocolVersion, SurfaceId, Transform, Visibility,
+    ProtocolVersion, RadialGradientExtent, RadialGradientShape, SurfaceId, Transform, Visibility,
 };
 
 use crate::module_api::built_in_element_factories;
@@ -96,17 +97,23 @@ impl Driver {
                 }
                 Command::Checkpoint { name, samples, .. } => {
                     if self.expected_scene.is_some() {
-                        let has_gradient = self.expected_scene.as_ref().is_some_and(|nodes| {
-                            nodes.iter().any(|node| node.linear_gradient.is_some())
-                        });
-                        assert_eq!(
-                            name,
-                            if has_gradient {
-                                "paint.background-layers.linear-gradient"
-                            } else {
-                                "paint.box"
-                            }
-                        );
+                        let expected_checkpoint = self
+                            .expected_scene
+                            .as_ref()
+                            .and_then(|nodes| {
+                                nodes.iter().find_map(|node| {
+                                    node.linear_gradient
+                                        .as_ref()
+                                        .map(|_| "paint.background-layers.linear-gradient")
+                                        .or_else(|| {
+                                            node.radial_gradient
+                                                .as_ref()
+                                                .map(|_| "paint.background-layers.radial-gradient")
+                                        })
+                                })
+                            })
+                            .unwrap_or("paint.box");
+                        assert_eq!(name, expected_checkpoint);
                         self.assert_scene_is_projected(samples);
                     } else {
                         assert_eq!(name, "paint.box");
@@ -208,13 +215,14 @@ impl Driver {
                     "background-image",
                     &fixture_linear_gradient_css(gradient),
                 );
-                assert_style(&style, "background-position", "0px 0px");
-                assert_style(&style, "background-size", "auto");
-                assert_style(&style, "background-repeat", "repeat");
-                assert_style(&style, "background-origin", "padding-box");
-                assert_style(&style, "background-clip", "border-box");
-                assert_style(&style, "background-attachment", "scroll");
-                assert_style(&style, "background-blend-mode", "normal");
+                assert_initial_background_layer_is_projected(&style);
+            } else if let Some(gradient) = &fixture_node.radial_gradient {
+                assert_style(
+                    &style,
+                    "background-image",
+                    &fixture_radial_gradient_css(gradient),
+                );
+                assert_initial_background_layer_is_projected(&style);
             } else {
                 assert_eq!(style.get_property_value("background-image").unwrap(), "");
             }
@@ -258,6 +266,7 @@ impl Driver {
                 expected.iter().any(|node| {
                     node.id.to_string() == id.as_str()
                         && (node.linear_gradient.is_some()
+                            || node.radial_gradient.is_some()
                             || !fixture_color_is_transparent(&node.background))
                 })
             });
@@ -271,7 +280,11 @@ impl Driver {
                         .iter()
                         .rev()
                         .find(|node| node.opacity.is_some())
-                        .or_else(|| expected.iter().find(|node| node.linear_gradient.is_some()))
+                        .or_else(|| {
+                            expected.iter().find(|node| {
+                                node.linear_gradient.is_some() || node.radial_gradient.is_some()
+                            })
+                        })
                         .expect("sRGBA sample requires an opacity or gradient source node")
                         .id
                         .to_string();
@@ -285,7 +298,11 @@ impl Driver {
                     let expected_node = expected
                         .iter()
                         .find(|node| node.background == *expected_color)
-                        .or_else(|| expected.iter().find(|node| node.linear_gradient.is_some()))
+                        .or_else(|| {
+                            expected.iter().find(|node| {
+                                node.linear_gradient.is_some() || node.radial_gradient.is_some()
+                            })
+                        })
                         .unwrap_or_else(|| {
                             panic!("sample color {expected_color:?} has no matching scene node")
                         })
@@ -349,6 +366,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-images/linear-gradient-1.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-images/linear-gradient-1.json"
+        ),
+        "wpt/css/css-images/radial-gradient-container-relative-units-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-images/radial-gradient-container-relative-units-001.json"
         ),
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
@@ -538,6 +558,11 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
                 node,
                 layers: vec![linear_gradient_layer(gradient)],
             });
+        } else if let Some(gradient) = &fixture_node.radial_gradient {
+            operations.push(Operation::SetBackgroundLayers {
+                node,
+                layers: vec![radial_gradient_layer(gradient)],
+            });
         }
     }
     for (node_index, fixture_node) in nodes.iter().enumerate() {
@@ -584,6 +609,55 @@ fn linear_gradient_layer(gradient: &LinearGradientFixture) -> BackgroundLayer {
         image: PaintImage::LinearGradient {
             angle_degrees: gradient.angle_degrees,
             repeating: gradient.repeating,
+            stops: gradient
+                .stops
+                .iter()
+                .map(|stop| GradientStop {
+                    color: color(&stop.color),
+                    position: Some(PaintCoordinate {
+                        length: 0.0,
+                        fraction: stop.position,
+                    }),
+                })
+                .collect(),
+        },
+        position: PaintPosition::default(),
+        size: BackgroundSize::Auto,
+        repeat_x: ImageRepeat::Repeat,
+        repeat_y: ImageRepeat::Repeat,
+        origin: PaintBox::Padding,
+        clip: PaintBox::Border,
+        attachment: BackgroundAttachment::Scroll,
+        blend_mode: BlendMode::Normal,
+    }
+}
+
+fn radial_gradient_layer(gradient: &RadialGradientFixture) -> BackgroundLayer {
+    BackgroundLayer {
+        image: PaintImage::RadialGradient {
+            shape: RadialGradientShape::Ellipse,
+            extent: RadialGradientExtent::Explicit,
+            center: PaintPosition {
+                x: PaintCoordinate {
+                    length: gradient.center[0],
+                    fraction: 0.0,
+                },
+                y: PaintCoordinate {
+                    length: gradient.center[1],
+                    fraction: 0.0,
+                },
+            },
+            radii: Some((
+                PaintLengthPercentage {
+                    length: gradient.radii[0],
+                    fraction: 0.0,
+                },
+                PaintLengthPercentage {
+                    length: gradient.radii[1],
+                    fraction: 0.0,
+                },
+            )),
+            repeating: false,
             stops: gradient
                 .stops
                 .iter()
@@ -820,6 +894,35 @@ fn fixture_linear_gradient_css(gradient: &LinearGradientFixture) -> String {
         .collect::<Vec<_>>()
         .join(", ");
     format!("linear-gradient({}deg, {stops})", gradient.angle_degrees)
+}
+
+fn fixture_radial_gradient_css(gradient: &RadialGradientFixture) -> String {
+    let stops = gradient
+        .stops
+        .iter()
+        .map(|stop| {
+            format!(
+                "{} {}%",
+                fixture_color_css(&stop.color),
+                stop.position * 100.0
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "radial-gradient(ellipse {}px {}px at {}px {}px, {stops})",
+        gradient.radii[0], gradient.radii[1], gradient.center[0], gradient.center[1]
+    )
+}
+
+fn assert_initial_background_layer_is_projected(style: &web_sys::CssStyleDeclaration) {
+    assert_style(style, "background-position", "0px 0px");
+    assert_style(style, "background-size", "auto");
+    assert_style(style, "background-repeat", "repeat");
+    assert_style(style, "background-origin", "padding-box");
+    assert_style(style, "background-clip", "border-box");
+    assert_style(style, "background-attachment", "scroll");
+    assert_style(style, "background-blend-mode", "normal");
 }
 
 fn fixture_border_style_css(value: BorderStyleFixture) -> &'static str {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -3,8 +3,8 @@ use wasm_bindgen_test::wasm_bindgen_test;
 use whisker::ElementRegistry;
 use whisker_engine::FrameSink;
 use whisker_host_conformance::{
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, Manifest, SCHEMA_VERSION, Scenario,
-    ScenarioSide,
+    BorderFixture, BorderStyleFixture, ColorFixture, Command, CornerRadiusFixture, Manifest,
+    SCHEMA_VERSION, Scenario, ScenarioSide,
 };
 use whisker_protocol::{
     BorderLineStyle, BoxPaint, FrameHeader, FrameMode, FramePacket, LayoutGeometry, LayoutRect,
@@ -123,7 +123,11 @@ impl Driver {
         );
 
         let (widths, styles, radii) = expected.border.as_ref().map_or(
-            ([0.0; 4], [BorderStyleFixture::None; 4], [0.0; 4]),
+            (
+                [0.0; 4],
+                [BorderStyleFixture::None; 4],
+                [CornerRadiusFixture::Circular(0.0); 4],
+            ),
             |border| (border.widths, border.styles, border.radii),
         );
         for (index, side) in ["top", "right", "bottom", "left"].iter().enumerate() {
@@ -150,11 +154,12 @@ impl Driver {
             .iter()
             .enumerate()
         {
-            let radius = fixture_px(radii[index]);
+            let horizontal = fixture_px(radii[index].horizontal());
+            let vertical = fixture_px(radii[index].vertical());
             assert_style(
                 &style,
                 &format!("border-{corner}-radius"),
-                &format!("{radius} {radius}"),
+                &format!("{horizontal} {vertical}"),
             );
         }
     }
@@ -200,6 +205,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
+        ),
+        "wpt/css/css-backgrounds/border-radius-004.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-004.json"
         ),
         "wpt/css/CSS2/borders/border-top-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json"
@@ -310,11 +318,15 @@ fn box_paint(
         length,
         fraction: 0.0,
     });
-    let radii = border.radii.map(|length| {
-        PaintCornerRadius::circular(PaintLengthPercentage {
-            length,
+    let radii = border.radii.map(|radius| PaintCornerRadius {
+        horizontal: PaintLengthPercentage {
+            length: radius.horizontal(),
             fraction: 0.0,
-        })
+        },
+        vertical: PaintLengthPercentage {
+            length: radius.vertical(),
+            fraction: 0.0,
+        },
     });
     BoxPaint {
         background_color: color(background),

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -10,7 +10,7 @@ use whisker_host_conformance::{
 use whisker_protocol::{
     BorderLineStyle, BoxClip, BoxPaint, FrameHeader, FrameMode, FramePacket, LayoutGeometry,
     LayoutRect, NodeId, Operation, OverflowClip, PaintColor, PaintCornerRadius, PaintCorners,
-    PaintEdges, PaintLengthPercentage, ProtocolVersion, SurfaceId,
+    PaintEdges, PaintLengthPercentage, ProtocolVersion, SurfaceId, Transform,
 };
 
 use crate::module_api::built_in_element_factories;
@@ -205,6 +205,13 @@ impl Driver {
                 "overflow-y",
                 fixture_overflow_css(fixture_node.clip.vertical),
             );
+            if let Some(transform) = fixture_node.transform {
+                assert_style(&style, "transform-origin", "0 0");
+                assert_style(&style, "transform", &fixture_transform_css(transform));
+            } else {
+                assert_eq!(style.get_property_value("transform").unwrap(), "");
+                assert_eq!(style.get_property_value("transform-origin").unwrap(), "");
+            }
 
             let actual_parent = node.parent_element().unwrap();
             match fixture_node.parent {
@@ -236,17 +243,29 @@ impl Driver {
                 .expect("fixture sample lies inside the browser viewport");
             let hit_node = hit.get_attribute("data-whisker-node");
             match &sample.color {
-                ColorFixture::Named { value } if value == "red" => assert_eq!(
-                    hit_node.as_deref(),
-                    Some("2"),
-                    "visible overflow sample did not hit the child DOM node"
+                ColorFixture::Named { value } if value == "transparent" => assert!(
+                    hit_node.as_deref().is_none_or(|id| {
+                        expected.iter().any(|node| {
+                            node.id.to_string() == id && node.background == sample.color
+                        })
+                    }),
+                    "transparent sample unexpectedly hit an opaque scene node {hit_node:?}"
                 ),
-                ColorFixture::Named { value } if value == "transparent" => assert_ne!(
-                    hit_node.as_deref(),
-                    Some("2"),
-                    "clipped overflow sample unexpectedly hit the child DOM node"
-                ),
-                _ => {}
+                expected_color => {
+                    let expected_node = expected
+                        .iter()
+                        .find(|node| node.background == *expected_color)
+                        .unwrap_or_else(|| {
+                            panic!("sample color {expected_color:?} has no matching scene node")
+                        })
+                        .id
+                        .to_string();
+                    assert_eq!(
+                        hit_node.as_deref(),
+                        Some(expected_node.as_str()),
+                        "paint sample did not hit the expected transformed scene node"
+                    );
+                }
             }
         }
     }
@@ -308,6 +327,15 @@ fn fixture(path: &str) -> &'static str {
         }
         "wpt/css/css-overflow/clip-002-vertical.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-overflow/clip-002-vertical.json"
+        ),
+        "wpt/css/css-transforms/transform-matrix-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-transforms/transform-matrix-001.json"
+        ),
+        "core/transform-local-origin.json" => {
+            include_str!("../../../../tests/host-conformance/core/transform-local-origin.json")
+        }
+        "core/transform-parent-composition.json" => include_str!(
+            "../../../../tests/host-conformance/core/transform-parent-composition.json"
         ),
         "wpt/css/CSS2/borders/border-top-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json"
@@ -438,6 +466,12 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
                 },
             },
         ]);
+        if let Some(transform) = fixture_node.transform {
+            operations.push(Operation::SetTransform {
+                node,
+                transform: Transform(transform),
+            });
+        }
     }
     for (node_index, fixture_node) in nodes.iter().enumerate() {
         if let Some(parent) = fixture_node.parent {
@@ -644,4 +678,13 @@ fn fixture_overflow_css(value: OverflowClipFixture) -> &'static str {
         OverflowClipFixture::Visible => "visible",
         OverflowClipFixture::Hidden => "clip",
     }
+}
+
+fn fixture_transform_css(transform: [f32; 16]) -> String {
+    let values = transform
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("matrix3d({values})")
 }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -104,11 +104,33 @@ impl Driver {
                             .and_then(|nodes| {
                                 nodes
                                     .iter()
-                                    .any(|node| {
-                                        node.background_layer.clip
-                                            == BackgroundBoxFixture::Padding
+                                    .find_map(|node| {
+                                        match (
+                                            node.background_layer.repeat_x,
+                                            node.background_layer.repeat_y,
+                                        ) {
+                                            (
+                                                ImageRepeatFixture::Repeat,
+                                                ImageRepeatFixture::NoRepeat,
+                                            ) => Some("paint.background-layers.repeat-x"),
+                                            (
+                                                ImageRepeatFixture::NoRepeat,
+                                                ImageRepeatFixture::Repeat,
+                                            ) => Some("paint.background-layers.repeat-y"),
+                                            _ => None,
+                                        }
                                     })
-                                    .then_some("paint.background-layers.clip-padding-box")
+                                    .or_else(|| {
+                                        nodes
+                                            .iter()
+                                            .any(|node| {
+                                                node.background_layer.clip
+                                                    == BackgroundBoxFixture::Padding
+                                            })
+                                            .then_some(
+                                                "paint.background-layers.clip-padding-box",
+                                            )
+                                    })
                                     .or_else(|| {
                                         nodes
                                             .iter()
@@ -439,6 +461,16 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-backgrounds/clip-padding-box-with-size.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/clip-padding-box-with-size.json"
         ),
+        "wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-x.json" => {
+            include_str!(
+                "../../../../tests/host-conformance/wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-x.json"
+            )
+        }
+        "wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-y.json" => {
+            include_str!(
+                "../../../../tests/host-conformance/wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-y.json"
+            )
+        }
         "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json"
         ),

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -4,12 +4,13 @@ use whisker::ElementRegistry;
 use whisker_engine::FrameSink;
 use whisker_host_conformance::{
     BorderFixture, BorderStyleFixture, ColorFixture, Command, CornerRadiusFixture, Manifest,
-    SCHEMA_VERSION, Scenario, ScenarioSide,
+    OverflowClipFixture, PixelSampleFixture, SCHEMA_VERSION, Scenario, ScenarioSide,
+    SceneNodeFixture,
 };
 use whisker_protocol::{
-    BorderLineStyle, BoxPaint, FrameHeader, FrameMode, FramePacket, LayoutGeometry, LayoutRect,
-    NodeId, Operation, PaintColor, PaintCornerRadius, PaintCorners, PaintEdges,
-    PaintLengthPercentage, ProtocolVersion, SurfaceId,
+    BorderLineStyle, BoxClip, BoxPaint, FrameHeader, FrameMode, FramePacket, LayoutGeometry,
+    LayoutRect, NodeId, Operation, OverflowClip, PaintColor, PaintCornerRadius, PaintCorners,
+    PaintEdges, PaintLengthPercentage, ProtocolVersion, SurfaceId,
 };
 
 use crate::module_api::built_in_element_factories;
@@ -23,6 +24,7 @@ struct Driver {
     root: web_sys::Element,
     sink: DomFrameSink,
     expected_box: Option<ExpectedBox>,
+    expected_scene: Option<Vec<SceneNodeFixture>>,
 }
 
 #[derive(Clone, Debug)]
@@ -53,6 +55,7 @@ impl Driver {
             root,
             sink,
             expected_box: None,
+            expected_scene: None,
         }
     }
 
@@ -82,10 +85,20 @@ impl Driver {
                         background: background.clone(),
                         border: border.clone(),
                     });
+                    self.expected_scene = None;
                 }
-                Command::Checkpoint { name, .. } => {
+                Command::PresentScene { revision, nodes } => {
+                    self.sink.present(&scene_packet(*revision, nodes)).unwrap();
+                    self.expected_scene = Some(nodes.clone());
+                    self.expected_box = None;
+                }
+                Command::Checkpoint { name, samples, .. } => {
                     assert_eq!(name, "paint.box");
-                    self.assert_box_is_projected();
+                    if self.expected_scene.is_some() {
+                        self.assert_scene_is_projected(samples);
+                    } else {
+                        self.assert_box_is_projected();
+                    }
                 }
                 Command::MeasureText { .. }
                 | Command::CheckpointMeasurement { .. }
@@ -163,6 +176,87 @@ impl Driver {
             );
         }
     }
+
+    fn assert_scene_is_projected(&self, samples: &[PixelSampleFixture]) {
+        let expected = self
+            .expected_scene
+            .as_ref()
+            .expect("paint checkpoint must follow present_scene");
+        for fixture_node in expected {
+            let node = self.node(fixture_node.id);
+            let html = node.dyn_ref::<web_sys::HtmlElement>().unwrap();
+            let style = html.style();
+            assert_style(&style, "left", &fixture_px(fixture_node.rect[0]));
+            assert_style(&style, "top", &fixture_px(fixture_node.rect[1]));
+            assert_style(&style, "width", &fixture_px(fixture_node.rect[2]));
+            assert_style(&style, "height", &fixture_px(fixture_node.rect[3]));
+            assert_style(
+                &style,
+                "background-color",
+                &fixture_color_css(&fixture_node.background),
+            );
+            assert_style(
+                &style,
+                "overflow-x",
+                fixture_overflow_css(fixture_node.clip.horizontal),
+            );
+            assert_style(
+                &style,
+                "overflow-y",
+                fixture_overflow_css(fixture_node.clip.vertical),
+            );
+
+            let actual_parent = node.parent_element().unwrap();
+            match fixture_node.parent {
+                Some(parent) => {
+                    let parent = parent.to_string();
+                    assert_eq!(
+                        actual_parent.get_attribute("data-whisker-node").as_deref(),
+                        Some(parent.as_str()),
+                        "fixture node {} was attached to the wrong DOM parent",
+                        fixture_node.id
+                    );
+                }
+                None => assert!(
+                    actual_parent.has_attribute("data-whisker-conformance-root"),
+                    "fixture root node {} was not attached to the Host surface",
+                    fixture_node.id
+                ),
+            }
+        }
+
+        let document = web_sys::window().unwrap().document().unwrap();
+        let bounds = self.root.get_bounding_client_rect();
+        for sample in samples {
+            let hit = document
+                .element_from_point(
+                    (bounds.left() + f64::from(sample.point[0])) as f32,
+                    (bounds.top() + f64::from(sample.point[1])) as f32,
+                )
+                .expect("fixture sample lies inside the browser viewport");
+            let hit_node = hit.get_attribute("data-whisker-node");
+            match &sample.color {
+                ColorFixture::Named { value } if value == "red" => assert_eq!(
+                    hit_node.as_deref(),
+                    Some("2"),
+                    "visible overflow sample did not hit the child DOM node"
+                ),
+                ColorFixture::Named { value } if value == "transparent" => assert_ne!(
+                    hit_node.as_deref(),
+                    Some("2"),
+                    "clipped overflow sample unexpectedly hit the child DOM node"
+                ),
+                _ => {}
+            }
+        }
+    }
+
+    fn node(&self, id: u64) -> web_sys::Element {
+        self.root
+            .query_selector(&format!("[data-whisker-node='{id}']"))
+            .unwrap()
+            .unwrap_or_else(|| panic!("fixture DOM node {id}"))
+    }
 }
 
 impl Drop for Driver {
@@ -181,12 +275,12 @@ fn every_shared_paint_fixture_reaches_the_production_dom_sink() {
         let scenario: Scenario = serde_json::from_str(json).unwrap();
         assert_eq!(scenario.schema, SCHEMA_VERSION);
         assert_eq!(scenario.id, entry.id);
-        if !scenario
-            .test
-            .commands
-            .iter()
-            .any(|command| matches!(command, Command::PresentBox { .. }))
-        {
+        if !scenario.test.commands.iter().any(|command| {
+            matches!(
+                command,
+                Command::PresentBox { .. } | Command::PresentScene { .. }
+            )
+        }) {
             continue;
         }
         Driver::new().execute(&scenario.test);
@@ -208,6 +302,12 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/border-radius-004.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-004.json"
+        ),
+        "wpt/css/css-overflow/clip-002.json" => {
+            include_str!("../../../../tests/host-conformance/wpt/css/css-overflow/clip-002.json")
+        }
+        "wpt/css/css-overflow/clip-002-vertical.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-overflow/clip-002-vertical.json"
         ),
         "wpt/css/CSS2/borders/border-top-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json"
@@ -297,6 +397,84 @@ fn packet(
                 paint: box_paint(background, border),
             },
         ],
+    }
+}
+
+fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
+    let surface = SurfaceId::new(1).unwrap();
+    let view = ElementRegistry::standard()
+        .registration_for_builtin(whisker::ElementTag::View)
+        .unwrap()
+        .element_type;
+    let mut operations = Vec::with_capacity(nodes.len() * 5);
+    for fixture_node in nodes {
+        let node = fixture_node_id(fixture_node.id);
+        operations.extend([
+            Operation::CreateNode {
+                node,
+                element_type: view,
+            },
+            Operation::SetLayout {
+                node,
+                geometry: LayoutGeometry {
+                    border_box: LayoutRect {
+                        x: fixture_node.rect[0],
+                        y: fixture_node.rect[1],
+                        width: fixture_node.rect[2],
+                        height: fixture_node.rect[3],
+                    },
+                    content_box: LayoutRect::default(),
+                },
+            },
+            Operation::SetBoxPaint {
+                node,
+                paint: box_paint(&fixture_node.background, fixture_node.border.as_ref()),
+            },
+            Operation::SetClip {
+                node,
+                clip: BoxClip {
+                    horizontal: overflow_clip(fixture_node.clip.horizontal),
+                    vertical: overflow_clip(fixture_node.clip.vertical),
+                },
+            },
+        ]);
+    }
+    for (node_index, fixture_node) in nodes.iter().enumerate() {
+        if let Some(parent) = fixture_node.parent {
+            let index = nodes[..node_index]
+                .iter()
+                .filter(|candidate| candidate.parent == Some(parent))
+                .count() as u32;
+            operations.push(Operation::InsertChild {
+                parent: fixture_node_id(parent),
+                child: fixture_node_id(fixture_node.id),
+                index,
+            });
+        }
+    }
+    FramePacket {
+        header: FrameHeader {
+            version: ProtocolVersion::CURRENT,
+            surface,
+            scene_epoch: 1,
+            frame_id: revision,
+            base_revision: 0,
+            target_revision: revision,
+            viewport_epoch: 1,
+            mode: FrameMode::Snapshot,
+        },
+        operations,
+    }
+}
+
+fn fixture_node_id(id: u64) -> NodeId {
+    NodeId::new(id).expect("fixture node ids are validated as non-zero")
+}
+
+fn overflow_clip(value: OverflowClipFixture) -> OverflowClip {
+    match value {
+        OverflowClipFixture::Visible => OverflowClip::Visible,
+        OverflowClipFixture::Hidden => OverflowClip::Hidden,
     }
 }
 
@@ -458,5 +636,12 @@ fn fixture_border_style_css(value: BorderStyleFixture) -> &'static str {
         BorderStyleFixture::Ridge => "ridge",
         BorderStyleFixture::Inset => "inset",
         BorderStyleFixture::Outset => "outset",
+    }
+}
+
+fn fixture_overflow_css(value: OverflowClipFixture) -> &'static str {
+    match value {
+        OverflowClipFixture::Visible => "visible",
+        OverflowClipFixture::Hidden => "clip",
     }
 }

--- a/tests/host-conformance/README.md
+++ b/tests/host-conformance/README.md
@@ -42,6 +42,11 @@ Android, and iOS assert those samples against production raster output. Web
 asserts the equivalent CSS projection and leaves dash/dot distribution to the
 browser, while sharing the same scenario and semantic values.
 
+The same checkpoint may use relative luminance `relations` when CSS requires
+a lighter or darker rendering but deliberately leaves the exact derived color
+to the user agent. Native rasterizers compare the requested pixels while Web
+continues to verify the corresponding semantic CSS value.
+
 From the repository root, run one Host with:
 
 ```sh

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -27,7 +27,7 @@
       "id": "paint.background-layers",
       "properties": ["background", "background-attachment", "background-clip", "background-image", "background-origin", "background-position", "background-position-x", "background-position-y", "background-repeat", "background-size"],
       "protocol": ["SetBackgroundLayers"],
-      "hosts": {"desktop": "protocol-only", "web": "protocol-only", "android": "protocol-only", "ios": "protocol-only"}
+      "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}
     },
     {
       "id": "paint.visual-effects",

--- a/tests/host-conformance/core/transform-local-origin.json
+++ b/tests/host-conformance/core/transform-local-origin.json
@@ -1,0 +1,38 @@
+{
+  "schema": 1,
+  "id": "core.transform-local-origin",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 60.0, "height": 50.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 10.0, 10.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip": { "horizontal": "visible", "vertical": "visible" },
+            "transform": [
+              2.0, 0.0, 0.0, 0.0,
+              0.0, 2.0, 0.0, 0.0,
+              0.0, 0.0, 1.0, 0.0,
+              0.0, 0.0, 0.0, 1.0
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [7.0, 15.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [27.0, 15.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [32.0, 15.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/core/transform-parent-composition.json
+++ b/tests/host-conformance/core/transform-parent-composition.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "core.transform-parent-composition",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 80.0, "height": 50.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 20.0, 20.0],
+            "background": { "kind": "named", "value": "transparent" },
+            "clip": { "horizontal": "visible", "vertical": "visible" },
+            "transform": [
+              1.0, 0.0, 0.0, 0.0,
+              0.0, 1.0, 0.0, 0.0,
+              0.0, 0.0, 1.0, 0.0,
+              20.0, 0.0, 0.0, 1.0
+            ]
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [5.0, 5.0, 10.0, 10.0],
+            "background": { "kind": "named", "value": "red" },
+            "clip": { "horizontal": "visible", "vertical": "visible" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [16.0, 16.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [36.0, 16.0], "color": { "kind": "named", "value": "red" }, "tolerance": 16 },
+          { "point": [47.0, 16.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -38,6 +38,27 @@
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-transforms.transform-matrix-001",
+      "feature": "transform",
+      "fixture": "wpt/css/css-transforms/transform-matrix-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "core.transform-local-origin",
+      "feature": "transform",
+      "fixture": "core/transform-local-origin.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "core.transform-parent-composition",
+      "feature": "transform",
+      "fixture": "core/transform-parent-composition.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-top-003",
       "feature": "border-top",
       "fixture": "wpt/css/CSS2/borders/border-top-003.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -10,6 +10,13 @@
       "checkpoints": ["semantic-projection", "pixel"]
     },
     {
+      "id": "wpt.css-images.linear-gradient-1",
+      "feature": "background-image-linear-gradient",
+      "fixture": "wpt/css/css-images/linear-gradient-1.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.border-radius-sum-of-radii-001.test1",
       "feature": "border-radius",
       "fixture": "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -24,6 +24,20 @@
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-overflow.clip-002.horizontal",
+      "feature": "overflow-x",
+      "fixture": "wpt/css/css-overflow/clip-002.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-overflow.clip-002.vertical",
+      "feature": "overflow-y",
+      "fixture": "wpt/css/css-overflow/clip-002-vertical.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-top-003",
       "feature": "border-top",
       "fixture": "wpt/css/CSS2/borders/border-top-003.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -45,6 +45,20 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.css3-background-origin-border-box",
+      "feature": "background-origin-border-box",
+      "fixture": "wpt/css/css-backgrounds/css3-background-origin-border-box.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-backgrounds.clip-padding-box-with-size",
+      "feature": "background-clip-padding-box",
+      "fixture": "wpt/css/css-backgrounds/clip-padding-box-with-size.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.border-radius-sum-of-radii-001.test1",
       "feature": "border-radius",
       "fixture": "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -31,6 +31,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.background-size-009",
+      "feature": "background-size-no-repeat",
+      "fixture": "wpt/css/css-backgrounds/background-size-009.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.border-radius-sum-of-radii-001.test1",
       "feature": "border-radius",
       "fixture": "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -24,6 +24,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-images.conic-gradient-angle",
+      "feature": "background-image-conic-gradient",
+      "fixture": "wpt/css/css-images/conic-gradient-angle.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.border-radius-sum-of-radii-001.test1",
       "feature": "border-radius",
       "fixture": "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -17,6 +17,13 @@
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel"]
     },
     {
+      "id": "wpt.css-backgrounds.border-radius-004",
+      "feature": "border-radius",
+      "fixture": "wpt/css/css-backgrounds/border-radius-004.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-top-003",
       "feature": "border-top",
       "fixture": "wpt/css/CSS2/borders/border-top-003.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -59,6 +59,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css2.borders.border-top-style-006",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-006.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "host.measure.text.basic",
       "feature": "text-measurement",
       "fixture": "core/text-measure-basic.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -80,6 +80,20 @@
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.border-radius-overflow-hidden",
+      "feature": "border-radius-overflow-clip",
+      "fixture": "wpt/css/css-backgrounds/border-radius-overflow-hidden.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-backgrounds.border-radius-clipping-with-transform-001",
+      "feature": "border-radius-overflow-transform",
+      "fixture": "wpt/css/css-backgrounds/border-radius-clipping-with-transform-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-top-003",
       "feature": "border-top",
       "fixture": "wpt/css/CSS2/borders/border-top-003.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -17,6 +17,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-images.radial-gradient-container-relative-units-001",
+      "feature": "background-image-radial-gradient",
+      "fixture": "wpt/css/css-images/radial-gradient-container-relative-units-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.border-radius-sum-of-radii-001.test1",
       "feature": "border-radius",
       "fixture": "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -59,6 +59,27 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-color.opacity-basic-0.6",
+      "feature": "opacity",
+      "fixture": "wpt/css/css-color/t32-opacity-basic-0.6-a.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css2.visibility-004",
+      "feature": "visibility",
+      "fixture": "wpt/css/CSS2/visufx/visibility-004.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css2.z-index-003",
+      "feature": "z-index",
+      "fixture": "wpt/css/CSS2/zindex/z-index-003.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-top-003",
       "feature": "border-top",
       "fixture": "wpt/css/CSS2/borders/border-top-003.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -66,6 +66,34 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css2.borders.border-top-style-007",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-007.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
+      "id": "wpt.css2.borders.border-top-style-008",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-008.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
+      "id": "wpt.css2.borders.border-top-style-009",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-009.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
+      "id": "wpt.css2.borders.border-top-style-010",
+      "feature": "border-top-style",
+      "fixture": "wpt/css/CSS2/borders/border-top-style-010.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
       "id": "host.measure.text.basic",
       "feature": "text-measurement",
       "fixture": "core/text-measure-basic.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -38,6 +38,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.background-position-three-four-values.test1",
+      "feature": "background-position",
+      "fixture": "wpt/css/css-backgrounds/background-position-three-four-values.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.border-radius-sum-of-radii-001.test1",
       "feature": "border-radius",
       "fixture": "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -59,6 +59,20 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.background-repeat.repeat-x",
+      "feature": "background-repeat-x",
+      "fixture": "wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-x.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-backgrounds.background-repeat.repeat-y",
+      "feature": "background-repeat-y",
+      "fixture": "wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-y.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.border-radius-sum-of-radii-001.test1",
       "feature": "border-radius",
       "fixture": "wpt/css/css-backgrounds/border-radius-sum-of-radii-001.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -135,7 +135,10 @@ private class Driver(
                 "present_box" -> present(command)
                 "present_scene" -> presentScene(command)
                 "checkpoint" -> {
-                    check(command.getString("name") == "paint.box")
+                    check(
+                        command.getString("name") == "paint.box" ||
+                            command.getString("name") == "paint.background-layers.linear-gradient",
+                    )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
                         assertPixelSamples(
@@ -240,6 +243,19 @@ private class Driver(
             if (node.has("z_order")) {
                 check(stage(tag = 12, node = id, integer = node.getInt("z_order")))
             }
+            node.optJSONObject("linear_gradient")?.let { gradient ->
+                val (numbers, names) = linearGradient(gradient)
+                check(
+                    stage(
+                        tag = 21,
+                        flags = if (gradient.optBoolean("repeating", false)) 1 else 0,
+                        node = id,
+                        scalar = gradient.getDouble("angle_degrees").toFloat(),
+                        numbers = numbers,
+                        names = names,
+                    ),
+                )
+            }
         }
         check(view.commitFrameFromNative())
     }
@@ -330,6 +346,17 @@ private class Driver(
         }
     }
 
+    private fun linearGradient(gradient: JSONObject): Pair<FloatArray, Array<String>> {
+        val numbers = ArrayList<Float>()
+        val names = ArrayList<String>()
+        gradient.getJSONArray("stops").objects().forEach { stop ->
+            appendColor(stop.getJSONObject("color"), numbers, names)
+            numbers += 0f
+            numbers += stop.getDouble("position").toFloat()
+        }
+        return numbers.toFloatArray() to names.toTypedArray()
+    }
+
     private fun borderStyle(value: String): Int {
         val names = arrayOf(
             "none", "hidden", "solid", "dashed", "dotted",
@@ -377,7 +404,12 @@ private fun assertPixelSamples(id: String, bitmap: Bitmap, samples: JSONArray, d
             android.graphics.Color.green(actual) to android.graphics.Color.green(expected),
             android.graphics.Color.blue(actual) to android.graphics.Color.blue(expected),
         ).maxOf { (left, right) -> abs(left - right) }
-        assertTrue("$id sample ($x, $y) differs by $difference", difference <= tolerance)
+        assertTrue(
+            "$id sample ($x, $y) differs by $difference: " +
+                "actual=${android.graphics.Color.valueOf(actual)} " +
+                "expected=${android.graphics.Color.valueOf(expected)}",
+            difference <= tolerance,
+        )
     }
 }
 

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -141,7 +141,9 @@ private class Driver(
                             command.getString("name") == "paint.background-layers.radial-gradient" ||
                             command.getString("name") == "paint.background-layers.conic-gradient" ||
                             command.getString("name") ==
-                            "paint.background-layers.explicit-size-no-repeat",
+                            "paint.background-layers.explicit-size-no-repeat" ||
+                            command.getString("name") ==
+                            "paint.background-layers.position-length-percentage",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -137,7 +137,8 @@ private class Driver(
                 "checkpoint" -> {
                     check(
                         command.getString("name") == "paint.box" ||
-                            command.getString("name") == "paint.background-layers.linear-gradient",
+                            command.getString("name") == "paint.background-layers.linear-gradient" ||
+                            command.getString("name") == "paint.background-layers.radial-gradient",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -256,6 +257,18 @@ private class Driver(
                     ),
                 )
             }
+            node.optJSONObject("radial_gradient")?.let { gradient ->
+                val (numbers, names) = radialGradient(gradient)
+                check(
+                    stage(
+                        tag = 21,
+                        flags = 1,
+                        node = id,
+                        numbers = numbers,
+                        names = names,
+                    ),
+                )
+            }
         }
         check(view.commitFrameFromNative())
     }
@@ -357,6 +370,25 @@ private class Driver(
         return numbers.toFloatArray() to names.toTypedArray()
     }
 
+    private fun radialGradient(gradient: JSONObject): Pair<FloatArray, Array<String>> {
+        val numbers = ArrayList<Float>()
+        val names = ArrayList<String>()
+        val center = gradient.getJSONArray("center")
+        val radii = gradient.getJSONArray("radii")
+        numbers += listOf(
+            center.getDouble(0).toFloat(), 0f,
+            center.getDouble(1).toFloat(), 0f,
+            radii.getDouble(0).toFloat(), 0f,
+            radii.getDouble(1).toFloat(), 0f,
+        )
+        gradient.getJSONArray("stops").objects().forEach { stop ->
+            appendColor(stop.getJSONObject("color"), numbers, names)
+            numbers += 0f
+            numbers += stop.getDouble("position").toFloat()
+        }
+        return numbers.toFloatArray() to names.toTypedArray()
+    }
+
     private fun borderStyle(value: String): Int {
         val names = arrayOf(
             "none", "hidden", "solid", "dashed", "dotted",
@@ -448,8 +480,11 @@ private fun luminance(color: Int): Int =
 private fun fixtureColor(value: JSONObject): Int =
     if (value.getString("kind") == "named") {
         val name = value.getString("value")
-        if (name == "transparent") android.graphics.Color.TRANSPARENT
-        else android.graphics.Color.parseColor(name)
+        when (name) {
+            "transparent" -> android.graphics.Color.TRANSPARENT
+            "green" -> android.graphics.Color.rgb(0, 128, 0)
+            else -> android.graphics.Color.parseColor(name)
+        }
     } else {
         android.graphics.Color.argb(
             (value.getDouble("alpha") * 255.0).roundToInt(),

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -139,7 +139,9 @@ private class Driver(
                         command.getString("name") == "paint.box" ||
                             command.getString("name") == "paint.background-layers.linear-gradient" ||
                             command.getString("name") == "paint.background-layers.radial-gradient" ||
-                            command.getString("name") == "paint.background-layers.conic-gradient",
+                            command.getString("name") == "paint.background-layers.conic-gradient" ||
+                            command.getString("name") ==
+                            "paint.background-layers.explicit-size-no-repeat",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -246,11 +248,11 @@ private class Driver(
                 check(stage(tag = 12, node = id, integer = node.getInt("z_order")))
             }
             node.optJSONObject("linear_gradient")?.let { gradient ->
-                val (numbers, names) = linearGradient(gradient)
+                val (numbers, names) = linearGradient(node, gradient)
                 check(
                     stage(
                         tag = 21,
-                        flags = if (gradient.optBoolean("repeating", false)) 1 else 0,
+                        flags = 0,
                         node = id,
                         scalar = gradient.getDouble("angle_degrees").toFloat(),
                         numbers = numbers,
@@ -259,7 +261,7 @@ private class Driver(
                 )
             }
             node.optJSONObject("radial_gradient")?.let { gradient ->
-                val (numbers, names) = radialGradient(gradient)
+                val (numbers, names) = radialGradient(node, gradient)
                 check(
                     stage(
                         tag = 21,
@@ -271,7 +273,7 @@ private class Driver(
                 )
             }
             node.optJSONObject("conic_gradient")?.let { gradient ->
-                val (numbers, names) = conicGradient(gradient)
+                val (numbers, names) = conicGradient(node, gradient)
                 check(
                     stage(
                         tag = 21,
@@ -373,8 +375,9 @@ private class Driver(
         }
     }
 
-    private fun linearGradient(gradient: JSONObject): Pair<FloatArray, Array<String>> {
-        val numbers = ArrayList<Float>()
+    private fun linearGradient(node: JSONObject, gradient: JSONObject): Pair<FloatArray, Array<String>> {
+        check(!gradient.optBoolean("repeating", false))
+        val numbers = backgroundGeometry(node)
         val names = ArrayList<String>()
         gradient.getJSONArray("stops").objects().forEach { stop ->
             appendColor(stop.getJSONObject("color"), numbers, names)
@@ -384,8 +387,8 @@ private class Driver(
         return numbers.toFloatArray() to names.toTypedArray()
     }
 
-    private fun radialGradient(gradient: JSONObject): Pair<FloatArray, Array<String>> {
-        val numbers = ArrayList<Float>()
+    private fun radialGradient(node: JSONObject, gradient: JSONObject): Pair<FloatArray, Array<String>> {
+        val numbers = backgroundGeometry(node)
         val names = ArrayList<String>()
         val center = gradient.getJSONArray("center")
         val radii = gradient.getJSONArray("radii")
@@ -403,8 +406,8 @@ private class Driver(
         return numbers.toFloatArray() to names.toTypedArray()
     }
 
-    private fun conicGradient(gradient: JSONObject): Pair<FloatArray, Array<String>> {
-        val numbers = ArrayList<Float>()
+    private fun conicGradient(node: JSONObject, gradient: JSONObject): Pair<FloatArray, Array<String>> {
+        val numbers = backgroundGeometry(node)
         val names = ArrayList<String>()
         val center = gradient.getJSONArray("center")
         numbers += listOf(
@@ -417,6 +420,44 @@ private class Driver(
             numbers += stop.getDouble("position").toFloat()
         }
         return numbers.toFloatArray() to names.toTypedArray()
+    }
+
+    private fun backgroundGeometry(node: JSONObject): ArrayList<Float> {
+        val layer = node.optJSONObject("background_layer")
+        val position = layer?.optJSONArray("position")
+        val size = layer?.optJSONArray("size")
+        val numbers = ArrayList<Float>()
+        appendLengthPercentage(position?.optJSONObject(0), numbers)
+        appendLengthPercentage(position?.optJSONObject(1), numbers)
+        appendLengthPercentage(size?.optJSONObject(0), numbers)
+        appendLengthPercentage(size?.optJSONObject(1), numbers)
+        numbers += if (size == null) 0f else 1f
+        numbers += backgroundRepeat(layer?.optString("repeat_x", "repeat") ?: "repeat").toFloat()
+        numbers += backgroundRepeat(layer?.optString("repeat_y", "repeat") ?: "repeat").toFloat()
+        numbers += backgroundBox(layer?.optString("origin", "padding") ?: "padding").toFloat()
+        numbers += backgroundBox(layer?.optString("clip", "border") ?: "border").toFloat()
+        numbers += 0f // scroll attachment
+        numbers += 0f // normal blend mode
+        check(numbers.size == 15)
+        return numbers
+    }
+
+    private fun appendLengthPercentage(value: JSONObject?, numbers: MutableList<Float>) {
+        numbers += value?.optDouble("length", 0.0)?.toFloat() ?: 0f
+        numbers += value?.optDouble("fraction", 0.0)?.toFloat() ?: 0f
+    }
+
+    private fun backgroundRepeat(value: String): Int = when (value) {
+        "repeat" -> 0
+        "no_repeat" -> 1
+        else -> error("unsupported background repeat: $value")
+    }
+
+    private fun backgroundBox(value: String): Int = when (value) {
+        "border" -> 0
+        "padding" -> 1
+        "content" -> 2
+        else -> error("unsupported background box: $value")
     }
 
     private fun borderStyle(value: String): Int {

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -147,7 +147,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.background-layers.origin-border-box" ||
                             command.getString("name") ==
-                            "paint.background-layers.clip-padding-box",
+                            "paint.background-layers.clip-padding-box" ||
+                            command.getString("name") == "paint.background-layers.repeat-x" ||
+                            command.getString("name") == "paint.background-layers.repeat-y",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -56,6 +56,22 @@ class HostConformanceTest {
             }
     }
 
+    @Test
+    fun rejectsAThreeDimensionalTransformInsteadOfFlatteningIt() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                val matrix = floatArrayOf(
+                    1f, 0f, 0f, 0f,
+                    0f, 1f, 0f, 0f,
+                    0f, 0f, 2f, 0f,
+                    0f, 0f, 0f, 1f,
+                )
+                assertTrue(Driver(context, "android.transform-3d-rejection").rejectTransform(matrix))
+            }
+    }
+
     private fun asset(path: String): String =
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()
@@ -130,6 +146,13 @@ private class Driver(
         return checkNotNull(checkpoint)
     }
 
+    fun rejectTransform(transform: FloatArray): Boolean {
+        check(view.beginFrameFromNative(0, 1, 0, 1) == 0)
+        check(stage(tag = 1, member = 1))
+        check(stage(tag = 9, numbers = transform))
+        return !view.commitFrameFromNative()
+    }
+
     private fun present(command: JSONObject) {
         val revision = command.getLong("revision")
         check(view.beginFrameFromNative(0, 1, 0, revision) == 0)
@@ -182,6 +205,9 @@ private class Driver(
                 (if (clip.getString("horizontal") == "hidden") 1 else 0) or
                     (if (clip.getString("vertical") == "hidden") 2 else 0)
             check(stage(tag = 8, node = id, flags = flags))
+            node.optJSONArray("transform")?.let { transform ->
+                check(stage(tag = 9, node = id, numbers = transform.floats()))
+            }
         }
         check(view.commitFrameFromNative())
     }

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -143,7 +143,11 @@ private class Driver(
                             command.getString("name") ==
                             "paint.background-layers.explicit-size-no-repeat" ||
                             command.getString("name") ==
-                            "paint.background-layers.position-length-percentage",
+                            "paint.background-layers.position-length-percentage" ||
+                            command.getString("name") ==
+                            "paint.background-layers.origin-border-box" ||
+                            command.getString("name") ==
+                            "paint.background-layers.clip-padding-box",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -162,7 +162,7 @@ private class Driver(
     )
 
     private fun paint(command: JSONObject): Pair<FloatArray, Array<String>> {
-        val numbers = ArrayList<Float>(41)
+        val numbers = ArrayList<Float>(53)
         val names = ArrayList<String>(5)
         appendColor(command.getJSONObject("background"), numbers, names)
         val border = command.optJSONObject("border")
@@ -176,11 +176,28 @@ private class Driver(
                 names,
             )
         }
-        val radii = border?.getJSONArray("radii")?.floats() ?: FloatArray(4)
-        radii.forEach { radius -> numbers += listOf(radius, 0f) }
+        val radii = border?.getJSONArray("radii")
+        val radiiHorizontal = FloatArray(4)
+        val radiiVertical = FloatArray(4)
+        repeat(4) { index ->
+            when (val radius = radii?.get(index)) {
+                is Number -> {
+                    radiiHorizontal[index] = radius.toFloat()
+                    radiiVertical[index] = radius.toFloat()
+                }
+                is JSONArray -> {
+                    radiiHorizontal[index] = radius.getDouble(0).toFloat()
+                    radiiVertical[index] = radius.getDouble(1).toFloat()
+                }
+                null -> Unit
+                else -> error("unsupported border radius: $radius")
+            }
+        }
+        radiiHorizontal.forEach { radius -> numbers += listOf(radius, 0f) }
+        radiiVertical.forEach { radius -> numbers += listOf(radius, 0f) }
         val styles = border?.getJSONArray("styles")?.strings() ?: Array(4) { "none" }
         styles.forEach { style -> numbers += borderStyle(style).toFloat() }
-        check(numbers.size == 45)
+        check(numbers.size == 53)
         check(names.size == 5)
         return numbers.toFloatArray() to names.toTypedArray()
     }
@@ -286,7 +303,9 @@ private fun luminance(color: Int): Int =
 
 private fun fixtureColor(value: JSONObject): Int =
     if (value.getString("kind") == "named") {
-        android.graphics.Color.parseColor(value.getString("value"))
+        val name = value.getString("value")
+        if (name == "transparent") android.graphics.Color.TRANSPARENT
+        else android.graphics.Color.parseColor(name)
     } else {
         android.graphics.Color.argb(
             (value.getDouble("alpha") * 255.0).roundToInt(),

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -72,6 +72,20 @@ class HostConformanceTest {
             }
     }
 
+    @Test
+    fun rejectsInvalidOpacityValues() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                listOf(Float.NaN, Float.NEGATIVE_INFINITY, -0.1f, 1.1f).forEach { opacity ->
+                    assertTrue(
+                        Driver(context, "android.opacity-rejection").rejectOpacity(opacity),
+                    )
+                }
+            }
+    }
+
     private fun asset(path: String): String =
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()
@@ -153,6 +167,13 @@ private class Driver(
         return !view.commitFrameFromNative()
     }
 
+    fun rejectOpacity(opacity: Float): Boolean {
+        check(view.beginFrameFromNative(0, 1, 0, 1) == 0)
+        check(stage(tag = 1, member = 1))
+        check(stage(tag = 10, scalar = opacity))
+        return !view.commitFrameFromNative()
+    }
+
     private fun present(command: JSONObject) {
         val revision = command.getLong("revision")
         check(view.beginFrameFromNative(0, 1, 0, revision) == 0)
@@ -200,13 +221,24 @@ private class Driver(
             )
             val (numbers, names) = paint(node)
             check(stage(tag = 7, node = id, numbers = numbers, names = names))
-            val clip = node.getJSONObject("clip")
+            val clip = node.optJSONObject("clip") ?: JSONObject(
+                "{\"horizontal\":\"visible\",\"vertical\":\"visible\"}",
+            )
             val flags =
                 (if (clip.getString("horizontal") == "hidden") 1 else 0) or
                     (if (clip.getString("vertical") == "hidden") 2 else 0)
             check(stage(tag = 8, node = id, flags = flags))
             node.optJSONArray("transform")?.let { transform ->
                 check(stage(tag = 9, node = id, numbers = transform.floats()))
+            }
+            if (node.has("opacity")) {
+                check(stage(tag = 10, node = id, scalar = node.getDouble("opacity").toFloat()))
+            }
+            node.optString("visibility").takeIf(String::isNotEmpty)?.let { visibility ->
+                check(stage(tag = 11, node = id, integer = if (visibility == "visible") 1 else 0))
+            }
+            if (node.has("z_order")) {
+                check(stage(tag = 12, node = id, integer = node.getInt("z_order")))
             }
         }
         check(view.commitFrameFromNative())
@@ -220,6 +252,8 @@ private class Driver(
         child: Long = 0,
         index: Int = 0,
         member: Int = 0,
+        integer: Int = 0,
+        scalar: Float = 0f,
         numbers: FloatArray? = null,
         names: Array<String>? = null,
     ): Boolean = view.stageOperationFromNative(
@@ -230,8 +264,8 @@ private class Driver(
         child,
         index,
         member,
-        0,
-        0f,
+        integer,
+        scalar,
         0,
         numbers,
         null,

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -113,6 +113,14 @@ private class Driver(
                             context.resources.displayMetrics.density,
                         )
                     }
+                    command.optJSONArray("relations")?.let { relations ->
+                        assertPixelRelations(
+                            id,
+                            checkNotNull(checkpoint),
+                            relations,
+                            context.resources.displayMetrics.density,
+                        )
+                    }
                 }
                 else -> error("unsupported Android paint command: ${command.getString("type")}")
             }
@@ -243,6 +251,38 @@ private fun assertPixelSamples(id: String, bitmap: Bitmap, samples: JSONArray, d
         assertTrue("$id sample ($x, $y) differs by $difference", difference <= tolerance)
     }
 }
+
+private fun assertPixelRelations(id: String, bitmap: Bitmap, relations: JSONArray, density: Float) {
+    relations.objects().forEach { relation ->
+        val first = pixelAt(bitmap, relation.getJSONArray("first"), density)
+        val second = pixelAt(bitmap, relation.getJSONArray("second"), density)
+        val firstLuminance = luminance(first)
+        val secondLuminance = luminance(second)
+        val minimum = relation.optInt("minimum_difference", 0)
+        val matches = when (val kind = relation.getString("relation")) {
+            "lighter" -> firstLuminance >= secondLuminance + minimum
+            "darker" -> firstLuminance + minimum <= secondLuminance
+            else -> error("unknown pixel relation: $kind")
+        }
+        assertTrue(
+            "$id ${relation.getString("relation")}: " +
+                "$first ($firstLuminance) vs $second ($secondLuminance)",
+            matches,
+        )
+    }
+}
+
+private fun pixelAt(bitmap: Bitmap, point: JSONArray, density: Float): Int {
+    val x = (point.getDouble(0) * density).toInt()
+    val y = (point.getDouble(1) * density).toInt()
+    check(x in 0 until bitmap.width && y in 0 until bitmap.height)
+    return bitmap.getPixel(x, y)
+}
+
+private fun luminance(color: Int): Int =
+    (android.graphics.Color.red(color) * 299 +
+        android.graphics.Color.green(color) * 587 +
+        android.graphics.Color.blue(color) * 114) / 1000
 
 private fun fixtureColor(value: JSONObject): Int =
     if (value.getString("kind") == "named") {

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -39,7 +39,8 @@ class HostConformanceTest {
                     check(scenario.getString("id") == entry.getString("id"))
                     val testSide = scenario.getJSONObject("test")
                     if (testSide.getJSONArray("commands").objects().none {
-                            it.getString("type") == "present_box"
+                            it.getString("type") == "present_box" ||
+                                it.getString("type") == "present_scene"
                         }) return@forEach
                     val id = scenario.getString("id")
                     val test = Driver(context, id).execute(testSide)
@@ -102,6 +103,7 @@ private class Driver(
                     logicalHeight = command.getDouble("height").toFloat()
                 }
                 "present_box" -> present(command)
+                "present_scene" -> presentScene(command)
                 "checkpoint" -> {
                     check(command.getString("name") == "paint.box")
                     checkpoint = capture()
@@ -139,18 +141,68 @@ private class Driver(
         check(view.commitFrameFromNative())
     }
 
+    private fun presentScene(command: JSONObject) {
+        val revision = command.getLong("revision")
+        val nodes = command.getJSONArray("nodes")
+        check(view.beginFrameFromNative(0, 1, 0, revision) == 0)
+        nodes.objects().forEach { node ->
+            check(stage(tag = 1, node = node.getLong("id"), member = 1))
+        }
+        val childIndices = HashMap<Long, Int>()
+        nodes.objects().forEach { node ->
+            if (!node.isNull("parent")) {
+                val parent = node.getLong("parent")
+                val index = childIndices.getOrDefault(parent, 0)
+                check(
+                    stage(
+                        tag = 3,
+                        node = 0,
+                        parent = parent,
+                        child = node.getLong("id"),
+                        index = index,
+                    ),
+                )
+                childIndices[parent] = index + 1
+            }
+        }
+        nodes.objects().forEach { node ->
+            val id = node.getLong("id")
+            val rect = node.getJSONArray("rect").floats()
+            check(
+                stage(
+                    tag = 6,
+                    node = id,
+                    numbers = rect + floatArrayOf(0f, 0f, rect[2], rect[3]),
+                ),
+            )
+            val (numbers, names) = paint(node)
+            check(stage(tag = 7, node = id, numbers = numbers, names = names))
+            val clip = node.getJSONObject("clip")
+            val flags =
+                (if (clip.getString("horizontal") == "hidden") 1 else 0) or
+                    (if (clip.getString("vertical") == "hidden") 2 else 0)
+            check(stage(tag = 8, node = id, flags = flags))
+        }
+        check(view.commitFrameFromNative())
+    }
+
     private fun stage(
         tag: Int,
+        flags: Int = 0,
+        node: Long = 1,
+        parent: Long = 0,
+        child: Long = 0,
+        index: Int = 0,
         member: Int = 0,
         numbers: FloatArray? = null,
         names: Array<String>? = null,
     ): Boolean = view.stageOperationFromNative(
         tag,
-        0,
-        1,
-        0,
-        0,
-        0,
+        flags,
+        node,
+        parent,
+        child,
+        index,
         member,
         0,
         0f,

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -138,7 +138,8 @@ private class Driver(
                     check(
                         command.getString("name") == "paint.box" ||
                             command.getString("name") == "paint.background-layers.linear-gradient" ||
-                            command.getString("name") == "paint.background-layers.radial-gradient",
+                            command.getString("name") == "paint.background-layers.radial-gradient" ||
+                            command.getString("name") == "paint.background-layers.conic-gradient",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -269,6 +270,19 @@ private class Driver(
                     ),
                 )
             }
+            node.optJSONObject("conic_gradient")?.let { gradient ->
+                val (numbers, names) = conicGradient(gradient)
+                check(
+                    stage(
+                        tag = 21,
+                        flags = 2,
+                        node = id,
+                        scalar = gradient.getDouble("from_degrees").toFloat(),
+                        numbers = numbers,
+                        names = names,
+                    ),
+                )
+            }
         }
         check(view.commitFrameFromNative())
     }
@@ -380,6 +394,22 @@ private class Driver(
             center.getDouble(1).toFloat(), 0f,
             radii.getDouble(0).toFloat(), 0f,
             radii.getDouble(1).toFloat(), 0f,
+        )
+        gradient.getJSONArray("stops").objects().forEach { stop ->
+            appendColor(stop.getJSONObject("color"), numbers, names)
+            numbers += 0f
+            numbers += stop.getDouble("position").toFloat()
+        }
+        return numbers.toFloatArray() to names.toTypedArray()
+    }
+
+    private fun conicGradient(gradient: JSONObject): Pair<FloatArray, Array<String>> {
+        val numbers = ArrayList<Float>()
+        val names = ArrayList<String>()
+        val center = gradient.getJSONArray("center")
+        numbers += listOf(
+            center.getDouble(0).toFloat(), 0f,
+            center.getDouble(1).toFloat(), 0f,
         )
         gradient.getJSONArray("stops").objects().forEach { stop ->
             appendColor(stop.getJSONObject("color"), numbers, names)

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -80,7 +80,8 @@ private final class Driver {
             case "present_scene":
                 try presentScene(command)
             case "checkpoint":
-                guard try string(command, "name") == "paint.box" else {
+                let name = try string(command, "name")
+                guard name == "paint.box" || name == "paint.background-layers.linear-gradient" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -161,9 +162,20 @@ private final class Driver {
         var transforms = fixtures.flatMap { fixture in
             fixture.transform ?? [Float](repeating: 0, count: 16)
         }
+        var gradientStops = [WhiskerMobileGradientStop]()
+        var gradientOffsets = [Int?]()
+        for fixture in fixtures {
+            guard let gradient = fixture.linearGradient else {
+                gradientOffsets.append(nil)
+                continue
+            }
+            gradientOffsets.append(gradientStops.count)
+            gradientStops.append(contentsOf: gradient.stops)
+        }
         try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
             try paints.withUnsafeMutableBufferPointer { paintBuffer in
                 try transforms.withUnsafeMutableBufferPointer { transformBuffer in
+                    try gradientStops.withUnsafeMutableBufferPointer { gradientBuffer in
                     var operations = fixtures.map {
                         operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
                     }
@@ -228,6 +240,18 @@ private final class Driver {
                                 integer: zOrder
                             ))
                         }
+                        if let gradient = fixture.linearGradient,
+                           let offset = gradientOffsets[index] {
+                            operations.append(operation(
+                                tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS),
+                                node: fixture.id,
+                                scalar: gradient.angleDegrees,
+                                payload: UnsafeRawPointer(
+                                    gradientBuffer.baseAddress!.advanced(by: offset)
+                                ),
+                                count: gradient.stops.count
+                            ))
+                        }
                     }
                     try operations.withUnsafeMutableBufferPointer { buffer in
                         var frame = WhiskerMobileFrame()
@@ -249,6 +273,7 @@ private final class Driver {
                               response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
                             throw Failure("UIKit Host rejected scene fixture frame")
                         }
+                    }
                     }
                 }
             }
@@ -298,6 +323,12 @@ private struct SceneFixtureNode {
     let opacity: Float?
     let visible: Bool?
     let zOrder: Int32?
+    let linearGradient: SceneLinearGradient?
+}
+
+private struct SceneLinearGradient {
+    let angleDegrees: Float
+    let stops: [WhiskerMobileGradientStop]
 }
 
 private struct Failure: Error, CustomStringConvertible {
@@ -382,6 +413,25 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     } else {
         zOrder = nil
     }
+    let linearGradient: SceneLinearGradient?
+    if let gradient = fixture["linear_gradient"] as? [String: Any] {
+        let stops = try objectArray(gradient, "stops").map { stop -> WhiskerMobileGradientStop in
+            var raw = WhiskerMobileGradientStop()
+            raw.color = try color(try object(stop, "color"))
+            raw.position = WhiskerMobileLengthPercentage(
+                length: 0,
+                fraction: Float(try number(stop, "position"))
+            )
+            return raw
+        }
+        guard stops.count >= 2 else { throw Failure("linear gradient needs at least two stops") }
+        linearGradient = SceneLinearGradient(
+            angleDegrees: Float(try number(gradient, "angle_degrees")),
+            stops: stops
+        )
+    } else {
+        linearGradient = nil
+    }
     return SceneFixtureNode(
         id: id,
         parent: parent,
@@ -391,7 +441,8 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         transform: transform,
         opacity: opacity,
         visible: visible,
-        zOrder: zOrder
+        zOrder: zOrder,
+        linearGradient: linearGradient
     )
 }
 
@@ -439,6 +490,7 @@ private func color(_ fixture: [String: Any]) throws -> WhiskerMobileColor {
         case "black": rgba = (0, 0, 0, 1)
         case "blue": rgba = (0, 0, 255, 1)
         case "green": rgba = (0, 128, 0, 1)
+        case "gold": rgba = (255, 215, 0, 1)
         case "red": rgba = (255, 0, 0, 1)
         case "transparent": rgba = (0, 0, 0, 0)
         case "white": rgba = (255, 255, 255, 1)

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -27,7 +27,8 @@ final class HostConformanceTests: XCTestCase {
             let id = try string(scenario, "id")
             let testSide = try object(scenario, "test")
             guard try array(testSide, "commands").contains(where: {
-                try string($0, "type") == "present_box"
+                let type = try string($0, "type")
+                return type == "present_box" || type == "present_scene"
             }) else { continue }
             let test = try Driver(id: id).execute(testSide)
             if let reference = scenario["reference"] as? [String: Any] {
@@ -76,6 +77,8 @@ private final class Driver {
                 )
             case "present_box":
                 try present(command)
+            case "present_scene":
+                try presentScene(command)
             case "checkpoint":
                 guard try string(command, "name") == "paint.box" else {
                     throw Failure("unsupported UIKit checkpoint")
@@ -150,6 +153,72 @@ private final class Driver {
         }
     }
 
+    private func presentScene(_ command: [String: Any]) throws {
+        let revision = UInt64(try number(command, "revision"))
+        let fixtures = try objectArray(command, "nodes").map(sceneNode)
+        var layouts = fixtures.map(\.layout)
+        var paints = fixtures.map(\.paint)
+        try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
+            try paints.withUnsafeMutableBufferPointer { paintBuffer in
+                var operations = fixtures.map {
+                    operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
+                }
+                var childCounts: [UInt64: UInt32] = [:]
+                for fixture in fixtures {
+                    guard let parent = fixture.parent else { continue }
+                    let index = childCounts[parent, default: 0]
+                    operations.append(operation(
+                        tag: UInt32(WHISKER_OP_INSERT),
+                        parent: parent,
+                        child: fixture.id,
+                        index: index
+                    ))
+                    childCounts[parent] = index + 1
+                }
+                for (index, fixture) in fixtures.enumerated() {
+                    operations.append(operation(
+                        tag: UInt32(WHISKER_OP_LAYOUT),
+                        node: fixture.id,
+                        payload: UnsafeRawPointer(layoutBuffer.baseAddress!.advanced(by: index)),
+                        count: 1
+                    ))
+                    operations.append(operation(
+                        tag: UInt32(WHISKER_OP_PAINT),
+                        node: fixture.id,
+                        payload: UnsafeRawPointer(paintBuffer.baseAddress!.advanced(by: index)),
+                        count: 1
+                    ))
+                    operations.append(operation(
+                        tag: UInt32(WHISKER_OP_CLIP),
+                        node: fixture.id,
+                        flags: fixture.clipFlags
+                    ))
+                }
+                try operations.withUnsafeMutableBufferPointer { buffer in
+                    var frame = WhiskerMobileFrame()
+                    frame.abi_major = UInt16(WHISKER_MOBILE_ABI_MAJOR)
+                    frame.abi_minor = UInt16(WHISKER_MOBILE_ABI_MINOR)
+                    frame.protocol_major = 1
+                    frame.protocol_minor = 0
+                    frame.mode = UInt8(WHISKER_FRAME_SNAPSHOT)
+                    frame.surface = 1
+                    frame.scene_epoch = 1
+                    frame.viewport_epoch = 1
+                    frame.frame_id = revision
+                    frame.base_revision = 0
+                    frame.target_revision = revision
+                    frame.operations = UnsafePointer(buffer.baseAddress!)
+                    frame.operation_count = buffer.count
+                    var response = WhiskerMobileApplyResponse()
+                    guard view.applyConformanceFrame(frame, response: &response),
+                          response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
+                        throw Failure("UIKit Host rejected scene fixture frame")
+                    }
+                }
+            }
+        }
+    }
+
     private func capture() throws -> Pixels {
         guard logicalSize.width > 0, logicalSize.height > 0 else {
             throw Failure("fixture has no surface")
@@ -183,6 +252,14 @@ private struct Pixels {
     let bytes: [UInt8]
 }
 
+private struct SceneFixtureNode {
+    let id: UInt64
+    let parent: UInt64?
+    let layout: WhiskerMobileLayoutGeometry
+    let paint: WhiskerMobileBoxPaint
+    let clipFlags: UInt32
+}
+
 private struct Failure: Error, CustomStringConvertible {
     let description: String
     init(_ description: String) { self.description = description }
@@ -190,17 +267,57 @@ private struct Failure: Error, CustomStringConvertible {
 
 private func operation(
     tag: UInt32,
+    node: UInt64 = 1,
+    parent: UInt64 = 0,
+    child: UInt64 = 0,
+    index: UInt32 = 0,
     member: UInt32 = 0,
+    flags: UInt32 = 0,
     payload: UnsafeRawPointer? = nil,
     count: Int = 0
 ) -> WhiskerMobileOperation {
     var value = WhiskerMobileOperation()
     value.tag = tag
-    value.node = 1
+    value.flags = flags
+    value.node = node
+    value.parent = parent
+    value.child = child
+    value.index = index
     value.member = member
     value.payload = payload
     value.payload_count = count
     return value
+}
+
+private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
+    let id = UInt64(try number(fixture, "id"))
+    let parent = (fixture["parent"] as? NSNumber).map { UInt64($0.doubleValue) }
+    let rect = try numberArray(fixture, "rect")
+    guard rect.count == 4 else { throw Failure("scene node rect needs four values") }
+    var layout = WhiskerMobileLayoutGeometry()
+    layout.border = WhiskerMobileRect(
+        x: Float(rect[0]),
+        y: Float(rect[1]),
+        width: Float(rect[2]),
+        height: Float(rect[3])
+    )
+    layout.content = WhiskerMobileRect()
+    let clip = try object(fixture, "clip")
+    let horizontal = try string(clip, "horizontal")
+    let vertical = try string(clip, "vertical")
+    guard horizontal == "visible" || horizontal == "hidden",
+          vertical == "visible" || vertical == "hidden" else {
+        throw Failure("unknown overflow clip")
+    }
+    let flags = UInt32(horizontal == "hidden" ? 1 : 0) |
+        UInt32(vertical == "hidden" ? 2 : 0)
+    return SceneFixtureNode(
+        id: id,
+        parent: parent,
+        layout: layout,
+        paint: try boxPaint(fixture),
+        clipFlags: flags
+    )
 }
 
 private func boxPaint(_ command: [String: Any]) throws -> WhiskerMobileBoxPaint {
@@ -247,6 +364,7 @@ private func color(_ fixture: [String: Any]) throws -> WhiskerMobileColor {
         case "black": rgba = (0, 0, 0, 1)
         case "blue": rgba = (0, 0, 255, 1)
         case "green": rgba = (0, 128, 0, 1)
+        case "red": rgba = (255, 0, 0, 1)
         case "transparent": rgba = (0, 0, 0, 0)
         case "white": rgba = (255, 255, 255, 1)
         default: throw Failure("unsupported fixture named color")

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -210,15 +210,32 @@ private func boxPaint(_ command: [String: Any]) throws -> WhiskerMobileBoxPaint 
     let widths = try numberArray(border, "widths").map(length)
     let colors = try objectArray(border, "colors").map(color)
     let styles = try stringArray(border, "styles").map(borderStyle)
-    let radii = try numberArray(border, "radii").map(length)
+    let radii = try radiusPairs(border)
     guard widths.count == 4, colors.count == 4, styles.count == 4, radii.count == 4 else {
         throw Failure("border arrays need four values")
     }
     value.widths = (widths[0], widths[1], widths[2], widths[3])
     value.colors = (colors[0], colors[1], colors[2], colors[3])
     value.styles = (styles[0], styles[1], styles[2], styles[3])
-    value.radii = (radii[0], radii[1], radii[2], radii[3])
+    let horizontal = radii.map { length($0.0) }
+    let vertical = radii.map { length($0.1) }
+    value.radii_horizontal = (horizontal[0], horizontal[1], horizontal[2], horizontal[3])
+    value.radii_vertical = (vertical[0], vertical[1], vertical[2], vertical[3])
     return value
+}
+
+private func radiusPairs(_ border: [String: Any]) throws -> [(Double, Double)] {
+    guard let values = border["radii"] as? [Any] else { throw Failure("missing or invalid radii") }
+    return try values.map { value in
+        if let number = value as? NSNumber {
+            let radius = number.doubleValue
+            return (radius, radius)
+        }
+        if let pair = value as? [NSNumber], pair.count == 2 {
+            return (pair[0].doubleValue, pair[1].doubleValue)
+        }
+        throw Failure("radius must be a number or horizontal/vertical pair")
+    }
 }
 
 private func color(_ fixture: [String: Any]) throws -> WhiskerMobileColor {

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -85,6 +85,9 @@ private final class Driver {
                 if let samples = command["samples"] as? [[String: Any]] {
                     try assertPixelSamples(id: id, pixels: pixels, samples: samples)
                 }
+                if let relations = command["relations"] as? [[String: Any]] {
+                    try assertPixelRelations(id: id, pixels: pixels, relations: relations)
+                }
             default:
                 throw Failure("unsupported UIKit paint command")
             }
@@ -226,6 +229,7 @@ private func color(_ fixture: [String: Any]) throws -> WhiskerMobileColor {
         case "aqua": rgba = (0, 255, 255, 1)
         case "black": rgba = (0, 0, 0, 1)
         case "blue": rgba = (0, 0, 255, 1)
+        case "green": rgba = (0, 128, 0, 1)
         case "transparent": rgba = (0, 0, 0, 0)
         case "white": rgba = (255, 255, 255, 1)
         default: throw Failure("unsupported fixture named color")
@@ -331,4 +335,47 @@ private func assertPixelSamples(
         let difference = largestDifference(actual, expected)
         XCTAssertLessThanOrEqual(difference, tolerance, "\(id) sample (\(x), \(y))")
     }
+}
+
+private func assertPixelRelations(
+    id: String,
+    pixels: Pixels,
+    relations: [[String: Any]]
+) throws {
+    for relation in relations {
+        let firstPoint = try numberArray(relation, "first")
+        let secondPoint = try numberArray(relation, "second")
+        guard firstPoint.count == 2, secondPoint.count == 2 else {
+            throw Failure("pixel relation needs two coordinates per point")
+        }
+        let first = try pixel(at: firstPoint, in: pixels)
+        let second = try pixel(at: secondPoint, in: pixels)
+        let firstLuminance = luminance(first)
+        let secondLuminance = luminance(second)
+        let minimum = UInt32(try number(relation, "minimum_difference"))
+        let matches: Bool
+        switch try string(relation, "relation") {
+        case "lighter": matches = firstLuminance >= secondLuminance + minimum
+        case "darker": matches = firstLuminance + minimum <= secondLuminance
+        default: throw Failure("unknown pixel relation")
+        }
+        XCTAssertTrue(
+            matches,
+            "\(id) relation: \(first) (\(firstLuminance)) vs \(second) (\(secondLuminance))"
+        )
+    }
+}
+
+private func pixel(at point: [Double], in pixels: Pixels) throws -> [UInt8] {
+    let x = Int(point[0].rounded(.down))
+    let y = Int(point[1].rounded(.down))
+    guard x >= 0, x < pixels.width, y >= 0, y < pixels.height else {
+        throw Failure("pixel relation is outside the surface")
+    }
+    let offset = (y * pixels.width + x) * 4
+    return Array(pixels.bytes[offset..<(offset + 4)])
+}
+
+private func luminance(_ color: [UInt8]) -> UInt32 {
+    (UInt32(color[0]) * 299 + UInt32(color[1]) * 587 + UInt32(color[2]) * 114) / 1000
 }

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -45,6 +45,12 @@ final class HostConformanceTests: XCTestCase {
         }
         XCTAssertGreaterThan(count, 0)
     }
+
+    func testNoRepeatLeadingEdgeUsesHalfADevicePixel() {
+        XCTAssertEqual(backgroundLeadingEdgeInset(deviceScale: 1), 0.5)
+        XCTAssertEqual(backgroundLeadingEdgeInset(deviceScale: 2), 0.25)
+        XCTAssertEqual(backgroundLeadingEdgeInset(deviceScale: 3), 1.0 / 6.0, accuracy: 0.000_001)
+    }
 }
 
 @MainActor
@@ -85,7 +91,8 @@ private final class Driver {
                     name == "paint.background-layers.linear-gradient" ||
                     name == "paint.background-layers.radial-gradient" ||
                     name == "paint.background-layers.conic-gradient" ||
-                    name == "paint.background-layers.explicit-size-no-repeat" else {
+                    name == "paint.background-layers.explicit-size-no-repeat" ||
+                    name == "paint.background-layers.position-length-percentage" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -207,6 +207,27 @@ private final class Driver {
                                 count: 16
                             ))
                         }
+                        if let opacity = fixture.opacity {
+                            operations.append(operation(
+                                tag: UInt32(WHISKER_OP_OPACITY),
+                                node: fixture.id,
+                                scalar: opacity
+                            ))
+                        }
+                        if let visible = fixture.visible {
+                            operations.append(operation(
+                                tag: UInt32(WHISKER_OP_VISIBILITY),
+                                node: fixture.id,
+                                integer: visible ? 1 : 0
+                            ))
+                        }
+                        if let zOrder = fixture.zOrder {
+                            operations.append(operation(
+                                tag: UInt32(WHISKER_OP_Z_ORDER),
+                                node: fixture.id,
+                                integer: zOrder
+                            ))
+                        }
                     }
                     try operations.withUnsafeMutableBufferPointer { buffer in
                         var frame = WhiskerMobileFrame()
@@ -274,6 +295,9 @@ private struct SceneFixtureNode {
     let paint: WhiskerMobileBoxPaint
     let clipFlags: UInt32
     let transform: [Float]?
+    let opacity: Float?
+    let visible: Bool?
+    let zOrder: Int32?
 }
 
 private struct Failure: Error, CustomStringConvertible {
@@ -289,6 +313,8 @@ private func operation(
     index: UInt32 = 0,
     member: UInt32 = 0,
     flags: UInt32 = 0,
+    integer: Int32 = 0,
+    scalar: Float = 0,
     payload: UnsafeRawPointer? = nil,
     count: Int = 0
 ) -> WhiskerMobileOperation {
@@ -300,6 +326,8 @@ private func operation(
     value.child = child
     value.index = index
     value.member = member
+    value.integer = integer
+    value.scalar = scalar
     value.payload = payload
     value.payload_count = count
     return value
@@ -318,9 +346,9 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         height: Float(rect[3])
     )
     layout.content = WhiskerMobileRect()
-    let clip = try object(fixture, "clip")
-    let horizontal = try string(clip, "horizontal")
-    let vertical = try string(clip, "vertical")
+    let clip = fixture["clip"] as? [String: Any]
+    let horizontal = try clip.map { try string($0, "horizontal") } ?? "visible"
+    let vertical = try clip.map { try string($0, "vertical") } ?? "visible"
     guard horizontal == "visible" || horizontal == "hidden",
           vertical == "visible" || vertical == "hidden" else {
         throw Failure("unknown overflow clip")
@@ -334,13 +362,36 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     } else {
         transform = nil
     }
+    let opacity = (fixture["opacity"] as? NSNumber)?.floatValue
+    let visible: Bool?
+    if let visibility = fixture["visibility"] as? String {
+        guard visibility == "visible" || visibility == "hidden" else {
+            throw Failure("unknown visibility")
+        }
+        visible = visibility == "visible"
+    } else {
+        visible = nil
+    }
+    let zOrder: Int32?
+    if let number = fixture["z_order"] as? NSNumber {
+        let value = number.int64Value
+        guard value >= Int64(Int32.min), value <= Int64(Int32.max) else {
+            throw Failure("z-order is outside signed 32-bit range")
+        }
+        zOrder = Int32(value)
+    } else {
+        zOrder = nil
+    }
     return SceneFixtureNode(
         id: id,
         parent: parent,
         layout: layout,
         paint: try boxPaint(fixture),
         clipFlags: flags,
-        transform: transform
+        transform: transform,
+        opacity: opacity,
+        visible: visible,
+        zOrder: zOrder
     )
 }
 
@@ -492,7 +543,11 @@ private func assertPixelSamples(
         ]
         let tolerance = UInt8((sample["tolerance"] as? NSNumber)?.uint8Value ?? 0)
         let difference = largestDifference(actual, expected)
-        XCTAssertLessThanOrEqual(difference, tolerance, "\(id) sample (\(x), \(y))")
+        XCTAssertLessThanOrEqual(
+            difference,
+            tolerance,
+            "\(id) sample (\(x), \(y)): \(actual) != \(expected)"
+        )
     }
 }
 

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -158,61 +158,76 @@ private final class Driver {
         let fixtures = try objectArray(command, "nodes").map(sceneNode)
         var layouts = fixtures.map(\.layout)
         var paints = fixtures.map(\.paint)
+        var transforms = fixtures.flatMap { fixture in
+            fixture.transform ?? [Float](repeating: 0, count: 16)
+        }
         try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
             try paints.withUnsafeMutableBufferPointer { paintBuffer in
-                var operations = fixtures.map {
-                    operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
-                }
-                var childCounts: [UInt64: UInt32] = [:]
-                for fixture in fixtures {
-                    guard let parent = fixture.parent else { continue }
-                    let index = childCounts[parent, default: 0]
-                    operations.append(operation(
-                        tag: UInt32(WHISKER_OP_INSERT),
-                        parent: parent,
-                        child: fixture.id,
-                        index: index
-                    ))
-                    childCounts[parent] = index + 1
-                }
-                for (index, fixture) in fixtures.enumerated() {
-                    operations.append(operation(
-                        tag: UInt32(WHISKER_OP_LAYOUT),
-                        node: fixture.id,
-                        payload: UnsafeRawPointer(layoutBuffer.baseAddress!.advanced(by: index)),
-                        count: 1
-                    ))
-                    operations.append(operation(
-                        tag: UInt32(WHISKER_OP_PAINT),
-                        node: fixture.id,
-                        payload: UnsafeRawPointer(paintBuffer.baseAddress!.advanced(by: index)),
-                        count: 1
-                    ))
-                    operations.append(operation(
-                        tag: UInt32(WHISKER_OP_CLIP),
-                        node: fixture.id,
-                        flags: fixture.clipFlags
-                    ))
-                }
-                try operations.withUnsafeMutableBufferPointer { buffer in
-                    var frame = WhiskerMobileFrame()
-                    frame.abi_major = UInt16(WHISKER_MOBILE_ABI_MAJOR)
-                    frame.abi_minor = UInt16(WHISKER_MOBILE_ABI_MINOR)
-                    frame.protocol_major = 1
-                    frame.protocol_minor = 0
-                    frame.mode = UInt8(WHISKER_FRAME_SNAPSHOT)
-                    frame.surface = 1
-                    frame.scene_epoch = 1
-                    frame.viewport_epoch = 1
-                    frame.frame_id = revision
-                    frame.base_revision = 0
-                    frame.target_revision = revision
-                    frame.operations = UnsafePointer(buffer.baseAddress!)
-                    frame.operation_count = buffer.count
-                    var response = WhiskerMobileApplyResponse()
-                    guard view.applyConformanceFrame(frame, response: &response),
-                          response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
-                        throw Failure("UIKit Host rejected scene fixture frame")
+                try transforms.withUnsafeMutableBufferPointer { transformBuffer in
+                    var operations = fixtures.map {
+                        operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
+                    }
+                    var childCounts: [UInt64: UInt32] = [:]
+                    for fixture in fixtures {
+                        guard let parent = fixture.parent else { continue }
+                        let index = childCounts[parent, default: 0]
+                        operations.append(operation(
+                            tag: UInt32(WHISKER_OP_INSERT),
+                            parent: parent,
+                            child: fixture.id,
+                            index: index
+                        ))
+                        childCounts[parent] = index + 1
+                    }
+                    for (index, fixture) in fixtures.enumerated() {
+                        operations.append(operation(
+                            tag: UInt32(WHISKER_OP_LAYOUT),
+                            node: fixture.id,
+                            payload: UnsafeRawPointer(layoutBuffer.baseAddress!.advanced(by: index)),
+                            count: 1
+                        ))
+                        operations.append(operation(
+                            tag: UInt32(WHISKER_OP_PAINT),
+                            node: fixture.id,
+                            payload: UnsafeRawPointer(paintBuffer.baseAddress!.advanced(by: index)),
+                            count: 1
+                        ))
+                        operations.append(operation(
+                            tag: UInt32(WHISKER_OP_CLIP),
+                            node: fixture.id,
+                            flags: fixture.clipFlags
+                        ))
+                        if fixture.transform != nil {
+                            operations.append(operation(
+                                tag: UInt32(WHISKER_OP_TRANSFORM),
+                                node: fixture.id,
+                                payload: UnsafeRawPointer(
+                                    transformBuffer.baseAddress!.advanced(by: index * 16)
+                                ),
+                                count: 16
+                            ))
+                        }
+                    }
+                    try operations.withUnsafeMutableBufferPointer { buffer in
+                        var frame = WhiskerMobileFrame()
+                        frame.abi_major = UInt16(WHISKER_MOBILE_ABI_MAJOR)
+                        frame.abi_minor = UInt16(WHISKER_MOBILE_ABI_MINOR)
+                        frame.protocol_major = 1
+                        frame.protocol_minor = 0
+                        frame.mode = UInt8(WHISKER_FRAME_SNAPSHOT)
+                        frame.surface = 1
+                        frame.scene_epoch = 1
+                        frame.viewport_epoch = 1
+                        frame.frame_id = revision
+                        frame.base_revision = 0
+                        frame.target_revision = revision
+                        frame.operations = UnsafePointer(buffer.baseAddress!)
+                        frame.operation_count = buffer.count
+                        var response = WhiskerMobileApplyResponse()
+                        guard view.applyConformanceFrame(frame, response: &response),
+                              response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
+                            throw Failure("UIKit Host rejected scene fixture frame")
+                        }
                     }
                 }
             }
@@ -258,6 +273,7 @@ private struct SceneFixtureNode {
     let layout: WhiskerMobileLayoutGeometry
     let paint: WhiskerMobileBoxPaint
     let clipFlags: UInt32
+    let transform: [Float]?
 }
 
 private struct Failure: Error, CustomStringConvertible {
@@ -311,12 +327,20 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     }
     let flags = UInt32(horizontal == "hidden" ? 1 : 0) |
         UInt32(vertical == "hidden" ? 2 : 0)
+    let transform: [Float]?
+    if let raw = fixture["transform"] as? [NSNumber] {
+        guard raw.count == 16 else { throw Failure("transform needs sixteen values") }
+        transform = raw.map { $0.floatValue }
+    } else {
+        transform = nil
+    }
     return SceneFixtureNode(
         id: id,
         parent: parent,
         layout: layout,
         paint: try boxPaint(fixture),
-        clipFlags: flags
+        clipFlags: flags,
+        transform: transform
     )
 }
 

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -92,7 +92,9 @@ private final class Driver {
                     name == "paint.background-layers.radial-gradient" ||
                     name == "paint.background-layers.conic-gradient" ||
                     name == "paint.background-layers.explicit-size-no-repeat" ||
-                    name == "paint.background-layers.position-length-percentage" else {
+                    name == "paint.background-layers.position-length-percentage" ||
+                    name == "paint.background-layers.origin-border-box" ||
+                    name == "paint.background-layers.clip-padding-box" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -81,7 +81,9 @@ private final class Driver {
                 try presentScene(command)
             case "checkpoint":
                 let name = try string(command, "name")
-                guard name == "paint.box" || name == "paint.background-layers.linear-gradient" else {
+                guard name == "paint.box" ||
+                    name == "paint.background-layers.linear-gradient" ||
+                    name == "paint.background-layers.radial-gradient" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -165,115 +167,159 @@ private final class Driver {
         var gradientStops = [WhiskerMobileGradientStop]()
         var gradientOffsets = [Int?]()
         for fixture in fixtures {
-            guard let gradient = fixture.linearGradient else {
+            if let gradient = fixture.linearGradient {
+                gradientOffsets.append(gradientStops.count)
+                gradientStops.append(contentsOf: gradient.stops)
+            } else if let gradient = fixture.radialGradient {
+                gradientOffsets.append(gradientStops.count)
+                gradientStops.append(contentsOf: gradient.stops)
+            } else {
                 gradientOffsets.append(nil)
-                continue
             }
-            gradientOffsets.append(gradientStops.count)
-            gradientStops.append(contentsOf: gradient.stops)
         }
+        var radialPayloads = [WhiskerMobileRadialGradient](
+            repeating: WhiskerMobileRadialGradient(),
+            count: fixtures.count
+        )
         try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
             try paints.withUnsafeMutableBufferPointer { paintBuffer in
                 try transforms.withUnsafeMutableBufferPointer { transformBuffer in
                     try gradientStops.withUnsafeMutableBufferPointer { gradientBuffer in
-                    var operations = fixtures.map {
-                        operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
-                    }
-                    var childCounts: [UInt64: UInt32] = [:]
-                    for fixture in fixtures {
-                        guard let parent = fixture.parent else { continue }
-                        let index = childCounts[parent, default: 0]
-                        operations.append(operation(
-                            tag: UInt32(WHISKER_OP_INSERT),
-                            parent: parent,
-                            child: fixture.id,
-                            index: index
-                        ))
-                        childCounts[parent] = index + 1
-                    }
-                    for (index, fixture) in fixtures.enumerated() {
-                        operations.append(operation(
-                            tag: UInt32(WHISKER_OP_LAYOUT),
-                            node: fixture.id,
-                            payload: UnsafeRawPointer(layoutBuffer.baseAddress!.advanced(by: index)),
-                            count: 1
-                        ))
-                        operations.append(operation(
-                            tag: UInt32(WHISKER_OP_PAINT),
-                            node: fixture.id,
-                            payload: UnsafeRawPointer(paintBuffer.baseAddress!.advanced(by: index)),
-                            count: 1
-                        ))
-                        operations.append(operation(
-                            tag: UInt32(WHISKER_OP_CLIP),
-                            node: fixture.id,
-                            flags: fixture.clipFlags
-                        ))
-                        if fixture.transform != nil {
-                            operations.append(operation(
-                                tag: UInt32(WHISKER_OP_TRANSFORM),
-                                node: fixture.id,
-                                payload: UnsafeRawPointer(
-                                    transformBuffer.baseAddress!.advanced(by: index * 16)
-                                ),
-                                count: 16
-                            ))
+                        for (index, fixture) in fixtures.enumerated() {
+                            guard let radial = fixture.radialGradient,
+                                  let offset = gradientOffsets[index] else { continue }
+                            radialPayloads[index].center_x = WhiskerMobileLengthPercentage(
+                                length: radial.center[0], fraction: 0
+                            )
+                            radialPayloads[index].center_y = WhiskerMobileLengthPercentage(
+                                length: radial.center[1], fraction: 0
+                            )
+                            radialPayloads[index].radius_x = WhiskerMobileLengthPercentage(
+                                length: radial.radii[0], fraction: 0
+                            )
+                            radialPayloads[index].radius_y = WhiskerMobileLengthPercentage(
+                                length: radial.radii[1], fraction: 0
+                            )
+                            radialPayloads[index].stops = UnsafePointer(
+                                gradientBuffer.baseAddress!.advanced(by: offset)
+                            )
+                            radialPayloads[index].stop_count = radial.stops.count
                         }
-                        if let opacity = fixture.opacity {
-                            operations.append(operation(
-                                tag: UInt32(WHISKER_OP_OPACITY),
-                                node: fixture.id,
-                                scalar: opacity
-                            ))
+                        try radialPayloads.withUnsafeMutableBufferPointer { radialBuffer in
+                            var operations = fixtures.map {
+                                operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
+                            }
+                            var childCounts: [UInt64: UInt32] = [:]
+                            for fixture in fixtures {
+                                guard let parent = fixture.parent else { continue }
+                                let index = childCounts[parent, default: 0]
+                                operations.append(operation(
+                                    tag: UInt32(WHISKER_OP_INSERT),
+                                    parent: parent,
+                                    child: fixture.id,
+                                    index: index
+                                ))
+                                childCounts[parent] = index + 1
+                            }
+                            for (index, fixture) in fixtures.enumerated() {
+                                operations.append(operation(
+                                    tag: UInt32(WHISKER_OP_LAYOUT),
+                                    node: fixture.id,
+                                    payload: UnsafeRawPointer(
+                                        layoutBuffer.baseAddress!.advanced(by: index)
+                                    ),
+                                    count: 1
+                                ))
+                                operations.append(operation(
+                                    tag: UInt32(WHISKER_OP_PAINT),
+                                    node: fixture.id,
+                                    payload: UnsafeRawPointer(
+                                        paintBuffer.baseAddress!.advanced(by: index)
+                                    ),
+                                    count: 1
+                                ))
+                                operations.append(operation(
+                                    tag: UInt32(WHISKER_OP_CLIP),
+                                    node: fixture.id,
+                                    flags: fixture.clipFlags
+                                ))
+                                if fixture.transform != nil {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_TRANSFORM),
+                                        node: fixture.id,
+                                        payload: UnsafeRawPointer(
+                                            transformBuffer.baseAddress!.advanced(by: index * 16)
+                                        ),
+                                        count: 16
+                                    ))
+                                }
+                                if let opacity = fixture.opacity {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_OPACITY),
+                                        node: fixture.id,
+                                        scalar: opacity
+                                    ))
+                                }
+                                if let visible = fixture.visible {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_VISIBILITY),
+                                        node: fixture.id,
+                                        integer: visible ? 1 : 0
+                                    ))
+                                }
+                                if let zOrder = fixture.zOrder {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_Z_ORDER),
+                                        node: fixture.id,
+                                        integer: zOrder
+                                    ))
+                                }
+                                if let gradient = fixture.linearGradient,
+                                   let offset = gradientOffsets[index] {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS),
+                                        node: fixture.id,
+                                        flags: UInt32(WHISKER_BACKGROUND_LINEAR),
+                                        scalar: gradient.angleDegrees,
+                                        payload: UnsafeRawPointer(
+                                            gradientBuffer.baseAddress!.advanced(by: offset)
+                                        ),
+                                        count: gradient.stops.count
+                                    ))
+                                } else if fixture.radialGradient != nil {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS),
+                                        node: fixture.id,
+                                        flags: UInt32(WHISKER_BACKGROUND_RADIAL),
+                                        payload: UnsafeRawPointer(
+                                            radialBuffer.baseAddress!.advanced(by: index)
+                                        ),
+                                        count: 1
+                                    ))
+                                }
+                            }
+                            try operations.withUnsafeMutableBufferPointer { buffer in
+                                var frame = WhiskerMobileFrame()
+                                frame.abi_major = UInt16(WHISKER_MOBILE_ABI_MAJOR)
+                                frame.abi_minor = UInt16(WHISKER_MOBILE_ABI_MINOR)
+                                frame.protocol_major = 1
+                                frame.protocol_minor = 0
+                                frame.mode = UInt8(WHISKER_FRAME_SNAPSHOT)
+                                frame.surface = 1
+                                frame.scene_epoch = 1
+                                frame.viewport_epoch = 1
+                                frame.frame_id = revision
+                                frame.base_revision = 0
+                                frame.target_revision = revision
+                                frame.operations = UnsafePointer(buffer.baseAddress!)
+                                frame.operation_count = buffer.count
+                                var response = WhiskerMobileApplyResponse()
+                                guard view.applyConformanceFrame(frame, response: &response),
+                                      response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
+                                    throw Failure("UIKit Host rejected scene fixture frame")
+                                }
+                            }
                         }
-                        if let visible = fixture.visible {
-                            operations.append(operation(
-                                tag: UInt32(WHISKER_OP_VISIBILITY),
-                                node: fixture.id,
-                                integer: visible ? 1 : 0
-                            ))
-                        }
-                        if let zOrder = fixture.zOrder {
-                            operations.append(operation(
-                                tag: UInt32(WHISKER_OP_Z_ORDER),
-                                node: fixture.id,
-                                integer: zOrder
-                            ))
-                        }
-                        if let gradient = fixture.linearGradient,
-                           let offset = gradientOffsets[index] {
-                            operations.append(operation(
-                                tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS),
-                                node: fixture.id,
-                                scalar: gradient.angleDegrees,
-                                payload: UnsafeRawPointer(
-                                    gradientBuffer.baseAddress!.advanced(by: offset)
-                                ),
-                                count: gradient.stops.count
-                            ))
-                        }
-                    }
-                    try operations.withUnsafeMutableBufferPointer { buffer in
-                        var frame = WhiskerMobileFrame()
-                        frame.abi_major = UInt16(WHISKER_MOBILE_ABI_MAJOR)
-                        frame.abi_minor = UInt16(WHISKER_MOBILE_ABI_MINOR)
-                        frame.protocol_major = 1
-                        frame.protocol_minor = 0
-                        frame.mode = UInt8(WHISKER_FRAME_SNAPSHOT)
-                        frame.surface = 1
-                        frame.scene_epoch = 1
-                        frame.viewport_epoch = 1
-                        frame.frame_id = revision
-                        frame.base_revision = 0
-                        frame.target_revision = revision
-                        frame.operations = UnsafePointer(buffer.baseAddress!)
-                        frame.operation_count = buffer.count
-                        var response = WhiskerMobileApplyResponse()
-                        guard view.applyConformanceFrame(frame, response: &response),
-                              response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
-                            throw Failure("UIKit Host rejected scene fixture frame")
-                        }
-                    }
                     }
                 }
             }
@@ -324,10 +370,17 @@ private struct SceneFixtureNode {
     let visible: Bool?
     let zOrder: Int32?
     let linearGradient: SceneLinearGradient?
+    let radialGradient: SceneRadialGradient?
 }
 
 private struct SceneLinearGradient {
     let angleDegrees: Float
+    let stops: [WhiskerMobileGradientStop]
+}
+
+private struct SceneRadialGradient {
+    let center: [Float]
+    let radii: [Float]
     let stops: [WhiskerMobileGradientStop]
 }
 
@@ -432,6 +485,26 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     } else {
         linearGradient = nil
     }
+    let radialGradient: SceneRadialGradient?
+    if let gradient = fixture["radial_gradient"] as? [String: Any] {
+        let center = try numberArray(gradient, "center").map(Float.init)
+        let radii = try numberArray(gradient, "radii").map(Float.init)
+        let stops = try objectArray(gradient, "stops").map { stop -> WhiskerMobileGradientStop in
+            var raw = WhiskerMobileGradientStop()
+            raw.color = try color(try object(stop, "color"))
+            raw.position = WhiskerMobileLengthPercentage(
+                length: 0,
+                fraction: Float(try number(stop, "position"))
+            )
+            return raw
+        }
+        guard center.count == 2, radii.count == 2, stops.count >= 2 else {
+            throw Failure("radial gradient needs a center, two radii, and at least two stops")
+        }
+        radialGradient = SceneRadialGradient(center: center, radii: radii, stops: stops)
+    } else {
+        radialGradient = nil
+    }
     return SceneFixtureNode(
         id: id,
         parent: parent,
@@ -442,7 +515,8 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         opacity: opacity,
         visible: visible,
         zOrder: zOrder,
-        linearGradient: linearGradient
+        linearGradient: linearGradient,
+        radialGradient: radialGradient
     )
 }
 

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -51,6 +51,27 @@ final class HostConformanceTests: XCTestCase {
         XCTAssertEqual(backgroundLeadingEdgeInset(deviceScale: 2), 0.25)
         XCTAssertEqual(backgroundLeadingEdgeInset(deviceScale: 3), 1.0 / 6.0, accuracy: 0.000_001)
     }
+
+    func testBackgroundTileOriginsRespectEachRepeatAxis() {
+        XCTAssertEqual(
+            backgroundTileOrigins(
+                base: 20,
+                tileSize: 20,
+                coverage: 0..<100,
+                repeatMode: .repeat
+            ),
+            [0, 20, 40, 60, 80]
+        )
+        XCTAssertEqual(
+            backgroundTileOrigins(
+                base: 20,
+                tileSize: 20,
+                coverage: 0..<100,
+                repeatMode: .noRepeat
+            ),
+            [20]
+        )
+    }
 }
 
 @MainActor
@@ -94,7 +115,9 @@ private final class Driver {
                     name == "paint.background-layers.explicit-size-no-repeat" ||
                     name == "paint.background-layers.position-length-percentage" ||
                     name == "paint.background-layers.origin-border-box" ||
-                    name == "paint.background-layers.clip-padding-box" else {
+                    name == "paint.background-layers.clip-padding-box" ||
+                    name == "paint.background-layers.repeat-x" ||
+                    name == "paint.background-layers.repeat-y" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -83,7 +83,8 @@ private final class Driver {
                 let name = try string(command, "name")
                 guard name == "paint.box" ||
                     name == "paint.background-layers.linear-gradient" ||
-                    name == "paint.background-layers.radial-gradient" else {
+                    name == "paint.background-layers.radial-gradient" ||
+                    name == "paint.background-layers.conic-gradient" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -173,6 +174,9 @@ private final class Driver {
             } else if let gradient = fixture.radialGradient {
                 gradientOffsets.append(gradientStops.count)
                 gradientStops.append(contentsOf: gradient.stops)
+            } else if let gradient = fixture.conicGradient {
+                gradientOffsets.append(gradientStops.count)
+                gradientStops.append(contentsOf: gradient.stops)
             } else {
                 gradientOffsets.append(nil)
             }
@@ -181,31 +185,47 @@ private final class Driver {
             repeating: WhiskerMobileRadialGradient(),
             count: fixtures.count
         )
+        var conicPayloads = [WhiskerMobileConicGradient](
+            repeating: WhiskerMobileConicGradient(),
+            count: fixtures.count
+        )
         try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
             try paints.withUnsafeMutableBufferPointer { paintBuffer in
                 try transforms.withUnsafeMutableBufferPointer { transformBuffer in
                     try gradientStops.withUnsafeMutableBufferPointer { gradientBuffer in
                         for (index, fixture) in fixtures.enumerated() {
-                            guard let radial = fixture.radialGradient,
-                                  let offset = gradientOffsets[index] else { continue }
-                            radialPayloads[index].center_x = WhiskerMobileLengthPercentage(
-                                length: radial.center[0], fraction: 0
-                            )
-                            radialPayloads[index].center_y = WhiskerMobileLengthPercentage(
-                                length: radial.center[1], fraction: 0
-                            )
-                            radialPayloads[index].radius_x = WhiskerMobileLengthPercentage(
-                                length: radial.radii[0], fraction: 0
-                            )
-                            radialPayloads[index].radius_y = WhiskerMobileLengthPercentage(
-                                length: radial.radii[1], fraction: 0
-                            )
-                            radialPayloads[index].stops = UnsafePointer(
+                            guard let offset = gradientOffsets[index] else { continue }
+                            let stops = UnsafePointer(
                                 gradientBuffer.baseAddress!.advanced(by: offset)
                             )
-                            radialPayloads[index].stop_count = radial.stops.count
+                            if let radial = fixture.radialGradient {
+                                radialPayloads[index].center_x = WhiskerMobileLengthPercentage(
+                                    length: radial.center[0], fraction: 0
+                                )
+                                radialPayloads[index].center_y = WhiskerMobileLengthPercentage(
+                                    length: radial.center[1], fraction: 0
+                                )
+                                radialPayloads[index].radius_x = WhiskerMobileLengthPercentage(
+                                    length: radial.radii[0], fraction: 0
+                                )
+                                radialPayloads[index].radius_y = WhiskerMobileLengthPercentage(
+                                    length: radial.radii[1], fraction: 0
+                                )
+                                radialPayloads[index].stops = stops
+                                radialPayloads[index].stop_count = radial.stops.count
+                            } else if let conic = fixture.conicGradient {
+                                conicPayloads[index].center_x = WhiskerMobileLengthPercentage(
+                                    length: conic.center[0], fraction: 0
+                                )
+                                conicPayloads[index].center_y = WhiskerMobileLengthPercentage(
+                                    length: conic.center[1], fraction: 0
+                                )
+                                conicPayloads[index].stops = stops
+                                conicPayloads[index].stop_count = conic.stops.count
+                            }
                         }
                         try radialPayloads.withUnsafeMutableBufferPointer { radialBuffer in
+                            try conicPayloads.withUnsafeMutableBufferPointer { conicBuffer in
                             var operations = fixtures.map {
                                 operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
                             }
@@ -296,6 +316,17 @@ private final class Driver {
                                         ),
                                         count: 1
                                     ))
+                                } else if let conic = fixture.conicGradient {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS),
+                                        node: fixture.id,
+                                        flags: UInt32(WHISKER_BACKGROUND_CONIC),
+                                        scalar: conic.fromDegrees,
+                                        payload: UnsafeRawPointer(
+                                            conicBuffer.baseAddress!.advanced(by: index)
+                                        ),
+                                        count: 1
+                                    ))
                                 }
                             }
                             try operations.withUnsafeMutableBufferPointer { buffer in
@@ -318,6 +349,7 @@ private final class Driver {
                                       response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
                                     throw Failure("UIKit Host rejected scene fixture frame")
                                 }
+                            }
                             }
                         }
                     }
@@ -371,6 +403,7 @@ private struct SceneFixtureNode {
     let zOrder: Int32?
     let linearGradient: SceneLinearGradient?
     let radialGradient: SceneRadialGradient?
+    let conicGradient: SceneConicGradient?
 }
 
 private struct SceneLinearGradient {
@@ -381,6 +414,12 @@ private struct SceneLinearGradient {
 private struct SceneRadialGradient {
     let center: [Float]
     let radii: [Float]
+    let stops: [WhiskerMobileGradientStop]
+}
+
+private struct SceneConicGradient {
+    let fromDegrees: Float
+    let center: [Float]
     let stops: [WhiskerMobileGradientStop]
 }
 
@@ -505,6 +544,29 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     } else {
         radialGradient = nil
     }
+    let conicGradient: SceneConicGradient?
+    if let gradient = fixture["conic_gradient"] as? [String: Any] {
+        let center = try numberArray(gradient, "center").map(Float.init)
+        let stops = try objectArray(gradient, "stops").map { stop -> WhiskerMobileGradientStop in
+            var raw = WhiskerMobileGradientStop()
+            raw.color = try color(try object(stop, "color"))
+            raw.position = WhiskerMobileLengthPercentage(
+                length: 0,
+                fraction: Float(try number(stop, "position"))
+            )
+            return raw
+        }
+        guard center.count == 2, stops.count >= 2 else {
+            throw Failure("conic gradient needs a center and at least two stops")
+        }
+        conicGradient = SceneConicGradient(
+            fromDegrees: Float(try number(gradient, "from_degrees")),
+            center: center,
+            stops: stops
+        )
+    } else {
+        conicGradient = nil
+    }
     return SceneFixtureNode(
         id: id,
         parent: parent,
@@ -516,7 +578,8 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         visible: visible,
         zOrder: zOrder,
         linearGradient: linearGradient,
-        radialGradient: radialGradient
+        radialGradient: radialGradient,
+        conicGradient: conicGradient
     )
 }
 

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -84,7 +84,8 @@ private final class Driver {
                 guard name == "paint.box" ||
                     name == "paint.background-layers.linear-gradient" ||
                     name == "paint.background-layers.radial-gradient" ||
-                    name == "paint.background-layers.conic-gradient" else {
+                    name == "paint.background-layers.conic-gradient" ||
+                    name == "paint.background-layers.explicit-size-no-repeat" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -189,6 +190,10 @@ private final class Driver {
             repeating: WhiskerMobileConicGradient(),
             count: fixtures.count
         )
+        var backgroundPayloads = [WhiskerMobileBackgroundLayer](
+            repeating: WhiskerMobileBackgroundLayer(),
+            count: fixtures.count
+        )
         try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
             try paints.withUnsafeMutableBufferPointer { paintBuffer in
                 try transforms.withUnsafeMutableBufferPointer { transformBuffer in
@@ -226,6 +231,58 @@ private final class Driver {
                         }
                         try radialPayloads.withUnsafeMutableBufferPointer { radialBuffer in
                             try conicPayloads.withUnsafeMutableBufferPointer { conicBuffer in
+                            for (index, fixture) in fixtures.enumerated() {
+                                guard let offset = gradientOffsets[index] else { continue }
+                                let geometry = fixture.backgroundLayer
+                                backgroundPayloads[index].position_x = geometry.position[0]
+                                backgroundPayloads[index].position_y = geometry.position[1]
+                                backgroundPayloads[index].size_kind = geometry.size == nil
+                                    ? UInt32(WHISKER_BACKGROUND_SIZE_AUTO)
+                                    : UInt32(WHISKER_BACKGROUND_SIZE_EXPLICIT)
+                                if let size = geometry.size {
+                                    backgroundPayloads[index].size_width = size[0]
+                                    backgroundPayloads[index].size_height = size[1]
+                                }
+                                backgroundPayloads[index].repeat_x = geometry.repeatX
+                                backgroundPayloads[index].repeat_y = geometry.repeatY
+                                backgroundPayloads[index].origin = geometry.origin
+                                backgroundPayloads[index].clip = geometry.clip
+                                backgroundPayloads[index].attachment = UInt32(
+                                    WHISKER_BACKGROUND_ATTACHMENT_SCROLL
+                                )
+                                backgroundPayloads[index].blend_mode = UInt32(
+                                    WHISKER_BACKGROUND_BLEND_NORMAL
+                                )
+                                if let gradient = fixture.linearGradient {
+                                    backgroundPayloads[index].image.kind = UInt32(
+                                        WHISKER_BACKGROUND_LINEAR
+                                    )
+                                    backgroundPayloads[index].image.scalar = gradient.angleDegrees
+                                    backgroundPayloads[index].image.payload = UnsafeRawPointer(
+                                        gradientBuffer.baseAddress!.advanced(by: offset)
+                                    )
+                                    backgroundPayloads[index].image.payload_count = gradient.stops.count
+                                } else if fixture.radialGradient != nil {
+                                    backgroundPayloads[index].image.kind = UInt32(
+                                        WHISKER_BACKGROUND_RADIAL
+                                    )
+                                    backgroundPayloads[index].image.payload = UnsafeRawPointer(
+                                        radialBuffer.baseAddress!.advanced(by: index)
+                                    )
+                                    backgroundPayloads[index].image.payload_count = 1
+                                } else if let gradient = fixture.conicGradient {
+                                    backgroundPayloads[index].image.kind = UInt32(
+                                        WHISKER_BACKGROUND_CONIC
+                                    )
+                                    backgroundPayloads[index].image.scalar = gradient.fromDegrees
+                                    backgroundPayloads[index].image.payload = UnsafeRawPointer(
+                                        conicBuffer.baseAddress!.advanced(by: index)
+                                    )
+                                    backgroundPayloads[index].image.payload_count = 1
+                                }
+                            }
+                            try backgroundPayloads.withUnsafeMutableBufferPointer {
+                                backgroundBuffer in
                             var operations = fixtures.map {
                                 operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
                             }
@@ -294,36 +351,12 @@ private final class Driver {
                                         integer: zOrder
                                     ))
                                 }
-                                if let gradient = fixture.linearGradient,
-                                   let offset = gradientOffsets[index] {
+                                if gradientOffsets[index] != nil {
                                     operations.append(operation(
                                         tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS),
                                         node: fixture.id,
-                                        flags: UInt32(WHISKER_BACKGROUND_LINEAR),
-                                        scalar: gradient.angleDegrees,
                                         payload: UnsafeRawPointer(
-                                            gradientBuffer.baseAddress!.advanced(by: offset)
-                                        ),
-                                        count: gradient.stops.count
-                                    ))
-                                } else if fixture.radialGradient != nil {
-                                    operations.append(operation(
-                                        tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS),
-                                        node: fixture.id,
-                                        flags: UInt32(WHISKER_BACKGROUND_RADIAL),
-                                        payload: UnsafeRawPointer(
-                                            radialBuffer.baseAddress!.advanced(by: index)
-                                        ),
-                                        count: 1
-                                    ))
-                                } else if let conic = fixture.conicGradient {
-                                    operations.append(operation(
-                                        tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS),
-                                        node: fixture.id,
-                                        flags: UInt32(WHISKER_BACKGROUND_CONIC),
-                                        scalar: conic.fromDegrees,
-                                        payload: UnsafeRawPointer(
-                                            conicBuffer.baseAddress!.advanced(by: index)
+                                            backgroundBuffer.baseAddress!.advanced(by: index)
                                         ),
                                         count: 1
                                     ))
@@ -349,6 +382,7 @@ private final class Driver {
                                       response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
                                     throw Failure("UIKit Host rejected scene fixture frame")
                                 }
+                            }
                             }
                             }
                         }
@@ -401,9 +435,28 @@ private struct SceneFixtureNode {
     let opacity: Float?
     let visible: Bool?
     let zOrder: Int32?
+    let backgroundLayer: SceneBackgroundLayer
     let linearGradient: SceneLinearGradient?
     let radialGradient: SceneRadialGradient?
     let conicGradient: SceneConicGradient?
+}
+
+private struct SceneBackgroundLayer {
+    let position: [WhiskerMobileLengthPercentage]
+    let size: [WhiskerMobileLengthPercentage]?
+    let repeatX: UInt32
+    let repeatY: UInt32
+    let origin: UInt32
+    let clip: UInt32
+
+    static let initial = SceneBackgroundLayer(
+        position: [WhiskerMobileLengthPercentage(), WhiskerMobileLengthPercentage()],
+        size: nil,
+        repeatX: UInt32(WHISKER_BACKGROUND_REPEAT),
+        repeatY: UInt32(WHISKER_BACKGROUND_REPEAT),
+        origin: UInt32(WHISKER_BACKGROUND_BOX_PADDING),
+        clip: UInt32(WHISKER_BACKGROUND_BOX_BORDER)
+    )
 }
 
 private struct SceneLinearGradient {
@@ -505,6 +558,8 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     } else {
         zOrder = nil
     }
+    let backgroundLayer = try fixture["background_layer"]
+        .map { try sceneBackgroundLayer($0) } ?? .initial
     let linearGradient: SceneLinearGradient?
     if let gradient = fixture["linear_gradient"] as? [String: Any] {
         let stops = try objectArray(gradient, "stops").map { stop -> WhiskerMobileGradientStop in
@@ -577,10 +632,58 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         opacity: opacity,
         visible: visible,
         zOrder: zOrder,
+        backgroundLayer: backgroundLayer,
         linearGradient: linearGradient,
         radialGradient: radialGradient,
         conicGradient: conicGradient
     )
+}
+
+private func sceneBackgroundLayer(_ value: Any) throws -> SceneBackgroundLayer {
+    guard let object = value as? [String: Any] else {
+        throw Failure("background_layer must be an object")
+    }
+    let position = try (object["position"] as? [Any])?
+        .map(lengthPercentage) ?? SceneBackgroundLayer.initial.position
+    let size = try (object["size"] as? [Any])?.map(lengthPercentage)
+    guard position.count == 2, size?.count ?? 2 == 2 else {
+        throw Failure("background layer position and size need two axes")
+    }
+    return SceneBackgroundLayer(
+        position: position,
+        size: size,
+        repeatX: try backgroundRepeat(object["repeat_x"] as? String ?? "repeat"),
+        repeatY: try backgroundRepeat(object["repeat_y"] as? String ?? "repeat"),
+        origin: try backgroundBox(object["origin"] as? String ?? "padding"),
+        clip: try backgroundBox(object["clip"] as? String ?? "border")
+    )
+}
+
+private func lengthPercentage(_ value: Any) throws -> WhiskerMobileLengthPercentage {
+    guard let object = value as? [String: Any] else {
+        throw Failure("length-percentage must be an object")
+    }
+    return WhiskerMobileLengthPercentage(
+        length: Float(try number(object, "length")),
+        fraction: Float(try number(object, "fraction"))
+    )
+}
+
+private func backgroundRepeat(_ value: String) throws -> UInt32 {
+    switch value {
+    case "repeat": UInt32(WHISKER_BACKGROUND_REPEAT)
+    case "no_repeat": UInt32(WHISKER_BACKGROUND_NO_REPEAT)
+    default: throw Failure("unsupported background repeat")
+    }
+}
+
+private func backgroundBox(_ value: String) throws -> UInt32 {
+    switch value {
+    case "border": UInt32(WHISKER_BACKGROUND_BOX_BORDER)
+    case "padding": UInt32(WHISKER_BACKGROUND_BOX_PADDING)
+    case "content": UInt32(WHISKER_BACKGROUND_BOX_CONTENT)
+    default: throw Failure("unsupported background box")
+    }
 }
 
 private func boxPaint(_ command: [String: Any]) throws -> WhiskerMobileBoxPaint {

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -91,6 +91,10 @@
         "samples": {
           "type": "array",
           "items": { "$ref": "#/$defs/pixelSample" }
+        },
+        "relations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pixelRelation" }
         }
       }
     },
@@ -108,6 +112,23 @@
         "color": { "$ref": "#/$defs/color" },
         "tolerance": { "type": "integer", "minimum": 0, "maximum": 255 }
       }
+    },
+    "pixelRelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["first", "second", "relation"],
+      "properties": {
+        "first": { "$ref": "#/$defs/point" },
+        "second": { "$ref": "#/$defs/point" },
+        "relation": { "enum": ["lighter", "darker"] },
+        "minimum_difference": { "type": "integer", "minimum": 0, "maximum": 255 }
+      }
+    },
+    "point": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": { "type": "number", "minimum": 0 }
     },
     "measureText": {
       "type": "object",

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -106,7 +106,13 @@
         "rect": { "$ref": "#/$defs/quadNumber" },
         "background": { "$ref": "#/$defs/color" },
         "border": { "$ref": "#/$defs/border" },
-        "clip": { "$ref": "#/$defs/boxClip" }
+        "clip": { "$ref": "#/$defs/boxClip" },
+        "transform": {
+          "type": "array",
+          "minItems": 16,
+          "maxItems": 16,
+          "items": { "type": "number" }
+        }
       }
     },
     "boxClip": {

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -240,8 +240,24 @@
             ]
           }
         },
-        "radii": { "$ref": "#/$defs/quadNumber" }
+        "radii": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": { "$ref": "#/$defs/cornerRadius" }
+        }
       }
+    },
+    "cornerRadius": {
+      "oneOf": [
+        { "type": "number", "minimum": 0 },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "number", "minimum": 0 }
+        }
+      ]
     },
     "quadNumber": {
       "type": "array",

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -51,6 +51,7 @@
       "oneOf": [
         { "$ref": "#/$defs/attachSurface" },
         { "$ref": "#/$defs/presentBox" },
+        { "$ref": "#/$defs/presentScene" },
         { "$ref": "#/$defs/checkpoint" },
         { "$ref": "#/$defs/measureText" },
         { "$ref": "#/$defs/checkpointMeasurement" },
@@ -79,6 +80,42 @@
         "rect": { "$ref": "#/$defs/quadNumber" },
         "background": { "$ref": "#/$defs/color" },
         "border": { "$ref": "#/$defs/border" }
+      }
+    },
+    "presentScene": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "revision", "nodes"],
+      "properties": {
+        "type": { "const": "present_scene" },
+        "revision": { "type": "integer", "minimum": 1 },
+        "nodes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/sceneNode" }
+        }
+      }
+    },
+    "sceneNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "parent", "rect", "background", "clip"],
+      "properties": {
+        "id": { "type": "integer", "minimum": 1 },
+        "parent": { "type": ["integer", "null"], "minimum": 1 },
+        "rect": { "$ref": "#/$defs/quadNumber" },
+        "background": { "$ref": "#/$defs/color" },
+        "border": { "$ref": "#/$defs/border" },
+        "clip": { "$ref": "#/$defs/boxClip" }
+      }
+    },
+    "boxClip": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["horizontal", "vertical"],
+      "properties": {
+        "horizontal": { "enum": ["visible", "hidden"] },
+        "vertical": { "enum": ["visible", "hidden"] }
       }
     },
     "checkpoint": {

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -112,7 +112,10 @@
           "minItems": 16,
           "maxItems": 16,
           "items": { "type": "number" }
-        }
+        },
+        "opacity": { "type": "number", "minimum": 0, "maximum": 1 },
+        "visibility": { "enum": ["visible", "hidden"] },
+        "z_order": { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 }
       }
     },
     "boxClip": {

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-006.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-006.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-006",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-006.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A double border-top renders two solid lines separated by a transparent gap.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection plus logical-pixel samples in the outer line, center gap, inner line, and white box background. The specified 9px width divides into three equal bands."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 20.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 20.0],
+        "background": { "kind": "named", "value": "white" },
+        "border": {
+          "widths": [9.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["double", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 1.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [50.0, 4.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 },
+          { "point": [50.0, 7.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [50.0, 15.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-007.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-007.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-007",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-007.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A groove border uses two shades of its border color to appear carved into the canvas.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection, an unchanged green background sample, and a relative luminance assertion requiring the outer half of the top border to be darker than its inner half. Exact shade colors remain Host-defined."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 24.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 24.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [12.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["groove", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ],
+        "relations": [
+          { "first": [50.0, 2.0], "second": [50.0, 9.0], "relation": "darker", "minimum_difference": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-008.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-008.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-008",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-008.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A ridge border uses two shades of its border color to appear raised from the canvas.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection, an unchanged green background sample, and a relative luminance assertion requiring the outer half of the top border to be lighter than its inner half. Exact shade colors remain Host-defined."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 24.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 24.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [12.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["ridge", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ],
+        "relations": [
+          { "first": [50.0, 2.0], "second": [50.0, 9.0], "relation": "lighter", "minimum_difference": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-009.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-009.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-009",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-009.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "An inset top border is darker than its border color to make the box appear embedded in the canvas.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection and a relative luminance assertion comparing the shaded top border with the unchanged green box background. Exact shade colors remain Host-defined."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 24.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 24.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [12.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["inset", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ],
+        "relations": [
+          { "first": [50.0, 6.0], "second": [50.0, 18.0], "relation": "darker", "minimum_difference": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-010.json
+++ b/tests/host-conformance/wpt/css/CSS2/borders/border-top-style-010.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.borders.border-top-style-010",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/borders/border-top-style-010.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "An outset top border is lighter than its border color to make the box appear raised from the canvas.",
+    "adaptation": "The WPT manual visual assertion is represented by semantic style projection and a relative luminance assertion comparing the shaded top border with the unchanged green box background. Exact shade colors remain Host-defined."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 24.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 24.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [12.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["outset", "none", "none", "none"],
+          "radii": [0.0, 0.0, 0.0, 0.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [50.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ],
+        "relations": [
+          { "first": [50.0, 6.0], "second": [50.0, 18.0], "relation": "lighter", "minimum_difference": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/CSS2/visufx/visibility-004.json
+++ b/tests/host-conformance/wpt/css/CSS2/visufx/visibility-004.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.visibility-004",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/visufx/visibility-004.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A child inheriting hidden visibility from its parent is not painted, while layout remains present.",
+    "adaptation": "The hidden parent retains a red child in the Host tree. A transparent sample at the child's laid-out position verifies that SetVisibility suppresses descendant paint without deleting or relaying out the subtree."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 80.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [20.0, 10.0, 40.0, 40.0],
+            "background": { "kind": "named", "value": "transparent" },
+            "visibility": "hidden"
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [5.0, 5.0, 30.0, 30.0],
+            "background": { "kind": "named", "value": "red" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [30.0, 30.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/CSS2/zindex/z-index-003.json
+++ b/tests/host-conformance/wpt/css/CSS2/zindex/z-index-003.json
@@ -1,0 +1,52 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.z-index-003",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/zindex/z-index-003.xht",
+    "reference_path": "css/CSS2/reference/ref-filled-green-100px-square.xht",
+    "license": "BSD-3-Clause",
+    "assertion": "A positioned element with z-index -100 paints above a later positioned sibling with z-index -2147483647.",
+    "adaptation": "The WPT's two overlapping children and signed 32-bit z-index values are retained at a smaller logical size. The green sample verifies that SetZOrder takes precedence over insertion order."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 70.0, "height": 70.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "transparent" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [0.0, 0.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "green" },
+            "z_order": -100
+          },
+          {
+            "id": 3,
+            "parent": 1,
+            "rect": [0.0, 0.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "red" },
+            "z_order": -2147483647
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [35.0, 35.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/background-position-three-four-values.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/background-position-three-four-values.json
@@ -1,0 +1,61 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.background-position-three-four-values.test1",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/background-position-three-four-values.html",
+    "reference_path": "css/css-backgrounds/reference/background-position-three-four-values-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "Length and percentage background-position components offset a no-repeat image within its positioning area.",
+    "adaptation": "This fixture isolates upstream test1 (`left 50px center`). CSS parsing resolves it to x=50px and y=50%; the Host receives those length/fraction components plus an explicit 20 by 20 image size. A constant blue gradient replaces the resource image so samples test only positioning semantics."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 100.0],
+            "background": { "kind": "srgba", "red": 255, "green": 255, "blue": 255, "alpha": 0.0 },
+            "background_layer": {
+              "position": [
+                { "length": 50.0, "fraction": 0.0 },
+                { "length": 0.0, "fraction": 0.5 }
+              ],
+              "size": [
+                { "length": 20.0, "fraction": 0.0 },
+                { "length": 20.0, "fraction": 0.0 }
+              ],
+              "repeat_x": "no_repeat",
+              "repeat_y": "no_repeat"
+            },
+            "linear_gradient": {
+              "angle_degrees": 180.0,
+              "stops": [
+                { "color": { "kind": "named", "value": "blue" }, "position": 0.0 },
+                { "color": { "kind": "named", "value": "blue" }, "position": 1.0 }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.position-length-percentage",
+        "samples": [
+          { "point": [51.0, 41.0], "color": { "kind": "named", "value": "blue" }, "tolerance": 5 },
+          { "point": [68.0, 58.0], "color": { "kind": "named", "value": "blue" }, "tolerance": 5 },
+          { "point": [49.0, 50.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 },
+          { "point": [71.0, 50.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 },
+          { "point": [60.0, 39.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 },
+          { "point": [60.0, 61.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-x.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-x.json
@@ -1,0 +1,56 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.background-repeat.repeat-x",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/background-repeat/background-repeat-repeat-x.xht",
+    "reference_path": "css/css-backgrounds/background-repeat/reference/background-repeat-repeat-x.xht",
+    "license": "BSD-3-Clause",
+    "assertion": "The image is repeated horizontally as often as needed to cover the background painting area.",
+    "adaptation": "The upstream resource is replaced by a constant green gradient tile and its dimensions are reduced to 20 by 20 logical pixels in a 100 by 100 box. Samples verify that repeat-x covers the full horizontal axis while the no-repeat vertical axis leaves the gray background visible below the first tile row."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 100.0],
+            "background": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 },
+            "background_layer": {
+              "size": [
+                { "length": 20.0, "fraction": 0.0 },
+                { "length": 20.0, "fraction": 0.0 }
+              ],
+              "repeat_x": "repeat",
+              "repeat_y": "no_repeat"
+            },
+            "linear_gradient": {
+              "angle_degrees": 180.0,
+              "stops": [
+                { "color": { "kind": "named", "value": "green" }, "position": 0.0 },
+                { "color": { "kind": "named", "value": "green" }, "position": 1.0 }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.repeat-x",
+        "samples": [
+          { "point": [1.0, 1.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [39.0, 10.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [99.0, 10.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [10.0, 21.0], "color": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [90.0, 90.0], "color": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-y.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/background-repeat/background-repeat-repeat-y.json
@@ -1,0 +1,56 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.background-repeat.repeat-y",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/background-repeat/background-repeat-repeat-y.xht",
+    "reference_path": "css/css-backgrounds/background-repeat/reference/background-repeat-repeat-y.xht",
+    "license": "BSD-3-Clause",
+    "assertion": "The image is repeated vertically as often as needed to cover the background painting area.",
+    "adaptation": "The upstream resource is replaced by a constant green gradient tile and its dimensions are reduced to 20 by 20 logical pixels in a 100 by 100 box. Samples verify that repeat-y covers the full vertical axis while the no-repeat horizontal axis leaves the gray background visible to the right of the first tile column."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 100.0],
+            "background": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 },
+            "background_layer": {
+              "size": [
+                { "length": 20.0, "fraction": 0.0 },
+                { "length": 20.0, "fraction": 0.0 }
+              ],
+              "repeat_x": "no_repeat",
+              "repeat_y": "repeat"
+            },
+            "linear_gradient": {
+              "angle_degrees": 180.0,
+              "stops": [
+                { "color": { "kind": "named", "value": "green" }, "position": 0.0 },
+                { "color": { "kind": "named", "value": "green" }, "position": 1.0 }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.repeat-y",
+        "samples": [
+          { "point": [1.0, 1.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [10.0, 39.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [10.0, 99.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [21.0, 10.0], "color": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [90.0, 90.0], "color": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/background-size-009.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/background-size-009.json
@@ -1,0 +1,56 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.background-size-009",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/background-size-009.html",
+    "reference_path": "css/css-backgrounds/reference/background-size-006-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "A percentage background width resolves against the positioning area and no-repeat paints only the resolved image rectangle.",
+    "adaptation": "Percentage and intrinsic-ratio resolution remain Rust responsibilities. The Host receives the WPT result as an explicit 45 by 45 logical-pixel background size in a 100 by 50 box. A constant green gradient replaces the upstream 1 by 1 green resource so this case isolates layer sizing and no-repeat geometry from resource loading."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 50.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 50.0],
+            "background": { "kind": "srgba", "red": 255, "green": 255, "blue": 255, "alpha": 0.0 },
+            "background_layer": {
+              "size": [
+                { "length": 45.0, "fraction": 0.0 },
+                { "length": 45.0, "fraction": 0.0 }
+              ],
+              "repeat_x": "no_repeat",
+              "repeat_y": "no_repeat"
+            },
+            "linear_gradient": {
+              "angle_degrees": 180.0,
+              "stops": [
+                { "color": { "kind": "named", "value": "green" }, "position": 0.0 },
+                { "color": { "kind": "named", "value": "green" }, "position": 1.0 }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.explicit-size-no-repeat",
+        "samples": [
+          { "point": [1.0, 1.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [43.0, 43.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [46.0, 20.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 },
+          { "point": [20.0, 46.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 },
+          { "point": [90.0, 20.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-004.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-004.json
@@ -1,0 +1,44 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-004",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-004.xht",
+    "reference_path": "css/css-backgrounds/border-radius-004-ref.xht",
+    "license": "BSD-3-Clause",
+    "assertion": "The slash syntax preserves independent horizontal and vertical border radii.",
+    "adaptation": "The WPT 200 by 100 box is represented as a 100 by 60 Host frame with proportionally similar 40 by 10 elliptical radii. Interior and exterior pixel samples distinguish the ellipse from both a circular radius and an unclipped box."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [0.0, 0.0, 100.0, 60.0],
+        "background": { "kind": "named", "value": "green" },
+        "border": {
+          "widths": [0.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" },
+            { "kind": "named", "value": "transparent" }
+          ],
+          "styles": ["none", "none", "none", "none"],
+          "radii": [[40.0, 10.0], [40.0, 10.0], [40.0, 10.0], [40.0, 10.0]]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [12.0, 5.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [2.0, 2.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-clipping-with-transform-001.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-clipping-with-transform-001.json
@@ -1,0 +1,65 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-clipping-with-transform-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-clipping-with-transform-001.html",
+    "reference_path": "css/css-backgrounds/border-radius-clipping-with-transform-001-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "Descendant content remains clipped to a rounded overflow curve when the clipping element is transformed.",
+    "adaptation": "The upstream rotation and 3D promotion are reduced to the resolved SetTransform translation needed to distinguish local clip geometry from untransformed surface scissoring. A red child fills the translated rounded parent."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 90.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [5.0, 10.0, 40.0, 40.0],
+            "background": { "kind": "named", "value": "transparent" },
+            "border": {
+              "widths": [0.0, 0.0, 0.0, 0.0],
+              "colors": [
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" }
+              ],
+              "styles": ["none", "none", "none", "none"],
+              "radii": [12.0, 12.0, 12.0, 12.0]
+            },
+            "clip": { "horizontal": "hidden", "vertical": "hidden" },
+            "transform": [
+              1.0, 0.0, 0.0, 0.0,
+              0.0, 1.0, 0.0, 0.0,
+              0.0, 0.0, 1.0, 0.0,
+              30.0, 0.0, 0.0, 1.0
+            ]
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [0.0, 0.0, 40.0, 40.0],
+            "background": { "kind": "named", "value": "red" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [20.0, 30.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 18 },
+          { "point": [50.0, 30.0], "color": { "kind": "named", "value": "red" }, "tolerance": 18 },
+          { "point": [36.0, 11.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 18 },
+          { "point": [64.0, 30.0], "color": { "kind": "named", "value": "red" }, "tolerance": 18 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-overflow-hidden.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-overflow-hidden.json
@@ -1,0 +1,58 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-overflow-hidden",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-overflow-hidden.html",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "Effects that clip to the border or padding edge, including overflow other than visible, must clip descendant content to the border-radius curve.",
+    "adaptation": "A red child fills a transparent rounded parent with overflow hidden. Samples at the center and corner directly observe the curved descendant clip without the upstream document's covering reference box."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 70.0, "height": 70.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "transparent" },
+            "border": {
+              "widths": [0.0, 0.0, 0.0, 0.0],
+              "colors": [
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" }
+              ],
+              "styles": ["none", "none", "none", "none"],
+              "radii": [15.0, 15.0, 15.0, 15.0]
+            },
+            "clip": { "horizontal": "hidden", "vertical": "hidden" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [0.0, 0.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "red" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [11.0, 11.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 18 },
+          { "point": [35.0, 35.0], "color": { "kind": "named", "value": "red" }, "tolerance": 18 },
+          { "point": [59.0, 59.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 18 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/clip-padding-box-with-size.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/clip-padding-box-with-size.json
@@ -1,0 +1,40 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.clip-padding-box-with-size",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/background-clip/clip-padding-box_with_size.html",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A sized background with padding-box clip does not paint beneath the border.",
+    "adaptation": "The resource is replaced by a constant green gradient sized to the 100 by 100 border box. A transparent border exposes whether the Host intersects the image with the padding edge."
+  },
+  "test": { "commands": [
+    { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+    { "type": "present_scene", "revision": 1, "nodes": [{
+      "id": 1, "parent": null, "rect": [0.0, 0.0, 100.0, 100.0],
+      "background": { "kind": "named", "value": "transparent" },
+      "border": {
+        "widths": [10.0, 10.0, 10.0, 10.0],
+        "colors": [{ "kind": "named", "value": "transparent" }, { "kind": "named", "value": "transparent" }, { "kind": "named", "value": "transparent" }, { "kind": "named", "value": "transparent" }],
+        "styles": ["solid", "solid", "solid", "solid"],
+        "radii": [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]
+      },
+      "background_layer": {
+        "size": [{ "length": 100.0, "fraction": 0.0 }, { "length": 100.0, "fraction": 0.0 }],
+        "repeat_x": "no_repeat", "repeat_y": "no_repeat", "origin": "border", "clip": "padding"
+      },
+      "linear_gradient": { "angle_degrees": 180.0, "stops": [
+        { "color": { "kind": "named", "value": "green" }, "position": 0.0 },
+        { "color": { "kind": "named", "value": "green" }, "position": 1.0 }
+      ] }
+    }] },
+    { "type": "checkpoint", "name": "paint.background-layers.clip-padding-box", "samples": [
+      { "point": [5.0, 50.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 },
+      { "point": [11.0, 50.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+      { "point": [50.0, 5.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 },
+      { "point": [50.0, 11.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 }
+    ] }
+  ] }
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/css3-background-origin-border-box.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/css3-background-origin-border-box.json
@@ -1,0 +1,39 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.css3-background-origin-border-box",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/css3-background-origin-border-box.html",
+    "reference_path": "css/css-backgrounds/reference/css3-background-origin-border-box-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "A no-repeat background with border-box origin starts beneath the border rather than at the padding edge.",
+    "adaptation": "The resource image is replaced by a constant green gradient explicitly sized to 20 logical pixels. A transparent solid border makes samples distinguish the border-box origin from the padding-box origin without coupling the case to dashed-border rasterization."
+  },
+  "test": { "commands": [
+    { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+    { "type": "present_scene", "revision": 1, "nodes": [{
+      "id": 1, "parent": null, "rect": [0.0, 0.0, 100.0, 100.0],
+      "background": { "kind": "named", "value": "transparent" },
+      "border": {
+        "widths": [10.0, 10.0, 10.0, 10.0],
+        "colors": [{ "kind": "named", "value": "transparent" }, { "kind": "named", "value": "transparent" }, { "kind": "named", "value": "transparent" }, { "kind": "named", "value": "transparent" }],
+        "styles": ["solid", "solid", "solid", "solid"],
+        "radii": [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]
+      },
+      "background_layer": {
+        "size": [{ "length": 20.0, "fraction": 0.0 }, { "length": 20.0, "fraction": 0.0 }],
+        "repeat_x": "no_repeat", "repeat_y": "no_repeat", "origin": "border"
+      },
+      "linear_gradient": { "angle_degrees": 180.0, "stops": [
+        { "color": { "kind": "named", "value": "green" }, "position": 0.0 },
+        { "color": { "kind": "named", "value": "green" }, "position": 1.0 }
+      ] }
+    }] },
+    { "type": "checkpoint", "name": "paint.background-layers.origin-border-box", "samples": [
+      { "point": [1.0, 1.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+      { "point": [18.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+      { "point": [21.0, 10.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 }
+    ] }
+  ] }
+}

--- a/tests/host-conformance/wpt/css/css-color/t32-opacity-basic-0.6-a.json
+++ b/tests/host-conformance/wpt/css/css-color/t32-opacity-basic-0.6-a.json
@@ -1,0 +1,49 @@
+{
+  "schema": 1,
+  "id": "wpt.css-color.opacity-basic-0.6",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-color/t32-opacity-basic-0.6-a.xht",
+    "reference_path": "css/css-color/t32-opacity-basic-0.6-a-ref.xht",
+    "license": "BSD-3-Clause",
+    "assertion": "Opacity of 0.6 makes a box partially opaque in the sRGB color space.",
+    "adaptation": "A red box with opacity 0.6 is composited over an opaque white sibling. The expected pink sample is the source-over sRGB result and distinguishes SetOpacity from an opaque projection."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 60.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 40.0, 40.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": null,
+            "rect": [10.0, 10.0, 40.0, 40.0],
+            "background": { "kind": "named", "value": "red" },
+            "opacity": 0.6
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          {
+            "point": [30.0, 30.0],
+            "color": { "kind": "srgba", "red": 255, "green": 102, "blue": 102, "alpha": 1.0 },
+            "tolerance": 18
+          }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-images/conic-gradient-angle.json
+++ b/tests/host-conformance/wpt/css/css-images/conic-gradient-angle.json
@@ -1,0 +1,54 @@
+{
+  "schema": 1,
+  "id": "wpt.css-images.conic-gradient-angle",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-images/conic-gradient-angle.html",
+    "reference_path": "css/css-images/reference/200x200-blue-black-green-red.html",
+    "license": "BSD-3-Clause",
+    "assertion": "A conic gradient with a 90 degree starting angle paints the four quadrants in the reference order.",
+    "adaptation": "CSS parsing and stop-list expansion remain Rust responsibilities. The Host receives the WPT gradient as an explicit SetBackgroundLayers conic image; the box is reduced to 100 logical pixels and interior quadrant samples avoid antialiased boundaries."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 100.0],
+            "background": { "kind": "srgba", "red": 255, "green": 255, "blue": 255, "alpha": 0.0 },
+            "conic_gradient": {
+              "from_degrees": 90.0,
+              "center": [50.0, 50.0],
+              "stops": [
+                { "color": { "kind": "named", "value": "red" }, "position": 0.0 },
+                { "color": { "kind": "named", "value": "red" }, "position": 0.25 },
+                { "color": { "kind": "named", "value": "green" }, "position": 0.25 },
+                { "color": { "kind": "named", "value": "green" }, "position": 0.5 },
+                { "color": { "kind": "named", "value": "blue" }, "position": 0.5 },
+                { "color": { "kind": "named", "value": "blue" }, "position": 0.75 },
+                { "color": { "kind": "named", "value": "black" }, "position": 0.75 },
+                { "color": { "kind": "named", "value": "black" }, "position": 1.0 }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.conic-gradient",
+        "samples": [
+          { "point": [25.0, 25.0], "color": { "kind": "named", "value": "blue" }, "tolerance": 5 },
+          { "point": [75.0, 25.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [25.0, 75.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [75.0, 75.0], "color": { "kind": "named", "value": "red" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-images/linear-gradient-1.json
+++ b/tests/host-conformance/wpt/css/css-images/linear-gradient-1.json
@@ -1,0 +1,47 @@
+{
+  "schema": 1,
+  "id": "wpt.css-images.linear-gradient-1",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-images/linear-gradient-1.html",
+    "reference_path": "css/css-images/linear-gradient-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "Implicit linear-gradient stop positions are distributed between the surrounding explicit positions.",
+    "adaptation": "CSS parsing and implicit-stop resolution remain Rust responsibilities, so the Host receives the equivalent resolved SetBackgroundLayers payload used by the WPT reference. The 400 by 300 box is reduced to 100 by 60 logical pixels and representative sRGB samples verify the gradient image."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 60.0],
+            "background": { "kind": "srgba", "red": 255, "green": 255, "blue": 255, "alpha": 0.0 },
+            "linear_gradient": {
+              "angle_degrees": 90.0,
+              "stops": [
+                { "color": { "kind": "named", "value": "black" }, "position": 0.0 },
+                { "color": { "kind": "named", "value": "red" }, "position": 0.5 },
+                { "color": { "kind": "named", "value": "gold" }, "position": 1.0 }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.linear-gradient",
+        "samples": [
+          { "point": [25.0, 30.0], "color": { "kind": "srgba", "red": 128, "green": 0, "blue": 0, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [50.0, 30.0], "color": { "kind": "named", "value": "red" }, "tolerance": 5 },
+          { "point": [75.0, 30.0], "color": { "kind": "srgba", "red": 255, "green": 108, "blue": 0, "alpha": 1.0 }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-images/radial-gradient-container-relative-units-001.json
+++ b/tests/host-conformance/wpt/css/css-images/radial-gradient-container-relative-units-001.json
@@ -1,0 +1,47 @@
+{
+  "schema": 1,
+  "id": "wpt.css-images.radial-gradient-container-relative-units-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-images/radial-gradient-container-relative-units-001.html",
+    "reference_path": "css/css-images/radial-gradient-container-relative-units-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "A container-relative horizontal center resolves to the same radial gradient as the equivalent absolute center.",
+    "adaptation": "Container-unit and CSS position resolution remain Rust responsibilities. The Host receives the WPT reference as an explicit 50 by 50 logical-pixel ellipse centered at 50,50 in a 100 by 100 box; representative sRGB samples verify radial interpolation."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 100.0],
+            "background": { "kind": "srgba", "red": 255, "green": 255, "blue": 255, "alpha": 0.0 },
+            "radial_gradient": {
+              "center": [50.0, 50.0],
+              "radii": [50.0, 50.0],
+              "stops": [
+                { "color": { "kind": "named", "value": "green" }, "position": 0.0 },
+                { "color": { "kind": "named", "value": "blue" }, "position": 1.0 }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.radial-gradient",
+        "samples": [
+          { "point": [50.0, 50.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [25.0, 50.0], "color": { "kind": "srgba", "red": 0, "green": 64, "blue": 128, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [1.0, 50.0], "color": { "kind": "srgba", "red": 0, "green": 3, "blue": 250, "alpha": 1.0 }, "tolerance": 6 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-overflow/clip-002-vertical.json
+++ b/tests/host-conformance/wpt/css/css-overflow/clip-002-vertical.json
@@ -1,0 +1,49 @@
+{
+  "schema": 1,
+  "id": "wpt.css-overflow.clip-002.vertical",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-overflow/clip-002.html",
+    "reference_path": "css/css-overflow/clip-002-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "Overflow clipping can be applied on the vertical axis while horizontal overflow remains visible.",
+    "adaptation": "The WPT overflow-y:clip section is represented as a two-node Host scene. Opaque colors and pixel samples replace the document's three translucent examples while retaining independent-axis clipping."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [25.0, 25.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "black" },
+            "clip": { "horizontal": "visible", "vertical": "hidden" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [-20.0, -20.0, 90.0, 90.0],
+            "background": { "kind": "named", "value": "red" },
+            "clip": { "horizontal": "visible", "vertical": "visible" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [20.0, 40.0], "color": { "kind": "named", "value": "red" }, "tolerance": 16 },
+          { "point": [40.0, 20.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [40.0, 40.0], "color": { "kind": "named", "value": "red" }, "tolerance": 16 },
+          { "point": [40.0, 80.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-overflow/clip-002.json
+++ b/tests/host-conformance/wpt/css/css-overflow/clip-002.json
@@ -1,0 +1,49 @@
+{
+  "schema": 1,
+  "id": "wpt.css-overflow.clip-002.horizontal",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-overflow/clip-002.html",
+    "reference_path": "css/css-overflow/clip-002-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "Overflow clipping can be applied on the horizontal axis while vertical overflow remains visible.",
+    "adaptation": "The WPT overflow-x:clip section is represented as a two-node Host scene. Opaque colors and pixel samples replace the document's three translucent examples while retaining independent-axis clipping."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [25.0, 25.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "black" },
+            "clip": { "horizontal": "hidden", "vertical": "visible" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [-20.0, -20.0, 90.0, 90.0],
+            "background": { "kind": "named", "value": "red" },
+            "clip": { "horizontal": "visible", "vertical": "visible" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [20.0, 40.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [40.0, 20.0], "color": { "kind": "named", "value": "red" }, "tolerance": 16 },
+          { "point": [40.0, 40.0], "color": { "kind": "named", "value": "red" }, "tolerance": 16 },
+          { "point": [80.0, 40.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-transforms/transform-matrix-001.json
+++ b/tests/host-conformance/wpt/css/css-transforms/transform-matrix-001.json
@@ -1,0 +1,47 @@
+{
+  "schema": 1,
+  "id": "wpt.css-transforms.transform-matrix-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-transforms/transform-matrix-001.html",
+    "reference_path": "css/css-transforms/transform-matrix-001-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "A translation expressed as a matrix has the same visual effect as translated layout geometry.",
+    "adaptation": "The WPT matrix(1, 0, 0, 1, 100, 0) is scaled to a 40 logical-pixel translation and delivered as the equivalent column-major SetTransform matrix. Pixel samples distinguish transformed paint from its original layout position."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 70.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 20.0, 30.0, 30.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip": { "horizontal": "visible", "vertical": "visible" },
+            "transform": [
+              1.0, 0.0, 0.0, 0.0,
+              0.0, 1.0, 0.0, 0.0,
+              0.0, 0.0, 1.0, 0.0,
+              40.0, 0.0, 0.0, 1.0
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [5.0, 25.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [45.0, 25.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [75.0, 25.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}


### PR DESCRIPTION
## Summary
- add shared WPT-derived repeat-x and repeat-y fixtures
- negotiate explicit background geometry with independent Repeat/NoRepeat axes while keeping Space/Round outside the subset
- lower per-axis repeat values through the existing mobile ABI 2.4 contract
- render repeated gradient tiles on Android and iOS, project them to native CSS on Web, and wrap tile coordinates in the Desktop GPU shader
- preserve background origin, rounded background clip, and positioned tile anchoring across all Hosts

## Verification
- `cargo test -p whisker-host-conformance`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`
- `cargo llvm-cov -p whisker-protocol --summary-only --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100`
- `cargo clippy -p whisker-protocol -p whisker -p whisker-desktop -p whisker-web --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`