### PR TITLE
feat(layout): complete Taffy intrinsic core semantics

### DIFF
--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -13,8 +13,8 @@ use taffy::{
     Clear as TaffyClear, Dimension, Direction, Display, FlexDirection, FlexWrap,
     Float as TaffyFloat, GridAutoFlow, GridPlacement, GridTemplateArea, GridTemplateAreas,
     GridTemplateComponent, GridTemplateRepetition, LengthPercentage, LengthPercentageAuto, Line,
-    MaxTrackSizingFunction, MinTrackSizingFunction, Position, Rect, RepetitionCount, Size, Style,
-    TaffyTree, TrackSizingFunction,
+    MaxTrackSizingFunction, MinTrackSizingFunction, Overflow as TaffyOverflow, Point, Position,
+    Rect, RepetitionCount, Size, Style, TaffyTree, TrackSizingFunction,
 };
 pub use whisker_protocol::AvailableSpace;
 use whisker_protocol::{LayoutGeometry, LayoutRect, MeasureConstraints, NodeId};
@@ -25,7 +25,7 @@ use whisker_style::{
     ComputedLayoutStyle, ComputedLengthPercentage, ComputedLengthPercentageAuto, ComputedSizeValue,
     DirectionValue, DisplayValue, FlexDirectionValue, FlexWrapValue, FloatValue, GridAutoFlowValue,
     GridPlacementLineValue, GridPlacementValue, GridRepetitionCountValue, GridTemplateAreasValue,
-    JustifyContentValue, PositionValue, PropertyImpactSet,
+    JustifyContentValue, OverflowValue, PositionValue, PropertyImpactSet,
 };
 
 /// A width and height in logical pixels.
@@ -247,7 +247,7 @@ impl LayoutTree {
         if self.contains(node) {
             return Err(LayoutError::DuplicateNode(node));
         }
-        let converted = convert_style(&style)?;
+        let converted = convert_retained_style(&style, false)?;
         let backend = self
             .backend
             .new_leaf(converted)
@@ -279,7 +279,7 @@ impl LayoutTree {
         if impact.is_empty() {
             return Ok(impact);
         }
-        let converted = convert_style(&style)?;
+        let converted = convert_retained_style(&style, retained.measurable)?;
         let backend_node = retained.backend;
         let parent = retained.parent;
         self.backend
@@ -302,6 +302,11 @@ impl LayoutTree {
             return Ok(false);
         }
         let backend = retained.backend;
+        let converted = convert_retained_style(&retained.style, measurable)
+            .expect("a retained style was validated when it entered layout");
+        self.backend
+            .set_style(backend, converted)
+            .expect("retained backend node");
         self.backend
             .set_node_context(backend, measurable.then_some(node))
             .expect("retained backend node");
@@ -627,6 +632,10 @@ fn convert_style(input: &ComputedLayoutStyle) -> Result<Style, LayoutError> {
             ClearValue::Right => TaffyClear::Right,
             ClearValue::Both => TaffyClear::Both,
         },
+        overflow: Point {
+            x: overflow(input.overflow.width),
+            y: overflow(input.overflow.height),
+        },
         position: match input.position {
             PositionValue::Relative => Position::Relative,
             PositionValue::Absolute => Position::Absolute,
@@ -744,6 +753,23 @@ fn convert_style(input: &ComputedLayoutStyle) -> Result<Style, LayoutError> {
         grid_row: grid_placement_line(&input.grid_row),
         ..Style::default()
     })
+}
+
+fn convert_retained_style(
+    input: &ComputedLayoutStyle,
+    item_is_replaced: bool,
+) -> Result<Style, LayoutError> {
+    convert_style(input).map(|mut style| {
+        style.item_is_replaced = item_is_replaced;
+        style
+    })
+}
+
+fn overflow(value: OverflowValue) -> TaffyOverflow {
+    match value {
+        OverflowValue::Visible => TaffyOverflow::Visible,
+        OverflowValue::Hidden => TaffyOverflow::Hidden,
+    }
 }
 
 fn align_self(value: AlignSelfValue) -> AlignItems {

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -972,7 +972,8 @@ mod tests {
         Axes, ClearValue, ComputedGridTemplate, ComputedGridTemplateComponent,
         ComputedGridTemplateRepetition, ComputedGridTrackSizing, Edges, FloatValue,
         GridPlacementLineValue, GridRepetitionCountValue, GridTemplateAreaValue,
-        GridTemplateAreasValue, StyleNumber,
+        GridTemplateAreasValue, OverflowValue, SpecifiedStyle, StyleEnvironment, StyleNumber,
+        StyleProperty, StyleValue, resolve_style,
     };
 
     const MIXED: ComputedLengthPercentage = ComputedLengthPercentage::new(1.0, 0.5);
@@ -993,6 +994,77 @@ mod tests {
 
     fn zero_measure(_: NodeId, _: MeasureRequest) -> LayoutSize {
         LayoutSize::default()
+    }
+
+    fn resolved_layout(specified: &SpecifiedStyle) -> ComputedLayoutStyle {
+        resolve_style(
+            specified,
+            None,
+            StyleEnvironment::new(100.0, 100.0, 1.0, 16.0),
+        )
+        .unwrap()
+        .computed()
+        .layout()
+        .clone()
+    }
+
+    #[test]
+    fn intrinsic_leaf_uses_replaced_block_sizing() {
+        let root = id(1);
+        let leaf = id(2);
+        let mut tree = LayoutTree::new();
+        tree.create_node(
+            root,
+            ComputedLayoutStyle {
+                display: DisplayValue::Block,
+                size: Axes {
+                    width: ComputedSizeValue::Value(ComputedLengthPercentage::new(200.0, 0.0)),
+                    height: ComputedSizeValue::Auto,
+                },
+                ..ComputedLayoutStyle::default()
+            },
+        )
+        .unwrap();
+        tree.create_node(leaf, ComputedLayoutStyle::default())
+            .unwrap();
+        tree.set_measurable(leaf, true).unwrap();
+        tree.set_children(root, &[leaf]).unwrap();
+
+        let snapshot = tree
+            .compute(root, LayoutSize::new(200.0, 100.0), &mut |_, _| {
+                LayoutSize::new(50.0, 20.0)
+            })
+            .unwrap();
+        assert_eq!(snapshot.get(leaf).unwrap().border_box.width, 50.0);
+    }
+
+    #[test]
+    fn overflow_controls_flex_automatic_minimum_size() {
+        fn child_width(overflow: OverflowValue) -> f32 {
+            let root = id(1);
+            let child = id(2);
+            let mut tree = LayoutTree::new();
+            tree.create_node(root, sized(100.0, 20.0)).unwrap();
+            let child_style = resolved_layout(
+                &SpecifiedStyle::new()
+                    .push(StyleProperty::OverflowX, StyleValue::Overflow(overflow))
+                    .push(StyleProperty::OverflowY, StyleValue::Overflow(overflow)),
+            );
+            tree.create_node(child, child_style).unwrap();
+            tree.set_measurable(child, true).unwrap();
+            tree.set_children(root, &[child]).unwrap();
+            tree.compute(root, LayoutSize::new(100.0, 20.0), &mut |_, _| {
+                LayoutSize::new(200.0, 20.0)
+            })
+            .unwrap()
+            .get(child)
+            .unwrap()
+            .border_box
+            .width
+        }
+
+        assert_eq!(child_width(OverflowValue::Visible), 200.0);
+        assert_eq!(child_width(OverflowValue::Hidden), 100.0);
     }
 
     #[test]

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -5,9 +5,9 @@ use crate::{
     CalcExpression, ClearValue, DirectionValue, DisplayValue, FlexBasisValue, FlexDirectionValue,
     FlexWrapValue, FloatValue, GridMaxTrackSizingValue, GridMinTrackSizingValue,
     GridTemplateComponentValue, GridTemplateValue, GridTrackSizingValue, JustifyContentValue,
-    LengthPercentageAutoValue, LengthPercentageValue, LengthUnit, LengthValue, PositionValue,
-    PropertyImpactSet, SizeValue, SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty,
-    StyleResolutionError, StyleValue,
+    LengthPercentageAutoValue, LengthPercentageValue, LengthUnit, LengthValue, OverflowValue,
+    PositionValue, PropertyImpactSet, SizeValue, SpecifiedStyle, StyleEnvironment, StyleNumber,
+    StyleProperty, StyleResolutionError, StyleValue,
 };
 
 const RPX_REFERENCE_WIDTH: f32 = 750.0;
@@ -336,6 +336,8 @@ pub struct ComputedLayoutStyle {
     pub float: FloatValue,
     /// Clearance applied against preceding floats.
     pub clear: ClearValue,
+    /// Horizontal and vertical overflow behavior that also affects Taffy's automatic minimums.
+    pub overflow: Axes<OverflowValue>,
     /// Positioning model.
     pub position: PositionValue,
     /// Inline writing direction.
@@ -408,11 +410,12 @@ impl Default for ComputedLayoutStyle {
             display: DisplayValue::Linear,
             float: FloatValue::None,
             clear: ClearValue::None,
+            overflow: Axes::all(OverflowValue::Visible),
             position: PositionValue::Relative,
             direction: DirectionValue::Ltr,
             box_sizing: BoxSizingValue::BorderBox,
             size: Axes::all(ComputedSizeValue::Auto),
-            min_size: Axes::all(ComputedSizeValue::Value(ComputedLengthPercentage::ZERO)),
+            min_size: Axes::all(ComputedSizeValue::Auto),
             max_size: Axes::all(ComputedSizeValue::None),
             margin: Edges::all(ComputedLengthPercentageAuto::Value(
                 ComputedLengthPercentage::ZERO,
@@ -493,6 +496,26 @@ pub(crate) fn resolve_layout_style(
         },
     )?
     .unwrap_or(style.clear);
+    style.overflow.width =
+        copied(
+            declarations.overflow_x,
+            StyleProperty::OverflowX,
+            |value| match value {
+                StyleValue::Overflow(value) => Some(*value),
+                _ => None,
+            },
+        )?
+        .unwrap_or(style.overflow.width);
+    style.overflow.height =
+        copied(
+            declarations.overflow_y,
+            StyleProperty::OverflowY,
+            |value| match value {
+                StyleValue::Overflow(value) => Some(*value),
+                _ => None,
+            },
+        )?
+        .unwrap_or(style.overflow.height);
     style.position = copied(
         declarations.position,
         StyleProperty::Position,
@@ -1346,6 +1369,8 @@ struct LayoutDeclarations<'a> {
     display: Option<&'a StyleValue>,
     float: Option<&'a StyleValue>,
     clear: Option<&'a StyleValue>,
+    overflow_x: Option<&'a StyleValue>,
+    overflow_y: Option<&'a StyleValue>,
     position: Option<&'a StyleValue>,
     direction: Option<&'a StyleValue>,
     box_sizing: Option<&'a StyleValue>,
@@ -1402,6 +1427,8 @@ impl<'a> LayoutDeclarations<'a> {
                 StyleProperty::Display => &mut values.display,
                 StyleProperty::Float => &mut values.float,
                 StyleProperty::Clear => &mut values.clear,
+                StyleProperty::OverflowX => &mut values.overflow_x,
+                StyleProperty::OverflowY => &mut values.overflow_y,
                 StyleProperty::Position => &mut values.position,
                 StyleProperty::Direction => &mut values.direction,
                 StyleProperty::BoxSizing => &mut values.box_sizing,
@@ -1503,6 +1530,7 @@ mod tests {
         assert_eq!(style.display, DisplayValue::Linear);
         assert_eq!(style.float, FloatValue::None);
         assert_eq!(style.clear, ClearValue::None);
+        assert_eq!(style.overflow, Axes::all(OverflowValue::Visible));
         assert_eq!(style.position, PositionValue::Relative);
         assert_eq!(style.direction, DirectionValue::Ltr);
         assert_eq!(style.box_sizing, BoxSizingValue::BorderBox);
@@ -1941,11 +1969,20 @@ mod tests {
                 StyleValue::Display(DisplayValue::FlowRoot),
             )
             .push(StyleProperty::Float, StyleValue::Float(FloatValue::Right))
-            .push(StyleProperty::Clear, StyleValue::Clear(ClearValue::Both));
+            .push(StyleProperty::Clear, StyleValue::Clear(ClearValue::Both))
+            .push(
+                StyleProperty::OverflowX,
+                StyleValue::Overflow(OverflowValue::Hidden),
+            )
+            .push(
+                StyleProperty::OverflowY,
+                StyleValue::Overflow(OverflowValue::Hidden),
+            );
         let style = resolve(&specified).unwrap();
         assert_eq!(style.display, DisplayValue::FlowRoot);
         assert_eq!(style.float, FloatValue::Right);
         assert_eq!(style.clear, ClearValue::Both);
+        assert_eq!(style.overflow, Axes::all(OverflowValue::Hidden));
     }
 
     #[test]
@@ -2314,6 +2351,8 @@ mod tests {
             StyleProperty::Display,
             StyleProperty::Float,
             StyleProperty::Clear,
+            StyleProperty::OverflowX,
+            StyleProperty::OverflowY,
             StyleProperty::Position,
             StyleProperty::Direction,
             StyleProperty::BoxSizing,

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -1507,10 +1507,7 @@ mod tests {
         assert_eq!(style.direction, DirectionValue::Ltr);
         assert_eq!(style.box_sizing, BoxSizingValue::BorderBox);
         assert_eq!(style.size, Axes::all(ComputedSizeValue::Auto));
-        assert_eq!(
-            style.min_size,
-            Axes::all(ComputedSizeValue::Value(ComputedLengthPercentage::ZERO))
-        );
+        assert_eq!(style.min_size, Axes::all(ComputedSizeValue::Auto));
         assert_eq!(style.max_size, Axes::all(ComputedSizeValue::None));
         assert_eq!(
             style.margin,

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -837,14 +837,28 @@ mod tests {
             StyleProperty::BorderBottomLeftRadius,
             StyleProperty::Opacity,
             StyleProperty::Visibility,
-            StyleProperty::OverflowX,
-            StyleProperty::OverflowY,
             StyleProperty::ZIndex,
         ] {
             assert_eq!(
                 crate::resolve_style(
                     &SpecifiedStyle::new().push(property, StyleValue::Bool(true)),
                     None,
+                    StyleEnvironment::default(),
+                ),
+                Err(StyleResolutionError::InvalidPropertyValue(property))
+            );
+        }
+        let inherited =
+            crate::resolve_style(&SpecifiedStyle::new(), None, StyleEnvironment::default())
+                .unwrap()
+                .computed()
+                .inherited_text()
+                .clone();
+        for property in [StyleProperty::OverflowX, StyleProperty::OverflowY] {
+            assert_eq!(
+                resolve_paint_style(
+                    &SpecifiedStyle::new().push(property, StyleValue::Bool(true)),
+                    &inherited,
                     StyleEnvironment::default(),
                 ),
                 Err(StyleResolutionError::InvalidPropertyValue(property))

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -51,10 +51,10 @@
       "id": "layout.core",
       "basis": "taffy-0.13",
       "properties": ["align-content", "align-items", "align-self", "aspect-ratio", "bottom", "box-sizing", "column-gap", "direction", "display", "flex", "flex-basis", "flex-direction", "flex-flow", "flex-grow", "flex-shrink", "flex-wrap", "gap", "height", "inset-inline-end", "inset-inline-start", "justify-content", "left", "margin", "margin-bottom", "margin-inline-end", "margin-inline-start", "margin-left", "margin-right", "margin-top", "max-height", "max-width", "min-height", "min-width", "order", "padding", "padding-bottom", "padding-inline-end", "padding-inline-start", "padding-left", "padding-right", "padding-top", "position", "right", "row-gap", "top", "width"],
-      "supported_subset": ["block-flex-grid", "relative-absolute-position", "length-percentage-auto-sizing", "content-border-box", "ltr-rtl"],
+      "supported_subset": ["block-flex-grid", "relative-absolute-position", "length-percentage-auto-sizing", "content-border-box", "ltr-rtl", "overflow-visible-hidden-automatic-minimums", "host-measured-replaced-leaves"],
       "unsupported_browser_subset": ["display-contents-inline-table", "static-fixed-sticky-position", "intrinsic-size-keywords"],
       "protocol": ["SetLayout"],
-      "rust": "partial",
+      "rust": "implemented",
       "hosts": {"desktop": "not-applicable", "web": "not-applicable", "android": "not-applicable", "ios": "not-applicable"}
     },
     {


### PR DESCRIPTION
## Summary
- restore CSS/Taffy automatic minimum-size defaults
- feed visible/hidden overflow into Taffy automatic minimum sizing
- treat Host-measured leaves as replaced elements for intrinsic block sizing
- mark the Rust layout.core capability implemented

## Verification
- cargo test -p whisker-style -p whisker-layout -p whisker-host-conformance -p whisker-engine -p whisker --lib --tests
- cargo llvm-cov -p whisker-style --summary-only (100% lines/functions/regions)
- cargo llvm-cov -p whisker-layout --summary-only (100% lines/functions/regions)
- cargo clippy -p whisker-style -p whisker-layout -p whisker-engine -p whisker-host-conformance -p whisker --all-targets -- -D warnings