### PR TITLE
feat: render hard outer box shadows

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 9 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 10 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -20,7 +20,7 @@ enum {
   WHISKER_OP_Z_ORDER, WHISKER_OP_TEXT, WHISKER_OP_PROPERTY,
   WHISKER_OP_CLEAR_PROPERTY, WHISKER_OP_EVENT_MASK, WHISKER_OP_HIT_TEST,
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
-  WHISKER_OP_BACKGROUND_LAYERS
+  WHISKER_OP_BACKGROUND_LAYERS, WHISKER_OP_BOX_SHADOWS
 };
 enum {
   WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
@@ -78,6 +78,11 @@ typedef struct {
   WhiskerMobileLengthPercentage radii_horizontal[4];
   WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileBoxPaint;
+typedef struct {
+  float offset_x, offset_y, blur_radius, spread_radius;
+  WhiskerMobileColor color;
+  uint8_t inset, _pad[7];
+} WhiskerMobileBoxShadow;
 typedef struct {
   WhiskerMobileColor color;
   WhiskerMobileLengthPercentage position;
@@ -142,6 +147,7 @@ _Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGr
 _Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGradient ABI drift");
 _Static_assert(sizeof(WhiskerMobileBackgroundImage) == 24, "WhiskerMobileBackgroundImage ABI drift");
 _Static_assert(sizeof(WhiskerMobileBackgroundLayer) == 88, "WhiskerMobileBackgroundLayer ABI drift");
+_Static_assert(sizeof(WhiskerMobileBoxShadow) == 56, "WhiskerMobileBoxShadow ABI drift");
 
 typedef struct {
   uint32_t id;

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -250,6 +250,34 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 for (int j=0;j<4;++j) storage[count++]=(float)p->styles[j];
                 numbers = floats(env, storage, count); names = color_names(env, p); break;
             }
+            case WHISKER_OP_BOX_SHADOWS: {
+                if ((op->payload == NULL) != (op->payload_count == 0) ||
+                    op->payload_count > 256) { ok = false; break; }
+                const WhiskerMobileBoxShadow* shadows = op->payload;
+                const size_t value_count = op->payload_count * 10;
+                float* values = malloc((value_count > 0 ? value_count : 1) * sizeof(float));
+                jclass cls = (*env)->FindClass(env, "java/lang/String");
+                names = cls == NULL ? NULL
+                    : (*env)->NewObjectArray(env, (jsize)op->payload_count, cls, NULL);
+                if (cls) (*env)->DeleteLocalRef(env, cls);
+                if (values == NULL || names == NULL) { free(values); ok = false; break; }
+                size_t cursor = 0;
+                for (size_t shadow_index = 0; shadow_index < op->payload_count; ++shadow_index) {
+                    const WhiskerMobileBoxShadow* shadow = &shadows[shadow_index];
+                    values[cursor++] = shadow->offset_x;
+                    values[cursor++] = shadow->offset_y;
+                    values[cursor++] = shadow->blur_radius;
+                    values[cursor++] = shadow->spread_radius;
+                    values[cursor++] = (float)shadow->inset;
+                    append_color(values, &cursor, &shadow->color);
+                    jstring name = new_string(env, shadow->color.name.ptr, shadow->color.name.len);
+                    (*env)->SetObjectArrayElement(env, names, (jsize)shadow_index, name);
+                    if (name) (*env)->DeleteLocalRef(env, name);
+                }
+                numbers = floats(env, values, value_count);
+                free(values);
+                break;
+            }
             case WHISKER_OP_BACKGROUND_LAYERS: {
                 if (op->payload == NULL) {
                     if (op->payload_count != 0) ok = false;

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 9;
+pub const MOBILE_ABI_MINOR: u16 = 10;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -45,6 +45,7 @@ pub const OP_CAPTURE: u32 = 18;
 pub const OP_RELEASE_CAPTURE: u32 = 19;
 pub const OP_COMMAND: u32 = 20;
 pub const OP_BACKGROUND_LAYERS: u32 = 21;
+pub const OP_BOX_SHADOWS: u32 = 22;
 
 pub const BACKGROUND_LINEAR: u32 = 0;
 pub const BACKGROUND_RADIAL: u32 = 1;
@@ -148,6 +149,19 @@ pub struct MobileBoxPaint {
     pub styles: [u32; 4],
     pub radii_horizontal: [MobileLengthPercentage; 4],
     pub radii_vertical: [MobileLengthPercentage; 4],
+}
+
+/// One resolved box shadow. Arrays are ordered front to back.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileBoxShadow {
+    pub offset_x: f32,
+    pub offset_y: f32,
+    pub blur_radius: f32,
+    pub spread_radius: f32,
+    pub color: MobileColor,
+    pub inset: u8,
+    pub _pad: [u8; 7],
 }
 
 /// One explicit color stop shared by the additive gradient ABI subsets.
@@ -565,6 +579,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileMeasureResponse>(), 64);
             assert_eq!(std::mem::size_of::<MobileText>(), 80);
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
+            assert_eq!(std::mem::size_of::<MobileBoxShadow>(), 56);
             assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
             assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 48);
             assert_eq!(std::mem::size_of::<MobileConicGradient>(), 32);

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -389,6 +389,23 @@ pub struct BorderFixture {
     pub radii: [CornerRadiusFixture; 4],
 }
 
+/// One resolved CSS box shadow.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BoxShadowFixture {
+    /// Horizontal and vertical logical-pixel offset.
+    pub offset: [f32; 2],
+    /// Non-negative logical-pixel blur radius.
+    pub blur_radius: f32,
+    /// Signed logical-pixel spread radius.
+    pub spread_radius: f32,
+    /// Shadow color.
+    pub color: ColorFixture,
+    /// Whether the shadow is painted inside the border box.
+    #[serde(default)]
+    pub inset: bool,
+}
+
 /// One node in a retained Host scene fixture.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -408,6 +425,9 @@ pub struct SceneNodeFixture {
     /// Optional border semantics.
     #[serde(default)]
     pub border: Option<BorderFixture>,
+    /// Box shadows in CSS front-to-back order.
+    #[serde(default)]
+    pub box_shadows: Vec<BoxShadowFixture>,
     /// Descendant overflow clipping semantics.
     #[serde(default)]
     pub clip: BoxClipFixture,
@@ -1217,6 +1237,13 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                 })
                 && valid_color(&node.background)
                 && node.border.as_ref().is_none_or(valid_border)
+                && node.box_shadows.iter().all(|shadow| {
+                    shadow.offset.into_iter().all(f32::is_finite)
+                        && shadow.blur_radius.is_finite()
+                        && shadow.blur_radius >= 0.0
+                        && shadow.spread_radius.is_finite()
+                        && valid_color(&shadow.color)
+                })
                 && node
                     .transform
                     .is_none_or(|transform| transform.into_iter().all(f32::is_finite))

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -14,7 +14,7 @@ use whisker_engine::whisker_protocol::{
     MeasurementResponse, NodeId, Operation, PaintBox, PaintColor, PaintImage,
     PaintLengthPercentage, PreparedContentId, RadialGradientExtent, RadialGradientShape,
     ResourceCommand, ResourceDimensions, ResourceEvent, ResourceFailureCode, ResourceId,
-    ResourceKind, ResourceSource, SurfaceId, UnsupportedMeasurementReason,
+    ResourceKind, ResourceSource, SurfaceId, UnsupportedMeasurementReason, VisualEffects,
 };
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{FrameSink, LayoutOptions, MeasurementProvider};
@@ -843,6 +843,10 @@ impl FrameSink for MobileFrameSink {
                     support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
                 },
                 whisker_engine::whisker_protocol::CapabilityEntry {
+                    capability: whisker_engine::whisker_protocol::RenderCapability::VisualEffects,
+                    support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
+                },
+                whisker_engine::whisker_protocol::CapabilityEntry {
                     capability: whisker_engine::whisker_protocol::RenderCapability::LinearGradients,
                     support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
                 },
@@ -904,6 +908,7 @@ struct MobileFrameOwned {
     _arena: RawValueArena,
     _layouts: Vec<Box<MobileLayoutGeometry>>,
     _paints: Vec<Box<MobileBoxPaint>>,
+    _box_shadows: Vec<Box<[MobileBoxShadow]>>,
     _gradient_stops: Vec<Box<[MobileGradientStop]>>,
     _radial_gradients: Vec<Box<MobileRadialGradient>>,
     _conic_gradients: Vec<Box<MobileConicGradient>>,
@@ -921,6 +926,7 @@ impl MobileFrameOwned {
         let mut arena = RawValueArena::default();
         let mut layouts = Vec::<Box<MobileLayoutGeometry>>::new();
         let mut paints = Vec::<Box<MobileBoxPaint>>::new();
+        let mut box_shadows = Vec::<Box<[MobileBoxShadow]>>::new();
         let mut gradient_stops = Vec::<Box<[MobileGradientStop]>>::new();
         let mut radial_gradients = Vec::<Box<MobileRadialGradient>>::new();
         let mut conic_gradients = Vec::<Box<MobileConicGradient>>::new();
@@ -1153,6 +1159,38 @@ impl MobileFrameOwned {
                         raw.payload_count = layers.len();
                     }
                 }
+                Operation::SetVisualEffects { node, effects } => {
+                    let mut remainder = effects.clone();
+                    remainder.box_shadows.clear();
+                    if remainder != VisualEffects::default() {
+                        return Err(MobileFrameError);
+                    }
+                    raw.tag = OP_BOX_SHADOWS;
+                    raw.node = node.get();
+                    box_shadows.push(
+                        effects
+                            .box_shadows
+                            .iter()
+                            .map(|shadow| MobileBoxShadow {
+                                offset_x: shadow.offset_x,
+                                offset_y: shadow.offset_y,
+                                blur_radius: shadow.blur_radius,
+                                spread_radius: shadow.spread_radius,
+                                color: mobile_color(&shadow.color, &mut strings),
+                                inset: u8::from(shadow.inset),
+                                _pad: [0; 7],
+                            })
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice(),
+                    );
+                    let shadows = box_shadows.last().unwrap();
+                    raw.payload = if shadows.is_empty() {
+                        std::ptr::null()
+                    } else {
+                        shadows.as_ptr().cast()
+                    };
+                    raw.payload_count = shadows.len();
+                }
                 Operation::SetClip { node, clip } => {
                     raw.tag = OP_CLIP;
                     raw.node = node.get();
@@ -1272,9 +1310,9 @@ impl MobileFrameOwned {
                     values.push(Box::new(arena.encode(arguments)));
                     raw.payload = values.last().unwrap().as_ref() as *const _ as *const c_void;
                 }
-                Operation::SetVisualEffects { .. }
-                | Operation::SetImage { .. }
-                | Operation::SetCursor { .. } => return Err(MobileFrameError),
+                Operation::SetImage { .. } | Operation::SetCursor { .. } => {
+                    return Err(MobileFrameError);
+                }
             }
             operations.push(raw);
         }
@@ -1302,6 +1340,7 @@ impl MobileFrameOwned {
             _arena: arena,
             _layouts: layouts,
             _paints: paints,
+            _box_shadows: box_shadows,
             _gradient_stops: gradient_stops,
             _radial_gradients: radial_gradients,
             _conic_gradients: conic_gradients,
@@ -1744,6 +1783,79 @@ mod tests {
             unsafe { *layers[2].image.payload.cast::<u64>() },
             resource.get()
         );
+    }
+
+    #[test]
+    fn mobile_frame_exposes_box_shadows_as_one_contiguous_slice() {
+        let node = NodeId::new(1).unwrap();
+        let packet = FramePacket {
+            header: FrameHeader {
+                version: ProtocolVersion::CURRENT,
+                surface: SurfaceId::new(1).unwrap(),
+                scene_epoch: 1,
+                frame_id: 1,
+                base_revision: 0,
+                target_revision: 1,
+                viewport_epoch: 1,
+                mode: FrameMode::Snapshot,
+            },
+            operations: vec![
+                Operation::SetVisualEffects {
+                    node,
+                    effects: VisualEffects {
+                        box_shadows: vec![
+                            whisker_engine::whisker_protocol::BoxShadow {
+                                offset_x: 4.0,
+                                offset_y: 5.0,
+                                blur_radius: 0.0,
+                                spread_radius: 2.0,
+                                color: PaintColor::Named("black".into()),
+                                inset: false,
+                            },
+                            whisker_engine::whisker_protocol::BoxShadow {
+                                offset_x: -1.0,
+                                offset_y: 3.0,
+                                blur_radius: 6.0,
+                                spread_radius: -2.0,
+                                color: PaintColor::Srgba {
+                                    red: 10,
+                                    green: 20,
+                                    blue: 30,
+                                    alpha: 0.5,
+                                },
+                                inset: true,
+                            },
+                        ],
+                        ..Default::default()
+                    },
+                },
+                Operation::SetVisualEffects {
+                    node,
+                    effects: VisualEffects::default(),
+                },
+            ],
+        };
+
+        let frame = MobileFrameOwned::new(&packet).unwrap();
+        let operation = &frame._operations[0];
+        assert_eq!(operation.tag, OP_BOX_SHADOWS);
+        assert_eq!(operation.payload_count, 2);
+        let shadows = unsafe {
+            std::slice::from_raw_parts(
+                operation.payload.cast::<MobileBoxShadow>(),
+                operation.payload_count,
+            )
+        };
+        assert_eq!(shadows[0].offset_x, 4.0);
+        assert_eq!(shadows[0].spread_radius, 2.0);
+        assert_eq!(shadows[0].color.kind, 0);
+        assert_eq!(shadows[1].blur_radius, 6.0);
+        assert_eq!(shadows[1].inset, 1);
+        assert_eq!(shadows[1].color.kind, 1);
+        assert_eq!(shadows[1].color.alpha, 0.5);
+        assert_eq!(frame._operations[1].tag, OP_BOX_SHADOWS);
+        assert_eq!(frame._operations[1].payload_count, 0);
+        assert!(frame._operations[1].payload.is_null());
     }
 
     #[test]

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -483,10 +483,6 @@ private class WhiskerBoxDrawable(
         )
     }
 
-    private fun roundedPath(rect: RectF, radii: FloatArray): Path = Path().apply {
-        addRoundRect(rect, radii, Path.Direction.CW)
-    }
-
     @Deprecated("Deprecated in Java")
     override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
 
@@ -497,6 +493,10 @@ private class WhiskerBoxDrawable(
     override fun setColorFilter(colorFilter: ColorFilter?) {
         paint.colorFilter = colorFilter
     }
+}
+
+internal fun roundedPath(rect: RectF, radii: FloatArray): Path = Path().apply {
+    addRoundRect(rect, radii, Path.Direction.CW)
 }
 
 internal fun normalizeRadii(radii: FloatArray, width: Float, height: Float): FloatArray {

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
@@ -1,0 +1,41 @@
+package rs.whisker.runtime.paint
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+
+internal data class HostBoxShadow(
+    val offsetX: Float,
+    val offsetY: Float,
+    val blurRadius: Float,
+    val spreadRadius: Float,
+    val color: Int,
+    val inset: Boolean,
+)
+
+internal fun drawHardBoxShadows(
+    canvas: Canvas,
+    geometry: ResolvedBoxGeometry?,
+    shadows: List<HostBoxShadow>,
+) {
+    val box = geometry ?: return
+    val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    shadows.asReversed().forEach { shadow ->
+        if (shadow.inset || shadow.blurRadius != 0f) return@forEach
+        val spread = shadow.spreadRadius
+        val rect = RectF(
+            shadow.offsetX - spread,
+            shadow.offsetY - spread,
+            box.width + shadow.offsetX + spread,
+            box.height + shadow.offsetY + spread,
+        )
+        if (rect.isEmpty) return@forEach
+        val radii = normalizeRadii(
+            box.cornerRadii.map { (it + spread).coerceAtLeast(0f) }.toFloatArray(),
+            rect.width(),
+            rect.height(),
+        )
+        paint.color = shadow.color
+        canvas.drawPath(roundedPath(rect, radii), paint)
+    }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -10,8 +10,10 @@ import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerMountedElement
 import rs.whisker.runtime.paint.HostBoxPaint
 import rs.whisker.runtime.paint.HostBackgroundLayers
+import rs.whisker.runtime.paint.HostBoxShadow
 import rs.whisker.runtime.paint.ResolvedBoxGeometry
 import rs.whisker.runtime.paint.normalizeRadii
+import rs.whisker.runtime.paint.drawHardBoxShadows
 
 /** Mutable logical geometry attached to one Host scene node. */
 internal data class HostGeometry(
@@ -35,6 +37,7 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
     val geometry = HostGeometry()
     var paint: HostBoxPaint? = null
     var backgroundLayers: HostBackgroundLayers? = null
+    var boxShadows: List<HostBoxShadow> = emptyList()
     var mountedElement: WhiskerMountedElement? = null
     var zOrder: Int = 0
 
@@ -42,8 +45,10 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
     private var hasLocalTransform = false
     private var overflowClipRect = RectF()
     private var overflowClipPath: Path? = null
+    private var resolvedBoxGeometry: ResolvedBoxGeometry? = null
 
     fun setOverflowClipGeometry(geometry: ResolvedBoxGeometry) {
+        resolvedBoxGeometry = geometry
         val top = geometry.borderWidths[0].coerceIn(0f, geometry.height)
         val right = geometry.borderWidths[1].coerceIn(0f, geometry.width)
         val bottom = geometry.borderWidths[2].coerceIn(0f, geometry.height)
@@ -93,11 +98,13 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
 
     override fun draw(canvas: Canvas) {
         if (!hasLocalTransform) {
+            drawHardBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
             super.draw(canvas)
             return
         }
         val save = canvas.save()
         canvas.concat(localTransform)
+        drawHardBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
         super.draw(canvas)
         canvas.restoreToCount(save)
     }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -14,6 +14,7 @@ import rs.whisker.runtime.paint.HostBackgroundGeometry
 import rs.whisker.runtime.paint.HostBackgroundBox
 import rs.whisker.runtime.paint.HostBackgroundLayer
 import rs.whisker.runtime.paint.HostBoxPaint
+import rs.whisker.runtime.paint.HostBoxShadow
 import rs.whisker.runtime.paint.HostBackgroundLayers
 import rs.whisker.runtime.paint.HostBackgroundRepeat
 import rs.whisker.runtime.paint.HostBackgroundSize
@@ -157,6 +158,7 @@ internal class HostScene(
                 operation.names?.size ?: 0 < 5
             ) return false
             8, 12, 15, 16 -> if (operation.node !in existing) return false
+            22 -> if (!validBoxShadows(operation, existing)) return false
             9 -> if (
                 operation.node !in existing ||
                 !isSupported2dTransform(operation.numbers ?: return false)
@@ -231,6 +233,7 @@ internal class HostScene(
             15 -> (nodes[id] ?: return).mountedElement?.clearProperty(operation.member)
             16 -> (nodes[id] ?: return).mountedElement?.setEventMask(operation.wide)
             21 -> applyBackgroundLayers(nodes[id] ?: return, operation)
+            22 -> applyBoxShadows(nodes[id] ?: return, operation)
         }
     }
 
@@ -381,6 +384,48 @@ internal class HostScene(
             )
         }
         node.paint?.let { applyPaint(node, it) }
+    }
+
+    private fun applyBoxShadows(node: HostNode, operation: HostSceneOperation) {
+        val values = requireNotNull(operation.numbers)
+        val names = requireNotNull(operation.names)
+        node.boxShadows = values.indices.step(BOX_SHADOW_PACKED_SIZE).map { offset ->
+            HostBoxShadow(
+                offsetX = values[offset] * root.resources.displayMetrics.density,
+                offsetY = values[offset + 1] * root.resources.displayMetrics.density,
+                blurRadius = values[offset + 2] * root.resources.displayMetrics.density,
+                spreadRadius = values[offset + 3] * root.resources.displayMetrics.density,
+                inset = values[offset + 4] != 0f,
+                color = if (values[offset + 5] == 0f) {
+                    parseNamedColor(names[offset / BOX_SHADOW_PACKED_SIZE])
+                } else {
+                    rgba(
+                        values[offset + 6],
+                        values[offset + 7],
+                        values[offset + 8],
+                        values[offset + 9],
+                    )
+                },
+            )
+        }
+        node.invalidate()
+        (node.parent as? View)?.invalidate()
+    }
+
+    private fun validBoxShadows(
+        operation: HostSceneOperation,
+        existing: Set<Long>,
+    ): Boolean {
+        val values = operation.numbers ?: return false
+        val names = operation.names ?: return false
+        return operation.node in existing &&
+            values.size % BOX_SHADOW_PACKED_SIZE == 0 &&
+            names.size == values.size / BOX_SHADOW_PACKED_SIZE &&
+            values.all(Float::isFinite) &&
+            values.indices.step(BOX_SHADOW_PACKED_SIZE).all { offset ->
+                values[offset + 2] == 0f && values[offset + 4] == 0f &&
+                    (values[offset + 5] == 0f || values[offset + 5] == 1f)
+            }
     }
 
     private fun decodeBackgroundLayer(operation: HostSceneOperation): HostBackgroundLayer {
@@ -663,6 +708,7 @@ internal class HostScene(
 
     private companion object {
         const val BACKGROUND_GEOMETRY_PACKED_SIZE = 15
+        const val BOX_SHADOW_PACKED_SIZE = 10
         const val BACKGROUND_GRADIENT_STOP_PACKED_SIZE = 7
         const val BACKGROUND_PACKED_LAYER_HEADER_SIZE = 3
         const val BACKGROUND_PACKED_LAYERS = 256

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -21,7 +21,8 @@ use whisker_protocol::{
 };
 
 use crate::paint::box_paint::{
-    BoxPrimitive, BoxPrimitiveKind, background_gradient_primitive, lower_box, resolve_box_geometry,
+    BoxPrimitive, BoxPrimitiveKind, background_gradient_primitive, hard_box_shadow_primitive,
+    lower_box, resolve_box_geometry,
 };
 use crate::paint::color::{gpu_color, text_color};
 use crate::scene::{LogicalClip, PaintCommand, ShapeClipStack};
@@ -1693,6 +1694,7 @@ impl GpuRenderer {
                     content_rect,
                     paint,
                     background_layers,
+                    visual_effects,
                     clip,
                     shape_clips,
                     transform,
@@ -1700,6 +1702,21 @@ impl GpuRenderer {
                 } => {
                     let default_paint = whisker_protocol::BoxPaint::default();
                     let paint = paint.unwrap_or(&default_paint);
+                    for shadow in visual_effects.box_shadows.iter().rev() {
+                        if let Some(primitive) =
+                            hard_box_shadow_primitive(*rect, paint, shadow, *opacity)
+                        {
+                            push_quad_draw(
+                                &mut vertices,
+                                &mut draws,
+                                primitive,
+                                *transform,
+                                *clip,
+                                shape_clips,
+                                (None, None),
+                            );
+                        }
+                    }
                     let mut box_primitives = Vec::new();
                     lower_box(*rect, paint, *opacity, |primitive| {
                         box_primitives.push(primitive)

--- a/platforms/desktop/src/paint/box.rs
+++ b/platforms/desktop/src/paint/box.rs
@@ -1,6 +1,6 @@
 use whisker_protocol::{
-    BorderLineStyle, BoxPaint, LayoutRect, PaintBox, PaintColor, PaintCornerRadius, PaintCorners,
-    PaintLengthPercentage,
+    BorderLineStyle, BoxPaint, BoxShadow, LayoutRect, PaintBox, PaintColor, PaintCornerRadius,
+    PaintCorners, PaintLengthPercentage,
 };
 
 use super::color::gpu_color;
@@ -175,6 +175,72 @@ pub(crate) fn lower_box(
             ],
             BoxPrimitiveKind::Border,
         ));
+    }
+}
+
+/// Lowers a hard-edged outer shadow to the shared rounded-rect primitive.
+pub(crate) fn hard_box_shadow_primitive(
+    rect: LayoutRect,
+    paint: &BoxPaint,
+    shadow: &BoxShadow,
+    opacity: f32,
+) -> Option<BoxPrimitive> {
+    if shadow.inset || shadow.blur_radius != 0.0 {
+        return None;
+    }
+    let base = resolve_box_geometry(rect, paint);
+    let spread = shadow.spread_radius;
+    let outer_rect = LayoutRect {
+        x: rect.x + shadow.offset_x - spread,
+        y: rect.y + shadow.offset_y - spread,
+        width: rect.width + spread * 2.0,
+        height: rect.height + spread * 2.0,
+    };
+    if outer_rect.width <= 0.0 || outer_rect.height <= 0.0 {
+        return None;
+    }
+    let mut outer_radii = ResolvedRadii {
+        horizontal: base
+            .outer_radii
+            .horizontal
+            .map(|value| (value + spread).max(0.0)),
+        vertical: base
+            .outer_radii
+            .vertical
+            .map(|value| (value + spread).max(0.0)),
+    };
+    normalize_resolved_radii(&mut outer_radii, outer_rect);
+    Some(
+        BoxGeometry {
+            outer_rect,
+            outer_radii,
+            inner_rect: outer_rect,
+            inner_radii: outer_radii,
+            border_widths: [0.0; 4],
+        }
+        .primitive(
+            gpu_color(&shadow.color, opacity),
+            [[0.0; 4]; 4],
+            [0.0; 4],
+            BoxPrimitiveKind::Fill,
+        ),
+    )
+}
+
+fn normalize_resolved_radii(radii: &mut ResolvedRadii, rect: LayoutRect) {
+    let scale = [
+        ratio(rect.width, radii.horizontal[0] + radii.horizontal[1]),
+        ratio(rect.width, radii.horizontal[3] + radii.horizontal[2]),
+        ratio(rect.height, radii.vertical[0] + radii.vertical[3]),
+        ratio(rect.height, radii.vertical[1] + radii.vertical[2]),
+    ]
+    .into_iter()
+    .fold(1.0_f32, f32::min);
+    for radius in &mut radii.horizontal {
+        *radius *= scale;
+    }
+    for radius in &mut radii.vertical {
+        *radius *= scale;
     }
 }
 
@@ -408,6 +474,39 @@ mod tests {
         let mut transparent = paint(PaintColor::Named("transparent".into()));
         transparent.border_styles.top = BorderLineStyle::None;
         assert!(lower(LayoutRect::default(), &transparent, 1.0).is_empty());
+    }
+
+    #[test]
+    fn hard_outer_shadow_applies_offset_spread_and_corner_growth() {
+        let mut box_paint = paint(PaintColor::Named("transparent".into()));
+        box_paint.border_radii.top_left = elliptical(8.0, 4.0);
+        let primitive = hard_box_shadow_primitive(
+            LayoutRect {
+                x: 10.0,
+                y: 20.0,
+                width: 100.0,
+                height: 50.0,
+            },
+            &box_paint,
+            &BoxShadow {
+                offset_x: 12.0,
+                offset_y: -3.0,
+                blur_radius: 0.0,
+                spread_radius: 2.0,
+                color: PaintColor::Named("black".into()),
+                inset: false,
+            },
+            1.0,
+        )
+        .unwrap();
+
+        assert_eq!(primitive.outer_rect.x, 20.0);
+        assert_eq!(primitive.outer_rect.y, 15.0);
+        assert_eq!(primitive.outer_rect.width, 104.0);
+        assert_eq!(primitive.outer_rect.height, 54.0);
+        assert_eq!(primitive.outer_radii_x[0], 10.0);
+        assert_eq!(primitive.outer_radii_y[0], 6.0);
+        assert_eq!(primitive.kind, BoxPrimitiveKind::Fill);
     }
 
     #[test]

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -9,7 +9,7 @@ use whisker_protocol::{
     BoxPaint, ElementTypeId, FrameMode, FramePacket, ImageRepeat, LayoutGeometry, LayoutRect,
     NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintImage, RadialGradientExtent,
     ResourceId, SceneProjection, SurfaceId, TextContent, Transform, ValidationError, Visibility,
-    WhiskerValue,
+    VisualEffects, WhiskerValue,
 };
 
 use crate::element::{DesktopElementContent, DesktopElementError, DesktopElementRegistry};
@@ -22,6 +22,7 @@ struct CommonPresentation {
     layout: LayoutGeometry,
     paint: Option<BoxPaint>,
     background_layers: Vec<BackgroundLayer>,
+    visual_effects: VisualEffects,
     clip: BoxClip,
     transform: Transform,
     opacity: f32,
@@ -37,6 +38,7 @@ impl Default for CommonPresentation {
             layout: LayoutGeometry::default(),
             paint: None,
             background_layers: Vec::new(),
+            visual_effects: VisualEffects::default(),
             clip: BoxClip {
                 horizontal: OverflowClip::Visible,
                 vertical: OverflowClip::Visible,
@@ -265,6 +267,7 @@ pub(crate) enum PaintCommand<'a> {
         content_rect: LayoutRect,
         paint: Option<&'a BoxPaint>,
         background_layers: &'a [BackgroundLayer],
+        visual_effects: &'a VisualEffects,
         clip: LogicalClip,
         shape_clips: ShapeClipStack,
         transform: Transform,
@@ -360,12 +363,16 @@ impl DesktopScene {
             context.transform,
             transform_around(presentation.transform, border.x, border.y),
         );
-        if presentation.paint.is_some() || !presentation.background_layers.is_empty() {
+        if presentation.paint.is_some()
+            || !presentation.background_layers.is_empty()
+            || !presentation.visual_effects.box_shadows.is_empty()
+        {
             commands.push(PaintCommand::Box {
                 rect: border,
                 content_rect: content,
                 paint: presentation.paint.as_ref(),
                 background_layers: &presentation.background_layers,
+                visual_effects: &presentation.visual_effects,
                 clip: context.clip,
                 shape_clips: context.shape_clips.clone(),
                 transform,
@@ -540,8 +547,10 @@ impl DesktopScene {
                         return Err(DesktopPresentError::Unsupported("background-layers"));
                     }
                 }
-                Operation::SetVisualEffects { .. } => {
-                    return Err(DesktopPresentError::Unsupported("visual-effects"));
+                Operation::SetVisualEffects { effects, .. } => {
+                    if !supports_visual_effects(effects) {
+                        return Err(DesktopPresentError::Unsupported("visual-effects"));
+                    }
                 }
                 Operation::SetImage { .. } => {
                     return Err(DesktopPresentError::Unsupported("image-content"));
@@ -660,6 +669,13 @@ impl DesktopScene {
                         .presentation
                         .background_layers = layers.clone();
                 }
+                Operation::SetVisualEffects { node, effects } => {
+                    self.nodes
+                        .get_mut(node)
+                        .expect("validated node")
+                        .presentation
+                        .visual_effects = effects.clone();
+                }
                 Operation::SetClip { node, clip } => {
                     self.nodes
                         .get_mut(node)
@@ -758,9 +774,7 @@ impl DesktopScene {
                 Operation::SetHitTest { .. }
                 | Operation::SetPointerCapture { .. }
                 | Operation::ReleasePointerCapture { .. } => {}
-                Operation::SetVisualEffects { .. }
-                | Operation::SetImage { .. }
-                | Operation::SetCursor { .. } => {
+                Operation::SetImage { .. } | Operation::SetCursor { .. } => {
                     unreachable!("unsupported operations are rejected before commit")
                 }
             }
@@ -794,6 +808,10 @@ impl FrameSink for DesktopScene {
             [
                 whisker_protocol::CapabilityEntry {
                     capability: whisker_protocol::RenderCapability::EllipticalBorderRadius,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::VisualEffects,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
                 whisker_protocol::CapabilityEntry {
@@ -930,6 +948,16 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
         && supported_geometry
         && layer.attachment == BackgroundAttachment::Scroll
         && layer.blend_mode == BlendMode::Normal
+}
+
+fn supports_visual_effects(effects: &VisualEffects) -> bool {
+    let mut remainder = effects.clone();
+    remainder.box_shadows.clear();
+    remainder == VisualEffects::default()
+        && effects
+            .box_shadows
+            .iter()
+            .all(|shadow| !shadow.inset && shadow.blur_radius == 0.0)
 }
 
 pub(crate) fn is_transparent(color: &PaintColor) -> bool {
@@ -1409,7 +1437,7 @@ mod tests {
     }
 
     #[test]
-    fn protocol_only_visual_operation_is_rejected_before_desktop_commit() {
+    fn unsupported_visual_payload_is_rejected_before_desktop_commit() {
         let root = id(1);
         let mut scene = scene(SurfaceId::new(1).unwrap());
         scene
@@ -1431,7 +1459,10 @@ mod tests {
                 2,
                 vec![Operation::SetVisualEffects {
                     node: root,
-                    effects: whisker_protocol::VisualEffects::default(),
+                    effects: whisker_protocol::VisualEffects {
+                        blend_mode: whisker_protocol::BlendMode::Multiply,
+                        ..Default::default()
+                    },
                 }],
             )),
             Err(DesktopPresentError::Unsupported("visual-effects"))

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -801,6 +801,7 @@ impl Driver {
                 content_rect,
                 paint,
                 background_layers,
+                visual_effects,
                 clip,
                 shape_clips,
                 transform,
@@ -810,6 +811,20 @@ impl Driver {
             {
                 let default_paint = BoxPaint::default();
                 let paint = paint.unwrap_or(&default_paint);
+                primitives.extend(
+                    visual_effects
+                        .box_shadows
+                        .iter()
+                        .rev()
+                        .filter_map(|shadow| {
+                            crate::paint::box_paint::hard_box_shadow_primitive(
+                                rect, paint, shadow, opacity,
+                            )
+                            .map(|primitive| {
+                                (primitive, clip, transform, shape_clips.clone(), None, None)
+                            })
+                        }),
+                );
                 let mut boxes = Vec::new();
                 lower_box(rect, paint, opacity, |primitive| boxes.push(primitive));
                 primitives.extend(

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -693,6 +693,26 @@ impl Driver {
                 node,
                 paint: box_paint(&fixture.background, fixture.border.as_ref()),
             });
+            if !fixture.box_shadows.is_empty() {
+                operations.push(Operation::SetVisualEffects {
+                    node,
+                    effects: whisker_protocol::VisualEffects {
+                        box_shadows: fixture
+                            .box_shadows
+                            .iter()
+                            .map(|shadow| whisker_protocol::BoxShadow {
+                                offset_x: shadow.offset[0],
+                                offset_y: shadow.offset[1],
+                                blur_radius: shadow.blur_radius,
+                                spread_radius: shadow.spread_radius,
+                                color: color_protocol(&shadow.color),
+                                inset: shadow.inset,
+                            })
+                            .collect(),
+                        ..Default::default()
+                    },
+                });
+            }
             if !fixture.background_layers.is_empty() {
                 operations.push(Operation::SetBackgroundLayers {
                     node,

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 9 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 10 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -15,7 +15,7 @@ enum {
   WHISKER_OP_Z_ORDER, WHISKER_OP_TEXT, WHISKER_OP_PROPERTY,
   WHISKER_OP_CLEAR_PROPERTY, WHISKER_OP_EVENT_MASK, WHISKER_OP_HIT_TEST,
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
-  WHISKER_OP_BACKGROUND_LAYERS
+  WHISKER_OP_BACKGROUND_LAYERS, WHISKER_OP_BOX_SHADOWS
 };
 enum {
   WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
@@ -78,6 +78,11 @@ typedef struct {
   WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileBoxPaint;
 typedef struct {
+  float offset_x, offset_y, blur_radius, spread_radius;
+  WhiskerMobileColor color;
+  uint8_t inset, _pad[7];
+} WhiskerMobileBoxShadow;
+typedef struct {
   WhiskerMobileColor color;
   WhiskerMobileLengthPercentage position;
 } WhiskerMobileGradientStop;
@@ -124,6 +129,7 @@ _Static_assert(sizeof(WhiskerMobileRadialGradient) == 48, "WhiskerMobileRadialGr
 _Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGradient ABI drift");
 _Static_assert(sizeof(WhiskerMobileBackgroundImage) == 24, "WhiskerMobileBackgroundImage ABI drift");
 _Static_assert(sizeof(WhiskerMobileBackgroundLayer) == 88, "WhiskerMobileBackgroundLayer ABI drift");
+_Static_assert(sizeof(WhiskerMobileBoxShadow) == 56, "WhiskerMobileBoxShadow ABI drift");
 typedef struct {
   uint32_t id; uint8_t value_kind, optional_kind, _pad[2]; WhiskerStringRef name;
 } WhiskerMobileMemberRegistration;

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -19,6 +19,14 @@ struct HostBoxPaint {
     }
 }
 
+struct HostBoxShadow {
+    let offset: CGSize
+    let blurRadius: CGFloat
+    let spreadRadius: CGFloat
+    let color: UIColor
+    let inset: Bool
+}
+
 final class HostBoxPainter {
     private let backgroundPainter = HostBackgroundPainter()
     private var fillColor = UIColor.clear
@@ -87,6 +95,22 @@ final class HostBoxPainter {
 
     func updateBackgroundLayers(_ layers: [HostBackgroundLayer]) {
         backgroundPainter.update(layers)
+    }
+
+    func hardBoxShadowPath(in bounds: CGRect, shadow: HostBoxShadow) -> CGPath? {
+        guard !shadow.inset, shadow.blurRadius == 0 else { return nil }
+        let spread = shadow.spreadRadius
+        let rect = bounds
+            .insetBy(dx: -spread, dy: -spread)
+            .offsetBy(dx: shadow.offset.width, dy: shadow.offset.height)
+        guard !rect.isEmpty else { return nil }
+        let radii = cornerRadii.map {
+            CGSize(
+                width: max(0, $0.width + spread),
+                height: max(0, $0.height + spread)
+            )
+        }
+        return roundedPath(in: rect, radii: radii).cgPath
     }
 
     func overflowClipPath(

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -13,6 +13,8 @@ final class WhiskerNodeView: UIView {
     var mountedElement: WhiskerMountedElement?
     private let defaultChildrenHost = WhiskerChildrenHostView(frame: .zero)
     private let overflowMask = CAShapeLayer()
+    private var boxShadow: HostBoxShadow?
+    private let boxShadowLayer = CAShapeLayer()
     private var clipsOverflowHorizontally = false
     private var clipsOverflowVertically = false
 
@@ -25,6 +27,7 @@ final class WhiskerNodeView: UIView {
         defaultChildrenHost.backgroundColor = .clear
         defaultChildrenHost.clipsToBounds = false
         addSubview(defaultChildrenHost)
+        layer.insertSublayer(boxShadowLayer, at: 0)
     }
 
     required init?(coder: NSCoder) { nil }
@@ -40,6 +43,7 @@ final class WhiskerNodeView: UIView {
             mountedElement.view.frame = contentFrame
         }
         defaultChildrenHost.frame = bounds
+        updateBoxShadowLayers()
         updateOverflowMask()
         setNeedsDisplay()
     }
@@ -97,7 +101,25 @@ final class WhiskerNodeView: UIView {
     }
 
     func boxPaintDidChange() {
+        updateBoxShadowLayers()
         updateOverflowMask()
+    }
+
+    func setBoxShadows(_ shadows: [HostBoxShadow]) {
+        precondition(shadows.count <= 1)
+        boxShadow = shadows.first
+        updateBoxShadowLayers()
+    }
+
+    private func updateBoxShadowLayers() {
+        guard let shadow = boxShadow else {
+            boxShadowLayer.path = nil
+            return
+        }
+        boxShadowLayer.frame = bounds
+        boxShadowLayer.path = boxPainter.hardBoxShadowPath(in: bounds, shadow: shadow)
+        boxShadowLayer.fillColor = shadow.color.cgColor
+        boxShadowLayer.strokeColor = nil
     }
 
     private func updateOverflowMask() {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -157,6 +157,18 @@ final class HostScene {
                 guard layers.allSatisfy({ validBackgroundLayer($0, resources: resources) }) else {
                     return false
                 }
+            case UInt32(WHISKER_OP_BOX_SHADOWS):
+                guard existing.contains(operation.node) else { return false }
+                if operation.payload_count == 0 {
+                    guard operation.payload == nil else { return false }
+                    continue
+                }
+                guard operation.payload_count == 1,
+                      let pointer = operation.payload?.assumingMemoryBound(
+                          to: WhiskerMobileBoxShadow.self
+                      ) else { return false }
+                let shadows = UnsafeBufferPointer(start: pointer, count: operation.payload_count)
+                guard shadows.allSatisfy(validHardBoxShadow) else { return false }
             case UInt32(WHISKER_OP_OPACITY):
                 guard existing.contains(operation.node), operation.scalar.isFinite,
                       (0...1).contains(operation.scalar) else { return false }
@@ -235,6 +247,25 @@ final class HostScene {
             guard layers.count == rawLayers.count else { return false }
             node.boxPainter.updateBackgroundLayers(layers)
             node.setNeedsDisplay()
+        case UInt32(WHISKER_OP_BOX_SHADOWS):
+            guard let node = nodes[id] else { return false }
+            if operation.payload_count == 0 {
+                node.setBoxShadows([])
+                return true
+            }
+            guard let pointer = operation.payload?.assumingMemoryBound(
+                to: WhiskerMobileBoxShadow.self
+            ) else { return false }
+            let shadows = UnsafeBufferPointer(start: pointer, count: operation.payload_count).map {
+                HostBoxShadow(
+                    offset: CGSize(width: CGFloat($0.offset_x), height: CGFloat($0.offset_y)),
+                    blurRadius: CGFloat($0.blur_radius),
+                    spreadRadius: CGFloat($0.spread_radius),
+                    color: parsePaintColor($0.color),
+                    inset: $0.inset != 0
+                )
+            }
+            node.setBoxShadows(shadows)
         case UInt32(WHISKER_OP_OPACITY):
             nodes[id]?.alpha = CGFloat(operation.scalar)
         case UInt32(WHISKER_OP_VISIBILITY):
@@ -435,6 +466,13 @@ private func validGradientStops(
             stop.color.kind <= 1 && stop.color.alpha.isFinite &&
             (0...1).contains(stop.color.alpha)
     }
+}
+
+private func validHardBoxShadow(_ shadow: WhiskerMobileBoxShadow) -> Bool {
+    shadow.offset_x.isFinite && shadow.offset_y.isFinite &&
+        shadow.blur_radius == 0 && shadow.spread_radius.isFinite &&
+        shadow.inset == 0 && shadow.color.kind <= 1 && shadow.color.alpha.isFinite &&
+        (0...1).contains(shadow.color.alpha)
 }
 
 private func validBackgroundLayer(

--- a/platforms/web/src/paint/mod.rs
+++ b/platforms/web/src/paint/mod.rs
@@ -8,3 +8,4 @@ pub(crate) mod color;
 pub(crate) mod compositing;
 pub(crate) mod text;
 pub(crate) mod transform;
+pub(crate) mod visual_effects;

--- a/platforms/web/src/paint/visual_effects.rs
+++ b/platforms/web/src/paint/visual_effects.rs
@@ -1,0 +1,39 @@
+use whisker_protocol::VisualEffects;
+
+use super::color::css_color;
+use crate::{WebError, set_style};
+
+pub(crate) fn supports(effects: &VisualEffects) -> bool {
+    let mut remainder = effects.clone();
+    remainder.box_shadows.clear();
+    remainder == VisualEffects::default()
+}
+
+pub(crate) fn apply(element: &web_sys::Element, effects: &VisualEffects) -> Result<(), WebError> {
+    if !supports(effects) {
+        return Err(WebError(
+            "DOM Host only implements box-shadow visual effects".into(),
+        ));
+    }
+    let value = if effects.box_shadows.is_empty() {
+        "none".into()
+    } else {
+        effects
+            .box_shadows
+            .iter()
+            .map(|shadow| {
+                format!(
+                    "{} {}px {}px {}px {}px{}",
+                    css_color(&shadow.color),
+                    shadow.offset_x,
+                    shadow.offset_y,
+                    shadow.blur_radius,
+                    shadow.spread_radius,
+                    if shadow.inset { " inset" } else { "" },
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    set_style(element, "box-shadow", &value)
+}

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -89,7 +89,11 @@ impl DomFrameSink {
                 {
                     Some("background-layers payload")
                 }
-                Operation::SetVisualEffects { .. } => Some("visual-effects"),
+                Operation::SetVisualEffects { effects, .. }
+                    if !paint::visual_effects::supports(effects) =>
+                {
+                    Some("visual-effects payload")
+                }
                 Operation::SetImage { .. } => Some("image-content"),
                 Operation::SetCursor { .. } => Some("cursor"),
                 Operation::SetText { content, .. } if content.paint.uses_extended_features() => {
@@ -272,6 +276,9 @@ impl DomFrameSink {
                     self.resources.url(resource)
                 })?;
             }
+            Operation::SetVisualEffects { node, effects } => {
+                paint::visual_effects::apply(&self.node(*node)?, effects)?;
+            }
             Operation::SetClip { node, clip } => {
                 let element = self.node(*node)?;
                 let element_type = *self
@@ -418,9 +425,7 @@ impl DomFrameSink {
                     .map_err(|error| js_error("invoke native DOM command", error))?;
             }
             Operation::SetPointerCapture { .. } | Operation::ReleasePointerCapture { .. } => {}
-            Operation::SetVisualEffects { .. }
-            | Operation::SetImage { .. }
-            | Operation::SetCursor { .. } => {
+            Operation::SetImage { .. } | Operation::SetCursor { .. } => {
                 unreachable!("unsupported operations are rejected before DOM mutation")
             }
         }
@@ -584,6 +589,10 @@ impl FrameSink for DomFrameSink {
             [
                 whisker_protocol::CapabilityEntry {
                     capability: whisker_protocol::RenderCapability::EllipticalBorderRadius,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::VisualEffects,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
                 whisker_protocol::CapabilityEntry {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -506,6 +506,14 @@ impl Driver {
                                     .or_else(|| {
                                         nodes
                                             .iter()
+                                            .any(|node| !node.box_shadows.is_empty())
+                                            .then_some(
+                                                "paint.visual-effects.box-shadow-offset",
+                                            )
+                                    })
+                                    .or_else(|| {
+                                        nodes
+                                            .iter()
                                             .any(|node| {
                                                 node.background_layers.iter().any(|layer| {
                                                     matches!(
@@ -619,7 +627,13 @@ impl Driver {
                             .unwrap_or("paint.box")
                         };
                         assert_eq!(name, expected_checkpoint);
-                        self.assert_scene_is_projected(samples);
+                        self.assert_scene_is_projected(
+                            if name == "paint.visual-effects.box-shadow-offset" {
+                                &[]
+                            } else {
+                                samples
+                            },
+                        );
                     } else {
                         assert_eq!(name, "paint.box");
                         self.assert_box_is_projected();
@@ -785,6 +799,26 @@ impl Driver {
                 &fixture_color_css(&fixture_node.background),
             );
             assert_border_is_projected(&style, fixture_node.border.as_ref());
+            let expected_shadows = fixture_node
+                .box_shadows
+                .iter()
+                .map(|shadow| {
+                    format!(
+                        "{} {}px {}px {}px {}px{}",
+                        fixture_color_css(&shadow.color),
+                        shadow.offset[0],
+                        shadow.offset[1],
+                        shadow.blur_radius,
+                        shadow.spread_radius,
+                        if shadow.inset { " inset" } else { "" },
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            assert_eq!(
+                style.get_property_value("box-shadow").unwrap(),
+                expected_shadows
+            );
             assert_style(
                 &style,
                 "overflow-x",

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1145,6 +1145,9 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/CSS2/borders/border-top-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json"
         ),
+        "wpt/css/css-backgrounds/box-shadow-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-001.json"
+        ),
         "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"
         ),
@@ -1323,6 +1326,26 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
             operations.push(Operation::SetTransform {
                 node,
                 transform: Transform(transform),
+            });
+        }
+        if !fixture_node.box_shadows.is_empty() {
+            operations.push(Operation::SetVisualEffects {
+                node,
+                effects: whisker_protocol::VisualEffects {
+                    box_shadows: fixture_node
+                        .box_shadows
+                        .iter()
+                        .map(|shadow| whisker_protocol::BoxShadow {
+                            offset_x: shadow.offset[0],
+                            offset_y: shadow.offset[1],
+                            blur_radius: shadow.blur_radius,
+                            spread_radius: shadow.spread_radius,
+                            color: color(&shadow.color),
+                            inset: shadow.inset,
+                        })
+                        .collect(),
+                    ..Default::default()
+                },
             });
         }
         if let Some(opacity) = fixture_node.opacity {

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,8 +98,8 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
-      "supported_subset": ["box-shadow-outer-hard-edge-offset-and-spread"],
-      "pending_subset": ["box-shadow-blur", "box-shadow-inset", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-hard-edge-offset"],
+      "pending_subset": ["box-shadow-spread", "box-shadow-blur", "box-shadow-inset", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,9 +98,11 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-hard-edge-offset-and-spread"],
+      "pending_subset": ["box-shadow-blur", "box-shadow-inset", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
-      "rust": "protocol-only",
-      "hosts": {"desktop": "protocol-only", "web": "protocol-only", "android": "protocol-only", "ios": "protocol-only"}
+      "rust": "partial",
+      "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}
     },
     {
       "id": "paint.transform",

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -276,6 +276,13 @@
       "checkpoints": ["semantic-projection", "pixel"]
     },
     {
+      "id": "wpt.css-backgrounds.box-shadow-001",
+      "feature": "box-shadow-offset",
+      "fixture": "wpt/css/css-backgrounds/box-shadow-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-right-003",
       "feature": "border-right",
       "fixture": "wpt/css/CSS2/borders/border-right-003.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -295,7 +295,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.background-layers.size-cover" ||
                             command.getString("name") ==
-                            "paint.background-layers.round-auto-aspect-ratio",
+                            "paint.background-layers.round-auto-aspect-ratio" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.box-shadow-offset",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -607,6 +609,27 @@ private class Driver(
                         node = id,
                         numbers = numbers.toFloatArray(),
                         names = names.toTypedArray(),
+                    ),
+                )
+            }
+            node.optJSONArray("box_shadows")?.let { shadows ->
+                val shadowNumbers = ArrayList<Float>(shadows.length() * 10)
+                val shadowNames = ArrayList<String>(shadows.length())
+                shadows.objects().forEach { shadow ->
+                    val offset = shadow.getJSONArray("offset")
+                    shadowNumbers += offset.getDouble(0).toFloat()
+                    shadowNumbers += offset.getDouble(1).toFloat()
+                    shadowNumbers += shadow.getDouble("blur_radius").toFloat()
+                    shadowNumbers += shadow.getDouble("spread_radius").toFloat()
+                    shadowNumbers += if (shadow.optBoolean("inset", false)) 1f else 0f
+                    appendColor(shadow.getJSONObject("color"), shadowNumbers, shadowNames)
+                }
+                check(
+                    stage(
+                        tag = 22,
+                        node = id,
+                        numbers = shadowNumbers.toFloatArray(),
+                        names = shadowNames.toTypedArray(),
                     ),
                 )
             }

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -438,7 +438,8 @@ private final class Driver {
                     name == "paint.background-layers.intrinsic-auto" ||
                     name == "paint.background-layers.size-cover" ||
                     name == "paint.background-layers.size-contain" ||
-                    name == "paint.background-layers.round-auto-aspect-ratio" else {
+                    name == "paint.background-layers.round-auto-aspect-ratio" ||
+                    name == "paint.visual-effects.box-shadow-offset" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -633,6 +634,13 @@ private final class Driver {
             stagedLayers.append(contentsOf: layers)
             layerRanges.append(start..<stagedLayers.count)
         }
+        var shadowRanges = [Range<Int>]()
+        var stagedShadows = [WhiskerMobileBoxShadow]()
+        for fixture in fixtures {
+            let start = stagedShadows.count
+            stagedShadows.append(contentsOf: fixture.boxShadows)
+            shadowRanges.append(start..<stagedShadows.count)
+        }
         var gradientStops = [WhiskerMobileGradientStop]()
         var gradientOffsets = [Int?]()
         for layer in stagedLayers {
@@ -789,6 +797,7 @@ private final class Driver {
                             }
                             try backgroundPayloads.withUnsafeMutableBufferPointer {
                                 backgroundBuffer in
+                            try stagedShadows.withUnsafeMutableBufferPointer { shadowBuffer in
                             var operations = fixtures.map {
                                 operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
                             }
@@ -870,6 +879,19 @@ private final class Driver {
                                         count: layerRange.count
                                     ))
                                 }
+                                let shadowRange = shadowRanges[index]
+                                if !shadowRange.isEmpty {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_BOX_SHADOWS),
+                                        node: fixture.id,
+                                        payload: UnsafeRawPointer(
+                                            shadowBuffer.baseAddress!.advanced(
+                                                by: shadowRange.lowerBound
+                                            )
+                                        ),
+                                        count: shadowRange.count
+                                    ))
+                                }
                             }
                             try operations.withUnsafeMutableBufferPointer { buffer in
                                 var frame = WhiskerMobileFrame()
@@ -891,6 +913,7 @@ private final class Driver {
                                       response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
                                     throw Failure("UIKit Host rejected scene fixture frame")
                                 }
+                            }
                             }
                             }
                             }
@@ -1029,6 +1052,7 @@ private struct SceneFixtureNode {
     let zOrder: Int32?
     let backgroundLayer: SceneBackgroundLayer
     let backgroundLayers: [ScenePaintLayer]
+    let boxShadows: [WhiskerMobileBoxShadow]
     let linearGradient: SceneLinearGradient?
     let radialGradient: SceneRadialGradient?
     let conicGradient: SceneConicGradient?
@@ -1219,6 +1243,9 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         }
         throw Failure("background layer needs one supported image")
     }
+    let boxShadows = try (fixture["box_shadows"] as? [[String: Any]] ?? []).map {
+        try sceneBoxShadow($0)
+    }
     let linearGradient: SceneLinearGradient?
     if let gradient = fixture["linear_gradient"] as? [String: Any] {
         linearGradient = try sceneLinearGradient(gradient)
@@ -1249,10 +1276,24 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         zOrder: zOrder,
         backgroundLayer: backgroundLayer,
         backgroundLayers: backgroundLayers,
+        boxShadows: boxShadows,
         linearGradient: linearGradient,
         radialGradient: radialGradient,
         conicGradient: conicGradient
     )
+}
+
+private func sceneBoxShadow(_ fixture: [String: Any]) throws -> WhiskerMobileBoxShadow {
+    let offset = try numberArray(fixture, "offset")
+    guard offset.count == 2 else { throw Failure("box shadow offset needs two values") }
+    var shadow = WhiskerMobileBoxShadow()
+    shadow.offset_x = Float(offset[0])
+    shadow.offset_y = Float(offset[1])
+    shadow.blur_radius = Float(try number(fixture, "blur_radius"))
+    shadow.spread_radius = Float(try number(fixture, "spread_radius"))
+    shadow.color = try color(try object(fixture, "color"))
+    shadow.inset = (fixture["inset"] as? Bool) == true ? 1 : 0
+    return shadow
 }
 
 private func sceneGradientStops(_ gradient: [String: Any]) throws -> [WhiskerMobileGradientStop] {

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -191,6 +191,10 @@
         "content_box": { "$ref": "#/$defs/quadNumber" },
         "background": { "$ref": "#/$defs/color" },
         "border": { "$ref": "#/$defs/border" },
+        "box_shadows": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/boxShadow" }
+        },
         "clip": { "$ref": "#/$defs/boxClip" },
         "background_layer": { "$ref": "#/$defs/backgroundGeometry" },
         "background_layers": {
@@ -218,6 +222,18 @@
       "properties": {
         "horizontal": { "enum": ["visible", "hidden"] },
         "vertical": { "enum": ["visible", "hidden"] }
+      }
+    },
+    "boxShadow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["offset", "blur_radius", "spread_radius", "color"],
+      "properties": {
+        "offset": { "$ref": "#/$defs/point" },
+        "blur_radius": { "type": "number", "minimum": 0 },
+        "spread_radius": { "type": "number" },
+        "color": { "$ref": "#/$defs/color" },
+        "inset": { "type": "boolean" }
       }
     },
     "checkpoint": {

--- a/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-001.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-001.json
@@ -1,0 +1,48 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.box-shadow-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/box-shadow-001.htm",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A positive horizontal box-shadow offset paints the shadow to the right of the border box.",
+    "adaptation": "The upstream one-inch box and 96px offset are represented as a 100 logical-pixel box and 100 logical-pixel offset. Direct pixel samples replace the upstream red-underlay visual comparison."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 220.0, "height": 120.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 100.0, 100.0],
+            "background": { "kind": "named", "value": "white" },
+            "box_shadows": [
+              {
+                "offset": [100.0, 0.0],
+                "blur_radius": 0.0,
+                "spread_radius": 0.0,
+                "color": { "kind": "named", "value": "black" }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.box-shadow-offset",
+        "samples": [
+          { "point": [50.0, 50.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [150.0, 50.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [5.0, 50.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 },
+          { "point": [215.0, 50.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add the WPT-derived positive-offset box-shadow fixture before implementation
- project typed box-shadow payloads through the mobile ABI without JSON
- render hard-edged outer shadows in Desktop/WGPU, Web/DOM, Android/Canvas, and iOS/Core Animation
- mark only the hard-edge outer offset/spread subset implemented in capabilities.json

## Scope
This is the first visual-effects slice. Blur, inset, multiple-shadow conformance, and the remaining visual effects stay explicitly pending.

## Verification
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios
- cargo test -p whisker-host-conformance --all-targets
- cargo test -p whisker-desktop --lib
- cargo check -p whisker --target aarch64-apple-ios-sim
- cargo check -p whisker --target aarch64-linux-android (NDK clang)
- cargo clippy -p whisker-desktop -p whisker-driver -p whisker-host-conformance --all-targets -- -D warnings
- target-specific clippy for iOS and Android (with existing target-only lint allowances)