### PR TITLE
feat(transform): lower typed 2D transforms after layout

### DIFF
--- a/crates/whisker-css/src/prop/transform.rs
+++ b/crates/whisker-css/src/prop/transform.rs
@@ -9,7 +9,7 @@ impl Css {
     /// Sets `transform-origin`.
     /// <https://lynxjs.org/api/css/properties/transform-origin>
     pub fn transform_origin(self, v: Position) -> Self {
-        self.push(crate::StyleProperty::TransformOrigin, v)
+        self.push_typed(crate::StyleProperty::TransformOrigin, v)
     }
 
     /// Sets `transform-box`.

--- a/crates/whisker-css/src/shorthand/transform.rs
+++ b/crates/whisker-css/src/shorthand/transform.rs
@@ -194,7 +194,7 @@ impl Css {
     /// applied left-to-right.
     /// <https://lynxjs.org/api/css/properties/transform>
     pub fn transform(self, t: impl Into<Transform>) -> Self {
-        self.push(crate::StyleProperty::Transform, t.into())
+        self.push_typed(crate::StyleProperty::Transform, t.into())
     }
 }
 

--- a/crates/whisker-css/src/style_value.rs
+++ b/crates/whisker-css/src/style_value.rs
@@ -9,15 +9,17 @@ use whisker_style::{
     GridTemplateComponentValue, GridTemplateRepetitionValue, GridTemplateValue,
     GridTrackSizingValue, JustifyContentValue, LengthPercentageAutoValue, LengthPercentageValue,
     LengthUnit, LengthValue, LineHeightValue, PositionValue, SizeValue, StyleNumber, StyleValue,
+    TransformFunctionValue, TransformOriginValue, TransformValue,
 };
 
+use crate::data_type_ext::PositionKeyword;
 use crate::{
     AlignContent, AlignItems, AlignSelf, Angle, BackdropFilter, BoxSizing, CalcExpr, Clear, Color,
     CssString, Direction, Display, FlexBasis, FlexDirection, FlexWrap, Float, FontStyle,
     FontWeight, GridAutoFlow, GridLine, GridRepeatCount, GridTemplate, GridTemplateAreas,
     GridTemplateComponent, GridTrack, GridTrackMax, GridTrackMin, Integer, JustifyContent, Length,
-    LengthPercentage, LineHeight, MarginValue, Number, Overflow, Percentage, PositionKind, Size,
-    Visibility,
+    LengthPercentage, LineHeight, MarginValue, Number, Overflow, Percentage, Position,
+    PositionKind, Size, Transform, TransformFn, Visibility,
 };
 use whisker_style::{OverflowValue, VisibilityValue};
 
@@ -36,6 +38,24 @@ impl ToStyleValue for BackdropFilter {
         StyleValue::BackdropFilter(match self {
             Self::None => BackdropFilterValue::None,
             Self::Blur(radius) => BackdropFilterValue::Blur(to_length(*radius)),
+        })
+    }
+}
+
+impl ToStyleValue for Transform {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::Transform(TransformValue(
+            self.0.iter().map(to_transform_function).collect(),
+        ))
+    }
+}
+
+impl ToStyleValue for Position {
+    fn to_style_value(&self) -> StyleValue {
+        let (horizontal, vertical) = transform_origin(self);
+        StyleValue::TransformOrigin(TransformOriginValue {
+            horizontal,
+            vertical,
         })
     }
 }
@@ -486,6 +506,112 @@ fn angle_degrees(value: Angle) -> f32 {
         Angle::Deg(value) => value,
         Angle::Rad(value) => value.to_degrees(),
         Angle::Turn(value) => value * 360.0,
+    }
+}
+
+fn to_transform_function(value: &TransformFn) -> TransformFunctionValue {
+    match value {
+        TransformFn::Translate(x, y) => {
+            TransformFunctionValue::Translate(to_length_percentage(x), to_length_percentage(y))
+        }
+        TransformFn::TranslateX(x) => TransformFunctionValue::TranslateX(to_length_percentage(x)),
+        TransformFn::TranslateY(y) => TransformFunctionValue::TranslateY(to_length_percentage(y)),
+        TransformFn::TranslateZ(z) => TransformFunctionValue::TranslateZ(to_length(*z)),
+        TransformFn::Translate3d(x, y, z) => TransformFunctionValue::Translate3d(
+            to_length_percentage(x),
+            to_length_percentage(y),
+            to_length(*z),
+        ),
+        TransformFn::Rotate(angle) => {
+            TransformFunctionValue::Rotate(StyleNumber::new(angle_degrees(*angle)))
+        }
+        TransformFn::RotateX(angle) => {
+            TransformFunctionValue::RotateX(StyleNumber::new(angle_degrees(*angle)))
+        }
+        TransformFn::RotateY(angle) => {
+            TransformFunctionValue::RotateY(StyleNumber::new(angle_degrees(*angle)))
+        }
+        TransformFn::RotateZ(angle) => {
+            TransformFunctionValue::RotateZ(StyleNumber::new(angle_degrees(*angle)))
+        }
+        TransformFn::Scale(x, y) => {
+            TransformFunctionValue::Scale(StyleNumber::new(*x), StyleNumber::new(*y))
+        }
+        TransformFn::ScaleX(x) => TransformFunctionValue::ScaleX(StyleNumber::new(*x)),
+        TransformFn::ScaleY(y) => TransformFunctionValue::ScaleY(StyleNumber::new(*y)),
+        TransformFn::Skew(x, y) => TransformFunctionValue::Skew(
+            StyleNumber::new(angle_degrees(*x)),
+            StyleNumber::new(angle_degrees(*y)),
+        ),
+        TransformFn::SkewX(angle) => {
+            TransformFunctionValue::SkewX(StyleNumber::new(angle_degrees(*angle)))
+        }
+        TransformFn::SkewY(angle) => {
+            TransformFunctionValue::SkewY(StyleNumber::new(angle_degrees(*angle)))
+        }
+        TransformFn::Matrix(matrix) => TransformFunctionValue::Matrix(matrix.map(StyleNumber::new)),
+        TransformFn::Matrix3d(matrix) => {
+            TransformFunctionValue::Matrix3d(matrix.map(StyleNumber::new))
+        }
+    }
+}
+
+fn transform_origin(value: &Position) -> (LengthPercentageValue, LengthPercentageValue) {
+    let center = || LengthPercentageValue::Percentage(StyleNumber::new(50.0));
+    let keyword = |value, horizontal: bool| {
+        let percentage = match (value, horizontal) {
+            (PositionKeyword::Left, true) | (PositionKeyword::Top, false) => 0.0,
+            (PositionKeyword::Right, true) | (PositionKeyword::Bottom, false) => 100.0,
+            (PositionKeyword::Center, _) => 50.0,
+            _ => 50.0,
+        };
+        LengthPercentageValue::Percentage(StyleNumber::new(percentage))
+    };
+    match value {
+        Position::Keyword(PositionKeyword::Left | PositionKeyword::Right) => {
+            (keyword(position_keyword(value), true), center())
+        }
+        Position::Keyword(PositionKeyword::Top | PositionKeyword::Bottom) => {
+            (center(), keyword(position_keyword(value), false))
+        }
+        Position::Keyword(PositionKeyword::Center) => (center(), center()),
+        Position::Keywords(first, second) => match first {
+            PositionKeyword::Top | PositionKeyword::Bottom => {
+                (keyword(*second, true), keyword(*first, false))
+            }
+            PositionKeyword::Left | PositionKeyword::Right => {
+                (keyword(*first, true), keyword(*second, false))
+            }
+            PositionKeyword::Center => match second {
+                PositionKeyword::Top | PositionKeyword::Bottom => {
+                    (center(), keyword(*second, false))
+                }
+                PositionKeyword::Left | PositionKeyword::Right => {
+                    (keyword(*second, true), center())
+                }
+                PositionKeyword::Center => (center(), center()),
+            },
+        },
+        Position::Coords(horizontal, vertical) => (
+            to_length_percentage(horizontal),
+            to_length_percentage(vertical),
+        ),
+        Position::Mixed(axis, offset) => match axis {
+            PositionKeyword::Top | PositionKeyword::Bottom => {
+                (to_length_percentage(offset), keyword(*axis, false))
+            }
+            PositionKeyword::Left | PositionKeyword::Right => {
+                (keyword(*axis, true), to_length_percentage(offset))
+            }
+            PositionKeyword::Center => (center(), to_length_percentage(offset)),
+        },
+    }
+}
+
+fn position_keyword(value: &Position) -> PositionKeyword {
+    match value {
+        Position::Keyword(value) => *value,
+        _ => unreachable!("called only for Position::Keyword"),
     }
 }
 

--- a/crates/whisker-engine/src/lib.rs
+++ b/crates/whisker-engine/src/lib.rs
@@ -29,7 +29,7 @@ pub use layout::{LayoutError, LayoutOptions, MeasurementProvider};
 pub use measurement::{
     DeferredMeasurementApply, LayoutProgress, MeasurementApply, MeasurementError,
 };
-pub use paint::{LoweredPaint, lower_color, lower_paint};
+pub use paint::{LoweredPaint, lower_color, lower_paint, lower_transform};
 pub use recording::{FrameSink, RecordedFrame, RecordingRenderer};
 pub use scene::{Scene, SceneError, SceneNode};
 pub use surface::{LayoutUpdate, SurfaceEngine, SurfaceError, SurfacePresentError};

--- a/crates/whisker-engine/src/paint.rs
+++ b/crates/whisker-engine/src/paint.rs
@@ -2,11 +2,12 @@
 
 use whisker_protocol::{
     BorderLineStyle, BoxClip, BoxPaint, OverflowClip, PaintColor, PaintCornerRadius, PaintCorners,
-    PaintEdges, PaintLengthPercentage, Visibility, VisualEffects,
+    PaintEdges, PaintLengthPercentage, Transform, Visibility, VisualEffects,
 };
 use whisker_style::{
     BorderStyleValue, ColorValue, ComputedLayoutStyle, ComputedLengthPercentage,
-    ComputedPaintStyle, OverflowValue, VisibilityValue,
+    ComputedPaintStyle, ComputedTransformFunction, ComputedTransformStyle, OverflowValue,
+    VisibilityValue,
 };
 
 /// Complete common presentation values derived from one computed node style.
@@ -18,6 +19,8 @@ pub struct LoweredPaint {
     pub visual_effects: VisualEffects,
     /// Descendant overflow clip.
     pub clip: BoxClip,
+    /// Transform retained until the border-box size is known.
+    pub transform: ComputedTransformStyle,
     /// Group opacity.
     pub opacity: f32,
     /// Paint visibility.
@@ -60,6 +63,7 @@ pub fn lower_paint(style: &ComputedPaintStyle, layout: &ComputedLayoutStyle) -> 
             horizontal: lower_overflow(style.overflow_x),
             vertical: lower_overflow(style.overflow_y),
         },
+        transform: style.transform.clone(),
         opacity: style.opacity.get(),
         visibility: match style.visibility {
             VisibilityValue::Visible => Visibility::Visible,
@@ -67,6 +71,149 @@ pub fn lower_paint(style: &ComputedPaintStyle, layout: &ComputedLayoutStyle) -> 
         },
         z_order: style.z_index,
     }
+}
+
+/// Resolves a computed transform against one node's border-box size.
+///
+/// Hosts receive only the resulting matrix; percentages and transform-origin
+/// never cross the renderer boundary.
+pub fn lower_transform(
+    style: &ComputedTransformStyle,
+    border_width: f32,
+    border_height: f32,
+) -> Option<Transform> {
+    if !border_width.is_finite()
+        || !border_height.is_finite()
+        || border_width < 0.0
+        || border_height < 0.0
+    {
+        return None;
+    }
+
+    let mut matrix = identity();
+    for function in &style.functions {
+        matrix = multiply(
+            matrix,
+            function_matrix(function, border_width, border_height)?,
+        );
+    }
+    let origin_x = resolve_box_length(style.origin_x, border_width);
+    let origin_y = resolve_box_length(style.origin_y, border_height);
+    let around_origin = multiply(
+        multiply(translation(origin_x, origin_y, 0.0), matrix),
+        translation(-origin_x, -origin_y, 0.0),
+    );
+    around_origin
+        .iter()
+        .all(|value| value.is_finite())
+        .then_some(Transform(around_origin))
+}
+
+fn function_matrix(
+    function: &ComputedTransformFunction,
+    border_width: f32,
+    border_height: f32,
+) -> Option<[f32; 16]> {
+    let matrix = match function {
+        ComputedTransformFunction::Translate { x, y, z } => translation(
+            resolve_box_length(*x, border_width),
+            resolve_box_length(*y, border_height),
+            z.get(),
+        ),
+        ComputedTransformFunction::RotateX(degrees) => {
+            let radians = degrees.get().to_radians();
+            let (sin, cos) = radians.sin_cos();
+            [
+                1.0, 0.0, 0.0, 0.0, 0.0, cos, sin, 0.0, 0.0, -sin, cos, 0.0, 0.0, 0.0, 0.0, 1.0,
+            ]
+        }
+        ComputedTransformFunction::RotateY(degrees) => {
+            let radians = degrees.get().to_radians();
+            let (sin, cos) = radians.sin_cos();
+            [
+                cos, 0.0, -sin, 0.0, 0.0, 1.0, 0.0, 0.0, sin, 0.0, cos, 0.0, 0.0, 0.0, 0.0, 1.0,
+            ]
+        }
+        ComputedTransformFunction::RotateZ(degrees) => {
+            let radians = degrees.get().to_radians();
+            let (sin, cos) = radians.sin_cos();
+            [
+                cos, sin, 0.0, 0.0, -sin, cos, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+            ]
+        }
+        ComputedTransformFunction::Scale { x, y, z } => [
+            x.get(),
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            y.get(),
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            z.get(),
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+        ],
+        ComputedTransformFunction::Skew {
+            x_degrees,
+            y_degrees,
+        } => [
+            1.0,
+            y_degrees.get().to_radians().tan(),
+            0.0,
+            0.0,
+            x_degrees.get().to_radians().tan(),
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+        ],
+        ComputedTransformFunction::Matrix(values) => values.map(|value| value.get()),
+    };
+    matrix
+        .iter()
+        .all(|value| value.is_finite())
+        .then_some(matrix)
+}
+
+fn identity() -> [f32; 16] {
+    [
+        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+    ]
+}
+
+fn translation(x: f32, y: f32, z: f32) -> [f32; 16] {
+    [
+        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, x, y, z, 1.0,
+    ]
+}
+
+fn multiply(left: [f32; 16], right: [f32; 16]) -> [f32; 16] {
+    let mut output = [0.0; 16];
+    for column in 0..4 {
+        for row in 0..4 {
+            output[column * 4 + row] = (0..4)
+                .map(|index| left[index * 4 + row] * right[column * 4 + index])
+                .sum();
+        }
+    }
+    output
+}
+
+fn resolve_box_length(value: ComputedLengthPercentage, extent: f32) -> f32 {
+    value.length() + value.fraction() * extent
 }
 
 fn edges<T, U>(input: &whisker_style::Edges<T>, map: impl Fn(&T) -> U) -> PaintEdges<U> {
@@ -188,6 +335,7 @@ mod tests {
                 bottom_right: radius(3.0, 0.3, 13.0, 0.13),
                 bottom_left: radius(4.0, 0.4, 14.0, 0.14),
             },
+            transform: ComputedTransformStyle::default(),
             opacity: StyleNumber::new(0.5),
             visibility: VisibilityValue::Hidden,
             overflow_x: OverflowValue::Visible,
@@ -250,6 +398,92 @@ mod tests {
         assert_eq!(lowered.visibility, Visibility::Hidden);
         assert_eq!(lowered.z_order, -3);
         assert_eq!(lowered.visual_effects.backdrop_blur, Some(8.0));
+    }
+
+    #[test]
+    fn resolves_transform_percentages_and_origin_against_border_box() {
+        let style = ComputedTransformStyle {
+            functions: vec![ComputedTransformFunction::Scale {
+                x: StyleNumber::new(2.0),
+                y: StyleNumber::new(2.0),
+                z: StyleNumber::new(1.0),
+            }],
+            origin_x: ComputedLengthPercentage::new(0.0, 0.25),
+            origin_y: ComputedLengthPercentage::new(0.0, 0.5),
+        };
+        assert_eq!(
+            lower_transform(&style, 40.0, 20.0),
+            Some(Transform([
+                2.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, -10.0, -10.0, 0.0, 1.0,
+            ]))
+        );
+
+        let translated = ComputedTransformStyle {
+            functions: vec![ComputedTransformFunction::Translate {
+                x: ComputedLengthPercentage::new(3.0, 0.5),
+                y: ComputedLengthPercentage::new(4.0, 0.25),
+                z: StyleNumber::new(0.0),
+            }],
+            origin_x: ComputedLengthPercentage::ZERO,
+            origin_y: ComputedLengthPercentage::ZERO,
+        };
+        let matrix = lower_transform(&translated, 40.0, 20.0).unwrap();
+        assert_eq!(matrix.0[12], 23.0);
+        assert_eq!(matrix.0[13], 9.0);
+        assert_eq!(lower_transform(&translated, f32::NAN, 20.0), None);
+    }
+
+    #[test]
+    fn lowers_every_flat_transform_function_and_rejects_invalid_output() {
+        let number = StyleNumber::new;
+        for function in [
+            ComputedTransformFunction::RotateX(number(0.0)),
+            ComputedTransformFunction::RotateY(number(0.0)),
+            ComputedTransformFunction::RotateZ(number(90.0)),
+            ComputedTransformFunction::Skew {
+                x_degrees: number(10.0),
+                y_degrees: number(20.0),
+            },
+            ComputedTransformFunction::Matrix([
+                number(1.0),
+                number(0.0),
+                number(0.0),
+                number(0.0),
+                number(0.0),
+                number(1.0),
+                number(0.0),
+                number(0.0),
+                number(0.0),
+                number(0.0),
+                number(1.0),
+                number(0.0),
+                number(2.0),
+                number(3.0),
+                number(0.0),
+                number(1.0),
+            ]),
+        ] {
+            let style = ComputedTransformStyle {
+                functions: vec![function],
+                origin_x: ComputedLengthPercentage::ZERO,
+                origin_y: ComputedLengthPercentage::ZERO,
+            };
+            assert!(lower_transform(&style, 40.0, 20.0).is_some());
+        }
+
+        let mut non_finite = [number(0.0); 16];
+        non_finite[0] = number(f32::NAN);
+        let invalid_function = ComputedTransformStyle {
+            functions: vec![ComputedTransformFunction::Matrix(non_finite)],
+            ..ComputedTransformStyle::default()
+        };
+        assert_eq!(lower_transform(&invalid_function, 1.0, 1.0), None);
+
+        let invalid_origin = ComputedTransformStyle {
+            origin_x: ComputedLengthPercentage::new(f32::INFINITY, 0.0),
+            ..ComputedTransformStyle::default()
+        };
+        assert_eq!(lower_transform(&invalid_origin, 1.0, 1.0), None);
     }
 
     #[test]

--- a/crates/whisker-engine/src/scene.rs
+++ b/crates/whisker-engine/src/scene.rs
@@ -101,6 +101,11 @@ impl SceneNode {
         self.clip
     }
 
+    /// Returns the retained resolved transform matrix.
+    pub const fn transform(&self) -> Option<Transform> {
+        self.transform
+    }
+
     /// Returns retained group opacity.
     pub const fn opacity(&self) -> Option<f32> {
         self.opacity
@@ -1349,6 +1354,7 @@ mod tests {
         assert_eq!(root_state.box_paint(), Some(&paint));
         assert_eq!(root_state.visual_effects(), &effects);
         assert_eq!(root_state.clip(), Some(clip));
+        assert_eq!(root_state.transform(), Some(Transform::IDENTITY));
         assert_eq!(root_state.opacity(), Some(0.75));
         assert_eq!(root_state.visibility(), Some(Visibility::Visible));
         assert_eq!(root_state.z_order(), Some(-1));

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -1,6 +1,6 @@
 //! Surface-level orchestration of retained scene and layout state.
 
-use std::{error::Error, fmt};
+use std::{collections::HashMap, error::Error, fmt};
 
 use whisker_layout::{IntrinsicMeasurer, LayoutError, LayoutSize, LayoutSnapshot, LayoutTree};
 use whisker_protocol::{
@@ -8,11 +8,13 @@ use whisker_protocol::{
     LayoutGeometry, MeasurementMetrics, MeasurementReady, MeasurementResponse, MeasurementSpec,
     NodeId, PointerId, PropertyId, ResultId, SurfaceId, TextContent, WhiskerValue,
 };
-use whisker_style::{ComputedLayoutStyle, ComputedStyle, InheritedStyle, PropertyImpactSet};
+use whisker_style::{
+    ComputedLayoutStyle, ComputedStyle, ComputedTransformStyle, InheritedStyle, PropertyImpactSet,
+};
 
 use crate::{
     DeferredMeasurementApply, FrameSink, LayoutProgress, MeasurementApply, MeasurementError,
-    PlainTextInput, Scene, SceneError, SceneNode, lower_paint, lower_plain_text,
+    PlainTextInput, Scene, SceneError, SceneNode, lower_paint, lower_plain_text, lower_transform,
     measurement::MeasurementCoordinator,
 };
 
@@ -59,6 +61,11 @@ pub enum SurfaceError {
         /// Node whose rectangle was invalid.
         node: NodeId,
     },
+    /// A computed transform produced a non-finite matrix after box resolution.
+    InvalidTransformOutput {
+        /// Node whose transform could not be represented.
+        node: NodeId,
+    },
     /// Intrinsic measurement state or a Host response was invalid.
     Measurement(MeasurementError),
 }
@@ -75,7 +82,9 @@ impl Error for SurfaceError {
             Self::Scene(error) => Some(error),
             Self::Layout(error) => Some(error),
             Self::Measurement(error) => Some(error),
-            Self::SceneLayoutMismatch { .. } | Self::InvalidLayoutOutput { .. } => None,
+            Self::SceneLayoutMismatch { .. }
+            | Self::InvalidLayoutOutput { .. }
+            | Self::InvalidTransformOutput { .. } => None,
         }
     }
 }
@@ -141,6 +150,7 @@ pub struct SurfaceEngine {
     last_inputs: Option<LayoutInputs>,
     layout_dirty: bool,
     layout_provisional: bool,
+    transforms: HashMap<NodeId, ComputedTransformStyle>,
     measurements: MeasurementCoordinator,
 }
 
@@ -154,6 +164,7 @@ impl SurfaceEngine {
             last_inputs: None,
             layout_dirty: false,
             layout_provisional: false,
+            transforms: HashMap::new(),
             measurements: MeasurementCoordinator::default(),
         }
     }
@@ -287,6 +298,7 @@ impl SurfaceEngine {
             .remove_subtree(node)
             .expect("scene and layout trees remain structurally synchronized");
         for removed in removed {
+            self.transforms.remove(&removed);
             self.measurements.remove_node(removed);
         }
         self.layout_dirty = true;
@@ -361,6 +373,21 @@ impl SurfaceEngine {
     ) -> Result<PropertyImpactSet, SurfaceError> {
         self.ensure_mutable()?;
         let lowered = lower_paint(style.paint(), style.layout());
+        let transform_changed = self.transforms.get(&node) != Some(&lowered.transform);
+        let projected_transform = self
+            .last_layout
+            .as_ref()
+            .and_then(|layout| layout.get(node))
+            .copied()
+            .map(|geometry| {
+                self.resolve_node_transform(
+                    node,
+                    &lowered.transform,
+                    geometry.border_box.width,
+                    geometry.border_box.height,
+                )
+            })
+            .transpose()?;
         let paint_changed = {
             let current = self
                 .scene
@@ -372,6 +399,7 @@ impl SurfaceEngine {
                 || current.opacity() != Some(lowered.opacity)
                 || current.visibility() != Some(lowered.visibility)
                 || current.z_order() != Some(lowered.z_order)
+                || transform_changed
         };
         let mut impacts = self.update_layout_style(node, style.layout().clone())?;
         self.scene
@@ -392,6 +420,12 @@ impl SurfaceEngine {
         self.scene
             .set_z_order(node, lowered.z_order)
             .expect("the retained scene node was validated above");
+        self.transforms.insert(node, lowered.transform);
+        if let Some(transform) = projected_transform.flatten() {
+            self.scene
+                .set_transform(node, transform)
+                .expect("the transform was validated before retained style mutation");
+        }
         if paint_changed {
             impacts |= PropertyImpactSet::PAINT;
         }
@@ -726,15 +760,58 @@ impl SurfaceEngine {
                     != Some(rect)
             })
             .collect::<Vec<_>>();
-        for (node, rect) in &changed {
+        let transforms = changed
+            .iter()
+            .map(|(node, rect)| {
+                self.transforms
+                    .get(node)
+                    .map(|style| {
+                        self.resolve_node_transform(
+                            *node,
+                            style,
+                            rect.border_box.width,
+                            rect.border_box.height,
+                        )
+                    })
+                    .transpose()
+                    .map(Option::flatten)
+            })
+            .collect::<Result<Vec<_>, SurfaceError>>()?;
+        for ((node, rect), transform) in changed.iter().zip(transforms) {
             self.scene
                 .set_layout(*node, *rect)
                 .expect("validated layout projection must enter a mutable synchronized scene");
+            if let Some(transform) = transform {
+                self.scene
+                    .set_transform(*node, transform)
+                    .expect("the transform was validated before layout projection");
+            }
         }
         self.last_layout = Some(snapshot);
         self.last_inputs = Some(inputs);
         self.layout_dirty = false;
         Ok(LayoutUpdate::computed(changed.len()))
+    }
+
+    fn resolve_node_transform(
+        &self,
+        node: NodeId,
+        style: &ComputedTransformStyle,
+        border_width: f32,
+        border_height: f32,
+    ) -> Result<Option<whisker_protocol::Transform>, SurfaceError> {
+        if style.functions.is_empty()
+            && self
+                .scene
+                .node(node)
+                .and_then(SceneNode::transform)
+                .is_none()
+        {
+            return Ok(None);
+        }
+        let transform = lower_transform(style, border_width, border_height)
+            .ok_or(SurfaceError::InvalidTransformOutput { node })?;
+        Ok(Some(transform))
     }
 
     fn sync_text_presentations(&mut self, nodes: &[NodeId]) {
@@ -803,8 +880,10 @@ mod tests {
         SurfaceId, TextMeasurePayload, TextMeasureStyle, UnsupportedMeasurementReason,
     };
     use whisker_style::{
-        Axes, ComputedLengthPercentage, ComputedSizeValue, PositionValue, SpecifiedStyle,
-        StyleEnvironment, resolve_style,
+        Axes, ComputedLengthPercentage, ComputedSizeValue, ComputedTransformFunction,
+        ComputedTransformStyle, LengthPercentageValue, PositionValue, SpecifiedStyle,
+        StyleEnvironment, StyleNumber, StyleProperty, StyleValue, TransformFunctionValue,
+        TransformValue, resolve_style,
     };
 
     use super::*;
@@ -1007,6 +1086,107 @@ mod tests {
         let delta = present_and_accept(&mut surface, &mut renderer, 2);
         assert_eq!(delta.header.mode, FrameMode::Delta);
         assert_eq!(layout_operation_count(&delta), 2);
+    }
+
+    #[test]
+    fn transform_style_projects_before_and_after_layout_and_rejects_invalid_matrices() {
+        let resolved = |function| {
+            resolve_style(
+                &SpecifiedStyle::new().push(
+                    StyleProperty::Transform,
+                    StyleValue::Transform(TransformValue(vec![function])),
+                ),
+                None,
+                StyleEnvironment::default(),
+            )
+            .unwrap()
+        };
+        let translated = resolved(TransformFunctionValue::TranslateX(
+            LengthPercentageValue::Percentage(StyleNumber::new(50.0)),
+        ));
+        let mut surface = SurfaceEngine::new(surface_id());
+        let root = surface
+            .create_node(element_type(), translated.computed().layout().clone())
+            .unwrap();
+        surface
+            .update_computed_style(root, translated.computed())
+            .unwrap();
+        assert_eq!(surface.node(root).unwrap().transform(), None);
+        surface
+            .compute_layout(root, LayoutSize::new(40.0, 20.0), &mut zero_measure)
+            .unwrap();
+        let projected = surface.node(root).unwrap().transform().unwrap();
+        assert_eq!(projected.0[12], 20.0);
+
+        let rotated = resolved(TransformFunctionValue::Rotate(StyleNumber::new(90.0)));
+        assert!(
+            surface
+                .update_computed_style(root, rotated.computed())
+                .unwrap()
+                .contains(PropertyImpactSet::PAINT)
+        );
+        assert_ne!(surface.node(root).unwrap().transform(), Some(projected));
+
+        let huge = resolved(TransformFunctionValue::Matrix([
+            StyleNumber::new(f32::MAX),
+            StyleNumber::new(0.0),
+            StyleNumber::new(0.0),
+            StyleNumber::new(1.0),
+            StyleNumber::new(0.0),
+            StyleNumber::new(0.0),
+        ]));
+        assert_eq!(
+            surface.update_computed_style(root, huge.computed()),
+            Err(SurfaceError::InvalidTransformOutput { node: root })
+        );
+
+        let mut values = [StyleNumber::new(0.0); 16];
+        values[0] = StyleNumber::new(f32::NAN);
+        let invalid = ComputedTransformStyle {
+            functions: vec![ComputedTransformFunction::Matrix(values)],
+            ..ComputedTransformStyle::default()
+        };
+        assert_eq!(
+            surface.resolve_node_transform(root, &invalid, 40.0, 20.0),
+            Err(SurfaceError::InvalidTransformOutput { node: root })
+        );
+
+        let mut invalid_projection = SurfaceEngine::new(surface_id());
+        let invalid_root = invalid_projection
+            .create_node(element_type(), sized(40.0, 20.0))
+            .unwrap();
+        invalid_projection
+            .transforms
+            .insert(invalid_root, invalid.clone());
+        assert_eq!(
+            invalid_projection.compute_layout(
+                invalid_root,
+                LayoutSize::new(40.0, 20.0),
+                &mut zero_measure,
+            ),
+            Err(SurfaceError::InvalidTransformOutput { node: invalid_root })
+        );
+
+        let mut empty_surface = SurfaceEngine::new(surface_id());
+        let empty = empty_surface
+            .create_node(element_type(), ComputedLayoutStyle::default())
+            .unwrap();
+        assert_eq!(
+            empty_surface
+                .resolve_node_transform(empty, &ComputedTransformStyle::default(), 1.0, 1.0)
+                .unwrap(),
+            None
+        );
+        empty_surface
+            .scene
+            .set_transform(empty, whisker_protocol::Transform::IDENTITY)
+            .unwrap();
+        assert_eq!(
+            empty_surface
+                .resolve_node_transform(empty, &ComputedTransformStyle::default(), 1.0, 1.0)
+                .unwrap(),
+            Some(whisker_protocol::Transform::IDENTITY)
+        );
     }
 
     #[test]

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -34,7 +34,8 @@ pub use layout_value::{
 pub use paint::{
     BorderStyleValue, ComputedBackgroundImage, ComputedBackgroundLayerStyle,
     ComputedBackgroundPosition, ComputedBackgroundSize, ComputedCornerRadius, ComputedGradient,
-    ComputedGradientStop, ComputedPaintStyle, Corners, OverflowValue, VisibilityValue,
+    ComputedGradientStop, ComputedPaintStyle, ComputedTransformFunction, ComputedTransformStyle,
+    Corners, OverflowValue, VisibilityValue,
 };
 pub use property::{
     PropertyMetadata, PropertyOrigin, StyleProperty, StylePropertyDomain, StylePropertyId,
@@ -50,5 +51,5 @@ pub use value::{
     BackgroundRepeatValue, BackgroundSizeValue, BackgroundValue, BorderRadiusValue, CalcExpression,
     ColorValue, FontFamilyValue, FontStyleValue, FontWeightValue, GradientStopValue, GradientValue,
     LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, RadialGradientValue,
-    StyleNumber, StyleValue,
+    StyleNumber, StyleValue, TransformFunctionValue, TransformOriginValue, TransformValue,
 };

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -5,7 +5,8 @@ use crate::{
     BackgroundPositionValue, BackgroundRepeatModeValue, BackgroundSizeValue, ColorValue,
     ComputedLengthPercentage, DirectionValue, Edges, GradientValue, InheritedStyle,
     LengthPercentageValue, RadialGradientValue, SpecifiedStyle, StyleEnvironment, StyleNumber,
-    StyleProperty, StyleResolutionError, StyleValue, layout::resolve_affine,
+    StyleProperty, StyleResolutionError, StyleValue, TransformFunctionValue, TransformOriginValue,
+    TransformValue, layout::resolve_affine,
 };
 
 /// Four physical corners in top-left, top-right, bottom-right, bottom-left order.
@@ -171,6 +172,66 @@ pub enum ComputedBackgroundImage {
     Gradient(ComputedGradient),
 }
 
+/// One transform function after environment-dependent units are resolved.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ComputedTransformFunction {
+    /// Three-axis translation. Horizontal and vertical percentages remain
+    /// relative to the node's border box.
+    Translate {
+        /// Horizontal translation.
+        x: ComputedLengthPercentage,
+        /// Vertical translation.
+        y: ComputedLengthPercentage,
+        /// Depth translation in logical pixels.
+        z: StyleNumber,
+    },
+    /// Rotation around the x axis in degrees.
+    RotateX(StyleNumber),
+    /// Rotation around the y axis in degrees.
+    RotateY(StyleNumber),
+    /// Rotation around the z axis in degrees.
+    RotateZ(StyleNumber),
+    /// Three-axis scale.
+    Scale {
+        /// Horizontal scale.
+        x: StyleNumber,
+        /// Vertical scale.
+        y: StyleNumber,
+        /// Depth scale.
+        z: StyleNumber,
+    },
+    /// Two-axis skew in degrees.
+    Skew {
+        /// Horizontal skew.
+        x_degrees: StyleNumber,
+        /// Vertical skew.
+        y_degrees: StyleNumber,
+    },
+    /// A fully specified column-major matrix.
+    Matrix([StyleNumber; 16]),
+}
+
+/// Transform functions and origin retained until border-box layout is known.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedTransformStyle {
+    /// Ordered transform functions.
+    pub functions: Vec<ComputedTransformFunction>,
+    /// Horizontal origin relative to border-box width.
+    pub origin_x: ComputedLengthPercentage,
+    /// Vertical origin relative to border-box height.
+    pub origin_y: ComputedLengthPercentage,
+}
+
+impl Default for ComputedTransformStyle {
+    fn default() -> Self {
+        Self {
+            functions: Vec::new(),
+            origin_x: ComputedLengthPercentage::new(0.0, 0.5),
+            origin_y: ComputedLengthPercentage::new(0.0, 0.5),
+        }
+    }
+}
+
 /// Computed geometry and scrolling values paired with one background image.
 ///
 /// The authoring API currently exposes one scalar set of longhands. Keeping
@@ -228,6 +289,8 @@ pub struct ComputedPaintStyle {
     pub border_styles: Edges<BorderStyleValue>,
     /// Corner radii retaining their border-box percentage component.
     pub border_radii: Corners<ComputedCornerRadius>,
+    /// Transform retained until the border-box size is known.
+    pub transform: ComputedTransformStyle,
     /// Group opacity, clamped to `0.0..=1.0`.
     pub opacity: StyleNumber,
     /// Paint visibility.
@@ -266,6 +329,7 @@ impl ComputedPaintStyle {
                 left: BorderStyleValue::None,
             },
             border_radii: Corners::all(ComputedCornerRadius::ZERO),
+            transform: ComputedTransformStyle::default(),
             opacity: StyleNumber::new(1.0),
             visibility: VisibilityValue::Visible,
             overflow_x: OverflowValue::Visible,
@@ -315,6 +379,22 @@ pub(crate) fn resolve_paint_style(
                         Some(StyleNumber::new(radius))
                     }
                 };
+            }
+            StyleProperty::Transform => {
+                let StyleValue::Transform(value) = value else {
+                    return Err(invalid(property));
+                };
+                paint.transform.functions =
+                    resolve_transform_functions(value, inherited, environment, property)?;
+            }
+            StyleProperty::TransformOrigin => {
+                let StyleValue::TransformOrigin(value) = value else {
+                    return Err(invalid(property));
+                };
+                let (horizontal, vertical) =
+                    resolve_transform_origin(value, inherited, environment, property)?;
+                paint.transform.origin_x = horizontal;
+                paint.transform.origin_y = vertical;
             }
             StyleProperty::Background => {
                 let StyleValue::Background(value) = value else {
@@ -552,6 +632,189 @@ pub(crate) fn resolve_paint_style(
         }
     }
     Ok(paint)
+}
+
+fn resolve_transform_functions(
+    value: &TransformValue,
+    inherited: &InheritedStyle,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<Vec<ComputedTransformFunction>, StyleResolutionError> {
+    let length_percentage = |value: &LengthPercentageValue| {
+        resolve_affine(value, inherited.font_size(), environment, property)
+    };
+    let length = |value: &crate::LengthValue| {
+        resolve_affine(
+            &LengthPercentageValue::Length(*value),
+            inherited.font_size(),
+            environment,
+            property,
+        )
+        .map(|value| StyleNumber::new(value.length()))
+    };
+    let finite = |value: StyleNumber| {
+        if value.get().is_finite() {
+            Ok(value)
+        } else {
+            Err(invalid(property))
+        }
+    };
+
+    value
+        .0
+        .iter()
+        .map(|function| {
+            Ok(match function {
+                TransformFunctionValue::Translate(x, y) => ComputedTransformFunction::Translate {
+                    x: length_percentage(x)?,
+                    y: length_percentage(y)?,
+                    z: StyleNumber::new(0.0),
+                },
+                TransformFunctionValue::TranslateX(x) => ComputedTransformFunction::Translate {
+                    x: length_percentage(x)?,
+                    y: ComputedLengthPercentage::ZERO,
+                    z: StyleNumber::new(0.0),
+                },
+                TransformFunctionValue::TranslateY(y) => ComputedTransformFunction::Translate {
+                    x: ComputedLengthPercentage::ZERO,
+                    y: length_percentage(y)?,
+                    z: StyleNumber::new(0.0),
+                },
+                TransformFunctionValue::TranslateZ(z) => {
+                    let z = length(z)?;
+                    if z.get() != 0.0 {
+                        return Err(invalid(property));
+                    }
+                    ComputedTransformFunction::Translate {
+                        x: ComputedLengthPercentage::ZERO,
+                        y: ComputedLengthPercentage::ZERO,
+                        z,
+                    }
+                }
+                TransformFunctionValue::Translate3d(x, y, z) => {
+                    let z = length(z)?;
+                    if z.get() != 0.0 {
+                        return Err(invalid(property));
+                    }
+                    ComputedTransformFunction::Translate {
+                        x: length_percentage(x)?,
+                        y: length_percentage(y)?,
+                        z,
+                    }
+                }
+                TransformFunctionValue::Rotate(angle) | TransformFunctionValue::RotateZ(angle) => {
+                    ComputedTransformFunction::RotateZ(finite(*angle)?)
+                }
+                TransformFunctionValue::RotateX(angle) => {
+                    let angle = finite(*angle)?;
+                    if angle.get() != 0.0 {
+                        return Err(invalid(property));
+                    }
+                    ComputedTransformFunction::RotateX(angle)
+                }
+                TransformFunctionValue::RotateY(angle) => {
+                    let angle = finite(*angle)?;
+                    if angle.get() != 0.0 {
+                        return Err(invalid(property));
+                    }
+                    ComputedTransformFunction::RotateY(angle)
+                }
+                TransformFunctionValue::Scale(x, y) => ComputedTransformFunction::Scale {
+                    x: finite(*x)?,
+                    y: finite(*y)?,
+                    z: StyleNumber::new(1.0),
+                },
+                TransformFunctionValue::ScaleX(x) => ComputedTransformFunction::Scale {
+                    x: finite(*x)?,
+                    y: StyleNumber::new(1.0),
+                    z: StyleNumber::new(1.0),
+                },
+                TransformFunctionValue::ScaleY(y) => ComputedTransformFunction::Scale {
+                    x: StyleNumber::new(1.0),
+                    y: finite(*y)?,
+                    z: StyleNumber::new(1.0),
+                },
+                TransformFunctionValue::Skew(x, y) => ComputedTransformFunction::Skew {
+                    x_degrees: finite(*x)?,
+                    y_degrees: finite(*y)?,
+                },
+                TransformFunctionValue::SkewX(x) => ComputedTransformFunction::Skew {
+                    x_degrees: finite(*x)?,
+                    y_degrees: StyleNumber::new(0.0),
+                },
+                TransformFunctionValue::SkewY(y) => ComputedTransformFunction::Skew {
+                    x_degrees: StyleNumber::new(0.0),
+                    y_degrees: finite(*y)?,
+                },
+                TransformFunctionValue::Matrix(values) => {
+                    if !values.iter().all(|value| value.get().is_finite()) {
+                        return Err(invalid(property));
+                    }
+                    let [a, b, c, d, tx, ty] = *values;
+                    ComputedTransformFunction::Matrix([
+                        a,
+                        b,
+                        StyleNumber::new(0.0),
+                        StyleNumber::new(0.0),
+                        c,
+                        d,
+                        StyleNumber::new(0.0),
+                        StyleNumber::new(0.0),
+                        StyleNumber::new(0.0),
+                        StyleNumber::new(0.0),
+                        StyleNumber::new(1.0),
+                        StyleNumber::new(0.0),
+                        tx,
+                        ty,
+                        StyleNumber::new(0.0),
+                        StyleNumber::new(1.0),
+                    ])
+                }
+                TransformFunctionValue::Matrix3d(values) => {
+                    if !values.iter().all(|value| value.get().is_finite()) {
+                        return Err(invalid(property));
+                    }
+                    let raw = values.map(|value| value.get());
+                    if raw[2] != 0.0
+                        || raw[3] != 0.0
+                        || raw[6] != 0.0
+                        || raw[7] != 0.0
+                        || raw[8] != 0.0
+                        || raw[9] != 0.0
+                        || raw[10] != 1.0
+                        || raw[11] != 0.0
+                        || raw[14] != 0.0
+                        || raw[15] != 1.0
+                    {
+                        return Err(invalid(property));
+                    }
+                    ComputedTransformFunction::Matrix(*values)
+                }
+            })
+        })
+        .collect()
+}
+
+fn resolve_transform_origin(
+    value: &TransformOriginValue,
+    inherited: &InheritedStyle,
+    environment: StyleEnvironment,
+    property: StyleProperty,
+) -> Result<(ComputedLengthPercentage, ComputedLengthPercentage), StyleResolutionError> {
+    Ok((
+        resolve_affine(
+            &value.horizontal,
+            inherited.font_size(),
+            environment,
+            property,
+        )?,
+        resolve_affine(
+            &value.vertical,
+            inherited.font_size(),
+            environment,
+            property,
+        )?,
+    ))
 }
 
 fn resolve_background_image(
@@ -898,6 +1161,279 @@ mod tests {
                 Err(StyleResolutionError::InvalidPropertyValue(
                     StyleProperty::BackdropFilter
                 ))
+            );
+        }
+    }
+
+    #[test]
+    fn transform_retains_box_percentages_and_rejects_non_2d_functions() {
+        let transform = StyleValue::Transform(TransformValue(vec![
+            TransformFunctionValue::Translate(
+                LengthPercentageValue::Percentage(number(50.0)),
+                px_length(4.0),
+            ),
+            TransformFunctionValue::Scale(number(2.0), number(3.0)),
+        ]));
+        let origin = StyleValue::TransformOrigin(TransformOriginValue {
+            horizontal: LengthPercentageValue::Percentage(number(25.0)),
+            vertical: LengthPercentageValue::Percentage(number(75.0)),
+        });
+        let resolved = crate::resolve_style(
+            &SpecifiedStyle::new()
+                .push(StyleProperty::Transform, transform)
+                .push(StyleProperty::TransformOrigin, origin),
+            None,
+            StyleEnvironment::default(),
+        )
+        .unwrap();
+        let transform = &resolved.computed().paint().transform;
+        assert_eq!(transform.origin_x, ComputedLengthPercentage::new(0.0, 0.25));
+        assert_eq!(transform.origin_y, ComputedLengthPercentage::new(0.0, 0.75));
+        assert_eq!(
+            transform.functions,
+            [
+                ComputedTransformFunction::Translate {
+                    x: ComputedLengthPercentage::new(0.0, 0.5),
+                    y: ComputedLengthPercentage::new(4.0, 0.0),
+                    z: number(0.0),
+                },
+                ComputedTransformFunction::Scale {
+                    x: number(2.0),
+                    y: number(3.0),
+                    z: number(1.0),
+                },
+            ]
+        );
+
+        assert_eq!(
+            crate::resolve_style(
+                &SpecifiedStyle::new().push(
+                    StyleProperty::Transform,
+                    StyleValue::Transform(TransformValue(vec![TransformFunctionValue::RotateX(
+                        number(30.0)
+                    ),])),
+                ),
+                None,
+                StyleEnvironment::default(),
+            ),
+            Err(StyleResolutionError::InvalidPropertyValue(
+                StyleProperty::Transform
+            ))
+        );
+    }
+
+    #[test]
+    fn transform_resolves_every_flat_function_and_rejects_invalid_inputs() {
+        let length = |value| LengthValue::Dimension {
+            value: number(value),
+            unit: LengthUnit::Px,
+        };
+        let mut matrix_3d = [number(0.0); 16];
+        for index in [0, 5, 10, 15] {
+            matrix_3d[index] = number(1.0);
+        }
+        let functions = vec![
+            TransformFunctionValue::TranslateX(percentage(10.0)),
+            TransformFunctionValue::TranslateY(px_length(2.0)),
+            TransformFunctionValue::TranslateZ(LengthValue::Zero),
+            TransformFunctionValue::Translate3d(
+                px_length(3.0),
+                percentage(20.0),
+                LengthValue::Zero,
+            ),
+            TransformFunctionValue::Rotate(number(10.0)),
+            TransformFunctionValue::RotateX(number(0.0)),
+            TransformFunctionValue::RotateY(number(0.0)),
+            TransformFunctionValue::RotateZ(number(20.0)),
+            TransformFunctionValue::ScaleX(number(2.0)),
+            TransformFunctionValue::ScaleY(number(3.0)),
+            TransformFunctionValue::Skew(number(4.0), number(5.0)),
+            TransformFunctionValue::SkewX(number(6.0)),
+            TransformFunctionValue::SkewY(number(7.0)),
+            TransformFunctionValue::Matrix([
+                number(1.0),
+                number(2.0),
+                number(3.0),
+                number(4.0),
+                number(5.0),
+                number(6.0),
+            ]),
+            TransformFunctionValue::Matrix3d(matrix_3d),
+        ];
+        let resolved = crate::resolve_style(
+            &SpecifiedStyle::new().push(
+                StyleProperty::Transform,
+                StyleValue::Transform(TransformValue(functions)),
+            ),
+            None,
+            StyleEnvironment::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            resolved.computed().paint().transform.functions,
+            [
+                ComputedTransformFunction::Translate {
+                    x: ComputedLengthPercentage::new(0.0, 0.1),
+                    y: ComputedLengthPercentage::ZERO,
+                    z: number(0.0),
+                },
+                ComputedTransformFunction::Translate {
+                    x: ComputedLengthPercentage::ZERO,
+                    y: ComputedLengthPercentage::new(2.0, 0.0),
+                    z: number(0.0),
+                },
+                ComputedTransformFunction::Translate {
+                    x: ComputedLengthPercentage::ZERO,
+                    y: ComputedLengthPercentage::ZERO,
+                    z: number(0.0),
+                },
+                ComputedTransformFunction::Translate {
+                    x: ComputedLengthPercentage::new(3.0, 0.0),
+                    y: ComputedLengthPercentage::new(0.0, 0.2),
+                    z: number(0.0),
+                },
+                ComputedTransformFunction::RotateZ(number(10.0)),
+                ComputedTransformFunction::RotateX(number(0.0)),
+                ComputedTransformFunction::RotateY(number(0.0)),
+                ComputedTransformFunction::RotateZ(number(20.0)),
+                ComputedTransformFunction::Scale {
+                    x: number(2.0),
+                    y: number(1.0),
+                    z: number(1.0),
+                },
+                ComputedTransformFunction::Scale {
+                    x: number(1.0),
+                    y: number(3.0),
+                    z: number(1.0),
+                },
+                ComputedTransformFunction::Skew {
+                    x_degrees: number(4.0),
+                    y_degrees: number(5.0),
+                },
+                ComputedTransformFunction::Skew {
+                    x_degrees: number(6.0),
+                    y_degrees: number(0.0),
+                },
+                ComputedTransformFunction::Skew {
+                    x_degrees: number(0.0),
+                    y_degrees: number(7.0),
+                },
+                ComputedTransformFunction::Matrix([
+                    number(1.0),
+                    number(2.0),
+                    number(0.0),
+                    number(0.0),
+                    number(3.0),
+                    number(4.0),
+                    number(0.0),
+                    number(0.0),
+                    number(0.0),
+                    number(0.0),
+                    number(1.0),
+                    number(0.0),
+                    number(5.0),
+                    number(6.0),
+                    number(0.0),
+                    number(1.0),
+                ]),
+                ComputedTransformFunction::Matrix(matrix_3d),
+            ]
+        );
+
+        let invalid_transform = |function| {
+            crate::resolve_style(
+                &SpecifiedStyle::new().push(
+                    StyleProperty::Transform,
+                    StyleValue::Transform(TransformValue(vec![function])),
+                ),
+                None,
+                StyleEnvironment::default(),
+            )
+        };
+        let mut non_finite_matrix = [number(0.0); 6];
+        non_finite_matrix[0] = number(f32::NAN);
+        let mut non_finite_matrix_3d = matrix_3d;
+        non_finite_matrix_3d[0] = number(f32::INFINITY);
+        let mut spatial_matrix_3d = matrix_3d;
+        spatial_matrix_3d[14] = number(1.0);
+        for function in [
+            TransformFunctionValue::Translate(
+                LengthPercentageValue::Length(length(f32::NAN)),
+                px_length(0.0),
+            ),
+            TransformFunctionValue::Translate(
+                px_length(0.0),
+                LengthPercentageValue::Length(length(f32::NAN)),
+            ),
+            TransformFunctionValue::TranslateX(LengthPercentageValue::Length(length(f32::NAN))),
+            TransformFunctionValue::TranslateY(LengthPercentageValue::Length(length(f32::NAN))),
+            TransformFunctionValue::TranslateZ(length(f32::NAN)),
+            TransformFunctionValue::TranslateZ(length(1.0)),
+            TransformFunctionValue::Translate3d(px_length(0.0), px_length(0.0), length(f32::NAN)),
+            TransformFunctionValue::Translate3d(
+                LengthPercentageValue::Length(length(f32::NAN)),
+                px_length(0.0),
+                LengthValue::Zero,
+            ),
+            TransformFunctionValue::Translate3d(
+                px_length(0.0),
+                LengthPercentageValue::Length(length(f32::NAN)),
+                LengthValue::Zero,
+            ),
+            TransformFunctionValue::Translate3d(px_length(0.0), px_length(0.0), length(1.0)),
+            TransformFunctionValue::Rotate(number(f32::NAN)),
+            TransformFunctionValue::RotateX(number(f32::NAN)),
+            TransformFunctionValue::RotateX(number(1.0)),
+            TransformFunctionValue::RotateY(number(f32::NAN)),
+            TransformFunctionValue::RotateY(number(1.0)),
+            TransformFunctionValue::Scale(number(f32::NAN), number(1.0)),
+            TransformFunctionValue::Scale(number(1.0), number(f32::NAN)),
+            TransformFunctionValue::ScaleX(number(f32::INFINITY)),
+            TransformFunctionValue::ScaleY(number(f32::INFINITY)),
+            TransformFunctionValue::Skew(number(f32::NAN), number(0.0)),
+            TransformFunctionValue::Skew(number(0.0), number(f32::NAN)),
+            TransformFunctionValue::SkewX(number(f32::NAN)),
+            TransformFunctionValue::SkewY(number(f32::NAN)),
+            TransformFunctionValue::Matrix(non_finite_matrix),
+            TransformFunctionValue::Matrix3d(non_finite_matrix_3d),
+            TransformFunctionValue::Matrix3d(spatial_matrix_3d),
+        ] {
+            assert_eq!(
+                invalid_transform(function),
+                Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::Transform
+                ))
+            );
+        }
+
+        for (property, value) in [
+            (StyleProperty::Transform, StyleValue::Number(number(1.0))),
+            (
+                StyleProperty::TransformOrigin,
+                StyleValue::Number(number(1.0)),
+            ),
+            (
+                StyleProperty::TransformOrigin,
+                StyleValue::TransformOrigin(TransformOriginValue {
+                    horizontal: LengthPercentageValue::Length(length(f32::NAN)),
+                    vertical: px_length(0.0),
+                }),
+            ),
+            (
+                StyleProperty::TransformOrigin,
+                StyleValue::TransformOrigin(TransformOriginValue {
+                    horizontal: px_length(0.0),
+                    vertical: LengthPercentageValue::Length(length(f32::NAN)),
+                }),
+            ),
+        ] {
+            assert_eq!(
+                crate::resolve_style(
+                    &SpecifiedStyle::new().push(property, value),
+                    None,
+                    StyleEnvironment::default(),
+                ),
+                Err(StyleResolutionError::InvalidPropertyValue(property))
             );
         }
     }

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -353,6 +353,58 @@ pub enum BackdropFilterValue {
     Blur(LengthValue),
 }
 
+/// One typed transform function before environment and box-size resolution.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TransformFunctionValue {
+    /// Two-axis translation.
+    Translate(LengthPercentageValue, LengthPercentageValue),
+    /// Horizontal translation.
+    TranslateX(LengthPercentageValue),
+    /// Vertical translation.
+    TranslateY(LengthPercentageValue),
+    /// Depth translation.
+    TranslateZ(LengthValue),
+    /// Three-axis translation.
+    Translate3d(LengthPercentageValue, LengthPercentageValue, LengthValue),
+    /// Rotation around the z axis, in degrees.
+    Rotate(StyleNumber),
+    /// Rotation around the x axis, in degrees.
+    RotateX(StyleNumber),
+    /// Rotation around the y axis, in degrees.
+    RotateY(StyleNumber),
+    /// Rotation around the z axis, in degrees.
+    RotateZ(StyleNumber),
+    /// Two-axis scale.
+    Scale(StyleNumber, StyleNumber),
+    /// Horizontal scale.
+    ScaleX(StyleNumber),
+    /// Vertical scale.
+    ScaleY(StyleNumber),
+    /// Two-axis skew, in degrees.
+    Skew(StyleNumber, StyleNumber),
+    /// Horizontal skew, in degrees.
+    SkewX(StyleNumber),
+    /// Vertical skew, in degrees.
+    SkewY(StyleNumber),
+    /// CSS six-value affine matrix.
+    Matrix([StyleNumber; 6]),
+    /// Column-major four-by-four matrix.
+    Matrix3d([StyleNumber; 16]),
+}
+
+/// Ordered typed value of the `transform` property.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TransformValue(pub Vec<TransformFunctionValue>);
+
+/// Two-dimensional `transform-origin` before border-box resolution.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TransformOriginValue {
+    /// Horizontal origin coordinate.
+    pub horizontal: LengthPercentageValue,
+    /// Vertical origin coordinate.
+    pub vertical: LengthPercentageValue,
+}
+
 /// An owned value in a specified inline-style declaration.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StyleValue {
@@ -386,6 +438,10 @@ pub enum StyleValue {
     BackgroundAttachment(BackgroundAttachmentValue),
     /// Background-pixel filter applied behind this node.
     BackdropFilter(BackdropFilterValue),
+    /// Ordered transform function list.
+    Transform(TransformValue),
+    /// Transform origin resolved against the node border box.
+    TransformOrigin(TransformOriginValue),
     /// Font family.
     FontFamily(FontFamilyValue),
     /// Font face style.

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -1,7 +1,8 @@
 use std::convert::Infallible;
 
 use whisker::css::{
-    BorderStyle, Clear, Direction, Float, GridLine, GridTemplate, GridTrack, Overflow,
+    BorderStyle, Clear, Direction, Float, GridLine, GridTemplate, GridTrack, Overflow, Position,
+    TransformFn,
 };
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
@@ -464,6 +465,111 @@ fn render_box_paint_and_clip_reach_the_frame_sink() {
                     alpha: 1.0,
                 }
     ));
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn render_transform_and_origin_reach_the_frame_sink_after_layout() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(24).expect("test surface"),
+        StyleEnvironment::new(100.0, 100.0, 1.0, 14.0),
+    );
+    let style = Css::new()
+        .width(px(40))
+        .height(px(20))
+        .transform(TransformFn::Scale(2.0, 2.0))
+        .transform_origin(Position::Coords(percent(25).into(), percent(50).into()));
+    let root_element = with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| render! { view(style: style) });
+        set_root(root);
+        root
+    });
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(100.0, 100.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .expect("transformed frame");
+
+    let root = surface.root().expect("surface root");
+    let packet = &renderer.frames()[0].packet;
+    assert!(packet.operations.iter().any(|operation| matches!(
+        operation,
+        Operation::SetTransform { node, transform }
+            if *node == root
+                && transform.0 == [
+                    2.0, 0.0, 0.0, 0.0,
+                    0.0, 2.0, 0.0, 0.0,
+                    0.0, 0.0, 1.0, 0.0,
+                    -10.0, -10.0, 0.0, 1.0,
+                ]
+    )));
+
+    let resized = Css::new()
+        .width(px(80))
+        .height(px(20))
+        .transform(TransformFn::Scale(2.0, 2.0))
+        .transform_origin(Position::Coords(percent(25).into(), percent(50).into()));
+    with_installed_renderer(surface.renderer(), || {
+        whisker::apply_style(root_element, resized)
+    });
+    surface
+        .drive_layout(
+            LayoutSize::new(100.0, 100.0),
+            1,
+            &mut host,
+            LayoutOptions::default(),
+        )
+        .expect("resized transformed layout");
+    surface
+        .present(1, &mut renderer)
+        .expect("present resized transform")
+        .expect("resized transform delta exists");
+    assert!(
+        renderer.frames()[1]
+            .packet
+            .operations
+            .iter()
+            .any(|operation| matches!(
+                operation,
+                Operation::SetTransform { node, transform }
+                    if *node == root && transform.0[12] == -20.0 && transform.0[13] == -10.0
+            ))
+    );
+
+    with_installed_renderer(surface.renderer(), || {
+        whisker::apply_style(root_element, Css::new().width(px(80)).height(px(20)))
+    });
+    surface
+        .drive_layout(
+            LayoutSize::new(100.0, 100.0),
+            1,
+            &mut host,
+            LayoutOptions::default(),
+        )
+        .expect("clear transform");
+    surface
+        .present(1, &mut renderer)
+        .expect("present cleared transform")
+        .expect("cleared transform delta exists");
+    assert!(renderer.frames()[2]
+        .packet
+        .operations
+        .iter()
+        .any(|operation| matches!(
+            operation,
+            Operation::SetTransform { node, transform }
+                if *node == root && *transform == whisker_engine::whisker_protocol::Transform::IDENTITY
+        )));
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }
 

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -817,6 +817,16 @@ Commands
   InvokeCommand(node, command_id, arguments, result_id?)
 ```
 
+`SetTransform` always carries a resolved column-major 4-by-4 matrix around
+the node's local border-box origin. Rust retains typed transform functions,
+length-percentage translations, and `transform-origin` until Taffy has
+produced the border-box size, then bakes them into that matrix. Hosts therefore
+do not parse CSS or independently resolve percentages and origin semantics.
+Changing a node's border-box size recomputes its matrix even when its specified
+transform is unchanged. The current common subset is the CSS/Lynx 2-D
+transform family; 3-D transforms, perspective, and motion paths require later
+capability slices rather than silently degrading on Android.
+
 The final opcode set may combine common operations for compactness. The
 semantic separation matters because it enables dirty classification,
 validation, and backend-specific fast paths.

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -472,6 +472,16 @@ Rust resolves the semantic values for:
 - stacking order and isolated stacking contexts;
 - visibility and hit-test participation.
 
+For the common transform subset, specified function lists and
+`transform-origin` remain typed computed values until layout is available.
+The surface resolves percentage translations against border-box width or
+height, resolves the origin against that same box, composes the functions in
+CSS matrix order, and emits one `SetTransform` matrix. A Host applies that
+matrix at its local border-box origin and does not repeat CSS resolution. This
+slice currently accepts 2-D transforms, including 2-D-compatible `matrix3d`;
+3-D transforms, perspective, and offset-path motion remain separate planned
+capabilities.
+
 Protocol minor 1 groups those resolved meanings by Host capability rather
 than by CSS spelling. `SetBackgroundLayers` carries resource-backed images,
 linear/radial/conic gradients, positioning, sizing, repeat, origin, clip,

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -126,9 +126,11 @@
       "id": "paint.transform",
       "basis": "lynx-4.0",
       "properties": ["offset-distance", "offset-path", "offset-rotate", "perspective", "transform", "transform-origin"],
+      "supported_subset": ["transform-2d-functions", "matrix", "2d-compatible-matrix3d", "length-percentage-translate", "border-box-transform-origin"],
+      "unsupported_browser_subset": ["3d-transform-functions", "perspective", "motion-path"],
       "protocol": ["SetTransform", "SetVisualEffects"],
       "rust": "partial",
-      "hosts": {"desktop": "planned", "web": "implemented", "android": "planned", "ios": "planned"}
+      "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}
     },
     {
       "id": "paint.compositing",


### PR DESCRIPTION
## Summary
- migrate transform and transform-origin from compatibility CSS text to typed Whisker style values
- retain length-percentage translations and origin until Taffy provides the border-box size, then emit one resolved SetTransform matrix
- recompute percentage transforms on relayout and emit identity when a transform is cleared
- document and register the common 2D subset while leaving 3D, perspective, and motion paths as explicit later slices

## Verification
- cargo check --workspace
- cargo clippy -p whisker-style -p whisker-css -p whisker-engine -p whisker --all-targets -- -D warnings
- cargo test -p whisker-style -p whisker-css -p whisker-engine --lib
- cargo test -p whisker --test surface_render_pipeline
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios

## Scope
The existing four Host SetTransform projections and three shared transform fixtures already covered matrix rendering. This PR closes the missing render-to-style-to-layout-to-FramePacket path. Non-planar 3D transforms remain rejected during style resolution so Android cannot fail later at the Host boundary.