### PR TITLE
feat: render inset box-shadow spread and blur

### DIFF
--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
@@ -5,6 +5,8 @@ import android.graphics.BlurMaskFilter
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.RectF
+import kotlin.math.abs
+import kotlin.math.max
 
 internal data class HostBoxShadow(
     val offsetX: Float,
@@ -80,17 +82,35 @@ internal fun drawInsetBoxShadows(
     val save = canvas.save()
     canvas.clipPath(paddingPath)
     shadows.asReversed().forEach { shadow ->
-        if (!shadow.inset || shadow.blurRadius != 0f || shadow.spreadRadius != 0f) {
-            return@forEach
+        if (!shadow.inset) return@forEach
+        val spread = shadow.spreadRadius
+        val hole = RectF(paddingRect).apply {
+            inset(spread, spread)
+            offset(shadow.offsetX, shadow.offsetY)
         }
-        val hole = RectF(paddingRect).apply { offset(shadow.offsetX, shadow.offsetY) }
+        val extent = max(box.width, box.height) + abs(shadow.offsetX) +
+            abs(shadow.offsetY) + abs(spread) + shadow.blurRadius * 2f
+        val exterior = RectF(paddingRect).apply { inset(-extent, -extent) }
         val ring = Path().apply {
             fillType = Path.FillType.EVEN_ODD
-            addPath(paddingPath)
-            addPath(roundedPath(hole, paddingRadii))
+            addRect(exterior, Path.Direction.CW)
+            if (!hole.isEmpty) {
+                val holeRadii = normalizeRadii(
+                    paddingRadii.map { (it - spread).coerceAtLeast(0f) }.toFloatArray(),
+                    hole.width(),
+                    hole.height(),
+                )
+                addPath(roundedPath(hole, holeRadii))
+            }
         }
         paint.color = shadow.color
+        paint.maskFilter = if (shadow.blurRadius > 0f) {
+            BlurMaskFilter(shadow.blurRadius / 2f, BlurMaskFilter.Blur.NORMAL)
+        } else {
+            null
+        }
         canvas.drawPath(ring, paint)
     }
+    paint.maskFilter = null
     canvas.restoreToCount(save)
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -424,9 +424,8 @@ internal class HostScene(
             values.all(Float::isFinite) &&
             values.indices.step(BOX_SHADOW_PACKED_SIZE).all { offset ->
                 val blur = values[offset + 2]
-                val spread = values[offset + 3]
                 val inset = values[offset + 4]
-                blur >= 0f && (inset == 0f || inset == 1f && blur == 0f && spread == 0f) &&
+                blur >= 0f && (inset == 0f || inset == 1f) &&
                     (values[offset + 5] == 0f || values[offset + 5] == 1f)
             }
     }

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -543,7 +543,14 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
             input.inner_radii_x,
             input.inner_radii_y,
         );
-        inner_coverage = shape_coverage(inner_distance);
+        if input.mode > 3.5 {
+            let sigma = input.border_widths.x * 0.5;
+            inner_coverage = 0.5 * (1.0 - erf_approx(
+                inner_distance / (1.41421356237 * sigma),
+            ));
+        } else {
+            inner_coverage = shape_coverage(inner_distance);
+        }
     }
     if input.mode > 1.5 {
         let coverage = max(outer_coverage - inner_coverage, 0.0);

--- a/platforms/desktop/src/paint/box.rs
+++ b/platforms/desktop/src/paint/box.rs
@@ -28,6 +28,7 @@ pub(crate) enum BoxPrimitiveKind {
     Fill,
     BoxShadowBlur,
     InsetShadow,
+    InsetShadowBlur,
     LinearGradient,
     BackgroundBorderArea,
     Border,
@@ -39,6 +40,7 @@ impl BoxPrimitiveKind {
             Self::Fill => -1.0,
             Self::BoxShadowBlur => -3.0,
             Self::InsetShadow => 3.0,
+            Self::InsetShadowBlur => 4.0,
             Self::LinearGradient => -2.0,
             Self::BackgroundBorderArea => 2.0,
             Self::Border => 1.0,
@@ -190,29 +192,46 @@ pub(crate) fn box_shadow_primitive(
     opacity: f32,
 ) -> Option<BoxPrimitive> {
     if shadow.inset {
-        if shadow.blur_radius != 0.0 || shadow.spread_radius != 0.0 {
-            return None;
-        }
         let base = resolve_box_geometry(rect, paint);
         let padding_rect = base.inner_rect;
+        let spread = shadow.spread_radius;
         let hole_rect = LayoutRect {
-            x: padding_rect.x + shadow.offset_x,
-            y: padding_rect.y + shadow.offset_y,
-            ..padding_rect
+            x: padding_rect.x + shadow.offset_x + spread,
+            y: padding_rect.y + shadow.offset_y + spread,
+            width: padding_rect.width - spread * 2.0,
+            height: padding_rect.height - spread * 2.0,
         };
+        let mut hole_radii = ResolvedRadii {
+            horizontal: base
+                .inner_radii
+                .horizontal
+                .map(|value| (value - spread).max(0.0)),
+            vertical: base
+                .inner_radii
+                .vertical
+                .map(|value| (value - spread).max(0.0)),
+        };
+        if hole_rect.width > 0.0 && hole_rect.height > 0.0 {
+            normalize_resolved_radii(&mut hole_radii, hole_rect);
+        }
+        let blurred = shadow.blur_radius > 0.0;
         return Some(
             BoxGeometry {
                 outer_rect: padding_rect,
                 outer_radii: base.inner_radii,
                 inner_rect: hole_rect,
-                inner_radii: base.inner_radii,
-                border_widths: [0.0; 4],
+                inner_radii: hole_radii,
+                border_widths: [shadow.blur_radius, 0.0, 0.0, 0.0],
             }
             .primitive(
                 gpu_color(&shadow.color, opacity),
                 [[0.0; 4]; 4],
                 [0.0; 4],
-                BoxPrimitiveKind::InsetShadow,
+                if blurred {
+                    BoxPrimitiveKind::InsetShadowBlur
+                } else {
+                    BoxPrimitiveKind::InsetShadow
+                },
             ),
         );
     }
@@ -589,6 +608,38 @@ mod tests {
         assert_eq!(primitive.outer_rect.height, 64.0);
         assert_eq!(primitive.inner_rect.x, 38.0);
         assert_eq!(primitive.inner_rect.y, 38.0);
+    }
+
+    #[test]
+    fn inset_spread_contracts_the_hole_and_blur_selects_gaussian_coverage() {
+        let primitive = box_shadow_primitive(
+            LayoutRect {
+                x: 10.0,
+                y: 20.0,
+                width: 100.0,
+                height: 80.0,
+            },
+            &BoxPaint::default(),
+            &BoxShadow {
+                offset_x: 10.0,
+                offset_y: -5.0,
+                blur_radius: 20.0,
+                spread_radius: 15.0,
+                color: PaintColor::Named("black".into()),
+                inset: true,
+            },
+            1.0,
+        )
+        .unwrap();
+
+        assert_eq!(primitive.kind, BoxPrimitiveKind::InsetShadowBlur);
+        assert_eq!(primitive.outer_rect.x, 10.0);
+        assert_eq!(primitive.outer_rect.y, 20.0);
+        assert_eq!(primitive.inner_rect.x, 35.0);
+        assert_eq!(primitive.inner_rect.y, 30.0);
+        assert_eq!(primitive.inner_rect.width, 70.0);
+        assert_eq!(primitive.inner_rect.height, 50.0);
+        assert_eq!(primitive.border_widths[0], 20.0);
     }
 
     #[test]

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -954,10 +954,6 @@ fn supports_visual_effects(effects: &VisualEffects) -> bool {
     let mut remainder = effects.clone();
     remainder.box_shadows.clear();
     remainder == VisualEffects::default()
-        && effects
-            .box_shadows
-            .iter()
-            .all(|shadow| !shadow.inset || shadow.blur_radius == 0.0 && shadow.spread_radius == 0.0)
 }
 
 pub(crate) fn is_transparent(color: &PaintColor) -> bool {

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -113,8 +113,8 @@ final class HostBoxPainter {
         return roundedPath(in: rect, radii: radii).cgPath
     }
 
-    func hardInsetBoxShadowPath(in bounds: CGRect, shadow: HostBoxShadow) -> CGPath? {
-        guard shadow.inset, shadow.blurRadius == 0, shadow.spreadRadius == 0 else { return nil }
+    func insetBoxShadowPath(in bounds: CGRect, shadow: HostBoxShadow) -> CGPath? {
+        guard shadow.inset else { return nil }
         let widths = Array((borderWidths + [0, 0, 0, 0]).prefix(4)).map { max(0, $0) }
         let top = min(widths[0], bounds.height)
         let right = min(widths[1], bounds.width)
@@ -134,11 +134,47 @@ final class HostBoxPainter {
             bottom: bottom,
             left: left
         )
-        let hole = paddingBox.offsetBy(dx: shadow.offset.width, dy: shadow.offset.height)
+        let spread = shadow.spreadRadius
+        let hole = paddingBox
+            .insetBy(dx: spread, dy: spread)
+            .offsetBy(dx: shadow.offset.width, dy: shadow.offset.height)
+        let extent = max(bounds.width, bounds.height) + abs(shadow.offset.width) +
+            abs(shadow.offset.height) + abs(spread) + shadow.blurRadius * 2
+        let exterior = paddingBox.insetBy(dx: -extent, dy: -extent)
         let path = CGMutablePath()
-        path.addPath(roundedPath(in: paddingBox, radii: paddingRadii).cgPath)
-        path.addPath(roundedPath(in: hole, radii: paddingRadii).cgPath)
+        path.addRect(exterior)
+        if !hole.isEmpty {
+            let holeRadii = paddingRadii.map {
+                CGSize(
+                    width: max(0, $0.width - spread),
+                    height: max(0, $0.height - spread)
+                )
+            }
+            path.addPath(roundedPath(in: hole, radii: holeRadii).cgPath)
+        }
         return path
+    }
+
+    func paddingBoxPath(in bounds: CGRect) -> CGPath {
+        let widths = Array((borderWidths + [0, 0, 0, 0]).prefix(4)).map { max(0, $0) }
+        let top = min(widths[0], bounds.height)
+        let right = min(widths[1], bounds.width)
+        let bottom = min(widths[2], bounds.height)
+        let left = min(widths[3], bounds.width)
+        let paddingBox = CGRect(
+            x: bounds.minX + left,
+            y: bounds.minY + top,
+            width: max(0, bounds.width - left - right),
+            height: max(0, bounds.height - top - bottom)
+        )
+        let radii = insetCornerRadii(
+            normalizedRadii(cornerRadii, in: bounds),
+            top: top,
+            right: right,
+            bottom: bottom,
+            left: left
+        )
+        return roundedPath(in: paddingBox, radii: radii).cgPath
     }
 
     func borderBoxPath(in bounds: CGRect) -> CGPath {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -120,7 +120,7 @@ final class WhiskerNodeView: UIView {
             return
         }
         if shadow.inset {
-            guard let shadowPath = boxPainter.hardInsetBoxShadowPath(in: bounds, shadow: shadow) else {
+            guard let shadowPath = boxPainter.insetBoxShadowPath(in: bounds, shadow: shadow) else {
                 boxShadowLayer.path = nil
                 boxShadowLayer.mask = nil
                 boxShadowLayer.shadowPath = nil
@@ -131,10 +131,18 @@ final class WhiskerNodeView: UIView {
             boxShadowLayer.fillColor = shadow.color.cgColor
             boxShadowLayer.fillRule = .evenOdd
             boxShadowLayer.strokeColor = nil
-            boxShadowLayer.mask = nil
+            // Let Core Animation derive the shadow from the even-odd ring;
+            // `shadowPath` itself does not carry the layer's fill rule.
             boxShadowLayer.shadowPath = nil
-            boxShadowLayer.shadowOpacity = 0
-            boxShadowLayer.shadowRadius = 0
+            boxShadowLayer.shadowColor = shadow.color.withAlphaComponent(1).cgColor
+            boxShadowLayer.shadowOpacity = Float(shadow.color.cgColor.alpha)
+            boxShadowLayer.shadowOffset = .zero
+            boxShadowLayer.shadowRadius = shadow.blurRadius / 2
+            boxShadowMaskLayer.frame = bounds
+            boxShadowMaskLayer.path = boxPainter.paddingBoxPath(in: bounds)
+            boxShadowMaskLayer.fillColor = UIColor.white.cgColor
+            boxShadowMaskLayer.fillRule = .nonZero
+            boxShadowLayer.mask = boxShadowMaskLayer
             return
         }
         guard let shadowPath = boxPainter.hardBoxShadowPath(in: bounds, shadow: shadow) else {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -471,8 +471,7 @@ private func validGradientStops(
 private func validHardBoxShadow(_ shadow: WhiskerMobileBoxShadow) -> Bool {
     shadow.offset_x.isFinite && shadow.offset_y.isFinite &&
         shadow.blur_radius.isFinite && shadow.blur_radius >= 0 && shadow.spread_radius.isFinite &&
-        (shadow.inset == 0 ||
-            shadow.inset == 1 && shadow.blur_radius == 0 && shadow.spread_radius == 0) &&
+        (shadow.inset == 0 || shadow.inset == 1) &&
         shadow.color.kind <= 1 && shadow.color.alpha.isFinite &&
         (0...1).contains(shadow.color.alpha)
 }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1198,6 +1198,12 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-backgrounds/box-shadow-inset-without-border-radius.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-without-border-radius.json"
         ),
+        "wpt/css/css-backgrounds/box-shadow-inset-spread.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-spread.json"
+        ),
+        "wpt/css/css-backgrounds/box-shadow-inset-blur-definition.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-blur-definition.json"
+        ),
         "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"
         ),

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,8 +98,8 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
-      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-hard-offset"],
-      "pending_subset": ["box-shadow-inset-spread-and-blur", "multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur"],
+      "pending_subset": ["multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -304,6 +304,20 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.box-shadow-inset-spread",
+      "feature": "box-shadow-inset-spread",
+      "fixture": "wpt/css/css-backgrounds/box-shadow-inset-spread.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-backgrounds.box-shadow-inset-blur-definition",
+      "feature": "box-shadow-inset-blur",
+      "fixture": "wpt/css/css-backgrounds/box-shadow-inset-blur-definition.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
+    },
+    {
       "id": "wpt.css2.borders.border-right-003",
       "feature": "border-right",
       "fixture": "wpt/css/CSS2/borders/border-right-003.json",

--- a/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-blur-definition.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-blur-definition.json
@@ -1,0 +1,56 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.box-shadow-inset-blur-definition",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/box-shadow/box-shadow-blur-definition-001.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "Inset box-shadow blur uses the same Gaussian falloff as an outer shadow and is clipped to the padding edge.",
+    "adaptation": "The upstream 20px Gaussian blur definition is applied to the inner edge of a 100px padding box. Relative luminance samples replace the generated light/dark bound images while preserving its monotonic falloff requirement."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 160.0, "height": 160.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 160.0, 160.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [30.0, 30.0, 100.0, 100.0],
+            "background": { "kind": "named", "value": "white" },
+            "box_shadows": [
+              {
+                "offset": [0.0, 0.0],
+                "blur_radius": 20.0,
+                "spread_radius": 0.0,
+                "color": { "kind": "named", "value": "black" },
+                "inset": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.box-shadow-inset",
+        "samples": [
+          { "point": [80.0, 80.0], "color": { "kind": "named", "value": "white" }, "tolerance": 12 }
+        ],
+        "relations": [
+          { "first": [55.0, 80.0], "second": [40.0, 80.0], "relation": "lighter", "minimum_difference": 5 },
+          { "first": [40.0, 80.0], "second": [31.0, 80.0], "relation": "lighter", "minimum_difference": 20 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-spread.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-spread.json
@@ -1,0 +1,62 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.box-shadow-inset-spread",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/box-shadow-inset-without-border-radius.html",
+    "reference_path": "css/css-backgrounds/reference/box-shadow-inset-without-border-radius-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "A positive inset spread contracts the shadow perimeter inward while the result remains clipped to the padding box.",
+    "adaptation": "The upstream second subtest is isolated as an 80px border box with an 8px transparent border, a 10px/10px offset, and a 15px inset spread. Direct samples replace its HTML reference rendering."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 120.0, "height": 120.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [20.0, 20.0, 80.0, 80.0],
+            "content_box": [24.0, 24.0, 32.0, 32.0],
+            "background": { "kind": "named", "value": "white" },
+            "border": {
+              "widths": [8.0, 8.0, 8.0, 8.0],
+              "colors": [
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" },
+                { "kind": "named", "value": "transparent" }
+              ],
+              "styles": ["solid", "solid", "solid", "solid"],
+              "radii": [0.0, 0.0, 0.0, 0.0]
+            },
+            "box_shadows": [
+              {
+                "offset": [10.0, 10.0],
+                "blur_radius": 0.0,
+                "spread_radius": 15.0,
+                "color": { "kind": "named", "value": "black" },
+                "inset": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.box-shadow-inset",
+        "samples": [
+          { "point": [32.0, 50.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [50.0, 50.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [60.0, 60.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [88.0, 60.0], "color": { "kind": "named", "value": "black" }, "tolerance": 5 },
+          { "point": [24.0, 60.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- adapt WPT inset spread and Gaussian blur cases into two shared Host fixtures
- contract the inset shadow hole by positive spread on all native Hosts
- blur the inner edge with Desktop analytic Gaussian coverage, Android BlurMaskFilter, and UIKit/Core Animation
- keep the result clipped to the rounded padding edge and Web on native CSS
- promote inset offset, spread, and blur into the supported visual-effects subset

## Verification
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios
- cargo test -p whisker-host-conformance
- cargo test -p whisker-desktop inset_spread_contracts_the_hole_and_blur_selects_gaussian_coverage
- cargo clippy -p whisker-desktop --all-targets -- -D warnings