### PR TITLE
feat: render circle and ellipse clip paths across Hosts

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 11 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 12 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -37,7 +37,7 @@ enum {
 };
 enum { WHISKER_BACKGROUND_ATTACHMENT_SCROLL = 0 };
 enum { WHISKER_BACKGROUND_BLEND_NORMAL = 0 };
-enum { WHISKER_CLIP_SHAPE_INSET = 0 };
+enum { WHISKER_CLIP_SHAPE_INSET = 0, WHISKER_CLIP_SHAPE_CIRCLE = 1, WHISKER_CLIP_SHAPE_ELLIPSE = 2 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -89,6 +89,12 @@ typedef struct {
   WhiskerMobileLengthPercentage radii_horizontal[4];
   WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileClipInset;
+typedef struct {
+  WhiskerMobileLengthPercentage radius, center_x, center_y;
+} WhiskerMobileClipCircle;
+typedef struct {
+  WhiskerMobileLengthPercentage radius_x, radius_y, center_x, center_y;
+} WhiskerMobileClipEllipse;
 typedef struct {
   uint32_t reference_box, shape_kind;
   const void *payload;
@@ -160,6 +166,8 @@ _Static_assert(sizeof(WhiskerMobileBackgroundImage) == 24, "WhiskerMobileBackgro
 _Static_assert(sizeof(WhiskerMobileBackgroundLayer) == 88, "WhiskerMobileBackgroundLayer ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxShadow) == 56, "WhiskerMobileBoxShadow ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipInset) == 96, "WhiskerMobileClipInset ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipCircle) == 24, "WhiskerMobileClipCircle ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipEllipse) == 32, "WhiskerMobileClipEllipse ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipPath) == 24, "WhiskerMobileClipPath ABI drift");
 
 typedef struct {

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -285,24 +285,26 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 }
                 if (op->payload_count != 1) { ok = false; break; }
                 const WhiskerMobileClipPath* clip = op->payload;
-                if (clip->shape_kind != WHISKER_CLIP_SHAPE_INSET ||
-                    clip->payload == NULL || clip->payload_count != 1) {
+                if (clip->payload == NULL || clip->payload_count != 1) {
                     ok = false; break;
                 }
-                const WhiskerMobileClipInset* inset = clip->payload;
                 storage[count++] = (float)clip->reference_box;
                 storage[count++] = (float)clip->shape_kind;
-                for (int j=0;j<4;++j) {
-                    storage[count++]=inset->edges[j].length;
-                    storage[count++]=inset->edges[j].fraction;
-                }
-                for (int j=0;j<4;++j) {
-                    storage[count++]=inset->radii_horizontal[j].length;
-                    storage[count++]=inset->radii_horizontal[j].fraction;
-                }
-                for (int j=0;j<4;++j) {
-                    storage[count++]=inset->radii_vertical[j].length;
-                    storage[count++]=inset->radii_vertical[j].fraction;
+                if (clip->shape_kind == WHISKER_CLIP_SHAPE_INSET) {
+                    const WhiskerMobileClipInset* inset = clip->payload;
+                    for (int j=0;j<4;++j) { storage[count++]=inset->edges[j].length; storage[count++]=inset->edges[j].fraction; }
+                    for (int j=0;j<4;++j) { storage[count++]=inset->radii_horizontal[j].length; storage[count++]=inset->radii_horizontal[j].fraction; }
+                    for (int j=0;j<4;++j) { storage[count++]=inset->radii_vertical[j].length; storage[count++]=inset->radii_vertical[j].fraction; }
+                } else if (clip->shape_kind == WHISKER_CLIP_SHAPE_CIRCLE) {
+                    const WhiskerMobileClipCircle* circle = clip->payload;
+                    const WhiskerMobileLengthPercentage values[] = {circle->radius, circle->center_x, circle->center_y};
+                    for (int j=0;j<3;++j) { storage[count++]=values[j].length; storage[count++]=values[j].fraction; }
+                } else if (clip->shape_kind == WHISKER_CLIP_SHAPE_ELLIPSE) {
+                    const WhiskerMobileClipEllipse* ellipse = clip->payload;
+                    const WhiskerMobileLengthPercentage values[] = {ellipse->radius_x, ellipse->radius_y, ellipse->center_x, ellipse->center_y};
+                    for (int j=0;j<4;++j) { storage[count++]=values[j].length; storage[count++]=values[j].fraction; }
+                } else {
+                    ok = false; break;
                 }
                 numbers = floats(env, storage, count);
                 break;

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 11;
+pub const MOBILE_ABI_MINOR: u16 = 12;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -74,6 +74,8 @@ pub const BACKGROUND_ATTACHMENT_SCROLL: u32 = 0;
 pub const BACKGROUND_BLEND_NORMAL: u32 = 0;
 
 pub const CLIP_SHAPE_INSET: u32 = 0;
+pub const CLIP_SHAPE_CIRCLE: u32 = 1;
+pub const CLIP_SHAPE_ELLIPSE: u32 = 2;
 
 pub const MEASURE_TEXT: u32 = 1;
 pub const MEASURE_REPLACED_CONTENT: u32 = 2;
@@ -175,6 +177,23 @@ pub struct MobileClipInset {
     pub edges: [MobileLengthPercentage; 4],
     pub radii_horizontal: [MobileLengthPercentage; 4],
     pub radii_vertical: [MobileLengthPercentage; 4],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileClipCircle {
+    pub radius: MobileLengthPercentage,
+    pub center_x: MobileLengthPercentage,
+    pub center_y: MobileLengthPercentage,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileClipEllipse {
+    pub radius_x: MobileLengthPercentage,
+    pub radius_y: MobileLengthPercentage,
+    pub center_x: MobileLengthPercentage,
+    pub center_y: MobileLengthPercentage,
 }
 
 /// One typed clip path. `payload` points to the shape selected by `shape_kind`.
@@ -604,6 +623,8 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::size_of::<MobileBoxShadow>(), 56);
             assert_eq!(std::mem::size_of::<MobileClipInset>(), 96);
+            assert_eq!(std::mem::size_of::<MobileClipCircle>(), 24);
+            assert_eq!(std::mem::size_of::<MobileClipEllipse>(), 32);
             assert_eq!(std::mem::size_of::<MobileClipPath>(), 24);
             assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
             assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 48);

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -428,6 +428,20 @@ pub enum ClipShapeFixture {
         /// Top-left, top-right, bottom-right, and bottom-left radii.
         radii: [CornerRadiusFixture; 4],
     },
+    /// Circle with an explicit radius and center.
+    Circle {
+        /// Radius length-percentage.
+        radius: LengthPercentageFixture,
+        /// Center x/y coordinates.
+        center: [LengthPercentageFixture; 2],
+    },
+    /// Ellipse with explicit horizontal/vertical radii and center.
+    Ellipse {
+        /// Horizontal and vertical radii.
+        radii: [LengthPercentageFixture; 2],
+        /// Center x/y coordinates.
+        center: [LengthPercentageFixture; 2],
+    },
 }
 
 /// CSS geometry boxes accepted as clip-path reference boxes.
@@ -1292,6 +1306,14 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                             edges.iter().all(LengthPercentageFixture::is_finite)
                                 && radii.iter().copied().all(CornerRadiusFixture::is_valid)
                         }
+                        ClipShapeFixture::Circle { radius, center } => {
+                            radius.is_non_negative()
+                                && center.iter().all(LengthPercentageFixture::is_finite)
+                        }
+                        ClipShapeFixture::Ellipse { radii, center } => {
+                            radii.iter().all(LengthPercentageFixture::is_non_negative)
+                                && center.iter().all(LengthPercentageFixture::is_finite)
+                        }
                     })
                 && node
                     .transform
@@ -1349,6 +1371,10 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
 impl LengthPercentageFixture {
     fn is_finite(&self) -> bool {
         self.length.is_finite() && self.fraction.is_finite()
+    }
+
+    fn is_non_negative(&self) -> bool {
+        self.is_finite() && self.length >= 0.0 && self.fraction >= 0.0
     }
 }
 

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -910,6 +910,8 @@ struct MobileFrameOwned {
     _paints: Vec<Box<MobileBoxPaint>>,
     _box_shadows: Vec<Box<[MobileBoxShadow]>>,
     _clip_insets: Vec<Box<MobileClipInset>>,
+    _clip_circles: Vec<Box<MobileClipCircle>>,
+    _clip_ellipses: Vec<Box<MobileClipEllipse>>,
     _clip_paths: Vec<Box<MobileClipPath>>,
     _gradient_stops: Vec<Box<[MobileGradientStop]>>,
     _radial_gradients: Vec<Box<MobileRadialGradient>>,
@@ -947,6 +949,8 @@ impl MobileFrameOwned {
         let mut paints = Vec::<Box<MobileBoxPaint>>::new();
         let mut box_shadows = Vec::<Box<[MobileBoxShadow]>>::new();
         let mut clip_insets = Vec::<Box<MobileClipInset>>::new();
+        let mut clip_circles = Vec::<Box<MobileClipCircle>>::new();
+        let mut clip_ellipses = Vec::<Box<MobileClipEllipse>>::new();
         let mut clip_paths = Vec::<Box<MobileClipPath>>::new();
         let mut gradient_stops = Vec::<Box<[MobileGradientStop]>>::new();
         let mut radial_gradients = Vec::<Box<MobileRadialGradient>>::new();
@@ -1211,34 +1215,69 @@ impl MobileFrameOwned {
                             PaintBox::Content => BACKGROUND_BOX_CONTENT,
                             _ => return Err(MobileFrameError),
                         };
-                        let ClipShape::Inset { edges, radii } = shape else {
-                            return Err(MobileFrameError);
+                        let (shape_kind, payload) = match shape {
+                            ClipShape::Inset { edges, radii } => {
+                                clip_insets.push(Box::new(MobileClipInset {
+                                    edges: [
+                                        mobile_coordinate(edges.top),
+                                        mobile_coordinate(edges.right),
+                                        mobile_coordinate(edges.bottom),
+                                        mobile_coordinate(edges.left),
+                                    ],
+                                    radii_horizontal: [
+                                        mobile_length(radii.top_left.horizontal),
+                                        mobile_length(radii.top_right.horizontal),
+                                        mobile_length(radii.bottom_right.horizontal),
+                                        mobile_length(radii.bottom_left.horizontal),
+                                    ],
+                                    radii_vertical: [
+                                        mobile_length(radii.top_left.vertical),
+                                        mobile_length(radii.top_right.vertical),
+                                        mobile_length(radii.bottom_right.vertical),
+                                        mobile_length(radii.bottom_left.vertical),
+                                    ],
+                                }));
+                                (
+                                    CLIP_SHAPE_INSET,
+                                    clip_insets.last().unwrap().as_ref() as *const _
+                                        as *const c_void,
+                                )
+                            }
+                            ClipShape::Circle { radius, center } => {
+                                clip_circles.push(Box::new(MobileClipCircle {
+                                    radius: mobile_length(*radius),
+                                    center_x: mobile_coordinate(center.x),
+                                    center_y: mobile_coordinate(center.y),
+                                }));
+                                (
+                                    CLIP_SHAPE_CIRCLE,
+                                    clip_circles.last().unwrap().as_ref() as *const _
+                                        as *const c_void,
+                                )
+                            }
+                            ClipShape::Ellipse {
+                                radius_x,
+                                radius_y,
+                                center,
+                            } => {
+                                clip_ellipses.push(Box::new(MobileClipEllipse {
+                                    radius_x: mobile_length(*radius_x),
+                                    radius_y: mobile_length(*radius_y),
+                                    center_x: mobile_coordinate(center.x),
+                                    center_y: mobile_coordinate(center.y),
+                                }));
+                                (
+                                    CLIP_SHAPE_ELLIPSE,
+                                    clip_ellipses.last().unwrap().as_ref() as *const _
+                                        as *const c_void,
+                                )
+                            }
+                            _ => return Err(MobileFrameError),
                         };
-                        clip_insets.push(Box::new(MobileClipInset {
-                            edges: [
-                                mobile_coordinate(edges.top),
-                                mobile_coordinate(edges.right),
-                                mobile_coordinate(edges.bottom),
-                                mobile_coordinate(edges.left),
-                            ],
-                            radii_horizontal: [
-                                mobile_length(radii.top_left.horizontal),
-                                mobile_length(radii.top_right.horizontal),
-                                mobile_length(radii.bottom_right.horizontal),
-                                mobile_length(radii.bottom_left.horizontal),
-                            ],
-                            radii_vertical: [
-                                mobile_length(radii.top_left.vertical),
-                                mobile_length(radii.top_right.vertical),
-                                mobile_length(radii.bottom_right.vertical),
-                                mobile_length(radii.bottom_left.vertical),
-                            ],
-                        }));
                         clip_paths.push(Box::new(MobileClipPath {
                             reference_box,
-                            shape_kind: CLIP_SHAPE_INSET,
-                            payload: clip_insets.last().unwrap().as_ref() as *const _
-                                as *const c_void,
+                            shape_kind,
+                            payload,
                             payload_count: 1,
                         }));
                         raw.payload =
@@ -1397,6 +1436,8 @@ impl MobileFrameOwned {
             _paints: paints,
             _box_shadows: box_shadows,
             _clip_insets: clip_insets,
+            _clip_circles: clip_circles,
+            _clip_ellipses: clip_ellipses,
             _clip_paths: clip_paths,
             _gradient_stops: gradient_stops,
             _radial_gradients: radial_gradients,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/ClipPath.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/ClipPath.kt
@@ -5,16 +5,33 @@ import android.graphics.RectF
 
 internal enum class HostClipReferenceBox { Border, Padding, Content }
 
+internal sealed interface HostClipPath { val referenceBox: HostClipReferenceBox }
+
 /** Rounded inset basic shape retained in physical Host coordinates. */
 internal data class HostInsetClipPath(
-    val referenceBox: HostClipReferenceBox,
+    override val referenceBox: HostClipReferenceBox,
     val edges: List<HostPaintCoordinate>,
     val radiiHorizontal: List<HostPaintCoordinate>,
     val radiiVertical: List<HostPaintCoordinate>,
-)
+) : HostClipPath
 
-internal fun resolveInsetClipPath(
-    clip: HostInsetClipPath,
+internal data class HostCircleClipPath(
+    override val referenceBox: HostClipReferenceBox,
+    val radius: HostPaintCoordinate,
+    val centerX: HostPaintCoordinate,
+    val centerY: HostPaintCoordinate,
+) : HostClipPath
+
+internal data class HostEllipseClipPath(
+    override val referenceBox: HostClipReferenceBox,
+    val radiusX: HostPaintCoordinate,
+    val radiusY: HostPaintCoordinate,
+    val centerX: HostPaintCoordinate,
+    val centerY: HostPaintCoordinate,
+) : HostClipPath
+
+internal fun resolveClipPath(
+    clip: HostClipPath,
     width: Float,
     height: Float,
     borderWidths: FloatArray,
@@ -30,6 +47,23 @@ internal fun resolveInsetClipPath(
         )
         HostClipReferenceBox.Content -> RectF(contentBox)
     }
+    if (clip is HostCircleClipPath) {
+        val centerX = reference.left + clip.centerX.resolve(reference.width())
+        val centerY = reference.top + clip.centerY.resolve(reference.height())
+        val diagonal = kotlin.math.hypot(reference.width(), reference.height()) / kotlin.math.sqrt(2f)
+        val radius = clip.radius.resolve(diagonal).coerceAtLeast(0f)
+        return Path().apply { addCircle(centerX, centerY, radius, Path.Direction.CW) }
+    }
+    if (clip is HostEllipseClipPath) {
+        val centerX = reference.left + clip.centerX.resolve(reference.width())
+        val centerY = reference.top + clip.centerY.resolve(reference.height())
+        val radiusX = clip.radiusX.resolve(reference.width()).coerceAtLeast(0f)
+        val radiusY = clip.radiusY.resolve(reference.height()).coerceAtLeast(0f)
+        return Path().apply {
+            addOval(RectF(centerX - radiusX, centerY - radiusY, centerX + radiusX, centerY + radiusY), Path.Direction.CW)
+        }
+    }
+    clip as HostInsetClipPath
     val top = clip.edges[0].resolve(reference.height())
     val right = clip.edges[1].resolve(reference.width())
     val bottom = clip.edges[2].resolve(reference.height())

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -11,7 +11,7 @@ import rs.whisker.runtime.WhiskerMountedElement
 import rs.whisker.runtime.paint.HostBoxPaint
 import rs.whisker.runtime.paint.HostBackgroundLayers
 import rs.whisker.runtime.paint.HostBoxShadow
-import rs.whisker.runtime.paint.HostInsetClipPath
+import rs.whisker.runtime.paint.HostClipPath
 import rs.whisker.runtime.paint.ResolvedBoxGeometry
 import rs.whisker.runtime.paint.normalizeRadii
 import rs.whisker.runtime.paint.drawInsetBoxShadows
@@ -40,7 +40,7 @@ internal class HostNode(context: Context, val element: String) : WhiskerContaine
     var paint: HostBoxPaint? = null
     var backgroundLayers: HostBackgroundLayers? = null
     var boxShadows: List<HostBoxShadow> = emptyList()
-    var clipPath: HostInsetClipPath? = null
+    var clipPath: HostClipPath? = null
     var mountedElement: WhiskerMountedElement? = null
     var zOrder: Int = 0
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -21,6 +21,8 @@ import rs.whisker.runtime.paint.HostBackgroundSize
 import rs.whisker.runtime.paint.HostConicGradient
 import rs.whisker.runtime.paint.HostGradientStop
 import rs.whisker.runtime.paint.HostClipReferenceBox
+import rs.whisker.runtime.paint.HostCircleClipPath
+import rs.whisker.runtime.paint.HostEllipseClipPath
 import rs.whisker.runtime.paint.HostInsetClipPath
 import rs.whisker.runtime.paint.HostLinearGradient
 import rs.whisker.runtime.paint.HostPaintCoordinate
@@ -29,7 +31,7 @@ import rs.whisker.runtime.paint.HostRasterResourceStore
 import rs.whisker.runtime.paint.applyBoxPaint
 import rs.whisker.runtime.paint.parseNamedColor
 import rs.whisker.runtime.paint.rgba
-import rs.whisker.runtime.paint.resolveInsetClipPath
+import rs.whisker.runtime.paint.resolveClipPath
 import kotlin.math.min
 
 internal data class HostSceneOperation(
@@ -429,19 +431,33 @@ internal class HostScene(
                 val cursor = offset + index * 2
                 HostPaintCoordinate(values[cursor] * density, values[cursor + 1])
             }
-            HostInsetClipPath(
-                referenceBox = when (values[0].toInt()) {
-                    BACKGROUND_BOX_PADDING -> HostClipReferenceBox.Padding
-                    BACKGROUND_BOX_CONTENT -> HostClipReferenceBox.Content
-                    else -> HostClipReferenceBox.Border
-                },
-                edges = coordinates(2),
-                radiiHorizontal = coordinates(10),
-                radiiVertical = coordinates(18),
-            )
+            val referenceBox = when (values[0].toInt()) {
+                BACKGROUND_BOX_PADDING -> HostClipReferenceBox.Padding
+                BACKGROUND_BOX_CONTENT -> HostClipReferenceBox.Content
+                else -> HostClipReferenceBox.Border
+            }
+            when (values[1].toInt()) {
+                CLIP_SHAPE_CIRCLE -> HostCircleClipPath(
+                    referenceBox, coordinate(values, 2, density),
+                    coordinate(values, 4, density), coordinate(values, 6, density),
+                )
+                CLIP_SHAPE_ELLIPSE -> HostEllipseClipPath(
+                    referenceBox, coordinate(values, 2, density), coordinate(values, 4, density),
+                    coordinate(values, 6, density), coordinate(values, 8, density),
+                )
+                else -> HostInsetClipPath(
+                    referenceBox = referenceBox,
+                    edges = coordinates(2),
+                    radiiHorizontal = coordinates(10),
+                    radiiVertical = coordinates(18),
+                )
+            }
         }
         refreshClipPath(node)
     }
+
+    private fun coordinate(values: FloatArray, offset: Int, density: Float) =
+        HostPaintCoordinate(values[offset] * density, values[offset + 1])
 
     private fun refreshClipPath(node: HostNode) {
         val clip = node.clipPath
@@ -451,7 +467,7 @@ internal class HostScene(
         }
         val density = root.resources.displayMetrics.density
         node.setPaintClipPath(
-            resolveInsetClipPath(
+            resolveClipPath(
                 clip,
                 node.geometry.width * density,
                 node.geometry.height * density,
@@ -472,12 +488,23 @@ internal class HostScene(
     ): Boolean {
         if (operation.node !in existing) return false
         val values = operation.numbers ?: return true
-        return values.size == CLIP_PATH_PACKED_SIZE &&
+        val shape = values.getOrNull(1)?.toInt() ?: return false
+        val expectedSize = when (shape) {
+            CLIP_SHAPE_INSET -> CLIP_PATH_INSET_PACKED_SIZE
+            CLIP_SHAPE_CIRCLE -> CLIP_PATH_CIRCLE_PACKED_SIZE
+            CLIP_SHAPE_ELLIPSE -> CLIP_PATH_ELLIPSE_PACKED_SIZE
+            else -> return false
+        }
+        return values.size == expectedSize &&
             values.all(Float::isFinite) &&
             values[0].toInt() in BACKGROUND_BOX_BORDER..BACKGROUND_BOX_CONTENT &&
             values[0] == values[0].toInt().toFloat() &&
-            values[1] == CLIP_SHAPE_INSET.toFloat() &&
-            (10 until CLIP_PATH_PACKED_SIZE).all { values[it] >= 0f }
+            values[1] == shape.toFloat() &&
+            when (shape) {
+                CLIP_SHAPE_INSET -> (10 until expectedSize).all { values[it] >= 0f }
+                CLIP_SHAPE_CIRCLE -> values[2] >= 0f && values[3] >= 0f
+                else -> values[2] >= 0f && values[3] >= 0f && values[4] >= 0f && values[5] >= 0f
+            }
     }
 
     private fun validBoxShadows(
@@ -779,8 +806,12 @@ internal class HostScene(
     private companion object {
         const val BACKGROUND_GEOMETRY_PACKED_SIZE = 15
         const val BOX_SHADOW_PACKED_SIZE = 10
-        const val CLIP_PATH_PACKED_SIZE = 26
+        const val CLIP_PATH_INSET_PACKED_SIZE = 26
+        const val CLIP_PATH_CIRCLE_PACKED_SIZE = 8
+        const val CLIP_PATH_ELLIPSE_PACKED_SIZE = 10
         const val CLIP_SHAPE_INSET = 0
+        const val CLIP_SHAPE_CIRCLE = 1
+        const val CLIP_SHAPE_ELLIPSE = 2
         const val BACKGROUND_GRADIENT_STOP_PACKED_SIZE = 7
         const val BACKGROUND_PACKED_LAYER_HEADER_SIZE = 3
         const val BACKGROUND_PACKED_LAYERS = 256

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -365,9 +365,7 @@ impl DesktopScene {
         );
         let mut node_shape_clips = context.shape_clips.clone();
         let mut node_clip_bounds = None;
-        if let Some((reference_box, ClipShape::Inset { edges, radii })) =
-            presentation.visual_effects.clip_path.as_ref()
-        {
+        if let Some((reference_box, shape)) = presentation.visual_effects.clip_path.as_ref() {
             let reference = match reference_box {
                 PaintBox::Border => border,
                 PaintBox::Padding => presentation.paint.as_ref().map_or(border, |paint| {
@@ -376,10 +374,10 @@ impl DesktopScene {
                 PaintBox::Content => content,
                 _ => unreachable!("unsupported clip-path reference box passed validation"),
             };
-            let clip_rect = inset_clip_rect(reference, edges);
+            let (clip_rect, clip_radii) = clip_shape_geometry(reference, shape);
             node_shape_clips = node_shape_clips.push(ShapeClip {
                 rect: clip_rect,
-                radii: resolve_radii(radii, clip_rect),
+                radii: clip_radii,
                 inverse_transform: inverse_transform(transform).unwrap_or(Transform::IDENTITY),
                 horizontal: true,
                 vertical: true,
@@ -985,8 +983,63 @@ fn supports_visual_effects(effects: &VisualEffects) -> bool {
             matches!(
                 reference,
                 PaintBox::Border | PaintBox::Padding | PaintBox::Content
-            ) && matches!(shape, ClipShape::Inset { .. })
+            ) && matches!(
+                shape,
+                ClipShape::Inset { .. } | ClipShape::Circle { .. } | ClipShape::Ellipse { .. }
+            )
         })
+}
+
+fn clip_shape_geometry(reference: LayoutRect, shape: &ClipShape) -> (LayoutRect, ResolvedRadii) {
+    match shape {
+        ClipShape::Inset { edges, radii } => {
+            let rect = inset_clip_rect(reference, edges);
+            let radii = resolve_radii(radii, rect);
+            (rect, radii)
+        }
+        ClipShape::Circle { radius, center } => {
+            let center_x = reference.x + resolve_coordinate(center.x, reference.width);
+            let center_y = reference.y + resolve_coordinate(center.y, reference.height);
+            let normalized_diagonal = reference.width.hypot(reference.height) / 2.0_f32.sqrt();
+            let radius = resolve_length_percentage(*radius, normalized_diagonal);
+            let rect = LayoutRect {
+                x: center_x - radius,
+                y: center_y - radius,
+                width: radius * 2.0,
+                height: radius * 2.0,
+            };
+            (
+                rect,
+                ResolvedRadii {
+                    horizontal: [radius; 4],
+                    vertical: [radius; 4],
+                },
+            )
+        }
+        ClipShape::Ellipse {
+            radius_x,
+            radius_y,
+            center,
+        } => {
+            let center_x = reference.x + resolve_coordinate(center.x, reference.width);
+            let center_y = reference.y + resolve_coordinate(center.y, reference.height);
+            let radius_x = resolve_length_percentage(*radius_x, reference.width);
+            let radius_y = resolve_length_percentage(*radius_y, reference.height);
+            (
+                LayoutRect {
+                    x: center_x - radius_x,
+                    y: center_y - radius_y,
+                    width: radius_x * 2.0,
+                    height: radius_y * 2.0,
+                },
+                ResolvedRadii {
+                    horizontal: [radius_x; 4],
+                    vertical: [radius_y; 4],
+                },
+            )
+        }
+        _ => unreachable!("unsupported clip-path shape passed validation"),
+    }
 }
 
 fn inset_clip_rect(
@@ -1006,6 +1059,13 @@ fn inset_clip_rect(
 }
 
 fn resolve_coordinate(value: PaintCoordinate, available: f32) -> f32 {
+    value.length + value.fraction * available
+}
+
+fn resolve_length_percentage(
+    value: whisker_protocol::PaintLengthPercentage,
+    available: f32,
+) -> f32 {
     value.length + value.fraction * available
 }
 

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -1072,6 +1072,42 @@ fn clip_path_protocol(value: &ClipPathFixture) -> (PaintBox, ClipShape) {
                 },
             }
         }
+        ClipShapeFixture::Circle { radius, center } => ClipShape::Circle {
+            radius: PaintLengthPercentage {
+                length: radius.length,
+                fraction: radius.fraction,
+            },
+            center: PaintPosition {
+                x: PaintCoordinate {
+                    length: center[0].length,
+                    fraction: center[0].fraction,
+                },
+                y: PaintCoordinate {
+                    length: center[1].length,
+                    fraction: center[1].fraction,
+                },
+            },
+        },
+        ClipShapeFixture::Ellipse { radii, center } => ClipShape::Ellipse {
+            radius_x: PaintLengthPercentage {
+                length: radii[0].length,
+                fraction: radii[0].fraction,
+            },
+            radius_y: PaintLengthPercentage {
+                length: radii[1].length,
+                fraction: radii[1].fraction,
+            },
+            center: PaintPosition {
+                x: PaintCoordinate {
+                    length: center[0].length,
+                    fraction: center[0].fraction,
+                },
+                y: PaintCoordinate {
+                    length: center[1].length,
+                    fraction: center[1].fraction,
+                },
+            },
+        },
     };
     (reference_box, shape)
 }

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 11 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 12 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -39,7 +39,7 @@ enum {
 };
 enum { WHISKER_BACKGROUND_ATTACHMENT_SCROLL = 0 };
 enum { WHISKER_BACKGROUND_BLEND_NORMAL = 0 };
-enum { WHISKER_CLIP_SHAPE_INSET = 0 };
+enum { WHISKER_CLIP_SHAPE_INSET = 0, WHISKER_CLIP_SHAPE_CIRCLE = 1, WHISKER_CLIP_SHAPE_ELLIPSE = 2 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -88,6 +88,8 @@ typedef struct {
   WhiskerMobileLengthPercentage radii_horizontal[4];
   WhiskerMobileLengthPercentage radii_vertical[4];
 } WhiskerMobileClipInset;
+typedef struct { WhiskerMobileLengthPercentage radius, center_x, center_y; } WhiskerMobileClipCircle;
+typedef struct { WhiskerMobileLengthPercentage radius_x, radius_y, center_x, center_y; } WhiskerMobileClipEllipse;
 typedef struct {
   uint32_t reference_box, shape_kind; const void *payload; size_t payload_count;
 } WhiskerMobileClipPath;
@@ -140,6 +142,8 @@ _Static_assert(sizeof(WhiskerMobileBackgroundImage) == 24, "WhiskerMobileBackgro
 _Static_assert(sizeof(WhiskerMobileBackgroundLayer) == 88, "WhiskerMobileBackgroundLayer ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxShadow) == 56, "WhiskerMobileBoxShadow ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipInset) == 96, "WhiskerMobileClipInset ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipCircle) == 24, "WhiskerMobileClipCircle ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipEllipse) == 32, "WhiskerMobileClipEllipse ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipPath) == 24, "WhiskerMobileClipPath ABI drift");
 typedef struct {
   uint32_t id; uint8_t value_kind, optional_kind, _pad[2]; WhiskerStringRef name;

--- a/platforms/ios/Sources/WhiskerRuntime/paint/ClipPath.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/ClipPath.swift
@@ -7,6 +7,20 @@ enum HostClipReferenceBox {
     case content
 }
 
+enum HostClipPath {
+    case inset(HostInsetClipPath)
+    case circle(HostCircleClipPath)
+    case ellipse(HostEllipseClipPath)
+
+    func path(in bounds: CGRect, contentBox: CGRect, painter: HostBoxPainter) -> CGPath {
+        switch self {
+        case let .inset(shape): shape.path(in: bounds, contentBox: contentBox, painter: painter)
+        case let .circle(shape): shape.path(in: bounds, contentBox: contentBox, painter: painter)
+        case let .ellipse(shape): shape.path(in: bounds, contentBox: contentBox, painter: painter)
+        }
+    }
+}
+
 /// Rounded inset basic shape copied out of the borrowed mobile ABI payload.
 struct HostInsetClipPath {
     let referenceBox: HostClipReferenceBox
@@ -37,6 +51,57 @@ struct HostInsetClipPath {
             )
         }
         return roundedPath(in: inset, radii: radii).cgPath
+    }
+}
+
+struct HostCircleClipPath {
+    let referenceBox: HostClipReferenceBox
+    let radius: WhiskerMobileLengthPercentage
+    let centerX: WhiskerMobileLengthPercentage
+    let centerY: WhiskerMobileLengthPercentage
+
+    func path(in bounds: CGRect, contentBox: CGRect, painter: HostBoxPainter) -> CGPath {
+        let reference = clipReferenceBox(referenceBox, bounds, contentBox, painter)
+        let center = CGPoint(
+            x: reference.minX + resolve(centerX, axis: reference.width),
+            y: reference.minY + resolve(centerY, axis: reference.height)
+        )
+        let diagonal = hypot(reference.width, reference.height) / sqrt(2)
+        let radius = max(0, resolve(radius, axis: diagonal))
+        return UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: .pi * 2, clockwise: true).cgPath
+    }
+}
+
+struct HostEllipseClipPath {
+    let referenceBox: HostClipReferenceBox
+    let radiusX: WhiskerMobileLengthPercentage
+    let radiusY: WhiskerMobileLengthPercentage
+    let centerX: WhiskerMobileLengthPercentage
+    let centerY: WhiskerMobileLengthPercentage
+
+    func path(in bounds: CGRect, contentBox: CGRect, painter: HostBoxPainter) -> CGPath {
+        let reference = clipReferenceBox(referenceBox, bounds, contentBox, painter)
+        let centerX = reference.minX + resolve(centerX, axis: reference.width)
+        let centerY = reference.minY + resolve(centerY, axis: reference.height)
+        let radiusX = max(0, resolve(radiusX, axis: reference.width))
+        let radiusY = max(0, resolve(radiusY, axis: reference.height))
+        return UIBezierPath(ovalIn: CGRect(
+            x: centerX - radiusX, y: centerY - radiusY,
+            width: radiusX * 2, height: radiusY * 2
+        )).cgPath
+    }
+}
+
+private func clipReferenceBox(
+    _ box: HostClipReferenceBox,
+    _ bounds: CGRect,
+    _ contentBox: CGRect,
+    _ painter: HostBoxPainter
+) -> CGRect {
+    switch box {
+    case .border: bounds
+    case .padding: painter.paddingBoxRect(in: bounds)
+    case .content: contentBox
     }
 }
 

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -14,7 +14,7 @@ final class WhiskerNodeView: UIView {
     private let defaultChildrenHost = WhiskerChildrenHostView(frame: .zero)
     private let overflowMask = CAShapeLayer()
     private let clipPathMask = CAShapeLayer()
-    private var clipPath: HostInsetClipPath?
+    private var clipPath: HostClipPath?
     private var boxShadows: [HostBoxShadow] = []
     private var boxShadowLayers: [CAShapeLayer] = []
     private var boxShadowMaskLayers: [CAShapeLayer] = []
@@ -110,7 +110,7 @@ final class WhiskerNodeView: UIView {
         updateClipPathMask()
     }
 
-    func setClipPath(_ clipPath: HostInsetClipPath?) {
+    func setClipPath(_ clipPath: HostClipPath?) {
         self.clipPath = clipPath
         updateClipPathMask()
     }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -285,22 +285,41 @@ final class HostScene {
             }
             guard let raw = operation.payload?.assumingMemoryBound(
                 to: WhiskerMobileClipPath.self
-            ).pointee,
-                  raw.shape_kind == UInt32(WHISKER_CLIP_SHAPE_INSET),
-                  let inset = raw.payload?.assumingMemoryBound(
-                      to: WhiskerMobileClipInset.self
-                  ).pointee else { return false }
+            ).pointee else { return false }
             let referenceBox: HostClipReferenceBox = switch raw.reference_box {
             case UInt32(WHISKER_BACKGROUND_BOX_PADDING): .padding
             case UInt32(WHISKER_BACKGROUND_BOX_CONTENT): .content
             default: .border
             }
-            node.setClipPath(HostInsetClipPath(
-                referenceBox: referenceBox,
-                edges: tupleArray(inset.edges),
-                radiiHorizontal: tupleArray(inset.radii_horizontal),
-                radiiVertical: tupleArray(inset.radii_vertical)
-            ))
+            switch raw.shape_kind {
+            case UInt32(WHISKER_CLIP_SHAPE_INSET):
+                guard let inset = raw.payload?.assumingMemoryBound(
+                    to: WhiskerMobileClipInset.self
+                ).pointee else { return false }
+                node.setClipPath(.inset(HostInsetClipPath(
+                    referenceBox: referenceBox, edges: tupleArray(inset.edges),
+                    radiiHorizontal: tupleArray(inset.radii_horizontal),
+                    radiiVertical: tupleArray(inset.radii_vertical)
+                )))
+            case UInt32(WHISKER_CLIP_SHAPE_CIRCLE):
+                guard let circle = raw.payload?.assumingMemoryBound(
+                    to: WhiskerMobileClipCircle.self
+                ).pointee else { return false }
+                node.setClipPath(.circle(HostCircleClipPath(
+                    referenceBox: referenceBox, radius: circle.radius,
+                    centerX: circle.center_x, centerY: circle.center_y
+                )))
+            case UInt32(WHISKER_CLIP_SHAPE_ELLIPSE):
+                guard let ellipse = raw.payload?.assumingMemoryBound(
+                    to: WhiskerMobileClipEllipse.self
+                ).pointee else { return false }
+                node.setClipPath(.ellipse(HostEllipseClipPath(
+                    referenceBox: referenceBox, radiusX: ellipse.radius_x,
+                    radiusY: ellipse.radius_y, centerX: ellipse.center_x,
+                    centerY: ellipse.center_y
+                )))
+            default: return false
+            }
         case UInt32(WHISKER_OP_OPACITY):
             nodes[id]?.alpha = CGFloat(operation.scalar)
         case UInt32(WHISKER_OP_VISIBILITY):
@@ -513,14 +532,24 @@ private func validHardBoxShadow(_ shadow: WhiskerMobileBoxShadow) -> Bool {
 
 private func validClipPath(_ clip: WhiskerMobileClipPath) -> Bool {
     guard clip.reference_box <= UInt32(WHISKER_BACKGROUND_BOX_CONTENT),
-          clip.shape_kind == UInt32(WHISKER_CLIP_SHAPE_INSET),
           clip.payload_count == 1,
-          let inset = clip.payload?.assumingMemoryBound(
-              to: WhiskerMobileClipInset.self
-          ).pointee else { return false }
-    let radii = tupleArray(inset.radii_horizontal) + tupleArray(inset.radii_vertical)
-    return tupleArray(inset.edges).allSatisfy(\.isFinite) && radii.allSatisfy {
-        $0.isFinite && $0.length >= 0 && $0.fraction >= 0
+          let payload = clip.payload else { return false }
+    switch clip.shape_kind {
+    case UInt32(WHISKER_CLIP_SHAPE_INSET):
+        let inset = payload.assumingMemoryBound(to: WhiskerMobileClipInset.self).pointee
+        let radii = tupleArray(inset.radii_horizontal) + tupleArray(inset.radii_vertical)
+        return tupleArray(inset.edges).allSatisfy(\.isFinite) && radii.allSatisfy {
+            $0.isFinite && $0.length >= 0 && $0.fraction >= 0
+        }
+    case UInt32(WHISKER_CLIP_SHAPE_CIRCLE):
+        let circle = payload.assumingMemoryBound(to: WhiskerMobileClipCircle.self).pointee
+        return circle.radius.isNonNegativeFinite && circle.center_x.isFinite && circle.center_y.isFinite
+    case UInt32(WHISKER_CLIP_SHAPE_ELLIPSE):
+        let ellipse = payload.assumingMemoryBound(to: WhiskerMobileClipEllipse.self).pointee
+        return ellipse.radius_x.isNonNegativeFinite && ellipse.radius_y.isNonNegativeFinite &&
+            ellipse.center_x.isFinite && ellipse.center_y.isFinite
+    default:
+        return false
     }
 }
 

--- a/platforms/web/src/paint/visual_effects.rs
+++ b/platforms/web/src/paint/visual_effects.rs
@@ -14,7 +14,10 @@ pub(crate) fn supports(effects: &VisualEffects) -> bool {
             matches!(
                 reference,
                 PaintBox::Border | PaintBox::Padding | PaintBox::Content
-            ) && matches!(shape, ClipShape::Inset { .. })
+            ) && matches!(
+                shape,
+                ClipShape::Inset { .. } | ClipShape::Circle { .. } | ClipShape::Ellipse { .. }
+            )
         })
 }
 
@@ -61,24 +64,42 @@ fn clip_path_css(value: &(PaintBox, ClipShape)) -> Result<String, WebError> {
         PaintBox::Content => "content-box",
         _ => return Err(WebError("unsupported DOM clip-path reference box".into())),
     };
-    let ClipShape::Inset { edges, radii } = &value.1 else {
-        return Err(WebError("unsupported DOM clip-path shape".into()));
+    let shape = match &value.1 {
+        ClipShape::Inset { edges, radii } => format!(
+            "inset({} {} {} {} round {} {} {} {} / {} {} {} {})",
+            coordinate(edges.top),
+            coordinate(edges.right),
+            coordinate(edges.bottom),
+            coordinate(edges.left),
+            length(radii.top_left.horizontal),
+            length(radii.top_right.horizontal),
+            length(radii.bottom_right.horizontal),
+            length(radii.bottom_left.horizontal),
+            length(radii.top_left.vertical),
+            length(radii.top_right.vertical),
+            length(radii.bottom_right.vertical),
+            length(radii.bottom_left.vertical),
+        ),
+        ClipShape::Circle { radius, center } => format!(
+            "circle({} at {} {})",
+            length(*radius),
+            coordinate(center.x),
+            coordinate(center.y),
+        ),
+        ClipShape::Ellipse {
+            radius_x,
+            radius_y,
+            center,
+        } => format!(
+            "ellipse({} {} at {} {})",
+            length(*radius_x),
+            length(*radius_y),
+            coordinate(center.x),
+            coordinate(center.y),
+        ),
+        _ => return Err(WebError("unsupported DOM clip-path shape".into())),
     };
-    Ok(format!(
-        "inset({} {} {} {} round {} {} {} {} / {} {} {} {}) {reference_box}",
-        coordinate(edges.top),
-        coordinate(edges.right),
-        coordinate(edges.bottom),
-        coordinate(edges.left),
-        length(radii.top_left.horizontal),
-        length(radii.top_right.horizontal),
-        length(radii.bottom_right.horizontal),
-        length(radii.bottom_left.horizontal),
-        length(radii.top_left.vertical),
-        length(radii.top_right.vertical),
-        length(radii.bottom_right.vertical),
-        length(radii.bottom_left.vertical),
-    ))
+    Ok(format!("{shape} {reference_box}"))
 }
 
 fn coordinate(value: PaintCoordinate) -> String {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -507,7 +507,17 @@ impl Driver {
                                         nodes.iter().find_map(|node| {
                                             node.clip_path
                                                 .as_ref()
-                                                .map(|_| "paint.visual-effects.clip-path-inset")
+                                                .map(|clip| match &clip.shape {
+                                                    ClipShapeFixture::Inset { .. } => {
+                                                        "paint.visual-effects.clip-path-inset"
+                                                    }
+                                                    ClipShapeFixture::Circle { .. } => {
+                                                        "paint.visual-effects.clip-path-circle"
+                                                    }
+                                                    ClipShapeFixture::Ellipse { .. } => {
+                                                        "paint.visual-effects.clip-path-ellipse"
+                                                    }
+                                                })
                                         })
                                     })
                                     .or_else(|| {
@@ -1234,6 +1244,12 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-masking/clip-path-inset-round-rendering.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-masking/clip-path-inset-round-rendering.json"
         ),
+        "wpt/css/css-masking/clip-path-circle-002.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-masking/clip-path-circle-002.json"
+        ),
+        "wpt/css/css-masking/clip-path-ellipse-002.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-masking/clip-path-ellipse-002.json"
+        ),
         "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"
         ),
@@ -1728,6 +1744,21 @@ fn clip_path_protocol(value: &ClipPathFixture) -> (PaintBox, ClipShape) {
                 },
             }
         }
+        ClipShapeFixture::Circle { radius, center } => ClipShape::Circle {
+            radius: paint_length_percentage(*radius),
+            center: whisker_protocol::PaintPosition {
+                x: paint_coordinate(center[0]),
+                y: paint_coordinate(center[1]),
+            },
+        },
+        ClipShapeFixture::Ellipse { radii, center } => ClipShape::Ellipse {
+            radius_x: paint_length_percentage(radii[0]),
+            radius_y: paint_length_percentage(radii[1]),
+            center: whisker_protocol::PaintPosition {
+                x: paint_coordinate(center[0]),
+                y: paint_coordinate(center[1]),
+            },
+        },
     };
     (reference_box, shape)
 }
@@ -1943,31 +1974,50 @@ fn fixture_clip_path_css(value: &ClipPathFixture) -> String {
         ClipReferenceBoxFixture::Padding => "padding-box",
         ClipReferenceBoxFixture::Content => "content-box",
     };
-    let ClipShapeFixture::Inset { edges, radii } = &value.shape;
     let coordinate = |value: LengthPercentageFixture| {
         if value.fraction == 0.0 {
             format!("{}px", value.length)
         } else if value.length == 0.0 {
-            format!("{}%", value.fraction * 100.0)
+            let percentage = (value.fraction * 1_000_000.0).round() / 10_000.0;
+            format!("{percentage}%")
         } else {
             format!("calc({}px + {}%)", value.length, value.fraction * 100.0)
         }
     };
-    let edges = edges.map(coordinate);
-    let horizontal = radii.map(|radius| format!("{}px", radius.horizontal()));
-    let vertical = radii.map(|radius| format!("{}px", radius.vertical()));
-    let edges = css_four_value_shorthand(&edges);
-    let horizontal = css_four_value_shorthand(&horizontal);
-    let vertical = css_four_value_shorthand(&vertical);
-    let radii = if horizontal == vertical {
-        horizontal
-    } else {
-        format!("{horizontal} / {vertical}")
+    let inset = |edges: &[LengthPercentageFixture; 4], radii: &[CornerRadiusFixture; 4]| {
+        let edges = edges.map(coordinate);
+        let horizontal = radii.map(|radius| format!("{}px", radius.horizontal()));
+        let vertical = radii.map(|radius| format!("{}px", radius.vertical()));
+        let edges = css_four_value_shorthand(&edges);
+        let horizontal = css_four_value_shorthand(&horizontal);
+        let vertical = css_four_value_shorthand(&vertical);
+        let radii = if horizontal == vertical {
+            horizontal
+        } else {
+            format!("{horizontal} / {vertical}")
+        };
+        format!("inset({edges} round {radii})")
+    };
+    let shape = match &value.shape {
+        ClipShapeFixture::Inset { edges, radii } => inset(edges, radii),
+        ClipShapeFixture::Circle { radius, center } => format!(
+            "circle({} at {} {})",
+            coordinate(*radius),
+            coordinate(center[0]),
+            coordinate(center[1])
+        ),
+        ClipShapeFixture::Ellipse { radii, center } => format!(
+            "ellipse({} {} at {} {})",
+            coordinate(radii[0]),
+            coordinate(radii[1]),
+            coordinate(center[0]),
+            coordinate(center[1])
+        ),
     };
     let suffix = (!reference_box.is_empty())
         .then(|| format!(" {reference_box}"))
         .unwrap_or_default();
-    format!("inset({edges} round {radii}){suffix}")
+    format!("{shape}{suffix}")
 }
 
 fn css_four_value_shorthand(values: &[String; 4]) -> String {

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,8 +98,8 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
-      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur", "multiple-box-shadows", "clip-path-inset"],
-      "pending_subset": ["clip-path-circle-ellipse-and-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur", "multiple-box-shadows", "clip-path-inset", "clip-path-circle-and-ellipse"],
+      "pending_subset": ["clip-path-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -332,6 +332,20 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-masking.clip-path-circle-002",
+      "feature": "clip-path-circle",
+      "fixture": "wpt/css/css-masking/clip-path-circle-002.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-masking.clip-path-ellipse-002",
+      "feature": "clip-path-ellipse",
+      "fixture": "wpt/css/css-masking/clip-path-ellipse-002.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-right-003",
       "feature": "border-right",
       "fixture": "wpt/css/CSS2/borders/border-right-003.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -307,7 +307,11 @@ private class Driver(
                             command.getString("name") ==
                             "paint.visual-effects.box-shadow-multiple" ||
                             command.getString("name") ==
-                            "paint.visual-effects.clip-path-inset",
+                            "paint.visual-effects.clip-path-inset" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.clip-path-circle" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.clip-path-ellipse",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -645,33 +649,44 @@ private class Driver(
             }
             node.optJSONObject("clip_path")?.let { clip ->
                 val shape = clip.getJSONObject("shape")
-                check(shape.getString("kind") == "inset")
                 val numbers = ArrayList<Float>(26)
                 numbers += backgroundBox(clip.optString("reference_box", "border")).toFloat()
-                numbers += 0f // inset shape
-                shape.getJSONArray("edges").objects().forEach { edge ->
-                    appendLengthPercentage(edge, numbers)
-                }
-                val radii = shape.getJSONArray("radii")
-                repeat(4) { index ->
-                    val radius = radii.get(index)
-                    numbers += when (radius) {
-                        is Number -> radius.toFloat()
-                        is JSONArray -> radius.getDouble(0).toFloat()
-                        else -> error("unsupported clip radius: $radius")
+                when (shape.getString("kind")) {
+                    "circle" -> {
+                        numbers += 1f
+                        appendLengthPercentage(shape.getJSONObject("radius"), numbers)
+                        shape.getJSONArray("center").objects().forEach {
+                            appendLengthPercentage(it, numbers)
+                        }
                     }
-                    numbers += 0f
-                }
-                repeat(4) { index ->
-                    val radius = radii.get(index)
-                    numbers += when (radius) {
-                        is Number -> radius.toFloat()
-                        is JSONArray -> radius.getDouble(1).toFloat()
-                        else -> error("unsupported clip radius: $radius")
+                    "ellipse" -> {
+                        numbers += 2f
+                        shape.getJSONArray("radii").objects().forEach {
+                            appendLengthPercentage(it, numbers)
+                        }
+                        shape.getJSONArray("center").objects().forEach {
+                            appendLengthPercentage(it, numbers)
+                        }
                     }
-                    numbers += 0f
+                    else -> {
+                        numbers += 0f
+                        shape.getJSONArray("edges").objects().forEach { edge ->
+                            appendLengthPercentage(edge, numbers)
+                        }
+                        val radii = shape.getJSONArray("radii")
+                        repeat(2) { axis ->
+                            repeat(4) { index ->
+                                val radius = radii.get(index)
+                                numbers += when (radius) {
+                                    is Number -> radius.toFloat()
+                                    is JSONArray -> radius.getDouble(axis).toFloat()
+                                    else -> error("unsupported clip radius: $radius")
+                                }
+                                numbers += 0f
+                            }
+                        }
+                    }
                 }
-                check(numbers.size == 26)
                 check(stage(tag = 23, node = id, numbers = numbers.toFloatArray()))
             }
         }

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -444,7 +444,9 @@ private final class Driver {
                     name == "paint.visual-effects.box-shadow-blur" ||
                     name == "paint.visual-effects.box-shadow-inset" ||
                     name == "paint.visual-effects.box-shadow-multiple" ||
-                    name == "paint.visual-effects.clip-path-inset" else {
+                    name == "paint.visual-effects.clip-path-inset" ||
+                    name == "paint.visual-effects.clip-path-circle" ||
+                    name == "paint.visual-effects.clip-path-ellipse" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -686,15 +688,23 @@ private final class Driver {
         let clipPaths = UnsafeMutablePointer<WhiskerMobileClipPath>.allocate(
             capacity: clipStorageCount
         )
+        let clipCircles = UnsafeMutablePointer<WhiskerMobileClipCircle>.allocate(capacity: clipStorageCount)
+        let clipEllipses = UnsafeMutablePointer<WhiskerMobileClipEllipse>.allocate(capacity: clipStorageCount)
         for (index, fixture) in fixtures.enumerated() {
             clipInsets.advanced(by: index).initialize(
                 to: fixture.clipPath?.inset ?? WhiskerMobileClipInset()
             )
+            clipCircles.advanced(by: index).initialize(to: fixture.clipPath?.circle ?? WhiskerMobileClipCircle())
+            clipEllipses.advanced(by: index).initialize(to: fixture.clipPath?.ellipse ?? WhiskerMobileClipEllipse())
             var path = WhiskerMobileClipPath()
             if let clip = fixture.clipPath {
                 path.reference_box = clip.referenceBox
-                path.shape_kind = UInt32(WHISKER_CLIP_SHAPE_INSET)
-                path.payload = UnsafeRawPointer(clipInsets.advanced(by: index))
+                path.shape_kind = clip.shapeKind
+                path.payload = switch clip.shapeKind {
+                case UInt32(WHISKER_CLIP_SHAPE_CIRCLE): UnsafeRawPointer(clipCircles.advanced(by: index))
+                case UInt32(WHISKER_CLIP_SHAPE_ELLIPSE): UnsafeRawPointer(clipEllipses.advanced(by: index))
+                default: UnsafeRawPointer(clipInsets.advanced(by: index))
+                }
                 path.payload_count = 1
             }
             clipPaths.advanced(by: index).initialize(to: path)
@@ -704,6 +714,10 @@ private final class Driver {
             clipInsets.deallocate()
             clipPaths.deinitialize(count: fixtures.count)
             clipPaths.deallocate()
+            clipCircles.deinitialize(count: fixtures.count)
+            clipCircles.deallocate()
+            clipEllipses.deinitialize(count: fixtures.count)
+            clipEllipses.deallocate()
         }
         try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
             try paints.withUnsafeMutableBufferPointer { paintBuffer in
@@ -1102,7 +1116,10 @@ private struct SceneFixtureNode {
 
 private struct SceneClipPath {
     let referenceBox: UInt32
+    let shapeKind: UInt32
     let inset: WhiskerMobileClipInset
+    let circle: WhiskerMobileClipCircle
+    let ellipse: WhiskerMobileClipEllipse
 }
 
 private struct ScenePaintLayer {
@@ -1334,9 +1351,27 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
 
 private func sceneClipPath(_ fixture: [String: Any]) throws -> SceneClipPath {
     let shape = try object(fixture, "shape")
-    guard try string(shape, "kind") == "inset" else {
-        throw Failure("unsupported clip-path shape")
+    let kind = try string(shape, "kind")
+    let referenceBox = try backgroundBox(fixture["reference_box"] as? String ?? "border")
+    if kind == "circle" {
+        let center = try (shape["center"] as? [Any] ?? []).map(lengthPercentage)
+        guard center.count == 2 else { throw Failure("circle needs a center") }
+        var circle = WhiskerMobileClipCircle()
+        circle.radius = try lengthPercentage(shape["radius"] as Any)
+        circle.center_x = center[0]
+        circle.center_y = center[1]
+        return SceneClipPath(referenceBox: referenceBox, shapeKind: UInt32(WHISKER_CLIP_SHAPE_CIRCLE), inset: WhiskerMobileClipInset(), circle: circle, ellipse: WhiskerMobileClipEllipse())
     }
+    if kind == "ellipse" {
+        let radii = try (shape["radii"] as? [Any] ?? []).map(lengthPercentage)
+        let center = try (shape["center"] as? [Any] ?? []).map(lengthPercentage)
+        guard radii.count == 2, center.count == 2 else { throw Failure("ellipse needs radii and center") }
+        var ellipse = WhiskerMobileClipEllipse()
+        ellipse.radius_x = radii[0]; ellipse.radius_y = radii[1]
+        ellipse.center_x = center[0]; ellipse.center_y = center[1]
+        return SceneClipPath(referenceBox: referenceBox, shapeKind: UInt32(WHISKER_CLIP_SHAPE_ELLIPSE), inset: WhiskerMobileClipInset(), circle: WhiskerMobileClipCircle(), ellipse: ellipse)
+    }
+    guard kind == "inset" else { throw Failure("unsupported clip-path shape") }
     guard let rawEdges = shape["edges"] as? [Any],
           let rawRadii = shape["radii"] as? [Any] else {
         throw Failure("inset clip-path needs edge and radius arrays")
@@ -1370,8 +1405,11 @@ private func sceneClipPath(_ fixture: [String: Any]) throws -> SceneClipPath {
         WhiskerMobileLengthPercentage(length: radii[3].1, fraction: 0)
     )
     return SceneClipPath(
-        referenceBox: try backgroundBox(fixture["reference_box"] as? String ?? "border"),
-        inset: inset
+        referenceBox: referenceBox,
+        shapeKind: UInt32(WHISKER_CLIP_SHAPE_INSET),
+        inset: inset,
+        circle: WhiskerMobileClipCircle(),
+        ellipse: WhiskerMobileClipEllipse()
     )
 }
 

--- a/tests/host-conformance/wpt/css/css-masking/clip-path-circle-002.json
+++ b/tests/host-conformance/wpt/css/css-masking/clip-path-circle-002.json
@@ -1,0 +1,64 @@
+{
+  "schema": 1,
+  "id": "wpt.css-masking.clip-path-circle-002",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-masking/clip-path/clip-path-circle-002.html",
+    "reference_path": "css/css-masking/clip-path/reference/clip-path-circle-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "A percentage circle basic shape is resolved against the border box and clips the element.",
+    "adaptation": "The 200px upstream circle is reduced to a 100px box and a red child crosses its left edge so samples also verify descendant clipping."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 140.0, "height": 140.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 140.0, 140.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [20.0, 20.0, 100.0, 100.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip_path": {
+              "reference_box": "border",
+              "shape": {
+                "kind": "circle",
+                "radius": { "length": 0.0, "fraction": 0.4 },
+                "center": [
+                  { "length": 0.0, "fraction": 0.5 },
+                  { "length": 0.0, "fraction": 0.5 }
+                ]
+              }
+            }
+          },
+          {
+            "id": 3,
+            "parent": 2,
+            "rect": [-10.0, 40.0, 40.0, 20.0],
+            "background": { "kind": "named", "value": "red" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.clip-path-circle",
+        "samples": [
+          { "point": [20.0, 70.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [35.0, 70.0], "color": { "kind": "named", "value": "red" }, "tolerance": 5 },
+          { "point": [70.0, 70.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [30.0, 30.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [70.0, 35.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-masking/clip-path-ellipse-002.json
+++ b/tests/host-conformance/wpt/css/css-masking/clip-path-ellipse-002.json
@@ -1,0 +1,67 @@
+{
+  "schema": 1,
+  "id": "wpt.css-masking.clip-path-ellipse-002",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-masking/clip-path/clip-path-ellipse-002.html",
+    "reference_path": "css/css-masking/clip-path/reference/clip-path-ellipse-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "Percentage ellipse radii and center coordinates resolve against the selected reference box.",
+    "adaptation": "The upstream box is reduced to 120x80 with an off-center ellipse, and a red child crosses its left edge to verify descendant clipping."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 160.0, "height": 120.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 160.0, 120.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [20.0, 20.0, 120.0, 80.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip_path": {
+              "reference_box": "border",
+              "shape": {
+                "kind": "ellipse",
+                "radii": [
+                  { "length": 0.0, "fraction": 0.4 },
+                  { "length": 0.0, "fraction": 0.35 }
+                ],
+                "center": [
+                  { "length": 0.0, "fraction": 0.6 },
+                  { "length": 0.0, "fraction": 0.5 }
+                ]
+              }
+            }
+          },
+          {
+            "id": 3,
+            "parent": 2,
+            "rect": [0.0, 30.0, 40.0, 20.0],
+            "background": { "kind": "named", "value": "red" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.clip-path-ellipse",
+        "samples": [
+          { "point": [35.0, 60.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [50.0, 60.0], "color": { "kind": "named", "value": "red" }, "tolerance": 5 },
+          { "point": [92.0, 60.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [45.0, 35.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [92.0, 35.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- add WPT-derived percentage circle and ellipse fixtures, including descendant clipping
- resolve CSS circle percentages against the normalized diagonal and ellipse radii against each axis
- extend Desktop/wgpu and Web/DOM clip projection
- extend the typed mobile ABI to 2.12 with circle and ellipse payloads
- add symmetric Android Path and iOS UIBezierPath projection

## Verification

- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`
- `cargo check -p whisker --target aarch64-apple-ios-sim`
- `cargo test -p whisker-driver mobile_abi_layouts_are_stable_on_64_bit_hosts`
- `cargo test -p whisker-host-conformance`