### PR TITLE
feat(transform): lower Lynx polyline motion paths

### DIFF
--- a/crates/whisker-css/src/lib.rs
+++ b/crates/whisker-css/src/lib.rs
@@ -74,6 +74,7 @@ pub use crate::to_css::ToCss;
 pub use crate::value::{
     BackdropFilter, BorderRadius, FlexBasis, GridArea, GridLine, GridRepeatCount, GridTemplate,
     GridTemplateAreas, GridTemplateComponent, GridTrack, GridTrackMax, GridTrackMin, ImageRef,
-    LineHeight, Repeated, Size,
+    LineHeight, MotionPathCommand, MotionPathPoint, OffsetDistance, OffsetPath, OffsetRotate,
+    Repeated, Size,
 };
 pub use whisker_style::{PropertyMetadata, PropertyOrigin, StyleProperty, StylePropertyId};

--- a/crates/whisker-css/src/prop/transform.rs
+++ b/crates/whisker-css/src/prop/transform.rs
@@ -4,6 +4,7 @@ use crate::css::Css;
 use crate::data_type::Length;
 use crate::data_type_ext::Position;
 use crate::keyword::{BackfaceVisibility, TransformBox, TransformStyle};
+use crate::{OffsetDistance, OffsetPath, OffsetRotate};
 
 impl Css {
     /// Sets `transform-origin`.
@@ -41,6 +42,24 @@ impl Css {
     pub fn perspective_origin(self, v: Position) -> Self {
         self.push(crate::StyleProperty::PerspectiveOrigin, v)
     }
+
+    /// Sets `offset-path` to a typed polyline path or `none`.
+    /// <https://lynxjs.org/api/css/properties/offset-path>
+    pub fn offset_path(self, value: OffsetPath) -> Self {
+        self.push_typed(crate::StyleProperty::OffsetPath, value)
+    }
+
+    /// Sets normalized progress along `offset-path`.
+    /// <https://lynxjs.org/api/css/properties/offset-distance>
+    pub fn offset_distance(self, value: impl Into<OffsetDistance>) -> Self {
+        self.push_typed(crate::StyleProperty::OffsetDistance, value.into())
+    }
+
+    /// Sets tangent-following or fixed motion-path rotation.
+    /// <https://lynxjs.org/api/css/properties/offset-rotate>
+    pub fn offset_rotate(self, value: OffsetRotate) -> Self {
+        self.push_typed(crate::StyleProperty::OffsetRotate, value)
+    }
 }
 
 #[cfg(test)]
@@ -49,6 +68,7 @@ mod tests {
     use crate::data_type_ext::{Position, PositionKeyword};
     use crate::ext::*;
     use crate::keyword::*;
+    use crate::{MotionPathCommand, MotionPathPoint, OffsetPath, OffsetRotate};
 
     #[test]
     fn transform_origin_keywords() {
@@ -77,5 +97,32 @@ mod tests {
             s.to_string(),
             "perspective: 500px; perspective-origin: center;"
         );
+    }
+
+    #[test]
+    fn motion_path_props_keep_css_and_semantic_values_together() {
+        let style = Css::new()
+            .offset_path(OffsetPath::path(vec![
+                MotionPathCommand::MoveTo(MotionPathPoint::new(0.0, 0.0)),
+                MotionPathCommand::LineTo(MotionPathPoint::new(40.0, 0.0)),
+                MotionPathCommand::Close,
+            ]))
+            .offset_distance(75.0.percent())
+            .offset_rotate(OffsetRotate::Auto);
+        assert_eq!(
+            style.to_string(),
+            "offset-path: path(\"M 0 0 L 40 0 Z\"); offset-distance: 75%; offset-rotate: auto;"
+        );
+        assert!(style.to_specified_style().is_ok());
+
+        let fixed = Css::new()
+            .offset_path(OffsetPath::None)
+            .offset_distance(crate::Number::new(0.5))
+            .offset_rotate(OffsetRotate::Angle(45.0.deg()));
+        assert_eq!(
+            fixed.to_string(),
+            "offset-path: none; offset-distance: 0.5; offset-rotate: 45deg;"
+        );
+        assert!(fixed.to_specified_style().is_ok());
     }
 }

--- a/crates/whisker-css/src/style_value.rs
+++ b/crates/whisker-css/src/style_value.rs
@@ -8,7 +8,8 @@ use whisker_style::{
     GridPlacementValue, GridRepetitionCountValue, GridTemplateAreaValue, GridTemplateAreasValue,
     GridTemplateComponentValue, GridTemplateRepetitionValue, GridTemplateValue,
     GridTrackSizingValue, JustifyContentValue, LengthPercentageAutoValue, LengthPercentageValue,
-    LengthUnit, LengthValue, LineHeightValue, PositionValue, SizeValue, StyleNumber, StyleValue,
+    LengthUnit, LengthValue, LineHeightValue, MotionPathCommandValue, MotionPathPointValue,
+    OffsetPathValue, OffsetRotateValue, PositionValue, SizeValue, StyleNumber, StyleValue,
     TransformFunctionValue, TransformOriginValue, TransformValue,
 };
 
@@ -18,8 +19,9 @@ use crate::{
     CssString, Direction, Display, FlexBasis, FlexDirection, FlexWrap, Float, FontStyle,
     FontWeight, GridAutoFlow, GridLine, GridRepeatCount, GridTemplate, GridTemplateAreas,
     GridTemplateComponent, GridTrack, GridTrackMax, GridTrackMin, Integer, JustifyContent, Length,
-    LengthPercentage, LineHeight, MarginValue, Number, Overflow, Percentage, Position,
-    PositionKind, Size, Transform, TransformFn, Visibility,
+    LengthPercentage, LineHeight, MarginValue, MotionPathCommand, Number, OffsetDistance,
+    OffsetPath, OffsetRotate, Overflow, Percentage, Position, PositionKind, Size, Transform,
+    TransformFn, Visibility,
 };
 use whisker_style::{OverflowValue, VisibilityValue};
 
@@ -47,6 +49,50 @@ impl ToStyleValue for Transform {
         StyleValue::Transform(TransformValue(
             self.0.iter().map(to_transform_function).collect(),
         ))
+    }
+}
+
+impl ToStyleValue for OffsetPath {
+    fn to_style_value(&self) -> StyleValue {
+        let point = |point: &crate::MotionPathPoint| MotionPathPointValue {
+            x: StyleNumber::new(point.x),
+            y: StyleNumber::new(point.y),
+        };
+        StyleValue::OffsetPath(match self {
+            Self::None => OffsetPathValue::None,
+            Self::Path(commands) => OffsetPathValue::Path(
+                commands
+                    .iter()
+                    .map(|command| match command {
+                        MotionPathCommand::MoveTo(value) => {
+                            MotionPathCommandValue::MoveTo(point(value))
+                        }
+                        MotionPathCommand::LineTo(value) => {
+                            MotionPathCommandValue::LineTo(point(value))
+                        }
+                        MotionPathCommand::Close => MotionPathCommandValue::Close,
+                    })
+                    .collect(),
+            ),
+        })
+    }
+}
+
+impl ToStyleValue for OffsetDistance {
+    fn to_style_value(&self) -> StyleValue {
+        match self {
+            Self::Number(value) => value.to_style_value(),
+            Self::Percentage(value) => value.to_style_value(),
+        }
+    }
+}
+
+impl ToStyleValue for OffsetRotate {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::OffsetRotate(match self {
+            Self::Auto => OffsetRotateValue::Auto,
+            Self::Angle(angle) => OffsetRotateValue::Angle(StyleNumber::new(angle_degrees(*angle))),
+        })
     }
 }
 

--- a/crates/whisker-css/src/value.rs
+++ b/crates/whisker-css/src/value.rs
@@ -10,7 +10,9 @@
 
 use core::fmt;
 
-use crate::data_type::{CssString, FitContent, Length, LengthPercentage, MaxContent, Percentage};
+use crate::data_type::{
+    CssString, FitContent, Length, LengthPercentage, MaxContent, Number, Percentage,
+};
 use crate::to_css::{ToCss, write_number};
 
 // ---------- BackdropFilter ----------
@@ -43,6 +45,129 @@ impl ToCss for BackdropFilter {
                 radius.to_css(dest)?;
                 dest.write_char(')')
             }
+        }
+    }
+}
+
+// ---------- Motion path ----------
+
+/// One absolute point in an `offset-path: path()` polyline.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MotionPathPoint {
+    /// Horizontal logical-pixel coordinate.
+    pub x: f32,
+    /// Vertical logical-pixel coordinate.
+    pub y: f32,
+}
+
+impl MotionPathPoint {
+    /// Creates an absolute motion-path point.
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+}
+
+/// One command in a polyline `offset-path: path()` value.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MotionPathCommand {
+    /// Start a new subpath.
+    MoveTo(MotionPathPoint),
+    /// Add a straight segment.
+    LineTo(MotionPathPoint),
+    /// Close the current subpath.
+    Close,
+}
+
+/// Supported `offset-path` value.
+#[derive(Clone, Debug, PartialEq)]
+pub enum OffsetPath {
+    /// Disable motion-path positioning.
+    None,
+    /// Follow an absolute polyline path.
+    Path(Vec<MotionPathCommand>),
+}
+
+impl OffsetPath {
+    /// Creates a polyline `path()` from absolute commands.
+    pub fn path(commands: impl Into<Vec<MotionPathCommand>>) -> Self {
+        Self::Path(commands.into())
+    }
+}
+
+impl ToCss for OffsetPath {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        let Self::Path(commands) = self else {
+            return dest.write_str("none");
+        };
+        dest.write_str("path(\"")?;
+        for (index, command) in commands.iter().enumerate() {
+            if index > 0 {
+                dest.write_char(' ')?;
+            }
+            match command {
+                MotionPathCommand::MoveTo(point) => {
+                    dest.write_str("M ")?;
+                    write_number(dest, point.x)?;
+                    dest.write_char(' ')?;
+                    write_number(dest, point.y)?;
+                }
+                MotionPathCommand::LineTo(point) => {
+                    dest.write_str("L ")?;
+                    write_number(dest, point.x)?;
+                    dest.write_char(' ')?;
+                    write_number(dest, point.y)?;
+                }
+                MotionPathCommand::Close => dest.write_char('Z')?,
+            }
+        }
+        dest.write_str("\")")
+    }
+}
+
+/// Supported `offset-distance` value.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum OffsetDistance {
+    /// Unitless normalized progress in the `0..=1` range.
+    Number(Number),
+    /// Percentage progress in the `0%..=100%` range.
+    Percentage(Percentage),
+}
+
+impl From<Number> for OffsetDistance {
+    fn from(value: Number) -> Self {
+        Self::Number(value)
+    }
+}
+
+impl From<Percentage> for OffsetDistance {
+    fn from(value: Percentage) -> Self {
+        Self::Percentage(value)
+    }
+}
+
+impl ToCss for OffsetDistance {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        match self {
+            Self::Number(value) => value.to_css(dest),
+            Self::Percentage(value) => value.to_css(dest),
+        }
+    }
+}
+
+/// Supported `offset-rotate` value.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum OffsetRotate {
+    /// Follow the path tangent.
+    Auto,
+    /// Use a fixed clockwise angle.
+    Angle(crate::Angle),
+}
+
+impl ToCss for OffsetRotate {
+    fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
+        match self {
+            Self::Auto => dest.write_str("auto"),
+            Self::Angle(angle) => angle.to_css(dest),
         }
     }
 }

--- a/crates/whisker-engine/src/paint.rs
+++ b/crates/whisker-engine/src/paint.rs
@@ -6,8 +6,8 @@ use whisker_protocol::{
 };
 use whisker_style::{
     BorderStyleValue, ColorValue, ComputedLayoutStyle, ComputedLengthPercentage,
-    ComputedPaintStyle, ComputedTransformFunction, ComputedTransformStyle, OverflowValue,
-    VisibilityValue,
+    ComputedPaintStyle, ComputedTransformFunction, ComputedTransformStyle, MotionPathCommandValue,
+    OffsetPathValue, OffsetRotateValue, OverflowValue, VisibilityValue,
 };
 
 /// Complete common presentation values derived from one computed node style.
@@ -97,6 +97,17 @@ pub fn lower_transform(
         .perspective
         .map(|distance| perspective(distance.get().max(1.0)))
         .unwrap_or_else(identity);
+    let motion = match &style.offset_path {
+        OffsetPathValue::None => None,
+        path => Some(motion_path_state(path, style.offset_distance.get())?),
+    };
+    if let Some((_, _, tangent)) = motion {
+        let angle = match style.offset_rotate {
+            OffsetRotateValue::Auto => tangent,
+            OffsetRotateValue::Angle(angle) => angle.get(),
+        };
+        matrix = multiply(matrix, rotation_z(angle));
+    }
     for function in &style.functions {
         matrix = multiply(
             matrix,
@@ -113,23 +124,26 @@ pub fn lower_transform(
     // X/Y/W projection of points on the local z=0 plane, but canonicalize the
     // unused depth row and column so GPU clip-space depth cannot discard CSS
     // pixels and descendants cannot accidentally share a 3-D context.
+    let positioned = motion.map_or(around_origin, |(x, y, _)| {
+        multiply(translation(x, y, 0.0), around_origin)
+    });
     let flat_plane = [
-        around_origin[0],
-        around_origin[1],
+        positioned[0],
+        positioned[1],
         0.0,
-        around_origin[3],
-        around_origin[4],
-        around_origin[5],
+        positioned[3],
+        positioned[4],
+        positioned[5],
         0.0,
-        around_origin[7],
+        positioned[7],
         0.0,
         0.0,
         1.0,
         0.0,
-        around_origin[12],
-        around_origin[13],
+        positioned[12],
+        positioned[13],
         0.0,
-        around_origin[15],
+        positioned[15],
     ];
     flat_plane
         .iter()
@@ -162,13 +176,7 @@ fn function_matrix(
                 cos, 0.0, -sin, 0.0, 0.0, 1.0, 0.0, 0.0, sin, 0.0, cos, 0.0, 0.0, 0.0, 0.0, 1.0,
             ]
         }
-        ComputedTransformFunction::RotateZ(degrees) => {
-            let radians = degrees.get().to_radians();
-            let (sin, cos) = radians.sin_cos();
-            [
-                cos, sin, 0.0, 0.0, -sin, cos, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
-            ]
-        }
+        ComputedTransformFunction::RotateZ(degrees) => rotation_z(degrees.get()),
         ComputedTransformFunction::Scale { x, y, z } => [
             x.get(),
             0.0,
@@ -214,6 +222,67 @@ fn function_matrix(
         .iter()
         .all(|value| value.is_finite())
         .then_some(matrix)
+}
+
+fn motion_path_state(path: &OffsetPathValue, progress: f32) -> Option<(f32, f32, f32)> {
+    let OffsetPathValue::Path(commands) = path else {
+        return None;
+    };
+    let mut segments = Vec::new();
+    let mut current = None;
+    let mut subpath_start = None;
+    let mut total_length = 0.0_f32;
+    for command in commands {
+        let next = match *command {
+            MotionPathCommandValue::MoveTo(point) => {
+                let point = (point.x.get(), point.y.get());
+                current = Some(point);
+                subpath_start = Some(point);
+                continue;
+            }
+            MotionPathCommandValue::LineTo(point) => (point.x.get(), point.y.get()),
+            MotionPathCommandValue::Close => subpath_start?,
+        };
+        let from = current?;
+        let length = (next.0 - from.0).hypot(next.1 - from.1);
+        if length > 0.0 && length.is_finite() {
+            segments.push((from, next, length));
+            total_length += length;
+        }
+        current = Some(next);
+    }
+    if segments.is_empty() || !total_length.is_finite() {
+        return None;
+    }
+    let target = progress.clamp(0.0, 1.0) * total_length;
+    let mut traversed = 0.0;
+    let (last, preceding) = segments
+        .split_last()
+        .expect("motion path segments were checked as non-empty");
+    for (from, to, length) in preceding {
+        if target <= traversed + length {
+            let local = ((target - traversed) / length).clamp(0.0, 1.0);
+            let x = from.0 + (to.0 - from.0) * local;
+            let y = from.1 + (to.1 - from.1) * local;
+            let angle = (to.1 - from.1).atan2(to.0 - from.0).to_degrees();
+            return Some((x, y, angle.rem_euclid(360.0)));
+        }
+        traversed += length;
+    }
+    let (from, to, length) = *last;
+    let local = ((target - traversed) / length).clamp(0.0, 1.0);
+    let x = from.0 + (to.0 - from.0) * local;
+    let y = from.1 + (to.1 - from.1) * local;
+    let angle = (to.1 - from.1).atan2(to.0 - from.0).to_degrees();
+    Some((x, y, angle.rem_euclid(360.0)))
+}
+
+fn rotation_z(degrees: f32) -> [f32; 16] {
+    let radians = degrees.to_radians();
+    let (sin, cos) = radians.sin_cos();
+    [
+        cos, sin, 0.0, 0.0, -sin, cos, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+    ]
 }
 
 fn identity() -> [f32; 16] {
@@ -340,7 +409,7 @@ fn lower_overflow(value: OverflowValue) -> OverflowClip {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use whisker_style::{ComputedCornerRadius, Corners, Edges, StyleNumber};
+    use whisker_style::{ComputedCornerRadius, Corners, Edges, MotionPathPointValue, StyleNumber};
 
     fn color(name: &str) -> ColorValue {
         ColorValue::Named(name.into())
@@ -438,6 +507,9 @@ mod tests {
     fn resolves_transform_percentages_and_origin_against_border_box() {
         let style = ComputedTransformStyle {
             perspective: None,
+            offset_path: OffsetPathValue::None,
+            offset_distance: StyleNumber::new(0.0),
+            offset_rotate: OffsetRotateValue::Auto,
             functions: vec![ComputedTransformFunction::Scale {
                 x: StyleNumber::new(2.0),
                 y: StyleNumber::new(2.0),
@@ -455,6 +527,9 @@ mod tests {
 
         let translated = ComputedTransformStyle {
             perspective: None,
+            offset_path: OffsetPathValue::None,
+            offset_distance: StyleNumber::new(0.0),
+            offset_rotate: OffsetRotateValue::Auto,
             functions: vec![ComputedTransformFunction::Translate {
                 x: ComputedLengthPercentage::new(3.0, 0.5),
                 y: ComputedLengthPercentage::new(4.0, 0.25),
@@ -501,6 +576,9 @@ mod tests {
         ] {
             let style = ComputedTransformStyle {
                 perspective: None,
+                offset_path: OffsetPathValue::None,
+                offset_distance: StyleNumber::new(0.0),
+                offset_rotate: OffsetRotateValue::Auto,
                 functions: vec![function],
                 origin_x: ComputedLengthPercentage::ZERO,
                 origin_y: ComputedLengthPercentage::ZERO,
@@ -527,6 +605,9 @@ mod tests {
     fn canonicalizes_three_dimensional_output_to_the_node_plane() {
         let style = ComputedTransformStyle {
             perspective: None,
+            offset_path: OffsetPathValue::None,
+            offset_distance: StyleNumber::new(0.0),
+            offset_rotate: OffsetRotateValue::Auto,
             functions: vec![ComputedTransformFunction::RotateY(StyleNumber::new(60.0))],
             origin_x: ComputedLengthPercentage::ZERO,
             origin_y: ComputedLengthPercentage::ZERO,
@@ -547,6 +628,9 @@ mod tests {
     fn prepends_lynx_current_node_perspective_to_the_transform_matrix() {
         let style = ComputedTransformStyle {
             perspective: Some(StyleNumber::new(100.0)),
+            offset_path: OffsetPathValue::None,
+            offset_distance: StyleNumber::new(0.0),
+            offset_rotate: OffsetRotateValue::Auto,
             functions: vec![ComputedTransformFunction::RotateY(StyleNumber::new(60.0))],
             origin_x: ComputedLengthPercentage::ZERO,
             origin_y: ComputedLengthPercentage::ZERO,
@@ -574,6 +658,79 @@ mod tests {
             assert!(
                 (actual - expected).abs() < 0.000_001,
                 "{actual} != {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn lowers_polyline_motion_progress_auto_rotation_and_post_translation() {
+        let point = |x, y| MotionPathPointValue {
+            x: StyleNumber::new(x),
+            y: StyleNumber::new(y),
+        };
+        assert_eq!(motion_path_state(&OffsetPathValue::None, 0.5), None);
+        let style = ComputedTransformStyle {
+            offset_path: OffsetPathValue::Path(vec![
+                MotionPathCommandValue::MoveTo(point(0.0, 0.0)),
+                MotionPathCommandValue::LineTo(point(40.0, 0.0)),
+                MotionPathCommandValue::LineTo(point(40.0, 30.0)),
+            ]),
+            offset_distance: StyleNumber::new(0.75),
+            offset_rotate: OffsetRotateValue::Auto,
+            ..ComputedTransformStyle::default()
+        };
+        let transform = lower_transform(&style, 20.0, 10.0).unwrap();
+        let expected = [
+            0.0, 1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 55.0, 7.5, 0.0, 1.0,
+        ];
+        for (actual, expected) in transform.0.into_iter().zip(expected) {
+            assert!(
+                (actual - expected).abs() < 0.000_01,
+                "{actual} != {expected}"
+            );
+        }
+
+        let first_segment = ComputedTransformStyle {
+            offset_distance: StyleNumber::new(0.25),
+            ..style.clone()
+        };
+        let transform = lower_transform(&first_segment, 20.0, 10.0).unwrap();
+        assert_eq!(transform.0[12], 17.5);
+        assert_eq!(transform.0[13], 0.0);
+
+        let fixed = ComputedTransformStyle {
+            offset_path: OffsetPathValue::Path(vec![
+                MotionPathCommandValue::MoveTo(point(0.0, 0.0)),
+                MotionPathCommandValue::LineTo(point(10.0, 0.0)),
+                MotionPathCommandValue::Close,
+            ]),
+            offset_distance: StyleNumber::new(1.0),
+            offset_rotate: OffsetRotateValue::Angle(StyleNumber::new(0.0)),
+            ..ComputedTransformStyle::default()
+        };
+        let transform = lower_transform(&fixed, 1.0, 1.0).unwrap();
+        assert_eq!(transform.0[12], 0.0);
+        assert_eq!(transform.0[13], 0.0);
+
+        for offset_path in [
+            OffsetPathValue::Path(Vec::new()),
+            OffsetPathValue::Path(vec![MotionPathCommandValue::LineTo(point(1.0, 0.0))]),
+            OffsetPathValue::Path(vec![MotionPathCommandValue::Close]),
+            OffsetPathValue::Path(vec![
+                MotionPathCommandValue::MoveTo(point(1.0, 1.0)),
+                MotionPathCommandValue::LineTo(point(1.0, 1.0)),
+            ]),
+        ] {
+            assert_eq!(
+                lower_transform(
+                    &ComputedTransformStyle {
+                        offset_path,
+                        ..ComputedTransformStyle::default()
+                    },
+                    1.0,
+                    1.0,
+                ),
+                None
             );
         }
     }

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -801,6 +801,7 @@ impl SurfaceEngine {
         border_height: f32,
     ) -> Result<Option<whisker_protocol::Transform>, SurfaceError> {
         if style.perspective.is_none()
+            && matches!(style.offset_path, whisker_style::OffsetPathValue::None)
             && style.functions.is_empty()
             && self
                 .scene
@@ -1187,6 +1188,27 @@ mod tests {
                 .resolve_node_transform(empty, &ComputedTransformStyle::default(), 1.0, 1.0)
                 .unwrap(),
             Some(whisker_protocol::Transform::IDENTITY)
+        );
+
+        let point = |x, y| whisker_style::MotionPathPointValue {
+            x: StyleNumber::new(x),
+            y: StyleNumber::new(y),
+        };
+        let motion = ComputedTransformStyle {
+            offset_path: whisker_style::OffsetPathValue::Path(vec![
+                whisker_style::MotionPathCommandValue::MoveTo(point(0.0, 0.0)),
+                whisker_style::MotionPathCommandValue::LineTo(point(10.0, 0.0)),
+            ]),
+            offset_distance: StyleNumber::new(0.5),
+            ..ComputedTransformStyle::default()
+        };
+        assert_eq!(
+            empty_surface
+                .resolve_node_transform(empty, &motion, 1.0, 1.0)
+                .unwrap()
+                .unwrap()
+                .0[12],
+            5.0
         );
     }
 

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -50,6 +50,7 @@ pub use value::{
     BackgroundLayerValue, BackgroundPositionValue, BackgroundRepeatModeValue,
     BackgroundRepeatValue, BackgroundSizeValue, BackgroundValue, BorderRadiusValue, CalcExpression,
     ColorValue, FontFamilyValue, FontStyleValue, FontWeightValue, GradientStopValue, GradientValue,
-    LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, RadialGradientValue,
-    StyleNumber, StyleValue, TransformFunctionValue, TransformOriginValue, TransformValue,
+    LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, MotionPathCommandValue,
+    MotionPathPointValue, OffsetPathValue, OffsetRotateValue, RadialGradientValue, StyleNumber,
+    StyleValue, TransformFunctionValue, TransformOriginValue, TransformValue,
 };

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -4,9 +4,10 @@ use crate::{
     BackdropFilterValue, BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue,
     BackgroundPositionValue, BackgroundRepeatModeValue, BackgroundSizeValue, ColorValue,
     ComputedLengthPercentage, DirectionValue, Edges, GradientValue, InheritedStyle,
-    LengthPercentageValue, RadialGradientValue, SpecifiedStyle, StyleEnvironment, StyleNumber,
-    StyleProperty, StyleResolutionError, StyleValue, TransformFunctionValue, TransformOriginValue,
-    TransformValue, layout::resolve_affine,
+    LengthPercentageValue, MotionPathCommandValue, OffsetPathValue, OffsetRotateValue,
+    RadialGradientValue, SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty,
+    StyleResolutionError, StyleValue, TransformFunctionValue, TransformOriginValue, TransformValue,
+    layout::resolve_affine,
 };
 
 /// Four physical corners in top-left, top-right, bottom-right, bottom-left order.
@@ -216,6 +217,12 @@ pub enum ComputedTransformFunction {
 pub struct ComputedTransformStyle {
     /// Lynx-compatible perspective distance applied to this node, or none.
     pub perspective: Option<StyleNumber>,
+    /// Polyline path followed by the current node.
+    pub offset_path: OffsetPathValue,
+    /// Normalized progress along `offset_path`.
+    pub offset_distance: StyleNumber,
+    /// Tangent-following or fixed motion-path rotation.
+    pub offset_rotate: OffsetRotateValue,
     /// Ordered transform functions.
     pub functions: Vec<ComputedTransformFunction>,
     /// Horizontal origin relative to border-box width.
@@ -228,6 +235,9 @@ impl Default for ComputedTransformStyle {
     fn default() -> Self {
         Self {
             perspective: None,
+            offset_path: OffsetPathValue::None,
+            offset_distance: StyleNumber::new(0.0),
+            offset_rotate: OffsetRotateValue::Auto,
             functions: Vec::new(),
             origin_x: ComputedLengthPercentage::new(0.0, 0.5),
             origin_y: ComputedLengthPercentage::new(0.0, 0.5),
@@ -405,6 +415,37 @@ pub(crate) fn resolve_paint_style(
                     return Err(invalid(property));
                 }
                 paint.transform.perspective = Some(StyleNumber::new(distance));
+            }
+            StyleProperty::OffsetPath => {
+                let StyleValue::OffsetPath(value) = value else {
+                    return Err(invalid(property));
+                };
+                if !valid_offset_path(value) {
+                    return Err(invalid(property));
+                }
+                paint.transform.offset_path = value.clone();
+            }
+            StyleProperty::OffsetDistance => {
+                let distance = match value {
+                    StyleValue::Number(value) => value.get(),
+                    StyleValue::LengthPercentage(LengthPercentageValue::Percentage(value)) => {
+                        value.get() / 100.0
+                    }
+                    _ => return Err(invalid(property)),
+                };
+                if !distance.is_finite() || !(0.0..=1.0).contains(&distance) {
+                    return Err(invalid(property));
+                }
+                paint.transform.offset_distance = StyleNumber::new(distance);
+            }
+            StyleProperty::OffsetRotate => {
+                let StyleValue::OffsetRotate(value) = value else {
+                    return Err(invalid(property));
+                };
+                if matches!(value, OffsetRotateValue::Angle(angle) if !angle.get().is_finite()) {
+                    return Err(invalid(property));
+                }
+                paint.transform.offset_rotate = *value;
             }
             StyleProperty::TransformOrigin => {
                 let StyleValue::TransformOrigin(value) = value else {
@@ -651,6 +692,49 @@ pub(crate) fn resolve_paint_style(
         }
     }
     Ok(paint)
+}
+
+fn valid_offset_path(value: &OffsetPathValue) -> bool {
+    let OffsetPathValue::Path(commands) = value else {
+        return true;
+    };
+    let mut current = None;
+    let mut subpath_start = None;
+    let mut total_length = 0.0_f32;
+    for command in commands {
+        match *command {
+            MotionPathCommandValue::MoveTo(point) => {
+                if !point.x.get().is_finite() || !point.y.get().is_finite() {
+                    return false;
+                }
+                let point = (point.x.get(), point.y.get());
+                current = Some(point);
+                subpath_start = Some(point);
+            }
+            MotionPathCommandValue::LineTo(point) => {
+                let Some(from) = current else {
+                    return false;
+                };
+                if !point.x.get().is_finite() || !point.y.get().is_finite() {
+                    return false;
+                }
+                let to = (point.x.get(), point.y.get());
+                total_length += (to.0 - from.0).hypot(to.1 - from.1);
+                current = Some(to);
+            }
+            MotionPathCommandValue::Close => {
+                let (Some(from), Some(to)) = (current, subpath_start) else {
+                    return false;
+                };
+                total_length += (to.0 - from.0).hypot(to.1 - from.1);
+                current = Some(to);
+            }
+        }
+        if !total_length.is_finite() {
+            return false;
+        }
+    }
+    total_length > 0.0
 }
 
 fn resolve_transform_functions(
@@ -1484,6 +1568,157 @@ mod tests {
                 ))
             );
         }
+    }
+
+    #[test]
+    fn motion_path_resolves_progress_and_rotation_and_rejects_invalid_values() {
+        let point = |x, y| crate::MotionPathPointValue {
+            x: number(x),
+            y: number(y),
+        };
+        let path = OffsetPathValue::Path(vec![
+            MotionPathCommandValue::MoveTo(point(0.0, 0.0)),
+            MotionPathCommandValue::LineTo(point(40.0, 0.0)),
+            MotionPathCommandValue::LineTo(point(40.0, 30.0)),
+        ]);
+        let resolved = crate::resolve_style(
+            &SpecifiedStyle::new()
+                .push(
+                    StyleProperty::OffsetPath,
+                    StyleValue::OffsetPath(path.clone()),
+                )
+                .push(
+                    StyleProperty::OffsetDistance,
+                    StyleValue::LengthPercentage(percentage(75.0)),
+                )
+                .push(
+                    StyleProperty::OffsetRotate,
+                    StyleValue::OffsetRotate(OffsetRotateValue::Auto),
+                ),
+            None,
+            StyleEnvironment::default(),
+        )
+        .unwrap();
+        let transform = &resolved.computed().paint().transform;
+        assert_eq!(transform.offset_path, path);
+        assert_eq!(transform.offset_distance, number(0.75));
+        assert_eq!(transform.offset_rotate, OffsetRotateValue::Auto);
+
+        let fixed = crate::resolve_style(
+            &SpecifiedStyle::new()
+                .push(
+                    StyleProperty::OffsetPath,
+                    StyleValue::OffsetPath(OffsetPathValue::None),
+                )
+                .push(
+                    StyleProperty::OffsetDistance,
+                    StyleValue::Number(number(0.5)),
+                )
+                .push(
+                    StyleProperty::OffsetRotate,
+                    StyleValue::OffsetRotate(OffsetRotateValue::Angle(number(45.0))),
+                ),
+            None,
+            StyleEnvironment::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            fixed.computed().paint().transform.offset_path,
+            OffsetPathValue::None
+        );
+        assert_eq!(
+            fixed.computed().paint().transform.offset_distance,
+            number(0.5)
+        );
+        assert_eq!(
+            fixed.computed().paint().transform.offset_rotate,
+            OffsetRotateValue::Angle(number(45.0))
+        );
+
+        let invalid_path = |path| {
+            crate::resolve_style(
+                &SpecifiedStyle::new().push(
+                    StyleProperty::OffsetPath,
+                    StyleValue::OffsetPath(OffsetPathValue::Path(path)),
+                ),
+                None,
+                StyleEnvironment::default(),
+            )
+        };
+        for commands in [
+            Vec::new(),
+            vec![MotionPathCommandValue::LineTo(point(1.0, 1.0))],
+            vec![MotionPathCommandValue::Close],
+            vec![MotionPathCommandValue::MoveTo(point(f32::NAN, 0.0))],
+            vec![
+                MotionPathCommandValue::MoveTo(point(0.0, 0.0)),
+                MotionPathCommandValue::LineTo(point(f32::NAN, 0.0)),
+            ],
+            vec![
+                MotionPathCommandValue::MoveTo(point(-f32::MAX, 0.0)),
+                MotionPathCommandValue::LineTo(point(f32::MAX, 0.0)),
+            ],
+            vec![
+                MotionPathCommandValue::MoveTo(point(1.0, 1.0)),
+                MotionPathCommandValue::LineTo(point(1.0, 1.0)),
+            ],
+        ] {
+            assert_eq!(
+                invalid_path(commands),
+                Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::OffsetPath
+                ))
+            );
+        }
+
+        let invalid_declaration = |property, value| {
+            crate::resolve_style(
+                &SpecifiedStyle::new().push(property, value),
+                None,
+                StyleEnvironment::default(),
+            )
+        };
+        for value in [
+            StyleValue::Text("invalid".into()),
+            StyleValue::Number(number(f32::NAN)),
+            StyleValue::Number(number(-0.1)),
+            StyleValue::Number(number(1.1)),
+            StyleValue::LengthPercentage(percentage(-1.0)),
+            StyleValue::LengthPercentage(percentage(101.0)),
+        ] {
+            assert_eq!(
+                invalid_declaration(StyleProperty::OffsetDistance, value),
+                Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::OffsetDistance
+                ))
+            );
+        }
+        for value in [
+            StyleValue::Number(number(0.0)),
+            StyleValue::OffsetRotate(OffsetRotateValue::Angle(number(f32::NAN))),
+        ] {
+            assert_eq!(
+                invalid_declaration(StyleProperty::OffsetRotate, value),
+                Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::OffsetRotate
+                ))
+            );
+        }
+        assert_eq!(
+            invalid_declaration(StyleProperty::OffsetPath, StyleValue::Number(number(0.0))),
+            Err(StyleResolutionError::InvalidPropertyValue(
+                StyleProperty::OffsetPath
+            ))
+        );
+
+        assert!(
+            invalid_path(vec![
+                MotionPathCommandValue::MoveTo(point(0.0, 0.0)),
+                MotionPathCommandValue::LineTo(point(10.0, 0.0)),
+                MotionPathCommandValue::Close,
+            ])
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -405,6 +405,46 @@ pub struct TransformOriginValue {
     pub vertical: LengthPercentageValue,
 }
 
+/// One absolute point in a Lynx `offset-path: path()` value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MotionPathPointValue {
+    /// Horizontal logical-pixel coordinate.
+    pub x: StyleNumber,
+    /// Vertical logical-pixel coordinate.
+    pub y: StyleNumber,
+}
+
+/// One command in the initially supported polyline motion-path subset.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MotionPathCommandValue {
+    /// Start a new subpath.
+    MoveTo(MotionPathPointValue),
+    /// Add a straight segment.
+    LineTo(MotionPathPointValue),
+    /// Close the current subpath with a straight segment.
+    Close,
+}
+
+/// Typed value of `offset-path`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub enum OffsetPathValue {
+    /// Disable motion-path translation and rotation.
+    #[default]
+    None,
+    /// Follow an absolute path in the node's local logical-pixel space.
+    Path(Vec<MotionPathCommandValue>),
+}
+
+/// Typed value of `offset-rotate`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum OffsetRotateValue {
+    /// Follow the path tangent.
+    #[default]
+    Auto,
+    /// Use a fixed clockwise angle in degrees.
+    Angle(StyleNumber),
+}
+
 /// An owned value in a specified inline-style declaration.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StyleValue {
@@ -442,6 +482,10 @@ pub enum StyleValue {
     Transform(TransformValue),
     /// Transform origin resolved against the node border box.
     TransformOrigin(TransformOriginValue),
+    /// Motion path followed by the current node.
+    OffsetPath(OffsetPathValue),
+    /// Motion-path tangent or fixed rotation.
+    OffsetRotate(OffsetRotateValue),
     /// Font family.
     FontFamily(FontFamilyValue),
     /// Font face style.

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -1,8 +1,8 @@
 use std::convert::Infallible;
 
 use whisker::css::{
-    Angle, BorderStyle, Clear, Direction, Float, GridLine, GridTemplate, GridTrack, Overflow,
-    Position, TransformFn,
+    Angle, BorderStyle, Clear, Direction, Float, GridLine, GridTemplate, GridTrack,
+    MotionPathCommand, MotionPathPoint, OffsetPath, OffsetRotate, Overflow, Position, TransformFn,
 };
 use whisker::prelude::*;
 use whisker::runtime::reactive::{__reset_for_tests, Owner};
@@ -664,6 +664,58 @@ fn render_lynx_perspective_is_lowered_into_the_current_node_transform() {
         .expect("perspective emits SetTransform");
     assert!((transform.0[3] - 3.0_f32.sqrt() / 200.0).abs() < 0.000_001);
     assert_eq!(transform.0[11], 0.0);
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn render_motion_path_is_baked_into_the_existing_transform_operation() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(27).expect("test surface"),
+        StyleEnvironment::new(100.0, 70.0, 1.0, 14.0),
+    );
+    let style = Css::new()
+        .width(px(20))
+        .height(px(10))
+        .offset_path(OffsetPath::path(vec![
+            MotionPathCommand::MoveTo(MotionPathPoint::new(0.0, 0.0)),
+            MotionPathCommand::LineTo(MotionPathPoint::new(40.0, 0.0)),
+            MotionPathCommand::LineTo(MotionPathPoint::new(40.0, 30.0)),
+        ]))
+        .offset_distance(percent(75))
+        .offset_rotate(OffsetRotate::Auto);
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| render! { view(style: style) });
+        set_root(root);
+    });
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(100.0, 70.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .expect("motion-path frame");
+    let root = surface.root().expect("surface root");
+    assert!(
+        renderer.frames()[0]
+            .packet
+            .operations
+            .iter()
+            .any(|operation| matches!(
+                operation,
+                Operation::SetTransform { node, transform }
+                    if *node == root
+                        && (transform.0[12] - 55.0).abs() < 0.000_01
+                        && (transform.0[13] - 7.5).abs() < 0.000_01
+            ))
+    );
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }
 

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -829,9 +829,15 @@ local plane. Each Host applies the projective result and flattens at that node;
 Android maps the `z = 0` slice exactly to a density-adjusted 3-by-3 homography.
 Lynx-compatible `perspective` applies to the current node rather than its
 children; Rust prepends its projection to the node transform before this same
-flat-plane normalization. Browser-style parent perspective, `perspective-origin`,
-shared `preserve-3d` descendant spaces, and motion paths are outside this
-subset rather than silently changing semantics on any Host.
+flat-plane normalization. Browser-style parent perspective,
+`perspective-origin`, and shared `preserve-3d` descendant spaces are outside
+this subset rather than silently changing semantics on any Host. The initial
+Lynx motion-path slice supports absolute `path()` polylines (`M`, `L`, `Z`),
+number/percentage `offset-distance`, and `offset-rotate: auto` or a fixed
+angle. Rust resolves the point and tangent, preserves Lynx's post-transform
+path translation, and emits the result through the existing `SetTransform`;
+no motion-path opcode or Host-side CSS parser is added. Curve commands, SVG
+arcs, and basic-shape paths remain pending follow-up slices.
 
 The final opcode set may combine common operations for compactness. The
 semantic separation matters because it enables dirty classification,

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -484,9 +484,15 @@ Android derives the exact density-adjusted 3-by-3 homography for that `z = 0`
 plane. In accordance with Lynx, `perspective` affects the current node rather
 than its children: Rust resolves the length, clamps values below one logical
 pixel for rendering, prepends the projection, and emits the same canonical
-flat-plane matrix. Browser-style parent perspective, `perspective-origin`,
-shared `preserve-3d` descendant spaces, and offset-path motion are outside the
-current subset.
+flat-plane matrix. Browser-style parent perspective, `perspective-origin`, and
+shared `preserve-3d` descendant spaces are outside the current subset. Lynx
+motion-path positioning is lowered through that same matrix operation: Rust
+measures absolute `path()` polylines (`M`, `L`, and `Z`), clamps normalized
+`offset-distance`, derives the tangent for `offset-rotate: auto` or uses a fixed
+angle, composes rotation before the ordinary transform list, and applies path
+translation after transform-origin. Quadratic/cubic commands, SVG arcs, and
+the `circle()`, `ellipse()`, and `inset()` path forms remain explicit pending
+subsets rather than Host-specific interpretations.
 
 Protocol minor 1 groups those resolved meanings by Host capability rather
 than by CSS spelling. `SetBackgroundLayers` carries resource-backed images,

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -457,8 +457,8 @@ impl Driver {
                 }
                 Command::Checkpoint { name, samples, .. } => {
                     if self.expected_scene.is_some() {
-                        let expected_checkpoint = if name == "paint.transform.projective-plane" {
-                            "paint.transform.projective-plane"
+                        let expected_checkpoint = if name.starts_with("paint.transform.") {
+                            name.as_str()
                         } else if self.resource_lifecycle {
                             "paint.background-layers.resource-lifecycle"
                         } else {
@@ -1236,6 +1236,9 @@ fn fixture(path: &str) -> &'static str {
         "core/transform-perspective-current-node.json" => include_str!(
             "../../../../tests/host-conformance/core/transform-perspective-current-node.json"
         ),
+        "core/transform-motion-path-line.json" => {
+            include_str!("../../../../tests/host-conformance/core/transform-motion-path-line.json")
+        }
         "wpt/css/css-color/t32-opacity-basic-0.6-a.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-color/t32-opacity-basic-0.6-a.json"
         ),
@@ -2119,9 +2122,11 @@ fn fixture_clip_path_css(value: &ClipPathFixture) -> String {
             }
         }
     };
-    let suffix = (!reference_box.is_empty())
-        .then(|| format!(" {reference_box}"))
-        .unwrap_or_default();
+    let suffix = if reference_box.is_empty() {
+        String::new()
+    } else {
+        format!(" {reference_box}")
+    };
     format!("{shape}{suffix}")
 }
 

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -126,8 +126,9 @@
       "id": "paint.transform",
       "basis": "lynx-4.0",
       "properties": ["offset-distance", "offset-path", "offset-rotate", "perspective", "transform", "transform-origin"],
-      "supported_subset": ["transform-2d-functions", "flat-plane-3d-functions", "matrix", "projective-matrix3d", "length-percentage-translate", "border-box-transform-origin", "lynx-current-node-perspective", "flat-at-each-node"],
-      "unsupported_browser_subset": ["web-parent-perspective-semantics", "perspective-origin", "preserve-3d", "motion-path"],
+      "supported_subset": ["transform-2d-functions", "flat-plane-3d-functions", "matrix", "projective-matrix3d", "length-percentage-translate", "border-box-transform-origin", "lynx-current-node-perspective", "motion-path-polyline", "offset-distance-number-and-percentage", "offset-rotate-auto-or-angle", "flat-at-each-node"],
+      "pending_subset": ["motion-path-quadratic-and-cubic", "motion-path-circle", "motion-path-ellipse", "motion-path-inset", "motion-path-svg-arc"],
+      "unsupported_browser_subset": ["web-parent-perspective-semantics", "perspective-origin", "preserve-3d"],
       "protocol": ["SetTransform", "SetVisualEffects"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/core/transform-motion-path-line.json
+++ b/tests/host-conformance/core/transform-motion-path-line.json
@@ -1,0 +1,39 @@
+{
+  "schema": 1,
+  "id": "core.transform-motion-path-line",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 70.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 15.0, 20.0, 10.0],
+            "background": { "kind": "named", "value": "green" },
+            "clip": { "horizontal": "visible", "vertical": "visible" },
+            "transform": [
+              0.0, 1.0, 0.0, 0.0,
+              -1.0, 0.0, 0.0, 0.0,
+              0.0, 0.0, 1.0, 0.0,
+              55.0, 7.5, 0.0, 1.0
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.transform.motion-path-line",
+        "samples": [
+          { "point": [56.0, 24.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [63.0, 40.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [52.0, 24.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [66.0, 30.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -248,6 +248,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "core.transform-motion-path-line",
+      "feature": "motion-path-line",
+      "fixture": "core/transform-motion-path-line.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-color.opacity-basic-0.6",
       "feature": "opacity",
       "fixture": "wpt/css/css-color/t32-opacity-basic-0.6-a.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -319,7 +319,9 @@ private class Driver(
                             command.getString("name") ==
                             "paint.visual-effects.backdrop-blur" ||
                             command.getString("name") ==
-                            "paint.transform.projective-plane",
+                            "paint.transform.projective-plane" ||
+                            command.getString("name") ==
+                            "paint.transform.motion-path-line",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -450,7 +450,8 @@ private final class Driver {
                     name == "paint.visual-effects.clip-path-path-nonzero" ||
                     name == "paint.visual-effects.clip-path-path-evenodd" ||
                     name == "paint.visual-effects.backdrop-blur" ||
-                    name == "paint.transform.projective-plane" else {
+                    name == "paint.transform.projective-plane" ||
+                    name == "paint.transform.motion-path-line" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 if name == "paint.visual-effects.backdrop-blur" {


### PR DESCRIPTION
## Summary
- add typed `offset-path`, `offset-distance`, and `offset-rotate` authoring and style resolution for the initial Lynx polyline subset (`M`, `L`, `Z`)
- resolve path position/tangent in Rust and bake motion translation/rotation into the existing `SetTransform` matrix without extending the Host ABI
- add one shared fixture required by Desktop, Web, Android, and iOS, and document the remaining curve/basic-shape/arc slices

## Semantics
- number and percentage distances are normalized to path progress
- `offset-rotate: auto` follows the segment tangent; fixed angles replace tangent rotation
- motion rotation precedes the ordinary transform list and path translation is applied after transform-origin, matching Lynx current behavior
- invalid, non-finite, or zero-length paths are rejected before projection

## Verification
- `cargo llvm-cov -p whisker-style --show-missing-lines --summary-only` (100% lines/functions/regions)
- `cargo llvm-cov -p whisker-engine --show-missing-lines --summary-only` (100% lines/functions/regions)
- targeted Rust CSS/style/render! E2E tests
- Clippy with warnings denied for Rust core and wasm32 Web Host
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`

Stacked on #475.