### PR TITLE
test(host): cover advanced text measurement

### DIFF
--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -1,6 +1,7 @@
 #if defined(__ANDROID__)
 
 #include <jni.h>
+#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -236,13 +237,32 @@ static jstring font_setting(JNIEnv* env, const uint8_t tag[4], double value, boo
     return length < 0 ? NULL : new_string(env, buffer, (size_t)length);
 }
 
-static jobjectArray font_settings(JNIEnv* env,
-                                  const WhiskerMobileFontFeature* features, size_t feature_count,
-                                  const WhiskerMobileFontVariation* variations, size_t variation_count) {
+static bool valid_font_tag(const uint8_t tag[4]) {
+    for (size_t i = 0; i < 4; ++i) {
+        if (tag[i] < 0x20 || tag[i] > 0x7e) return false;
+    }
+    return true;
+}
+
+static bool valid_font_settings(const WhiskerMobileFontFeature* features, size_t feature_count,
+                                const WhiskerMobileFontVariation* variations, size_t variation_count) {
     if (feature_count > 4096 || variation_count > 4096 ||
         (features == NULL) != (feature_count == 0) ||
         (variations == NULL) != (variation_count == 0) ||
-        feature_count + variation_count > 4096) return NULL;
+        feature_count + variation_count > 4096) return false;
+    for (size_t i = 0; i < feature_count; ++i) {
+        if (!valid_font_tag(features[i].tag)) return false;
+    }
+    for (size_t i = 0; i < variation_count; ++i) {
+        if (!valid_font_tag(variations[i].tag) || !isfinite(variations[i].value)) return false;
+    }
+    return true;
+}
+
+static jobjectArray font_settings(JNIEnv* env,
+                                  const WhiskerMobileFontFeature* features, size_t feature_count,
+                                  const WhiskerMobileFontVariation* variations, size_t variation_count) {
+    if (!valid_font_settings(features, feature_count, variations, variation_count)) return NULL;
     jclass cls = (*env)->FindClass(env, "java/lang/String");
     jobjectArray result = cls == NULL ? NULL : (*env)->NewObjectArray(
         env, (jsize)(feature_count + variation_count), cls, NULL);
@@ -553,7 +573,9 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                     p->font_family_count > 4096 ||
                     p->font_feature_count > 4096 ||
                     p->font_variation_count > 4096 ||
-                    p->font_family_count + p->font_feature_count + p->font_variation_count > 4096) { ok = false; break; }
+                    p->font_family_count + p->font_feature_count + p->font_variation_count > 4096 ||
+                    !valid_font_settings(p->font_features, p->font_feature_count,
+                                         p->font_variations, p->font_variation_count)) { ok = false; break; }
                 for (size_t j=0;j<p->font_family_count;++j) {
                     if (!valid_nonempty_string_ref(p->font_families[j])) { ok = false; break; }
                 }

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -234,6 +234,15 @@ pub enum Command {
         /// Additional logical pixels between glyph advances.
         #[serde(default)]
         letter_spacing: f32,
+        /// Ordered OpenType feature settings.
+        #[serde(default)]
+        font_features: Vec<FontFeatureFixture>,
+        /// Ordered variable-font axis settings.
+        #[serde(default)]
+        font_variations: Vec<FontVariationFixture>,
+        /// Lynx optical-sizing behavior.
+        #[serde(default)]
+        font_optical_sizing: FontOpticalSizingFixture,
         /// Definite available width.
         available_width: f32,
     },
@@ -1493,6 +1502,8 @@ fn validate_side(id: &str, label: &str, side: &ScenarioSide) -> Result<(), Fixtu
                 font_weight,
                 line_height,
                 letter_spacing,
+                font_features,
+                font_variations,
                 available_width,
                 ..
             } if *key > 0
@@ -1502,6 +1513,12 @@ fn validate_side(id: &str, label: &str, side: &ScenarioSide) -> Result<(), Fixtu
                 && (1..=1000).contains(font_weight)
                 && finite_positive(*line_height)
                 && letter_spacing.is_finite()
+                && font_features
+                    .iter()
+                    .all(|feature| valid_font_tag(&feature.tag))
+                && font_variations.iter().all(|variation| {
+                    valid_font_tag(&variation.tag) && variation.value.is_finite()
+                })
                 && available_width.is_finite()
                 && *available_width >= 0.0 => {}
             Command::CheckpointMeasurement {
@@ -1656,6 +1673,13 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
                             .line_height
                             .is_none_or(|height| height.is_finite() && height > 0.0)
                         && text.letter_spacing.is_finite()
+                        && text
+                            .font_features
+                            .iter()
+                            .all(|feature| valid_font_tag(&feature.tag))
+                        && text.font_variations.iter().all(|variation| {
+                            valid_font_tag(&variation.tag) && variation.value.is_finite()
+                        })
                         && valid_color(&text.color)
                         && text
                             .decoration
@@ -1751,6 +1775,10 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
             }
             true
         })
+}
+
+fn valid_font_tag(tag: &str) -> bool {
+    tag.as_bytes().len() == 4 && tag.bytes().all(|byte| (b' '..=b'~').contains(&byte))
 }
 
 impl LengthPercentageFixture {

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -1778,7 +1778,7 @@ fn valid_scene_nodes(nodes: &[SceneNodeFixture]) -> bool {
 }
 
 fn valid_font_tag(tag: &str) -> bool {
-    tag.as_bytes().len() == 4 && tag.bytes().all(|byte| (b' '..=b'~').contains(&byte))
+    tag.len() == 4 && tag.bytes().all(|byte| (b' '..=b'~').contains(&byte))
 }
 
 impl LengthPercentageFixture {

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -684,6 +684,9 @@ impl Driver {
                     font_style,
                     line_height,
                     letter_spacing,
+                    font_features,
+                    font_variations,
+                    font_optical_sizing,
                     available_width,
                 } => self.measure_text(
                     *key,
@@ -694,6 +697,9 @@ impl Driver {
                     *font_style,
                     *line_height,
                     *letter_spacing,
+                    font_features,
+                    font_variations,
+                    *font_optical_sizing,
                     *available_width,
                 ),
                 Command::CheckpointMeasurement {
@@ -1413,6 +1419,9 @@ impl Driver {
         font_style: whisker_host_conformance::FontStyleFixture,
         line_height: f32,
         letter_spacing: f32,
+        font_features: &[whisker_host_conformance::FontFeatureFixture],
+        font_variations: &[whisker_host_conformance::FontVariationFixture],
+        font_optical_sizing: whisker_host_conformance::FontOpticalSizingFixture,
         available_width: f32,
     ) {
         let surface = self.surface.expect("attach_surface precedes measure_text");
@@ -1456,6 +1465,28 @@ impl Driver {
                     },
                     line_height: MeasureLineHeight::LogicalPixels(line_height),
                     letter_spacing,
+                    features: font_features
+                        .iter()
+                        .map(|feature| whisker_protocol::FontFeature {
+                            tag: fixture_font_tag(&feature.tag),
+                            value: feature.value,
+                        })
+                        .collect(),
+                    variations: font_variations
+                        .iter()
+                        .map(|variation| whisker_protocol::FontVariation {
+                            tag: fixture_font_tag(&variation.tag),
+                            value: variation.value,
+                        })
+                        .collect(),
+                    optical_sizing: match font_optical_sizing {
+                        whisker_host_conformance::FontOpticalSizingFixture::Auto => {
+                            whisker_protocol::FontOpticalSizing::Auto
+                        }
+                        whisker_host_conformance::FontOpticalSizingFixture::None => {
+                            whisker_protocol::FontOpticalSizing::None
+                        }
+                    },
                     ..TextMeasureStyle::default()
                 },
                 locale: None,
@@ -1471,6 +1502,49 @@ impl Driver {
         self.text
             .measure_batch(surface, &[request], &mut self.measurement_responses)
             .expect("Desktop text measurement is infallible");
+        if !font_features.is_empty() || !font_variations.is_empty() {
+            let response = self
+                .measurement_responses
+                .last()
+                .expect("Desktop text measurement returned one response");
+            let MeasurementResponse::Ready { metrics, .. } = response else {
+                panic!("Desktop text measurement is synchronously ready");
+            };
+            let prepared = self
+                .text
+                .prepared
+                .get(
+                    &metrics
+                        .prepared_content
+                        .expect("Desktop retains shaped text"),
+                )
+                .expect("prepared text is retained by its response ID");
+            let attrs = prepared
+                .buffer
+                .lines
+                .first()
+                .expect("text produces one source line")
+                .attrs_list()
+                .defaults();
+            let expected_features = font_features
+                .iter()
+                .map(|feature| (feature.tag.as_bytes(), feature.value))
+                .collect::<Vec<_>>();
+            let actual_features = attrs
+                .font_features
+                .features
+                .iter()
+                .map(|feature| (feature.tag.as_bytes().as_slice(), feature.value))
+                .collect::<Vec<_>>();
+            assert_eq!(actual_features, expected_features);
+            if let Some(weight) = font_variations
+                .iter()
+                .rev()
+                .find(|variation| variation.tag == "wght")
+            {
+                assert_eq!(attrs.weight.0, weight.value.clamp(1.0, 1000.0) as u16);
+            }
+        }
     }
 
     fn check_measurement(

--- a/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
@@ -14,6 +14,12 @@ let whiskerIOSMeasure: WhiskerMeasureHost = { data, requests, count, responses i
               request.line_height.isFinite,
               request.line_height >= 0,
               request.letter_spacing.isFinite,
+              request.font_optical_sizing <= 1,
+              request.font_feature_count <= 4_096,
+              request.font_variation_count <= 4_096,
+              request.font_feature_count + request.font_variation_count <= 4_096,
+              validMeasureFontFeatures(request),
+              validMeasureFontVariations(request),
               let families = validatedFontFamilies(request) else { return false }
         textFontFamilies[index] = families
     }
@@ -133,6 +139,32 @@ private func validatedFontFamilies(_ request: WhiskerMobileMeasureRequest) -> [S
         result.append(family)
     }
     return result
+}
+
+private func validMeasureFontFeatures(_ request: WhiskerMobileMeasureRequest) -> Bool {
+    guard (request.font_features == nil) == (request.font_feature_count == 0) else {
+        return false
+    }
+    guard let pointer = request.font_features else { return true }
+    return UnsafeBufferPointer(start: pointer, count: request.font_feature_count).allSatisfy {
+        validOpenTypeTag($0.tag)
+    }
+}
+
+private func validMeasureFontVariations(_ request: WhiskerMobileMeasureRequest) -> Bool {
+    guard (request.font_variations == nil) == (request.font_variation_count == 0) else {
+        return false
+    }
+    guard let pointer = request.font_variations else { return true }
+    return UnsafeBufferPointer(start: pointer, count: request.font_variation_count).allSatisfy {
+        validOpenTypeTag($0.tag) && $0.value.isFinite
+    }
+}
+
+private func validOpenTypeTag<T>(_ tag: T) -> Bool {
+    withUnsafeBytes(of: tag) { bytes in
+        bytes.count == 4 && bytes.allSatisfy { (0x20...0x7E).contains($0) }
+    }
 }
 
 private func configuredMeasureFont(

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -729,6 +729,9 @@ impl Driver {
                     font_style,
                     line_height,
                     letter_spacing,
+                    font_features,
+                    font_variations,
+                    font_optical_sizing,
                     available_width,
                 } => self.measure_text(
                     *key,
@@ -739,6 +742,9 @@ impl Driver {
                     *font_style,
                     *line_height,
                     *letter_spacing,
+                    font_features,
+                    font_variations,
+                    *font_optical_sizing,
                     *available_width,
                 ),
                 Command::CheckpointMeasurement {
@@ -772,6 +778,9 @@ impl Driver {
         font_style: whisker_host_conformance::FontStyleFixture,
         line_height: f32,
         letter_spacing: f32,
+        font_features: &[whisker_host_conformance::FontFeatureFixture],
+        font_variations: &[whisker_host_conformance::FontVariationFixture],
+        font_optical_sizing: whisker_host_conformance::FontOpticalSizingFixture,
         available_width: f32,
     ) {
         let key_id = MeasurementKey::new(key).expect("fixture measurement key is non-zero");
@@ -809,6 +818,21 @@ impl Driver {
                     font_style: fixture_measure_font_style(font_style),
                     line_height: MeasureLineHeight::LogicalPixels(line_height),
                     letter_spacing,
+                    features: font_features
+                        .iter()
+                        .map(|feature| whisker_protocol::FontFeature {
+                            tag: fixture_font_tag(&feature.tag),
+                            value: feature.value,
+                        })
+                        .collect(),
+                    variations: font_variations
+                        .iter()
+                        .map(|variation| whisker_protocol::FontVariation {
+                            tag: fixture_font_tag(&variation.tag),
+                            value: variation.value,
+                        })
+                        .collect(),
+                    optical_sizing: fixture_font_optical_sizing(font_optical_sizing),
                     ..TextMeasureStyle::default()
                 },
                 locale: None,
@@ -821,6 +845,12 @@ impl Driver {
                 overflow: MeasureTextOverflow::Clip,
             }),
         };
+        self.assert_measurement_style(
+            &request,
+            font_features,
+            font_variations,
+            font_optical_sizing,
+        );
         let mut responses = Vec::new();
         self.measurements
             .measure_batch(SurfaceId::new(1).unwrap(), &[request], &mut responses)
@@ -841,6 +871,46 @@ impl Driver {
         assert_eq!(environment_epoch, 1);
         assert!(metrics.is_valid());
         self.measurement_results.insert(key, metrics);
+    }
+
+    fn assert_measurement_style(
+        &self,
+        request: &MeasurementRequest,
+        font_features: &[whisker_host_conformance::FontFeatureFixture],
+        font_variations: &[whisker_host_conformance::FontVariationFixture],
+        font_optical_sizing: whisker_host_conformance::FontOpticalSizingFixture,
+    ) {
+        let MeasurementPayload::Text(text) = &request.payload else {
+            panic!("Web text measurement fixture produced a non-text request")
+        };
+        let probe = web_sys::window()
+            .expect("browser window")
+            .document()
+            .expect("browser document")
+            .create_element("div")
+            .expect("create measurement style assertion probe");
+        crate::paint::text::apply_metrics_style(&probe, text)
+            .expect("production text measurement style projection succeeds");
+        let style = probe.dyn_ref::<web_sys::HtmlElement>().unwrap().style();
+
+        assert_style(
+            &style,
+            "font-feature-settings",
+            &fixture_font_settings(font_features, |value| value.value.to_string()),
+        );
+        assert_style(
+            &style,
+            "font-variation-settings",
+            &fixture_font_settings(font_variations, |value| value.value.to_string()),
+        );
+        assert_style(
+            &style,
+            "font-optical-sizing",
+            match font_optical_sizing {
+                whisker_host_conformance::FontOpticalSizingFixture::Auto => "auto",
+                whisker_host_conformance::FontOpticalSizingFixture::None => "none",
+            },
+        );
     }
 
     fn assert_measurement(
@@ -1714,6 +1784,9 @@ fn fixture(path: &str) -> &'static str {
         "core/text-measure-basic.json" => {
             include_str!("../../../../tests/host-conformance/core/text-measure-basic.json")
         }
+        "core/text-measure-font-features.json" => {
+            include_str!("../../../../tests/host-conformance/core/text-measure-font-features.json")
+        }
         "core/pointer-input-basic.json" => {
             include_str!("../../../../tests/host-conformance/core/pointer-input-basic.json")
         }
@@ -2438,6 +2511,19 @@ fn fixture_measure_font_style(
         whisker_host_conformance::FontStyleFixture::Normal => MeasureFontStyle::Normal,
         whisker_host_conformance::FontStyleFixture::Italic => MeasureFontStyle::Italic,
         whisker_host_conformance::FontStyleFixture::Oblique => MeasureFontStyle::Oblique,
+    }
+}
+
+fn fixture_font_optical_sizing(
+    value: whisker_host_conformance::FontOpticalSizingFixture,
+) -> whisker_protocol::FontOpticalSizing {
+    match value {
+        whisker_host_conformance::FontOpticalSizingFixture::Auto => {
+            whisker_protocol::FontOpticalSizing::Auto
+        }
+        whisker_host_conformance::FontOpticalSizingFixture::None => {
+            whisker_protocol::FontOpticalSizing::None
+        }
     }
 }
 

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -159,7 +159,7 @@
       "id": "paint.text",
       "basis": "lynx-4.0",
       "properties": ["color", "font-family", "font-feature-settings", "font-optical-sizing", "font-size", "font-style", "font-variation-settings", "font-weight", "letter-spacing", "line-height", "text-align", "text-decoration", "text-indent", "text-overflow", "text-shadow", "white-space", "word-break"],
-      "supported_subset": ["basic-font-metrics-and-color", "font-family-fallback-font-style-line-height-letter-spacing-all-hosts", "intrinsic-measurement-uses-paint-typography-all-hosts", "single-text-shadow", "lynx-single-line-text-decoration", "lynx-text-align", "lynx-text-indent-length-percentage", "lynx-white-space-word-break-text-overflow", "opentype-feature-settings-all-hosts", "variable-font-axes-web-android-ios", "font-weight-axis-desktop", "lynx-optical-sizing-web-android-ios"],
+      "supported_subset": ["basic-font-metrics-and-color", "font-family-fallback-font-style-line-height-letter-spacing-all-hosts", "intrinsic-measurement-uses-paint-typography-all-hosts", "intrinsic-measurement-opentype-features-and-weight-axis-all-hosts", "single-text-shadow", "lynx-single-line-text-decoration", "lynx-text-align", "lynx-text-indent-length-percentage", "lynx-white-space-word-break-text-overflow", "opentype-feature-settings-all-hosts", "variable-font-axes-web-android-ios", "font-weight-axis-desktop", "lynx-optical-sizing-web-android-ios"],
       "pending_subset": ["desktop-arbitrary-variable-font-axes-and-optical-sizing"],
       "protocol": ["SetText"],
       "rust": "implemented",

--- a/tests/host-conformance/core/text-measure-font-features.json
+++ b/tests/host-conformance/core/text-measure-font-features.json
@@ -1,0 +1,37 @@
+{
+  "schema": 1,
+  "id": "host.measure.text.font-features",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 260.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "measure_text",
+        "key": 2,
+        "text": "AVATAR",
+        "font_families": ["system"],
+        "font_size": 22.0,
+        "font_weight": 500,
+        "font_style": "normal",
+        "line_height": 30.0,
+        "letter_spacing": 0.5,
+        "font_features": [
+          { "tag": "kern", "value": 0 },
+          { "tag": "liga", "value": 0 }
+        ],
+        "font_variations": [
+          { "tag": "wght", "value": 720.0 }
+        ],
+        "font_optical_sizing": "none",
+        "available_width": 240.0
+      },
+      {
+        "type": "checkpoint_measurement",
+        "key": 2,
+        "min_width": 20.0,
+        "max_width": 240.0,
+        "min_height": 20.0,
+        "max_height": 70.0
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -549,6 +549,13 @@
       "checkpoints": ["measurement"]
     },
     {
+      "id": "host.measure.text.font-features",
+      "feature": "text-measurement-font-features",
+      "fixture": "core/text-measure-font-features.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["measurement", "semantic-projection"]
+    },
+    {
       "id": "core.pointer-style-lynx",
       "feature": "cursor-pointer-events",
       "fixture": "core/pointer-style-lynx.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -499,6 +499,16 @@ private class Driver(
     private fun measureText(command: JSONObject) {
         val families = command.getJSONArray("font_families").strings()
         check(families.isNotEmpty())
+        val featureSettings = command.optJSONArray("font_features")?.objects()?.map { setting ->
+            "${setting.getString("tag")}=${setting.getLong("value")}"
+        }?.toList().orEmpty()
+        val variationSettings = command.optJSONArray("font_variations")?.objects()?.map { setting ->
+            "${setting.getString("tag")}=${setting.getDouble("value")}"
+        }?.toList().orEmpty()
+        val opticalSizing = when (command.optString("font_optical_sizing", "none")) {
+            "auto" -> 0
+            else -> 1
+        }
         val result = view.measureFromNative(
             elementType = 2,
             kind = 1,
@@ -526,9 +536,9 @@ private class Driver(
             indentLogicalPixels = 0f,
             indentPercentage = 0f,
             maxLines = 0,
-            fontSettings = emptyArray(),
-            fontFeatureCount = 0,
-            fontOpticalSizing = 1,
+            fontSettings = (featureSettings + variationSettings).toTypedArray(),
+            fontFeatureCount = featureSettings.size,
+            fontOpticalSizing = opticalSizing,
             payloadVersion = 0,
             payload = byteArrayOf(),
             intrinsicWidth = 0f,
@@ -536,6 +546,11 @@ private class Driver(
             intrinsicMask = 0,
         )
         check(result.size >= 7 && result[0] == 1f) { "$id text measurement was not ready" }
+        if (id == "host.measure.text.font-features") {
+            check(featureSettings == listOf("kern=0", "liga=0"))
+            check(variationSettings == listOf("wght=720.0"))
+            check(opticalSizing == 1)
+        }
         measurements[command.getLong("key")] = result
     }
 

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -658,6 +658,24 @@ private final class Driver {
         case "oblique": fontStyle = 2
         default: throw Failure("unknown measurement font style")
         }
+        let fontFeatures = try (command["font_features"] as? [[String: Any]] ?? []).map {
+            SceneFontFeature(
+                tag: try string($0, "tag"),
+                value: UInt32(try number($0, "value"))
+            )
+        }
+        let fontVariations = try (command["font_variations"] as? [[String: Any]] ?? []).map {
+            SceneFontVariation(
+                tag: try string($0, "tag"),
+                value: Float(try number($0, "value"))
+            )
+        }
+        let fontOpticalSizing: UInt8
+        switch command["font_optical_sizing"] as? String ?? "none" {
+        case "auto": fontOpticalSizing = 0
+        case "none": fontOpticalSizing = 1
+        default: throw Failure("unknown measurement optical sizing")
+        }
 
         let textBytes = Array(value.utf8CString)
         let textStorage = UnsafeMutablePointer<CChar>.allocate(capacity: textBytes.count)
@@ -684,6 +702,34 @@ private final class Driver {
             ))
         }
 
+        let featureStorage: UnsafeMutablePointer<WhiskerMobileFontFeature>? =
+            fontFeatures.isEmpty ? nil : .allocate(capacity: fontFeatures.count)
+        defer {
+            featureStorage?.deinitialize(count: fontFeatures.count)
+            featureStorage?.deallocate()
+        }
+        for (index, setting) in fontFeatures.enumerated() {
+            var native = WhiskerMobileFontFeature()
+            let tag = try fontTag(setting.tag)
+            native.tag = (tag[0], tag[1], tag[2], tag[3])
+            native.value = setting.value
+            featureStorage?.advanced(by: index).initialize(to: native)
+        }
+
+        let variationStorage: UnsafeMutablePointer<WhiskerMobileFontVariation>? =
+            fontVariations.isEmpty ? nil : .allocate(capacity: fontVariations.count)
+        defer {
+            variationStorage?.deinitialize(count: fontVariations.count)
+            variationStorage?.deallocate()
+        }
+        for (index, setting) in fontVariations.enumerated() {
+            var native = WhiskerMobileFontVariation()
+            let tag = try fontTag(setting.tag)
+            native.tag = (tag[0], tag[1], tag[2], tag[3])
+            native.value = setting.value
+            variationStorage?.advanced(by: index).initialize(to: native)
+        }
+
         var request = WhiskerMobileMeasureRequest()
         request.key = key
         request.node = 1
@@ -705,7 +751,26 @@ private final class Driver {
         request.font_weight = UInt16((command["font_weight"] as? NSNumber)?.uintValue ?? 400)
         request.line_height = Float(try number(command, "line_height"))
         request.letter_spacing = (command["letter_spacing"] as? NSNumber)?.floatValue ?? 0
-        request.font_optical_sizing = 1
+        request.font_features = featureStorage.map { UnsafePointer($0) }
+        request.font_feature_count = fontFeatures.count
+        request.font_variations = variationStorage.map { UnsafePointer($0) }
+        request.font_variation_count = fontVariations.count
+        request.font_optical_sizing = fontOpticalSizing
+
+        if !fontFeatures.isEmpty || !fontVariations.isEmpty {
+            XCTAssertEqual(request.font_feature_count, 2)
+            let projectedFeatures = UnsafeBufferPointer(
+                start: request.font_features,
+                count: request.font_feature_count
+            )
+            XCTAssertEqual(projectedFeatures.map { decodedFontTag($0.tag) }, ["kern", "liga"])
+            XCTAssertEqual(projectedFeatures.map(\.value), [0, 0])
+            XCTAssertEqual(request.font_variation_count, 1)
+            let variation = try XCTUnwrap(request.font_variations?.pointee)
+            XCTAssertEqual(decodedFontTag(variation.tag), "wght")
+            XCTAssertEqual(variation.value, 720)
+            XCTAssertEqual(request.font_optical_sizing, 1)
+        }
 
         if id == "host.measure.text.basic" {
             XCTAssertEqual(families, ["Whisker Fixture Missing", "system"])
@@ -1997,6 +2062,10 @@ private func fontTag(_ value: String) throws -> [UInt8] {
         throw Failure("OpenType tag must contain four printable ASCII bytes")
     }
     return bytes
+}
+
+private func decodedFontTag<T>(_ value: T) -> String {
+    withUnsafeBytes(of: value) { String(decoding: $0, as: UTF8.self) }
 }
 
 private func sceneClipPath(_ fixture: [String: Any]) throws -> SceneClipPath {

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -397,6 +397,9 @@
         "font_style": { "enum": ["normal", "italic", "oblique"], "default": "normal" },
         "line_height": { "type": "number", "exclusiveMinimum": 0 },
         "letter_spacing": { "type": "number", "default": 0 },
+        "font_features": { "type": "array", "items": { "$ref": "#/$defs/fontFeature" } },
+        "font_variations": { "type": "array", "items": { "$ref": "#/$defs/fontVariation" } },
+        "font_optical_sizing": { "enum": ["auto", "none"], "default": "none" },
         "available_width": { "type": "number", "minimum": 0 }
       }
     },


### PR DESCRIPTION
## Summary
- add a shared four-host fixture for OpenType feature, variable-weight, and optical-sizing text measurement
- carry the advanced typography fields through each production measurement adapter
- reject malformed native font-setting payloads at the Android and iOS ABI boundaries
- assert semantic projection in every host runner

## Validation
- `cargo test -p whisker-host-conformance`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- Android `:app:compileDebugAndroidTestKotlin`
- Android bridge C syntax check with NDK clang
- iOS host-conformance XCTest (9 passed)
- `cargo fmt --all -- --check`
- `git diff --check`