### PR TITLE
feat(motion): type animation and transition declarations

### DIFF
--- a/crates/whisker-css/src/prop/animation.rs
+++ b/crates/whisker-css/src/prop/animation.rs
@@ -6,6 +6,8 @@ use crate::data_type_ext::EasingFunction;
 use crate::keyword::{
     AnimationDirection, AnimationFillMode, AnimationIterationCount, AnimationPlayState,
 };
+use crate::style_value::{to_motion_easing, to_motion_time};
+use crate::to_css::ToCss;
 
 impl Css {
     /// Sets `animation-name` — references a `@keyframes` block.
@@ -13,9 +15,10 @@ impl Css {
     pub fn animation_name(self, name: impl Into<String>) -> Self {
         // Names are CSS identifiers, written bare.
         let name = name.into();
+        let semantic = (name != "none").then_some(name.clone());
         self.push_semantic(
             crate::StyleProperty::AnimationName,
-            whisker_style::StyleValue::Text(name.clone()),
+            whisker_style::StyleValue::AnimationNames(vec![semantic]),
             name,
         )
     }
@@ -23,43 +26,55 @@ impl Css {
     /// Sets `animation-duration`.
     /// <https://lynxjs.org/api/css/properties/animation-duration>
     pub fn animation_duration(self, v: Time) -> Self {
-        self.push(crate::StyleProperty::AnimationDuration, v)
+        self.push_semantic(
+            crate::StyleProperty::AnimationDuration,
+            whisker_style::StyleValue::AnimationDurations(vec![to_motion_time(v)]),
+            v.to_css_string(),
+        )
     }
 
     /// Sets `animation-timing-function`.
     /// <https://lynxjs.org/api/css/properties/animation-timing-function>
     pub fn animation_timing_function(self, v: EasingFunction) -> Self {
-        self.push(crate::StyleProperty::AnimationTimingFunction, v)
+        self.push_semantic(
+            crate::StyleProperty::AnimationTimingFunction,
+            whisker_style::StyleValue::AnimationEasings(vec![to_motion_easing(v)]),
+            v.to_css_string(),
+        )
     }
 
     /// Sets `animation-delay`.
     /// <https://lynxjs.org/api/css/properties/animation-delay>
     pub fn animation_delay(self, v: Time) -> Self {
-        self.push(crate::StyleProperty::AnimationDelay, v)
+        self.push_semantic(
+            crate::StyleProperty::AnimationDelay,
+            whisker_style::StyleValue::AnimationDelays(vec![to_motion_time(v)]),
+            v.to_css_string(),
+        )
     }
 
     /// Sets `animation-iteration-count`.
     /// <https://lynxjs.org/api/css/properties/animation-iteration-count>
     pub fn animation_iteration_count(self, v: AnimationIterationCount) -> Self {
-        self.push(crate::StyleProperty::AnimationIterationCount, v)
+        self.push_typed(crate::StyleProperty::AnimationIterationCount, v)
     }
 
     /// Sets `animation-direction`.
     /// <https://lynxjs.org/api/css/properties/animation-direction>
     pub fn animation_direction(self, v: AnimationDirection) -> Self {
-        self.push(crate::StyleProperty::AnimationDirection, v)
+        self.push_typed(crate::StyleProperty::AnimationDirection, v)
     }
 
     /// Sets `animation-fill-mode`.
     /// <https://lynxjs.org/api/css/properties/animation-fill-mode>
     pub fn animation_fill_mode(self, v: AnimationFillMode) -> Self {
-        self.push(crate::StyleProperty::AnimationFillMode, v)
+        self.push_typed(crate::StyleProperty::AnimationFillMode, v)
     }
 
     /// Sets `animation-play-state`.
     /// <https://lynxjs.org/api/css/properties/animation-play-state>
     pub fn animation_play_state(self, v: AnimationPlayState) -> Self {
-        self.push(crate::StyleProperty::AnimationPlayState, v)
+        self.push_typed(crate::StyleProperty::AnimationPlayState, v)
     }
 }
 

--- a/crates/whisker-css/src/prop/transition.rs
+++ b/crates/whisker-css/src/prop/transition.rs
@@ -4,6 +4,8 @@ use crate::css::Css;
 use crate::data_type::Time;
 use crate::data_type_ext::EasingFunction;
 use crate::keyword::TransitionPropertyKind;
+use crate::style_value::{to_motion_easing, to_motion_time};
+use crate::to_css::ToCss;
 
 impl Css {
     /// Sets `transition-property` — the property to transition.
@@ -15,20 +17,32 @@ impl Css {
     /// Sets `transition-duration`.
     /// <https://lynxjs.org/api/css/properties/transition-duration>
     pub fn transition_duration(self, v: Time) -> Self {
-        self.push(crate::StyleProperty::TransitionDuration, v)
+        self.push_semantic(
+            crate::StyleProperty::TransitionDuration,
+            whisker_style::StyleValue::TransitionDurations(vec![to_motion_time(v)]),
+            v.to_css_string(),
+        )
     }
 
     /// Sets `transition-timing-function`.
     /// <https://lynxjs.org/api/css/properties/transition-timing-function>
     pub fn transition_timing_function(self, v: EasingFunction) -> Self {
-        self.push(crate::StyleProperty::TransitionTimingFunction, v)
+        self.push_semantic(
+            crate::StyleProperty::TransitionTimingFunction,
+            whisker_style::StyleValue::TransitionEasings(vec![to_motion_easing(v)]),
+            v.to_css_string(),
+        )
     }
 
     /// Sets `transition-delay`. Negative delays cause the transition
     /// to begin partway through its progression.
     /// <https://lynxjs.org/api/css/properties/transition-delay>
     pub fn transition_delay(self, v: Time) -> Self {
-        self.push(crate::StyleProperty::TransitionDelay, v)
+        self.push_semantic(
+            crate::StyleProperty::TransitionDelay,
+            whisker_style::StyleValue::TransitionDelays(vec![to_motion_time(v)]),
+            v.to_css_string(),
+        )
     }
 }
 

--- a/crates/whisker-css/src/shorthand/animation.rs
+++ b/crates/whisker-css/src/shorthand/animation.rs
@@ -9,6 +9,7 @@ use crate::data_type_ext::EasingFunction;
 use crate::keyword::{
     AnimationDirection, AnimationFillMode, AnimationIterationCount, AnimationPlayState,
 };
+use crate::style_value::to_animation_value;
 use crate::to_css::ToCss;
 
 /// One animation layer.
@@ -131,20 +132,31 @@ impl Css {
     /// Sets the `animation` shorthand for a single animation.
     /// <https://lynxjs.org/api/css/properties/animation>
     pub fn animation(self, a: Animation) -> Self {
-        self.push(crate::StyleProperty::Animation, a)
+        let lynx = a.to_css_string();
+        self.push_semantic(
+            crate::StyleProperty::Animation,
+            whisker_style::StyleValue::Animations(vec![to_animation_value(&a)]),
+            lynx,
+        )
     }
 
     /// Sets the `animation` shorthand for multiple comma-separated
     /// animations.
     pub fn animations(self, anims: impl IntoIterator<Item = Animation>) -> Self {
+        let anims = anims.into_iter().collect::<Vec<_>>();
         let mut s = String::new();
-        for (i, a) in anims.into_iter().enumerate() {
+        for (i, a) in anims.iter().enumerate() {
             if i > 0 {
                 s.push_str(", ");
             }
             let _ = a.to_css(&mut s);
         }
-        self.push_raw(crate::StyleProperty::Animation, s)
+        let semantic = anims.iter().map(to_animation_value).collect();
+        self.push_semantic(
+            crate::StyleProperty::Animation,
+            whisker_style::StyleValue::Animations(semantic),
+            s,
+        )
     }
 }
 
@@ -188,5 +200,20 @@ mod tests {
             Animation::new("slide").duration(500.ms()).delay(100.ms()),
         ]);
         assert_eq!(s.to_string(), "animation: fade 300ms, slide 500ms 100ms;");
+        let resolved = whisker_style::resolve_style(
+            &s.to_specified_style().unwrap(),
+            None,
+            whisker_style::StyleEnvironment::default(),
+        )
+        .unwrap();
+        assert_eq!(resolved.computed().motion().animations.len(), 2);
+        assert_eq!(
+            resolved.computed().motion().animations[1].name.as_deref(),
+            Some("slide")
+        );
+        assert_eq!(
+            resolved.computed().motion().animations[1].delay.get(),
+            100.0
+        );
     }
 }

--- a/crates/whisker-css/src/shorthand/transition.rs
+++ b/crates/whisker-css/src/shorthand/transition.rs
@@ -7,6 +7,7 @@ use crate::css::Css;
 use crate::data_type::Time;
 use crate::data_type_ext::EasingFunction;
 use crate::keyword::TransitionPropertyKind;
+use crate::style_value::to_transition_value;
 use crate::to_css::ToCss;
 
 /// One transition layer.
@@ -75,20 +76,31 @@ impl Css {
     /// Sets the `transition` shorthand for a single transition.
     /// <https://lynxjs.org/api/css/properties/transition>
     pub fn transition(self, t: Transition) -> Self {
-        self.push(crate::StyleProperty::Transition, t)
+        let lynx = t.to_css_string();
+        self.push_semantic(
+            crate::StyleProperty::Transition,
+            whisker_style::StyleValue::Transitions(vec![to_transition_value(&t)]),
+            lynx,
+        )
     }
 
     /// Sets the `transition` shorthand for multiple comma-separated
     /// transitions.
     pub fn transitions(self, ts: impl IntoIterator<Item = Transition>) -> Self {
+        let ts = ts.into_iter().collect::<Vec<_>>();
         let mut s = String::new();
-        for (i, t) in ts.into_iter().enumerate() {
+        for (i, t) in ts.iter().enumerate() {
             if i > 0 {
                 s.push_str(", ");
             }
             let _ = t.to_css(&mut s);
         }
-        self.push_raw(crate::StyleProperty::Transition, s)
+        let semantic = ts.iter().map(to_transition_value).collect();
+        self.push_semantic(
+            crate::StyleProperty::Transition,
+            whisker_style::StyleValue::Transitions(semantic),
+            s,
+        )
     }
 }
 
@@ -132,6 +144,23 @@ mod tests {
         assert_eq!(
             s.to_string(),
             "transition: opacity 300ms, transform 500ms 100ms;"
+        );
+        let resolved = whisker_style::resolve_style(
+            &s.to_specified_style().unwrap(),
+            None,
+            whisker_style::StyleEnvironment::default(),
+        )
+        .unwrap();
+        assert_eq!(resolved.computed().motion().transitions.len(), 2);
+        assert_eq!(
+            resolved.computed().motion().transitions[1].property,
+            whisker_style::ComputedTransitionProperty::Property(
+                whisker_style::StyleProperty::Transform
+            )
+        );
+        assert_eq!(
+            resolved.computed().motion().transitions[1].duration.get(),
+            500.0
         );
     }
 }

--- a/crates/whisker-css/src/style_value.rs
+++ b/crates/whisker-css/src/style_value.rs
@@ -1,33 +1,189 @@
 //! Conversion from the compatibility authoring types to semantic style values.
 
 use whisker_style::{
-    AlignContentValue, AlignItemsValue, AlignSelfValue, BackdropFilterValue, BorderRadiusValue,
-    BorderStyleValue, BoxSizingValue, CalcExpression, ClearValue, ColorValue, CursorValue,
-    DirectionValue, DisplayValue, FlexBasisValue, FlexDirectionValue, FlexWrapValue, FloatValue,
-    FontStyleValue, FontWeightValue, GridAutoFlowValue, GridMaxTrackSizingValue,
+    AlignContentValue, AlignItemsValue, AlignSelfValue, AnimationValue, BackdropFilterValue,
+    BorderRadiusValue, BorderStyleValue, BoxSizingValue, CalcExpression, ClearValue, ColorValue,
+    CursorValue, DirectionValue, DisplayValue, FlexBasisValue, FlexDirectionValue, FlexWrapValue,
+    FloatValue, FontStyleValue, FontWeightValue, GridAutoFlowValue, GridMaxTrackSizingValue,
     GridMinTrackSizingValue, GridPlacementValue, GridRepetitionCountValue, GridTemplateAreaValue,
     GridTemplateAreasValue, GridTemplateComponentValue, GridTemplateRepetitionValue,
     GridTemplateValue, GridTrackSizingValue, ImageRenderingValue, InsetPathValue,
     JustifyContentValue, LengthPercentageAutoValue, LengthPercentageValue, LengthUnit, LengthValue,
-    LineHeightValue, MotionPathCommandValue, MotionPathPointValue, OffsetPathValue,
-    OffsetRotateValue, PointerEventsValue, PositionValue, SizeValue, StyleNumber, StyleValue,
-    TransformFunctionValue, TransformOriginValue, TransformValue,
+    LineHeightValue, MotionDirection, MotionEasing, MotionFillMode, MotionIterationCount,
+    MotionPathCommandValue, MotionPathPointValue, MotionPlayState, MotionStepPosition, MotionTime,
+    OffsetPathValue, OffsetRotateValue, PointerEventsValue, PositionValue, SizeValue, StyleNumber,
+    StyleValue, TransformFunctionValue, TransformOriginValue, TransformValue,
+    TransitionPropertyValue, TransitionValue,
 };
 
-use crate::data_type_ext::PositionKeyword;
+use crate::data_type_ext::{PositionKeyword, StepPosition};
 use crate::{
-    AlignContent, AlignItems, AlignSelf, Angle, BackdropFilter, BoxSizing, CalcExpr, Clear, Color,
-    CssString, Cursor, Direction, Display, FlexBasis, FlexDirection, FlexWrap, Float, FontStyle,
-    FontWeight, GridAutoFlow, GridLine, GridRepeatCount, GridTemplate, GridTemplateAreas,
-    GridTemplateComponent, GridTrack, GridTrackMax, GridTrackMin, ImageRendering, Integer,
-    JustifyContent, Length, LengthPercentage, LineHeight, MarginValue, MotionPathCommand, Number,
-    OffsetDistance, OffsetPath, OffsetRotate, Overflow, Percentage, PointerEvents, Position,
-    PositionKind, Size, Transform, TransformFn, Visibility,
+    AlignContent, AlignItems, AlignSelf, Angle, Animation, AnimationDirection, AnimationFillMode,
+    AnimationIterationCount, AnimationPlayState, BackdropFilter, BoxSizing, CalcExpr, Clear, Color,
+    CssString, Cursor, Direction, Display, EasingFunction, FlexBasis, FlexDirection, FlexWrap,
+    Float, FontStyle, FontWeight, GridAutoFlow, GridLine, GridRepeatCount, GridTemplate,
+    GridTemplateAreas, GridTemplateComponent, GridTrack, GridTrackMax, GridTrackMin,
+    ImageRendering, Integer, JustifyContent, Length, LengthPercentage, LineHeight, MarginValue,
+    MotionPathCommand, Number, OffsetDistance, OffsetPath, OffsetRotate, Overflow, Percentage,
+    PointerEvents, Position, PositionKind, Size, Time, Transform, TransformFn, Transition,
+    TransitionPropertyKind, Visibility,
 };
 use whisker_style::{OverflowValue, VisibilityValue};
 
 pub(crate) trait ToStyleValue {
     fn to_style_value(&self) -> StyleValue;
+}
+
+pub(crate) fn to_motion_time(value: Time) -> MotionTime {
+    match value {
+        Time::S(value) => MotionTime::milliseconds(value * 1_000.0),
+        Time::Ms(value) => MotionTime::milliseconds(value),
+    }
+}
+
+pub(crate) fn to_motion_easing(value: EasingFunction) -> MotionEasing {
+    match value {
+        EasingFunction::Linear => MotionEasing::Linear,
+        EasingFunction::Ease => MotionEasing::Ease,
+        EasingFunction::EaseIn => MotionEasing::EaseIn,
+        EasingFunction::EaseOut => MotionEasing::EaseOut,
+        EasingFunction::EaseInOut => MotionEasing::EaseInOut,
+        EasingFunction::StepStart => MotionEasing::Steps {
+            count: 1,
+            position: MotionStepPosition::JumpStart,
+        },
+        EasingFunction::StepEnd => MotionEasing::Steps {
+            count: 1,
+            position: MotionStepPosition::JumpEnd,
+        },
+        EasingFunction::CubicBezier(x1, y1, x2, y2) => MotionEasing::CubicBezier([
+            StyleNumber::new(x1),
+            StyleNumber::new(y1),
+            StyleNumber::new(x2),
+            StyleNumber::new(y2),
+        ]),
+        EasingFunction::Steps(count, position) => MotionEasing::Steps {
+            count,
+            position: match position {
+                StepPosition::JumpStart | StepPosition::Start => MotionStepPosition::JumpStart,
+                StepPosition::JumpEnd | StepPosition::End => MotionStepPosition::JumpEnd,
+                StepPosition::JumpNone => MotionStepPosition::JumpNone,
+                StepPosition::JumpBoth => MotionStepPosition::JumpBoth,
+            },
+        },
+    }
+}
+
+pub(crate) fn to_transition_property(value: &TransitionPropertyKind) -> TransitionPropertyValue {
+    match value {
+        TransitionPropertyKind::All => TransitionPropertyValue::All,
+        TransitionPropertyKind::None => TransitionPropertyValue::None,
+        TransitionPropertyKind::Name(name) => {
+            TransitionPropertyValue::Named(name.as_str().to_owned())
+        }
+    }
+}
+
+pub(crate) fn to_motion_direction(value: AnimationDirection) -> MotionDirection {
+    match value {
+        AnimationDirection::Normal => MotionDirection::Normal,
+        AnimationDirection::Reverse => MotionDirection::Reverse,
+        AnimationDirection::Alternate => MotionDirection::Alternate,
+        AnimationDirection::AlternateReverse => MotionDirection::AlternateReverse,
+    }
+}
+
+pub(crate) fn to_motion_fill(value: AnimationFillMode) -> MotionFillMode {
+    match value {
+        AnimationFillMode::None => MotionFillMode::None,
+        AnimationFillMode::Forwards => MotionFillMode::Forwards,
+        AnimationFillMode::Backwards => MotionFillMode::Backwards,
+        AnimationFillMode::Both => MotionFillMode::Both,
+    }
+}
+
+pub(crate) fn to_motion_iterations(value: AnimationIterationCount) -> MotionIterationCount {
+    match value {
+        AnimationIterationCount::Infinite => MotionIterationCount::Infinite,
+        AnimationIterationCount::Count(value) => {
+            MotionIterationCount::Count(StyleNumber::new(value))
+        }
+    }
+}
+
+pub(crate) fn to_motion_play_state(value: AnimationPlayState) -> MotionPlayState {
+    match value {
+        AnimationPlayState::Running => MotionPlayState::Running,
+        AnimationPlayState::Paused => MotionPlayState::Paused,
+    }
+}
+
+pub(crate) fn to_transition_value(value: &Transition) -> TransitionValue {
+    TransitionValue {
+        property: to_transition_property(&value.property),
+        duration: value
+            .duration
+            .map_or_else(MotionTime::default, to_motion_time),
+        easing: value
+            .timing
+            .map_or_else(MotionEasing::default, to_motion_easing),
+        delay: value.delay.map_or_else(MotionTime::default, to_motion_time),
+    }
+}
+
+pub(crate) fn to_animation_value(value: &Animation) -> AnimationValue {
+    AnimationValue {
+        name: (value.name != "none").then(|| value.name.clone()),
+        duration: value
+            .duration
+            .map_or_else(MotionTime::default, to_motion_time),
+        easing: value
+            .timing
+            .map_or_else(MotionEasing::default, to_motion_easing),
+        delay: value.delay.map_or_else(MotionTime::default, to_motion_time),
+        iteration_count: value
+            .iteration_count
+            .map_or_else(MotionIterationCount::default, to_motion_iterations),
+        direction: value
+            .direction
+            .map_or_else(MotionDirection::default, to_motion_direction),
+        fill_mode: value
+            .fill_mode
+            .map_or_else(MotionFillMode::default, to_motion_fill),
+        play_state: value
+            .play_state
+            .map_or_else(MotionPlayState::default, to_motion_play_state),
+    }
+}
+
+impl ToStyleValue for TransitionPropertyKind {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::TransitionProperties(vec![to_transition_property(self)])
+    }
+}
+
+impl ToStyleValue for AnimationDirection {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::AnimationDirections(vec![to_motion_direction(*self)])
+    }
+}
+
+impl ToStyleValue for AnimationFillMode {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::AnimationFillModes(vec![to_motion_fill(*self)])
+    }
+}
+
+impl ToStyleValue for AnimationIterationCount {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::AnimationIterationCounts(vec![to_motion_iterations(*self)])
+    }
+}
+
+impl ToStyleValue for AnimationPlayState {
+    fn to_style_value(&self) -> StyleValue {
+        StyleValue::AnimationPlayStates(vec![to_motion_play_state(*self)])
+    }
 }
 
 impl ToStyleValue for Length {

--- a/crates/whisker-style/src/lib.rs
+++ b/crates/whisker-style/src/lib.rs
@@ -10,6 +10,7 @@
 mod declaration;
 mod layout;
 mod layout_value;
+mod motion;
 mod paint;
 mod property;
 mod resolution;
@@ -30,6 +31,11 @@ pub use layout_value::{
     FloatValue, GridMaxTrackSizingValue, GridMinTrackSizingValue, GridTemplateComponentValue,
     GridTemplateRepetitionValue, GridTemplateValue, GridTrackSizingValue, JustifyContentValue,
     LengthPercentageAutoValue, PositionValue, SizeValue,
+};
+pub use motion::{
+    AnimationValue, ComputedMotionStyle, ComputedTransition, ComputedTransitionProperty,
+    MotionDirection, MotionEasing, MotionFillMode, MotionIterationCount, MotionPlayState,
+    MotionStepPosition, MotionTime, TransitionPropertyValue, TransitionValue,
 };
 pub use paint::{
     BorderStyleValue, ComputedBackgroundImage, ComputedBackgroundLayerStyle,

--- a/crates/whisker-style/src/motion.rs
+++ b/crates/whisker-style/src/motion.rs
@@ -1,0 +1,592 @@
+//! Host-independent transition and keyframe-animation declarations.
+
+use crate::{SpecifiedStyle, StyleNumber, StyleProperty, StyleResolutionError, StyleValue};
+
+/// A CSS time normalized to milliseconds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MotionTime(pub StyleNumber);
+
+impl Default for MotionTime {
+    fn default() -> Self {
+        Self::milliseconds(0.0)
+    }
+}
+
+impl MotionTime {
+    /// Creates a millisecond value.
+    pub const fn milliseconds(value: f32) -> Self {
+        Self(StyleNumber::new(value))
+    }
+
+    /// Returns the normalized millisecond value.
+    pub const fn get(self) -> f32 {
+        self.0.get()
+    }
+}
+
+/// Jump placement for a discrete timing function.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MotionStepPosition {
+    /// Jump at the beginning of each interval.
+    JumpStart,
+    /// Jump at the end of each interval.
+    JumpEnd,
+    /// Omit jumps at both endpoints.
+    JumpNone,
+    /// Include jumps at both endpoints.
+    JumpBoth,
+}
+
+/// One normalized timing function.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum MotionEasing {
+    /// Constant-rate interpolation.
+    Linear,
+    /// CSS `ease` cubic curve.
+    #[default]
+    Ease,
+    /// CSS `ease-in` cubic curve.
+    EaseIn,
+    /// CSS `ease-out` cubic curve.
+    EaseOut,
+    /// CSS `ease-in-out` cubic curve.
+    EaseInOut,
+    /// A custom cubic Bézier curve `(x1, y1, x2, y2)`.
+    CubicBezier([StyleNumber; 4]),
+    /// A discrete step timing function.
+    Steps {
+        /// Number of equal intervals.
+        count: u32,
+        /// Endpoint jump placement.
+        position: MotionStepPosition,
+    },
+}
+
+/// The property selection in one specified transition layer.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TransitionPropertyValue {
+    /// Animate every supported property that changes.
+    All,
+    /// Disable the layer.
+    None,
+    /// A CSS property name resolved through Whisker's stable registry.
+    Named(String),
+}
+
+/// One fully expanded specified transition layer.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TransitionValue {
+    /// Selected property.
+    pub property: TransitionPropertyValue,
+    /// Active duration.
+    pub duration: MotionTime,
+    /// Sampling curve.
+    pub easing: MotionEasing,
+    /// Delay before the active interval; negative values seek into it.
+    pub delay: MotionTime,
+}
+
+/// Resolved property selection for one transition layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ComputedTransitionProperty {
+    /// Animate every supported property that changes.
+    All,
+    /// Disabled transition layer.
+    None,
+    /// One known stable property.
+    Property(StyleProperty),
+}
+
+/// One validated and registry-resolved transition layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ComputedTransition {
+    /// Selected property.
+    pub property: ComputedTransitionProperty,
+    /// Non-negative active duration.
+    pub duration: MotionTime,
+    /// Validated sampling curve.
+    pub easing: MotionEasing,
+    /// Delay before the active interval.
+    pub delay: MotionTime,
+}
+
+/// Direction in which keyframe iterations run.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum MotionDirection {
+    /// Every iteration runs from start to end.
+    #[default]
+    Normal,
+    /// Every iteration runs from end to start.
+    Reverse,
+    /// Odd iterations run forward and even iterations backward.
+    Alternate,
+    /// Odd iterations run backward and even iterations forward.
+    AlternateReverse,
+}
+
+/// Keyframe values retained outside the active interval.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum MotionFillMode {
+    /// Do not retain keyframe values outside the active interval.
+    #[default]
+    None,
+    /// Retain the final sampled value after completion.
+    Forwards,
+    /// Apply the initial sampled value during a positive delay.
+    Backwards,
+    /// Apply both backwards and forwards fill behavior.
+    Both,
+}
+
+/// Whether a keyframe animation timeline advances.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum MotionPlayState {
+    /// Advance with the runtime clock.
+    #[default]
+    Running,
+    /// Retain the current sample without advancing.
+    Paused,
+}
+
+/// Number of keyframe iterations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MotionIterationCount {
+    /// Repeat without a finite end.
+    Infinite,
+    /// Run a non-negative, possibly fractional number of iterations.
+    Count(StyleNumber),
+}
+
+impl Default for MotionIterationCount {
+    fn default() -> Self {
+        Self::Count(StyleNumber::new(1.0))
+    }
+}
+
+/// One fully expanded specified keyframe-animation layer.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct AnimationValue {
+    /// Registered keyframe name; `None` disables the layer.
+    pub name: Option<String>,
+    /// Active duration for one iteration.
+    pub duration: MotionTime,
+    /// Sampling curve applied within keyframe intervals.
+    pub easing: MotionEasing,
+    /// Delay before the active interval.
+    pub delay: MotionTime,
+    /// Number of iterations.
+    pub iteration_count: MotionIterationCount,
+    /// Iteration direction.
+    pub direction: MotionDirection,
+    /// Values retained outside the active interval.
+    pub fill_mode: MotionFillMode,
+    /// Whether the timeline advances.
+    pub play_state: MotionPlayState,
+}
+
+/// Motion declarations consumed entirely by the Rust timeline layer.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct ComputedMotionStyle {
+    /// Fully resolved transition layers.
+    pub transitions: Vec<ComputedTransition>,
+    /// Validated keyframe-animation layers. Keyframe names are bound later by
+    /// the runtime's animation registry.
+    pub animations: Vec<AnimationValue>,
+}
+
+fn invalid(property: StyleProperty) -> StyleResolutionError {
+    StyleResolutionError::InvalidPropertyValue(property)
+}
+
+fn valid_time(value: MotionTime) -> bool {
+    value.get().is_finite()
+}
+
+fn valid_easing(value: MotionEasing) -> bool {
+    match value {
+        MotionEasing::CubicBezier([x1, y1, x2, y2]) => {
+            [x1, y1, x2, y2]
+                .into_iter()
+                .all(|value| value.get().is_finite())
+                && (0.0..=1.0).contains(&x1.get())
+                && (0.0..=1.0).contains(&x2.get())
+        }
+        MotionEasing::Steps { count, position } => {
+            count > 0 && (position != MotionStepPosition::JumpNone || count > 1)
+        }
+        _ => true,
+    }
+}
+
+fn transitionable(property: StyleProperty) -> bool {
+    matches!(
+        property,
+        StyleProperty::Left
+            | StyleProperty::Right
+            | StyleProperty::Top
+            | StyleProperty::Bottom
+            | StyleProperty::Width
+            | StyleProperty::Height
+            | StyleProperty::Opacity
+            | StyleProperty::BackgroundColor
+            | StyleProperty::Color
+            | StyleProperty::Transform
+            | StyleProperty::TransformOrigin
+            | StyleProperty::MaxWidth
+            | StyleProperty::MinWidth
+            | StyleProperty::MaxHeight
+            | StyleProperty::MinHeight
+            | StyleProperty::PaddingLeft
+            | StyleProperty::PaddingRight
+            | StyleProperty::PaddingTop
+            | StyleProperty::PaddingBottom
+            | StyleProperty::MarginLeft
+            | StyleProperty::MarginRight
+            | StyleProperty::MarginTop
+            | StyleProperty::MarginBottom
+            | StyleProperty::BorderLeftWidth
+            | StyleProperty::BorderRightWidth
+            | StyleProperty::BorderTopWidth
+            | StyleProperty::BorderBottomWidth
+            | StyleProperty::BorderLeftColor
+            | StyleProperty::BorderRightColor
+            | StyleProperty::BorderTopColor
+            | StyleProperty::BorderBottomColor
+            | StyleProperty::FlexBasis
+            | StyleProperty::FlexGrow
+    )
+}
+
+fn resolve_transition_property(
+    value: &TransitionPropertyValue,
+) -> Result<ComputedTransitionProperty, StyleResolutionError> {
+    match value {
+        TransitionPropertyValue::All => Ok(ComputedTransitionProperty::All),
+        TransitionPropertyValue::None => Ok(ComputedTransitionProperty::None),
+        TransitionPropertyValue::Named(name) => StyleProperty::from_css_name(name)
+            .filter(|property| transitionable(*property))
+            .map(ComputedTransitionProperty::Property)
+            .ok_or_else(|| invalid(StyleProperty::TransitionProperty)),
+    }
+}
+
+fn cyclic<T: Clone>(values: &[T], index: usize) -> T {
+    values[index % values.len()].clone()
+}
+
+/// Resolves non-inherited motion declarations without involving a Host.
+pub(crate) fn resolve_motion_style(
+    specified: &SpecifiedStyle,
+) -> Result<ComputedMotionStyle, StyleResolutionError> {
+    let mut transition_properties = vec![TransitionPropertyValue::None];
+    let mut transition_durations = vec![MotionTime::default()];
+    let mut transition_easings = vec![MotionEasing::default()];
+    let mut transition_delays = vec![MotionTime::default()];
+
+    let mut animation_names = vec![None];
+    let mut animation_durations = vec![MotionTime::default()];
+    let mut animation_easings = vec![MotionEasing::default()];
+    let mut animation_delays = vec![MotionTime::default()];
+    let mut animation_iterations = vec![MotionIterationCount::default()];
+    let mut animation_directions = vec![MotionDirection::default()];
+    let mut animation_fills = vec![MotionFillMode::default()];
+    let mut animation_play_states = vec![MotionPlayState::default()];
+
+    for declaration in specified.resolved() {
+        match (declaration.property(), declaration.value()) {
+            (StyleProperty::Transition, StyleValue::Transitions(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::Transition));
+                }
+                transition_properties = values.iter().map(|value| value.property.clone()).collect();
+                transition_durations = values.iter().map(|value| value.duration).collect();
+                transition_easings = values.iter().map(|value| value.easing).collect();
+                transition_delays = values.iter().map(|value| value.delay).collect();
+            }
+            (StyleProperty::TransitionProperty, StyleValue::TransitionProperties(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::TransitionProperty));
+                }
+                transition_properties = values.clone();
+            }
+            (StyleProperty::TransitionDuration, StyleValue::TransitionDurations(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::TransitionDuration));
+                }
+                transition_durations = values.clone();
+            }
+            (StyleProperty::TransitionTimingFunction, StyleValue::TransitionEasings(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::TransitionTimingFunction));
+                }
+                transition_easings = values.clone();
+            }
+            (StyleProperty::TransitionDelay, StyleValue::TransitionDelays(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::TransitionDelay));
+                }
+                transition_delays = values.clone();
+            }
+            (StyleProperty::Animation, StyleValue::Animations(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::Animation));
+                }
+                animation_names = values.iter().map(|value| value.name.clone()).collect();
+                animation_durations = values.iter().map(|value| value.duration).collect();
+                animation_easings = values.iter().map(|value| value.easing).collect();
+                animation_delays = values.iter().map(|value| value.delay).collect();
+                animation_iterations = values.iter().map(|value| value.iteration_count).collect();
+                animation_directions = values.iter().map(|value| value.direction).collect();
+                animation_fills = values.iter().map(|value| value.fill_mode).collect();
+                animation_play_states = values.iter().map(|value| value.play_state).collect();
+            }
+            (StyleProperty::AnimationName, StyleValue::AnimationNames(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::AnimationName));
+                }
+                animation_names = values.clone();
+            }
+            (StyleProperty::AnimationDuration, StyleValue::AnimationDurations(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::AnimationDuration));
+                }
+                animation_durations = values.clone();
+            }
+            (StyleProperty::AnimationTimingFunction, StyleValue::AnimationEasings(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::AnimationTimingFunction));
+                }
+                animation_easings = values.clone();
+            }
+            (StyleProperty::AnimationDelay, StyleValue::AnimationDelays(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::AnimationDelay));
+                }
+                animation_delays = values.clone();
+            }
+            (
+                StyleProperty::AnimationIterationCount,
+                StyleValue::AnimationIterationCounts(values),
+            ) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::AnimationIterationCount));
+                }
+                animation_iterations = values.clone();
+            }
+            (StyleProperty::AnimationDirection, StyleValue::AnimationDirections(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::AnimationDirection));
+                }
+                animation_directions = values.clone();
+            }
+            (StyleProperty::AnimationFillMode, StyleValue::AnimationFillModes(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::AnimationFillMode));
+                }
+                animation_fills = values.clone();
+            }
+            (StyleProperty::AnimationPlayState, StyleValue::AnimationPlayStates(values)) => {
+                if values.is_empty() {
+                    return Err(invalid(StyleProperty::AnimationPlayState));
+                }
+                animation_play_states = values.clone();
+            }
+            (property, _) if matches!(property.domain(), crate::StylePropertyDomain::Motion) => {
+                return Err(invalid(property));
+            }
+            _ => {}
+        }
+    }
+
+    if transition_durations
+        .iter()
+        .any(|value| !valid_time(*value) || value.get() < 0.0)
+    {
+        return Err(invalid(StyleProperty::TransitionDuration));
+    }
+    if transition_delays.iter().any(|value| !valid_time(*value)) {
+        return Err(invalid(StyleProperty::TransitionDelay));
+    }
+    if transition_easings.iter().any(|value| !valid_easing(*value)) {
+        return Err(invalid(StyleProperty::TransitionTimingFunction));
+    }
+    let transition_count = transition_properties.len();
+    let transitions = (0..transition_count)
+        .map(|index| {
+            Ok(ComputedTransition {
+                property: resolve_transition_property(&transition_properties[index])?,
+                duration: cyclic(&transition_durations, index),
+                easing: cyclic(&transition_easings, index),
+                delay: cyclic(&transition_delays, index),
+            })
+        })
+        .collect::<Result<Vec<_>, StyleResolutionError>>()?;
+    let transitions = transitions
+        .into_iter()
+        .filter(|value| value.property != ComputedTransitionProperty::None)
+        .collect();
+
+    if animation_durations
+        .iter()
+        .any(|value| !valid_time(*value) || value.get() < 0.0)
+    {
+        return Err(invalid(StyleProperty::AnimationDuration));
+    }
+    if animation_delays.iter().any(|value| !valid_time(*value)) {
+        return Err(invalid(StyleProperty::AnimationDelay));
+    }
+    if animation_easings.iter().any(|value| !valid_easing(*value)) {
+        return Err(invalid(StyleProperty::AnimationTimingFunction));
+    }
+    if animation_iterations.iter().any(|value| match value {
+        MotionIterationCount::Infinite => false,
+        MotionIterationCount::Count(value) => !value.get().is_finite() || value.get() < 0.0,
+    }) {
+        return Err(invalid(StyleProperty::AnimationIterationCount));
+    }
+    let animations = (0..animation_names.len())
+        .map(|index| AnimationValue {
+            name: animation_names[index].clone(),
+            duration: cyclic(&animation_durations, index),
+            easing: cyclic(&animation_easings, index),
+            delay: cyclic(&animation_delays, index),
+            iteration_count: cyclic(&animation_iterations, index),
+            direction: cyclic(&animation_directions, index),
+            fill_mode: cyclic(&animation_fills, index),
+            play_state: cyclic(&animation_play_states, index),
+        })
+        .filter(|value| value.name.is_some())
+        .collect();
+
+    Ok(ComputedMotionStyle {
+        transitions,
+        animations,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transition(
+        property: TransitionPropertyValue,
+        duration: f32,
+        easing: MotionEasing,
+        delay: f32,
+    ) -> TransitionValue {
+        TransitionValue {
+            property,
+            duration: MotionTime::milliseconds(duration),
+            easing,
+            delay: MotionTime::milliseconds(delay),
+        }
+    }
+
+    #[test]
+    fn defaults_do_not_allocate_inactive_timeline_layers() {
+        assert_eq!(
+            resolve_motion_style(&SpecifiedStyle::new()).unwrap(),
+            ComputedMotionStyle::default()
+        );
+    }
+
+    #[test]
+    fn transition_shorthand_and_later_longhand_resolve_with_css_list_cycling() {
+        let specified = SpecifiedStyle::new()
+            .push(
+                StyleProperty::Transition,
+                StyleValue::Transitions(vec![
+                    transition(
+                        TransitionPropertyValue::Named("opacity".into()),
+                        300.0,
+                        MotionEasing::Linear,
+                        10.0,
+                    ),
+                    transition(
+                        TransitionPropertyValue::Named("background-color".into()),
+                        500.0,
+                        MotionEasing::EaseIn,
+                        20.0,
+                    ),
+                ]),
+            )
+            .push(
+                StyleProperty::TransitionDuration,
+                StyleValue::TransitionDurations(vec![MotionTime::milliseconds(125.0)]),
+            );
+        let motion = resolve_motion_style(&specified).unwrap();
+        assert_eq!(motion.transitions.len(), 2);
+        assert_eq!(
+            motion.transitions[0].property,
+            ComputedTransitionProperty::Property(StyleProperty::Opacity)
+        );
+        assert_eq!(
+            motion.transitions[1].property,
+            ComputedTransitionProperty::Property(StyleProperty::BackgroundColor)
+        );
+        assert_eq!(motion.transitions[0].duration.get(), 125.0);
+        assert_eq!(motion.transitions[1].duration.get(), 125.0);
+        assert_eq!(motion.transitions[1].easing, MotionEasing::EaseIn);
+        assert_eq!(motion.transitions[1].delay.get(), 20.0);
+    }
+
+    #[test]
+    fn animation_longhand_lists_cycle_against_names() {
+        let specified = SpecifiedStyle::new()
+            .push(
+                StyleProperty::AnimationName,
+                StyleValue::AnimationNames(vec![Some("fade".into()), Some("slide".into())]),
+            )
+            .push(
+                StyleProperty::AnimationDuration,
+                StyleValue::AnimationDurations(vec![MotionTime::milliseconds(400.0)]),
+            )
+            .push(
+                StyleProperty::AnimationDirection,
+                StyleValue::AnimationDirections(vec![
+                    MotionDirection::Normal,
+                    MotionDirection::Alternate,
+                ]),
+            );
+        let motion = resolve_motion_style(&specified).unwrap();
+        assert_eq!(motion.animations.len(), 2);
+        assert_eq!(motion.animations[0].name.as_deref(), Some("fade"));
+        assert_eq!(motion.animations[1].name.as_deref(), Some("slide"));
+        assert_eq!(motion.animations[1].duration.get(), 400.0);
+        assert_eq!(motion.animations[1].direction, MotionDirection::Alternate);
+    }
+
+    #[test]
+    fn invalid_timing_and_non_transitionable_properties_are_rejected() {
+        for (property, value) in [
+            (
+                StyleProperty::TransitionDuration,
+                StyleValue::TransitionDurations(vec![MotionTime::milliseconds(-1.0)]),
+            ),
+            (
+                StyleProperty::TransitionTimingFunction,
+                StyleValue::TransitionEasings(vec![MotionEasing::CubicBezier([
+                    StyleNumber::new(2.0),
+                    StyleNumber::new(0.0),
+                    StyleNumber::new(1.0),
+                    StyleNumber::new(1.0),
+                ])]),
+            ),
+        ] {
+            assert_eq!(
+                resolve_motion_style(&SpecifiedStyle::new().push(property, value)),
+                Err(invalid(property))
+            );
+        }
+
+        assert_eq!(
+            resolve_motion_style(&SpecifiedStyle::new().push(
+                StyleProperty::TransitionProperty,
+                StyleValue::TransitionProperties(vec![TransitionPropertyValue::Named(
+                    "filter".into()
+                )]),
+            )),
+            Err(invalid(StyleProperty::TransitionProperty))
+        );
+    }
+}

--- a/crates/whisker-style/src/motion.rs
+++ b/crates/whisker-style/src/motion.rs
@@ -482,12 +482,314 @@ mod tests {
         }
     }
 
+    fn animation(name: Option<&str>) -> AnimationValue {
+        AnimationValue {
+            name: name.map(str::to_owned),
+            duration: MotionTime::milliseconds(200.0),
+            easing: MotionEasing::Linear,
+            delay: MotionTime::milliseconds(10.0),
+            iteration_count: MotionIterationCount::Infinite,
+            direction: MotionDirection::AlternateReverse,
+            fill_mode: MotionFillMode::Both,
+            play_state: MotionPlayState::Paused,
+        }
+    }
+
     #[test]
     fn defaults_do_not_allocate_inactive_timeline_layers() {
         assert_eq!(
             resolve_motion_style(&SpecifiedStyle::new()).unwrap(),
             ComputedMotionStyle::default()
         );
+        let resolved = crate::resolve_style(
+            &SpecifiedStyle::new(),
+            None,
+            crate::StyleEnvironment::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            resolved.computed().motion(),
+            &ComputedMotionStyle::default()
+        );
+    }
+
+    #[test]
+    fn easing_and_transition_property_validation_cover_every_branch() {
+        let number = StyleNumber::new;
+        assert!(valid_easing(MotionEasing::Linear));
+        assert!(valid_easing(MotionEasing::CubicBezier([
+            number(0.0),
+            number(-2.0),
+            number(1.0),
+            number(3.0),
+        ])));
+        assert!(!valid_easing(MotionEasing::CubicBezier([
+            number(f32::NAN),
+            number(0.0),
+            number(1.0),
+            number(1.0),
+        ])));
+        assert!(!valid_easing(MotionEasing::CubicBezier([
+            number(-0.1),
+            number(0.0),
+            number(1.0),
+            number(1.0),
+        ])));
+        assert!(!valid_easing(MotionEasing::CubicBezier([
+            number(0.0),
+            number(0.0),
+            number(1.1),
+            number(1.0),
+        ])));
+        assert!(valid_easing(MotionEasing::Steps {
+            count: 1,
+            position: MotionStepPosition::JumpEnd,
+        }));
+        assert!(!valid_easing(MotionEasing::Steps {
+            count: 0,
+            position: MotionStepPosition::JumpEnd,
+        }));
+        assert!(!valid_easing(MotionEasing::Steps {
+            count: 1,
+            position: MotionStepPosition::JumpNone,
+        }));
+        assert!(valid_easing(MotionEasing::Steps {
+            count: 2,
+            position: MotionStepPosition::JumpNone,
+        }));
+
+        assert_eq!(
+            resolve_transition_property(&TransitionPropertyValue::All),
+            Ok(ComputedTransitionProperty::All)
+        );
+        assert_eq!(
+            resolve_transition_property(&TransitionPropertyValue::None),
+            Ok(ComputedTransitionProperty::None)
+        );
+        for property in [
+            StyleProperty::Left,
+            StyleProperty::Right,
+            StyleProperty::Top,
+            StyleProperty::Bottom,
+            StyleProperty::Width,
+            StyleProperty::Height,
+            StyleProperty::Opacity,
+            StyleProperty::BackgroundColor,
+            StyleProperty::Color,
+            StyleProperty::Transform,
+            StyleProperty::TransformOrigin,
+            StyleProperty::MaxWidth,
+            StyleProperty::MinWidth,
+            StyleProperty::MaxHeight,
+            StyleProperty::MinHeight,
+            StyleProperty::PaddingLeft,
+            StyleProperty::PaddingRight,
+            StyleProperty::PaddingTop,
+            StyleProperty::PaddingBottom,
+            StyleProperty::MarginLeft,
+            StyleProperty::MarginRight,
+            StyleProperty::MarginTop,
+            StyleProperty::MarginBottom,
+            StyleProperty::BorderLeftWidth,
+            StyleProperty::BorderRightWidth,
+            StyleProperty::BorderTopWidth,
+            StyleProperty::BorderBottomWidth,
+            StyleProperty::BorderLeftColor,
+            StyleProperty::BorderRightColor,
+            StyleProperty::BorderTopColor,
+            StyleProperty::BorderBottomColor,
+            StyleProperty::FlexBasis,
+            StyleProperty::FlexGrow,
+        ] {
+            assert!(transitionable(property));
+        }
+        assert!(!transitionable(StyleProperty::Display));
+    }
+
+    #[test]
+    fn empty_and_mismatched_motion_declarations_are_rejected() {
+        for (property, value) in [
+            (StyleProperty::Transition, StyleValue::Transitions(vec![])),
+            (
+                StyleProperty::TransitionProperty,
+                StyleValue::TransitionProperties(vec![]),
+            ),
+            (
+                StyleProperty::TransitionDuration,
+                StyleValue::TransitionDurations(vec![]),
+            ),
+            (
+                StyleProperty::TransitionTimingFunction,
+                StyleValue::TransitionEasings(vec![]),
+            ),
+            (
+                StyleProperty::TransitionDelay,
+                StyleValue::TransitionDelays(vec![]),
+            ),
+            (StyleProperty::Animation, StyleValue::Animations(vec![])),
+            (
+                StyleProperty::AnimationName,
+                StyleValue::AnimationNames(vec![]),
+            ),
+            (
+                StyleProperty::AnimationDuration,
+                StyleValue::AnimationDurations(vec![]),
+            ),
+            (
+                StyleProperty::AnimationTimingFunction,
+                StyleValue::AnimationEasings(vec![]),
+            ),
+            (
+                StyleProperty::AnimationDelay,
+                StyleValue::AnimationDelays(vec![]),
+            ),
+            (
+                StyleProperty::AnimationIterationCount,
+                StyleValue::AnimationIterationCounts(vec![]),
+            ),
+            (
+                StyleProperty::AnimationDirection,
+                StyleValue::AnimationDirections(vec![]),
+            ),
+            (
+                StyleProperty::AnimationFillMode,
+                StyleValue::AnimationFillModes(vec![]),
+            ),
+            (
+                StyleProperty::AnimationPlayState,
+                StyleValue::AnimationPlayStates(vec![]),
+            ),
+        ] {
+            assert_eq!(
+                resolve_motion_style(&SpecifiedStyle::new().push(property, value)),
+                Err(invalid(property))
+            );
+        }
+        assert_eq!(
+            resolve_motion_style(&SpecifiedStyle::new().push(
+                StyleProperty::AnimationName,
+                StyleValue::AnimationDurations(vec![MotionTime::milliseconds(1.0)]),
+            )),
+            Err(invalid(StyleProperty::AnimationName))
+        );
+        assert_eq!(
+            crate::resolve_style(
+                &SpecifiedStyle::new().push(
+                    StyleProperty::AnimationName,
+                    StyleValue::AnimationDurations(vec![MotionTime::milliseconds(1.0)]),
+                ),
+                None,
+                crate::StyleEnvironment::default(),
+            ),
+            Err(invalid(StyleProperty::AnimationName))
+        );
+    }
+
+    #[test]
+    fn animation_shorthand_and_every_longhand_resolve() {
+        let shorthand = resolve_motion_style(&SpecifiedStyle::new().push(
+            StyleProperty::Animation,
+            StyleValue::Animations(vec![animation(Some("pulse")), animation(None)]),
+        ))
+        .unwrap();
+        assert_eq!(shorthand.animations, vec![animation(Some("pulse"))]);
+
+        let longhands = resolve_motion_style(
+            &SpecifiedStyle::new()
+                .push(
+                    StyleProperty::AnimationName,
+                    StyleValue::AnimationNames(vec![Some("spin".into())]),
+                )
+                .push(
+                    StyleProperty::AnimationDuration,
+                    StyleValue::AnimationDurations(vec![MotionTime::milliseconds(300.0)]),
+                )
+                .push(
+                    StyleProperty::AnimationTimingFunction,
+                    StyleValue::AnimationEasings(vec![MotionEasing::EaseOut]),
+                )
+                .push(
+                    StyleProperty::AnimationDelay,
+                    StyleValue::AnimationDelays(vec![MotionTime::milliseconds(-10.0)]),
+                )
+                .push(
+                    StyleProperty::AnimationIterationCount,
+                    StyleValue::AnimationIterationCounts(vec![MotionIterationCount::Infinite]),
+                )
+                .push(
+                    StyleProperty::AnimationDirection,
+                    StyleValue::AnimationDirections(vec![MotionDirection::Reverse]),
+                )
+                .push(
+                    StyleProperty::AnimationFillMode,
+                    StyleValue::AnimationFillModes(vec![MotionFillMode::Forwards]),
+                )
+                .push(
+                    StyleProperty::AnimationPlayState,
+                    StyleValue::AnimationPlayStates(vec![MotionPlayState::Running]),
+                ),
+        )
+        .unwrap();
+        assert_eq!(longhands.animations.len(), 1);
+        assert_eq!(longhands.animations[0].name.as_deref(), Some("spin"));
+        assert_eq!(longhands.animations[0].duration.get(), 300.0);
+    }
+
+    #[test]
+    fn invalid_motion_numbers_report_their_own_longhand() {
+        for (property, value) in [
+            (
+                StyleProperty::TransitionDuration,
+                StyleValue::TransitionDurations(vec![MotionTime::milliseconds(f32::NAN)]),
+            ),
+            (
+                StyleProperty::TransitionDelay,
+                StyleValue::TransitionDelays(vec![MotionTime::milliseconds(f32::NAN)]),
+            ),
+            (
+                StyleProperty::TransitionTimingFunction,
+                StyleValue::TransitionEasings(vec![MotionEasing::Steps {
+                    count: 0,
+                    position: MotionStepPosition::JumpStart,
+                }]),
+            ),
+            (
+                StyleProperty::AnimationDuration,
+                StyleValue::AnimationDurations(vec![MotionTime::milliseconds(-1.0)]),
+            ),
+            (
+                StyleProperty::AnimationDuration,
+                StyleValue::AnimationDurations(vec![MotionTime::milliseconds(f32::NAN)]),
+            ),
+            (
+                StyleProperty::AnimationDelay,
+                StyleValue::AnimationDelays(vec![MotionTime::milliseconds(f32::NAN)]),
+            ),
+            (
+                StyleProperty::AnimationTimingFunction,
+                StyleValue::AnimationEasings(vec![MotionEasing::Steps {
+                    count: 0,
+                    position: MotionStepPosition::JumpBoth,
+                }]),
+            ),
+            (
+                StyleProperty::AnimationIterationCount,
+                StyleValue::AnimationIterationCounts(vec![MotionIterationCount::Count(
+                    StyleNumber::new(-1.0),
+                )]),
+            ),
+            (
+                StyleProperty::AnimationIterationCount,
+                StyleValue::AnimationIterationCounts(vec![MotionIterationCount::Count(
+                    StyleNumber::new(f32::NAN),
+                )]),
+            ),
+        ] {
+            assert_eq!(
+                resolve_motion_style(&SpecifiedStyle::new().push(property, value)),
+                Err(invalid(property))
+            );
+        }
     }
 
     #[test]

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -4,12 +4,12 @@ use core::fmt;
 use std::collections::BTreeMap;
 
 use crate::{
-    CalcExpression, ColorValue, ComputedLayoutStyle, ComputedPaintStyle, CursorValue,
-    FontFamilyValue, FontFeatureValue, FontOpticalSizingValue, FontStyleValue, FontVariationValue,
-    FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue,
-    PointerEventsValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue, TextAlignValue,
-    TextDecorationLineValue, TextDecorationStyleValue, TextDecorationValue, TextOverflowValue,
-    TextShadowValue, WhiteSpaceValue, WordBreakValue,
+    CalcExpression, ColorValue, ComputedLayoutStyle, ComputedMotionStyle, ComputedPaintStyle,
+    CursorValue, FontFamilyValue, FontFeatureValue, FontOpticalSizingValue, FontStyleValue,
+    FontVariationValue, FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue,
+    LineHeightValue, PointerEventsValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue,
+    TextAlignValue, TextDecorationLineValue, TextDecorationStyleValue, TextDecorationValue,
+    TextOverflowValue, TextShadowValue, WhiteSpaceValue, WordBreakValue,
 };
 
 const RPX_REFERENCE_WIDTH: f32 = 750.0;
@@ -369,6 +369,7 @@ pub struct ComputedStyle {
     text_overflow: TextOverflowValue,
     layout: ComputedLayoutStyle,
     paint: ComputedPaintStyle,
+    motion: ComputedMotionStyle,
 }
 
 impl ComputedStyle {
@@ -415,6 +416,11 @@ impl ComputedStyle {
     /// Returns Host-independent computed paint input for this node.
     pub const fn paint(&self) -> &ComputedPaintStyle {
         &self.paint
+    }
+
+    /// Returns Host-independent transition and keyframe timeline settings.
+    pub const fn motion(&self) -> &ComputedMotionStyle {
+        &self.motion
     }
 }
 
@@ -848,6 +854,7 @@ pub fn resolve_style(
         layout.direction,
         environment,
     )?;
+    let motion = crate::motion::resolve_motion_style(specified)?;
 
     Ok(ResolvedNodeStyle {
         computed: ComputedStyle {
@@ -858,6 +865,7 @@ pub fn resolve_style(
             text_overflow,
             layout,
             paint,
+            motion,
         },
     })
 }

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -814,6 +814,34 @@ pub enum StyleValue {
     Cursor(CursorValue),
     /// Pointer hit-test participation.
     PointerEvents(PointerEventsValue),
+    /// Fully expanded `transition` shorthand layers.
+    Transitions(Vec<crate::TransitionValue>),
+    /// `transition-property` list.
+    TransitionProperties(Vec<crate::TransitionPropertyValue>),
+    /// `transition-duration` list.
+    TransitionDurations(Vec<crate::MotionTime>),
+    /// `transition-timing-function` list.
+    TransitionEasings(Vec<crate::MotionEasing>),
+    /// `transition-delay` list.
+    TransitionDelays(Vec<crate::MotionTime>),
+    /// Fully expanded `animation` shorthand layers.
+    Animations(Vec<crate::AnimationValue>),
+    /// `animation-name` list; `None` is the CSS `none` keyword.
+    AnimationNames(Vec<Option<String>>),
+    /// `animation-duration` list.
+    AnimationDurations(Vec<crate::MotionTime>),
+    /// `animation-timing-function` list.
+    AnimationEasings(Vec<crate::MotionEasing>),
+    /// `animation-delay` list.
+    AnimationDelays(Vec<crate::MotionTime>),
+    /// `animation-iteration-count` list.
+    AnimationIterationCounts(Vec<crate::MotionIterationCount>),
+    /// `animation-direction` list.
+    AnimationDirections(Vec<crate::MotionDirection>),
+    /// `animation-fill-mode` list.
+    AnimationFillModes(Vec<crate::MotionFillMode>),
+    /// `animation-play-state` list.
+    AnimationPlayStates(Vec<crate::MotionPlayState>),
     /// Font face style.
     FontStyle(FontStyleValue),
     /// Numeric font weight.

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -181,8 +181,11 @@
       "id": "motion.rust",
       "basis": "lynx-4.0",
       "properties": ["animation", "animation-delay", "animation-direction", "animation-duration", "animation-fill-mode", "animation-iteration-count", "animation-name", "animation-play-state", "animation-timing-function", "transition", "transition-delay", "transition-duration", "transition-property", "transition-timing-function"],
+      "implemented_subset": ["typed-shorthand-longhand-normalization", "time-unit-normalization", "timing-function-validation", "css-list-cycling", "lynx-transition-property-validation"],
+      "pending_subset": ["runtime-transition-sampling", "typed-keyframe-registry", "keyframe-timeline-sampling", "motion-lifecycle-events"],
+      "unsupported_browser_subset": ["transition-filter"],
       "protocol": [],
-      "rust": "planned",
+      "rust": "partial",
       "hosts": {"desktop": "not-applicable", "web": "not-applicable", "android": "not-applicable", "ios": "not-applicable"}
     },
     {


### PR DESCRIPTION
## Summary
- normalize animation and transition shorthand/longhand declarations into Host-independent Rust timeline settings
- validate time values, cubic/step easing, iteration counts, list cycling, and Lynx transitionable property names
- retain the existing Expo/Lynx-shaped `Css` authoring API while removing its dependency on raw CSS strings for motion semantics
- record the motion capability as partial until runtime sampling, keyframe registration, and lifecycle events land

This unit is intentionally Host-independent: Hosts continue to receive only the ordinary sampled FramePacket operations, never animation timelines.

## Verification
- `cargo test -p whisker-style -p whisker-css --lib`
- `cargo test -p whisker-engine -p whisker -p whisker-host-conformance --lib`
- `cargo clippy -p whisker-style -p whisker-css --all-targets -- -D warnings`

Stacked on #489.