### PR TITLE
feat: render hard inset box shadows

### DIFF
--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
@@ -3,6 +3,7 @@ package rs.whisker.runtime.paint
 import android.graphics.Canvas
 import android.graphics.BlurMaskFilter
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.RectF
 
 internal data class HostBoxShadow(
@@ -14,7 +15,7 @@ internal data class HostBoxShadow(
     val inset: Boolean,
 )
 
-internal fun drawHardBoxShadows(
+internal fun drawOuterBoxShadows(
     canvas: Canvas,
     geometry: ResolvedBoxGeometry?,
     shadows: List<HostBoxShadow>,
@@ -45,4 +46,51 @@ internal fun drawHardBoxShadows(
         canvas.drawPath(roundedPath(rect, radii), paint)
     }
     paint.maskFilter = null
+}
+
+internal fun drawInsetBoxShadows(
+    canvas: Canvas,
+    geometry: ResolvedBoxGeometry?,
+    shadows: List<HostBoxShadow>,
+) {
+    val box = geometry ?: return
+    val top = box.borderWidths[0].coerceIn(0f, box.height)
+    val right = box.borderWidths[1].coerceIn(0f, box.width)
+    val bottom = box.borderWidths[2].coerceIn(0f, box.height)
+    val left = box.borderWidths[3].coerceIn(0f, box.width)
+    val paddingRect = RectF(left, top, box.width - right, box.height - bottom)
+    if (paddingRect.isEmpty) return
+    val outer = box.cornerRadii
+    val paddingRadii = normalizeRadii(
+        floatArrayOf(
+            (outer[0] - left).coerceAtLeast(0f),
+            (outer[1] - top).coerceAtLeast(0f),
+            (outer[2] - right).coerceAtLeast(0f),
+            (outer[3] - top).coerceAtLeast(0f),
+            (outer[4] - right).coerceAtLeast(0f),
+            (outer[5] - bottom).coerceAtLeast(0f),
+            (outer[6] - left).coerceAtLeast(0f),
+            (outer[7] - bottom).coerceAtLeast(0f),
+        ),
+        paddingRect.width(),
+        paddingRect.height(),
+    )
+    val paddingPath = roundedPath(paddingRect, paddingRadii)
+    val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    val save = canvas.save()
+    canvas.clipPath(paddingPath)
+    shadows.asReversed().forEach { shadow ->
+        if (!shadow.inset || shadow.blurRadius != 0f || shadow.spreadRadius != 0f) {
+            return@forEach
+        }
+        val hole = RectF(paddingRect).apply { offset(shadow.offsetX, shadow.offsetY) }
+        val ring = Path().apply {
+            fillType = Path.FillType.EVEN_ODD
+            addPath(paddingPath)
+            addPath(roundedPath(hole, paddingRadii))
+        }
+        paint.color = shadow.color
+        canvas.drawPath(ring, paint)
+    }
+    canvas.restoreToCount(save)
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -13,7 +13,8 @@ import rs.whisker.runtime.paint.HostBackgroundLayers
 import rs.whisker.runtime.paint.HostBoxShadow
 import rs.whisker.runtime.paint.ResolvedBoxGeometry
 import rs.whisker.runtime.paint.normalizeRadii
-import rs.whisker.runtime.paint.drawHardBoxShadows
+import rs.whisker.runtime.paint.drawInsetBoxShadows
+import rs.whisker.runtime.paint.drawOuterBoxShadows
 
 /** Mutable logical geometry attached to one Host scene node. */
 internal data class HostGeometry(
@@ -46,6 +47,10 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
     private var overflowClipRect = RectF()
     private var overflowClipPath: Path? = null
     private var resolvedBoxGeometry: ResolvedBoxGeometry? = null
+
+    init {
+        setWillNotDraw(false)
+    }
 
     fun setOverflowClipGeometry(geometry: ResolvedBoxGeometry) {
         resolvedBoxGeometry = geometry
@@ -98,15 +103,20 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
 
     override fun draw(canvas: Canvas) {
         if (!hasLocalTransform) {
-            drawHardBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
+            drawOuterBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
             super.draw(canvas)
             return
         }
         val save = canvas.save()
         canvas.concat(localTransform)
-        drawHardBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
+        drawOuterBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
         super.draw(canvas)
         canvas.restoreToCount(save)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        drawInsetBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
     }
 
     override fun clipDescendants(

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -423,7 +423,10 @@ internal class HostScene(
             names.size == values.size / BOX_SHADOW_PACKED_SIZE &&
             values.all(Float::isFinite) &&
             values.indices.step(BOX_SHADOW_PACKED_SIZE).all { offset ->
-                values[offset + 2] >= 0f && values[offset + 4] == 0f &&
+                val blur = values[offset + 2]
+                val spread = values[offset + 3]
+                val inset = values[offset + 4]
+                blur >= 0f && (inset == 0f || inset == 1f && blur == 0f && spread == 0f) &&
                     (values[offset + 5] == 0f || values[offset + 5] == 1f)
             }
     }

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -21,8 +21,8 @@ use whisker_protocol::{
 };
 
 use crate::paint::box_paint::{
-    BoxPrimitive, BoxPrimitiveKind, background_gradient_primitive, hard_box_shadow_primitive,
-    lower_box, resolve_box_geometry,
+    BoxPrimitive, BoxPrimitiveKind, background_gradient_primitive, box_shadow_primitive, lower_box,
+    resolve_box_geometry,
 };
 use crate::paint::color::{gpu_color, text_color};
 use crate::scene::{LogicalClip, PaintCommand, ShapeClipStack};
@@ -546,8 +546,14 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         inner_coverage = shape_coverage(inner_distance);
     }
     if input.mode > 1.5 {
-        let color = linear_gradient_color(input.draw_index, input.logical_position);
         let coverage = max(outer_coverage - inner_coverage, 0.0);
+        if input.mode > 2.5 {
+            return vec4<f32>(
+                input.color.rgb,
+                input.color.a * coverage * clip_coverage,
+            );
+        }
+        let color = linear_gradient_color(input.draw_index, input.logical_position);
         return vec4<f32>(color.rgb, color.a * coverage * clip_coverage);
     }
     let side_and_depth = border_side(
@@ -1722,9 +1728,14 @@ impl GpuRenderer {
                 } => {
                     let default_paint = whisker_protocol::BoxPaint::default();
                     let paint = paint.unwrap_or(&default_paint);
-                    for shadow in visual_effects.box_shadows.iter().rev() {
+                    for shadow in visual_effects
+                        .box_shadows
+                        .iter()
+                        .rev()
+                        .filter(|shadow| !shadow.inset)
+                    {
                         if let Some(primitive) =
-                            hard_box_shadow_primitive(*rect, paint, shadow, *opacity)
+                            box_shadow_primitive(*rect, paint, shadow, *opacity)
                         {
                             push_quad_draw(
                                 &mut vertices,
@@ -1797,6 +1808,26 @@ impl GpuRenderer {
                             shape_clips,
                             (Some(gradient), resource),
                         );
+                    }
+                    for shadow in visual_effects
+                        .box_shadows
+                        .iter()
+                        .rev()
+                        .filter(|shadow| shadow.inset)
+                    {
+                        if let Some(primitive) =
+                            box_shadow_primitive(*rect, paint, shadow, *opacity)
+                        {
+                            push_quad_draw(
+                                &mut vertices,
+                                &mut draws,
+                                primitive,
+                                *transform,
+                                *clip,
+                                shape_clips,
+                                (None, None),
+                            );
+                        }
                     }
                     for primitive in box_primitives
                         .into_iter()

--- a/platforms/desktop/src/paint/box.rs
+++ b/platforms/desktop/src/paint/box.rs
@@ -27,6 +27,7 @@ pub(crate) struct BoxPrimitive {
 pub(crate) enum BoxPrimitiveKind {
     Fill,
     BoxShadowBlur,
+    InsetShadow,
     LinearGradient,
     BackgroundBorderArea,
     Border,
@@ -37,6 +38,7 @@ impl BoxPrimitiveKind {
         match self {
             Self::Fill => -1.0,
             Self::BoxShadowBlur => -3.0,
+            Self::InsetShadow => 3.0,
             Self::LinearGradient => -2.0,
             Self::BackgroundBorderArea => 2.0,
             Self::Border => 1.0,
@@ -180,15 +182,39 @@ pub(crate) fn lower_box(
     }
 }
 
-/// Lowers a hard-edged outer shadow to the shared rounded-rect primitive.
-pub(crate) fn hard_box_shadow_primitive(
+/// Lowers a supported outer or inset shadow to the shared rounded-rect primitive.
+pub(crate) fn box_shadow_primitive(
     rect: LayoutRect,
     paint: &BoxPaint,
     shadow: &BoxShadow,
     opacity: f32,
 ) -> Option<BoxPrimitive> {
     if shadow.inset {
-        return None;
+        if shadow.blur_radius != 0.0 || shadow.spread_radius != 0.0 {
+            return None;
+        }
+        let base = resolve_box_geometry(rect, paint);
+        let padding_rect = base.inner_rect;
+        let hole_rect = LayoutRect {
+            x: padding_rect.x + shadow.offset_x,
+            y: padding_rect.y + shadow.offset_y,
+            ..padding_rect
+        };
+        return Some(
+            BoxGeometry {
+                outer_rect: padding_rect,
+                outer_radii: base.inner_radii,
+                inner_rect: hole_rect,
+                inner_radii: base.inner_radii,
+                border_widths: [0.0; 4],
+            }
+            .primitive(
+                gpu_color(&shadow.color, opacity),
+                [[0.0; 4]; 4],
+                [0.0; 4],
+                BoxPrimitiveKind::InsetShadow,
+            ),
+        );
     }
     let base = resolve_box_geometry(rect, paint);
     let spread = shadow.spread_radius;
@@ -494,7 +520,7 @@ mod tests {
     fn hard_outer_shadow_applies_offset_spread_and_corner_growth() {
         let mut box_paint = paint(PaintColor::Named("transparent".into()));
         box_paint.border_radii.top_left = elliptical(8.0, 4.0);
-        let primitive = hard_box_shadow_primitive(
+        let primitive = box_shadow_primitive(
             LayoutRect {
                 x: 10.0,
                 y: 20.0,
@@ -521,6 +547,48 @@ mod tests {
         assert_eq!(primitive.outer_radii_x[0], 10.0);
         assert_eq!(primitive.outer_radii_y[0], 6.0);
         assert_eq!(primitive.kind, BoxPrimitiveKind::Fill);
+    }
+
+    #[test]
+    fn hard_inset_shadow_uses_the_padding_edge_and_offsets_its_hole() {
+        let mut box_paint = paint(PaintColor::Named("transparent".into()));
+        let width = PaintLengthPercentage {
+            length: 8.0,
+            fraction: 0.0,
+        };
+        box_paint.border_widths = PaintEdges {
+            top: width,
+            right: width,
+            bottom: width,
+            left: width,
+        };
+        let primitive = box_shadow_primitive(
+            LayoutRect {
+                x: 20.0,
+                y: 20.0,
+                width: 80.0,
+                height: 80.0,
+            },
+            &box_paint,
+            &BoxShadow {
+                offset_x: 10.0,
+                offset_y: 10.0,
+                blur_radius: 0.0,
+                spread_radius: 0.0,
+                color: PaintColor::Named("black".into()),
+                inset: true,
+            },
+            1.0,
+        )
+        .unwrap();
+
+        assert_eq!(primitive.kind, BoxPrimitiveKind::InsetShadow);
+        assert_eq!(primitive.outer_rect.x, 28.0);
+        assert_eq!(primitive.outer_rect.y, 28.0);
+        assert_eq!(primitive.outer_rect.width, 64.0);
+        assert_eq!(primitive.outer_rect.height, 64.0);
+        assert_eq!(primitive.inner_rect.x, 38.0);
+        assert_eq!(primitive.inner_rect.y, 38.0);
     }
 
     #[test]

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -953,7 +953,11 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
 fn supports_visual_effects(effects: &VisualEffects) -> bool {
     let mut remainder = effects.clone();
     remainder.box_shadows.clear();
-    remainder == VisualEffects::default() && effects.box_shadows.iter().all(|shadow| !shadow.inset)
+    remainder == VisualEffects::default()
+        && effects
+            .box_shadows
+            .iter()
+            .all(|shadow| !shadow.inset || shadow.blur_radius == 0.0 && shadow.spread_radius == 0.0)
 }
 
 pub(crate) fn is_transparent(color: &PaintColor) -> bool {

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -816,8 +816,9 @@ impl Driver {
                         .box_shadows
                         .iter()
                         .rev()
+                        .filter(|shadow| !shadow.inset)
                         .filter_map(|shadow| {
-                            crate::paint::box_paint::hard_box_shadow_primitive(
+                            crate::paint::box_paint::box_shadow_primitive(
                                 rect, paint, shadow, opacity,
                             )
                             .map(|primitive| {
@@ -877,6 +878,21 @@ impl Driver {
                         resource,
                     ));
                 }
+                primitives.extend(
+                    visual_effects
+                        .box_shadows
+                        .iter()
+                        .rev()
+                        .filter(|shadow| shadow.inset)
+                        .filter_map(|shadow| {
+                            crate::paint::box_paint::box_shadow_primitive(
+                                rect, paint, shadow, opacity,
+                            )
+                            .map(|primitive| {
+                                (primitive, clip, transform, shape_clips.clone(), None, None)
+                            })
+                        }),
+                );
                 primitives.extend(
                     boxes
                         .into_iter()

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -113,6 +113,34 @@ final class HostBoxPainter {
         return roundedPath(in: rect, radii: radii).cgPath
     }
 
+    func hardInsetBoxShadowPath(in bounds: CGRect, shadow: HostBoxShadow) -> CGPath? {
+        guard shadow.inset, shadow.blurRadius == 0, shadow.spreadRadius == 0 else { return nil }
+        let widths = Array((borderWidths + [0, 0, 0, 0]).prefix(4)).map { max(0, $0) }
+        let top = min(widths[0], bounds.height)
+        let right = min(widths[1], bounds.width)
+        let bottom = min(widths[2], bounds.height)
+        let left = min(widths[3], bounds.width)
+        let paddingBox = CGRect(
+            x: bounds.minX + left,
+            y: bounds.minY + top,
+            width: max(0, bounds.width - left - right),
+            height: max(0, bounds.height - top - bottom)
+        )
+        guard !paddingBox.isEmpty else { return nil }
+        let paddingRadii = insetCornerRadii(
+            normalizedRadii(cornerRadii, in: bounds),
+            top: top,
+            right: right,
+            bottom: bottom,
+            left: left
+        )
+        let hole = paddingBox.offsetBy(dx: shadow.offset.width, dy: shadow.offset.height)
+        let path = CGMutablePath()
+        path.addPath(roundedPath(in: paddingBox, radii: paddingRadii).cgPath)
+        path.addPath(roundedPath(in: hole, radii: paddingRadii).cgPath)
+        return path
+    }
+
     func borderBoxPath(in bounds: CGRect) -> CGPath {
         roundedPath(in: bounds, radii: cornerRadii).cgPath
     }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -116,11 +116,31 @@ final class WhiskerNodeView: UIView {
         guard let shadow = boxShadow else {
             boxShadowLayer.path = nil
             boxShadowLayer.mask = nil
+            boxShadowLayer.shadowPath = nil
+            return
+        }
+        if shadow.inset {
+            guard let shadowPath = boxPainter.hardInsetBoxShadowPath(in: bounds, shadow: shadow) else {
+                boxShadowLayer.path = nil
+                boxShadowLayer.mask = nil
+                boxShadowLayer.shadowPath = nil
+                return
+            }
+            boxShadowLayer.frame = bounds
+            boxShadowLayer.path = shadowPath
+            boxShadowLayer.fillColor = shadow.color.cgColor
+            boxShadowLayer.fillRule = .evenOdd
+            boxShadowLayer.strokeColor = nil
+            boxShadowLayer.mask = nil
+            boxShadowLayer.shadowPath = nil
+            boxShadowLayer.shadowOpacity = 0
+            boxShadowLayer.shadowRadius = 0
             return
         }
         guard let shadowPath = boxPainter.hardBoxShadowPath(in: bounds, shadow: shadow) else {
             boxShadowLayer.path = nil
             boxShadowLayer.mask = nil
+            boxShadowLayer.shadowPath = nil
             return
         }
         let blurExtent = shadow.blurRadius * 1.5
@@ -134,6 +154,7 @@ final class WhiskerNodeView: UIView {
         boxShadowLayer.frame = layerFrame
         boxShadowLayer.path = shadowPath.copy(using: &translation)
         boxShadowLayer.fillColor = shadow.color.cgColor
+        boxShadowLayer.fillRule = .nonZero
         boxShadowLayer.strokeColor = nil
         boxShadowLayer.shadowPath = shadowPath.copy(using: &translation)
         boxShadowLayer.shadowColor = shadow.color.withAlphaComponent(1).cgColor

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -471,7 +471,9 @@ private func validGradientStops(
 private func validHardBoxShadow(_ shadow: WhiskerMobileBoxShadow) -> Bool {
     shadow.offset_x.isFinite && shadow.offset_y.isFinite &&
         shadow.blur_radius.isFinite && shadow.blur_radius >= 0 && shadow.spread_radius.isFinite &&
-        shadow.inset == 0 && shadow.color.kind <= 1 && shadow.color.alpha.isFinite &&
+        (shadow.inset == 0 ||
+            shadow.inset == 1 && shadow.blur_radius == 0 && shadow.spread_radius == 0) &&
+        shadow.color.kind <= 1 && shadow.color.alpha.isFinite &&
         (0...1).contains(shadow.color.alpha)
 }
 

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -506,7 +506,9 @@ impl Driver {
                                     .or_else(|| {
                                         nodes.iter().find_map(|node| {
                                             node.box_shadows.first().map(|shadow| {
-                                                if shadow.blur_radius != 0.0 {
+                                                if shadow.inset {
+                                                    "paint.visual-effects.box-shadow-inset"
+                                                } else if shadow.blur_radius != 0.0 {
                                                     "paint.visual-effects.box-shadow-blur"
                                                 } else if shadow.spread_radius != 0.0 {
                                                     "paint.visual-effects.box-shadow-spread"
@@ -1192,6 +1194,9 @@ fn fixture(path: &str) -> &'static str {
         ),
         "wpt/css/css-backgrounds/box-shadow-blur-definition-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-blur-definition-001.json"
+        ),
+        "wpt/css/css-backgrounds/box-shadow-inset-without-border-radius.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-without-border-radius.json"
         ),
         "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,8 +98,8 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
-      "supported_subset": ["box-shadow-outer-offset-spread-and-blur"],
-      "pending_subset": ["box-shadow-inset", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-hard-offset"],
+      "pending_subset": ["box-shadow-inset-spread-and-blur", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -297,6 +297,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
     },
     {
+      "id": "wpt.css-backgrounds.box-shadow-inset-without-border-radius",
+      "feature": "box-shadow-inset",
+      "fixture": "wpt/css/css-backgrounds/box-shadow-inset-without-border-radius.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-right-003",
       "feature": "border-right",
       "fixture": "wpt/css/CSS2/borders/border-right-003.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -301,7 +301,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.visual-effects.box-shadow-spread" ||
                             command.getString("name") ==
-                            "paint.visual-effects.box-shadow-blur",
+                            "paint.visual-effects.box-shadow-blur" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.box-shadow-inset",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -441,7 +441,8 @@ private final class Driver {
                     name == "paint.background-layers.round-auto-aspect-ratio" ||
                     name == "paint.visual-effects.box-shadow-offset" ||
                     name == "paint.visual-effects.box-shadow-spread" ||
-                    name == "paint.visual-effects.box-shadow-blur" else {
+                    name == "paint.visual-effects.box-shadow-blur" ||
+                    name == "paint.visual-effects.box-shadow-inset" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()

--- a/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-without-border-radius.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-without-border-radius.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.box-shadow-inset-without-border-radius",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/box-shadow-inset-without-border-radius.html",
+    "reference_path": "css/css-backgrounds/reference/box-shadow-inset-without-border-radius-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "An inset shadow is clipped to the padding box and a positive offset exposes the shadow along its top and left edges.",
+    "adaptation": "The upstream first subtest is isolated as an 80px border box with an 8px transparent border and a 10px/10px hard inset shadow. Direct samples replace its HTML reference rendering."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 120.0, "height": 120.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [20.0, 20.0, 80.0, 80.0],
+            "content_box": [24.0, 24.0, 32.0, 32.0],
+            "background": { "kind": "named", "value": "white" },
+            "border": {
+              "widths": [8.0, 8.0, 8.0, 8.0],
+              "colors": [
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" }
+              ],
+              "styles": ["solid", "solid", "solid", "solid"],
+              "radii": [0.0, 0.0, 0.0, 0.0]
+            },
+            "box_shadows": [
+              {
+                "offset": [10.0, 10.0],
+                "blur_radius": 0.0,
+                "spread_radius": 0.0,
+                "color": { "kind": "named", "value": "black" },
+                "inset": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.box-shadow-inset",
+        "samples": [
+          { "point": [32.0, 50.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [50.0, 32.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [50.0, 50.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [24.0, 50.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [88.0, 50.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- adapt the WPT inset box-shadow padding-edge case into the shared Host fixture suite
- render hard inset shadows between box backgrounds and child content on Desktop, Android, and iOS
- keep Web on its native CSS box-shadow implementation
- preserve the CSS outer/background/inset/border paint order
- promote hard inset offsets into the supported visual-effects subset

## Verification
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios
- cargo test -p whisker-desktop
- cargo test -p whisker-host-conformance
- cargo clippy -p whisker-desktop --all-targets -- -D warnings