### PR TITLE
feat(layout): support Taffy block floats

### DIFF
--- a/crates/whisker-css/src/keyword/layout.rs
+++ b/crates/whisker-css/src/keyword/layout.rs
@@ -23,6 +23,10 @@ pub enum Display {
     Flex,
     /// `grid` — CSS grid layout.
     Grid,
+    /// `block` — CSS block layout.
+    Block,
+    /// `flow-root` — block layout with an independent formatting context.
+    FlowRoot,
     /// `linear` — Lynx's linear layout (default for `<view>`).
     Linear,
     /// `relative` — Lynx's relative-positioning container.
@@ -35,8 +39,57 @@ impl ToCss for Display {
             Display::None => "none",
             Display::Flex => "flex",
             Display::Grid => "grid",
+            Display::Block => "block",
+            Display::FlowRoot => "flow-root",
             Display::Linear => "linear",
             Display::Relative => "relative",
+        })
+    }
+}
+
+/// The CSS `float` property.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Float {
+    /// Do not float the box.
+    #[default]
+    None,
+    /// Float to the physical left side.
+    Left,
+    /// Float to the physical right side.
+    Right,
+}
+
+impl ToCss for Float {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        dest.write_str(match self {
+            Self::None => "none",
+            Self::Left => "left",
+            Self::Right => "right",
+        })
+    }
+}
+
+/// The CSS `clear` property.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Clear {
+    /// Do not add clearance.
+    #[default]
+    None,
+    /// Clear preceding left floats.
+    Left,
+    /// Clear preceding right floats.
+    Right,
+    /// Clear preceding floats on both sides.
+    Both,
+}
+
+impl ToCss for Clear {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        dest.write_str(match self {
+            Self::None => "none",
+            Self::Left => "left",
+            Self::Right => "right",
+            Self::Both => "both",
         })
     }
 }
@@ -153,6 +206,8 @@ mod tests {
             (Display::None, "none"),
             (Display::Flex, "flex"),
             (Display::Grid, "grid"),
+            (Display::Block, "block"),
+            (Display::FlowRoot, "flow-root"),
             (Display::Linear, "linear"),
             (Display::Relative, "relative"),
         ];

--- a/crates/whisker-css/src/keyword/mod.rs
+++ b/crates/whisker-css/src/keyword/mod.rs
@@ -28,7 +28,9 @@ pub use background::{
 pub use border::BorderStyle;
 pub use flex::{AlignContent, AlignItems, AlignSelf, FlexDirection, FlexWrap, JustifyContent};
 pub use grid::GridAutoFlow;
-pub use layout::{BoxSizing, Display, Overflow, PointerEvents, PositionKind, Visibility};
+pub use layout::{
+    BoxSizing, Clear, Display, Float, Overflow, PointerEvents, PositionKind, Visibility,
+};
 pub use linear::{LinearCrossGravity, LinearGravity, LinearLayoutGravity, LinearOrientation};
 pub use text::{
     Direction, TextAlign, TextDecorationLine, TextDecorationStyle, TextOverflow, TextTransform,

--- a/crates/whisker-css/src/prop/display.rs
+++ b/crates/whisker-css/src/prop/display.rs
@@ -25,6 +25,16 @@ impl Css {
         self.push_typed(crate::StyleProperty::Display, Display::Grid)
     }
 
+    /// Sets `display: block`.
+    pub fn display_block(self) -> Self {
+        self.push_typed(crate::StyleProperty::Display, Display::Block)
+    }
+
+    /// Sets `display: flow-root` to establish an independent block formatting context.
+    pub fn display_flow_root(self) -> Self {
+        self.push_typed(crate::StyleProperty::Display, Display::FlowRoot)
+    }
+
     /// Sets `display: linear` — Lynx default linear layout.
     pub fn display_linear(self) -> Self {
         self.push_typed(crate::StyleProperty::Display, Display::Linear)
@@ -58,6 +68,11 @@ mod tests {
         assert_eq!(Css::new().display_none().to_string(), "display: none;");
         assert_eq!(Css::new().display_flex().to_string(), "display: flex;");
         assert_eq!(Css::new().display_grid().to_string(), "display: grid;");
+        assert_eq!(Css::new().display_block().to_string(), "display: block;");
+        assert_eq!(
+            Css::new().display_flow_root().to_string(),
+            "display: flow-root;"
+        );
         assert_eq!(Css::new().display_linear().to_string(), "display: linear;");
         assert_eq!(
             Css::new().display_relative().to_string(),

--- a/crates/whisker-css/src/prop/float.rs
+++ b/crates/whisker-css/src/prop/float.rs
@@ -1,0 +1,29 @@
+//! CSS block formatting-context float properties.
+
+use crate::css::Css;
+use crate::keyword::{Clear, Float};
+
+impl Css {
+    /// Sets the physical side to which this block floats.
+    pub fn float(self, value: Float) -> Self {
+        self.push_typed(crate::StyleProperty::Float, value)
+    }
+
+    /// Sets which preceding floats this block clears.
+    pub fn clear(self, value: Clear) -> Self {
+        self.push_typed(crate::StyleProperty::Clear, value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn float_and_clear_are_typed() {
+        let css = Css::new().float(Float::Left).clear(Clear::Both);
+        assert_eq!(css.to_string(), "float: left; clear: both;");
+        css.to_specified_style()
+            .expect("float declarations should not require CSS parsing");
+    }
+}

--- a/crates/whisker-css/src/prop/mod.rs
+++ b/crates/whisker-css/src/prop/mod.rs
@@ -13,6 +13,7 @@ mod box_model;
 mod display;
 mod effects;
 mod flex;
+mod float;
 mod grid;
 mod overflow;
 mod position;

--- a/crates/whisker-css/src/style_value.rs
+++ b/crates/whisker-css/src/style_value.rs
@@ -2,21 +2,22 @@
 
 use whisker_style::{
     AlignContentValue, AlignItemsValue, AlignSelfValue, BorderRadiusValue, BorderStyleValue,
-    BoxSizingValue, CalcExpression, ColorValue, DirectionValue, DisplayValue, FlexBasisValue,
-    FlexDirectionValue, FlexWrapValue, FontStyleValue, FontWeightValue, GridAutoFlowValue,
-    GridMaxTrackSizingValue, GridMinTrackSizingValue, GridPlacementValue, GridRepetitionCountValue,
-    GridTemplateAreaValue, GridTemplateAreasValue, GridTemplateComponentValue,
-    GridTemplateRepetitionValue, GridTemplateValue, GridTrackSizingValue, JustifyContentValue,
-    LengthPercentageAutoValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue,
-    PositionValue, SizeValue, StyleNumber, StyleValue,
+    BoxSizingValue, CalcExpression, ClearValue, ColorValue, DirectionValue, DisplayValue,
+    FlexBasisValue, FlexDirectionValue, FlexWrapValue, FloatValue, FontStyleValue, FontWeightValue,
+    GridAutoFlowValue, GridMaxTrackSizingValue, GridMinTrackSizingValue, GridPlacementValue,
+    GridRepetitionCountValue, GridTemplateAreaValue, GridTemplateAreasValue,
+    GridTemplateComponentValue, GridTemplateRepetitionValue, GridTemplateValue,
+    GridTrackSizingValue, JustifyContentValue, LengthPercentageAutoValue, LengthPercentageValue,
+    LengthUnit, LengthValue, LineHeightValue, PositionValue, SizeValue, StyleNumber, StyleValue,
 };
 
 use crate::{
-    AlignContent, AlignItems, AlignSelf, Angle, BoxSizing, CalcExpr, Color, CssString, Direction,
-    Display, FlexBasis, FlexDirection, FlexWrap, FontStyle, FontWeight, GridAutoFlow, GridLine,
-    GridRepeatCount, GridTemplate, GridTemplateAreas, GridTemplateComponent, GridTrack,
-    GridTrackMax, GridTrackMin, Integer, JustifyContent, Length, LengthPercentage, LineHeight,
-    MarginValue, Number, Overflow, Percentage, PositionKind, Size, Visibility,
+    AlignContent, AlignItems, AlignSelf, Angle, BoxSizing, CalcExpr, Clear, Color, CssString,
+    Direction, Display, FlexBasis, FlexDirection, FlexWrap, Float, FontStyle, FontWeight,
+    GridAutoFlow, GridLine, GridRepeatCount, GridTemplate, GridTemplateAreas,
+    GridTemplateComponent, GridTrack, GridTrackMax, GridTrackMin, Integer, JustifyContent, Length,
+    LengthPercentage, LineHeight, MarginValue, Number, Overflow, Percentage, PositionKind, Size,
+    Visibility,
 };
 use whisker_style::{OverflowValue, VisibilityValue};
 
@@ -172,8 +173,31 @@ impl ToStyleValue for Display {
             Self::None => DisplayValue::None,
             Self::Flex => DisplayValue::Flex,
             Self::Grid => DisplayValue::Grid,
+            Self::Block => DisplayValue::Block,
+            Self::FlowRoot => DisplayValue::FlowRoot,
             Self::Linear => DisplayValue::Linear,
             Self::Relative => DisplayValue::Relative,
+        })
+    }
+}
+
+impl ToStyleValue for Float {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::Float(match self {
+            Self::None => FloatValue::None,
+            Self::Left => FloatValue::Left,
+            Self::Right => FloatValue::Right,
+        })
+    }
+}
+
+impl ToStyleValue for Clear {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::Clear(match self {
+            Self::None => ClearValue::None,
+            Self::Left => ClearValue::Left,
+            Self::Right => ClearValue::Right,
+            Self::Both => ClearValue::Both,
         })
     }
 }

--- a/crates/whisker-layout/Cargo.toml
+++ b/crates/whisker-layout/Cargo.toml
@@ -12,6 +12,6 @@ categories.workspace = true
 description = "Retained, renderer-independent layout engine for Whisker."
 
 [dependencies]
-taffy = { version = "0.13", default-features = false, features = ["std", "taffy_tree", "flexbox", "grid", "block_layout", "content_size"] }
+taffy = { version = "0.13", default-features = false, features = ["std", "taffy_tree", "flexbox", "grid", "block_layout", "float_layout", "content_size"] }
 whisker-protocol.workspace = true
 whisker-style.workspace = true

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -956,8 +956,8 @@ mod tests {
     use super::*;
     use whisker_style::{
         Axes, ComputedGridTemplate, ComputedGridTemplateComponent, ComputedGridTemplateRepetition,
-        ComputedGridTrackSizing, Edges, GridPlacementLineValue, GridRepetitionCountValue,
-        GridTemplateAreaValue, GridTemplateAreasValue, StyleNumber,
+        ClearValue, ComputedGridTrackSizing, Edges, FloatValue, GridPlacementLineValue,
+        GridRepetitionCountValue, GridTemplateAreaValue, GridTemplateAreasValue, StyleNumber,
     };
 
     const MIXED: ComputedLengthPercentage = ComputedLengthPercentage::new(1.0, 0.5);
@@ -1306,6 +1306,62 @@ mod tests {
                 .is_err()
             );
         }
+    }
+
+    #[test]
+    fn block_float_and_clear_follow_the_taffy_formatting_context() {
+        let root = id(1);
+        let left = id(2);
+        let right = id(3);
+        let cleared = id(4);
+        let mut tree = LayoutTree::new();
+        tree.create_node(
+            root,
+            ComputedLayoutStyle {
+                display: DisplayValue::Block,
+                size: Axes {
+                    width: ComputedSizeValue::Value(ComputedLengthPercentage::new(200.0, 0.0)),
+                    height: ComputedSizeValue::Auto,
+                },
+                ..ComputedLayoutStyle::default()
+            },
+        )
+        .unwrap();
+        tree.create_node(
+            left,
+            ComputedLayoutStyle {
+                float: FloatValue::Left,
+                ..sized(50.0, 40.0)
+            },
+        )
+        .unwrap();
+        tree.create_node(
+            right,
+            ComputedLayoutStyle {
+                float: FloatValue::Right,
+                ..sized(60.0, 30.0)
+            },
+        )
+        .unwrap();
+        tree.create_node(
+            cleared,
+            ComputedLayoutStyle {
+                clear: ClearValue::Both,
+                ..sized(100.0, 10.0)
+            },
+        )
+        .unwrap();
+        tree.set_children(root, &[left, right, cleared]).unwrap();
+
+        let snapshot = tree
+            .compute(root, LayoutSize::new(200.0, 100.0), &mut zero_measure)
+            .unwrap();
+        assert_eq!(snapshot.get(left).unwrap().border_box.x, 0.0);
+        assert_eq!(snapshot.get(left).unwrap().border_box.y, 0.0);
+        assert_eq!(snapshot.get(right).unwrap().border_box.x, 140.0);
+        assert_eq!(snapshot.get(right).unwrap().border_box.y, 0.0);
+        assert_eq!(snapshot.get(cleared).unwrap().border_box.x, 0.0);
+        assert_eq!(snapshot.get(cleared).unwrap().border_box.y, 40.0);
     }
 
     fn assert_unsupported(style: ComputedLayoutStyle, feature: UnsupportedLayoutFeature) {

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -9,22 +9,23 @@
 use std::{collections::BTreeMap, error::Error, fmt};
 
 use taffy::{
-    AlignContent, AlignItems, AvailableSpace as TaffyAvailableSpace, BoxSizing, Dimension,
-    Direction, Display, FlexDirection, FlexWrap, GridAutoFlow, GridPlacement, GridTemplateArea,
-    GridTemplateAreas, GridTemplateComponent, GridTemplateRepetition, LengthPercentage,
-    LengthPercentageAuto, Line, MaxTrackSizingFunction, MinTrackSizingFunction, Position, Rect,
-    RepetitionCount, Size, Style, TaffyTree, TrackSizingFunction,
+    AlignContent, AlignItems, AvailableSpace as TaffyAvailableSpace, BoxSizing,
+    Clear as TaffyClear, Dimension, Direction, Display, FlexDirection, FlexWrap,
+    Float as TaffyFloat, GridAutoFlow, GridPlacement, GridTemplateArea, GridTemplateAreas,
+    GridTemplateComponent, GridTemplateRepetition, LengthPercentage, LengthPercentageAuto, Line,
+    MaxTrackSizingFunction, MinTrackSizingFunction, Position, Rect, RepetitionCount, Size, Style,
+    TaffyTree, TrackSizingFunction,
 };
 pub use whisker_protocol::AvailableSpace;
 use whisker_protocol::{LayoutGeometry, LayoutRect, MeasureConstraints, NodeId};
 use whisker_style::{
-    AlignContentValue, AlignItemsValue, AlignSelfValue, BoxSizingValue, ComputedFlexBasis,
-    ComputedGridMaxTrackSizing, ComputedGridMinTrackSizing, ComputedGridTemplate,
-    ComputedGridTemplateComponent, ComputedGridTrackSizing, ComputedLayoutStyle,
-    ComputedLengthPercentage, ComputedLengthPercentageAuto, ComputedSizeValue, DirectionValue,
-    DisplayValue, FlexDirectionValue, FlexWrapValue, GridAutoFlowValue, GridPlacementLineValue,
-    GridPlacementValue, GridRepetitionCountValue, GridTemplateAreasValue, JustifyContentValue,
-    PositionValue, PropertyImpactSet,
+    AlignContentValue, AlignItemsValue, AlignSelfValue, BoxSizingValue, ClearValue,
+    ComputedFlexBasis, ComputedGridMaxTrackSizing, ComputedGridMinTrackSizing,
+    ComputedGridTemplate, ComputedGridTemplateComponent, ComputedGridTrackSizing,
+    ComputedLayoutStyle, ComputedLengthPercentage, ComputedLengthPercentageAuto, ComputedSizeValue,
+    DirectionValue, DisplayValue, FlexDirectionValue, FlexWrapValue, FloatValue, GridAutoFlowValue,
+    GridPlacementLineValue, GridPlacementValue, GridRepetitionCountValue, GridTemplateAreasValue,
+    JustifyContentValue, PositionValue, PropertyImpactSet,
 };
 
 /// A width and height in logical pixels.
@@ -612,6 +613,19 @@ fn convert_style(input: &ComputedLayoutStyle) -> Result<Style, LayoutError> {
             DisplayValue::Flex | DisplayValue::Linear => Display::Flex,
             DisplayValue::Grid => Display::Grid,
             DisplayValue::Relative => Display::Block,
+            DisplayValue::Block => Display::Block,
+            DisplayValue::FlowRoot => Display::FlowRoot,
+        },
+        float: match input.float {
+            FloatValue::None => TaffyFloat::None,
+            FloatValue::Left => TaffyFloat::Left,
+            FloatValue::Right => TaffyFloat::Right,
+        },
+        clear: match input.clear {
+            ClearValue::None => TaffyClear::None,
+            ClearValue::Left => TaffyClear::Left,
+            ClearValue::Right => TaffyClear::Right,
+            ClearValue::Both => TaffyClear::Both,
         },
         position: match input.position {
             PositionValue::Relative => Position::Relative,
@@ -955,9 +969,10 @@ fn justify(value: JustifyContentValue) -> AlignContent {
 mod tests {
     use super::*;
     use whisker_style::{
-        Axes, ComputedGridTemplate, ComputedGridTemplateComponent, ComputedGridTemplateRepetition,
-        ClearValue, ComputedGridTrackSizing, Edges, FloatValue, GridPlacementLineValue,
-        GridRepetitionCountValue, GridTemplateAreaValue, GridTemplateAreasValue, StyleNumber,
+        Axes, ClearValue, ComputedGridTemplate, ComputedGridTemplateComponent,
+        ComputedGridTemplateRepetition, ComputedGridTrackSizing, Edges, FloatValue,
+        GridPlacementLineValue, GridRepetitionCountValue, GridTemplateAreaValue,
+        GridTemplateAreasValue, StyleNumber,
     };
 
     const MIXED: ComputedLengthPercentage = ComputedLengthPercentage::new(1.0, 0.5);

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -1897,8 +1897,23 @@ mod tests {
             DisplayValue::Grid,
             DisplayValue::Linear,
             DisplayValue::Relative,
+            DisplayValue::Block,
+            DisplayValue::FlowRoot,
         ] {
             style.display = display;
+            convert_style(&style).unwrap();
+        }
+        for value in [FloatValue::None, FloatValue::Left, FloatValue::Right] {
+            style.float = value;
+            convert_style(&style).unwrap();
+        }
+        for value in [
+            ClearValue::None,
+            ClearValue::Left,
+            ClearValue::Right,
+            ClearValue::Both,
+        ] {
+            style.clear = value;
             convert_style(&style).unwrap();
         }
         for direction in [

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -2,11 +2,12 @@
 
 use crate::{
     AlignContentValue, AlignItemsValue, AlignSelfValue, AspectRatioValue, BoxSizingValue,
-    CalcExpression, DirectionValue, DisplayValue, FlexBasisValue, FlexDirectionValue,
-    FlexWrapValue, GridMaxTrackSizingValue, GridMinTrackSizingValue, GridTemplateComponentValue,
-    GridTemplateValue, GridTrackSizingValue, JustifyContentValue, LengthPercentageAutoValue,
-    LengthPercentageValue, LengthUnit, LengthValue, PositionValue, PropertyImpactSet, SizeValue,
-    SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty, StyleResolutionError, StyleValue,
+    CalcExpression, ClearValue, DirectionValue, DisplayValue, FlexBasisValue, FlexDirectionValue,
+    FlexWrapValue, FloatValue, GridMaxTrackSizingValue, GridMinTrackSizingValue,
+    GridTemplateComponentValue, GridTemplateValue, GridTrackSizingValue, JustifyContentValue,
+    LengthPercentageAutoValue, LengthPercentageValue, LengthUnit, LengthValue, PositionValue,
+    PropertyImpactSet, SizeValue, SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty,
+    StyleResolutionError, StyleValue,
 };
 
 const RPX_REFERENCE_WIDTH: f32 = 750.0;
@@ -331,6 +332,10 @@ impl<T: Copy> Axes<T> {
 pub struct ComputedLayoutStyle {
     /// Selected layout algorithm.
     pub display: DisplayValue,
+    /// Float side when this node participates in block layout.
+    pub float: FloatValue,
+    /// Clearance applied against preceding floats.
+    pub clear: ClearValue,
     /// Positioning model.
     pub position: PositionValue,
     /// Inline writing direction.
@@ -401,6 +406,8 @@ impl Default for ComputedLayoutStyle {
     fn default() -> Self {
         Self {
             display: DisplayValue::Linear,
+            float: FloatValue::None,
+            clear: ClearValue::None,
             position: PositionValue::Relative,
             direction: DirectionValue::Ltr,
             box_sizing: BoxSizingValue::BorderBox,
@@ -468,6 +475,24 @@ pub(crate) fn resolve_layout_style(
         },
     )?
     .unwrap_or(style.display);
+    style.float = copied(
+        declarations.float,
+        StyleProperty::Float,
+        |value| match value {
+            StyleValue::Float(value) => Some(*value),
+            _ => None,
+        },
+    )?
+    .unwrap_or(style.float);
+    style.clear = copied(
+        declarations.clear,
+        StyleProperty::Clear,
+        |value| match value {
+            StyleValue::Clear(value) => Some(*value),
+            _ => None,
+        },
+    )?
+    .unwrap_or(style.clear);
     style.position = copied(
         declarations.position,
         StyleProperty::Position,
@@ -1319,6 +1344,8 @@ fn invalid(property: StyleProperty) -> StyleResolutionError {
 #[derive(Default)]
 struct LayoutDeclarations<'a> {
     display: Option<&'a StyleValue>,
+    float: Option<&'a StyleValue>,
+    clear: Option<&'a StyleValue>,
     position: Option<&'a StyleValue>,
     direction: Option<&'a StyleValue>,
     box_sizing: Option<&'a StyleValue>,
@@ -1373,6 +1400,8 @@ impl<'a> LayoutDeclarations<'a> {
         for declaration in specified.resolved() {
             let slot = match declaration.property() {
                 StyleProperty::Display => &mut values.display,
+                StyleProperty::Float => &mut values.float,
+                StyleProperty::Clear => &mut values.clear,
                 StyleProperty::Position => &mut values.position,
                 StyleProperty::Direction => &mut values.direction,
                 StyleProperty::BoxSizing => &mut values.box_sizing,
@@ -1472,6 +1501,8 @@ mod tests {
             ComputedLengthPercentage::ZERO
         );
         assert_eq!(style.display, DisplayValue::Linear);
+        assert_eq!(style.float, FloatValue::None);
+        assert_eq!(style.clear, ClearValue::None);
         assert_eq!(style.position, PositionValue::Relative);
         assert_eq!(style.direction, DirectionValue::Ltr);
         assert_eq!(style.box_sizing, BoxSizingValue::BorderBox);
@@ -1903,6 +1934,21 @@ mod tests {
                 .is_err()
             );
         }
+    }
+
+    #[test]
+    fn block_float_declarations_resolve_without_backend_types() {
+        let specified = SpecifiedStyle::new()
+            .push(
+                StyleProperty::Display,
+                StyleValue::Display(DisplayValue::FlowRoot),
+            )
+            .push(StyleProperty::Float, StyleValue::Float(FloatValue::Right))
+            .push(StyleProperty::Clear, StyleValue::Clear(ClearValue::Both));
+        let style = resolve(&specified).unwrap();
+        assert_eq!(style.display, DisplayValue::FlowRoot);
+        assert_eq!(style.float, FloatValue::Right);
+        assert_eq!(style.clear, ClearValue::Both);
     }
 
     #[test]

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -2315,6 +2315,8 @@ mod tests {
     fn invalid_types_are_reported_for_each_layout_property_family() {
         let properties = [
             StyleProperty::Display,
+            StyleProperty::Float,
+            StyleProperty::Clear,
             StyleProperty::Position,
             StyleProperty::Direction,
             StyleProperty::BoxSizing,

--- a/crates/whisker-style/src/layout_value.rs
+++ b/crates/whisker-style/src/layout_value.rs
@@ -11,10 +11,40 @@ pub enum DisplayValue {
     Flex,
     /// CSS grid.
     Grid,
+    /// CSS block layout.
+    Block,
+    /// CSS block layout establishing a new block formatting context.
+    FlowRoot,
     /// Lynx-compatible linear layout.
     Linear,
     /// Lynx-compatible relative layout.
     Relative,
+}
+
+/// Side to which a box floats in a block formatting context.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum FloatValue {
+    /// Do not float the box.
+    #[default]
+    None,
+    /// Float to the physical left side.
+    Left,
+    /// Float to the physical right side.
+    Right,
+}
+
+/// Floats that a block box must clear.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ClearValue {
+    /// Do not add clearance.
+    #[default]
+    None,
+    /// Clear preceding left floats.
+    Left,
+    /// Clear preceding right floats.
+    Right,
+    /// Clear preceding floats on both sides.
+    Both,
 }
 
 /// The positioning model selected for a node.

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -26,8 +26,8 @@ pub use layout::{
 };
 pub use layout_value::{
     AlignContentValue, AlignItemsValue, AlignSelfValue, AspectRatioValue, BoxSizingValue,
-    DirectionValue, DisplayValue, FlexBasisValue, FlexDirectionValue, FlexWrapValue,
-    GridMaxTrackSizingValue, GridMinTrackSizingValue, GridTemplateComponentValue,
+    ClearValue, DirectionValue, DisplayValue, FlexBasisValue, FlexDirectionValue, FlexWrapValue,
+    FloatValue, GridMaxTrackSizingValue, GridMinTrackSizingValue, GridTemplateComponentValue,
     GridTemplateRepetitionValue, GridTemplateValue, GridTrackSizingValue, JustifyContentValue,
     LengthPercentageAutoValue, PositionValue, SizeValue,
 };

--- a/crates/whisker-style/src/property.rs
+++ b/crates/whisker-style/src/property.rs
@@ -277,6 +277,8 @@ macro_rules! define_style_properties {
                     | Self::BoxSizing
                     | Self::ColumnGap
                     | Self::Display
+                    | Self::Float
+                    | Self::Clear
                     | Self::Flex
                     | Self::FlexBasis
                     | Self::FlexDirection
@@ -511,6 +513,8 @@ define_style_properties! {
     TextDecoration = 208 => "text-decoration",
     TextShadow = 209 => "text-shadow",
     GridTemplateAreas = 210 => "grid-template-areas",
+    Float = 211 => "float",
+    Clear = 212 => "clear",
 }
 
 #[cfg(test)]
@@ -544,7 +548,7 @@ mod tests {
 
     #[test]
     fn registry_contains_only_the_standard_property_target() {
-        assert_eq!(StyleProperty::ALL.len(), 175);
+        assert_eq!(StyleProperty::ALL.len(), 177);
         assert_eq!(StyleProperty::Color.metadata().origin, PropertyOrigin::Css);
         assert!(
             StyleProperty::ALL

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -306,6 +306,10 @@ pub enum StyleValue {
     LineHeight(LineHeightValue),
     /// Layout algorithm.
     Display(crate::DisplayValue),
+    /// Block-layout float side.
+    Float(crate::FloatValue),
+    /// Block-layout clearance rule.
+    Clear(crate::ClearValue),
     /// Positioning model.
     Position(crate::PositionValue),
     /// Box sizing model.

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use whisker::css::{BorderStyle, GridLine, GridTemplate, GridTrack, Overflow};
+use whisker::css::{BorderStyle, Clear, Float, GridLine, GridTemplate, GridTrack, Overflow};
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
 use whisker::runtime::view::{
@@ -536,6 +536,75 @@ fn render_grid_layout_reaches_frame_packet_geometry() {
     let second = geometry(child_nodes[1]).expect("second Grid item geometry");
     assert_eq!((first.x, first.width), (0.0, 50.0));
     assert_eq!((second.x, second.width), (50.0, 150.0));
+
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn render_block_float_and_clear_reach_frame_packet_geometry() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(19).expect("test surface"),
+        StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+    );
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| {
+            render! {
+                view(style: Css::new().display_block().width(px(200))) {
+                    view(style: Css::new().width(px(50)).height(px(40)).float(Float::Left))
+                    view(style: Css::new().width(px(60)).height(px(30)).float(Float::Right))
+                    view(style: Css::new().width(px(100)).height(px(10)).clear(Clear::Both))
+                }
+            }
+        });
+        set_root(root);
+    });
+    assert_eq!(surface.binding_error(), None);
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(200.0, 100.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .expect("render! float frame");
+    assert!(host.calls.is_empty());
+
+    let root_node = surface.root().expect("float root");
+    let packet = &renderer.frames()[0].packet;
+    let child_nodes: Vec<_> = packet
+        .operations
+        .iter()
+        .filter_map(|operation| match operation {
+            Operation::InsertChild { parent, child, .. } if *parent == root_node => Some(*child),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(child_nodes.len(), 3);
+    let geometry = |node| {
+        packet
+            .operations
+            .iter()
+            .find_map(|operation| match operation {
+                Operation::SetLayout {
+                    node: candidate,
+                    geometry,
+                } if *candidate == node => Some(geometry.border_box),
+                _ => None,
+            })
+    };
+    let left = geometry(child_nodes[0]).expect("left float geometry");
+    let right = geometry(child_nodes[1]).expect("right float geometry");
+    let cleared = geometry(child_nodes[2]).expect("cleared geometry");
+    assert_eq!((left.x, left.y), (0.0, 0.0));
+    assert_eq!((right.x, right.y), (140.0, 0.0));
+    assert_eq!((cleared.x, cleared.y), (0.0, 40.0));
 
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }

--- a/tests/host-conformance/README.md
+++ b/tests/host-conformance/README.md
@@ -82,8 +82,7 @@ The target follows two explicit baselines. Layout semantics are the CSS subset
 represented by Taffy 0.13. Non-layout properties follow the standard,
 non-vendor Lynx 4.0 inventory at the recorded upstream revision. The resulting
 target is 158 conformance features: 157 properties plus the CSS Custom
-Properties mechanism. Of the 175 currently registered spellings, 155 remain
-in the target, 20 are deliberately unsupported, and `float` and `clear` still
-need registry entries. The legacy aliases
+Properties mechanism. Of the 177 currently registered spellings, 157 remain
+in the target and 20 are deliberately unsupported. The legacy aliases
 `grid-column-gap`, `grid-row-gap`, and `word-wrap` remain absent. Stable IDs
 assigned to excluded spellings are reserved and are never reused.

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -13,9 +13,9 @@
   "target": {
     "feature_count": 158,
     "property_count": 157,
-    "registered_property_count": 175,
-    "target_registered_property_count": 155,
-    "pending_registry_properties": ["clear", "float"],
+    "registered_property_count": 177,
+    "target_registered_property_count": 157,
+    "pending_registry_properties": [],
     "excluded_registered_property_count": 20,
     "non_property_features": ["custom-properties"],
     "lynx_inventory": {
@@ -73,7 +73,7 @@
       "properties": ["clear", "float"],
       "supported_subset": ["block-formatting-context-floats"],
       "protocol": ["SetLayout"],
-      "rust": "planned",
+      "rust": "implemented",
       "hosts": {"desktop": "not-applicable", "web": "not-applicable", "android": "not-applicable", "ios": "not-applicable"}
     },
     {


### PR DESCRIPTION
## Summary
- enable the Taffy float-layout implementation
- add typed display block and flow-root values plus float and clear declarations
- resolve float and clear in renderer-independent computed style and lower them to Taffy
- verify render! produces left/right/cleared FramePacket geometry
- complete the 157-property target registry and mark layout.float implemented

## Verification
- cargo test -p whisker-css -p whisker-style -p whisker-layout -p whisker-host-conformance -p whisker --lib --tests
- cargo clippy -p whisker-css -p whisker-style -p whisker-layout -p whisker-host-conformance -p whisker --all-targets -- -D warnings