### PR TITLE
docs(css): adopt Taffy and Lynx capability baselines

### DIFF
--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -1277,6 +1277,7 @@ impl LengthPercentageFixture {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     #[test]
     fn repository_suite_is_well_formed() {
@@ -1294,5 +1295,60 @@ mod tests {
         );
         assert!(desktop.iter().any(|case| case.scenario.reference.is_some()));
         assert!(desktop.iter().any(|case| case.scenario.upstream.is_none()));
+    }
+
+    #[test]
+    fn capability_target_is_complete_and_disjoint() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/host-conformance");
+        let source = std::fs::read_to_string(root.join("capabilities.json")).unwrap();
+        let document: serde_json::Value = serde_json::from_str(&source).unwrap();
+        assert_eq!(document["schema"], 2);
+
+        let target = &document["target"];
+        let properties = document["capabilities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|capability| capability["properties"].as_array().into_iter().flatten())
+            .map(|property| property.as_str().unwrap())
+            .collect::<Vec<_>>();
+        let unique = properties.iter().copied().collect::<BTreeSet<_>>();
+        assert_eq!(
+            properties.len(),
+            target["property_count"].as_u64().unwrap() as usize
+        );
+        assert_eq!(unique.len(), properties.len());
+
+        let excluded = document["excluded_registered_properties"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|entry| entry["property"].as_str().unwrap())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            excluded.len(),
+            target["excluded_registered_property_count"]
+                .as_u64()
+                .unwrap() as usize
+        );
+        assert!(unique.is_disjoint(&excluded));
+
+        let pending = target["pending_registry_properties"].as_array().unwrap();
+        assert_eq!(
+            unique.len() - pending.len(),
+            target["target_registered_property_count"].as_u64().unwrap() as usize
+        );
+        assert_eq!(
+            target["target_registered_property_count"].as_u64().unwrap()
+                + target["excluded_registered_property_count"]
+                    .as_u64()
+                    .unwrap(),
+            target["registered_property_count"].as_u64().unwrap()
+        );
+        assert_eq!(
+            target["property_count"].as_u64().unwrap()
+                + target["non_property_features"].as_array().unwrap().len() as u64,
+            target["feature_count"].as_u64().unwrap()
+        );
     }
 }

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -702,23 +702,32 @@ Hydration identity is based on stable scene/node markers and application
 state, not generated class names. The exact HTML format, streaming model, and
 hydration protocol remain a later RFC.
 
-## Lynx styling coverage
+## Styling coverage
 
-The initial conformance target is fixed at 175 standard CSS features:
+The conformance target has two normative sources:
 
-- 156 standard properties from Lynx's 191-property inventory pinned at
-  `18a0a91009809de1d52a5637b82f573dc924e32a` after excluding 32 Lynx-specific
-  properties and three non-standard unprefixed `text-stroke*` properties;
-- 19 standard features present in Whisker's existing registry but absent from
-  that Lynx inventory;
-- represented in code as 174 `StyleProperty` entries plus CSS Custom
-  Properties as one non-fixed-property mechanism.
+- layout properties follow the CSS semantics represented by Taffy 0.13;
+- all other properties follow the standard, non-vendor Lynx 4.0 inventory
+  pinned at `18a0a91009809de1d52a5637b82f573dc924e32a`.
+
+This produces 158 target features: 157 properties plus CSS Custom Properties
+as one non-fixed-property mechanism. Of the current 174 `StyleProperty`
+entries, 154 remain in the target and 20 are deliberately unsupported. The
+Taffy baseline additionally requires `float`, `clear`, and
+`grid-template-areas`, which receive new stable IDs when registered.
+
+Taffy-supported Block, Flexbox, and Grid semantics are in scope. Browser
+layout modes or values that Taffy 0.13 cannot represent, including inline and
+table layout, subgrid, masonry, `position: static/fixed/sticky`, and
+`overflow: auto`, are deliberately outside the target. Taffy's feature-gated
+float layout and `calc()` resolution are part of the target and must be
+enabled by the Whisker layout integration.
 
 The deprecated aliases `grid-column-gap`, `grid-row-gap`, and `word-wrap` are
 not separate target features. Their canonical spellings are used. Retired
 numeric property IDs stay reserved and must not be reassigned. The normative
-machine-readable partition is
-`tests/host-conformance/capabilities.json`.
+machine-readable partition, including exclusion rationale, implementation
+status, and browser-subset notes, is `tests/host-conformance/capabilities.json`.
 
 Migration tracks semantic capability rather than CSS syntax. A generated
 property registry and coverage table must classify every Lynx style feature

--- a/tests/host-conformance/README.md
+++ b/tests/host-conformance/README.md
@@ -78,12 +78,12 @@ treated as successful no-op support. `partial` means at least one value family
 or required checkpoint is still missing, even when the common operation is
 already consumed.
 
-The target is pinned to 175 standard CSS conformance features: 174 registered
-property spellings plus the CSS Custom Properties mechanism. It starts from
-the 191-property Lynx inventory at the recorded upstream revision, excludes 32
-Lynx-only properties and the three unprefixed non-standard `text-stroke*`
-spellings, then adds 19 standard properties that were already part of
-Whisker's registry. The legacy aliases `grid-column-gap`, `grid-row-gap`, and
-`word-wrap` are intentionally absent; their canonical spellings are tracked
-instead. Stable IDs previously assigned to removed compatibility spellings are
-reserved and are never reused.
+The target follows two explicit baselines. Layout semantics are the CSS subset
+represented by Taffy 0.13. Non-layout properties follow the standard,
+non-vendor Lynx 4.0 inventory at the recorded upstream revision. The resulting
+target is 158 conformance features: 157 properties plus the CSS Custom
+Properties mechanism. Of the 174 currently registered spellings, 154 remain
+in the target, 20 are deliberately unsupported, and `float`, `clear`, and
+`grid-template-areas` still need registry entries. The legacy aliases
+`grid-column-gap`, `grid-row-gap`, and `word-wrap` remain absent. Stable IDs
+assigned to excluded spellings are reserved and are never reused.

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -1,8 +1,22 @@
 {
-  "schema": 1,
+  "schema": 2,
+  "policy": {
+    "layout": {
+      "basis": "taffy-0.13",
+      "rule": "Support the CSS layout semantics represented by Taffy 0.13; unsupported browser layout modes and values are out of scope."
+    },
+    "non_layout": {
+      "basis": "lynx-4.0",
+      "rule": "Follow the standard, non-vendor Lynx property grammar and semantics."
+    }
+  },
   "target": {
-    "feature_count": 175,
-    "property_count": 174,
+    "feature_count": 158,
+    "property_count": 157,
+    "registered_property_count": 174,
+    "target_registered_property_count": 154,
+    "pending_registry_properties": ["clear", "float", "grid-template-areas"],
+    "excluded_registered_property_count": 20,
     "non_property_features": ["custom-properties"],
     "lynx_inventory": {
       "revision": "18a0a91009809de1d52a5637b82f573dc924e32a",
@@ -10,72 +24,139 @@
     }
   },
   "statuses": ["implemented", "partial", "protocol-only", "planned", "not-applicable"],
+  "excluded_registered_properties": [
+    {"property": "backface-visibility", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "background-attachment", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "background-position-x", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "background-position-y", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "caret-color", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "font-variant", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "outline-color", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "outline-offset", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "outline-style", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "outline-width", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "overflow-wrap", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "perspective-origin", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "text-decoration-color", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "text-decoration-line", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "text-decoration-style", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "text-decoration-thickness", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "text-transform", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "transform-box", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "transform-style", "reason": "not-in-lynx-non-layout-baseline"},
+    {"property": "vertical-align", "reason": "requires-inline-or-table-layout-not-supported-by-taffy"}
+  ],
   "capabilities": [
     {
-      "id": "layout.geometry",
-      "properties": ["align-content", "align-items", "align-self", "aspect-ratio", "bottom", "box-sizing", "column-gap", "display", "flex", "flex-basis", "flex-direction", "flex-flow", "flex-grow", "flex-shrink", "flex-wrap", "gap", "grid-auto-columns", "grid-auto-flow", "grid-auto-rows", "grid-column", "grid-column-end", "grid-column-start", "grid-row", "grid-row-end", "grid-row-start", "grid-template-columns", "grid-template-rows", "height", "inset-inline-end", "inset-inline-start", "justify-content", "justify-items", "justify-self", "left", "margin", "margin-bottom", "margin-inline-end", "margin-inline-start", "margin-left", "margin-right", "margin-top", "max-height", "max-width", "min-height", "min-width", "order", "padding", "padding-bottom", "padding-inline-end", "padding-inline-start", "padding-left", "padding-right", "padding-top", "position", "right", "row-gap", "top", "vertical-align", "width"],
+      "id": "layout.core",
+      "basis": "taffy-0.13",
+      "properties": ["align-content", "align-items", "align-self", "aspect-ratio", "bottom", "box-sizing", "column-gap", "direction", "display", "flex", "flex-basis", "flex-direction", "flex-flow", "flex-grow", "flex-shrink", "flex-wrap", "gap", "height", "inset-inline-end", "inset-inline-start", "justify-content", "left", "margin", "margin-bottom", "margin-inline-end", "margin-inline-start", "margin-left", "margin-right", "margin-top", "max-height", "max-width", "min-height", "min-width", "order", "padding", "padding-bottom", "padding-inline-end", "padding-inline-start", "padding-left", "padding-right", "padding-top", "position", "right", "row-gap", "top", "width"],
+      "supported_subset": ["block-flex-grid", "relative-absolute-position", "length-percentage-auto-sizing", "content-border-box", "ltr-rtl"],
+      "unsupported_browser_subset": ["display-contents-inline-table", "static-fixed-sticky-position", "intrinsic-size-keywords"],
       "protocol": ["SetLayout"],
+      "rust": "partial",
+      "hosts": {"desktop": "not-applicable", "web": "not-applicable", "android": "not-applicable", "ios": "not-applicable"}
+    },
+    {
+      "id": "layout.grid",
+      "basis": "taffy-0.13",
+      "properties": ["grid-auto-columns", "grid-auto-flow", "grid-auto-rows", "grid-column", "grid-column-end", "grid-column-start", "grid-row", "grid-row-end", "grid-row-start", "grid-template-areas", "grid-template-columns", "grid-template-rows", "justify-items", "justify-self"],
+      "supported_subset": ["explicit-implicit-tracks", "fr-minmax-fit-content-repeat", "auto-fill-auto-fit", "row-column-dense-flow", "line-span-named-placement", "named-areas"],
+      "unsupported_browser_subset": ["subgrid", "masonry"],
+      "protocol": ["SetLayout"],
+      "rust": "planned",
+      "hosts": {"desktop": "not-applicable", "web": "not-applicable", "android": "not-applicable", "ios": "not-applicable"}
+    },
+    {
+      "id": "layout.float",
+      "basis": "taffy-0.13-float-layout",
+      "properties": ["clear", "float"],
+      "supported_subset": ["block-formatting-context-floats"],
+      "protocol": ["SetLayout"],
+      "rust": "planned",
       "hosts": {"desktop": "not-applicable", "web": "not-applicable", "android": "not-applicable", "ios": "not-applicable"}
     },
     {
       "id": "paint.box",
+      "basis": "lynx-4.0",
       "properties": ["background-color", "border", "border-bottom", "border-bottom-color", "border-bottom-left-radius", "border-bottom-right-radius", "border-bottom-style", "border-bottom-width", "border-color", "border-end-end-radius", "border-end-start-radius", "border-inline-end-color", "border-inline-end-style", "border-inline-end-width", "border-inline-start-color", "border-inline-start-style", "border-inline-start-width", "border-left", "border-left-color", "border-left-style", "border-left-width", "border-radius", "border-right", "border-right-color", "border-right-style", "border-right-width", "border-start-end-radius", "border-start-start-radius", "border-style", "border-top", "border-top-color", "border-top-left-radius", "border-top-right-radius", "border-top-style", "border-top-width", "border-width"],
       "protocol": ["SetBoxPaint"],
+      "rust": "partial",
       "hosts": {"desktop": "partial", "web": "implemented", "android": "partial", "ios": "partial"}
     },
     {
       "id": "paint.background-layers",
-      "properties": ["background", "background-attachment", "background-clip", "background-image", "background-origin", "background-position", "background-position-x", "background-position-y", "background-repeat", "background-size"],
+      "basis": "lynx-4.0",
+      "properties": ["background", "background-clip", "background-image", "background-origin", "background-position", "background-repeat", "background-size"],
       "protocol": ["SetBackgroundLayers"],
+      "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}
     },
     {
       "id": "paint.visual-effects",
-      "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image", "outline-color", "outline-offset", "outline-style", "outline-width"],
+      "basis": "lynx-4.0",
+      "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
+      "rust": "protocol-only",
       "hosts": {"desktop": "protocol-only", "web": "protocol-only", "android": "protocol-only", "ios": "protocol-only"}
     },
     {
       "id": "paint.transform",
-      "properties": ["backface-visibility", "offset-distance", "offset-path", "offset-rotate", "perspective", "perspective-origin", "transform", "transform-box", "transform-origin", "transform-style"],
+      "basis": "lynx-4.0",
+      "properties": ["offset-distance", "offset-path", "offset-rotate", "perspective", "transform", "transform-origin"],
       "protocol": ["SetTransform", "SetVisualEffects"],
+      "rust": "partial",
       "hosts": {"desktop": "planned", "web": "implemented", "android": "planned", "ios": "planned"}
     },
     {
       "id": "paint.compositing",
+      "basis": "lynx-4.0",
       "properties": ["opacity", "visibility", "z-index"],
       "protocol": ["SetOpacity", "SetVisibility", "SetZOrder"],
+      "rust": "implemented",
       "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}
     },
     {
       "id": "paint.clip-scroll",
+      "basis": "taffy-0.13-layout-and-lynx-4.0-paint",
       "properties": ["overflow", "overflow-x", "overflow-y"],
+      "supported_subset": ["visible", "clip", "hidden", "scroll"],
+      "unsupported_browser_subset": ["auto"],
       "protocol": ["SetClip"],
+      "rust": "partial",
       "hosts": {"desktop": "partial", "web": "implemented", "android": "partial", "ios": "partial"}
     },
     {
       "id": "paint.text",
-      "properties": ["color", "direction", "font-family", "font-feature-settings", "font-optical-sizing", "font-size", "font-style", "font-variation-settings", "font-variant", "font-weight", "letter-spacing", "line-height", "overflow-wrap", "text-align", "text-decoration", "text-decoration-color", "text-decoration-line", "text-decoration-style", "text-decoration-thickness", "text-indent", "text-overflow", "text-shadow", "text-transform", "white-space", "word-break"],
+      "basis": "lynx-4.0",
+      "properties": ["color", "font-family", "font-feature-settings", "font-optical-sizing", "font-size", "font-style", "font-variation-settings", "font-weight", "letter-spacing", "line-height", "text-align", "text-decoration", "text-indent", "text-overflow", "text-shadow", "white-space", "word-break"],
       "protocol": ["SetText"],
+      "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}
     },
     {
       "id": "interaction.pointer",
-      "properties": ["caret-color", "cursor", "pointer-events"],
+      "basis": "lynx-4.0",
+      "properties": ["cursor", "pointer-events"],
       "protocol": ["SetCursor", "SetHitTest", "SetProperty"],
+      "rust": "protocol-only",
       "hosts": {"desktop": "protocol-only", "web": "protocol-only", "android": "protocol-only", "ios": "protocol-only"}
     },
     {
       "id": "motion.rust",
+      "basis": "lynx-4.0",
       "properties": ["animation", "animation-delay", "animation-direction", "animation-duration", "animation-fill-mode", "animation-iteration-count", "animation-name", "animation-play-state", "animation-timing-function", "transition", "transition-delay", "transition-duration", "transition-property", "transition-timing-function"],
       "protocol": [],
+      "rust": "planned",
       "hosts": {"desktop": "not-applicable", "web": "not-applicable", "android": "not-applicable", "ios": "not-applicable"}
     },
     {
       "id": "style.custom-properties",
+      "basis": "lynx-4.0",
       "features": ["custom-properties"],
       "properties": [],
       "protocol": [],
+      "rust": "planned",
       "hosts": {"desktop": "not-applicable", "web": "not-applicable", "android": "not-applicable", "ios": "not-applicable"}
     }
   ]


### PR DESCRIPTION
## Summary
- make Taffy 0.13 the normative layout baseline and Lynx 4.0 the non-layout baseline
- classify 157 target properties, 20 excluded registered properties, and three pending Taffy properties
- split Grid and float layout into independently tracked capabilities
- validate target counts, uniqueness, and exclusion disjointness in Rust tests

## Verification
- `cargo test -p whisker-host-conformance`
- `cargo fmt --all -- --check`
- `git diff --check`