### PR TITLE
feat: render clip-path path commands across Hosts

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 12 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 13 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -37,7 +37,9 @@ enum {
 };
 enum { WHISKER_BACKGROUND_ATTACHMENT_SCROLL = 0 };
 enum { WHISKER_BACKGROUND_BLEND_NORMAL = 0 };
-enum { WHISKER_CLIP_SHAPE_INSET = 0, WHISKER_CLIP_SHAPE_CIRCLE = 1, WHISKER_CLIP_SHAPE_ELLIPSE = 2 };
+enum { WHISKER_CLIP_SHAPE_INSET = 0, WHISKER_CLIP_SHAPE_CIRCLE = 1, WHISKER_CLIP_SHAPE_ELLIPSE = 2, WHISKER_CLIP_SHAPE_PATH = 3 };
+enum { WHISKER_FILL_RULE_NON_ZERO = 0, WHISKER_FILL_RULE_EVEN_ODD = 1 };
+enum { WHISKER_PATH_MOVE_TO = 0, WHISKER_PATH_LINE_TO = 1, WHISKER_PATH_QUADRATIC_TO = 2, WHISKER_PATH_CUBIC_TO = 3, WHISKER_PATH_CLOSE = 4 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -95,6 +97,15 @@ typedef struct {
 typedef struct {
   WhiskerMobileLengthPercentage radius_x, radius_y, center_x, center_y;
 } WhiskerMobileClipEllipse;
+typedef struct {
+  uint32_t kind, _reserved;
+  WhiskerMobileLengthPercentage points[6];
+} WhiskerMobilePathCommand;
+typedef struct {
+  uint32_t fill_rule, _reserved;
+  const WhiskerMobilePathCommand *commands;
+  size_t command_count;
+} WhiskerMobileClipPathCommands;
 typedef struct {
   uint32_t reference_box, shape_kind;
   const void *payload;
@@ -168,6 +179,8 @@ _Static_assert(sizeof(WhiskerMobileBoxShadow) == 56, "WhiskerMobileBoxShadow ABI
 _Static_assert(sizeof(WhiskerMobileClipInset) == 96, "WhiskerMobileClipInset ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipCircle) == 24, "WhiskerMobileClipCircle ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipEllipse) == 32, "WhiskerMobileClipEllipse ABI drift");
+_Static_assert(sizeof(WhiskerMobilePathCommand) == 56, "WhiskerMobilePathCommand ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipPathCommands) == 24, "WhiskerMobileClipPathCommands ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipPath) == 24, "WhiskerMobileClipPath ABI drift");
 
 typedef struct {

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -288,25 +288,48 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 if (clip->payload == NULL || clip->payload_count != 1) {
                     ok = false; break;
                 }
-                storage[count++] = (float)clip->reference_box;
-                storage[count++] = (float)clip->shape_kind;
+                float *clip_values = storage;
+                size_t clip_capacity = 64;
+                const WhiskerMobileClipPathCommands *path = NULL;
+                if (clip->shape_kind == WHISKER_CLIP_SHAPE_PATH) {
+                    path = clip->payload;
+                    if (path->commands == NULL || path->command_count == 0 || path->command_count > 4096 ||
+                        path->command_count > (SIZE_MAX - 4) / 13) { ok = false; break; }
+                    clip_capacity = 4 + path->command_count * 13;
+                    clip_values = malloc(clip_capacity * sizeof(float));
+                    if (clip_values == NULL) { ok = false; break; }
+                }
+                clip_values[count++] = (float)clip->reference_box;
+                clip_values[count++] = (float)clip->shape_kind;
                 if (clip->shape_kind == WHISKER_CLIP_SHAPE_INSET) {
                     const WhiskerMobileClipInset* inset = clip->payload;
-                    for (int j=0;j<4;++j) { storage[count++]=inset->edges[j].length; storage[count++]=inset->edges[j].fraction; }
-                    for (int j=0;j<4;++j) { storage[count++]=inset->radii_horizontal[j].length; storage[count++]=inset->radii_horizontal[j].fraction; }
-                    for (int j=0;j<4;++j) { storage[count++]=inset->radii_vertical[j].length; storage[count++]=inset->radii_vertical[j].fraction; }
+                    for (int j=0;j<4;++j) { clip_values[count++]=inset->edges[j].length; clip_values[count++]=inset->edges[j].fraction; }
+                    for (int j=0;j<4;++j) { clip_values[count++]=inset->radii_horizontal[j].length; clip_values[count++]=inset->radii_horizontal[j].fraction; }
+                    for (int j=0;j<4;++j) { clip_values[count++]=inset->radii_vertical[j].length; clip_values[count++]=inset->radii_vertical[j].fraction; }
                 } else if (clip->shape_kind == WHISKER_CLIP_SHAPE_CIRCLE) {
                     const WhiskerMobileClipCircle* circle = clip->payload;
                     const WhiskerMobileLengthPercentage values[] = {circle->radius, circle->center_x, circle->center_y};
-                    for (int j=0;j<3;++j) { storage[count++]=values[j].length; storage[count++]=values[j].fraction; }
+                    for (int j=0;j<3;++j) { clip_values[count++]=values[j].length; clip_values[count++]=values[j].fraction; }
                 } else if (clip->shape_kind == WHISKER_CLIP_SHAPE_ELLIPSE) {
                     const WhiskerMobileClipEllipse* ellipse = clip->payload;
                     const WhiskerMobileLengthPercentage values[] = {ellipse->radius_x, ellipse->radius_y, ellipse->center_x, ellipse->center_y};
-                    for (int j=0;j<4;++j) { storage[count++]=values[j].length; storage[count++]=values[j].fraction; }
+                    for (int j=0;j<4;++j) { clip_values[count++]=values[j].length; clip_values[count++]=values[j].fraction; }
+                } else if (clip->shape_kind == WHISKER_CLIP_SHAPE_PATH) {
+                    clip_values[count++] = (float)path->fill_rule;
+                    clip_values[count++] = (float)path->command_count;
+                    for (size_t command_index = 0; command_index < path->command_count; ++command_index) {
+                        const WhiskerMobilePathCommand *command = &path->commands[command_index];
+                        clip_values[count++] = (float)command->kind;
+                        for (int j=0;j<6;++j) {
+                            clip_values[count++]=command->points[j].length;
+                            clip_values[count++]=command->points[j].fraction;
+                        }
+                    }
                 } else {
                     ok = false; break;
                 }
-                numbers = floats(env, storage, count);
+                numbers = floats(env, clip_values, count);
+                if (clip_values != storage) free(clip_values);
                 break;
             }
             case WHISKER_OP_BACKGROUND_LAYERS: {

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 12;
+pub const MOBILE_ABI_MINOR: u16 = 13;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -76,6 +76,14 @@ pub const BACKGROUND_BLEND_NORMAL: u32 = 0;
 pub const CLIP_SHAPE_INSET: u32 = 0;
 pub const CLIP_SHAPE_CIRCLE: u32 = 1;
 pub const CLIP_SHAPE_ELLIPSE: u32 = 2;
+pub const CLIP_SHAPE_PATH: u32 = 3;
+pub const FILL_RULE_NON_ZERO: u32 = 0;
+pub const FILL_RULE_EVEN_ODD: u32 = 1;
+pub const PATH_MOVE_TO: u32 = 0;
+pub const PATH_LINE_TO: u32 = 1;
+pub const PATH_QUADRATIC_TO: u32 = 2;
+pub const PATH_CUBIC_TO: u32 = 3;
+pub const PATH_CLOSE: u32 = 4;
 
 pub const MEASURE_TEXT: u32 = 1;
 pub const MEASURE_REPLACED_CONTENT: u32 = 2;
@@ -194,6 +202,25 @@ pub struct MobileClipEllipse {
     pub radius_y: MobileLengthPercentage,
     pub center_x: MobileLengthPercentage,
     pub center_y: MobileLengthPercentage,
+}
+
+/// One fixed-width absolute path command. Point slots are x/y pairs: one for
+/// move/line, two for quadratic, and three for cubic commands.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct MobilePathCommand {
+    pub kind: u32,
+    pub _reserved: u32,
+    pub points: [MobileLengthPercentage; 6],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MobileClipPathCommands {
+    pub fill_rule: u32,
+    pub _reserved: u32,
+    pub commands: *const MobilePathCommand,
+    pub command_count: usize,
 }
 
 /// One typed clip path. `payload` points to the shape selected by `shape_kind`.
@@ -625,6 +652,8 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileClipInset>(), 96);
             assert_eq!(std::mem::size_of::<MobileClipCircle>(), 24);
             assert_eq!(std::mem::size_of::<MobileClipEllipse>(), 32);
+            assert_eq!(std::mem::size_of::<MobilePathCommand>(), 56);
+            assert_eq!(std::mem::size_of::<MobileClipPathCommands>(), 24);
             assert_eq!(std::mem::size_of::<MobileClipPath>(), 24);
             assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
             assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 48);

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -442,6 +442,59 @@ pub enum ClipShapeFixture {
         /// Center x/y coordinates.
         center: [LengthPercentageFixture; 2],
     },
+    /// Arbitrary path with an explicit winding rule.
+    Path {
+        /// Rule used to determine the filled region.
+        #[serde(default)]
+        fill_rule: FillRuleFixture,
+        /// Normalized absolute path command stream.
+        commands: Vec<PathCommandFixture>,
+    },
+}
+
+/// Fill rule used by path fixtures.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FillRuleFixture {
+    /// Non-zero winding rule.
+    #[default]
+    NonZero,
+    /// Even-odd rule.
+    EvenOdd,
+}
+
+/// One absolute command in a path fixture.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(tag = "command", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PathCommandFixture {
+    /// Move the current point.
+    MoveTo {
+        /// Destination point.
+        point: [LengthPercentageFixture; 2],
+    },
+    /// Add a straight line.
+    LineTo {
+        /// Destination point.
+        point: [LengthPercentageFixture; 2],
+    },
+    /// Add a quadratic Bezier segment.
+    QuadraticTo {
+        /// Control point.
+        control: [LengthPercentageFixture; 2],
+        /// End point.
+        end: [LengthPercentageFixture; 2],
+    },
+    /// Add a cubic Bezier segment.
+    CubicTo {
+        /// First control point.
+        control_1: [LengthPercentageFixture; 2],
+        /// Second control point.
+        control_2: [LengthPercentageFixture; 2],
+        /// End point.
+        end: [LengthPercentageFixture; 2],
+    },
+    /// Close the current subpath.
+    Close,
 }
 
 /// CSS geometry boxes accepted as clip-path reference boxes.
@@ -680,6 +733,7 @@ pub struct LengthPercentageFixture {
     /// Absolute logical-pixel component.
     pub length: f32,
     /// Fractional component where `1` is 100 percent.
+    #[serde(default)]
     pub fraction: f32,
 }
 
@@ -1314,6 +1368,10 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                             radii.iter().all(LengthPercentageFixture::is_non_negative)
                                 && center.iter().all(LengthPercentageFixture::is_finite)
                         }
+                        ClipShapeFixture::Path { commands, .. } => {
+                            !commands.is_empty()
+                                && commands.iter().all(PathCommandFixture::is_valid)
+                        }
                     })
                 && node
                     .transform
@@ -1375,6 +1433,24 @@ impl LengthPercentageFixture {
 
     fn is_non_negative(&self) -> bool {
         self.is_finite() && self.length >= 0.0 && self.fraction >= 0.0
+    }
+}
+
+impl PathCommandFixture {
+    fn is_valid(&self) -> bool {
+        let point = |value: &[LengthPercentageFixture; 2]| {
+            value.iter().all(LengthPercentageFixture::is_finite)
+        };
+        match self {
+            Self::MoveTo { point: value } | Self::LineTo { point: value } => point(value),
+            Self::QuadraticTo { control, end } => point(control) && point(end),
+            Self::CubicTo {
+                control_1,
+                control_2,
+                end,
+            } => point(control_1) && point(control_2) && point(end),
+            Self::Close => true,
+        }
     }
 }
 

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -8,13 +8,14 @@ use whisker_driver::module::{
 };
 use whisker_engine::whisker_protocol::{
     ApplyResult, AvailableSpace, BackgroundAttachment, BackgroundSize, BlendMode, BorderLineStyle,
-    ChildPolicy, ClipShape, ElementMeasurement, ElementRegistration, ElementValueKind, FrameMode,
-    FramePacket, ImageRepeat, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+    ChildPolicy, ClipShape, ElementMeasurement, ElementRegistration, ElementValueKind, FillRule,
+    FrameMode, FramePacket, ImageRepeat, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
     MeasureTextWrap, MeasuredSize, MeasurementMetrics, MeasurementPayload, MeasurementRequest,
     MeasurementRequestId, MeasurementResponse, NodeId, Operation, PaintBox, PaintColor, PaintImage,
-    PaintLengthPercentage, PreparedContentId, RadialGradientExtent, RadialGradientShape,
-    ResourceCommand, ResourceDimensions, ResourceEvent, ResourceFailureCode, ResourceId,
-    ResourceKind, ResourceSource, SurfaceId, UnsupportedMeasurementReason, VisualEffects,
+    PaintLengthPercentage, PaintPosition, PathCommand, PreparedContentId, RadialGradientExtent,
+    RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent, ResourceFailureCode,
+    ResourceId, ResourceKind, ResourceSource, SurfaceId, UnsupportedMeasurementReason,
+    VisualEffects,
 };
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{FrameSink, LayoutOptions, MeasurementProvider};
@@ -912,6 +913,8 @@ struct MobileFrameOwned {
     _clip_insets: Vec<Box<MobileClipInset>>,
     _clip_circles: Vec<Box<MobileClipCircle>>,
     _clip_ellipses: Vec<Box<MobileClipEllipse>>,
+    _path_commands: Vec<Box<[MobilePathCommand]>>,
+    _clip_path_commands: Vec<Box<MobileClipPathCommands>>,
     _clip_paths: Vec<Box<MobileClipPath>>,
     _gradient_stops: Vec<Box<[MobileGradientStop]>>,
     _radial_gradients: Vec<Box<MobileRadialGradient>>,
@@ -951,6 +954,8 @@ impl MobileFrameOwned {
         let mut clip_insets = Vec::<Box<MobileClipInset>>::new();
         let mut clip_circles = Vec::<Box<MobileClipCircle>>::new();
         let mut clip_ellipses = Vec::<Box<MobileClipEllipse>>::new();
+        let mut path_commands = Vec::<Box<[MobilePathCommand]>>::new();
+        let mut clip_path_commands = Vec::<Box<MobileClipPathCommands>>::new();
         let mut clip_paths = Vec::<Box<MobileClipPath>>::new();
         let mut gradient_stops = Vec::<Box<[MobileGradientStop]>>::new();
         let mut radial_gradients = Vec::<Box<MobileRadialGradient>>::new();
@@ -1272,6 +1277,33 @@ impl MobileFrameOwned {
                                         as *const c_void,
                                 )
                             }
+                            ClipShape::Path {
+                                fill_rule,
+                                commands,
+                            } => {
+                                path_commands.push(
+                                    commands
+                                        .iter()
+                                        .map(mobile_path_command)
+                                        .collect::<Vec<_>>()
+                                        .into_boxed_slice(),
+                                );
+                                let commands = path_commands.last().unwrap();
+                                clip_path_commands.push(Box::new(MobileClipPathCommands {
+                                    fill_rule: match fill_rule {
+                                        FillRule::NonZero => FILL_RULE_NON_ZERO,
+                                        FillRule::EvenOdd => FILL_RULE_EVEN_ODD,
+                                    },
+                                    _reserved: 0,
+                                    commands: commands.as_ptr(),
+                                    command_count: commands.len(),
+                                }));
+                                (
+                                    CLIP_SHAPE_PATH,
+                                    clip_path_commands.last().unwrap().as_ref() as *const _
+                                        as *const c_void,
+                                )
+                            }
                             _ => return Err(MobileFrameError),
                         };
                         clip_paths.push(Box::new(MobileClipPath {
@@ -1438,6 +1470,8 @@ impl MobileFrameOwned {
             _clip_insets: clip_insets,
             _clip_circles: clip_circles,
             _clip_ellipses: clip_ellipses,
+            _path_commands: path_commands,
+            _clip_path_commands: clip_path_commands,
             _clip_paths: clip_paths,
             _gradient_stops: gradient_stops,
             _radial_gradients: radial_gradients,
@@ -1474,6 +1508,46 @@ fn mobile_length(value: PaintLengthPercentage) -> MobileLengthPercentage {
         length: value.length,
         fraction: value.fraction,
     }
+}
+
+fn mobile_path_point(
+    points: &mut [MobileLengthPercentage; 6],
+    offset: usize,
+    value: PaintPosition,
+) {
+    points[offset] = mobile_coordinate(value.x);
+    points[offset + 1] = mobile_coordinate(value.y);
+}
+
+fn mobile_path_command(value: &PathCommand) -> MobilePathCommand {
+    let mut result = MobilePathCommand::default();
+    match value {
+        PathCommand::MoveTo(point) => {
+            result.kind = PATH_MOVE_TO;
+            mobile_path_point(&mut result.points, 0, *point);
+        }
+        PathCommand::LineTo(point) => {
+            result.kind = PATH_LINE_TO;
+            mobile_path_point(&mut result.points, 0, *point);
+        }
+        PathCommand::QuadraticTo { control, end } => {
+            result.kind = PATH_QUADRATIC_TO;
+            mobile_path_point(&mut result.points, 0, *control);
+            mobile_path_point(&mut result.points, 2, *end);
+        }
+        PathCommand::CubicTo {
+            control_1,
+            control_2,
+            end,
+        } => {
+            result.kind = PATH_CUBIC_TO;
+            mobile_path_point(&mut result.points, 0, *control_1);
+            mobile_path_point(&mut result.points, 2, *control_2);
+            mobile_path_point(&mut result.points, 4, *end);
+        }
+        PathCommand::Close => result.kind = PATH_CLOSE,
+    }
+    result
 }
 
 fn mobile_background_repeat(value: ImageRepeat) -> u32 {
@@ -2026,6 +2100,73 @@ mod tests {
         assert_eq!(inset.edges[0].fraction, 0.1);
         assert_eq!(inset.radii_horizontal[0].length, 4.0);
         assert_eq!(inset.radii_vertical[0].fraction, 0.2);
+    }
+
+    #[test]
+    fn mobile_frame_exposes_path_commands_and_fill_rule_as_typed_payload() {
+        let position = |x, y| PaintPosition {
+            x: PaintCoordinate {
+                length: x,
+                fraction: 0.0,
+            },
+            y: PaintCoordinate {
+                length: y,
+                fraction: 0.0,
+            },
+        };
+        let packet = FramePacket {
+            header: FrameHeader {
+                version: ProtocolVersion::CURRENT,
+                surface: SurfaceId::new(1).unwrap(),
+                scene_epoch: 1,
+                frame_id: 1,
+                base_revision: 0,
+                target_revision: 1,
+                viewport_epoch: 1,
+                mode: FrameMode::Snapshot,
+            },
+            operations: vec![Operation::SetVisualEffects {
+                node: NodeId::new(1).unwrap(),
+                effects: VisualEffects {
+                    clip_path: Some((
+                        PaintBox::Border,
+                        ClipShape::Path {
+                            fill_rule: FillRule::EvenOdd,
+                            commands: vec![
+                                PathCommand::MoveTo(position(1.0, 2.0)),
+                                PathCommand::QuadraticTo {
+                                    control: position(3.0, 4.0),
+                                    end: position(5.0, 6.0),
+                                },
+                                PathCommand::CubicTo {
+                                    control_1: position(7.0, 8.0),
+                                    control_2: position(9.0, 10.0),
+                                    end: position(11.0, 12.0),
+                                },
+                                PathCommand::Close,
+                            ],
+                        },
+                    )),
+                    ..Default::default()
+                },
+            }],
+        };
+
+        let frame = MobileFrameOwned::new(&packet).unwrap();
+        let operation = &frame._operations[1];
+        let clip = unsafe { &*operation.payload.cast::<MobileClipPath>() };
+        assert_eq!(clip.shape_kind, CLIP_SHAPE_PATH);
+        let path = unsafe { &*clip.payload.cast::<MobileClipPathCommands>() };
+        assert_eq!(path.fill_rule, FILL_RULE_EVEN_ODD);
+        let commands = unsafe { std::slice::from_raw_parts(path.commands, path.command_count) };
+        assert_eq!(commands.len(), 4);
+        assert_eq!(commands[0].kind, PATH_MOVE_TO);
+        assert_eq!(commands[0].points[0].length, 1.0);
+        assert_eq!(commands[1].kind, PATH_QUADRATIC_TO);
+        assert_eq!(commands[1].points[2].length, 5.0);
+        assert_eq!(commands[2].kind, PATH_CUBIC_TO);
+        assert_eq!(commands[2].points[5].length, 12.0);
+        assert_eq!(commands[3].kind, PATH_CLOSE);
     }
 
     #[test]

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/ClipPath.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/ClipPath.kt
@@ -30,6 +30,17 @@ internal data class HostEllipseClipPath(
     val centerY: HostPaintCoordinate,
 ) : HostClipPath
 
+internal data class HostPathCommand(
+    val kind: Int,
+    val points: List<HostPaintCoordinate>,
+)
+
+internal data class HostPathClipPath(
+    override val referenceBox: HostClipReferenceBox,
+    val evenOdd: Boolean,
+    val commands: List<HostPathCommand>,
+) : HostClipPath
+
 internal fun resolveClipPath(
     clip: HostClipPath,
     width: Float,
@@ -46,6 +57,33 @@ internal fun resolveClipPath(
             height - borderWidths[2].coerceIn(0f, height),
         )
         HostClipReferenceBox.Content -> RectF(contentBox)
+    }
+    if (clip is HostPathClipPath) {
+        fun point(command: HostPathCommand, offset: Int) = android.graphics.PointF(
+            reference.left + command.points[offset].resolve(reference.width()),
+            reference.top + command.points[offset + 1].resolve(reference.height()),
+        )
+        return Path().apply {
+            fillType = if (clip.evenOdd) Path.FillType.EVEN_ODD else Path.FillType.WINDING
+            clip.commands.forEach { command ->
+                when (command.kind) {
+                    PATH_MOVE_TO -> point(command, 0).also { moveTo(it.x, it.y) }
+                    PATH_LINE_TO -> point(command, 0).also { lineTo(it.x, it.y) }
+                    PATH_QUADRATIC_TO -> {
+                        val control = point(command, 0)
+                        val end = point(command, 2)
+                        quadTo(control.x, control.y, end.x, end.y)
+                    }
+                    PATH_CUBIC_TO -> {
+                        val control1 = point(command, 0)
+                        val control2 = point(command, 2)
+                        val end = point(command, 4)
+                        cubicTo(control1.x, control1.y, control2.x, control2.y, end.x, end.y)
+                    }
+                    PATH_CLOSE -> close()
+                }
+            }
+        }
     }
     if (clip is HostCircleClipPath) {
         val centerX = reference.left + clip.centerX.resolve(reference.width())
@@ -91,3 +129,9 @@ internal fun resolveClipPath(
     )
     return Path().apply { addRoundRect(inset, radii, Path.Direction.CW) }
 }
+
+internal const val PATH_MOVE_TO = 0
+internal const val PATH_LINE_TO = 1
+internal const val PATH_QUADRATIC_TO = 2
+internal const val PATH_CUBIC_TO = 3
+internal const val PATH_CLOSE = 4

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -24,6 +24,8 @@ import rs.whisker.runtime.paint.HostClipReferenceBox
 import rs.whisker.runtime.paint.HostCircleClipPath
 import rs.whisker.runtime.paint.HostEllipseClipPath
 import rs.whisker.runtime.paint.HostInsetClipPath
+import rs.whisker.runtime.paint.HostPathClipPath
+import rs.whisker.runtime.paint.HostPathCommand
 import rs.whisker.runtime.paint.HostLinearGradient
 import rs.whisker.runtime.paint.HostPaintCoordinate
 import rs.whisker.runtime.paint.HostRadialGradient
@@ -445,6 +447,22 @@ internal class HostScene(
                     referenceBox, coordinate(values, 2, density), coordinate(values, 4, density),
                     coordinate(values, 6, density), coordinate(values, 8, density),
                 )
+                CLIP_SHAPE_PATH -> {
+                    val commandCount = values[3].toInt()
+                    HostPathClipPath(
+                        referenceBox = referenceBox,
+                        evenOdd = values[2].toInt() == FILL_RULE_EVEN_ODD,
+                        commands = (0 until commandCount).map { commandIndex ->
+                            val offset = CLIP_PATH_HEADER_SIZE + commandIndex * PATH_COMMAND_PACKED_SIZE
+                            HostPathCommand(
+                                kind = values[offset].toInt(),
+                                points = (0 until 6).map { pointIndex ->
+                                    coordinate(values, offset + 1 + pointIndex * 2, density)
+                                },
+                            )
+                        },
+                    )
+                }
                 else -> HostInsetClipPath(
                     referenceBox = referenceBox,
                     edges = coordinates(2),
@@ -493,6 +511,13 @@ internal class HostScene(
             CLIP_SHAPE_INSET -> CLIP_PATH_INSET_PACKED_SIZE
             CLIP_SHAPE_CIRCLE -> CLIP_PATH_CIRCLE_PACKED_SIZE
             CLIP_SHAPE_ELLIPSE -> CLIP_PATH_ELLIPSE_PACKED_SIZE
+            CLIP_SHAPE_PATH -> {
+                val commandCount = values.getOrNull(3)?.toInt() ?: return false
+                if (commandCount <= 0 || commandCount > MAX_PATH_COMMANDS ||
+                    values[3] != commandCount.toFloat()
+                ) return false
+                CLIP_PATH_HEADER_SIZE + commandCount * PATH_COMMAND_PACKED_SIZE
+            }
             else -> return false
         }
         return values.size == expectedSize &&
@@ -503,7 +528,15 @@ internal class HostScene(
             when (shape) {
                 CLIP_SHAPE_INSET -> (10 until expectedSize).all { values[it] >= 0f }
                 CLIP_SHAPE_CIRCLE -> values[2] >= 0f && values[3] >= 0f
-                else -> values[2] >= 0f && values[3] >= 0f && values[4] >= 0f && values[5] >= 0f
+                CLIP_SHAPE_ELLIPSE -> values[2] >= 0f && values[3] >= 0f && values[4] >= 0f && values[5] >= 0f
+                else -> {
+                    values[2].toInt() in FILL_RULE_NON_ZERO..FILL_RULE_EVEN_ODD &&
+                        values[2] == values[2].toInt().toFloat() &&
+                        (CLIP_PATH_HEADER_SIZE until expectedSize step PATH_COMMAND_PACKED_SIZE).all { offset ->
+                            values[offset].toInt() in PATH_MOVE_TO..PATH_CLOSE &&
+                                values[offset] == values[offset].toInt().toFloat()
+                        }
+                }
             }
     }
 
@@ -809,9 +842,17 @@ internal class HostScene(
         const val CLIP_PATH_INSET_PACKED_SIZE = 26
         const val CLIP_PATH_CIRCLE_PACKED_SIZE = 8
         const val CLIP_PATH_ELLIPSE_PACKED_SIZE = 10
+        const val CLIP_PATH_HEADER_SIZE = 4
+        const val PATH_COMMAND_PACKED_SIZE = 13
+        const val MAX_PATH_COMMANDS = 4096
         const val CLIP_SHAPE_INSET = 0
         const val CLIP_SHAPE_CIRCLE = 1
         const val CLIP_SHAPE_ELLIPSE = 2
+        const val CLIP_SHAPE_PATH = 3
+        const val FILL_RULE_NON_ZERO = 0
+        const val FILL_RULE_EVEN_ODD = 1
+        const val PATH_MOVE_TO = 0
+        const val PATH_CLOSE = 4
         const val BACKGROUND_GRADIENT_STOP_PACKED_SIZE = 7
         const val BACKGROUND_PACKED_LAYER_HEADER_SIZE = 3
         const val BACKGROUND_PACKED_LAYERS = 256

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -43,6 +43,11 @@ struct ShapeClipRecord {
     radii_y: vec4<f32>,
     inverse_transform: mat4x4<f32>,
     axes: vec4<u32>,
+    path: vec4<u32>,
+};
+
+struct ShapeClipSegment {
+    from_to: vec4<f32>,
 };
 
 struct ShapeClipSpan {
@@ -78,6 +83,9 @@ var<storage, read> linear_gradient_draws: array<LinearGradientDraw>;
 
 @group(1) @binding(3)
 var<storage, read> linear_gradient_stops: array<LinearGradientStop>;
+
+@group(1) @binding(4)
+var<storage, read> shape_clip_segments: array<ShapeClipSegment>;
 
 @group(2) @binding(0)
 var background_image_texture: texture_2d<f32>;
@@ -230,6 +238,33 @@ fn erf_approx(value: f32) -> f32 {
 fn shape_coverage(distance: f32) -> f32 {
     let smoothing = max(fwidth(distance), 0.0001);
     return clamp(0.5 - distance / smoothing, 0.0, 1.0);
+}
+
+fn path_contains(position: vec2<f32>, offset: u32, count: u32, even_odd: bool) -> bool {
+    var winding = 0i;
+    var parity = false;
+    for (var index = 0u; index < count; index++) {
+        let segment = shape_clip_segments[offset + index].from_to;
+        let start_point = segment.xy;
+        let end_point = segment.zw;
+        let crosses = (start_point.y <= position.y && end_point.y > position.y)
+            || (start_point.y > position.y && end_point.y <= position.y);
+        if crosses {
+            let intersection = start_point.x
+                + (position.y - start_point.y) * (end_point.x - start_point.x)
+                    / (end_point.y - start_point.y);
+            if intersection > position.x {
+                if even_odd {
+                    parity = !parity;
+                } else if end_point.y > start_point.y {
+                    winding += 1;
+                } else {
+                    winding -= 1;
+                }
+            }
+        }
+    }
+    return select(winding != 0, parity, even_odd);
 }
 
 fn border_side(position: vec2<f32>, rect: vec4<f32>, widths: vec4<f32>) -> vec2<f32> {
@@ -493,6 +528,14 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         let clip = shape_clip_records[span.offset + index];
         let local_h = clip.inverse_transform * vec4<f32>(world_position, 0.0, 1.0);
         let local = local_h.xy / local_h.w;
+        if clip.path.z != 0u {
+            clip_coverage *= select(
+                0.0,
+                1.0,
+                path_contains(local, clip.path.x, clip.path.y, clip.path.w != 0u),
+            );
+            continue;
+        }
         var distance = -1e20;
         if clip.axes.x != 0u && clip.axes.y != 0u {
             distance = rounded_rect_distance(local, clip.rect, clip.radii_x, clip.radii_y);
@@ -718,6 +761,13 @@ struct ShapeClipRecordGpu {
     radii_y: [f32; 4],
     inverse_transform: [f32; 16],
     axes: [u32; 4],
+    path: [u32; 4],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct ShapeClipSegmentGpu {
+    from_to: [f32; 4],
 }
 
 #[repr(C)]
@@ -880,6 +930,16 @@ impl BoxGpuPipeline {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 4,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: true },
@@ -1066,18 +1126,40 @@ impl BoxGpuPipeline {
 
     fn shape_clip_bind_group(&self, device: &Device, draws: &[DrawCommand]) -> wgpu::BindGroup {
         let mut records = Vec::new();
+        let mut path_segments = Vec::new();
         let spans = draws
             .iter()
             .map(|draw| {
                 let offset = records.len() as u32;
                 if let DrawCommand::Quads { shape_clips, .. } = draw {
-                    records.extend(shape_clips.iter().map(|clip| ShapeClipRecordGpu {
-                        rect: [clip.rect.x, clip.rect.y, clip.rect.width, clip.rect.height],
-                        radii_x: clip.radii.horizontal,
-                        radii_y: clip.radii.vertical,
-                        inverse_transform: clip.inverse_transform.0,
-                        axes: [u32::from(clip.horizontal), u32::from(clip.vertical), 0, 0],
-                    }));
+                    for clip in shape_clips.iter() {
+                        let path_offset = path_segments.len() as u32;
+                        if let Some(segments) = &clip.path {
+                            path_segments.extend(segments.iter().map(|segment| {
+                                ShapeClipSegmentGpu {
+                                    from_to: [
+                                        segment.from[0],
+                                        segment.from[1],
+                                        segment.to[0],
+                                        segment.to[1],
+                                    ],
+                                }
+                            }));
+                        }
+                        records.push(ShapeClipRecordGpu {
+                            rect: [clip.rect.x, clip.rect.y, clip.rect.width, clip.rect.height],
+                            radii_x: clip.radii.horizontal,
+                            radii_y: clip.radii.vertical,
+                            inverse_transform: clip.inverse_transform.0,
+                            axes: [u32::from(clip.horizontal), u32::from(clip.vertical), 0, 0],
+                            path: [
+                                path_offset,
+                                path_segments.len() as u32 - path_offset,
+                                u32::from(clip.path.is_some()),
+                                u32::from(clip.fill_rule == whisker_protocol::FillRule::EvenOdd),
+                            ],
+                        });
+                    }
                 }
                 ShapeClipSpanGpu {
                     offset,
@@ -1088,6 +1170,9 @@ impl BoxGpuPipeline {
             .collect::<Vec<_>>();
         if records.is_empty() {
             records.push(ShapeClipRecordGpu::zeroed());
+        }
+        if path_segments.is_empty() {
+            path_segments.push(ShapeClipSegmentGpu::zeroed());
         }
         let spans = if spans.is_empty() {
             vec![ShapeClipSpanGpu::zeroed()]
@@ -1143,6 +1228,11 @@ impl BoxGpuPipeline {
             contents: bytemuck::cast_slice(&gradient_stops),
             usage: BufferUsages::STORAGE,
         });
+        let path_segment_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("whisker Desktop shape clip path segments"),
+            contents: bytemuck::cast_slice(&path_segments),
+            usage: BufferUsages::STORAGE,
+        });
         device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("whisker Desktop shape clips"),
             layout: &self.shape_clip_layout,
@@ -1162,6 +1252,10 @@ impl BoxGpuPipeline {
                 wgpu::BindGroupEntry {
                     binding: 3,
                     resource: gradient_stop_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: path_segment_buffer.as_entire_binding(),
                 },
             ],
         })

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -6,10 +6,11 @@ use std::sync::Arc;
 use whisker_engine::FrameSink;
 use whisker_protocol::{
     ApplyResult, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BoxClip,
-    BoxPaint, ClipShape, ElementTypeId, FrameMode, FramePacket, ImageRepeat, LayoutGeometry,
-    LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate, PaintImage,
-    RadialGradientExtent, ResourceId, SceneProjection, SurfaceId, TextContent, Transform,
-    ValidationError, Visibility, VisualEffects, WhiskerValue,
+    BoxPaint, ClipShape, ElementTypeId, FillRule, FrameMode, FramePacket, ImageRepeat,
+    LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
+    PaintCoordinate, PaintImage, PaintPosition, PathCommand, RadialGradientExtent, ResourceId,
+    SceneProjection, SurfaceId, TextContent, Transform, ValidationError, Visibility, VisualEffects,
+    WhiskerValue,
 };
 
 use crate::element::{DesktopElementContent, DesktopElementError, DesktopElementRegistry};
@@ -101,12 +102,20 @@ impl LogicalClip {
 }
 
 #[derive(Clone, Copy, Debug)]
+pub(crate) struct PathSegment {
+    pub(crate) from: [f32; 2],
+    pub(crate) to: [f32; 2],
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct ShapeClip {
     pub(crate) rect: LayoutRect,
     pub(crate) radii: ResolvedRadii,
     pub(crate) inverse_transform: Transform,
     pub(crate) horizontal: bool,
     pub(crate) vertical: bool,
+    pub(crate) path: Option<Arc<[PathSegment]>>,
+    pub(crate) fill_rule: FillRule,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -128,7 +137,7 @@ impl ShapeClipStack {
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = ShapeClip> + '_ {
         std::iter::successors(self.0.as_deref(), |node| node.parent.0.as_deref())
-            .map(|node| node.clip)
+            .map(|node| node.clip.clone())
     }
 }
 
@@ -374,13 +383,15 @@ impl DesktopScene {
                 PaintBox::Content => content,
                 _ => unreachable!("unsupported clip-path reference box passed validation"),
             };
-            let (clip_rect, clip_radii) = clip_shape_geometry(reference, shape);
+            let (clip_rect, clip_radii, path, fill_rule) = clip_shape_geometry(reference, shape);
             node_shape_clips = node_shape_clips.push(ShapeClip {
                 rect: clip_rect,
                 radii: clip_radii,
                 inverse_transform: inverse_transform(transform).unwrap_or(Transform::IDENTITY),
                 horizontal: true,
                 vertical: true,
+                path,
+                fill_rule,
             });
             node_clip_bounds = transform_rect_aabb(clip_rect, transform);
         }
@@ -431,6 +442,8 @@ impl DesktopScene {
                 inverse_transform: inverse_transform(transform).unwrap_or(Transform::IDENTITY),
                 horizontal: clip_horizontal,
                 vertical: clip_vertical,
+                path: None,
+                fill_rule: FillRule::NonZero,
             });
             if let Some(bounds) = transform_rect_aabb(geometry.inner_rect, transform) {
                 let axis_aligned = preserves_screen_axes(transform);
@@ -985,17 +998,32 @@ fn supports_visual_effects(effects: &VisualEffects) -> bool {
                 PaintBox::Border | PaintBox::Padding | PaintBox::Content
             ) && matches!(
                 shape,
-                ClipShape::Inset { .. } | ClipShape::Circle { .. } | ClipShape::Ellipse { .. }
+                ClipShape::Inset { .. }
+                    | ClipShape::Circle { .. }
+                    | ClipShape::Ellipse { .. }
+                    | ClipShape::Path { .. }
             )
         })
 }
 
-fn clip_shape_geometry(reference: LayoutRect, shape: &ClipShape) -> (LayoutRect, ResolvedRadii) {
+fn clip_shape_geometry(
+    reference: LayoutRect,
+    shape: &ClipShape,
+) -> (
+    LayoutRect,
+    ResolvedRadii,
+    Option<Arc<[PathSegment]>>,
+    FillRule,
+) {
+    let zero_radii = || ResolvedRadii {
+        horizontal: [0.0; 4],
+        vertical: [0.0; 4],
+    };
     match shape {
         ClipShape::Inset { edges, radii } => {
             let rect = inset_clip_rect(reference, edges);
             let radii = resolve_radii(radii, rect);
-            (rect, radii)
+            (rect, radii, None, FillRule::NonZero)
         }
         ClipShape::Circle { radius, center } => {
             let center_x = reference.x + resolve_coordinate(center.x, reference.width);
@@ -1014,6 +1042,8 @@ fn clip_shape_geometry(reference: LayoutRect, shape: &ClipShape) -> (LayoutRect,
                     horizontal: [radius; 4],
                     vertical: [radius; 4],
                 },
+                None,
+                FillRule::NonZero,
             )
         }
         ClipShape::Ellipse {
@@ -1036,10 +1066,140 @@ fn clip_shape_geometry(reference: LayoutRect, shape: &ClipShape) -> (LayoutRect,
                     horizontal: [radius_x; 4],
                     vertical: [radius_y; 4],
                 },
+                None,
+                FillRule::NonZero,
             )
+        }
+        ClipShape::Path {
+            fill_rule,
+            commands,
+        } => {
+            let segments = flatten_path(reference, commands);
+            let bounds = path_bounds(&segments).unwrap_or(reference);
+            (bounds, zero_radii(), Some(segments.into()), *fill_rule)
         }
         _ => unreachable!("unsupported clip-path shape passed validation"),
     }
+}
+
+fn resolve_path_position(reference: LayoutRect, position: PaintPosition) -> [f32; 2] {
+    [
+        reference.x + resolve_coordinate(position.x, reference.width),
+        reference.y + resolve_coordinate(position.y, reference.height),
+    ]
+}
+
+fn add_path_segment(segments: &mut Vec<PathSegment>, from: [f32; 2], to: [f32; 2]) {
+    if from != to {
+        segments.push(PathSegment { from, to });
+    }
+}
+
+fn close_path_subpath(
+    segments: &mut Vec<PathSegment>,
+    current: &mut Option<[f32; 2]>,
+    start: Option<[f32; 2]>,
+) {
+    if let (Some(from), Some(to)) = (*current, start) {
+        add_path_segment(segments, from, to);
+        *current = Some(to);
+    }
+}
+
+fn flatten_path(reference: LayoutRect, commands: &[PathCommand]) -> Vec<PathSegment> {
+    const CURVE_STEPS: usize = 16;
+    let mut segments = Vec::new();
+    let mut current = None;
+    let mut start = None;
+    for command in commands {
+        match command {
+            PathCommand::MoveTo(point) => {
+                close_path_subpath(&mut segments, &mut current, start);
+                let point = resolve_path_position(reference, *point);
+                current = Some(point);
+                start = Some(point);
+            }
+            PathCommand::LineTo(point) => {
+                let to = resolve_path_position(reference, *point);
+                if let Some(from) = current {
+                    add_path_segment(&mut segments, from, to);
+                }
+                current = Some(to);
+            }
+            PathCommand::QuadraticTo { control, end } => {
+                let Some(from) = current else { continue };
+                let control = resolve_path_position(reference, *control);
+                let end = resolve_path_position(reference, *end);
+                let mut previous = from;
+                for step in 1..=CURVE_STEPS {
+                    let t = step as f32 / CURVE_STEPS as f32;
+                    let inverse = 1.0 - t;
+                    let to = [
+                        inverse * inverse * from[0]
+                            + 2.0 * inverse * t * control[0]
+                            + t * t * end[0],
+                        inverse * inverse * from[1]
+                            + 2.0 * inverse * t * control[1]
+                            + t * t * end[1],
+                    ];
+                    add_path_segment(&mut segments, previous, to);
+                    previous = to;
+                }
+                current = Some(end);
+            }
+            PathCommand::CubicTo {
+                control_1,
+                control_2,
+                end,
+            } => {
+                let Some(from) = current else { continue };
+                let control_1 = resolve_path_position(reference, *control_1);
+                let control_2 = resolve_path_position(reference, *control_2);
+                let end = resolve_path_position(reference, *end);
+                let mut previous = from;
+                for step in 1..=CURVE_STEPS {
+                    let t = step as f32 / CURVE_STEPS as f32;
+                    let inverse = 1.0 - t;
+                    let to = [
+                        inverse.powi(3) * from[0]
+                            + 3.0 * inverse * inverse * t * control_1[0]
+                            + 3.0 * inverse * t * t * control_2[0]
+                            + t.powi(3) * end[0],
+                        inverse.powi(3) * from[1]
+                            + 3.0 * inverse * inverse * t * control_1[1]
+                            + 3.0 * inverse * t * t * control_2[1]
+                            + t.powi(3) * end[1],
+                    ];
+                    add_path_segment(&mut segments, previous, to);
+                    previous = to;
+                }
+                current = Some(end);
+            }
+            PathCommand::Close => close_path_subpath(&mut segments, &mut current, start),
+        }
+    }
+    close_path_subpath(&mut segments, &mut current, start);
+    segments
+}
+
+fn path_bounds(segments: &[PathSegment]) -> Option<LayoutRect> {
+    let first = segments.first()?;
+    let mut left = first.from[0].min(first.to[0]);
+    let mut top = first.from[1].min(first.to[1]);
+    let mut right = first.from[0].max(first.to[0]);
+    let mut bottom = first.from[1].max(first.to[1]);
+    for segment in &segments[1..] {
+        left = left.min(segment.from[0]).min(segment.to[0]);
+        top = top.min(segment.from[1]).min(segment.to[1]);
+        right = right.max(segment.from[0]).max(segment.to[0]);
+        bottom = bottom.max(segment.from[1]).max(segment.to[1]);
+    }
+    Some(LayoutRect {
+        x: left,
+        y: top,
+        width: right - left,
+        height: bottom - top,
+    })
 }
 
 fn inset_clip_rect(

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -9,24 +9,25 @@ use whisker_engine::{FrameSink, MeasurementProvider};
 use whisker_host_conformance::{
     BackgroundBoxFixture, BackgroundImageFixture, BackgroundLayerFixture, BackgroundSizeFixture,
     BackgroundSizeKeywordFixture, BorderFixture, BorderStyleFixture, ClipPathFixture,
-    ClipReferenceBoxFixture, ClipShapeFixture, ColorFixture, Command, ConicGradientFixture, Host,
-    ImageRepeatFixture, LinearGradientFixture, LoadedCase, OverflowClipFixture,
-    PixelRelationFixture, PixelRelationKind, PixelSampleFixture, PointerEventFixture,
-    RadialGradientFixture, ResourceSourceFixture, ResourceStateFixture, Scenario, ScenarioSide,
-    SceneNodeFixture, VisibilityFixture, load_required,
+    ClipReferenceBoxFixture, ClipShapeFixture, ColorFixture, Command, ConicGradientFixture,
+    FillRuleFixture, Host, ImageRepeatFixture, LinearGradientFixture, LoadedCase,
+    OverflowClipFixture, PathCommandFixture, PixelRelationFixture, PixelRelationKind,
+    PixelSampleFixture, PointerEventFixture, RadialGradientFixture, ResourceSourceFixture,
+    ResourceStateFixture, Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture,
+    load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
-    BorderLineStyle, BoxClip, BoxPaint, ClipShape, ElementTypeId, FrameHeader, FrameMode,
+    BorderLineStyle, BoxClip, BoxPaint, ClipShape, ElementTypeId, FillRule, FrameHeader, FrameMode,
     FramePacket, GradientStop, ImageRepeat, InputEvent, InputEventKind, InputPoint, LayoutGeometry,
     LayoutRect, MeasureConstraints, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
     MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap, MeasurementKey, MeasurementPayload,
     MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
     PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
-    PaintLengthPercentage, PaintPosition, PointerId, PointerInput, PointerKind, ProtocolVersion,
-    RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceId, ResourceKind,
-    ResourceRequest, ResourceSource, SurfaceId, TextMeasurePayload, TextMeasureStyle, Transform,
-    Visibility, WhiskerValue,
+    PaintLengthPercentage, PaintPosition, PathCommand, PointerId, PointerInput, PointerKind,
+    ProtocolVersion, RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceId,
+    ResourceKind, ResourceRequest, ResourceSource, SurfaceId, TextMeasurePayload, TextMeasureStyle,
+    Transform, Visibility, WhiskerValue,
 };
 use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
@@ -1108,8 +1109,49 @@ fn clip_path_protocol(value: &ClipPathFixture) -> (PaintBox, ClipShape) {
                 },
             },
         },
+        ClipShapeFixture::Path {
+            fill_rule,
+            commands,
+        } => ClipShape::Path {
+            fill_rule: match fill_rule {
+                FillRuleFixture::NonZero => FillRule::NonZero,
+                FillRuleFixture::EvenOdd => FillRule::EvenOdd,
+            },
+            commands: commands.iter().map(path_command_protocol).collect(),
+        },
     };
     (reference_box, shape)
+}
+
+fn path_command_protocol(value: &PathCommandFixture) -> PathCommand {
+    let position = |point: &[whisker_host_conformance::LengthPercentageFixture; 2]| PaintPosition {
+        x: PaintCoordinate {
+            length: point[0].length,
+            fraction: point[0].fraction,
+        },
+        y: PaintCoordinate {
+            length: point[1].length,
+            fraction: point[1].fraction,
+        },
+    };
+    match value {
+        PathCommandFixture::MoveTo { point } => PathCommand::MoveTo(position(point)),
+        PathCommandFixture::LineTo { point } => PathCommand::LineTo(position(point)),
+        PathCommandFixture::QuadraticTo { control, end } => PathCommand::QuadraticTo {
+            control: position(control),
+            end: position(end),
+        },
+        PathCommandFixture::CubicTo {
+            control_1,
+            control_2,
+            end,
+        } => PathCommand::CubicTo {
+            control_1: position(control_1),
+            control_2: position(control_2),
+            end: position(end),
+        },
+        PathCommandFixture::Close => PathCommand::Close,
+    }
 }
 
 fn box_paint(background: &ColorFixture, border: Option<&BorderFixture>) -> BoxPaint {

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 12 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 13 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -39,7 +39,9 @@ enum {
 };
 enum { WHISKER_BACKGROUND_ATTACHMENT_SCROLL = 0 };
 enum { WHISKER_BACKGROUND_BLEND_NORMAL = 0 };
-enum { WHISKER_CLIP_SHAPE_INSET = 0, WHISKER_CLIP_SHAPE_CIRCLE = 1, WHISKER_CLIP_SHAPE_ELLIPSE = 2 };
+enum { WHISKER_CLIP_SHAPE_INSET = 0, WHISKER_CLIP_SHAPE_CIRCLE = 1, WHISKER_CLIP_SHAPE_ELLIPSE = 2, WHISKER_CLIP_SHAPE_PATH = 3 };
+enum { WHISKER_FILL_RULE_NON_ZERO = 0, WHISKER_FILL_RULE_EVEN_ODD = 1 };
+enum { WHISKER_PATH_MOVE_TO = 0, WHISKER_PATH_LINE_TO = 1, WHISKER_PATH_QUADRATIC_TO = 2, WHISKER_PATH_CUBIC_TO = 3, WHISKER_PATH_CLOSE = 4 };
 enum {
   WHISKER_MEASURE_TEXT = 1, WHISKER_MEASURE_REPLACED_CONTENT,
   WHISKER_MEASURE_NATIVE_CONTROL, WHISKER_MEASURE_EMBEDDED_SURFACE,
@@ -90,6 +92,8 @@ typedef struct {
 } WhiskerMobileClipInset;
 typedef struct { WhiskerMobileLengthPercentage radius, center_x, center_y; } WhiskerMobileClipCircle;
 typedef struct { WhiskerMobileLengthPercentage radius_x, radius_y, center_x, center_y; } WhiskerMobileClipEllipse;
+typedef struct { uint32_t kind, _reserved; WhiskerMobileLengthPercentage points[6]; } WhiskerMobilePathCommand;
+typedef struct { uint32_t fill_rule, _reserved; const WhiskerMobilePathCommand *commands; size_t command_count; } WhiskerMobileClipPathCommands;
 typedef struct {
   uint32_t reference_box, shape_kind; const void *payload; size_t payload_count;
 } WhiskerMobileClipPath;
@@ -144,6 +148,8 @@ _Static_assert(sizeof(WhiskerMobileBoxShadow) == 56, "WhiskerMobileBoxShadow ABI
 _Static_assert(sizeof(WhiskerMobileClipInset) == 96, "WhiskerMobileClipInset ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipCircle) == 24, "WhiskerMobileClipCircle ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipEllipse) == 32, "WhiskerMobileClipEllipse ABI drift");
+_Static_assert(sizeof(WhiskerMobilePathCommand) == 56, "WhiskerMobilePathCommand ABI drift");
+_Static_assert(sizeof(WhiskerMobileClipPathCommands) == 24, "WhiskerMobileClipPathCommands ABI drift");
 _Static_assert(sizeof(WhiskerMobileClipPath) == 24, "WhiskerMobileClipPath ABI drift");
 typedef struct {
   uint32_t id; uint8_t value_kind, optional_kind, _pad[2]; WhiskerStringRef name;

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -462,6 +462,10 @@ func tupleArray<T>(_ value: (T, T, T, T)) -> [T] {
     [value.0, value.1, value.2, value.3]
 }
 
+func tupleArray<T>(_ value: (T, T, T, T, T, T)) -> [T] {
+    [value.0, value.1, value.2, value.3, value.4, value.5]
+}
+
 private func resolve(_ value: WhiskerMobileLengthPercentage, axis: CGFloat) -> CGFloat {
     CGFloat(value.length) + CGFloat(value.fraction) * axis
 }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/ClipPath.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/ClipPath.swift
@@ -11,13 +11,59 @@ enum HostClipPath {
     case inset(HostInsetClipPath)
     case circle(HostCircleClipPath)
     case ellipse(HostEllipseClipPath)
+    case path(HostPathClipPath)
+
+    var fillRule: CAShapeLayerFillRule {
+        if case let .path(shape) = self, shape.evenOdd { return .evenOdd }
+        return .nonZero
+    }
 
     func path(in bounds: CGRect, contentBox: CGRect, painter: HostBoxPainter) -> CGPath {
         switch self {
         case let .inset(shape): shape.path(in: bounds, contentBox: contentBox, painter: painter)
         case let .circle(shape): shape.path(in: bounds, contentBox: contentBox, painter: painter)
         case let .ellipse(shape): shape.path(in: bounds, contentBox: contentBox, painter: painter)
+        case let .path(shape): shape.path(in: bounds, contentBox: contentBox, painter: painter)
         }
+    }
+}
+
+struct HostPathCommand {
+    let kind: UInt32
+    let points: [WhiskerMobileLengthPercentage]
+}
+
+struct HostPathClipPath {
+    let referenceBox: HostClipReferenceBox
+    let evenOdd: Bool
+    let commands: [HostPathCommand]
+
+    func path(in bounds: CGRect, contentBox: CGRect, painter: HostBoxPainter) -> CGPath {
+        let reference = clipReferenceBox(referenceBox, bounds, contentBox, painter)
+        func point(_ command: HostPathCommand, _ offset: Int) -> CGPoint {
+            CGPoint(
+                x: reference.minX + resolve(command.points[offset], axis: reference.width),
+                y: reference.minY + resolve(command.points[offset + 1], axis: reference.height)
+            )
+        }
+        let path = CGMutablePath()
+        for command in commands {
+            switch command.kind {
+            case UInt32(WHISKER_PATH_MOVE_TO): path.move(to: point(command, 0))
+            case UInt32(WHISKER_PATH_LINE_TO): path.addLine(to: point(command, 0))
+            case UInt32(WHISKER_PATH_QUADRATIC_TO):
+                path.addQuadCurve(to: point(command, 2), control: point(command, 0))
+            case UInt32(WHISKER_PATH_CUBIC_TO):
+                path.addCurve(
+                    to: point(command, 4),
+                    control1: point(command, 0),
+                    control2: point(command, 2)
+                )
+            case UInt32(WHISKER_PATH_CLOSE): path.closeSubpath()
+            default: break
+            }
+        }
+        return path
     }
 }
 

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -259,7 +259,7 @@ final class WhiskerNodeView: UIView {
             painter: boxPainter
         )
         clipPathMask.fillColor = UIColor.white.cgColor
-        clipPathMask.fillRule = .nonZero
+        clipPathMask.fillRule = clipPath.fillRule
         layer.mask = clipPathMask
     }
 

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -318,6 +318,18 @@ final class HostScene {
                     radiusY: ellipse.radius_y, centerX: ellipse.center_x,
                     centerY: ellipse.center_y
                 )))
+            case UInt32(WHISKER_CLIP_SHAPE_PATH):
+                guard let path = raw.payload?.assumingMemoryBound(
+                    to: WhiskerMobileClipPathCommands.self
+                ).pointee, let commands = path.commands else { return false }
+                let copied = UnsafeBufferPointer(start: commands, count: path.command_count).map {
+                    HostPathCommand(kind: $0.kind, points: tupleArray($0.points))
+                }
+                node.setClipPath(.path(HostPathClipPath(
+                    referenceBox: referenceBox,
+                    evenOdd: path.fill_rule == UInt32(WHISKER_FILL_RULE_EVEN_ODD),
+                    commands: copied
+                )))
             default: return false
             }
         case UInt32(WHISKER_OP_OPACITY):
@@ -548,6 +560,14 @@ private func validClipPath(_ clip: WhiskerMobileClipPath) -> Bool {
         let ellipse = payload.assumingMemoryBound(to: WhiskerMobileClipEllipse.self).pointee
         return ellipse.radius_x.isNonNegativeFinite && ellipse.radius_y.isNonNegativeFinite &&
             ellipse.center_x.isFinite && ellipse.center_y.isFinite
+    case UInt32(WHISKER_CLIP_SHAPE_PATH):
+        let path = payload.assumingMemoryBound(to: WhiskerMobileClipPathCommands.self).pointee
+        guard path.fill_rule <= UInt32(WHISKER_FILL_RULE_EVEN_ODD),
+              path.command_count > 0, path.command_count <= 4096,
+              let commands = path.commands else { return false }
+        return UnsafeBufferPointer(start: commands, count: path.command_count).allSatisfy {
+            $0.kind <= UInt32(WHISKER_PATH_CLOSE) && tupleArray($0.points).allSatisfy(\.isFinite)
+        }
     default:
         return false
     }

--- a/platforms/web/src/paint/visual_effects.rs
+++ b/platforms/web/src/paint/visual_effects.rs
@@ -1,5 +1,6 @@
 use whisker_protocol::{
-    ClipShape, PaintBox, PaintCoordinate, PaintLengthPercentage, VisualEffects,
+    ClipShape, FillRule, PaintBox, PaintCoordinate, PaintLengthPercentage, PaintPosition,
+    PathCommand, VisualEffects,
 };
 
 use super::color::css_color;
@@ -14,10 +15,10 @@ pub(crate) fn supports(effects: &VisualEffects) -> bool {
             matches!(
                 reference,
                 PaintBox::Border | PaintBox::Padding | PaintBox::Content
-            ) && matches!(
+            ) && (matches!(
                 shape,
                 ClipShape::Inset { .. } | ClipShape::Circle { .. } | ClipShape::Ellipse { .. }
-            )
+            ) || matches!(shape, ClipShape::Path { commands, .. } if path_is_absolute(commands)))
         })
 }
 
@@ -97,9 +98,60 @@ fn clip_path_css(value: &(PaintBox, ClipShape)) -> Result<String, WebError> {
             coordinate(center.x),
             coordinate(center.y),
         ),
+        ClipShape::Path {
+            fill_rule,
+            commands,
+        } => format!(
+            "path({}, \"{}\")",
+            match fill_rule {
+                FillRule::NonZero => "nonzero",
+                FillRule::EvenOdd => "evenodd",
+            },
+            path_data(commands)?,
+        ),
         _ => return Err(WebError("unsupported DOM clip-path shape".into())),
     };
     Ok(format!("{shape} {reference_box}"))
+}
+
+fn path_is_absolute(commands: &[PathCommand]) -> bool {
+    let position = |point: &PaintPosition| point.x.fraction == 0.0 && point.y.fraction == 0.0;
+    commands.iter().all(|command| match command {
+        PathCommand::MoveTo(point) | PathCommand::LineTo(point) => position(point),
+        PathCommand::QuadraticTo { control, end } => position(control) && position(end),
+        PathCommand::CubicTo {
+            control_1,
+            control_2,
+            end,
+        } => position(control_1) && position(control_2) && position(end),
+        PathCommand::Close => true,
+    })
+}
+
+fn path_data(commands: &[PathCommand]) -> Result<String, WebError> {
+    if !path_is_absolute(commands) {
+        return Err(WebError(
+            "CSS path() coordinates cannot contain percentages".into(),
+        ));
+    }
+    let point = |value: &PaintPosition| format!("{} {}", value.x.length, value.y.length);
+    Ok(commands
+        .iter()
+        .map(|command| match command {
+            PathCommand::MoveTo(value) => format!("M {}", point(value)),
+            PathCommand::LineTo(value) => format!("L {}", point(value)),
+            PathCommand::QuadraticTo { control, end } => {
+                format!("Q {} {}", point(control), point(end))
+            }
+            PathCommand::CubicTo {
+                control_1,
+                control_2,
+                end,
+            } => format!("C {} {} {}", point(control_1), point(control_2), point(end)),
+            PathCommand::Close => "Z".into(),
+        })
+        .collect::<Vec<_>>()
+        .join(" "))
 }
 
 fn coordinate(value: PaintCoordinate) -> String {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -2061,6 +2061,35 @@ fn fixture_clip_path_css(value: &ClipPathFixture) -> String {
             coordinate(center[0]),
             coordinate(center[1])
         ),
+        ClipShapeFixture::Path {
+            fill_rule,
+            commands,
+        } => {
+            let point = |value: &[LengthPercentageFixture; 2]| {
+                format!("{} {}", value[0].length, value[1].length)
+            };
+            let commands = commands
+                .iter()
+                .map(|command| match command {
+                    PathCommandFixture::MoveTo { point: value } => format!("M {}", point(value)),
+                    PathCommandFixture::LineTo { point: value } => format!("L {}", point(value)),
+                    PathCommandFixture::QuadraticTo { control, end } => {
+                        format!("Q {} {}", point(control), point(end))
+                    }
+                    PathCommandFixture::CubicTo {
+                        control_1,
+                        control_2,
+                        end,
+                    } => format!("C {} {} {}", point(control_1), point(control_2), point(end)),
+                    PathCommandFixture::Close => "Z".into(),
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            match fill_rule {
+                FillRuleFixture::NonZero => format!("path(\"{commands}\")"),
+                FillRuleFixture::EvenOdd => format!("path(evenodd, \"{commands}\")"),
+            }
+        }
     };
     let suffix = (!reference_box.is_empty())
         .then(|| format!(" {reference_box}"))

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -16,17 +16,18 @@ use whisker_host_conformance::{
     BackgroundBoxFixture, BackgroundImageFixture, BackgroundLayerFixture,
     BackgroundPaintLayerFixture, BackgroundSizeFixture, BackgroundSizeKeywordFixture,
     BorderFixture, BorderStyleFixture, ClipPathFixture, ClipReferenceBoxFixture, ClipShapeFixture,
-    ColorFixture, Command, ConicGradientFixture, CornerRadiusFixture, ImageRepeatFixture,
-    LengthPercentageFixture, LinearGradientFixture, Manifest, OverflowClipFixture,
-    PixelSampleFixture, RadialGradientFixture, ResourceSourceFixture, ResourceStateFixture,
-    SCHEMA_VERSION, Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture,
+    ColorFixture, Command, ConicGradientFixture, CornerRadiusFixture, FillRuleFixture,
+    ImageRepeatFixture, LengthPercentageFixture, LinearGradientFixture, Manifest,
+    OverflowClipFixture, PathCommandFixture, PixelSampleFixture, RadialGradientFixture,
+    ResourceSourceFixture, ResourceStateFixture, SCHEMA_VERSION, Scenario, ScenarioSide,
+    SceneNodeFixture, VisibilityFixture,
 };
 use whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
-    BoxPaint, ClipShape, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat,
+    BoxPaint, ClipShape, FillRule, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat,
     LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
     PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
-    PaintLengthPercentage, PaintPosition, ProtocolVersion, RadialGradientExtent,
+    PaintLengthPercentage, PaintPosition, PathCommand, ProtocolVersion, RadialGradientExtent,
     RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent, ResourceId,
     ResourceKind, ResourceRequest, ResourceSource, SurfaceId, Transform, Visibility,
 };
@@ -516,6 +517,12 @@ impl Driver {
                                                     }
                                                     ClipShapeFixture::Ellipse { .. } => {
                                                         "paint.visual-effects.clip-path-ellipse"
+                                                    }
+                                                    ClipShapeFixture::Path { fill_rule, .. } => {
+                                                        match fill_rule {
+                                                            FillRuleFixture::NonZero => "paint.visual-effects.clip-path-path-nonzero",
+                                                            FillRuleFixture::EvenOdd => "paint.visual-effects.clip-path-path-evenodd",
+                                                        }
                                                     }
                                                 })
                                         })
@@ -1250,6 +1257,12 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-masking/clip-path-ellipse-002.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-masking/clip-path-ellipse-002.json"
         ),
+        "wpt/css/css-masking/clip-path-path-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-masking/clip-path-path-001.json"
+        ),
+        "wpt/css/css-masking/clip-path-path-002.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-masking/clip-path-path-002.json"
+        ),
         "wpt/css/CSS2/borders/border-right-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-right-003.json"
         ),
@@ -1759,8 +1772,43 @@ fn clip_path_protocol(value: &ClipPathFixture) -> (PaintBox, ClipShape) {
                 y: paint_coordinate(center[1]),
             },
         },
+        ClipShapeFixture::Path {
+            fill_rule,
+            commands,
+        } => ClipShape::Path {
+            fill_rule: match fill_rule {
+                FillRuleFixture::NonZero => FillRule::NonZero,
+                FillRuleFixture::EvenOdd => FillRule::EvenOdd,
+            },
+            commands: commands.iter().map(path_command_protocol).collect(),
+        },
     };
     (reference_box, shape)
+}
+
+fn path_command_protocol(value: &PathCommandFixture) -> PathCommand {
+    let position = |point: &[LengthPercentageFixture; 2]| PaintPosition {
+        x: paint_coordinate(point[0]),
+        y: paint_coordinate(point[1]),
+    };
+    match value {
+        PathCommandFixture::MoveTo { point } => PathCommand::MoveTo(position(point)),
+        PathCommandFixture::LineTo { point } => PathCommand::LineTo(position(point)),
+        PathCommandFixture::QuadraticTo { control, end } => PathCommand::QuadraticTo {
+            control: position(control),
+            end: position(end),
+        },
+        PathCommandFixture::CubicTo {
+            control_1,
+            control_2,
+            end,
+        } => PathCommand::CubicTo {
+            control_1: position(control_1),
+            control_2: position(control_2),
+            end: position(end),
+        },
+        PathCommandFixture::Close => PathCommand::Close,
+    }
 }
 
 fn paint_length_percentage(value: LengthPercentageFixture) -> PaintLengthPercentage {

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -98,8 +98,8 @@
       "id": "paint.visual-effects",
       "basis": "lynx-4.0",
       "properties": ["box-shadow", "clip-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
-      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur", "multiple-box-shadows", "clip-path-inset", "clip-path-circle-and-ellipse"],
-      "pending_subset": ["clip-path-path", "filter", "image-rendering", "mask", "mask-composite", "mask-image"],
+      "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur", "multiple-box-shadows", "clip-path-inset", "clip-path-circle-and-ellipse", "clip-path-path"],
+      "pending_subset": ["filter", "image-rendering", "mask", "mask-composite", "mask-image"],
       "protocol": ["SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -346,6 +346,20 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-masking.clip-path-path-001",
+      "feature": "clip-path-path-nonzero",
+      "fixture": "wpt/css/css-masking/clip-path-path-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-masking.clip-path-path-002",
+      "feature": "clip-path-path-evenodd",
+      "fixture": "wpt/css/css-masking/clip-path-path-002.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.borders.border-right-003",
       "feature": "border-right",
       "fixture": "wpt/css/CSS2/borders/border-right-003.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -311,7 +311,11 @@ private class Driver(
                             command.getString("name") ==
                             "paint.visual-effects.clip-path-circle" ||
                             command.getString("name") ==
-                            "paint.visual-effects.clip-path-ellipse",
+                            "paint.visual-effects.clip-path-ellipse" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.clip-path-path-nonzero" ||
+                            command.getString("name") ==
+                            "paint.visual-effects.clip-path-path-evenodd",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -666,6 +670,31 @@ private class Driver(
                         }
                         shape.getJSONArray("center").objects().forEach {
                             appendLengthPercentage(it, numbers)
+                        }
+                    }
+                    "path" -> {
+                        numbers += 3f
+                        numbers += if (shape.optString("fill_rule", "non_zero") == "even_odd") 1f else 0f
+                        val commands = shape.getJSONArray("commands")
+                        numbers += commands.length().toFloat()
+                        commands.objects().forEach { command ->
+                            val pointNames = when (command.getString("command")) {
+                                "move_to" -> 0 to listOf("point")
+                                "line_to" -> 1 to listOf("point")
+                                "quadratic_to" -> 2 to listOf("control", "end")
+                                "cubic_to" -> 3 to listOf("control_1", "control_2", "end")
+                                "close" -> 4 to emptyList()
+                                else -> error("unsupported path command")
+                            }
+                            numbers += pointNames.first.toFloat()
+                            pointNames.second.forEach { name ->
+                                command.getJSONArray(name).objects().forEach {
+                                    appendLengthPercentage(it, numbers)
+                                }
+                            }
+                            repeat(6 - pointNames.second.size * 2) {
+                                appendLengthPercentage(JSONObject().put("length", 0), numbers)
+                            }
                         }
                     }
                     else -> {

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -446,7 +446,9 @@ private final class Driver {
                     name == "paint.visual-effects.box-shadow-multiple" ||
                     name == "paint.visual-effects.clip-path-inset" ||
                     name == "paint.visual-effects.clip-path-circle" ||
-                    name == "paint.visual-effects.clip-path-ellipse" else {
+                    name == "paint.visual-effects.clip-path-ellipse" ||
+                    name == "paint.visual-effects.clip-path-path-nonzero" ||
+                    name == "paint.visual-effects.clip-path-path-evenodd" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 let pixels = try capture()
@@ -690,12 +692,32 @@ private final class Driver {
         )
         let clipCircles = UnsafeMutablePointer<WhiskerMobileClipCircle>.allocate(capacity: clipStorageCount)
         let clipEllipses = UnsafeMutablePointer<WhiskerMobileClipEllipse>.allocate(capacity: clipStorageCount)
+        let clipPathPayloads = UnsafeMutablePointer<WhiskerMobileClipPathCommands>.allocate(
+            capacity: clipStorageCount
+        )
+        var clipCommandBuffers = [UnsafeMutablePointer<WhiskerMobilePathCommand>?](
+            repeating: nil, count: fixtures.count
+        )
         for (index, fixture) in fixtures.enumerated() {
             clipInsets.advanced(by: index).initialize(
                 to: fixture.clipPath?.inset ?? WhiskerMobileClipInset()
             )
             clipCircles.advanced(by: index).initialize(to: fixture.clipPath?.circle ?? WhiskerMobileClipCircle())
             clipEllipses.advanced(by: index).initialize(to: fixture.clipPath?.ellipse ?? WhiskerMobileClipEllipse())
+            var pathPayload = WhiskerMobileClipPathCommands()
+            if let clip = fixture.clipPath, !clip.pathCommands.isEmpty {
+                let commands = UnsafeMutablePointer<WhiskerMobilePathCommand>.allocate(
+                    capacity: clip.pathCommands.count
+                )
+                for (commandIndex, command) in clip.pathCommands.enumerated() {
+                    commands.advanced(by: commandIndex).initialize(to: command)
+                }
+                clipCommandBuffers[index] = commands
+                pathPayload.fill_rule = clip.pathFillRule
+                pathPayload.commands = UnsafePointer(commands)
+                pathPayload.command_count = clip.pathCommands.count
+            }
+            clipPathPayloads.advanced(by: index).initialize(to: pathPayload)
             var path = WhiskerMobileClipPath()
             if let clip = fixture.clipPath {
                 path.reference_box = clip.referenceBox
@@ -703,6 +725,7 @@ private final class Driver {
                 path.payload = switch clip.shapeKind {
                 case UInt32(WHISKER_CLIP_SHAPE_CIRCLE): UnsafeRawPointer(clipCircles.advanced(by: index))
                 case UInt32(WHISKER_CLIP_SHAPE_ELLIPSE): UnsafeRawPointer(clipEllipses.advanced(by: index))
+                case UInt32(WHISKER_CLIP_SHAPE_PATH): UnsafeRawPointer(clipPathPayloads.advanced(by: index))
                 default: UnsafeRawPointer(clipInsets.advanced(by: index))
                 }
                 path.payload_count = 1
@@ -718,6 +741,12 @@ private final class Driver {
             clipCircles.deallocate()
             clipEllipses.deinitialize(count: fixtures.count)
             clipEllipses.deallocate()
+            clipPathPayloads.deinitialize(count: fixtures.count)
+            clipPathPayloads.deallocate()
+            for (index, commands) in clipCommandBuffers.enumerated() {
+                commands?.deinitialize(count: fixtures[index].clipPath?.pathCommands.count ?? 0)
+                commands?.deallocate()
+            }
         }
         try layouts.withUnsafeMutableBufferPointer { layoutBuffer in
             try paints.withUnsafeMutableBufferPointer { paintBuffer in
@@ -1120,6 +1149,8 @@ private struct SceneClipPath {
     let inset: WhiskerMobileClipInset
     let circle: WhiskerMobileClipCircle
     let ellipse: WhiskerMobileClipEllipse
+    let pathFillRule: UInt32
+    let pathCommands: [WhiskerMobilePathCommand]
 }
 
 private struct ScenePaintLayer {
@@ -1360,7 +1391,7 @@ private func sceneClipPath(_ fixture: [String: Any]) throws -> SceneClipPath {
         circle.radius = try lengthPercentage(shape["radius"] as Any)
         circle.center_x = center[0]
         circle.center_y = center[1]
-        return SceneClipPath(referenceBox: referenceBox, shapeKind: UInt32(WHISKER_CLIP_SHAPE_CIRCLE), inset: WhiskerMobileClipInset(), circle: circle, ellipse: WhiskerMobileClipEllipse())
+        return SceneClipPath(referenceBox: referenceBox, shapeKind: UInt32(WHISKER_CLIP_SHAPE_CIRCLE), inset: WhiskerMobileClipInset(), circle: circle, ellipse: WhiskerMobileClipEllipse(), pathFillRule: 0, pathCommands: [])
     }
     if kind == "ellipse" {
         let radii = try (shape["radii"] as? [Any] ?? []).map(lengthPercentage)
@@ -1369,7 +1400,51 @@ private func sceneClipPath(_ fixture: [String: Any]) throws -> SceneClipPath {
         var ellipse = WhiskerMobileClipEllipse()
         ellipse.radius_x = radii[0]; ellipse.radius_y = radii[1]
         ellipse.center_x = center[0]; ellipse.center_y = center[1]
-        return SceneClipPath(referenceBox: referenceBox, shapeKind: UInt32(WHISKER_CLIP_SHAPE_ELLIPSE), inset: WhiskerMobileClipInset(), circle: WhiskerMobileClipCircle(), ellipse: ellipse)
+        return SceneClipPath(referenceBox: referenceBox, shapeKind: UInt32(WHISKER_CLIP_SHAPE_ELLIPSE), inset: WhiskerMobileClipInset(), circle: WhiskerMobileClipCircle(), ellipse: ellipse, pathFillRule: 0, pathCommands: [])
+    }
+    if kind == "path" {
+        guard let rawCommands = shape["commands"] as? [[String: Any]], !rawCommands.isEmpty else {
+            throw Failure("path clip needs commands")
+        }
+        let commands = try rawCommands.map { raw -> WhiskerMobilePathCommand in
+            let name = try string(raw, "command")
+            let fields: [String]
+            let commandKind: UInt32
+            switch name {
+            case "move_to": commandKind = UInt32(WHISKER_PATH_MOVE_TO); fields = ["point"]
+            case "line_to": commandKind = UInt32(WHISKER_PATH_LINE_TO); fields = ["point"]
+            case "quadratic_to": commandKind = UInt32(WHISKER_PATH_QUADRATIC_TO); fields = ["control", "end"]
+            case "cubic_to": commandKind = UInt32(WHISKER_PATH_CUBIC_TO); fields = ["control_1", "control_2", "end"]
+            case "close": commandKind = UInt32(WHISKER_PATH_CLOSE); fields = []
+            default: throw Failure("unsupported path command")
+            }
+            var points = [WhiskerMobileLengthPercentage](
+                repeating: WhiskerMobileLengthPercentage(), count: 6
+            )
+            var cursor = 0
+            for field in fields {
+                guard let pair = raw[field] as? [Any], pair.count == 2 else {
+                    throw Failure("path point needs two coordinates")
+                }
+                points[cursor] = try lengthPercentage(pair[0])
+                points[cursor + 1] = try lengthPercentage(pair[1])
+                cursor += 2
+            }
+            var command = WhiskerMobilePathCommand()
+            command.kind = commandKind
+            command.points = (points[0], points[1], points[2], points[3], points[4], points[5])
+            return command
+        }
+        return SceneClipPath(
+            referenceBox: referenceBox,
+            shapeKind: UInt32(WHISKER_CLIP_SHAPE_PATH),
+            inset: WhiskerMobileClipInset(),
+            circle: WhiskerMobileClipCircle(),
+            ellipse: WhiskerMobileClipEllipse(),
+            pathFillRule: (shape["fill_rule"] as? String) == "even_odd"
+                ? UInt32(WHISKER_FILL_RULE_EVEN_ODD) : UInt32(WHISKER_FILL_RULE_NON_ZERO),
+            pathCommands: commands
+        )
     }
     guard kind == "inset" else { throw Failure("unsupported clip-path shape") }
     guard let rawEdges = shape["edges"] as? [Any],
@@ -1409,7 +1484,9 @@ private func sceneClipPath(_ fixture: [String: Any]) throws -> SceneClipPath {
         shapeKind: UInt32(WHISKER_CLIP_SHAPE_INSET),
         inset: inset,
         circle: WhiskerMobileClipCircle(),
-        ellipse: WhiskerMobileClipEllipse()
+        ellipse: WhiskerMobileClipEllipse(),
+        pathFillRule: 0,
+        pathCommands: []
     )
 }
 
@@ -1528,7 +1605,7 @@ private func lengthPercentage(_ value: Any) throws -> WhiskerMobileLengthPercent
     }
     return WhiskerMobileLengthPercentage(
         length: Float(try number(object, "length")),
-        fraction: Float(try number(object, "fraction"))
+        fraction: (object["fraction"] as? NSNumber)?.floatValue ?? 0
     )
 }
 

--- a/tests/host-conformance/wpt/css/css-masking/clip-path-path-001.json
+++ b/tests/host-conformance/wpt/css/css-masking/clip-path-path-001.json
@@ -1,0 +1,71 @@
+{
+  "schema": 1,
+  "id": "wpt.css-masking.clip-path-path-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-masking/clip-path/clip-path-path-001.html",
+    "license": "BSD-3-Clause",
+    "assertion": "The non-zero fill rule keeps two same-winding path subregions filled.",
+    "adaptation": "The upstream nested squares are retained and a red child in the inner square verifies that path clipping applies to descendants."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 140.0, "height": 140.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 140.0, 140.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [20.0, 20.0, 100.0, 100.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip_path": {
+              "reference_box": "border",
+              "shape": {
+                "kind": "path",
+                "fill_rule": "non_zero",
+                "commands": [
+                  { "command": "move_to", "point": [{ "length": 10.0 }, { "length": 10.0 }] },
+                  { "command": "line_to", "point": [{ "length": 90.0 }, { "length": 10.0 }] },
+                  { "command": "line_to", "point": [{ "length": 90.0 }, { "length": 90.0 }] },
+                  { "command": "line_to", "point": [{ "length": 10.0 }, { "length": 90.0 }] },
+                  { "command": "close" },
+                  { "command": "move_to", "point": [{ "length": 25.0 }, { "length": 25.0 }] },
+                  { "command": "line_to", "point": [{ "length": 75.0 }, { "length": 25.0 }] },
+                  { "command": "line_to", "point": [{ "length": 75.0 }, { "length": 75.0 }] },
+                  { "command": "line_to", "point": [{ "length": 25.0 }, { "length": 75.0 }] },
+                  { "command": "close" }
+                ]
+              }
+            }
+          },
+          {
+            "id": 3,
+            "parent": 2,
+            "rect": [40.0, 40.0, 20.0, 20.0],
+            "background": { "kind": "named", "value": "red" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.clip-path-path-nonzero",
+        "samples": [
+          { "point": [25.0, 70.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [35.0, 70.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [70.0, 70.0], "color": { "kind": "named", "value": "red" }, "tolerance": 5 },
+          { "point": [105.0, 70.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [125.0, 70.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/wpt/css/css-masking/clip-path-path-002.json
+++ b/tests/host-conformance/wpt/css/css-masking/clip-path-path-002.json
@@ -1,0 +1,71 @@
+{
+  "schema": 1,
+  "id": "wpt.css-masking.clip-path-path-002",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-masking/clip-path/clip-path-path-002.html",
+    "license": "BSD-3-Clause",
+    "assertion": "The even-odd fill rule cuts a hole where two path subregions overlap.",
+    "adaptation": "The upstream nested squares are retained and a red child beneath the inner square verifies that the hole clips descendants."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 140.0, "height": 140.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 140.0, 140.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [20.0, 20.0, 100.0, 100.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip_path": {
+              "reference_box": "border",
+              "shape": {
+                "kind": "path",
+                "fill_rule": "even_odd",
+                "commands": [
+                  { "command": "move_to", "point": [{ "length": 10.0 }, { "length": 10.0 }] },
+                  { "command": "line_to", "point": [{ "length": 90.0 }, { "length": 10.0 }] },
+                  { "command": "line_to", "point": [{ "length": 90.0 }, { "length": 90.0 }] },
+                  { "command": "line_to", "point": [{ "length": 10.0 }, { "length": 90.0 }] },
+                  { "command": "close" },
+                  { "command": "move_to", "point": [{ "length": 25.0 }, { "length": 25.0 }] },
+                  { "command": "line_to", "point": [{ "length": 75.0 }, { "length": 25.0 }] },
+                  { "command": "line_to", "point": [{ "length": 75.0 }, { "length": 75.0 }] },
+                  { "command": "line_to", "point": [{ "length": 25.0 }, { "length": 75.0 }] },
+                  { "command": "close" }
+                ]
+              }
+            }
+          },
+          {
+            "id": 3,
+            "parent": 2,
+            "rect": [40.0, 40.0, 20.0, 20.0],
+            "background": { "kind": "named", "value": "red" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.clip-path-path-evenodd",
+        "samples": [
+          { "point": [25.0, 70.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [35.0, 70.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [70.0, 70.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 },
+          { "point": [105.0, 70.0], "color": { "kind": "named", "value": "green" }, "tolerance": 5 },
+          { "point": [125.0, 70.0], "color": { "kind": "named", "value": "white" }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add WPT-derived nonzero and evenodd `clip-path: path()` fixtures shared by all four Hosts
- render absolute Move/Line/Quadratic/Cubic/Close commands through DOM, wgpu, Android Path, and CGPath
- extend the mobile ABI to minor 13 with typed path commands and fill rules
- mark `clip-path-path` implemented in the Host capability matrix

## Validation
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`
- `cargo check -p whisker --target aarch64-apple-ios-sim`
- `cargo test -p whisker-host-conformance`
- `CARGO_BUILD_JOBS=1 cargo clippy -p whisker-desktop --lib -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy -p whisker-web --target wasm32-unknown-unknown --lib -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy -p whisker-driver --lib -- -D warnings`

Stacked on #470.