### PR TITLE
feat(background): lower typed gradients to frames

### DIFF
--- a/crates/whisker-css/src/prop/background.rs
+++ b/crates/whisker-css/src/prop/background.rs
@@ -2,7 +2,9 @@
 
 use crate::ToCss;
 use crate::css::Css;
-use crate::data_type::{Color, LengthPercentage};
+use crate::data_type::{
+    Color, Gradient, LengthPercentage, LinearDirection, RadialShape, StopPosition,
+};
 use crate::data_type_ext::Position;
 use crate::keyword::{
     BackgroundAttachment, BackgroundClip, BackgroundOrigin, BackgroundRepeat, BackgroundSize,
@@ -24,14 +26,11 @@ impl Css {
     pub fn background_image(self, v: impl Into<ImageRef>) -> Self {
         let image = v.into();
         let lynx_value = image.to_css_string();
-        match background_image_value(&image) {
-            Some(image) => self.push_semantic(
-                crate::StyleProperty::BackgroundImage,
-                whisker_style::StyleValue::BackgroundImages(vec![image]),
-                lynx_value,
-            ),
-            None => self.push_raw(crate::StyleProperty::BackgroundImage, lynx_value),
-        }
+        self.push_semantic(
+            crate::StyleProperty::BackgroundImage,
+            whisker_style::StyleValue::BackgroundImages(vec![background_image_value(&image)]),
+            lynx_value,
+        )
     }
 
     /// Sets `background-repeat`.
@@ -140,13 +139,104 @@ impl Css {
     }
 }
 
-pub(crate) fn background_image_value(
-    value: &ImageRef,
-) -> Option<whisker_style::BackgroundImageValue> {
+pub(crate) fn background_image_value(value: &ImageRef) -> whisker_style::BackgroundImageValue {
     match value {
-        ImageRef::None => Some(whisker_style::BackgroundImageValue::None),
-        ImageRef::Url(value) => Some(whisker_style::BackgroundImageValue::Url(value.0.clone())),
-        ImageRef::Gradient(_) => None,
+        ImageRef::None => whisker_style::BackgroundImageValue::None,
+        ImageRef::Url(value) => whisker_style::BackgroundImageValue::Url(value.0.clone()),
+        ImageRef::Gradient(value) => {
+            whisker_style::BackgroundImageValue::Gradient(gradient_value(value))
+        }
+    }
+}
+
+fn gradient_value(value: &Gradient) -> whisker_style::GradientValue {
+    use whisker_style::{
+        BackgroundPositionValue, GradientStopValue, GradientValue, RadialGradientValue,
+        StyleNumber, StyleValue,
+    };
+
+    let stops = |values: &[crate::ColorStop]| {
+        values
+            .iter()
+            .map(|stop| {
+                let StyleValue::Color(color) = stop.color.to_style_value() else {
+                    unreachable!("Color always has a semantic style value")
+                };
+                GradientStopValue {
+                    color,
+                    position: stop.position.as_ref().map(|position| match position {
+                        StopPosition::LengthPercentage(value) => length_percentage_value(value),
+                        StopPosition::Number(value) => {
+                            whisker_style::LengthPercentageValue::Percentage(StyleNumber::new(
+                                *value * 100.0,
+                            ))
+                        }
+                    }),
+                }
+            })
+            .collect()
+    };
+    match value {
+        Gradient::Linear {
+            direction,
+            stops: values,
+        } => GradientValue::Linear {
+            angle_degrees: StyleNumber::new(match direction {
+                LinearDirection::ToTop => 0.0,
+                LinearDirection::ToTopRight => 45.0,
+                LinearDirection::ToRight => 90.0,
+                LinearDirection::ToBottomRight => 135.0,
+                LinearDirection::ToBottom => 180.0,
+                LinearDirection::ToBottomLeft => 225.0,
+                LinearDirection::ToLeft => 270.0,
+                LinearDirection::ToTopLeft => 315.0,
+                LinearDirection::Angle(value) => angle_degrees(*value),
+            }),
+            stops: stops(values),
+        },
+        Gradient::Radial {
+            shape,
+            stops: values,
+        } => GradientValue::Radial {
+            shape: match shape {
+                RadialShape::Circle => RadialGradientValue::Circle,
+                RadialShape::Ellipse => RadialGradientValue::Ellipse,
+                RadialShape::CircleSized(radius) => {
+                    RadialGradientValue::CircleSized(length_percentage_value(radius))
+                }
+                RadialShape::EllipseSized(x, y) => RadialGradientValue::EllipseSized(
+                    length_percentage_value(x),
+                    length_percentage_value(y),
+                ),
+            },
+            stops: stops(values),
+        },
+        Gradient::Conic {
+            from,
+            at,
+            stops: values,
+        } => GradientValue::Conic {
+            from_degrees: StyleNumber::new(from.map_or(0.0, angle_degrees)),
+            center: at.as_ref().map_or_else(
+                || BackgroundPositionValue {
+                    horizontal: percentage(50.0),
+                    vertical: percentage(50.0),
+                },
+                |(x, y)| BackgroundPositionValue {
+                    horizontal: length_percentage_value(x),
+                    vertical: length_percentage_value(y),
+                },
+            ),
+            stops: stops(values),
+        },
+    }
+}
+
+fn angle_degrees(value: crate::Angle) -> f32 {
+    match value {
+        crate::Angle::Deg(value) => value,
+        crate::Angle::Rad(value) => value.to_degrees(),
+        crate::Angle::Turn(value) => value * 360.0,
     }
 }
 

--- a/crates/whisker-css/src/prop/background.rs
+++ b/crates/whisker-css/src/prop/background.rs
@@ -314,9 +314,40 @@ mod tests {
             s.to_string(),
             "background-image: linear-gradient(to bottom, red, blue);"
         );
-        assert_eq!(
-            s.to_specified_style().unwrap_err().property(),
-            "background-image"
+        assert!(s.to_specified_style().is_ok());
+    }
+
+    #[test]
+    fn background_radial_and_conic_gradients_are_typed() {
+        let stops = || {
+            vec![
+                ColorStop::at(NamedColor::Red.into(), Percentage(0.0)),
+                ColorStop::at(NamedColor::Blue.into(), Percentage(100.0)),
+            ]
+        };
+        let radial = Gradient::Radial {
+            shape: crate::RadialShape::EllipseSized(
+                crate::Length::Px(40.0).into(),
+                Percentage(25.0).into(),
+            ),
+            stops: stops(),
+        };
+        let conic = Gradient::Conic {
+            from: Some(crate::Angle::Turn(0.25)),
+            at: Some((Percentage(25.0).into(), Percentage(75.0).into())),
+            stops: stops(),
+        };
+        assert!(
+            Css::new()
+                .background_image(radial)
+                .to_specified_style()
+                .is_ok()
+        );
+        assert!(
+            Css::new()
+                .background_image(conic)
+                .to_specified_style()
+                .is_ok()
         );
     }
 

--- a/crates/whisker-css/src/shorthand/background.rs
+++ b/crates/whisker-css/src/shorthand/background.rs
@@ -207,7 +207,7 @@ fn background_value(background: &Background) -> Option<whisker_style::StyleValue
         .iter()
         .map(|layer| {
             Some(BackgroundLayerValue {
-                image: crate::prop::background::background_image_value(&layer.image)?,
+                image: crate::prop::background::background_image_value(&layer.image),
                 position: match layer.position.clone() {
                     Some(position) => crate::prop::background::background_position_value(position)?,
                     None => default_position(),

--- a/crates/whisker-css/src/shorthand/background.rs
+++ b/crates/whisker-css/src/shorthand/background.rs
@@ -297,6 +297,7 @@ mod tests {
             s.to_string(),
             "background: linear-gradient(to bottom, red, blue) white;"
         );
+        assert!(s.to_specified_style().is_ok());
     }
 
     #[test]

--- a/crates/whisker-engine/src/lib.rs
+++ b/crates/whisker-engine/src/lib.rs
@@ -29,7 +29,7 @@ pub use layout::{LayoutError, LayoutOptions, MeasurementProvider};
 pub use measurement::{
     DeferredMeasurementApply, LayoutProgress, MeasurementApply, MeasurementError,
 };
-pub use paint::{LoweredPaint, lower_paint};
+pub use paint::{LoweredPaint, lower_color, lower_paint};
 pub use recording::{FrameSink, RecordedFrame, RecordingRenderer};
 pub use scene::{Scene, SceneError, SceneNode};
 pub use surface::{LayoutUpdate, SurfaceEngine, SurfaceError, SurfacePresentError};

--- a/crates/whisker-engine/src/paint.rs
+++ b/crates/whisker-engine/src/paint.rs
@@ -86,7 +86,8 @@ fn corner_radius(value: &whisker_style::ComputedCornerRadius) -> PaintCornerRadi
     }
 }
 
-fn lower_color(color: &ColorValue) -> PaintColor {
+/// Lowers a renderer-independent computed color into the paint protocol.
+pub fn lower_color(color: &ColorValue) -> PaintColor {
     match color {
         ColorValue::Named(name) => PaintColor::Named(name.clone()),
         ColorValue::Rgba {

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -32,9 +32,9 @@ pub use layout_value::{
     LengthPercentageAutoValue, PositionValue, SizeValue,
 };
 pub use paint::{
-    BorderStyleValue, ComputedBackgroundLayerStyle, ComputedBackgroundPosition,
-    ComputedBackgroundSize, ComputedCornerRadius, ComputedPaintStyle, Corners, OverflowValue,
-    VisibilityValue,
+    BorderStyleValue, ComputedBackgroundImage, ComputedBackgroundLayerStyle,
+    ComputedBackgroundPosition, ComputedBackgroundSize, ComputedCornerRadius, ComputedGradient,
+    ComputedGradientStop, ComputedPaintStyle, Corners, OverflowValue, VisibilityValue,
 };
 pub use property::{
     PropertyMetadata, PropertyOrigin, StyleProperty, StylePropertyDomain, StylePropertyId,
@@ -48,6 +48,6 @@ pub use value::{
     BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue, BackgroundLayerValue,
     BackgroundPositionValue, BackgroundRepeatModeValue, BackgroundRepeatValue, BackgroundSizeValue,
     BackgroundValue, BorderRadiusValue, CalcExpression, ColorValue, FontFamilyValue,
-    FontStyleValue, FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue,
-    LineHeightValue, StyleNumber, StyleValue,
+    FontStyleValue, FontWeightValue, GradientStopValue, GradientValue, LengthPercentageValue,
+    LengthUnit, LengthValue, LineHeightValue, RadialGradientValue, StyleNumber, StyleValue,
 };

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -3,8 +3,9 @@
 use crate::{
     BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue, BackgroundPositionValue,
     BackgroundRepeatModeValue, BackgroundSizeValue, ColorValue, ComputedLengthPercentage,
-    DirectionValue, Edges, InheritedStyle, SpecifiedStyle, StyleEnvironment, StyleNumber,
-    StyleProperty, StyleResolutionError, StyleValue, layout::resolve_affine,
+    DirectionValue, Edges, GradientValue, InheritedStyle, RadialGradientValue, SpecifiedStyle,
+    StyleEnvironment, StyleNumber, StyleProperty, StyleResolutionError, StyleValue,
+    layout::resolve_affine,
 };
 
 /// Four physical corners in top-left, top-right, bottom-right, bottom-left order.
@@ -120,6 +121,56 @@ pub enum ComputedBackgroundSize {
     },
 }
 
+/// One gradient stop after environment-dependent lengths are resolved.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedGradientStop {
+    /// Stop color.
+    pub color: ColorValue,
+    /// Optional distance along the gradient line.
+    pub position: Option<ComputedLengthPercentage>,
+}
+
+/// Renderer-independent computed procedural gradient.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ComputedGradient {
+    /// Linear gradient.
+    Linear {
+        /// Direction in degrees clockwise from the positive vertical axis.
+        angle_degrees: StyleNumber,
+        /// Ordered stops.
+        stops: Vec<ComputedGradientStop>,
+    },
+    /// Radial gradient.
+    Radial {
+        /// Circle or ellipse.
+        circle: bool,
+        /// Explicit radii, or `None` for farthest-corner sizing.
+        radii: Option<(ComputedLengthPercentage, ComputedLengthPercentage)>,
+        /// Ordered stops.
+        stops: Vec<ComputedGradientStop>,
+    },
+    /// Conic gradient.
+    Conic {
+        /// Starting angle in degrees.
+        from_degrees: StyleNumber,
+        /// Center in the image box.
+        center: ComputedBackgroundPosition,
+        /// Ordered stops.
+        stops: Vec<ComputedGradientStop>,
+    },
+}
+
+/// One background image after style resolution but before Host resource policy.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ComputedBackgroundImage {
+    /// Explicit empty layer.
+    None,
+    /// URL awaiting Host resource loading.
+    Url(String),
+    /// Procedural image ready for protocol lowering.
+    Gradient(ComputedGradient),
+}
+
 /// Computed geometry and scrolling values paired with one background image.
 ///
 /// The authoring API currently exposes one scalar set of longhands. Keeping
@@ -166,7 +217,7 @@ pub struct ComputedPaintStyle {
     /// Resolved background color. Transparent is represented explicitly.
     pub background_color: ColorValue,
     /// Ordered Host-independent background image sources, front to back.
-    pub background_images: Vec<BackgroundImageValue>,
+    pub background_images: Vec<ComputedBackgroundImage>,
     /// Per-layer geometry aligned with `background_images` using CSS list cycling.
     pub background_layers: Vec<ComputedBackgroundLayerStyle>,
     /// Resolved border colors in physical edge order.
@@ -249,8 +300,10 @@ pub(crate) fn resolve_paint_style(
                 paint.background_images = value
                     .layers
                     .iter()
-                    .map(|layer| layer.image.clone())
-                    .collect();
+                    .map(|layer| {
+                        resolve_background_image(&layer.image, inherited, environment, property)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
                 paint.background_layers = value
                     .layers
                     .iter()
@@ -289,7 +342,10 @@ pub(crate) fn resolve_paint_style(
                 let StyleValue::BackgroundImages(images) = value else {
                     return Err(invalid(property));
                 };
-                paint.background_images = images.clone();
+                paint.background_images = images
+                    .iter()
+                    .map(|image| resolve_background_image(image, inherited, environment, property))
+                    .collect::<Result<Vec<_>, _>>()?;
             }
             StyleProperty::BackgroundRepeat => {
                 let StyleValue::BackgroundRepeat(value) = value else {
@@ -474,6 +530,145 @@ pub(crate) fn resolve_paint_style(
     Ok(paint)
 }
 
+fn resolve_background_image(
+    image: &BackgroundImageValue,
+    inherited: &InheritedStyle,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<ComputedBackgroundImage, StyleResolutionError> {
+    Ok(match image {
+        BackgroundImageValue::None => ComputedBackgroundImage::None,
+        BackgroundImageValue::Url(url) if url.trim().is_empty() => return Err(invalid(property)),
+        BackgroundImageValue::Url(url) => ComputedBackgroundImage::Url(url.clone()),
+        BackgroundImageValue::Gradient(gradient) => ComputedBackgroundImage::Gradient(
+            resolve_gradient(gradient, inherited, environment, property)?,
+        ),
+    })
+}
+
+fn resolve_gradient(
+    gradient: &GradientValue,
+    inherited: &InheritedStyle,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<ComputedGradient, StyleResolutionError> {
+    let stops = |values: &[crate::GradientStopValue]| {
+        if values.len() < 2 {
+            return Err(invalid(property));
+        }
+        let mut resolved = values
+            .iter()
+            .map(|stop| {
+                Ok(ComputedGradientStop {
+                    color: color(&StyleValue::Color(stop.color.clone()), property)?,
+                    position: stop
+                        .position
+                        .as_ref()
+                        .map(|position| {
+                            resolve_length_percentage(
+                                &StyleValue::LengthPercentage(position.clone()),
+                                inherited,
+                                environment,
+                                property,
+                            )
+                        })
+                        .transpose()?,
+                })
+            })
+            .collect::<Result<Vec<_>, StyleResolutionError>>()?;
+        normalize_gradient_stops(&mut resolved);
+        Ok(resolved)
+    };
+    Ok(match gradient {
+        GradientValue::Linear {
+            angle_degrees,
+            stops: values,
+        } => {
+            if !angle_degrees.get().is_finite() {
+                return Err(invalid(property));
+            }
+            ComputedGradient::Linear {
+                angle_degrees: *angle_degrees,
+                stops: stops(values)?,
+            }
+        }
+        GradientValue::Radial {
+            shape,
+            stops: values,
+        } => {
+            let resolve_radius = |value: &crate::LengthPercentageValue| {
+                resolve_length_percentage(
+                    &StyleValue::LengthPercentage(value.clone()),
+                    inherited,
+                    environment,
+                    property,
+                )
+            };
+            let (circle, radii) = match shape {
+                RadialGradientValue::Circle => (true, None),
+                RadialGradientValue::Ellipse => (false, None),
+                RadialGradientValue::CircleSized(radius) => {
+                    let radius = resolve_radius(radius)?;
+                    (true, Some((radius, radius)))
+                }
+                RadialGradientValue::EllipseSized(x, y) => {
+                    (false, Some((resolve_radius(x)?, resolve_radius(y)?)))
+                }
+            };
+            ComputedGradient::Radial {
+                circle,
+                radii,
+                stops: stops(values)?,
+            }
+        }
+        GradientValue::Conic {
+            from_degrees,
+            center,
+            stops: values,
+        } => {
+            if !from_degrees.get().is_finite() {
+                return Err(invalid(property));
+            }
+            ComputedGradient::Conic {
+                from_degrees: *from_degrees,
+                center: resolve_background_position(center, inherited, environment, property)?,
+                stops: stops(values)?,
+            }
+        }
+    })
+}
+
+fn normalize_gradient_stops(stops: &mut [ComputedGradientStop]) {
+    let last = stops.len() - 1;
+    stops[0]
+        .position
+        .get_or_insert(ComputedLengthPercentage::ZERO);
+    stops[last]
+        .position
+        .get_or_insert(ComputedLengthPercentage::new(0.0, 1.0));
+
+    let mut start = 0;
+    while start < last {
+        let mut end = start + 1;
+        while stops[end].position.is_none() {
+            end += 1;
+        }
+        if end > start + 1 {
+            let from = stops[start].position.unwrap();
+            let to = stops[end].position.unwrap();
+            let span = (end - start) as f32;
+            for (offset, stop) in stops[(start + 1)..end].iter_mut().enumerate() {
+                let progress = (offset + 1) as f32 / span;
+                stop.position = Some(ComputedLengthPercentage::new(
+                    from.length() + (to.length() - from.length()) * progress,
+                    from.fraction() + (to.fraction() - from.fraction()) * progress,
+                ));
+            }
+        }
+        start = end;
+    }
+}
+
 fn color(value: &StyleValue, property: StyleProperty) -> Result<ColorValue, StyleResolutionError> {
     let StyleValue::Color(value) = value else {
         return Err(invalid(property));
@@ -598,7 +793,7 @@ mod tests {
     use super::*;
     use crate::{
         BackgroundLayerValue, BackgroundRepeatValue, BackgroundValue, BorderRadiusValue,
-        LengthPercentageValue, LengthUnit, LengthValue,
+        GradientStopValue, LengthPercentageValue, LengthUnit, LengthValue,
     };
 
     fn number(value: f32) -> StyleNumber {
@@ -816,8 +1011,8 @@ mod tests {
         assert_eq!(
             paint.background_images,
             vec![
-                BackgroundImageValue::Url("front".into()),
-                BackgroundImageValue::Url("back".into()),
+                ComputedBackgroundImage::Url("front".into()),
+                ComputedBackgroundImage::Url("back".into()),
             ]
         );
         assert_eq!(paint.background_layers.len(), 2);
@@ -880,7 +1075,15 @@ mod tests {
             width: Some(px_length(-1.0)),
             height: None,
         };
-        for layer in [invalid_position, invalid_size] {
+        let invalid_image = layer(
+            "  ",
+            0.0,
+            BackgroundSizeValue::Auto,
+            BackgroundRepeatModeValue::Repeat,
+            BackgroundBoxValue::Padding,
+            BackgroundBoxValue::Border,
+        );
+        for layer in [invalid_position, invalid_size, invalid_image] {
             assert_eq!(
                 crate::resolve_style(
                     &SpecifiedStyle::new().push(
@@ -895,6 +1098,195 @@ mod tests {
                 ),
                 Err(StyleResolutionError::InvalidPropertyValue(
                     StyleProperty::Background
+                ))
+            );
+        }
+    }
+
+    #[test]
+    fn background_gradients_resolve_all_shapes_and_reject_invalid_values() {
+        let stop = |name: &str, position| GradientStopValue {
+            color: ColorValue::Named(name.into()),
+            position,
+        };
+        let stops = || {
+            vec![
+                stop("red", None),
+                stop("gold", None),
+                stop("blue", Some(percentage(100.0))),
+            ]
+        };
+        let resolve = |image| {
+            crate::resolve_style(
+                &SpecifiedStyle::new().push(
+                    StyleProperty::BackgroundImage,
+                    StyleValue::BackgroundImages(vec![image]),
+                ),
+                None,
+                StyleEnvironment::default(),
+            )
+        };
+
+        assert_eq!(
+            resolve(BackgroundImageValue::None)
+                .unwrap()
+                .computed()
+                .paint()
+                .background_images,
+            vec![ComputedBackgroundImage::None]
+        );
+        let linear = resolve(BackgroundImageValue::Gradient(GradientValue::Linear {
+            angle_degrees: number(90.0),
+            stops: stops(),
+        }))
+        .unwrap();
+        assert!(matches!(
+            &linear.computed().paint().background_images[0],
+            ComputedBackgroundImage::Gradient(ComputedGradient::Linear {
+                angle_degrees,
+                stops,
+            }) if angle_degrees.get() == 90.0
+                && stops[0].position.unwrap().fraction() == 0.0
+                && stops[1].position.unwrap().fraction() == 0.5
+                && stops[2].position.unwrap().fraction() == 1.0
+        ));
+        let implicit_endpoints = resolve(BackgroundImageValue::Gradient(GradientValue::Linear {
+            angle_degrees: number(0.0),
+            stops: vec![stop("start", None), stop("end", None)],
+        }))
+        .unwrap();
+        assert!(matches!(
+            &implicit_endpoints.computed().paint().background_images[0],
+            ComputedBackgroundImage::Gradient(ComputedGradient::Linear { stops, .. })
+                if stops[0].position.unwrap().fraction() == 0.0
+                    && stops[1].position.unwrap().fraction() == 1.0
+        ));
+
+        for (shape, circle, explicit) in [
+            (RadialGradientValue::Circle, true, false),
+            (RadialGradientValue::Ellipse, false, false),
+            (
+                RadialGradientValue::CircleSized(px_length(20.0)),
+                true,
+                true,
+            ),
+            (
+                RadialGradientValue::EllipseSized(px_length(30.0), percentage(40.0)),
+                false,
+                true,
+            ),
+        ] {
+            let resolved = resolve(BackgroundImageValue::Gradient(GradientValue::Radial {
+                shape,
+                stops: stops(),
+            }))
+            .unwrap();
+            assert!(matches!(
+                &resolved.computed().paint().background_images[0],
+                ComputedBackgroundImage::Gradient(ComputedGradient::Radial {
+                    circle: actual_circle,
+                    radii,
+                    ..
+                }) if *actual_circle == circle && radii.is_some() == explicit
+            ));
+        }
+
+        let conic = resolve(BackgroundImageValue::Gradient(GradientValue::Conic {
+            from_degrees: number(45.0),
+            center: BackgroundPositionValue {
+                horizontal: percentage(25.0),
+                vertical: percentage(75.0),
+            },
+            stops: stops(),
+        }))
+        .unwrap();
+        assert!(matches!(
+            &conic.computed().paint().background_images[0],
+            ComputedBackgroundImage::Gradient(ComputedGradient::Conic {
+                from_degrees,
+                center,
+                ..
+            }) if from_degrees.get() == 45.0
+                && center.horizontal.fraction() == 0.25
+                && center.vertical.fraction() == 0.75
+        ));
+
+        let invalid_color = GradientStopValue {
+            color: ColorValue::Rgba {
+                red: 0,
+                green: 0,
+                blue: 0,
+                alpha: number(f32::NAN),
+            },
+            position: None,
+        };
+        let invalid = [
+            BackgroundImageValue::Url("  ".into()),
+            BackgroundImageValue::Gradient(GradientValue::Linear {
+                angle_degrees: number(f32::NAN),
+                stops: stops(),
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Linear {
+                angle_degrees: number(0.0),
+                stops: vec![stop("only", None)],
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Linear {
+                angle_degrees: number(0.0),
+                stops: vec![
+                    stop("bad-position", Some(px_length(f32::NAN))),
+                    stop("end", None),
+                ],
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Linear {
+                angle_degrees: number(0.0),
+                stops: vec![invalid_color, stop("end", None)],
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Radial {
+                shape: RadialGradientValue::CircleSized(px_length(f32::NAN)),
+                stops: stops(),
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Radial {
+                shape: RadialGradientValue::EllipseSized(px_length(1.0), px_length(f32::NAN)),
+                stops: stops(),
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Radial {
+                shape: RadialGradientValue::EllipseSized(px_length(f32::NAN), px_length(1.0)),
+                stops: stops(),
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Radial {
+                shape: RadialGradientValue::Circle,
+                stops: vec![stop("only", None)],
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Conic {
+                from_degrees: number(f32::NAN),
+                center: BackgroundPositionValue {
+                    horizontal: percentage(50.0),
+                    vertical: percentage(50.0),
+                },
+                stops: stops(),
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Conic {
+                from_degrees: number(0.0),
+                center: BackgroundPositionValue {
+                    horizontal: px_length(f32::NAN),
+                    vertical: percentage(50.0),
+                },
+                stops: stops(),
+            }),
+            BackgroundImageValue::Gradient(GradientValue::Conic {
+                from_degrees: number(0.0),
+                center: BackgroundPositionValue {
+                    horizontal: percentage(50.0),
+                    vertical: percentage(50.0),
+                },
+                stops: vec![stop("only", None)],
+            }),
+        ];
+        for image in invalid {
+            assert_eq!(
+                resolve(image),
+                Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::BackgroundImage
                 ))
             );
         }
@@ -1025,7 +1417,7 @@ mod tests {
         );
         assert_eq!(
             paint.background_images,
-            vec![BackgroundImageValue::Url(
+            vec![ComputedBackgroundImage::Url(
                 "https://example.com/image.png".into()
             )]
         );

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -186,6 +186,58 @@ pub enum BackgroundImageValue {
     None,
     /// URL text resolved under Host resource policy.
     Url(String),
+    /// A procedural gradient resolved without Host resource loading.
+    Gradient(GradientValue),
+}
+
+/// One specified gradient color stop.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GradientStopValue {
+    /// Stop color.
+    pub color: ColorValue,
+    /// Optional distance along the gradient line.
+    pub position: Option<LengthPercentageValue>,
+}
+
+/// Shape and optional explicit radii of a radial gradient.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum RadialGradientValue {
+    /// Circle using the CSS farthest-corner extent.
+    Circle,
+    /// Ellipse using the CSS farthest-corner extent.
+    Ellipse,
+    /// Circle with an explicit radius.
+    CircleSized(LengthPercentageValue),
+    /// Ellipse with explicit horizontal and vertical radii.
+    EllipseSized(LengthPercentageValue, LengthPercentageValue),
+}
+
+/// A specified procedural gradient image.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GradientValue {
+    /// Linear gradient with a clockwise angle from the positive vertical axis.
+    Linear {
+        /// Direction in degrees.
+        angle_degrees: StyleNumber,
+        /// Ordered stops.
+        stops: Vec<GradientStopValue>,
+    },
+    /// Radial gradient centered in its image box.
+    Radial {
+        /// Shape and sizing rule.
+        shape: RadialGradientValue,
+        /// Ordered stops.
+        stops: Vec<GradientStopValue>,
+    },
+    /// Conic gradient around a configurable center.
+    Conic {
+        /// Starting angle in degrees.
+        from_degrees: StyleNumber,
+        /// Center in the image box.
+        center: BackgroundPositionValue,
+        /// Ordered stops.
+        stops: Vec<GradientStopValue>,
+    },
 }
 
 /// Tiling behavior on one background axis.

--- a/crates/whisker/src/background_resources.rs
+++ b/crates/whisker/src/background_resources.rs
@@ -2,14 +2,17 @@
 
 use std::collections::{HashMap, HashSet};
 
+use whisker_engine::lower_color;
 use whisker_engine::whisker_protocol::{
-    BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, ImageRepeat, NodeId,
-    PaintBox, PaintCoordinate, PaintImage, PaintLengthPercentage, PaintPosition, ResourceCommand,
-    ResourceEvent, ResourceId, ResourceKind, ResourceRequest, ResourceSource,
+    BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, GradientStop, ImageRepeat,
+    NodeId, PaintBox, PaintCoordinate, PaintImage, PaintLengthPercentage, PaintPosition,
+    RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceEvent, ResourceId,
+    ResourceKind, ResourceRequest, ResourceSource,
 };
 use whisker_engine::whisker_style::{
-    BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue, BackgroundRepeatModeValue,
-    ComputedBackgroundLayerStyle, ComputedBackgroundSize, ComputedLengthPercentage,
+    BackgroundAttachmentValue, BackgroundBoxValue, BackgroundRepeatModeValue,
+    ComputedBackgroundImage, ComputedBackgroundLayerStyle, ComputedBackgroundSize,
+    ComputedGradient, ComputedGradientStop, ComputedLengthPercentage,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -42,6 +45,7 @@ impl ResourceKey {
 enum DesiredImage {
     None,
     Resource(ResourceKey),
+    Gradient(ComputedGradient),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -120,19 +124,22 @@ impl BackgroundResourceManager {
     pub(super) fn reconcile_node(
         &mut self,
         node: NodeId,
-        images: &[BackgroundImageValue],
+        images: &[ComputedBackgroundImage],
         layer_styles: &[ComputedBackgroundLayerStyle],
         externally_used: &HashSet<ResourceId>,
     ) -> Result<ReconcileResult, BackgroundResourceError> {
         let desired = images
             .iter()
             .map(|image| match image {
-                BackgroundImageValue::None => Ok(DesiredImage::None),
-                BackgroundImageValue::Url(url) if url.trim().is_empty() => {
+                ComputedBackgroundImage::None => Ok(DesiredImage::None),
+                ComputedBackgroundImage::Url(url) if url.trim().is_empty() => {
                     Err(BackgroundResourceError::InvalidSource)
                 }
-                BackgroundImageValue::Url(url) => {
+                ComputedBackgroundImage::Url(url) => {
                     Ok(DesiredImage::Resource(ResourceKey::raster_url(url.clone())))
+                }
+                ComputedBackgroundImage::Gradient(gradient) => {
+                    Ok(DesiredImage::Gradient(gradient.clone()))
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -390,6 +397,13 @@ impl BackgroundResourceManager {
             .enumerate()
             .filter_map(|(index, image)| match image {
                 DesiredImage::None => None,
+                DesiredImage::Gradient(gradient) => {
+                    let styles = &self.node_layer_styles[&node];
+                    Some(initial_gradient_layer(
+                        gradient,
+                        styles[index % styles.len()],
+                    ))
+                }
                 DesiredImage::Resource(key) => {
                     let resource = self.resources_by_key[key];
                     let styles = &self.node_layer_styles[&node];
@@ -406,6 +420,7 @@ fn resource_keys(images: &[DesiredImage]) -> HashSet<ResourceKey> {
         .iter()
         .filter_map(|image| match image {
             DesiredImage::None => None,
+            DesiredImage::Gradient(_) => None,
             DesiredImage::Resource(key) => Some(key.clone()),
         })
         .collect()
@@ -415,8 +430,80 @@ fn initial_resource_layer(
     resource: ResourceId,
     style: ComputedBackgroundLayerStyle,
 ) -> BackgroundLayer {
+    initial_layer(PaintImage::Resource(resource), style)
+}
+
+fn initial_gradient_layer(
+    gradient: &ComputedGradient,
+    style: ComputedBackgroundLayerStyle,
+) -> BackgroundLayer {
+    let stops = |values: &[ComputedGradientStop]| {
+        values
+            .iter()
+            .map(|stop| GradientStop {
+                color: lower_color(&stop.color),
+                position: stop.position.map(paint_coordinate),
+            })
+            .collect()
+    };
+    let image = match gradient {
+        ComputedGradient::Linear {
+            angle_degrees,
+            stops: values,
+        } => PaintImage::LinearGradient {
+            angle_degrees: angle_degrees.get(),
+            repeating: false,
+            stops: stops(values),
+        },
+        ComputedGradient::Radial {
+            circle,
+            radii,
+            stops: values,
+        } => PaintImage::RadialGradient {
+            shape: if *circle {
+                RadialGradientShape::Circle
+            } else {
+                RadialGradientShape::Ellipse
+            },
+            extent: if radii.is_some() {
+                RadialGradientExtent::Explicit
+            } else {
+                RadialGradientExtent::FarthestCorner
+            },
+            center: PaintPosition {
+                x: PaintCoordinate {
+                    length: 0.0,
+                    fraction: 0.5,
+                },
+                y: PaintCoordinate {
+                    length: 0.0,
+                    fraction: 0.5,
+                },
+            },
+            radii: radii.map(|(x, y)| (paint_length_percentage(x), paint_length_percentage(y))),
+            repeating: false,
+            stops: stops(values),
+        },
+        ComputedGradient::Conic {
+            from_degrees,
+            center,
+            stops: values,
+        } => PaintImage::ConicGradient {
+            from_degrees: from_degrees.get(),
+            center: PaintPosition {
+                x: paint_coordinate(center.horizontal),
+                y: paint_coordinate(center.vertical),
+            },
+            repeating: false,
+            stops: stops(values),
+        },
+    };
+    initial_layer(image, style)
+}
+
+fn initial_layer(image: PaintImage, style: ComputedBackgroundLayerStyle) -> BackgroundLayer {
     BackgroundLayer {
-        image: PaintImage::Resource(resource),
+        image,
         position: PaintPosition {
             x: paint_coordinate(style.position.horizontal),
             y: paint_coordinate(style.position.vertical),
@@ -490,8 +577,8 @@ mod tests {
         NodeId::new(value).unwrap()
     }
 
-    fn url(value: &str) -> BackgroundImageValue {
-        BackgroundImageValue::Url(value.into())
+    fn url(value: &str) -> ComputedBackgroundImage {
+        ComputedBackgroundImage::Url(value.into())
     }
 
     fn load(command: &ResourceCommand) -> (ResourceId, u64) {

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -7,11 +7,12 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use whisker::css::{
-    Background as CssBackground, BackgroundAttachment as CssBackgroundAttachment,
+    Angle, Background as CssBackground, BackgroundAttachment as CssBackgroundAttachment,
     BackgroundClip as CssBackgroundClip, BackgroundLayer as CssBackgroundLayer,
     BackgroundOrigin as CssBackgroundOrigin, BackgroundRepeat as CssBackgroundRepeat,
     BackgroundSize as CssBackgroundSize, BackgroundSizeAxis as CssBackgroundSizeAxis, CalcExpr,
-    CssString, ImageRef, LengthPercentage, Percentage, Position,
+    ColorStop, CssString, Gradient, ImageRef, LengthPercentage, NamedColor, Percentage, Position,
+    RadialShape,
 };
 use whisker::prelude::*;
 use whisker::{
@@ -175,6 +176,41 @@ fn render_ready_background(surface_id: u64, style: Css) -> BackgroundLayer {
             _ => None,
         })
         .expect("Ready URL must be lowered into SetBackgroundLayers")
+}
+
+fn render_gradient(surface_id: u64, gradient: Gradient) -> PaintImage {
+    let surface = surface(surface_id);
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    runtime
+        .mount(move || {
+            render! { view(style: Css::new().width(px(100)).height(px(100)).background_image(gradient.clone())) }
+        })
+        .unwrap();
+    assert!(surface.take_resource_commands().is_empty());
+    let mut measurements = NoMeasurement;
+    let mut sink = RecordingRenderer::new(surface.surface());
+    runtime
+        .drive_frame(
+            1.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    sink.frames()
+        .iter()
+        .rev()
+        .flat_map(|frame| frame.packet.operations.iter().rev())
+        .find_map(|operation| match operation {
+            Operation::SetBackgroundLayers { layers, .. } if layers.len() == 1 => {
+                Some(layers[0].image.clone())
+            }
+            _ => None,
+        })
+        .expect("gradient must be lowered into SetBackgroundLayers")
 }
 
 fn dispatch_control_tap(runtime: &RuntimeInstance, surface: &SurfaceRuntime, timestamp_ms: f64) {
@@ -602,6 +638,87 @@ fn background_shorthand_preserves_geometry_for_each_url_layer() {
         (layers[1].origin, layers[1].clip),
         (PaintBox::Border, PaintBox::Content)
     );
+}
+
+#[test]
+fn background_gradients_lower_without_host_resources() {
+    let stops = || {
+        vec![
+            ColorStop::new(NamedColor::Red.into()),
+            ColorStop::new(NamedColor::Blue.into()),
+        ]
+    };
+    let linear = render_gradient(
+        47,
+        Gradient::Linear {
+            direction: whisker::css::LinearDirection::ToRight,
+            stops: stops(),
+        },
+    );
+    let PaintImage::LinearGradient {
+        angle_degrees,
+        repeating,
+        stops: linear_stops,
+    } = linear
+    else {
+        panic!("expected linear gradient")
+    };
+    assert_eq!(angle_degrees, 90.0);
+    assert!(!repeating);
+    assert_eq!(linear_stops.len(), 2);
+    assert_eq!(linear_stops[0].position.unwrap().fraction, 0.0);
+    assert_eq!(linear_stops[1].position.unwrap().fraction, 1.0);
+
+    let radial = render_gradient(
+        48,
+        Gradient::Radial {
+            shape: RadialShape::EllipseSized(px(40).into(), Percentage(25.0).into()),
+            stops: stops(),
+        },
+    );
+    let PaintImage::RadialGradient {
+        shape,
+        extent,
+        center,
+        radii,
+        ..
+    } = radial
+    else {
+        panic!("expected radial gradient")
+    };
+    assert_eq!(
+        shape,
+        whisker_engine::whisker_protocol::RadialGradientShape::Ellipse
+    );
+    assert_eq!(
+        extent,
+        whisker_engine::whisker_protocol::RadialGradientExtent::Explicit
+    );
+    assert_eq!(center.x.fraction, 0.5);
+    let (radius_x, radius_y) = radii.unwrap();
+    assert_eq!(radius_x.length, 40.0);
+    assert_eq!(radius_y.fraction, 0.25);
+
+    let conic = render_gradient(
+        49,
+        Gradient::Conic {
+            from: Some(Angle::Turn(0.25)),
+            at: Some((Percentage(25.0).into(), Percentage(75.0).into())),
+            stops: stops(),
+        },
+    );
+    let PaintImage::ConicGradient {
+        from_degrees,
+        center,
+        stops: conic_stops,
+        ..
+    } = conic
+    else {
+        panic!("expected conic gradient")
+    };
+    assert_eq!(from_degrees, 90.0);
+    assert_eq!((center.x.fraction, center.y.fraction), (0.25, 0.75));
+    assert_eq!(conic_stops.len(), 2);
 }
 
 #[test]

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -88,6 +88,8 @@
       "id": "paint.background-layers",
       "basis": "lynx-4.0",
       "properties": ["background", "background-clip", "background-image", "background-origin", "background-position", "background-repeat", "background-size"],
+      "supported_subset": ["url-resource-lifecycle", "linear-radial-conic-gradients", "multiple-layers-with-independent-geometry"],
+      "pending_subset": ["background-clip-border-area"],
       "protocol": ["SetBackgroundLayers"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}


### PR DESCRIPTION
## Summary
- add Host-independent specified and computed models for linear, radial, and conic gradients
- resolve relative units, angles, centers, explicit radii, colors, and implicit color-stop positions in Rust
- lower gradients directly to `PaintImage` without resource loads
- exercise all three gradient kinds through `render!` to `SetBackgroundLayers`
- record the remaining Lynx background gap as `background-clip: border-area`

## Verification
- `cargo test -p whisker-css --lib`
- `cargo test -p whisker-style --lib`
- `cargo test -p whisker-engine --lib`
- `cargo test -p whisker --lib background_resources::tests`
- `cargo test -p whisker --test runtime_instance background_gradients_lower_without_host_resources -- --exact`
- `cargo test -p whisker-host-conformance --lib`
- strict 100% line/function/region coverage for `whisker-style` and `whisker-engine`
- `cargo clippy -p whisker-css -p whisker-style -p whisker-engine -p whisker --all-targets -- -D warnings`

## Stack
Depends on #460.