### PR TITLE
feat(background): preserve per-layer URL geometry

### DIFF
--- a/crates/whisker-css/src/prop/background.rs
+++ b/crates/whisker-css/src/prop/background.rs
@@ -24,46 +24,22 @@ impl Css {
     pub fn background_image(self, v: impl Into<ImageRef>) -> Self {
         let image = v.into();
         let lynx_value = image.to_css_string();
-        match image {
-            ImageRef::None => self.push_semantic(
+        match background_image_value(&image) {
+            Some(image) => self.push_semantic(
                 crate::StyleProperty::BackgroundImage,
-                whisker_style::StyleValue::BackgroundImages(vec![
-                    whisker_style::BackgroundImageValue::None,
-                ]),
+                whisker_style::StyleValue::BackgroundImages(vec![image]),
                 lynx_value,
             ),
-            ImageRef::Url(value) => self.push_semantic(
-                crate::StyleProperty::BackgroundImage,
-                whisker_style::StyleValue::BackgroundImages(vec![
-                    whisker_style::BackgroundImageValue::Url(value.0),
-                ]),
-                lynx_value,
-            ),
-            ImageRef::Gradient(_) => {
-                self.push_raw(crate::StyleProperty::BackgroundImage, lynx_value)
-            }
+            None => self.push_raw(crate::StyleProperty::BackgroundImage, lynx_value),
         }
     }
 
     /// Sets `background-repeat`.
     /// <https://lynxjs.org/api/css/properties/background-repeat>
     pub fn background_repeat(self, v: BackgroundRepeat) -> Self {
-        use whisker_style::{BackgroundRepeatModeValue as Mode, BackgroundRepeatValue};
-
-        let (horizontal, vertical) = match v {
-            BackgroundRepeat::Repeat => (Mode::Repeat, Mode::Repeat),
-            BackgroundRepeat::NoRepeat => (Mode::NoRepeat, Mode::NoRepeat),
-            BackgroundRepeat::RepeatX => (Mode::Repeat, Mode::NoRepeat),
-            BackgroundRepeat::RepeatY => (Mode::NoRepeat, Mode::Repeat),
-            BackgroundRepeat::Space => (Mode::Space, Mode::Space),
-            BackgroundRepeat::Round => (Mode::Round, Mode::Round),
-        };
         self.push_semantic(
             crate::StyleProperty::BackgroundRepeat,
-            whisker_style::StyleValue::BackgroundRepeat(BackgroundRepeatValue {
-                horizontal,
-                vertical,
-            }),
+            whisker_style::StyleValue::BackgroundRepeat(background_repeat_value(v)),
             v.to_css_string(),
         )
     }
@@ -98,20 +74,9 @@ impl Css {
     /// <https://lynxjs.org/api/css/properties/background-size>
     pub fn background_size(self, v: BackgroundSize) -> Self {
         let lynx_value = v.to_css_string();
-        let value = match v {
-            BackgroundSize::Auto => whisker_style::BackgroundSizeValue::Auto,
-            BackgroundSize::Explicit(width, height) => {
-                whisker_style::BackgroundSizeValue::Explicit {
-                    width: background_size_axis(width),
-                    height: background_size_axis(height),
-                }
-            }
-            BackgroundSize::Cover => whisker_style::BackgroundSizeValue::Cover,
-            BackgroundSize::Contain => whisker_style::BackgroundSizeValue::Contain,
-        };
         self.push_semantic(
             crate::StyleProperty::BackgroundSize,
-            whisker_style::StyleValue::BackgroundSize(value),
+            whisker_style::StyleValue::BackgroundSize(background_size_value(v)),
             lynx_value,
         )
     }
@@ -175,6 +140,47 @@ impl Css {
     }
 }
 
+pub(crate) fn background_image_value(
+    value: &ImageRef,
+) -> Option<whisker_style::BackgroundImageValue> {
+    match value {
+        ImageRef::None => Some(whisker_style::BackgroundImageValue::None),
+        ImageRef::Url(value) => Some(whisker_style::BackgroundImageValue::Url(value.0.clone())),
+        ImageRef::Gradient(_) => None,
+    }
+}
+
+pub(crate) fn background_repeat_value(
+    value: BackgroundRepeat,
+) -> whisker_style::BackgroundRepeatValue {
+    use whisker_style::{BackgroundRepeatModeValue as Mode, BackgroundRepeatValue};
+
+    let (horizontal, vertical) = match value {
+        BackgroundRepeat::Repeat => (Mode::Repeat, Mode::Repeat),
+        BackgroundRepeat::NoRepeat => (Mode::NoRepeat, Mode::NoRepeat),
+        BackgroundRepeat::RepeatX => (Mode::Repeat, Mode::NoRepeat),
+        BackgroundRepeat::RepeatY => (Mode::NoRepeat, Mode::Repeat),
+        BackgroundRepeat::Space => (Mode::Space, Mode::Space),
+        BackgroundRepeat::Round => (Mode::Round, Mode::Round),
+    };
+    BackgroundRepeatValue {
+        horizontal,
+        vertical,
+    }
+}
+
+pub(crate) fn background_size_value(value: BackgroundSize) -> whisker_style::BackgroundSizeValue {
+    match value {
+        BackgroundSize::Auto => whisker_style::BackgroundSizeValue::Auto,
+        BackgroundSize::Explicit(width, height) => whisker_style::BackgroundSizeValue::Explicit {
+            width: background_size_axis(width),
+            height: background_size_axis(height),
+        },
+        BackgroundSize::Cover => whisker_style::BackgroundSizeValue::Cover,
+        BackgroundSize::Contain => whisker_style::BackgroundSizeValue::Contain,
+    }
+}
+
 fn background_size_axis(value: BackgroundSizeAxis) -> Option<whisker_style::LengthPercentageValue> {
     match value {
         BackgroundSizeAxis::Auto => None,
@@ -205,7 +211,9 @@ fn keyword_value(
     })
 }
 
-fn background_position_value(position: Position) -> Option<whisker_style::BackgroundPositionValue> {
+pub(crate) fn background_position_value(
+    position: Position,
+) -> Option<whisker_style::BackgroundPositionValue> {
     use crate::data_type_ext::PositionKeyword;
 
     let center = || keyword_value(PositionKeyword::Center);

--- a/crates/whisker-css/src/prop/mod.rs
+++ b/crates/whisker-css/src/prop/mod.rs
@@ -7,7 +7,7 @@
 //! corresponding `lynxjs.org/api/css/properties/<name>` page.
 
 mod animation;
-mod background;
+pub(crate) mod background;
 mod border;
 mod box_model;
 mod display;

--- a/crates/whisker-css/src/shorthand/background.rs
+++ b/crates/whisker-css/src/shorthand/background.rs
@@ -8,6 +8,7 @@ use crate::data_type_ext::Position;
 use crate::keyword::{
     BackgroundAttachment, BackgroundClip, BackgroundOrigin, BackgroundRepeat, BackgroundSize,
 };
+use crate::style_value::ToStyleValue;
 use crate::to_css::ToCss;
 use crate::value::ImageRef;
 
@@ -176,8 +177,84 @@ impl Css {
     /// Sets the `background` shorthand.
     /// <https://lynxjs.org/api/css/properties/background>
     pub fn background(self, b: Background) -> Self {
-        self.push(crate::StyleProperty::Background, b)
+        let lynx_value = b.to_css_string();
+        let Some(value) = background_value(&b) else {
+            return self.push_raw(crate::StyleProperty::Background, lynx_value);
+        };
+        self.push_semantic(crate::StyleProperty::Background, value, lynx_value)
     }
+}
+
+fn background_value(background: &Background) -> Option<whisker_style::StyleValue> {
+    use whisker_style::{
+        BackgroundAttachmentValue, BackgroundBoxValue, BackgroundLayerValue,
+        BackgroundPositionValue, BackgroundRepeatModeValue, BackgroundRepeatValue,
+        BackgroundSizeValue, BackgroundValue, ColorValue, LengthPercentageValue, StyleNumber,
+        StyleValue,
+    };
+
+    let zero = || LengthPercentageValue::Percentage(StyleNumber::new(0.0));
+    let default_position = || BackgroundPositionValue {
+        horizontal: zero(),
+        vertical: zero(),
+    };
+    let default_repeat = BackgroundRepeatValue {
+        horizontal: BackgroundRepeatModeValue::Repeat,
+        vertical: BackgroundRepeatModeValue::Repeat,
+    };
+    let layers = background
+        .layers
+        .iter()
+        .map(|layer| {
+            Some(BackgroundLayerValue {
+                image: crate::prop::background::background_image_value(&layer.image)?,
+                position: match layer.position.clone() {
+                    Some(position) => crate::prop::background::background_position_value(position)?,
+                    None => default_position(),
+                },
+                size: layer
+                    .size
+                    .clone()
+                    .map(crate::prop::background::background_size_value)
+                    .unwrap_or(BackgroundSizeValue::Auto),
+                repeat: layer
+                    .repeat
+                    .map(crate::prop::background::background_repeat_value)
+                    .unwrap_or(default_repeat),
+                origin: match layer.origin.unwrap_or(BackgroundOrigin::PaddingBox) {
+                    BackgroundOrigin::BorderBox => BackgroundBoxValue::Border,
+                    BackgroundOrigin::PaddingBox => BackgroundBoxValue::Padding,
+                    BackgroundOrigin::ContentBox => BackgroundBoxValue::Content,
+                },
+                clip: match layer.clip.unwrap_or(BackgroundClip::BorderBox) {
+                    BackgroundClip::BorderBox => BackgroundBoxValue::Border,
+                    BackgroundClip::PaddingBox => BackgroundBoxValue::Padding,
+                    BackgroundClip::ContentBox => BackgroundBoxValue::Content,
+                    BackgroundClip::Text => return None,
+                },
+                attachment: match layer.attachment.unwrap_or(BackgroundAttachment::Scroll) {
+                    BackgroundAttachment::Scroll => BackgroundAttachmentValue::Scroll,
+                    BackgroundAttachment::Fixed => BackgroundAttachmentValue::Fixed,
+                    BackgroundAttachment::Local => BackgroundAttachmentValue::Local,
+                },
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let color = background.color.as_ref().map_or_else(
+        || ColorValue::Rgba {
+            red: 0,
+            green: 0,
+            blue: 0,
+            alpha: StyleNumber::new(0.0),
+        },
+        |color| {
+            let StyleValue::Color(value) = color.to_style_value() else {
+                unreachable!("Color always has a semantic style value")
+            };
+            value
+        },
+    );
+    Some(StyleValue::Background(BackgroundValue { layers, color }))
 }
 
 #[cfg(test)]

--- a/crates/whisker-css/src/shorthand/background.rs
+++ b/crates/whisker-css/src/shorthand/background.rs
@@ -194,6 +194,7 @@ mod tests {
     fn background_color_only() {
         let s = Css::new().background(Background::new().color(Color::Named(NamedColor::Red)));
         assert_eq!(s.to_string(), "background: red;");
+        assert!(s.to_specified_style().is_ok());
     }
 
     #[test]
@@ -231,6 +232,7 @@ mod tests {
             s.to_string(),
             "background: url(\"top.png\") no-repeat, url(\"base.png\");"
         );
+        assert!(s.to_specified_style().is_ok());
     }
 
     #[test]
@@ -240,6 +242,7 @@ mod tests {
             .size(BackgroundSize::Cover);
         let s = Css::new().background(Background::new().layer(layer));
         assert_eq!(s.to_string(), "background: url(\"a.png\") center / cover;");
+        assert!(s.to_specified_style().is_ok());
     }
 
     #[test]

--- a/crates/whisker-engine/src/paint.rs
+++ b/crates/whisker-engine/src/paint.rs
@@ -162,7 +162,7 @@ mod tests {
         ComputedPaintStyle {
             background_color: color("background"),
             background_images: Vec::new(),
-            background_layer: Default::default(),
+            background_layers: vec![Default::default()],
             border_colors: Edges {
                 top: color("top"),
                 right: color("right"),

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -45,8 +45,9 @@ pub use resolution::{
     resolve_text_style,
 };
 pub use value::{
-    BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue, BackgroundPositionValue,
-    BackgroundRepeatModeValue, BackgroundRepeatValue, BackgroundSizeValue, BorderRadiusValue,
-    CalcExpression, ColorValue, FontFamilyValue, FontStyleValue, FontWeightValue,
-    LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, StyleNumber, StyleValue,
+    BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue, BackgroundLayerValue,
+    BackgroundPositionValue, BackgroundRepeatModeValue, BackgroundRepeatValue, BackgroundSizeValue,
+    BackgroundValue, BorderRadiusValue, CalcExpression, ColorValue, FontFamilyValue,
+    FontStyleValue, FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue,
+    LineHeightValue, StyleNumber, StyleValue,
 };

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -167,8 +167,8 @@ pub struct ComputedPaintStyle {
     pub background_color: ColorValue,
     /// Ordered Host-independent background image sources, front to back.
     pub background_images: Vec<BackgroundImageValue>,
-    /// Scalar longhands applied to the current background image layer.
-    pub background_layer: ComputedBackgroundLayerStyle,
+    /// Per-layer geometry aligned with `background_images` using CSS list cycling.
+    pub background_layers: Vec<ComputedBackgroundLayerStyle>,
     /// Resolved border colors in physical edge order.
     pub border_colors: Edges<ColorValue>,
     /// Border line styles in physical edge order.
@@ -198,7 +198,7 @@ impl ComputedPaintStyle {
         Self {
             background_color: transparent,
             background_images: Vec::new(),
-            background_layer: ComputedBackgroundLayerStyle::default(),
+            background_layers: vec![ComputedBackgroundLayerStyle::default()],
             border_colors: Edges {
                 top: current_color.clone(),
                 right: current_color.clone(),
@@ -241,6 +241,47 @@ pub(crate) fn resolve_paint_style(
         let property = declaration.property();
         let value = declaration.value();
         match property {
+            StyleProperty::Background => {
+                let StyleValue::Background(value) = value else {
+                    return Err(invalid(property));
+                };
+                paint.background_color = value.color.clone();
+                paint.background_images = value
+                    .layers
+                    .iter()
+                    .map(|layer| layer.image.clone())
+                    .collect();
+                paint.background_layers = value
+                    .layers
+                    .iter()
+                    .map(|layer| {
+                        Ok(ComputedBackgroundLayerStyle {
+                            position: resolve_background_position(
+                                &layer.position,
+                                inherited,
+                                environment,
+                                property,
+                            )?,
+                            size: resolve_background_size(
+                                &layer.size,
+                                inherited,
+                                environment,
+                                property,
+                            )?,
+                            repeat_x: layer.repeat.horizontal,
+                            repeat_y: layer.repeat.vertical,
+                            origin: layer.origin,
+                            clip: layer.clip,
+                            attachment: layer.attachment,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, StyleResolutionError>>()?;
+                if paint.background_layers.is_empty() {
+                    paint
+                        .background_layers
+                        .push(ComputedBackgroundLayerStyle::default());
+                }
+            }
             StyleProperty::BackgroundColor => {
                 paint.background_color = color(value, property)?;
             }
@@ -254,48 +295,66 @@ pub(crate) fn resolve_paint_style(
                 let StyleValue::BackgroundRepeat(value) = value else {
                     return Err(invalid(property));
                 };
-                paint.background_layer.repeat_x = value.horizontal;
-                paint.background_layer.repeat_y = value.vertical;
+                for layer in &mut paint.background_layers {
+                    layer.repeat_x = value.horizontal;
+                    layer.repeat_y = value.vertical;
+                }
             }
             StyleProperty::BackgroundPosition => {
                 let StyleValue::BackgroundPosition(value) = value else {
                     return Err(invalid(property));
                 };
-                paint.background_layer.position =
+                let position =
                     resolve_background_position(value, inherited, environment, property)?;
+                for layer in &mut paint.background_layers {
+                    layer.position = position;
+                }
             }
             StyleProperty::BackgroundPositionX => {
-                paint.background_layer.position.horizontal =
+                let horizontal =
                     resolve_length_percentage(value, inherited, environment, property)?;
+                for layer in &mut paint.background_layers {
+                    layer.position.horizontal = horizontal;
+                }
             }
             StyleProperty::BackgroundPositionY => {
-                paint.background_layer.position.vertical =
-                    resolve_length_percentage(value, inherited, environment, property)?;
+                let vertical = resolve_length_percentage(value, inherited, environment, property)?;
+                for layer in &mut paint.background_layers {
+                    layer.position.vertical = vertical;
+                }
             }
             StyleProperty::BackgroundSize => {
                 let StyleValue::BackgroundSize(value) = value else {
                     return Err(invalid(property));
                 };
-                paint.background_layer.size =
-                    resolve_background_size(value, inherited, environment, property)?;
+                let size = resolve_background_size(value, inherited, environment, property)?;
+                for layer in &mut paint.background_layers {
+                    layer.size = size;
+                }
             }
             StyleProperty::BackgroundOrigin => {
                 let StyleValue::BackgroundBox(value) = value else {
                     return Err(invalid(property));
                 };
-                paint.background_layer.origin = *value;
+                for layer in &mut paint.background_layers {
+                    layer.origin = *value;
+                }
             }
             StyleProperty::BackgroundClip => {
                 let StyleValue::BackgroundBox(value) = value else {
                     return Err(invalid(property));
                 };
-                paint.background_layer.clip = *value;
+                for layer in &mut paint.background_layers {
+                    layer.clip = *value;
+                }
             }
             StyleProperty::BackgroundAttachment => {
                 let StyleValue::BackgroundAttachment(value) = value else {
                     return Err(invalid(property));
                 };
-                paint.background_layer.attachment = *value;
+                for layer in &mut paint.background_layers {
+                    layer.attachment = *value;
+                }
             }
             StyleProperty::BorderTopColor => paint.border_colors.top = color(value, property)?,
             StyleProperty::BorderRightColor => paint.border_colors.right = color(value, property)?,
@@ -538,7 +597,8 @@ fn invalid(property: StyleProperty) -> StyleResolutionError {
 mod tests {
     use super::*;
     use crate::{
-        BackgroundRepeatValue, BorderRadiusValue, LengthPercentageValue, LengthUnit, LengthValue,
+        BackgroundLayerValue, BackgroundRepeatValue, BackgroundValue, BorderRadiusValue,
+        LengthPercentageValue, LengthUnit, LengthValue,
     };
 
     fn number(value: f32) -> StyleNumber {
@@ -701,9 +761,143 @@ mod tests {
             crate::resolve_style(&SpecifiedStyle::new(), None, StyleEnvironment::default())
                 .unwrap();
         assert_eq!(
-            resolved.computed().paint().background_layer,
+            resolved.computed().paint().background_layers[0],
             ComputedBackgroundLayerStyle::default()
         );
+    }
+
+    #[test]
+    fn background_shorthand_resolves_layer_lists_and_empty_initials() {
+        let layer = |url: &str, x: f32, size, repeat_x, origin, clip| BackgroundLayerValue {
+            image: BackgroundImageValue::Url(url.into()),
+            position: BackgroundPositionValue {
+                horizontal: percentage(x),
+                vertical: px_length(4.0),
+            },
+            size,
+            repeat: BackgroundRepeatValue {
+                horizontal: repeat_x,
+                vertical: BackgroundRepeatModeValue::NoRepeat,
+            },
+            origin,
+            clip,
+            attachment: BackgroundAttachmentValue::Scroll,
+        };
+        let color = ColorValue::Named("background".into());
+        let specified = SpecifiedStyle::new()
+            .push(
+                StyleProperty::Background,
+                StyleValue::Background(BackgroundValue {
+                    layers: vec![
+                        layer(
+                            "front",
+                            25.0,
+                            BackgroundSizeValue::Cover,
+                            BackgroundRepeatModeValue::Space,
+                            BackgroundBoxValue::Content,
+                            BackgroundBoxValue::Padding,
+                        ),
+                        layer(
+                            "back",
+                            75.0,
+                            BackgroundSizeValue::Contain,
+                            BackgroundRepeatModeValue::Round,
+                            BackgroundBoxValue::Border,
+                            BackgroundBoxValue::Content,
+                        ),
+                    ],
+                    color: color.clone(),
+                }),
+            )
+            .push(StyleProperty::BackgroundPositionY, px(9.0));
+        let resolved = crate::resolve_style(&specified, None, StyleEnvironment::default()).unwrap();
+        let paint = resolved.computed().paint();
+        assert_eq!(paint.background_color, color);
+        assert_eq!(
+            paint.background_images,
+            vec![
+                BackgroundImageValue::Url("front".into()),
+                BackgroundImageValue::Url("back".into()),
+            ]
+        );
+        assert_eq!(paint.background_layers.len(), 2);
+        assert_eq!(
+            paint.background_layers[0].position.horizontal.fraction(),
+            0.25
+        );
+        assert_eq!(
+            paint.background_layers[1].position.horizontal.fraction(),
+            0.75
+        );
+        assert!(
+            paint
+                .background_layers
+                .iter()
+                .all(|layer| layer.position.vertical.length() == 9.0)
+        );
+        assert_eq!(
+            paint.background_layers[0].size,
+            ComputedBackgroundSize::Cover
+        );
+        assert_eq!(
+            paint.background_layers[1].size,
+            ComputedBackgroundSize::Contain
+        );
+
+        let empty = crate::resolve_style(
+            &SpecifiedStyle::new().push(
+                StyleProperty::Background,
+                StyleValue::Background(BackgroundValue {
+                    layers: Vec::new(),
+                    color: ColorValue::Named("empty".into()),
+                }),
+            ),
+            None,
+            StyleEnvironment::default(),
+        )
+        .unwrap();
+        assert!(empty.computed().paint().background_images.is_empty());
+        assert_eq!(empty.computed().paint().background_layers.len(), 1);
+
+        let mut invalid_position = layer(
+            "invalid-position",
+            0.0,
+            BackgroundSizeValue::Auto,
+            BackgroundRepeatModeValue::Repeat,
+            BackgroundBoxValue::Padding,
+            BackgroundBoxValue::Border,
+        );
+        invalid_position.position.horizontal = px_length(f32::NAN);
+        let mut invalid_size = layer(
+            "invalid-size",
+            0.0,
+            BackgroundSizeValue::Auto,
+            BackgroundRepeatModeValue::Repeat,
+            BackgroundBoxValue::Padding,
+            BackgroundBoxValue::Border,
+        );
+        invalid_size.size = BackgroundSizeValue::Explicit {
+            width: Some(px_length(-1.0)),
+            height: None,
+        };
+        for layer in [invalid_position, invalid_size] {
+            assert_eq!(
+                crate::resolve_style(
+                    &SpecifiedStyle::new().push(
+                        StyleProperty::Background,
+                        StyleValue::Background(BackgroundValue {
+                            layers: vec![layer],
+                            color: ColorValue::Named("invalid".into()),
+                        }),
+                    ),
+                    None,
+                    StyleEnvironment::default(),
+                ),
+                Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::Background
+                ))
+            );
+        }
     }
 
     #[test]
@@ -835,28 +1029,34 @@ mod tests {
                 "https://example.com/image.png".into()
             )]
         );
-        assert_eq!(paint.background_layer.position.horizontal.length(), 5.0);
-        assert_eq!(paint.background_layer.position.horizontal.fraction(), 0.0);
-        assert_eq!(paint.background_layer.position.vertical.length(), 10.0);
+        assert_eq!(paint.background_layers[0].position.horizontal.length(), 5.0);
         assert_eq!(
-            paint.background_layer.size,
+            paint.background_layers[0].position.horizontal.fraction(),
+            0.0
+        );
+        assert_eq!(paint.background_layers[0].position.vertical.length(), 10.0);
+        assert_eq!(
+            paint.background_layers[0].size,
             ComputedBackgroundSize::Explicit {
                 width: Some(ComputedLengthPercentage::new(0.0, 0.5)),
                 height: Some(ComputedLengthPercentage::new(20.0, 0.0)),
             }
         );
         assert_eq!(
-            paint.background_layer.repeat_x,
+            paint.background_layers[0].repeat_x,
             BackgroundRepeatModeValue::Space
         );
         assert_eq!(
-            paint.background_layer.repeat_y,
+            paint.background_layers[0].repeat_y,
             BackgroundRepeatModeValue::Round
         );
-        assert_eq!(paint.background_layer.origin, BackgroundBoxValue::Content);
-        assert_eq!(paint.background_layer.clip, BackgroundBoxValue::Padding);
         assert_eq!(
-            paint.background_layer.attachment,
+            paint.background_layers[0].origin,
+            BackgroundBoxValue::Content
+        );
+        assert_eq!(paint.background_layers[0].clip, BackgroundBoxValue::Padding);
+        assert_eq!(
+            paint.background_layers[0].attachment,
             BackgroundAttachmentValue::Scroll
         );
         assert_eq!(paint.border_colors.top, ColorValue::Named("top".into()));
@@ -940,7 +1140,7 @@ mod tests {
                     .unwrap()
                     .computed()
                     .paint()
-                    .background_layer
+                    .background_layers[0]
                     .size,
                 computed
             );
@@ -997,6 +1197,7 @@ mod tests {
     #[test]
     fn invalid_paint_values_are_diagnostic() {
         for property in [
+            StyleProperty::Background,
             StyleProperty::BackgroundColor,
             StyleProperty::BackgroundImage,
             StyleProperty::BackgroundRepeat,

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -259,6 +259,34 @@ pub enum BackgroundAttachmentValue {
     Local,
 }
 
+/// One fully expanded background layer before environment resolution.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BackgroundLayerValue {
+    /// Image source painted by this layer.
+    pub image: BackgroundImageValue,
+    /// Position within the selected origin box.
+    pub position: BackgroundPositionValue,
+    /// Image sizing behavior.
+    pub size: BackgroundSizeValue,
+    /// Two-axis tiling behavior.
+    pub repeat: BackgroundRepeatValue,
+    /// Box defining the positioning area.
+    pub origin: BackgroundBoxValue,
+    /// Box clipping background paint.
+    pub clip: BackgroundBoxValue,
+    /// Relationship to scrolling.
+    pub attachment: BackgroundAttachmentValue,
+}
+
+/// Expanded semantic value of the `background` shorthand.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BackgroundValue {
+    /// Ordered image layers, front to back.
+    pub layers: Vec<BackgroundLayerValue>,
+    /// The shorthand's resolved specified color, including transparent default.
+    pub color: ColorValue,
+}
+
 /// An owned value in a specified inline-style declaration.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StyleValue {
@@ -278,6 +306,8 @@ pub enum StyleValue {
     BorderRadius(BorderRadiusValue),
     /// Ordered background images, front to back.
     BackgroundImages(Vec<BackgroundImageValue>),
+    /// Fully expanded `background` shorthand.
+    Background(BackgroundValue),
     /// Expanded tiling behavior of one background layer.
     BackgroundRepeat(BackgroundRepeatValue),
     /// Specified position of one background layer.

--- a/crates/whisker/src/background_resources.rs
+++ b/crates/whisker/src/background_resources.rs
@@ -94,7 +94,7 @@ pub(super) struct BackgroundResourceManager {
     entries: HashMap<ResourceId, ResourceEntry>,
     owned_ids: HashSet<ResourceId>,
     node_images: HashMap<NodeId, Vec<DesiredImage>>,
-    node_layer_styles: HashMap<NodeId, ComputedBackgroundLayerStyle>,
+    node_layer_styles: HashMap<NodeId, Vec<ComputedBackgroundLayerStyle>>,
     dirty_nodes: HashSet<NodeId>,
 }
 
@@ -121,7 +121,7 @@ impl BackgroundResourceManager {
         &mut self,
         node: NodeId,
         images: &[BackgroundImageValue],
-        layer_style: ComputedBackgroundLayerStyle,
+        layer_styles: &[ComputedBackgroundLayerStyle],
         externally_used: &HashSet<ResourceId>,
     ) -> Result<ReconcileResult, BackgroundResourceError> {
         let desired = images
@@ -157,7 +157,14 @@ impl BackgroundResourceManager {
         }
 
         self.node_images.insert(node, desired);
-        self.node_layer_styles.insert(node, layer_style);
+        self.node_layer_styles.insert(
+            node,
+            if layer_styles.is_empty() {
+                vec![ComputedBackgroundLayerStyle::default()]
+            } else {
+                layer_styles.to_vec()
+            },
+        );
         self.refresh_projected_node(node);
 
         for key in previous_keys.difference(&desired_keys) {
@@ -380,12 +387,14 @@ impl BackgroundResourceManager {
             .get(&node)
             .into_iter()
             .flatten()
-            .filter_map(|image| match image {
+            .enumerate()
+            .filter_map(|(index, image)| match image {
                 DesiredImage::None => None,
                 DesiredImage::Resource(key) => {
                     let resource = self.resources_by_key[key];
+                    let styles = &self.node_layer_styles[&node];
                     (self.entries[&resource].phase == ResourcePhase::Ready)
-                        .then(|| initial_resource_layer(resource, self.node_layer_styles[&node]))
+                        .then(|| initial_resource_layer(resource, styles[index % styles.len()]))
                 }
             })
             .collect()
@@ -499,7 +508,7 @@ mod tests {
             .reconcile_node(
                 node(1),
                 &[url("https://example.test/a.png")],
-                ComputedBackgroundLayerStyle::default(),
+                &[ComputedBackgroundLayerStyle::default()],
                 &HashSet::new(),
             )
             .unwrap();
@@ -511,7 +520,7 @@ mod tests {
             .reconcile_node(
                 node(2),
                 &[url("https://example.test/a.png")],
-                ComputedBackgroundLayerStyle::default(),
+                &[ComputedBackgroundLayerStyle::default()],
                 &HashSet::new(),
             )
             .unwrap();
@@ -536,7 +545,7 @@ mod tests {
             .reconcile_node(
                 node(1),
                 &[url("same")],
-                ComputedBackgroundLayerStyle::default(),
+                &[ComputedBackgroundLayerStyle::default()],
                 &HashSet::new(),
             )
             .unwrap();
@@ -554,7 +563,7 @@ mod tests {
             .reconcile_node(
                 node(1),
                 &[],
-                ComputedBackgroundLayerStyle::default(),
+                &[ComputedBackgroundLayerStyle::default()],
                 &HashSet::new(),
             )
             .unwrap();
@@ -563,7 +572,7 @@ mod tests {
             .reconcile_node(
                 node(1),
                 &[url("same")],
-                ComputedBackgroundLayerStyle::default(),
+                &[ComputedBackgroundLayerStyle::default()],
                 &HashSet::new(),
             )
             .unwrap();
@@ -579,7 +588,7 @@ mod tests {
             .reconcile_node(
                 node(1),
                 &[url("same")],
-                ComputedBackgroundLayerStyle::default(),
+                &[ComputedBackgroundLayerStyle::default()],
                 &HashSet::new(),
             )
             .unwrap();
@@ -588,7 +597,7 @@ mod tests {
             .reconcile_node(
                 node(1),
                 &[],
-                ComputedBackgroundLayerStyle::default(),
+                &[ComputedBackgroundLayerStyle::default()],
                 &HashSet::new(),
             )
             .unwrap();
@@ -603,7 +612,7 @@ mod tests {
             .reconcile_node(
                 node(1),
                 &[url("same")],
-                ComputedBackgroundLayerStyle::default(),
+                &[ComputedBackgroundLayerStyle::default()],
                 &HashSet::new(),
             )
             .unwrap();

--- a/crates/whisker/src/surface_runtime.rs
+++ b/crates/whisker/src/surface_runtime.rs
@@ -863,7 +863,7 @@ impl BindingState {
             let background = background_resources.reconcile_node(
                 update.node,
                 &update.resolved.computed().paint().background_images,
-                update.resolved.computed().paint().background_layer,
+                &update.resolved.computed().paint().background_layers,
                 &externally_used,
             )?;
             surface.set_background_layers(update.node, background.layers)?;
@@ -1125,7 +1125,7 @@ impl BindingState {
         let background = background_resources.reconcile_node(
             node,
             &resolved.computed().paint().background_images,
-            resolved.computed().paint().background_layer,
+            &resolved.computed().paint().background_layers,
             externally_used,
         )?;
         surface.set_background_layers(node, background.layers)?;

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -7,10 +7,11 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use whisker::css::{
-    BackgroundAttachment as CssBackgroundAttachment, BackgroundClip as CssBackgroundClip,
+    Background as CssBackground, BackgroundAttachment as CssBackgroundAttachment,
+    BackgroundClip as CssBackgroundClip, BackgroundLayer as CssBackgroundLayer,
     BackgroundOrigin as CssBackgroundOrigin, BackgroundRepeat as CssBackgroundRepeat,
     BackgroundSize as CssBackgroundSize, BackgroundSizeAxis as CssBackgroundSizeAxis, CalcExpr,
-    CssString, ImageRef, LengthPercentage, Percentage,
+    CssString, ImageRef, LengthPercentage, Percentage, Position,
 };
 use whisker::prelude::*;
 use whisker::{
@@ -477,6 +478,130 @@ fn background_url_lowers_explicit_geometry_repeat_boxes_and_attachment() {
     assert_eq!(layer.origin, PaintBox::Content);
     assert_eq!(layer.clip, PaintBox::Padding);
     assert_eq!(layer.attachment, BackgroundAttachment::Scroll);
+}
+
+#[test]
+fn background_shorthand_preserves_geometry_for_each_url_layer() {
+    let front_url = "https://example.com/front.png";
+    let back_url = "https://example.com/back.png";
+    let style = Css::new().width(px(100)).height(px(100)).background(
+        CssBackground::new()
+            .layer(
+                CssBackgroundLayer::new(ImageRef::Url(CssString::new(front_url)))
+                    .position(Position::Coords(Percentage(25.0).into(), px(8).into()))
+                    .size(CssBackgroundSize::Cover)
+                    .repeat(CssBackgroundRepeat::NoRepeat)
+                    .origin(CssBackgroundOrigin::ContentBox)
+                    .clip(CssBackgroundClip::PaddingBox),
+            )
+            .layer(
+                CssBackgroundLayer::new(ImageRef::Url(CssString::new(back_url)))
+                    .position(Position::Coords(Percentage(75.0).into(), px(12).into()))
+                    .size(CssBackgroundSize::Contain)
+                    .repeat(CssBackgroundRepeat::RepeatY)
+                    .origin(CssBackgroundOrigin::BorderBox)
+                    .clip(CssBackgroundClip::ContentBox),
+            ),
+    );
+    let surface = surface(46);
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    runtime
+        .mount(move || render! { view(style: style) })
+        .unwrap();
+
+    let commands = surface.take_resource_commands();
+    assert_eq!(commands.len(), 2);
+    let mut front_resource = None;
+    let mut back_resource = None;
+    for command in &commands {
+        let ResourceCommand::Load(request) = command else {
+            panic!("background URL must produce a load")
+        };
+        match &request.source {
+            ResourceSource::Url(url) if url == front_url => front_resource = Some(request.resource),
+            ResourceSource::Url(url) if url == back_url => back_resource = Some(request.resource),
+            source => panic!("unexpected background source: {source:?}"),
+        }
+        runtime
+            .dispatch_resource_event(&ready_raster(request.resource, request.generation))
+            .unwrap();
+    }
+    let front_resource = front_resource.unwrap();
+    let back_resource = back_resource.unwrap();
+
+    let mut measurements = NoMeasurement;
+    let mut sink = RecordingRenderer::new(surface.surface());
+    runtime
+        .drive_frame(
+            1.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    let layers = sink
+        .frames()
+        .iter()
+        .rev()
+        .flat_map(|frame| frame.packet.operations.iter().rev())
+        .find_map(|operation| match operation {
+            Operation::SetBackgroundLayers { layers, .. } if layers.len() == 2 => Some(layers),
+            _ => None,
+        })
+        .expect("both ready layers must be emitted together");
+
+    assert_eq!(layers[0].image, PaintImage::Resource(front_resource));
+    assert_eq!(
+        layers[0].position.x,
+        PaintCoordinate {
+            length: 0.0,
+            fraction: 0.25
+        }
+    );
+    assert_eq!(
+        layers[0].position.y,
+        PaintCoordinate {
+            length: 8.0,
+            fraction: 0.0
+        }
+    );
+    assert_eq!(layers[0].size, BackgroundSize::Cover);
+    assert_eq!(
+        (layers[0].repeat_x, layers[0].repeat_y),
+        (ImageRepeat::NoRepeat, ImageRepeat::NoRepeat)
+    );
+    assert_eq!(
+        (layers[0].origin, layers[0].clip),
+        (PaintBox::Content, PaintBox::Padding)
+    );
+
+    assert_eq!(layers[1].image, PaintImage::Resource(back_resource));
+    assert_eq!(
+        layers[1].position.x,
+        PaintCoordinate {
+            length: 0.0,
+            fraction: 0.75
+        }
+    );
+    assert_eq!(
+        layers[1].position.y,
+        PaintCoordinate {
+            length: 12.0,
+            fraction: 0.0
+        }
+    );
+    assert_eq!(layers[1].size, BackgroundSize::Contain);
+    assert_eq!(
+        (layers[1].repeat_x, layers[1].repeat_y),
+        (ImageRepeat::NoRepeat, ImageRepeat::Repeat)
+    );
+    assert_eq!(
+        (layers[1].origin, layers[1].clip),
+        (PaintBox::Border, PaintBox::Content)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a typed semantic `background` shorthand with ordered URL/none layers
- retain per-layer position, size, repeat, origin, clip, and attachment through computed style
- align resource-backed images with their own geometry when lowering to `SetBackgroundLayers`
- add render-to-FramePacket E2E coverage for two independently configured URL layers

## Verification
- `cargo test -p whisker-css --lib`
- `cargo test -p whisker-style --lib`
- `cargo test -p whisker --lib background_resources::tests`
- `cargo test -p whisker --test runtime_instance background_shorthand_preserves_geometry_for_each_url_layer -- --exact`
- `cargo llvm-cov -p whisker-style --summary-only --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100`
- `cargo clippy -p whisker-css -p whisker-style -p whisker-engine -p whisker --all-targets -- -D warnings`

## Stack
Depends on #459.