### PR TITLE
feat(paint): implement single text shadow

### DIFF
--- a/crates/whisker-css/src/prop/text.rs
+++ b/crates/whisker-css/src/prop/text.rs
@@ -7,8 +7,60 @@ use crate::keyword::{
     TextAlign, TextDecorationLine, TextDecorationStyle, TextOverflow, TextTransform, VerticalAlign,
     WhiteSpace, WordBreak, WordWrap,
 };
+use crate::style_value::ToStyleValue;
 
 impl Css {
+    /// Sets the Lynx-compatible single `text-shadow` layer.
+    /// <https://lynxjs.org/api/css/properties/text-shadow>
+    pub fn text_shadow(
+        self,
+        offset_x: Length,
+        offset_y: Length,
+        blur_radius: Length,
+        color: Color,
+    ) -> Self {
+        use crate::to_css::ToCss;
+        let whisker_style::StyleValue::Length(offset_x_value) = offset_x.to_style_value() else {
+            unreachable!()
+        };
+        let whisker_style::StyleValue::Length(offset_y_value) = offset_y.to_style_value() else {
+            unreachable!()
+        };
+        let whisker_style::StyleValue::Length(blur_radius_value) = blur_radius.to_style_value()
+        else {
+            unreachable!()
+        };
+        let whisker_style::StyleValue::Color(color_value) = color.to_style_value() else {
+            unreachable!()
+        };
+        let mut css = String::new();
+        let _ = offset_x.to_css(&mut css);
+        css.push(' ');
+        let _ = offset_y.to_css(&mut css);
+        css.push(' ');
+        let _ = blur_radius.to_css(&mut css);
+        css.push(' ');
+        let _ = color.to_css(&mut css);
+        self.push_semantic(
+            crate::StyleProperty::TextShadow,
+            whisker_style::StyleValue::TextShadow(whisker_style::TextShadowValue::Shadow {
+                offset_x: offset_x_value,
+                offset_y: offset_y_value,
+                blur_radius: blur_radius_value,
+                color: color_value,
+            }),
+            css,
+        )
+    }
+
+    /// Disables inherited text shadow paint.
+    pub fn text_shadow_none(self) -> Self {
+        self.push_semantic(
+            crate::StyleProperty::TextShadow,
+            whisker_style::StyleValue::TextShadow(whisker_style::TextShadowValue::None),
+            "none",
+        )
+    }
     /// Sets `text-align`. **`justify` is not supported by Lynx**.
     /// <https://lynxjs.org/api/css/properties/text-align>
     pub fn text_align(self, v: TextAlign) -> Self {
@@ -93,6 +145,24 @@ mod tests {
     fn text_align_keywords() {
         let s = Css::new().text_align(TextAlign::Center);
         assert_eq!(s.to_string(), "text-align: center;");
+    }
+
+    #[test]
+    fn single_text_shadow_is_typed_and_uses_lynx_order() {
+        let style = Css::new().text_shadow(1.px(), 2.px(), 3.px(), Color::rgba(255, 0, 0, 0.5));
+        assert_eq!(
+            style.to_string(),
+            "text-shadow: 1px 2px 3px rgba(255, 0, 0, 0.5);"
+        );
+        let specified = style.to_specified_style().unwrap();
+        assert!(matches!(
+            specified.resolved()[0].value(),
+            whisker_style::StyleValue::TextShadow(whisker_style::TextShadowValue::Shadow { .. })
+        ));
+        assert_eq!(
+            Css::new().text_shadow_none().to_string(),
+            "text-shadow: none;"
+        );
     }
 
     #[test]

--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 15 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 16 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -150,6 +150,9 @@ typedef struct {
   uint32_t max_lines;
   float line_height, letter_spacing;
   WhiskerMobileColor color;
+  float shadow_offset_x, shadow_offset_y, shadow_blur_radius;
+  uint32_t shadow_flags;
+  WhiskerMobileColor shadow_color;
   uint64_t prepared_content;
 } WhiskerMobileText;
 typedef struct {
@@ -251,7 +254,7 @@ _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 160, "WhiskerMobileMeasure
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceCommand) == 64, "WhiskerMobileResourceCommand ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceEvent) == 56, "WhiskerMobileResourceEvent ABI drift");
-_Static_assert(sizeof(WhiskerMobileText) == 80, "WhiskerMobileText ABI drift");
+_Static_assert(sizeof(WhiskerMobileText) == 128, "WhiskerMobileText ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 
 typedef void (*WhiskerMobileRequestFrameCallback)(void*);

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -490,10 +490,17 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 storage[0]=p->font_size; storage[1]=(float)p->font_weight; storage[2]=(float)p->font_style;
                 storage[3]=(float)p->color.red; storage[4]=(float)p->color.green; storage[5]=(float)p->color.blue;
                 storage[6]=p->color.alpha; storage[7]=(float)p->color.kind;
-                numbers = floats(env, storage, 8);
-                jclass cls = (*env)->FindClass(env, "java/lang/String"); names = (*env)->NewObjectArray(env, 1, cls, NULL);
+                storage[8]=(float)p->shadow_flags; storage[9]=p->shadow_offset_x; storage[10]=p->shadow_offset_y;
+                storage[11]=p->shadow_blur_radius; storage[12]=(float)p->shadow_color.red;
+                storage[13]=(float)p->shadow_color.green; storage[14]=(float)p->shadow_color.blue;
+                storage[15]=p->shadow_color.alpha; storage[16]=(float)p->shadow_color.kind;
+                numbers = floats(env, storage, 17);
+                jclass cls = (*env)->FindClass(env, "java/lang/String"); names = (*env)->NewObjectArray(env, 2, cls, NULL);
                 jstring color_name = new_string(env, p->color.name.ptr, p->color.name.len); (*env)->SetObjectArrayElement(env, names, 0, color_name);
-                if (color_name) (*env)->DeleteLocalRef(env, color_name); (*env)->DeleteLocalRef(env, cls); break;
+                jstring shadow_name = new_string(env, p->shadow_color.name.ptr, p->shadow_color.name.len); (*env)->SetObjectArrayElement(env, names, 1, shadow_name);
+                if (color_name) (*env)->DeleteLocalRef(env, color_name);
+                if (shadow_name) (*env)->DeleteLocalRef(env, shadow_name);
+                (*env)->DeleteLocalRef(env, cls); break;
             }
             case WHISKER_OP_PROPERTY: case WHISKER_OP_COMMAND: value = raw_to_value(env, op->payload); break;
         }

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 15;
+pub const MOBILE_ABI_MINOR: u16 = 16;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -309,6 +309,11 @@ pub struct MobileText {
     pub line_height: f32,
     pub letter_spacing: f32,
     pub color: MobileColor,
+    pub shadow_offset_x: f32,
+    pub shadow_offset_y: f32,
+    pub shadow_blur_radius: f32,
+    pub shadow_flags: u32,
+    pub shadow_color: MobileColor,
     pub prepared_content: u64,
 }
 
@@ -652,7 +657,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileBootstrap>(), 24);
             assert_eq!(std::mem::size_of::<MobileMeasureRequest>(), 160);
             assert_eq!(std::mem::size_of::<MobileMeasureResponse>(), 64);
-            assert_eq!(std::mem::size_of::<MobileText>(), 80);
+            assert_eq!(std::mem::size_of::<MobileText>(), 128);
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::size_of::<MobileBoxShadow>(), 56);
             assert_eq!(std::mem::size_of::<MobileClipInset>(), 96);

--- a/crates/whisker-engine/src/text.rs
+++ b/crates/whisker-engine/src/text.rs
@@ -8,7 +8,7 @@ use std::{
 use whisker_protocol::{
     MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextDirection,
     MeasureTextOverflow, MeasureTextWrap, MeasurementPayload, MeasurementSpec, PaintColor,
-    PendingMeasurePolicy, TextContent, TextMeasurePayload, TextMeasureStyle, TextPaint,
+    PendingMeasurePolicy, TextContent, TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow,
 };
 use whisker_style::{
     ColorValue, ComputedLineHeight, FontFamilyValue, FontStyleValue, InheritedStyle,
@@ -113,6 +113,16 @@ pub fn lower_plain_text(input: &PlainTextInput, style: &InheritedStyle) -> Lower
             payload,
             paint: TextPaint {
                 foreground: lower_color(style.color()),
+                shadows: style
+                    .text_shadow()
+                    .into_iter()
+                    .map(|shadow| TextShadow {
+                        offset_x: shadow.offset_x(),
+                        offset_y: shadow.offset_y(),
+                        blur_radius: shadow.blur_radius(),
+                        color: lower_color(shadow.color()),
+                    })
+                    .collect(),
                 ..TextPaint::default()
             },
             prepared_content: None,
@@ -177,7 +187,7 @@ mod tests {
     use whisker_style::{
         FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue,
         SpecifiedStyle, StyleDeclaration, StyleEnvironment, StyleNumber, StyleProperty, StyleValue,
-        resolve_style,
+        TextShadowValue, resolve_style,
     };
 
     fn resolved(declarations: Vec<StyleDeclaration>) -> whisker_style::ResolvedNodeStyle {
@@ -345,5 +355,41 @@ mod tests {
             }
         );
         assert_eq!(named.measurement(), hsla.measurement());
+    }
+
+    #[test]
+    fn inherited_single_shadow_lowers_to_paint_without_changing_measurement() {
+        let input = PlainTextInput::new("shadow");
+        let plain = resolved(Vec::new());
+        let shadowed = resolved(vec![StyleDeclaration::new(
+            StyleProperty::TextShadow,
+            StyleValue::TextShadow(TextShadowValue::Shadow {
+                offset_x: LengthValue::Dimension {
+                    value: StyleNumber::new(1.0),
+                    unit: LengthUnit::Em,
+                },
+                offset_y: LengthValue::Dimension {
+                    value: StyleNumber::new(2.0),
+                    unit: LengthUnit::Px,
+                },
+                blur_radius: LengthValue::Dimension {
+                    value: StyleNumber::new(3.0),
+                    unit: LengthUnit::Px,
+                },
+                color: ColorValue::Named("red".into()),
+            }),
+        )]);
+        let plain = lower_plain_text(&input, plain.computed().inherited_text());
+        let shadowed = lower_plain_text(&input, shadowed.computed().inherited_text());
+        assert_eq!(plain.measurement(), shadowed.measurement());
+        assert_eq!(
+            shadowed.content().paint.shadows,
+            vec![TextShadow {
+                offset_x: 14.0,
+                offset_y: 2.0,
+                blur_radius: 3.0,
+                color: PaintColor::Named("red".into()),
+            }]
+        );
     }
 }

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -539,6 +539,9 @@ pub struct SceneNodeFixture {
     pub content_box: Option<[f32; 4]>,
     /// Box background color.
     pub background: ColorFixture,
+    /// Optional native text content and its resolved paint values.
+    #[serde(default)]
+    pub text: Option<TextFixture>,
     /// Optional border semantics.
     #[serde(default)]
     pub border: Option<BorderFixture>,
@@ -588,6 +591,40 @@ pub struct SceneNodeFixture {
     /// Optional explicit, non-repeating conic-gradient background image.
     #[serde(default)]
     pub conic_gradient: Option<ConicGradientFixture>,
+}
+
+/// Native text content used by a retained scene fixture.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TextFixture {
+    /// UTF-8 text value.
+    pub value: String,
+    /// Logical-pixel font size.
+    pub font_size: f32,
+    /// CSS numeric font weight.
+    #[serde(default = "default_font_weight")]
+    pub font_weight: u16,
+    /// Foreground glyph color.
+    pub color: ColorFixture,
+    /// Optional single Lynx-compatible shadow.
+    #[serde(default)]
+    pub shadow: Option<TextShadowFixture>,
+}
+
+/// One resolved native text shadow.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TextShadowFixture {
+    /// Horizontal and vertical logical-pixel offset.
+    pub offset: [f32; 2],
+    /// Non-negative logical-pixel blur radius.
+    pub blur_radius: f32,
+    /// Shadow color.
+    pub color: ColorFixture,
+}
+
+const fn default_font_weight() -> u16 {
+    400
 }
 
 impl SceneNodeFixture {
@@ -1363,6 +1400,18 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                     rect.into_iter().all(f32::is_finite) && rect[2] >= 0.0 && rect[3] >= 0.0
                 })
                 && valid_color(&node.background)
+                && node.text.as_ref().is_none_or(|text| {
+                    text.font_size.is_finite()
+                        && text.font_size > 0.0
+                        && (1..=1000).contains(&text.font_weight)
+                        && valid_color(&text.color)
+                        && text.shadow.as_ref().is_none_or(|shadow| {
+                            shadow.offset.into_iter().all(f32::is_finite)
+                                && shadow.blur_radius.is_finite()
+                                && shadow.blur_radius >= 0.0
+                                && valid_color(&shadow.color)
+                        })
+                })
                 && node.border.as_ref().is_none_or(valid_border)
                 && node.box_shadows.iter().all(|shadow| {
                     shadow.offset.into_iter().all(f32::is_finite)

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -41,9 +41,9 @@ pub use property::{
     PropertyMetadata, PropertyOrigin, StyleProperty, StylePropertyDomain, StylePropertyId,
 };
 pub use resolution::{
-    ComputedLineHeight, ComputedStyle, InheritedPropertySet, InheritedStyle, InheritedStyleChange,
-    PropertyImpactSet, ResolvedNodeStyle, StyleEnvironment, StyleResolutionError, resolve_style,
-    resolve_text_style,
+    ComputedLineHeight, ComputedStyle, ComputedTextShadow, InheritedPropertySet, InheritedStyle,
+    InheritedStyleChange, PropertyImpactSet, ResolvedNodeStyle, StyleEnvironment,
+    StyleResolutionError, resolve_style, resolve_text_style,
 };
 pub use value::{
     BackdropFilterValue, BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue,
@@ -52,6 +52,6 @@ pub use value::{
     ColorValue, FontFamilyValue, FontStyleValue, FontWeightValue, GradientStopValue, GradientValue,
     ImageRenderingValue, InsetPathValue, LengthPercentageValue, LengthUnit, LengthValue,
     LineHeightValue, MotionPathCommandValue, MotionPathPointValue, OffsetPathValue,
-    OffsetRotateValue, RadialGradientValue, StyleNumber, StyleValue, TransformFunctionValue,
-    TransformOriginValue, TransformValue,
+    OffsetRotateValue, RadialGradientValue, StyleNumber, StyleValue, TextShadowValue,
+    TransformFunctionValue, TransformOriginValue, TransformValue,
 };

--- a/crates/whisker-style/src/property.rs
+++ b/crates/whisker-style/src/property.rs
@@ -131,6 +131,7 @@ macro_rules! define_style_properties {
                         | Self::LineHeight
                         | Self::LetterSpacing
                         | Self::Color
+                        | Self::TextShadow
                 );
                 let domain = self.domain();
                 PropertyMetadata {
@@ -579,6 +580,7 @@ mod tests {
                 StyleProperty::FontWeight,
                 StyleProperty::LetterSpacing,
                 StyleProperty::LineHeight,
+                StyleProperty::TextShadow,
             ]
         );
         assert!(!StyleProperty::Opacity.metadata().inherited);

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use crate::{
     CalcExpression, ColorValue, ComputedLayoutStyle, ComputedPaintStyle, FontFamilyValue,
     FontStyleValue, FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue,
-    LineHeightValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue,
+    LineHeightValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue, TextShadowValue,
 };
 
 const RPX_REFERENCE_WIDTH: f32 = 750.0;
@@ -86,7 +86,35 @@ pub enum ComputedLineHeight {
     LogicalPixels(StyleNumber),
 }
 
-/// The seven computed text values inherited by descendant nodes.
+/// One resolved inherited text shadow.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedTextShadow {
+    offset_x: StyleNumber,
+    offset_y: StyleNumber,
+    blur_radius: StyleNumber,
+    color: ColorValue,
+}
+
+impl ComputedTextShadow {
+    /// Returns the horizontal offset in logical pixels.
+    pub const fn offset_x(&self) -> f32 {
+        self.offset_x.get()
+    }
+    /// Returns the vertical offset in logical pixels.
+    pub const fn offset_y(&self) -> f32 {
+        self.offset_y.get()
+    }
+    /// Returns the blur radius in logical pixels.
+    pub const fn blur_radius(&self) -> f32 {
+        self.blur_radius.get()
+    }
+    /// Returns the shadow color.
+    pub const fn color(&self) -> &ColorValue {
+        &self.color
+    }
+}
+
+/// The computed text values inherited by descendant nodes.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct InheritedStyle {
     font_family: FontFamilyValue,
@@ -96,6 +124,7 @@ pub struct InheritedStyle {
     line_height: ComputedLineHeight,
     letter_spacing: StyleNumber,
     color: ColorValue,
+    text_shadow: Option<ComputedTextShadow>,
 }
 
 impl InheritedStyle {
@@ -113,6 +142,7 @@ impl InheritedStyle {
                 blue: 0,
                 alpha: StyleNumber::new(1.0),
             },
+            text_shadow: None,
         }
     }
 
@@ -151,6 +181,11 @@ impl InheritedStyle {
         &self.color
     }
 
+    /// Returns the optional single inherited text shadow.
+    pub const fn text_shadow(&self) -> Option<&ComputedTextShadow> {
+        self.text_shadow.as_ref()
+    }
+
     /// Classifies inherited changes and their downstream work.
     pub fn changes_from(&self, previous: &Self) -> InheritedStyleChange {
         let mut properties = InheritedPropertySet::EMPTY;
@@ -181,6 +216,10 @@ impl InheritedStyle {
         }
         if self.color != previous.color {
             properties |= InheritedPropertySet::COLOR;
+            impacts |= PropertyImpactSet::PAINT;
+        }
+        if self.text_shadow != previous.text_shadow {
+            properties |= InheritedPropertySet::TEXT_SHADOW;
             impacts |= PropertyImpactSet::PAINT;
         }
         InheritedStyleChange {
@@ -285,6 +324,8 @@ impl InheritedPropertySet {
     pub const LETTER_SPACING: Self = Self(1 << 5);
     /// `color`.
     pub const COLOR: Self = Self(1 << 6);
+    /// `text-shadow`.
+    pub const TEXT_SHADOW: Self = Self(1 << 7);
 
     /// Returns whether this set contains every bit from `other`.
     pub const fn contains(self, other: Self) -> bool {
@@ -463,6 +504,47 @@ pub fn resolve_style(
         Some(_) => return Err(wrong_type(StyleProperty::Color)),
         None => base.color.clone(),
     };
+    let text_shadow = match declarations.text_shadow {
+        Some(StyleValue::TextShadow(TextShadowValue::None)) => None,
+        Some(StyleValue::TextShadow(TextShadowValue::Shadow {
+            offset_x,
+            offset_y,
+            blur_radius,
+            color,
+        })) => {
+            let offset_x = resolve_length(
+                *offset_x,
+                font_size.get(),
+                environment,
+                StyleProperty::TextShadow,
+            )?;
+            let offset_y = resolve_length(
+                *offset_y,
+                font_size.get(),
+                environment,
+                StyleProperty::TextShadow,
+            )?;
+            let blur_radius = resolve_length(
+                *blur_radius,
+                font_size.get(),
+                environment,
+                StyleProperty::TextShadow,
+            )?;
+            if blur_radius < 0.0 {
+                return Err(StyleResolutionError::InvalidPropertyValue(
+                    StyleProperty::TextShadow,
+                ));
+            }
+            Some(ComputedTextShadow {
+                offset_x: StyleNumber::new(offset_x),
+                offset_y: StyleNumber::new(offset_y),
+                blur_radius: StyleNumber::new(blur_radius),
+                color: normalize_color(color)?,
+            })
+        }
+        Some(_) => return Err(wrong_type(StyleProperty::TextShadow)),
+        None => base.text_shadow.clone(),
+    };
 
     let inherited_text = InheritedStyle {
         font_family,
@@ -472,6 +554,7 @@ pub fn resolve_style(
         line_height,
         letter_spacing,
         color,
+        text_shadow,
     };
     let layout =
         crate::layout::resolve_layout_style(specified, inherited_text.font_size(), environment)?;
@@ -512,6 +595,7 @@ struct InheritedDeclarations<'a> {
     line_height: Option<&'a StyleValue>,
     letter_spacing: Option<&'a StyleValue>,
     color: Option<&'a StyleValue>,
+    text_shadow: Option<&'a StyleValue>,
 }
 
 impl<'a> InheritedDeclarations<'a> {
@@ -526,6 +610,7 @@ impl<'a> InheritedDeclarations<'a> {
                 StyleProperty::LineHeight => &mut values.line_height,
                 StyleProperty::LetterSpacing => &mut values.letter_spacing,
                 StyleProperty::Color => &mut values.color,
+                StyleProperty::TextShadow => &mut values.text_shadow,
                 _ => continue,
             };
             *slot = Some(declaration.value());
@@ -1130,6 +1215,7 @@ mod tests {
             StyleProperty::LineHeight,
             StyleProperty::LetterSpacing,
             StyleProperty::Color,
+            StyleProperty::TextShadow,
         ] {
             let error = resolve_text_style(
                 &declaration(property, StyleValue::Bool(true)),
@@ -1150,6 +1236,58 @@ mod tests {
         assert_eq!(
             StyleResolutionError::InvalidCalculation(StyleProperty::FontSize).to_string(),
             "invalid calculation for `font-size`"
+        );
+    }
+
+    #[test]
+    fn text_shadow_resolves_inherits_clears_and_rejects_negative_blur() {
+        let environment = StyleEnvironment::default();
+        let shadow = declaration(
+            StyleProperty::TextShadow,
+            StyleValue::TextShadow(TextShadowValue::Shadow {
+                offset_x: px(1.0),
+                offset_y: LengthValue::Dimension {
+                    value: number(1.0),
+                    unit: LengthUnit::Em,
+                },
+                blur_radius: px(3.0),
+                color: ColorValue::Named("red".into()),
+            }),
+        );
+        let parent = resolve_text_style(&shadow, None, environment).unwrap();
+        let child = resolve_text_style(
+            &SpecifiedStyle::new(),
+            Some(parent.inherited_for_children()),
+            environment,
+        )
+        .unwrap();
+        let value = inherited(&child).text_shadow().unwrap();
+        assert_eq!([value.offset_x(), value.offset_y()], [1.0, 14.0]);
+        assert_eq!(value.blur_radius(), 3.0);
+
+        let cleared = resolve_text_style(
+            &declaration(
+                StyleProperty::TextShadow,
+                StyleValue::TextShadow(TextShadowValue::None),
+            ),
+            Some(parent.inherited_for_children()),
+            environment,
+        )
+        .unwrap();
+        assert!(inherited(&cleared).text_shadow().is_none());
+
+        let invalid = declaration(
+            StyleProperty::TextShadow,
+            StyleValue::TextShadow(TextShadowValue::Shadow {
+                offset_x: LengthValue::Zero,
+                offset_y: LengthValue::Zero,
+                blur_radius: px(-1.0),
+                color: ColorValue::Named("black".into()),
+            }),
+        );
+        assert_eq!(
+            resolve_text_style(&invalid, None, environment).unwrap_err(),
+            StyleResolutionError::InvalidPropertyValue(StyleProperty::TextShadow)
         );
     }
 
@@ -1398,6 +1536,12 @@ mod tests {
             line_height: ComputedLineHeight::LogicalPixels(number(24.0)),
             letter_spacing: number(1.0),
             color: ColorValue::Named("red".into()),
+            text_shadow: Some(ComputedTextShadow {
+                offset_x: number(1.0),
+                offset_y: number(2.0),
+                blur_radius: number(3.0),
+                color: ColorValue::Named("blue".into()),
+            }),
         };
         let change = changed.changes_from(initial);
         for property in [
@@ -1408,6 +1552,7 @@ mod tests {
             InheritedPropertySet::LINE_HEIGHT,
             InheritedPropertySet::LETTER_SPACING,
             InheritedPropertySet::COLOR,
+            InheritedPropertySet::TEXT_SHADOW,
         ] {
             assert!(change.properties().contains(property));
         }

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -1264,6 +1264,7 @@ mod tests {
         let value = inherited(&child).text_shadow().unwrap();
         assert_eq!([value.offset_x(), value.offset_y()], [1.0, 14.0]);
         assert_eq!(value.blur_radius(), 3.0);
+        assert_eq!(value.color(), &ColorValue::Named("red".into()));
 
         let cleared = resolve_text_style(
             &declaration(
@@ -1288,6 +1289,64 @@ mod tests {
         assert_eq!(
             resolve_text_style(&invalid, None, environment).unwrap_err(),
             StyleResolutionError::InvalidPropertyValue(StyleProperty::TextShadow)
+        );
+
+        let invalid_offset_x = declaration(
+            StyleProperty::TextShadow,
+            StyleValue::TextShadow(TextShadowValue::Shadow {
+                offset_x: px(f32::NAN),
+                offset_y: LengthValue::Zero,
+                blur_radius: LengthValue::Zero,
+                color: ColorValue::Named("black".into()),
+            }),
+        );
+        let invalid_offset_y = declaration(
+            StyleProperty::TextShadow,
+            StyleValue::TextShadow(TextShadowValue::Shadow {
+                offset_x: LengthValue::Zero,
+                offset_y: px(f32::NAN),
+                blur_radius: LengthValue::Zero,
+                color: ColorValue::Named("black".into()),
+            }),
+        );
+        let invalid_blur = declaration(
+            StyleProperty::TextShadow,
+            StyleValue::TextShadow(TextShadowValue::Shadow {
+                offset_x: LengthValue::Zero,
+                offset_y: LengthValue::Zero,
+                blur_radius: px(f32::NAN),
+                color: ColorValue::Named("black".into()),
+            }),
+        );
+        assert_eq!(
+            resolve_text_style(&invalid_offset_x, None, environment).unwrap_err(),
+            StyleResolutionError::InvalidPropertyValue(StyleProperty::TextShadow)
+        );
+        assert_eq!(
+            resolve_text_style(&invalid_offset_y, None, environment).unwrap_err(),
+            StyleResolutionError::InvalidPropertyValue(StyleProperty::TextShadow)
+        );
+        assert_eq!(
+            resolve_text_style(&invalid_blur, None, environment).unwrap_err(),
+            StyleResolutionError::InvalidPropertyValue(StyleProperty::TextShadow)
+        );
+        let invalid_color = declaration(
+            StyleProperty::TextShadow,
+            StyleValue::TextShadow(TextShadowValue::Shadow {
+                offset_x: LengthValue::Zero,
+                offset_y: LengthValue::Zero,
+                blur_radius: LengthValue::Zero,
+                color: ColorValue::Rgba {
+                    red: 0,
+                    green: 0,
+                    blue: 0,
+                    alpha: number(f32::NAN),
+                },
+            }),
+        );
+        assert_eq!(
+            resolve_text_style(&invalid_color, None, environment).unwrap_err(),
+            StyleResolutionError::InvalidPropertyValue(StyleProperty::Color)
         );
     }
 

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -519,6 +519,24 @@ pub enum OffsetRotateValue {
     Angle(StyleNumber),
 }
 
+/// The Lynx-compatible single `text-shadow` value.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TextShadowValue {
+    /// Disable inherited text shadow paint.
+    None,
+    /// Paint one shadow behind the glyphs.
+    Shadow {
+        /// Horizontal offset.
+        offset_x: LengthValue,
+        /// Vertical offset.
+        offset_y: LengthValue,
+        /// Non-negative blur radius.
+        blur_radius: LengthValue,
+        /// Shadow color.
+        color: ColorValue,
+    },
+}
+
 /// An owned value in a specified inline-style declaration.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StyleValue {
@@ -570,6 +588,8 @@ pub enum StyleValue {
     FontWeight(FontWeightValue),
     /// Text color.
     Color(ColorValue),
+    /// Single inherited text shadow.
+    TextShadow(TextShadowValue),
     /// Border line style.
     BorderStyle(crate::BorderStyleValue),
     /// Overflow behavior on one axis.

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -1396,6 +1396,10 @@ impl MobileFrameOwned {
                     raw.tag = OP_TEXT;
                     raw.node = node.get();
                     let shadow = content.paint.shadows.first();
+                    let shadow_color = match shadow {
+                        Some(value) => mobile_color(&value.color, &mut strings),
+                        None => mobile_color(&PaintColor::default(), &mut strings),
+                    };
                     texts.push(Box::new(MobileText {
                         text: push_string(&mut strings, &content.payload.text),
                         font_size: content.payload.style.font_size,
@@ -1417,10 +1421,7 @@ impl MobileFrameOwned {
                         shadow_offset_y: shadow.map_or(0.0, |value| value.offset_y),
                         shadow_blur_radius: shadow.map_or(0.0, |value| value.blur_radius),
                         shadow_flags: u32::from(shadow.is_some()),
-                        shadow_color: shadow.map_or_else(
-                            || mobile_color(&PaintColor::default(), &mut strings),
-                            |value| mobile_color(&value.color, &mut strings),
-                        ),
+                        shadow_color,
                         prepared_content: content.prepared_content.map_or(0, |value| value.get()),
                     }));
                     raw.payload = texts.last().unwrap().as_ref() as *const _ as *const c_void;

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -848,6 +848,10 @@ impl FrameSink for MobileFrameSink {
                     support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
                 },
                 whisker_engine::whisker_protocol::CapabilityEntry {
+                    capability: whisker_engine::whisker_protocol::RenderCapability::TextEffects,
+                    support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
+                },
+                whisker_engine::whisker_protocol::CapabilityEntry {
                     capability: whisker_engine::whisker_protocol::RenderCapability::LinearGradients,
                     support: whisker_engine::whisker_protocol::CapabilitySupport::Native,
                 },
@@ -1381,13 +1385,17 @@ impl MobileFrameOwned {
                     raw.integer = *z_order;
                 }
                 Operation::SetText { node, content } => {
-                    if content.paint.uses_extended_features()
+                    if content.paint.decoration.lines.underline
+                        || content.paint.decoration.lines.overline
+                        || content.paint.decoration.lines.line_through
+                        || content.paint.shadows.len() > 1
                         || content.payload.style.uses_extended_typography()
                     {
                         return Err(MobileFrameError);
                     }
                     raw.tag = OP_TEXT;
                     raw.node = node.get();
+                    let shadow = content.paint.shadows.first();
                     texts.push(Box::new(MobileText {
                         text: push_string(&mut strings, &content.payload.text),
                         font_size: content.payload.style.font_size,
@@ -1405,6 +1413,14 @@ impl MobileFrameOwned {
                         },
                         letter_spacing: content.payload.style.letter_spacing,
                         color: mobile_color(&content.paint.foreground, &mut strings),
+                        shadow_offset_x: shadow.map_or(0.0, |value| value.offset_x),
+                        shadow_offset_y: shadow.map_or(0.0, |value| value.offset_y),
+                        shadow_blur_radius: shadow.map_or(0.0, |value| value.blur_radius),
+                        shadow_flags: u32::from(shadow.is_some()),
+                        shadow_color: shadow.map_or_else(
+                            || mobile_color(&PaintColor::default(), &mut strings),
+                            |value| mobile_color(&value.color, &mut strings),
+                        ),
                         prepared_content: content.prepared_content.map_or(0, |value| value.get()),
                     }));
                     raw.payload = texts.last().unwrap().as_ref() as *const _ as *const c_void;
@@ -1726,7 +1742,8 @@ mod tests {
     use super::*;
     use std::cell::RefCell;
     use whisker_engine::whisker_protocol::{
-        BackgroundLayer, FrameHeader, GradientStop, PaintCoordinate, PaintPosition, ProtocolVersion,
+        BackgroundLayer, FrameHeader, GradientStop, PaintCoordinate, PaintPosition,
+        ProtocolVersion, TextContent, TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow,
     };
 
     fn linear_background(name: &str) -> BackgroundLayer {
@@ -1753,6 +1770,26 @@ mod tests {
             clip: PaintBox::Border,
             attachment: BackgroundAttachment::Scroll,
             blend_mode: BlendMode::Normal,
+        }
+    }
+
+    fn text_with_shadow(shadows: Vec<TextShadow>) -> TextContent {
+        TextContent {
+            payload: TextMeasurePayload {
+                text: "shadow".into(),
+                style: TextMeasureStyle::default(),
+                locale: None,
+                direction: Default::default(),
+                wrap: MeasureTextWrap::Wrap,
+                max_lines: None,
+                overflow: Default::default(),
+            },
+            paint: TextPaint {
+                foreground: PaintColor::Named("black".into()),
+                shadows,
+                ..TextPaint::default()
+            },
+            prepared_content: None,
         }
     }
 
@@ -1935,6 +1972,79 @@ mod tests {
         let raw = mobile_paint(&paint, &mut Vec::new());
         assert_eq!(raw.radii_horizontal[0].length, 40.0);
         assert_eq!(raw.radii_vertical[0].length, 10.0);
+    }
+
+    #[test]
+    fn mobile_frame_encodes_one_text_shadow_without_string_protocols() {
+        let shadow = TextShadow {
+            offset_x: 3.0,
+            offset_y: -2.0,
+            blur_radius: 5.0,
+            color: PaintColor::Srgba {
+                red: 10,
+                green: 20,
+                blue: 30,
+                alpha: 0.4,
+            },
+        };
+        let packet = FramePacket {
+            header: FrameHeader {
+                version: ProtocolVersion::CURRENT,
+                surface: SurfaceId::new(1).unwrap(),
+                scene_epoch: 1,
+                frame_id: 1,
+                base_revision: 0,
+                target_revision: 1,
+                viewport_epoch: 1,
+                mode: FrameMode::Snapshot,
+            },
+            operations: vec![Operation::SetText {
+                node: NodeId::new(1).unwrap(),
+                content: text_with_shadow(vec![shadow]),
+            }],
+        };
+
+        let frame = MobileFrameOwned::new(&packet).unwrap();
+        let operation = &frame._operations[0];
+        assert_eq!(operation.tag, OP_TEXT);
+        let text = unsafe { &*operation.payload.cast::<MobileText>() };
+        assert_eq!(text.shadow_flags, 1);
+        assert_eq!(text.shadow_offset_x, 3.0);
+        assert_eq!(text.shadow_offset_y, -2.0);
+        assert_eq!(text.shadow_blur_radius, 5.0);
+        assert_eq!(text.shadow_color.kind, 1);
+        assert_eq!(text.shadow_color.red, 10);
+        assert_eq!(text.shadow_color.green, 20);
+        assert_eq!(text.shadow_color.blue, 30);
+        assert_eq!(text.shadow_color.alpha, 0.4);
+    }
+
+    #[test]
+    fn mobile_frame_rejects_multiple_text_shadows() {
+        let shadow = TextShadow {
+            offset_x: 0.0,
+            offset_y: 1.0,
+            blur_radius: 0.0,
+            color: PaintColor::default(),
+        };
+        let packet = FramePacket {
+            header: FrameHeader {
+                version: ProtocolVersion::CURRENT,
+                surface: SurfaceId::new(1).unwrap(),
+                scene_epoch: 1,
+                frame_id: 1,
+                base_revision: 0,
+                target_revision: 1,
+                viewport_epoch: 1,
+                mode: FrameMode::Snapshot,
+            },
+            operations: vec![Operation::SetText {
+                node: NodeId::new(1).unwrap(),
+                content: text_with_shadow(vec![shadow.clone(), shadow]),
+            }],
+        };
+
+        assert!(MobileFrameOwned::new(&packet).is_err());
     }
 
     #[test]

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
@@ -25,6 +25,15 @@ public object WhiskerBuiltInElements {
                 view.textSize = content.fontSize
                 view.setTextColor(content.color)
                 view.setTypeface(view.typeface, if (content.fontWeight >= 600) 1 else 0)
+                content.shadow?.let { shadow ->
+                    val density = view.resources.displayMetrics.density
+                    view.setShadowLayer(
+                        shadow.blurRadius * density,
+                        shadow.offsetX * density,
+                        shadow.offsetY * density,
+                        shadow.color,
+                    )
+                } ?: view.setShadowLayer(0f, 0f, 0f, 0)
             },
         ) { context ->
             TextView(context).apply {

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -20,6 +20,15 @@ public data class WhiskerTextContent(
     public val fontSize: Float,
     public val fontWeight: Int,
     public val color: Int,
+    public val shadow: WhiskerTextShadow?,
+)
+
+/** One resolved shadow painted behind native text glyphs. */
+public data class WhiskerTextShadow(
+    public val offsetX: Float,
+    public val offsetY: Float,
+    public val blurRadius: Float,
+    public val color: Int,
 )
 
 /** One native View mounted for a retained Whisker node. */

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -11,6 +11,7 @@ import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerView
 import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerTextContent
+import rs.whisker.runtime.WhiskerTextShadow
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.paint.HostBackgroundGeometry
 import rs.whisker.runtime.paint.HostBackgroundBox
@@ -185,7 +186,7 @@ internal class HostScene(
             11 -> if (operation.node !in existing || operation.integer !in 0..1) return false
             13 -> if (
                 operation.node !in existing || operation.text == null ||
-                operation.numbers?.size ?: 0 < 8 || operation.names?.isEmpty() != false
+                operation.numbers?.size ?: 0 < 17 || operation.names?.size ?: 0 < 2
             ) return false
             14 -> if (operation.node !in existing || operation.value == null) return false
             21 -> if (!validBackgroundLayers(operation, existing)) return false
@@ -357,7 +358,7 @@ internal class HostScene(
     }
 
     private fun applyText(node: HostNode, text: String, values: FloatArray, names: Array<String>) {
-        require(values.size >= 8)
+        require(values.size >= 17)
         val mounted = requireNotNull(node.mountedElement)
         require(
             mounted.setText(
@@ -370,6 +371,16 @@ internal class HostScene(
                     } else {
                         rgba(values[3], values[4], values[5], values[6])
                     },
+                    shadow = if (values[8] == 0f) null else WhiskerTextShadow(
+                        offsetX = values[9],
+                        offsetY = values[10],
+                        blurRadius = values[11],
+                        color = if (values[16] == 0f) {
+                            parseNamedColor(names[1])
+                        } else {
+                            rgba(values[12], values[13], values[14], values[15])
+                        },
+                    ),
                 ),
             ),
         ) {

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -2232,6 +2232,57 @@ impl GpuRenderer {
             }
             let bounds = text_bounds(*clip, self.config.width, self.config.height, scale);
             let color = text_color(&content.paint.foreground, *opacity);
+            let mut areas = Vec::with_capacity(content.paint.shadows.len() + 1);
+            for shadow in &content.paint.shadows {
+                if shadow.blur_radius <= 0.0 {
+                    let shadow_color = text_color(&shadow.color, *opacity);
+                    areas.push(TextArea {
+                        buffer: &prepared.buffer,
+                        left: (rect.x + shadow.offset_x) * scale,
+                        top: (rect.y + shadow.offset_y) * scale,
+                        scale,
+                        bounds,
+                        default_color: shadow_color,
+                        custom_glyphs: &[],
+                    });
+                } else {
+                    // Glyphon does not expose a blur primitive. Approximate the
+                    // single Lynx shadow with a compact, normalized sample disk.
+                    let radius = shadow.blur_radius.min(12.0);
+                    let offsets = [
+                        (0.0, 0.0),
+                        (-radius, 0.0),
+                        (radius, 0.0),
+                        (0.0, -radius),
+                        (0.0, radius),
+                        (-radius * 0.7, -radius * 0.7),
+                        (radius * 0.7, -radius * 0.7),
+                        (-radius * 0.7, radius * 0.7),
+                        (radius * 0.7, radius * 0.7),
+                    ];
+                    let sampled_color = text_color(&shadow.color, *opacity / offsets.len() as f32);
+                    for (x, y) in offsets {
+                        areas.push(TextArea {
+                            buffer: &prepared.buffer,
+                            left: (rect.x + shadow.offset_x + x) * scale,
+                            top: (rect.y + shadow.offset_y + y) * scale,
+                            scale,
+                            bounds,
+                            default_color: sampled_color,
+                            custom_glyphs: &[],
+                        });
+                    }
+                }
+            }
+            areas.push(TextArea {
+                buffer: &prepared.buffer,
+                left: rect.x * scale,
+                top: rect.y * scale,
+                scale,
+                bounds,
+                default_color: color,
+                custom_glyphs: &[],
+            });
             self.text_renderers
                 .get_mut(node)
                 .expect("renderer inserted for live text node")
@@ -2241,15 +2292,7 @@ impl GpuRenderer {
                     &mut text.font_system,
                     &mut self.text_atlas,
                     &self.text_viewport,
-                    [TextArea {
-                        buffer: &prepared.buffer,
-                        left: rect.x * scale,
-                        top: rect.y * scale,
-                        scale,
-                        bounds,
-                        default_color: color,
-                        custom_glyphs: &[],
-                    }],
+                    areas,
                     &mut text.swash_cache,
                 )
                 .map_err(|error| GpuError(format!("prepare glyph atlas: {error}")))?;

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -545,8 +545,11 @@ impl DesktopScene {
                     }
                 }
                 Operation::SetText { node, content } => {
-                    if content.paint.uses_extended_features() {
-                        return Err(DesktopPresentError::Unsupported("text-effects"));
+                    if content.paint.decoration.lines.underline
+                        || content.paint.decoration.lines.overline
+                        || content.paint.decoration.lines.line_through
+                    {
+                        return Err(DesktopPresentError::Unsupported("text-decoration"));
                     }
                     if content.payload.style.uses_extended_typography() {
                         return Err(DesktopPresentError::Unsupported("text-typography"));
@@ -866,6 +869,10 @@ impl FrameSink for DesktopScene {
                 },
                 whisker_protocol::CapabilityEntry {
                     capability: whisker_protocol::RenderCapability::VisualEffects,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::TextEffects,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
                 whisker_protocol::CapabilityEntry {

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -26,8 +26,8 @@ use whisker_protocol::{
     PaintBox, PaintColor, PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
     PaintLengthPercentage, PaintPosition, PathCommand, PointerId, PointerInput, PointerKind,
     ProtocolVersion, RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceId,
-    ResourceKind, ResourceRequest, ResourceSource, SurfaceId, TextMeasurePayload, TextMeasureStyle,
-    Transform, Visibility, WhiskerValue,
+    ResourceKind, ResourceRequest, ResourceSource, SurfaceId, TextContent, TextMeasurePayload,
+    TextMeasureStyle, TextPaint, TextShadow, Transform, Visibility, WhiskerValue,
 };
 use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
@@ -71,6 +71,39 @@ fn color_protocol(value: &ColorFixture) -> PaintColor {
             blue: *blue,
             alpha: *alpha,
         },
+    }
+}
+
+fn fixture_text_content(text: &whisker_host_conformance::TextFixture) -> TextContent {
+    TextContent {
+        payload: TextMeasurePayload {
+            text: text.value.clone(),
+            style: TextMeasureStyle {
+                font_size: text.font_size,
+                font_weight: text.font_weight,
+                ..TextMeasureStyle::default()
+            },
+            locale: None,
+            direction: MeasureTextDirection::Auto,
+            wrap: MeasureTextWrap::Wrap,
+            max_lines: None,
+            overflow: MeasureTextOverflow::Clip,
+        },
+        paint: TextPaint {
+            foreground: color_protocol(&text.color),
+            shadows: text
+                .shadow
+                .iter()
+                .map(|shadow| TextShadow {
+                    offset_x: shadow.offset[0],
+                    offset_y: shadow.offset[1],
+                    blur_radius: shadow.blur_radius,
+                    color: color_protocol(&shadow.color),
+                })
+                .collect(),
+            ..TextPaint::default()
+        },
+        prepared_content: None,
     }
 }
 
@@ -476,6 +509,9 @@ impl Driver {
                     relations,
                 } => {
                     assert!(name.starts_with("paint."), "unsupported Desktop checkpoint");
+                    if name == "paint.text.shadow-single" {
+                        self.assert_text_shadow();
+                    }
                     checkpoints.push(Checkpoint {
                         logical_size: [
                             self.logical_size[0].round() as u32,
@@ -667,12 +703,15 @@ impl Driver {
 
     fn present_scene(&mut self, revision: u64, nodes: &[SceneNodeFixture]) {
         let surface = self.surface.expect("attach_surface precedes present_scene");
-        let element_type = standard_element_type(whisker::VIEW_ELEMENT_NAME);
         let mut operations = Vec::new();
         for fixture in nodes {
             operations.push(Operation::CreateNode {
                 node: NodeId::new(fixture.id).expect("validated fixture node id"),
-                element_type,
+                element_type: standard_element_type(if fixture.text.is_some() {
+                    whisker::TEXT_ELEMENT_NAME
+                } else {
+                    whisker::VIEW_ELEMENT_NAME
+                }),
             });
         }
         let mut child_counts = std::collections::BTreeMap::<u64, u32>::new();
@@ -699,6 +738,12 @@ impl Driver {
                 node,
                 paint: box_paint(&fixture.background, fixture.border.as_ref()),
             });
+            if let Some(text) = &fixture.text {
+                operations.push(Operation::SetText {
+                    node,
+                    content: fixture_text_content(text),
+                });
+            }
             if !fixture.box_shadows.is_empty()
                 || fixture.clip_path.is_some()
                 || fixture.backdrop_blur.is_some()
@@ -807,6 +852,37 @@ impl Driver {
                 operations,
             })
             .expect("canonical Host scene fixture is valid");
+    }
+
+    fn assert_text_shadow(&self) {
+        let commands = self
+            .scene
+            .as_ref()
+            .expect("checkpoint follows attach")
+            .paint_commands();
+        let content = commands
+            .iter()
+            .find_map(|command| match command {
+                PaintCommand::Text { content, .. } => Some(content),
+                _ => None,
+            })
+            .expect("text fixture creates one text paint command");
+        let shadow = content
+            .paint
+            .shadows
+            .first()
+            .expect("text shadow is retained");
+        assert_eq!([shadow.offset_x, shadow.offset_y], [3.0, 4.0]);
+        assert_eq!(shadow.blur_radius, 2.0);
+        assert_eq!(
+            shadow.color,
+            PaintColor::Srgba {
+                red: 255,
+                green: 0,
+                blue: 0,
+                alpha: 0.75
+            }
+        );
     }
 
     fn clipped_box_primitives(&self) -> Vec<ClippedBoxPrimitive> {

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 15 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 16 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -128,7 +128,9 @@ typedef struct {
 typedef struct {
   WhiskerStringRef text; float font_size; uint16_t font_weight;
   uint8_t font_style, wrap; uint32_t max_lines; float line_height, letter_spacing;
-  WhiskerMobileColor color; uint64_t prepared_content;
+  WhiskerMobileColor color;
+  float shadow_offset_x, shadow_offset_y, shadow_blur_radius; uint32_t shadow_flags;
+  WhiskerMobileColor shadow_color; uint64_t prepared_content;
 } WhiskerMobileText;
 typedef struct {
   uint32_t tag, flags; uint64_t node, parent, child; uint32_t index, member;
@@ -199,6 +201,6 @@ _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 160, "WhiskerMobileMeasure
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceCommand) == 64, "WhiskerMobileResourceCommand ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceEvent) == 56, "WhiskerMobileResourceEvent ABI drift");
-_Static_assert(sizeof(WhiskerMobileText) == 80, "WhiskerMobileText ABI drift");
+_Static_assert(sizeof(WhiskerMobileText) == 128, "WhiskerMobileText ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 #endif

--- a/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
@@ -56,12 +56,28 @@ public enum WhiskerBuiltInElements {
                 guard let label = view as? UILabel else {
                     preconditionFailure("\(textName) factory must create UILabel")
                 }
-                label.text = content.value
                 label.font = .systemFont(
                     ofSize: content.fontSize,
                     weight: content.fontWeight >= 600 ? .bold : .regular
                 )
                 label.textColor = content.color
+                if let shadow = content.shadow {
+                    let nativeShadow = NSShadow()
+                    nativeShadow.shadowOffset = shadow.offset
+                    nativeShadow.shadowBlurRadius = shadow.blurRadius
+                    nativeShadow.shadowColor = shadow.color
+                    label.attributedText = NSAttributedString(
+                        string: content.value,
+                        attributes: [
+                            .font: label.font as Any,
+                            .foregroundColor: content.color,
+                            .shadow: nativeShadow,
+                        ]
+                    )
+                } else {
+                    label.attributedText = nil
+                    label.text = content.value
+                }
             }
         ) {
             let label = UILabel(frame: .zero)

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
@@ -43,11 +43,31 @@ public struct WhiskerTextContent {
     public let fontSize: CGFloat
     public let fontWeight: Int
     public let color: UIColor
+    public let shadow: WhiskerTextShadow?
 
-    public init(value: String, fontSize: CGFloat, fontWeight: Int, color: UIColor) {
+    public init(
+        value: String,
+        fontSize: CGFloat,
+        fontWeight: Int,
+        color: UIColor,
+        shadow: WhiskerTextShadow? = nil
+    ) {
         self.value = value
         self.fontSize = fontSize
         self.fontWeight = fontWeight
+        self.color = color
+        self.shadow = shadow
+    }
+}
+
+public struct WhiskerTextShadow {
+    public let offset: CGSize
+    public let blurRadius: CGFloat
+    public let color: UIColor
+
+    public init(offset: CGSize, blurRadius: CGFloat, color: UIColor) {
+        self.offset = offset
+        self.blurRadius = blurRadius
         self.color = color
     }
 }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -504,7 +504,15 @@ final class HostScene {
             value: hostString(content.text),
             fontSize: CGFloat(content.font_size),
             fontWeight: Int(content.font_weight),
-            color: parsePaintColor(content.color)
+            color: parsePaintColor(content.color),
+            shadow: content.shadow_flags == 0 ? nil : WhiskerTextShadow(
+                offset: CGSize(
+                    width: CGFloat(content.shadow_offset_x),
+                    height: CGFloat(content.shadow_offset_y)
+                ),
+                blurRadius: CGFloat(content.shadow_blur_radius),
+                color: parsePaintColor(content.shadow_color)
+            )
         )) else {
             preconditionFailure(
                 "text operation sent to element \(mounted.registration.name) without a text implementation"

--- a/platforms/web/src/paint/text.rs
+++ b/platforms/web/src/paint/text.rs
@@ -9,6 +9,22 @@ use crate::{WebError, px, set_style};
 pub(crate) fn apply(element: &web_sys::Element, content: &TextContent) -> Result<(), WebError> {
     apply_metrics_style(element, &content.payload)?;
     set_style(element, "color", &css_color(&content.paint.foreground))?;
+    set_style(
+        element,
+        "text-shadow",
+        &content.paint.shadows.first().map_or_else(
+            || "none".to_string(),
+            |shadow| {
+                format!(
+                    "{} {} {} {}",
+                    px(shadow.offset_x),
+                    px(shadow.offset_y),
+                    px(shadow.blur_radius),
+                    css_color(&shadow.color),
+                )
+            },
+        ),
+    )?;
     element.set_text_content(Some(&content.payload.text));
     Ok(())
 }

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -96,7 +96,12 @@ impl DomFrameSink {
                 }
                 Operation::SetImage { .. } => Some("image-content"),
                 Operation::SetCursor { .. } => Some("cursor"),
-                Operation::SetText { content, .. } if content.paint.uses_extended_features() => {
+                Operation::SetText { content, .. }
+                    if content.paint.decoration.lines.underline
+                        || content.paint.decoration.lines.overline
+                        || content.paint.decoration.lines.line_through
+                        || content.paint.shadows.len() > 1 =>
+                {
                     Some("text-effects")
                 }
                 Operation::SetText { content, .. }
@@ -593,6 +598,10 @@ impl FrameSink for DomFrameSink {
                 },
                 whisker_protocol::CapabilityEntry {
                     capability: whisker_protocol::RenderCapability::VisualEffects,
+                    support: whisker_protocol::CapabilitySupport::Native,
+                },
+                whisker_protocol::CapabilityEntry {
+                    capability: whisker_protocol::RenderCapability::TextEffects,
                     support: whisker_protocol::CapabilitySupport::Native,
                 },
                 whisker_protocol::CapabilityEntry {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -25,11 +25,13 @@ use whisker_host_conformance::{
 use whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
     BoxPaint, ClipShape, FillRule, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat,
-    LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
-    PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
-    PaintLengthPercentage, PaintPosition, PathCommand, ProtocolVersion, RadialGradientExtent,
-    RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent, ResourceId,
-    ResourceKind, ResourceRequest, ResourceSource, SurfaceId, Transform, Visibility,
+    LayoutGeometry, LayoutRect, MeasureTextDirection, MeasureTextOverflow, MeasureTextWrap, NodeId,
+    Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate, PaintCornerRadius,
+    PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition, PathCommand,
+    ProtocolVersion, RadialGradientExtent, RadialGradientShape, ResourceCommand,
+    ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest, ResourceSource,
+    SurfaceId, TextContent, TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow, Transform,
+    Visibility,
 };
 use whisker_style::StyleEnvironment;
 
@@ -47,7 +49,8 @@ fn padded_parent_preserves_child_border_box_coordinates() {
     let mut driver = Driver::new();
     let parent = NodeId::new(1).unwrap();
     let child = NodeId::new(2).unwrap();
-    let view = ElementRegistry::standard()
+    let registry = ElementRegistry::standard();
+    let view = registry
         .registration_for_builtin(whisker::ElementTag::View)
         .unwrap()
         .element_type;
@@ -459,6 +462,8 @@ impl Driver {
                     if self.expected_scene.is_some() {
                         let expected_checkpoint = if name.starts_with("paint.transform.") {
                             name.as_str()
+                        } else if name == "paint.text.shadow-single" {
+                            "paint.text.shadow-single"
                         } else if name == "paint.visual-effects.image-rendering-pixelated" {
                             "paint.visual-effects.image-rendering-pixelated"
                         } else if self.resource_lifecycle {
@@ -853,6 +858,33 @@ impl Driver {
                 &fixture_color_css(&fixture_node.background),
             );
             assert_border_is_projected(&style, fixture_node.border.as_ref());
+            if let Some(text) = &fixture_node.text {
+                let text_node = node
+                    .query_selector("[data-whisker-text]")
+                    .unwrap()
+                    .expect("text element has a native text projection");
+                let text_style = text_node.dyn_ref::<web_sys::HtmlElement>().unwrap().style();
+                assert_eq!(
+                    text_node.text_content().as_deref(),
+                    Some(text.value.as_str())
+                );
+                assert_style(&text_style, "font-size", &fixture_px(text.font_size));
+                assert_style(&text_style, "font-weight", &text.font_weight.to_string());
+                assert_style(&text_style, "color", &fixture_color_css(&text.color));
+                let expected_shadow = text.shadow.as_ref().map_or_else(
+                    || "none".to_string(),
+                    |shadow| {
+                        format!(
+                            "{}px {}px {}px {}",
+                            shadow.offset[0],
+                            shadow.offset[1],
+                            shadow.blur_radius,
+                            fixture_color_css(&shadow.color),
+                        )
+                    },
+                );
+                assert_style(&text_style, "text-shadow", &expected_shadow);
+            }
             let mut expected_shadows = fixture_node
                 .box_shadows
                 .iter()
@@ -1372,6 +1404,9 @@ fn fixture(path: &str) -> &'static str {
         "core/backdrop-filter-blur.json" => {
             include_str!("../../../../tests/host-conformance/core/backdrop-filter-blur.json")
         }
+        "core/text-shadow-single.json" => {
+            include_str!("../../../../tests/host-conformance/core/text-shadow-single.json")
+        }
         _ => panic!("manifest fixture is not embedded in the Web test: {path}"),
     }
 }
@@ -1466,17 +1501,21 @@ fn packet(
 
 fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
     let surface = SurfaceId::new(1).unwrap();
-    let view = ElementRegistry::standard()
-        .registration_for_builtin(whisker::ElementTag::View)
-        .unwrap()
-        .element_type;
+    let registry = ElementRegistry::standard();
     let mut operations = Vec::with_capacity(nodes.len() * 5);
     for fixture_node in nodes {
         let node = fixture_node_id(fixture_node.id);
         operations.extend([
             Operation::CreateNode {
                 node,
-                element_type: view,
+                element_type: registry
+                    .registration_for_builtin(if fixture_node.text.is_some() {
+                        whisker::ElementTag::Text
+                    } else {
+                        whisker::ElementTag::View
+                    })
+                    .unwrap()
+                    .element_type,
             },
             Operation::SetLayout {
                 node,
@@ -1510,6 +1549,12 @@ fn scene_packet(revision: u64, nodes: &[SceneNodeFixture]) -> FramePacket {
                 },
             },
         ]);
+        if let Some(text) = &fixture_node.text {
+            operations.push(Operation::SetText {
+                node,
+                content: fixture_text_content(text),
+            });
+        }
         if let Some(transform) = fixture_node.transform {
             operations.push(Operation::SetTransform {
                 node,
@@ -1996,6 +2041,39 @@ fn color(value: &ColorFixture) -> PaintColor {
             blue: *blue,
             alpha: *alpha,
         },
+    }
+}
+
+fn fixture_text_content(text: &whisker_host_conformance::TextFixture) -> TextContent {
+    TextContent {
+        payload: TextMeasurePayload {
+            text: text.value.clone(),
+            style: TextMeasureStyle {
+                font_size: text.font_size,
+                font_weight: text.font_weight,
+                ..TextMeasureStyle::default()
+            },
+            locale: None,
+            direction: MeasureTextDirection::Auto,
+            wrap: MeasureTextWrap::Wrap,
+            max_lines: None,
+            overflow: MeasureTextOverflow::Clip,
+        },
+        paint: TextPaint {
+            foreground: color(&text.color),
+            shadows: text
+                .shadow
+                .iter()
+                .map(|shadow| TextShadow {
+                    offset_x: shadow.offset[0],
+                    offset_y: shadow.offset[1],
+                    blur_radius: shadow.blur_radius,
+                    color: color(&shadow.color),
+                })
+                .collect(),
+            ..TextPaint::default()
+        },
+        prepared_content: None,
     }
 }
 

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -159,6 +159,8 @@
       "id": "paint.text",
       "basis": "lynx-4.0",
       "properties": ["color", "font-family", "font-feature-settings", "font-optical-sizing", "font-size", "font-style", "font-variation-settings", "font-weight", "letter-spacing", "line-height", "text-align", "text-decoration", "text-indent", "text-overflow", "text-shadow", "white-space", "word-break"],
+      "supported_subset": ["basic-font-metrics-and-color", "single-text-shadow"],
+      "pending_subset": ["font-features-and-variations", "text-decoration", "alignment-indent-wrap-and-overflow"],
       "protocol": ["SetText"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/core/text-shadow-single.json
+++ b/tests/host-conformance/core/text-shadow-single.json
@@ -1,0 +1,59 @@
+{
+  "schema": 1,
+  "id": "core.text-shadow-single",
+  "test": {
+    "commands": [
+      {
+        "type": "attach_surface",
+        "width": 220,
+        "height": 100,
+        "scale": 1
+      },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [20, 20, 180, 60],
+            "background": {
+              "kind": "srgba",
+              "red": 255,
+              "green": 255,
+              "blue": 255,
+              "alpha": 0
+            },
+            "text": {
+              "value": "Whisker",
+              "font_size": 24,
+              "font_weight": 400,
+              "color": {
+                "kind": "srgba",
+                "red": 0,
+                "green": 0,
+                "blue": 0,
+                "alpha": 1
+              },
+              "shadow": {
+                "offset": [3, 4],
+                "blur_radius": 2,
+                "color": {
+                  "kind": "srgba",
+                  "red": 255,
+                  "green": 0,
+                  "blue": 0,
+                  "alpha": 0.75
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.text.shadow-single"
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -493,6 +493,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples", "pixel-relations"]
     },
     {
+      "id": "core.text-shadow-single",
+      "feature": "text-shadow-single",
+      "fixture": "core/text-shadow-single.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection"]
+    },
+    {
       "id": "host.measure.text.basic",
       "feature": "text-measurement",
       "fixture": "core/text-measure-basic.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -1,6 +1,8 @@
 package rs.whisker.runtime
 
 import android.graphics.Bitmap
+import android.view.ViewGroup
+import android.widget.TextView
 import android.graphics.Canvas
 import android.util.Base64
 import android.view.View
@@ -237,6 +239,15 @@ private class Driver(
             intArrayOf(),
             emptyArray(),
         )
+        view.registerElementFromNative(
+            2,
+            WhiskerBuiltInElements.TEXT,
+            WhiskerChildPolicy.PlainText.ordinal,
+            WhiskerMeasurement.Text.ordinal,
+            intArrayOf(), intArrayOf(), emptyArray(),
+            intArrayOf(), intArrayOf(), emptyArray(),
+            intArrayOf(), intArrayOf(), emptyArray(),
+        )
         check(view.finishBootstrapFromNative())
     }
 
@@ -254,6 +265,13 @@ private class Driver(
                 "present_box" -> present(command)
                 "present_scene" -> presentScene(command)
                 "checkpoint" -> {
+                    if (command.getString("name") == "paint.text.shadow-single") {
+                        val text = checkNotNull(findTextView(view))
+                        check(text.text.toString() == "Whisker")
+                        check(text.shadowDx == 3f * context.resources.displayMetrics.density)
+                        check(text.shadowDy == 4f * context.resources.displayMetrics.density)
+                        check(text.shadowRadius == 2f * context.resources.displayMetrics.density)
+                    }
                     check(
                         command.getString("name") == "paint.box" ||
                             command.getString("name") == "paint.background-layers.linear-gradient" ||
@@ -331,7 +349,8 @@ private class Driver(
                             command.getString("name") ==
                             "paint.transform.motion-path-inset" ||
                             command.getString("name") ==
-                            "paint.transform.motion-path-arcs",
+                            "paint.transform.motion-path-arcs" ||
+                            command.getString("name") == "paint.text.shadow-single",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -487,7 +506,7 @@ private class Driver(
         check(stage(tag = 6, numbers = rect + floatArrayOf(0f, 0f, 0f, 0f)))
         val (numbers, names) = paint(command)
         check(stage(tag = 7, numbers = numbers, names = names))
-        check(view.commitFrameFromNative())
+        check(view.commitFrameFromNative()) { "$id rejected present_box" }
     }
 
     private fun presentScene(command: JSONObject) {
@@ -495,7 +514,7 @@ private class Driver(
         val nodes = command.getJSONArray("nodes")
         check(view.beginFrameFromNative(0, 1, 0, revision) == 0)
         nodes.objects().forEach { node ->
-            check(stage(tag = 1, node = node.getLong("id"), member = 1))
+            check(stage(tag = 1, node = node.getLong("id"), member = if (node.has("text")) 2 else 1))
         }
         val childIndices = HashMap<Long, Int>()
         nodes.objects().forEach { node ->
@@ -528,6 +547,33 @@ private class Driver(
             )
             val (numbers, names) = paint(node)
             check(stage(tag = 7, node = id, numbers = numbers, names = names))
+            node.optJSONObject("text")?.let { text ->
+                val textNumbers = ArrayList<Float>(17)
+                val textNames = ArrayList<String>(2)
+                textNumbers += text.getDouble("font_size").toFloat()
+                textNumbers += text.optInt("font_weight", 400).toFloat()
+                textNumbers += 0f
+                appendColor(text.getJSONObject("color"), textNumbers, textNames)
+                val shadow = text.optJSONObject("shadow")
+                textNumbers += if (shadow == null) 0f else 1f
+                val offset = shadow?.getJSONArray("offset")
+                textNumbers += offset?.getDouble(0)?.toFloat() ?: 0f
+                textNumbers += offset?.getDouble(1)?.toFloat() ?: 0f
+                textNumbers += shadow?.getDouble("blur_radius")?.toFloat() ?: 0f
+                appendColor(
+                    shadow?.getJSONObject("color")
+                        ?: JSONObject("{\"kind\":\"srgba\",\"red\":0,\"green\":0,\"blue\":0,\"alpha\":0}"),
+                    textNumbers,
+                    textNames,
+                )
+                check(stage(
+                    tag = 13,
+                    node = id,
+                    text = text.getString("value"),
+                    numbers = textNumbers.toFloatArray(),
+                    names = textNames.toTypedArray(),
+                ))
+            }
             val clip = node.optJSONObject("clip") ?: JSONObject(
                 "{\"horizontal\":\"visible\",\"vertical\":\"visible\"}",
             )
@@ -766,6 +812,7 @@ private class Driver(
         integer: Int = 0,
         scalar: Float = 0f,
         numbers: FloatArray? = null,
+        text: String? = null,
         names: Array<String>? = null,
     ): Boolean = view.stageOperationFromNative(
         tag,
@@ -779,7 +826,7 @@ private class Driver(
         scalar,
         0,
         numbers,
-        null,
+        text,
         names,
         null,
     )
@@ -992,6 +1039,16 @@ private class Driver(
         view.draw(Canvas(bitmap))
         return bitmap
     }
+}
+
+private fun findTextView(view: android.view.View): TextView? {
+    if (view is TextView) return view
+    if (view is ViewGroup) {
+        for (index in 0 until view.childCount) {
+            findTextView(view.getChildAt(index))?.let { return it }
+        }
+    }
+    return null
 }
 
 private fun JSONArray.objects(): Sequence<JSONObject> =

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -386,7 +386,13 @@ private final class Driver {
             childPolicy: .elements,
             measurement: .none
         )
-        guard WhiskerElementRegistry.bind([registration]) else {
+        let textRegistration = WhiskerElementRegistration(
+            elementType: 2,
+            name: WhiskerBuiltInElements.textName,
+            childPolicy: .plainText,
+            measurement: .text
+        )
+        guard WhiskerElementRegistry.bind([registration, textRegistration]) else {
             throw Failure("bind built-in UIKit View")
         }
     }
@@ -456,7 +462,8 @@ private final class Driver {
                     name == "paint.transform.motion-path-curves" ||
                     name == "paint.transform.motion-path-ellipses" ||
                     name == "paint.transform.motion-path-inset" ||
-                    name == "paint.transform.motion-path-arcs" else {
+                    name == "paint.transform.motion-path-arcs" ||
+                    name == "paint.text.shadow-single" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 if name == "paint.visual-effects.backdrop-blur" {
@@ -470,6 +477,16 @@ private final class Driver {
                         containsProjectiveTransform(view),
                         "\(id) must project the 4x4 matrix to CATransform3D"
                     )
+                }
+                if name == "paint.text.shadow-single" {
+                    let label = try XCTUnwrap(findLabel(view))
+                    XCTAssertEqual(label.attributedText?.string ?? label.text, "Whisker")
+                    let shadow = try XCTUnwrap(
+                        label.attributedText?.attribute(.shadow, at: 0, effectiveRange: nil)
+                            as? NSShadow
+                    )
+                    XCTAssertEqual(shadow.shadowOffset, CGSize(width: 3, height: 4))
+                    XCTAssertEqual(shadow.shadowBlurRadius, 2)
                 }
                 let pixels = try capture()
                 checkpoint = pixels
@@ -652,6 +669,38 @@ private final class Driver {
     private func presentScene(_ command: [String: Any]) throws {
         let revision = UInt64(try number(command, "revision"))
         let fixtures = try objectArray(command, "nodes").map(sceneNode)
+        let textPayloads = UnsafeMutablePointer<WhiskerMobileText>.allocate(
+            capacity: max(fixtures.count, 1)
+        )
+        var textStrings = [UnsafeMutablePointer<CChar>?](repeating: nil, count: fixtures.count)
+        for (index, fixture) in fixtures.enumerated() {
+            var payload = WhiskerMobileText()
+            if let text = fixture.text {
+                let bytes = Array(text.value.utf8CString)
+                let storage = UnsafeMutablePointer<CChar>.allocate(capacity: bytes.count)
+                storage.initialize(from: bytes, count: bytes.count)
+                textStrings[index] = storage
+                payload.text = WhiskerStringRef(ptr: UnsafePointer(storage), len: bytes.count - 1)
+                payload.font_size = text.fontSize
+                payload.font_weight = text.fontWeight
+                payload.color = text.color
+                if let offset = text.shadowOffset {
+                    payload.shadow_flags = 1
+                    payload.shadow_offset_x = Float(offset.width)
+                    payload.shadow_offset_y = Float(offset.height)
+                    payload.shadow_blur_radius = text.shadowBlurRadius
+                    payload.shadow_color = text.shadowColor
+                }
+            }
+            textPayloads.advanced(by: index).initialize(to: payload)
+        }
+        defer {
+            textPayloads.deinitialize(count: fixtures.count)
+            textPayloads.deallocate()
+            for storage in textStrings {
+                storage?.deallocate()
+            }
+        }
         var layouts = fixtures.map(\.layout)
         var paints = fixtures.map(\.paint)
         var transforms = fixtures.flatMap { fixture in
@@ -895,7 +944,11 @@ private final class Driver {
                                 backgroundBuffer in
                             try stagedShadows.withUnsafeMutableBufferPointer { shadowBuffer in
                             var operations = fixtures.map {
-                                operation(tag: UInt32(WHISKER_OP_CREATE), node: $0.id, member: 1)
+                                operation(
+                                    tag: UInt32(WHISKER_OP_CREATE),
+                                    node: $0.id,
+                                    member: $0.text == nil ? 1 : 2
+                                )
                             }
                             var childCounts: [UInt64: UInt32] = [:]
                             for fixture in fixtures {
@@ -926,6 +979,14 @@ private final class Driver {
                                     ),
                                     count: 1
                                 ))
+                                if fixture.text != nil {
+                                    operations.append(operation(
+                                        tag: UInt32(WHISKER_OP_TEXT),
+                                        node: fixture.id,
+                                        payload: UnsafeRawPointer(textPayloads.advanced(by: index)),
+                                        count: 1
+                                    ))
+                                }
                                 operations.append(operation(
                                     tag: UInt32(WHISKER_OP_CLIP),
                                     node: fixture.id,
@@ -1168,6 +1229,7 @@ private struct SceneFixtureNode {
     let opacity: Float?
     let visible: Bool?
     let zOrder: Int32?
+    let text: SceneText?
     let backgroundLayer: SceneBackgroundLayer
     let backgroundLayers: [ScenePaintLayer]
     let boxShadows: [WhiskerMobileBoxShadow]
@@ -1177,6 +1239,16 @@ private struct SceneFixtureNode {
     let linearGradient: SceneLinearGradient?
     let radialGradient: SceneRadialGradient?
     let conicGradient: SceneConicGradient?
+}
+
+private struct SceneText {
+    let value: String
+    let fontSize: Float
+    let fontWeight: UInt16
+    let color: WhiskerMobileColor
+    let shadowOffset: CGSize?
+    let shadowBlurRadius: Float
+    let shadowColor: WhiskerMobileColor
 }
 
 private struct SceneClipPath {
@@ -1352,6 +1424,23 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     } else {
         zOrder = nil
     }
+    let text: SceneText?
+    if let raw = fixture["text"] as? [String: Any] {
+        let shadow = raw["shadow"] as? [String: Any]
+        let offset = try shadow.map { try numberArray($0, "offset") }
+        text = SceneText(
+            value: try string(raw, "value"),
+            fontSize: Float(try number(raw, "font_size")),
+            fontWeight: UInt16((raw["font_weight"] as? NSNumber)?.intValue ?? 400),
+            color: try color(object(raw, "color")),
+            shadowOffset: offset.map { CGSize(width: $0[0], height: $0[1]) },
+            shadowBlurRadius: Float(try shadow.map { try number($0, "blur_radius") } ?? 0),
+            shadowColor: try shadow.map { try color(object($0, "color")) }
+                ?? WhiskerMobileColor()
+        )
+    } else {
+        text = nil
+    }
     let backgroundLayer = try fixture["background_layer"]
         .map { try sceneBackgroundLayer($0) } ?? .initial
     let backgroundLayers = try (fixture["background_layers"] as? [[String: Any]] ?? []).map {
@@ -1412,6 +1501,7 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         opacity: opacity,
         visible: visible,
         zOrder: zOrder,
+        text: text,
         backgroundLayer: backgroundLayer,
         backgroundLayers: backgroundLayers,
         boxShadows: boxShadows,
@@ -1875,6 +1965,11 @@ private func containsActiveBackdropBlur(_ view: UIView) -> Bool {
         return true
     }
     return view.subviews.contains(where: containsActiveBackdropBlur)
+}
+
+private func findLabel(_ view: UIView) -> UILabel? {
+    if let label = view as? UILabel { return label }
+    return view.subviews.lazy.compactMap(findLabel).first
 }
 
 private func containsProjectiveTransform(_ view: UIView) -> Bool {

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -163,7 +163,35 @@
         "revision": { "type": "integer", "minimum": 1 },
         "rect": { "$ref": "#/$defs/quadNumber" },
         "background": { "$ref": "#/$defs/color" },
+        "text": { "$ref": "#/$defs/text" },
         "border": { "$ref": "#/$defs/border" }
+      }
+    },
+    "text": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "font_size", "color"],
+      "properties": {
+        "value": { "type": "string" },
+        "font_size": { "type": "number", "exclusiveMinimum": 0 },
+        "font_weight": { "type": "integer", "minimum": 1, "maximum": 1000 },
+        "color": { "$ref": "#/$defs/color" },
+        "shadow": { "$ref": "#/$defs/textShadow" }
+      }
+    },
+    "textShadow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["offset", "blur_radius", "color"],
+      "properties": {
+        "offset": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "number" }
+        },
+        "blur_radius": { "type": "number", "minimum": 0 },
+        "color": { "$ref": "#/$defs/color" }
       }
     },
     "presentScene": {


### PR DESCRIPTION
## Summary
- add a typed, inherited single `text-shadow` value and lower it into `TextPaint`
- carry shadow geometry and color through the mobile ABI without JSON/string matching
- implement the semantic operation in Desktop/wgpu, Web, Android, and iOS
- add one shared Host conformance fixture and native semantic assertions for all four Hosts
- record the supported and pending `paint.text` subsets in `capabilities.json`

The supported shape intentionally follows Lynx's single-shadow subset. Multiple shadows and text decoration remain rejected before Host mutation.

## Verification
- `cargo test -p whisker-style -p whisker-host-conformance --lib`
- `cargo test -p whisker-css -p whisker-engine --lib`
- `cargo test -p whisker-driver -p whisker --lib`
- `cargo test -p whisker-desktop --lib`
- `cargo clippy -p whisker-style -p whisker-css -p whisker-engine -p whisker-driver -p whisker-desktop --all-targets -- -D warnings`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android`
- `cargo xtask host-conformance ios`
