### PR TITLE
feat: render Gaussian outer box-shadow blur

### DIFF
--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
@@ -1,6 +1,7 @@
 package rs.whisker.runtime.paint
 
 import android.graphics.Canvas
+import android.graphics.BlurMaskFilter
 import android.graphics.Paint
 import android.graphics.RectF
 
@@ -21,7 +22,7 @@ internal fun drawHardBoxShadows(
     val box = geometry ?: return
     val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
     shadows.asReversed().forEach { shadow ->
-        if (shadow.inset || shadow.blurRadius != 0f) return@forEach
+        if (shadow.inset) return@forEach
         val spread = shadow.spreadRadius
         val rect = RectF(
             shadow.offsetX - spread,
@@ -36,6 +37,12 @@ internal fun drawHardBoxShadows(
             rect.height(),
         )
         paint.color = shadow.color
+        paint.maskFilter = if (shadow.blurRadius > 0f) {
+            BlurMaskFilter(shadow.blurRadius / 2f, BlurMaskFilter.Blur.NORMAL)
+        } else {
+            null
+        }
         canvas.drawPath(roundedPath(rect, radii), paint)
     }
+    paint.maskFilter = null
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -423,7 +423,7 @@ internal class HostScene(
             names.size == values.size / BOX_SHADOW_PACKED_SIZE &&
             values.all(Float::isFinite) &&
             values.indices.step(BOX_SHADOW_PACKED_SIZE).all { offset ->
-                values[offset + 2] == 0f && values[offset + 4] == 0f &&
+                values[offset + 2] >= 0f && values[offset + 4] == 0f &&
                     (values[offset + 5] == 0f || values[offset + 5] == 1f)
             }
     }

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -218,6 +218,15 @@ fn rounded_rect_distance(
     return distance;
 }
 
+fn erf_approx(value: f32) -> f32 {
+    let sign = select(-1.0, 1.0, value >= 0.0);
+    let x = abs(value);
+    let t = 1.0 / (1.0 + 0.3275911 * x);
+    let polynomial = (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+        - 0.284496736) * t + 0.254829592) * t;
+    return sign * (1.0 - polynomial * exp(-x * x));
+}
+
 fn shape_coverage(distance: f32) -> f32 {
     let smoothing = max(fwidth(distance), 0.0001);
     return clamp(0.5 - distance / smoothing, 0.0, 1.0);
@@ -506,6 +515,17 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         input.outer_radii_x,
         input.outer_radii_y,
     );
+    if input.mode < -2.5 {
+        let distance = rounded_rect_distance(
+            input.logical_position,
+            input.inner_rect,
+            input.inner_radii_x,
+            input.inner_radii_y,
+        );
+        let sigma = input.border_widths.x * 0.5;
+        let coverage = 0.5 * (1.0 - erf_approx(distance / (1.41421356237 * sigma)));
+        return vec4<f32>(input.color.rgb, input.color.a * coverage * clip_coverage);
+    }
     let outer_coverage = shape_coverage(outer_distance);
     if input.mode < -1.5 {
         let color = linear_gradient_color(input.draw_index, input.logical_position);

--- a/platforms/desktop/src/paint/box.rs
+++ b/platforms/desktop/src/paint/box.rs
@@ -26,6 +26,7 @@ pub(crate) struct BoxPrimitive {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BoxPrimitiveKind {
     Fill,
+    BoxShadowBlur,
     LinearGradient,
     BackgroundBorderArea,
     Border,
@@ -35,6 +36,7 @@ impl BoxPrimitiveKind {
     pub(crate) const fn shader_mode(self) -> f32 {
         match self {
             Self::Fill => -1.0,
+            Self::BoxShadowBlur => -3.0,
             Self::LinearGradient => -2.0,
             Self::BackgroundBorderArea => 2.0,
             Self::Border => 1.0,
@@ -185,7 +187,7 @@ pub(crate) fn hard_box_shadow_primitive(
     shadow: &BoxShadow,
     opacity: f32,
 ) -> Option<BoxPrimitive> {
-    if shadow.inset || shadow.blur_radius != 0.0 {
+    if shadow.inset {
         return None;
     }
     let base = resolve_box_geometry(rect, paint);
@@ -210,19 +212,31 @@ pub(crate) fn hard_box_shadow_primitive(
             .map(|value| (value + spread).max(0.0)),
     };
     normalize_resolved_radii(&mut outer_radii, outer_rect);
+    let blur_extent = shadow.blur_radius * 1.5;
+    let draw_rect = LayoutRect {
+        x: outer_rect.x - blur_extent,
+        y: outer_rect.y - blur_extent,
+        width: outer_rect.width + blur_extent * 2.0,
+        height: outer_rect.height + blur_extent * 2.0,
+    };
+    let blurred = shadow.blur_radius > 0.0;
     Some(
         BoxGeometry {
-            outer_rect,
+            outer_rect: if blurred { draw_rect } else { outer_rect },
             outer_radii,
             inner_rect: outer_rect,
             inner_radii: outer_radii,
-            border_widths: [0.0; 4],
+            border_widths: [shadow.blur_radius, 0.0, 0.0, 0.0],
         }
         .primitive(
             gpu_color(&shadow.color, opacity),
             [[0.0; 4]; 4],
             [0.0; 4],
-            BoxPrimitiveKind::Fill,
+            if blurred {
+                BoxPrimitiveKind::BoxShadowBlur
+            } else {
+                BoxPrimitiveKind::Fill
+            },
         ),
     )
 }

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -953,11 +953,7 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
 fn supports_visual_effects(effects: &VisualEffects) -> bool {
     let mut remainder = effects.clone();
     remainder.box_shadows.clear();
-    remainder == VisualEffects::default()
-        && effects
-            .box_shadows
-            .iter()
-            .all(|shadow| !shadow.inset && shadow.blur_radius == 0.0)
+    remainder == VisualEffects::default() && effects.box_shadows.iter().all(|shadow| !shadow.inset)
 }
 
 pub(crate) fn is_transparent(color: &PaintColor) -> bool {

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -98,7 +98,7 @@ final class HostBoxPainter {
     }
 
     func hardBoxShadowPath(in bounds: CGRect, shadow: HostBoxShadow) -> CGPath? {
-        guard !shadow.inset, shadow.blurRadius == 0 else { return nil }
+        guard !shadow.inset else { return nil }
         let spread = shadow.spreadRadius
         let rect = bounds
             .insetBy(dx: -spread, dy: -spread)

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -123,7 +123,10 @@ final class WhiskerNodeView: UIView {
             boxShadowLayer.mask = nil
             return
         }
-        let layerFrame = shadowPath.boundingBoxOfPath.union(bounds)
+        let blurExtent = shadow.blurRadius * 1.5
+        let layerFrame = shadowPath.boundingBoxOfPath
+            .insetBy(dx: -blurExtent, dy: -blurExtent)
+            .union(bounds)
         var translation = CGAffineTransform(
             translationX: -layerFrame.minX,
             y: -layerFrame.minY
@@ -132,6 +135,11 @@ final class WhiskerNodeView: UIView {
         boxShadowLayer.path = shadowPath.copy(using: &translation)
         boxShadowLayer.fillColor = shadow.color.cgColor
         boxShadowLayer.strokeColor = nil
+        boxShadowLayer.shadowPath = shadowPath.copy(using: &translation)
+        boxShadowLayer.shadowColor = shadow.color.withAlphaComponent(1).cgColor
+        boxShadowLayer.shadowOpacity = Float(shadow.color.cgColor.alpha)
+        boxShadowLayer.shadowOffset = .zero
+        boxShadowLayer.shadowRadius = shadow.blurRadius / 2
 
         let maskPath = CGMutablePath()
         maskPath.addRect(CGRect(origin: .zero, size: layerFrame.size))

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -470,7 +470,7 @@ private func validGradientStops(
 
 private func validHardBoxShadow(_ shadow: WhiskerMobileBoxShadow) -> Bool {
     shadow.offset_x.isFinite && shadow.offset_y.isFinite &&
-        shadow.blur_radius == 0 && shadow.spread_radius.isFinite &&
+        shadow.blur_radius.isFinite && shadow.blur_radius >= 0 && shadow.spread_radius.isFinite &&
         shadow.inset == 0 && shadow.color.kind <= 1 && shadow.color.alpha.isFinite &&
         (0...1).contains(shadow.color.alpha)
 }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -506,7 +506,9 @@ impl Driver {
                                     .or_else(|| {
                                         nodes.iter().find_map(|node| {
                                             node.box_shadows.first().map(|shadow| {
-                                                if shadow.spread_radius != 0.0 {
+                                                if shadow.blur_radius != 0.0 {
+                                                    "paint.visual-effects.box-shadow-blur"
+                                                } else if shadow.spread_radius != 0.0 {
                                                     "paint.visual-effects.box-shadow-spread"
                                                 } else {
                                                     "paint.visual-effects.box-shadow-offset"
@@ -1187,6 +1189,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/box-shadow-002.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-002.json"
+        ),
+        "wpt/css/css-backgrounds/box-shadow-blur-definition-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-blur-definition-001.json"
         ),
         "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,8 +98,8 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
-      "supported_subset": ["box-shadow-outer-hard-edge-offset-and-spread"],
-      "pending_subset": ["box-shadow-blur", "box-shadow-inset", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-offset-spread-and-blur"],
+      "pending_subset": ["box-shadow-inset", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -290,6 +290,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.box-shadow-blur-definition-001",
+      "feature": "box-shadow-blur",
+      "fixture": "wpt/css/css-backgrounds/box-shadow-blur-definition-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
       "id": "wpt.css2.borders.border-right-003",
       "feature": "border-right",
       "fixture": "wpt/css/CSS2/borders/border-right-003.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -299,7 +299,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.visual-effects.box-shadow-offset" ||
                             command.getString("name") ==
-                            "paint.visual-effects.box-shadow-spread",
+                            "paint.visual-effects.box-shadow-spread" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.box-shadow-blur",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -440,7 +440,8 @@ private final class Driver {
                     name == "paint.background-layers.size-contain" ||
                     name == "paint.background-layers.round-auto-aspect-ratio" ||
                     name == "paint.visual-effects.box-shadow-offset" ||
-                    name == "paint.visual-effects.box-shadow-spread" else {
+                    name == "paint.visual-effects.box-shadow-spread" ||
+                    name == "paint.visual-effects.box-shadow-blur" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()

--- a/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-blur-definition-001.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-blur-definition-001.json
@@ -1,0 +1,56 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.box-shadow-blur-definition-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/box-shadow/box-shadow-blur-definition-001.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "Box-shadow blur approximates a Gaussian blur whose standard deviation is half the blur radius.",
+    "adaptation": "A 20px blur is composited over a white parent. Relative luminance samples across a straight edge replace the upstream generated light/dark bound images while preserving the monotonic Gaussian falloff requirement."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 200.0, "height": 200.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 200.0, 200.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [50.0, 50.0, 100.0, 100.0],
+            "background": { "kind": "named", "value": "white" },
+            "box_shadows": [
+              {
+                "offset": [0.0, 0.0],
+                "blur_radius": 20.0,
+                "spread_radius": 0.0,
+                "color": { "kind": "named", "value": "black" }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.box-shadow-blur",
+        "samples": [
+          { "point": [100.0, 100.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [25.0, 100.0], "color": { "kind": "named", "value": "white" }, "tolerance": 12 }
+        ],
+        "relations": [
+          { "first": [40.0, 100.0], "second": [49.0, 100.0], "relation": "lighter", "minimum_difference": 30 },
+          { "first": [25.0, 100.0], "second": [40.0, 100.0], "relation": "lighter", "minimum_difference": 10 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- adapt the WPT Gaussian blur definition into shared luminance falloff assertions
- add an analytic Gaussian edge falloff to the Desktop WGPU rounded-box shader
- render native blur masks on Android and Core Animation blur on iOS
- keep Web on its native CSS box-shadow implementation
- promote outer blur into the supported visual-effects subset

## Verification
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios
- cargo test -p whisker-desktop --lib
- cargo test -p whisker-host-conformance --all-targets
- cargo clippy -p whisker-desktop --all-targets -- -D warnings