### PR TITLE
feat(host): manage raster resource lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5959,11 +5959,14 @@ dependencies = [
 name = "whisker-desktop"
 version = "0.12.0"
 dependencies = [
+ "base64 0.22.1",
  "bytemuck",
  "csscolorparser",
  "glyphon",
+ "image",
  "pollster",
  "serde_json",
+ "ureq",
  "wgpu",
  "whisker",
  "whisker-engine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6380,8 +6380,11 @@ dependencies = [
 name = "whisker-web"
 version = "0.12.0"
 dependencies = [
+ "base64 0.22.1",
+ "js-sys",
  "serde_json",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
  "whisker",

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -147,6 +147,39 @@ pub enum Command {
         /// Row-major pixels from top-left to bottom-right.
         pixels: Vec<ColorFixture>,
     },
+    /// Asks the production Host resource service to acquire and decode a
+    /// raster outside the frame transaction.
+    LoadRasterResource {
+        /// Stable non-zero resource identifier.
+        id: u64,
+        /// Monotonic non-zero generation for replacement safety.
+        generation: u64,
+        /// Encoded source consumed once by the Host resource service.
+        source: ResourceSourceFixture,
+    },
+    /// Releases one exact resource generation after accepted frames no longer
+    /// reference it.
+    ReleaseRasterResource {
+        /// Stable non-zero resource identifier.
+        id: u64,
+        /// Exact non-zero generation to release.
+        generation: u64,
+    },
+    /// Checks the latest event and retained state for one resource generation.
+    CheckpointResource {
+        /// Stable non-zero resource identifier.
+        id: u64,
+        /// Exact non-zero generation being observed.
+        generation: u64,
+        /// Expected resource lifecycle state.
+        state: ResourceStateFixture,
+        /// Expected intrinsic raster width for a ready resource.
+        #[serde(default)]
+        width: Option<u32>,
+        /// Expected intrinsic raster height for a ready resource.
+        #[serde(default)]
+        height: Option<u32>,
+    },
     /// Presents one semantic box through the production Host path.
     PresentBox {
         /// Frame target revision.
@@ -235,6 +268,37 @@ pub enum Command {
         /// Expected logical y coordinate.
         y: f32,
     },
+}
+
+/// Encoded source variants accepted by the mock Host resource boundary.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ResourceSourceFixture {
+    /// URL acquired under Host network and security policy. Data URLs keep
+    /// conformance deterministic while exercising the URL source path.
+    Url {
+        /// Absolute source URL.
+        value: String,
+    },
+    /// One-time encoded bytes represented as base64 in the language-neutral fixture.
+    Bytes {
+        /// Non-empty MIME media type.
+        media_type: String,
+        /// Standard padded base64 encoded contents.
+        base64: String,
+    },
+}
+
+/// Observable resource lifecycle states used by conformance checkpoints.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceStateFixture {
+    /// Decode completed and the image is retained for painting.
+    Ready,
+    /// The exact generation failed acquisition or decode.
+    Failed,
+    /// The exact generation was released and is no longer paintable.
+    Released,
 }
 
 /// Pointer phase used by input fixtures.
@@ -757,6 +821,7 @@ fn validate_manifest(manifest: &Manifest) -> Result<(), FixtureError> {
                     | "pixel-samples"
                     | "pixel-relations"
                     | "resource-registration"
+                    | "resource-lifecycle"
                     | "measurement"
                     | "input"
             ) {
@@ -815,6 +880,21 @@ fn validate_scenario(
     {
         return Err(FixtureError(format!(
             "scenario {} declares pixel-samples without sample assertions",
+            scenario.id
+        )));
+    }
+    if entry
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint == "resource-lifecycle")
+        && !scenario
+            .test
+            .commands
+            .iter()
+            .any(|command| matches!(command, Command::CheckpointResource { .. }))
+    {
+        return Err(FixtureError(format!(
+            "scenario {} declares resource-lifecycle without a resource checkpoint",
             scenario.id
         )));
     }
@@ -888,6 +968,29 @@ fn validate_side(id: &str, label: &str, side: &ScenarioSide) -> Result<(), Fixtu
                     .checked_mul(*height)
                     .is_some_and(|count| count as usize == pixels.len())
                 && pixels.iter().all(valid_color) => {}
+            Command::LoadRasterResource {
+                id,
+                generation,
+                source,
+            } if *id > 0 && *generation > 0 && valid_resource_source(source) => {}
+            Command::ReleaseRasterResource { id, generation } if *id > 0 && *generation > 0 => {}
+            Command::CheckpointResource {
+                id,
+                generation,
+                state,
+                width,
+                height,
+            } if *id > 0
+                && *generation > 0
+                && match state {
+                    ResourceStateFixture::Ready => {
+                        width.is_some_and(|value| value > 0)
+                            && height.is_some_and(|value| value > 0)
+                    }
+                    ResourceStateFixture::Failed | ResourceStateFixture::Released => {
+                        width.is_none() && height.is_none()
+                    }
+                } => {}
             Command::PresentBox {
                 revision,
                 rect,
@@ -959,6 +1062,19 @@ fn validate_side(id: &str, label: &str, side: &ScenarioSide) -> Result<(), Fixtu
         }
     }
     Ok(())
+}
+
+fn valid_resource_source(source: &ResourceSourceFixture) -> bool {
+    match source {
+        ResourceSourceFixture::Url { value } => !value.trim().is_empty(),
+        ResourceSourceFixture::Bytes { media_type, base64 } => {
+            !media_type.trim().is_empty()
+                && !base64.trim().is_empty()
+                && base64
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/' | b'='))
+        }
+    }
 }
 
 fn finite_positive(value: f32) -> bool {

--- a/platforms/android/runtime/src/main/AndroidManifest.xml
+++ b/platforms/android/runtime/src/main/AndroidManifest.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -8,6 +8,10 @@ import android.view.View
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.measure.HostMeasurementProvider
 import rs.whisker.runtime.module.HostModuleDispatcher
+import rs.whisker.runtime.paint.HostRasterResourceStore
+import rs.whisker.runtime.resource.HostRasterSource
+import rs.whisker.runtime.resource.HostResourceService
+import rs.whisker.runtime.resource.HostResourceSnapshot
 import rs.whisker.runtime.scene.HostElementBootstrap
 import rs.whisker.runtime.scene.HostScene
 import rs.whisker.runtime.scene.HostSceneOperation
@@ -26,7 +30,9 @@ class WhiskerView(context: Context) :
     private var windowVisible = true
     private val measurements = HostMeasurementProvider(context)
     private val bootstrap = HostElementBootstrap()
-    private val scene = HostScene(this, context, ::dispatchElementEvent)
+    private val rasterResources = HostRasterResourceStore()
+    private val scene = HostScene(this, context, ::dispatchElementEvent, rasterResources)
+    private val resourceService = HostResourceService(rasterResources, ::handleResourceEvent)
     private val modules = HostModuleDispatcher(::nativeResolveModule)
 
     init {
@@ -158,7 +164,34 @@ class WhiskerView(context: Context) :
 
     /** Registers an already decoded raster. Acquisition and eviction are separate Host concerns. */
     fun registerRasterResourceFromNative(resourceId: Long, bitmap: Bitmap): Boolean =
-        scene.registerRasterResource(resourceId, bitmap)
+        rasterResources.register(resourceId, bitmap)
+
+    fun loadRasterResourceBytesFromNative(
+        resourceId: Long,
+        generation: Long,
+        mediaType: String,
+        data: ByteArray,
+    ): Boolean = resourceService.load(
+        resourceId,
+        generation,
+        HostRasterSource.Bytes(mediaType, data.copyOf()),
+    )
+
+    fun loadRasterResourceUrlFromNative(
+        resourceId: Long,
+        generation: Long,
+        url: String,
+    ): Boolean = resourceService.load(resourceId, generation, HostRasterSource.Url(url))
+
+    fun releaseRasterResourceFromNative(resourceId: Long, generation: Long): Boolean =
+        resourceService.release(resourceId, generation)
+
+    fun awaitRasterResourceFromNative(
+        resourceId: Long,
+        generation: Long,
+        timeoutMillis: Long,
+    ): HostResourceSnapshot? =
+        resourceService.awaitTerminal(resourceId, generation, timeoutMillis)
 
     @Suppress("LongParameterList")
     fun stageOperationFromNative(
@@ -196,6 +229,14 @@ class WhiskerView(context: Context) :
     )
 
     fun commitFrameFromNative(): Boolean = scene.commit()
+
+    private fun handleResourceEvent(@Suppress("UNUSED_PARAMETER") event: HostResourceSnapshot) {
+        post {
+            invalidate()
+            requestFrameFromNative()
+        }
+    }
+
     private fun dispatchElementEvent(node: Long, name: String, detail: WhiskerValue) {
         scene.dispatchOrDefer {
             val handle = nativeHandle

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/HostRasterResources.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/HostRasterResources.kt
@@ -5,15 +5,35 @@ import java.util.concurrent.ConcurrentHashMap
 
 /** Decoded raster resources keyed by the lossless 64-bit protocol ResourceId bits. */
 internal class HostRasterResourceStore {
-    private val bitmaps = ConcurrentHashMap<Long, Bitmap>()
+    private data class Entry(val generation: Long, val bitmap: Bitmap)
 
-    fun register(resourceId: Long, bitmap: Bitmap): Boolean {
-        if (resourceId == 0L || bitmap.isRecycled || bitmap.width <= 0 || bitmap.height <= 0) {
+    private val bitmaps = ConcurrentHashMap<Long, Entry>()
+
+    fun register(resourceId: Long, bitmap: Bitmap): Boolean =
+        registerEntry(resourceId, 0L, bitmap)
+
+    fun register(resourceId: Long, generation: Long, bitmap: Bitmap): Boolean {
+        if (generation == 0L) return false
+        return registerEntry(resourceId, generation, bitmap)
+    }
+
+    private fun registerEntry(resourceId: Long, generation: Long, bitmap: Bitmap): Boolean {
+        if (
+            resourceId == 0L || bitmap.isRecycled ||
+            bitmap.width <= 0 || bitmap.height <= 0
+        ) {
             return false
         }
-        bitmaps[resourceId] = bitmap
+        bitmaps[resourceId] = Entry(generation, bitmap)
         return true
     }
 
-    fun resolve(resourceId: Long): Bitmap? = bitmaps[resourceId]?.takeUnless(Bitmap::isRecycled)
+    fun release(resourceId: Long, generation: Long) {
+        bitmaps.computeIfPresent(resourceId) { _, entry ->
+            entry.takeUnless { it.generation == generation }
+        }
+    }
+
+    fun resolve(resourceId: Long): Bitmap? =
+        bitmaps[resourceId]?.bitmap?.takeUnless(Bitmap::isRecycled)
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/resource/HostResourceService.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/resource/HostResourceService.kt
@@ -1,0 +1,260 @@
+package rs.whisker.runtime.resource
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Base64
+import java.io.ByteArrayOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import rs.whisker.runtime.paint.HostRasterResourceStore
+
+/** Observable state of one exact resource generation. */
+enum class HostResourceState {
+    Loading,
+    Ready,
+    Failed,
+    Released,
+}
+
+/** Generation-specific resource state retained outside scene transactions. */
+data class HostResourceSnapshot(
+    val resourceId: Long,
+    val generation: Long,
+    val state: HostResourceState,
+    val width: Int = 0,
+    val height: Int = 0,
+)
+
+internal sealed interface HostRasterSource {
+    data class Bytes(val mediaType: String, val data: ByteArray) : HostRasterSource
+    data class Url(val value: String) : HostRasterSource
+}
+
+/**
+ * Android-owned raster acquisition and decode lifecycle.
+ *
+ * Network and decode work always runs off the UI thread. Completion publishes
+ * into the paint store only when both ResourceId and generation remain current.
+ */
+internal class HostResourceService(
+    private val rasterStore: HostRasterResourceStore,
+    private val onEvent: (HostResourceSnapshot) -> Unit,
+    private val executor: ExecutorService = newResourceExecutor(),
+) {
+    private data class Key(val resourceId: Long, val generation: Long)
+
+    private val lock = ReentrantLock()
+    private val changed = lock.newCondition()
+    private val highestGeneration = HashMap<Long, Long>()
+    private val snapshots = HashMap<Key, HostResourceSnapshot>()
+
+    fun load(resourceId: Long, generation: Long, source: HostRasterSource): Boolean {
+        if (resourceId == 0L || generation == 0L || !validSource(source)) return false
+        val key = Key(resourceId, generation)
+        lock.withLock {
+            val highest = highestGeneration[resourceId]
+            if (highest != null && java.lang.Long.compareUnsigned(generation, highest) <= 0) {
+                return false
+            }
+            highestGeneration[resourceId] = generation
+            snapshots[key] = HostResourceSnapshot(resourceId, generation, HostResourceState.Loading)
+            changed.signalAll()
+        }
+        return try {
+            executor.execute { acquire(key, source) }
+            true
+        } catch (_: RuntimeException) {
+            completeFailure(key)
+            false
+        }
+    }
+
+    fun release(resourceId: Long, generation: Long): Boolean {
+        if (resourceId == 0L || generation == 0L) return false
+        val snapshot = lock.withLock {
+            val key = Key(resourceId, generation)
+            if (snapshots[key] == null) return false
+            HostResourceSnapshot(resourceId, generation, HostResourceState.Released).also {
+                snapshots[key] = it
+                rasterStore.release(resourceId, generation)
+                changed.signalAll()
+            }
+        }
+        onEvent(snapshot)
+        return true
+    }
+
+    fun snapshot(resourceId: Long, generation: Long): HostResourceSnapshot? =
+        lock.withLock { snapshots[Key(resourceId, generation)] }
+
+    fun awaitTerminal(
+        resourceId: Long,
+        generation: Long,
+        timeoutMillis: Long,
+    ): HostResourceSnapshot? {
+        var remaining = TimeUnit.MILLISECONDS.toNanos(timeoutMillis.coerceAtLeast(0L))
+        lock.lock()
+        try {
+            val key = Key(resourceId, generation)
+            while (true) {
+                val snapshot = snapshots[key] ?: return null
+                if (snapshot.state != HostResourceState.Loading || remaining <= 0L) return snapshot
+                remaining = changed.awaitNanos(remaining)
+            }
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun acquire(key: Key, source: HostRasterSource) {
+        val bitmap = try {
+            val encoded = when (source) {
+                is HostRasterSource.Bytes -> source.data
+                is HostRasterSource.Url -> acquireUrl(source.value)
+            }
+            decodeRaster(encoded)
+        } catch (_: Exception) {
+            null
+        } catch (_: OutOfMemoryError) {
+            null
+        }
+        if (bitmap == null) {
+            completeFailure(key)
+            return
+        }
+        val ready = lock.withLock {
+            val current = snapshots[key]
+            if (
+                highestGeneration[key.resourceId] != key.generation ||
+                current?.state != HostResourceState.Loading
+            ) {
+                null
+            } else if (!rasterStore.register(key.resourceId, key.generation, bitmap)) {
+                HostResourceSnapshot(key.resourceId, key.generation, HostResourceState.Failed).also {
+                    snapshots[key] = it
+                    changed.signalAll()
+                }
+            } else {
+                HostResourceSnapshot(
+                    key.resourceId,
+                    key.generation,
+                    HostResourceState.Ready,
+                    bitmap.width,
+                    bitmap.height,
+                ).also {
+                    snapshots[key] = it
+                    changed.signalAll()
+                }
+            }
+        }
+        if (ready == null) {
+            bitmap.recycle()
+        } else {
+            onEvent(ready)
+        }
+    }
+
+    private fun completeFailure(key: Key) {
+        val failed = lock.withLock {
+            val current = snapshots[key]
+            if (
+                highestGeneration[key.resourceId] != key.generation ||
+                current?.state != HostResourceState.Loading
+            ) {
+                null
+            } else {
+                HostResourceSnapshot(key.resourceId, key.generation, HostResourceState.Failed).also {
+                    snapshots[key] = it
+                    changed.signalAll()
+                }
+            }
+        }
+        if (failed != null) onEvent(failed)
+    }
+
+    private fun acquireUrl(value: String): ByteArray {
+        if (value.startsWith("data:", ignoreCase = true)) return decodeDataUrl(value)
+        val url = URL(value)
+        require(url.protocol == "http" || url.protocol == "https")
+        val connection = url.openConnection() as HttpURLConnection
+        return try {
+            connection.connectTimeout = NETWORK_TIMEOUT_MILLIS
+            connection.readTimeout = NETWORK_TIMEOUT_MILLIS
+            connection.instanceFollowRedirects = true
+            connection.requestMethod = "GET"
+            connection.connect()
+            require(connection.responseCode in 200..299)
+            require(connection.contentLengthLong <= 0L || connection.contentLengthLong <= MAX_ENCODED_BYTES)
+            connection.inputStream.use(::readBounded)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun decodeDataUrl(value: String): ByteArray {
+        val comma = value.indexOf(',')
+        require(comma > 5)
+        val metadata = value.substring(5, comma)
+        require(metadata.substringBefore(';').startsWith("image/", ignoreCase = true))
+        require(metadata.split(';').drop(1).any { it.equals("base64", ignoreCase = true) })
+        return Base64.decode(value.substring(comma + 1), Base64.DEFAULT).also {
+            require(it.isNotEmpty() && it.size <= MAX_ENCODED_BYTES)
+        }
+    }
+
+    private fun decodeRaster(encoded: ByteArray): Bitmap? {
+        if (encoded.isEmpty() || encoded.size > MAX_ENCODED_BYTES) return null
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(encoded, 0, encoded.size, bounds)
+        val width = bounds.outWidth
+        val height = bounds.outHeight
+        if (
+            width <= 0 || height <= 0 || width > MAX_RASTER_AXIS || height > MAX_RASTER_AXIS ||
+            width.toLong() * height.toLong() > MAX_RASTER_PIXELS
+        ) {
+            return null
+        }
+        return BitmapFactory.decodeByteArray(encoded, 0, encoded.size)
+    }
+
+    private fun readBounded(input: java.io.InputStream): ByteArray {
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(16 * 1024)
+        while (true) {
+            val count = input.read(buffer)
+            if (count < 0) break
+            require(output.size() + count <= MAX_ENCODED_BYTES)
+            output.write(buffer, 0, count)
+        }
+        return output.toByteArray()
+    }
+
+    private fun validSource(source: HostRasterSource): Boolean = when (source) {
+        is HostRasterSource.Bytes ->
+            source.mediaType.startsWith("image/", ignoreCase = true) &&
+                source.data.isNotEmpty() && source.data.size <= MAX_ENCODED_BYTES
+        is HostRasterSource.Url -> source.value.isNotBlank()
+    }
+
+    private companion object {
+        const val NETWORK_TIMEOUT_MILLIS = 15_000
+        const val MAX_ENCODED_BYTES = 64 * 1024 * 1024
+        const val MAX_RASTER_AXIS = 16_384
+        const val MAX_RASTER_PIXELS = 100_000_000L
+
+        private val threadNumber = AtomicInteger()
+
+        private fun newResourceExecutor(): ExecutorService =
+            Executors.newFixedThreadPool(2) { runnable ->
+                Thread(runnable, "whisker-resource-${threadNumber.incrementAndGet()}").apply {
+                    isDaemon = true
+                }
+            }
+    }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -1,7 +1,6 @@
 package rs.whisker.runtime.scene
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.graphics.RectF
 import android.util.Log
 import android.view.View
@@ -50,9 +49,9 @@ internal class HostScene(
     private val root: WhiskerContainerView,
     private val context: Context,
     private val emitElementEvent: (Long, String, WhiskerValue) -> Unit,
+    private val rasterResources: HostRasterResourceStore,
 ) {
     private val nodes = LinkedHashMap<Long, HostNode>()
-    private val rasterResources = HostRasterResourceStore()
     private val parents = HashMap<Long, Long>()
     private var sceneEpoch = 0
     private var revision = 0L
@@ -75,9 +74,6 @@ internal class HostScene(
     }
 
     fun currentRevision(): Long = revision
-
-    fun registerRasterResource(resourceId: Long, bitmap: Bitmap): Boolean =
-        rasterResources.register(resourceId, bitmap)
 
     fun stage(operation: HostSceneOperation): Boolean {
         stagedOperations += operation

--- a/platforms/desktop/Cargo.toml
+++ b/platforms/desktop/Cargo.toml
@@ -24,9 +24,12 @@ whisker-style = { workspace = true }
 whisker-value = { workspace = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
+base64 = { workspace = true }
 bytemuck = { version = "1", features = ["derive"] }
 csscolorparser = "0.7.2"
 glyphon = "0.9.0"
+image = { version = "0.25", default-features = false, features = ["png"] }
+ureq = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 wgpu = { version = "25.0.2", default-features = false, features = ["metal", "wgsl"] }

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -1590,6 +1590,10 @@ impl GpuRenderer {
         self.image_resources.insert(resource, image);
     }
 
+    pub(crate) fn release_raster_resource(&mut self, resource: ResourceId) {
+        self.image_resources.remove(&resource);
+    }
+
     pub(crate) fn resize(&mut self, physical_size: [u32; 2]) {
         if physical_size[0] == 0 || physical_size[1] == 0 {
             return;

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -13,6 +13,7 @@ use std::error::Error;
 use std::fmt;
 
 use whisker::RuntimeInstance;
+use whisker::runtime::RuntimeWakeHandle;
 use whisker_engine::LayoutOptions;
 use whisker_protocol::{ElementRegistration, InputEvent, InputEventKind, ResourceId, SurfaceId};
 use whisker_style::StyleEnvironment;
@@ -25,6 +26,7 @@ pub use whisker_value::WhiskerValue;
 mod element;
 mod gpu;
 mod paint;
+mod resource;
 mod scene;
 mod surface;
 mod text;
@@ -41,6 +43,7 @@ pub use element::{
 /// Desktop Host module declaration, named consistently with native Hosts.
 pub type ModuleDefinition = DesktopModuleDefinition;
 use gpu::RasterResource;
+use resource::{DesktopResourceService, DesktopResourceUpdate};
 use surface::DesktopSurface;
 use text::NativeTextHost;
 
@@ -88,6 +91,8 @@ impl Error for DesktopError {}
 pub struct DesktopRuntime {
     measurements: NativeTextHost,
     surface: DesktopSurface,
+    resources: DesktopResourceService,
+    resource_events: Vec<whisker_protocol::ResourceEvent>,
 }
 
 impl DesktopRuntime {
@@ -102,6 +107,7 @@ impl DesktopRuntime {
         surface: SurfaceId,
         elements: &[ElementRegistration],
         element_factories: &[DesktopElementFactory],
+        resource_wake: RuntimeWakeHandle,
     ) -> Result<Self, DesktopError> {
         let elements = DesktopElementRegistry::bind(elements, element_factories)
             .map_err(|error| DesktopError(format!("bind Desktop elements: {error}")))?;
@@ -111,6 +117,10 @@ impl DesktopRuntime {
         Ok(Self {
             measurements: NativeTextHost::new(elements),
             surface,
+            resources: DesktopResourceService::new(std::path::PathBuf::new(), move || {
+                resource_wake.wake();
+            }),
+            resource_events: Vec::new(),
         })
     }
 
@@ -135,6 +145,27 @@ impl DesktopRuntime {
         Ok(())
     }
 
+    /// Starts or releases one Host-owned resource acquisition. Completion is
+    /// applied on a later UI-thread frame and exposed through
+    /// [`Self::take_resource_events`].
+    pub fn resource_command(
+        &mut self,
+        command: whisker_protocol::ResourceCommand,
+    ) -> Result<(), DesktopError> {
+        let updates = self
+            .resources
+            .command(command)
+            .map_err(|error| DesktopError(error.to_string()))?;
+        self.apply_resource_updates(updates);
+        Ok(())
+    }
+
+    /// Drains ready/failed resource events for forwarding to the Rust runtime.
+    pub fn take_resource_events(&mut self) -> Vec<whisker_protocol::ResourceEvent> {
+        self.apply_pending_resource_updates();
+        std::mem::take(&mut self.resource_events)
+    }
+
     /// Runs measurement, layout, frame presentation, and native painting once.
     pub fn drive_frame(
         &mut self,
@@ -142,6 +173,7 @@ impl DesktopRuntime {
         context: DesktopFrameContext,
     ) -> Result<DesktopFrameResult, DesktopError> {
         validate_context(context)?;
+        self.apply_pending_resource_updates();
         let environment = StyleEnvironment::new(
             context.logical_width,
             context.logical_height,
@@ -185,6 +217,33 @@ impl DesktopRuntime {
         Ok(DesktopFrameResult {
             needs_frame: drive.needs_frame || dispatched_provider_event,
         })
+    }
+
+    fn apply_pending_resource_updates(&mut self) {
+        let updates = self.resources.drain();
+        self.apply_resource_updates(updates);
+    }
+
+    fn apply_resource_updates(&mut self, updates: Vec<DesktopResourceUpdate>) {
+        for update in updates {
+            match update {
+                DesktopResourceUpdate::Ready { event, raster } => {
+                    let whisker_protocol::ResourceEvent::Ready { resource, .. } = event else {
+                        unreachable!()
+                    };
+                    self.surface.register_raster_resource(resource, &raster);
+                    self.resource_events.push(event);
+                }
+                DesktopResourceUpdate::Failed(event) => self.resource_events.push(event),
+                DesktopResourceUpdate::Released {
+                    resource, evict, ..
+                } => {
+                    if evict {
+                        self.surface.release_raster_resource(resource);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/platforms/desktop/src/resource.rs
+++ b/platforms/desktop/src/resource.rs
@@ -1,0 +1,263 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::io::Read;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver};
+
+use base64::Engine;
+use whisker_protocol::{
+    ResourceCommand, ResourceDimensions, ResourceEvent, ResourceFailureCode, ResourceId,
+    ResourceKind, ResourceMessageError, ResourceRequest, ResourceSource,
+};
+
+use crate::gpu::RasterResource;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DesktopResourceState {
+    Loading,
+    Ready { width: u32, height: u32 },
+    Failed(ResourceFailureCode),
+    Released,
+}
+
+#[derive(Debug)]
+pub(crate) enum DesktopResourceUpdate {
+    Ready {
+        event: ResourceEvent,
+        raster: RasterResource,
+    },
+    Failed(ResourceEvent),
+    Released {
+        resource: ResourceId,
+        evict: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum DesktopResourceError {
+    InvalidMessage(ResourceMessageError),
+    UnsupportedKind(ResourceKind),
+    NonMonotonicGeneration {
+        resource: ResourceId,
+        current: u64,
+        received: u64,
+    },
+}
+
+impl fmt::Display for DesktopResourceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Desktop resource error: {self:?}")
+    }
+}
+
+impl Error for DesktopResourceError {}
+
+struct Completion {
+    resource: ResourceId,
+    generation: u64,
+    result: Result<RasterResource, (ResourceFailureCode, String)>,
+}
+
+pub(crate) struct DesktopResourceService {
+    asset_root: PathBuf,
+    current: HashMap<ResourceId, u64>,
+    states: HashMap<(ResourceId, u64), DesktopResourceState>,
+    sender: mpsc::Sender<Completion>,
+    receiver: Receiver<Completion>,
+    wake: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl DesktopResourceService {
+    pub(crate) fn new(asset_root: PathBuf, wake: impl Fn() + Send + Sync + 'static) -> Self {
+        let (sender, receiver) = mpsc::channel();
+        Self {
+            asset_root,
+            current: HashMap::new(),
+            states: HashMap::new(),
+            sender,
+            receiver,
+            wake: Arc::new(wake),
+        }
+    }
+
+    pub(crate) fn command(
+        &mut self,
+        command: ResourceCommand,
+    ) -> Result<Vec<DesktopResourceUpdate>, DesktopResourceError> {
+        command
+            .validate()
+            .map_err(DesktopResourceError::InvalidMessage)?;
+        match command {
+            ResourceCommand::Load(request) => {
+                self.load(request)?;
+                Ok(Vec::new())
+            }
+            ResourceCommand::Release {
+                resource,
+                generation,
+            } => Ok(vec![self.release(resource, generation)]),
+        }
+    }
+
+    fn load(&mut self, request: ResourceRequest) -> Result<(), DesktopResourceError> {
+        if request.kind != ResourceKind::RasterImage {
+            return Err(DesktopResourceError::UnsupportedKind(request.kind));
+        }
+        if let Some(current) = self.current.get(&request.resource).copied()
+            && request.generation <= current
+        {
+            return Err(DesktopResourceError::NonMonotonicGeneration {
+                resource: request.resource,
+                current,
+                received: request.generation,
+            });
+        }
+        self.current.insert(request.resource, request.generation);
+        self.states.insert(
+            (request.resource, request.generation),
+            DesktopResourceState::Loading,
+        );
+        let sender = self.sender.clone();
+        let wake = Arc::clone(&self.wake);
+        let asset_root = self.asset_root.clone();
+        std::thread::Builder::new()
+            .name("whisker-desktop-resource".into())
+            .spawn(move || {
+                let completion = Completion {
+                    resource: request.resource,
+                    generation: request.generation,
+                    result: acquire_raster(request.source, asset_root),
+                };
+                let _ = sender.send(completion);
+                wake();
+            })
+            .expect("Desktop Host can spawn a resource worker");
+        Ok(())
+    }
+
+    fn release(&mut self, resource: ResourceId, generation: u64) -> DesktopResourceUpdate {
+        self.states
+            .insert((resource, generation), DesktopResourceState::Released);
+        let evict = self.current.get(&resource).copied() == Some(generation);
+        if evict {
+            self.current.remove(&resource);
+        }
+        DesktopResourceUpdate::Released { resource, evict }
+    }
+
+    pub(crate) fn drain(&mut self) -> Vec<DesktopResourceUpdate> {
+        let mut updates = Vec::new();
+        while let Ok(completion) = self.receiver.try_recv() {
+            if self.current.get(&completion.resource).copied() != Some(completion.generation)
+                || self
+                    .states
+                    .get(&(completion.resource, completion.generation))
+                    .is_some_and(|state| *state == DesktopResourceState::Released)
+            {
+                continue;
+            }
+            match completion.result {
+                Ok(raster) => {
+                    let dimensions = ResourceDimensions {
+                        width: raster.width as f32,
+                        height: raster.height as f32,
+                        scale: 1.0,
+                    };
+                    self.states.insert(
+                        (completion.resource, completion.generation),
+                        DesktopResourceState::Ready {
+                            width: raster.width,
+                            height: raster.height,
+                        },
+                    );
+                    updates.push(DesktopResourceUpdate::Ready {
+                        event: ResourceEvent::Ready {
+                            resource: completion.resource,
+                            generation: completion.generation,
+                            dimensions: Some(dimensions),
+                        },
+                        raster,
+                    });
+                }
+                Err((code, diagnostic)) => {
+                    self.states.insert(
+                        (completion.resource, completion.generation),
+                        DesktopResourceState::Failed(code),
+                    );
+                    updates.push(DesktopResourceUpdate::Failed(ResourceEvent::Failed {
+                        resource: completion.resource,
+                        generation: completion.generation,
+                        code,
+                        diagnostic: Some(diagnostic),
+                    }));
+                }
+            }
+        }
+        updates
+    }
+
+    #[cfg(all(test, feature = "host-conformance"))]
+    pub(crate) fn state(
+        &self,
+        resource: ResourceId,
+        generation: u64,
+    ) -> Option<DesktopResourceState> {
+        self.states.get(&(resource, generation)).copied()
+    }
+}
+
+fn acquire_raster(
+    source: ResourceSource,
+    asset_root: PathBuf,
+) -> Result<RasterResource, (ResourceFailureCode, String)> {
+    let bytes = match source {
+        ResourceSource::Bytes { data, .. } => data,
+        ResourceSource::BundledAsset(path) => std::fs::read(asset_root.join(path))
+            .map_err(|error| (ResourceFailureCode::NotFound, error.to_string()))?,
+        ResourceSource::Url(url) if url.starts_with("data:") => decode_data_url(&url)?,
+        ResourceSource::Url(url) if url.starts_with("https://") || url.starts_with("http://") => {
+            let response = ureq::get(&url)
+                .call()
+                .map_err(|error| (ResourceFailureCode::Network, error.to_string()))?;
+            let mut bytes = Vec::new();
+            response
+                .into_reader()
+                .take(64 * 1024 * 1024)
+                .read_to_end(&mut bytes)
+                .map_err(|error| (ResourceFailureCode::Network, error.to_string()))?;
+            bytes
+        }
+        ResourceSource::Url(url) => {
+            return Err((
+                ResourceFailureCode::Unsupported,
+                format!("unsupported Desktop resource URL: {url}"),
+            ));
+        }
+    };
+    let image = image::load_from_memory(&bytes)
+        .map_err(|error| (ResourceFailureCode::Decode, error.to_string()))?
+        .into_rgba8();
+    let (width, height) = image.dimensions();
+    RasterResource::new(width, height, image.into_raw())
+        .map_err(|error| (ResourceFailureCode::Decode, error.to_string()))
+}
+
+fn decode_data_url(url: &str) -> Result<Vec<u8>, (ResourceFailureCode, String)> {
+    let (metadata, payload) = url.split_once(',').ok_or_else(|| {
+        (
+            ResourceFailureCode::Decode,
+            "data URL has no payload delimiter".into(),
+        )
+    })?;
+    if !metadata.starts_with("data:image/") || !metadata.ends_with(";base64") {
+        return Err((
+            ResourceFailureCode::Unsupported,
+            "Desktop raster data URL must be base64 image data".into(),
+        ));
+    }
+    base64::engine::general_purpose::STANDARD
+        .decode(payload)
+        .map_err(|error| (ResourceFailureCode::Decode, error.to_string()))
+}

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -305,6 +305,10 @@ impl DesktopScene {
         self.raster_resources.insert(resource);
     }
 
+    pub(crate) fn release_raster_resource(&mut self, resource: ResourceId) {
+        self.raster_resources.remove(&resource);
+    }
+
     pub(crate) fn take_events(&mut self) -> Vec<DesktopProviderEvent> {
         std::mem::take(&mut self.pending_events)
     }

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -40,6 +40,11 @@ impl DesktopSurface {
         self.scene.register_raster_resource(resource);
     }
 
+    pub(crate) fn release_raster_resource(&mut self, resource: ResourceId) {
+        self.gpu.release_raster_resource(resource);
+        self.scene.release_raster_resource(resource);
+    }
+
     pub(crate) fn paint(
         &mut self,
         text: &mut NativeTextHost,

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use whisker::css::BorderStyle;
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
@@ -9,8 +10,9 @@ use whisker_host_conformance::{
     BackgroundBoxFixture, BackgroundImageFixture, BackgroundLayerFixture, BorderFixture,
     BorderStyleFixture, ColorFixture, Command, ConicGradientFixture, Host, ImageRepeatFixture,
     LinearGradientFixture, LoadedCase, OverflowClipFixture, PixelRelationFixture,
-    PixelRelationKind, PixelSampleFixture, PointerEventFixture, RadialGradientFixture, Scenario,
-    ScenarioSide, SceneNodeFixture, VisibilityFixture, load_required,
+    PixelRelationKind, PixelSampleFixture, PointerEventFixture, RadialGradientFixture,
+    ResourceSourceFixture, ResourceStateFixture, Scenario, ScenarioSide, SceneNodeFixture,
+    VisibilityFixture, load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
@@ -21,8 +23,9 @@ use whisker_protocol::{
     MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
     PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
     PaintLengthPercentage, PaintPosition, PointerId, PointerInput, PointerKind, ProtocolVersion,
-    RadialGradientExtent, RadialGradientShape, ResourceId, SurfaceId, TextMeasurePayload,
-    TextMeasureStyle, Transform, Visibility, WhiskerValue,
+    RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceId, ResourceKind,
+    ResourceRequest, ResourceSource, SurfaceId, TextMeasurePayload, TextMeasureStyle, Transform,
+    Visibility, WhiskerValue,
 };
 use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
@@ -35,6 +38,7 @@ use crate::paint::box_paint::{
     BoxPrimitiveKind, background_gradient_primitive, lower_box, resolve_box_geometry,
 };
 use crate::paint::color::srgba;
+use crate::resource::{DesktopResourceService, DesktopResourceState, DesktopResourceUpdate};
 use crate::scene::{DesktopScene, PaintCommand};
 use crate::text::NativeTextHost;
 
@@ -296,6 +300,7 @@ struct Driver {
     measurement_responses: Vec<MeasurementResponse>,
     input: RecordingInputSink,
     raster_resources: std::collections::HashMap<ResourceId, RasterResource>,
+    resource_service: DesktopResourceService,
 }
 
 #[derive(Default)]
@@ -356,6 +361,7 @@ impl Driver {
             measurement_responses: Vec::new(),
             input: RecordingInputSink::default(),
             raster_resources: std::collections::HashMap::new(),
+            resource_service: DesktopResourceService::new(std::path::PathBuf::new(), || {}),
         }
     }
 
@@ -398,6 +404,48 @@ impl Driver {
                         .register_raster_resource(resource);
                     self.raster_resources.insert(resource, raster);
                 }
+                Command::LoadRasterResource {
+                    id,
+                    generation,
+                    source,
+                } => {
+                    let source = match source {
+                        ResourceSourceFixture::Url { value } => ResourceSource::Url(value.clone()),
+                        ResourceSourceFixture::Bytes { media_type, base64 } => {
+                            ResourceSource::Bytes {
+                                media_type: media_type.clone(),
+                                data: base64::engine::general_purpose::STANDARD
+                                    .decode(base64)
+                                    .expect("validated fixture base64"),
+                            }
+                        }
+                    };
+                    self.resource_service
+                        .command(ResourceCommand::Load(ResourceRequest {
+                            resource: ResourceId::new(*id).unwrap(),
+                            generation: *generation,
+                            kind: ResourceKind::RasterImage,
+                            source,
+                        }))
+                        .expect("valid Desktop resource load");
+                }
+                Command::ReleaseRasterResource { id, generation } => {
+                    let updates = self
+                        .resource_service
+                        .command(ResourceCommand::Release {
+                            resource: ResourceId::new(*id).unwrap(),
+                            generation: *generation,
+                        })
+                        .expect("valid Desktop resource release");
+                    self.apply_resource_updates(updates);
+                }
+                Command::CheckpointResource {
+                    id,
+                    generation,
+                    state,
+                    width,
+                    height,
+                } => self.check_resource(*id, *generation, *state, *width, *height),
                 Command::PresentBox {
                     revision,
                     rect,
@@ -528,6 +576,74 @@ impl Driver {
                 assert_eq!(*actual_paint, Some(&expected_paint));
             }
             _ => panic!("one projected Desktop box command"),
+        }
+    }
+
+    fn apply_resource_updates(&mut self, updates: Vec<DesktopResourceUpdate>) {
+        for update in updates {
+            match update {
+                DesktopResourceUpdate::Ready { event, raster } => {
+                    let whisker_protocol::ResourceEvent::Ready { resource, .. } = event else {
+                        unreachable!()
+                    };
+                    self.scene
+                        .as_mut()
+                        .expect("resource load follows surface attach")
+                        .register_raster_resource(resource);
+                    self.raster_resources.insert(resource, raster);
+                }
+                DesktopResourceUpdate::Failed(_) => {}
+                DesktopResourceUpdate::Released {
+                    resource, evict, ..
+                } => {
+                    if evict {
+                        self.scene
+                            .as_mut()
+                            .expect("resource release follows surface attach")
+                            .release_raster_resource(resource);
+                        self.raster_resources.remove(&resource);
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_resource(
+        &mut self,
+        id: u64,
+        generation: u64,
+        expected: ResourceStateFixture,
+        width: Option<u32>,
+        height: Option<u32>,
+    ) {
+        let resource = ResourceId::new(id).unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while self.resource_service.state(resource, generation)
+            == Some(DesktopResourceState::Loading)
+        {
+            let updates = self.resource_service.drain();
+            self.apply_resource_updates(updates);
+            assert!(
+                std::time::Instant::now() < deadline,
+                "Desktop resource checkpoint timed out"
+            );
+            std::thread::yield_now();
+        }
+        let actual = self.resource_service.state(resource, generation);
+        match expected {
+            ResourceStateFixture::Ready => assert_eq!(
+                actual,
+                Some(DesktopResourceState::Ready {
+                    width: width.unwrap(),
+                    height: height.unwrap(),
+                })
+            ),
+            ResourceStateFixture::Failed => {
+                assert!(matches!(actual, Some(DesktopResourceState::Failed(_))))
+            }
+            ResourceStateFixture::Released => {
+                assert_eq!(actual, Some(DesktopResourceState::Released))
+            }
         }
     }
 

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -9,6 +9,7 @@ public final class WhiskerView: UIView {
     private var isApplicationActive = true
     private let modules = HostModuleDispatcher()
     private let resources = HostResourceStore()
+    private lazy var resourceService = HostResourceService(store: resources)
     private lazy var scene = HostScene(
         root: self,
         resources: resources,
@@ -44,6 +45,37 @@ public final class WhiskerView: UIView {
     @discardableResult
     public func registerRasterResource(id: UInt64, image: CGImage) -> Bool {
         resources.registerRasterImage(image, id: id)
+    }
+
+    /// Starts native acquisition and decode for one monotonically newer generation.
+    @discardableResult
+    public func loadRasterResource(
+        id: UInt64,
+        generation: UInt64,
+        source: WhiskerRasterResourceSource
+    ) -> Bool {
+        resourceService.load(id: id, generation: generation, source: source)
+    }
+
+    /// Releases exactly one generation without evicting a newer replacement.
+    @discardableResult
+    public func releaseRasterResource(id: UInt64, generation: UInt64) -> Bool {
+        resourceService.release(id: id, generation: generation)
+    }
+
+    /// Returns the retained lifecycle state for one exact generation.
+    public func rasterResourceState(
+        id: UInt64,
+        generation: UInt64
+    ) -> WhiskerRasterResourceState? {
+        resourceService.state(id: id, generation: generation)
+    }
+
+    /// Installs the Host-to-runtime notification boundary for lifecycle events.
+    public func observeRasterResourceEvents(
+        _ handler: ((WhiskerRasterResourceEvent) -> Void)?
+    ) {
+        resourceService.eventHandler = handler
     }
 
     deinit {

--- a/platforms/ios/Sources/WhiskerRuntime/resource/HostResourceService.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/resource/HostResourceService.swift
@@ -1,0 +1,207 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// Encoded raster input acquired by the native Host outside frame transactions.
+public enum WhiskerRasterResourceSource {
+    case bytes(mediaType: String, data: Data)
+    case url(String)
+}
+
+/// Observable lifecycle state for one exact resource generation.
+public enum WhiskerRasterResourceState: Equatable {
+    case loading
+    case ready(width: Int, height: Int)
+    case failed
+    case released
+}
+
+/// One generation-safe lifecycle notification emitted by the native Host.
+public struct WhiskerRasterResourceEvent: Equatable {
+    public let id: UInt64
+    public let generation: UInt64
+    public let state: WhiskerRasterResourceState
+}
+
+typealias HostResourceURLLoader = (
+    URL,
+    @escaping (Result<Data, Error>) -> Void
+) -> () -> Void
+
+/// Acquires and decodes raster resources independently from frame application.
+///
+/// All retained state and store mutations are serialized on the main thread.
+/// Acquisition and decoding run off-thread; their completions must still match
+/// the latest generation before they can replace the paintable image.
+@MainActor
+final class HostResourceService {
+    private struct Key: Hashable {
+        let id: UInt64
+        let generation: UInt64
+    }
+
+    private let store: HostResourceStore
+    private let urlLoader: HostResourceURLLoader
+    private let decodeQueue: DispatchQueue
+    private var latestGenerations = [UInt64: UInt64]()
+    private var currentGenerations = [UInt64: UInt64]()
+    private var installedGenerations = [UInt64: UInt64]()
+    private var states = [Key: WhiskerRasterResourceState]()
+    private var pendingCancellations = [UInt64: () -> Void]()
+
+    var eventHandler: ((WhiskerRasterResourceEvent) -> Void)?
+
+    init(
+        store: HostResourceStore,
+        decodeQueue: DispatchQueue = DispatchQueue(
+            label: "dev.whisker.resource-decode",
+            qos: .userInitiated
+        ),
+        urlLoader: @escaping HostResourceURLLoader = HostResourceService.loadURL
+    ) {
+        self.store = store
+        self.decodeQueue = decodeQueue
+        self.urlLoader = urlLoader
+    }
+
+    @discardableResult
+    func load(id: UInt64, generation: UInt64, source: WhiskerRasterResourceSource) -> Bool {
+        guard id != 0, generation != 0,
+              generation > latestGenerations[id, default: 0] else { return false }
+
+        pendingCancellations.removeValue(forKey: id)?()
+        latestGenerations[id] = generation
+        currentGenerations[id] = generation
+        setState(.loading, id: id, generation: generation)
+
+        switch source {
+        case let .bytes(mediaType, data):
+            guard !mediaType.isEmpty, mediaType.lowercased().hasPrefix("image/"), !data.isEmpty else {
+                failIfCurrent(id: id, generation: generation)
+                return true
+            }
+            decode(data, id: id, generation: generation)
+        case let .url(value):
+            guard let url = URL(string: value), let scheme = url.scheme?.lowercased() else {
+                failIfCurrent(id: id, generation: generation)
+                return true
+            }
+            if scheme == "data" {
+                guard let data = Self.pngData(from: value) else {
+                    failIfCurrent(id: id, generation: generation)
+                    return true
+                }
+                decode(data, id: id, generation: generation)
+            } else if scheme == "http" || scheme == "https" {
+                pendingCancellations[id] = urlLoader(url) { [weak self] result in
+                    DispatchQueue.main.async {
+                        guard let self,
+                              self.currentGenerations[id] == generation else { return }
+                        self.pendingCancellations.removeValue(forKey: id)
+                        switch result {
+                        case let .success(data):
+                            guard !data.isEmpty else {
+                                self.failIfCurrent(id: id, generation: generation)
+                                return
+                            }
+                            self.decode(data, id: id, generation: generation)
+                        case .failure:
+                            self.failIfCurrent(id: id, generation: generation)
+                        }
+                    }
+                }
+            } else {
+                failIfCurrent(id: id, generation: generation)
+            }
+        }
+        return true
+    }
+
+    @discardableResult
+    func release(id: UInt64, generation: UInt64) -> Bool {
+        let key = Key(id: id, generation: generation)
+        guard id != 0, generation != 0, states[key] != nil else { return false }
+
+        if currentGenerations[id] == generation {
+            pendingCancellations.removeValue(forKey: id)?()
+            currentGenerations.removeValue(forKey: id)
+        }
+        if installedGenerations[id] == generation {
+            store.removeRasterImage(id: id)
+            installedGenerations.removeValue(forKey: id)
+        }
+        setState(.released, id: id, generation: generation)
+        return true
+    }
+
+    func state(id: UInt64, generation: UInt64) -> WhiskerRasterResourceState? {
+        states[Key(id: id, generation: generation)]
+    }
+
+    private func decode(_ data: Data, id: UInt64, generation: UInt64) {
+        decodeQueue.async { [weak self] in
+            let image = Self.decodeImage(data)
+            DispatchQueue.main.async {
+                guard let self,
+                      self.currentGenerations[id] == generation,
+                      self.states[Key(id: id, generation: generation)] == .loading else { return }
+                guard let image, self.store.registerRasterImage(image, id: id) else {
+                    self.failIfCurrent(id: id, generation: generation)
+                    return
+                }
+                self.installedGenerations[id] = generation
+                self.setState(
+                    .ready(width: image.width, height: image.height),
+                    id: id,
+                    generation: generation
+                )
+            }
+        }
+    }
+
+    private func failIfCurrent(id: UInt64, generation: UInt64) {
+        guard currentGenerations[id] == generation else { return }
+        pendingCancellations.removeValue(forKey: id)
+        setState(.failed, id: id, generation: generation)
+    }
+
+    private func setState(_ state: WhiskerRasterResourceState, id: UInt64, generation: UInt64) {
+        states[Key(id: id, generation: generation)] = state
+        eventHandler?(WhiskerRasterResourceEvent(id: id, generation: generation, state: state))
+    }
+
+    private nonisolated static func pngData(from value: String) -> Data? {
+        let prefix = "data:image/png;base64,"
+        guard value.hasPrefix(prefix) else { return nil }
+        return Data(base64Encoded: String(value.dropFirst(prefix.count)), options: [])
+    }
+
+    private nonisolated static func decodeImage(_ data: Data) -> CGImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    private nonisolated static func loadURL(
+        _ url: URL,
+        completion: @escaping (Result<Data, Error>) -> Void
+    ) -> () -> Void {
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error {
+                completion(.failure(error))
+                return
+            }
+            if let response = response as? HTTPURLResponse,
+               !(200...299).contains(response.statusCode) {
+                completion(.failure(URLError(.badServerResponse)))
+                return
+            }
+            guard let data else {
+                completion(.failure(URLError(.zeroByteResource)))
+                return
+            }
+            completion(.success(data))
+        }
+        task.resume()
+        return { task.cancel() }
+    }
+}

--- a/platforms/ios/Sources/WhiskerRuntime/resource/HostResourceStore.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/resource/HostResourceStore.swift
@@ -14,4 +14,8 @@ final class HostResourceStore {
     func rasterImage(id: UInt64) -> CGImage? {
         rasterImages[id]
     }
+
+    func removeRasterImage(id: UInt64) {
+        rasterImages.removeValue(forKey: id)
+    }
 }

--- a/platforms/linux/src/app.rs
+++ b/platforms/linux/src/app.rs
@@ -170,6 +170,7 @@ impl LinuxApplication {
             surface_id,
             &element_registrations,
             &self.config.element_factories,
+            wake.clone(),
         ))
         .map_err(|error| LinuxError(error.to_string()))?;
         let mut runtime = RuntimeInstance::new(surface, wake);

--- a/platforms/macos/src/app.rs
+++ b/platforms/macos/src/app.rs
@@ -170,6 +170,7 @@ impl MacosApplication {
             surface_id,
             &element_registrations,
             &self.config.element_factories,
+            wake.clone(),
         ))
         .map_err(|error| MacosError(error.to_string()))?;
         let mut runtime = RuntimeInstance::new(surface, wake);

--- a/platforms/web/Cargo.toml
+++ b/platforms/web/Cargo.toml
@@ -17,8 +17,12 @@ whisker-engine = { workspace = true }
 whisker-protocol = { workspace = true }
 whisker-style = { workspace = true }
 whisker-value = { workspace = true }
+js-sys = "0.3"
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = [
+    "Blob",
+    "BlobPropertyBag",
     "console",
     "CssStyleDeclaration",
     "CanvasRenderingContext2d",
@@ -30,14 +34,17 @@ web-sys = { version = "0.3", features = [
     "HtmlCollection",
     "HtmlCanvasElement",
     "HtmlElement",
+    "HtmlImageElement",
     "HtmlInputElement",
     "ImageData",
     "Node",
     "Performance",
+    "Url",
     "Window",
 ] }
 
 [dev-dependencies]
+base64 = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen-test = "0.3"
 whisker-host-conformance = { workspace = true }

--- a/platforms/web/src/application.rs
+++ b/platforms/web/src/application.rs
@@ -5,11 +5,15 @@ use wasm_bindgen::closure::Closure;
 use whisker::runtime::RuntimeWakeHandle;
 use whisker::{Element, ElementRegistry, RuntimeInstance, SurfaceRuntime, WhiskerModule};
 use whisker_engine::LayoutOptions;
-use whisker_protocol::{InputEvent, InputEventKind, ResourceId, SurfaceId};
+use whisker_protocol::{
+    InputEvent, InputEventKind, ResourceCommand, ResourceEvent, ResourceId, SurfaceId,
+};
 use whisker_style::StyleEnvironment;
 
 use crate::measure::text::DomMeasurementProvider;
 use crate::scene::frame_sink::DomFrameSink;
+use crate::scene::resource_service::WebResourceService;
+use crate::scene::resource_store::WebResourceStore;
 use crate::{
     BuiltInElementModule, WebAppConfig, WebError, WebModuleDefinition, js_error, set_style,
 };
@@ -72,10 +76,29 @@ pub fn register_resource_url(resource: ResourceId, url: impl Into<String>) -> Re
     Ok(())
 }
 
+/// Sends one out-of-frame protocol resource command to the mounted browser
+/// Host and returns the non-stale completion produced by a load.
+pub async fn handle_resource_command(
+    command: ResourceCommand,
+) -> Result<Option<ResourceEvent>, WebError> {
+    let resources = APPLICATION.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|application| application.resources.clone())
+            .ok_or_else(|| WebError("a Web application is not mounted".into()))
+    })?;
+    let event = resources.handle(command).await?;
+    if event.is_some() {
+        request_frame();
+    }
+    Ok(event)
+}
+
 struct WebApplication {
     runtime: RuntimeInstance,
     measurements: DomMeasurementProvider,
     frames: DomFrameSink,
+    resources: WebResourceService,
     viewport: (f32, f32, f32),
     viewport_epoch: u32,
     environment_epoch: u64,
@@ -116,16 +139,20 @@ impl WebApplication {
             elements,
         );
         let wake = RuntimeWakeHandle::new(request_frame);
+        let resource_store = WebResourceStore::new();
+        let resources = WebResourceService::new(resource_store.clone());
         Ok(Self {
             runtime: RuntimeInstance::new(surface, wake),
             measurements: DomMeasurementProvider::new(document.clone()),
-            frames: DomFrameSink::new(
+            frames: DomFrameSink::new_with_resources(
                 document,
                 root,
                 surface_id,
                 &registrations,
                 &element_factories,
+                resource_store,
             )?,
+            resources,
             viewport,
             viewport_epoch: 1,
             environment_epoch: 1,

--- a/platforms/web/src/lib.rs
+++ b/platforms/web/src/lib.rs
@@ -23,11 +23,12 @@ mod module_api;
 mod paint;
 mod scene;
 
-pub use application::{register_resource_url, run};
+pub use application::{handle_resource_command, register_resource_url, run};
 pub use dom::WebError;
 pub(crate) use dom::{js_error, px, set_style};
 pub(crate) use module_api::WebElementFactoryKind;
 pub use module_api::*;
+pub use scene::resource_service::{WebResourceService, WebResourceState};
 pub use scene::resource_store::WebResourceStore;
 
 #[cfg(all(test, target_arch = "wasm32"))]

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -41,23 +41,6 @@ pub(crate) struct WebProviderEvent {
 }
 
 impl DomFrameSink {
-    pub(crate) fn new(
-        document: web_sys::Document,
-        root: web_sys::Element,
-        surface: SurfaceId,
-        registrations: &[ElementRegistration],
-        factories: &[WebElementFactory],
-    ) -> Result<Self, WebError> {
-        Self::new_with_resources(
-            document,
-            root,
-            surface,
-            registrations,
-            factories,
-            WebResourceStore::new(),
-        )
-    }
-
     pub(crate) fn new_with_resources(
         document: web_sys::Document,
         root: web_sys::Element,

--- a/platforms/web/src/scene/mod.rs
+++ b/platforms/web/src/scene/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod element_registry;
 pub(crate) mod frame_sink;
+pub(crate) mod resource_service;
 pub(crate) mod resource_store;

--- a/platforms/web/src/scene/resource_service.rs
+++ b/platforms/web/src/scene/resource_service.rs
@@ -1,0 +1,346 @@
+use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
+use std::rc::Rc;
+
+use js_sys::{Array, Uint8Array};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::JsFuture;
+use whisker_protocol::{
+    ResourceCommand, ResourceDimensions, ResourceEvent, ResourceFailureCode, ResourceId,
+    ResourceKind, ResourceRequest, ResourceSource,
+};
+
+use crate::scene::resource_store::WebResourceStore;
+use crate::{WebError, js_error};
+
+/// Observable state retained for one resource generation.
+#[derive(Clone, Debug, PartialEq)]
+pub enum WebResourceState {
+    /// Acquisition or browser decoding has not completed yet.
+    Loading,
+    /// The generation decoded successfully and is available to paint.
+    Ready {
+        /// Intrinsic dimensions reported to the runtime.
+        dimensions: ResourceDimensions,
+    },
+    /// Acquisition or decoding failed.
+    Failed {
+        /// Portable protocol failure classification.
+        code: ResourceFailureCode,
+        /// Optional browser diagnostic.
+        diagnostic: Option<String>,
+    },
+    /// The exact generation was released.
+    Released,
+}
+
+#[derive(Clone)]
+struct GenerationRecord {
+    state: WebResourceState,
+    owned_url: Option<String>,
+}
+
+#[derive(Default)]
+struct ServiceState {
+    current: HashMap<ResourceId, u64>,
+    published: HashMap<ResourceId, u64>,
+    generations: HashMap<(ResourceId, u64), GenerationRecord>,
+    events: HashMap<(ResourceId, u64), ResourceEvent>,
+    pending_events: VecDeque<ResourceEvent>,
+}
+
+/// Browser implementation of Whisker's out-of-frame resource channel.
+///
+/// The service consumes protocol commands directly. Successful decodes publish
+/// a URL into the frame sink's [`WebResourceStore`] only after the requested
+/// generation is still current.
+#[derive(Clone, Default)]
+pub struct WebResourceService {
+    store: WebResourceStore,
+    state: Rc<RefCell<ServiceState>>,
+}
+
+impl WebResourceService {
+    /// Creates a service backed by the URL store read by the DOM frame sink.
+    pub fn new(store: WebResourceStore) -> Self {
+        Self {
+            store,
+            state: Rc::new(RefCell::new(ServiceState::default())),
+        }
+    }
+
+    /// Applies one protocol command, awaiting browser acquisition and decode
+    /// for `Load` and returning its non-stale completion event.
+    pub async fn handle(
+        &self,
+        command: ResourceCommand,
+    ) -> Result<Option<ResourceEvent>, WebError> {
+        command
+            .validate()
+            .map_err(|error| WebError(format!("invalid Web resource command: {error:?}")))?;
+        match command {
+            ResourceCommand::Load(request) => self.load(request).await,
+            ResourceCommand::Release {
+                resource,
+                generation,
+            } => {
+                self.release(resource, generation)?;
+                Ok(None)
+            }
+        }
+    }
+
+    /// Returns retained lifecycle state for one exact generation.
+    pub fn state(&self, resource: ResourceId, generation: u64) -> Option<WebResourceState> {
+        self.state
+            .borrow()
+            .generations
+            .get(&(resource, generation))
+            .map(|record| record.state.clone())
+    }
+
+    /// Returns the retained protocol completion for one exact generation.
+    pub fn event(&self, resource: ResourceId, generation: u64) -> Option<ResourceEvent> {
+        self.state
+            .borrow()
+            .events
+            .get(&(resource, generation))
+            .cloned()
+    }
+
+    /// Drains completions not yet delivered to the runtime resource channel.
+    pub fn take_events(&self) -> Vec<ResourceEvent> {
+        self.state.borrow_mut().pending_events.drain(..).collect()
+    }
+
+    async fn load(&self, request: ResourceRequest) -> Result<Option<ResourceEvent>, WebError> {
+        {
+            let mut state = self.state.borrow_mut();
+            if state
+                .current
+                .get(&request.resource)
+                .is_some_and(|generation| *generation >= request.generation)
+            {
+                return Err(WebError(format!(
+                    "Web resource {} generation {} does not advance the current generation",
+                    request.resource.get(),
+                    request.generation
+                )));
+            }
+            state.current.insert(request.resource, request.generation);
+            state.generations.insert(
+                (request.resource, request.generation),
+                GenerationRecord {
+                    state: WebResourceState::Loading,
+                    owned_url: None,
+                },
+            );
+        }
+
+        if request.kind != ResourceKind::RasterImage {
+            return Ok(self.complete_failure(
+                request.resource,
+                request.generation,
+                ResourceFailureCode::Unsupported,
+                Some("Web resource service currently decodes raster images only".into()),
+            ));
+        }
+
+        let (url, owned) = match source_url(&request.source) {
+            Ok(value) => value,
+            Err((code, diagnostic)) => {
+                return Ok(self.complete_failure(
+                    request.resource,
+                    request.generation,
+                    code,
+                    Some(diagnostic),
+                ));
+            }
+        };
+        let decoded = decode_raster(&url).await;
+        match decoded {
+            Ok(dimensions) => {
+                self.complete_ready(request.resource, request.generation, url, owned, dimensions)
+            }
+            Err(diagnostic) => {
+                if owned {
+                    let _ = web_sys::Url::revoke_object_url(&url);
+                }
+                Ok(self.complete_failure(
+                    request.resource,
+                    request.generation,
+                    match request.source {
+                        ResourceSource::Url(_) => ResourceFailureCode::Network,
+                        _ => ResourceFailureCode::Decode,
+                    },
+                    Some(diagnostic),
+                ))
+            }
+        }
+    }
+
+    fn complete_ready(
+        &self,
+        resource: ResourceId,
+        generation: u64,
+        url: String,
+        owned: bool,
+        dimensions: ResourceDimensions,
+    ) -> Result<Option<ResourceEvent>, WebError> {
+        let mut state = self.state.borrow_mut();
+        if state.current.get(&resource) != Some(&generation) {
+            if owned {
+                let _ = web_sys::Url::revoke_object_url(&url);
+            }
+            return Ok(None);
+        }
+
+        self.store.register_url(resource, url.clone())?;
+        let event = ResourceEvent::Ready {
+            resource,
+            generation,
+            dimensions: Some(dimensions),
+        };
+        state.published.insert(resource, generation);
+        state.generations.insert(
+            (resource, generation),
+            GenerationRecord {
+                state: WebResourceState::Ready { dimensions },
+                owned_url: owned.then_some(url),
+            },
+        );
+        retain_event(&mut state, event.clone());
+        Ok(Some(event))
+    }
+
+    fn complete_failure(
+        &self,
+        resource: ResourceId,
+        generation: u64,
+        code: ResourceFailureCode,
+        diagnostic: Option<String>,
+    ) -> Option<ResourceEvent> {
+        let mut state = self.state.borrow_mut();
+        if state.current.get(&resource) != Some(&generation) {
+            return None;
+        }
+        let event = ResourceEvent::Failed {
+            resource,
+            generation,
+            code,
+            diagnostic: diagnostic.clone(),
+        };
+        state.generations.insert(
+            (resource, generation),
+            GenerationRecord {
+                state: WebResourceState::Failed { code, diagnostic },
+                owned_url: None,
+            },
+        );
+        retain_event(&mut state, event.clone());
+        Some(event)
+    }
+
+    fn release(&self, resource: ResourceId, generation: u64) -> Result<(), WebError> {
+        let (owned_url, unpublish) = {
+            let mut state = self.state.borrow_mut();
+            let owned_url = state
+                .generations
+                .get(&(resource, generation))
+                .and_then(|record| record.owned_url.clone());
+            state.generations.insert(
+                (resource, generation),
+                GenerationRecord {
+                    state: WebResourceState::Released,
+                    owned_url: None,
+                },
+            );
+            let unpublish = state.published.get(&resource) == Some(&generation);
+            if unpublish {
+                state.published.remove(&resource);
+            }
+            if state.current.get(&resource) == Some(&generation) {
+                state.current.remove(&resource);
+            }
+            (owned_url, unpublish)
+        };
+        if unpublish {
+            self.store.unregister(resource);
+        }
+        if let Some(url) = owned_url {
+            web_sys::Url::revoke_object_url(&url)
+                .map_err(|error| js_error("revoke Web resource object URL", error))?;
+        }
+        Ok(())
+    }
+}
+
+fn retain_event(state: &mut ServiceState, event: ResourceEvent) {
+    let key = match &event {
+        ResourceEvent::Ready {
+            resource,
+            generation,
+            ..
+        }
+        | ResourceEvent::Failed {
+            resource,
+            generation,
+            ..
+        } => (*resource, *generation),
+    };
+    state.events.insert(key, event.clone());
+    state.pending_events.push_back(event);
+}
+
+fn source_url(source: &ResourceSource) -> Result<(String, bool), (ResourceFailureCode, String)> {
+    match source {
+        ResourceSource::Url(url) => Ok((url.clone(), false)),
+        ResourceSource::Bytes { media_type, data } => {
+            let bytes = Uint8Array::from(data.as_slice());
+            let parts = Array::new();
+            parts.push(&bytes);
+            let options = web_sys::BlobPropertyBag::new();
+            options.set_type(media_type);
+            let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(&parts, &options)
+                .map_err(|error| {
+                    (
+                        ResourceFailureCode::Decode,
+                        js_diagnostic("create Web resource Blob", error),
+                    )
+                })?;
+            web_sys::Url::create_object_url_with_blob(&blob)
+                .map(|url| (url, true))
+                .map_err(|error| {
+                    (
+                        ResourceFailureCode::Decode,
+                        js_diagnostic("create Web resource object URL", error),
+                    )
+                })
+        }
+        ResourceSource::BundledAsset(_) => Err((
+            ResourceFailureCode::Unsupported,
+            "Web bundled assets require a generated asset URL".into(),
+        )),
+    }
+}
+
+async fn decode_raster(url: &str) -> Result<ResourceDimensions, String> {
+    let image = web_sys::HtmlImageElement::new()
+        .map_err(|error| js_diagnostic("create Web resource image", error))?;
+    image.set_src(url);
+    JsFuture::from(image.decode())
+        .await
+        .map_err(|error| js_diagnostic("decode Web raster resource", error))?;
+    Ok(ResourceDimensions {
+        width: image.natural_width() as f32,
+        height: image.natural_height() as f32,
+        scale: 1.0,
+    })
+}
+
+fn js_diagnostic(context: &str, error: JsValue) -> String {
+    format!(
+        "{context}: {}",
+        error.as_string().unwrap_or_else(|| format!("{error:?}"))
+    )
+}

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
+use std::future::Future;
+use std::task::Poll;
 
+use base64::Engine as _;
 use wasm_bindgen::Clamped;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::wasm_bindgen_test;
@@ -10,23 +13,25 @@ use whisker_host_conformance::{
     BackgroundPaintLayerFixture, BorderFixture, BorderStyleFixture, ColorFixture, Command,
     ConicGradientFixture, CornerRadiusFixture, ImageRepeatFixture, LengthPercentageFixture,
     LinearGradientFixture, Manifest, OverflowClipFixture, PixelSampleFixture,
-    RadialGradientFixture, SCHEMA_VERSION, Scenario, ScenarioSide, SceneNodeFixture,
-    VisibilityFixture,
+    RadialGradientFixture, ResourceSourceFixture, ResourceStateFixture, SCHEMA_VERSION, Scenario,
+    ScenarioSide, SceneNodeFixture, VisibilityFixture,
 };
 use whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
     BoxPaint, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat, LayoutGeometry,
     LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate,
     PaintCornerRadius, PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition,
-    ProtocolVersion, RadialGradientExtent, RadialGradientShape, ResourceId, SurfaceId, Transform,
-    Visibility,
+    ProtocolVersion, RadialGradientExtent, RadialGradientShape, ResourceCommand,
+    ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest, ResourceSource,
+    SurfaceId, Transform, Visibility,
 };
 
-use crate::WebResourceStore;
 use crate::module_api::built_in_element_factories;
 use crate::scene::frame_sink::DomFrameSink;
+use crate::{WebResourceService, WebResourceState, WebResourceStore};
 
 const MANIFEST: &str = include_str!("../../../../tests/host-conformance/manifest.json");
+const RASTER_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAF0lEQVR4nAXBAQEAAACCIKb33EBkQpUOQdYIeRyCeLsAAAAASUVORK5CYII=";
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -203,11 +208,69 @@ fn missing_background_resource_rejects_before_dom_mutation() {
     assert_eq!(driver.root.inner_html(), before);
 }
 
+#[wasm_bindgen_test]
+async fn stale_resource_completion_cannot_replace_or_release_current_generation() {
+    let store = WebResourceStore::new();
+    let service = WebResourceService::new(store.clone());
+    let resource = ResourceId::new(1).unwrap();
+    let mut first = Box::pin(
+        service.handle(ResourceCommand::Load(ResourceRequest {
+            resource,
+            generation: 1,
+            kind: ResourceKind::RasterImage,
+            source: ResourceSource::Bytes {
+                media_type: "image/png".into(),
+                data: base64::engine::general_purpose::STANDARD
+                    .decode(RASTER_PNG_BASE64)
+                    .unwrap(),
+            },
+        })),
+    );
+    std::future::poll_fn(|context| match first.as_mut().poll(context) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(result) => panic!("first browser decode completed synchronously: {result:?}"),
+    })
+    .await;
+
+    let current = service
+        .handle(ResourceCommand::Load(ResourceRequest {
+            resource,
+            generation: 2,
+            kind: ResourceKind::RasterImage,
+            source: ResourceSource::Url(format!("data:image/png;base64,{RASTER_PNG_BASE64}")),
+        }))
+        .await
+        .unwrap();
+    assert!(matches!(
+        current,
+        Some(ResourceEvent::Ready { generation: 2, .. })
+    ));
+    let current_url = store.url(resource).unwrap();
+
+    assert_eq!(first.await.unwrap(), None);
+    assert_eq!(service.event(resource, 1), None);
+    assert_eq!(store.url(resource).as_deref(), Some(current_url.as_str()));
+    service
+        .handle(ResourceCommand::Release {
+            resource,
+            generation: 1,
+        })
+        .await
+        .unwrap();
+    assert_eq!(store.url(resource).as_deref(), Some(current_url.as_str()));
+    assert!(matches!(
+        service.state(resource, 2),
+        Some(WebResourceState::Ready { .. })
+    ));
+}
+
 struct Driver {
     root: web_sys::Element,
     sink: DomFrameSink,
     resources: WebResourceStore,
+    resource_service: WebResourceService,
     resource_urls: HashMap<u64, String>,
+    resource_lifecycle: bool,
     expected_box: Option<ExpectedBox>,
     expected_scene: Option<Vec<SceneNodeFixture>>,
 }
@@ -229,6 +292,7 @@ impl Driver {
         let surface = SurfaceId::new(1).unwrap();
         let elements = ElementRegistry::standard();
         let resources = WebResourceStore::new();
+        let resource_service = WebResourceService::new(resources.clone());
         let sink = DomFrameSink::new_with_resources(
             document,
             root.clone(),
@@ -242,13 +306,15 @@ impl Driver {
             root,
             sink,
             resources,
+            resource_service,
             resource_urls: HashMap::new(),
+            resource_lifecycle: false,
             expected_box: None,
             expected_scene: None,
         }
     }
 
-    fn execute(&mut self, side: &ScenarioSide) {
+    async fn execute(&mut self, side: &ScenarioSide) {
         for command in &side.commands {
             match command {
                 Command::AttachSurface {
@@ -267,6 +333,49 @@ impl Driver {
                     height,
                     pixels,
                 } => self.register_raster_resource(*id, *width, *height, pixels),
+                Command::LoadRasterResource {
+                    id,
+                    generation,
+                    source,
+                } => {
+                    self.resource_lifecycle = true;
+                    let source = match source {
+                        ResourceSourceFixture::Url { value } => ResourceSource::Url(value.clone()),
+                        ResourceSourceFixture::Bytes { media_type, base64 } => {
+                            ResourceSource::Bytes {
+                                media_type: media_type.clone(),
+                                data: base64::engine::general_purpose::STANDARD
+                                    .decode(base64)
+                                    .unwrap(),
+                            }
+                        }
+                    };
+                    self.resource_service
+                        .handle(ResourceCommand::Load(ResourceRequest {
+                            resource: ResourceId::new(*id).unwrap(),
+                            generation: *generation,
+                            kind: ResourceKind::RasterImage,
+                            source,
+                        }))
+                        .await
+                        .unwrap();
+                }
+                Command::ReleaseRasterResource { id, generation } => {
+                    self.resource_service
+                        .handle(ResourceCommand::Release {
+                            resource: ResourceId::new(*id).unwrap(),
+                            generation: *generation,
+                        })
+                        .await
+                        .unwrap();
+                }
+                Command::CheckpointResource {
+                    id,
+                    generation,
+                    state,
+                    width,
+                    height,
+                } => self.assert_resource_state(*id, *generation, *state, *width, *height),
                 Command::PresentBox {
                     revision,
                     rect,
@@ -289,7 +398,10 @@ impl Driver {
                 }
                 Command::Checkpoint { name, samples, .. } => {
                     if self.expected_scene.is_some() {
-                        let expected_checkpoint = self
+                        let expected_checkpoint = if self.resource_lifecycle {
+                            "paint.background-layers.resource-lifecycle"
+                        } else {
+                            self
                             .expected_scene
                             .as_ref()
                             .and_then(|nodes| {
@@ -390,7 +502,8 @@ impl Driver {
                                         })
                                     })
                             })
-                            .unwrap_or("paint.box");
+                            .unwrap_or("paint.box")
+                        };
                         assert_eq!(name, expected_checkpoint);
                         self.assert_scene_is_projected(samples);
                     } else {
@@ -445,6 +558,59 @@ impl Driver {
             .register_url(ResourceId::new(id).unwrap(), url.clone())
             .unwrap();
         self.resource_urls.insert(id, url);
+    }
+
+    fn assert_resource_state(
+        &mut self,
+        id: u64,
+        generation: u64,
+        expected: ResourceStateFixture,
+        width: Option<u32>,
+        height: Option<u32>,
+    ) {
+        let resource = ResourceId::new(id).unwrap();
+        let state = self
+            .resource_service
+            .state(resource, generation)
+            .unwrap_or_else(|| panic!("missing Web resource state {id}:{generation}"));
+        match expected {
+            ResourceStateFixture::Ready => {
+                let dimensions = ResourceDimensions {
+                    width: width.unwrap() as f32,
+                    height: height.unwrap() as f32,
+                    scale: 1.0,
+                };
+                assert_eq!(state, WebResourceState::Ready { dimensions });
+                assert_eq!(
+                    self.resource_service.event(resource, generation),
+                    Some(ResourceEvent::Ready {
+                        resource,
+                        generation,
+                        dimensions: Some(dimensions),
+                    })
+                );
+                self.resource_urls
+                    .insert(id, self.resources.url(resource).unwrap());
+            }
+            ResourceStateFixture::Failed => {
+                let WebResourceState::Failed { code, diagnostic } = state else {
+                    panic!("resource {id}:{generation} was not failed: {state:?}");
+                };
+                assert!(diagnostic.is_some());
+                assert_eq!(
+                    self.resource_service.event(resource, generation),
+                    Some(ResourceEvent::Failed {
+                        resource,
+                        generation,
+                        code,
+                        diagnostic,
+                    })
+                );
+            }
+            ResourceStateFixture::Released => {
+                assert_eq!(state, WebResourceState::Released);
+            }
+        }
     }
 
     fn assert_box_is_projected(&self) {
@@ -673,7 +839,7 @@ impl Drop for Driver {
 }
 
 #[wasm_bindgen_test]
-fn every_shared_paint_fixture_reaches_the_production_dom_sink() {
+async fn every_shared_paint_fixture_reaches_the_production_dom_sink() {
     let manifest: Manifest = serde_json::from_str(MANIFEST).unwrap();
     assert_eq!(manifest.schema, SCHEMA_VERSION);
     let mut count = 0;
@@ -690,9 +856,11 @@ fn every_shared_paint_fixture_reaches_the_production_dom_sink() {
         }) {
             continue;
         }
-        Driver::new().execute(&scenario.test);
+        let mut driver = Driver::new();
+        driver.execute(&scenario.test).await;
         if let Some(reference) = &scenario.reference {
-            Driver::new().execute(reference);
+            let mut driver = Driver::new();
+            driver.execute(reference).await;
         }
         count += 1;
     }
@@ -701,6 +869,9 @@ fn every_shared_paint_fixture_reaches_the_production_dom_sink() {
 
 fn fixture(path: &str) -> &'static str {
     match path {
+        "core/resource-raster-lifecycle.json" => {
+            include_str!("../../../../tests/host-conformance/core/resource-raster-lifecycle.json")
+        }
         "wpt/css/CSS2/backgrounds/background-color-129.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/backgrounds/background-color-129.json"
         ),

--- a/platforms/windows/src/app.rs
+++ b/platforms/windows/src/app.rs
@@ -170,6 +170,7 @@ impl WindowsApplication {
             surface_id,
             &element_registrations,
             &self.config.element_factories,
+            wake.clone(),
         ))
         .map_err(|error| WindowsError(error.to_string()))?;
         let mut runtime = RuntimeInstance::new(surface, wake);

--- a/tests/host-conformance/core/resource-raster-lifecycle.json
+++ b/tests/host-conformance/core/resource-raster-lifecycle.json
@@ -1,0 +1,94 @@
+{
+  "schema": 1,
+  "id": "core.resource-raster-lifecycle",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "load_raster_resource",
+        "id": 1,
+        "generation": 1,
+        "source": {
+          "kind": "bytes",
+          "media_type": "image/png",
+          "base64": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAF0lEQVR4nAXBAQEAAACCIKb33EBkQpUOQdYIeRyCeLsAAAAASUVORK5CYII="
+        }
+      },
+      {
+        "type": "checkpoint_resource",
+        "id": 1,
+        "generation": 1,
+        "state": "ready",
+        "width": 2,
+        "height": 2
+      },
+      {
+        "type": "load_raster_resource",
+        "id": 1,
+        "generation": 2,
+        "source": {
+          "kind": "url",
+          "value": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAF0lEQVR4nAXBAQEAAACCIKb33EBkQpUOQdYIeRyCeLsAAAAASUVORK5CYII="
+        }
+      },
+      {
+        "type": "checkpoint_resource",
+        "id": 1,
+        "generation": 2,
+        "state": "ready",
+        "width": 2,
+        "height": 2
+      },
+      { "type": "release_raster_resource", "id": 1, "generation": 1 },
+      { "type": "checkpoint_resource", "id": 1, "generation": 1, "state": "released" },
+      {
+        "type": "checkpoint_resource",
+        "id": 1,
+        "generation": 2,
+        "state": "ready",
+        "width": 2,
+        "height": 2
+      },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 100.0],
+            "background": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 },
+            "background_layers": [
+              {
+                "geometry": {
+                  "position": [
+                    { "length": 10.0, "fraction": 0.0 },
+                    { "length": 10.0, "fraction": 0.0 }
+                  ],
+                  "size": [
+                    { "length": 80.0, "fraction": 0.0 },
+                    { "length": 80.0, "fraction": 0.0 }
+                  ],
+                  "repeat_x": "no_repeat",
+                  "repeat_y": "no_repeat"
+                },
+                "image": { "resource": 1 }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.resource-lifecycle",
+        "samples": [
+          { "point": [5.0, 5.0], "color": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [25.0, 25.0], "color": { "kind": "srgba", "red": 255, "green": 0, "blue": 0, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [75.0, 25.0], "color": { "kind": "srgba", "red": 0, "green": 128, "blue": 0, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [25.0, 75.0], "color": { "kind": "srgba", "red": 0, "green": 0, "blue": 255, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [75.0, 75.0], "color": { "kind": "srgba", "red": 255, "green": 255, "blue": 0, "alpha": 1.0 }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -45,6 +45,13 @@
       "checkpoints": ["resource-registration", "semantic-projection", "pixel-samples"]
     },
     {
+      "id": "core.resource-raster-lifecycle",
+      "feature": "resource-raster-lifecycle",
+      "fixture": "core/resource-raster-lifecycle.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["resource-lifecycle", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.background-size-009",
       "feature": "background-size-no-repeat",
       "fixture": "wpt/css/css-backgrounds/background-size-009.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -2,6 +2,7 @@ package rs.whisker.runtime
 
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.util.Base64
 import android.view.View
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -14,6 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.math.abs
 import kotlin.math.roundToInt
+import rs.whisker.runtime.resource.HostResourceState
 
 private const val BACKGROUND_PACKED_LAYERS = 256
 
@@ -114,6 +116,16 @@ class HostConformanceTest {
             }
     }
 
+    @Test
+    fun reportsRasterDecodeFailure() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                assertTrue(Driver(context, "android.resource-failure").reportsRasterDecodeFailure())
+            }
+    }
+
     private fun asset(path: String): String =
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()
@@ -161,6 +173,9 @@ private class Driver(
                     logicalHeight = command.getDouble("height").toFloat()
                 }
                 "register_raster_resource" -> registerRasterResource(command)
+                "load_raster_resource" -> loadRasterResource(command)
+                "release_raster_resource" -> releaseRasterResource(command)
+                "checkpoint_resource" -> checkpointRasterResource(command)
                 "present_box" -> present(command)
                 "present_scene" -> presentScene(command)
                 "checkpoint" -> {
@@ -193,7 +208,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.background-layers.stacking" ||
                             command.getString("name") ==
-                            "paint.background-layers.resource-image",
+                            "paint.background-layers.resource-image" ||
+                            command.getString("name") ==
+                            "paint.background-layers.resource-lifecycle",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -243,6 +260,19 @@ private class Driver(
         return commitRasterResource(resourceId)
     }
 
+    fun reportsRasterDecodeFailure(): Boolean {
+        check(
+            view.loadRasterResourceBytesFromNative(
+                7L,
+                1L,
+                "image/png",
+                byteArrayOf(0, 1, 2, 3),
+            ),
+        )
+        return view.awaitRasterResourceFromNative(7L, 1L, 5_000)?.state ==
+            HostResourceState.Failed
+    }
+
     private fun commitRasterResource(resourceId: Long): Boolean {
         check(view.beginFrameFromNative(0, 1, 0, 1) == 0)
         check(stage(tag = 1, member = 1))
@@ -275,6 +305,57 @@ private class Driver(
             setPixels(colors, 0, width, 0, 0, width, height)
         }
         check(view.registerRasterResourceFromNative(command.getLong("id"), bitmap))
+    }
+
+    private fun loadRasterResource(command: JSONObject) {
+        val resourceId = command.getLong("id")
+        val generation = command.getLong("generation")
+        val source = command.getJSONObject("source")
+        val accepted = when (source.getString("kind")) {
+            "bytes" -> view.loadRasterResourceBytesFromNative(
+                resourceId,
+                generation,
+                source.getString("media_type"),
+                Base64.decode(source.getString("base64"), Base64.DEFAULT),
+            )
+            "url" -> view.loadRasterResourceUrlFromNative(
+                resourceId,
+                generation,
+                source.getString("value"),
+            )
+            else -> error("unsupported raster resource source: $source")
+        }
+        check(accepted)
+    }
+
+    private fun releaseRasterResource(command: JSONObject) {
+        check(
+            view.releaseRasterResourceFromNative(
+                command.getLong("id"),
+                command.getLong("generation"),
+            ),
+        )
+    }
+
+    private fun checkpointRasterResource(command: JSONObject) {
+        val snapshot = checkNotNull(
+            view.awaitRasterResourceFromNative(
+                command.getLong("id"),
+                command.getLong("generation"),
+                5_000,
+            ),
+        )
+        val expectedState = when (command.getString("state")) {
+            "ready" -> HostResourceState.Ready
+            "failed" -> HostResourceState.Failed
+            "released" -> HostResourceState.Released
+            else -> error("unsupported resource checkpoint: $command")
+        }
+        check(snapshot.state == expectedState)
+        if (expectedState == HostResourceState.Ready) {
+            check(snapshot.width == command.getInt("width"))
+            check(snapshot.height == command.getInt("height"))
+        }
     }
 
     private fun present(command: JSONObject) {

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -266,6 +266,55 @@ final class HostConformanceTests: XCTestCase {
             ]
         )
     }
+
+    func testResourceServiceIgnoresStaleCompletionAndOldRelease() throws {
+        let store = HostResourceStore()
+        var completions = [(Result<Data, Error>) -> Void]()
+        let service = HostResourceService(store: store, urlLoader: { _, completion in
+            completions.append(completion)
+            return {}
+        })
+
+        XCTAssertTrue(service.load(
+            id: 7,
+            generation: 1,
+            source: .url("https://example.com/old.png")
+        ))
+        XCTAssertTrue(service.load(
+            id: 7,
+            generation: 2,
+            source: .url("https://example.com/new.png")
+        ))
+        XCTAssertEqual(completions.count, 2)
+
+        completions[1](.success(try fixturePNGData()))
+        XCTAssertEqual(
+            try awaitResourceState(in: service, id: 7, generation: 2),
+            .ready(width: 2, height: 2)
+        )
+        completions[0](.failure(URLError(.cancelled)))
+        RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        XCTAssertEqual(service.state(id: 7, generation: 2), .ready(width: 2, height: 2))
+
+        XCTAssertTrue(service.release(id: 7, generation: 1))
+        XCTAssertNotNil(store.rasterImage(id: 7))
+        XCTAssertEqual(service.state(id: 7, generation: 1), .released)
+        XCTAssertTrue(service.release(id: 7, generation: 2))
+        XCTAssertNil(store.rasterImage(id: 7))
+    }
+
+    func testResourceServiceReportsDecodeFailure() throws {
+        let service = HostResourceService(store: HostResourceStore())
+        XCTAssertTrue(service.load(
+            id: 8,
+            generation: 1,
+            source: .bytes(mediaType: "image/png", data: Data([0, 1, 2, 3]))
+        ))
+        XCTAssertEqual(
+            try awaitResourceState(in: service, id: 8, generation: 1),
+            .failed
+        )
+    }
 }
 
 @MainActor
@@ -300,6 +349,12 @@ private final class Driver {
                 surfaceScale = CGFloat(try number(command, "scale"))
             case "register_raster_resource":
                 try registerRasterResource(command)
+            case "load_raster_resource":
+                try loadRasterResource(command)
+            case "release_raster_resource":
+                try releaseRasterResource(command)
+            case "checkpoint_resource":
+                try checkpointRasterResource(command)
             case "present_box":
                 try present(command)
             case "present_scene":
@@ -324,7 +379,8 @@ private final class Driver {
                     name == "paint.background-layers.origin-content-box" ||
                     name == "paint.background-layers.clip-content-box" ||
                     name == "paint.background-layers.stacking" ||
-                    name == "paint.background-layers.resource-image" else {
+                    name == "paint.background-layers.resource-image" ||
+                    name == "paint.background-layers.resource-lifecycle" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -370,6 +426,54 @@ private final class Driver {
             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
         ), let image = context.makeImage(), view.registerRasterResource(id: id, image: image) else {
             throw Failure("register raster resource")
+        }
+    }
+
+    private func loadRasterResource(_ command: [String: Any]) throws {
+        let id = UInt64(try number(command, "id"))
+        let generation = UInt64(try number(command, "generation"))
+        let fixture = try object(command, "source")
+        let source: WhiskerRasterResourceSource
+        switch try string(fixture, "kind") {
+        case "bytes":
+            guard let data = Data(base64Encoded: try string(fixture, "base64")) else {
+                throw Failure("invalid base64 raster resource")
+            }
+            source = .bytes(mediaType: try string(fixture, "media_type"), data: data)
+        case "url":
+            source = .url(try string(fixture, "value"))
+        default:
+            throw Failure("unsupported raster resource source")
+        }
+        guard view.loadRasterResource(id: id, generation: generation, source: source) else {
+            throw Failure("load raster resource")
+        }
+    }
+
+    private func releaseRasterResource(_ command: [String: Any]) throws {
+        guard view.releaseRasterResource(
+            id: UInt64(try number(command, "id")),
+            generation: UInt64(try number(command, "generation"))
+        ) else {
+            throw Failure("release raster resource")
+        }
+    }
+
+    private func checkpointRasterResource(_ command: [String: Any]) throws {
+        let id = UInt64(try number(command, "id"))
+        let generation = UInt64(try number(command, "generation"))
+        let expected = try string(command, "state")
+        let state = try awaitResourceState(in: view, id: id, generation: generation)
+        switch (expected, state) {
+        case let ("ready", .ready(width, height)):
+            guard width == Int(try number(command, "width")),
+                  height == Int(try number(command, "height")) else {
+                throw Failure("raster resource dimensions disagree")
+            }
+        case ("failed", .failed), ("released", .released):
+            break
+        default:
+            throw Failure("raster resource state disagrees")
         }
     }
 
@@ -732,6 +836,47 @@ private func setContentScale(_ scale: CGFloat, in view: UIView) {
     view.contentScaleFactor = scale
     view.setNeedsDisplay()
     view.subviews.forEach { setContentScale(scale, in: $0) }
+}
+
+@MainActor
+private func awaitResourceState(
+    in view: WhiskerView,
+    id: UInt64,
+    generation: UInt64
+) throws -> WhiskerRasterResourceState {
+    try awaitResourceState(id: id, generation: generation) {
+        view.rasterResourceState(id: id, generation: generation)
+    }
+}
+
+@MainActor
+private func awaitResourceState(
+    in service: HostResourceService,
+    id: UInt64,
+    generation: UInt64
+) throws -> WhiskerRasterResourceState {
+    try awaitResourceState(id: id, generation: generation) {
+        service.state(id: id, generation: generation)
+    }
+}
+
+@MainActor
+private func awaitResourceState(
+    id: UInt64,
+    generation: UInt64,
+    read: () -> WhiskerRasterResourceState?
+) throws -> WhiskerRasterResourceState {
+    let deadline = Date().addingTimeInterval(5)
+    repeat {
+        if let state = read(), state != .loading { return state }
+        RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+    } while Date() < deadline
+    throw Failure("timed out waiting for raster resource \(id):\(generation)")
+}
+
+private func fixturePNGData() throws -> Data {
+    let encoded = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAF0lEQVR4nAXBAQEAAACCIKb33EBkQpUOQdYIeRyCeLsAAAAASUVORK5CYII="
+    return try unwrap(Data(base64Encoded: encoded), "fixture PNG")
 }
 
 private struct Pixels {

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -51,6 +51,9 @@
       "oneOf": [
         { "$ref": "#/$defs/attachSurface" },
         { "$ref": "#/$defs/registerRasterResource" },
+        { "$ref": "#/$defs/loadRasterResource" },
+        { "$ref": "#/$defs/releaseRasterResource" },
+        { "$ref": "#/$defs/checkpointResource" },
         { "$ref": "#/$defs/presentBox" },
         { "$ref": "#/$defs/presentScene" },
         { "$ref": "#/$defs/checkpoint" },
@@ -86,6 +89,70 @@
           "items": { "$ref": "#/$defs/color" }
         }
       }
+    },
+    "resourceSource": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "value"],
+          "properties": {
+            "kind": { "const": "url" },
+            "value": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "media_type", "base64"],
+          "properties": {
+            "kind": { "const": "bytes" },
+            "media_type": { "type": "string", "minLength": 1 },
+            "base64": { "type": "string", "minLength": 1, "pattern": "^[A-Za-z0-9+/]+={0,2}$" }
+          }
+        }
+      ]
+    },
+    "loadRasterResource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id", "generation", "source"],
+      "properties": {
+        "type": { "const": "load_raster_resource" },
+        "id": { "type": "integer", "minimum": 1 },
+        "generation": { "type": "integer", "minimum": 1 },
+        "source": { "$ref": "#/$defs/resourceSource" }
+      }
+    },
+    "releaseRasterResource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id", "generation"],
+      "properties": {
+        "type": { "const": "release_raster_resource" },
+        "id": { "type": "integer", "minimum": 1 },
+        "generation": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "checkpointResource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id", "generation", "state"],
+      "properties": {
+        "type": { "const": "checkpoint_resource" },
+        "id": { "type": "integer", "minimum": 1 },
+        "generation": { "type": "integer", "minimum": 1 },
+        "state": { "enum": ["ready", "failed", "released"] },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "state": { "const": "ready" } } },
+          "then": { "required": ["width", "height"] },
+          "else": { "not": { "anyOf": [{ "required": ["width"] }, { "required": ["height"] }] } }
+        }
+      ]
     },
     "presentBox": {
       "type": "object",


### PR DESCRIPTION
## Summary

- add a shared lifecycle fixture for bytes/data-URL decode, generation replacement, exact release, and subsequent resource-backed paint
- add generation-safe production resource services to Android, iOS, Web, and Desktop
- acquire HTTP(S) off the UI thread on native Hosts and use browser-native async image decode on Web
- publish decoded resources atomically into each existing paint store and wake/request a frame on completion
- ignore stale async completions and prevent an old-generation release from evicting the current image
- revoke owned Web object URLs and report Ready dimensions / Failed classifications

## Verification

- `cargo test -p whisker-host-conformance`
- `cargo clippy -p whisker-desktop --features host-conformance --tests -- -D warnings`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web` (4 passed)
- Android instrumentation (6 passed)
- `cargo xtask host-conformance ios` (7 passed)
- Desktop macOS adapter check plus Windows/Linux cfg checks

## Boundary follow-up

The Host services now expose/retain typed Ready and Failed events, but mobile runtime ABI does not yet carry `ResourceCommand` and `ResourceEvent`. The next stacked slice will add that shared non-frame ABI and the RuntimeInstance wake/invalidation entry point; it is intentionally not represented as JSON or folded into `FramePacket`.