### PR TITLE
feat(paint): implement Lynx text decoration

### DIFF
--- a/crates/whisker-css/src/keyword/text.rs
+++ b/crates/whisker-css/src/keyword/text.rs
@@ -49,8 +49,6 @@ pub enum TextDecorationLine {
     None,
     /// `underline` — line below the text.
     Underline,
-    /// `overline` — line above the text.
-    Overline,
     /// `line-through` — line through the middle of the text.
     LineThrough,
 }
@@ -60,7 +58,6 @@ impl ToCss for TextDecorationLine {
         dest.write_str(match self {
             TextDecorationLine::None => "none",
             TextDecorationLine::Underline => "underline",
-            TextDecorationLine::Overline => "overline",
             TextDecorationLine::LineThrough => "line-through",
         })
     }
@@ -277,7 +274,6 @@ mod tests {
         assert_keyword_set!([
             (TextDecorationLine::None, "none"),
             (TextDecorationLine::Underline, "underline"),
-            (TextDecorationLine::Overline, "overline"),
             (TextDecorationLine::LineThrough, "line-through"),
         ]);
     }

--- a/crates/whisker-css/src/prop/text.rs
+++ b/crates/whisker-css/src/prop/text.rs
@@ -61,6 +61,64 @@ impl Css {
             "none",
         )
     }
+
+    /// Sets Lynx's inherited, single-line `text-decoration` shorthand.
+    ///
+    /// Lynx supports `underline` or `line-through`, one stroke style, and one
+    /// color. Multiple lines and explicit thickness remain outside the core.
+    /// <https://lynxjs.org/api/css/properties/text-decoration>
+    pub fn text_decoration(
+        self,
+        line: TextDecorationLine,
+        style: TextDecorationStyle,
+        color: Color,
+    ) -> Self {
+        use crate::to_css::ToCss;
+        let line_value = match line {
+            TextDecorationLine::None => whisker_style::TextDecorationLineValue::None,
+            TextDecorationLine::Underline => whisker_style::TextDecorationLineValue::Underline,
+            TextDecorationLine::LineThrough => whisker_style::TextDecorationLineValue::LineThrough,
+        };
+        let style_value = match style {
+            TextDecorationStyle::Solid => whisker_style::TextDecorationStyleValue::Solid,
+            TextDecorationStyle::Double => whisker_style::TextDecorationStyleValue::Double,
+            TextDecorationStyle::Dotted => whisker_style::TextDecorationStyleValue::Dotted,
+            TextDecorationStyle::Dashed => whisker_style::TextDecorationStyleValue::Dashed,
+            TextDecorationStyle::Wavy => whisker_style::TextDecorationStyleValue::Wavy,
+        };
+        let whisker_style::StyleValue::Color(color_value) = color.to_style_value() else {
+            unreachable!()
+        };
+        let mut css = String::new();
+        let _ = line.to_css(&mut css);
+        css.push(' ');
+        let _ = style.to_css(&mut css);
+        css.push(' ');
+        let _ = color.to_css(&mut css);
+        self.push_semantic(
+            crate::StyleProperty::TextDecoration,
+            whisker_style::StyleValue::TextDecoration(whisker_style::TextDecorationValue {
+                line: line_value,
+                style: style_value,
+                color: Some(color_value),
+            }),
+            css,
+        )
+    }
+
+    /// Disables inherited text decoration.
+    pub fn text_decoration_none(self) -> Self {
+        self.push_semantic(
+            crate::StyleProperty::TextDecoration,
+            whisker_style::StyleValue::TextDecoration(whisker_style::TextDecorationValue {
+                line: whisker_style::TextDecorationLineValue::None,
+                style: whisker_style::TextDecorationStyleValue::Solid,
+                color: None,
+            }),
+            "none",
+        )
+    }
+
     /// Sets `text-align`. **`justify` is not supported by Lynx**.
     /// <https://lynxjs.org/api/css/properties/text-align>
     pub fn text_align(self, v: TextAlign) -> Self {
@@ -162,6 +220,31 @@ mod tests {
         assert_eq!(
             Css::new().text_shadow_none().to_string(),
             "text-shadow: none;"
+        );
+    }
+
+    #[test]
+    fn lynx_text_decoration_shorthand_is_typed() {
+        let style = Css::new().text_decoration(
+            TextDecorationLine::LineThrough,
+            TextDecorationStyle::Dashed,
+            Color::Named(NamedColor::Red),
+        );
+        assert_eq!(
+            style.to_string(),
+            "text-decoration: line-through dashed red;"
+        );
+        assert!(matches!(
+            style.to_specified_style().unwrap().resolved()[0].value(),
+            whisker_style::StyleValue::TextDecoration(whisker_style::TextDecorationValue {
+                line: whisker_style::TextDecorationLineValue::LineThrough,
+                style: whisker_style::TextDecorationStyleValue::Dashed,
+                ..
+            })
+        ));
+        assert_eq!(
+            Css::new().text_decoration_none().to_string(),
+            "text-decoration: none;"
         );
     }
 

--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 16 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 17 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -153,6 +153,8 @@ typedef struct {
   float shadow_offset_x, shadow_offset_y, shadow_blur_radius;
   uint32_t shadow_flags;
   WhiskerMobileColor shadow_color;
+  uint32_t decoration_flags, decoration_style;
+  WhiskerMobileColor decoration_color;
   uint64_t prepared_content;
 } WhiskerMobileText;
 typedef struct {
@@ -254,7 +256,7 @@ _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 160, "WhiskerMobileMeasure
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceCommand) == 64, "WhiskerMobileResourceCommand ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceEvent) == 56, "WhiskerMobileResourceEvent ABI drift");
-_Static_assert(sizeof(WhiskerMobileText) == 128, "WhiskerMobileText ABI drift");
+_Static_assert(sizeof(WhiskerMobileText) == 168, "WhiskerMobileText ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 
 typedef void (*WhiskerMobileRequestFrameCallback)(void*);

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -494,12 +494,18 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 storage[11]=p->shadow_blur_radius; storage[12]=(float)p->shadow_color.red;
                 storage[13]=(float)p->shadow_color.green; storage[14]=(float)p->shadow_color.blue;
                 storage[15]=p->shadow_color.alpha; storage[16]=(float)p->shadow_color.kind;
-                numbers = floats(env, storage, 17);
-                jclass cls = (*env)->FindClass(env, "java/lang/String"); names = (*env)->NewObjectArray(env, 2, cls, NULL);
+                storage[17]=(float)p->decoration_flags; storage[18]=(float)p->decoration_style;
+                storage[19]=(float)p->decoration_color.red; storage[20]=(float)p->decoration_color.green;
+                storage[21]=(float)p->decoration_color.blue; storage[22]=p->decoration_color.alpha;
+                storage[23]=(float)p->decoration_color.kind;
+                numbers = floats(env, storage, 24);
+                jclass cls = (*env)->FindClass(env, "java/lang/String"); names = (*env)->NewObjectArray(env, 3, cls, NULL);
                 jstring color_name = new_string(env, p->color.name.ptr, p->color.name.len); (*env)->SetObjectArrayElement(env, names, 0, color_name);
                 jstring shadow_name = new_string(env, p->shadow_color.name.ptr, p->shadow_color.name.len); (*env)->SetObjectArrayElement(env, names, 1, shadow_name);
+                jstring decoration_name = new_string(env, p->decoration_color.name.ptr, p->decoration_color.name.len); (*env)->SetObjectArrayElement(env, names, 2, decoration_name);
                 if (color_name) (*env)->DeleteLocalRef(env, color_name);
                 if (shadow_name) (*env)->DeleteLocalRef(env, shadow_name);
+                if (decoration_name) (*env)->DeleteLocalRef(env, decoration_name);
                 (*env)->DeleteLocalRef(env, cls); break;
             }
             case WHISKER_OP_PROPERTY: case WHISKER_OP_COMMAND: value = raw_to_value(env, op->payload); break;

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 16;
+pub const MOBILE_ABI_MINOR: u16 = 17;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -314,6 +314,9 @@ pub struct MobileText {
     pub shadow_blur_radius: f32,
     pub shadow_flags: u32,
     pub shadow_color: MobileColor,
+    pub decoration_flags: u32,
+    pub decoration_style: u32,
+    pub decoration_color: MobileColor,
     pub prepared_content: u64,
 }
 
@@ -657,7 +660,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileBootstrap>(), 24);
             assert_eq!(std::mem::size_of::<MobileMeasureRequest>(), 160);
             assert_eq!(std::mem::size_of::<MobileMeasureResponse>(), 64);
-            assert_eq!(std::mem::size_of::<MobileText>(), 128);
+            assert_eq!(std::mem::size_of::<MobileText>(), 168);
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::size_of::<MobileBoxShadow>(), 56);
             assert_eq!(std::mem::size_of::<MobileClipInset>(), 96);

--- a/crates/whisker-engine/src/text.rs
+++ b/crates/whisker-engine/src/text.rs
@@ -449,5 +449,36 @@ mod tests {
             decorated.content().paint.decoration.color,
             PaintColor::Named("red".into())
         );
+        for (style, expected) in [
+            (
+                TextDecorationStyleValue::Double,
+                whisker_protocol::TextDecorationStyle::Double,
+            ),
+            (
+                TextDecorationStyleValue::Dotted,
+                whisker_protocol::TextDecorationStyle::Dotted,
+            ),
+            (
+                TextDecorationStyleValue::Dashed,
+                whisker_protocol::TextDecorationStyle::Dashed,
+            ),
+        ] {
+            let resolved = resolved(vec![StyleDeclaration::new(
+                StyleProperty::TextDecoration,
+                StyleValue::TextDecoration(TextDecorationValue {
+                    line: TextDecorationLineValue::Underline,
+                    style,
+                    color: None,
+                }),
+            )]);
+            assert_eq!(
+                lower_plain_text(&input, resolved.computed().inherited_text())
+                    .content()
+                    .paint
+                    .decoration
+                    .style,
+                expected
+            );
+        }
     }
 }

--- a/crates/whisker-engine/src/text.rs
+++ b/crates/whisker-engine/src/text.rs
@@ -12,6 +12,7 @@ use whisker_protocol::{
 };
 use whisker_style::{
     ColorValue, ComputedLineHeight, FontFamilyValue, FontStyleValue, InheritedStyle,
+    TextDecorationLineValue, TextDecorationStyleValue,
 };
 
 /// Plain UTF-8 text and the shaping behavior not supplied by inherited style.
@@ -113,6 +114,38 @@ pub fn lower_plain_text(input: &PlainTextInput, style: &InheritedStyle) -> Lower
             payload,
             paint: TextPaint {
                 foreground: lower_color(style.color()),
+                decoration: whisker_protocol::TextDecoration {
+                    lines: whisker_protocol::TextDecorationLines {
+                        underline: matches!(
+                            style.text_decoration().line(),
+                            TextDecorationLineValue::Underline
+                        ),
+                        overline: false,
+                        line_through: matches!(
+                            style.text_decoration().line(),
+                            TextDecorationLineValue::LineThrough
+                        ),
+                    },
+                    color: lower_color(style.text_decoration().color()),
+                    style: match style.text_decoration().style() {
+                        TextDecorationStyleValue::Solid => {
+                            whisker_protocol::TextDecorationStyle::Solid
+                        }
+                        TextDecorationStyleValue::Double => {
+                            whisker_protocol::TextDecorationStyle::Double
+                        }
+                        TextDecorationStyleValue::Dotted => {
+                            whisker_protocol::TextDecorationStyle::Dotted
+                        }
+                        TextDecorationStyleValue::Dashed => {
+                            whisker_protocol::TextDecorationStyle::Dashed
+                        }
+                        TextDecorationStyleValue::Wavy => {
+                            whisker_protocol::TextDecorationStyle::Wavy
+                        }
+                    },
+                    thickness: whisker_protocol::TextDecorationThickness::Auto,
+                },
                 shadows: style
                     .text_shadow()
                     .into_iter()
@@ -123,7 +156,6 @@ pub fn lower_plain_text(input: &PlainTextInput, style: &InheritedStyle) -> Lower
                         color: lower_color(shadow.color()),
                     })
                     .collect(),
-                ..TextPaint::default()
             },
             prepared_content: None,
         },
@@ -187,7 +219,7 @@ mod tests {
     use whisker_style::{
         FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue,
         SpecifiedStyle, StyleDeclaration, StyleEnvironment, StyleNumber, StyleProperty, StyleValue,
-        TextShadowValue, resolve_style,
+        TextDecorationValue, TextShadowValue, resolve_style,
     };
 
     fn resolved(declarations: Vec<StyleDeclaration>) -> whisker_style::ResolvedNodeStyle {
@@ -390,6 +422,32 @@ mod tests {
                 blur_radius: 3.0,
                 color: PaintColor::Named("red".into()),
             }]
+        );
+    }
+
+    #[test]
+    fn lynx_text_decoration_lowers_to_paint_without_changing_measurement() {
+        let input = PlainTextInput::new("decoration");
+        let plain = lower_plain_text(&input, resolved(Vec::new()).computed().inherited_text());
+        let decorated = resolved(vec![StyleDeclaration::new(
+            StyleProperty::TextDecoration,
+            StyleValue::TextDecoration(TextDecorationValue {
+                line: TextDecorationLineValue::LineThrough,
+                style: TextDecorationStyleValue::Wavy,
+                color: Some(ColorValue::Named("red".into())),
+            }),
+        )]);
+        let decorated = lower_plain_text(&input, decorated.computed().inherited_text());
+        assert_eq!(plain.measurement(), decorated.measurement());
+        assert!(decorated.content().paint.decoration.lines.line_through);
+        assert!(!decorated.content().paint.decoration.lines.underline);
+        assert_eq!(
+            decorated.content().paint.decoration.style,
+            whisker_protocol::TextDecorationStyle::Wavy
+        );
+        assert_eq!(
+            decorated.content().paint.decoration.color,
+            PaintColor::Named("red".into())
         );
     }
 }

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -606,9 +606,50 @@ pub struct TextFixture {
     pub font_weight: u16,
     /// Foreground glyph color.
     pub color: ColorFixture,
+    /// Optional single Lynx text decoration.
+    #[serde(default)]
+    pub decoration: Option<TextDecorationFixture>,
     /// Optional single Lynx-compatible shadow.
     #[serde(default)]
     pub shadow: Option<TextShadowFixture>,
+}
+
+/// One resolved Lynx text decoration.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct TextDecorationFixture {
+    /// Single supported line kind.
+    pub line: TextDecorationLineFixture,
+    /// Stroke style.
+    pub style: TextDecorationStyleFixture,
+    /// Decoration color.
+    pub color: ColorFixture,
+}
+
+/// Lynx's single decoration line.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TextDecorationLineFixture {
+    /// A line below the glyphs.
+    Underline,
+    /// A line through the glyphs.
+    LineThrough,
+}
+
+/// Lynx decoration stroke styles.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TextDecorationStyleFixture {
+    /// One solid line.
+    Solid,
+    /// Two parallel lines.
+    Double,
+    /// A sequence of dots.
+    Dotted,
+    /// A sequence of dashes.
+    Dashed,
+    /// A wave-shaped line.
+    Wavy,
 }
 
 /// One resolved native text shadow.
@@ -1405,6 +1446,10 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                         && text.font_size > 0.0
                         && (1..=1000).contains(&text.font_weight)
                         && valid_color(&text.color)
+                        && text
+                            .decoration
+                            .as_ref()
+                            .is_none_or(|decoration| valid_color(&decoration.color))
                         && text.shadow.as_ref().is_none_or(|shadow| {
                             shadow.offset.into_iter().all(f32::is_finite)
                                 && shadow.blur_radius.is_finite()

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -41,9 +41,9 @@ pub use property::{
     PropertyMetadata, PropertyOrigin, StyleProperty, StylePropertyDomain, StylePropertyId,
 };
 pub use resolution::{
-    ComputedLineHeight, ComputedStyle, ComputedTextShadow, InheritedPropertySet, InheritedStyle,
-    InheritedStyleChange, PropertyImpactSet, ResolvedNodeStyle, StyleEnvironment,
-    StyleResolutionError, resolve_style, resolve_text_style,
+    ComputedLineHeight, ComputedStyle, ComputedTextDecoration, ComputedTextShadow,
+    InheritedPropertySet, InheritedStyle, InheritedStyleChange, PropertyImpactSet,
+    ResolvedNodeStyle, StyleEnvironment, StyleResolutionError, resolve_style, resolve_text_style,
 };
 pub use value::{
     BackdropFilterValue, BackgroundAttachmentValue, BackgroundBoxValue, BackgroundImageValue,
@@ -52,6 +52,7 @@ pub use value::{
     ColorValue, FontFamilyValue, FontStyleValue, FontWeightValue, GradientStopValue, GradientValue,
     ImageRenderingValue, InsetPathValue, LengthPercentageValue, LengthUnit, LengthValue,
     LineHeightValue, MotionPathCommandValue, MotionPathPointValue, OffsetPathValue,
-    OffsetRotateValue, RadialGradientValue, StyleNumber, StyleValue, TextShadowValue,
-    TransformFunctionValue, TransformOriginValue, TransformValue,
+    OffsetRotateValue, RadialGradientValue, StyleNumber, StyleValue, TextDecorationLineValue,
+    TextDecorationStyleValue, TextDecorationValue, TextShadowValue, TransformFunctionValue,
+    TransformOriginValue, TransformValue,
 };

--- a/crates/whisker-style/src/property.rs
+++ b/crates/whisker-style/src/property.rs
@@ -131,6 +131,7 @@ macro_rules! define_style_properties {
                         | Self::LineHeight
                         | Self::LetterSpacing
                         | Self::Color
+                        | Self::TextDecoration
                         | Self::TextShadow
                 );
                 let domain = self.domain();
@@ -580,6 +581,7 @@ mod tests {
                 StyleProperty::FontWeight,
                 StyleProperty::LetterSpacing,
                 StyleProperty::LineHeight,
+                StyleProperty::TextDecoration,
                 StyleProperty::TextShadow,
             ]
         );

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -1446,6 +1446,24 @@ mod tests {
         )
         .unwrap();
         assert_eq!(inherited(&child).text_decoration(), decoration);
+
+        let invalid_color = declaration(
+            StyleProperty::TextDecoration,
+            StyleValue::TextDecoration(TextDecorationValue {
+                line: TextDecorationLineValue::Underline,
+                style: TextDecorationStyleValue::Solid,
+                color: Some(ColorValue::Rgba {
+                    red: 0,
+                    green: 0,
+                    blue: 0,
+                    alpha: number(f32::NAN),
+                }),
+            }),
+        );
+        assert_eq!(
+            resolve_text_style(&invalid_color, None, environment).unwrap_err(),
+            StyleResolutionError::InvalidPropertyValue(StyleProperty::Color)
+        );
     }
 
     #[test]

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -5,7 +5,8 @@ use core::fmt;
 use crate::{
     CalcExpression, ColorValue, ComputedLayoutStyle, ComputedPaintStyle, FontFamilyValue,
     FontStyleValue, FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue,
-    LineHeightValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue, TextShadowValue,
+    LineHeightValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue,
+    TextDecorationLineValue, TextDecorationStyleValue, TextDecorationValue, TextShadowValue,
 };
 
 const RPX_REFERENCE_WIDTH: f32 = 750.0;
@@ -114,6 +115,29 @@ impl ComputedTextShadow {
     }
 }
 
+/// One resolved inherited Lynx text decoration.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedTextDecoration {
+    line: TextDecorationLineValue,
+    style: TextDecorationStyleValue,
+    color: ColorValue,
+}
+
+impl ComputedTextDecoration {
+    /// Returns the selected line kind.
+    pub const fn line(&self) -> TextDecorationLineValue {
+        self.line
+    }
+    /// Returns the selected stroke style.
+    pub const fn style(&self) -> TextDecorationStyleValue {
+        self.style
+    }
+    /// Returns the resolved decoration color.
+    pub const fn color(&self) -> &ColorValue {
+        &self.color
+    }
+}
+
 /// The computed text values inherited by descendant nodes.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct InheritedStyle {
@@ -124,6 +148,7 @@ pub struct InheritedStyle {
     line_height: ComputedLineHeight,
     letter_spacing: StyleNumber,
     color: ColorValue,
+    text_decoration: ComputedTextDecoration,
     text_shadow: Option<ComputedTextShadow>,
 }
 
@@ -141,6 +166,16 @@ impl InheritedStyle {
                 green: 0,
                 blue: 0,
                 alpha: StyleNumber::new(1.0),
+            },
+            text_decoration: ComputedTextDecoration {
+                line: TextDecorationLineValue::None,
+                style: TextDecorationStyleValue::Solid,
+                color: ColorValue::Rgba {
+                    red: 0,
+                    green: 0,
+                    blue: 0,
+                    alpha: StyleNumber::new(1.0),
+                },
             },
             text_shadow: None,
         }
@@ -181,6 +216,11 @@ impl InheritedStyle {
         &self.color
     }
 
+    /// Returns the inherited single-line text decoration.
+    pub const fn text_decoration(&self) -> &ComputedTextDecoration {
+        &self.text_decoration
+    }
+
     /// Returns the optional single inherited text shadow.
     pub const fn text_shadow(&self) -> Option<&ComputedTextShadow> {
         self.text_shadow.as_ref()
@@ -216,6 +256,10 @@ impl InheritedStyle {
         }
         if self.color != previous.color {
             properties |= InheritedPropertySet::COLOR;
+            impacts |= PropertyImpactSet::PAINT;
+        }
+        if self.text_decoration != previous.text_decoration {
+            properties |= InheritedPropertySet::TEXT_DECORATION;
             impacts |= PropertyImpactSet::PAINT;
         }
         if self.text_shadow != previous.text_shadow {
@@ -305,7 +349,7 @@ impl std::error::Error for StyleResolutionError {}
 
 /// Bit set identifying which inherited values changed.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct InheritedPropertySet(u8);
+pub struct InheritedPropertySet(u16);
 
 impl InheritedPropertySet {
     /// No inherited property.
@@ -326,6 +370,8 @@ impl InheritedPropertySet {
     pub const COLOR: Self = Self(1 << 6);
     /// `text-shadow`.
     pub const TEXT_SHADOW: Self = Self(1 << 7);
+    /// `text-decoration`.
+    pub const TEXT_DECORATION: Self = Self(1 << 8);
 
     /// Returns whether this set contains every bit from `other`.
     pub const fn contains(self, other: Self) -> bool {
@@ -504,6 +550,23 @@ pub fn resolve_style(
         Some(_) => return Err(wrong_type(StyleProperty::Color)),
         None => base.color.clone(),
     };
+    let text_decoration = match declarations.text_decoration {
+        Some(StyleValue::TextDecoration(TextDecorationValue {
+            line,
+            style,
+            color: decoration_color,
+        })) => ComputedTextDecoration {
+            line: *line,
+            style: *style,
+            color: decoration_color
+                .as_ref()
+                .map(normalize_color)
+                .transpose()?
+                .unwrap_or_else(|| color.clone()),
+        },
+        Some(_) => return Err(wrong_type(StyleProperty::TextDecoration)),
+        None => base.text_decoration.clone(),
+    };
     let text_shadow = match declarations.text_shadow {
         Some(StyleValue::TextShadow(TextShadowValue::None)) => None,
         Some(StyleValue::TextShadow(TextShadowValue::Shadow {
@@ -554,6 +617,7 @@ pub fn resolve_style(
         line_height,
         letter_spacing,
         color,
+        text_decoration,
         text_shadow,
     };
     let layout =
@@ -595,6 +659,7 @@ struct InheritedDeclarations<'a> {
     line_height: Option<&'a StyleValue>,
     letter_spacing: Option<&'a StyleValue>,
     color: Option<&'a StyleValue>,
+    text_decoration: Option<&'a StyleValue>,
     text_shadow: Option<&'a StyleValue>,
 }
 
@@ -610,6 +675,7 @@ impl<'a> InheritedDeclarations<'a> {
                 StyleProperty::LineHeight => &mut values.line_height,
                 StyleProperty::LetterSpacing => &mut values.letter_spacing,
                 StyleProperty::Color => &mut values.color,
+                StyleProperty::TextDecoration => &mut values.text_decoration,
                 StyleProperty::TextShadow => &mut values.text_shadow,
                 _ => continue,
             };
@@ -1215,6 +1281,7 @@ mod tests {
             StyleProperty::LineHeight,
             StyleProperty::LetterSpacing,
             StyleProperty::Color,
+            StyleProperty::TextDecoration,
             StyleProperty::TextShadow,
         ] {
             let error = resolve_text_style(
@@ -1348,6 +1415,37 @@ mod tests {
             resolve_text_style(&invalid_color, None, environment).unwrap_err(),
             StyleResolutionError::InvalidPropertyValue(StyleProperty::Color)
         );
+    }
+
+    #[test]
+    fn text_decoration_resolves_current_color_and_inherits() {
+        let environment = StyleEnvironment::default();
+        let specified = SpecifiedStyle::new()
+            .push(
+                StyleProperty::Color,
+                StyleValue::Color(ColorValue::Named("blue".into())),
+            )
+            .push(
+                StyleProperty::TextDecoration,
+                StyleValue::TextDecoration(TextDecorationValue {
+                    line: TextDecorationLineValue::Underline,
+                    style: TextDecorationStyleValue::Wavy,
+                    color: None,
+                }),
+            );
+        let parent = resolve_text_style(&specified, None, environment).unwrap();
+        let decoration = inherited(&parent).text_decoration();
+        assert_eq!(decoration.line(), TextDecorationLineValue::Underline);
+        assert_eq!(decoration.style(), TextDecorationStyleValue::Wavy);
+        assert_eq!(decoration.color(), &ColorValue::Named("blue".into()));
+
+        let child = resolve_text_style(
+            &SpecifiedStyle::new(),
+            Some(parent.inherited_for_children()),
+            environment,
+        )
+        .unwrap();
+        assert_eq!(inherited(&child).text_decoration(), decoration);
     }
 
     #[test]
@@ -1595,6 +1693,11 @@ mod tests {
             line_height: ComputedLineHeight::LogicalPixels(number(24.0)),
             letter_spacing: number(1.0),
             color: ColorValue::Named("red".into()),
+            text_decoration: ComputedTextDecoration {
+                line: TextDecorationLineValue::Underline,
+                style: TextDecorationStyleValue::Dashed,
+                color: ColorValue::Named("green".into()),
+            },
             text_shadow: Some(ComputedTextShadow {
                 offset_x: number(1.0),
                 offset_y: number(2.0),
@@ -1611,6 +1714,7 @@ mod tests {
             InheritedPropertySet::LINE_HEIGHT,
             InheritedPropertySet::LETTER_SPACING,
             InheritedPropertySet::COLOR,
+            InheritedPropertySet::TEXT_DECORATION,
             InheritedPropertySet::TEXT_SHADOW,
         ] {
             assert!(change.properties().contains(property));

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -537,6 +537,43 @@ pub enum TextShadowValue {
     },
 }
 
+/// The single decoration line supported by Lynx's `text-decoration` shorthand.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextDecorationLineValue {
+    /// No decoration.
+    None,
+    /// A line below the glyphs.
+    Underline,
+    /// A line through the glyphs.
+    LineThrough,
+}
+
+/// Lynx-compatible decoration stroke style.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextDecorationStyleValue {
+    /// One solid line.
+    Solid,
+    /// Two parallel lines.
+    Double,
+    /// A sequence of dots.
+    Dotted,
+    /// A sequence of dashes.
+    Dashed,
+    /// A wave-shaped line.
+    Wavy,
+}
+
+/// Typed value for Lynx's inherited, single-line `text-decoration` shorthand.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TextDecorationValue {
+    /// Selected line kind.
+    pub line: TextDecorationLineValue,
+    /// Selected stroke style.
+    pub style: TextDecorationStyleValue,
+    /// Explicit decoration color, or the resolved text color when omitted.
+    pub color: Option<ColorValue>,
+}
+
 /// An owned value in a specified inline-style declaration.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StyleValue {
@@ -590,6 +627,8 @@ pub enum StyleValue {
     Color(ColorValue),
     /// Single inherited text shadow.
     TextShadow(TextShadowValue),
+    /// Single inherited Lynx text decoration.
+    TextDecoration(TextDecorationValue),
     /// Border line style.
     BorderStyle(crate::BorderStyleValue),
     /// Overflow behavior on one axis.

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -1385,9 +1385,13 @@ impl MobileFrameOwned {
                     raw.integer = *z_order;
                 }
                 Operation::SetText { node, content } => {
-                    if content.paint.decoration.lines.underline
-                        || content.paint.decoration.lines.overline
-                        || content.paint.decoration.lines.line_through
+                    if content.paint.decoration.lines.overline
+                        || (content.paint.decoration.lines.underline
+                            && content.paint.decoration.lines.line_through)
+                        || !matches!(
+                            content.paint.decoration.thickness,
+                            whisker_engine::whisker_protocol::TextDecorationThickness::Auto
+                        )
                         || content.paint.shadows.len() > 1
                         || content.payload.style.uses_extended_typography()
                     {
@@ -1400,6 +1404,8 @@ impl MobileFrameOwned {
                         Some(value) => mobile_color(&value.color, &mut strings),
                         None => mobile_color(&PaintColor::default(), &mut strings),
                     };
+                    let decoration_color =
+                        mobile_color(&content.paint.decoration.color, &mut strings);
                     texts.push(Box::new(MobileText {
                         text: push_string(&mut strings, &content.payload.text),
                         font_size: content.payload.style.font_size,
@@ -1422,6 +1428,16 @@ impl MobileFrameOwned {
                         shadow_blur_radius: shadow.map_or(0.0, |value| value.blur_radius),
                         shadow_flags: u32::from(shadow.is_some()),
                         shadow_color,
+                        decoration_flags: u32::from(content.paint.decoration.lines.underline)
+                            | (u32::from(content.paint.decoration.lines.line_through) << 1),
+                        decoration_style: match content.paint.decoration.style {
+                            whisker_engine::whisker_protocol::TextDecorationStyle::Solid => 0,
+                            whisker_engine::whisker_protocol::TextDecorationStyle::Double => 1,
+                            whisker_engine::whisker_protocol::TextDecorationStyle::Dotted => 2,
+                            whisker_engine::whisker_protocol::TextDecorationStyle::Dashed => 3,
+                            whisker_engine::whisker_protocol::TextDecorationStyle::Wavy => 4,
+                        },
+                        decoration_color,
                         prepared_content: content.prepared_content.map_or(0, |value| value.get()),
                     }));
                     raw.payload = texts.last().unwrap().as_ref() as *const _ as *const c_void;

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
@@ -1,7 +1,6 @@
 package rs.whisker.runtime
 
 import android.view.Gravity
-import android.widget.TextView
 
 /** Hand-written Android implementations matched to Rust registrations by name. */
 public object WhiskerBuiltInElements {
@@ -20,11 +19,12 @@ public object WhiskerBuiltInElements {
         WhiskerElementFactory(
             name = TEXT,
             textUpdater = { view, content ->
-                require(view is TextView) { "$TEXT factory must create TextView" }
+                require(view is WhiskerTextView) { "$TEXT factory must create WhiskerTextView" }
                 view.text = content.value
                 view.textSize = content.fontSize
                 view.setTextColor(content.color)
                 view.setTypeface(view.typeface, if (content.fontWeight >= 600) 1 else 0)
+                view.whiskerDecoration = content.decoration
                 content.shadow?.let { shadow ->
                     val density = view.resources.displayMetrics.density
                     view.setShadowLayer(
@@ -36,7 +36,7 @@ public object WhiskerBuiltInElements {
                 } ?: view.setShadowLayer(0f, 0f, 0f, 0)
             },
         ) { context ->
-            TextView(context).apply {
+            WhiskerTextView(context).apply {
                 includeFontPadding = false
                 gravity = Gravity.TOP or Gravity.START
             }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -20,8 +20,20 @@ public data class WhiskerTextContent(
     public val fontSize: Float,
     public val fontWeight: Int,
     public val color: Int,
-    public val shadow: WhiskerTextShadow?,
+    public val decoration: WhiskerTextDecoration? = null,
+    public val shadow: WhiskerTextShadow? = null,
 )
+
+/** One inherited Lynx text decoration. */
+public data class WhiskerTextDecoration(
+    public val line: WhiskerTextDecorationLine,
+    public val style: WhiskerTextDecorationStyle,
+    public val color: Int,
+)
+
+public enum class WhiskerTextDecorationLine { UNDERLINE, LINE_THROUGH }
+
+public enum class WhiskerTextDecorationStyle { SOLID, DOUBLE, DOTTED, DASHED, WAVY }
 
 /** One resolved shadow painted behind native text glyphs. */
 public data class WhiskerTextShadow(

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerTextView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerTextView.kt
@@ -1,0 +1,83 @@
+package rs.whisker.runtime
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.DashPathEffect
+import android.graphics.Paint
+import android.graphics.Path
+import android.widget.TextView
+import kotlin.math.max
+
+/** Native text element with Lynx-compatible single-line decorations. */
+public class WhiskerTextView(context: Context) : TextView(context) {
+    public var whiskerDecoration: WhiskerTextDecoration? = null
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        val decoration = whiskerDecoration ?: return
+        val textLayout = layout ?: return
+        val density = resources.displayMetrics.density
+        val stroke = max(density, textSize / 16f)
+        val decorationPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = decoration.color
+            style = Paint.Style.STROKE
+            strokeWidth = stroke
+        }
+        for (line in 0 until textLayout.lineCount) {
+            val left = totalPaddingLeft + textLayout.getLineLeft(line)
+            val right = totalPaddingLeft + textLayout.getLineRight(line)
+            if (right <= left) continue
+            val baseline = extendedPaddingTop + textLayout.getLineBaseline(line)
+            val y = when (decoration.line) {
+                WhiskerTextDecorationLine.UNDERLINE -> baseline + stroke * 1.5f
+                WhiskerTextDecorationLine.LINE_THROUGH -> baseline + paint.fontMetrics.ascent * 0.35f
+            }
+            drawDecoration(canvas, decorationPaint, decoration.style, left, right, y, stroke)
+        }
+    }
+
+    private fun drawDecoration(
+        canvas: Canvas,
+        paint: Paint,
+        style: WhiskerTextDecorationStyle,
+        left: Float,
+        right: Float,
+        y: Float,
+        stroke: Float,
+    ) {
+        paint.pathEffect = null
+        paint.strokeCap = Paint.Cap.BUTT
+        when (style) {
+            WhiskerTextDecorationStyle.SOLID -> canvas.drawLine(left, y, right, y, paint)
+            WhiskerTextDecorationStyle.DOUBLE -> {
+                canvas.drawLine(left, y - stroke, right, y - stroke, paint)
+                canvas.drawLine(left, y + stroke, right, y + stroke, paint)
+            }
+            WhiskerTextDecorationStyle.DOTTED -> {
+                paint.strokeCap = Paint.Cap.ROUND
+                paint.pathEffect = DashPathEffect(floatArrayOf(stroke, stroke * 2f), 0f)
+                canvas.drawLine(left, y, right, y, paint)
+            }
+            WhiskerTextDecorationStyle.DASHED -> {
+                paint.pathEffect = DashPathEffect(floatArrayOf(stroke * 4f, stroke * 2f), 0f)
+                canvas.drawLine(left, y, right, y, paint)
+            }
+            WhiskerTextDecorationStyle.WAVY -> {
+                val path = Path().apply { moveTo(left, y) }
+                val step = stroke * 2f
+                var x = left
+                var up = true
+                while (x < right) {
+                    x = (x + step).coerceAtMost(right)
+                    path.lineTo(x, y + if (up) -stroke else stroke)
+                    up = !up
+                }
+                canvas.drawPath(path, paint)
+            }
+        }
+    }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -11,6 +11,9 @@ import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerView
 import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerTextContent
+import rs.whisker.runtime.WhiskerTextDecoration
+import rs.whisker.runtime.WhiskerTextDecorationLine
+import rs.whisker.runtime.WhiskerTextDecorationStyle
 import rs.whisker.runtime.WhiskerTextShadow
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.paint.HostBackgroundGeometry
@@ -184,10 +187,17 @@ internal class HostScene(
                 operation.scalar !in 0f..1f
             ) return false
             11 -> if (operation.node !in existing || operation.integer !in 0..1) return false
-            13 -> if (
-                operation.node !in existing || operation.text == null ||
-                operation.numbers?.size ?: 0 < 17 || operation.names?.size ?: 0 < 2
-            ) return false
+            13 -> {
+                val values = operation.numbers ?: return false
+                if (
+                    operation.node !in existing || operation.text == null ||
+                    values.size < 24 || operation.names?.size ?: 0 < 3 ||
+                    !values.all { it.isFinite() } || values[17].toInt() !in 0..2 ||
+                    values[17] != values[17].toInt().toFloat() ||
+                    values[18].toInt() !in 0..4 ||
+                    values[18] != values[18].toInt().toFloat()
+                ) return false
+            }
             14 -> if (operation.node !in existing || operation.value == null) return false
             21 -> if (!validBackgroundLayers(operation, existing)) return false
             else -> return false
@@ -358,7 +368,7 @@ internal class HostScene(
     }
 
     private fun applyText(node: HostNode, text: String, values: FloatArray, names: Array<String>) {
-        require(values.size >= 17)
+        require(values.size >= 24)
         val mounted = requireNotNull(node.mountedElement)
         require(
             mounted.setText(
@@ -371,6 +381,19 @@ internal class HostScene(
                     } else {
                         rgba(values[3], values[4], values[5], values[6])
                     },
+                    decoration = if (values[17] == 0f) null else WhiskerTextDecoration(
+                        line = if (values[17].toInt() and 1 != 0) {
+                            WhiskerTextDecorationLine.UNDERLINE
+                        } else {
+                            WhiskerTextDecorationLine.LINE_THROUGH
+                        },
+                        style = WhiskerTextDecorationStyle.entries[values[18].toInt()],
+                        color = if (values[23] == 0f) {
+                            parseNamedColor(names[2])
+                        } else {
+                            rgba(values[19], values[20], values[21], values[22])
+                        },
+                    ),
                     shadow = if (values[8] == 0f) null else WhiskerTextShadow(
                         offsetX = values[9],
                         offsetY = values[10],

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -22,7 +22,7 @@ use whisker_protocol::{
 
 use crate::paint::box_paint::{
     BoxPrimitive, BoxPrimitiveKind, background_gradient_primitive, box_shadow_primitive, lower_box,
-    resolve_box_geometry,
+    resolve_box_geometry, solid_rect_primitive,
 };
 use crate::paint::color::{gpu_color, text_color};
 use crate::scene::{LogicalClip, PaintCommand, ShapeClipStack};
@@ -2178,13 +2178,50 @@ impl GpuRenderer {
                 }
                 PaintCommand::Text {
                     node,
+                    rect,
+                    content,
+                    clip,
                     transform,
                     shape_clips,
+                    opacity,
                     ..
                 } => {
-                    // Glyph transforms and shape clips are implemented with the
-                    // SetText paint slice; retain both states on the command now.
-                    let _ = (transform, shape_clips);
+                    let decoration = &content.paint.decoration;
+                    if (decoration.lines.underline || decoration.lines.line_through)
+                        && let Some(prepared) = content
+                            .prepared_content
+                            .and_then(|id| text.prepared.get(&id))
+                    {
+                        let thickness = (content.payload.style.font_size / 16.0).max(1.0);
+                        for run in prepared.buffer.layout_runs() {
+                            let baseline = rect.y + run.line_y;
+                            let y = if decoration.lines.underline {
+                                baseline + thickness * 1.5
+                            } else {
+                                baseline - content.payload.style.font_size * 0.3
+                            };
+                            for line in text_decoration_rects(
+                                rect.x,
+                                run.line_w,
+                                y,
+                                thickness,
+                                decoration.style,
+                            ) {
+                                push_quad_draw(
+                                    &mut vertices,
+                                    &mut draws,
+                                    solid_rect_primitive(
+                                        line,
+                                        gpu_color(&decoration.color, *opacity),
+                                    ),
+                                    *transform,
+                                    *clip,
+                                    shape_clips,
+                                    (None, None, false),
+                                );
+                            }
+                        }
+                    }
                     draws.push(DrawCommand::Text { index, node: *node })
                 }
             }
@@ -2608,6 +2645,61 @@ fn transform_point(transform: Transform, [x, y]: [f32; 2]) -> [f32; 4] {
         transform.0[2] * x + transform.0[6] * y + transform.0[14],
         transform.0[3] * x + transform.0[7] * y + transform.0[15],
     ]
+}
+
+fn text_decoration_rects(
+    left: f32,
+    width: f32,
+    y: f32,
+    thickness: f32,
+    style: whisker_protocol::TextDecorationStyle,
+) -> Vec<LayoutRect> {
+    let line = |x: f32, y: f32, width: f32| LayoutRect {
+        x,
+        y: y - thickness * 0.5,
+        width: width.max(0.0),
+        height: thickness,
+    };
+    match style {
+        whisker_protocol::TextDecorationStyle::Solid => vec![line(left, y, width)],
+        whisker_protocol::TextDecorationStyle::Double => vec![
+            line(left, y - thickness, width),
+            line(left, y + thickness, width),
+        ],
+        whisker_protocol::TextDecorationStyle::Dotted
+        | whisker_protocol::TextDecorationStyle::Dashed => {
+            let segment = if matches!(style, whisker_protocol::TextDecorationStyle::Dotted) {
+                thickness
+            } else {
+                thickness * 4.0
+            };
+            let gap = thickness * 2.0;
+            let mut result = Vec::new();
+            let mut x = left;
+            while x < left + width {
+                result.push(line(x, y, segment.min(left + width - x)));
+                x += segment + gap;
+            }
+            result
+        }
+        whisker_protocol::TextDecorationStyle::Wavy => {
+            let segment = (thickness * 0.75).max(0.75);
+            let wavelength = (thickness * 4.0).max(3.0);
+            let mut result = Vec::new();
+            let mut x = left;
+            while x < left + width {
+                let center = x + segment * 0.5;
+                let phase = (center - left) / wavelength * std::f32::consts::TAU;
+                result.push(line(
+                    x,
+                    y + phase.sin() * thickness,
+                    (segment + thickness * 0.25).min(left + width - x),
+                ));
+                x += segment;
+            }
+            result
+        }
+    }
 }
 
 fn text_bounds(clip: LogicalClip, width: u32, height: u32, scale: f32) -> TextBounds {
@@ -3357,5 +3449,29 @@ mod tests {
                 bottom: 80
             }
         );
+    }
+
+    #[test]
+    fn text_decoration_styles_lower_to_bounded_line_segments() {
+        use whisker_protocol::TextDecorationStyle as Style;
+
+        assert_eq!(
+            text_decoration_rects(2.0, 20.0, 8.0, 2.0, Style::Solid).len(),
+            1
+        );
+        assert_eq!(
+            text_decoration_rects(2.0, 20.0, 8.0, 2.0, Style::Double).len(),
+            2
+        );
+        for style in [Style::Dotted, Style::Dashed, Style::Wavy] {
+            let segments = text_decoration_rects(2.0, 20.0, 8.0, 2.0, style);
+            assert!(!segments.is_empty());
+            assert!(segments.iter().all(|segment| {
+                segment.x >= 2.0
+                    && segment.x + segment.width <= 22.0
+                    && segment.width >= 0.0
+                    && segment.height == 2.0
+            }));
+        }
     }
 }

--- a/platforms/desktop/src/paint/box.rs
+++ b/platforms/desktop/src/paint/box.rs
@@ -48,6 +48,23 @@ impl BoxPrimitiveKind {
     }
 }
 
+/// Builds one axis-aligned solid fill used by non-box paint such as text decoration.
+pub(crate) fn solid_rect_primitive(rect: LayoutRect, color: [f32; 4]) -> BoxPrimitive {
+    BoxPrimitive {
+        outer_rect: rect,
+        outer_radii_x: [0.0; 4],
+        outer_radii_y: [0.0; 4],
+        inner_rect: rect,
+        inner_radii_x: [0.0; 4],
+        inner_radii_y: [0.0; 4],
+        border_widths: [0.0; 4],
+        color,
+        border_colors: [[0.0; 4]; 4],
+        border_styles: [0.0; 4],
+        kind: BoxPrimitiveKind::Fill,
+    }
+}
+
 /// Builds the quad used by a background image layer. The shader evaluates the
 /// gradient against its independently resolved positioning box.
 pub(crate) fn background_gradient_primitive(

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -545,9 +545,13 @@ impl DesktopScene {
                     }
                 }
                 Operation::SetText { node, content } => {
-                    if content.paint.decoration.lines.underline
-                        || content.paint.decoration.lines.overline
-                        || content.paint.decoration.lines.line_through
+                    if content.paint.decoration.lines.overline
+                        || (content.paint.decoration.lines.underline
+                            && content.paint.decoration.lines.line_through)
+                        || !matches!(
+                            content.paint.decoration.thickness,
+                            whisker_protocol::TextDecorationThickness::Auto
+                        )
                     {
                         return Err(DesktopPresentError::Unsupported("text-decoration"));
                     }

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -91,6 +91,41 @@ fn fixture_text_content(text: &whisker_host_conformance::TextFixture) -> TextCon
         },
         paint: TextPaint {
             foreground: color_protocol(&text.color),
+            decoration: text.decoration.as_ref().map_or_else(
+                whisker_protocol::TextDecoration::default,
+                |decoration| whisker_protocol::TextDecoration {
+                    lines: whisker_protocol::TextDecorationLines {
+                        underline: matches!(
+                            decoration.line,
+                            whisker_host_conformance::TextDecorationLineFixture::Underline
+                        ),
+                        overline: false,
+                        line_through: matches!(
+                            decoration.line,
+                            whisker_host_conformance::TextDecorationLineFixture::LineThrough
+                        ),
+                    },
+                    color: color_protocol(&decoration.color),
+                    style: match decoration.style {
+                        whisker_host_conformance::TextDecorationStyleFixture::Solid => {
+                            whisker_protocol::TextDecorationStyle::Solid
+                        }
+                        whisker_host_conformance::TextDecorationStyleFixture::Double => {
+                            whisker_protocol::TextDecorationStyle::Double
+                        }
+                        whisker_host_conformance::TextDecorationStyleFixture::Dotted => {
+                            whisker_protocol::TextDecorationStyle::Dotted
+                        }
+                        whisker_host_conformance::TextDecorationStyleFixture::Dashed => {
+                            whisker_protocol::TextDecorationStyle::Dashed
+                        }
+                        whisker_host_conformance::TextDecorationStyleFixture::Wavy => {
+                            whisker_protocol::TextDecorationStyle::Wavy
+                        }
+                    },
+                    thickness: whisker_protocol::TextDecorationThickness::Auto,
+                },
+            ),
             shadows: text
                 .shadow
                 .iter()
@@ -511,6 +546,8 @@ impl Driver {
                     assert!(name.starts_with("paint."), "unsupported Desktop checkpoint");
                     if name == "paint.text.shadow-single" {
                         self.assert_text_shadow();
+                    } else if name == "paint.text.decoration-lynx" {
+                        self.assert_text_decoration();
                     }
                     checkpoints.push(Checkpoint {
                         logical_size: [
@@ -883,6 +920,48 @@ impl Driver {
                 alpha: 0.75
             }
         );
+    }
+
+    fn assert_text_decoration(&self) {
+        let commands = self
+            .scene
+            .as_ref()
+            .expect("checkpoint follows attach")
+            .paint_commands();
+        let decorations = commands
+            .iter()
+            .filter_map(|command| match command {
+                PaintCommand::Text { content, .. } => Some(&content.paint.decoration),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(decorations.len(), 5);
+        assert!(decorations[0].lines.underline);
+        assert_eq!(
+            decorations[0].style,
+            whisker_protocol::TextDecorationStyle::Solid
+        );
+        assert!(decorations[1].lines.underline);
+        assert_eq!(
+            decorations[1].style,
+            whisker_protocol::TextDecorationStyle::Double
+        );
+        assert!(decorations[2].lines.underline);
+        assert_eq!(
+            decorations[2].style,
+            whisker_protocol::TextDecorationStyle::Dotted
+        );
+        assert!(decorations[3].lines.line_through);
+        assert_eq!(
+            decorations[3].style,
+            whisker_protocol::TextDecorationStyle::Dashed
+        );
+        assert!(decorations[4].lines.line_through);
+        assert_eq!(
+            decorations[4].style,
+            whisker_protocol::TextDecorationStyle::Wavy
+        );
+        assert_eq!(decorations[0].color, PaintColor::Named("red".into()));
     }
 
     fn clipped_box_primitives(&self) -> Vec<ClippedBoxPrimitive> {

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 16 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 17 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -130,7 +130,9 @@ typedef struct {
   uint8_t font_style, wrap; uint32_t max_lines; float line_height, letter_spacing;
   WhiskerMobileColor color;
   float shadow_offset_x, shadow_offset_y, shadow_blur_radius; uint32_t shadow_flags;
-  WhiskerMobileColor shadow_color; uint64_t prepared_content;
+  WhiskerMobileColor shadow_color;
+  uint32_t decoration_flags, decoration_style;
+  WhiskerMobileColor decoration_color; uint64_t prepared_content;
 } WhiskerMobileText;
 typedef struct {
   uint32_t tag, flags; uint64_t node, parent, child; uint32_t index, member;
@@ -201,6 +203,6 @@ _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 160, "WhiskerMobileMeasure
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceCommand) == 64, "WhiskerMobileResourceCommand ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceEvent) == 56, "WhiskerMobileResourceEvent ABI drift");
-_Static_assert(sizeof(WhiskerMobileText) == 128, "WhiskerMobileText ABI drift");
+_Static_assert(sizeof(WhiskerMobileText) == 168, "WhiskerMobileText ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 #endif

--- a/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
@@ -37,6 +37,39 @@ public final class WhiskerScrollContainerView: UIScrollView {
     }
 }
 
+/** Native text element with the Lynx single-line decoration contract. */
+public final class WhiskerTextLabel: UILabel {
+    public var whiskerDecoration: WhiskerTextDecoration? {
+        didSet { setNeedsDisplay() }
+    }
+
+    public override func drawText(in rect: CGRect) {
+        super.drawText(in: rect)
+        guard let decoration = whiskerDecoration, decoration.style == .wavy else { return }
+        let textRect = self.textRect(forBounds: rect, limitedToNumberOfLines: numberOfLines)
+        let width = min(textRect.width, sizeThatFits(textRect.size).width)
+        guard width > 0, let context = UIGraphicsGetCurrentContext() else { return }
+        let stroke = max(1, font.pointSize / 16)
+        let baseline = textRect.minY + font.ascender
+        let y = decoration.line == .underline
+            ? baseline + stroke * 1.5
+            : baseline - font.xHeight * 0.45
+        context.saveGState()
+        context.setStrokeColor(decoration.color.cgColor)
+        context.setLineWidth(stroke)
+        context.move(to: CGPoint(x: textRect.minX, y: y))
+        var x = textRect.minX
+        var up = true
+        while x < textRect.minX + width {
+            x = min(x + stroke * 2, textRect.minX + width)
+            context.addLine(to: CGPoint(x: x, y: y + (up ? -stroke : stroke)))
+            up.toggle()
+        }
+        context.strokePath()
+        context.restoreGState()
+    }
+}
+
 /** Hand-written iOS implementations matched to Rust registrations by name. */
 public enum WhiskerBuiltInElements {
     public static let viewName = "whisker.ui/View"
@@ -53,34 +86,50 @@ public enum WhiskerBuiltInElements {
         WhiskerElementFactory(
             name: textName,
             textUpdater: { view, content in
-                guard let label = view as? UILabel else {
-                    preconditionFailure("\(textName) factory must create UILabel")
+                guard let label = view as? WhiskerTextLabel else {
+                    preconditionFailure("\(textName) factory must create WhiskerTextLabel")
                 }
                 label.font = .systemFont(
                     ofSize: content.fontSize,
                     weight: content.fontWeight >= 600 ? .bold : .regular
                 )
                 label.textColor = content.color
+                label.whiskerDecoration = content.decoration
+                var attributes: [NSAttributedString.Key: Any] = [
+                    .font: label.font as Any,
+                    .foregroundColor: content.color,
+                ]
                 if let shadow = content.shadow {
                     let nativeShadow = NSShadow()
                     nativeShadow.shadowOffset = shadow.offset
                     nativeShadow.shadowBlurRadius = shadow.blurRadius
                     nativeShadow.shadowColor = shadow.color
-                    label.attributedText = NSAttributedString(
-                        string: content.value,
-                        attributes: [
-                            .font: label.font as Any,
-                            .foregroundColor: content.color,
-                            .shadow: nativeShadow,
-                        ]
-                    )
-                } else {
-                    label.attributedText = nil
-                    label.text = content.value
+                    attributes[.shadow] = nativeShadow
                 }
+                if let decoration = content.decoration, decoration.style != .wavy {
+                    let style: NSUnderlineStyle = switch decoration.style {
+                    case .solid: .single
+                    case .double: .double
+                    case .dotted: [.single, .patternDot]
+                    case .dashed: [.single, .patternDash]
+                    case .wavy: []
+                    }
+                    switch decoration.line {
+                    case .underline:
+                        attributes[.underlineStyle] = style.rawValue
+                        attributes[.underlineColor] = decoration.color
+                    case .lineThrough:
+                        attributes[.strikethroughStyle] = style.rawValue
+                        attributes[.strikethroughColor] = decoration.color
+                    }
+                }
+                label.attributedText = NSAttributedString(
+                    string: content.value,
+                    attributes: attributes
+                )
             }
         ) {
-            let label = UILabel(frame: .zero)
+            let label = WhiskerTextLabel(frame: .zero)
             label.numberOfLines = 0
             return label
         }

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
@@ -43,6 +43,7 @@ public struct WhiskerTextContent {
     public let fontSize: CGFloat
     public let fontWeight: Int
     public let color: UIColor
+    public let decoration: WhiskerTextDecoration?
     public let shadow: WhiskerTextShadow?
 
     public init(
@@ -50,15 +51,36 @@ public struct WhiskerTextContent {
         fontSize: CGFloat,
         fontWeight: Int,
         color: UIColor,
+        decoration: WhiskerTextDecoration? = nil,
         shadow: WhiskerTextShadow? = nil
     ) {
         self.value = value
         self.fontSize = fontSize
         self.fontWeight = fontWeight
         self.color = color
+        self.decoration = decoration
         self.shadow = shadow
     }
 }
+
+public struct WhiskerTextDecoration {
+    public let line: WhiskerTextDecorationLine
+    public let style: WhiskerTextDecorationStyle
+    public let color: UIColor
+
+    public init(
+        line: WhiskerTextDecorationLine,
+        style: WhiskerTextDecorationStyle,
+        color: UIColor
+    ) {
+        self.line = line
+        self.style = style
+        self.color = color
+    }
+}
+
+public enum WhiskerTextDecorationLine: Equatable { case underline, lineThrough }
+public enum WhiskerTextDecorationStyle: Equatable { case solid, double, dotted, dashed, wavy }
 
 public struct WhiskerTextShadow {
     public let offset: CGSize

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -128,8 +128,14 @@ final class HostScene {
             case UInt32(WHISKER_OP_MOVE):
                 guard stagedParents[operation.child] == operation.parent else { return false }
             case UInt32(WHISKER_OP_LAYOUT), UInt32(WHISKER_OP_PAINT),
-                 UInt32(WHISKER_OP_TEXT), UInt32(WHISKER_OP_PROPERTY):
+                 UInt32(WHISKER_OP_PROPERTY):
                 guard existing.contains(operation.node), operation.payload != nil else { return false }
+            case UInt32(WHISKER_OP_TEXT):
+                guard existing.contains(operation.node),
+                      let text = operation.payload?
+                        .assumingMemoryBound(to: WhiskerMobileText.self).pointee,
+                      text.decoration_flags <= 2,
+                      text.decoration_style <= 4 else { return false }
             case UInt32(WHISKER_OP_TRANSFORM):
                 guard existing.contains(operation.node), operation.payload != nil,
                       operation.payload_count == 16 else { return false }
@@ -505,6 +511,20 @@ final class HostScene {
             fontSize: CGFloat(content.font_size),
             fontWeight: Int(content.font_weight),
             color: parsePaintColor(content.color),
+            decoration: content.decoration_flags == 0 ? nil : WhiskerTextDecoration(
+                line: content.decoration_flags & 1 != 0 ? .underline : .lineThrough,
+                style: {
+                    switch content.decoration_style {
+                    case 0: return .solid
+                    case 1: return .double
+                    case 2: return .dotted
+                    case 3: return .dashed
+                    case 4: return .wavy
+                    default: preconditionFailure("invalid text decoration style")
+                    }
+                }(),
+                color: parsePaintColor(content.decoration_color)
+            ),
             shadow: content.shadow_flags == 0 ? nil : WhiskerTextShadow(
                 offset: CGSize(
                     width: CGFloat(content.shadow_offset_x),

--- a/platforms/web/src/paint/text.rs
+++ b/platforms/web/src/paint/text.rs
@@ -9,6 +9,31 @@ use crate::{WebError, px, set_style};
 pub(crate) fn apply(element: &web_sys::Element, content: &TextContent) -> Result<(), WebError> {
     apply_metrics_style(element, &content.payload)?;
     set_style(element, "color", &css_color(&content.paint.foreground))?;
+    let decoration = &content.paint.decoration;
+    let line = if decoration.lines.underline {
+        "underline"
+    } else if decoration.lines.line_through {
+        "line-through"
+    } else {
+        "none"
+    };
+    set_style(element, "text-decoration-line", line)?;
+    set_style(
+        element,
+        "text-decoration-style",
+        match decoration.style {
+            whisker_protocol::TextDecorationStyle::Solid => "solid",
+            whisker_protocol::TextDecorationStyle::Double => "double",
+            whisker_protocol::TextDecorationStyle::Dotted => "dotted",
+            whisker_protocol::TextDecorationStyle::Dashed => "dashed",
+            whisker_protocol::TextDecorationStyle::Wavy => "wavy",
+        },
+    )?;
+    set_style(
+        element,
+        "text-decoration-color",
+        &css_color(&decoration.color),
+    )?;
     set_style(
         element,
         "text-shadow",

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -97,9 +97,13 @@ impl DomFrameSink {
                 Operation::SetImage { .. } => Some("image-content"),
                 Operation::SetCursor { .. } => Some("cursor"),
                 Operation::SetText { content, .. }
-                    if content.paint.decoration.lines.underline
-                        || content.paint.decoration.lines.overline
-                        || content.paint.decoration.lines.line_through
+                    if content.paint.decoration.lines.overline
+                        || (content.paint.decoration.lines.underline
+                            && content.paint.decoration.lines.line_through)
+                        || !matches!(
+                            content.paint.decoration.thickness,
+                            whisker_protocol::TextDecorationThickness::Auto
+                        )
                         || content.paint.shadows.len() > 1 =>
                 {
                     Some("text-effects")

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -464,6 +464,8 @@ impl Driver {
                             name.as_str()
                         } else if name == "paint.text.shadow-single" {
                             "paint.text.shadow-single"
+                        } else if name == "paint.text.decoration-lynx" {
+                            "paint.text.decoration-lynx"
                         } else if name == "paint.visual-effects.image-rendering-pixelated" {
                             "paint.visual-effects.image-rendering-pixelated"
                         } else if self.resource_lifecycle {
@@ -884,6 +886,43 @@ impl Driver {
                     },
                 );
                 assert_style(&text_style, "text-shadow", &expected_shadow);
+                let expected_decoration = text.decoration.as_ref();
+                assert_style(
+                    &text_style,
+                    "text-decoration-line",
+                    expected_decoration.map_or("none", |decoration| match decoration.line {
+                        whisker_host_conformance::TextDecorationLineFixture::Underline => {
+                            "underline"
+                        }
+                        whisker_host_conformance::TextDecorationLineFixture::LineThrough => {
+                            "line-through"
+                        }
+                    }),
+                );
+                if let Some(decoration) = expected_decoration {
+                    assert_style(
+                        &text_style,
+                        "text-decoration-style",
+                        match decoration.style {
+                            whisker_host_conformance::TextDecorationStyleFixture::Solid => "solid",
+                            whisker_host_conformance::TextDecorationStyleFixture::Double => {
+                                "double"
+                            }
+                            whisker_host_conformance::TextDecorationStyleFixture::Dotted => {
+                                "dotted"
+                            }
+                            whisker_host_conformance::TextDecorationStyleFixture::Dashed => {
+                                "dashed"
+                            }
+                            whisker_host_conformance::TextDecorationStyleFixture::Wavy => "wavy",
+                        },
+                    );
+                    assert_style(
+                        &text_style,
+                        "text-decoration-color",
+                        &fixture_color_css(&decoration.color),
+                    );
+                }
             }
             let mut expected_shadows = fixture_node
                 .box_shadows
@@ -1406,6 +1445,9 @@ fn fixture(path: &str) -> &'static str {
         }
         "core/text-shadow-single.json" => {
             include_str!("../../../../tests/host-conformance/core/text-shadow-single.json")
+        }
+        "core/text-decoration-lynx.json" => {
+            include_str!("../../../../tests/host-conformance/core/text-decoration-lynx.json")
         }
         _ => panic!("manifest fixture is not embedded in the Web test: {path}"),
     }
@@ -2061,6 +2103,41 @@ fn fixture_text_content(text: &whisker_host_conformance::TextFixture) -> TextCon
         },
         paint: TextPaint {
             foreground: color(&text.color),
+            decoration: text.decoration.as_ref().map_or_else(
+                whisker_protocol::TextDecoration::default,
+                |decoration| whisker_protocol::TextDecoration {
+                    lines: whisker_protocol::TextDecorationLines {
+                        underline: matches!(
+                            decoration.line,
+                            whisker_host_conformance::TextDecorationLineFixture::Underline
+                        ),
+                        overline: false,
+                        line_through: matches!(
+                            decoration.line,
+                            whisker_host_conformance::TextDecorationLineFixture::LineThrough
+                        ),
+                    },
+                    color: color(&decoration.color),
+                    style: match decoration.style {
+                        whisker_host_conformance::TextDecorationStyleFixture::Solid => {
+                            whisker_protocol::TextDecorationStyle::Solid
+                        }
+                        whisker_host_conformance::TextDecorationStyleFixture::Double => {
+                            whisker_protocol::TextDecorationStyle::Double
+                        }
+                        whisker_host_conformance::TextDecorationStyleFixture::Dotted => {
+                            whisker_protocol::TextDecorationStyle::Dotted
+                        }
+                        whisker_host_conformance::TextDecorationStyleFixture::Dashed => {
+                            whisker_protocol::TextDecorationStyle::Dashed
+                        }
+                        whisker_host_conformance::TextDecorationStyleFixture::Wavy => {
+                            whisker_protocol::TextDecorationStyle::Wavy
+                        }
+                    },
+                    thickness: whisker_protocol::TextDecorationThickness::Auto,
+                },
+            ),
             shadows: text
                 .shadow
                 .iter()

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -159,8 +159,8 @@
       "id": "paint.text",
       "basis": "lynx-4.0",
       "properties": ["color", "font-family", "font-feature-settings", "font-optical-sizing", "font-size", "font-style", "font-variation-settings", "font-weight", "letter-spacing", "line-height", "text-align", "text-decoration", "text-indent", "text-overflow", "text-shadow", "white-space", "word-break"],
-      "supported_subset": ["basic-font-metrics-and-color", "single-text-shadow"],
-      "pending_subset": ["font-features-and-variations", "text-decoration", "alignment-indent-wrap-and-overflow"],
+      "supported_subset": ["basic-font-metrics-and-color", "single-text-shadow", "lynx-single-line-text-decoration"],
+      "pending_subset": ["font-features-and-variations", "alignment-indent-wrap-and-overflow"],
       "protocol": ["SetText"],
       "rust": "partial",
       "hosts": {"desktop": "partial", "web": "partial", "android": "partial", "ios": "partial"}

--- a/tests/host-conformance/core/text-decoration-lynx.json
+++ b/tests/host-conformance/core/text-decoration-lynx.json
@@ -1,0 +1,104 @@
+{
+  "schema": 1,
+  "id": "core.text-decoration-lynx",
+  "test": {
+    "commands": [
+      {
+        "type": "attach_surface",
+        "width": 260,
+        "height": 180,
+        "scale": 1
+      },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10, 10, 240, 28],
+            "background": { "kind": "named", "value": "transparent" },
+            "text": {
+              "value": "solid underline",
+              "font_size": 20,
+              "color": { "kind": "named", "value": "black" },
+              "decoration": {
+                "line": "underline",
+                "style": "solid",
+                "color": { "kind": "named", "value": "red" }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "parent": null,
+            "rect": [10, 42, 240, 28],
+            "background": { "kind": "named", "value": "transparent" },
+            "text": {
+              "value": "double underline",
+              "font_size": 20,
+              "color": { "kind": "named", "value": "black" },
+              "decoration": {
+                "line": "underline",
+                "style": "double",
+                "color": { "kind": "named", "value": "green" }
+              }
+            }
+          },
+          {
+            "id": 3,
+            "parent": null,
+            "rect": [10, 74, 240, 28],
+            "background": { "kind": "named", "value": "transparent" },
+            "text": {
+              "value": "dotted underline",
+              "font_size": 20,
+              "color": { "kind": "named", "value": "black" },
+              "decoration": {
+                "line": "underline",
+                "style": "dotted",
+                "color": { "kind": "named", "value": "blue" }
+              }
+            }
+          },
+          {
+            "id": 4,
+            "parent": null,
+            "rect": [10, 106, 240, 28],
+            "background": { "kind": "named", "value": "transparent" },
+            "text": {
+              "value": "dashed strike",
+              "font_size": 20,
+              "color": { "kind": "named", "value": "black" },
+              "decoration": {
+                "line": "line_through",
+                "style": "dashed",
+                "color": { "kind": "named", "value": "gold" }
+              }
+            }
+          },
+          {
+            "id": 5,
+            "parent": null,
+            "rect": [10, 138, 240, 28],
+            "background": { "kind": "named", "value": "transparent" },
+            "text": {
+              "value": "wavy strike",
+              "font_size": 20,
+              "color": { "kind": "named", "value": "black" },
+              "decoration": {
+                "line": "line_through",
+                "style": "wavy",
+                "color": { "kind": "named", "value": "aqua" }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.text.decoration-lynx"
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -500,6 +500,13 @@
       "checkpoints": ["semantic-projection"]
     },
     {
+      "id": "core.text-decoration-lynx",
+      "feature": "text-decoration-lynx",
+      "fixture": "core/text-decoration-lynx.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection"]
+    },
+    {
       "id": "host.measure.text.basic",
       "feature": "text-measurement",
       "fixture": "core/text-measure-basic.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -272,6 +272,17 @@ private class Driver(
                         check(text.shadowDy == 4f * context.resources.displayMetrics.density)
                         check(text.shadowRadius == 2f * context.resources.displayMetrics.density)
                     }
+                    if (command.getString("name") == "paint.text.decoration-lynx") {
+                        val texts = findTextViews(view)
+                        check(texts.size == 5)
+                        check(texts[0].whiskerDecoration?.style == WhiskerTextDecorationStyle.SOLID)
+                        check(texts[1].whiskerDecoration?.style == WhiskerTextDecorationStyle.DOUBLE)
+                        check(texts[2].whiskerDecoration?.style == WhiskerTextDecorationStyle.DOTTED)
+                        check(texts[3].whiskerDecoration?.style == WhiskerTextDecorationStyle.DASHED)
+                        check(texts[4].whiskerDecoration?.style == WhiskerTextDecorationStyle.WAVY)
+                        check(texts[0].whiskerDecoration?.line == WhiskerTextDecorationLine.UNDERLINE)
+                        check(texts[4].whiskerDecoration?.line == WhiskerTextDecorationLine.LINE_THROUGH)
+                    }
                     check(
                         command.getString("name") == "paint.box" ||
                             command.getString("name") == "paint.background-layers.linear-gradient" ||
@@ -350,7 +361,8 @@ private class Driver(
                             "paint.transform.motion-path-inset" ||
                             command.getString("name") ==
                             "paint.transform.motion-path-arcs" ||
-                            command.getString("name") == "paint.text.shadow-single",
+                            command.getString("name") == "paint.text.shadow-single" ||
+                            command.getString("name") == "paint.text.decoration-lynx",
                     )
                     checkpoint = capture()
                     command.optJSONArray("samples")?.let { samples ->
@@ -548,8 +560,8 @@ private class Driver(
             val (numbers, names) = paint(node)
             check(stage(tag = 7, node = id, numbers = numbers, names = names))
             node.optJSONObject("text")?.let { text ->
-                val textNumbers = ArrayList<Float>(17)
-                val textNames = ArrayList<String>(2)
+                val textNumbers = ArrayList<Float>(24)
+                val textNames = ArrayList<String>(3)
                 textNumbers += text.getDouble("font_size").toFloat()
                 textNumbers += text.optInt("font_weight", 400).toFloat()
                 textNumbers += 0f
@@ -562,6 +574,25 @@ private class Driver(
                 textNumbers += shadow?.getDouble("blur_radius")?.toFloat() ?: 0f
                 appendColor(
                     shadow?.getJSONObject("color")
+                        ?: JSONObject("{\"kind\":\"srgba\",\"red\":0,\"green\":0,\"blue\":0,\"alpha\":0}"),
+                    textNumbers,
+                    textNames,
+                )
+                val decoration = text.optJSONObject("decoration")
+                textNumbers += when (decoration?.getString("line")) {
+                    "underline" -> 1f
+                    "line_through" -> 2f
+                    else -> 0f
+                }
+                textNumbers += when (decoration?.getString("style")) {
+                    "double" -> 1f
+                    "dotted" -> 2f
+                    "dashed" -> 3f
+                    "wavy" -> 4f
+                    else -> 0f
+                }
+                appendColor(
+                    decoration?.getJSONObject("color")
                         ?: JSONObject("{\"kind\":\"srgba\",\"red\":0,\"green\":0,\"blue\":0,\"alpha\":0}"),
                     textNumbers,
                     textNames,
@@ -1049,6 +1080,18 @@ private fun findTextView(view: android.view.View): TextView? {
         }
     }
     return null
+}
+
+private fun findTextViews(view: android.view.View): List<WhiskerTextView> {
+    val result = ArrayList<WhiskerTextView>()
+    fun visit(candidate: android.view.View) {
+        if (candidate is WhiskerTextView) result += candidate
+        if (candidate is ViewGroup) {
+            for (index in 0 until candidate.childCount) visit(candidate.getChildAt(index))
+        }
+    }
+    visit(view)
+    return result
 }
 
 private fun JSONArray.objects(): Sequence<JSONObject> =

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -463,7 +463,8 @@ private final class Driver {
                     name == "paint.transform.motion-path-ellipses" ||
                     name == "paint.transform.motion-path-inset" ||
                     name == "paint.transform.motion-path-arcs" ||
-                    name == "paint.text.shadow-single" else {
+                    name == "paint.text.shadow-single" ||
+                    name == "paint.text.decoration-lynx" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
                 if name == "paint.visual-effects.backdrop-blur" {
@@ -487,6 +488,17 @@ private final class Driver {
                     )
                     XCTAssertEqual(shadow.shadowOffset, CGSize(width: 3, height: 4))
                     XCTAssertEqual(shadow.shadowBlurRadius, 2)
+                }
+                if name == "paint.text.decoration-lynx" {
+                    let labels = findTextLabels(view)
+                    XCTAssertEqual(labels.count, 5)
+                    XCTAssertEqual(labels[0].whiskerDecoration?.style, .solid)
+                    XCTAssertEqual(labels[1].whiskerDecoration?.style, .double)
+                    XCTAssertEqual(labels[2].whiskerDecoration?.style, .dotted)
+                    XCTAssertEqual(labels[3].whiskerDecoration?.style, .dashed)
+                    XCTAssertEqual(labels[4].whiskerDecoration?.style, .wavy)
+                    XCTAssertEqual(labels[0].whiskerDecoration?.line, .underline)
+                    XCTAssertEqual(labels[4].whiskerDecoration?.line, .lineThrough)
                 }
                 let pixels = try capture()
                 checkpoint = pixels
@@ -691,6 +703,9 @@ private final class Driver {
                     payload.shadow_blur_radius = text.shadowBlurRadius
                     payload.shadow_color = text.shadowColor
                 }
+                payload.decoration_flags = text.decorationFlags
+                payload.decoration_style = text.decorationStyle
+                payload.decoration_color = text.decorationColor
             }
             textPayloads.advanced(by: index).initialize(to: payload)
         }
@@ -1246,6 +1261,9 @@ private struct SceneText {
     let fontSize: Float
     let fontWeight: UInt16
     let color: WhiskerMobileColor
+    let decorationFlags: UInt32
+    let decorationStyle: UInt32
+    let decorationColor: WhiskerMobileColor
     let shadowOffset: CGSize?
     let shadowBlurRadius: Float
     let shadowColor: WhiskerMobileColor
@@ -1427,12 +1445,32 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
     let text: SceneText?
     if let raw = fixture["text"] as? [String: Any] {
         let shadow = raw["shadow"] as? [String: Any]
+        let decoration = raw["decoration"] as? [String: Any]
         let offset = try shadow.map { try numberArray($0, "offset") }
         text = SceneText(
             value: try string(raw, "value"),
             fontSize: Float(try number(raw, "font_size")),
             fontWeight: UInt16((raw["font_weight"] as? NSNumber)?.intValue ?? 400),
             color: try color(object(raw, "color")),
+            decorationFlags: try decoration.map {
+                switch try string($0, "line") {
+                case "underline": 1
+                case "line_through": 2
+                default: throw Failure("unknown text decoration line")
+                }
+            } ?? 0,
+            decorationStyle: try decoration.map {
+                switch try string($0, "style") {
+                case "solid": 0
+                case "double": 1
+                case "dotted": 2
+                case "dashed": 3
+                case "wavy": 4
+                default: throw Failure("unknown text decoration style")
+                }
+            } ?? 0,
+            decorationColor: try decoration.map { try color(object($0, "color")) }
+                ?? WhiskerMobileColor(),
             shadowOffset: offset.map { CGSize(width: $0[0], height: $0[1]) },
             shadowBlurRadius: Float(try shadow.map { try number($0, "blur_radius") } ?? 0),
             shadowColor: try shadow.map { try color(object($0, "color")) }
@@ -1970,6 +2008,12 @@ private func containsActiveBackdropBlur(_ view: UIView) -> Bool {
 private func findLabel(_ view: UIView) -> UILabel? {
     if let label = view as? UILabel { return label }
     return view.subviews.lazy.compactMap(findLabel).first
+}
+
+private func findTextLabels(_ view: UIView) -> [WhiskerTextLabel] {
+    var result = view.subviews.flatMap(findTextLabels)
+    if let label = view as? WhiskerTextLabel { result.insert(label, at: 0) }
+    return result
 }
 
 private func containsProjectiveTransform(_ view: UIView) -> Bool {

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -176,7 +176,18 @@
         "font_size": { "type": "number", "exclusiveMinimum": 0 },
         "font_weight": { "type": "integer", "minimum": 1, "maximum": 1000 },
         "color": { "$ref": "#/$defs/color" },
+        "decoration": { "$ref": "#/$defs/textDecoration" },
         "shadow": { "$ref": "#/$defs/textShadow" }
+      }
+    },
+    "textDecoration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["line", "style", "color"],
+      "properties": {
+        "line": { "enum": ["underline", "line_through"] },
+        "style": { "enum": ["solid", "double", "dotted", "dashed", "wavy"] },
+        "color": { "$ref": "#/$defs/color" }
       }
     },
     "textShadow": {


### PR DESCRIPTION
## Summary
- add a shared Lynx-compatible text-decoration fixture covering underline/line-through and solid/double/dotted/dashed/wavy styles
- resolve inherited single-line text decoration into SetText without changing intrinsic measurement keys
- render and validate decoration consistently in Web, desktop/WGPU, Android, and iOS hosts
- extend the zero-copy mobile ABI to carry decoration line, style, and color
- mark the text-decoration subset implemented in capabilities.json

## Supported subset
Lynx 4.0 semantics: one decoration line (`none`, `underline`, or `line-through`), five line styles, and explicit/current text color. CSS multiple-line decorations, `overline`, and non-auto thickness remain outside this subset.

## Verification
- cargo test -p whisker-style -p whisker-css -p whisker-engine -p whisker-host-conformance -p whisker-driver --lib
- cargo check -p whisker --target aarch64-apple-ios-sim
- cargo clippy -p whisker-style -p whisker-css -p whisker-engine -p whisker-driver -p whisker-desktop --all-targets -- -D warnings
- cargo llvm-cov -p whisker-style --summary-only --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100
- cargo llvm-cov -p whisker-engine --summary-only --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo xtask host-conformance android
- cargo xtask host-conformance ios