### PR TITLE
feat(host): implement crisp edge image sampling

### DIFF
--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
@@ -62,15 +62,30 @@ internal data class HostBackgroundLayer(
 /** CSS-ordered layers. The first entry is painted nearest the user. */
 internal data class HostBackgroundLayers(val layers: List<HostBackgroundLayer>)
 
+internal enum class HostImageRendering(val wireValue: Int) {
+    Auto(0),
+    Pixelated(1),
+    CrispEdges(2);
+
+    val usesNearestSampling: Boolean
+        get() = this != Auto
+
+    companion object {
+        fun fromWire(value: Int): HostImageRendering? = entries.firstOrNull {
+            it.wireValue == value
+        }
+    }
+}
+
 internal fun drawBackgroundLayers(
     canvas: Canvas,
     boxes: HostBackgroundPaintBoxes,
     layers: HostBackgroundLayers?,
     paint: Paint,
-    pixelatedImages: Boolean,
+    imageRendering: HostImageRendering,
 ) {
     layers?.layers?.asReversed()?.forEach { layer ->
-        drawBackgroundLayer(canvas, boxes, layer, paint, pixelatedImages)
+        drawBackgroundLayer(canvas, boxes, layer, paint, imageRendering)
     }
 }
 
@@ -79,7 +94,7 @@ private fun drawBackgroundLayer(
     boxes: HostBackgroundPaintBoxes,
     layer: HostBackgroundLayer,
     paint: Paint,
-    pixelatedImages: Boolean,
+    imageRendering: HostImageRendering,
 ) {
     val geometry = layer.geometry
     val positioningBox = boxes.select(geometry.origin).rect
@@ -96,7 +111,7 @@ private fun drawBackgroundLayer(
         ) { imageBox ->
             val tileSaveCount = canvas.save().also { canvas.clipRect(imageBox) }
             try {
-                drawBackgroundImage(canvas, painting.clip, imageBox, layer, paint, pixelatedImages)
+                drawBackgroundImage(canvas, painting.clip, imageBox, layer, paint, imageRendering)
             } finally {
                 canvas.restoreToCount(tileSaveCount)
             }
@@ -112,12 +127,12 @@ private fun drawBackgroundImage(
     imageBox: RectF,
     layer: HostBackgroundLayer,
     paint: Paint,
-    pixelatedImages: Boolean,
+    imageRendering: HostImageRendering,
 ) {
     layer.rasterBitmap?.let { bitmap ->
         paint.color = Color.WHITE
         paint.shader = null
-        paint.isFilterBitmap = !pixelatedImages
+        paint.isFilterBitmap = !imageRendering.usesNearestSampling
         canvas.drawBitmap(bitmap, null, imageBox, paint)
         return
     }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxPaint.kt
@@ -31,7 +31,7 @@ internal fun applyBoxPaint(
     logicalHeight: Float,
     density: Float,
     backgroundLayers: HostBackgroundLayers? = null,
-    pixelatedImages: Boolean = false,
+    imageRendering: HostImageRendering = HostImageRendering.Auto,
     logicalContentBox: RectF = RectF(0f, 0f, logicalWidth, logicalHeight),
 ): ResolvedBoxGeometry {
     val values = paint.values
@@ -89,7 +89,7 @@ internal fun applyBoxPaint(
             physicalWidth,
             physicalHeight,
             backgroundLayers,
-            pixelatedImages,
+            imageRendering,
             RectF(
                 logicalContentBox.left * density,
                 logicalContentBox.top * density,
@@ -119,7 +119,7 @@ private class WhiskerBoxDrawable(
     private val backgroundBoxWidth: Float,
     private val backgroundBoxHeight: Float,
     private val backgroundLayers: HostBackgroundLayers?,
-    private val pixelatedImages: Boolean,
+    private val imageRendering: HostImageRendering,
     private val localContentBox: RectF,
 ) : Drawable() {
     private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
@@ -214,7 +214,7 @@ private class WhiskerBoxDrawable(
             ),
             backgroundLayers,
             paint,
-            pixelatedImages,
+            imageRendering,
         )
 
         val widths = floatArrayOf(top, right, bottom, left)

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -17,6 +17,7 @@ import rs.whisker.runtime.paint.HostBackgroundLayers
 import rs.whisker.runtime.paint.HostBoxShadow
 import rs.whisker.runtime.paint.HostBackdropBlurRenderer
 import rs.whisker.runtime.paint.HostClipPath
+import rs.whisker.runtime.paint.HostImageRendering
 import rs.whisker.runtime.paint.ResolvedBoxGeometry
 import rs.whisker.runtime.paint.normalizeRadii
 import rs.whisker.runtime.paint.drawInsetBoxShadows
@@ -52,7 +53,7 @@ internal class HostNode(
     var clipPath: HostClipPath? = null
     var mountedElement: WhiskerMountedElement? = null
     var zOrder: Int = 0
-    var pixelatedImages: Boolean = false
+    var imageRendering: HostImageRendering = HostImageRendering.Auto
     var backdropBlur: Float = 0f
         set(value) {
             field = value

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -38,6 +38,7 @@ import rs.whisker.runtime.paint.HostClipReferenceBox
 import rs.whisker.runtime.paint.HostCircleClipPath
 import rs.whisker.runtime.paint.HostEllipseClipPath
 import rs.whisker.runtime.paint.HostInsetClipPath
+import rs.whisker.runtime.paint.HostImageRendering
 import rs.whisker.runtime.paint.HostPathClipPath
 import rs.whisker.runtime.paint.HostPathCommand
 import rs.whisker.runtime.paint.HostLinearGradient
@@ -278,7 +279,7 @@ internal class HostScene(
                 operation.scalar * root.resources.displayMetrics.density
             25 -> {
                 val node = nodes[id] ?: return
-                node.pixelatedImages = operation.integer == 1
+                node.imageRendering = HostImageRendering.fromWire(operation.integer) ?: return
                 node.paint?.let { applyPaint(node, it) }
             }
             26 -> (nodes[id] ?: return).setCursorKeyword(operation.integer)
@@ -484,7 +485,7 @@ internal class HostScene(
             node.geometry.height,
             root.resources.displayMetrics.density,
             node.backgroundLayers,
-            node.pixelatedImages,
+            node.imageRendering,
             RectF(
                 node.geometry.contentX,
                 node.geometry.contentY,

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -2136,8 +2136,11 @@ impl GpuRenderer {
                                 Some(gradient),
                                 resource,
                                 resource.is_some()
-                                    && visual_effects.image_rendering
-                                        == whisker_protocol::ImageRendering::Pixelated,
+                                    && matches!(
+                                        visual_effects.image_rendering,
+                                        whisker_protocol::ImageRendering::Pixelated
+                                            | whisker_protocol::ImageRendering::CrispEdges
+                                    ),
                             ),
                         );
                     }

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -1349,7 +1349,10 @@ impl Driver {
                         Some(gradient),
                         resource,
                         resource.is_some()
-                            && visual_effects.image_rendering == ImageRendering::Pixelated,
+                            && matches!(
+                                visual_effects.image_rendering,
+                                ImageRendering::Pixelated | ImageRendering::CrispEdges
+                            ),
                     ));
                 }
                 primitives.extend(

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -217,16 +217,29 @@ final class HostBackgroundLayer {
     }
 }
 
+enum HostImageRendering: Int32, Equatable {
+    case auto = 0
+    case pixelated = 1
+    case crispEdges = 2
+
+    var interpolationQuality: CGInterpolationQuality {
+        switch self {
+        case .auto: .default
+        case .pixelated, .crispEdges: .none
+        }
+    }
+}
+
 final class HostBackgroundPainter {
     private var layers = [HostBackgroundLayer]()
-    private var pixelatedImages = false
+    private var imageRendering: HostImageRendering = .auto
 
     func update(_ layers: [HostBackgroundLayer]) {
         self.layers = layers
     }
 
-    func setPixelatedImages(_ pixelated: Bool) {
-        pixelatedImages = pixelated
+    func setImageRendering(_ value: HostImageRendering) {
+        imageRendering = value
     }
 
     func draw(
@@ -330,7 +343,7 @@ final class HostBackgroundPainter {
 
     private func drawRaster(_ image: CGImage, in bounds: CGRect, context: CGContext) {
         context.saveGState()
-        context.interpolationQuality = pixelatedImages ? .none : .default
+        context.interpolationQuality = imageRendering.interpolationQuality
         UIImage(cgImage: image, scale: 1, orientation: .up).draw(in: bounds)
         context.restoreGState()
     }

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -97,8 +97,8 @@ final class HostBoxPainter {
         backgroundPainter.update(layers)
     }
 
-    func setPixelatedImages(_ pixelated: Bool) {
-        backgroundPainter.setPixelatedImages(pixelated)
+    func setImageRendering(_ value: HostImageRendering) {
+        backgroundPainter.setImageRendering(value)
     }
 
     func hardBoxShadowPath(in bounds: CGRect, shadow: HostBoxShadow) -> CGPath? {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -22,6 +22,7 @@ final class WhiskerNodeView: UIView {
     private var clipsOverflowHorizontally = false
     private var clipsOverflowVertically = false
     private var backdropBlurView: HostBackdropBlurView?
+    private(set) var imageRendering: HostImageRendering = .auto
     private(set) var hitTestBehavior: Int32 = 0
     private(set) var cursorKeyword: Int32 = 0
     private var pointerDelegate: AnyObject?
@@ -181,8 +182,9 @@ final class WhiskerNodeView: UIView {
         updateBackdropBlurGeometry()
     }
 
-    func setImageRendering(pixelated: Bool) {
-        boxPainter.setPixelatedImages(pixelated)
+    func setImageRendering(_ value: HostImageRendering) {
+        imageRendering = value
+        boxPainter.setImageRendering(value)
         paintView.setNeedsDisplay()
     }
 

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -381,10 +381,10 @@ final class HostScene {
             guard let node = nodes[id] else { return false }
             node.setBackdropBlur(CGFloat(operation.scalar))
         case UInt32(WHISKER_OP_IMAGE_RENDERING):
-            guard let node = nodes[id] else { return false }
-            node.setImageRendering(
-                pixelated: operation.integer == Int32(WHISKER_IMAGE_RENDERING_PIXELATED)
-            )
+            guard let node = nodes[id],
+                  let imageRendering = HostImageRendering(rawValue: operation.integer)
+            else { return false }
+            node.setImageRendering(imageRendering)
         case UInt32(WHISKER_OP_HIT_TEST):
             nodes[id]?.setHitTestBehavior(operation.integer)
         case UInt32(WHISKER_OP_CURSOR):

--- a/platforms/web/src/paint/visual_effects.rs
+++ b/platforms/web/src/paint/visual_effects.rs
@@ -67,7 +67,8 @@ pub(crate) fn apply(element: &web_sys::Element, effects: &VisualEffects) -> Resu
         "image-rendering",
         match effects.image_rendering {
             ImageRendering::Pixelated => "pixelated",
-            ImageRendering::Auto | ImageRendering::CrispEdges => "auto",
+            ImageRendering::CrispEdges => "crisp-edges",
+            ImageRendering::Auto => "auto",
             _ => unreachable!("unsupported image-rendering rejected above"),
         },
     )?;

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -488,6 +488,8 @@ impl Driver {
                             "interaction.pointer.lynx"
                         } else if name == "paint.visual-effects.image-rendering-pixelated" {
                             "paint.visual-effects.image-rendering-pixelated"
+                        } else if name == "paint.visual-effects.image-rendering-crisp-edges" {
+                            "paint.visual-effects.image-rendering-crisp-edges"
                         } else if self.resource_lifecycle {
                             "paint.background-layers.resource-lifecycle"
                         } else {
@@ -1315,8 +1317,10 @@ impl Driver {
                     "image-rendering",
                     match fixture_node.image_rendering {
                         whisker_host_conformance::ImageRenderingFixture::Pixelated => "pixelated",
-                        whisker_host_conformance::ImageRenderingFixture::Auto
-                        | whisker_host_conformance::ImageRenderingFixture::CrispEdges => "auto",
+                        whisker_host_conformance::ImageRenderingFixture::CrispEdges => {
+                            "crisp-edges"
+                        }
+                        whisker_host_conformance::ImageRenderingFixture::Auto => "auto",
                     },
                 );
             }
@@ -1573,6 +1577,9 @@ fn fixture(path: &str) -> &'static str {
         }
         "core/image-rendering-pixelated.json" => {
             include_str!("../../../../tests/host-conformance/core/image-rendering-pixelated.json")
+        }
+        "core/image-rendering-crisp-edges.json" => {
+            include_str!("../../../../tests/host-conformance/core/image-rendering-crisp-edges.json")
         }
         "core/background-layer-geometry-symmetry.json" => include_str!(
             "../../../../tests/host-conformance/core/background-layer-geometry-symmetry.json"

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -111,6 +111,7 @@
       "properties": ["box-shadow", "clip-path", "image-rendering"],
       "supported_subset": ["box-shadow-outer-offset-spread-and-blur", "box-shadow-inset-offset-spread-and-blur", "multiple-box-shadows", "clip-path-inset", "clip-path-circle-and-ellipse", "clip-path-path", "image-rendering-auto-pixelated-crisp-edges"],
       "pending_subset": [],
+      "compatibility_notes": ["Web preserves the crisp-edges keyword; native Hosts implement its contrast-preserving scaling requirement with nearest-neighbor sampling while retaining the distinct protocol value."],
       "protocol": ["SetVisualEffects"],
       "rust": "implemented",
       "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}

--- a/tests/host-conformance/core/image-rendering-crisp-edges.json
+++ b/tests/host-conformance/core/image-rendering-crisp-edges.json
@@ -1,0 +1,67 @@
+{
+  "schema": 1,
+  "id": "core.image-rendering-crisp-edges",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 100.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "load_raster_resource",
+        "id": 1,
+        "generation": 1,
+        "source": {
+          "kind": "bytes",
+          "media_type": "image/png",
+          "base64": "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAF0lEQVR4nAXBAQEAAACCIKb33EBkQpUOQdYIeRyCeLsAAAAASUVORK5CYII="
+        }
+      },
+      {
+        "type": "checkpoint_resource",
+        "id": 1,
+        "generation": 1,
+        "state": "ready",
+        "width": 2,
+        "height": 2
+      },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 100.0, 100.0],
+            "background": { "kind": "srgba", "red": 128, "green": 128, "blue": 128, "alpha": 1.0 },
+            "image_rendering": "crisp_edges",
+            "background_layers": [
+              {
+                "geometry": {
+                  "position": [
+                    { "length": 10.0, "fraction": 0.0 },
+                    { "length": 10.0, "fraction": 0.0 }
+                  ],
+                  "size": [
+                    { "length": 80.0, "fraction": 0.0 },
+                    { "length": 80.0, "fraction": 0.0 }
+                  ],
+                  "repeat_x": "no_repeat",
+                  "repeat_y": "no_repeat"
+                },
+                "image": { "resource": 1 }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.visual-effects.image-rendering-crisp-edges",
+        "samples": [
+          { "point": [45.0, 25.0], "color": { "kind": "srgba", "red": 255, "green": 0, "blue": 0, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [55.0, 25.0], "color": { "kind": "srgba", "red": 0, "green": 128, "blue": 0, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [45.0, 75.0], "color": { "kind": "srgba", "red": 0, "green": 0, "blue": 255, "alpha": 1.0 }, "tolerance": 5 },
+          { "point": [55.0, 75.0], "color": { "kind": "srgba", "red": 255, "green": 255, "blue": 0, "alpha": 1.0 }, "tolerance": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -66,6 +66,13 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "core.image-rendering-crisp-edges",
+      "feature": "image-rendering-crisp-edges",
+      "fixture": "core/image-rendering-crisp-edges.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.background-size-009",
       "feature": "background-size-no-repeat",
       "fixture": "wpt/css/css-backgrounds/background-size-009.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -438,6 +438,8 @@ private class Driver(
                             command.getString("name") ==
                             "paint.visual-effects.image-rendering-pixelated" ||
                             command.getString("name") ==
+                            "paint.visual-effects.image-rendering-crisp-edges" ||
+                            command.getString("name") ==
                             "paint.transform.projective-plane" ||
                             command.getString("name") ==
                             "paint.transform.motion-path-line" ||

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -484,6 +484,7 @@ private final class Driver {
                     name == "paint.visual-effects.clip-path-path-evenodd" ||
                     name == "paint.visual-effects.backdrop-blur" ||
                     name == "paint.visual-effects.image-rendering-pixelated" ||
+                    name == "paint.visual-effects.image-rendering-crisp-edges" ||
                     name == "paint.transform.projective-plane" ||
                     name == "paint.transform.motion-path-line" ||
                     name == "paint.transform.motion-path-curves" ||
@@ -504,6 +505,15 @@ private final class Driver {
                     XCTAssertTrue(
                         containsActiveBackdropBlur(view),
                         "\(id) must project backdrop blur to UIVisualEffectView"
+                    )
+                }
+                if name == "paint.visual-effects.image-rendering-crisp-edges" {
+                    let nodes = findNodeViews(view)
+                    XCTAssertEqual(nodes.count, 1)
+                    XCTAssertEqual(nodes.first?.imageRendering, .crispEdges)
+                    XCTAssertEqual(
+                        nodes.first?.imageRendering.interpolationQuality,
+                        CGInterpolationQuality.none
                     )
                 }
                 if id == "core.pointer-cursor-fidelity" {


### PR DESCRIPTION
## Summary
- add a shared four-host `image-rendering: crisp-edges` fixture with semantic and pixel checkpoints
- preserve the distinct image-rendering value in every Host projection
- use nearest-neighbor sampling for the native contrast-preserving implementation
- emit the standard `crisp-edges` CSS value on Web

## Validation
- `cargo test -p whisker-host-conformance`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- Android `:app:compileDebugAndroidTestKotlin`
- iOS Simulator XCTest (9 passed)
- `cargo fmt --all -- --check`
- `git diff --check`