### PR TITLE
feat(paint): resolve logical borders in Rust

### DIFF
--- a/crates/whisker-css/src/prop/border.rs
+++ b/crates/whisker-css/src/prop/border.rs
@@ -31,6 +31,16 @@ impl Css {
         self.push_typed(crate::StyleProperty::BorderLeftWidth, v.into())
     }
 
+    /// Sets `border-inline-start-width`; Rust resolves it using `direction`.
+    pub fn border_inline_start_width(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::BorderInlineStartWidth, v.into())
+    }
+
+    /// Sets `border-inline-end-width`; Rust resolves it using `direction`.
+    pub fn border_inline_end_width(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::BorderInlineEndWidth, v.into())
+    }
+
     // ---------- border-style longhands ----------
 
     /// Sets `border-top-style`.
@@ -55,6 +65,16 @@ impl Css {
     /// <https://lynxjs.org/api/css/properties/border-left-style>
     pub fn border_left_style(self, v: BorderStyle) -> Self {
         self.push_typed(crate::StyleProperty::BorderLeftStyle, v)
+    }
+
+    /// Sets `border-inline-start-style`; Rust resolves it using `direction`.
+    pub fn border_inline_start_style(self, v: BorderStyle) -> Self {
+        self.push_typed(crate::StyleProperty::BorderInlineStartStyle, v)
+    }
+
+    /// Sets `border-inline-end-style`; Rust resolves it using `direction`.
+    pub fn border_inline_end_style(self, v: BorderStyle) -> Self {
+        self.push_typed(crate::StyleProperty::BorderInlineEndStyle, v)
     }
 
     // ---------- border-color longhands ----------
@@ -83,6 +103,16 @@ impl Css {
         self.push_typed(crate::StyleProperty::BorderLeftColor, v)
     }
 
+    /// Sets `border-inline-start-color`; Rust resolves it using `direction`.
+    pub fn border_inline_start_color(self, v: Color) -> Self {
+        self.push_typed(crate::StyleProperty::BorderInlineStartColor, v)
+    }
+
+    /// Sets `border-inline-end-color`; Rust resolves it using `direction`.
+    pub fn border_inline_end_color(self, v: Color) -> Self {
+        self.push_typed(crate::StyleProperty::BorderInlineEndColor, v)
+    }
+
     // ---------- border-radius corners ----------
 
     /// Sets `border-top-left-radius`.
@@ -107,6 +137,26 @@ impl Css {
     /// <https://lynxjs.org/api/css/properties/border-bottom-left-radius>
     pub fn border_bottom_left_radius(self, v: impl Into<LengthPercentage>) -> Self {
         self.push_typed(crate::StyleProperty::BorderBottomLeftRadius, v.into())
+    }
+
+    /// Sets `border-start-start-radius`; Rust resolves it using `direction`.
+    pub fn border_start_start_radius(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::BorderStartStartRadius, v.into())
+    }
+
+    /// Sets `border-start-end-radius`; Rust resolves it using `direction`.
+    pub fn border_start_end_radius(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::BorderStartEndRadius, v.into())
+    }
+
+    /// Sets `border-end-start-radius`; Rust resolves it using `direction`.
+    pub fn border_end_start_radius(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::BorderEndStartRadius, v.into())
+    }
+
+    /// Sets `border-end-end-radius`; Rust resolves it using `direction`.
+    pub fn border_end_end_radius(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::BorderEndEndRadius, v.into())
     }
 
     /// Sets `border-radius` shorthand. Expands to the four corner
@@ -222,6 +272,26 @@ mod tests {
         assert_eq!(
             s.to_string(),
             "border-top-right-radius: 8px; border-bottom-right-radius: 8px; border-bottom-left-radius: 8px; border-top-left-radius: 0px;"
+        );
+    }
+
+    #[test]
+    fn logical_border_longhands_keep_typed_semantics() {
+        let css = Css::new()
+            .border_inline_start_width(px(2))
+            .border_inline_end_width(px(3))
+            .border_inline_start_style(BorderStyle::Dotted)
+            .border_inline_end_style(BorderStyle::Double)
+            .border_inline_start_color(Color::hex(0x112233))
+            .border_inline_end_color(Color::hex(0x445566))
+            .border_start_start_radius(px(4))
+            .border_start_end_radius(px(5))
+            .border_end_start_radius(px(6))
+            .border_end_end_radius(px(7));
+        assert_eq!(css.to_specified_style().unwrap().len(), 10);
+        assert_eq!(
+            css.to_string(),
+            "border-inline-start-width: 2px; border-inline-end-width: 3px; border-inline-start-style: dotted; border-inline-end-style: double; border-inline-start-color: rgb(17, 34, 51); border-inline-end-color: rgb(68, 85, 102); border-start-start-radius: 4px; border-start-end-radius: 5px; border-end-start-radius: 6px; border-end-end-radius: 7px;"
         );
     }
 }

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -645,34 +645,7 @@ pub(crate) fn resolve_layout_style(
         StyleProperty::PaddingLeft,
     )?;
 
-    style.border.top = resolve_non_negative_length_percentage(
-        declarations.border_top_width,
-        style.border.top,
-        font_size,
-        environment,
-        StyleProperty::BorderTopWidth,
-    )?;
-    style.border.right = resolve_non_negative_length_percentage(
-        declarations.border_right_width,
-        style.border.right,
-        font_size,
-        environment,
-        StyleProperty::BorderRightWidth,
-    )?;
-    style.border.bottom = resolve_non_negative_length_percentage(
-        declarations.border_bottom_width,
-        style.border.bottom,
-        font_size,
-        environment,
-        StyleProperty::BorderBottomWidth,
-    )?;
-    style.border.left = resolve_non_negative_length_percentage(
-        declarations.border_left_width,
-        style.border.left,
-        font_size,
-        environment,
-        StyleProperty::BorderLeftWidth,
-    )?;
+    style.border = resolve_borders(specified, style.direction, font_size, environment)?;
 
     style.inset = resolve_insets(specified, style.direction, font_size, environment)?;
 
@@ -1165,6 +1138,46 @@ fn resolve_insets(
     Ok(inset)
 }
 
+fn resolve_borders(
+    specified: &SpecifiedStyle,
+    direction: DirectionValue,
+    font_size: f32,
+    environment: StyleEnvironment,
+) -> Result<Edges<ComputedLengthPercentage>, StyleResolutionError> {
+    let mut border = Edges::all(ComputedLengthPercentage::ZERO);
+    for declaration in specified.resolved() {
+        let (edge, property) = match declaration.property() {
+            StyleProperty::BorderTopWidth => (&mut border.top, StyleProperty::BorderTopWidth),
+            StyleProperty::BorderRightWidth => (&mut border.right, StyleProperty::BorderRightWidth),
+            StyleProperty::BorderBottomWidth => {
+                (&mut border.bottom, StyleProperty::BorderBottomWidth)
+            }
+            StyleProperty::BorderLeftWidth => (&mut border.left, StyleProperty::BorderLeftWidth),
+            StyleProperty::BorderInlineStartWidth if direction == DirectionValue::Ltr => {
+                (&mut border.left, StyleProperty::BorderInlineStartWidth)
+            }
+            StyleProperty::BorderInlineStartWidth => {
+                (&mut border.right, StyleProperty::BorderInlineStartWidth)
+            }
+            StyleProperty::BorderInlineEndWidth if direction == DirectionValue::Ltr => {
+                (&mut border.right, StyleProperty::BorderInlineEndWidth)
+            }
+            StyleProperty::BorderInlineEndWidth => {
+                (&mut border.left, StyleProperty::BorderInlineEndWidth)
+            }
+            _ => continue,
+        };
+        *edge = resolve_non_negative_length_percentage(
+            Some(declaration.value()),
+            *edge,
+            font_size,
+            environment,
+            property,
+        )?;
+    }
+    Ok(border)
+}
+
 fn resolve_non_negative_number(
     value: Option<&StyleValue>,
     initial: StyleNumber,
@@ -1388,10 +1401,6 @@ struct LayoutDeclarations<'a> {
     padding_right: Option<&'a StyleValue>,
     padding_bottom: Option<&'a StyleValue>,
     padding_left: Option<&'a StyleValue>,
-    border_top_width: Option<&'a StyleValue>,
-    border_right_width: Option<&'a StyleValue>,
-    border_bottom_width: Option<&'a StyleValue>,
-    border_left_width: Option<&'a StyleValue>,
     flex_direction: Option<&'a StyleValue>,
     flex_wrap: Option<&'a StyleValue>,
     flex_grow: Option<&'a StyleValue>,
@@ -1446,10 +1455,6 @@ impl<'a> LayoutDeclarations<'a> {
                 StyleProperty::PaddingRight => &mut values.padding_right,
                 StyleProperty::PaddingBottom => &mut values.padding_bottom,
                 StyleProperty::PaddingLeft => &mut values.padding_left,
-                StyleProperty::BorderTopWidth => &mut values.border_top_width,
-                StyleProperty::BorderRightWidth => &mut values.border_right_width,
-                StyleProperty::BorderBottomWidth => &mut values.border_bottom_width,
-                StyleProperty::BorderLeftWidth => &mut values.border_left_width,
                 StyleProperty::FlexDirection => &mut values.flex_direction,
                 StyleProperty::FlexWrap => &mut values.flex_wrap,
                 StyleProperty::FlexGrow => &mut values.flex_grow,
@@ -2374,6 +2379,8 @@ mod tests {
             StyleProperty::BorderRightWidth,
             StyleProperty::BorderBottomWidth,
             StyleProperty::BorderLeftWidth,
+            StyleProperty::BorderInlineStartWidth,
+            StyleProperty::BorderInlineEndWidth,
             StyleProperty::Top,
             StyleProperty::Right,
             StyleProperty::Bottom,

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -512,6 +512,141 @@ mod tests {
     }
 
     #[test]
+    fn logical_borders_resolve_to_physical_edges_and_corners() {
+        let specified = |direction| {
+            SpecifiedStyle::new()
+                .push(StyleProperty::Direction, StyleValue::Direction(direction))
+                .push(StyleProperty::BorderInlineStartWidth, px(2.0))
+                .push(StyleProperty::BorderInlineEndWidth, px(3.0))
+                .push(
+                    StyleProperty::BorderInlineStartColor,
+                    StyleValue::Color(ColorValue::Named("start".into())),
+                )
+                .push(
+                    StyleProperty::BorderInlineEndColor,
+                    StyleValue::Color(ColorValue::Named("end".into())),
+                )
+                .push(
+                    StyleProperty::BorderInlineStartStyle,
+                    StyleValue::BorderStyle(BorderStyleValue::Dotted),
+                )
+                .push(
+                    StyleProperty::BorderInlineEndStyle,
+                    StyleValue::BorderStyle(BorderStyleValue::Double),
+                )
+                .push(StyleProperty::BorderStartStartRadius, px(11.0))
+                .push(StyleProperty::BorderStartEndRadius, px(12.0))
+                .push(StyleProperty::BorderEndStartRadius, px(13.0))
+                .push(StyleProperty::BorderEndEndRadius, px(14.0))
+        };
+
+        for (direction, start_is_left) in [
+            (crate::DirectionValue::Ltr, true),
+            (crate::DirectionValue::Rtl, false),
+        ] {
+            let resolved =
+                crate::resolve_style(&specified(direction), None, StyleEnvironment::default())
+                    .unwrap();
+            let layout = resolved.computed().layout();
+            let paint = resolved.computed().paint();
+            let (start_width, end_width) = if start_is_left {
+                (layout.border.left.length(), layout.border.right.length())
+            } else {
+                (layout.border.right.length(), layout.border.left.length())
+            };
+            assert_eq!((start_width, end_width), (2.0, 3.0));
+
+            let (start_color, end_color, start_style, end_style) = if start_is_left {
+                (
+                    &paint.border_colors.left,
+                    &paint.border_colors.right,
+                    paint.border_styles.left,
+                    paint.border_styles.right,
+                )
+            } else {
+                (
+                    &paint.border_colors.right,
+                    &paint.border_colors.left,
+                    paint.border_styles.right,
+                    paint.border_styles.left,
+                )
+            };
+            assert_eq!(start_color, &ColorValue::Named("start".into()));
+            assert_eq!(end_color, &ColorValue::Named("end".into()));
+            assert_eq!(start_style, BorderStyleValue::Dotted);
+            assert_eq!(end_style, BorderStyleValue::Double);
+
+            let corners = &paint.border_radii;
+            let logical = if start_is_left {
+                [
+                    corners.top_left,
+                    corners.top_right,
+                    corners.bottom_left,
+                    corners.bottom_right,
+                ]
+            } else {
+                [
+                    corners.top_right,
+                    corners.top_left,
+                    corners.bottom_right,
+                    corners.bottom_left,
+                ]
+            };
+            assert_eq!(
+                logical.map(|corner| corner.horizontal.length()),
+                [11.0, 12.0, 13.0, 14.0]
+            );
+        }
+    }
+
+    #[test]
+    fn logical_and_physical_border_declarations_share_final_write_order() {
+        let resolved = crate::resolve_style(
+            &SpecifiedStyle::new()
+                .push(StyleProperty::BorderInlineStartWidth, px(2.0))
+                .push(StyleProperty::BorderLeftWidth, px(4.0))
+                .push(
+                    StyleProperty::BorderInlineStartColor,
+                    StyleValue::Color(ColorValue::Named("logical".into())),
+                )
+                .push(
+                    StyleProperty::BorderLeftColor,
+                    StyleValue::Color(ColorValue::Named("physical".into())),
+                ),
+            None,
+            StyleEnvironment::default(),
+        )
+        .unwrap();
+        assert_eq!(resolved.computed().layout().border.left.length(), 4.0);
+        assert_eq!(
+            resolved.computed().paint().border_colors.left,
+            ColorValue::Named("physical".into())
+        );
+
+        let resolved = crate::resolve_style(
+            &SpecifiedStyle::new()
+                .push(StyleProperty::BorderLeftWidth, px(4.0))
+                .push(StyleProperty::BorderInlineStartWidth, px(6.0))
+                .push(
+                    StyleProperty::BorderLeftColor,
+                    StyleValue::Color(ColorValue::Named("physical".into())),
+                )
+                .push(
+                    StyleProperty::BorderInlineStartColor,
+                    StyleValue::Color(ColorValue::Named("logical".into())),
+                ),
+            None,
+            StyleEnvironment::default(),
+        )
+        .unwrap();
+        assert_eq!(resolved.computed().layout().border.left.length(), 6.0);
+        assert_eq!(
+            resolved.computed().paint().border_colors.left,
+            ColorValue::Named("logical".into())
+        );
+    }
+
+    #[test]
     fn background_layer_initial_values_match_css() {
         let resolved =
             crate::resolve_style(&SpecifiedStyle::new(), None, StyleEnvironment::default())

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -2,9 +2,9 @@
 
 use crate::{
     BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue, BackgroundPositionValue,
-    BackgroundRepeatModeValue, BackgroundSizeValue, ColorValue, ComputedLengthPercentage, Edges,
-    InheritedStyle, SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty,
-    StyleResolutionError, StyleValue, layout::resolve_affine,
+    BackgroundRepeatModeValue, BackgroundSizeValue, ColorValue, ComputedLengthPercentage,
+    DirectionValue, Edges, InheritedStyle, SpecifiedStyle, StyleEnvironment, StyleNumber,
+    StyleProperty, StyleResolutionError, StyleValue, layout::resolve_affine,
 };
 
 /// Four physical corners in top-left, top-right, bottom-right, bottom-left order.
@@ -233,6 +233,7 @@ impl ComputedPaintStyle {
 pub(crate) fn resolve_paint_style(
     specified: &SpecifiedStyle,
     inherited: &InheritedStyle,
+    direction: DirectionValue,
     environment: StyleEnvironment,
 ) -> Result<ComputedPaintStyle, StyleResolutionError> {
     let mut paint = ComputedPaintStyle::initial(inherited.color());
@@ -302,6 +303,18 @@ pub(crate) fn resolve_paint_style(
                 paint.border_colors.bottom = color(value, property)?;
             }
             StyleProperty::BorderLeftColor => paint.border_colors.left = color(value, property)?,
+            StyleProperty::BorderInlineStartColor if direction == DirectionValue::Ltr => {
+                paint.border_colors.left = color(value, property)?;
+            }
+            StyleProperty::BorderInlineStartColor => {
+                paint.border_colors.right = color(value, property)?;
+            }
+            StyleProperty::BorderInlineEndColor if direction == DirectionValue::Ltr => {
+                paint.border_colors.right = color(value, property)?;
+            }
+            StyleProperty::BorderInlineEndColor => {
+                paint.border_colors.left = color(value, property)?;
+            }
             StyleProperty::BorderTopStyle => {
                 paint.border_styles.top = border_style(value, property)?
             }
@@ -314,6 +327,18 @@ pub(crate) fn resolve_paint_style(
             StyleProperty::BorderLeftStyle => {
                 paint.border_styles.left = border_style(value, property)?;
             }
+            StyleProperty::BorderInlineStartStyle if direction == DirectionValue::Ltr => {
+                paint.border_styles.left = border_style(value, property)?;
+            }
+            StyleProperty::BorderInlineStartStyle => {
+                paint.border_styles.right = border_style(value, property)?;
+            }
+            StyleProperty::BorderInlineEndStyle if direction == DirectionValue::Ltr => {
+                paint.border_styles.right = border_style(value, property)?;
+            }
+            StyleProperty::BorderInlineEndStyle => {
+                paint.border_styles.left = border_style(value, property)?;
+            }
             StyleProperty::BorderTopLeftRadius => {
                 paint.border_radii.top_left = radius(value, inherited, environment, property)?;
             }
@@ -324,6 +349,30 @@ pub(crate) fn resolve_paint_style(
                 paint.border_radii.bottom_right = radius(value, inherited, environment, property)?;
             }
             StyleProperty::BorderBottomLeftRadius => {
+                paint.border_radii.bottom_left = radius(value, inherited, environment, property)?;
+            }
+            StyleProperty::BorderStartStartRadius if direction == DirectionValue::Ltr => {
+                paint.border_radii.top_left = radius(value, inherited, environment, property)?;
+            }
+            StyleProperty::BorderStartStartRadius => {
+                paint.border_radii.top_right = radius(value, inherited, environment, property)?;
+            }
+            StyleProperty::BorderStartEndRadius if direction == DirectionValue::Ltr => {
+                paint.border_radii.top_right = radius(value, inherited, environment, property)?;
+            }
+            StyleProperty::BorderStartEndRadius => {
+                paint.border_radii.top_left = radius(value, inherited, environment, property)?;
+            }
+            StyleProperty::BorderEndStartRadius if direction == DirectionValue::Ltr => {
+                paint.border_radii.bottom_left = radius(value, inherited, environment, property)?;
+            }
+            StyleProperty::BorderEndStartRadius => {
+                paint.border_radii.bottom_right = radius(value, inherited, environment, property)?;
+            }
+            StyleProperty::BorderEndEndRadius if direction == DirectionValue::Ltr => {
+                paint.border_radii.bottom_right = radius(value, inherited, environment, property)?;
+            }
+            StyleProperty::BorderEndEndRadius => {
                 paint.border_radii.bottom_left = radius(value, inherited, environment, property)?;
             }
             StyleProperty::Opacity => {
@@ -962,14 +1011,22 @@ mod tests {
             StyleProperty::BorderRightColor,
             StyleProperty::BorderBottomColor,
             StyleProperty::BorderLeftColor,
+            StyleProperty::BorderInlineStartColor,
+            StyleProperty::BorderInlineEndColor,
             StyleProperty::BorderTopStyle,
             StyleProperty::BorderRightStyle,
             StyleProperty::BorderBottomStyle,
             StyleProperty::BorderLeftStyle,
+            StyleProperty::BorderInlineStartStyle,
+            StyleProperty::BorderInlineEndStyle,
             StyleProperty::BorderTopLeftRadius,
             StyleProperty::BorderTopRightRadius,
             StyleProperty::BorderBottomRightRadius,
             StyleProperty::BorderBottomLeftRadius,
+            StyleProperty::BorderStartStartRadius,
+            StyleProperty::BorderStartEndRadius,
+            StyleProperty::BorderEndStartRadius,
+            StyleProperty::BorderEndEndRadius,
             StyleProperty::Opacity,
             StyleProperty::Visibility,
             StyleProperty::ZIndex,
@@ -994,6 +1051,31 @@ mod tests {
                 resolve_paint_style(
                     &SpecifiedStyle::new().push(property, StyleValue::Bool(true)),
                     &inherited,
+                    DirectionValue::Ltr,
+                    StyleEnvironment::default(),
+                ),
+                Err(StyleResolutionError::InvalidPropertyValue(property))
+            );
+        }
+        for property in [
+            StyleProperty::BorderInlineStartColor,
+            StyleProperty::BorderInlineEndColor,
+            StyleProperty::BorderInlineStartStyle,
+            StyleProperty::BorderInlineEndStyle,
+            StyleProperty::BorderStartStartRadius,
+            StyleProperty::BorderStartEndRadius,
+            StyleProperty::BorderEndStartRadius,
+            StyleProperty::BorderEndEndRadius,
+        ] {
+            assert_eq!(
+                crate::resolve_style(
+                    &SpecifiedStyle::new()
+                        .push(
+                            StyleProperty::Direction,
+                            StyleValue::Direction(DirectionValue::Rtl),
+                        )
+                        .push(property, StyleValue::Bool(true)),
+                    None,
                     StyleEnvironment::default(),
                 ),
                 Err(StyleResolutionError::InvalidPropertyValue(property))

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -475,7 +475,12 @@ pub fn resolve_style(
     };
     let layout =
         crate::layout::resolve_layout_style(specified, inherited_text.font_size(), environment)?;
-    let paint = crate::paint::resolve_paint_style(specified, &inherited_text, environment)?;
+    let paint = crate::paint::resolve_paint_style(
+        specified,
+        &inherited_text,
+        layout.direction,
+        environment,
+    )?;
 
     Ok(ResolvedNodeStyle {
         computed: ComputedStyle {

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -1,6 +1,8 @@
 use std::convert::Infallible;
 
-use whisker::css::{BorderStyle, Clear, Float, GridLine, GridTemplate, GridTrack, Overflow};
+use whisker::css::{
+    BorderStyle, Clear, Direction, Float, GridLine, GridTemplate, GridTrack, Overflow,
+};
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
 use whisker::runtime::view::{
@@ -462,6 +464,70 @@ fn render_box_paint_and_clip_reach_the_frame_sink() {
                     alpha: 1.0,
                 }
     ));
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn render_logical_borders_reach_physical_frame_edges_in_rtl() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(21).expect("test surface"),
+        StyleEnvironment::new(100.0, 50.0, 1.0, 14.0),
+    );
+    let style = Css::new()
+        .direction(Direction::Rtl)
+        .width(px(100))
+        .height(px(50))
+        .border_inline_start_width(px(7))
+        .border_inline_end_width(px(3))
+        .border_inline_start_style(BorderStyle::Solid)
+        .border_inline_end_style(BorderStyle::Dotted)
+        .border_inline_start_color(Color::rgb(10, 20, 30))
+        .border_inline_end_color(Color::rgb(40, 50, 60))
+        .border_start_start_radius(px(11))
+        .border_start_end_radius(px(12))
+        .border_end_start_radius(px(13))
+        .border_end_end_radius(px(14));
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| render! { view(style: style) });
+        set_root(root);
+    });
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(100.0, 50.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    let root = surface.root().unwrap();
+    let packet = &renderer.frames()[0].packet;
+    assert!(packet.operations.iter().any(|operation| matches!(
+        operation,
+        Operation::SetLayout { node, geometry }
+            if *node == root
+                && geometry.content_box.x == 3.0
+                && geometry.content_box.width == 90.0
+    )));
+    assert!(packet.operations.iter().any(|operation| matches!(
+        operation,
+        Operation::SetBoxPaint { node, paint }
+            if *node == root
+                && paint.border_widths.left.length == 3.0
+                && paint.border_widths.right.length == 7.0
+                && paint.border_colors.left == PaintColor::Srgba { red: 40, green: 50, blue: 60, alpha: 1.0 }
+                && paint.border_colors.right == PaintColor::Srgba { red: 10, green: 20, blue: 30, alpha: 1.0 }
+                && paint.border_radii.top_left.horizontal.length == 12.0
+                && paint.border_radii.top_right.horizontal.length == 11.0
+                && paint.border_radii.bottom_right.horizontal.length == 13.0
+                && paint.border_radii.bottom_left.horizontal.length == 14.0
+    )));
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }
 

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -81,8 +81,8 @@
       "basis": "lynx-4.0",
       "properties": ["background-color", "border", "border-bottom", "border-bottom-color", "border-bottom-left-radius", "border-bottom-right-radius", "border-bottom-style", "border-bottom-width", "border-color", "border-end-end-radius", "border-end-start-radius", "border-inline-end-color", "border-inline-end-style", "border-inline-end-width", "border-inline-start-color", "border-inline-start-style", "border-inline-start-width", "border-left", "border-left-color", "border-left-style", "border-left-width", "border-radius", "border-right", "border-right-color", "border-right-style", "border-right-width", "border-start-end-radius", "border-start-start-radius", "border-style", "border-top", "border-top-color", "border-top-left-radius", "border-top-right-radius", "border-top-style", "border-top-width", "border-width"],
       "protocol": ["SetBoxPaint"],
-      "rust": "partial",
-      "hosts": {"desktop": "partial", "web": "implemented", "android": "partial", "ios": "partial"}
+      "rust": "implemented",
+      "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}
     },
     {
       "id": "paint.background-layers",


### PR DESCRIPTION
## Summary
- add typed authoring for all logical border width, style, color, and radius longhands
- resolve logical edges and corners to physical FramePacket state in final declaration order
- keep all Host implementations on the existing physical SetLayout/SetBoxPaint contract
- mark paint.box implemented for Rust and all four Hosts

## Verification
- cargo test -p whisker-css --lib
- cargo test -p whisker-style --lib
- cargo test -p whisker --test surface_render_pipeline render_logical_borders_reach_physical_frame_edges_in_rtl -- --exact
- cargo llvm-cov -p whisker-style --summary-only (100% lines/functions/regions)
- cargo clippy -p whisker-css -p whisker-style -p whisker-layout -p whisker-engine -p whisker-host-conformance -p whisker --all-targets -- -D warnings