### PR TITLE
feat(host): preserve basic text styling across hosts

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 22 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 23 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -146,6 +146,7 @@ typedef struct { uint8_t tag[4]; uint32_t value; } WhiskerMobileFontFeature;
 typedef struct { uint8_t tag[4]; float value; } WhiskerMobileFontVariation;
 typedef struct {
   WhiskerStringRef text;
+  const WhiskerStringRef* font_families; size_t font_family_count;
   float font_size;
   uint16_t font_weight;
   uint8_t font_style, wrap, word_break, overflow;
@@ -268,7 +269,7 @@ _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 216, "WhiskerMobileMeasure
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceCommand) == 64, "WhiskerMobileResourceCommand ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceEvent) == 56, "WhiskerMobileResourceEvent ABI drift");
-_Static_assert(sizeof(WhiskerMobileText) == 224, "WhiskerMobileText ABI drift");
+_Static_assert(sizeof(WhiskerMobileText) == 240, "WhiskerMobileText ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 
 typedef void (*WhiskerMobileRequestFrameCallback)(void*);

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -68,6 +68,10 @@ static jstring new_string(JNIEnv* env, const char* bytes, size_t length) {
     return result;
 }
 
+static bool valid_nonempty_string_ref(WhiskerStringRef value) {
+    return value.ptr != NULL && value.len > 0 && value.len <= INT32_MAX;
+}
+
 static jintArray member_ints(JNIEnv* env, const WhiskerMobileMemberRegistration* values,
                              size_t count, bool kinds, bool optional) {
     jintArray result = (*env)->NewIntArray(env, (jsize)count);
@@ -518,9 +522,18 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
             case WHISKER_OP_TEXT: {
                 const WhiskerMobileText* p = op->payload; if (!p) { ok = false; break; }
                 if (p->font_optical_sizing > 1 ||
+                    p->font_family_count == 0 ||
+                    (p->font_families == NULL) != (p->font_family_count == 0) ||
                     (p->font_features == NULL) != (p->font_feature_count == 0) ||
                     (p->font_variations == NULL) != (p->font_variation_count == 0) ||
-                    p->font_feature_count + p->font_variation_count > 4096) { ok = false; break; }
+                    p->font_family_count > 4096 ||
+                    p->font_feature_count > 4096 ||
+                    p->font_variation_count > 4096 ||
+                    p->font_family_count + p->font_feature_count + p->font_variation_count > 4096) { ok = false; break; }
+                for (size_t j=0;j<p->font_family_count;++j) {
+                    if (!valid_nonempty_string_ref(p->font_families[j])) { ok = false; break; }
+                }
+                if (!ok) break;
                 text = new_string(env, p->text.ptr, p->text.len);
                 storage[0]=p->font_size; storage[1]=(float)p->font_weight; storage[2]=(float)p->font_style;
                 storage[3]=(float)p->color.red; storage[4]=(float)p->color.green; storage[5]=(float)p->color.blue;
@@ -538,13 +551,16 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                 storage[27]=(float)p->wrap; storage[28]=(float)p->word_break;
                 storage[29]=(float)p->max_lines; storage[30]=(float)p->overflow;
                 storage[31]=(float)p->font_optical_sizing; storage[32]=(float)p->font_feature_count;
-                numbers = floats(env, storage, 33);
-                jclass cls = (*env)->FindClass(env, "java/lang/String"); names = (*env)->NewObjectArray(env, (jsize)(3 + p->font_feature_count + p->font_variation_count), cls, NULL);
+                storage[33]=(float)p->font_family_count;
+                storage[34]=p->line_height; storage[35]=p->letter_spacing;
+                numbers = floats(env, storage, 36);
+                jclass cls = (*env)->FindClass(env, "java/lang/String"); names = (*env)->NewObjectArray(env, (jsize)(3 + p->font_family_count + p->font_feature_count + p->font_variation_count), cls, NULL);
                 jstring color_name = new_string(env, p->color.name.ptr, p->color.name.len); (*env)->SetObjectArrayElement(env, names, 0, color_name);
                 jstring shadow_name = new_string(env, p->shadow_color.name.ptr, p->shadow_color.name.len); (*env)->SetObjectArrayElement(env, names, 1, shadow_name);
                 jstring decoration_name = new_string(env, p->decoration_color.name.ptr, p->decoration_color.name.len); (*env)->SetObjectArrayElement(env, names, 2, decoration_name);
-                for (size_t j=0;j<p->font_feature_count;++j) { jstring value=font_setting(env,p->font_features[j].tag,p->font_features[j].value,true); (*env)->SetObjectArrayElement(env,names,(jsize)(3+j),value); if(value)(*env)->DeleteLocalRef(env,value); }
-                for (size_t j=0;j<p->font_variation_count;++j) { jstring value=font_setting(env,p->font_variations[j].tag,p->font_variations[j].value,false); (*env)->SetObjectArrayElement(env,names,(jsize)(3+p->font_feature_count+j),value); if(value)(*env)->DeleteLocalRef(env,value); }
+                for (size_t j=0;j<p->font_family_count;++j) { jstring value=new_string(env,p->font_families[j].ptr,p->font_families[j].len); (*env)->SetObjectArrayElement(env,names,(jsize)(3+j),value); if(value)(*env)->DeleteLocalRef(env,value); }
+                for (size_t j=0;j<p->font_feature_count;++j) { jstring value=font_setting(env,p->font_features[j].tag,p->font_features[j].value,true); (*env)->SetObjectArrayElement(env,names,(jsize)(3+p->font_family_count+j),value); if(value)(*env)->DeleteLocalRef(env,value); }
+                for (size_t j=0;j<p->font_variation_count;++j) { jstring value=font_setting(env,p->font_variations[j].tag,p->font_variations[j].value,false); (*env)->SetObjectArrayElement(env,names,(jsize)(3+p->font_family_count+p->font_feature_count+j),value); if(value)(*env)->DeleteLocalRef(env,value); }
                 if (color_name) (*env)->DeleteLocalRef(env, color_name);
                 if (shadow_name) (*env)->DeleteLocalRef(env, shadow_name);
                 if (decoration_name) (*env)->DeleteLocalRef(env, decoration_name);

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 22;
+pub const MOBILE_ABI_MINOR: u16 = 23;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;
@@ -316,6 +316,8 @@ pub struct MobileFontVariation {
 #[derive(Clone, Copy)]
 pub struct MobileText {
     pub text: WhiskerStringRef,
+    pub font_families: *const WhiskerStringRef,
+    pub font_family_count: usize,
     pub font_size: f32,
     pub font_weight: u16,
     pub font_style: u8,
@@ -696,7 +698,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileBootstrap>(), 24);
             assert_eq!(std::mem::size_of::<MobileMeasureRequest>(), 216);
             assert_eq!(std::mem::size_of::<MobileMeasureResponse>(), 64);
-            assert_eq!(std::mem::size_of::<MobileText>(), 224);
+            assert_eq!(std::mem::size_of::<MobileText>(), 240);
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);
             assert_eq!(std::mem::size_of::<MobileBoxShadow>(), 56);
             assert_eq!(std::mem::size_of::<MobileClipInset>(), 96);

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -633,11 +633,24 @@ pub struct SceneNodeFixture {
 pub struct TextFixture {
     /// UTF-8 text value.
     pub value: String,
+    /// Ordered font-family fallback list. The reserved `system` spelling maps
+    /// to each Host's platform UI font; every other value is a named family.
+    #[serde(default = "default_font_families")]
+    pub font_families: Vec<String>,
     /// Logical-pixel font size.
     pub font_size: f32,
     /// CSS numeric font weight.
     #[serde(default = "default_font_weight")]
     pub font_weight: u16,
+    /// Resolved font posture.
+    #[serde(default)]
+    pub font_style: FontStyleFixture,
+    /// Explicit logical-pixel line height. Omission means `normal`.
+    #[serde(default)]
+    pub line_height: Option<f32>,
+    /// Additional logical pixels between glyph advances.
+    #[serde(default)]
+    pub letter_spacing: f32,
     /// Ordered OpenType feature settings.
     #[serde(default)]
     pub font_features: Vec<FontFeatureFixture>,
@@ -673,6 +686,19 @@ pub struct TextFixture {
     /// Optional single Lynx-compatible shadow.
     #[serde(default)]
     pub shadow: Option<TextShadowFixture>,
+}
+
+/// Font posture used by a retained text fixture.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FontStyleFixture {
+    /// Upright glyphs.
+    #[default]
+    Normal,
+    /// Use the font's italic face when available.
+    Italic,
+    /// Use an oblique face or synthetic slant.
+    Oblique,
 }
 
 /// One OpenType feature selector in a shared fixture.
@@ -820,6 +846,10 @@ pub struct TextShadowFixture {
 
 const fn default_font_weight() -> u16 {
     400
+}
+
+fn default_font_families() -> Vec<String> {
+    vec!["system".to_owned()]
 }
 
 impl SceneNodeFixture {
@@ -1599,6 +1629,12 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                     text.font_size.is_finite()
                         && text.font_size > 0.0
                         && (1..=1000).contains(&text.font_weight)
+                        && !text.font_families.is_empty()
+                        && text.font_families.iter().all(|family| !family.is_empty())
+                        && text
+                            .line_height
+                            .is_none_or(|height| height.is_finite() && height > 0.0)
+                        && text.letter_spacing.is_finite()
                         && valid_color(&text.color)
                         && text
                             .decoration

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -997,6 +997,7 @@ struct MobileFrameOwned {
     _background_layers: Vec<Box<[MobileBackgroundLayer]>>,
     _background_resource_ids: Vec<Box<u64>>,
     _texts: Vec<Box<MobileText>>,
+    _text_font_families: Vec<Box<[WhiskerStringRef]>>,
     _font_features: Vec<Box<[MobileFontFeature]>>,
     _font_variations: Vec<Box<[MobileFontVariation]>>,
     _transforms: Vec<Box<[f32; 16]>>,
@@ -1081,6 +1082,7 @@ impl MobileFrameOwned {
         let mut background_layers = Vec::<Box<[MobileBackgroundLayer]>>::new();
         let mut background_resource_ids = Vec::<Box<u64>>::new();
         let mut texts = Vec::<Box<MobileText>>::new();
+        let mut text_font_families = Vec::<Box<[WhiskerStringRef]>>::new();
         let mut font_features = Vec::<Box<[MobileFontFeature]>>::new();
         let mut font_variations = Vec::<Box<[MobileFontVariation]>>::new();
         let mut transforms = Vec::<Box<[f32; 16]>>::new();
@@ -1525,8 +1527,24 @@ impl MobileFrameOwned {
                     let features = font_features.last().unwrap();
                     font_variations.push(mobile_font_variations(&content.payload.style.variations));
                     let variations = font_variations.last().unwrap();
+                    text_font_families.push(
+                        content
+                            .payload
+                            .style
+                            .font_families
+                            .iter()
+                            .map(|family| match family {
+                                MeasureFontFamily::System => push_string(&mut strings, "system"),
+                                MeasureFontFamily::Named(value) => push_string(&mut strings, value),
+                            })
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice(),
+                    );
+                    let families = text_font_families.last().unwrap();
                     texts.push(Box::new(MobileText {
                         text: push_string(&mut strings, &content.payload.text),
+                        font_families: nonempty_ptr(families),
+                        font_family_count: families.len(),
                         font_size: content.payload.style.font_size,
                         font_weight: content.payload.style.font_weight,
                         font_style: match content.payload.style.font_style {
@@ -1693,6 +1711,7 @@ impl MobileFrameOwned {
             _background_layers: background_layers,
             _background_resource_ids: background_resource_ids,
             _texts: texts,
+            _text_font_families: text_font_families,
             _font_features: font_features,
             _font_variations: font_variations,
             _transforms: transforms,
@@ -1953,13 +1972,13 @@ mod tests {
                 text: "shadow".into(),
                 style: TextMeasureStyle::default(),
                 locale: None,
-                direction: Default::default(),
+                direction: whisker_engine::whisker_protocol::MeasureTextDirection::Auto,
                 alignment: Default::default(),
                 indent: Default::default(),
                 wrap: MeasureTextWrap::Wrap,
                 word_break: Default::default(),
                 max_lines: None,
-                overflow: Default::default(),
+                overflow: MeasureTextOverflow::Clip,
             },
             paint: TextPaint {
                 foreground: PaintColor::Named("black".into()),
@@ -2221,6 +2240,13 @@ mod tests {
             tag: FontTag::new(*b"wght").unwrap(),
             value: 650.0,
         }];
+        content.payload.style.font_families = vec![
+            MeasureFontFamily::Named("Whisker Fixture Sans".into()),
+            MeasureFontFamily::System,
+        ];
+        content.payload.style.font_style = MeasureFontStyle::Italic;
+        content.payload.style.line_height = MeasureLineHeight::LogicalPixels(28.0);
+        content.payload.style.letter_spacing = 1.5;
         content.payload.style.optical_sizing = FontOpticalSizing::Auto;
         let packet = FramePacket {
             header: FrameHeader {
@@ -2243,6 +2269,20 @@ mod tests {
         let operation = &frame._operations[0];
         assert_eq!(operation.tag, OP_TEXT);
         let text = unsafe { &*operation.payload.cast::<MobileText>() };
+        assert_eq!(text.font_family_count, 2);
+        let families =
+            unsafe { std::slice::from_raw_parts(text.font_families, text.font_family_count) };
+        let family = |value: WhiskerStringRef| unsafe {
+            String::from_utf8(
+                std::slice::from_raw_parts(value.ptr.cast::<u8>(), value.len).to_vec(),
+            )
+            .unwrap()
+        };
+        assert_eq!(family(families[0]), "Whisker Fixture Sans");
+        assert_eq!(family(families[1]), "system");
+        assert_eq!(text.font_style, 1);
+        assert_eq!(text.line_height, 28.0);
+        assert_eq!(text.letter_spacing, 1.5);
         assert_eq!(text.shadow_flags, 1);
         assert_eq!(text.shadow_offset_x, 3.0);
         assert_eq!(text.shadow_offset_y, -2.0);

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
@@ -1,5 +1,8 @@
 package rs.whisker.runtime
 
+import android.graphics.Typeface
+import android.os.Build
+import android.util.TypedValue
 import android.view.Gravity
 
 /** Hand-written Android implementations matched to Rust registrations by name. */
@@ -20,10 +23,31 @@ public object WhiskerBuiltInElements {
             name = TEXT,
             textUpdater = { view, content ->
                 require(view is WhiskerTextView) { "$TEXT factory must create WhiskerTextView" }
-                view.setWhiskerText(content)
-                view.textSize = content.fontSize
+                val density = view.resources.displayMetrics.density
+                view.setTextSize(TypedValue.COMPLEX_UNIT_PX, content.fontSize * density)
                 view.setTextColor(content.color)
-                view.setTypeface(view.typeface, if (content.fontWeight >= 600) 1 else 0)
+                val baseTypeface = resolveTypeface(content.fontFamilies)
+                view.typeface = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    Typeface.create(
+                        baseTypeface,
+                        content.fontWeight.coerceIn(1, 1000),
+                        content.fontStyle != WhiskerFontStyle.NORMAL,
+                    )
+                } else {
+                    val style = (if (content.fontWeight >= 600) Typeface.BOLD else 0) or
+                        (if (content.fontStyle != WhiskerFontStyle.NORMAL) Typeface.ITALIC else 0)
+                    Typeface.create(baseTypeface, style)
+                }
+                view.letterSpacing = if (content.fontSize > 0f) {
+                    content.letterSpacing / content.fontSize
+                } else {
+                    0f
+                }
+                content.lineHeight?.let { lineHeight ->
+                    val fontHeight = view.paint.fontMetrics.run { descent - ascent }
+                    view.setLineSpacing((lineHeight * density - fontHeight).coerceAtLeast(0f), 1f)
+                } ?: view.setLineSpacing(0f, 1f)
+                view.setWhiskerText(content)
                 view.gravity = Gravity.TOP or when (content.alignment) {
                     WhiskerTextAlignment.START -> Gravity.START
                     WhiskerTextAlignment.END -> Gravity.END
@@ -73,4 +97,13 @@ public class BuiltInElementModule : Module() {
         View(WhiskerBuiltInElements.text())
         View(WhiskerBuiltInElements.scrollView())
     }
+}
+
+private fun resolveTypeface(families: List<String>): Typeface {
+    for (family in families) {
+        if (family == "system") return Typeface.DEFAULT
+        val candidate = Typeface.create(family, Typeface.NORMAL)
+        if (candidate != Typeface.DEFAULT) return candidate
+    }
+    return Typeface.DEFAULT
 }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -19,6 +19,10 @@ public data class WhiskerTextContent(
     public val value: String,
     public val fontSize: Float,
     public val fontWeight: Int,
+    public val fontFamilies: List<String> = listOf("system"),
+    public val fontStyle: WhiskerFontStyle = WhiskerFontStyle.NORMAL,
+    public val lineHeight: Float? = null,
+    public val letterSpacing: Float = 0f,
     public val fontFeatures: List<WhiskerFontFeature> = emptyList(),
     public val fontVariations: List<WhiskerFontVariation> = emptyList(),
     public val fontOpticalSizing: WhiskerFontOpticalSizing = WhiskerFontOpticalSizing.NONE,
@@ -36,6 +40,7 @@ public data class WhiskerTextContent(
 public data class WhiskerFontFeature(public val tag: String, public val value: Long)
 public data class WhiskerFontVariation(public val tag: String, public val value: Float)
 public enum class WhiskerFontOpticalSizing { AUTO, NONE }
+public enum class WhiskerFontStyle { NORMAL, ITALIC, OBLIQUE }
 
 public enum class WhiskerTextAlignment { START, END, LEFT, RIGHT, CENTER }
 

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerTextView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerTextView.kt
@@ -25,6 +25,14 @@ public class WhiskerTextView(context: Context) : TextView(context) {
         private set
     public var whiskerFontOpticalSizing: WhiskerFontOpticalSizing = WhiskerFontOpticalSizing.NONE
         private set
+    public var whiskerFontFamilies: List<String> = listOf("system")
+        private set
+    public var whiskerFontStyle: WhiskerFontStyle = WhiskerFontStyle.NORMAL
+        private set
+    public var whiskerLineHeight: Float? = null
+        private set
+    public var whiskerLetterSpacing: Float = 0f
+        private set
 
     public fun setWhiskerText(content: WhiskerTextContent) {
         whiskerTextValue = content.value
@@ -33,6 +41,10 @@ public class WhiskerTextView(context: Context) : TextView(context) {
         whiskerFontFeatures = content.fontFeatures
         whiskerFontVariations = content.fontVariations
         whiskerFontOpticalSizing = content.fontOpticalSizing
+        whiskerFontFamilies = content.fontFamilies
+        whiskerFontStyle = content.fontStyle
+        whiskerLineHeight = content.lineHeight
+        whiskerLetterSpacing = content.letterSpacing
         fontFeatureSettings = content.fontFeatures.joinToString(", ") {
             "'${it.tag}' ${it.value}"
         }.ifEmpty { null }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -11,6 +11,7 @@ import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerView
 import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerTextContent
+import rs.whisker.runtime.WhiskerFontStyle
 import rs.whisker.runtime.WhiskerFontFeature
 import rs.whisker.runtime.WhiskerFontOpticalSizing
 import rs.whisker.runtime.WhiskerFontVariation
@@ -381,7 +382,10 @@ internal class HostScene(
     }
 
     private fun applyText(node: HostNode, text: String, values: FloatArray, names: Array<String>) {
-        require(values.size >= 33)
+        require(values.size >= 36)
+        require(values[0].isFinite() && values[0] > 0f)
+        require(values[1] in 1f..1000f && values[1] == values[1].toInt().toFloat())
+        require(values[2] in 0f..2f && values[2] == values[2].toInt().toFloat())
         require(values[27] == 0f || values[27] == 1f)
         require(values[28] in 0f..2f && values[28] == values[28].toInt().toFloat())
         require(values[29] >= 0f && values[29] == values[29].toInt().toFloat())
@@ -389,8 +393,14 @@ internal class HostScene(
         require(values[31] == 0f || values[31] == 1f)
         val featureCount = values[32].toInt()
         require(featureCount >= 0 && values[32] == featureCount.toFloat())
-        require(names.size >= 3 + featureCount)
-        val settings = names.drop(3).map(::parseFontSetting)
+        val familyCount = values[33].toInt()
+        require(familyCount > 0 && values[33] == familyCount.toFloat())
+        require(values[34].isFinite() && values[34] >= 0f)
+        require(values[35].isFinite())
+        require(names.size >= 3 + familyCount + featureCount)
+        val families = names.slice(3 until 3 + familyCount)
+        require(families.all(String::isNotEmpty))
+        val settings = names.drop(3 + familyCount).map(::parseFontSetting)
         val features = settings.take(featureCount).map {
             WhiskerFontFeature(it.first, it.second.toLong())
         }
@@ -402,8 +412,12 @@ internal class HostScene(
             mounted.setText(
                 WhiskerTextContent(
                     value = text,
+                    fontFamilies = families,
                     fontSize = values[0],
                     fontWeight = values[1].toInt(),
+                    fontStyle = WhiskerFontStyle.entries[values[2].toInt()],
+                    lineHeight = values[34].takeIf { it > 0f },
+                    letterSpacing = values[35],
                     fontFeatures = features,
                     fontVariations = variations,
                     fontOpticalSizing = if (values[31] == 0f) {

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -108,8 +108,32 @@ fn fixture_text_content(text: &whisker_host_conformance::TextFixture) -> TextCon
         payload: TextMeasurePayload {
             text: text.value.clone(),
             style: TextMeasureStyle {
+                font_families: text
+                    .font_families
+                    .iter()
+                    .map(|family| {
+                        if family == "system" {
+                            MeasureFontFamily::System
+                        } else {
+                            MeasureFontFamily::Named(family.clone())
+                        }
+                    })
+                    .collect(),
                 font_size: text.font_size,
                 font_weight: text.font_weight,
+                font_style: match text.font_style {
+                    whisker_host_conformance::FontStyleFixture::Normal => MeasureFontStyle::Normal,
+                    whisker_host_conformance::FontStyleFixture::Italic => MeasureFontStyle::Italic,
+                    whisker_host_conformance::FontStyleFixture::Oblique => {
+                        MeasureFontStyle::Oblique
+                    }
+                },
+                line_height: text
+                    .line_height
+                    .map_or(MeasureLineHeight::Normal, |height| {
+                        MeasureLineHeight::LogicalPixels(height)
+                    }),
+                letter_spacing: text.letter_spacing,
                 features: text
                     .font_features
                     .iter()
@@ -636,6 +660,8 @@ impl Driver {
                         self.assert_text_wrap_overflow();
                     } else if name == "paint.text.font-features-lynx" {
                         self.assert_text_font_features();
+                    } else if name == "paint.text.basic-style-lynx" {
+                        self.assert_text_basic_style();
                     }
                     checkpoints.push(Checkpoint {
                         logical_size: [
@@ -1048,6 +1074,46 @@ impl Driver {
         assert_eq!(
             texts[2].payload.style.optical_sizing,
             whisker_protocol::FontOpticalSizing::Auto
+        );
+    }
+
+    fn assert_text_basic_style(&self) {
+        let commands = self
+            .scene
+            .as_ref()
+            .expect("checkpoint follows attach")
+            .paint_commands();
+        let content = commands
+            .iter()
+            .find_map(|command| match command {
+                PaintCommand::Text { content, .. } => Some(content),
+                _ => None,
+            })
+            .expect("basic style fixture creates one text paint command");
+
+        assert_eq!(
+            content.payload.style.font_families,
+            vec![
+                MeasureFontFamily::Named("Whisker Fixture Sans".into()),
+                MeasureFontFamily::System,
+            ]
+        );
+        assert_eq!(content.payload.style.font_size, 20.0);
+        assert_eq!(content.payload.style.font_weight, 650);
+        assert_eq!(content.payload.style.font_style, MeasureFontStyle::Italic);
+        assert_eq!(
+            content.payload.style.line_height,
+            MeasureLineHeight::LogicalPixels(28.0)
+        );
+        assert_eq!(content.payload.style.letter_spacing, 1.5);
+        assert_eq!(
+            content.paint.foreground,
+            PaintColor::Srgba {
+                red: 32,
+                green: 64,
+                blue: 192,
+                alpha: 1.0,
+            }
         );
     }
 

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 22 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 23 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -128,7 +128,9 @@ typedef struct {
 typedef struct { uint8_t tag[4]; uint32_t value; } WhiskerMobileFontFeature;
 typedef struct { uint8_t tag[4]; float value; } WhiskerMobileFontVariation;
 typedef struct {
-  WhiskerStringRef text; float font_size; uint16_t font_weight;
+  WhiskerStringRef text;
+  const WhiskerStringRef* font_families; size_t font_family_count;
+  float font_size; uint16_t font_weight;
   uint8_t font_style, wrap, word_break, overflow; uint32_t max_lines; float line_height, letter_spacing;
   const WhiskerMobileFontFeature* font_features; size_t font_feature_count;
   const WhiskerMobileFontVariation* font_variations; size_t font_variation_count;
@@ -215,6 +217,6 @@ _Static_assert(sizeof(WhiskerMobileMeasureRequest) == 216, "WhiskerMobileMeasure
 _Static_assert(sizeof(WhiskerMobileMeasureResponse) == 64, "WhiskerMobileMeasureResponse ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceCommand) == 64, "WhiskerMobileResourceCommand ABI drift");
 _Static_assert(sizeof(WhiskerMobileResourceEvent) == 56, "WhiskerMobileResourceEvent ABI drift");
-_Static_assert(sizeof(WhiskerMobileText) == 224, "WhiskerMobileText ABI drift");
+_Static_assert(sizeof(WhiskerMobileText) == 240, "WhiskerMobileText ABI drift");
 _Static_assert(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");
 #endif

--- a/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
@@ -45,6 +45,12 @@ public final class WhiskerTextLabel: UILabel {
     public internal(set) var whiskerFontFeatures: [WhiskerFontFeature] = []
     public internal(set) var whiskerFontVariations: [WhiskerFontVariation] = []
     public internal(set) var whiskerFontOpticalSizing: WhiskerFontOpticalSizing = .none
+    public internal(set) var whiskerFontFamilies: [String] = ["system"]
+    public internal(set) var whiskerResolvedFontFamily = ""
+    public internal(set) var whiskerFontWeight = 400
+    public internal(set) var whiskerFontStyle: WhiskerTextFontStyle = .normal
+    public internal(set) var whiskerLineHeight: CGFloat?
+    public internal(set) var whiskerLetterSpacing: CGFloat = 0
 
     public func setWhiskerIndent(_ indent: WhiskerTextIndent) {
         whiskerIndent = indent
@@ -62,7 +68,12 @@ public final class WhiskerTextLabel: UILabel {
         guard appliedIndent != resolved, let attributedText else { return }
         appliedIndent = resolved
         let mutable = NSMutableAttributedString(attributedString: attributedText)
-        let paragraph = NSMutableParagraphStyle()
+        let existingParagraph = attributedText.length > 0
+            ? attributedText.attribute(.paragraphStyle, at: 0, effectiveRange: nil)
+                as? NSParagraphStyle
+            : nil
+        let paragraph = existingParagraph?.mutableCopy() as? NSMutableParagraphStyle
+            ?? NSMutableParagraphStyle()
         paragraph.alignment = textAlignment
         paragraph.lineBreakMode = lineBreakMode
         paragraph.firstLineHeadIndent = resolved
@@ -120,10 +131,14 @@ public enum WhiskerBuiltInElements {
                 guard let label = view as? WhiskerTextLabel else {
                     preconditionFailure("\(textName) factory must create WhiskerTextLabel")
                 }
-                label.font = configuredFont(base: .systemFont(
-                    ofSize: content.fontSize,
-                    weight: content.fontWeight >= 600 ? .bold : .regular
-                ), content: content)
+                let base = resolvedBaseFont(content)
+                label.font = configuredFont(base: base.font, content: content)
+                label.whiskerFontFamilies = content.fontFamilies
+                label.whiskerResolvedFontFamily = base.family
+                label.whiskerFontWeight = content.fontWeight
+                label.whiskerFontStyle = content.fontStyle
+                label.whiskerLineHeight = content.lineHeight
+                label.whiskerLetterSpacing = content.letterSpacing
                 label.whiskerFontFeatures = content.fontFeatures
                 label.whiskerFontVariations = content.fontVariations
                 label.whiskerFontOpticalSizing = content.fontOpticalSizing
@@ -136,9 +151,25 @@ public enum WhiskerBuiltInElements {
                 case .center: .center
                 }
                 label.whiskerDecoration = content.decoration
+                label.numberOfLines = content.wrap
+                    ? (content.maxLines == 0 ? 0 : content.maxLines)
+                    : 1
+                label.lineBreakMode = switch content.overflow {
+                case .ellipsis: .byTruncatingTail
+                case .clip: content.wordBreak == .breakAll ? .byCharWrapping : .byWordWrapping
+                }
+                let paragraph = NSMutableParagraphStyle()
+                paragraph.alignment = label.textAlignment
+                paragraph.lineBreakMode = label.lineBreakMode
+                if let lineHeight = content.lineHeight {
+                    paragraph.minimumLineHeight = lineHeight
+                    paragraph.maximumLineHeight = lineHeight
+                }
                 var attributes: [NSAttributedString.Key: Any] = [
                     .font: label.font as Any,
                     .foregroundColor: content.color,
+                    .kern: content.letterSpacing,
+                    .paragraphStyle: paragraph,
                 ]
                 if let shadow = content.shadow {
                     let nativeShadow = NSShadow()
@@ -170,13 +201,6 @@ public enum WhiskerBuiltInElements {
                     attributes: attributes
                 )
                 label.setWhiskerIndent(content.indent)
-                label.numberOfLines = content.wrap
-                    ? (content.maxLines == 0 ? 0 : content.maxLines)
-                    : 1
-                label.lineBreakMode = switch content.overflow {
-                case .ellipsis: .byTruncatingTail
-                case .clip: content.wordBreak == .breakAll ? .byCharWrapping : .byWordWrapping
-                }
             }
         ) {
             let label = WhiskerTextLabel(frame: .zero)
@@ -200,6 +224,39 @@ public enum WhiskerBuiltInElements {
             WhiskerScrollContainerView(frame: .zero)
         }
     }
+}
+
+private func resolvedBaseFont(_ content: WhiskerTextContent) -> (font: UIFont, family: String) {
+    let weight = UIFont.Weight(rawValue: max(
+        -1,
+        min(1, CGFloat(content.fontWeight - 400) / 500)
+    ))
+    for family in content.fontFamilies {
+        if family == "system" {
+            let font = UIFont.systemFont(ofSize: content.fontSize, weight: weight)
+            return (styledFont(font, style: content.fontStyle, size: content.fontSize), "system")
+        }
+        guard let named = UIFont(name: family, size: content.fontSize) else { continue }
+        let weightedDescriptor = named.fontDescriptor.addingAttributes([
+            .traits: [UIFontDescriptor.TraitKey.weight: weight],
+        ])
+        let weighted = UIFont(descriptor: weightedDescriptor, size: content.fontSize)
+        return (styledFont(weighted, style: content.fontStyle, size: content.fontSize), family)
+    }
+    let font = UIFont.systemFont(ofSize: content.fontSize, weight: weight)
+    return (styledFont(font, style: content.fontStyle, size: content.fontSize), "system")
+}
+
+private func styledFont(
+    _ font: UIFont,
+    style: WhiskerTextFontStyle,
+    size: CGFloat
+) -> UIFont {
+    guard style != .normal,
+          let descriptor = font.fontDescriptor.withSymbolicTraits(
+              font.fontDescriptor.symbolicTraits.union(.traitItalic)
+          ) else { return font }
+    return UIFont(descriptor: descriptor, size: size)
 }
 
 private func configuredFont(base: UIFont, content: WhiskerTextContent) -> UIFont {

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
@@ -40,8 +40,12 @@ public struct WhiskerMeasuredSize {
 
 public struct WhiskerTextContent {
     public let value: String
+    public let fontFamilies: [String]
     public let fontSize: CGFloat
     public let fontWeight: Int
+    public let fontStyle: WhiskerTextFontStyle
+    public let lineHeight: CGFloat?
+    public let letterSpacing: CGFloat
     public let fontFeatures: [WhiskerFontFeature]
     public let fontVariations: [WhiskerFontVariation]
     public let fontOpticalSizing: WhiskerFontOpticalSizing
@@ -57,8 +61,12 @@ public struct WhiskerTextContent {
 
     public init(
         value: String,
+        fontFamilies: [String] = ["system"],
         fontSize: CGFloat,
         fontWeight: Int,
+        fontStyle: WhiskerTextFontStyle = .normal,
+        lineHeight: CGFloat? = nil,
+        letterSpacing: CGFloat = 0,
         fontFeatures: [WhiskerFontFeature] = [],
         fontVariations: [WhiskerFontVariation] = [],
         fontOpticalSizing: WhiskerFontOpticalSizing = .none,
@@ -73,8 +81,12 @@ public struct WhiskerTextContent {
         shadow: WhiskerTextShadow? = nil
     ) {
         self.value = value
+        self.fontFamilies = fontFamilies
         self.fontSize = fontSize
         self.fontWeight = fontWeight
+        self.fontStyle = fontStyle
+        self.lineHeight = lineHeight
+        self.letterSpacing = letterSpacing
         self.fontFeatures = fontFeatures
         self.fontVariations = fontVariations
         self.fontOpticalSizing = fontOpticalSizing
@@ -88,6 +100,12 @@ public struct WhiskerTextContent {
         self.decoration = decoration
         self.shadow = shadow
     }
+}
+
+public enum WhiskerTextFontStyle: Equatable {
+    case normal
+    case italic
+    case oblique
 }
 
 public struct WhiskerFontFeature: Equatable {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -140,11 +140,24 @@ final class HostScene {
                       text.wrap <= 1,
                       text.word_break <= 2,
                       text.overflow <= 1,
+                      text.font_style <= 2,
                       text.font_optical_sizing <= 1,
+                      text.font_size.isFinite,
+                      text.font_size > 0,
+                      (1...1_000).contains(Int(text.font_weight)),
+                      text.line_height.isFinite,
+                      text.line_height >= 0,
+                      text.letter_spacing.isFinite,
+                      validBorrowedArray(text.font_families, text.font_family_count),
                       validBorrowedArray(text.font_features, text.font_feature_count),
                       validBorrowedArray(text.font_variations, text.font_variation_count),
+                      text.font_family_count > 0,
+                      text.font_family_count <= 4_096,
+                      validBorrowedStrings(text.font_families, text.font_family_count),
                       text.font_feature_count <= 4_096,
                       text.font_variation_count <= 4_096,
+                      text.font_family_count + text.font_feature_count
+                        + text.font_variation_count <= 4_096,
                       text.indent_logical_pixels.isFinite,
                       text.indent_percentage.isFinite else { return false }
             case UInt32(WHISKER_OP_TRANSFORM):
@@ -529,8 +542,19 @@ final class HostScene {
         guard let node, let mounted = node.mountedElement else { return }
         guard mounted.setText(WhiskerTextContent(
             value: hostString(content.text),
+            fontFamilies: hostFontFamilies(content),
             fontSize: CGFloat(content.font_size),
             fontWeight: Int(content.font_weight),
+            fontStyle: {
+                switch content.font_style {
+                case 0: return .normal
+                case 1: return .italic
+                case 2: return .oblique
+                default: preconditionFailure("invalid font style")
+                }
+            }(),
+            lineHeight: content.line_height > 0 ? CGFloat(content.line_height) : nil,
+            letterSpacing: CGFloat(content.letter_spacing),
             fontFeatures: hostFontFeatures(content),
             fontVariations: hostFontVariations(content),
             fontOpticalSizing: content.font_optical_sizing == 0 ? .auto : .none,
@@ -606,11 +630,26 @@ private func validBorrowedArray<T>(_ pointer: UnsafePointer<T>?, _ count: Int) -
     (pointer == nil) == (count == 0)
 }
 
+private func validBorrowedStrings(
+    _ pointer: UnsafePointer<WhiskerStringRef>?,
+    _ count: Int
+) -> Bool {
+    guard let pointer, count > 0 else { return false }
+    return UnsafeBufferPointer(start: pointer, count: count).allSatisfy {
+        $0.len > 0 && $0.ptr != nil
+    }
+}
+
 private func hostFontFeatures(_ content: WhiskerMobileText) -> [WhiskerFontFeature] {
     guard let pointer = content.font_features else { return [] }
     return UnsafeBufferPointer(start: pointer, count: content.font_feature_count).map {
         WhiskerFontFeature(tag: hostFontTag($0.tag), value: $0.value)
     }
+}
+
+private func hostFontFamilies(_ content: WhiskerMobileText) -> [String] {
+    guard let pointer = content.font_families else { return [] }
+    return UnsafeBufferPointer(start: pointer, count: content.font_family_count).map(hostString)
 }
 
 private func hostFontVariations(_ content: WhiskerMobileText) -> [WhiskerFontVariation] {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -25,10 +25,11 @@ use whisker_host_conformance::{
 use whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
     BoxPaint, ClipShape, FillRule, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat,
-    LayoutGeometry, LayoutRect, MeasureTextDirection, MeasureTextOverflow, MeasureTextWordBreak,
-    MeasureTextWrap, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate,
-    PaintCornerRadius, PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition,
-    PathCommand, ProtocolVersion, RadialGradientExtent, RadialGradientShape, ResourceCommand,
+    LayoutGeometry, LayoutRect, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+    MeasureTextDirection, MeasureTextOverflow, MeasureTextWordBreak, MeasureTextWrap, NodeId,
+    Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate, PaintCornerRadius,
+    PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition, PathCommand,
+    ProtocolVersion, RadialGradientExtent, RadialGradientShape, ResourceCommand,
     ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest, ResourceSource,
     SurfaceId, TextContent, TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow, Transform,
     Visibility,
@@ -474,6 +475,8 @@ impl Driver {
                             "paint.text.wrap-overflow-lynx"
                         } else if name == "paint.text.font-features-lynx" {
                             "paint.text.font-features-lynx"
+                        } else if name == "paint.text.basic-style-lynx" {
+                            "paint.text.basic-style-lynx"
                         } else if name == "interaction.pointer.lynx" {
                             "interaction.pointer.lynx"
                         } else if name == "paint.visual-effects.image-rendering-pixelated" {
@@ -900,6 +903,30 @@ impl Driver {
                     Some(text.value.as_str())
                 );
                 assert_style(&text_style, "font-size", &fixture_px(text.font_size));
+                assert_style(
+                    &text_style,
+                    "font-family",
+                    &fixture_font_families_css(&text.font_families),
+                );
+                assert_style(
+                    &text_style,
+                    "font-style",
+                    match text.font_style {
+                        whisker_host_conformance::FontStyleFixture::Normal => "normal",
+                        whisker_host_conformance::FontStyleFixture::Italic => "italic",
+                        whisker_host_conformance::FontStyleFixture::Oblique => "oblique",
+                    },
+                );
+                assert_style(
+                    &text_style,
+                    "line-height",
+                    &text.line_height.map_or_else(|| "normal".into(), fixture_px),
+                );
+                assert_style(
+                    &text_style,
+                    "letter-spacing",
+                    &fixture_px(text.letter_spacing),
+                );
                 assert_style(
                     &text_style,
                     "font-feature-settings",
@@ -1568,6 +1595,9 @@ fn fixture(path: &str) -> &'static str {
         }
         "core/text-font-features-lynx.json" => {
             include_str!("../../../../tests/host-conformance/core/text-font-features-lynx.json")
+        }
+        "core/text-basic-style-lynx.json" => {
+            include_str!("../../../../tests/host-conformance/core/text-basic-style-lynx.json")
         }
         _ => panic!("manifest fixture is not embedded in the Web test: {path}"),
     }
@@ -2259,8 +2289,30 @@ fn fixture_text_content(text: &whisker_host_conformance::TextFixture) -> TextCon
         payload: TextMeasurePayload {
             text: text.value.clone(),
             style: TextMeasureStyle {
+                font_families: text
+                    .font_families
+                    .iter()
+                    .map(|family| {
+                        if family == "system" {
+                            MeasureFontFamily::System
+                        } else {
+                            MeasureFontFamily::Named(family.clone())
+                        }
+                    })
+                    .collect(),
                 font_size: text.font_size,
                 font_weight: text.font_weight,
+                font_style: match text.font_style {
+                    whisker_host_conformance::FontStyleFixture::Normal => MeasureFontStyle::Normal,
+                    whisker_host_conformance::FontStyleFixture::Italic => MeasureFontStyle::Italic,
+                    whisker_host_conformance::FontStyleFixture::Oblique => {
+                        MeasureFontStyle::Oblique
+                    }
+                },
+                line_height: text
+                    .line_height
+                    .map_or(MeasureLineHeight::Normal, MeasureLineHeight::LogicalPixels),
+                letter_spacing: text.letter_spacing,
                 features: text
                     .font_features
                     .iter()
@@ -2368,6 +2420,20 @@ fn fixture_font_tag(value: &str) -> whisker_protocol::FontTag {
         .try_into()
         .expect("fixture schema validates four-byte ASCII tags");
     whisker_protocol::FontTag::new(bytes).expect("fixture schema validates printable tags")
+}
+
+fn fixture_font_families_css(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|family| {
+            if family == "system" {
+                "system-ui".to_owned()
+            } else {
+                format!("{family:?}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn fixture_font_settings<T>(values: &[T], value: impl Fn(&T) -> String) -> String

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -159,7 +159,7 @@
       "id": "paint.text",
       "basis": "lynx-4.0",
       "properties": ["color", "font-family", "font-feature-settings", "font-optical-sizing", "font-size", "font-style", "font-variation-settings", "font-weight", "letter-spacing", "line-height", "text-align", "text-decoration", "text-indent", "text-overflow", "text-shadow", "white-space", "word-break"],
-      "supported_subset": ["basic-font-metrics-and-color", "single-text-shadow", "lynx-single-line-text-decoration", "lynx-text-align", "lynx-text-indent-length-percentage", "lynx-white-space-word-break-text-overflow", "opentype-feature-settings-all-hosts", "variable-font-axes-web-android-ios", "font-weight-axis-desktop", "lynx-optical-sizing-web-android-ios"],
+      "supported_subset": ["basic-font-metrics-and-color", "font-family-fallback-font-style-line-height-letter-spacing-all-hosts", "single-text-shadow", "lynx-single-line-text-decoration", "lynx-text-align", "lynx-text-indent-length-percentage", "lynx-white-space-word-break-text-overflow", "opentype-feature-settings-all-hosts", "variable-font-axes-web-android-ios", "font-weight-axis-desktop", "lynx-optical-sizing-web-android-ios"],
       "pending_subset": ["desktop-arbitrary-variable-font-axes-and-optical-sizing"],
       "protocol": ["SetText"],
       "rust": "implemented",

--- a/tests/host-conformance/core/text-basic-style-lynx.json
+++ b/tests/host-conformance/core/text-basic-style-lynx.json
@@ -1,0 +1,32 @@
+{
+  "schema": 1,
+  "id": "core.text-basic-style-lynx",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 260.0, "height": 64.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 260.0, 64.0],
+            "background": { "kind": "named", "value": "transparent" },
+            "text": {
+              "value": "Whisker text metrics",
+              "font_families": ["Whisker Fixture Sans", "system"],
+              "font_size": 20.0,
+              "font_weight": 650,
+              "font_style": "italic",
+              "line_height": 28.0,
+              "letter_spacing": 1.5,
+              "color": { "kind": "srgba", "red": 32, "green": 64, "blue": 192, "alpha": 1.0 }
+            }
+          }
+        ]
+      },
+      { "type": "checkpoint", "name": "paint.text.basic-style-lynx", "samples": [] }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -535,6 +535,13 @@
       "checkpoints": ["semantic-projection"]
     },
     {
+      "id": "core.text-basic-style-lynx",
+      "feature": "text-basic-style-lynx",
+      "fixture": "core/text-basic-style-lynx.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection"]
+    },
+    {
       "id": "host.measure.text.basic",
       "feature": "text-measurement",
       "fixture": "core/text-measure-basic.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -1,6 +1,7 @@
 package rs.whisker.runtime
 
 import android.graphics.Bitmap
+import android.os.Build
 import android.view.ViewGroup
 import android.widget.TextView
 import android.graphics.Canvas
@@ -327,6 +328,27 @@ private class Driver(
                             listOf("wdth" to 90f, "wght" to 650f))
                         check(texts[2].whiskerFontOpticalSizing == WhiskerFontOpticalSizing.AUTO)
                     }
+                    if (command.getString("name") == "paint.text.basic-style-lynx") {
+                        val text = findTextViews(view).single()
+                        val density = context.resources.displayMetrics.density
+                        check(text.whiskerFontFamilies ==
+                            listOf("Whisker Fixture Sans", "system"))
+                        check(text.whiskerFontStyle == WhiskerFontStyle.ITALIC)
+                        check(text.whiskerLineHeight == 28f)
+                        check(text.whiskerLetterSpacing == 1.5f)
+                        check(abs(text.textSize / density - 20f) < 0.01f)
+                        check(text.typeface.isItalic)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                            check(text.typeface.weight == 650)
+                        } else {
+                            check(text.typeface.isBold)
+                        }
+                        check(abs(text.letterSpacing - 0.075f) < 0.0001f)
+                        val actualLineHeight =
+                            text.paint.fontMetrics.run { descent - ascent } + text.lineSpacingExtra
+                        check(abs(actualLineHeight / density - 28f) < 0.01f)
+                        check(text.lineSpacingMultiplier == 1f)
+                    }
                     check(
                         command.getString("name") == "paint.box" ||
                             command.getString("name") == "paint.background-layers.linear-gradient" ||
@@ -411,6 +433,7 @@ private class Driver(
                             command.getString("name") == "paint.text.indent-lynx" ||
                             command.getString("name") == "paint.text.wrap-overflow-lynx" ||
                             command.getString("name") == "paint.text.font-features-lynx" ||
+                            command.getString("name") == "paint.text.basic-style-lynx" ||
                             command.getString("name") == "interaction.pointer.lynx",
                     )
                     checkpoint = capture()
@@ -609,11 +632,15 @@ private class Driver(
             val (numbers, names) = paint(node)
             check(stage(tag = 7, node = id, numbers = numbers, names = names))
             node.optJSONObject("text")?.let { text ->
-                val textNumbers = ArrayList<Float>(33)
+                val textNumbers = ArrayList<Float>(36)
                 val textNames = ArrayList<String>(3)
                 textNumbers += text.getDouble("font_size").toFloat()
                 textNumbers += text.optInt("font_weight", 400).toFloat()
-                textNumbers += 0f
+                textNumbers += when (text.optString("font_style", "normal")) {
+                    "italic" -> 1f
+                    "oblique" -> 2f
+                    else -> 0f
+                }
                 appendColor(text.getJSONObject("color"), textNumbers, textNames)
                 val shadow = text.optJSONObject("shadow")
                 textNumbers += if (shadow == null) 0f else 1f
@@ -667,6 +694,11 @@ private class Driver(
                 textNumbers += if (text.optString("font_optical_sizing", "none") == "auto") 0f else 1f
                 val features = text.optJSONArray("font_features")
                 textNumbers += (features?.length() ?: 0).toFloat()
+                val families = text.optJSONArray("font_families") ?: JSONArray("[\"system\"]")
+                textNumbers += families.length().toFloat()
+                textNumbers += text.optDouble("line_height", 0.0).toFloat()
+                textNumbers += text.optDouble("letter_spacing", 0.0).toFloat()
+                families.strings().forEach(textNames::add)
                 features?.objects()?.forEach { setting ->
                     textNames += "${setting.getString("tag")}=${setting.getLong("value")}"
                 }

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -491,6 +491,7 @@ private final class Driver {
                     name == "paint.text.indent-lynx" ||
                     name == "paint.text.wrap-overflow-lynx" ||
                     name == "paint.text.font-features-lynx" ||
+                    name == "paint.text.basic-style-lynx" ||
                     name == "interaction.pointer.lynx" else {
                     throw Failure("unsupported UIKit checkpoint")
                 }
@@ -585,6 +586,38 @@ private final class Driver {
                         ]
                     )
                     XCTAssertEqual(labels[2].whiskerFontOpticalSizing, .auto)
+                }
+                if name == "paint.text.basic-style-lynx" {
+                    let labels = findTextLabels(view)
+                    XCTAssertEqual(labels.count, 1)
+                    let label = try XCTUnwrap(labels.first)
+                    XCTAssertEqual(label.whiskerFontFamilies, ["Whisker Fixture Sans", "system"])
+                    XCTAssertEqual(label.whiskerResolvedFontFamily, "system")
+                    XCTAssertEqual(label.font.pointSize, 20, accuracy: 0.001)
+                    XCTAssertEqual(label.whiskerFontWeight, 650)
+                    let traits = try XCTUnwrap(
+                        label.font.fontDescriptor.object(forKey: .traits)
+                            as? [UIFontDescriptor.TraitKey: Any]
+                    )
+                    let appliedWeight = try XCTUnwrap(
+                        traits[.weight] as? NSNumber
+                    )
+                    XCTAssertGreaterThan(appliedWeight.doubleValue, 0)
+                    XCTAssertEqual(label.whiskerFontStyle, .italic)
+                    XCTAssertTrue(label.font.fontDescriptor.symbolicTraits.contains(.traitItalic))
+                    XCTAssertEqual(try XCTUnwrap(label.whiskerLineHeight), 28)
+                    XCTAssertEqual(label.whiskerLetterSpacing, 1.5)
+                    let attributes = try XCTUnwrap(label.attributedText)
+                    let paragraph = try XCTUnwrap(
+                        attributes.attribute(.paragraphStyle, at: 0, effectiveRange: nil)
+                            as? NSParagraphStyle
+                    )
+                    XCTAssertEqual(paragraph.minimumLineHeight, 28)
+                    XCTAssertEqual(paragraph.maximumLineHeight, 28)
+                    let kern = try XCTUnwrap(
+                        attributes.attribute(.kern, at: 0, effectiveRange: nil) as? NSNumber
+                    )
+                    XCTAssertEqual(kern.doubleValue, 1.5)
                 }
                 let pixels = try capture()
                 checkpoint = pixels
@@ -771,6 +804,14 @@ private final class Driver {
             capacity: max(fixtures.count, 1)
         )
         var textStrings = [UnsafeMutablePointer<CChar>?](repeating: nil, count: fixtures.count)
+        var textFamilyRefs = [UnsafeMutablePointer<WhiskerStringRef>?](
+            repeating: nil,
+            count: fixtures.count
+        )
+        var textFamilyStrings = [[UnsafeMutablePointer<CChar>]](
+            repeating: [],
+            count: fixtures.count
+        )
         var textFeatures = [UnsafeMutablePointer<WhiskerMobileFontFeature>?](
             repeating: nil,
             count: fixtures.count
@@ -787,8 +828,31 @@ private final class Driver {
                 storage.initialize(from: bytes, count: bytes.count)
                 textStrings[index] = storage
                 payload.text = WhiskerStringRef(ptr: UnsafePointer(storage), len: bytes.count - 1)
+                if !text.fontFamilies.isEmpty {
+                    let references = UnsafeMutablePointer<WhiskerStringRef>.allocate(
+                        capacity: text.fontFamilies.count
+                    )
+                    for (familyIndex, family) in text.fontFamilies.enumerated() {
+                        let familyBytes = Array(family.utf8CString)
+                        let familyStorage = UnsafeMutablePointer<CChar>.allocate(
+                            capacity: familyBytes.count
+                        )
+                        familyStorage.initialize(from: familyBytes, count: familyBytes.count)
+                        textFamilyStrings[index].append(familyStorage)
+                        references.advanced(by: familyIndex).initialize(to: WhiskerStringRef(
+                            ptr: UnsafePointer(familyStorage),
+                            len: familyBytes.count - 1
+                        ))
+                    }
+                    textFamilyRefs[index] = references
+                    payload.font_families = UnsafePointer(references)
+                    payload.font_family_count = text.fontFamilies.count
+                }
                 payload.font_size = text.fontSize
                 payload.font_weight = text.fontWeight
+                payload.font_style = text.fontStyle
+                payload.line_height = text.lineHeight
+                payload.letter_spacing = text.letterSpacing
                 payload.color = text.color
                 if let offset = text.shadowOffset {
                     payload.shadow_flags = 1
@@ -846,6 +910,13 @@ private final class Driver {
             textPayloads.deallocate()
             for storage in textStrings {
                 storage?.deallocate()
+            }
+            for (index, storage) in textFamilyRefs.enumerated() {
+                storage?.deinitialize(count: fixtures[index].text?.fontFamilies.count ?? 0)
+                storage?.deallocate()
+            }
+            for strings in textFamilyStrings {
+                for storage in strings { storage.deallocate() }
             }
             for (index, storage) in textFeatures.enumerated() {
                 storage?.deinitialize(count: fixtures[index].text?.fontFeatures.count ?? 0)
@@ -1410,8 +1481,12 @@ private struct SceneFixtureNode {
 
 private struct SceneText {
     let value: String
+    let fontFamilies: [String]
     let fontSize: Float
     let fontWeight: UInt16
+    let fontStyle: UInt8
+    let lineHeight: Float
+    let letterSpacing: Float
     let color: WhiskerMobileColor
     let alignment: UInt32
     let indentLogicalPixels: Float
@@ -1636,10 +1711,26 @@ private func sceneNode(_ fixture: [String: Any]) throws -> SceneFixtureNode {
         case "keep_all": wordBreak = 2
         default: throw Failure("unknown word-break")
         }
+        let fontStyle: UInt8
+        switch raw["font_style"] as? String ?? "normal" {
+        case "normal": fontStyle = 0
+        case "italic": fontStyle = 1
+        case "oblique": fontStyle = 2
+        default: throw Failure("unknown font style")
+        }
         text = SceneText(
             value: try string(raw, "value"),
+            fontFamilies: try (raw["font_families"] as? [Any] ?? ["system"]).map {
+                guard let family = $0 as? String else {
+                    throw Failure("font family must be a string")
+                }
+                return family
+            },
             fontSize: Float(try number(raw, "font_size")),
             fontWeight: UInt16((raw["font_weight"] as? NSNumber)?.intValue ?? 400),
+            fontStyle: fontStyle,
+            lineHeight: (raw["line_height"] as? NSNumber)?.floatValue ?? 0,
+            letterSpacing: (raw["letter_spacing"] as? NSNumber)?.floatValue ?? 0,
             color: try color(object(raw, "color")),
             alignment: alignment,
             indentLogicalPixels: Float(try indent.map { try number($0, "logical_pixels") } ?? 0),

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -173,8 +173,16 @@
       "required": ["value", "font_size", "color"],
       "properties": {
         "value": { "type": "string" },
+        "font_families": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
         "font_size": { "type": "number", "exclusiveMinimum": 0 },
         "font_weight": { "type": "integer", "minimum": 1, "maximum": 1000 },
+        "font_style": { "enum": ["normal", "italic", "oblique"] },
+        "line_height": { "type": "number", "exclusiveMinimum": 0 },
+        "letter_spacing": { "type": "number" },
         "font_features": { "type": "array", "items": { "$ref": "#/$defs/fontFeature" } },
         "font_variations": { "type": "array", "items": { "$ref": "#/$defs/fontVariation" } },
         "font_optical_sizing": { "enum": ["auto", "none"] },


### PR DESCRIPTION
## Summary
- add one shared text fixture for font-family fallback, font-size, numeric weight, font-style, line-height, letter-spacing, and color
- extend mobile ABI 2.23 so ordered font families and existing metric fields reach Android/iOS production Hosts
- apply continuous weight/posture and text metrics in Android TextView and iOS UILabel implementations
- project and assert the same fixture through Desktop, Web, Android, and iOS runners
- fix mobile-only Rust test compilation exposed by the Android target check

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p whisker-host-conformance -p whisker-driver`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance android` (7/7 on Pixel 9 Pro API 36)
- `cargo xtask host-conformance ios` (9/9)
- Android NDK aarch64 C syntax check
- `cargo check -p whisker --target aarch64-linux-android`
- `cargo check -p whisker --target aarch64-linux-android --tests`
- `git diff --check`

## Notes
The shared fixture initially exposed a real production gap: FramePacket retained these values, but the mobile SetText ABI dropped font families and Android did not consume font-style, line-height, or letter-spacing. The runner was not made artificially green; the ABI and built-in Text implementations were fixed first.