### PR TITLE
feat: render rounded inset clip paths across Hosts

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 10 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 11 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -20,7 +20,7 @@ enum {
   WHISKER_OP_Z_ORDER, WHISKER_OP_TEXT, WHISKER_OP_PROPERTY,
   WHISKER_OP_CLEAR_PROPERTY, WHISKER_OP_EVENT_MASK, WHISKER_OP_HIT_TEST,
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
-  WHISKER_OP_BACKGROUND_LAYERS, WHISKER_OP_BOX_SHADOWS
+  WHISKER_OP_BACKGROUND_LAYERS, WHISKER_OP_BOX_SHADOWS, WHISKER_OP_CLIP_PATH
 };
 enum {
   WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
@@ -37,6 +37,7 @@ enum {
 };
 enum { WHISKER_BACKGROUND_ATTACHMENT_SCROLL = 0 };
 enum { WHISKER_BACKGROUND_BLEND_NORMAL = 0 };
+enum { WHISKER_CLIP_SHAPE_INSET = 0 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -83,6 +84,16 @@ typedef struct {
   WhiskerMobileColor color;
   uint8_t inset, _pad[7];
 } WhiskerMobileBoxShadow;
+typedef struct {
+  WhiskerMobileLengthPercentage edges[4];
+  WhiskerMobileLengthPercentage radii_horizontal[4];
+  WhiskerMobileLengthPercentage radii_vertical[4];
+} WhiskerMobileClipInset;
+typedef struct {
+  uint32_t reference_box, shape_kind;
+  const void *payload;
+  size_t payload_count;
+} WhiskerMobileClipPath;
 typedef struct {
   WhiskerMobileColor color;
   WhiskerMobileLengthPercentage position;
@@ -148,6 +159,8 @@ _Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGrad
 _Static_assert(sizeof(WhiskerMobileBackgroundImage) == 24, "WhiskerMobileBackgroundImage ABI drift");
 _Static_assert(sizeof(WhiskerMobileBackgroundLayer) == 88, "WhiskerMobileBackgroundLayer ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxShadow) == 56, "WhiskerMobileBoxShadow ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipInset) == 96, "WhiskerMobileClipInset ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipPath) == 24, "WhiskerMobileClipPath ABI drift");
 
 typedef struct {
   uint32_t id;

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -278,6 +278,35 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 free(values);
                 break;
             }
+            case WHISKER_OP_CLIP_PATH: {
+                if (op->payload == NULL) {
+                    if (op->payload_count != 0) ok = false;
+                    break;
+                }
+                if (op->payload_count != 1) { ok = false; break; }
+                const WhiskerMobileClipPath* clip = op->payload;
+                if (clip->shape_kind != WHISKER_CLIP_SHAPE_INSET ||
+                    clip->payload == NULL || clip->payload_count != 1) {
+                    ok = false; break;
+                }
+                const WhiskerMobileClipInset* inset = clip->payload;
+                storage[count++] = (float)clip->reference_box;
+                storage[count++] = (float)clip->shape_kind;
+                for (int j=0;j<4;++j) {
+                    storage[count++]=inset->edges[j].length;
+                    storage[count++]=inset->edges[j].fraction;
+                }
+                for (int j=0;j<4;++j) {
+                    storage[count++]=inset->radii_horizontal[j].length;
+                    storage[count++]=inset->radii_horizontal[j].fraction;
+                }
+                for (int j=0;j<4;++j) {
+                    storage[count++]=inset->radii_vertical[j].length;
+                    storage[count++]=inset->radii_vertical[j].fraction;
+                }
+                numbers = floats(env, storage, count);
+                break;
+            }
             case WHISKER_OP_BACKGROUND_LAYERS: {
                 if (op->payload == NULL) {
                     if (op->payload_count != 0) ok = false;

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 10;
+pub const MOBILE_ABI_MINOR: u16 = 11;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -46,6 +46,7 @@ pub const OP_RELEASE_CAPTURE: u32 = 19;
 pub const OP_COMMAND: u32 = 20;
 pub const OP_BACKGROUND_LAYERS: u32 = 21;
 pub const OP_BOX_SHADOWS: u32 = 22;
+pub const OP_CLIP_PATH: u32 = 23;
 
 pub const BACKGROUND_LINEAR: u32 = 0;
 pub const BACKGROUND_RADIAL: u32 = 1;
@@ -71,6 +72,8 @@ pub const BACKGROUND_BOX_BORDER_AREA: u32 = 3;
 
 pub const BACKGROUND_ATTACHMENT_SCROLL: u32 = 0;
 pub const BACKGROUND_BLEND_NORMAL: u32 = 0;
+
+pub const CLIP_SHAPE_INSET: u32 = 0;
 
 pub const MEASURE_TEXT: u32 = 1;
 pub const MEASURE_REPLACED_CONTENT: u32 = 2;
@@ -162,6 +165,26 @@ pub struct MobileBoxShadow {
     pub color: MobileColor,
     pub inset: u8,
     pub _pad: [u8; 7],
+}
+
+/// One rounded inset basic shape. Arrays use CSS top/right/bottom/left and
+/// top-left/top-right/bottom-right/bottom-left ordering respectively.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileClipInset {
+    pub edges: [MobileLengthPercentage; 4],
+    pub radii_horizontal: [MobileLengthPercentage; 4],
+    pub radii_vertical: [MobileLengthPercentage; 4],
+}
+
+/// One typed clip path. `payload` points to the shape selected by `shape_kind`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileClipPath {
+    pub reference_box: u32,
+    pub shape_kind: u32,
+    pub payload: *const c_void,
+    pub payload_count: usize,
 }
 
 /// One explicit color stop shared by the additive gradient ABI subsets.
@@ -580,6 +603,8 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileText>(), 80);
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::size_of::<MobileBoxShadow>(), 56);
+            assert_eq!(std::mem::size_of::<MobileClipInset>(), 96);
+            assert_eq!(std::mem::size_of::<MobileClipPath>(), 24);
             assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
             assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 48);
             assert_eq!(std::mem::size_of::<MobileConicGradient>(), 32);

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -406,6 +406,43 @@ pub struct BoxShadowFixture {
     pub inset: bool,
 }
 
+/// One resolved `clip-path` and its geometry reference box.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ClipPathFixture {
+    /// Box used to resolve shape coordinates.
+    #[serde(default)]
+    pub reference_box: ClipReferenceBoxFixture,
+    /// Resolved basic shape.
+    pub shape: ClipShapeFixture,
+}
+
+/// Basic shape vocabulary currently exercised by shared Host fixtures.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ClipShapeFixture {
+    /// Inset rectangle with independent edges and corner radii.
+    Inset {
+        /// Top, right, bottom, and left length-percentage insets.
+        edges: [LengthPercentageFixture; 4],
+        /// Top-left, top-right, bottom-right, and bottom-left radii.
+        radii: [CornerRadiusFixture; 4],
+    },
+}
+
+/// CSS geometry boxes accepted as clip-path reference boxes.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ClipReferenceBoxFixture {
+    /// Border box, and the Lynx-compatible default.
+    #[default]
+    Border,
+    /// Padding box.
+    Padding,
+    /// Content box.
+    Content,
+}
+
 /// One node in a retained Host scene fixture.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -428,6 +465,9 @@ pub struct SceneNodeFixture {
     /// Box shadows in CSS front-to-back order.
     #[serde(default)]
     pub box_shadows: Vec<BoxShadowFixture>,
+    /// Optional basic-shape clip applied to the node and its descendants.
+    #[serde(default)]
+    pub clip_path: Option<ClipPathFixture>,
     /// Descendant overflow clipping semantics.
     #[serde(default)]
     pub clip: BoxClipFixture,
@@ -1244,6 +1284,15 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                         && shadow.spread_radius.is_finite()
                         && valid_color(&shadow.color)
                 })
+                && node
+                    .clip_path
+                    .as_ref()
+                    .is_none_or(|clip| match &clip.shape {
+                        ClipShapeFixture::Inset { edges, radii } => {
+                            edges.iter().all(LengthPercentageFixture::is_finite)
+                                && radii.iter().copied().all(CornerRadiusFixture::is_valid)
+                        }
+                    })
                 && node
                     .transform
                     .is_none_or(|transform| transform.into_iter().all(f32::is_finite))

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -8,10 +8,10 @@ use whisker_driver::module::{
 };
 use whisker_engine::whisker_protocol::{
     ApplyResult, AvailableSpace, BackgroundAttachment, BackgroundSize, BlendMode, BorderLineStyle,
-    ChildPolicy, ElementMeasurement, ElementRegistration, ElementValueKind, FrameMode, FramePacket,
-    ImageRepeat, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextWrap,
-    MeasuredSize, MeasurementMetrics, MeasurementPayload, MeasurementRequest, MeasurementRequestId,
-    MeasurementResponse, NodeId, Operation, PaintBox, PaintColor, PaintImage,
+    ChildPolicy, ClipShape, ElementMeasurement, ElementRegistration, ElementValueKind, FrameMode,
+    FramePacket, ImageRepeat, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+    MeasureTextWrap, MeasuredSize, MeasurementMetrics, MeasurementPayload, MeasurementRequest,
+    MeasurementRequestId, MeasurementResponse, NodeId, Operation, PaintBox, PaintColor, PaintImage,
     PaintLengthPercentage, PreparedContentId, RadialGradientExtent, RadialGradientShape,
     ResourceCommand, ResourceDimensions, ResourceEvent, ResourceFailureCode, ResourceId,
     ResourceKind, ResourceSource, SurfaceId, UnsupportedMeasurementReason, VisualEffects,
@@ -909,6 +909,8 @@ struct MobileFrameOwned {
     _layouts: Vec<Box<MobileLayoutGeometry>>,
     _paints: Vec<Box<MobileBoxPaint>>,
     _box_shadows: Vec<Box<[MobileBoxShadow]>>,
+    _clip_insets: Vec<Box<MobileClipInset>>,
+    _clip_paths: Vec<Box<MobileClipPath>>,
     _gradient_stops: Vec<Box<[MobileGradientStop]>>,
     _radial_gradients: Vec<Box<MobileRadialGradient>>,
     _conic_gradients: Vec<Box<MobileConicGradient>>,
@@ -921,12 +923,31 @@ struct MobileFrameOwned {
     _operations: Vec<MobileOperation>,
 }
 
+fn empty_mobile_operation() -> MobileOperation {
+    MobileOperation {
+        tag: 0,
+        flags: 0,
+        node: 0,
+        parent: 0,
+        child: 0,
+        index: 0,
+        member: 0,
+        integer: 0,
+        scalar: 0.0,
+        wide: 0,
+        payload: std::ptr::null(),
+        payload_count: 0,
+    }
+}
+
 impl MobileFrameOwned {
     fn new(packet: &FramePacket) -> Result<Self, MobileFrameError> {
         let mut arena = RawValueArena::default();
         let mut layouts = Vec::<Box<MobileLayoutGeometry>>::new();
         let mut paints = Vec::<Box<MobileBoxPaint>>::new();
         let mut box_shadows = Vec::<Box<[MobileBoxShadow]>>::new();
+        let mut clip_insets = Vec::<Box<MobileClipInset>>::new();
+        let mut clip_paths = Vec::<Box<MobileClipPath>>::new();
         let mut gradient_stops = Vec::<Box<[MobileGradientStop]>>::new();
         let mut radial_gradients = Vec::<Box<MobileRadialGradient>>::new();
         let mut conic_gradients = Vec::<Box<MobileConicGradient>>::new();
@@ -936,22 +957,9 @@ impl MobileFrameOwned {
         let mut transforms = Vec::<Box<[f32; 16]>>::new();
         let mut values = Vec::<Box<WhiskerValueRaw>>::new();
         let mut strings = Vec::new();
-        let mut operations = Vec::with_capacity(packet.operations.len());
+        let mut operations = Vec::with_capacity(packet.operations.len() * 2);
         for operation in &packet.operations {
-            let mut raw = MobileOperation {
-                tag: 0,
-                flags: 0,
-                node: 0,
-                parent: 0,
-                child: 0,
-                index: 0,
-                member: 0,
-                integer: 0,
-                scalar: 0.0,
-                wide: 0,
-                payload: std::ptr::null(),
-                payload_count: 0,
-            };
+            let mut raw = empty_mobile_operation();
             match operation {
                 Operation::CreateNode { node, element_type } => {
                     raw.tag = OP_CREATE;
@@ -1162,6 +1170,7 @@ impl MobileFrameOwned {
                 Operation::SetVisualEffects { node, effects } => {
                     let mut remainder = effects.clone();
                     remainder.box_shadows.clear();
+                    remainder.clip_path = None;
                     if remainder != VisualEffects::default() {
                         return Err(MobileFrameError);
                     }
@@ -1190,6 +1199,52 @@ impl MobileFrameOwned {
                         shadows.as_ptr().cast()
                     };
                     raw.payload_count = shadows.len();
+                    operations.push(raw);
+
+                    raw = empty_mobile_operation();
+                    raw.tag = OP_CLIP_PATH;
+                    raw.node = node.get();
+                    if let Some((reference_box, shape)) = effects.clip_path.as_ref() {
+                        let reference_box = match reference_box {
+                            PaintBox::Border => BACKGROUND_BOX_BORDER,
+                            PaintBox::Padding => BACKGROUND_BOX_PADDING,
+                            PaintBox::Content => BACKGROUND_BOX_CONTENT,
+                            _ => return Err(MobileFrameError),
+                        };
+                        let ClipShape::Inset { edges, radii } = shape else {
+                            return Err(MobileFrameError);
+                        };
+                        clip_insets.push(Box::new(MobileClipInset {
+                            edges: [
+                                mobile_coordinate(edges.top),
+                                mobile_coordinate(edges.right),
+                                mobile_coordinate(edges.bottom),
+                                mobile_coordinate(edges.left),
+                            ],
+                            radii_horizontal: [
+                                mobile_length(radii.top_left.horizontal),
+                                mobile_length(radii.top_right.horizontal),
+                                mobile_length(radii.bottom_right.horizontal),
+                                mobile_length(radii.bottom_left.horizontal),
+                            ],
+                            radii_vertical: [
+                                mobile_length(radii.top_left.vertical),
+                                mobile_length(radii.top_right.vertical),
+                                mobile_length(radii.bottom_right.vertical),
+                                mobile_length(radii.bottom_left.vertical),
+                            ],
+                        }));
+                        clip_paths.push(Box::new(MobileClipPath {
+                            reference_box,
+                            shape_kind: CLIP_SHAPE_INSET,
+                            payload: clip_insets.last().unwrap().as_ref() as *const _
+                                as *const c_void,
+                            payload_count: 1,
+                        }));
+                        raw.payload =
+                            clip_paths.last().unwrap().as_ref() as *const _ as *const c_void;
+                        raw.payload_count = 1;
+                    }
                 }
                 Operation::SetClip { node, clip } => {
                     raw.tag = OP_CLIP;
@@ -1341,6 +1396,8 @@ impl MobileFrameOwned {
             _layouts: layouts,
             _paints: paints,
             _box_shadows: box_shadows,
+            _clip_insets: clip_insets,
+            _clip_paths: clip_paths,
             _gradient_stops: gradient_stops,
             _radial_gradients: radial_gradients,
             _conic_gradients: conic_gradients,
@@ -1853,9 +1910,81 @@ mod tests {
         assert_eq!(shadows[1].inset, 1);
         assert_eq!(shadows[1].color.kind, 1);
         assert_eq!(shadows[1].color.alpha, 0.5);
-        assert_eq!(frame._operations[1].tag, OP_BOX_SHADOWS);
+        assert_eq!(frame._operations[1].tag, OP_CLIP_PATH);
         assert_eq!(frame._operations[1].payload_count, 0);
         assert!(frame._operations[1].payload.is_null());
+        assert_eq!(frame._operations[2].tag, OP_BOX_SHADOWS);
+        assert_eq!(frame._operations[2].payload_count, 0);
+        assert!(frame._operations[2].payload.is_null());
+        assert_eq!(frame._operations[3].tag, OP_CLIP_PATH);
+        assert_eq!(frame._operations[3].payload_count, 0);
+        assert!(frame._operations[3].payload.is_null());
+    }
+
+    #[test]
+    fn mobile_frame_exposes_rounded_inset_clip_path_as_typed_payload() {
+        use whisker_engine::whisker_protocol::{PaintCornerRadius, PaintCorners, PaintEdges};
+
+        let node = NodeId::new(1).unwrap();
+        let coordinate = PaintCoordinate {
+            length: 2.0,
+            fraction: 0.1,
+        };
+        let radius = PaintCornerRadius::circular(PaintLengthPercentage {
+            length: 4.0,
+            fraction: 0.2,
+        });
+        let packet = FramePacket {
+            header: FrameHeader {
+                version: ProtocolVersion::CURRENT,
+                surface: SurfaceId::new(1).unwrap(),
+                scene_epoch: 1,
+                frame_id: 1,
+                base_revision: 0,
+                target_revision: 1,
+                viewport_epoch: 1,
+                mode: FrameMode::Snapshot,
+            },
+            operations: vec![Operation::SetVisualEffects {
+                node,
+                effects: VisualEffects {
+                    clip_path: Some((
+                        PaintBox::Padding,
+                        ClipShape::Inset {
+                            edges: PaintEdges {
+                                top: coordinate,
+                                right: coordinate,
+                                bottom: coordinate,
+                                left: coordinate,
+                            },
+                            radii: PaintCorners {
+                                top_left: radius,
+                                top_right: radius,
+                                bottom_right: radius,
+                                bottom_left: radius,
+                            },
+                        },
+                    )),
+                    ..Default::default()
+                },
+            }],
+        };
+
+        let frame = MobileFrameOwned::new(&packet).unwrap();
+        assert_eq!(frame._operations.len(), 2);
+        assert_eq!(frame._operations[0].tag, OP_BOX_SHADOWS);
+        let operation = &frame._operations[1];
+        assert_eq!(operation.tag, OP_CLIP_PATH);
+        assert_eq!(operation.payload_count, 1);
+        let clip = unsafe { &*operation.payload.cast::<MobileClipPath>() };
+        assert_eq!(clip.reference_box, BACKGROUND_BOX_PADDING);
+        assert_eq!(clip.shape_kind, CLIP_SHAPE_INSET);
+        assert_eq!(clip.payload_count, 1);
+        let inset = unsafe { &*clip.payload.cast::<MobileClipInset>() };
+        assert_eq!(inset.edges[0].length, 2.0);
+        assert_eq!(inset.edges[0].fraction, 0.1);
+        assert_eq!(inset.radii_horizontal[0].length, 4.0);
+        assert_eq!(inset.radii_vertical[0].fraction, 0.2);
     }
 
     #[test]

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/ClipPath.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/ClipPath.kt
@@ -1,0 +1,59 @@
+package rs.whisker.runtime.paint
+
+import android.graphics.Path
+import android.graphics.RectF
+
+internal enum class HostClipReferenceBox { Border, Padding, Content }
+
+/** Rounded inset basic shape retained in physical Host coordinates. */
+internal data class HostInsetClipPath(
+    val referenceBox: HostClipReferenceBox,
+    val edges: List<HostPaintCoordinate>,
+    val radiiHorizontal: List<HostPaintCoordinate>,
+    val radiiVertical: List<HostPaintCoordinate>,
+)
+
+internal fun resolveInsetClipPath(
+    clip: HostInsetClipPath,
+    width: Float,
+    height: Float,
+    borderWidths: FloatArray,
+    contentBox: RectF,
+): Path {
+    val reference = when (clip.referenceBox) {
+        HostClipReferenceBox.Border -> RectF(0f, 0f, width, height)
+        HostClipReferenceBox.Padding -> RectF(
+            borderWidths[3].coerceIn(0f, width),
+            borderWidths[0].coerceIn(0f, height),
+            width - borderWidths[1].coerceIn(0f, width),
+            height - borderWidths[2].coerceIn(0f, height),
+        )
+        HostClipReferenceBox.Content -> RectF(contentBox)
+    }
+    val top = clip.edges[0].resolve(reference.height())
+    val right = clip.edges[1].resolve(reference.width())
+    val bottom = clip.edges[2].resolve(reference.height())
+    val left = clip.edges[3].resolve(reference.width())
+    val inset = RectF(
+        reference.left + left,
+        reference.top + top,
+        (reference.right - right).coerceAtLeast(reference.left + left),
+        (reference.bottom - bottom).coerceAtLeast(reference.top + top),
+    )
+    if (inset.isEmpty) return Path()
+    val radii = normalizeRadii(
+        floatArrayOf(
+            clip.radiiHorizontal[0].resolve(inset.width()).coerceAtLeast(0f),
+            clip.radiiVertical[0].resolve(inset.height()).coerceAtLeast(0f),
+            clip.radiiHorizontal[1].resolve(inset.width()).coerceAtLeast(0f),
+            clip.radiiVertical[1].resolve(inset.height()).coerceAtLeast(0f),
+            clip.radiiHorizontal[2].resolve(inset.width()).coerceAtLeast(0f),
+            clip.radiiVertical[2].resolve(inset.height()).coerceAtLeast(0f),
+            clip.radiiHorizontal[3].resolve(inset.width()).coerceAtLeast(0f),
+            clip.radiiVertical[3].resolve(inset.height()).coerceAtLeast(0f),
+        ),
+        inset.width(),
+        inset.height(),
+    )
+    return Path().apply { addRoundRect(inset, radii, Path.Direction.CW) }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -11,6 +11,7 @@ import rs.whisker.runtime.WhiskerMountedElement
 import rs.whisker.runtime.paint.HostBoxPaint
 import rs.whisker.runtime.paint.HostBackgroundLayers
 import rs.whisker.runtime.paint.HostBoxShadow
+import rs.whisker.runtime.paint.HostInsetClipPath
 import rs.whisker.runtime.paint.ResolvedBoxGeometry
 import rs.whisker.runtime.paint.normalizeRadii
 import rs.whisker.runtime.paint.drawInsetBoxShadows
@@ -39,6 +40,7 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
     var paint: HostBoxPaint? = null
     var backgroundLayers: HostBackgroundLayers? = null
     var boxShadows: List<HostBoxShadow> = emptyList()
+    var clipPath: HostInsetClipPath? = null
     var mountedElement: WhiskerMountedElement? = null
     var zOrder: Int = 0
 
@@ -46,6 +48,7 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
     private var hasLocalTransform = false
     private var overflowClipRect = RectF()
     private var overflowClipPath: Path? = null
+    private var paintClipPath: Path? = null
     private var resolvedBoxGeometry: ResolvedBoxGeometry? = null
 
     init {
@@ -85,6 +88,14 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
         invalidate()
     }
 
+    fun setPaintClipPath(path: Path?) {
+        paintClipPath = path
+        invalidate()
+        (parent as? android.view.View)?.invalidate()
+    }
+
+    fun resolvedBorderWidths(): FloatArray = resolvedBoxGeometry?.borderWidths ?: FloatArray(4)
+
     /** Applies a protocol transform around the local border-box origin. */
     fun setLocalTransform(values: FloatArray, density: Float) {
         require(isSupported2dTransform(values))
@@ -103,12 +114,18 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
 
     override fun draw(canvas: Canvas) {
         if (!hasLocalTransform) {
-            drawOuterBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
-            super.draw(canvas)
+            drawClipped(canvas)
             return
         }
         val save = canvas.save()
         canvas.concat(localTransform)
+        drawClipped(canvas)
+        canvas.restoreToCount(save)
+    }
+
+    private fun drawClipped(canvas: Canvas) {
+        val save = canvas.save()
+        paintClipPath?.let(canvas::clipPath)
         drawOuterBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
         super.draw(canvas)
         canvas.restoreToCount(save)

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -20,6 +20,8 @@ import rs.whisker.runtime.paint.HostBackgroundRepeat
 import rs.whisker.runtime.paint.HostBackgroundSize
 import rs.whisker.runtime.paint.HostConicGradient
 import rs.whisker.runtime.paint.HostGradientStop
+import rs.whisker.runtime.paint.HostClipReferenceBox
+import rs.whisker.runtime.paint.HostInsetClipPath
 import rs.whisker.runtime.paint.HostLinearGradient
 import rs.whisker.runtime.paint.HostPaintCoordinate
 import rs.whisker.runtime.paint.HostRadialGradient
@@ -27,6 +29,7 @@ import rs.whisker.runtime.paint.HostRasterResourceStore
 import rs.whisker.runtime.paint.applyBoxPaint
 import rs.whisker.runtime.paint.parseNamedColor
 import rs.whisker.runtime.paint.rgba
+import rs.whisker.runtime.paint.resolveInsetClipPath
 import kotlin.math.min
 
 internal data class HostSceneOperation(
@@ -159,6 +162,7 @@ internal class HostScene(
             ) return false
             8, 12, 15, 16 -> if (operation.node !in existing) return false
             22 -> if (!validBoxShadows(operation, existing)) return false
+            23 -> if (!validClipPath(operation, existing)) return false
             9 -> if (
                 operation.node !in existing ||
                 !isSupported2dTransform(operation.numbers ?: return false)
@@ -234,6 +238,7 @@ internal class HostScene(
             16 -> (nodes[id] ?: return).mountedElement?.setEventMask(operation.wide)
             21 -> applyBackgroundLayers(nodes[id] ?: return, operation)
             22 -> applyBoxShadows(nodes[id] ?: return, operation)
+            23 -> applyClipPath(nodes[id] ?: return, operation)
         }
     }
 
@@ -330,6 +335,7 @@ internal class HostScene(
             }
         }
         node.paint?.let { applyPaint(node, it) }
+        refreshClipPath(node)
     }
 
     private fun applyText(node: HostNode, text: String, values: FloatArray, names: Array<String>) {
@@ -370,6 +376,7 @@ internal class HostScene(
             ),
         )
         node.setOverflowClipGeometry(geometry)
+        refreshClipPath(node)
     }
 
     private fun applyBackgroundLayers(node: HostNode, operation: HostSceneOperation) {
@@ -410,6 +417,67 @@ internal class HostScene(
         }
         node.invalidate()
         (node.parent as? View)?.invalidate()
+    }
+
+    private fun applyClipPath(node: HostNode, operation: HostSceneOperation) {
+        val values = operation.numbers ?: FloatArray(0)
+        node.clipPath = if (values.isEmpty()) {
+            null
+        } else {
+            val density = root.resources.displayMetrics.density
+            fun coordinates(offset: Int) = (0 until 4).map { index ->
+                val cursor = offset + index * 2
+                HostPaintCoordinate(values[cursor] * density, values[cursor + 1])
+            }
+            HostInsetClipPath(
+                referenceBox = when (values[0].toInt()) {
+                    BACKGROUND_BOX_PADDING -> HostClipReferenceBox.Padding
+                    BACKGROUND_BOX_CONTENT -> HostClipReferenceBox.Content
+                    else -> HostClipReferenceBox.Border
+                },
+                edges = coordinates(2),
+                radiiHorizontal = coordinates(10),
+                radiiVertical = coordinates(18),
+            )
+        }
+        refreshClipPath(node)
+    }
+
+    private fun refreshClipPath(node: HostNode) {
+        val clip = node.clipPath
+        if (clip == null) {
+            node.setPaintClipPath(null)
+            return
+        }
+        val density = root.resources.displayMetrics.density
+        node.setPaintClipPath(
+            resolveInsetClipPath(
+                clip,
+                node.geometry.width * density,
+                node.geometry.height * density,
+                node.resolvedBorderWidths(),
+                RectF(
+                    node.geometry.contentX * density,
+                    node.geometry.contentY * density,
+                    (node.geometry.contentX + node.geometry.contentWidth) * density,
+                    (node.geometry.contentY + node.geometry.contentHeight) * density,
+                ),
+            ),
+        )
+    }
+
+    private fun validClipPath(
+        operation: HostSceneOperation,
+        existing: Set<Long>,
+    ): Boolean {
+        if (operation.node !in existing) return false
+        val values = operation.numbers ?: return true
+        return values.size == CLIP_PATH_PACKED_SIZE &&
+            values.all(Float::isFinite) &&
+            values[0].toInt() in BACKGROUND_BOX_BORDER..BACKGROUND_BOX_CONTENT &&
+            values[0] == values[0].toInt().toFloat() &&
+            values[1] == CLIP_SHAPE_INSET.toFloat() &&
+            (10 until CLIP_PATH_PACKED_SIZE).all { values[it] >= 0f }
     }
 
     private fun validBoxShadows(
@@ -711,6 +779,8 @@ internal class HostScene(
     private companion object {
         const val BACKGROUND_GEOMETRY_PACKED_SIZE = 15
         const val BOX_SHADOW_PACKED_SIZE = 10
+        const val CLIP_PATH_PACKED_SIZE = 26
+        const val CLIP_SHAPE_INSET = 0
         const val BACKGROUND_GRADIENT_STOP_PACKED_SIZE = 7
         const val BACKGROUND_PACKED_LAYER_HEADER_SIZE = 3
         const val BACKGROUND_PACKED_LAYERS = 256

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -6,14 +6,14 @@ use std::sync::Arc;
 use whisker_engine::FrameSink;
 use whisker_protocol::{
     ApplyResult, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BoxClip,
-    BoxPaint, ElementTypeId, FrameMode, FramePacket, ImageRepeat, LayoutGeometry, LayoutRect,
-    NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintImage, RadialGradientExtent,
-    ResourceId, SceneProjection, SurfaceId, TextContent, Transform, ValidationError, Visibility,
-    VisualEffects, WhiskerValue,
+    BoxPaint, ClipShape, ElementTypeId, FrameMode, FramePacket, ImageRepeat, LayoutGeometry,
+    LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate, PaintImage,
+    RadialGradientExtent, ResourceId, SceneProjection, SurfaceId, TextContent, Transform,
+    ValidationError, Visibility, VisualEffects, WhiskerValue,
 };
 
 use crate::element::{DesktopElementContent, DesktopElementError, DesktopElementRegistry};
-use crate::paint::box_paint::{ResolvedRadii, resolve_box_geometry};
+use crate::paint::box_paint::{ResolvedRadii, resolve_box_geometry, resolve_radii};
 
 #[derive(Clone, Debug)]
 struct CommonPresentation {
@@ -363,6 +363,29 @@ impl DesktopScene {
             context.transform,
             transform_around(presentation.transform, border.x, border.y),
         );
+        let mut node_shape_clips = context.shape_clips.clone();
+        let mut node_clip_bounds = None;
+        if let Some((reference_box, ClipShape::Inset { edges, radii })) =
+            presentation.visual_effects.clip_path.as_ref()
+        {
+            let reference = match reference_box {
+                PaintBox::Border => border,
+                PaintBox::Padding => presentation.paint.as_ref().map_or(border, |paint| {
+                    resolve_box_geometry(border, paint).inner_rect
+                }),
+                PaintBox::Content => content,
+                _ => unreachable!("unsupported clip-path reference box passed validation"),
+            };
+            let clip_rect = inset_clip_rect(reference, edges);
+            node_shape_clips = node_shape_clips.push(ShapeClip {
+                rect: clip_rect,
+                radii: resolve_radii(radii, clip_rect),
+                inverse_transform: inverse_transform(transform).unwrap_or(Transform::IDENTITY),
+                horizontal: true,
+                vertical: true,
+            });
+            node_clip_bounds = transform_rect_aabb(clip_rect, transform);
+        }
         if presentation.paint.is_some()
             || !presentation.background_layers.is_empty()
             || !presentation.visual_effects.box_shadows.is_empty()
@@ -374,7 +397,7 @@ impl DesktopScene {
                 background_layers: &presentation.background_layers,
                 visual_effects: &presentation.visual_effects,
                 clip: context.clip,
-                shape_clips: context.shape_clips.clone(),
+                shape_clips: node_shape_clips.clone(),
                 transform,
                 opacity,
             });
@@ -383,7 +406,10 @@ impl DesktopScene {
         let clip_horizontal = presentation.clip.horizontal == OverflowClip::Hidden;
         let clip_vertical = presentation.clip.vertical == OverflowClip::Hidden;
         let mut descendant_clip = context.clip;
-        let mut descendant_shape_clips = context.shape_clips.clone();
+        if let Some(bounds) = node_clip_bounds {
+            descendant_clip = descendant_clip.intersect(bounds, true, true);
+        }
+        let mut descendant_shape_clips = node_shape_clips;
         if clip_horizontal || clip_vertical {
             let geometry = presentation.paint.as_ref().map_or_else(
                 || crate::paint::box_paint::BoxGeometry {
@@ -953,7 +979,34 @@ fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
 fn supports_visual_effects(effects: &VisualEffects) -> bool {
     let mut remainder = effects.clone();
     remainder.box_shadows.clear();
+    remainder.clip_path = None;
     remainder == VisualEffects::default()
+        && effects.clip_path.as_ref().is_none_or(|(reference, shape)| {
+            matches!(
+                reference,
+                PaintBox::Border | PaintBox::Padding | PaintBox::Content
+            ) && matches!(shape, ClipShape::Inset { .. })
+        })
+}
+
+fn inset_clip_rect(
+    reference: LayoutRect,
+    edges: &whisker_protocol::PaintEdges<PaintCoordinate>,
+) -> LayoutRect {
+    let top = resolve_coordinate(edges.top, reference.height);
+    let right = resolve_coordinate(edges.right, reference.width);
+    let bottom = resolve_coordinate(edges.bottom, reference.height);
+    let left = resolve_coordinate(edges.left, reference.width);
+    LayoutRect {
+        x: reference.x + left,
+        y: reference.y + top,
+        width: (reference.width - left - right).max(0.0),
+        height: (reference.height - top - bottom).max(0.0),
+    }
+}
+
+fn resolve_coordinate(value: PaintCoordinate, available: f32) -> f32 {
+    value.length + value.fraction * available
 }
 
 pub(crate) fn is_transparent(color: &PaintColor) -> bool {

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -8,17 +8,18 @@ use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
     BackgroundBoxFixture, BackgroundImageFixture, BackgroundLayerFixture, BackgroundSizeFixture,
-    BackgroundSizeKeywordFixture, BorderFixture, BorderStyleFixture, ColorFixture, Command,
-    ConicGradientFixture, Host, ImageRepeatFixture, LinearGradientFixture, LoadedCase,
-    OverflowClipFixture, PixelRelationFixture, PixelRelationKind, PixelSampleFixture,
-    PointerEventFixture, RadialGradientFixture, ResourceSourceFixture, ResourceStateFixture,
-    Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture, load_required,
+    BackgroundSizeKeywordFixture, BorderFixture, BorderStyleFixture, ClipPathFixture,
+    ClipReferenceBoxFixture, ClipShapeFixture, ColorFixture, Command, ConicGradientFixture, Host,
+    ImageRepeatFixture, LinearGradientFixture, LoadedCase, OverflowClipFixture,
+    PixelRelationFixture, PixelRelationKind, PixelSampleFixture, PointerEventFixture,
+    RadialGradientFixture, ResourceSourceFixture, ResourceStateFixture, Scenario, ScenarioSide,
+    SceneNodeFixture, VisibilityFixture, load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
-    BorderLineStyle, BoxClip, BoxPaint, ElementTypeId, FrameHeader, FrameMode, FramePacket,
-    GradientStop, ImageRepeat, InputEvent, InputEventKind, InputPoint, LayoutGeometry, LayoutRect,
-    MeasureConstraints, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+    BorderLineStyle, BoxClip, BoxPaint, ClipShape, ElementTypeId, FrameHeader, FrameMode,
+    FramePacket, GradientStop, ImageRepeat, InputEvent, InputEventKind, InputPoint, LayoutGeometry,
+    LayoutRect, MeasureConstraints, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
     MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap, MeasurementKey, MeasurementPayload,
     MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
     PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
@@ -693,7 +694,7 @@ impl Driver {
                 node,
                 paint: box_paint(&fixture.background, fixture.border.as_ref()),
             });
-            if !fixture.box_shadows.is_empty() {
+            if !fixture.box_shadows.is_empty() || fixture.clip_path.is_some() {
                 operations.push(Operation::SetVisualEffects {
                     node,
                     effects: whisker_protocol::VisualEffects {
@@ -709,6 +710,7 @@ impl Driver {
                                 inset: shadow.inset,
                             })
                             .collect(),
+                        clip_path: fixture.clip_path.as_ref().map(clip_path_protocol),
                         ..Default::default()
                     },
                 });
@@ -1030,6 +1032,48 @@ fn overflow_clip_protocol(value: OverflowClipFixture) -> OverflowClip {
         OverflowClipFixture::Visible => OverflowClip::Visible,
         OverflowClipFixture::Hidden => OverflowClip::Hidden,
     }
+}
+
+fn clip_path_protocol(value: &ClipPathFixture) -> (PaintBox, ClipShape) {
+    let reference_box = match value.reference_box {
+        ClipReferenceBoxFixture::Border => PaintBox::Border,
+        ClipReferenceBoxFixture::Padding => PaintBox::Padding,
+        ClipReferenceBoxFixture::Content => PaintBox::Content,
+    };
+    let shape = match &value.shape {
+        ClipShapeFixture::Inset { edges, radii } => {
+            let coordinate =
+                |value: whisker_host_conformance::LengthPercentageFixture| PaintCoordinate {
+                    length: value.length,
+                    fraction: value.fraction,
+                };
+            let radius = |value: whisker_host_conformance::CornerRadiusFixture| PaintCornerRadius {
+                horizontal: PaintLengthPercentage {
+                    length: value.horizontal(),
+                    fraction: 0.0,
+                },
+                vertical: PaintLengthPercentage {
+                    length: value.vertical(),
+                    fraction: 0.0,
+                },
+            };
+            ClipShape::Inset {
+                edges: PaintEdges {
+                    top: coordinate(edges[0]),
+                    right: coordinate(edges[1]),
+                    bottom: coordinate(edges[2]),
+                    left: coordinate(edges[3]),
+                },
+                radii: PaintCorners {
+                    top_left: radius(radii[0]),
+                    top_right: radius(radii[1]),
+                    bottom_right: radius(radii[2]),
+                    bottom_left: radius(radii[3]),
+                },
+            }
+        }
+    };
+    (reference_box, shape)
 }
 
 fn box_paint(background: &ColorFixture, border: Option<&BorderFixture>) -> BoxPaint {

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 10 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 11 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -15,7 +15,7 @@ enum {
   WHISKER_OP_Z_ORDER, WHISKER_OP_TEXT, WHISKER_OP_PROPERTY,
   WHISKER_OP_CLEAR_PROPERTY, WHISKER_OP_EVENT_MASK, WHISKER_OP_HIT_TEST,
   WHISKER_OP_CAPTURE, WHISKER_OP_RELEASE_CAPTURE, WHISKER_OP_COMMAND,
-  WHISKER_OP_BACKGROUND_LAYERS, WHISKER_OP_BOX_SHADOWS
+  WHISKER_OP_BACKGROUND_LAYERS, WHISKER_OP_BOX_SHADOWS, WHISKER_OP_CLIP_PATH
 };
 enum {
   WHISKER_BACKGROUND_LINEAR = 0, WHISKER_BACKGROUND_RADIAL = 1,
@@ -39,6 +39,7 @@ enum {
 };
 enum { WHISKER_BACKGROUND_ATTACHMENT_SCROLL = 0 };
 enum { WHISKER_BACKGROUND_BLEND_NORMAL = 0 };
+enum { WHISKER_CLIP_SHAPE_INSET = 0 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -82,6 +83,14 @@ typedef struct {
   WhiskerMobileColor color;
   uint8_t inset, _pad[7];
 } WhiskerMobileBoxShadow;
+typedef struct {
+  WhiskerMobileLengthPercentage edges[4];
+  WhiskerMobileLengthPercentage radii_horizontal[4];
+  WhiskerMobileLengthPercentage radii_vertical[4];
+} WhiskerMobileClipInset;
+typedef struct {
+  uint32_t reference_box, shape_kind; const void *payload; size_t payload_count;
+} WhiskerMobileClipPath;
 typedef struct {
   WhiskerMobileColor color;
   WhiskerMobileLengthPercentage position;
@@ -130,6 +139,8 @@ _Static_assert(sizeof(WhiskerMobileConicGradient) == 32, "WhiskerMobileConicGrad
 _Static_assert(sizeof(WhiskerMobileBackgroundImage) == 24, "WhiskerMobileBackgroundImage ABI drift");
 _Static_assert(sizeof(WhiskerMobileBackgroundLayer) == 88, "WhiskerMobileBackgroundLayer ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxShadow) == 56, "WhiskerMobileBoxShadow ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipInset) == 96, "WhiskerMobileClipInset ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipPath) == 24, "WhiskerMobileClipPath ABI drift");
 typedef struct {
   uint32_t id; uint8_t value_kind, optional_kind, _pad[2]; WhiskerStringRef name;
 } WhiskerMobileMemberRegistration;

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -156,17 +156,12 @@ final class HostBoxPainter {
     }
 
     func paddingBoxPath(in bounds: CGRect) -> CGPath {
+        let paddingBox = paddingBoxRect(in: bounds)
         let widths = Array((borderWidths + [0, 0, 0, 0]).prefix(4)).map { max(0, $0) }
         let top = min(widths[0], bounds.height)
         let right = min(widths[1], bounds.width)
         let bottom = min(widths[2], bounds.height)
         let left = min(widths[3], bounds.width)
-        let paddingBox = CGRect(
-            x: bounds.minX + left,
-            y: bounds.minY + top,
-            width: max(0, bounds.width - left - right),
-            height: max(0, bounds.height - top - bottom)
-        )
         let radii = insetCornerRadii(
             normalizedRadii(cornerRadii, in: bounds),
             top: top,
@@ -175,6 +170,20 @@ final class HostBoxPainter {
             left: left
         )
         return roundedPath(in: paddingBox, radii: radii).cgPath
+    }
+
+    func paddingBoxRect(in bounds: CGRect) -> CGRect {
+        let widths = Array((borderWidths + [0, 0, 0, 0]).prefix(4)).map { max(0, $0) }
+        let top = min(widths[0], bounds.height)
+        let right = min(widths[1], bounds.width)
+        let bottom = min(widths[2], bounds.height)
+        let left = min(widths[3], bounds.width)
+        return CGRect(
+            x: bounds.minX + left,
+            y: bounds.minY + top,
+            width: max(0, bounds.width - left - right),
+            height: max(0, bounds.height - top - bottom)
+        )
     }
 
     func borderBoxPath(in bounds: CGRect) -> CGPath {
@@ -449,7 +458,7 @@ final class HostBoxPainter {
     }
 }
 
-private func tupleArray<T>(_ value: (T, T, T, T)) -> [T] {
+func tupleArray<T>(_ value: (T, T, T, T)) -> [T] {
     [value.0, value.1, value.2, value.3]
 }
 
@@ -485,7 +494,7 @@ func insetCornerRadii(
     ]
 }
 
-private func roundedPath(in rect: CGRect, radii: [CGSize]) -> UIBezierPath {
+func roundedPath(in rect: CGRect, radii: [CGSize]) -> UIBezierPath {
     let normalized = normalizedRadii(radii, in: rect)
 
     let k: CGFloat = 0.552_284_749_830_793_6

--- a/platforms/ios/Sources/WhiskerRuntime/paint/ClipPath.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/ClipPath.swift
@@ -1,0 +1,45 @@
+import UIKit
+import WhiskerModule
+
+enum HostClipReferenceBox {
+    case border
+    case padding
+    case content
+}
+
+/// Rounded inset basic shape copied out of the borrowed mobile ABI payload.
+struct HostInsetClipPath {
+    let referenceBox: HostClipReferenceBox
+    let edges: [WhiskerMobileLengthPercentage]
+    let radiiHorizontal: [WhiskerMobileLengthPercentage]
+    let radiiVertical: [WhiskerMobileLengthPercentage]
+
+    func path(in bounds: CGRect, contentBox: CGRect, painter: HostBoxPainter) -> CGPath {
+        let reference = switch referenceBox {
+        case .border: bounds
+        case .padding: painter.paddingBoxRect(in: bounds)
+        case .content: contentBox
+        }
+        let top = resolve(edges[0], axis: reference.height)
+        let right = resolve(edges[1], axis: reference.width)
+        let bottom = resolve(edges[2], axis: reference.height)
+        let left = resolve(edges[3], axis: reference.width)
+        let inset = CGRect(
+            x: reference.minX + left,
+            y: reference.minY + top,
+            width: max(0, reference.width - left - right),
+            height: max(0, reference.height - top - bottom)
+        )
+        let radii = radiiHorizontal.indices.map { index in
+            CGSize(
+                width: max(0, resolve(radiiHorizontal[index], axis: inset.width)),
+                height: max(0, resolve(radiiVertical[index], axis: inset.height))
+            )
+        }
+        return roundedPath(in: inset, radii: radii).cgPath
+    }
+}
+
+private func resolve(_ value: WhiskerMobileLengthPercentage, axis: CGFloat) -> CGFloat {
+    CGFloat(value.length) + CGFloat(value.fraction) * axis
+}

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -13,6 +13,8 @@ final class WhiskerNodeView: UIView {
     var mountedElement: WhiskerMountedElement?
     private let defaultChildrenHost = WhiskerChildrenHostView(frame: .zero)
     private let overflowMask = CAShapeLayer()
+    private let clipPathMask = CAShapeLayer()
+    private var clipPath: HostInsetClipPath?
     private var boxShadows: [HostBoxShadow] = []
     private var boxShadowLayers: [CAShapeLayer] = []
     private var boxShadowMaskLayers: [CAShapeLayer] = []
@@ -45,6 +47,7 @@ final class WhiskerNodeView: UIView {
         defaultChildrenHost.frame = bounds
         updateBoxShadowLayers()
         updateOverflowMask()
+        updateClipPathMask()
         setNeedsDisplay()
     }
 
@@ -60,6 +63,7 @@ final class WhiskerNodeView: UIView {
         layer.position = frame.origin
         defaultChildrenHost.frame = bounds
         updateOverflowMask()
+        updateClipPathMask()
     }
 
     func setPresentationTransform(_ values: UnsafeBufferPointer<Float>) {
@@ -103,6 +107,12 @@ final class WhiskerNodeView: UIView {
     func boxPaintDidChange() {
         updateBoxShadowLayers()
         updateOverflowMask()
+        updateClipPathMask()
+    }
+
+    func setClipPath(_ clipPath: HostInsetClipPath?) {
+        self.clipPath = clipPath
+        updateClipPathMask()
     }
 
     func setBoxShadows(_ shadows: [HostBoxShadow]) {
@@ -235,6 +245,22 @@ final class WhiskerNodeView: UIView {
         overflowMask.backgroundColor = UIColor.clear.cgColor
         overflowMask.fillColor = UIColor.white.cgColor
         host.layer.mask = overflowMask
+    }
+
+    private func updateClipPathMask() {
+        guard let clipPath else {
+            layer.mask = nil
+            return
+        }
+        clipPathMask.frame = bounds
+        clipPathMask.path = clipPath.path(
+            in: bounds,
+            contentBox: contentFrame,
+            painter: boxPainter
+        )
+        clipPathMask.fillColor = UIColor.white.cgColor
+        clipPathMask.fillRule = .nonZero
+        layer.mask = clipPathMask
     }
 
     private func hostCompositionBounds() -> CGRect {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -169,6 +169,17 @@ final class HostScene {
                       ) else { return false }
                 let shadows = UnsafeBufferPointer(start: pointer, count: operation.payload_count)
                 guard shadows.allSatisfy(validHardBoxShadow) else { return false }
+            case UInt32(WHISKER_OP_CLIP_PATH):
+                guard existing.contains(operation.node) else { return false }
+                if operation.payload_count == 0 {
+                    guard operation.payload == nil else { return false }
+                    continue
+                }
+                guard operation.payload_count == 1,
+                      let clip = operation.payload?.assumingMemoryBound(
+                          to: WhiskerMobileClipPath.self
+                      ).pointee,
+                      validClipPath(clip) else { return false }
             case UInt32(WHISKER_OP_OPACITY):
                 guard existing.contains(operation.node), operation.scalar.isFinite,
                       (0...1).contains(operation.scalar) else { return false }
@@ -266,6 +277,30 @@ final class HostScene {
                 )
             }
             node.setBoxShadows(shadows)
+        case UInt32(WHISKER_OP_CLIP_PATH):
+            guard let node = nodes[id] else { return false }
+            if operation.payload_count == 0 {
+                node.setClipPath(nil)
+                return true
+            }
+            guard let raw = operation.payload?.assumingMemoryBound(
+                to: WhiskerMobileClipPath.self
+            ).pointee,
+                  raw.shape_kind == UInt32(WHISKER_CLIP_SHAPE_INSET),
+                  let inset = raw.payload?.assumingMemoryBound(
+                      to: WhiskerMobileClipInset.self
+                  ).pointee else { return false }
+            let referenceBox: HostClipReferenceBox = switch raw.reference_box {
+            case UInt32(WHISKER_BACKGROUND_BOX_PADDING): .padding
+            case UInt32(WHISKER_BACKGROUND_BOX_CONTENT): .content
+            default: .border
+            }
+            node.setClipPath(HostInsetClipPath(
+                referenceBox: referenceBox,
+                edges: tupleArray(inset.edges),
+                radiiHorizontal: tupleArray(inset.radii_horizontal),
+                radiiVertical: tupleArray(inset.radii_vertical)
+            ))
         case UInt32(WHISKER_OP_OPACITY):
             nodes[id]?.alpha = CGFloat(operation.scalar)
         case UInt32(WHISKER_OP_VISIBILITY):
@@ -474,6 +509,19 @@ private func validHardBoxShadow(_ shadow: WhiskerMobileBoxShadow) -> Bool {
         (shadow.inset == 0 || shadow.inset == 1) &&
         shadow.color.kind <= 1 && shadow.color.alpha.isFinite &&
         (0...1).contains(shadow.color.alpha)
+}
+
+private func validClipPath(_ clip: WhiskerMobileClipPath) -> Bool {
+    guard clip.reference_box <= UInt32(WHISKER_BACKGROUND_BOX_CONTENT),
+          clip.shape_kind == UInt32(WHISKER_CLIP_SHAPE_INSET),
+          clip.payload_count == 1,
+          let inset = clip.payload?.assumingMemoryBound(
+              to: WhiskerMobileClipInset.self
+          ).pointee else { return false }
+    let radii = tupleArray(inset.radii_horizontal) + tupleArray(inset.radii_vertical)
+    return tupleArray(inset.edges).allSatisfy(\.isFinite) && radii.allSatisfy {
+        $0.isFinite && $0.length >= 0 && $0.fraction >= 0
+    }
 }
 
 private func validBackgroundLayer(

--- a/platforms/web/src/paint/visual_effects.rs
+++ b/platforms/web/src/paint/visual_effects.rs
@@ -1,4 +1,6 @@
-use whisker_protocol::VisualEffects;
+use whisker_protocol::{
+    ClipShape, PaintBox, PaintCoordinate, PaintLengthPercentage, VisualEffects,
+};
 
 use super::color::css_color;
 use crate::{WebError, set_style};
@@ -6,13 +8,20 @@ use crate::{WebError, set_style};
 pub(crate) fn supports(effects: &VisualEffects) -> bool {
     let mut remainder = effects.clone();
     remainder.box_shadows.clear();
+    remainder.clip_path = None;
     remainder == VisualEffects::default()
+        && effects.clip_path.as_ref().is_none_or(|(reference, shape)| {
+            matches!(
+                reference,
+                PaintBox::Border | PaintBox::Padding | PaintBox::Content
+            ) && matches!(shape, ClipShape::Inset { .. })
+        })
 }
 
 pub(crate) fn apply(element: &web_sys::Element, effects: &VisualEffects) -> Result<(), WebError> {
     if !supports(effects) {
         return Err(WebError(
-            "DOM Host only implements box-shadow visual effects".into(),
+            "DOM Host only implements the supported box-shadow and clip-path subset".into(),
         ));
     }
     let value = if effects.box_shadows.is_empty() {
@@ -35,5 +44,57 @@ pub(crate) fn apply(element: &web_sys::Element, effects: &VisualEffects) -> Resu
             .collect::<Vec<_>>()
             .join(", ")
     };
-    set_style(element, "box-shadow", &value)
+    set_style(element, "box-shadow", &value)?;
+    let clip_path = effects
+        .clip_path
+        .as_ref()
+        .map(clip_path_css)
+        .transpose()?
+        .unwrap_or_else(|| "none".into());
+    set_style(element, "clip-path", &clip_path)
+}
+
+fn clip_path_css(value: &(PaintBox, ClipShape)) -> Result<String, WebError> {
+    let reference_box = match value.0 {
+        PaintBox::Border => "border-box",
+        PaintBox::Padding => "padding-box",
+        PaintBox::Content => "content-box",
+        _ => return Err(WebError("unsupported DOM clip-path reference box".into())),
+    };
+    let ClipShape::Inset { edges, radii } = &value.1 else {
+        return Err(WebError("unsupported DOM clip-path shape".into()));
+    };
+    Ok(format!(
+        "inset({} {} {} {} round {} {} {} {} / {} {} {} {}) {reference_box}",
+        coordinate(edges.top),
+        coordinate(edges.right),
+        coordinate(edges.bottom),
+        coordinate(edges.left),
+        length(radii.top_left.horizontal),
+        length(radii.top_right.horizontal),
+        length(radii.bottom_right.horizontal),
+        length(radii.bottom_left.horizontal),
+        length(radii.top_left.vertical),
+        length(radii.top_right.vertical),
+        length(radii.bottom_right.vertical),
+        length(radii.bottom_left.vertical),
+    ))
+}
+
+fn coordinate(value: PaintCoordinate) -> String {
+    css_length(value.length, value.fraction)
+}
+
+fn length(value: PaintLengthPercentage) -> String {
+    css_length(value.length, value.fraction)
+}
+
+fn css_length(length: f32, fraction: f32) -> String {
+    if fraction == 0.0 {
+        format!("{length}px")
+    } else if length == 0.0 {
+        format!("{}%", fraction * 100.0)
+    } else {
+        format!("calc({length}px + {}%)", fraction * 100.0)
+    }
 }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -15,20 +15,20 @@ use whisker_engine::FrameSink;
 use whisker_host_conformance::{
     BackgroundBoxFixture, BackgroundImageFixture, BackgroundLayerFixture,
     BackgroundPaintLayerFixture, BackgroundSizeFixture, BackgroundSizeKeywordFixture,
-    BorderFixture, BorderStyleFixture, ColorFixture, Command, ConicGradientFixture,
-    CornerRadiusFixture, ImageRepeatFixture, LengthPercentageFixture, LinearGradientFixture,
-    Manifest, OverflowClipFixture, PixelSampleFixture, RadialGradientFixture,
-    ResourceSourceFixture, ResourceStateFixture, SCHEMA_VERSION, Scenario, ScenarioSide,
-    SceneNodeFixture, VisibilityFixture,
+    BorderFixture, BorderStyleFixture, ClipPathFixture, ClipReferenceBoxFixture, ClipShapeFixture,
+    ColorFixture, Command, ConicGradientFixture, CornerRadiusFixture, ImageRepeatFixture,
+    LengthPercentageFixture, LinearGradientFixture, Manifest, OverflowClipFixture,
+    PixelSampleFixture, RadialGradientFixture, ResourceSourceFixture, ResourceStateFixture,
+    SCHEMA_VERSION, Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture,
 };
 use whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
-    BoxPaint, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat, LayoutGeometry,
-    LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate,
-    PaintCornerRadius, PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition,
-    ProtocolVersion, RadialGradientExtent, RadialGradientShape, ResourceCommand,
-    ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest, ResourceSource,
-    SurfaceId, Transform, Visibility,
+    BoxPaint, ClipShape, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat,
+    LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
+    PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
+    PaintLengthPercentage, PaintPosition, ProtocolVersion, RadialGradientExtent,
+    RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent, ResourceId,
+    ResourceKind, ResourceRequest, ResourceSource, SurfaceId, Transform, Visibility,
 };
 use whisker_style::StyleEnvironment;
 
@@ -505,6 +505,13 @@ impl Driver {
                                     })
                                     .or_else(|| {
                                         nodes.iter().find_map(|node| {
+                                            node.clip_path
+                                                .as_ref()
+                                                .map(|_| "paint.visual-effects.clip-path-inset")
+                                        })
+                                    })
+                                    .or_else(|| {
+                                        nodes.iter().find_map(|node| {
                                             node.box_shadows.first().map(|shadow| {
                                                 if node.box_shadows.len() > 1 {
                                                     "paint.visual-effects.box-shadow-multiple"
@@ -808,7 +815,7 @@ impl Driver {
                 &fixture_color_css(&fixture_node.background),
             );
             assert_border_is_projected(&style, fixture_node.border.as_ref());
-            let expected_shadows = fixture_node
+            let mut expected_shadows = fixture_node
                 .box_shadows
                 .iter()
                 .map(|shadow| {
@@ -824,9 +831,24 @@ impl Driver {
                 })
                 .collect::<Vec<_>>()
                 .join(", ");
+            if expected_shadows.is_empty() && fixture_node.clip_path.is_some() {
+                expected_shadows = "none".into();
+            }
             assert_eq!(
                 style.get_property_value("box-shadow").unwrap(),
                 expected_shadows
+            );
+            let mut expected_clip_path = fixture_node
+                .clip_path
+                .as_ref()
+                .map(fixture_clip_path_css)
+                .unwrap_or_default();
+            if expected_clip_path.is_empty() && !fixture_node.box_shadows.is_empty() {
+                expected_clip_path = "none".into();
+            }
+            assert_eq!(
+                style.get_property_value("clip-path").unwrap(),
+                expected_clip_path
             );
             assert_style(
                 &style,
@@ -1209,6 +1231,9 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-backgrounds/box-shadow-multiple-001.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/box-shadow-multiple-001.json"
         ),
+        "wpt/css/css-masking/clip-path-inset-round-rendering.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-masking/clip-path-inset-round-rendering.json"
+        ),
         "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"
         ),
@@ -1389,7 +1414,7 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
                 transform: Transform(transform),
             });
         }
-        if !fixture_node.box_shadows.is_empty() {
+        if !fixture_node.box_shadows.is_empty() || fixture_node.clip_path.is_some() {
             operations.push(Operation::SetVisualEffects {
                 node,
                 effects: whisker_protocol::VisualEffects {
@@ -1405,6 +1430,7 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
                             inset: shadow.inset,
                         })
                         .collect(),
+                    clip_path: fixture_node.clip_path.as_ref().map(clip_path_protocol),
                     ..Default::default()
                 },
             });
@@ -1669,6 +1695,43 @@ fn paint_coordinate(value: LengthPercentageFixture) -> PaintCoordinate {
     }
 }
 
+fn clip_path_protocol(value: &ClipPathFixture) -> (PaintBox, ClipShape) {
+    let reference_box = match value.reference_box {
+        ClipReferenceBoxFixture::Border => PaintBox::Border,
+        ClipReferenceBoxFixture::Padding => PaintBox::Padding,
+        ClipReferenceBoxFixture::Content => PaintBox::Content,
+    };
+    let shape = match &value.shape {
+        ClipShapeFixture::Inset { edges, radii } => {
+            let radius = |value: CornerRadiusFixture| PaintCornerRadius {
+                horizontal: PaintLengthPercentage {
+                    length: value.horizontal(),
+                    fraction: 0.0,
+                },
+                vertical: PaintLengthPercentage {
+                    length: value.vertical(),
+                    fraction: 0.0,
+                },
+            };
+            ClipShape::Inset {
+                edges: PaintEdges {
+                    top: paint_coordinate(edges[0]),
+                    right: paint_coordinate(edges[1]),
+                    bottom: paint_coordinate(edges[2]),
+                    left: paint_coordinate(edges[3]),
+                },
+                radii: PaintCorners {
+                    top_left: radius(radii[0]),
+                    top_right: radius(radii[1]),
+                    bottom_right: radius(radii[2]),
+                    bottom_left: radius(radii[3]),
+                },
+            }
+        }
+    };
+    (reference_box, shape)
+}
+
 fn paint_length_percentage(value: LengthPercentageFixture) -> PaintLengthPercentage {
     PaintLengthPercentage {
         length: value.length,
@@ -1872,6 +1935,51 @@ fn assert_border_is_projected(
 
 fn fixture_px(value: f32) -> String {
     format!("{value}px")
+}
+
+fn fixture_clip_path_css(value: &ClipPathFixture) -> String {
+    let reference_box = match value.reference_box {
+        ClipReferenceBoxFixture::Border => "",
+        ClipReferenceBoxFixture::Padding => "padding-box",
+        ClipReferenceBoxFixture::Content => "content-box",
+    };
+    let ClipShapeFixture::Inset { edges, radii } = &value.shape;
+    let coordinate = |value: LengthPercentageFixture| {
+        if value.fraction == 0.0 {
+            format!("{}px", value.length)
+        } else if value.length == 0.0 {
+            format!("{}%", value.fraction * 100.0)
+        } else {
+            format!("calc({}px + {}%)", value.length, value.fraction * 100.0)
+        }
+    };
+    let edges = edges.map(coordinate);
+    let horizontal = radii.map(|radius| format!("{}px", radius.horizontal()));
+    let vertical = radii.map(|radius| format!("{}px", radius.vertical()));
+    let edges = css_four_value_shorthand(&edges);
+    let horizontal = css_four_value_shorthand(&horizontal);
+    let vertical = css_four_value_shorthand(&vertical);
+    let radii = if horizontal == vertical {
+        horizontal
+    } else {
+        format!("{horizontal} / {vertical}")
+    };
+    let suffix = (!reference_box.is_empty())
+        .then(|| format!(" {reference_box}"))
+        .unwrap_or_default();
+    format!("inset({edges} round {radii}){suffix}")
+}
+
+fn css_four_value_shorthand(values: &[String; 4]) -> String {
+    if values.iter().all(|value| value == &values[0]) {
+        values[0].clone()
+    } else if values[0] == values[2] && values[1] == values[3] {
+        format!("{} {}", values[0], values[1])
+    } else if values[1] == values[3] {
+        format!("{} {} {}", values[0], values[1], values[2])
+    } else {
+        values.join(" ")
+    }
 }
 
 fn fixture_color_css(value: &ColorFixture) -> String {

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,8 +98,8 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
-      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur", "multiple-box-shadows"],
-      "pending_subset": ["clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur", "multiple-box-shadows", "clip-path-inset"],
+      "pending_subset": ["clip-path-circle-ellipse-and-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -325,6 +325,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-masking.clip-path-inset-round-rendering",
+      "feature": "clip-path-inset",
+      "fixture": "wpt/css/css-masking/clip-path-inset-round-rendering.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-right-003",
       "feature": "border-right",
       "fixture": "wpt/css/CSS2/borders/border-right-003.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -305,7 +305,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.visual-effects.box-shadow-inset" ||
                             command.getString("name") ==
-                            "paint.visual-effects.box-shadow-multiple",
+                            "paint.visual-effects.box-shadow-multiple" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.clip-path-inset",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -640,6 +642,37 @@ private class Driver(
                         names = shadowNames.toTypedArray(),
                     ),
                 )
+            }
+            node.optJSONObject("clip_path")?.let { clip ->
+                val shape = clip.getJSONObject("shape")
+                check(shape.getString("kind") == "inset")
+                val numbers = ArrayList<Float>(26)
+                numbers += backgroundBox(clip.optString("reference_box", "border")).toFloat()
+                numbers += 0f // inset shape
+                shape.getJSONArray("edges").objects().forEach { edge ->
+                    appendLengthPercentage(edge, numbers)
+                }
+                val radii = shape.getJSONArray("radii")
+                repeat(4) { index ->
+                    val radius = radii.get(index)
+                    numbers += when (radius) {
+                        is Number -> radius.toFloat()
+                        is JSONArray -> radius.getDouble(0).toFloat()
+                        else -> error("unsupported clip radius: $radius")
+                    }
+                    numbers += 0f
+                }
+                repeat(4) { index ->
+                    val radius = radii.get(index)
+                    numbers += when (radius) {
+                        is Number -> radius.toFloat()
+                        is JSONArray -> radius.getDouble(1).toFloat()
+                        else -> error("unsupported clip radius: $radius")
+                    }
+                    numbers += 0f
+                }
+                check(numbers.size == 26)
+                check(stage(tag = 23, node = id, numbers = numbers.toFloatArray()))
             }
         }
         check(view.commitFrameFromNative())

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -443,7 +443,8 @@ private final class Driver {
                     name == "paint.visual-effects.box-shadow-spread" ||
                     name == "paint.visual-effects.box-shadow-blur" ||
                     name == "paint.visual-effects.box-shadow-inset" ||
-                    name == "paint.visual-effects.box-shadow-multiple" else {
+                    name == "paint.visual-effects.box-shadow-multiple" ||
+                    name == "paint.visual-effects.clip-path-inset" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -678,6 +679,32 @@ private final class Driver {
             repeating: WhiskerMobileBackgroundLayer(),
             count: stagedLayers.count
         )
+        let clipStorageCount = max(fixtures.count, 1)
+        let clipInsets = UnsafeMutablePointer<WhiskerMobileClipInset>.allocate(
+            capacity: clipStorageCount
+        )
+        let clipPaths = UnsafeMutablePointer<WhiskerMobileClipPath>.allocate(
+            capacity: clipStorageCount
+        )
+        for (index, fixture) in fixtures.enumerated() {
+            clipInsets.advanced(by: index).initialize(
+                to: fixture.clipPath?.inset ?? WhiskerMobileClipInset()
+            )
+            var path = WhiskerMobileClipPath()
+            if let clip = fixture.clipPath {
+                path.reference_box = clip.referenceBox
+                path.shape_kind = UInt32(WHISKER_CLIP_SHAPE_INSET)
+                path.payload = UnsafeRawPointer(clipInsets.advanced(by: index))
+                path.payload_count = 1
+            }
+            clipPaths.advanced(by: index).initialize(to: path)
+        }
+        defer {
+            clipInsets.deinitialize(count: fixtures.count)
+            clipInsets.deallocate()
+            clipPaths.deinitialize(count: fixtures.count)
+            clipPaths.deallocate()
+        }
         try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
             try paints.withUnsafeMutableBufferPointer { paintBuffer in
                 try transforms.withUnsafeMutableBufferPointer { transformBuffer in
@@ -896,6 +923,16 @@ private final class Driver {
                                         count: shadowRange.count
                                     ))
                                 }
+                                if fixture.clipPath != nil {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_CLIP_PATH),
+                                        node: fixture.id,
+                                        payload: UnsafeRawPointer(
+                                            clipPaths.advanced(by: index)
+                                        ),
+                                        count: 1
+                                    ))
+                                }
                             }
                             try operations.withUnsafeMutableBufferPointer { buffer in
                                 var frame = WhiskerMobileFrame()
@@ -1057,9 +1094,15 @@ private struct SceneFixtureNode {
     let backgroundLayer: SceneBackgroundLayer
     let backgroundLayers: [ScenePaintLayer]
     let boxShadows: [WhiskerMobileBoxShadow]
+    let clipPath: SceneClipPath?
     let linearGradient: SceneLinearGradient?
     let radialGradient: SceneRadialGradient?
     let conicGradient: SceneConicGradient?
+}
+
+private struct SceneClipPath {
+    let referenceBox: UInt32
+    let inset: WhiskerMobileClipInset
 }
 
 private struct ScenePaintLayer {
@@ -1250,6 +1293,7 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     let boxShadows = try (fixture["box_shadows"] as? [[String: Any]] ?? []).map {
         try sceneBoxShadow($0)
     }
+    let clipPath = try (fixture["clip_path"] as? [String: Any]).map(sceneClipPath)
     let linearGradient: SceneLinearGradient?
     if let gradient = fixture["linear_gradient"] as? [String: Any] {
         linearGradient = try sceneLinearGradient(gradient)
@@ -1281,9 +1325,53 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         backgroundLayer: backgroundLayer,
         backgroundLayers: backgroundLayers,
         boxShadows: boxShadows,
+        clipPath: clipPath,
         linearGradient: linearGradient,
         radialGradient: radialGradient,
         conicGradient: conicGradient
+    )
+}
+
+private func sceneClipPath(_ fixture: [String: Any]) throws -> SceneClipPath {
+    let shape = try object(fixture, "shape")
+    guard try string(shape, "kind") == "inset" else {
+        throw Failure("unsupported clip-path shape")
+    }
+    guard let rawEdges = shape["edges"] as? [Any],
+          let rawRadii = shape["radii"] as? [Any] else {
+        throw Failure("inset clip-path needs edge and radius arrays")
+    }
+    let edges = try rawEdges.map(lengthPercentage)
+    guard edges.count == 4, rawRadii.count == 4 else {
+        throw Failure("inset clip-path needs four edges and radii")
+    }
+    let radii = try rawRadii.map { value -> (Float, Float) in
+        if let number = value as? NSNumber {
+            return (number.floatValue, number.floatValue)
+        }
+        guard let pair = value as? [NSNumber] else {
+            throw Failure("clip-path radius must be a number or pair")
+        }
+        guard pair.count == 2 else { throw Failure("clip-path radius pair needs two values") }
+        return (pair[0].floatValue, pair[1].floatValue)
+    }
+    var inset = WhiskerMobileClipInset()
+    inset.edges = (edges[0], edges[1], edges[2], edges[3])
+    inset.radii_horizontal = (
+        WhiskerMobileLengthPercentage(length: radii[0].0, fraction: 0),
+        WhiskerMobileLengthPercentage(length: radii[1].0, fraction: 0),
+        WhiskerMobileLengthPercentage(length: radii[2].0, fraction: 0),
+        WhiskerMobileLengthPercentage(length: radii[3].0, fraction: 0)
+    )
+    inset.radii_vertical = (
+        WhiskerMobileLengthPercentage(length: radii[0].1, fraction: 0),
+        WhiskerMobileLengthPercentage(length: radii[1].1, fraction: 0),
+        WhiskerMobileLengthPercentage(length: radii[2].1, fraction: 0),
+        WhiskerMobileLengthPercentage(length: radii[3].1, fraction: 0)
+    )
+    return SceneClipPath(
+        referenceBox: try backgroundBox(fixture["reference_box"] as? String ?? "border"),
+        inset: inset
     )
 }
 

--- a/tests/host-conformance/wpt/css/css-masking/clip-path-inset-round-rendering.json
+++ b/tests/host-conformance/wpt/css/css-masking/clip-path-inset-round-rendering.json
@@ -1,0 +1,67 @@
+{
+  "schema": 1,
+  "id": "wpt.css-masking.clip-path-inset-round-rendering",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-masking/clip-path/clip-path-inset-round-rendering.html",
+    "reference_path": "css/css-masking/clip-path/clip-path-inset-round-rendering-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "An inset clip-path with rounded corners clips both the element's own paint and its descendants.",
+    "adaptation": "The upstream large floating-point inset is reduced to a deterministic 100px border box using inset(20px round 20px). A red child crosses the left shape edge so direct samples verify descendant clipping as well as the rounded parent paint clip."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 140.0, "height": 140.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 140.0, 140.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [20.0, 20.0, 100.0, 100.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip_path": {
+              "reference_box": "border",
+              "shape": {
+                "kind": "inset",
+                "edges": [
+                  { "length": 20.0, "fraction": 0.0 },
+                  { "length": 20.0, "fraction": 0.0 },
+                  { "length": 20.0, "fraction": 0.0 },
+                  { "length": 20.0, "fraction": 0.0 }
+                ],
+                "radii": [20.0, 20.0, 20.0, 20.0]
+              }
+            }
+          },
+          {
+            "id": 3,
+            "parent": 2,
+            "rect": [-10.0, 40.0, 40.0, 20.0],
+            "background": { "kind": "named", "value": "red" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.clip-path-inset",
+        "samples": [
+          { "point": [30.0, 70.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [45.0, 70.0], "color": { "kind": "named", "value": "red" }, "tolerance": 5 },
+          { "point": [70.0, 70.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [42.0, 42.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [60.0, 42.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [105.0, 105.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- add a shared WPT-derived `clip-path: inset(... round ...)` fixture that verifies both self paint and descendant clipping
- project rounded inset clips through Desktop/wgpu and Web/DOM
- extend the typed mobile ABI to 2.11 with `WhiskerMobileClipPath` and `WhiskerMobileClipInset`
- implement matching Android `Path` and iOS `CAShapeLayer` masks in dedicated paint files
- mark `clip-path-inset` supported while leaving circle, ellipse, and path pending

## Verification

- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`
- `cargo test -p whisker-driver`
- `cargo test -p whisker-host-conformance`
- `cargo check -p whisker --target aarch64-apple-ios-sim`
- `cargo clippy -p whisker-driver -p whisker-host-conformance -p whisker-desktop --all-targets -- -D warnings`

The direct Android Rust cross-check could not run locally because the NDK clang driver is not installed; the Android emulator conformance suite passed, and CI cross-build remains authoritative for that compiler path.