### PR TITLE
feat(transform): lower Lynx current-node perspective

### DIFF
--- a/crates/whisker-engine/src/paint.rs
+++ b/crates/whisker-engine/src/paint.rs
@@ -90,7 +90,13 @@ pub fn lower_transform(
         return None;
     }
 
-    let mut matrix = identity();
+    // Lynx intentionally differs from browser CSS here: `perspective` affects
+    // the current node. Prepending it makes the node's transform functions run
+    // first and the perspective divide run afterward.
+    let mut matrix = style
+        .perspective
+        .map(|distance| perspective(distance.get().max(1.0)))
+        .unwrap_or_else(identity);
     for function in &style.functions {
         matrix = multiply(
             matrix,
@@ -220,6 +226,12 @@ fn translation(x: f32, y: f32, z: f32) -> [f32; 16] {
     [
         1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, x, y, z, 1.0,
     ]
+}
+
+fn perspective(distance: f32) -> [f32; 16] {
+    let mut matrix = identity();
+    matrix[11] = -1.0 / distance;
+    matrix
 }
 
 fn multiply(left: [f32; 16], right: [f32; 16]) -> [f32; 16] {
@@ -425,6 +437,7 @@ mod tests {
     #[test]
     fn resolves_transform_percentages_and_origin_against_border_box() {
         let style = ComputedTransformStyle {
+            perspective: None,
             functions: vec![ComputedTransformFunction::Scale {
                 x: StyleNumber::new(2.0),
                 y: StyleNumber::new(2.0),
@@ -441,6 +454,7 @@ mod tests {
         );
 
         let translated = ComputedTransformStyle {
+            perspective: None,
             functions: vec![ComputedTransformFunction::Translate {
                 x: ComputedLengthPercentage::new(3.0, 0.5),
                 y: ComputedLengthPercentage::new(4.0, 0.25),
@@ -486,6 +500,7 @@ mod tests {
             ]),
         ] {
             let style = ComputedTransformStyle {
+                perspective: None,
                 functions: vec![function],
                 origin_x: ComputedLengthPercentage::ZERO,
                 origin_y: ComputedLengthPercentage::ZERO,
@@ -511,6 +526,7 @@ mod tests {
     #[test]
     fn canonicalizes_three_dimensional_output_to_the_node_plane() {
         let style = ComputedTransformStyle {
+            perspective: None,
             functions: vec![ComputedTransformFunction::RotateY(StyleNumber::new(60.0))],
             origin_x: ComputedLengthPercentage::ZERO,
             origin_y: ComputedLengthPercentage::ZERO,
@@ -518,6 +534,41 @@ mod tests {
         let transform = lower_transform(&style, 40.0, 20.0).expect("finite transform");
         let expected = [
             0.5, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        ];
+        for (actual, expected) in transform.0.into_iter().zip(expected) {
+            assert!(
+                (actual - expected).abs() < 0.000_001,
+                "{actual} != {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn prepends_lynx_current_node_perspective_to_the_transform_matrix() {
+        let style = ComputedTransformStyle {
+            perspective: Some(StyleNumber::new(100.0)),
+            functions: vec![ComputedTransformFunction::RotateY(StyleNumber::new(60.0))],
+            origin_x: ComputedLengthPercentage::ZERO,
+            origin_y: ComputedLengthPercentage::ZERO,
+        };
+        let transform = lower_transform(&style, 40.0, 20.0).expect("finite perspective");
+        let expected = [
+            0.5,
+            0.0,
+            0.0,
+            3.0_f32.sqrt() / 200.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
         ];
         for (actual, expected) in transform.0.into_iter().zip(expected) {
             assert!(

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -800,7 +800,8 @@ impl SurfaceEngine {
         border_width: f32,
         border_height: f32,
     ) -> Result<Option<whisker_protocol::Transform>, SurfaceError> {
-        if style.functions.is_empty()
+        if style.perspective.is_none()
+            && style.functions.is_empty()
             && self
                 .scene
                 .node(node)

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -214,6 +214,8 @@ pub enum ComputedTransformFunction {
 /// Transform functions and origin retained until border-box layout is known.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ComputedTransformStyle {
+    /// Lynx-compatible perspective distance applied to this node, or none.
+    pub perspective: Option<StyleNumber>,
     /// Ordered transform functions.
     pub functions: Vec<ComputedTransformFunction>,
     /// Horizontal origin relative to border-box width.
@@ -225,6 +227,7 @@ pub struct ComputedTransformStyle {
 impl Default for ComputedTransformStyle {
     fn default() -> Self {
         Self {
+            perspective: None,
             functions: Vec::new(),
             origin_x: ComputedLengthPercentage::new(0.0, 0.5),
             origin_y: ComputedLengthPercentage::new(0.0, 0.5),
@@ -386,6 +389,22 @@ pub(crate) fn resolve_paint_style(
                 };
                 paint.transform.functions =
                     resolve_transform_functions(value, inherited, environment, property)?;
+            }
+            StyleProperty::Perspective => {
+                let StyleValue::Length(value) = value else {
+                    return Err(invalid(property));
+                };
+                let distance = resolve_affine(
+                    &LengthPercentageValue::Length(*value),
+                    inherited.font_size(),
+                    environment,
+                    property,
+                )?
+                .length();
+                if distance < 0.0 {
+                    return Err(invalid(property));
+                }
+                paint.transform.perspective = Some(StyleNumber::new(distance));
             }
             StyleProperty::TransformOrigin => {
                 let StyleValue::TransformOrigin(value) = value else {
@@ -1421,6 +1440,48 @@ mod tests {
                     StyleEnvironment::default(),
                 ),
                 Err(StyleResolutionError::InvalidPropertyValue(property))
+            );
+        }
+    }
+
+    #[test]
+    fn perspective_resolves_absolute_length_and_rejects_negative_distance() {
+        let perspective = |value| {
+            StyleValue::Length(LengthValue::Dimension {
+                value: number(value),
+                unit: LengthUnit::Rem,
+            })
+        };
+        let resolved = crate::resolve_style(
+            &SpecifiedStyle::new().push(StyleProperty::Perspective, perspective(2.0)),
+            None,
+            StyleEnvironment::new(320.0, 480.0, 2.0, 16.0),
+        )
+        .unwrap();
+        assert_eq!(
+            resolved.computed().paint().transform.perspective,
+            Some(number(32.0))
+        );
+        assert_eq!(
+            crate::resolve_style(
+                &SpecifiedStyle::new().push(StyleProperty::Perspective, perspective(-1.0)),
+                None,
+                StyleEnvironment::default(),
+            ),
+            Err(StyleResolutionError::InvalidPropertyValue(
+                StyleProperty::Perspective
+            ))
+        );
+        for value in [StyleValue::Number(number(1.0)), perspective(f32::NAN)] {
+            assert_eq!(
+                crate::resolve_style(
+                    &SpecifiedStyle::new().push(StyleProperty::Perspective, value),
+                    None,
+                    StyleEnvironment::default(),
+                ),
+                Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::Perspective
+                ))
             );
         }
     }

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -1,8 +1,8 @@
 use std::convert::Infallible;
 
 use whisker::css::{
-    BorderStyle, Clear, Direction, Float, GridLine, GridTemplate, GridTrack, Overflow, Position,
-    TransformFn,
+    Angle, BorderStyle, Clear, Direction, Float, GridLine, GridTemplate, GridTrack, Overflow,
+    Position, TransformFn,
 };
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
@@ -618,6 +618,52 @@ fn render_projective_matrix3d_reaches_the_frame_sink() {
                     if *node == root && transform.0 == matrix
             ))
     );
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn render_lynx_perspective_is_lowered_into_the_current_node_transform() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(26).expect("test surface"),
+        StyleEnvironment::new(100.0, 60.0, 1.0, 14.0),
+    );
+    let style = Css::new()
+        .width(px(40))
+        .height(px(20))
+        .perspective(px(100))
+        .transform(TransformFn::RotateY(Angle::Deg(60.0)))
+        .transform_origin(Position::Coords(px(0).into(), px(0).into()));
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| render! { view(style: style) });
+        set_root(root);
+    });
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(100.0, 60.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .expect("perspective frame");
+    let root = surface.root().expect("surface root");
+    let transform = renderer.frames()[0]
+        .packet
+        .operations
+        .iter()
+        .find_map(|operation| match operation {
+            Operation::SetTransform { node, transform } if *node == root => Some(*transform),
+            _ => None,
+        })
+        .expect("perspective emits SetTransform");
+    assert!((transform.0[3] - 3.0_f32.sqrt() / 200.0).abs() < 0.000_001);
+    assert_eq!(transform.0[11], 0.0);
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }
 

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -827,8 +827,11 @@ transform is unchanged. The current common subset includes CSS/Lynx 2-D
 transforms and 3-D functions or `matrix3d` values that project a node's flat
 local plane. Each Host applies the projective result and flattens at that node;
 Android maps the `z = 0` slice exactly to a density-adjusted 3-by-3 homography.
-Parent `perspective`, shared `preserve-3d` descendant spaces, and motion paths
-remain later capability slices rather than silently degrading on any Host.
+Lynx-compatible `perspective` applies to the current node rather than its
+children; Rust prepends its projection to the node transform before this same
+flat-plane normalization. Browser-style parent perspective, `perspective-origin`,
+shared `preserve-3d` descendant spaces, and motion paths are outside this
+subset rather than silently changing semantics on any Host.
 
 The final opcode set may combine common operations for compactness. The
 semantic separation matters because it enables dirty classification,

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -481,8 +481,12 @@ matrix at its local border-box origin and does not repeat CSS resolution. This
 slice accepts 2-D transforms plus 3-D functions and projective `matrix3d`
 values applied to the node's flat local plane. Hosts flatten at each node;
 Android derives the exact density-adjusted 3-by-3 homography for that `z = 0`
-plane. Parent `perspective`, shared `preserve-3d` descendant spaces, and
-offset-path motion remain separate planned capabilities.
+plane. In accordance with Lynx, `perspective` affects the current node rather
+than its children: Rust resolves the length, clamps values below one logical
+pixel for rendering, prepends the projection, and emits the same canonical
+flat-plane matrix. Browser-style parent perspective, `perspective-origin`,
+shared `preserve-3d` descendant spaces, and offset-path motion are outside the
+current subset.
 
 Protocol minor 1 groups those resolved meanings by Host capability rather
 than by CSS spelling. `SetBackgroundLayers` carries resource-backed images,

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1233,6 +1233,9 @@ fn fixture(path: &str) -> &'static str {
         "core/transform-projective-plane.json" => {
             include_str!("../../../../tests/host-conformance/core/transform-projective-plane.json")
         }
+        "core/transform-perspective-current-node.json" => include_str!(
+            "../../../../tests/host-conformance/core/transform-perspective-current-node.json"
+        ),
         "wpt/css/css-color/t32-opacity-basic-0.6-a.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-color/t32-opacity-basic-0.6-a.json"
         ),

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -126,8 +126,8 @@
       "id": "paint.transform",
       "basis": "lynx-4.0",
       "properties": ["offset-distance", "offset-path", "offset-rotate", "perspective", "transform", "transform-origin"],
-      "supported_subset": ["transform-2d-functions", "flat-plane-3d-functions", "matrix", "projective-matrix3d", "length-percentage-translate", "border-box-transform-origin", "flat-at-each-node"],
-      "unsupported_browser_subset": ["perspective-property", "preserve-3d", "motion-path"],
+      "supported_subset": ["transform-2d-functions", "flat-plane-3d-functions", "matrix", "projective-matrix3d", "length-percentage-translate", "border-box-transform-origin", "lynx-current-node-perspective", "flat-at-each-node"],
+      "unsupported_browser_subset": ["web-parent-perspective-semantics", "perspective-origin", "preserve-3d", "motion-path"],
       "protocol": ["SetTransform", "SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/core/transform-perspective-current-node.json
+++ b/tests/host-conformance/core/transform-perspective-current-node.json
@@ -1,0 +1,41 @@
+{
+  "schema": 1,
+  "id": "core.transform-perspective-current-node",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 15.0, 40.0, 20.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip": { "horizontal": "visible", "vertical": "visible" },
+            "transform": [
+              0.6732051, 0.08660254, 0.0, 0.008660254,
+              0.0, 1.0, 0.0, 0.0,
+              0.0, 0.0, 1.0, 0.0,
+              6.535898, -1.7320508, 0.0, 0.8267949
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.transform.projective-plane",
+        "samples": [
+          { "point": [20.0, 20.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [20.0, 35.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [36.0, 30.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [15.0, 20.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [40.0, 20.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [36.0, 36.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -241,6 +241,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "core.transform-perspective-current-node",
+      "feature": "perspective-current-node",
+      "fixture": "core/transform-perspective-current-node.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-color.opacity-basic-0.6",
       "feature": "opacity",
       "fixture": "wpt/css/css-color/t32-opacity-basic-0.6-a.json",


### PR DESCRIPTION
## Summary

- resolve typed perspective lengths in Rust and reject negative distances
- follow Lynx semantics by applying perspective to the current node, not browser CSS parent-to-child semantics
- prepend perspective before the transform list, clamp rendering distances below one logical pixel, and lower to the existing SetTransform matrix
- add a shared perspective + rotateY fixture that reaches Desktop, Web, Android, and iOS production Host paths
- document that perspective-origin, browser parent perspective, preserve-3d, and motion paths remain outside the current subset

No new FramePacket or mobile ABI operation is needed: Hosts continue receiving one canonical flat-plane 4x4 transform.

## Test plan

- cargo test -p whisker-style --lib
- cargo test -p whisker-engine --lib
- cargo test -p whisker --test surface_render_pipeline
- cargo clippy -p whisker-style -p whisker-css -p whisker-engine -p whisker --all-targets -- -D warnings
- cargo check --workspace
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios

## Test note

The shared fixture reuses the projective-transform checkpoint. iOS verifies the CATransform3D structurally because CALayer.render(in:) does not rasterize projective transforms in the headless runner; the other Hosts retain pixel samples.

Stacked on #474.