### PR TITLE
feat: conform outer box-shadow spread

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -113,6 +113,10 @@ final class HostBoxPainter {
         return roundedPath(in: rect, radii: radii).cgPath
     }
 
+    func borderBoxPath(in bounds: CGRect) -> CGPath {
+        roundedPath(in: bounds, radii: cornerRadii).cgPath
+    }
+
     func overflowClipPath(
         in bounds: CGRect,
         visibleBounds: CGRect,

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -15,6 +15,7 @@ final class WhiskerNodeView: UIView {
     private let overflowMask = CAShapeLayer()
     private var boxShadow: HostBoxShadow?
     private let boxShadowLayer = CAShapeLayer()
+    private let boxShadowMaskLayer = CAShapeLayer()
     private var clipsOverflowHorizontally = false
     private var clipsOverflowVertically = false
 
@@ -114,12 +115,34 @@ final class WhiskerNodeView: UIView {
     private func updateBoxShadowLayers() {
         guard let shadow = boxShadow else {
             boxShadowLayer.path = nil
+            boxShadowLayer.mask = nil
             return
         }
-        boxShadowLayer.frame = bounds
-        boxShadowLayer.path = boxPainter.hardBoxShadowPath(in: bounds, shadow: shadow)
+        guard let shadowPath = boxPainter.hardBoxShadowPath(in: bounds, shadow: shadow) else {
+            boxShadowLayer.path = nil
+            boxShadowLayer.mask = nil
+            return
+        }
+        let layerFrame = shadowPath.boundingBoxOfPath.union(bounds)
+        var translation = CGAffineTransform(
+            translationX: -layerFrame.minX,
+            y: -layerFrame.minY
+        )
+        boxShadowLayer.frame = layerFrame
+        boxShadowLayer.path = shadowPath.copy(using: &translation)
         boxShadowLayer.fillColor = shadow.color.cgColor
         boxShadowLayer.strokeColor = nil
+
+        let maskPath = CGMutablePath()
+        maskPath.addRect(CGRect(origin: .zero, size: layerFrame.size))
+        if let borderPath = boxPainter.borderBoxPath(in: bounds).copy(using: &translation) {
+            maskPath.addPath(borderPath)
+        }
+        boxShadowMaskLayer.frame = CGRect(origin: .zero, size: layerFrame.size)
+        boxShadowMaskLayer.path = maskPath
+        boxShadowMaskLayer.fillColor = UIColor.white.cgColor
+        boxShadowMaskLayer.fillRule = .evenOdd
+        boxShadowLayer.mask = boxShadowMaskLayer
     }
 
     private func updateOverflowMask() {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -504,12 +504,15 @@ impl Driver {
                                         }
                                     })
                                     .or_else(|| {
-                                        nodes
-                                            .iter()
-                                            .any(|node| !node.box_shadows.is_empty())
-                                            .then_some(
-                                                "paint.visual-effects.box-shadow-offset",
-                                            )
+                                        nodes.iter().find_map(|node| {
+                                            node.box_shadows.first().map(|shadow| {
+                                                if shadow.spread_radius != 0.0 {
+                                                    "paint.visual-effects.box-shadow-spread"
+                                                } else {
+                                                    "paint.visual-effects.box-shadow-offset"
+                                                }
+                                            })
+                                        })
                                     })
                                     .or_else(|| {
                                         nodes
@@ -628,7 +631,7 @@ impl Driver {
                         };
                         assert_eq!(name, expected_checkpoint);
                         self.assert_scene_is_projected(
-                            if name == "paint.visual-effects.box-shadow-offset" {
+                            if name.starts_with("paint.visual-effects.box-shadow-") {
                                 &[]
                             } else {
                                 samples
@@ -1181,6 +1184,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/box-shadow-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-001.json"
+        ),
+        "wpt/css/css-backgrounds/box-shadow-002.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-002.json"
         ),
         "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,8 +98,8 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
-      "supported_subset": ["box-shadow-outer-hard-edge-offset"],
-      "pending_subset": ["box-shadow-spread", "box-shadow-blur", "box-shadow-inset", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-hard-edge-offset-and-spread"],
+      "pending_subset": ["box-shadow-blur", "box-shadow-inset", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -283,6 +283,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.box-shadow-002",
+      "feature": "box-shadow-spread",
+      "fixture": "wpt/css/css-backgrounds/box-shadow-002.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-right-003",
       "feature": "border-right",
       "fixture": "wpt/css/CSS2/borders/border-right-003.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -297,7 +297,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.background-layers.round-auto-aspect-ratio" ||
                             command.getString("name") ==
-                            "paint.visual-effects.box-shadow-offset",
+                            "paint.visual-effects.box-shadow-offset" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.box-shadow-spread",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -439,7 +439,8 @@ private final class Driver {
                     name == "paint.background-layers.size-cover" ||
                     name == "paint.background-layers.size-contain" ||
                     name == "paint.background-layers.round-auto-aspect-ratio" ||
-                    name == "paint.visual-effects.box-shadow-offset" else {
+                    name == "paint.visual-effects.box-shadow-offset" ||
+                    name == "paint.visual-effects.box-shadow-spread" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()

--- a/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-002.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-002.json
@@ -1,0 +1,49 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.box-shadow-002",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/box-shadow-002.htm",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "Positive spread distance grows an outer shadow equally in every direction.",
+    "adaptation": "The upstream 100px box, 50px/10px offset, and 10px spread are retained. A white source box distinguishes the required shadow-below-background paint order, while direct samples replace the upstream red-underlay comparison."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 190.0, "height": 140.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 100.0, 100.0],
+            "background": { "kind": "named", "value": "white" },
+            "box_shadows": [
+              {
+                "offset": [50.0, 10.0],
+                "blur_radius": 0.0,
+                "spread_radius": 10.0,
+                "color": { "kind": "named", "value": "black" }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.box-shadow-spread",
+        "samples": [
+          { "point": [70.0, 50.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [55.0, 125.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [165.0, 125.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [175.0, 125.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 },
+          { "point": [5.0, 50.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- adapt WPT `box-shadow-002` as shared positive-spread pixel fixture
- verify spread growth and that outer shadows remain behind the border box
- mask the iOS shadow paint layer with the rounded border-box geometry
- promote spread from pending to the supported hard-edge outer-shadow subset

## Verification
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios
- cargo test -p whisker-host-conformance --all-targets