### PR TITLE
feat(runtime): lower background layer geometry

### DIFF
--- a/crates/whisker-css/src/prop/background.rs
+++ b/crates/whisker-css/src/prop/background.rs
@@ -7,6 +7,7 @@ use crate::data_type_ext::Position;
 use crate::keyword::{
     BackgroundAttachment, BackgroundClip, BackgroundOrigin, BackgroundRepeat, BackgroundSize,
 };
+use crate::style_value::ToStyleValue;
 use crate::value::ImageRef;
 
 impl Css {
@@ -46,13 +47,38 @@ impl Css {
     /// Sets `background-repeat`.
     /// <https://lynxjs.org/api/css/properties/background-repeat>
     pub fn background_repeat(self, v: BackgroundRepeat) -> Self {
-        self.push(crate::StyleProperty::BackgroundRepeat, v)
+        use whisker_style::{BackgroundRepeatModeValue as Mode, BackgroundRepeatValue};
+
+        let (horizontal, vertical) = match v {
+            BackgroundRepeat::Repeat => (Mode::Repeat, Mode::Repeat),
+            BackgroundRepeat::NoRepeat => (Mode::NoRepeat, Mode::NoRepeat),
+            BackgroundRepeat::RepeatX => (Mode::Repeat, Mode::NoRepeat),
+            BackgroundRepeat::RepeatY => (Mode::NoRepeat, Mode::Repeat),
+            BackgroundRepeat::Space => (Mode::Space, Mode::Space),
+            BackgroundRepeat::Round => (Mode::Round, Mode::Round),
+        };
+        self.push_semantic(
+            crate::StyleProperty::BackgroundRepeat,
+            whisker_style::StyleValue::BackgroundRepeat(BackgroundRepeatValue {
+                horizontal,
+                vertical,
+            }),
+            v.to_css_string(),
+        )
     }
 
     /// Sets `background-position`.
     /// <https://lynxjs.org/api/css/properties/background-position>
     pub fn background_position(self, v: Position) -> Self {
-        self.push(crate::StyleProperty::BackgroundPosition, v)
+        let lynx_value = v.to_css_string();
+        let Some(value) = background_position_value(v) else {
+            return self.push_raw(crate::StyleProperty::BackgroundPosition, lynx_value);
+        };
+        self.push_semantic(
+            crate::StyleProperty::BackgroundPosition,
+            whisker_style::StyleValue::BackgroundPosition(value),
+            lynx_value,
+        )
     }
 
     /// Sets `background-position-x` — horizontal component only.
@@ -70,25 +96,76 @@ impl Css {
     /// Sets `background-size`.
     /// <https://lynxjs.org/api/css/properties/background-size>
     pub fn background_size(self, v: BackgroundSize) -> Self {
-        self.push(crate::StyleProperty::BackgroundSize, v)
+        let lynx_value = v.to_css_string();
+        let value = match v {
+            BackgroundSize::Auto => whisker_style::BackgroundSizeValue::Auto,
+            BackgroundSize::Explicit(width, height) => {
+                whisker_style::BackgroundSizeValue::Explicit {
+                    width: length_percentage_value(&width),
+                    height: length_percentage_value(&height),
+                }
+            }
+            BackgroundSize::Cover | BackgroundSize::Contain => {
+                return self.push_raw(crate::StyleProperty::BackgroundSize, lynx_value);
+            }
+        };
+        self.push_semantic(
+            crate::StyleProperty::BackgroundSize,
+            whisker_style::StyleValue::BackgroundSize(value),
+            lynx_value,
+        )
     }
 
     /// Sets `background-origin`. Lynx default: `padding-box`.
     /// <https://lynxjs.org/api/css/properties/background-origin>
     pub fn background_origin(self, v: BackgroundOrigin) -> Self {
-        self.push(crate::StyleProperty::BackgroundOrigin, v)
+        let value = match v {
+            BackgroundOrigin::BorderBox => whisker_style::BackgroundBoxValue::Border,
+            BackgroundOrigin::PaddingBox => whisker_style::BackgroundBoxValue::Padding,
+            BackgroundOrigin::ContentBox => whisker_style::BackgroundBoxValue::Content,
+        };
+        self.push_semantic(
+            crate::StyleProperty::BackgroundOrigin,
+            whisker_style::StyleValue::BackgroundBox(value),
+            v.to_css_string(),
+        )
     }
 
     /// Sets `background-clip`. Lynx default: `border-box`.
     /// <https://lynxjs.org/api/css/properties/background-clip>
     pub fn background_clip(self, v: BackgroundClip) -> Self {
-        self.push(crate::StyleProperty::BackgroundClip, v)
+        let lynx_value = v.to_css_string();
+        let value = match v {
+            BackgroundClip::BorderBox => whisker_style::BackgroundBoxValue::Border,
+            BackgroundClip::PaddingBox => whisker_style::BackgroundBoxValue::Padding,
+            BackgroundClip::ContentBox => whisker_style::BackgroundBoxValue::Content,
+            BackgroundClip::Text => {
+                return self.push_raw(crate::StyleProperty::BackgroundClip, lynx_value);
+            }
+        };
+        self.push_semantic(
+            crate::StyleProperty::BackgroundClip,
+            whisker_style::StyleValue::BackgroundBox(value),
+            lynx_value,
+        )
     }
 
     /// Sets `background-attachment`. Lynx default: `scroll`.
     /// <https://lynxjs.org/api/css/properties/background-attachment>
     pub fn background_attachment(self, v: BackgroundAttachment) -> Self {
-        self.push(crate::StyleProperty::BackgroundAttachment, v)
+        let lynx_value = v.to_css_string();
+        match v {
+            BackgroundAttachment::Scroll => self.push_semantic(
+                crate::StyleProperty::BackgroundAttachment,
+                whisker_style::StyleValue::BackgroundAttachment(
+                    whisker_style::BackgroundAttachmentValue::Scroll,
+                ),
+                lynx_value,
+            ),
+            BackgroundAttachment::Fixed | BackgroundAttachment::Local => {
+                self.push_raw(crate::StyleProperty::BackgroundAttachment, lynx_value)
+            }
+        }
     }
 
     /// Sets `color` — the foreground color used by text and SVG strokes.
@@ -96,6 +173,85 @@ impl Css {
     pub fn color(self, v: Color) -> Self {
         self.push_typed(crate::StyleProperty::Color, v)
     }
+}
+
+fn length_percentage_value(value: &LengthPercentage) -> whisker_style::LengthPercentageValue {
+    let whisker_style::StyleValue::LengthPercentage(value) = value.to_style_value() else {
+        unreachable!("LengthPercentage always has a semantic style value")
+    };
+    value
+}
+
+fn percentage(value: f32) -> whisker_style::LengthPercentageValue {
+    whisker_style::LengthPercentageValue::Percentage(whisker_style::StyleNumber::new(value))
+}
+
+fn keyword_value(
+    keyword: crate::data_type_ext::PositionKeyword,
+) -> whisker_style::LengthPercentageValue {
+    use crate::data_type_ext::PositionKeyword;
+
+    percentage(match keyword {
+        PositionKeyword::Left | PositionKeyword::Top => 0.0,
+        PositionKeyword::Center => 50.0,
+        PositionKeyword::Right | PositionKeyword::Bottom => 100.0,
+    })
+}
+
+fn background_position_value(position: Position) -> Option<whisker_style::BackgroundPositionValue> {
+    use crate::data_type_ext::PositionKeyword;
+
+    let center = || keyword_value(PositionKeyword::Center);
+    let (horizontal, vertical) = match position {
+        Position::Keyword(keyword @ (PositionKeyword::Left | PositionKeyword::Right)) => {
+            (keyword_value(keyword), center())
+        }
+        Position::Keyword(keyword @ (PositionKeyword::Top | PositionKeyword::Bottom)) => {
+            (center(), keyword_value(keyword))
+        }
+        Position::Keyword(PositionKeyword::Center) => (center(), center()),
+        Position::Coords(horizontal, vertical) => (
+            length_percentage_value(&horizontal),
+            length_percentage_value(&vertical),
+        ),
+        Position::Mixed(keyword @ (PositionKeyword::Left | PositionKeyword::Right), offset) => {
+            (keyword_value(keyword), length_percentage_value(&offset))
+        }
+        Position::Mixed(keyword @ (PositionKeyword::Top | PositionKeyword::Bottom), offset) => {
+            (length_percentage_value(&offset), keyword_value(keyword))
+        }
+        Position::Mixed(PositionKeyword::Center, offset) => {
+            (center(), length_percentage_value(&offset))
+        }
+        Position::Keywords(first, second) => {
+            let horizontal =
+                |keyword| matches!(keyword, PositionKeyword::Left | PositionKeyword::Right);
+            let vertical =
+                |keyword| matches!(keyword, PositionKeyword::Top | PositionKeyword::Bottom);
+            match (first, second) {
+                (PositionKeyword::Center, PositionKeyword::Center) => (center(), center()),
+                (PositionKeyword::Center, value) if vertical(value) => {
+                    (center(), keyword_value(value))
+                }
+                (PositionKeyword::Center, value) if horizontal(value) => {
+                    (keyword_value(value), center())
+                }
+                (value, PositionKeyword::Center) if horizontal(value) => {
+                    (keyword_value(value), center())
+                }
+                (value, PositionKeyword::Center) if vertical(value) => {
+                    (center(), keyword_value(value))
+                }
+                (x, y) if horizontal(x) && vertical(y) => (keyword_value(x), keyword_value(y)),
+                (y, x) if vertical(y) && horizontal(x) => (keyword_value(x), keyword_value(y)),
+                _ => return None,
+            }
+        }
+    };
+    Some(whisker_style::BackgroundPositionValue {
+        horizontal,
+        vertical,
+    })
 }
 
 #[cfg(test)]
@@ -167,6 +323,27 @@ mod tests {
             s.to_string(),
             "background-repeat: no-repeat; background-position: center top;"
         );
+        let specified = s.to_specified_style().unwrap();
+        assert_eq!(
+            specified.resolved()[0].value(),
+            &whisker_style::StyleValue::BackgroundRepeat(whisker_style::BackgroundRepeatValue {
+                horizontal: whisker_style::BackgroundRepeatModeValue::NoRepeat,
+                vertical: whisker_style::BackgroundRepeatModeValue::NoRepeat,
+            })
+        );
+        assert_eq!(
+            specified.resolved()[1].value(),
+            &whisker_style::StyleValue::BackgroundPosition(
+                whisker_style::BackgroundPositionValue {
+                    horizontal: whisker_style::LengthPercentageValue::Percentage(
+                        whisker_style::StyleNumber::new(50.0),
+                    ),
+                    vertical: whisker_style::LengthPercentageValue::Percentage(
+                        whisker_style::StyleNumber::new(0.0),
+                    ),
+                }
+            )
+        );
     }
 
     #[test]
@@ -188,6 +365,30 @@ mod tests {
         assert_eq!(s.to_string(), "background-size: contain;");
         let s = Css::new().background_size(BackgroundSize::Auto);
         assert_eq!(s.to_string(), "background-size: auto;");
+        assert_eq!(
+            s.to_specified_style().unwrap().resolved()[0].value(),
+            &whisker_style::StyleValue::BackgroundSize(whisker_style::BackgroundSizeValue::Auto)
+        );
+
+        let explicit = Css::new().background_size(BackgroundSize::Explicit(
+            px(20).into(),
+            Percentage(50.0).into(),
+        ));
+        assert!(matches!(
+            explicit.to_specified_style().unwrap().resolved()[0].value(),
+            whisker_style::StyleValue::BackgroundSize(
+                whisker_style::BackgroundSizeValue::Explicit { .. }
+            )
+        ));
+
+        assert_eq!(
+            Css::new()
+                .background_size(BackgroundSize::Cover)
+                .to_specified_style()
+                .unwrap_err()
+                .property(),
+            "background-size"
+        );
     }
 
     #[test]
@@ -199,11 +400,44 @@ mod tests {
             s.to_string(),
             "background-origin: content-box; background-clip: text;"
         );
+        assert_eq!(
+            s.to_specified_style().unwrap_err().property(),
+            "background-clip"
+        );
+
+        let supported = Css::new()
+            .background_origin(BackgroundOrigin::ContentBox)
+            .background_clip(BackgroundClip::PaddingBox)
+            .to_specified_style()
+            .unwrap();
+        assert_eq!(
+            supported.resolved()[0].value(),
+            &whisker_style::StyleValue::BackgroundBox(whisker_style::BackgroundBoxValue::Content)
+        );
+        assert_eq!(
+            supported.resolved()[1].value(),
+            &whisker_style::StyleValue::BackgroundBox(whisker_style::BackgroundBoxValue::Padding)
+        );
     }
 
     #[test]
     fn background_attachment() {
         let s = Css::new().background_attachment(BackgroundAttachment::Fixed);
         assert_eq!(s.to_string(), "background-attachment: fixed;");
+        assert_eq!(
+            s.to_specified_style().unwrap_err().property(),
+            "background-attachment"
+        );
+        assert_eq!(
+            Css::new()
+                .background_attachment(BackgroundAttachment::Scroll)
+                .to_specified_style()
+                .unwrap()
+                .resolved()[0]
+                .value(),
+            &whisker_style::StyleValue::BackgroundAttachment(
+                whisker_style::BackgroundAttachmentValue::Scroll
+            )
+        );
     }
 }

--- a/crates/whisker-engine/src/paint.rs
+++ b/crates/whisker-engine/src/paint.rs
@@ -162,6 +162,7 @@ mod tests {
         ComputedPaintStyle {
             background_color: color("background"),
             background_images: Vec::new(),
+            background_layer: Default::default(),
             border_colors: Edges {
                 top: color("top"),
                 right: color("right"),

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -26,7 +26,8 @@ pub use layout_value::{
     JustifyContentValue, LengthPercentageAutoValue, PositionValue, SizeValue,
 };
 pub use paint::{
-    BorderStyleValue, ComputedCornerRadius, ComputedPaintStyle, Corners, OverflowValue,
+    BorderStyleValue, ComputedBackgroundLayerStyle, ComputedBackgroundPosition,
+    ComputedBackgroundSize, ComputedCornerRadius, ComputedPaintStyle, Corners, OverflowValue,
     VisibilityValue,
 };
 pub use property::{
@@ -38,7 +39,8 @@ pub use resolution::{
     resolve_text_style,
 };
 pub use value::{
-    BackgroundImageValue, BorderRadiusValue, CalcExpression, ColorValue, FontFamilyValue,
-    FontStyleValue, FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue,
-    LineHeightValue, StyleNumber, StyleValue,
+    BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue, BackgroundPositionValue,
+    BackgroundRepeatModeValue, BackgroundRepeatValue, BackgroundSizeValue, BorderRadiusValue,
+    CalcExpression, ColorValue, FontFamilyValue, FontStyleValue, FontWeightValue,
+    LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, StyleNumber, StyleValue,
 };

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -1,9 +1,10 @@
 //! Computed paint values that remain independent of every Host renderer.
 
 use crate::{
-    BackgroundImageValue, ColorValue, ComputedLengthPercentage, Edges, InheritedStyle,
-    SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty, StyleResolutionError, StyleValue,
-    layout::resolve_affine,
+    BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue, BackgroundPositionValue,
+    BackgroundRepeatModeValue, BackgroundSizeValue, ColorValue, ComputedLengthPercentage, Edges,
+    InheritedStyle, SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty,
+    StyleResolutionError, StyleValue, layout::resolve_affine,
 };
 
 /// Four physical corners in top-left, top-right, bottom-right, bottom-left order.
@@ -92,6 +93,73 @@ pub enum VisibilityValue {
     Hidden,
 }
 
+/// Computed position of one background layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedBackgroundPosition {
+    /// Horizontal length plus positioning-area fraction.
+    pub horizontal: ComputedLengthPercentage,
+    /// Vertical length plus positioning-area fraction.
+    pub vertical: ComputedLengthPercentage,
+}
+
+/// Computed size of one background layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ComputedBackgroundSize {
+    /// Use the image's intrinsic dimensions.
+    Auto,
+    /// Preserve aspect ratio while covering the positioning area.
+    Cover,
+    /// Preserve aspect ratio while fitting inside the positioning area.
+    Contain,
+    /// Resolve an explicit width and height against the positioning area.
+    Explicit {
+        /// Computed image width.
+        width: ComputedLengthPercentage,
+        /// Computed image height.
+        height: ComputedLengthPercentage,
+    },
+}
+
+/// Computed geometry and scrolling values paired with one background image.
+///
+/// The authoring API currently exposes one scalar set of longhands. Keeping
+/// them grouped makes later CSS list alignment an expansion from one layer to
+/// many rather than a collection of unrelated parallel fields.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedBackgroundLayerStyle {
+    /// Position within the selected origin box.
+    pub position: ComputedBackgroundPosition,
+    /// Image sizing behavior.
+    pub size: ComputedBackgroundSize,
+    /// Horizontal tiling behavior.
+    pub repeat_x: BackgroundRepeatModeValue,
+    /// Vertical tiling behavior.
+    pub repeat_y: BackgroundRepeatModeValue,
+    /// Box defining the positioning area.
+    pub origin: BackgroundBoxValue,
+    /// Box clipping background paint.
+    pub clip: BackgroundBoxValue,
+    /// Relationship to scrolling.
+    pub attachment: BackgroundAttachmentValue,
+}
+
+impl Default for ComputedBackgroundLayerStyle {
+    fn default() -> Self {
+        Self {
+            position: ComputedBackgroundPosition {
+                horizontal: ComputedLengthPercentage::ZERO,
+                vertical: ComputedLengthPercentage::ZERO,
+            },
+            size: ComputedBackgroundSize::Auto,
+            repeat_x: BackgroundRepeatModeValue::Repeat,
+            repeat_y: BackgroundRepeatModeValue::Repeat,
+            origin: BackgroundBoxValue::Padding,
+            clip: BackgroundBoxValue::Border,
+            attachment: BackgroundAttachmentValue::Scroll,
+        }
+    }
+}
+
 /// Computed background, border, clip, and compositing values for one node.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ComputedPaintStyle {
@@ -99,6 +167,8 @@ pub struct ComputedPaintStyle {
     pub background_color: ColorValue,
     /// Ordered Host-independent background image sources, front to back.
     pub background_images: Vec<BackgroundImageValue>,
+    /// Scalar longhands applied to the current background image layer.
+    pub background_layer: ComputedBackgroundLayerStyle,
     /// Resolved border colors in physical edge order.
     pub border_colors: Edges<ColorValue>,
     /// Border line styles in physical edge order.
@@ -128,6 +198,7 @@ impl ComputedPaintStyle {
         Self {
             background_color: transparent,
             background_images: Vec::new(),
+            background_layer: ComputedBackgroundLayerStyle::default(),
             border_colors: Edges {
                 top: current_color.clone(),
                 right: current_color.clone(),
@@ -177,6 +248,53 @@ pub(crate) fn resolve_paint_style(
                     return Err(invalid(property));
                 };
                 paint.background_images = images.clone();
+            }
+            StyleProperty::BackgroundRepeat => {
+                let StyleValue::BackgroundRepeat(value) = value else {
+                    return Err(invalid(property));
+                };
+                paint.background_layer.repeat_x = value.horizontal;
+                paint.background_layer.repeat_y = value.vertical;
+            }
+            StyleProperty::BackgroundPosition => {
+                let StyleValue::BackgroundPosition(value) = value else {
+                    return Err(invalid(property));
+                };
+                paint.background_layer.position =
+                    resolve_background_position(value, inherited, environment, property)?;
+            }
+            StyleProperty::BackgroundPositionX => {
+                paint.background_layer.position.horizontal =
+                    resolve_length_percentage(value, inherited, environment, property)?;
+            }
+            StyleProperty::BackgroundPositionY => {
+                paint.background_layer.position.vertical =
+                    resolve_length_percentage(value, inherited, environment, property)?;
+            }
+            StyleProperty::BackgroundSize => {
+                let StyleValue::BackgroundSize(value) = value else {
+                    return Err(invalid(property));
+                };
+                paint.background_layer.size =
+                    resolve_background_size(value, inherited, environment, property)?;
+            }
+            StyleProperty::BackgroundOrigin => {
+                let StyleValue::BackgroundBox(value) = value else {
+                    return Err(invalid(property));
+                };
+                paint.background_layer.origin = *value;
+            }
+            StyleProperty::BackgroundClip => {
+                let StyleValue::BackgroundBox(value) = value else {
+                    return Err(invalid(property));
+                };
+                paint.background_layer.clip = *value;
+            }
+            StyleProperty::BackgroundAttachment => {
+                let StyleValue::BackgroundAttachment(value) = value else {
+                    return Err(invalid(property));
+                };
+                paint.background_layer.attachment = *value;
             }
             StyleProperty::BorderTopColor => paint.border_colors.top = color(value, property)?,
             StyleProperty::BorderRightColor => paint.border_colors.right = color(value, property)?,
@@ -291,6 +409,66 @@ fn radius(
     })
 }
 
+fn resolve_length_percentage(
+    value: &StyleValue,
+    inherited: &InheritedStyle,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<ComputedLengthPercentage, StyleResolutionError> {
+    let StyleValue::LengthPercentage(value) = value else {
+        return Err(invalid(property));
+    };
+    resolve_affine(value, inherited.font_size(), environment, property)
+}
+
+fn resolve_background_position(
+    value: &BackgroundPositionValue,
+    inherited: &InheritedStyle,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<ComputedBackgroundPosition, StyleResolutionError> {
+    Ok(ComputedBackgroundPosition {
+        horizontal: resolve_affine(
+            &value.horizontal,
+            inherited.font_size(),
+            environment,
+            property,
+        )?,
+        vertical: resolve_affine(
+            &value.vertical,
+            inherited.font_size(),
+            environment,
+            property,
+        )?,
+    })
+}
+
+fn resolve_background_size(
+    value: &BackgroundSizeValue,
+    inherited: &InheritedStyle,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<ComputedBackgroundSize, StyleResolutionError> {
+    let size = match value {
+        BackgroundSizeValue::Auto => ComputedBackgroundSize::Auto,
+        BackgroundSizeValue::Cover => ComputedBackgroundSize::Cover,
+        BackgroundSizeValue::Contain => ComputedBackgroundSize::Contain,
+        BackgroundSizeValue::Explicit { width, height } => {
+            let width = resolve_affine(width, inherited.font_size(), environment, property)?;
+            let height = resolve_affine(height, inherited.font_size(), environment, property)?;
+            if width.length() < 0.0
+                || width.fraction() < 0.0
+                || height.length() < 0.0
+                || height.fraction() < 0.0
+            {
+                return Err(invalid(property));
+            }
+            ComputedBackgroundSize::Explicit { width, height }
+        }
+    };
+    Ok(size)
+}
+
 fn invalid(property: StyleProperty) -> StyleResolutionError {
     StyleResolutionError::InvalidPropertyValue(property)
 }
@@ -298,7 +476,9 @@ fn invalid(property: StyleProperty) -> StyleResolutionError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BorderRadiusValue, LengthPercentageValue, LengthUnit, LengthValue};
+    use crate::{
+        BackgroundRepeatValue, BorderRadiusValue, LengthPercentageValue, LengthUnit, LengthValue,
+    };
 
     fn number(value: f32) -> StyleNumber {
         StyleNumber::new(value)
@@ -313,6 +493,21 @@ mod tests {
 
     fn px(value: f32) -> StyleValue {
         StyleValue::LengthPercentage(px_length(value))
+    }
+
+    fn percentage(value: f32) -> LengthPercentageValue {
+        LengthPercentageValue::Percentage(number(value))
+    }
+
+    #[test]
+    fn background_layer_initial_values_match_css() {
+        let resolved =
+            crate::resolve_style(&SpecifiedStyle::new(), None, StyleEnvironment::default())
+                .unwrap();
+        assert_eq!(
+            resolved.computed().paint().background_layer,
+            ComputedBackgroundLayerStyle::default()
+        );
     }
 
     #[test]
@@ -336,6 +531,40 @@ mod tests {
                 StyleValue::BackgroundImages(vec![BackgroundImageValue::Url(
                     "https://example.com/image.png".into(),
                 )]),
+            )
+            .push(
+                StyleProperty::BackgroundPosition,
+                StyleValue::BackgroundPosition(BackgroundPositionValue {
+                    horizontal: percentage(25.0),
+                    vertical: px_length(10.0),
+                }),
+            )
+            .push(StyleProperty::BackgroundPositionX, px(5.0))
+            .push(
+                StyleProperty::BackgroundSize,
+                StyleValue::BackgroundSize(BackgroundSizeValue::Explicit {
+                    width: percentage(50.0),
+                    height: px_length(20.0),
+                }),
+            )
+            .push(
+                StyleProperty::BackgroundRepeat,
+                StyleValue::BackgroundRepeat(BackgroundRepeatValue {
+                    horizontal: BackgroundRepeatModeValue::Space,
+                    vertical: BackgroundRepeatModeValue::Round,
+                }),
+            )
+            .push(
+                StyleProperty::BackgroundOrigin,
+                StyleValue::BackgroundBox(BackgroundBoxValue::Content),
+            )
+            .push(
+                StyleProperty::BackgroundClip,
+                StyleValue::BackgroundBox(BackgroundBoxValue::Padding),
+            )
+            .push(
+                StyleProperty::BackgroundAttachment,
+                StyleValue::BackgroundAttachment(BackgroundAttachmentValue::Scroll),
             )
             .push(
                 StyleProperty::BorderTopStyle,
@@ -410,6 +639,30 @@ mod tests {
                 "https://example.com/image.png".into()
             )]
         );
+        assert_eq!(paint.background_layer.position.horizontal.length(), 5.0);
+        assert_eq!(paint.background_layer.position.horizontal.fraction(), 0.0);
+        assert_eq!(paint.background_layer.position.vertical.length(), 10.0);
+        assert_eq!(
+            paint.background_layer.size,
+            ComputedBackgroundSize::Explicit {
+                width: ComputedLengthPercentage::new(0.0, 0.5),
+                height: ComputedLengthPercentage::new(20.0, 0.0),
+            }
+        );
+        assert_eq!(
+            paint.background_layer.repeat_x,
+            BackgroundRepeatModeValue::Space
+        );
+        assert_eq!(
+            paint.background_layer.repeat_y,
+            BackgroundRepeatModeValue::Round
+        );
+        assert_eq!(paint.background_layer.origin, BackgroundBoxValue::Content);
+        assert_eq!(paint.background_layer.clip, BackgroundBoxValue::Padding);
+        assert_eq!(
+            paint.background_layer.attachment,
+            BackgroundAttachmentValue::Scroll
+        );
         assert_eq!(paint.border_colors.top, ColorValue::Named("top".into()));
         assert_eq!(paint.border_colors.right, ColorValue::Named("right".into()));
         assert_eq!(
@@ -444,6 +697,14 @@ mod tests {
         for property in [
             StyleProperty::BackgroundColor,
             StyleProperty::BackgroundImage,
+            StyleProperty::BackgroundRepeat,
+            StyleProperty::BackgroundPosition,
+            StyleProperty::BackgroundPositionX,
+            StyleProperty::BackgroundPositionY,
+            StyleProperty::BackgroundSize,
+            StyleProperty::BackgroundOrigin,
+            StyleProperty::BackgroundClip,
+            StyleProperty::BackgroundAttachment,
             StyleProperty::BorderTopColor,
             StyleProperty::BorderRightColor,
             StyleProperty::BorderBottomColor,
@@ -485,6 +746,13 @@ mod tests {
             (
                 StyleProperty::BackgroundColor,
                 StyleValue::Color(ColorValue::Named(String::new())),
+            ),
+            (
+                StyleProperty::BackgroundSize,
+                StyleValue::BackgroundSize(BackgroundSizeValue::Explicit {
+                    width: px_length(-1.0),
+                    height: px_length(1.0),
+                }),
             ),
             (StyleProperty::Opacity, StyleValue::Number(number(f32::NAN))),
             (StyleProperty::ZIndex, StyleValue::Integer(i64::MAX)),

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -693,6 +693,76 @@ mod tests {
     }
 
     #[test]
+    fn background_geometry_resolves_keywords_and_reports_axis_errors() {
+        for (specified, computed) in [
+            (BackgroundSizeValue::Auto, ComputedBackgroundSize::Auto),
+            (BackgroundSizeValue::Cover, ComputedBackgroundSize::Cover),
+            (
+                BackgroundSizeValue::Contain,
+                ComputedBackgroundSize::Contain,
+            ),
+        ] {
+            let resolved = crate::resolve_style(
+                &SpecifiedStyle::new().push(
+                    StyleProperty::BackgroundSize,
+                    StyleValue::BackgroundSize(specified),
+                ),
+                None,
+                StyleEnvironment::default(),
+            )
+            .unwrap();
+            assert_eq!(resolved.computed().paint().background_layer.size, computed);
+        }
+
+        for position in [
+            BackgroundPositionValue {
+                horizontal: px_length(f32::NAN),
+                vertical: px_length(0.0),
+            },
+            BackgroundPositionValue {
+                horizontal: px_length(0.0),
+                vertical: px_length(f32::NAN),
+            },
+        ] {
+            assert_eq!(
+                crate::resolve_style(
+                    &SpecifiedStyle::new().push(
+                        StyleProperty::BackgroundPosition,
+                        StyleValue::BackgroundPosition(position),
+                    ),
+                    None,
+                    StyleEnvironment::default(),
+                ),
+                Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::BackgroundPosition
+                ))
+            );
+        }
+
+        for (width, height) in [
+            (px_length(f32::NAN), px_length(1.0)),
+            (px_length(1.0), px_length(f32::NAN)),
+            (percentage(-1.0), px_length(1.0)),
+            (px_length(1.0), px_length(-1.0)),
+            (px_length(1.0), percentage(-1.0)),
+        ] {
+            assert_eq!(
+                crate::resolve_style(
+                    &SpecifiedStyle::new().push(
+                        StyleProperty::BackgroundSize,
+                        StyleValue::BackgroundSize(BackgroundSizeValue::Explicit { width, height }),
+                    ),
+                    None,
+                    StyleEnvironment::default(),
+                ),
+                Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::BackgroundSize
+                ))
+            );
+        }
+    }
+
+    #[test]
     fn invalid_paint_values_are_diagnostic() {
         for property in [
             StyleProperty::BackgroundColor,

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -188,6 +188,77 @@ pub enum BackgroundImageValue {
     Url(String),
 }
 
+/// Tiling behavior on one background axis.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BackgroundRepeatModeValue {
+    /// Repeat adjacent tiles without adding space.
+    Repeat,
+    /// Paint at most one tile.
+    NoRepeat,
+    /// Distribute whole tiles with equal gaps.
+    Space,
+    /// Resize tiles so a whole number fills the axis.
+    Round,
+}
+
+/// Expanded two-axis value of one `background-repeat` layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BackgroundRepeatValue {
+    /// Horizontal tiling behavior.
+    pub horizontal: BackgroundRepeatModeValue,
+    /// Vertical tiling behavior.
+    pub vertical: BackgroundRepeatModeValue,
+}
+
+/// Specified position of one background layer.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BackgroundPositionValue {
+    /// Horizontal position relative to the positioning area.
+    pub horizontal: LengthPercentageValue,
+    /// Vertical position relative to the positioning area.
+    pub vertical: LengthPercentageValue,
+}
+
+/// Specified size of one background layer.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum BackgroundSizeValue {
+    /// Use the image's intrinsic dimensions.
+    Auto,
+    /// Preserve aspect ratio while covering the positioning area.
+    Cover,
+    /// Preserve aspect ratio while fitting inside the positioning area.
+    Contain,
+    /// Resolve an explicit width and height.
+    Explicit {
+        /// Specified image width.
+        width: LengthPercentageValue,
+        /// Specified image height.
+        height: LengthPercentageValue,
+    },
+}
+
+/// Box used to position or clip a background layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BackgroundBoxValue {
+    /// The outer border box.
+    Border,
+    /// The inner padding box.
+    Padding,
+    /// The content box.
+    Content,
+}
+
+/// Scrolling relationship of one background layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BackgroundAttachmentValue {
+    /// Scroll with the element's border box.
+    Scroll,
+    /// Remain fixed relative to the viewport.
+    Fixed,
+    /// Scroll with the element's contents.
+    Local,
+}
+
 /// An owned value in a specified inline-style declaration.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StyleValue {
@@ -207,6 +278,16 @@ pub enum StyleValue {
     BorderRadius(BorderRadiusValue),
     /// Ordered background images, front to back.
     BackgroundImages(Vec<BackgroundImageValue>),
+    /// Expanded tiling behavior of one background layer.
+    BackgroundRepeat(BackgroundRepeatValue),
+    /// Specified position of one background layer.
+    BackgroundPosition(BackgroundPositionValue),
+    /// Specified size of one background layer.
+    BackgroundSize(BackgroundSizeValue),
+    /// Positioning or clipping box of one background layer.
+    BackgroundBox(BackgroundBoxValue),
+    /// Scrolling relationship of one background layer.
+    BackgroundAttachment(BackgroundAttachmentValue),
     /// Font family.
     FontFamily(FontFamilyValue),
     /// Font face style.

--- a/crates/whisker/src/background_resources.rs
+++ b/crates/whisker/src/background_resources.rs
@@ -4,10 +4,13 @@ use std::collections::{HashMap, HashSet};
 
 use whisker_engine::whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, ImageRepeat, NodeId,
-    PaintBox, PaintImage, PaintPosition, ResourceCommand, ResourceEvent, ResourceId, ResourceKind,
-    ResourceRequest, ResourceSource,
+    PaintBox, PaintCoordinate, PaintImage, PaintLengthPercentage, PaintPosition, ResourceCommand,
+    ResourceEvent, ResourceId, ResourceKind, ResourceRequest, ResourceSource,
 };
-use whisker_engine::whisker_style::BackgroundImageValue;
+use whisker_engine::whisker_style::{
+    BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue, BackgroundRepeatModeValue,
+    ComputedBackgroundLayerStyle, ComputedBackgroundSize, ComputedLengthPercentage,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct ResourceKey {
@@ -91,6 +94,7 @@ pub(super) struct BackgroundResourceManager {
     entries: HashMap<ResourceId, ResourceEntry>,
     owned_ids: HashSet<ResourceId>,
     node_images: HashMap<NodeId, Vec<DesiredImage>>,
+    node_layer_styles: HashMap<NodeId, ComputedBackgroundLayerStyle>,
     dirty_nodes: HashSet<NodeId>,
 }
 
@@ -102,6 +106,7 @@ impl Default for BackgroundResourceManager {
             entries: HashMap::new(),
             owned_ids: HashSet::new(),
             node_images: HashMap::new(),
+            node_layer_styles: HashMap::new(),
             dirty_nodes: HashSet::new(),
         }
     }
@@ -116,6 +121,7 @@ impl BackgroundResourceManager {
         &mut self,
         node: NodeId,
         images: &[BackgroundImageValue],
+        layer_style: ComputedBackgroundLayerStyle,
         externally_used: &HashSet<ResourceId>,
     ) -> Result<ReconcileResult, BackgroundResourceError> {
         let desired = images
@@ -151,6 +157,7 @@ impl BackgroundResourceManager {
         }
 
         self.node_images.insert(node, desired);
+        self.node_layer_styles.insert(node, layer_style);
         self.refresh_projected_node(node);
 
         for key in previous_keys.difference(&desired_keys) {
@@ -158,6 +165,7 @@ impl BackgroundResourceManager {
         }
         if images.is_empty() {
             self.node_images.remove(&node);
+            self.node_layer_styles.remove(&node);
         }
         self.dirty_nodes.remove(&node);
 
@@ -171,6 +179,7 @@ impl BackgroundResourceManager {
         let mut commands = Vec::new();
         for node in nodes {
             let previous = self.node_images.remove(node).unwrap_or_default();
+            self.node_layer_styles.remove(node);
             self.dirty_nodes.remove(node);
             for key in resource_keys(&previous) {
                 if let Some(resource) = self.resources_by_key.get(&key).copied()
@@ -376,7 +385,7 @@ impl BackgroundResourceManager {
                 DesiredImage::Resource(key) => {
                     let resource = self.resources_by_key[key];
                     (self.entries[&resource].phase == ResourcePhase::Ready)
-                        .then(|| initial_resource_layer(resource))
+                        .then(|| initial_resource_layer(resource, self.node_layer_styles[&node]))
                 }
             })
             .collect()
@@ -393,17 +402,74 @@ fn resource_keys(images: &[DesiredImage]) -> HashSet<ResourceKey> {
         .collect()
 }
 
-fn initial_resource_layer(resource: ResourceId) -> BackgroundLayer {
+fn initial_resource_layer(
+    resource: ResourceId,
+    style: ComputedBackgroundLayerStyle,
+) -> BackgroundLayer {
     BackgroundLayer {
         image: PaintImage::Resource(resource),
-        position: PaintPosition::default(),
-        size: BackgroundSize::Auto,
-        repeat_x: ImageRepeat::Repeat,
-        repeat_y: ImageRepeat::Repeat,
-        origin: PaintBox::Padding,
-        clip: PaintBox::Border,
-        attachment: BackgroundAttachment::Scroll,
+        position: PaintPosition {
+            x: paint_coordinate(style.position.horizontal),
+            y: paint_coordinate(style.position.vertical),
+        },
+        size: background_size(style.size),
+        repeat_x: image_repeat(style.repeat_x),
+        repeat_y: image_repeat(style.repeat_y),
+        origin: paint_box(style.origin),
+        clip: paint_box(style.clip),
+        attachment: background_attachment(style.attachment),
         blend_mode: BlendMode::Normal,
+    }
+}
+
+fn paint_coordinate(value: ComputedLengthPercentage) -> PaintCoordinate {
+    PaintCoordinate {
+        length: value.length(),
+        fraction: value.fraction(),
+    }
+}
+
+fn paint_length_percentage(value: ComputedLengthPercentage) -> PaintLengthPercentage {
+    PaintLengthPercentage {
+        length: value.length(),
+        fraction: value.fraction(),
+    }
+}
+
+fn background_size(value: ComputedBackgroundSize) -> BackgroundSize {
+    match value {
+        ComputedBackgroundSize::Auto => BackgroundSize::Auto,
+        ComputedBackgroundSize::Cover => BackgroundSize::Cover,
+        ComputedBackgroundSize::Contain => BackgroundSize::Contain,
+        ComputedBackgroundSize::Explicit { width, height } => BackgroundSize::Explicit {
+            width: Some(paint_length_percentage(width)),
+            height: Some(paint_length_percentage(height)),
+        },
+    }
+}
+
+fn image_repeat(value: BackgroundRepeatModeValue) -> ImageRepeat {
+    match value {
+        BackgroundRepeatModeValue::Repeat => ImageRepeat::Repeat,
+        BackgroundRepeatModeValue::NoRepeat => ImageRepeat::NoRepeat,
+        BackgroundRepeatModeValue::Space => ImageRepeat::Space,
+        BackgroundRepeatModeValue::Round => ImageRepeat::Round,
+    }
+}
+
+fn paint_box(value: BackgroundBoxValue) -> PaintBox {
+    match value {
+        BackgroundBoxValue::Border => PaintBox::Border,
+        BackgroundBoxValue::Padding => PaintBox::Padding,
+        BackgroundBoxValue::Content => PaintBox::Content,
+    }
+}
+
+fn background_attachment(value: BackgroundAttachmentValue) -> BackgroundAttachment {
+    match value {
+        BackgroundAttachmentValue::Scroll => BackgroundAttachment::Scroll,
+        BackgroundAttachmentValue::Fixed => BackgroundAttachment::Fixed,
+        BackgroundAttachmentValue::Local => BackgroundAttachment::Local,
     }
 }
 
@@ -433,6 +499,7 @@ mod tests {
             .reconcile_node(
                 node(1),
                 &[url("https://example.test/a.png")],
+                ComputedBackgroundLayerStyle::default(),
                 &HashSet::new(),
             )
             .unwrap();
@@ -444,6 +511,7 @@ mod tests {
             .reconcile_node(
                 node(2),
                 &[url("https://example.test/a.png")],
+                ComputedBackgroundLayerStyle::default(),
                 &HashSet::new(),
             )
             .unwrap();
@@ -465,7 +533,12 @@ mod tests {
     fn accepted_reference_defers_release_and_reacquire_cancels_retirement() {
         let mut manager = BackgroundResourceManager::default();
         let acquired = manager
-            .reconcile_node(node(1), &[url("same")], &HashSet::new())
+            .reconcile_node(
+                node(1),
+                &[url("same")],
+                ComputedBackgroundLayerStyle::default(),
+                &HashSet::new(),
+            )
             .unwrap();
         let (resource, generation) = load(&acquired.commands[0]);
         manager.apply_event(&ResourceEvent::Ready {
@@ -478,11 +551,21 @@ mod tests {
         assert!(manager.accept_frame().is_empty());
 
         let removed = manager
-            .reconcile_node(node(1), &[], &HashSet::new())
+            .reconcile_node(
+                node(1),
+                &[],
+                ComputedBackgroundLayerStyle::default(),
+                &HashSet::new(),
+            )
             .unwrap();
         assert!(removed.commands.is_empty());
         let reacquired = manager
-            .reconcile_node(node(1), &[url("same")], &HashSet::new())
+            .reconcile_node(
+                node(1),
+                &[url("same")],
+                ComputedBackgroundLayerStyle::default(),
+                &HashSet::new(),
+            )
             .unwrap();
         assert!(reacquired.commands.is_empty());
         assert_eq!(reacquired.layers[0].image, PaintImage::Resource(resource));
@@ -493,11 +576,21 @@ mod tests {
     fn source_reacquired_after_release_gets_fresh_id() {
         let mut manager = BackgroundResourceManager::default();
         let acquired = manager
-            .reconcile_node(node(1), &[url("same")], &HashSet::new())
+            .reconcile_node(
+                node(1),
+                &[url("same")],
+                ComputedBackgroundLayerStyle::default(),
+                &HashSet::new(),
+            )
             .unwrap();
         let (first, _) = load(&acquired.commands[0]);
         let removed = manager
-            .reconcile_node(node(1), &[], &HashSet::new())
+            .reconcile_node(
+                node(1),
+                &[],
+                ComputedBackgroundLayerStyle::default(),
+                &HashSet::new(),
+            )
             .unwrap();
         assert_eq!(
             removed.commands,
@@ -507,7 +600,12 @@ mod tests {
             }]
         );
         let reacquired = manager
-            .reconcile_node(node(1), &[url("same")], &HashSet::new())
+            .reconcile_node(
+                node(1),
+                &[url("same")],
+                ComputedBackgroundLayerStyle::default(),
+                &HashSet::new(),
+            )
             .unwrap();
         let (second, generation) = load(&reacquired.commands[0]);
         assert_ne!(first, second);

--- a/crates/whisker/src/surface_runtime.rs
+++ b/crates/whisker/src/surface_runtime.rs
@@ -863,6 +863,7 @@ impl BindingState {
             let background = background_resources.reconcile_node(
                 update.node,
                 &update.resolved.computed().paint().background_images,
+                update.resolved.computed().paint().background_layer,
                 &externally_used,
             )?;
             surface.set_background_layers(update.node, background.layers)?;
@@ -1124,6 +1125,7 @@ impl BindingState {
         let background = background_resources.reconcile_node(
             node,
             &resolved.computed().paint().background_images,
+            resolved.computed().paint().background_layer,
             externally_used,
         )?;
         surface.set_background_layers(node, background.layers)?;

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -6,18 +6,24 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
-use whisker::css::{CssString, ImageRef};
+use whisker::css::{
+    BackgroundAttachment as CssBackgroundAttachment, BackgroundClip as CssBackgroundClip,
+    BackgroundOrigin as CssBackgroundOrigin, BackgroundRepeat as CssBackgroundRepeat,
+    BackgroundSize as CssBackgroundSize, CalcExpr, CssString, ImageRef, LengthPercentage,
+    Percentage,
+};
 use whisker::prelude::*;
 use whisker::{
     RuntimeBindingError, RuntimeDriveError, RuntimeInstance, RuntimeLifecycle, SurfaceRuntime,
 };
 use whisker_engine::whisker_protocol::{
-    ApplyResult, BackgroundAttachment, BackgroundSize, BlendMode, FrameMode, FramePacket,
-    ImageRepeat, InputEvent, InputEventKind, InputPoint, MeasuredSize, MeasurementMetrics,
-    MeasurementPayload, MeasurementReady, MeasurementRequest, MeasurementRequestId,
-    MeasurementResponse, Operation, PaintBox, PaintImage, PaintPosition, PointerId, PointerInput,
-    PointerKind, RenderCapabilities, ResourceCommand, ResourceDimensions, ResourceEvent,
-    ResourceId, ResourceKind, ResourceRequest, ResourceSource, SurfaceId, WhiskerValue,
+    ApplyResult, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, FrameMode,
+    FramePacket, ImageRepeat, InputEvent, InputEventKind, InputPoint, MeasuredSize,
+    MeasurementMetrics, MeasurementPayload, MeasurementReady, MeasurementRequest,
+    MeasurementRequestId, MeasurementResponse, Operation, PaintBox, PaintCoordinate, PaintImage,
+    PaintLengthPercentage, PaintPosition, PointerId, PointerInput, PointerKind, RenderCapabilities,
+    ResourceCommand, ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest,
+    ResourceSource, SurfaceId, WhiskerValue,
 };
 use whisker_engine::whisker_style::{StyleEnvironment, StyleResolutionError};
 use whisker_engine::{FrameSink, LayoutOptions, MeasurementProvider, RecordingRenderer};
@@ -126,6 +132,48 @@ fn ready_raster(resource: ResourceId, generation: u64) -> ResourceEvent {
             scale: 1.0,
         }),
     }
+}
+
+fn render_ready_background(surface_id: u64, style: Css) -> BackgroundLayer {
+    let surface = surface(surface_id);
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    runtime
+        .mount(move || render! { view(style: style) })
+        .unwrap();
+    let commands = surface.take_resource_commands();
+    assert_eq!(commands.len(), 1, "one URL must produce one Host load");
+    let ResourceCommand::Load(request) = &commands[0] else {
+        panic!("URL background must produce a load")
+    };
+    let resource = request.resource;
+    runtime
+        .dispatch_resource_event(&ready_raster(resource, request.generation))
+        .unwrap();
+
+    let mut measurements = NoMeasurement;
+    let mut sink = RecordingRenderer::new(surface.surface());
+    runtime
+        .drive_frame(
+            1.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    sink.frames()
+        .iter()
+        .rev()
+        .flat_map(|frame| frame.packet.operations.iter().rev())
+        .find_map(|operation| match operation {
+            Operation::SetBackgroundLayers { layers, .. } if !layers.is_empty() => {
+                Some(layers[0].clone())
+            }
+            _ => None,
+        })
+        .expect("Ready URL must be lowered into SetBackgroundLayers")
 }
 
 fn dispatch_control_tap(runtime: &RuntimeInstance, surface: &SurfaceRuntime, timestamp_ms: f64) {
@@ -374,6 +422,116 @@ fn background_url_loads_out_of_frame_and_is_emitted_only_after_ready() {
         )
     }));
     assert!(surface.take_resource_commands().is_empty());
+}
+
+#[test]
+fn background_url_lowers_explicit_geometry_repeat_boxes_and_attachment() {
+    let x = LengthPercentage::calc(CalcExpr::value(px(12)).add(CalcExpr::value(Percentage(25.0))));
+    let y = LengthPercentage::calc(CalcExpr::value(px(8)).add(CalcExpr::value(Percentage(75.0))));
+    let layer = render_ready_background(
+        44,
+        Css::new()
+            .width(px(100))
+            .height(px(100))
+            .background_image(ImageRef::Url(CssString::new(BACKGROUND_URL)))
+            .background_position_x(x)
+            .background_position_y(y)
+            .background_size(CssBackgroundSize::Explicit(
+                px(40).into(),
+                Percentage(50.0).into(),
+            ))
+            .background_repeat(CssBackgroundRepeat::RepeatX)
+            .background_origin(CssBackgroundOrigin::ContentBox)
+            .background_clip(CssBackgroundClip::PaddingBox)
+            .background_attachment(CssBackgroundAttachment::Scroll),
+    );
+
+    assert_eq!(
+        layer.position,
+        PaintPosition {
+            x: PaintCoordinate {
+                length: 12.0,
+                fraction: 0.25,
+            },
+            y: PaintCoordinate {
+                length: 8.0,
+                fraction: 0.75,
+            },
+        }
+    );
+    assert_eq!(
+        layer.size,
+        BackgroundSize::Explicit {
+            width: Some(PaintLengthPercentage {
+                length: 40.0,
+                fraction: 0.0,
+            }),
+            height: Some(PaintLengthPercentage {
+                length: 0.0,
+                fraction: 0.5,
+            }),
+        }
+    );
+    assert_eq!(layer.repeat_x, ImageRepeat::Repeat);
+    assert_eq!(layer.repeat_y, ImageRepeat::NoRepeat);
+    assert_eq!(layer.origin, PaintBox::Content);
+    assert_eq!(layer.clip, PaintBox::Padding);
+    assert_eq!(layer.attachment, BackgroundAttachment::Scroll);
+}
+
+#[test]
+fn background_url_lowers_remaining_repeat_modes_with_explicit_size() {
+    let cases = [
+        (
+            "repeat",
+            CssBackgroundRepeat::Repeat,
+            ImageRepeat::Repeat,
+            ImageRepeat::Repeat,
+        ),
+        (
+            "no-repeat",
+            CssBackgroundRepeat::NoRepeat,
+            ImageRepeat::NoRepeat,
+            ImageRepeat::NoRepeat,
+        ),
+        (
+            "repeat-y",
+            CssBackgroundRepeat::RepeatY,
+            ImageRepeat::NoRepeat,
+            ImageRepeat::Repeat,
+        ),
+    ];
+
+    for (index, (name, css_repeat, repeat_x, repeat_y)) in cases.into_iter().enumerate() {
+        let layer = render_ready_background(
+            45 + index as u64,
+            Css::new()
+                .width(px(100))
+                .height(px(100))
+                .background_image(ImageRef::Url(CssString::new(BACKGROUND_URL)))
+                .background_size(CssBackgroundSize::Explicit(
+                    px(32).into(),
+                    Percentage(25.0).into(),
+                ))
+                .background_repeat(css_repeat),
+        );
+        assert_eq!(
+            layer.size,
+            BackgroundSize::Explicit {
+                width: Some(PaintLengthPercentage {
+                    length: 32.0,
+                    fraction: 0.0,
+                }),
+                height: Some(PaintLengthPercentage {
+                    length: 0.0,
+                    fraction: 0.25,
+                }),
+            },
+            "{name}"
+        );
+        assert_eq!(layer.repeat_x, repeat_x, "{name}");
+        assert_eq!(layer.repeat_y, repeat_y, "{name}");
+    }
 }
 
 #[test]

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -524,6 +524,16 @@ decoding to the Host resource service. Background resources do not influence
 Taffy layout; intrinsic dimensions returned by the Host are retained for
 future replaced-content consumers but do not resize a CSS background.
 
+The next slice lowers the Host-independent background geometry that every
+current receiver can apply symmetrically: two-axis explicit size, affine
+position, all repeat modes, border/padding/content origin and clip boxes, and
+scroll attachment. CSS initial `auto` remains valid for the initial geometry.
+Intrinsic `auto`, one-axis `auto`, `cover`, `contain`, fixed/local attachment,
+text clipping, and non-normal blend modes stay outside this slice until their
+resource-size or scrolling semantics and all four Host receivers land
+together. Unsupported combinations are rejected transactionally rather than
+silently approximated.
+
 Adding the semantic value does not declare a Host implementation complete.
 Until a Host advertises and implements the corresponding capability, its
 receiver rejects the operation before mutating retained state. It must not
@@ -845,13 +855,12 @@ Visual snapshots supplement but do not replace semantic assertions.
    validation. It also retains elliptical radius axes, OpenType
    feature/variation/optical-sizing measurement inputs, image-rendering intent,
    optional capability profiles, and a generation-safe resource lifecycle.
-   Existing Desktop and Web Hosts advertise elliptical radius support; all
-   other newly introduced groups are rejected before retained-state mutation.
-   Mobile advertises the base profile until its packed ABI grows equivalent
-   fields. Except for box radius, these operations are intentionally not
-   emitted by style lowering yet; each property group lands next as a complete
-   specified-value -> computed-value -> operation slice and then advances the
-   per-Host checklist.
+   Existing Desktop and Web Hosts advertise elliptical radius support, while
+   the common background-layer subset is now represented in every Host ABI.
+   URL-backed backgrounds and their supported layer geometry are emitted by
+   style lowering; remaining operation groups are rejected before retained
+   state mutation. Each property group lands as a complete specified-value ->
+   computed-value -> operation slice and then advances the per-Host checklist.
 6. Route signal and `whisker-motion` writes through the shared property slots
    and incremental dirty classifier.
 7. Add the shared Host conformance scenario format, standalone runners, and

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -927,6 +927,9 @@ fn fixture(path: &str) -> &'static str {
         "core/resource-raster-lifecycle.json" => {
             include_str!("../../../../tests/host-conformance/core/resource-raster-lifecycle.json")
         }
+        "core/background-layer-geometry-symmetry.json" => include_str!(
+            "../../../../tests/host-conformance/core/background-layer-geometry-symmetry.json"
+        ),
         "wpt/css/CSS2/backgrounds/background-color-129.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/backgrounds/background-color-129.json"
         ),

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1973,11 +1973,54 @@ fn fixture_background_layer_paints_at(
             + layer.position[1].length
             + layer.position[1].fraction * (positioning_area[3] - size[1]),
     ];
-    let paints_x = layer.repeat_x != ImageRepeatFixture::NoRepeat
-        || (position[0]..position[0] + size[0]).contains(&point[0]);
-    let paints_y = layer.repeat_y != ImageRepeatFixture::NoRepeat
-        || (position[1]..position[1] + size[1]).contains(&point[1]);
+    let paints_x = fixture_background_axis_paints_at(
+        positioning_area[0],
+        positioning_area[2],
+        position[0],
+        size[0],
+        layer.repeat_x,
+        point[0],
+    );
+    let paints_y = fixture_background_axis_paints_at(
+        positioning_area[1],
+        positioning_area[3],
+        position[1],
+        size[1],
+        layer.repeat_y,
+        point[1],
+    );
     paints_x && paints_y
+}
+
+fn fixture_background_axis_paints_at(
+    area_start: f32,
+    area_length: f32,
+    tile_start: f32,
+    tile_length: f32,
+    repeat: ImageRepeatFixture,
+    point: f32,
+) -> bool {
+    if tile_length <= 0.0 {
+        return false;
+    }
+    match repeat {
+        ImageRepeatFixture::NoRepeat => (tile_start..tile_start + tile_length).contains(&point),
+        ImageRepeatFixture::Repeat | ImageRepeatFixture::Round => true,
+        ImageRepeatFixture::Space => {
+            let tile_count = (area_length / tile_length).floor() as usize;
+            if tile_count < 2 {
+                return (tile_start..tile_start + tile_length).contains(&point);
+            }
+            let offset = point - area_start;
+            if !(0.0..area_length).contains(&offset) {
+                return false;
+            }
+            let gap = (area_length - tile_count as f32 * tile_length)
+                / (tile_count.saturating_sub(1)) as f32;
+            let stride = tile_length + gap;
+            offset % stride < tile_length
+        }
+    }
 }
 
 fn fixture_background_area(

--- a/tests/host-conformance/core/background-layer-geometry-symmetry.json
+++ b/tests/host-conformance/core/background-layer-geometry-symmetry.json
@@ -1,0 +1,151 @@
+{
+  "schema": 1,
+  "id": "core.background-layer-geometry-symmetry",
+  "test": {
+    "commands": [
+      {
+        "type": "attach_surface",
+        "width": 120.0,
+        "height": 120.0,
+        "scale": 1.0
+      },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 120.0, 120.0],
+            "content_box": [30.0, 30.0, 60.0, 60.0],
+            "background": { "kind": "named", "value": "transparent" },
+            "border": {
+              "widths": [10.0, 10.0, 10.0, 10.0],
+              "colors": [
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" }
+              ],
+              "styles": ["solid", "solid", "solid", "solid"],
+              "radii": [0.0, 0.0, 0.0, 0.0]
+            },
+            "background_layers": [
+              {
+                "geometry": {
+                  "position": [
+                    { "length": 7.0, "fraction": 0.25 },
+                    { "length": -20.0, "fraction": 0.25 }
+                  ],
+                  "size": [
+                    { "length": 16.0, "fraction": 0.0 },
+                    { "length": 16.0, "fraction": 0.0 }
+                  ],
+                  "repeat_x": "space",
+                  "repeat_y": "no_repeat",
+                  "origin": "content",
+                  "clip": "padding"
+                },
+                "image": {
+                  "linear_gradient": {
+                    "angle_degrees": 180.0,
+                    "stops": [
+                      { "color": { "kind": "named", "value": "red" }, "position": 0.0 },
+                      { "color": { "kind": "named", "value": "red" }, "position": 1.0 }
+                    ]
+                  }
+                }
+              },
+              {
+                "geometry": {
+                  "position": [
+                    { "length": 7.0, "fraction": 0.25 },
+                    { "length": 3.0, "fraction": 0.25 }
+                  ],
+                  "size": [
+                    { "length": 18.0, "fraction": 0.0 },
+                    { "length": 18.0, "fraction": 0.0 }
+                  ],
+                  "repeat_x": "no_repeat",
+                  "repeat_y": "space",
+                  "origin": "padding",
+                  "clip": "content"
+                },
+                "image": {
+                  "linear_gradient": {
+                    "angle_degrees": 180.0,
+                    "stops": [
+                      { "color": { "kind": "named", "value": "green" }, "position": 0.0 },
+                      { "color": { "kind": "named", "value": "green" }, "position": 1.0 }
+                    ]
+                  }
+                }
+              },
+              {
+                "geometry": {
+                  "position": [
+                    { "length": 2.0, "fraction": 0.0 },
+                    { "length": 2.0, "fraction": 0.0 }
+                  ],
+                  "size": [
+                    { "length": 18.0, "fraction": 0.0 },
+                    { "length": 18.0, "fraction": 0.0 }
+                  ],
+                  "repeat_x": "no_repeat",
+                  "repeat_y": "no_repeat",
+                  "origin": "border",
+                  "clip": "border"
+                },
+                "image": {
+                  "linear_gradient": {
+                    "angle_degrees": 180.0,
+                    "stops": [
+                      { "color": { "kind": "named", "value": "blue" }, "position": 0.0 },
+                      { "color": { "kind": "named", "value": "blue" }, "position": 1.0 }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.stacking",
+        "samples": [
+          {
+            "point": [5.0, 5.0],
+            "color": { "kind": "named", "value": "blue" },
+            "tolerance": 5
+          },
+          {
+            "point": [80.0, 22.0],
+            "color": { "kind": "named", "value": "red" },
+            "tolerance": 5
+          },
+          {
+            "point": [48.0, 22.0],
+            "color": { "kind": "named", "value": "transparent" },
+            "tolerance": 5
+          },
+          {
+            "point": [40.0, 60.0],
+            "color": { "kind": "named", "value": "green" },
+            "tolerance": 5
+          },
+          {
+            "point": [40.0, 20.0],
+            "color": { "kind": "named", "value": "transparent" },
+            "tolerance": 5
+          },
+          {
+            "point": [60.0, 60.0],
+            "color": { "kind": "named", "value": "transparent" },
+            "tolerance": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -38,6 +38,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "core.background-layer-geometry-symmetry",
+      "feature": "background-layer-geometry-symmetry",
+      "fixture": "core/background-layer-geometry-symmetry.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.background-resource-image",
       "feature": "background-image-resource",
       "fixture": "wpt/css/css-backgrounds/background-resource-image.json",


### PR DESCRIPTION
## Summary
- add a shared four-Host fixture for asymmetric multi-layer background geometry
- lower typed background position, explicit size, repeat, origin/clip boxes, and scroll attachment through the style/runtime pipeline
- project the computed geometry into URL-backed `BackgroundLayer` frame operations
- make the Web conformance oracle model `background-repeat: space` gaps
- document the supported subset and transactional deferrals

## Validation
- `cargo test -p whisker-style --lib`
- `cargo test -p whisker-css --lib`
- `cargo test -p whisker-engine --lib`
- `cargo test -p whisker --test runtime_instance`
- `cargo llvm-cov -p whisker-engine --summary-only --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100`
- `cargo clippy -p whisker-style -p whisker-css -p whisker-engine -p whisker --all-targets -- -D warnings`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`

## Deferred follow-ups
- intrinsic resource-backed `auto`, one-axis `auto`, `cover`, and `contain` sizing
- fixed/local background attachment
- text clipping and non-normal blend modes