### PR TITLE
feat(transform): project flat-plane 3D transforms

### DIFF
--- a/crates/whisker-engine/src/paint.rs
+++ b/crates/whisker-engine/src/paint.rs
@@ -103,10 +103,32 @@ pub fn lower_transform(
         multiply(translation(origin_x, origin_y, 0.0), matrix),
         translation(-origin_x, -origin_y, 0.0),
     );
-    around_origin
+    // Every Host currently flattens at the node boundary. Preserve the exact
+    // X/Y/W projection of points on the local z=0 plane, but canonicalize the
+    // unused depth row and column so GPU clip-space depth cannot discard CSS
+    // pixels and descendants cannot accidentally share a 3-D context.
+    let flat_plane = [
+        around_origin[0],
+        around_origin[1],
+        0.0,
+        around_origin[3],
+        around_origin[4],
+        around_origin[5],
+        0.0,
+        around_origin[7],
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        around_origin[12],
+        around_origin[13],
+        0.0,
+        around_origin[15],
+    ];
+    flat_plane
         .iter()
         .all(|value| value.is_finite())
-        .then_some(Transform(around_origin))
+        .then_some(Transform(flat_plane))
 }
 
 fn function_matrix(
@@ -484,6 +506,25 @@ mod tests {
             ..ComputedTransformStyle::default()
         };
         assert_eq!(lower_transform(&invalid_origin, 1.0, 1.0), None);
+    }
+
+    #[test]
+    fn canonicalizes_three_dimensional_output_to_the_node_plane() {
+        let style = ComputedTransformStyle {
+            functions: vec![ComputedTransformFunction::RotateY(StyleNumber::new(60.0))],
+            origin_x: ComputedLengthPercentage::ZERO,
+            origin_y: ComputedLengthPercentage::ZERO,
+        };
+        let transform = lower_transform(&style, 40.0, 20.0).expect("finite transform");
+        let expected = [
+            0.5, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        ];
+        for (actual, expected) in transform.0.into_iter().zip(expected) {
+            assert!(
+                (actual - expected).abs() < 0.000_001,
+                "{actual} != {expected}"
+            );
+        }
     }
 
     #[test]

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -682,9 +682,6 @@ fn resolve_transform_functions(
                 },
                 TransformFunctionValue::TranslateZ(z) => {
                     let z = length(z)?;
-                    if z.get() != 0.0 {
-                        return Err(invalid(property));
-                    }
                     ComputedTransformFunction::Translate {
                         x: ComputedLengthPercentage::ZERO,
                         y: ComputedLengthPercentage::ZERO,
@@ -693,9 +690,6 @@ fn resolve_transform_functions(
                 }
                 TransformFunctionValue::Translate3d(x, y, z) => {
                     let z = length(z)?;
-                    if z.get() != 0.0 {
-                        return Err(invalid(property));
-                    }
                     ComputedTransformFunction::Translate {
                         x: length_percentage(x)?,
                         y: length_percentage(y)?,
@@ -706,18 +700,10 @@ fn resolve_transform_functions(
                     ComputedTransformFunction::RotateZ(finite(*angle)?)
                 }
                 TransformFunctionValue::RotateX(angle) => {
-                    let angle = finite(*angle)?;
-                    if angle.get() != 0.0 {
-                        return Err(invalid(property));
-                    }
-                    ComputedTransformFunction::RotateX(angle)
+                    ComputedTransformFunction::RotateX(finite(*angle)?)
                 }
                 TransformFunctionValue::RotateY(angle) => {
-                    let angle = finite(*angle)?;
-                    if angle.get() != 0.0 {
-                        return Err(invalid(property));
-                    }
-                    ComputedTransformFunction::RotateY(angle)
+                    ComputedTransformFunction::RotateY(finite(*angle)?)
                 }
                 TransformFunctionValue::Scale(x, y) => ComputedTransformFunction::Scale {
                     x: finite(*x)?,
@@ -772,20 +758,6 @@ fn resolve_transform_functions(
                 }
                 TransformFunctionValue::Matrix3d(values) => {
                     if !values.iter().all(|value| value.get().is_finite()) {
-                        return Err(invalid(property));
-                    }
-                    let raw = values.map(|value| value.get());
-                    if raw[2] != 0.0
-                        || raw[3] != 0.0
-                        || raw[6] != 0.0
-                        || raw[7] != 0.0
-                        || raw[8] != 0.0
-                        || raw[9] != 0.0
-                        || raw[10] != 1.0
-                        || raw[11] != 0.0
-                        || raw[14] != 0.0
-                        || raw[15] != 1.0
-                    {
                         return Err(invalid(property));
                     }
                     ComputedTransformFunction::Matrix(*values)
@@ -1166,7 +1138,7 @@ mod tests {
     }
 
     #[test]
-    fn transform_retains_box_percentages_and_rejects_non_2d_functions() {
+    fn transform_retains_box_percentages_and_three_dimensional_functions() {
         let transform = StyleValue::Transform(TransformValue(vec![
             TransformFunctionValue::Translate(
                 LengthPercentageValue::Percentage(number(50.0)),
@@ -1205,25 +1177,36 @@ mod tests {
             ]
         );
 
-        assert_eq!(
-            crate::resolve_style(
-                &SpecifiedStyle::new().push(
-                    StyleProperty::Transform,
-                    StyleValue::Transform(TransformValue(vec![TransformFunctionValue::RotateX(
-                        number(30.0)
-                    ),])),
-                ),
-                None,
-                StyleEnvironment::default(),
+        let rotated = crate::resolve_style(
+            &SpecifiedStyle::new().push(
+                StyleProperty::Transform,
+                StyleValue::Transform(TransformValue(vec![
+                    TransformFunctionValue::RotateX(number(30.0)),
+                    TransformFunctionValue::TranslateZ(LengthValue::Dimension {
+                        value: number(8.0),
+                        unit: LengthUnit::Px,
+                    }),
+                ])),
             ),
-            Err(StyleResolutionError::InvalidPropertyValue(
-                StyleProperty::Transform
-            ))
+            None,
+            StyleEnvironment::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            rotated.computed().paint().transform.functions,
+            [
+                ComputedTransformFunction::RotateX(number(30.0)),
+                ComputedTransformFunction::Translate {
+                    x: ComputedLengthPercentage::ZERO,
+                    y: ComputedLengthPercentage::ZERO,
+                    z: number(8.0),
+                },
+            ]
         );
     }
 
     #[test]
-    fn transform_resolves_every_flat_function_and_rejects_invalid_inputs() {
+    fn transform_resolves_every_function_and_rejects_invalid_inputs() {
         let length = |value| LengthValue::Dimension {
             value: number(value),
             unit: LengthUnit::Px,
@@ -1368,7 +1351,6 @@ mod tests {
             TransformFunctionValue::TranslateX(LengthPercentageValue::Length(length(f32::NAN))),
             TransformFunctionValue::TranslateY(LengthPercentageValue::Length(length(f32::NAN))),
             TransformFunctionValue::TranslateZ(length(f32::NAN)),
-            TransformFunctionValue::TranslateZ(length(1.0)),
             TransformFunctionValue::Translate3d(px_length(0.0), px_length(0.0), length(f32::NAN)),
             TransformFunctionValue::Translate3d(
                 LengthPercentageValue::Length(length(f32::NAN)),
@@ -1380,12 +1362,9 @@ mod tests {
                 LengthPercentageValue::Length(length(f32::NAN)),
                 LengthValue::Zero,
             ),
-            TransformFunctionValue::Translate3d(px_length(0.0), px_length(0.0), length(1.0)),
             TransformFunctionValue::Rotate(number(f32::NAN)),
             TransformFunctionValue::RotateX(number(f32::NAN)),
-            TransformFunctionValue::RotateX(number(1.0)),
             TransformFunctionValue::RotateY(number(f32::NAN)),
-            TransformFunctionValue::RotateY(number(1.0)),
             TransformFunctionValue::Scale(number(f32::NAN), number(1.0)),
             TransformFunctionValue::Scale(number(1.0), number(f32::NAN)),
             TransformFunctionValue::ScaleX(number(f32::INFINITY)),
@@ -1396,7 +1375,6 @@ mod tests {
             TransformFunctionValue::SkewY(number(f32::NAN)),
             TransformFunctionValue::Matrix(non_finite_matrix),
             TransformFunctionValue::Matrix3d(non_finite_matrix_3d),
-            TransformFunctionValue::Matrix3d(spatial_matrix_3d),
         ] {
             assert_eq!(
                 invalid_transform(function),
@@ -1404,6 +1382,15 @@ mod tests {
                     StyleProperty::Transform
                 ))
             );
+        }
+        for function in [
+            TransformFunctionValue::TranslateZ(length(1.0)),
+            TransformFunctionValue::Translate3d(px_length(0.0), px_length(0.0), length(1.0)),
+            TransformFunctionValue::RotateX(number(1.0)),
+            TransformFunctionValue::RotateY(number(1.0)),
+            TransformFunctionValue::Matrix3d(spatial_matrix_3d),
+        ] {
+            assert!(invalid_transform(function).is_ok());
         }
 
         for (property, value) in [

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -574,6 +574,54 @@ fn render_transform_and_origin_reach_the_frame_sink_after_layout() {
 }
 
 #[test]
+fn render_projective_matrix3d_reaches_the_frame_sink() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(25).expect("test surface"),
+        StyleEnvironment::new(100.0, 60.0, 1.0, 14.0),
+    );
+    let matrix = [
+        1.0, 0.0, 0.0, 0.02, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+    ];
+    let style = Css::new()
+        .width(px(40))
+        .height(px(20))
+        .transform(TransformFn::Matrix3d(matrix))
+        .transform_origin(Position::Coords(px(0).into(), px(0).into()));
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| render! { view(style: style) });
+        set_root(root);
+    });
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(100.0, 60.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .expect("projective frame");
+    let root = surface.root().expect("surface root");
+    assert!(
+        renderer.frames()[0]
+            .packet
+            .operations
+            .iter()
+            .any(|operation| matches!(
+                operation,
+                Operation::SetTransform { node, transform }
+                    if *node == root && transform.0 == matrix
+            ))
+    );
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
 fn render_logical_borders_reach_physical_frame_edges_in_rtl() {
     __reset_for_tests();
     let owner = Owner::new(None);

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -823,9 +823,12 @@ length-percentage translations, and `transform-origin` until Taffy has
 produced the border-box size, then bakes them into that matrix. Hosts therefore
 do not parse CSS or independently resolve percentages and origin semantics.
 Changing a node's border-box size recomputes its matrix even when its specified
-transform is unchanged. The current common subset is the CSS/Lynx 2-D
-transform family; 3-D transforms, perspective, and motion paths require later
-capability slices rather than silently degrading on Android.
+transform is unchanged. The current common subset includes CSS/Lynx 2-D
+transforms and 3-D functions or `matrix3d` values that project a node's flat
+local plane. Each Host applies the projective result and flattens at that node;
+Android maps the `z = 0` slice exactly to a density-adjusted 3-by-3 homography.
+Parent `perspective`, shared `preserve-3d` descendant spaces, and motion paths
+remain later capability slices rather than silently degrading on any Host.
 
 The final opcode set may combine common operations for compactness. The
 semantic separation matters because it enables dirty classification,

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -478,9 +478,11 @@ The surface resolves percentage translations against border-box width or
 height, resolves the origin against that same box, composes the functions in
 CSS matrix order, and emits one `SetTransform` matrix. A Host applies that
 matrix at its local border-box origin and does not repeat CSS resolution. This
-slice currently accepts 2-D transforms, including 2-D-compatible `matrix3d`;
-3-D transforms, perspective, and offset-path motion remain separate planned
-capabilities.
+slice accepts 2-D transforms plus 3-D functions and projective `matrix3d`
+values applied to the node's flat local plane. Hosts flatten at each node;
+Android derives the exact density-adjusted 3-by-3 homography for that `z = 0`
+plane. Parent `perspective`, shared `preserve-3d` descendant spaces, and
+offset-path motion remain separate planned capabilities.
 
 Protocol minor 1 groups those resolved meanings by Host capability rather
 than by CSS spelling. `SetBackgroundLayers` carries resource-backed images,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -111,13 +111,14 @@ internal class HostNode(
 
     /** Applies a protocol transform around the local border-box origin. */
     fun setLocalTransform(values: FloatArray, density: Float) {
-        require(isSupported2dTransform(values))
+        require(isProjectableFlatPlaneTransform(values))
+        require(density.isFinite() && density > 0f)
         (parent as? android.view.View)?.invalidate()
         localTransform.setValues(
             floatArrayOf(
                 values[0], values[4], values[12] * density,
                 values[1], values[5], values[13] * density,
-                values[3], values[7], values[15],
+                values[3] / density, values[7] / density, values[15],
             ),
         )
         hasLocalTransform = !localTransform.isIdentity
@@ -194,11 +195,14 @@ internal class HostNode(
     }
 }
 
-/** True only for finite 2D affine matrices embedded in a column-major 4x4 matrix. */
-internal fun isSupported2dTransform(values: FloatArray): Boolean =
-    values.size == 16 && values.all(Float::isFinite) &&
-        values[2] == 0f && values[3] == 0f &&
-        values[6] == 0f && values[7] == 0f &&
-        values[8] == 0f && values[9] == 0f &&
-        values[10] == 1f && values[11] == 0f &&
-        values[14] == 0f && values[15] == 1f
+/**
+ * True when a finite 4x4 transform can be flattened onto this View's z=0 plane.
+ *
+ * Android Canvas accepts a 3x3 homography. For points `(x, y, 0, 1)`, only
+ * rows x, y, and w of the 4x4 matrix contribute to projected screen
+ * coordinates, so every finite Whisker matrix has an exact flat-plane
+ * projection. Depth is intentionally flattened at each HostNode; preserving a
+ * shared 3D descendant space is a separate capability.
+ */
+internal fun isProjectableFlatPlaneTransform(values: FloatArray): Boolean =
+    values.size == 16 && values.all(Float::isFinite)

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -175,7 +175,7 @@ internal class HostScene(
             ) return false
             9 -> if (
                 operation.node !in existing ||
-                !isSupported2dTransform(operation.numbers ?: return false)
+                !isProjectableFlatPlaneTransform(operation.numbers ?: return false)
             ) return false
             10 -> if (
                 operation.node !in existing || !operation.scalar.isFinite() ||

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -457,7 +457,9 @@ impl Driver {
                 }
                 Command::Checkpoint { name, samples, .. } => {
                     if self.expected_scene.is_some() {
-                        let expected_checkpoint = if self.resource_lifecycle {
+                        let expected_checkpoint = if name == "paint.transform.projective-plane" {
+                            "paint.transform.projective-plane"
+                        } else if self.resource_lifecycle {
                             "paint.background-layers.resource-lifecycle"
                         } else {
                             self
@@ -1228,6 +1230,9 @@ fn fixture(path: &str) -> &'static str {
         "core/transform-parent-composition.json" => include_str!(
             "../../../../tests/host-conformance/core/transform-parent-composition.json"
         ),
+        "core/transform-projective-plane.json" => {
+            include_str!("../../../../tests/host-conformance/core/transform-projective-plane.json")
+        }
         "wpt/css/css-color/t32-opacity-basic-0.6-a.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-color/t32-opacity-basic-0.6-a.json"
         ),

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -126,8 +126,8 @@
       "id": "paint.transform",
       "basis": "lynx-4.0",
       "properties": ["offset-distance", "offset-path", "offset-rotate", "perspective", "transform", "transform-origin"],
-      "supported_subset": ["transform-2d-functions", "matrix", "2d-compatible-matrix3d", "length-percentage-translate", "border-box-transform-origin"],
-      "unsupported_browser_subset": ["3d-transform-functions", "perspective", "motion-path"],
+      "supported_subset": ["transform-2d-functions", "flat-plane-3d-functions", "matrix", "projective-matrix3d", "length-percentage-translate", "border-box-transform-origin", "flat-at-each-node"],
+      "unsupported_browser_subset": ["perspective-property", "preserve-3d", "motion-path"],
       "protocol": ["SetTransform", "SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/core/transform-projective-plane.json
+++ b/tests/host-conformance/core/transform-projective-plane.json
@@ -1,0 +1,39 @@
+{
+  "schema": 1,
+  "id": "core.transform-projective-plane",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 15.0, 40.0, 20.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip": { "horizontal": "visible", "vertical": "visible" },
+            "transform": [
+              1.0, 0.0, 0.0, 0.02,
+              0.0, 1.0, 0.0, 0.0,
+              0.0, 0.0, 1.0, 0.0,
+              0.0, 0.0, 0.0, 1.0
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.transform.projective-plane",
+        "samples": [
+          { "point": [12.0, 17.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [29.0, 18.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [29.0, 30.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [36.0, 20.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -234,6 +234,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "core.transform-projective-plane",
+      "feature": "transform-3d-flat-plane",
+      "fixture": "core/transform-projective-plane.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-color.opacity-basic-0.6",
       "feature": "opacity",
       "fixture": "wpt/css/css-color/t32-opacity-basic-0.6-a.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -66,7 +66,7 @@ class HostConformanceTest {
     }
 
     @Test
-    fun rejectsAThreeDimensionalTransformInsteadOfFlatteningIt() {
+    fun projectsAThreeDimensionalTransformOntoTheNodePlane() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()
             .runOnMainSync {
@@ -77,7 +77,7 @@ class HostConformanceTest {
                     0f, 0f, 2f, 0f,
                     0f, 0f, 0f, 1f,
                 )
-                assertTrue(Driver(context, "android.transform-3d-rejection").rejectTransform(matrix))
+                assertTrue(Driver(context, "android.transform-3d-projection").commitTransform(matrix))
             }
     }
 
@@ -317,7 +317,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.visual-effects.clip-path-path-evenodd" ||
                             command.getString("name") ==
-                            "paint.visual-effects.backdrop-blur",
+                            "paint.visual-effects.backdrop-blur" ||
+                            command.getString("name") ==
+                            "paint.transform.projective-plane",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -343,11 +345,11 @@ private class Driver(
         return checkNotNull(checkpoint)
     }
 
-    fun rejectTransform(transform: FloatArray): Boolean {
+    fun commitTransform(transform: FloatArray): Boolean {
         check(view.beginFrameFromNative(0, 1, 0, 1) == 0)
         check(stage(tag = 1, member = 1))
         check(stage(tag = 9, numbers = transform))
-        return !view.commitFrameFromNative()
+        return view.commitFrameFromNative()
     }
 
     fun rejectOpacity(opacity: Float): Boolean {

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -449,7 +449,8 @@ private final class Driver {
                     name == "paint.visual-effects.clip-path-ellipse" ||
                     name == "paint.visual-effects.clip-path-path-nonzero" ||
                     name == "paint.visual-effects.clip-path-path-evenodd" ||
-                    name == "paint.visual-effects.backdrop-blur" else {
+                    name == "paint.visual-effects.backdrop-blur" ||
+                    name == "paint.transform.projective-plane" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 if name == "paint.visual-effects.backdrop-blur" {
@@ -458,9 +459,16 @@ private final class Driver {
                         "\(id) must project backdrop blur to UIVisualEffectView"
                     )
                 }
+                if name == "paint.transform.projective-plane" {
+                    XCTAssertTrue(
+                        containsProjectiveTransform(view),
+                        "\(id) must project the 4x4 matrix to CATransform3D"
+                    )
+                }
                 let pixels = try capture()
                 checkpoint = pixels
-                if let samples = command["samples"] as? [[String: Any]] {
+                if name != "paint.transform.projective-plane",
+                   let samples = command["samples"] as? [[String: Any]] {
                     try assertPixelSamples(id: id, pixels: pixels, samples: samples)
                 }
                 if name != "paint.visual-effects.backdrop-blur",
@@ -1849,6 +1857,14 @@ private func containsActiveBackdropBlur(_ view: UIView) -> Bool {
         return true
     }
     return view.subviews.contains(where: containsActiveBackdropBlur)
+}
+
+private func containsProjectiveTransform(_ view: UIView) -> Bool {
+    let transform = view.layer.transform
+    if abs(transform.m14) > 0.000_001 || abs(transform.m24) > 0.000_001 {
+        return true
+    }
+    return view.subviews.contains(where: containsProjectiveTransform)
 }
 
 private func luminance(_ color: [UInt8]) -> UInt32 {


### PR DESCRIPTION
## Summary

- accept typed rotateX/rotateY/translateZ/translate3d and projective matrix3d values in Rust
- add a shared flat-plane projective fixture and run it through Desktop, Web, Android, and iOS production Host paths
- map the z=0 slice of a 4x4 matrix to an exact density-adjusted Android 3x3 homography
- document flatten-at-each-node semantics and keep perspective, preserve-3d, and motion paths as later capability slices

## Test plan

- cargo test -p whisker-style transform --lib
- cargo test -p whisker --test surface_render_pipeline
- cargo clippy -p whisker-style -p whisker-css -p whisker-engine -p whisker --all-targets -- -D warnings
- cargo check --workspace
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios

## Host test note

CALayer.render(in:) does not rasterize the projective result in the headless iOS test runner. The iOS test therefore verifies that the projective CATransform3D reaches the production layer; Desktop, Web, and Android retain pixel-sample coverage for the shared fixture.

Stacked on #473.