### PR TITLE
feat(runtime): lower URL backgrounds through resources

### DIFF
--- a/crates/whisker-css/src/prop/background.rs
+++ b/crates/whisker-css/src/prop/background.rs
@@ -1,5 +1,6 @@
 //! Background longhand properties.
 
+use crate::ToCss;
 use crate::css::Css;
 use crate::data_type::{Color, LengthPercentage};
 use crate::data_type_ext::Position;
@@ -19,7 +20,27 @@ impl Css {
     /// `none` clears any existing image.
     /// <https://lynxjs.org/api/css/properties/background-image>
     pub fn background_image(self, v: impl Into<ImageRef>) -> Self {
-        self.push(crate::StyleProperty::BackgroundImage, v.into())
+        let image = v.into();
+        let lynx_value = image.to_css_string();
+        match image {
+            ImageRef::None => self.push_semantic(
+                crate::StyleProperty::BackgroundImage,
+                whisker_style::StyleValue::BackgroundImages(vec![
+                    whisker_style::BackgroundImageValue::None,
+                ]),
+                lynx_value,
+            ),
+            ImageRef::Url(value) => self.push_semantic(
+                crate::StyleProperty::BackgroundImage,
+                whisker_style::StyleValue::BackgroundImages(vec![
+                    whisker_style::BackgroundImageValue::Url(value.0),
+                ]),
+                lynx_value,
+            ),
+            ImageRef::Gradient(_) => {
+                self.push_raw(crate::StyleProperty::BackgroundImage, lynx_value)
+            }
+        }
     }
 
     /// Sets `background-repeat`.
@@ -103,6 +124,12 @@ mod tests {
     fn background_image_url() {
         let s = Css::new().background_image(ImageRef::Url(CssString::new("a.png")));
         assert_eq!(s.to_string(), "background-image: url(\"a.png\");");
+        assert_eq!(
+            s.to_specified_style().unwrap().resolved()[0].value(),
+            &whisker_style::StyleValue::BackgroundImages(vec![
+                whisker_style::BackgroundImageValue::Url("a.png".into()),
+            ])
+        );
     }
 
     #[test]
@@ -115,6 +142,10 @@ mod tests {
         assert_eq!(
             s.to_string(),
             "background-image: linear-gradient(to bottom, red, blue);"
+        );
+        assert_eq!(
+            s.to_specified_style().unwrap_err().property(),
+            "background-image"
         );
     }
 

--- a/crates/whisker-engine/src/paint.rs
+++ b/crates/whisker-engine/src/paint.rs
@@ -161,6 +161,7 @@ mod tests {
     fn paint_style() -> ComputedPaintStyle {
         ComputedPaintStyle {
             background_color: color("background"),
+            background_images: Vec::new(),
             border_colors: Edges {
                 top: color("top"),
                 right: color("right"),

--- a/crates/whisker-engine/src/scene.rs
+++ b/crates/whisker-engine/src/scene.rs
@@ -5,10 +5,10 @@ use std::error::Error;
 use std::fmt;
 
 use whisker_protocol::{
-    BoxClip, BoxPaint, CommandId, ElementTypeId, FrameHeader, FrameMode, FramePacket,
-    HitTestBehavior, InputPoint, LayoutGeometry, NodeId, Operation, OverflowClip, PointerId,
-    PropertyId, ProtocolVersion, ResultId, SurfaceId, TextContent, TextContentError, Transform,
-    Visibility, WhiskerValue,
+    BackgroundLayer, BoxClip, BoxPaint, CommandId, ElementTypeId, FrameHeader, FrameMode,
+    FramePacket, HitTestBehavior, InputPoint, LayoutGeometry, NodeId, Operation, OverflowClip,
+    PointerId, PropertyId, ProtocolVersion, ResultId, SurfaceId, TextContent, TextContentError,
+    Transform, Visibility, WhiskerValue,
 };
 
 /// A retained logical node owned by a [`Scene`].
@@ -19,6 +19,7 @@ pub struct SceneNode {
     children: Vec<NodeId>,
     layout: Option<LayoutGeometry>,
     box_paint: Option<BoxPaint>,
+    background_layers: Vec<BackgroundLayer>,
     clip: Option<BoxClip>,
     transform: Option<Transform>,
     opacity: Option<f32>,
@@ -39,6 +40,7 @@ impl SceneNode {
             children: Vec::new(),
             layout: None,
             box_paint: None,
+            background_layers: Vec::new(),
             clip: None,
             transform: None,
             opacity: None,
@@ -80,6 +82,11 @@ impl SceneNode {
     /// Returns retained background and border paint.
     pub const fn box_paint(&self) -> Option<&BoxPaint> {
         self.box_paint.as_ref()
+    }
+
+    /// Returns retained background image layers in front-to-back order.
+    pub fn background_layers(&self) -> &[BackgroundLayer] {
+        &self.background_layers
     }
 
     /// Returns retained descendant overflow clipping.
@@ -176,6 +183,8 @@ pub enum SceneError {
     },
     /// Background or border paint contained an invalid value.
     InvalidBoxPaint,
+    /// One or more retained background image layers were invalid.
+    InvalidBackgroundLayers,
     /// A pending command result identifier was reused.
     DuplicateResultId {
         /// Duplicate result identifier.
@@ -203,6 +212,7 @@ impl Error for SceneError {}
 enum DirtySlot {
     Layout(NodeId),
     BoxPaint(NodeId),
+    BackgroundLayers(NodeId),
     Clip(NodeId),
     Transform(NodeId),
     Opacity(NodeId),
@@ -561,6 +571,31 @@ impl Scene {
         self.journal.push_coalesced(
             DirtySlot::BoxPaint(node),
             Operation::SetBoxPaint { node, paint },
+        );
+        Ok(())
+    }
+
+    /// Sets the ordered background image layers when they differ from retained
+    /// state. An empty list clears every image while preserving box color.
+    pub fn set_background_layers(
+        &mut self,
+        node: NodeId,
+        layers: Vec<BackgroundLayer>,
+    ) -> Result<(), SceneError> {
+        self.ensure_mutable()?;
+        if !layers.iter().all(BackgroundLayer::validate) {
+            return Err(SceneError::InvalidBackgroundLayers);
+        }
+        if self.require_node(node)?.background_layers == layers {
+            return Ok(());
+        }
+        self.nodes
+            .get_mut(&node)
+            .expect("node checked above")
+            .background_layers = layers.clone();
+        self.journal.push_coalesced(
+            DirtySlot::BackgroundLayers(node),
+            Operation::SetBackgroundLayers { node, layers },
         );
         Ok(())
     }
@@ -989,6 +1024,12 @@ impl Scene {
                     paint: paint.clone(),
                 });
             }
+            if !state.background_layers.is_empty() {
+                operations.push(Operation::SetBackgroundLayers {
+                    node: *node,
+                    layers: state.background_layers.clone(),
+                });
+            }
             if let Some(clip) = state.clip {
                 operations.push(Operation::SetClip { node: *node, clip });
             }
@@ -1063,10 +1104,11 @@ mod tests {
     use super::*;
     use crate::{FrameSink, RecordingRenderer};
     use whisker_protocol::{
-        ApplyResult, BorderLineStyle, LayoutRect, MeasureFontFamily, MeasureFontStyle,
-        MeasureLineHeight, MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap, PaintColor,
-        PaintCorners, PaintEdges, PaintLengthPercentage, TextContentError, TextMeasurePayload,
-        TextMeasureStyle, ValidationError,
+        ApplyResult, BackgroundAttachment, BackgroundSize, BlendMode, BorderLineStyle, ImageRepeat,
+        LayoutRect, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextDirection,
+        MeasureTextOverflow, MeasureTextWrap, PaintBox, PaintColor, PaintCorners, PaintEdges,
+        PaintImage, PaintLengthPercentage, PaintPosition, ResourceId, TextContentError,
+        TextMeasurePayload, TextMeasureStyle, ValidationError,
     };
 
     fn surface() -> SurfaceId {
@@ -1152,6 +1194,20 @@ mod tests {
         }
     }
 
+    fn resource_background(resource: u64) -> BackgroundLayer {
+        BackgroundLayer {
+            image: PaintImage::Resource(ResourceId::new(resource).unwrap()),
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Padding,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
+        }
+    }
+
     fn prepared(scene: &mut Scene) -> FramePacket {
         scene
             .prepare_frame(7)
@@ -1199,6 +1255,10 @@ mod tests {
         scene.set_layout(root, rect).expect("layout");
         let paint = box_paint("navy");
         scene.set_box_paint(root, paint.clone()).expect("box paint");
+        let background = resource_background(9);
+        scene
+            .set_background_layers(root, vec![background.clone()])
+            .expect("background layers");
         let clip = BoxClip {
             horizontal: OverflowClip::Hidden,
             vertical: OverflowClip::Visible,
@@ -1257,6 +1317,13 @@ mod tests {
         assert_eq!(packet.header.viewport_epoch, 7);
         assert_eq!(renderer.projection().node_count(), 2);
         assert_eq!(scene.accepted_revision(), 1);
+        assert!(packet.operations.iter().any(|operation| {
+            matches!(
+                operation,
+                Operation::SetBackgroundLayers { node, layers }
+                    if *node == root && layers == &[background.clone()]
+            )
+        }));
         assert!(!scene.has_pending_work());
         assert_eq!(scene.prepare_frame(8).expect("idle frame"), None);
     }
@@ -1288,6 +1355,15 @@ mod tests {
         scene
             .set_box_paint(root, second_paint)
             .expect("equal box paint");
+        scene
+            .set_background_layers(root, vec![resource_background(1)])
+            .expect("first background");
+        scene
+            .set_background_layers(root, vec![resource_background(2)])
+            .expect("coalesced background");
+        scene
+            .set_background_layers(root, vec![resource_background(2)])
+            .expect("equal background");
         let clip = BoxClip {
             horizontal: OverflowClip::Visible,
             vertical: OverflowClip::Hidden,

--- a/crates/whisker-engine/src/scene.rs
+++ b/crates/whisker-engine/src/scene.rs
@@ -1321,7 +1321,7 @@ mod tests {
             matches!(
                 operation,
                 Operation::SetBackgroundLayers { node, layers }
-                    if *node == root && layers == &[background.clone()]
+                    if *node == root && layers == std::slice::from_ref(&background)
             )
         }));
         assert!(!scene.has_pending_work());

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -788,14 +788,15 @@ mod tests {
 
     use whisker_layout::{AvailableSpace, LayoutSize, MeasureRequest, UnsupportedLayoutFeature};
     use whisker_protocol::{
-        ApplyResult, CustomMeasurePayload, ElementTypeId, EmbeddedSurfaceMeasurePayload, FrameMode,
-        HitTestBehavior, InputPoint, LayoutRect, MeasureFontFamily, MeasureFontStyle,
+        ApplyResult, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
+        CustomMeasurePayload, ElementTypeId, EmbeddedSurfaceMeasurePayload, FrameMode,
+        HitTestBehavior, ImageRepeat, InputPoint, LayoutRect, MeasureFontFamily, MeasureFontStyle,
         MeasureLineHeight, MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap,
         MeasuredSize, MeasurementKey, MeasurementKind, MeasurementMetrics, MeasurementPayload,
         MeasurementReady, MeasurementRequestId, MeasurementResponse, MeasurementSpec,
-        NativeControlMeasurePayload, NodeId, Operation, PendingMeasurePolicy, PointerId,
-        ReplacedContentMeasurePayload, SurfaceId, TextMeasurePayload, TextMeasureStyle,
-        UnsupportedMeasurementReason,
+        NativeControlMeasurePayload, NodeId, Operation, PaintBox, PaintCoordinate, PaintImage,
+        PaintPosition, PendingMeasurePolicy, PointerId, ReplacedContentMeasurePayload, ResourceId,
+        SurfaceId, TextMeasurePayload, TextMeasureStyle, UnsupportedMeasurementReason,
     };
     use whisker_style::{
         Axes, ComputedLengthPercentage, ComputedSizeValue, PositionValue, SpecifiedStyle,
@@ -824,6 +825,20 @@ mod tests {
                 height: ComputedSizeValue::Value(ComputedLengthPercentage::new(height, 0.0)),
             },
             ..ComputedLayoutStyle::default()
+        }
+    }
+
+    fn resource_background(resource: u64) -> BackgroundLayer {
+        BackgroundLayer {
+            image: PaintImage::Resource(ResourceId::new(resource).expect("test resource")),
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Padding,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
         }
     }
 
@@ -1004,6 +1019,30 @@ mod tests {
             .create_node(element_type(), style.layout().clone())
             .unwrap();
         let missing = node_id(99);
+
+        let background = resource_background(1);
+        surface
+            .set_background_layers(root, vec![background.clone()])
+            .unwrap();
+        assert_eq!(
+            surface.node(root).unwrap().background_layers(),
+            std::slice::from_ref(&background)
+        );
+        assert_eq!(
+            surface.set_background_layers(missing, vec![background]),
+            Err(SurfaceError::Scene(SceneError::UnknownNode {
+                node: missing
+            }))
+        );
+        let mut invalid_background = resource_background(2);
+        invalid_background.position.x = PaintCoordinate {
+            length: f32::NAN,
+            fraction: 0.0,
+        };
+        assert_eq!(
+            surface.set_background_layers(root, vec![invalid_background]),
+            Err(SurfaceError::Scene(SceneError::InvalidBackgroundLayers))
+        );
 
         assert_eq!(
             surface.update_computed_style(missing, style),
@@ -1720,6 +1759,16 @@ mod tests {
         );
         assert_eq!(
             surface.scene.set_box_paint(root, lowered.box_paint),
+            Err(SceneError::FramePending)
+        );
+        assert_eq!(
+            surface.set_background_layers(root, vec![resource_background(1)]),
+            Err(SurfaceError::Scene(SceneError::FramePending))
+        );
+        assert_eq!(
+            surface
+                .scene
+                .set_background_layers(root, vec![resource_background(1)]),
             Err(SceneError::FramePending)
         );
         assert_eq!(

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -394,6 +394,19 @@ impl SurfaceEngine {
         Ok(impacts)
     }
 
+    /// Updates retained background image layers independently from computed
+    /// box paint. Resource identity is assigned by the runtime boundary, not
+    /// by the layout/style engine.
+    pub fn set_background_layers(
+        &mut self,
+        node: NodeId,
+        layers: Vec<whisker_protocol::BackgroundLayer>,
+    ) -> Result<(), SurfaceError> {
+        self.ensure_mutable()?;
+        self.scene.set_background_layers(node, layers)?;
+        Ok(())
+    }
+
     /// Marks or unmarks a leaf as requiring intrinsic Host measurement.
     ///
     /// Returns whether retained measurement behavior changed.

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -38,7 +38,7 @@ pub use resolution::{
     resolve_text_style,
 };
 pub use value::{
-    BorderRadiusValue, CalcExpression, ColorValue, FontFamilyValue, FontStyleValue,
-    FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, StyleNumber,
-    StyleValue,
+    BackgroundImageValue, BorderRadiusValue, CalcExpression, ColorValue, FontFamilyValue,
+    FontStyleValue, FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue,
+    LineHeightValue, StyleNumber, StyleValue,
 };

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -1,8 +1,9 @@
 //! Computed paint values that remain independent of every Host renderer.
 
 use crate::{
-    ColorValue, ComputedLengthPercentage, Edges, InheritedStyle, SpecifiedStyle, StyleEnvironment,
-    StyleNumber, StyleProperty, StyleResolutionError, StyleValue, layout::resolve_affine,
+    BackgroundImageValue, ColorValue, ComputedLengthPercentage, Edges, InheritedStyle,
+    SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty, StyleResolutionError, StyleValue,
+    layout::resolve_affine,
 };
 
 /// Four physical corners in top-left, top-right, bottom-right, bottom-left order.
@@ -96,6 +97,8 @@ pub enum VisibilityValue {
 pub struct ComputedPaintStyle {
     /// Resolved background color. Transparent is represented explicitly.
     pub background_color: ColorValue,
+    /// Ordered Host-independent background image sources, front to back.
+    pub background_images: Vec<BackgroundImageValue>,
     /// Resolved border colors in physical edge order.
     pub border_colors: Edges<ColorValue>,
     /// Border line styles in physical edge order.
@@ -124,6 +127,7 @@ impl ComputedPaintStyle {
         };
         Self {
             background_color: transparent,
+            background_images: Vec::new(),
             border_colors: Edges {
                 top: current_color.clone(),
                 right: current_color.clone(),
@@ -167,6 +171,12 @@ pub(crate) fn resolve_paint_style(
         match property {
             StyleProperty::BackgroundColor => {
                 paint.background_color = color(value, property)?;
+            }
+            StyleProperty::BackgroundImage => {
+                let StyleValue::BackgroundImages(images) = value else {
+                    return Err(invalid(property));
+                };
+                paint.background_images = images.clone();
             }
             StyleProperty::BorderTopColor => paint.border_colors.top = color(value, property)?,
             StyleProperty::BorderRightColor => paint.border_colors.right = color(value, property)?,
@@ -322,6 +332,12 @@ mod tests {
                 }),
             )
             .push(
+                StyleProperty::BackgroundImage,
+                StyleValue::BackgroundImages(vec![BackgroundImageValue::Url(
+                    "https://example.com/image.png".into(),
+                )]),
+            )
+            .push(
                 StyleProperty::BorderTopStyle,
                 StyleValue::BorderStyle(BorderStyleValue::Solid),
             )
@@ -388,6 +404,12 @@ mod tests {
                 alpha: number(0.5),
             }
         );
+        assert_eq!(
+            paint.background_images,
+            vec![BackgroundImageValue::Url(
+                "https://example.com/image.png".into()
+            )]
+        );
         assert_eq!(paint.border_colors.top, ColorValue::Named("top".into()));
         assert_eq!(paint.border_colors.right, ColorValue::Named("right".into()));
         assert_eq!(
@@ -421,6 +443,7 @@ mod tests {
     fn invalid_paint_values_are_diagnostic() {
         for property in [
             StyleProperty::BackgroundColor,
+            StyleProperty::BackgroundImage,
             StyleProperty::BorderTopColor,
             StyleProperty::BorderRightColor,
             StyleProperty::BorderBottomColor,

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -179,6 +179,15 @@ pub struct BorderRadiusValue {
     pub vertical: LengthPercentageValue,
 }
 
+/// One specified background image that does not contain Host resource IDs.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum BackgroundImageValue {
+    /// An explicit `none` layer retained for future list alignment.
+    None,
+    /// URL text resolved under Host resource policy.
+    Url(String),
+}
+
 /// An owned value in a specified inline-style declaration.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StyleValue {
@@ -196,6 +205,8 @@ pub enum StyleValue {
     LengthPercentage(LengthPercentageValue),
     /// One border corner's horizontal and vertical radii.
     BorderRadius(BorderRadiusValue),
+    /// Ordered background images, front to back.
+    BackgroundImages(Vec<BackgroundImageValue>),
     /// Font family.
     FontFamily(FontFamilyValue),
     /// Font face style.

--- a/crates/whisker/src/background_resources.rs
+++ b/crates/whisker/src/background_resources.rs
@@ -1,0 +1,516 @@
+//! Runtime-owned lowering from semantic background URLs to Host resources.
+
+use std::collections::{HashMap, HashSet};
+
+use whisker_engine::whisker_protocol::{
+    BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, ImageRepeat, NodeId,
+    PaintBox, PaintImage, PaintPosition, ResourceCommand, ResourceEvent, ResourceId, ResourceKind,
+    ResourceRequest, ResourceSource,
+};
+use whisker_engine::whisker_style::BackgroundImageValue;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ResourceKey {
+    kind: ResourceKind,
+    source: ResourceSourceKey,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum ResourceSourceKey {
+    Url(String),
+}
+
+impl ResourceKey {
+    fn raster_url(url: String) -> Self {
+        Self {
+            kind: ResourceKind::RasterImage,
+            source: ResourceSourceKey::Url(url),
+        }
+    }
+
+    fn source(&self) -> ResourceSource {
+        match &self.source {
+            ResourceSourceKey::Url(url) => ResourceSource::Url(url.clone()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum DesiredImage {
+    None,
+    Resource(ResourceKey),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResourcePhase {
+    Pending,
+    Ready,
+    Failed,
+}
+
+#[derive(Clone, Debug)]
+struct ResourceEntry {
+    key: ResourceKey,
+    resource: ResourceId,
+    generation: u64,
+    phase: ResourcePhase,
+    desired_users: HashSet<NodeId>,
+    projected_users: HashSet<NodeId>,
+    accepted_users: HashSet<NodeId>,
+    retirement_pending: bool,
+}
+
+/// Failure while assigning an internal resource identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum BackgroundResourceError {
+    InvalidSource,
+    ResourceIdExhausted,
+}
+
+/// Scene projection and resource commands produced by one style mutation.
+pub(super) struct ReconcileResult {
+    pub(super) layers: Vec<BackgroundLayer>,
+    pub(super) commands: Vec<ResourceCommand>,
+}
+
+/// One deferred projection made safe at a runtime frame boundary.
+pub(super) struct BackgroundProjection {
+    pub(super) node: NodeId,
+    pub(super) layers: Vec<BackgroundLayer>,
+}
+
+/// Per-surface resource cache shared by every node using the same exact source.
+///
+/// IDs are never reused. A source that is reacquired before its retirement
+/// frame is accepted cancels retirement and keeps its ID. Once Release is
+/// emitted, the same source receives a fresh ID with generation one.
+#[derive(Clone, Debug)]
+pub(super) struct BackgroundResourceManager {
+    next_resource_id: u64,
+    resources_by_key: HashMap<ResourceKey, ResourceId>,
+    entries: HashMap<ResourceId, ResourceEntry>,
+    owned_ids: HashSet<ResourceId>,
+    node_images: HashMap<NodeId, Vec<DesiredImage>>,
+    dirty_nodes: HashSet<NodeId>,
+}
+
+impl Default for BackgroundResourceManager {
+    fn default() -> Self {
+        Self {
+            next_resource_id: 1,
+            resources_by_key: HashMap::new(),
+            entries: HashMap::new(),
+            owned_ids: HashSet::new(),
+            node_images: HashMap::new(),
+            dirty_nodes: HashSet::new(),
+        }
+    }
+}
+
+impl BackgroundResourceManager {
+    pub(super) fn owns(&self, resource: ResourceId) -> bool {
+        self.owned_ids.contains(&resource)
+    }
+
+    pub(super) fn reconcile_node(
+        &mut self,
+        node: NodeId,
+        images: &[BackgroundImageValue],
+        externally_used: &HashSet<ResourceId>,
+    ) -> Result<ReconcileResult, BackgroundResourceError> {
+        let desired = images
+            .iter()
+            .map(|image| match image {
+                BackgroundImageValue::None => Ok(DesiredImage::None),
+                BackgroundImageValue::Url(url) if url.trim().is_empty() => {
+                    Err(BackgroundResourceError::InvalidSource)
+                }
+                BackgroundImageValue::Url(url) => {
+                    Ok(DesiredImage::Resource(ResourceKey::raster_url(url.clone())))
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let previous = self.node_images.get(&node).cloned().unwrap_or_default();
+        let previous_keys = resource_keys(&previous);
+        let desired_keys = resource_keys(&desired);
+        let mut commands = Vec::new();
+
+        // Acquire first so an unchanged source, or one whose retirement has not
+        // crossed the Host boundary, never churns its identity.
+        for key in desired_keys.difference(&previous_keys) {
+            commands.extend(self.acquire(node, key.clone(), externally_used)?);
+        }
+        for key in desired_keys.intersection(&previous_keys) {
+            let resource = self.resources_by_key[key];
+            let entry = self
+                .entries
+                .get_mut(&resource)
+                .expect("a shared key always names a live entry");
+            entry.desired_users.insert(node);
+            entry.retirement_pending = false;
+        }
+
+        self.node_images.insert(node, desired);
+        self.refresh_projected_node(node);
+
+        for key in previous_keys.difference(&desired_keys) {
+            commands.extend(self.drop_user(node, key));
+        }
+        if images.is_empty() {
+            self.node_images.remove(&node);
+        }
+        self.dirty_nodes.remove(&node);
+
+        Ok(ReconcileResult {
+            layers: self.projected_layers(node),
+            commands,
+        })
+    }
+
+    pub(super) fn remove_nodes(&mut self, nodes: &[NodeId]) -> Vec<ResourceCommand> {
+        let mut commands = Vec::new();
+        for node in nodes {
+            let previous = self.node_images.remove(node).unwrap_or_default();
+            self.dirty_nodes.remove(node);
+            for key in resource_keys(&previous) {
+                if let Some(resource) = self.resources_by_key.get(&key).copied()
+                    && let Some(entry) = self.entries.get_mut(&resource)
+                {
+                    entry.projected_users.remove(node);
+                }
+                commands.extend(self.drop_user(*node, &key));
+            }
+        }
+        commands
+    }
+
+    /// Records a Host completion without mutating the retained scene.
+    ///
+    /// The caller flushes `dirty_projections` at the next safe layout/present
+    /// boundary, because a Host callback may arrive while a frame is prepared.
+    pub(super) fn apply_event(&mut self, event: &ResourceEvent) -> bool {
+        let (resource, generation, phase) = match event {
+            ResourceEvent::Ready {
+                resource,
+                generation,
+                ..
+            } => (*resource, *generation, ResourcePhase::Ready),
+            ResourceEvent::Failed {
+                resource,
+                generation,
+                ..
+            } => (*resource, *generation, ResourcePhase::Failed),
+        };
+        let Some(entry) = self.entries.get_mut(&resource) else {
+            return false;
+        };
+        if entry.generation != generation {
+            return true;
+        }
+        entry.phase = phase;
+        self.dirty_nodes.extend(entry.desired_users.iter().copied());
+        true
+    }
+
+    pub(super) fn dirty_projections(&self) -> Vec<BackgroundProjection> {
+        let mut nodes = self.dirty_nodes.iter().copied().collect::<Vec<_>>();
+        nodes.sort_by_key(|node| node.get());
+        nodes
+            .into_iter()
+            .filter(|node| self.node_images.contains_key(node))
+            .map(|node| BackgroundProjection {
+                node,
+                layers: self.projected_layers(node),
+            })
+            .collect()
+    }
+
+    pub(super) fn commit_dirty_projections(&mut self, projections: &[BackgroundProjection]) {
+        for projection in projections {
+            self.refresh_projected_node(projection.node);
+            self.dirty_nodes.remove(&projection.node);
+        }
+    }
+
+    /// Advances the accepted-reference ledger after Scene accepted the frame.
+    pub(super) fn accept_frame(&mut self) -> Vec<ResourceCommand> {
+        for entry in self.entries.values_mut() {
+            entry.accepted_users.clone_from(&entry.projected_users);
+        }
+        let mut retire = self
+            .entries
+            .iter()
+            .filter_map(|(resource, entry)| {
+                (entry.retirement_pending
+                    && entry.desired_users.is_empty()
+                    && entry.accepted_users.is_empty())
+                .then_some(*resource)
+            })
+            .collect::<Vec<_>>();
+        retire.sort_by_key(|resource| resource.get());
+        retire
+            .into_iter()
+            .map(|resource| self.finish_release(resource))
+            .collect()
+    }
+
+    fn acquire(
+        &mut self,
+        node: NodeId,
+        key: ResourceKey,
+        externally_used: &HashSet<ResourceId>,
+    ) -> Result<Vec<ResourceCommand>, BackgroundResourceError> {
+        if let Some(resource) = self.resources_by_key.get(&key).copied() {
+            let entry = self
+                .entries
+                .get_mut(&resource)
+                .expect("a shared key always names a live entry");
+            entry.desired_users.insert(node);
+            entry.retirement_pending = false;
+            return Ok(Vec::new());
+        }
+
+        let resource = self.allocate_id(externally_used)?;
+        let generation = 1;
+        self.owned_ids.insert(resource);
+        self.resources_by_key.insert(key.clone(), resource);
+        self.entries.insert(
+            resource,
+            ResourceEntry {
+                key: key.clone(),
+                resource,
+                generation,
+                phase: ResourcePhase::Pending,
+                desired_users: HashSet::from([node]),
+                projected_users: HashSet::new(),
+                accepted_users: HashSet::new(),
+                retirement_pending: false,
+            },
+        );
+        Ok(vec![ResourceCommand::Load(ResourceRequest {
+            resource,
+            generation,
+            kind: key.kind,
+            source: key.source(),
+        })])
+    }
+
+    fn allocate_id(
+        &mut self,
+        externally_used: &HashSet<ResourceId>,
+    ) -> Result<ResourceId, BackgroundResourceError> {
+        while self.next_resource_id != 0 {
+            let raw = self.next_resource_id;
+            self.next_resource_id = raw.checked_add(1).unwrap_or(0);
+            let resource = ResourceId::new(raw).expect("the allocator skips reserved zero");
+            if !self.owned_ids.contains(&resource) && !externally_used.contains(&resource) {
+                return Ok(resource);
+            }
+        }
+        Err(BackgroundResourceError::ResourceIdExhausted)
+    }
+
+    fn drop_user(&mut self, node: NodeId, key: &ResourceKey) -> Vec<ResourceCommand> {
+        let Some(resource) = self.resources_by_key.get(key).copied() else {
+            return Vec::new();
+        };
+        let entry = self
+            .entries
+            .get_mut(&resource)
+            .expect("a shared key always names a live entry");
+        entry.desired_users.remove(&node);
+        entry.projected_users.remove(&node);
+        if !entry.desired_users.is_empty() {
+            return Vec::new();
+        }
+        if entry.accepted_users.is_empty() {
+            vec![self.finish_release(resource)]
+        } else {
+            entry.retirement_pending = true;
+            Vec::new()
+        }
+    }
+
+    fn finish_release(&mut self, resource: ResourceId) -> ResourceCommand {
+        let entry = self
+            .entries
+            .remove(&resource)
+            .expect("only a live automatic resource can retire");
+        if self.resources_by_key.get(&entry.key) == Some(&resource) {
+            self.resources_by_key.remove(&entry.key);
+        }
+        ResourceCommand::Release {
+            resource: entry.resource,
+            generation: entry.generation,
+        }
+    }
+
+    fn refresh_projected_node(&mut self, node: NodeId) {
+        for entry in self.entries.values_mut() {
+            entry.projected_users.remove(&node);
+        }
+        let keys = self
+            .node_images
+            .get(&node)
+            .map(|images| resource_keys(images))
+            .unwrap_or_default();
+        for key in keys {
+            let resource = self.resources_by_key[&key];
+            let entry = self
+                .entries
+                .get_mut(&resource)
+                .expect("a desired key always names a live entry");
+            if entry.phase == ResourcePhase::Ready {
+                entry.projected_users.insert(node);
+            }
+        }
+    }
+
+    fn projected_layers(&self, node: NodeId) -> Vec<BackgroundLayer> {
+        self.node_images
+            .get(&node)
+            .into_iter()
+            .flatten()
+            .filter_map(|image| match image {
+                DesiredImage::None => None,
+                DesiredImage::Resource(key) => {
+                    let resource = self.resources_by_key[key];
+                    (self.entries[&resource].phase == ResourcePhase::Ready)
+                        .then(|| initial_resource_layer(resource))
+                }
+            })
+            .collect()
+    }
+}
+
+fn resource_keys(images: &[DesiredImage]) -> HashSet<ResourceKey> {
+    images
+        .iter()
+        .filter_map(|image| match image {
+            DesiredImage::None => None,
+            DesiredImage::Resource(key) => Some(key.clone()),
+        })
+        .collect()
+}
+
+fn initial_resource_layer(resource: ResourceId) -> BackgroundLayer {
+    BackgroundLayer {
+        image: PaintImage::Resource(resource),
+        position: PaintPosition::default(),
+        size: BackgroundSize::Auto,
+        repeat_x: ImageRepeat::Repeat,
+        repeat_y: ImageRepeat::Repeat,
+        origin: PaintBox::Padding,
+        clip: PaintBox::Border,
+        attachment: BackgroundAttachment::Scroll,
+        blend_mode: BlendMode::Normal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(value: u64) -> NodeId {
+        NodeId::new(value).unwrap()
+    }
+
+    fn url(value: &str) -> BackgroundImageValue {
+        BackgroundImageValue::Url(value.into())
+    }
+
+    fn load(command: &ResourceCommand) -> (ResourceId, u64) {
+        let ResourceCommand::Load(request) = command else {
+            panic!("expected load")
+        };
+        (request.resource, request.generation)
+    }
+
+    #[test]
+    fn exact_url_is_shared_and_only_ready_resources_project() {
+        let mut manager = BackgroundResourceManager::default();
+        let first = manager
+            .reconcile_node(
+                node(1),
+                &[url("https://example.test/a.png")],
+                &HashSet::new(),
+            )
+            .unwrap();
+        assert_eq!(first.commands.len(), 1);
+        assert!(first.layers.is_empty());
+        let (resource, generation) = load(&first.commands[0]);
+
+        let second = manager
+            .reconcile_node(
+                node(2),
+                &[url("https://example.test/a.png")],
+                &HashSet::new(),
+            )
+            .unwrap();
+        assert!(second.commands.is_empty());
+        assert!(manager.apply_event(&ResourceEvent::Ready {
+            resource,
+            generation,
+            dimensions: None,
+        }));
+        let projections = manager.dirty_projections();
+        assert_eq!(projections.len(), 2);
+        assert!(projections.iter().all(|projection| {
+            projection.layers.len() == 1
+                && projection.layers[0].image == PaintImage::Resource(resource)
+        }));
+    }
+
+    #[test]
+    fn accepted_reference_defers_release_and_reacquire_cancels_retirement() {
+        let mut manager = BackgroundResourceManager::default();
+        let acquired = manager
+            .reconcile_node(node(1), &[url("same")], &HashSet::new())
+            .unwrap();
+        let (resource, generation) = load(&acquired.commands[0]);
+        manager.apply_event(&ResourceEvent::Ready {
+            resource,
+            generation,
+            dimensions: None,
+        });
+        let projections = manager.dirty_projections();
+        manager.commit_dirty_projections(&projections);
+        assert!(manager.accept_frame().is_empty());
+
+        let removed = manager
+            .reconcile_node(node(1), &[], &HashSet::new())
+            .unwrap();
+        assert!(removed.commands.is_empty());
+        let reacquired = manager
+            .reconcile_node(node(1), &[url("same")], &HashSet::new())
+            .unwrap();
+        assert!(reacquired.commands.is_empty());
+        assert_eq!(reacquired.layers[0].image, PaintImage::Resource(resource));
+        assert!(manager.accept_frame().is_empty());
+    }
+
+    #[test]
+    fn source_reacquired_after_release_gets_fresh_id() {
+        let mut manager = BackgroundResourceManager::default();
+        let acquired = manager
+            .reconcile_node(node(1), &[url("same")], &HashSet::new())
+            .unwrap();
+        let (first, _) = load(&acquired.commands[0]);
+        let removed = manager
+            .reconcile_node(node(1), &[], &HashSet::new())
+            .unwrap();
+        assert_eq!(
+            removed.commands,
+            vec![ResourceCommand::Release {
+                resource: first,
+                generation: 1,
+            }]
+        );
+        let reacquired = manager
+            .reconcile_node(node(1), &[url("same")], &HashSet::new())
+            .unwrap();
+        let (second, generation) = load(&reacquired.commands[0]);
+        assert_ne!(first, second);
+        assert_eq!(generation, 1);
+    }
+}

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -185,6 +185,7 @@ pub use whisker_runtime::{RuntimeDispatcher, runtime_dispatcher};
 // Frame-driving internal used by the host tick loop, not app code.
 #[doc(hidden)]
 pub use whisker_runtime::tasks::run_until_stalled;
+mod background_resources;
 mod control_flow;
 mod element_registry;
 #[doc(hidden)]

--- a/crates/whisker/src/surface_runtime.rs
+++ b/crates/whisker/src/surface_runtime.rs
@@ -8,6 +8,9 @@ use std::rc::Rc;
 
 use crate::ElementRegistry;
 use crate::ElementRegistryError;
+use crate::background_resources::{
+    BackgroundProjection, BackgroundResourceError, BackgroundResourceManager,
+};
 use crate::runtime::element::ElementTag;
 use crate::runtime::value::WhiskerValue;
 use crate::runtime::view::{BindType, DynRenderer, Element};
@@ -97,6 +100,10 @@ pub enum RuntimeBindingError {
     },
     /// Runtime element handles exhausted their reserved `u32` range.
     ElementIdExhausted,
+    /// Automatic paint resource IDs exhausted their non-zero `u64` range.
+    ResourceIdExhausted,
+    /// A typed background resource source was empty or otherwise malformed.
+    InvalidBackgroundResourceSource,
     /// Typed style resolution failed.
     Style(StyleResolutionError),
     /// The retained scene or layout engine rejected the mutation.
@@ -135,6 +142,15 @@ impl From<SurfaceError> for RuntimeBindingError {
 impl From<ElementRegistryError> for RuntimeBindingError {
     fn from(error: ElementRegistryError) -> Self {
         Self::ElementRegistry(error)
+    }
+}
+
+impl From<BackgroundResourceError> for RuntimeBindingError {
+    fn from(error: BackgroundResourceError) -> Self {
+        match error {
+            BackgroundResourceError::InvalidSource => Self::InvalidBackgroundResourceSource,
+            BackgroundResourceError::ResourceIdExhausted => Self::ResourceIdExhausted,
+        }
     }
 }
 
@@ -215,6 +231,11 @@ pub enum RuntimeResourceError {
         resource: ResourceId,
         /// Named generation.
         generation: u64,
+    },
+    /// Public/manual resource traffic attempted to claim a runtime-owned ID.
+    AutomaticResourceId {
+        /// ID reserved permanently by automatic style lowering.
+        resource: ResourceId,
     },
 }
 
@@ -361,6 +382,7 @@ impl SurfaceRuntime {
                 known_resource_generations: HashSet::new(),
                 released_resource_generations: HashSet::new(),
                 resource_events: HashMap::new(),
+                background_resources: BackgroundResourceManager::default(),
             })),
         }
     }
@@ -482,47 +504,8 @@ impl SurfaceRuntime {
         &self,
         command: ResourceCommand,
     ) -> Result<(), RuntimeResourceError> {
-        command
-            .validate()
-            .map_err(RuntimeResourceError::InvalidMessage)?;
         let mut state = self.state.borrow_mut();
-        match &command {
-            ResourceCommand::Load(request) => {
-                if let Some(current) = state.resource_generations.get(&request.resource).copied()
-                    && request.generation <= current
-                {
-                    return Err(RuntimeResourceError::NonMonotonicGeneration {
-                        resource: request.resource,
-                        current,
-                        received: request.generation,
-                    });
-                }
-                state
-                    .resource_generations
-                    .insert(request.resource, request.generation);
-                state
-                    .known_resource_generations
-                    .insert((request.resource, request.generation));
-            }
-            ResourceCommand::Release {
-                resource,
-                generation,
-            } => {
-                if !state
-                    .known_resource_generations
-                    .contains(&(*resource, *generation))
-                {
-                    return Err(RuntimeResourceError::UnknownGeneration {
-                        resource: *resource,
-                        generation: *generation,
-                    });
-                }
-                state
-                    .released_resource_generations
-                    .insert((*resource, *generation));
-            }
-        }
-        state.resource_commands.push_back(command);
+        state.enqueue_resource_command(command, false)?;
         crate::runtime::runtime_wake::wake_runtime();
         Ok(())
     }
@@ -574,6 +557,11 @@ impl SurfaceRuntime {
         {
             return Ok(ResourceEventApply::Stale);
         }
+        if state.background_resources.owns(resource) {
+            // This only changes manager state. Scene mutation is intentionally
+            // deferred to drive_layout/present, outside the Host callback.
+            debug_assert!(state.background_resources.apply_event(event));
+        }
         state
             .resource_events
             .insert((resource, generation), event.clone());
@@ -601,6 +589,9 @@ impl SurfaceRuntime {
         if let Some(error) = state.error.clone() {
             return Err(RuntimeLayoutError::Binding(error));
         }
+        state
+            .flush_background_projections()
+            .map_err(RuntimeLayoutError::Binding)?;
         let root = state.root.ok_or(RuntimeLayoutError::MissingRoot)?;
         state
             .surface
@@ -620,9 +611,20 @@ impl SurfaceRuntime {
         let mut state = self.state.borrow_mut();
         state.ensure_valid().map_err(RuntimePresentError::Binding)?;
         state
+            .flush_background_projections()
+            .map_err(RuntimePresentError::Binding)?;
+        let presentation = state
             .surface
             .present(viewport_epoch, sink)
-            .map_err(RuntimePresentError::Present)
+            .map_err(RuntimePresentError::Present)?;
+        if matches!(
+            presentation,
+            Some(whisker_engine::whisker_protocol::ApplyResult::Accepted { .. })
+        ) {
+            let commands = state.background_resources.accept_frame();
+            state.enqueue_automatic_commands(commands);
+        }
+        Ok(presentation)
     }
 
     /// Runs Host measurement, final layout, and transactional presentation.
@@ -720,6 +722,7 @@ struct BindingState {
     known_resource_generations: HashSet<(ResourceId, u64)>,
     released_resource_generations: HashSet<(ResourceId, u64)>,
     resource_events: HashMap<(ResourceId, u64), ResourceEvent>,
+    background_resources: BackgroundResourceManager,
 }
 
 struct EnvironmentStyleUpdate {
@@ -743,6 +746,89 @@ impl BindingState {
             Err(error) if self.error.is_none() => self.error = Some(error),
             Err(_) => {}
         }
+    }
+
+    fn enqueue_resource_command(
+        &mut self,
+        command: ResourceCommand,
+        automatic: bool,
+    ) -> Result<(), RuntimeResourceError> {
+        command
+            .validate()
+            .map_err(RuntimeResourceError::InvalidMessage)?;
+        let resource = match &command {
+            ResourceCommand::Load(request) => request.resource,
+            ResourceCommand::Release { resource, .. } => *resource,
+        };
+        if !automatic && self.background_resources.owns(resource) {
+            return Err(RuntimeResourceError::AutomaticResourceId { resource });
+        }
+        match &command {
+            ResourceCommand::Load(request) => {
+                if let Some(current) = self.resource_generations.get(&request.resource).copied()
+                    && request.generation <= current
+                {
+                    return Err(RuntimeResourceError::NonMonotonicGeneration {
+                        resource: request.resource,
+                        current,
+                        received: request.generation,
+                    });
+                }
+                self.resource_generations
+                    .insert(request.resource, request.generation);
+                self.known_resource_generations
+                    .insert((request.resource, request.generation));
+            }
+            ResourceCommand::Release {
+                resource,
+                generation,
+            } => {
+                if !self
+                    .known_resource_generations
+                    .contains(&(*resource, *generation))
+                {
+                    return Err(RuntimeResourceError::UnknownGeneration {
+                        resource: *resource,
+                        generation: *generation,
+                    });
+                }
+                self.released_resource_generations
+                    .insert((*resource, *generation));
+            }
+        }
+        self.resource_commands.push_back(command);
+        Ok(())
+    }
+
+    fn enqueue_automatic_commands(&mut self, commands: Vec<ResourceCommand>) {
+        for command in commands {
+            self.enqueue_resource_command(command, true)
+                .expect("automatic resource commands preserve lifecycle invariants");
+        }
+    }
+
+    fn externally_used_resource_ids(&self) -> HashSet<ResourceId> {
+        self.resource_generations.keys().copied().collect()
+    }
+
+    fn flush_background_projections(&mut self) -> Result<(), RuntimeBindingError> {
+        let projections = self.background_resources.dirty_projections();
+        if projections.is_empty() {
+            return Ok(());
+        }
+        let mut surface = self.surface.clone();
+        for BackgroundProjection { node, layers } in &projections {
+            // A node can be released between completion delivery and the next
+            // safe boundary. `remove_nodes` normally removes its dirty bit,
+            // while this guard keeps the boundary robust to duplicate release.
+            if surface.node(*node).is_some() {
+                surface.set_background_layers(*node, layers.clone())?;
+            }
+        }
+        self.surface = surface;
+        self.background_resources
+            .commit_dirty_projections(&projections);
+        Ok(())
     }
 
     fn update_environment(
@@ -769,8 +855,18 @@ impl BindingState {
         }
 
         let mut surface = self.surface.clone();
+        let mut background_resources = self.background_resources.clone();
+        let externally_used = self.externally_used_resource_ids();
+        let mut resource_commands = Vec::new();
         for update in &updates {
             surface.update_computed_style(update.node, update.resolved.computed())?;
+            let background = background_resources.reconcile_node(
+                update.node,
+                &update.resolved.computed().paint().background_images,
+                &externally_used,
+            )?;
+            surface.set_background_layers(update.node, background.layers)?;
+            resource_commands.extend(background.commands);
             if let Some(text) = &update.text {
                 surface.set_plain_text(
                     update.node,
@@ -781,6 +877,8 @@ impl BindingState {
         }
 
         self.surface = surface;
+        self.background_resources = background_resources;
+        self.enqueue_automatic_commands(resource_commands);
         self.environment = environment;
         for update in updates {
             self.element_mut(update.element)?.resolved = Some(update.resolved);
@@ -982,26 +1080,86 @@ impl BindingState {
             .and_then(|parent| self.elements.get(&parent))
             .and_then(|parent| parent.resolved.as_ref())
             .map(|resolved| resolved.inherited_for_children().clone());
-        let specified = self.element(element)?.specified.clone();
-        let Some(node) = self.element(element)?.node else {
+        let mut surface = self.surface.clone();
+        let mut background_resources = self.background_resources.clone();
+        let externally_used = self.externally_used_resource_ids();
+        let mut updates = Vec::new();
+        let mut resource_commands = Vec::new();
+        self.prepare_subtree(
+            element,
+            parent_style.as_ref(),
+            &mut surface,
+            &mut background_resources,
+            &externally_used,
+            &mut updates,
+            &mut resource_commands,
+        )?;
+
+        self.surface = surface;
+        self.background_resources = background_resources;
+        for (element, resolved) in updates {
+            self.element_mut(element)?.resolved = Some(resolved);
+        }
+        self.enqueue_automatic_commands(resource_commands);
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_subtree(
+        &self,
+        element: Element,
+        parent_style: Option<&InheritedStyle>,
+        surface: &mut SurfaceEngine,
+        background_resources: &mut BackgroundResourceManager,
+        externally_used: &HashSet<ResourceId>,
+        updates: &mut Vec<(Element, ResolvedNodeStyle)>,
+        resource_commands: &mut Vec<ResourceCommand>,
+    ) -> Result<(), RuntimeBindingError> {
+        let entry = self.element(element)?;
+        let Some(node) = entry.node else {
             return Ok(());
         };
-        let resolved = resolve_style(&specified, parent_style.as_ref(), self.environment)?;
-        self.surface
-            .update_computed_style(node, resolved.computed())?;
-        let text = self.element(element)?.text.clone();
-        if let Some(input) = text {
-            self.surface
-                .set_plain_text(node, &input, resolved.computed().inherited_text())?;
+        let resolved = resolve_style(&entry.specified, parent_style, self.environment)?;
+        surface.update_computed_style(node, resolved.computed())?;
+        let background = background_resources.reconcile_node(
+            node,
+            &resolved.computed().paint().background_images,
+            externally_used,
+        )?;
+        surface.set_background_layers(node, background.layers)?;
+        resource_commands.extend(background.commands);
+        if let Some(text) = &entry.text {
+            surface.set_plain_text(node, text, resolved.computed().inherited_text())?;
         }
-        let children = self.element(element)?.children.clone();
-        self.element_mut(element)?.resolved = Some(resolved);
+        let children = entry.children.clone();
+        updates.push((element, resolved.clone()));
         for child in children {
             if self.element(child)?.node.is_some() {
-                self.apply_subtree(child)?;
+                self.prepare_subtree(
+                    child,
+                    Some(resolved.inherited_for_children()),
+                    surface,
+                    background_resources,
+                    externally_used,
+                    updates,
+                    resource_commands,
+                )?;
             }
         }
         Ok(())
+    }
+
+    fn surface_subtree(&self, root: NodeId) -> Vec<NodeId> {
+        let mut nodes = Vec::new();
+        let mut pending = vec![root];
+        while let Some(node) = pending.pop() {
+            let Some(entry) = self.surface.node(node) else {
+                continue;
+            };
+            nodes.push(node);
+            pending.extend(entry.children().iter().copied());
+        }
+        nodes
     }
 
     fn refresh_text(&mut self, text_element: Element) -> Result<(), RuntimeBindingError> {
@@ -1394,7 +1552,12 @@ impl DynRenderer for SurfaceRuntime {
             if let Some(node) = entry.node {
                 state.node_elements.remove(&node);
                 if state.surface.node(node).is_some() {
+                    let removed_nodes = state.surface_subtree(node);
+                    let mut background_resources = state.background_resources.clone();
+                    let resource_commands = background_resources.remove_nodes(&removed_nodes);
                     state.surface.delete_node(node)?;
+                    state.background_resources = background_resources;
+                    state.enqueue_automatic_commands(resource_commands);
                 }
             }
             Ok(())
@@ -1440,8 +1603,13 @@ impl DynRenderer for SurfaceRuntime {
     fn set_specified_style(&self, handle: Element, style: &SpecifiedStyle) -> bool {
         let mut state = self.state.borrow_mut();
         let result = (|| {
+            let previous = state.element(handle)?.specified.clone();
             state.element_mut(handle)?.specified = style.clone();
-            state.apply_subtree(handle)
+            if let Err(error) = state.apply_subtree(handle) {
+                state.element_mut(handle)?.specified = previous;
+                return Err(error);
+            }
+            Ok(())
         })();
         let accepted = result.is_ok();
         state.record(result);

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::convert::Infallible;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -12,15 +12,15 @@ use whisker::{
     RuntimeBindingError, RuntimeDriveError, RuntimeInstance, RuntimeLifecycle, SurfaceRuntime,
 };
 use whisker_engine::whisker_protocol::{
-    BackgroundAttachment, BackgroundSize, BlendMode, FrameMode, ImageRepeat, InputEvent,
-    InputEventKind, InputPoint, MeasuredSize, MeasurementMetrics, MeasurementPayload,
-    MeasurementReady, MeasurementRequest, MeasurementRequestId, MeasurementResponse, Operation,
-    PaintBox, PaintImage, PaintPosition, PointerId, PointerInput, PointerKind, ResourceCommand,
-    ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest, ResourceSource,
-    SurfaceId, WhiskerValue,
+    ApplyResult, BackgroundAttachment, BackgroundSize, BlendMode, FrameMode, FramePacket,
+    ImageRepeat, InputEvent, InputEventKind, InputPoint, MeasuredSize, MeasurementMetrics,
+    MeasurementPayload, MeasurementReady, MeasurementRequest, MeasurementRequestId,
+    MeasurementResponse, Operation, PaintBox, PaintImage, PaintPosition, PointerId, PointerInput,
+    PointerKind, RenderCapabilities, ResourceCommand, ResourceDimensions, ResourceEvent,
+    ResourceId, ResourceKind, ResourceRequest, ResourceSource, SurfaceId, WhiskerValue,
 };
 use whisker_engine::whisker_style::{StyleEnvironment, StyleResolutionError};
-use whisker_engine::{LayoutOptions, MeasurementProvider, RecordingRenderer};
+use whisker_engine::{FrameSink, LayoutOptions, MeasurementProvider, RecordingRenderer};
 use whisker_runtime::RuntimeWakeHandle;
 
 #[derive(Default)]
@@ -105,6 +105,72 @@ fn surface(id: u64) -> SurfaceRuntime {
         SurfaceId::new(id).unwrap(),
         StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
     )
+}
+
+const BACKGROUND_URL: &str = "https://example.com/background.png";
+
+fn url_background_style() -> Css {
+    Css::new()
+        .width(px(100))
+        .height(px(100))
+        .background_image(ImageRef::Url(CssString::new(BACKGROUND_URL)))
+}
+
+fn ready_raster(resource: ResourceId, generation: u64) -> ResourceEvent {
+    ResourceEvent::Ready {
+        resource,
+        generation,
+        dimensions: Some(ResourceDimensions {
+            width: 2.0,
+            height: 2.0,
+            scale: 1.0,
+        }),
+    }
+}
+
+fn dispatch_control_tap(runtime: &RuntimeInstance, surface: &SurfaceRuntime, timestamp_ms: f64) {
+    let dispatch = runtime
+        .dispatch_input(&InputEvent {
+            surface: surface.surface(),
+            timestamp_ms,
+            kind: InputEventKind::Tap,
+            pointer: Some(PointerInput {
+                id: PointerId::new(99).unwrap(),
+                kind: PointerKind::Touch,
+                position: InputPoint { x: 1.0, y: 1.0 },
+                buttons: 1,
+                changed_button: 0,
+            }),
+            target: surface.root(),
+            detail: WhiskerValue::Null,
+        })
+        .expect("control tap must route through the runtime context");
+    assert!(dispatch.consumed);
+}
+
+struct NeedSnapshotOnceSink {
+    request_snapshot: bool,
+}
+
+impl FrameSink for NeedSnapshotOnceSink {
+    type Error = Infallible;
+
+    fn capabilities(&self) -> RenderCapabilities {
+        RenderCapabilities::all_frame_native()
+    }
+
+    fn present(&mut self, packet: &FramePacket) -> Result<ApplyResult, Self::Error> {
+        if self.request_snapshot {
+            self.request_snapshot = false;
+            Ok(ApplyResult::NeedSnapshot {
+                receiver_revision: packet.header.base_revision,
+            })
+        } else {
+            Ok(ApplyResult::Accepted {
+                revision: packet.header.target_revision,
+            })
+        }
+    }
 }
 
 #[test]
@@ -308,6 +374,409 @@ fn background_url_loads_out_of_frame_and_is_emitted_only_after_ready() {
         )
     }));
     assert!(surface.take_resource_commands().is_empty());
+}
+
+#[test]
+fn background_url_is_shared_and_released_only_after_the_last_clear_is_accepted() {
+    let surface = surface(41);
+    let desired_visibility = Rc::new(Cell::new((true, true)));
+    let mounted_visibility = Rc::clone(&desired_visibility);
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    runtime
+        .mount(move || {
+            let first = RwSignal::new(true);
+            let second = RwSignal::new(true);
+            render! {
+                view(
+                    style: css!(width: px(200), height: px(100)),
+                    on_tap: move |_| {
+                        let (show_first, show_second) = mounted_visibility.get();
+                        first.set(show_first);
+                        second.set(show_second);
+                    },
+                ) {
+                    Show(when: move || first.get()) {
+                        view(style: url_background_style())
+                    }
+                    Show(when: move || second.get()) {
+                        view(style: url_background_style())
+                    }
+                }
+            }
+        })
+        .unwrap();
+
+    let commands = surface.take_resource_commands();
+    assert_eq!(commands.len(), 1, "equal URLs must share one Host load");
+    let ResourceCommand::Load(request) = &commands[0] else {
+        panic!("shared background URL must load once")
+    };
+    assert_eq!(request.generation, 1);
+    assert_eq!(request.source, ResourceSource::Url(BACKGROUND_URL.into()));
+    let resource = request.resource;
+    assert_eq!(
+        runtime
+            .dispatch_resource_event(&ready_raster(resource, 1))
+            .unwrap(),
+        whisker::ResourceEventApply::Applied
+    );
+
+    let mut measurements = NoMeasurement;
+    let mut sink = RecordingRenderer::new(surface.surface());
+    runtime
+        .drive_frame(
+            1.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(surface.take_resource_commands().is_empty());
+
+    desired_visibility.set((false, true));
+    dispatch_control_tap(&runtime, &surface, 1.5);
+    runtime
+        .drive_frame(
+            2.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(
+        surface.take_resource_commands().is_empty(),
+        "deleting one of two users must retain the shared generation"
+    );
+
+    desired_visibility.set((true, true));
+    dispatch_control_tap(&runtime, &surface, 2.5);
+    runtime
+        .drive_frame(
+            3.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(
+        surface.take_resource_commands().is_empty(),
+        "reacquiring a still-shared URL must not reload it"
+    );
+
+    desired_visibility.set((false, true));
+    dispatch_control_tap(&runtime, &surface, 3.5);
+    runtime
+        .drive_frame(
+            4.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(surface.take_resource_commands().is_empty());
+
+    desired_visibility.set((false, false));
+    dispatch_control_tap(&runtime, &surface, 4.5);
+    assert!(
+        surface.take_resource_commands().is_empty(),
+        "Release must not precede the frame which removes the final user"
+    );
+    let removal_frame_index = sink.frames().len();
+    let removed = runtime
+        .drive_frame(
+            5.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(matches!(
+        removed.frame.presentation,
+        Some(ApplyResult::Accepted { .. })
+    ));
+    assert!(
+        sink.frames()[removal_frame_index]
+            .packet
+            .operations
+            .iter()
+            .any(|operation| matches!(operation, Operation::DeleteNode { .. }))
+    );
+    assert_eq!(
+        surface.take_resource_commands(),
+        vec![ResourceCommand::Release {
+            resource,
+            generation: 1,
+        }],
+        "the accepted clear is the earliest safe Release point"
+    );
+}
+
+#[test]
+fn background_url_reacquired_before_clear_ack_keeps_the_current_generation() {
+    let surface = surface(42);
+    let desired_visibility = Rc::new(Cell::new(true));
+    let mounted_visibility = Rc::clone(&desired_visibility);
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    runtime
+        .mount(move || {
+            let visible = RwSignal::new(true);
+            render! {
+                view(
+                    style: css!(width: px(100), height: px(100)),
+                    on_tap: move |_| visible.set(mounted_visibility.get()),
+                ) {
+                    Show(when: move || visible.get()) {
+                        view(style: url_background_style())
+                    }
+                }
+            }
+        })
+        .unwrap();
+    let commands = surface.take_resource_commands();
+    let ResourceCommand::Load(request) = &commands[0] else {
+        panic!("initial background URL must load")
+    };
+    assert_eq!(request.generation, 1);
+    assert_eq!(request.source, ResourceSource::Url(BACKGROUND_URL.into()));
+    let resource = request.resource;
+    runtime
+        .dispatch_resource_event(&ready_raster(resource, request.generation))
+        .unwrap();
+
+    let mut measurements = NoMeasurement;
+    let mut accepted = RecordingRenderer::new(surface.surface());
+    runtime
+        .drive_frame(
+            1.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut accepted,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+
+    desired_visibility.set(false);
+    dispatch_control_tap(&runtime, &surface, 1.5);
+    let mut recovery = NeedSnapshotOnceSink {
+        request_snapshot: true,
+    };
+    let clear = runtime
+        .drive_frame(
+            2.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut recovery,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(matches!(
+        clear.frame.presentation,
+        Some(ApplyResult::NeedSnapshot { .. })
+    ));
+    assert!(
+        surface.take_resource_commands().is_empty(),
+        "an unacknowledged clear must not release its resource"
+    );
+
+    desired_visibility.set(true);
+    dispatch_control_tap(&runtime, &surface, 2.5);
+    let reacquired = runtime
+        .drive_frame(
+            3.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut recovery,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(matches!(
+        reacquired.frame.presentation,
+        Some(ApplyResult::Accepted { .. })
+    ));
+    assert!(
+        surface.take_resource_commands().is_empty(),
+        "reacquiring before Release must cancel retirement without a new Load"
+    );
+}
+
+#[test]
+fn stale_ready_for_a_released_background_does_not_affect_its_replacement() {
+    let surface = surface(43);
+    let desired_visibility = Rc::new(Cell::new(true));
+    let mounted_visibility = Rc::clone(&desired_visibility);
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    runtime
+        .mount(move || {
+            let visible = RwSignal::new(true);
+            render! {
+                view(
+                    style: css!(width: px(100), height: px(100)),
+                    on_tap: move |_| visible.set(mounted_visibility.get()),
+                ) {
+                    Show(when: move || visible.get()) {
+                        view(style: url_background_style())
+                    }
+                }
+            }
+        })
+        .unwrap();
+    let first_commands = surface.take_resource_commands();
+    let ResourceCommand::Load(first_load) = &first_commands[0] else {
+        panic!("initial background URL must load")
+    };
+    let resource = first_load.resource;
+    assert_eq!(first_load.generation, 1);
+    runtime
+        .dispatch_resource_event(&ready_raster(resource, first_load.generation))
+        .unwrap();
+
+    let mut measurements = NoMeasurement;
+    let mut sink = RecordingRenderer::new(surface.surface());
+    runtime
+        .drive_frame(
+            1.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+
+    desired_visibility.set(false);
+    dispatch_control_tap(&runtime, &surface, 1.5);
+    assert!(surface.take_resource_commands().is_empty());
+    runtime
+        .drive_frame(
+            2.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(
+        surface.take_resource_commands(),
+        vec![ResourceCommand::Release {
+            resource,
+            generation: 1,
+        }]
+    );
+
+    desired_visibility.set(true);
+    dispatch_control_tap(&runtime, &surface, 2.5);
+    runtime
+        .drive_frame(
+            3.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    let second_commands = surface.take_resource_commands();
+    assert_eq!(second_commands.len(), 1);
+    let ResourceCommand::Load(second_load) = &second_commands[0] else {
+        panic!("reacquiring a released URL must start a new load")
+    };
+    assert_ne!(
+        second_load.resource, resource,
+        "a resource ID published in FramePacket must not be reused"
+    );
+    assert_eq!(second_load.generation, 1);
+    assert_eq!(
+        second_load.source,
+        ResourceSource::Url(BACKGROUND_URL.into())
+    );
+    let replacement = second_load.resource;
+
+    let frames_before_stale = sink.frames().len();
+    assert_eq!(
+        runtime
+            .dispatch_resource_event(&ready_raster(resource, 1))
+            .unwrap(),
+        whisker::ResourceEventApply::Stale,
+        "a completion for the released ID must never become paintable again"
+    );
+    runtime
+        .drive_frame(
+            4.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(sink.frames()[frames_before_stale..].iter().all(|frame| {
+        frame.packet.operations.iter().all(|operation| {
+            !matches!(
+                operation,
+                Operation::SetBackgroundLayers { layers, .. }
+                    if layers.iter().any(|layer| {
+                        matches!(layer.image, PaintImage::Resource(id) if id == resource || id == replacement)
+                    })
+            )
+        })
+    }));
+
+    assert_eq!(
+        runtime
+            .dispatch_resource_event(&ready_raster(replacement, 1))
+            .unwrap(),
+        whisker::ResourceEventApply::Applied
+    );
+    runtime
+        .drive_frame(
+            5.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(
+        sink.frames()
+            .last()
+            .unwrap()
+            .packet
+            .operations
+            .iter()
+            .any(|operation| matches!(
+                operation,
+                Operation::SetBackgroundLayers { layers, .. }
+                    if layers.iter().any(|layer| layer.image == PaintImage::Resource(replacement))
+            ))
+    );
 }
 
 #[test]

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -6,14 +6,16 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
+use whisker::css::{CssString, ImageRef};
 use whisker::prelude::*;
 use whisker::{
     RuntimeBindingError, RuntimeDriveError, RuntimeInstance, RuntimeLifecycle, SurfaceRuntime,
 };
 use whisker_engine::whisker_protocol::{
-    FrameMode, InputEvent, InputEventKind, InputPoint, MeasuredSize, MeasurementMetrics,
-    MeasurementPayload, MeasurementReady, MeasurementRequest, MeasurementRequestId,
-    MeasurementResponse, Operation, PointerId, PointerInput, PointerKind, ResourceCommand,
+    BackgroundAttachment, BackgroundSize, BlendMode, FrameMode, ImageRepeat, InputEvent,
+    InputEventKind, InputPoint, MeasuredSize, MeasurementMetrics, MeasurementPayload,
+    MeasurementReady, MeasurementRequest, MeasurementRequestId, MeasurementResponse, Operation,
+    PaintBox, PaintImage, PaintPosition, PointerId, PointerInput, PointerKind, ResourceCommand,
     ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest, ResourceSource,
     SurfaceId, WhiskerValue,
 };
@@ -213,6 +215,99 @@ fn current_resource_completion_wakes_running_but_not_paused_runtime() {
         })
         .unwrap();
     assert_eq!(wakes.load(Ordering::SeqCst), before_paused);
+}
+
+#[test]
+fn background_url_loads_out_of_frame_and_is_emitted_only_after_ready() {
+    let surface = surface(40);
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    runtime
+        .mount(|| {
+            render! {
+                view(style: Css::new()
+                    .width(px(100))
+                    .height(px(100))
+                    .background_image(ImageRef::Url(CssString::new(
+                        "https://example.com/background.png",
+                    ))))
+            }
+        })
+        .unwrap();
+
+    let commands = surface.take_resource_commands();
+    assert_eq!(commands.len(), 1);
+    let ResourceCommand::Load(request) = &commands[0] else {
+        panic!("background URL must acquire a raster resource")
+    };
+    assert_eq!(request.generation, 1);
+    assert_eq!(request.kind, ResourceKind::RasterImage);
+    assert_eq!(
+        request.source,
+        ResourceSource::Url("https://example.com/background.png".into())
+    );
+    let resource = request.resource;
+
+    let mut measurements = NoMeasurement;
+    let mut sink = RecordingRenderer::new(surface.surface());
+    runtime
+        .drive_frame(
+            1.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert!(sink.frames()[0].packet.operations.iter().all(|operation| {
+        !matches!(operation, Operation::SetBackgroundLayers { layers, .. } if !layers.is_empty())
+    }));
+
+    assert_eq!(
+        runtime
+            .dispatch_resource_event(&ResourceEvent::Ready {
+                resource,
+                generation: 1,
+                dimensions: Some(ResourceDimensions {
+                    width: 2.0,
+                    height: 2.0,
+                    scale: 1.0,
+                }),
+            })
+            .unwrap(),
+        whisker::ResourceEventApply::Applied
+    );
+    runtime
+        .drive_frame(
+            2.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    let root = surface.root().unwrap();
+    assert!(sink.frames()[1].packet.operations.iter().any(|operation| {
+        matches!(
+            operation,
+            Operation::SetBackgroundLayers { node, layers }
+                if *node == root
+                    && layers.len() == 1
+                    && layers[0].image == PaintImage::Resource(resource)
+                    && layers[0].position == PaintPosition::default()
+                    && layers[0].size == BackgroundSize::Auto
+                    && layers[0].repeat_x == ImageRepeat::Repeat
+                    && layers[0].repeat_y == ImageRepeat::Repeat
+                    && layers[0].origin == PaintBox::Padding
+                    && layers[0].clip == PaintBox::Border
+                    && layers[0].attachment == BackgroundAttachment::Scroll
+                    && layers[0].blend_mode == BlendMode::Normal
+        )
+    }));
+    assert!(surface.take_resource_commands().is_empty());
 }
 
 #[test]

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -501,6 +501,29 @@ retains current completion state, ignores replaced or released generations,
 and wakes a running runtime only for a current Ready or Failed event. JSON and
 encoded resource bytes never enter the frame transaction path.
 
+Style lowering owns resource identity rather than assigning an ID to each
+element slot. Equal `(ResourceKind, ResourceSource)` values share one
+`ResourceId` across the surface, so repeated uses of the same URL issue one
+load and one Host decode. A pending or failed generation is omitted from paint
+operations; only a current `Ready` generation may be projected as
+`PaintImage::Resource`. Removing the last reference first emits and commits the
+frame that clears that resource from retained paint. Only after the Host
+accepts that frame may Rust enqueue `ResourceCommand::Release`. A sink error or
+`NeedSnapshot` therefore cannot release an object that the Host may still
+reference. Reacquiring the source before that acceptance cancels retirement;
+reacquiring it after release allocates a fresh ID. Automatic style lowering
+never changes the content behind an ID that an accepted frame may reference,
+because frame paint references intentionally contain only `ResourceId`, not a
+generation. Generations remain available to the lower-level resource channel
+for cancellation and stale-completion rejection before publication.
+
+The first typed style slice applies this lifecycle to URL-backed
+`background-image`. URL text remains unresolved in Rust and is passed as
+`ResourceSource::Url`, leaving relative-URL bases, network policy, caching, and
+decoding to the Host resource service. Background resources do not influence
+Taffy layout; intrinsic dimensions returned by the Host are retained for
+future replaced-content consumers but do not resize a CSS background.
+
 Adding the semantic value does not declare a Host implementation complete.
 Until a Host advertises and implements the corresponding capability, its
 receiver rejects the operation before mutating retained state. It must not


### PR DESCRIPTION
## Summary

- lower typed `background-image: url(...)` into the out-of-frame raster resource channel
- share equal URL sources across nodes while keeping pending and failed resources out of `FramePacket`
- project only current Ready resources as `SetBackgroundLayers(PaintImage::Resource)`
- track desired, projected, and Host-accepted references separately
- emit Release only after the frame removing the final reference is accepted
- cancel retirement on pre-ack reacquisition and allocate a fresh ID after release
- prevent automatic/manual resource ID collisions and clean up whole deleted subtrees
- keep style, scene, resource planning, and command enqueue transactional
- document why automatic style resources never replace content behind a published ID

## Stack

Parent: #450

## Validation

- `cargo test -p whisker --lib`
- `cargo test -p whisker --test resource_channel`
- `cargo test -p whisker --test runtime_instance`
- `cargo test -p whisker-style --lib`
- `cargo test -p whisker-css --lib prop::background::tests`
- `cargo test -p whisker-engine --lib scene::tests::`
- `cargo clippy -p whisker -p whisker-css -p whisker-engine -p whisker-style --all-targets -- -D warnings`
- `cargo xtask host-conformance desktop` (1 passed)
- `cargo xtask host-conformance web` (5 passed)
- `cargo xtask host-conformance android` (7 passed)
- `cargo xtask host-conformance ios` (8 passed)

## Follow-up

This slice implements URL/none image selection with the protocol defaults for position, size, repeat, origin, clip, attachment, and blend. The next style-to-frame slices should lower the corresponding CSS longhands, then gradients, while reusing this resource lifecycle for image-backed masks, replaced images, cursors, and paint servers.
