### PR TITLE
feat(hosts): preserve rounded background aspect ratio

### DIFF
--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -533,10 +533,12 @@ continues to identify the image only by `ResourceId`, and the receiver resolves
 the final tile size from that cached metadata. This avoids duplicating mutable
 resource facts in `FramePacket` while keeping the geometry operation semantic.
 Gradients have no intrinsic dimensions, so only their initial `auto` and
-two-axis explicit sizes are currently accepted. Fixed/local attachment, the
-aspect-ratio coupling required when `round` changes only one tile axis, text
-clipping, and non-normal blend modes remain deferred. Unsupported combinations
-are rejected transactionally rather than silently approximated.
+two-axis explicit sizes are currently accepted. When `round` changes exactly
+one tile axis of a resource-backed image and the opposite explicit-size axis is
+`auto`, every Host rescales that opposite axis to restore the intrinsic aspect
+ratio after rounding, as required by CSS Backgrounds. Fixed/local attachment,
+text clipping, and non-normal blend modes remain deferred. Unsupported
+combinations are rejected transactionally rather than silently approximated.
 
 Adding the semantic value does not declare a Host implementation complete.
 Until a Host advertises and implements the corresponding capability, its

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundGeometry.kt
@@ -82,8 +82,22 @@ internal data class HostBackgroundGeometry(
             intrinsicHeight,
         )
         if (originalWidth <= 0f || originalHeight <= 0f) return
-        val tileWidth = adjustedTileSize(originalWidth, positioningBox.width(), repeatX)
-        val tileHeight = adjustedTileSize(originalHeight, positioningBox.height(), repeatY)
+        var tileWidth = adjustedTileSize(originalWidth, positioningBox.width(), repeatX)
+        var tileHeight = adjustedTileSize(originalHeight, positioningBox.height(), repeatY)
+        val hasIntrinsicAspectRatio = intrinsicWidth != null && intrinsicHeight != null &&
+            intrinsicWidth > 0f && intrinsicHeight > 0f &&
+            intrinsicWidth.isFinite() && intrinsicHeight.isFinite()
+        if (
+            hasIntrinsicAspectRatio && size == HostBackgroundSize.Width &&
+            repeatX == HostBackgroundRepeat.Round && repeatY != HostBackgroundRepeat.Round
+        ) {
+            tileHeight = originalHeight * tileWidth / originalWidth
+        } else if (
+            hasIntrinsicAspectRatio && size == HostBackgroundSize.Height &&
+            repeatY == HostBackgroundRepeat.Round && repeatX != HostBackgroundRepeat.Round
+        ) {
+            tileWidth = originalWidth * tileHeight / originalHeight
+        }
         val base = imageBox(positioningBox, tileWidth, tileHeight)
         if (
             base.isEmpty || paintingBox.isEmpty ||

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -85,6 +85,8 @@ internal fun applyBoxPaint(
             borderColors,
             borderStyles,
             normalizedRadii,
+            physicalWidth,
+            physicalHeight,
             backgroundLayers,
             RectF(
                 logicalContentBox.left * density,
@@ -112,6 +114,8 @@ private class WhiskerBoxDrawable(
     private val borderColors: IntArray,
     private val borderStyles: IntArray,
     private val cornerRadii: FloatArray,
+    private val backgroundBoxWidth: Float,
+    private val backgroundBoxHeight: Float,
     private val backgroundLayers: HostBackgroundLayers?,
     private val localContentBox: RectF,
 ) : Drawable() {
@@ -131,6 +135,18 @@ private class WhiskerBoxDrawable(
             box.top + top,
             box.right - right,
             box.bottom - bottom,
+        )
+        val backgroundBorderBox = RectF(
+            box.left,
+            box.top,
+            box.left + backgroundBoxWidth,
+            box.top + backgroundBoxHeight,
+        )
+        val backgroundPaddingBox = RectF(
+            backgroundBorderBox.left + left,
+            backgroundBorderBox.top + top,
+            backgroundBorderBox.right - right,
+            backgroundBorderBox.bottom - bottom,
         )
         val paddingPath = if (paddingBox.width() > 0f && paddingBox.height() > 0f) {
             roundedPath(
@@ -183,8 +199,8 @@ private class WhiskerBoxDrawable(
         drawBackgroundLayers(
             canvas,
             HostBackgroundPaintBoxes(
-                border = HostBackgroundPaintBox(box, outer),
-                padding = HostBackgroundPaintBox(paddingBox, paddingPath),
+                border = HostBackgroundPaintBox(backgroundBorderBox, outer),
+                padding = HostBackgroundPaintBox(backgroundPaddingBox, paddingPath),
                 content = HostBackgroundPaintBox(contentBox, contentPath),
             ),
             backgroundLayers,

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -1363,12 +1363,12 @@ fn background_tile_geometry(
     layer: &whisker_protocol::BackgroundLayer,
     intrinsic_size: Option<[f32; 2]>,
 ) -> Option<BackgroundTileGeometry> {
-    use whisker_protocol::BackgroundSize;
+    use whisker_protocol::{BackgroundSize, ImageRepeat};
 
     let resolve = |value: whisker_protocol::PaintLengthPercentage, extent: f32| {
         value.length + value.fraction * extent
     };
-    let [width, height] = match layer.size {
+    let [mut width, mut height] = match layer.size {
         BackgroundSize::Auto => {
             intrinsic_size.unwrap_or([positioning_rect.width, positioning_rect.height])
         }
@@ -1405,7 +1405,24 @@ fn background_tile_geometry(
     if width <= 0.0 || height <= 0.0 {
         return None;
     }
-    let x = background_axis_geometry(
+    let height_tracks_rounded_width = matches!(
+        layer.size,
+        BackgroundSize::Explicit {
+            width: Some(_),
+            height: None
+        }
+    ) && layer.repeat_x == ImageRepeat::Round
+        && layer.repeat_y != ImageRepeat::Round;
+    let width_tracks_rounded_height = matches!(
+        layer.size,
+        BackgroundSize::Explicit {
+            width: None,
+            height: Some(_)
+        }
+    ) && layer.repeat_y == ImageRepeat::Round
+        && layer.repeat_x != ImageRepeat::Round;
+
+    let mut x = background_axis_geometry(
         positioning_rect.x,
         positioning_rect.width,
         width,
@@ -1414,6 +1431,9 @@ fn background_tile_geometry(
         1,
         4,
     );
+    if height_tracks_rounded_width {
+        height *= x.tile_size / width;
+    }
     let y = background_axis_geometry(
         positioning_rect.y,
         positioning_rect.height,
@@ -1423,6 +1443,18 @@ fn background_tile_geometry(
         2,
         8,
     );
+    if width_tracks_rounded_height {
+        width *= y.tile_size / height;
+        x = background_axis_geometry(
+            positioning_rect.x,
+            positioning_rect.width,
+            width,
+            layer.position.x,
+            layer.repeat_x,
+            1,
+            4,
+        );
+    }
     Some(BackgroundTileGeometry {
         rect: LayoutRect {
             x: x.origin,
@@ -2404,6 +2436,43 @@ mod tests {
                 height: 30.0
             }
         );
+    }
+
+    #[test]
+    fn one_axis_round_rescales_the_opposite_auto_axis() {
+        let area = LayoutRect {
+            x: 0.0,
+            y: 0.0,
+            width: 100.0,
+            height: 80.0,
+        };
+        let intrinsic = [4.0, 2.0];
+
+        let mut round_width = resource_layer(BackgroundSize::Explicit {
+            width: Some(PaintLengthPercentage {
+                length: 40.0,
+                fraction: 0.0,
+            }),
+            height: None,
+        });
+        round_width.position = PaintPosition::default();
+        round_width.repeat_x = ImageRepeat::Round;
+        let horizontal = background_tile_geometry(area, &round_width, Some(intrinsic)).unwrap();
+        assert!((horizontal.rect.width - 100.0 / 3.0).abs() < 0.001);
+        assert!((horizontal.rect.height - 50.0 / 3.0).abs() < 0.001);
+
+        let mut round_height = resource_layer(BackgroundSize::Explicit {
+            width: None,
+            height: Some(PaintLengthPercentage {
+                length: 30.0,
+                fraction: 0.0,
+            }),
+        });
+        round_height.position = PaintPosition::default();
+        round_height.repeat_y = ImageRepeat::Round;
+        let vertical = background_tile_geometry(area, &round_height, Some(intrinsic)).unwrap();
+        assert!((vertical.rect.width - 160.0 / 3.0).abs() < 0.001);
+        assert!((vertical.rect.height - 80.0 / 3.0).abs() < 0.001);
     }
 
     #[test]

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -101,16 +101,23 @@ struct HostBackgroundGeometry {
 
     func imageBounds(in positioningBox: CGRect) -> CGRect {
         let originalSize = resolvedImageSize(in: positioningBox)
-        let width = backgroundRoundTileSize(
+        var width = backgroundRoundTileSize(
             originalTileSize: originalSize.width,
             positioningSize: positioningBox.width,
             repeatMode: repeatX
         )
-        let height = backgroundRoundTileSize(
+        var height = backgroundRoundTileSize(
             originalTileSize: originalSize.height,
             positioningSize: positioningBox.height,
             repeatMode: repeatY
         )
+        if sizeKind == .explicit, sizeWidth != nil, sizeHeight == nil,
+           repeatX == .round, repeatY != .round, originalSize.width > 0 {
+            height = originalSize.height * width / originalSize.width
+        } else if sizeKind == .explicit, sizeWidth == nil, sizeHeight != nil,
+                  repeatY == .round, repeatX != .round, originalSize.height > 0 {
+            width = originalSize.width * height / originalSize.height
+        }
         return CGRect(
             x: positioningBox.minX + CGFloat(positionX.length) +
                 CGFloat(positionX.fraction) * (positioningBox.width - width),

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -466,20 +466,42 @@ impl Driver {
                                 nodes
                                     .iter()
                                     .flat_map(|node| &node.background_layers)
-                                    .find_map(|layer| match layer.geometry.size {
-                                        BackgroundSizeFixture::Keyword(
-                                            BackgroundSizeKeywordFixture::Cover,
-                                        ) => Some("paint.background-layers.size-cover"),
-                                        BackgroundSizeFixture::Keyword(
-                                            BackgroundSizeKeywordFixture::Contain,
-                                        ) => Some("paint.background-layers.size-contain"),
-                                        BackgroundSizeFixture::Keyword(
-                                            BackgroundSizeKeywordFixture::Auto,
-                                        )
-                                        | BackgroundSizeFixture::ExplicitAxes { .. } => {
-                                            Some("paint.background-layers.intrinsic-auto")
+                                    .find_map(|layer| {
+                                        let round_auto_axis = matches!(
+                                            layer.geometry.size,
+                                            BackgroundSizeFixture::ExplicitAxes {
+                                                width: Some(_),
+                                                height: None,
+                                            } if layer.geometry.repeat_x == ImageRepeatFixture::Round
+                                                && layer.geometry.repeat_y != ImageRepeatFixture::Round
+                                        ) || matches!(
+                                            layer.geometry.size,
+                                            BackgroundSizeFixture::ExplicitAxes {
+                                                width: None,
+                                                height: Some(_),
+                                            } if layer.geometry.repeat_y == ImageRepeatFixture::Round
+                                                && layer.geometry.repeat_x != ImageRepeatFixture::Round
+                                        );
+                                        if round_auto_axis {
+                                            return Some(
+                                                "paint.background-layers.round-auto-aspect-ratio",
+                                            );
                                         }
-                                        BackgroundSizeFixture::ExplicitPair(_) => None,
+                                        match layer.geometry.size {
+                                            BackgroundSizeFixture::Keyword(
+                                                BackgroundSizeKeywordFixture::Cover,
+                                            ) => Some("paint.background-layers.size-cover"),
+                                            BackgroundSizeFixture::Keyword(
+                                                BackgroundSizeKeywordFixture::Contain,
+                                            ) => Some("paint.background-layers.size-contain"),
+                                            BackgroundSizeFixture::Keyword(
+                                                BackgroundSizeKeywordFixture::Auto,
+                                            )
+                                            | BackgroundSizeFixture::ExplicitAxes { .. } => {
+                                                Some("paint.background-layers.intrinsic-auto")
+                                            }
+                                            BackgroundSizeFixture::ExplicitPair(_) => None,
+                                        }
                                     })
                                     .or_else(|| {
                                         nodes
@@ -910,6 +932,18 @@ impl Driver {
                         .find(|node| node.background == *expected_color)
                         .or_else(|| {
                             expected.iter().find(|node| {
+                                node.background_layers.iter().any(|layer| {
+                                    matches!(layer.image, BackgroundImageFixture::Resource(_))
+                                }) && fixture_node_paints_at(
+                                    node,
+                                    sample.point,
+                                    &sample.color,
+                                    &self.resource_dimensions,
+                                )
+                            })
+                        })
+                        .or_else(|| {
+                            expected.iter().find(|node| {
                                 !node.background_layers.is_empty()
                                     || node.linear_gradient.is_some()
                                     || node.radial_gradient.is_some()
@@ -924,7 +958,8 @@ impl Driver {
                     assert_eq!(
                         opaque_hit.map(String::as_str),
                         Some(expected_node.as_str()),
-                        "paint sample did not hit the expected transformed scene node"
+                        "paint sample at {:?} did not hit its expected scene node",
+                        sample.point
                     );
                 }
             }
@@ -999,6 +1034,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/background-size-intrinsic-auto.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/background-size-intrinsic-auto.json"
+        ),
+        "wpt/css/css-backgrounds/background-size-auto-round-aspect-ratio.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/background-size-auto-round-aspect-ratio.json"
         ),
         "wpt/css/css-backgrounds/background-size-contain-001-intrinsic.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/background-size-contain-001-intrinsic.json"
@@ -2050,7 +2088,34 @@ fn fixture_background_layer_paints_at(
     if !fixture_rect_contains(clip_area, point) {
         return false;
     }
-    let size = fixture_background_image_size(layer.size, positioning_area, intrinsic_size);
+    let mut size = fixture_background_image_size(layer.size, positioning_area, intrinsic_size);
+    if intrinsic_size.is_some() {
+        match layer.size {
+            BackgroundSizeFixture::ExplicitAxes {
+                width: Some(_),
+                height: None,
+            } if layer.repeat_x == ImageRepeatFixture::Round
+                && layer.repeat_y != ImageRepeatFixture::Round
+                && size[0] > 0.0 =>
+            {
+                let rounded_width = fixture_round_tile_length(positioning_area[2], size[0]);
+                size[1] *= rounded_width / size[0];
+                size[0] = rounded_width;
+            }
+            BackgroundSizeFixture::ExplicitAxes {
+                width: None,
+                height: Some(_),
+            } if layer.repeat_y == ImageRepeatFixture::Round
+                && layer.repeat_x != ImageRepeatFixture::Round
+                && size[1] > 0.0 =>
+            {
+                let rounded_height = fixture_round_tile_length(positioning_area[3], size[1]);
+                size[0] *= rounded_height / size[1];
+                size[1] = rounded_height;
+            }
+            _ => {}
+        }
+    }
     let position = [
         positioning_area[0]
             + layer.position[0].length
@@ -2076,6 +2141,11 @@ fn fixture_background_layer_paints_at(
         point[1],
     );
     paints_x && paints_y
+}
+
+fn fixture_round_tile_length(area_length: f32, tile_length: f32) -> f32 {
+    let tile_count = (area_length / tile_length).round().max(1.0);
+    area_length / tile_count
 }
 
 fn fixture_background_image_size(

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -73,6 +73,13 @@
       "checkpoints": ["resource-registration", "semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.background-size-auto-round-aspect-ratio",
+      "feature": "background-size-auto-round-aspect-ratio",
+      "fixture": "wpt/css/css-backgrounds/background-size-auto-round-aspect-ratio.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["resource-registration", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.background-size-contain-001-intrinsic",
       "feature": "background-size-contain",
       "fixture": "wpt/css/css-backgrounds/background-size-contain-001-intrinsic.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -291,7 +291,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.background-layers.size-contain" ||
                             command.getString("name") ==
-                            "paint.background-layers.size-cover",
+                            "paint.background-layers.size-cover" ||
+                            command.getString("name") ==
+                            "paint.background-layers.round-auto-aspect-ratio",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -436,7 +436,8 @@ private final class Driver {
                     name == "paint.background-layers.resource-lifecycle" ||
                     name == "paint.background-layers.intrinsic-auto" ||
                     name == "paint.background-layers.size-cover" ||
-                    name == "paint.background-layers.size-contain" else {
+                    name == "paint.background-layers.size-contain" ||
+                    name == "paint.background-layers.round-auto-aspect-ratio" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()

--- a/tests/host-conformance/wpt/css/css-backgrounds/background-size-auto-round-aspect-ratio.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/background-size-auto-round-aspect-ratio.json
@@ -1,0 +1,77 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.background-size-auto-round-aspect-ratio",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/background-size-aspect-ratio.htm",
+    "license": "BSD-3-Clause",
+    "assertion": "When round changes one tile axis and the opposite background-size axis is auto, the opposite axis is rescaled to preserve the image's intrinsic aspect ratio.",
+    "adaptation": "A deterministic four-by-two raster replaces the upstream image. Separate boxes exercise horizontal and vertical round adjustment; samples just inside and outside the aspect-ratio-preserving opposite edge distinguish coupled sizing from independent axis rounding."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 220.0, "height": 80.0, "scale": 1.0 },
+      {
+        "type": "register_raster_resource",
+        "id": 1,
+        "width": 4,
+        "height": 2,
+        "pixels": [
+          { "kind": "named", "value": "red" },
+          { "kind": "named", "value": "red" },
+          { "kind": "named", "value": "red" },
+          { "kind": "named", "value": "red" },
+          { "kind": "named", "value": "red" },
+          { "kind": "named", "value": "red" },
+          { "kind": "named", "value": "red" },
+          { "kind": "named", "value": "red" }
+        ]
+      },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 60.0],
+            "background": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 },
+            "background_layers": [{
+              "geometry": {
+                "size": { "width": { "length": 40.0, "fraction": 0.0 }, "height": null },
+                "repeat_x": "round",
+                "repeat_y": "no_repeat"
+              },
+              "image": { "resource": 1 }
+            }]
+          },
+          {
+            "id": 2,
+            "parent": null,
+            "rect": [120.0, 0.0, 100.0, 80.0],
+            "background": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 },
+            "background_layers": [{
+              "geometry": {
+                "size": { "width": null, "height": { "length": 30.0, "fraction": 0.0 } },
+                "repeat_x": "no_repeat",
+                "repeat_y": "round"
+              },
+              "image": { "resource": 1 }
+            }]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.background-layers.round-auto-aspect-ratio",
+        "samples": [
+          { "point": [50.0, 15.0], "color": { "kind": "named", "value": "red" }, "tolerance": 8 },
+          { "point": [50.0, 18.0], "color": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 }, "tolerance": 8 },
+          { "point": [170.0, 40.0], "color": { "kind": "named", "value": "red" }, "tolerance": 8 },
+          { "point": [176.0, 40.0], "color": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 }, "tolerance": 8 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- adapt the WPT background-size aspect-ratio case into one shared four-Host fixture
- preserve intrinsic aspect ratio when `round` changes exactly one explicit size axis and the opposite axis is `auto`
- implement the rule in Desktop/wgpu, Android/Canvas, and iOS/CoreGraphics; Web delegates production behavior to CSS and updates its semantic oracle
- keep Android background positioning geometry at CSS float precision across non-integer display densities
- update RFC 0003 with the completed subset

## Validation

- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android` (7/7)
- `cargo xtask host-conformance ios` (8/8)
- Desktop unit test `one_axis_round_rescales_the_opposite_auto_axis`
- relevant Desktop/Web clippy checks with `-D warnings`

## Stack

Depends on #453.