### PR TITLE
feat: preserve multiple box-shadow paint order

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -13,9 +13,9 @@ final class WhiskerNodeView: UIView {
     var mountedElement: WhiskerMountedElement?
     private let defaultChildrenHost = WhiskerChildrenHostView(frame: .zero)
     private let overflowMask = CAShapeLayer()
-    private var boxShadow: HostBoxShadow?
-    private let boxShadowLayer = CAShapeLayer()
-    private let boxShadowMaskLayer = CAShapeLayer()
+    private var boxShadows: [HostBoxShadow] = []
+    private var boxShadowLayers: [CAShapeLayer] = []
+    private var boxShadowMaskLayers: [CAShapeLayer] = []
     private var clipsOverflowHorizontally = false
     private var clipsOverflowVertically = false
 
@@ -28,7 +28,6 @@ final class WhiskerNodeView: UIView {
         defaultChildrenHost.backgroundColor = .clear
         defaultChildrenHost.clipsToBounds = false
         addSubview(defaultChildrenHost)
-        layer.insertSublayer(boxShadowLayer, at: 0)
     }
 
     required init?(coder: NSCoder) { nil }
@@ -107,48 +106,67 @@ final class WhiskerNodeView: UIView {
     }
 
     func setBoxShadows(_ shadows: [HostBoxShadow]) {
-        precondition(shadows.count <= 1)
-        boxShadow = shadows.first
+        while boxShadowLayers.count > shadows.count {
+            boxShadowLayers.removeLast().removeFromSuperlayer()
+            boxShadowMaskLayers.removeLast()
+        }
+        while boxShadowLayers.count < shadows.count {
+            let shadowLayer = CAShapeLayer()
+            // New entries are farther back in CSS list order. Inserting each
+            // at zero keeps the first shadow visually above all later ones.
+            layer.insertSublayer(shadowLayer, at: 0)
+            boxShadowLayers.append(shadowLayer)
+            boxShadowMaskLayers.append(CAShapeLayer())
+        }
+        boxShadows = shadows
         updateBoxShadowLayers()
     }
 
     private func updateBoxShadowLayers() {
-        guard let shadow = boxShadow else {
-            boxShadowLayer.path = nil
-            boxShadowLayer.mask = nil
-            boxShadowLayer.shadowPath = nil
-            return
+        for index in boxShadows.indices {
+            updateBoxShadowLayer(
+                boxShadowLayers[index],
+                maskLayer: boxShadowMaskLayers[index],
+                shadow: boxShadows[index]
+            )
         }
+    }
+
+    private func updateBoxShadowLayer(
+        _ shadowLayer: CAShapeLayer,
+        maskLayer: CAShapeLayer,
+        shadow: HostBoxShadow
+    ) {
         if shadow.inset {
             guard let shadowPath = boxPainter.insetBoxShadowPath(in: bounds, shadow: shadow) else {
-                boxShadowLayer.path = nil
-                boxShadowLayer.mask = nil
-                boxShadowLayer.shadowPath = nil
+                shadowLayer.path = nil
+                shadowLayer.mask = nil
+                shadowLayer.shadowPath = nil
                 return
             }
-            boxShadowLayer.frame = bounds
-            boxShadowLayer.path = shadowPath
-            boxShadowLayer.fillColor = shadow.color.cgColor
-            boxShadowLayer.fillRule = .evenOdd
-            boxShadowLayer.strokeColor = nil
+            shadowLayer.frame = bounds
+            shadowLayer.path = shadowPath
+            shadowLayer.fillColor = shadow.color.cgColor
+            shadowLayer.fillRule = .evenOdd
+            shadowLayer.strokeColor = nil
             // Let Core Animation derive the shadow from the even-odd ring;
             // `shadowPath` itself does not carry the layer's fill rule.
-            boxShadowLayer.shadowPath = nil
-            boxShadowLayer.shadowColor = shadow.color.withAlphaComponent(1).cgColor
-            boxShadowLayer.shadowOpacity = Float(shadow.color.cgColor.alpha)
-            boxShadowLayer.shadowOffset = .zero
-            boxShadowLayer.shadowRadius = shadow.blurRadius / 2
-            boxShadowMaskLayer.frame = bounds
-            boxShadowMaskLayer.path = boxPainter.paddingBoxPath(in: bounds)
-            boxShadowMaskLayer.fillColor = UIColor.white.cgColor
-            boxShadowMaskLayer.fillRule = .nonZero
-            boxShadowLayer.mask = boxShadowMaskLayer
+            shadowLayer.shadowPath = nil
+            shadowLayer.shadowColor = shadow.color.withAlphaComponent(1).cgColor
+            shadowLayer.shadowOpacity = Float(shadow.color.cgColor.alpha)
+            shadowLayer.shadowOffset = .zero
+            shadowLayer.shadowRadius = shadow.blurRadius / 2
+            maskLayer.frame = bounds
+            maskLayer.path = boxPainter.paddingBoxPath(in: bounds)
+            maskLayer.fillColor = UIColor.white.cgColor
+            maskLayer.fillRule = .nonZero
+            shadowLayer.mask = maskLayer
             return
         }
         guard let shadowPath = boxPainter.hardBoxShadowPath(in: bounds, shadow: shadow) else {
-            boxShadowLayer.path = nil
-            boxShadowLayer.mask = nil
-            boxShadowLayer.shadowPath = nil
+            shadowLayer.path = nil
+            shadowLayer.mask = nil
+            shadowLayer.shadowPath = nil
             return
         }
         let blurExtent = shadow.blurRadius * 1.5
@@ -159,27 +177,27 @@ final class WhiskerNodeView: UIView {
             translationX: -layerFrame.minX,
             y: -layerFrame.minY
         )
-        boxShadowLayer.frame = layerFrame
-        boxShadowLayer.path = shadowPath.copy(using: &translation)
-        boxShadowLayer.fillColor = shadow.color.cgColor
-        boxShadowLayer.fillRule = .nonZero
-        boxShadowLayer.strokeColor = nil
-        boxShadowLayer.shadowPath = shadowPath.copy(using: &translation)
-        boxShadowLayer.shadowColor = shadow.color.withAlphaComponent(1).cgColor
-        boxShadowLayer.shadowOpacity = Float(shadow.color.cgColor.alpha)
-        boxShadowLayer.shadowOffset = .zero
-        boxShadowLayer.shadowRadius = shadow.blurRadius / 2
+        shadowLayer.frame = layerFrame
+        shadowLayer.path = shadowPath.copy(using: &translation)
+        shadowLayer.fillColor = shadow.color.cgColor
+        shadowLayer.fillRule = .nonZero
+        shadowLayer.strokeColor = nil
+        shadowLayer.shadowPath = shadowPath.copy(using: &translation)
+        shadowLayer.shadowColor = shadow.color.withAlphaComponent(1).cgColor
+        shadowLayer.shadowOpacity = Float(shadow.color.cgColor.alpha)
+        shadowLayer.shadowOffset = .zero
+        shadowLayer.shadowRadius = shadow.blurRadius / 2
 
         let maskPath = CGMutablePath()
         maskPath.addRect(CGRect(origin: .zero, size: layerFrame.size))
         if let borderPath = boxPainter.borderBoxPath(in: bounds).copy(using: &translation) {
             maskPath.addPath(borderPath)
         }
-        boxShadowMaskLayer.frame = CGRect(origin: .zero, size: layerFrame.size)
-        boxShadowMaskLayer.path = maskPath
-        boxShadowMaskLayer.fillColor = UIColor.white.cgColor
-        boxShadowMaskLayer.fillRule = .evenOdd
-        boxShadowLayer.mask = boxShadowMaskLayer
+        maskLayer.frame = CGRect(origin: .zero, size: layerFrame.size)
+        maskLayer.path = maskPath
+        maskLayer.fillColor = UIColor.white.cgColor
+        maskLayer.fillRule = .evenOdd
+        shadowLayer.mask = maskLayer
     }
 
     private func updateOverflowMask() {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -163,7 +163,7 @@ final class HostScene {
                     guard operation.payload == nil else { return false }
                     continue
                 }
-                guard operation.payload_count == 1,
+                guard (1...4_096).contains(operation.payload_count),
                       let pointer = operation.payload?.assumingMemoryBound(
                           to: WhiskerMobileBoxShadow.self
                       ) else { return false }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -506,7 +506,9 @@ impl Driver {
                                     .or_else(|| {
                                         nodes.iter().find_map(|node| {
                                             node.box_shadows.first().map(|shadow| {
-                                                if shadow.inset {
+                                                if node.box_shadows.len() > 1 {
+                                                    "paint.visual-effects.box-shadow-multiple"
+                                                } else if shadow.inset {
                                                     "paint.visual-effects.box-shadow-inset"
                                                 } else if shadow.blur_radius != 0.0 {
                                                     "paint.visual-effects.box-shadow-blur"
@@ -1204,6 +1206,9 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-backgrounds/box-shadow-inset-blur-definition.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-inset-blur-definition.json"
         ),
+        "wpt/css/css-backgrounds/box-shadow-multiple-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-multiple-001.json"
+        ),
         "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"
         ),
@@ -1872,6 +1877,12 @@ fn fixture_px(value: f32) -> String {
 fn fixture_color_css(value: &ColorFixture) -> String {
     match value {
         ColorFixture::Named { value } => value.clone(),
+        ColorFixture::Srgba {
+            red,
+            green,
+            blue,
+            alpha,
+        } if *alpha == 1.0 => format!("rgb({red}, {green}, {blue})"),
         ColorFixture::Srgba {
             red,
             green,

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,8 +98,8 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
-      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur"],
-      "pending_subset": ["multiple-box-shadows", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur", "multiple-box-shadows"],
+      "pending_subset": ["clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -318,6 +318,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
     },
     {
+      "id": "wpt.css-backgrounds.box-shadow-multiple-001",
+      "feature": "multiple-box-shadows",
+      "fixture": "wpt/css/css-backgrounds/box-shadow-multiple-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-right-003",
       "feature": "border-right",
       "fixture": "wpt/css/CSS2/borders/border-right-003.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -303,7 +303,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.visual-effects.box-shadow-blur" ||
                             command.getString("name") ==
-                            "paint.visual-effects.box-shadow-inset",
+                            "paint.visual-effects.box-shadow-inset" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.box-shadow-multiple",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -442,7 +442,8 @@ private final class Driver {
                     name == "paint.visual-effects.box-shadow-offset" ||
                     name == "paint.visual-effects.box-shadow-spread" ||
                     name == "paint.visual-effects.box-shadow-blur" ||
-                    name == "paint.visual-effects.box-shadow-inset" else {
+                    name == "paint.visual-effects.box-shadow-inset" ||
+                    name == "paint.visual-effects.box-shadow-multiple" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()

--- a/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-multiple-001.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/box-shadow-multiple-001.json
@@ -1,0 +1,51 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.box-shadow-multiple-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/box-shadow-multiple-001.html",
+    "reference_path": "css/css-backgrounds/reference/box-shadow-multiple-001-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "A comma-separated box-shadow list is painted front to back, so the first shadow is visible above later overlapping shadows.",
+    "adaptation": "The upstream multiple-overlapping1 subtest is reduced to a 40px yellow box and four pairs of same-offset hard shadows. Samples verify all four directions and that each first-listed color covers the red shadow behind it."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 200.0, "height": 200.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [80.0, 80.0, 40.0, 40.0],
+            "background": { "kind": "srgba", "red": 255, "green": 255, "blue": 0, "alpha": 1.0 },
+            "box_shadows": [
+              { "offset": [0.0, -40.0], "blur_radius": 0.0, "spread_radius": 0.0, "color": { "kind": "srgba", "red": 128, "green": 0, "blue": 128, "alpha": 1.0 } },
+              { "offset": [0.0, -40.0], "blur_radius": 0.0, "spread_radius": 0.0, "color": { "kind": "named", "value": "red" } },
+              { "offset": [40.0, 0.0], "blur_radius": 0.0, "spread_radius": 0.0, "color": { "kind": "named", "value": "blue" } },
+              { "offset": [40.0, 0.0], "blur_radius": 0.0, "spread_radius": 0.0, "color": { "kind": "named", "value": "red" } },
+              { "offset": [0.0, 40.0], "blur_radius": 0.0, "spread_radius": 0.0, "color": { "kind": "srgba", "red": 255, "green": 0, "blue": 255, "alpha": 1.0 } },
+              { "offset": [0.0, 40.0], "blur_radius": 0.0, "spread_radius": 0.0, "color": { "kind": "named", "value": "red" } },
+              { "offset": [-40.0, 0.0], "blur_radius": 0.0, "spread_radius": 0.0, "color": { "kind": "srgba", "red": 255, "green": 165, "blue": 0, "alpha": 1.0 } },
+              { "offset": [-40.0, 0.0], "blur_radius": 0.0, "spread_radius": 0.0, "color": { "kind": "named", "value": "red" } }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.box-shadow-multiple",
+        "samples": [
+          { "point": [100.0, 60.0], "color": { "kind": "srgba", "red": 128, "green": 0, "blue": 128, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [140.0, 100.0], "color": { "kind": "named", "value": "blue" }, "tolerance": 5 },
+          { "point": [100.0, 140.0], "color": { "kind": "srgba", "red": 255, "green": 0, "blue": 255, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [60.0, 100.0], "color": { "kind": "srgba", "red": 255, "green": 165, "blue": 0, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [100.0, 100.0], "color": { "kind": "srgba", "red": 255, "green": 255, "blue": 0, "alpha": 1.0 }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- adapt the WPT overlapping multiple-shadow case into the shared Host fixture suite
- verify the complete shadow list and first-to-last CSS paint order on Desktop, Web, Android, and iOS
- replace the single iOS shadow layer with reusable per-shadow shape and mask layers
- accept bounded shadow arrays in the iOS transaction validator
- promote multiple box shadows into the supported visual-effects subset

## Verification
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios
- cargo test -p whisker-host-conformance