### PR TITLE
feat(layout): implement Taffy Grid end to end

### DIFF
--- a/crates/whisker-css/src/lib.rs
+++ b/crates/whisker-css/src/lib.rs
@@ -72,6 +72,8 @@ pub use crate::shorthand::{
 };
 pub use crate::to_css::ToCss;
 pub use crate::value::{
-    BorderRadius, FlexBasis, GridLine, GridTemplate, ImageRef, LineHeight, Repeated, Size,
+    BorderRadius, FlexBasis, GridArea, GridLine, GridRepeatCount, GridTemplate, GridTemplateAreas,
+    GridTemplateComponent, GridTrack, GridTrackMax, GridTrackMin, ImageRef, LineHeight, Repeated,
+    Size,
 };
 pub use whisker_style::{PropertyMetadata, PropertyOrigin, StyleProperty, StylePropertyId};

--- a/crates/whisker-css/src/prop/grid.rs
+++ b/crates/whisker-css/src/prop/grid.rs
@@ -1,76 +1,125 @@
 //! CSS Grid properties.
 
 use crate::css::Css;
-use crate::keyword::GridAutoFlow;
-use crate::value::{GridLine, GridTemplate};
+use crate::keyword::{AlignItems, AlignSelf, GridAutoFlow};
+use crate::style_value::grid_auto_tracks;
+use crate::to_css::ToCss;
+use crate::value::{GridLine, GridTemplate, GridTemplateAreas, GridTrack};
 
 impl Css {
     /// Sets `grid-template-rows` — track-sizing along the block axis.
     /// <https://lynxjs.org/api/css/properties/grid-template-rows>
     pub fn grid_template_rows(self, v: GridTemplate) -> Self {
-        self.push(crate::StyleProperty::GridTemplateRows, v)
+        self.push_typed(crate::StyleProperty::GridTemplateRows, v)
     }
 
     /// Sets `grid-template-columns` — track-sizing along the inline axis.
     /// <https://lynxjs.org/api/css/properties/grid-template-columns>
     pub fn grid_template_columns(self, v: GridTemplate) -> Self {
-        self.push(crate::StyleProperty::GridTemplateColumns, v)
+        self.push_typed(crate::StyleProperty::GridTemplateColumns, v)
+    }
+
+    /// Sets named rectangular Grid regions.
+    pub fn grid_template_areas(self, v: GridTemplateAreas) -> Self {
+        self.push_typed(crate::StyleProperty::GridTemplateAreas, v)
     }
 
     /// Sets `grid-auto-rows`.
     /// <https://lynxjs.org/api/css/properties/grid-auto-rows>
-    pub fn grid_auto_rows(self, v: GridTemplate) -> Self {
-        self.push(crate::StyleProperty::GridAutoRows, v)
+    pub fn grid_auto_rows<T: Into<GridTrack>>(self, v: impl IntoIterator<Item = T>) -> Self {
+        let template = GridTemplate::tracks(v);
+        let css = template.to_css_string();
+        self.push_semantic(
+            crate::StyleProperty::GridAutoRows,
+            grid_auto_tracks(&template),
+            css,
+        )
     }
 
     /// Sets `grid-auto-columns`.
     /// <https://lynxjs.org/api/css/properties/grid-auto-columns>
-    pub fn grid_auto_columns(self, v: GridTemplate) -> Self {
-        self.push(crate::StyleProperty::GridAutoColumns, v)
+    pub fn grid_auto_columns<T: Into<GridTrack>>(self, v: impl IntoIterator<Item = T>) -> Self {
+        let template = GridTemplate::tracks(v);
+        let css = template.to_css_string();
+        self.push_semantic(
+            crate::StyleProperty::GridAutoColumns,
+            grid_auto_tracks(&template),
+            css,
+        )
     }
 
     /// Sets `grid-auto-flow`.
     /// <https://lynxjs.org/api/css/properties/grid-auto-flow>
     pub fn grid_auto_flow(self, v: GridAutoFlow) -> Self {
-        self.push(crate::StyleProperty::GridAutoFlow, v)
+        self.push_typed(crate::StyleProperty::GridAutoFlow, v)
     }
 
     /// Sets `grid-row-start`.
     /// <https://lynxjs.org/api/css/properties/grid-row-start>
     pub fn grid_row_start(self, v: GridLine) -> Self {
-        self.push(crate::StyleProperty::GridRowStart, v)
+        self.push_typed(crate::StyleProperty::GridRowStart, v)
     }
 
     /// Sets `grid-row-end`.
     /// <https://lynxjs.org/api/css/properties/grid-row-end>
     pub fn grid_row_end(self, v: GridLine) -> Self {
-        self.push(crate::StyleProperty::GridRowEnd, v)
+        self.push_typed(crate::StyleProperty::GridRowEnd, v)
     }
 
     /// Sets `grid-column-start`.
     /// <https://lynxjs.org/api/css/properties/grid-column-start>
     pub fn grid_column_start(self, v: GridLine) -> Self {
-        self.push(crate::StyleProperty::GridColumnStart, v)
+        self.push_typed(crate::StyleProperty::GridColumnStart, v)
     }
 
     /// Sets `grid-column-end`.
     /// <https://lynxjs.org/api/css/properties/grid-column-end>
     pub fn grid_column_end(self, v: GridLine) -> Self {
-        self.push(crate::StyleProperty::GridColumnEnd, v)
+        self.push_typed(crate::StyleProperty::GridColumnEnd, v)
+    }
+
+    /// Sets both `grid-row-start` and `grid-row-end`.
+    pub fn grid_row(self, start: GridLine, end: GridLine) -> Self {
+        self.grid_row_start(start).grid_row_end(end)
+    }
+
+    /// Sets both `grid-column-start` and `grid-column-end`.
+    pub fn grid_column(self, start: GridLine, end: GridLine) -> Self {
+        self.grid_column_start(start).grid_column_end(end)
+    }
+
+    /// Sets Grid inline-axis alignment for all children.
+    pub fn justify_items(self, v: AlignItems) -> Self {
+        self.push_typed(crate::StyleProperty::JustifyItems, v)
+    }
+
+    /// Sets Grid inline-axis alignment for this item.
+    pub fn justify_self(self, v: AlignSelf) -> Self {
+        self.push_typed(crate::StyleProperty::JustifySelf, v)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::Css;
+    use crate::ext::*;
     use crate::keyword::GridAutoFlow;
-    use crate::value::{GridLine, GridTemplate};
+    use crate::value::{
+        GridArea, GridLine, GridRepeatCount, GridTemplate, GridTemplateAreas, GridTrack,
+        GridTrackMax, GridTrackMin,
+    };
 
     #[test]
     fn template_rows_and_columns() {
         let s = Css::new()
-            .grid_template_rows(GridTemplate::tracks(["auto", "1fr"]))
-            .grid_template_columns(GridTemplate::tracks(["1fr", "2fr"]));
+            .grid_template_rows(GridTemplate::tracks([
+                GridTrack::auto(),
+                GridTrack::fraction(1.0),
+            ]))
+            .grid_template_columns(GridTemplate::tracks([
+                GridTrack::fraction(1.0),
+                GridTrack::fraction(2.0),
+            ]));
         assert_eq!(
             s.to_string(),
             "grid-template-rows: auto 1fr; grid-template-columns: 1fr 2fr;"
@@ -80,8 +129,8 @@ mod tests {
     #[test]
     fn auto_rows_columns_flow() {
         let s = Css::new()
-            .grid_auto_rows(GridTemplate::tracks(["minmax(100px, auto)"]))
-            .grid_auto_columns(GridTemplate::tracks(["50px"]))
+            .grid_auto_rows([GridTrack::minmax(px(100).into(), GridTrackMax::Auto)])
+            .grid_auto_columns([GridTrack::fixed(px(50))])
             .grid_auto_flow(GridAutoFlow::ColumnDense);
         assert_eq!(
             s.to_string(),
@@ -100,5 +149,70 @@ mod tests {
             s.to_string(),
             "grid-row-start: 1; grid-row-end: span 2; grid-column-start: auto; grid-column-end: -1;"
         );
+    }
+
+    #[test]
+    fn semantic_grid_values_are_available_without_css_parsing() {
+        let style = Css::new()
+            .grid_template_columns(GridTemplate::tracks([
+                GridTrack::fraction(1.0),
+                GridTrack::minmax(GridTrackMin::MinContent, GridTrackMax::Fraction(2.0)),
+            ]))
+            .grid_row(GridLine::Number(1), GridLine::Span(2))
+            .to_specified_style()
+            .expect("all grid declarations should be typed");
+        let value = |property| {
+            style
+                .declarations()
+                .find(|declaration| declaration.property() == property)
+                .map(|declaration| declaration.value())
+        };
+        assert!(matches!(
+            value(crate::StyleProperty::GridTemplateColumns),
+            Some(whisker_style::StyleValue::GridTemplate(_))
+        ));
+        assert!(matches!(
+            value(crate::StyleProperty::GridRowEnd),
+            Some(whisker_style::StyleValue::GridPlacement(_))
+        ));
+    }
+
+    #[test]
+    fn named_areas_are_typed_and_serialize_as_css_rows() {
+        let areas = GridTemplateAreas::new(2, 2)
+            .area(GridArea::new("header", 0, 1, 0, 2))
+            .area(GridArea::new("main", 1, 2, 1, 2));
+        let css = Css::new().grid_template_areas(areas);
+        assert_eq!(
+            css.to_string(),
+            "grid-template-areas: \"header header\" \". main\";"
+        );
+        css.to_specified_style()
+            .expect("grid-template-areas should not require CSS parsing");
+    }
+
+    #[test]
+    fn repeat_and_named_lines_remain_semantic() {
+        let template = GridTemplate::repeat(
+            GridRepeatCount::AutoFit,
+            [GridTrack::minmax(
+                GridTrackMin::Fixed(px(100).into()),
+                GridTrackMax::Fraction(1.0),
+            )],
+        )
+        .line_names([["content-start"], ["content-end"]]);
+        let css = Css::new().grid_template_columns(template);
+        assert_eq!(
+            css.to_string(),
+            "grid-template-columns: [content-start] repeat(auto-fit, minmax(100px, 1fr)) [content-end];"
+        );
+        let specified = css
+            .to_specified_style()
+            .expect("repeat() should not require CSS parsing");
+        assert!(matches!(
+            specified.declarations().next().map(|value| value.value()),
+            Some(whisker_style::StyleValue::GridTemplate(template))
+                if matches!(template.components.as_slice(), [whisker_style::GridTemplateComponentValue::Repeat(_)])
+        ));
     }
 }

--- a/crates/whisker-css/src/style_value.rs
+++ b/crates/whisker-css/src/style_value.rs
@@ -3,16 +3,20 @@
 use whisker_style::{
     AlignContentValue, AlignItemsValue, AlignSelfValue, BorderRadiusValue, BorderStyleValue,
     BoxSizingValue, CalcExpression, ColorValue, DirectionValue, DisplayValue, FlexBasisValue,
-    FlexDirectionValue, FlexWrapValue, FontStyleValue, FontWeightValue, JustifyContentValue,
+    FlexDirectionValue, FlexWrapValue, FontStyleValue, FontWeightValue, GridAutoFlowValue,
+    GridMaxTrackSizingValue, GridMinTrackSizingValue, GridPlacementValue, GridRepetitionCountValue,
+    GridTemplateAreaValue, GridTemplateAreasValue, GridTemplateComponentValue,
+    GridTemplateRepetitionValue, GridTemplateValue, GridTrackSizingValue, JustifyContentValue,
     LengthPercentageAutoValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue,
     PositionValue, SizeValue, StyleNumber, StyleValue,
 };
 
 use crate::{
     AlignContent, AlignItems, AlignSelf, Angle, BoxSizing, CalcExpr, Color, CssString, Direction,
-    Display, FlexBasis, FlexDirection, FlexWrap, FontStyle, FontWeight, Integer, JustifyContent,
-    Length, LengthPercentage, LineHeight, MarginValue, Number, Overflow, Percentage, PositionKind,
-    Size, Visibility,
+    Display, FlexBasis, FlexDirection, FlexWrap, FontStyle, FontWeight, GridAutoFlow, GridLine,
+    GridRepeatCount, GridTemplate, GridTemplateAreas, GridTemplateComponent, GridTrack,
+    GridTrackMax, GridTrackMin, Integer, JustifyContent, Length, LengthPercentage, LineHeight,
+    MarginValue, Number, Overflow, Percentage, PositionKind, Size, Visibility,
 };
 use whisker_style::{OverflowValue, VisibilityValue};
 
@@ -261,6 +265,127 @@ impl ToStyleValue for FlexBasis {
                 FlexBasisValue::LengthPercentage(to_length_percentage(value))
             }
         })
+    }
+}
+
+impl ToStyleValue for GridLine {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::GridPlacement(match self {
+            Self::Auto => GridPlacementValue::Auto,
+            Self::Number(value) => GridPlacementValue::Line(*value),
+            Self::Span(value) => GridPlacementValue::Span(*value),
+            Self::Named(name, occurrence) => {
+                GridPlacementValue::NamedLine(name.clone(), *occurrence)
+            }
+            Self::NamedSpan(name, occurrence) => {
+                GridPlacementValue::NamedSpan(name.clone(), *occurrence)
+            }
+        })
+    }
+}
+
+impl ToStyleValue for GridAutoFlow {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::GridAutoFlow(match self {
+            Self::Row => GridAutoFlowValue::Row,
+            Self::Column => GridAutoFlowValue::Column,
+            Self::RowDense => GridAutoFlowValue::RowDense,
+            Self::ColumnDense => GridAutoFlowValue::ColumnDense,
+        })
+    }
+}
+
+impl ToStyleValue for GridTemplate {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::GridTemplate(GridTemplateValue {
+            components: self
+                .components
+                .iter()
+                .map(to_grid_template_component)
+                .collect(),
+            line_names: self.line_names.clone(),
+        })
+    }
+}
+
+impl ToStyleValue for GridTemplateAreas {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::GridTemplateAreas(GridTemplateAreasValue {
+            areas: self
+                .areas
+                .iter()
+                .map(|area| GridTemplateAreaValue {
+                    name: area.name.clone(),
+                    row_start: area.row_start,
+                    row_end: area.row_end,
+                    column_start: area.column_start,
+                    column_end: area.column_end,
+                })
+                .collect(),
+            row_count: self.row_count,
+            column_count: self.column_count,
+        })
+    }
+}
+
+pub(crate) fn grid_auto_tracks(value: &GridTemplate) -> StyleValue {
+    StyleValue::GridTracks(
+        value
+            .components
+            .iter()
+            .filter_map(|component| match component {
+                GridTemplateComponent::Track(track) => Some(to_grid_track(track)),
+                GridTemplateComponent::Repeat { .. } => None,
+            })
+            .collect(),
+    )
+}
+
+fn to_grid_template_component(value: &GridTemplateComponent) -> GridTemplateComponentValue {
+    match value {
+        GridTemplateComponent::Track(track) => {
+            GridTemplateComponentValue::Track(to_grid_track(track))
+        }
+        GridTemplateComponent::Repeat {
+            count,
+            tracks,
+            line_names,
+        } => GridTemplateComponentValue::Repeat(GridTemplateRepetitionValue {
+            count: match count {
+                GridRepeatCount::Count(value) => GridRepetitionCountValue::Count(*value),
+                GridRepeatCount::AutoFill => GridRepetitionCountValue::AutoFill,
+                GridRepeatCount::AutoFit => GridRepetitionCountValue::AutoFit,
+            },
+            tracks: tracks.iter().map(to_grid_track).collect(),
+            line_names: line_names.clone(),
+        }),
+    }
+}
+
+fn to_grid_track(value: &GridTrack) -> GridTrackSizingValue {
+    GridTrackSizingValue {
+        min: match &value.min {
+            GridTrackMin::Fixed(value) => {
+                GridMinTrackSizingValue::Fixed(to_length_percentage(value))
+            }
+            GridTrackMin::MinContent => GridMinTrackSizingValue::MinContent,
+            GridTrackMin::MaxContent => GridMinTrackSizingValue::MaxContent,
+            GridTrackMin::Auto => GridMinTrackSizingValue::Auto,
+        },
+        max: match &value.max {
+            GridTrackMax::Fixed(value) => {
+                GridMaxTrackSizingValue::Fixed(to_length_percentage(value))
+            }
+            GridTrackMax::MinContent => GridMaxTrackSizingValue::MinContent,
+            GridTrackMax::MaxContent => GridMaxTrackSizingValue::MaxContent,
+            GridTrackMax::FitContent(value) => {
+                GridMaxTrackSizingValue::FitContent(to_length_percentage(value))
+            }
+            GridTrackMax::Auto => GridMaxTrackSizingValue::Auto,
+            GridTrackMax::Fraction(value) => {
+                GridMaxTrackSizingValue::Fraction(StyleNumber::new(*value))
+            }
+        },
     }
 }
 

--- a/crates/whisker-css/src/value.rs
+++ b/crates/whisker-css/src/value.rs
@@ -264,19 +264,23 @@ fn write_four(dest: &mut dyn fmt::Write, v: &[LengthPercentage; 4]) -> fmt::Resu
     Ok(())
 }
 
-// ---------- GridLine, GridTemplate ----------
+// ---------- CSS Grid ----------
 
 /// Value for `grid-row-start`, `grid-row-end`, `grid-column-start`,
 /// `grid-column-end`. Lynx accepts numeric line references and
 /// `span <integer>`.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum GridLine {
     /// `auto` — let the layout algorithm decide.
     Auto,
     /// Numeric line reference; negative values count from the end.
-    Number(i32),
+    Number(i16),
     /// `span <integer>` — span N tracks from the opposite edge.
-    Span(u32),
+    Span(u16),
+    /// A named line, optionally selecting the nth occurrence.
+    Named(String, i16),
+    /// Span to a named line.
+    NamedSpan(String, u16),
 }
 
 impl ToCss for GridLine {
@@ -285,35 +289,479 @@ impl ToCss for GridLine {
             GridLine::Auto => dest.write_str("auto"),
             GridLine::Number(n) => write!(dest, "{n}"),
             GridLine::Span(n) => write!(dest, "span {n}"),
+            GridLine::Named(name, occurrence) if *occurrence == 0 => dest.write_str(name),
+            GridLine::Named(name, occurrence) => write!(dest, "{occurrence} {name}"),
+            GridLine::NamedSpan(name, occurrence) if *occurrence == 0 => {
+                write!(dest, "span {name}")
+            }
+            GridLine::NamedSpan(name, occurrence) => write!(dest, "span {occurrence} {name}"),
         }
     }
 }
 
-/// Value for `grid-template-rows` / `grid-template-columns`. Lynx
-/// accepts a sequence of track-sizing values; this struct stores
-/// them as already-serialized track strings since the grammar is
-/// rich enough that a typed model is impractical.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct GridTemplate(pub String);
+/// Minimum sizing function accepted by `minmax()`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GridTrackMin {
+    /// A fixed length or percentage.
+    Fixed(LengthPercentage),
+    /// The minimum intrinsic contribution.
+    MinContent,
+    /// The maximum intrinsic contribution.
+    MaxContent,
+    /// Automatic minimum sizing.
+    Auto,
+}
+
+/// Maximum sizing function accepted by `minmax()`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GridTrackMax {
+    /// A fixed length or percentage.
+    Fixed(LengthPercentage),
+    /// The minimum intrinsic contribution.
+    MinContent,
+    /// The maximum intrinsic contribution.
+    MaxContent,
+    /// `fit-content(<limit>)`.
+    FitContent(LengthPercentage),
+    /// Automatic maximum sizing.
+    Auto,
+    /// A flexible share in `fr` units.
+    Fraction(f32),
+}
+
+/// One CSS Grid track sizing function.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GridTrack {
+    pub(crate) min: GridTrackMin,
+    pub(crate) max: GridTrackMax,
+}
+
+impl GridTrack {
+    /// `auto`.
+    pub const fn auto() -> Self {
+        Self {
+            min: GridTrackMin::Auto,
+            max: GridTrackMax::Auto,
+        }
+    }
+
+    /// `min-content`.
+    pub const fn min_content() -> Self {
+        Self {
+            min: GridTrackMin::MinContent,
+            max: GridTrackMax::MinContent,
+        }
+    }
+
+    /// `max-content`.
+    pub const fn max_content() -> Self {
+        Self {
+            min: GridTrackMin::MaxContent,
+            max: GridTrackMax::MaxContent,
+        }
+    }
+
+    /// A fixed length or percentage.
+    pub fn fixed(value: impl Into<LengthPercentage>) -> Self {
+        let value = value.into();
+        Self {
+            min: GridTrackMin::Fixed(value.clone()),
+            max: GridTrackMax::Fixed(value),
+        }
+    }
+
+    /// A flexible `fr` track.
+    pub const fn fraction(value: f32) -> Self {
+        Self {
+            min: GridTrackMin::Auto,
+            max: GridTrackMax::Fraction(value),
+        }
+    }
+
+    /// `fit-content(<limit>)`.
+    pub fn fit_content(limit: impl Into<LengthPercentage>) -> Self {
+        Self {
+            min: GridTrackMin::Auto,
+            max: GridTrackMax::FitContent(limit.into()),
+        }
+    }
+
+    /// `minmax(<min>, <max>)`.
+    pub const fn minmax(min: GridTrackMin, max: GridTrackMax) -> Self {
+        Self { min, max }
+    }
+}
+
+impl From<Length> for GridTrack {
+    fn from(value: Length) -> Self {
+        Self::fixed(value)
+    }
+}
+
+impl From<Percentage> for GridTrack {
+    fn from(value: Percentage) -> Self {
+        Self::fixed(value)
+    }
+}
+
+impl From<LengthPercentage> for GridTrack {
+    fn from(value: LengthPercentage) -> Self {
+        Self::fixed(value)
+    }
+}
+
+impl From<Length> for GridTrackMin {
+    fn from(value: Length) -> Self {
+        Self::Fixed(value.into())
+    }
+}
+
+impl From<Percentage> for GridTrackMin {
+    fn from(value: Percentage) -> Self {
+        Self::Fixed(value.into())
+    }
+}
+
+impl From<LengthPercentage> for GridTrackMin {
+    fn from(value: LengthPercentage) -> Self {
+        Self::Fixed(value)
+    }
+}
+
+impl From<Length> for GridTrackMax {
+    fn from(value: Length) -> Self {
+        Self::Fixed(value.into())
+    }
+}
+
+impl From<Percentage> for GridTrackMax {
+    fn from(value: Percentage) -> Self {
+        Self::Fixed(value.into())
+    }
+}
+
+impl From<LengthPercentage> for GridTrackMax {
+    fn from(value: LengthPercentage) -> Self {
+        Self::Fixed(value)
+    }
+}
+
+impl ToCss for GridTrack {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        match (&self.min, &self.max) {
+            (GridTrackMin::Auto, GridTrackMax::Auto) => dest.write_str("auto"),
+            (GridTrackMin::MinContent, GridTrackMax::MinContent) => dest.write_str("min-content"),
+            (GridTrackMin::MaxContent, GridTrackMax::MaxContent) => dest.write_str("max-content"),
+            (GridTrackMin::Fixed(min), GridTrackMax::Fixed(max)) if min == max => min.to_css(dest),
+            (GridTrackMin::Auto, GridTrackMax::Fraction(value)) => {
+                write_number(dest, *value)?;
+                dest.write_str("fr")
+            }
+            (GridTrackMin::Auto, GridTrackMax::FitContent(limit)) => {
+                dest.write_str("fit-content(")?;
+                limit.to_css(dest)?;
+                dest.write_char(')')
+            }
+            (min, max) => {
+                dest.write_str("minmax(")?;
+                min.to_css(dest)?;
+                dest.write_str(", ")?;
+                max.to_css(dest)?;
+                dest.write_char(')')
+            }
+        }
+    }
+}
+
+impl ToCss for GridTrackMin {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        match self {
+            Self::Fixed(value) => value.to_css(dest),
+            Self::MinContent => dest.write_str("min-content"),
+            Self::MaxContent => dest.write_str("max-content"),
+            Self::Auto => dest.write_str("auto"),
+        }
+    }
+}
+
+impl ToCss for GridTrackMax {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        match self {
+            Self::Fixed(value) => value.to_css(dest),
+            Self::MinContent => dest.write_str("min-content"),
+            Self::MaxContent => dest.write_str("max-content"),
+            Self::FitContent(limit) => {
+                dest.write_str("fit-content(")?;
+                limit.to_css(dest)?;
+                dest.write_char(')')
+            }
+            Self::Auto => dest.write_str("auto"),
+            Self::Fraction(value) => {
+                write_number(dest, *value)?;
+                dest.write_str("fr")
+            }
+        }
+    }
+}
+
+/// Count used by a Grid `repeat()` fragment.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GridRepeatCount {
+    /// Repeat a fixed number of times.
+    Count(u16),
+    /// Fill the available axis while retaining empty repeated tracks.
+    AutoFill,
+    /// Fill the available axis and collapse empty repeated tracks.
+    AutoFit,
+}
+
+/// One explicit track or repeated track fragment.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GridTemplateComponent {
+    /// One track.
+    Track(GridTrack),
+    /// A repeated fragment.
+    Repeat {
+        /// Fixed or automatic repetition count.
+        count: GridRepeatCount,
+        /// Tracks inside the repeated fragment.
+        tracks: Vec<GridTrack>,
+        /// Named lines before, between, and after repeated tracks.
+        line_names: Vec<Vec<String>>,
+    },
+}
+
+impl From<GridTrack> for GridTemplateComponent {
+    fn from(value: GridTrack) -> Self {
+        Self::Track(value)
+    }
+}
+
+/// Value for `grid-template-rows` / `grid-template-columns`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GridTemplate {
+    pub(crate) components: Vec<GridTemplateComponent>,
+    pub(crate) line_names: Vec<Vec<String>>,
+}
 
 impl GridTemplate {
     /// Build from a list of track-sizing tokens. Each token is
     /// joined with a space.
-    pub fn tracks(tracks: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        let mut out = String::new();
-        for (i, t) in tracks.into_iter().enumerate() {
-            if i > 0 {
-                out.push(' ');
-            }
-            out.push_str(&t.into());
+    pub fn tracks(tracks: impl IntoIterator<Item = impl Into<GridTrack>>) -> Self {
+        let components: Vec<_> = tracks
+            .into_iter()
+            .map(|track| track.into().into())
+            .collect();
+        let line_names = vec![Vec::new(); components.len() + 1];
+        Self {
+            components,
+            line_names,
         }
-        Self(out)
+    }
+
+    /// Build a template from explicit track and `repeat()` components.
+    pub fn components(components: impl IntoIterator<Item = GridTemplateComponent>) -> Self {
+        let components: Vec<_> = components.into_iter().collect();
+        let line_names = vec![Vec::new(); components.len() + 1];
+        Self {
+            components,
+            line_names,
+        }
+    }
+
+    /// Build a template containing one `repeat()` fragment.
+    pub fn repeat(
+        count: GridRepeatCount,
+        tracks: impl IntoIterator<Item = impl Into<GridTrack>>,
+    ) -> Self {
+        let tracks: Vec<_> = tracks.into_iter().map(Into::into).collect();
+        let line_names = vec![Vec::new(); tracks.len() + 1];
+        Self::components([GridTemplateComponent::Repeat {
+            count,
+            tracks,
+            line_names,
+        }])
+    }
+
+    /// Attach names to the lines before, between, and after components.
+    /// Invalid line-name counts are rejected during style resolution.
+    pub fn line_names(
+        mut self,
+        line_names: impl IntoIterator<Item = impl IntoIterator<Item = impl Into<String>>>,
+    ) -> Self {
+        self.line_names = line_names
+            .into_iter()
+            .map(|names| names.into_iter().map(Into::into).collect())
+            .collect();
+        self
     }
 }
 
 impl ToCss for GridTemplate {
     fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
-        dest.write_str(&self.0)
+        for (index, component) in self.components.iter().enumerate() {
+            if index > 0 {
+                dest.write_char(' ')?;
+            }
+            write_grid_line_names(dest, self.line_names.get(index))?;
+            if !self.line_names.get(index).is_none_or(Vec::is_empty) {
+                dest.write_char(' ')?;
+            }
+            component.to_css(dest)?;
+        }
+        if !self
+            .line_names
+            .get(self.components.len())
+            .is_none_or(Vec::is_empty)
+        {
+            if !self.components.is_empty() {
+                dest.write_char(' ')?;
+            }
+            write_grid_line_names(dest, self.line_names.get(self.components.len()))?;
+        }
+        Ok(())
+    }
+}
+
+impl ToCss for GridTemplateComponent {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        match self {
+            Self::Track(track) => track.to_css(dest),
+            Self::Repeat {
+                count,
+                tracks,
+                line_names,
+            } => {
+                dest.write_str("repeat(")?;
+                count.to_css(dest)?;
+                dest.write_str(", ")?;
+                for (index, track) in tracks.iter().enumerate() {
+                    if index > 0 {
+                        dest.write_char(' ')?;
+                    }
+                    write_grid_line_names(dest, line_names.get(index))?;
+                    if !line_names.get(index).is_none_or(Vec::is_empty) {
+                        dest.write_char(' ')?;
+                    }
+                    track.to_css(dest)?;
+                }
+                if !line_names.get(tracks.len()).is_none_or(Vec::is_empty) {
+                    if !tracks.is_empty() {
+                        dest.write_char(' ')?;
+                    }
+                    write_grid_line_names(dest, line_names.get(tracks.len()))?;
+                }
+                dest.write_char(')')
+            }
+        }
+    }
+}
+
+impl ToCss for GridRepeatCount {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        match self {
+            Self::Count(value) => write!(dest, "{value}"),
+            Self::AutoFill => dest.write_str("auto-fill"),
+            Self::AutoFit => dest.write_str("auto-fit"),
+        }
+    }
+}
+
+fn write_grid_line_names(dest: &mut dyn fmt::Write, names: Option<&Vec<String>>) -> fmt::Result {
+    let Some(names) = names.filter(|names| !names.is_empty()) else {
+        return Ok(());
+    };
+    dest.write_char('[')?;
+    for (index, name) in names.iter().enumerate() {
+        if index > 0 {
+            dest.write_char(' ')?;
+        }
+        dest.write_str(name)?;
+    }
+    dest.write_char(']')
+}
+
+/// One rectangular named region in `grid-template-areas`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GridArea {
+    pub(crate) name: String,
+    pub(crate) row_start: u16,
+    pub(crate) row_end: u16,
+    pub(crate) column_start: u16,
+    pub(crate) column_end: u16,
+}
+
+impl GridArea {
+    /// Defines a zero-based, end-exclusive rectangular area.
+    pub fn new(
+        name: impl Into<String>,
+        row_start: u16,
+        row_end: u16,
+        column_start: u16,
+        column_end: u16,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            row_start,
+            row_end,
+            column_start,
+            column_end,
+        }
+    }
+}
+
+/// Rectangular named regions for `grid-template-areas`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GridTemplateAreas {
+    pub(crate) row_count: u16,
+    pub(crate) column_count: u16,
+    pub(crate) areas: Vec<GridArea>,
+}
+
+impl GridTemplateAreas {
+    /// Creates an empty named-area matrix with explicit dimensions.
+    pub const fn new(row_count: u16, column_count: u16) -> Self {
+        Self {
+            row_count,
+            column_count,
+            areas: Vec::new(),
+        }
+    }
+
+    /// Adds one named rectangular area.
+    pub fn area(mut self, area: GridArea) -> Self {
+        self.areas.push(area);
+        self
+    }
+}
+
+impl ToCss for GridTemplateAreas {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        for row in 0..self.row_count {
+            if row > 0 {
+                dest.write_char(' ')?;
+            }
+            dest.write_char('"')?;
+            for column in 0..self.column_count {
+                if column > 0 {
+                    dest.write_char(' ')?;
+                }
+                let name = self
+                    .areas
+                    .iter()
+                    .rev()
+                    .find(|area| {
+                        area.row_start <= row
+                            && row < area.row_end
+                            && area.column_start <= column
+                            && column < area.column_end
+                    })
+                    .map_or(".", |area| area.name.as_str());
+                dest.write_str(name)?;
+            }
+            dest.write_char('"')?;
+        }
+        Ok(())
     }
 }
 
@@ -440,11 +888,23 @@ mod tests {
         assert_eq!(GridLine::Number(1).to_css_string(), "1");
         assert_eq!(GridLine::Number(-1).to_css_string(), "-1");
         assert_eq!(GridLine::Span(2).to_css_string(), "span 2");
+        assert_eq!(
+            GridLine::Named("content".into(), 0).to_css_string(),
+            "content"
+        );
+        assert_eq!(
+            GridLine::NamedSpan("content".into(), 2).to_css_string(),
+            "span 2 content"
+        );
     }
 
     #[test]
     fn grid_template_joins_tracks() {
-        let t = GridTemplate::tracks(["1fr", "auto", "2fr"]);
+        let t = GridTemplate::tracks([
+            GridTrack::fraction(1.0),
+            GridTrack::auto(),
+            GridTrack::fraction(2.0),
+        ]);
         assert_eq!(t.to_css_string(), "1fr auto 2fr");
     }
 

--- a/crates/whisker-css/tests/compound_cases.rs
+++ b/crates/whisker-css/tests/compound_cases.rs
@@ -16,8 +16,8 @@ use whisker_css::ext::*;
 use whisker_css::keyword::{AlignItems, Overflow};
 use whisker_css::{
     Animation, Background, BackgroundLayer, Border, BorderRadius, Color, ColorStop, Css, CssString,
-    EasingFunction, Flex, FlexBasis, FlexDirection, Gradient, GridLine, GridTemplate, ImageRef,
-    JustifyContent, LengthPercentage, NamedColor, PositionKind, Size, ToCss, TransformFn,
+    EasingFunction, Flex, FlexBasis, FlexDirection, Gradient, GridLine, GridTemplate, GridTrack,
+    ImageRef, JustifyContent, LengthPercentage, NamedColor, PositionKind, Size, ToCss, TransformFn,
     Transition, TransitionPropertyKind, Visibility,
 };
 
@@ -247,8 +247,12 @@ fn background_full_shorthand() {
 fn grid_definition_block() {
     let s = Css::new()
         .display_grid()
-        .grid_template_columns(GridTemplate::tracks(["1fr", "auto", "1fr"]))
-        .grid_template_rows(GridTemplate::tracks(["auto"]))
+        .grid_template_columns(GridTemplate::tracks([
+            GridTrack::fraction(1.0),
+            GridTrack::auto(),
+            GridTrack::fraction(1.0),
+        ]))
+        .grid_template_rows(GridTemplate::tracks([GridTrack::auto()]))
         .grid_row_start(GridLine::Number(1))
         .grid_column_end(GridLine::Span(2));
     let css = s.to_string();

--- a/crates/whisker-css/tests/coverage_gaps.rs
+++ b/crates/whisker-css/tests/coverage_gaps.rs
@@ -13,7 +13,8 @@ use whisker_css::ext::*;
 use whisker_css::shorthand::padding_margin::MarginValue;
 use whisker_css::shorthand::{Animation, Background, BackgroundLayer, Border, Transition};
 use whisker_css::value::{
-    BorderRadius, FlexBasis, GridLine, GridTemplate, ImageRef, LineHeight, Repeated, Size,
+    BorderRadius, FlexBasis, GridLine, GridTemplate, GridTrack, ImageRef, LineHeight, Repeated,
+    Size,
 };
 use whisker_css::{Css, ToCss};
 
@@ -244,10 +245,10 @@ fn grid_line_all_variants() {
 
 #[test]
 fn grid_template_empty_then_extend() {
-    let tracks: Vec<String> = Vec::new();
+    let tracks: Vec<GridTrack> = Vec::new();
     let t1 = GridTemplate::tracks(tracks);
     assert!(t1.to_css_string().is_empty());
-    let t2 = GridTemplate::tracks(["1fr".to_string(), "2fr".to_string()]);
+    let t2 = GridTemplate::tracks([GridTrack::fraction(1.0), GridTrack::fraction(2.0)]);
     assert_eq!(t2.to_css_string(), "1fr 2fr");
 }
 

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -10,15 +10,20 @@ use std::{collections::BTreeMap, error::Error, fmt};
 
 use taffy::{
     AlignContent, AlignItems, AvailableSpace as TaffyAvailableSpace, BoxSizing, Dimension,
-    Direction, Display, FlexDirection, FlexWrap, LengthPercentage, LengthPercentageAuto, Position,
-    Rect, Size, Style, TaffyTree,
+    Direction, Display, FlexDirection, FlexWrap, GridAutoFlow, GridPlacement, GridTemplateArea,
+    GridTemplateAreas, GridTemplateComponent, GridTemplateRepetition, LengthPercentage,
+    LengthPercentageAuto, Line, MaxTrackSizingFunction, MinTrackSizingFunction, Position, Rect,
+    RepetitionCount, Size, Style, TaffyTree, TrackSizingFunction,
 };
 pub use whisker_protocol::AvailableSpace;
 use whisker_protocol::{LayoutGeometry, LayoutRect, MeasureConstraints, NodeId};
 use whisker_style::{
     AlignContentValue, AlignItemsValue, AlignSelfValue, BoxSizingValue, ComputedFlexBasis,
-    ComputedLayoutStyle, ComputedLengthPercentage, ComputedLengthPercentageAuto, ComputedSizeValue,
-    DirectionValue, DisplayValue, FlexDirectionValue, FlexWrapValue, JustifyContentValue,
+    ComputedGridMaxTrackSizing, ComputedGridMinTrackSizing, ComputedGridTemplate,
+    ComputedGridTemplateComponent, ComputedGridTrackSizing, ComputedLayoutStyle,
+    ComputedLengthPercentage, ComputedLengthPercentageAuto, ComputedSizeValue, DirectionValue,
+    DisplayValue, FlexDirectionValue, FlexWrapValue, GridAutoFlowValue, GridPlacementLineValue,
+    GridPlacementValue, GridRepetitionCountValue, GridTemplateAreasValue, JustifyContentValue,
     PositionValue, PropertyImpactSet,
 };
 
@@ -690,14 +695,160 @@ fn convert_style(input: &ComputedLayoutStyle) -> Result<Style, LayoutError> {
             AlignSelfValue::Start => Some(AlignItems::START),
             AlignSelfValue::End => Some(AlignItems::END),
         },
+        justify_items: input.justify_items.map(align_items),
+        justify_self: input.justify_self.map(align_self),
         align_content: Some(align_content(input.align_content)),
         gap: Size {
             width: length(input.gap.width, false)?,
             height: length(input.gap.height, false)?,
         },
         aspect_ratio: input.aspect_ratio.map(|ratio| ratio.get()),
+        grid_template_columns: grid_template(&input.grid_template_columns)?,
+        grid_template_column_names: input.grid_template_columns.line_names.clone(),
+        grid_template_rows: grid_template(&input.grid_template_rows)?,
+        grid_template_row_names: input.grid_template_rows.line_names.clone(),
+        grid_auto_columns: input
+            .grid_auto_columns
+            .iter()
+            .copied()
+            .map(grid_track)
+            .collect::<Result<Vec<_>, _>>()?,
+        grid_auto_rows: input
+            .grid_auto_rows
+            .iter()
+            .copied()
+            .map(grid_track)
+            .collect::<Result<Vec<_>, _>>()?,
+        grid_auto_flow: match input.grid_auto_flow {
+            GridAutoFlowValue::Row => GridAutoFlow::Row,
+            GridAutoFlowValue::Column => GridAutoFlow::Column,
+            GridAutoFlowValue::RowDense => GridAutoFlow::RowDense,
+            GridAutoFlowValue::ColumnDense => GridAutoFlow::ColumnDense,
+        },
+        grid_template_areas: input.grid_template_areas.as_ref().map(grid_template_areas),
+        grid_column: grid_placement_line(&input.grid_column),
+        grid_row: grid_placement_line(&input.grid_row),
         ..Style::default()
     })
+}
+
+fn align_self(value: AlignSelfValue) -> AlignItems {
+    match value {
+        AlignSelfValue::Auto | AlignSelfValue::Stretch => AlignItems::STRETCH,
+        AlignSelfValue::FlexStart => AlignItems::FLEX_START,
+        AlignSelfValue::FlexEnd => AlignItems::FLEX_END,
+        AlignSelfValue::Center => AlignItems::CENTER,
+        AlignSelfValue::Baseline => AlignItems::BASELINE,
+        AlignSelfValue::Start => AlignItems::START,
+        AlignSelfValue::End => AlignItems::END,
+    }
+}
+
+fn grid_template(
+    value: &ComputedGridTemplate,
+) -> Result<Vec<GridTemplateComponent<String>>, LayoutError> {
+    value
+        .components
+        .iter()
+        .map(|component| match component {
+            ComputedGridTemplateComponent::Track(track) => {
+                grid_track(*track).map(GridTemplateComponent::Single)
+            }
+            ComputedGridTemplateComponent::Repeat(repetition) => {
+                let count = match repetition.count {
+                    GridRepetitionCountValue::Count(value) => RepetitionCount::Count(value),
+                    GridRepetitionCountValue::AutoFill => RepetitionCount::AutoFill,
+                    GridRepetitionCountValue::AutoFit => RepetitionCount::AutoFit,
+                };
+                let tracks = repetition
+                    .tracks
+                    .iter()
+                    .copied()
+                    .map(grid_track)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(GridTemplateComponent::Repeat(GridTemplateRepetition {
+                    count,
+                    tracks,
+                    line_names: repetition.line_names.clone(),
+                }))
+            }
+        })
+        .collect()
+}
+
+fn grid_track(value: ComputedGridTrackSizing) -> Result<TrackSizingFunction, LayoutError> {
+    Ok(TrackSizingFunction {
+        min: match value.min {
+            ComputedGridMinTrackSizing::Fixed(value) => grid_min_fixed(value)?,
+            ComputedGridMinTrackSizing::MinContent => MinTrackSizingFunction::min_content(),
+            ComputedGridMinTrackSizing::MaxContent => MinTrackSizingFunction::max_content(),
+            ComputedGridMinTrackSizing::Auto => MinTrackSizingFunction::auto(),
+        },
+        max: match value.max {
+            ComputedGridMaxTrackSizing::Fixed(value) => grid_max_fixed(value)?,
+            ComputedGridMaxTrackSizing::MinContent => MaxTrackSizingFunction::min_content(),
+            ComputedGridMaxTrackSizing::MaxContent => MaxTrackSizingFunction::max_content(),
+            ComputedGridMaxTrackSizing::FitContent(value) => match scalar(value)? {
+                Scalar::Length(value) => MaxTrackSizingFunction::fit_content_px(value),
+                Scalar::Percent(value) => MaxTrackSizingFunction::fit_content_percent(value),
+            },
+            ComputedGridMaxTrackSizing::Auto => MaxTrackSizingFunction::auto(),
+            ComputedGridMaxTrackSizing::Fraction(value) => MaxTrackSizingFunction::fr(value.get()),
+        },
+    })
+}
+
+fn grid_min_fixed(value: ComputedLengthPercentage) -> Result<MinTrackSizingFunction, LayoutError> {
+    scalar(value).map(|value| match value {
+        Scalar::Length(value) => MinTrackSizingFunction::length(value),
+        Scalar::Percent(value) => MinTrackSizingFunction::percent(value),
+    })
+}
+
+fn grid_max_fixed(value: ComputedLengthPercentage) -> Result<MaxTrackSizingFunction, LayoutError> {
+    scalar(value).map(|value| match value {
+        Scalar::Length(value) => MaxTrackSizingFunction::length(value),
+        Scalar::Percent(value) => MaxTrackSizingFunction::percent(value),
+    })
+}
+
+fn grid_template_areas(value: &GridTemplateAreasValue) -> GridTemplateAreas<String> {
+    GridTemplateAreas {
+        areas: value
+            .areas
+            .iter()
+            .map(|area| GridTemplateArea {
+                name: area.name.clone(),
+                row_start: area.row_start,
+                row_end: area.row_end,
+                column_start: area.column_start,
+                column_end: area.column_end,
+            })
+            .collect(),
+        row_count: value.row_count,
+        column_count: value.column_count,
+    }
+}
+
+fn grid_placement_line(value: &GridPlacementLineValue) -> Line<GridPlacement<String>> {
+    Line {
+        start: grid_placement(&value.start),
+        end: grid_placement(&value.end),
+    }
+}
+
+fn grid_placement(value: &GridPlacementValue) -> GridPlacement<String> {
+    match value {
+        GridPlacementValue::Auto => GridPlacement::Auto,
+        GridPlacementValue::Line(value) => GridPlacement::Line((*value).into()),
+        GridPlacementValue::NamedLine(name, index) => {
+            GridPlacement::NamedLine(name.clone(), *index)
+        }
+        GridPlacementValue::Span(value) => GridPlacement::Span(*value),
+        GridPlacementValue::NamedSpan(name, count) => {
+            GridPlacement::NamedSpan(name.clone(), *count)
+        }
+    }
 }
 
 fn unsupported<T>(feature: UnsupportedLayoutFeature) -> Result<T, LayoutError> {
@@ -1454,6 +1605,7 @@ mod tests {
             },
             aspect_ratio: Some(StyleNumber::new(1.5)),
             order: 7,
+            ..ComputedLayoutStyle::default()
         };
         let converted = convert_style(&style).unwrap();
         assert_eq!(converted.display, Display::None);

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -1162,6 +1162,152 @@ mod tests {
         assert_eq!(snapshot.get(children[2]).unwrap().border_box.x, 100.0);
     }
 
+    #[test]
+    fn every_grid_value_lowers_to_taffy_or_reports_mixed_units() {
+        for value in [
+            AlignSelfValue::Auto,
+            AlignSelfValue::Stretch,
+            AlignSelfValue::FlexStart,
+            AlignSelfValue::FlexEnd,
+            AlignSelfValue::Center,
+            AlignSelfValue::Baseline,
+            AlignSelfValue::Start,
+            AlignSelfValue::End,
+        ] {
+            let _ = align_self(value);
+        }
+
+        for flow in [
+            GridAutoFlowValue::Row,
+            GridAutoFlowValue::Column,
+            GridAutoFlowValue::RowDense,
+            GridAutoFlowValue::ColumnDense,
+        ] {
+            convert_style(&ComputedLayoutStyle {
+                grid_auto_flow: flow,
+                ..ComputedLayoutStyle::default()
+            })
+            .unwrap();
+        }
+
+        let percent = ComputedLengthPercentage::new(0.0, 0.5);
+        let min_values = [
+            ComputedGridMinTrackSizing::Fixed(percent),
+            ComputedGridMinTrackSizing::MinContent,
+            ComputedGridMinTrackSizing::MaxContent,
+            ComputedGridMinTrackSizing::Auto,
+        ];
+        for min in min_values {
+            grid_track(ComputedGridTrackSizing {
+                min,
+                max: ComputedGridMaxTrackSizing::Auto,
+            })
+            .unwrap();
+        }
+
+        let max_values = [
+            ComputedGridMaxTrackSizing::Fixed(percent),
+            ComputedGridMaxTrackSizing::MinContent,
+            ComputedGridMaxTrackSizing::MaxContent,
+            ComputedGridMaxTrackSizing::FitContent(ComputedLengthPercentage::new(10.0, 0.0)),
+            ComputedGridMaxTrackSizing::FitContent(percent),
+            ComputedGridMaxTrackSizing::Auto,
+            ComputedGridMaxTrackSizing::Fraction(StyleNumber::new(2.0)),
+        ];
+        for max in max_values {
+            grid_track(ComputedGridTrackSizing {
+                min: ComputedGridMinTrackSizing::Auto,
+                max,
+            })
+            .unwrap();
+        }
+
+        for count in [
+            GridRepetitionCountValue::AutoFill,
+            GridRepetitionCountValue::AutoFit,
+        ] {
+            grid_template(&ComputedGridTemplate {
+                components: vec![ComputedGridTemplateComponent::Repeat(
+                    ComputedGridTemplateRepetition {
+                        count,
+                        tracks: vec![ComputedGridTrackSizing::auto()],
+                        line_names: vec![Vec::new(), Vec::new()],
+                    },
+                )],
+                line_names: vec![Vec::new(), Vec::new()],
+            })
+            .unwrap();
+        }
+
+        for placement in [
+            GridPlacementValue::Auto,
+            GridPlacementValue::Line(2),
+            GridPlacementValue::NamedLine("line".into(), 1),
+            GridPlacementValue::Span(2),
+            GridPlacementValue::NamedSpan("span".into(), 2),
+        ] {
+            let _ = grid_placement(&placement);
+        }
+
+        let mixed_min = ComputedGridTrackSizing {
+            min: ComputedGridMinTrackSizing::Fixed(MIXED),
+            max: ComputedGridMaxTrackSizing::Auto,
+        };
+        let mixed_max = ComputedGridTrackSizing {
+            min: ComputedGridMinTrackSizing::Auto,
+            max: ComputedGridMaxTrackSizing::Fixed(MIXED),
+        };
+        let mixed_fit_content = ComputedGridTrackSizing {
+            min: ComputedGridMinTrackSizing::Auto,
+            max: ComputedGridMaxTrackSizing::FitContent(MIXED),
+        };
+        for track in [mixed_min, mixed_max, mixed_fit_content] {
+            assert_eq!(
+                grid_track(track),
+                Err(LayoutError::UnsupportedStyle(
+                    UnsupportedLayoutFeature::MixedLengthPercentage
+                ))
+            );
+        }
+
+        let invalid_template = ComputedGridTemplate {
+            components: vec![ComputedGridTemplateComponent::Repeat(
+                ComputedGridTemplateRepetition {
+                    count: GridRepetitionCountValue::Count(1),
+                    tracks: vec![mixed_min],
+                    line_names: vec![Vec::new(), Vec::new()],
+                },
+            )],
+            line_names: vec![Vec::new(), Vec::new()],
+        };
+        assert!(grid_template(&invalid_template).is_err());
+
+        for (columns, rows) in [
+            (invalid_template.clone(), ComputedGridTemplate::default()),
+            (ComputedGridTemplate::default(), invalid_template),
+        ] {
+            assert!(
+                convert_style(&ComputedLayoutStyle {
+                    grid_template_columns: columns,
+                    grid_template_rows: rows,
+                    ..ComputedLayoutStyle::default()
+                })
+                .is_err()
+            );
+        }
+
+        for (columns, rows) in [(vec![mixed_min], Vec::new()), (Vec::new(), vec![mixed_max])] {
+            assert!(
+                convert_style(&ComputedLayoutStyle {
+                    grid_auto_columns: columns,
+                    grid_auto_rows: rows,
+                    ..ComputedLayoutStyle::default()
+                })
+                .is_err()
+            );
+        }
+    }
+
     fn assert_unsupported(style: ComputedLayoutStyle, feature: UnsupportedLayoutFeature) {
         assert_eq!(
             convert_style(&style),

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -955,8 +955,9 @@ fn justify(value: JustifyContentValue) -> AlignContent {
 mod tests {
     use super::*;
     use whisker_style::{
-        Axes, ComputedGridTemplate, ComputedGridTrackSizing, Edges, GridPlacementLineValue,
-        StyleNumber,
+        Axes, ComputedGridTemplate, ComputedGridTemplateComponent, ComputedGridTemplateRepetition,
+        ComputedGridTrackSizing, Edges, GridPlacementLineValue, GridRepetitionCountValue,
+        GridTemplateAreaValue, GridTemplateAreasValue, StyleNumber,
     };
 
     const MIXED: ComputedLengthPercentage = ComputedLengthPercentage::new(1.0, 0.5);
@@ -1100,6 +1101,65 @@ mod tests {
             .unwrap();
         assert_eq!(snapshot.get(centered).unwrap().border_box.x, 40.0);
         assert_eq!(snapshot.get(ended).unwrap().border_box.x, 180.0);
+    }
+
+    #[test]
+    fn grid_repeat_and_named_areas_reach_taffy() {
+        let root = id(1);
+        let children = [id(2), id(3), id(4)];
+        let template = ComputedGridTemplate {
+            components: vec![ComputedGridTemplateComponent::Repeat(
+                ComputedGridTemplateRepetition {
+                    count: GridRepetitionCountValue::Count(3),
+                    tracks: vec![ComputedGridTrackSizing::length(50.0)],
+                    line_names: vec![vec!["cell-start".into()], vec!["cell-end".into()]],
+                },
+            )],
+            line_names: vec![Vec::new(), Vec::new()],
+        };
+        let areas = GridTemplateAreasValue {
+            areas: vec![GridTemplateAreaValue {
+                name: "content".into(),
+                row_start: 0,
+                row_end: 1,
+                column_start: 0,
+                column_end: 3,
+            }],
+            row_count: 1,
+            column_count: 3,
+        };
+        let root_style = ComputedLayoutStyle {
+            display: DisplayValue::Grid,
+            size: Axes {
+                width: ComputedSizeValue::Value(ComputedLengthPercentage::new(150.0, 0.0)),
+                height: ComputedSizeValue::Value(ComputedLengthPercentage::new(50.0, 0.0)),
+            },
+            grid_template_columns: template,
+            grid_template_rows: ComputedGridTemplate::tracks([ComputedGridTrackSizing::length(
+                50.0,
+            )]),
+            grid_template_areas: Some(areas),
+            ..ComputedLayoutStyle::default()
+        };
+        let converted = convert_style(&root_style).unwrap();
+        assert_eq!(
+            converted.grid_template_areas.as_ref().unwrap().areas[0].name,
+            "content"
+        );
+
+        let mut tree = LayoutTree::new();
+        tree.create_node(root, root_style).unwrap();
+        for child in children {
+            tree.create_node(child, ComputedLayoutStyle::default())
+                .unwrap();
+        }
+        tree.set_children(root, &children).unwrap();
+        let snapshot = tree
+            .compute(root, LayoutSize::new(150.0, 50.0), &mut zero_measure)
+            .unwrap();
+        assert_eq!(snapshot.get(children[0]).unwrap().border_box.x, 0.0);
+        assert_eq!(snapshot.get(children[1]).unwrap().border_box.x, 50.0);
+        assert_eq!(snapshot.get(children[2]).unwrap().border_box.x, 100.0);
     }
 
     fn assert_unsupported(style: ComputedLayoutStyle, feature: UnsupportedLayoutFeature) {

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -803,7 +803,10 @@ fn justify(value: JustifyContentValue) -> AlignContent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use whisker_style::{Axes, Edges, StyleNumber};
+    use whisker_style::{
+        Axes, ComputedGridTemplate, ComputedGridTrackSizing, Edges, GridPlacementLineValue,
+        StyleNumber,
+    };
 
     const MIXED: ComputedLengthPercentage = ComputedLengthPercentage::new(1.0, 0.5);
 
@@ -823,6 +826,129 @@ mod tests {
 
     fn zero_measure(_: NodeId, _: MeasureRequest) -> LayoutSize {
         LayoutSize::default()
+    }
+
+    #[test]
+    fn grid_tracks_and_explicit_placement_reach_taffy() {
+        let root = id(1);
+        let first = id(2);
+        let second = id(3);
+        let third = id(4);
+        let mut tree = LayoutTree::new();
+        let root_style = ComputedLayoutStyle {
+            display: DisplayValue::Grid,
+            size: Axes {
+                width: ComputedSizeValue::Value(ComputedLengthPercentage::new(300.0, 0.0)),
+                height: ComputedSizeValue::Value(ComputedLengthPercentage::new(100.0, 0.0)),
+            },
+            grid_template_columns: ComputedGridTemplate::tracks([
+                ComputedGridTrackSizing::length(100.0),
+                ComputedGridTrackSizing::fraction(1.0),
+                ComputedGridTrackSizing::length(50.0),
+            ]),
+            grid_template_rows: ComputedGridTemplate::tracks([
+                ComputedGridTrackSizing::length(40.0),
+                ComputedGridTrackSizing::length(60.0),
+            ]),
+            ..ComputedLayoutStyle::default()
+        };
+        tree.create_node(root, root_style).unwrap();
+        tree.create_node(first, ComputedLayoutStyle::default())
+            .unwrap();
+        tree.create_node(
+            second,
+            ComputedLayoutStyle {
+                grid_column: GridPlacementLineValue::lines(2, 3),
+                grid_row: GridPlacementLineValue::lines(2, 3),
+                ..ComputedLayoutStyle::default()
+            },
+        )
+        .unwrap();
+        tree.create_node(
+            third,
+            ComputedLayoutStyle {
+                grid_column: GridPlacementLineValue::lines(3, 4),
+                grid_row: GridPlacementLineValue::lines(1, 2),
+                ..ComputedLayoutStyle::default()
+            },
+        )
+        .unwrap();
+        tree.set_children(root, &[first, second, third]).unwrap();
+
+        let snapshot = tree
+            .compute(root, LayoutSize::new(300.0, 100.0), &mut zero_measure)
+            .unwrap();
+        assert_eq!(
+            snapshot.get(first).unwrap().border_box,
+            LayoutRect {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 40.0,
+            }
+        );
+        assert_eq!(
+            snapshot.get(second).unwrap().border_box,
+            LayoutRect {
+                x: 100.0,
+                y: 40.0,
+                width: 150.0,
+                height: 60.0,
+            }
+        );
+        assert_eq!(
+            snapshot.get(third).unwrap().border_box,
+            LayoutRect {
+                x: 250.0,
+                y: 0.0,
+                width: 50.0,
+                height: 40.0,
+            }
+        );
+    }
+
+    #[test]
+    fn grid_justify_items_and_self_control_inline_alignment() {
+        let root = id(1);
+        let centered = id(2);
+        let ended = id(3);
+        let mut tree = LayoutTree::new();
+        tree.create_node(
+            root,
+            ComputedLayoutStyle {
+                display: DisplayValue::Grid,
+                size: Axes {
+                    width: ComputedSizeValue::Value(ComputedLengthPercentage::new(200.0, 0.0)),
+                    height: ComputedSizeValue::Value(ComputedLengthPercentage::new(50.0, 0.0)),
+                },
+                grid_template_columns: ComputedGridTemplate::tracks([
+                    ComputedGridTrackSizing::length(100.0),
+                    ComputedGridTrackSizing::length(100.0),
+                ]),
+                grid_template_rows: ComputedGridTemplate::tracks([
+                    ComputedGridTrackSizing::length(50.0),
+                ]),
+                justify_items: Some(AlignItemsValue::Center),
+                ..ComputedLayoutStyle::default()
+            },
+        )
+        .unwrap();
+        tree.create_node(centered, sized(20.0, 10.0)).unwrap();
+        tree.create_node(
+            ended,
+            ComputedLayoutStyle {
+                justify_self: Some(AlignSelfValue::End),
+                ..sized(20.0, 10.0)
+            },
+        )
+        .unwrap();
+        tree.set_children(root, &[centered, ended]).unwrap();
+
+        let snapshot = tree
+            .compute(root, LayoutSize::new(200.0, 50.0), &mut zero_measure)
+            .unwrap();
+        assert_eq!(snapshot.get(centered).unwrap().border_box.x, 40.0);
+        assert_eq!(snapshot.get(ended).unwrap().border_box.x, 180.0);
     }
 
     fn assert_unsupported(style: ComputedLayoutStyle, feature: UnsupportedLayoutFeature) {

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -3,9 +3,10 @@
 use crate::{
     AlignContentValue, AlignItemsValue, AlignSelfValue, AspectRatioValue, BoxSizingValue,
     CalcExpression, DirectionValue, DisplayValue, FlexBasisValue, FlexDirectionValue,
-    FlexWrapValue, JustifyContentValue, LengthPercentageAutoValue, LengthPercentageValue,
-    LengthUnit, LengthValue, PositionValue, PropertyImpactSet, SizeValue, SpecifiedStyle,
-    StyleEnvironment, StyleNumber, StyleProperty, StyleResolutionError, StyleValue,
+    FlexWrapValue, GridMaxTrackSizingValue, GridMinTrackSizingValue, GridTemplateComponentValue,
+    GridTemplateValue, GridTrackSizingValue, JustifyContentValue, LengthPercentageAutoValue,
+    LengthPercentageValue, LengthUnit, LengthValue, PositionValue, PropertyImpactSet, SizeValue,
+    SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty, StyleResolutionError, StyleValue,
 };
 
 const RPX_REFERENCE_WIDTH: f32 = 750.0;
@@ -701,6 +702,19 @@ pub(crate) fn resolve_layout_style(
         },
     )?
     .unwrap_or(style.align_self);
+    style.justify_items = copied(
+        declarations.justify_items,
+        StyleProperty::JustifyItems,
+        |value| match value {
+            StyleValue::AlignItems(value) => Some(*value),
+            _ => None,
+        },
+    )?;
+    style.justify_self = match declarations.justify_self {
+        Some(StyleValue::AlignSelf(AlignSelfValue::Auto)) | None => None,
+        Some(StyleValue::AlignSelf(value)) => Some(*value),
+        Some(_) => return Err(invalid(StyleProperty::JustifySelf)),
+    };
     style.align_content = copied(
         declarations.align_content,
         StyleProperty::AlignContent,
@@ -736,8 +750,223 @@ pub(crate) fn resolve_layout_style(
         };
         style.order = i32::try_from(*value).map_err(|_| invalid(StyleProperty::Order))?;
     }
+    style.grid_template_columns = resolve_optional_grid_template(
+        declarations.grid_template_columns,
+        font_size,
+        environment,
+        StyleProperty::GridTemplateColumns,
+    )?;
+    style.grid_template_rows = resolve_optional_grid_template(
+        declarations.grid_template_rows,
+        font_size,
+        environment,
+        StyleProperty::GridTemplateRows,
+    )?;
+    style.grid_auto_columns = resolve_optional_grid_tracks(
+        declarations.grid_auto_columns,
+        font_size,
+        environment,
+        StyleProperty::GridAutoColumns,
+    )?;
+    style.grid_auto_rows = resolve_optional_grid_tracks(
+        declarations.grid_auto_rows,
+        font_size,
+        environment,
+        StyleProperty::GridAutoRows,
+    )?;
+    style.grid_auto_flow = copied(
+        declarations.grid_auto_flow,
+        StyleProperty::GridAutoFlow,
+        |value| match value {
+            StyleValue::GridAutoFlow(value) => Some(*value),
+            _ => None,
+        },
+    )?
+    .unwrap_or(style.grid_auto_flow);
+    style.grid_template_areas = match declarations.grid_template_areas {
+        Some(StyleValue::GridTemplateAreas(value)) => {
+            validate_grid_template_areas(value)?;
+            Some(value.clone())
+        }
+        Some(_) => return Err(invalid(StyleProperty::GridTemplateAreas)),
+        None => None,
+    };
+    style.grid_column.start = resolve_grid_placement(
+        declarations.grid_column_start,
+        StyleProperty::GridColumnStart,
+    )?;
+    style.grid_column.end =
+        resolve_grid_placement(declarations.grid_column_end, StyleProperty::GridColumnEnd)?;
+    style.grid_row.start =
+        resolve_grid_placement(declarations.grid_row_start, StyleProperty::GridRowStart)?;
+    style.grid_row.end =
+        resolve_grid_placement(declarations.grid_row_end, StyleProperty::GridRowEnd)?;
 
     Ok(style)
+}
+
+fn resolve_optional_grid_template(
+    value: Option<&StyleValue>,
+    font_size: f32,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<ComputedGridTemplate, StyleResolutionError> {
+    match value {
+        Some(StyleValue::GridTemplate(value)) => {
+            resolve_grid_template(value, font_size, environment, property)
+        }
+        Some(_) => Err(invalid(property)),
+        None => Ok(ComputedGridTemplate::default()),
+    }
+}
+
+fn resolve_grid_template(
+    value: &GridTemplateValue,
+    font_size: f32,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<ComputedGridTemplate, StyleResolutionError> {
+    let components = value
+        .components
+        .iter()
+        .map(|component| match component {
+            GridTemplateComponentValue::Track(track) => {
+                resolve_grid_track(track, font_size, environment, property)
+                    .map(ComputedGridTemplateComponent::Track)
+            }
+            GridTemplateComponentValue::Repeat(repetition) => {
+                if matches!(repetition.count, GridRepetitionCountValue::Count(0)) {
+                    return Err(invalid(property));
+                }
+                let tracks = repetition
+                    .tracks
+                    .iter()
+                    .map(|track| resolve_grid_track(track, font_size, environment, property))
+                    .collect::<Result<Vec<_>, _>>()?;
+                if tracks.is_empty() || repetition.line_names.len() != tracks.len() + 1 {
+                    return Err(invalid(property));
+                }
+                Ok(ComputedGridTemplateComponent::Repeat(
+                    ComputedGridTemplateRepetition {
+                        count: repetition.count,
+                        tracks,
+                        line_names: repetition.line_names.clone(),
+                    },
+                ))
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if value.line_names.len() != components.len() + 1 {
+        return Err(invalid(property));
+    }
+    Ok(ComputedGridTemplate {
+        components,
+        line_names: value.line_names.clone(),
+    })
+}
+
+fn resolve_optional_grid_tracks(
+    value: Option<&StyleValue>,
+    font_size: f32,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<Vec<ComputedGridTrackSizing>, StyleResolutionError> {
+    match value {
+        Some(StyleValue::GridTracks(value)) => value
+            .iter()
+            .map(|track| resolve_grid_track(track, font_size, environment, property))
+            .collect(),
+        Some(_) => Err(invalid(property)),
+        None => Ok(Vec::new()),
+    }
+}
+
+fn resolve_grid_track(
+    value: &GridTrackSizingValue,
+    font_size: f32,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<ComputedGridTrackSizing, StyleResolutionError> {
+    let min =
+        match &value.min {
+            GridMinTrackSizingValue::Fixed(value) => ComputedGridMinTrackSizing::Fixed(
+                resolve_affine(value, font_size, environment, property)?,
+            ),
+            GridMinTrackSizingValue::MinContent => ComputedGridMinTrackSizing::MinContent,
+            GridMinTrackSizingValue::MaxContent => ComputedGridMinTrackSizing::MaxContent,
+            GridMinTrackSizingValue::Auto => ComputedGridMinTrackSizing::Auto,
+        };
+    let max =
+        match &value.max {
+            GridMaxTrackSizingValue::Fixed(value) => ComputedGridMaxTrackSizing::Fixed(
+                resolve_affine(value, font_size, environment, property)?,
+            ),
+            GridMaxTrackSizingValue::MinContent => ComputedGridMaxTrackSizing::MinContent,
+            GridMaxTrackSizingValue::MaxContent => ComputedGridMaxTrackSizing::MaxContent,
+            GridMaxTrackSizingValue::FitContent(value) => ComputedGridMaxTrackSizing::FitContent(
+                resolve_affine(value, font_size, environment, property)?,
+            ),
+            GridMaxTrackSizingValue::Auto => ComputedGridMaxTrackSizing::Auto,
+            GridMaxTrackSizingValue::Fraction(value)
+                if value.get().is_finite() && value.get() >= 0.0 =>
+            {
+                ComputedGridMaxTrackSizing::Fraction(*value)
+            }
+            GridMaxTrackSizingValue::Fraction(_) => return Err(invalid(property)),
+        };
+    Ok(ComputedGridTrackSizing { min, max })
+}
+
+fn resolve_grid_placement(
+    value: Option<&StyleValue>,
+    property: StyleProperty,
+) -> Result<GridPlacementValue, StyleResolutionError> {
+    match value {
+        Some(StyleValue::GridPlacement(GridPlacementValue::Line(0)))
+        | Some(StyleValue::GridPlacement(GridPlacementValue::Span(0))) => Err(invalid(property)),
+        Some(StyleValue::GridPlacement(GridPlacementValue::NamedLine(name, _)))
+        | Some(StyleValue::GridPlacement(GridPlacementValue::NamedSpan(name, _)))
+            if name.is_empty() || name.chars().any(char::is_whitespace) =>
+        {
+            Err(invalid(property))
+        }
+        Some(StyleValue::GridPlacement(value)) => Ok(value.clone()),
+        Some(_) => Err(invalid(property)),
+        None => Ok(GridPlacementValue::Auto),
+    }
+}
+
+fn validate_grid_template_areas(
+    value: &GridTemplateAreasValue,
+) -> Result<(), StyleResolutionError> {
+    let area_shapes_are_valid = value.row_count > 0
+        && value.column_count > 0
+        && value.areas.iter().all(|area| {
+            !area.name.is_empty()
+                && !area.name.chars().any(char::is_whitespace)
+                && area.row_start < area.row_end
+                && area.row_end <= value.row_count
+                && area.column_start < area.column_end
+                && area.column_end <= value.column_count
+        });
+    let names_are_unique = value.areas.iter().enumerate().all(|(index, area)| {
+        value.areas[index + 1..]
+            .iter()
+            .all(|other| other.name != area.name)
+    });
+    let areas_do_not_overlap = value.areas.iter().enumerate().all(|(index, area)| {
+        value.areas[index + 1..].iter().all(|other| {
+            area.row_end <= other.row_start
+                || other.row_end <= area.row_start
+                || area.column_end <= other.column_start
+                || other.column_end <= area.column_start
+        })
+    });
+    if area_shapes_are_valid && names_are_unique && areas_do_not_overlap {
+        Ok(())
+    } else {
+        Err(invalid(StyleProperty::GridTemplateAreas))
+    }
 }
 
 fn copied<T: Copy>(
@@ -1119,11 +1348,23 @@ struct LayoutDeclarations<'a> {
     justify_content: Option<&'a StyleValue>,
     align_items: Option<&'a StyleValue>,
     align_self: Option<&'a StyleValue>,
+    justify_items: Option<&'a StyleValue>,
+    justify_self: Option<&'a StyleValue>,
     align_content: Option<&'a StyleValue>,
     row_gap: Option<&'a StyleValue>,
     column_gap: Option<&'a StyleValue>,
     aspect_ratio: Option<&'a StyleValue>,
     order: Option<&'a StyleValue>,
+    grid_template_columns: Option<&'a StyleValue>,
+    grid_template_rows: Option<&'a StyleValue>,
+    grid_auto_columns: Option<&'a StyleValue>,
+    grid_auto_rows: Option<&'a StyleValue>,
+    grid_auto_flow: Option<&'a StyleValue>,
+    grid_template_areas: Option<&'a StyleValue>,
+    grid_column_start: Option<&'a StyleValue>,
+    grid_column_end: Option<&'a StyleValue>,
+    grid_row_start: Option<&'a StyleValue>,
+    grid_row_end: Option<&'a StyleValue>,
 }
 
 impl<'a> LayoutDeclarations<'a> {
@@ -1161,11 +1402,23 @@ impl<'a> LayoutDeclarations<'a> {
                 StyleProperty::JustifyContent => &mut values.justify_content,
                 StyleProperty::AlignItems => &mut values.align_items,
                 StyleProperty::AlignSelf => &mut values.align_self,
+                StyleProperty::JustifyItems => &mut values.justify_items,
+                StyleProperty::JustifySelf => &mut values.justify_self,
                 StyleProperty::AlignContent => &mut values.align_content,
                 StyleProperty::RowGap => &mut values.row_gap,
                 StyleProperty::ColumnGap => &mut values.column_gap,
                 StyleProperty::AspectRatio => &mut values.aspect_ratio,
                 StyleProperty::Order => &mut values.order,
+                StyleProperty::GridTemplateColumns => &mut values.grid_template_columns,
+                StyleProperty::GridTemplateRows => &mut values.grid_template_rows,
+                StyleProperty::GridAutoColumns => &mut values.grid_auto_columns,
+                StyleProperty::GridAutoRows => &mut values.grid_auto_rows,
+                StyleProperty::GridAutoFlow => &mut values.grid_auto_flow,
+                StyleProperty::GridTemplateAreas => &mut values.grid_template_areas,
+                StyleProperty::GridColumnStart => &mut values.grid_column_start,
+                StyleProperty::GridColumnEnd => &mut values.grid_column_end,
+                StyleProperty::GridRowStart => &mut values.grid_row_start,
+                StyleProperty::GridRowEnd => &mut values.grid_row_end,
                 _ => continue,
             };
             *slot = Some(declaration.value());
@@ -1241,6 +1494,139 @@ mod tests {
         assert_eq!(style.order, 0);
         assert!(style.aspect_ratio.is_none());
         assert!(style.changes_from(&style).is_empty());
+    }
+
+    #[test]
+    fn grid_declarations_resolve_to_backend_independent_values() {
+        let fixed = |value: LengthPercentageValue| GridTrackSizingValue {
+            min: GridMinTrackSizingValue::Fixed(value.clone()),
+            max: GridMaxTrackSizingValue::Fixed(value),
+        };
+        let fraction = |value| GridTrackSizingValue {
+            min: GridMinTrackSizingValue::Auto,
+            max: GridMaxTrackSizingValue::Fraction(number(value)),
+        };
+        let columns = GridTemplateValue {
+            components: vec![
+                GridTemplateComponentValue::Track(fixed(LengthPercentageValue::Length(length(
+                    2.0,
+                    LengthUnit::Em,
+                )))),
+                GridTemplateComponentValue::Track(fraction(1.0)),
+            ],
+            line_names: vec![vec!["start".into()], Vec::new(), vec!["end".into()]],
+        };
+        let areas = GridTemplateAreasValue {
+            areas: vec![GridTemplateAreaValue {
+                name: "content".into(),
+                row_start: 0,
+                row_end: 1,
+                column_start: 0,
+                column_end: 2,
+            }],
+            row_count: 1,
+            column_count: 2,
+        };
+        let specified = SpecifiedStyle::new()
+            .push(
+                StyleProperty::GridTemplateColumns,
+                StyleValue::GridTemplate(columns),
+            )
+            .push(
+                StyleProperty::GridAutoRows,
+                StyleValue::GridTracks(vec![fixed(percent(25.0))]),
+            )
+            .push(
+                StyleProperty::GridAutoFlow,
+                StyleValue::GridAutoFlow(GridAutoFlowValue::ColumnDense),
+            )
+            .push(
+                StyleProperty::GridColumnStart,
+                StyleValue::GridPlacement(GridPlacementValue::NamedLine("start".into(), 0)),
+            )
+            .push(
+                StyleProperty::GridColumnEnd,
+                StyleValue::GridPlacement(GridPlacementValue::Span(2)),
+            )
+            .push(
+                StyleProperty::GridTemplateAreas,
+                StyleValue::GridTemplateAreas(areas.clone()),
+            )
+            .push(
+                StyleProperty::JustifyItems,
+                StyleValue::AlignItems(AlignItemsValue::Center),
+            )
+            .push(
+                StyleProperty::JustifySelf,
+                StyleValue::AlignSelf(AlignSelfValue::End),
+            );
+
+        let style = resolve(&specified).unwrap();
+        assert_eq!(style.grid_template_columns.components.len(), 2);
+        assert_eq!(
+            style.grid_template_columns.components[0],
+            ComputedGridTemplateComponent::Track(ComputedGridTrackSizing::length(40.0))
+        );
+        assert_eq!(
+            style.grid_auto_rows[0].min,
+            ComputedGridMinTrackSizing::Fixed(ComputedLengthPercentage::new(0.0, 0.25))
+        );
+        assert_eq!(style.grid_auto_flow, GridAutoFlowValue::ColumnDense);
+        assert_eq!(
+            style.grid_column,
+            GridPlacementLineValue {
+                start: GridPlacementValue::NamedLine("start".into(), 0),
+                end: GridPlacementValue::Span(2),
+            }
+        );
+        assert_eq!(style.grid_template_areas, Some(areas));
+        assert_eq!(style.justify_items, Some(AlignItemsValue::Center));
+        assert_eq!(style.justify_self, Some(AlignSelfValue::End));
+    }
+
+    #[test]
+    fn invalid_grid_placements_and_overlapping_areas_are_rejected() {
+        let invalid_line = SpecifiedStyle::new().push(
+            StyleProperty::GridColumnStart,
+            StyleValue::GridPlacement(GridPlacementValue::Line(0)),
+        );
+        assert_eq!(
+            resolve(&invalid_line),
+            Err(StyleResolutionError::InvalidPropertyValue(
+                StyleProperty::GridColumnStart
+            ))
+        );
+
+        let overlapping = GridTemplateAreasValue {
+            areas: vec![
+                GridTemplateAreaValue {
+                    name: "first".into(),
+                    row_start: 0,
+                    row_end: 2,
+                    column_start: 0,
+                    column_end: 2,
+                },
+                GridTemplateAreaValue {
+                    name: "second".into(),
+                    row_start: 1,
+                    row_end: 2,
+                    column_start: 1,
+                    column_end: 2,
+                },
+            ],
+            row_count: 2,
+            column_count: 2,
+        };
+        let invalid_areas = SpecifiedStyle::new().push(
+            StyleProperty::GridTemplateAreas,
+            StyleValue::GridTemplateAreas(overlapping),
+        );
+        assert_eq!(
+            resolve(&invalid_areas),
+            Err(StyleResolutionError::InvalidPropertyValue(
+                StyleProperty::GridTemplateAreas
+            ))
+        );
     }
 
     #[test]

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -1430,6 +1430,7 @@ impl<'a> LayoutDeclarations<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::GridTemplateRepetitionValue;
 
     fn number(value: f32) -> StyleNumber {
         StyleNumber::new(value)
@@ -1627,6 +1628,281 @@ mod tests {
                 StyleProperty::GridTemplateAreas
             ))
         );
+    }
+
+    #[test]
+    fn grid_helpers_and_every_track_sizing_variant_resolve() {
+        assert_eq!(
+            ComputedGridTrackSizing::fraction(2.0).max,
+            ComputedGridMaxTrackSizing::Fraction(number(2.0))
+        );
+        assert_eq!(
+            ComputedGridTrackSizing::auto(),
+            ComputedGridTrackSizing {
+                min: ComputedGridMinTrackSizing::Auto,
+                max: ComputedGridMaxTrackSizing::Auto,
+            }
+        );
+        assert_eq!(
+            ComputedGridTemplate::tracks([ComputedGridTrackSizing::length(10.0)])
+                .components
+                .len(),
+            1
+        );
+        assert_eq!(
+            GridPlacementLineValue::lines(1, 3),
+            GridPlacementLineValue {
+                start: GridPlacementValue::Line(1),
+                end: GridPlacementValue::Line(3),
+            }
+        );
+
+        let fixed = |value: LengthPercentageValue| GridTrackSizingValue {
+            min: GridMinTrackSizingValue::Fixed(value.clone()),
+            max: GridMaxTrackSizingValue::Fixed(value),
+        };
+        let variants = vec![
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::MinContent,
+                max: GridMaxTrackSizingValue::MinContent,
+            },
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::MaxContent,
+                max: GridMaxTrackSizingValue::MaxContent,
+            },
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::Auto,
+                max: GridMaxTrackSizingValue::Auto,
+            },
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::Fixed(px(10.0)),
+                max: GridMaxTrackSizingValue::FitContent(percent(50.0)),
+            },
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::Auto,
+                max: GridMaxTrackSizingValue::Fraction(number(2.0)),
+            },
+        ];
+        let repeated = GridTemplateValue {
+            components: vec![GridTemplateComponentValue::Repeat(
+                GridTemplateRepetitionValue {
+                    count: GridRepetitionCountValue::AutoFit,
+                    tracks: vec![fixed(px(20.0))],
+                    line_names: vec![vec!["repeat-start".into()], vec!["repeat-end".into()]],
+                },
+            )],
+            line_names: vec![vec!["outer-start".into()], vec!["outer-end".into()]],
+        };
+        let specified = SpecifiedStyle::new()
+            .push(
+                StyleProperty::GridTemplateRows,
+                StyleValue::GridTemplate(repeated),
+            )
+            .push(
+                StyleProperty::GridAutoColumns,
+                StyleValue::GridTracks(variants),
+            )
+            .push(
+                StyleProperty::GridRowStart,
+                StyleValue::GridPlacement(GridPlacementValue::NamedLine("outer-start".into(), 0)),
+            )
+            .push(
+                StyleProperty::GridRowEnd,
+                StyleValue::GridPlacement(GridPlacementValue::NamedSpan("outer-end".into(), 0)),
+            );
+        let style = resolve(&specified).unwrap();
+        assert!(matches!(
+            style.grid_template_rows.components.as_slice(),
+            [ComputedGridTemplateComponent::Repeat(_)]
+        ));
+        assert_eq!(style.grid_auto_columns.len(), 5);
+        assert_eq!(
+            style.grid_row,
+            GridPlacementLineValue {
+                start: GridPlacementValue::NamedLine("outer-start".into(), 0),
+                end: GridPlacementValue::NamedSpan("outer-end".into(), 0),
+            }
+        );
+    }
+
+    #[test]
+    fn every_invalid_grid_shape_is_rejected() {
+        let fixed = || GridTrackSizingValue {
+            min: GridMinTrackSizingValue::Fixed(px(10.0)),
+            max: GridMaxTrackSizingValue::Fixed(px(10.0)),
+        };
+        for template in [
+            GridTemplateValue {
+                components: vec![GridTemplateComponentValue::Repeat(
+                    GridTemplateRepetitionValue {
+                        count: GridRepetitionCountValue::Count(0),
+                        tracks: vec![fixed()],
+                        line_names: vec![Vec::new(), Vec::new()],
+                    },
+                )],
+                line_names: vec![Vec::new(), Vec::new()],
+            },
+            GridTemplateValue {
+                components: vec![GridTemplateComponentValue::Repeat(
+                    GridTemplateRepetitionValue {
+                        count: GridRepetitionCountValue::AutoFill,
+                        tracks: Vec::new(),
+                        line_names: vec![Vec::new()],
+                    },
+                )],
+                line_names: vec![Vec::new(), Vec::new()],
+            },
+            GridTemplateValue {
+                components: vec![GridTemplateComponentValue::Repeat(
+                    GridTemplateRepetitionValue {
+                        count: GridRepetitionCountValue::Count(2),
+                        tracks: vec![fixed()],
+                        line_names: vec![Vec::new()],
+                    },
+                )],
+                line_names: vec![Vec::new(), Vec::new()],
+            },
+            GridTemplateValue {
+                components: vec![GridTemplateComponentValue::Track(fixed())],
+                line_names: vec![Vec::new()],
+            },
+            GridTemplateValue {
+                components: vec![GridTemplateComponentValue::Repeat(
+                    GridTemplateRepetitionValue {
+                        count: GridRepetitionCountValue::Count(1),
+                        tracks: vec![GridTrackSizingValue {
+                            min: GridMinTrackSizingValue::Fixed(px(f32::NAN)),
+                            max: GridMaxTrackSizingValue::Auto,
+                        }],
+                        line_names: vec![Vec::new(), Vec::new()],
+                    },
+                )],
+                line_names: vec![Vec::new(), Vec::new()],
+            },
+        ] {
+            assert!(
+                resolve(&declaration(
+                    StyleProperty::GridTemplateColumns,
+                    StyleValue::GridTemplate(template)
+                ))
+                .is_err()
+            );
+        }
+
+        for track in [
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::Fixed(px(f32::NAN)),
+                max: GridMaxTrackSizingValue::Auto,
+            },
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::Auto,
+                max: GridMaxTrackSizingValue::FitContent(px(f32::NAN)),
+            },
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::Auto,
+                max: GridMaxTrackSizingValue::Fixed(px(f32::NAN)),
+            },
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::Auto,
+                max: GridMaxTrackSizingValue::Fraction(number(-1.0)),
+            },
+            GridTrackSizingValue {
+                min: GridMinTrackSizingValue::Auto,
+                max: GridMaxTrackSizingValue::Fraction(number(f32::NAN)),
+            },
+        ] {
+            assert!(
+                resolve(&declaration(
+                    StyleProperty::GridAutoRows,
+                    StyleValue::GridTracks(vec![track])
+                ))
+                .is_err()
+            );
+        }
+
+        for placement in [
+            GridPlacementValue::Span(0),
+            GridPlacementValue::NamedLine(String::new(), 0),
+            GridPlacementValue::NamedLine("two words".into(), 1),
+            GridPlacementValue::NamedSpan(String::new(), 0),
+            GridPlacementValue::NamedSpan("two words".into(), 1),
+        ] {
+            assert!(
+                resolve(&declaration(
+                    StyleProperty::GridRowStart,
+                    StyleValue::GridPlacement(placement)
+                ))
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn every_invalid_named_area_shape_is_rejected() {
+        let area =
+            |name: &str, row_start, row_end, column_start, column_end| GridTemplateAreaValue {
+                name: name.into(),
+                row_start,
+                row_end,
+                column_start,
+                column_end,
+            };
+        let cases = [
+            GridTemplateAreasValue {
+                areas: vec![],
+                row_count: 0,
+                column_count: 1,
+            },
+            GridTemplateAreasValue {
+                areas: vec![],
+                row_count: 1,
+                column_count: 0,
+            },
+            GridTemplateAreasValue {
+                areas: vec![area("", 0, 1, 0, 1)],
+                row_count: 1,
+                column_count: 1,
+            },
+            GridTemplateAreasValue {
+                areas: vec![area("two words", 0, 1, 0, 1)],
+                row_count: 1,
+                column_count: 1,
+            },
+            GridTemplateAreasValue {
+                areas: vec![area("bad-row", 1, 1, 0, 1)],
+                row_count: 1,
+                column_count: 1,
+            },
+            GridTemplateAreasValue {
+                areas: vec![area("row-bounds", 0, 2, 0, 1)],
+                row_count: 1,
+                column_count: 1,
+            },
+            GridTemplateAreasValue {
+                areas: vec![area("bad-column", 0, 1, 1, 1)],
+                row_count: 1,
+                column_count: 1,
+            },
+            GridTemplateAreasValue {
+                areas: vec![area("column-bounds", 0, 1, 0, 2)],
+                row_count: 1,
+                column_count: 1,
+            },
+            GridTemplateAreasValue {
+                areas: vec![area("same", 0, 1, 0, 1), area("same", 1, 2, 0, 1)],
+                row_count: 2,
+                column_count: 1,
+            },
+        ];
+        for areas in cases {
+            assert!(
+                resolve(&declaration(
+                    StyleProperty::GridTemplateAreas,
+                    StyleValue::GridTemplateAreas(areas)
+                ))
+                .is_err()
+            );
+        }
     }
 
     #[test]
@@ -2028,11 +2304,23 @@ mod tests {
             StyleProperty::JustifyContent,
             StyleProperty::AlignItems,
             StyleProperty::AlignSelf,
+            StyleProperty::JustifyItems,
+            StyleProperty::JustifySelf,
             StyleProperty::AlignContent,
             StyleProperty::RowGap,
             StyleProperty::ColumnGap,
             StyleProperty::AspectRatio,
             StyleProperty::Order,
+            StyleProperty::GridTemplateColumns,
+            StyleProperty::GridTemplateRows,
+            StyleProperty::GridAutoColumns,
+            StyleProperty::GridAutoRows,
+            StyleProperty::GridAutoFlow,
+            StyleProperty::GridTemplateAreas,
+            StyleProperty::GridColumnStart,
+            StyleProperty::GridColumnEnd,
+            StyleProperty::GridRowStart,
+            StyleProperty::GridRowEnd,
         ];
         for property in properties {
             assert_eq!(

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -121,6 +121,201 @@ pub struct Axes<T> {
     pub height: T,
 }
 
+/// Minimum sizing function for one computed CSS Grid track.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ComputedGridMinTrackSizing {
+    /// A fixed length or percentage.
+    Fixed(ComputedLengthPercentage),
+    /// The track's min-content contribution.
+    MinContent,
+    /// The track's max-content contribution.
+    MaxContent,
+    /// Automatic minimum sizing.
+    Auto,
+}
+
+/// Maximum sizing function for one computed CSS Grid track.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ComputedGridMaxTrackSizing {
+    /// A fixed length or percentage.
+    Fixed(ComputedLengthPercentage),
+    /// The track's min-content contribution.
+    MinContent,
+    /// The track's max-content contribution.
+    MaxContent,
+    /// Fit content up to the supplied limit.
+    FitContent(ComputedLengthPercentage),
+    /// Automatic maximum sizing.
+    Auto,
+    /// A flexible `fr` share.
+    Fraction(StyleNumber),
+}
+
+/// Computed minimum and maximum sizing functions for one CSS Grid track.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedGridTrackSizing {
+    /// Minimum sizing function.
+    pub min: ComputedGridMinTrackSizing,
+    /// Maximum sizing function.
+    pub max: ComputedGridMaxTrackSizing,
+}
+
+impl ComputedGridTrackSizing {
+    /// Creates a fixed logical-pixel track.
+    pub const fn length(value: f32) -> Self {
+        let value = ComputedLengthPercentage::new(value, 0.0);
+        Self {
+            min: ComputedGridMinTrackSizing::Fixed(value),
+            max: ComputedGridMaxTrackSizing::Fixed(value),
+        }
+    }
+
+    /// Creates a flexible `fr` track with an automatic minimum.
+    pub const fn fraction(value: f32) -> Self {
+        Self {
+            min: ComputedGridMinTrackSizing::Auto,
+            max: ComputedGridMaxTrackSizing::Fraction(StyleNumber::new(value)),
+        }
+    }
+
+    /// Creates an automatic track.
+    pub const fn auto() -> Self {
+        Self {
+            min: ComputedGridMinTrackSizing::Auto,
+            max: ComputedGridMaxTrackSizing::Auto,
+        }
+    }
+}
+
+/// Repetition count used by `repeat()` in a computed Grid template.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum GridRepetitionCountValue {
+    /// Repeat a fixed number of times.
+    Count(u16),
+    /// Add tracks while they fit.
+    AutoFill,
+    /// Add tracks while they fit and collapse empty tracks.
+    AutoFit,
+}
+
+/// One repeated fragment in a computed Grid template.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedGridTemplateRepetition {
+    /// Repetition count.
+    pub count: GridRepetitionCountValue,
+    /// Track sizing functions inside the repeated fragment.
+    pub tracks: Vec<ComputedGridTrackSizing>,
+    /// Named lines surrounding the repeated tracks.
+    pub line_names: Vec<Vec<String>>,
+}
+
+/// One component of a computed Grid template.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ComputedGridTemplateComponent {
+    /// One non-repeated track.
+    Track(ComputedGridTrackSizing),
+    /// A `repeat()` fragment.
+    Repeat(ComputedGridTemplateRepetition),
+}
+
+/// Computed track components and named lines for one Grid axis.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct ComputedGridTemplate {
+    /// Track or repetition components.
+    pub components: Vec<ComputedGridTemplateComponent>,
+    /// Named lines outside repetition components.
+    pub line_names: Vec<Vec<String>>,
+}
+
+impl ComputedGridTemplate {
+    /// Creates a template containing only non-repeated tracks.
+    pub fn tracks(tracks: impl IntoIterator<Item = ComputedGridTrackSizing>) -> Self {
+        let components = tracks
+            .into_iter()
+            .map(ComputedGridTemplateComponent::Track)
+            .collect::<Vec<_>>();
+        Self {
+            line_names: vec![Vec::new(); components.len() + 1],
+            components,
+        }
+    }
+}
+
+/// Placement of one edge of a Grid item.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub enum GridPlacementValue {
+    /// Use auto-placement.
+    #[default]
+    Auto,
+    /// Place at a numbered Grid line.
+    Line(i16),
+    /// Place at the nth line with this name.
+    NamedLine(String, i16),
+    /// Span a number of tracks.
+    Span(u16),
+    /// Span to the nth line with this name.
+    NamedSpan(String, u16),
+}
+
+/// Start and end placement for one Grid item axis.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct GridPlacementLineValue {
+    /// Start edge placement.
+    pub start: GridPlacementValue,
+    /// End edge placement.
+    pub end: GridPlacementValue,
+}
+
+impl GridPlacementLineValue {
+    /// Places an item between two numbered lines.
+    pub const fn lines(start: i16, end: i16) -> Self {
+        Self {
+            start: GridPlacementValue::Line(start),
+            end: GridPlacementValue::Line(end),
+        }
+    }
+}
+
+/// Auto-placement direction and packing mode for Grid items.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum GridAutoFlowValue {
+    /// Fill rows using sparse placement.
+    #[default]
+    Row,
+    /// Fill columns using sparse placement.
+    Column,
+    /// Fill rows and back-fill holes.
+    RowDense,
+    /// Fill columns and back-fill holes.
+    ColumnDense,
+}
+
+/// One named rectangle in a Grid area template.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GridTemplateAreaValue {
+    /// Area name.
+    pub name: String,
+    /// Zero-based starting row.
+    pub row_start: u16,
+    /// Exclusive ending row.
+    pub row_end: u16,
+    /// Zero-based starting column.
+    pub column_start: u16,
+    /// Exclusive ending column.
+    pub column_end: u16,
+}
+
+/// Named area rectangles and dimensions for `grid-template-areas`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GridTemplateAreasValue {
+    /// Named rectangles.
+    pub areas: Vec<GridTemplateAreaValue>,
+    /// Number of template rows.
+    pub row_count: u16,
+    /// Number of template columns.
+    pub column_count: u16,
+}
+
 impl<T: Copy> Axes<T> {
     const fn all(value: T) -> Self {
         Self {
@@ -171,6 +366,10 @@ pub struct ComputedLayoutStyle {
     pub align_items: AlignItemsValue,
     /// Per-item cross-axis alignment.
     pub align_self: AlignSelfValue,
+    /// Inline-axis child alignment for Grid containers.
+    pub justify_items: Option<AlignItemsValue>,
+    /// Inline-axis alignment for one Grid item.
+    pub justify_self: Option<AlignSelfValue>,
     /// Wrapped-line cross-axis distribution.
     pub align_content: AlignContentValue,
     /// Row and column gaps.
@@ -179,6 +378,22 @@ pub struct ComputedLayoutStyle {
     pub aspect_ratio: Option<StyleNumber>,
     /// Flex/grid ordering key.
     pub order: i32,
+    /// Explicit Grid column template.
+    pub grid_template_columns: ComputedGridTemplate,
+    /// Explicit Grid row template.
+    pub grid_template_rows: ComputedGridTemplate,
+    /// Implicit Grid column sizing functions.
+    pub grid_auto_columns: Vec<ComputedGridTrackSizing>,
+    /// Implicit Grid row sizing functions.
+    pub grid_auto_rows: Vec<ComputedGridTrackSizing>,
+    /// Grid auto-placement mode.
+    pub grid_auto_flow: GridAutoFlowValue,
+    /// Optional named area template.
+    pub grid_template_areas: Option<GridTemplateAreasValue>,
+    /// Grid column placement for this item.
+    pub grid_column: GridPlacementLineValue,
+    /// Grid row placement for this item.
+    pub grid_row: GridPlacementLineValue,
 }
 
 impl Default for ComputedLayoutStyle {
@@ -205,10 +420,20 @@ impl Default for ComputedLayoutStyle {
             justify_content: JustifyContentValue::FlexStart,
             align_items: AlignItemsValue::Stretch,
             align_self: AlignSelfValue::Auto,
+            justify_items: None,
+            justify_self: None,
             align_content: AlignContentValue::Stretch,
             gap: Axes::all(ComputedLengthPercentage::ZERO),
             aspect_ratio: None,
             order: 0,
+            grid_template_columns: ComputedGridTemplate::default(),
+            grid_template_rows: ComputedGridTemplate::default(),
+            grid_auto_columns: Vec::new(),
+            grid_auto_rows: Vec::new(),
+            grid_auto_flow: GridAutoFlowValue::Row,
+            grid_template_areas: None,
+            grid_column: GridPlacementLineValue::default(),
+            grid_row: GridPlacementLineValue::default(),
         }
     }
 }

--- a/crates/whisker-style/src/layout_value.rs
+++ b/crates/whisker-style/src/layout_value.rs
@@ -109,6 +109,74 @@ pub enum FlexBasisValue {
     LengthPercentage(LengthPercentageValue),
 }
 
+/// Minimum sizing function for one specified CSS Grid track.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GridMinTrackSizingValue {
+    /// A fixed length or percentage.
+    Fixed(LengthPercentageValue),
+    /// The min-content contribution.
+    MinContent,
+    /// The max-content contribution.
+    MaxContent,
+    /// Automatic minimum sizing.
+    Auto,
+}
+
+/// Maximum sizing function for one specified CSS Grid track.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GridMaxTrackSizingValue {
+    /// A fixed length or percentage.
+    Fixed(LengthPercentageValue),
+    /// The min-content contribution.
+    MinContent,
+    /// The max-content contribution.
+    MaxContent,
+    /// Fit content up to a limit.
+    FitContent(LengthPercentageValue),
+    /// Automatic maximum sizing.
+    Auto,
+    /// A flexible `fr` share.
+    Fraction(StyleNumber),
+}
+
+/// Specified minimum and maximum sizing functions for one Grid track.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GridTrackSizingValue {
+    /// Minimum sizing function.
+    pub min: GridMinTrackSizingValue,
+    /// Maximum sizing function.
+    pub max: GridMaxTrackSizingValue,
+}
+
+/// One repeated fragment in a specified Grid template.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GridTemplateRepetitionValue {
+    /// Repetition count.
+    pub count: crate::GridRepetitionCountValue,
+    /// Tracks inside the repeated fragment.
+    pub tracks: Vec<GridTrackSizingValue>,
+    /// Named lines surrounding the repeated tracks.
+    pub line_names: Vec<Vec<String>>,
+}
+
+/// One component in a specified Grid template.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GridTemplateComponentValue {
+    /// One non-repeated track.
+    Track(GridTrackSizingValue),
+    /// A `repeat()` fragment.
+    Repeat(GridTemplateRepetitionValue),
+}
+
+/// Specified track components and named lines for one Grid axis.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct GridTemplateValue {
+    /// Track or repetition components.
+    pub components: Vec<GridTemplateComponentValue>,
+    /// Named lines outside repetition components.
+    pub line_names: Vec<Vec<String>>,
+}
+
 /// Main-axis distribution.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum JustifyContentValue {

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -17,8 +17,12 @@ mod value;
 
 pub use declaration::{SpecifiedStyle, StyleDeclaration};
 pub use layout::{
-    Axes, ComputedFlexBasis, ComputedLayoutStyle, ComputedLengthPercentage,
-    ComputedLengthPercentageAuto, ComputedSizeValue, Edges,
+    Axes, ComputedFlexBasis, ComputedGridMaxTrackSizing, ComputedGridMinTrackSizing,
+    ComputedGridTemplate, ComputedGridTemplateComponent, ComputedGridTemplateRepetition,
+    ComputedGridTrackSizing, ComputedLayoutStyle, ComputedLengthPercentage,
+    ComputedLengthPercentageAuto, ComputedSizeValue, Edges, GridAutoFlowValue,
+    GridPlacementLineValue, GridPlacementValue, GridRepetitionCountValue, GridTemplateAreaValue,
+    GridTemplateAreasValue,
 };
 pub use layout_value::{
     AlignContentValue, AlignItemsValue, AlignSelfValue, AspectRatioValue, BoxSizingValue,

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -27,7 +27,9 @@ pub use layout::{
 pub use layout_value::{
     AlignContentValue, AlignItemsValue, AlignSelfValue, AspectRatioValue, BoxSizingValue,
     DirectionValue, DisplayValue, FlexBasisValue, FlexDirectionValue, FlexWrapValue,
-    JustifyContentValue, LengthPercentageAutoValue, PositionValue, SizeValue,
+    GridMaxTrackSizingValue, GridMinTrackSizingValue, GridTemplateComponentValue,
+    GridTemplateRepetitionValue, GridTemplateValue, GridTrackSizingValue, JustifyContentValue,
+    LengthPercentageAutoValue, PositionValue, SizeValue,
 };
 pub use paint::{
     BorderStyleValue, ComputedBackgroundLayerStyle, ComputedBackgroundPosition,

--- a/crates/whisker-style/src/property.rs
+++ b/crates/whisker-style/src/property.rs
@@ -294,6 +294,7 @@ macro_rules! define_style_properties {
                     | Self::GridRowEnd
                     | Self::GridRowStart
                     | Self::GridTemplateColumns
+                    | Self::GridTemplateAreas
                     | Self::GridTemplateRows
                     | Self::Height
                     | Self::InsetInlineEnd
@@ -509,6 +510,7 @@ define_style_properties! {
     PaddingInlineStart = 207 => "padding-inline-start",
     TextDecoration = 208 => "text-decoration",
     TextShadow = 209 => "text-shadow",
+    GridTemplateAreas = 210 => "grid-template-areas",
 }
 
 #[cfg(test)]
@@ -542,7 +544,7 @@ mod tests {
 
     #[test]
     fn registry_contains_only_the_standard_property_target() {
-        assert_eq!(StyleProperty::ALL.len(), 174);
+        assert_eq!(StyleProperty::ALL.len(), 175);
         assert_eq!(StyleProperty::Color.metadata().origin, PropertyOrigin::Css);
         assert!(
             StyleProperty::ALL

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -330,6 +330,16 @@ pub enum StyleValue {
     AlignSelf(crate::AlignSelfValue),
     /// Cross-axis line distribution.
     AlignContent(crate::AlignContentValue),
+    /// Explicit Grid track template for one axis.
+    GridTemplate(crate::GridTemplateValue),
+    /// Implicit Grid track sizing functions for one axis.
+    GridTracks(Vec<crate::GridTrackSizingValue>),
+    /// Grid auto-placement direction and density.
+    GridAutoFlow(crate::GridAutoFlowValue),
+    /// One Grid item edge placement.
+    GridPlacement(crate::GridPlacementValue),
+    /// Named Grid area rectangles.
+    GridTemplateAreas(crate::GridTemplateAreasValue),
     /// Width-to-height ratio.
     AspectRatio(crate::AspectRatioValue),
 }

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use whisker::css::{BorderStyle, Overflow};
+use whisker::css::{BorderStyle, GridLine, GridTemplate, GridTrack, Overflow};
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
 use whisker::runtime::view::{
@@ -462,6 +462,81 @@ fn render_box_paint_and_clip_reach_the_frame_sink() {
                     alpha: 1.0,
                 }
     ));
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn render_grid_layout_reaches_frame_packet_geometry() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(18).expect("test surface"),
+        StyleEnvironment::new(200.0, 50.0, 1.0, 14.0),
+    );
+    let root_style = Css::new()
+        .display_grid()
+        .width(px(200))
+        .height(px(50))
+        .grid_template_columns(GridTemplate::tracks([
+            GridTrack::fixed(px(50)),
+            GridTrack::fraction(1.0),
+        ]))
+        .grid_template_rows(GridTemplate::tracks([GridTrack::fixed(px(50))]));
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| {
+            render! {
+                view(style: root_style) {
+                    view(style: Css::new().grid_column(GridLine::Number(1), GridLine::Number(2)))
+                    view(style: Css::new().grid_column(GridLine::Number(2), GridLine::Number(3)))
+                }
+            }
+        });
+        set_root(root);
+    });
+    assert_eq!(surface.binding_error(), None);
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(200.0, 50.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .expect("render! grid frame");
+    assert!(host.calls.is_empty());
+
+    let root_node = surface.root().expect("grid root");
+    let packet = &renderer.frames()[0].packet;
+    let child_nodes: Vec<_> = packet
+        .operations
+        .iter()
+        .filter_map(|operation| match operation {
+            Operation::InsertChild { parent, child, .. } if *parent == root_node => Some(*child),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(child_nodes.len(), 2);
+    let geometry = |node| {
+        packet
+            .operations
+            .iter()
+            .find_map(|operation| match operation {
+                Operation::SetLayout {
+                    node: candidate,
+                    geometry,
+                } if *candidate == node => Some(geometry.border_box),
+                _ => None,
+            })
+    };
+    let first = geometry(child_nodes[0]).expect("first Grid item geometry");
+    let second = geometry(child_nodes[1]).expect("second Grid item geometry");
+    assert_eq!((first.x, first.width), (0.0, 50.0));
+    assert_eq!((second.x, second.width), (50.0, 150.0));
+
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }
 

--- a/tests/host-conformance/README.md
+++ b/tests/host-conformance/README.md
@@ -82,8 +82,8 @@ The target follows two explicit baselines. Layout semantics are the CSS subset
 represented by Taffy 0.13. Non-layout properties follow the standard,
 non-vendor Lynx 4.0 inventory at the recorded upstream revision. The resulting
 target is 158 conformance features: 157 properties plus the CSS Custom
-Properties mechanism. Of the 174 currently registered spellings, 154 remain
-in the target, 20 are deliberately unsupported, and `float`, `clear`, and
-`grid-template-areas` still need registry entries. The legacy aliases
+Properties mechanism. Of the 175 currently registered spellings, 155 remain
+in the target, 20 are deliberately unsupported, and `float` and `clear` still
+need registry entries. The legacy aliases
 `grid-column-gap`, `grid-row-gap`, and `word-wrap` remain absent. Stable IDs
 assigned to excluded spellings are reserved and are never reused.

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -13,9 +13,9 @@
   "target": {
     "feature_count": 158,
     "property_count": 157,
-    "registered_property_count": 174,
-    "target_registered_property_count": 154,
-    "pending_registry_properties": ["clear", "float", "grid-template-areas"],
+    "registered_property_count": 175,
+    "target_registered_property_count": 155,
+    "pending_registry_properties": ["clear", "float"],
     "excluded_registered_property_count": 20,
     "non_property_features": ["custom-properties"],
     "lynx_inventory": {
@@ -64,7 +64,7 @@
       "supported_subset": ["explicit-implicit-tracks", "fr-minmax-fit-content-repeat", "auto-fill-auto-fit", "row-column-dense-flow", "line-span-named-placement", "named-areas"],
       "unsupported_browser_subset": ["subgrid", "masonry"],
       "protocol": ["SetLayout"],
-      "rust": "planned",
+      "rust": "implemented",
       "hosts": {"desktop": "not-applicable", "web": "not-applicable", "android": "not-applicable", "ios": "not-applicable"}
     },
     {


### PR DESCRIPTION
## Summary
- add renderer-independent Grid track, repeat, placement, alignment, and named-area values
- lower computed Grid styles to Taffy without exposing Taffy types in Whisker APIs
- replace string-only Grid authoring with typed Rust values and connect render! through to FramePacket geometry
- register grid-template-areas and mark the Taffy Grid capability implemented

## Verification
- cargo test -p whisker-css -p whisker-style -p whisker-layout -p whisker-host-conformance -p whisker --lib --tests
- cargo clippy -p whisker-css -p whisker-style -p whisker-layout -p whisker-host-conformance -p whisker --all-targets -- -D warnings