### PR TITLE
feat(host): normalize pointer input across hosts

### DIFF
--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -179,7 +179,7 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
     let vs_path = vs_dir.join("android-jni-exports.ver");
     std::fs::write(
         &vs_path,
-        b"{\n  global:\n    Java_*;\n    JNI_OnLoad;\n    whisker_view_create;\n    whisker_view_tick;\n    whisker_view_destroy;\n    whisker_view_dispatch_event;\n    whisker_view_dispatch_module_event;\n    whisker_view_dispatch_resource_event;\n};\n",
+        b"{\n  global:\n    Java_*;\n    JNI_OnLoad;\n    whisker_view_create;\n    whisker_view_tick;\n    whisker_view_destroy;\n    whisker_view_dispatch_event;\n    whisker_view_dispatch_pointer;\n    whisker_view_dispatch_module_event;\n    whisker_view_dispatch_resource_event;\n};\n",
     )
     .with_context(|| format!("write {}", vs_path.display()))?;
 

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -63,6 +63,7 @@ const BRIDGE_EXPORTS: &[&str] = &[
     "_whisker_view_tick",
     "_whisker_view_destroy",
     "_whisker_view_dispatch_event",
+    "_whisker_view_dispatch_pointer",
     "_whisker_view_dispatch_module_event",
     "_whisker_view_dispatch_resource_event",
     "_whisker_aslr_anchor",

--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 24 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 25 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -296,6 +296,16 @@ bool whisker_view_tick(void*, double, float, float, float);
 void whisker_view_destroy(void*);
 bool whisker_view_dispatch_event(void*, double, uint64_t, const uint8_t*, size_t,
                                  const WhiskerValueRaw*);
+enum {
+  WHISKER_POINTER_DOWN = 0, WHISKER_POINTER_MOVE = 1,
+  WHISKER_POINTER_UP = 2, WHISKER_POINTER_CANCEL = 3
+};
+enum {
+  WHISKER_POINTER_MOUSE = 0, WHISKER_POINTER_TOUCH = 1,
+  WHISKER_POINTER_PEN = 2, WHISKER_POINTER_UNKNOWN = 3
+};
+bool whisker_view_dispatch_pointer(void*, double, uint32_t, uint64_t, uint32_t,
+                                   float, float, uint32_t, int16_t);
 bool whisker_view_dispatch_module_event(void*, const uint8_t*, size_t, const uint8_t*, size_t,
                                         const WhiskerValueRaw*);
 bool whisker_view_dispatch_resource_event(void*, const WhiskerMobileResourceEvent*);

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -853,6 +853,13 @@ JNIEXPORT jboolean JNICALL Java_rs_whisker_runtime_WhiskerView_nativeDispatchEve
     release_raw(&raw);free(bytes);return consumed?JNI_TRUE:JNI_FALSE;
 }
 
+JNIEXPORT jboolean JNICALL Java_rs_whisker_runtime_WhiskerView_nativeDispatchPointer(JNIEnv* env,jobject self,jlong handle,jdouble timestamp,jint event,jlong pointer_id,jint pointer_kind,jfloat x,jfloat y,jint buttons,jint changed_button){
+    (void)env;(void)self;WhiskerAndroidView* view=(void*)(uintptr_t)handle;
+    if(!view||!view->runtime||pointer_id<=0||buttons<0||changed_button<INT16_MIN||changed_button>INT16_MAX)return JNI_FALSE;
+    return whisker_view_dispatch_pointer(view->runtime,timestamp,(uint32_t)event,(uint64_t)pointer_id,
+        (uint32_t)pointer_kind,x,y,(uint32_t)buttons,(int16_t)changed_button)?JNI_TRUE:JNI_FALSE;
+}
+
 JNIEXPORT void JNICALL Java_rs_whisker_runtime_WhiskerView_nativeResolveModule(JNIEnv* env,jobject self,jlong callback_ptr,jlong data_ptr,jobject payload){
     (void)self;WhiskerMobileModuleResultCallback callback=(void*)(uintptr_t)callback_ptr;if(!callback)return;WhiskerValueRaw raw=object_to_raw(env,payload);callback((void*)(uintptr_t)data_ptr,&raw);release_raw(&raw);
 }

--- a/crates/whisker-driver/src/mobile_abi.rs
+++ b/crates/whisker-driver/src/mobile_abi.rs
@@ -15,7 +15,16 @@ pub use ffi::{
 };
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 24;
+pub const MOBILE_ABI_MINOR: u16 = 25;
+
+pub const POINTER_DOWN: u32 = 0;
+pub const POINTER_MOVE: u32 = 1;
+pub const POINTER_UP: u32 = 2;
+pub const POINTER_CANCEL: u32 = 3;
+pub const POINTER_MOUSE: u32 = 0;
+pub const POINTER_TOUCH: u32 = 1;
+pub const POINTER_PEN: u32 = 2;
+pub const POINTER_UNKNOWN: u32 = 3;
 
 pub const APPLY_ACCEPTED: u8 = 0;
 pub const APPLY_NEED_SNAPSHOT: u8 = 1;

--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -267,6 +267,8 @@ pub enum Command {
     EmitPointer {
         /// Pointer event phase.
         event: PointerEventFixture,
+        /// Physical pointer source after Host normalization.
+        pointer_kind: PointerKindFixture,
         /// Stable pointer identifier.
         pointer_id: u64,
         /// Host monotonic timestamp.
@@ -284,6 +286,8 @@ pub enum Command {
     CheckpointInput {
         /// Expected pointer event phase.
         event: PointerEventFixture,
+        /// Expected physical pointer source.
+        pointer_kind: PointerKindFixture,
         /// Expected pointer identifier.
         pointer_id: u64,
         /// Expected logical x coordinate.
@@ -336,6 +340,20 @@ pub enum PointerEventFixture {
     Up,
     /// Pointer sequence cancelled.
     Cancel,
+}
+
+/// Physical pointer source used by input fixtures.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PointerKindFixture {
+    /// Mouse or trackpad cursor.
+    Mouse,
+    /// Direct touch contact.
+    Touch,
+    /// Stylus or pen contact.
+    Pen,
+    /// Host source not otherwise represented.
+    Unknown,
 }
 
 /// Color syntax accepted by Host scenarios.
@@ -1535,12 +1553,19 @@ fn validate_side(id: &str, label: &str, side: &ScenarioSide) -> Result<(), Fixtu
                 && min_width <= max_width
                 && min_height <= max_height => {}
             Command::EmitPointer {
-                timestamp_ms, x, y, ..
-            } if timestamp_ms.is_finite()
+                pointer_id,
+                timestamp_ms,
+                x,
+                y,
+                ..
+            } if *pointer_id > 0
+                && timestamp_ms.is_finite()
                 && *timestamp_ms >= 0.0
                 && x.is_finite()
                 && y.is_finite() => {}
-            Command::CheckpointInput { x, y, .. } if x.is_finite() && y.is_finite() => {}
+            Command::CheckpointInput {
+                pointer_id, x, y, ..
+            } if *pointer_id > 0 && x.is_finite() && y.is_finite() => {}
             _ => {
                 return Err(FixtureError(format!(
                     "scenario {id} has an invalid {label} command"

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -264,6 +264,34 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #[cfg(any(target_os = "android", target_os = "ios"))]
         #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn whisker_view_dispatch_pointer(
+            handle: *mut ::std::ffi::c_void,
+            timestamp_ms: f64,
+            event: u32,
+            pointer_id: u64,
+            pointer_kind: u32,
+            x: f32,
+            y: f32,
+            buttons: u32,
+            changed_button: i16,
+        ) -> bool {
+            unsafe {
+                ::whisker::__mobile_runtime::dispatch_pointer(
+                    handle,
+                    timestamp_ms,
+                    event,
+                    pointer_id,
+                    pointer_kind,
+                    x,
+                    y,
+                    buttons,
+                    changed_button,
+                )
+            }
+        }
+
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn whisker_view_dispatch_module_event(
             handle: *mut ::std::ffi::c_void,
             module: *const u8,

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -1827,7 +1827,8 @@ pub mod __main_runtime {
 #[cfg(any(target_os = "android", target_os = "ios"))]
 pub mod __mobile_runtime {
     pub use crate::mobile_runtime::{
-        create, destroy, dispatch_event, dispatch_module_event, dispatch_resource_event, tick,
+        create, destroy, dispatch_event, dispatch_module_event, dispatch_pointer,
+        dispatch_resource_event, tick,
     };
 }
 

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -9,14 +9,15 @@ use whisker_driver::module::{
 use whisker_engine::whisker_protocol::{
     ApplyResult, AvailableSpace, BackgroundAttachment, BackgroundSize, BlendMode, BorderLineStyle,
     ChildPolicy, ClipShape, ElementMeasurement, ElementRegistration, ElementValueKind, FillRule,
-    FrameMode, FramePacket, ImageRendering, ImageRepeat, MeasureFontFamily, MeasureFontStyle,
-    MeasureLineHeight, MeasureTextOverflow, MeasureTextWordBreak, MeasureTextWrap, MeasuredSize,
-    MeasurementMetrics, MeasurementPayload, MeasurementRequest, MeasurementRequestId,
-    MeasurementResponse, NodeId, Operation, PaintBox, PaintColor, PaintImage,
-    PaintLengthPercentage, PaintPosition, PathCommand, PreparedContentId, RadialGradientExtent,
-    RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent, ResourceFailureCode,
-    ResourceId, ResourceKind, ResourceSource, SurfaceId, UnsupportedMeasurementReason,
-    VisualEffects,
+    FrameMode, FramePacket, ImageRendering, ImageRepeat, InputEvent, InputEventKind, InputPoint,
+    MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextOverflow,
+    MeasureTextWordBreak, MeasureTextWrap, MeasuredSize, MeasurementMetrics, MeasurementPayload,
+    MeasurementRequest, MeasurementRequestId, MeasurementResponse, NodeId, Operation, PaintBox,
+    PaintColor, PaintImage, PaintLengthPercentage, PaintPosition, PathCommand, PointerId,
+    PointerInput, PointerKind, PreparedContentId, RadialGradientExtent, RadialGradientShape,
+    ResourceCommand, ResourceDimensions, ResourceEvent, ResourceFailureCode, ResourceId,
+    ResourceKind, ResourceSource, SurfaceId, UnsupportedMeasurementReason, VisualEffects,
+    WhiskerValue,
 };
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{FrameSink, LayoutOptions, MeasurementProvider};
@@ -231,6 +232,92 @@ pub unsafe fn dispatch_event(
             eprintln!("Whisker mobile event failed: {error}");
             false
         })
+}
+
+/// Dispatches one Host-normalized pointer event. The target intentionally
+/// remains empty so the retained Rust scene performs hit testing and pointer
+/// capture resolution consistently across Hosts.
+///
+/// # Safety
+/// `handle` must identify a live mobile runtime for the duration of this call.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn dispatch_pointer(
+    handle: *mut c_void,
+    timestamp_ms: f64,
+    event: u32,
+    pointer_id: u64,
+    pointer_kind: u32,
+    x: f32,
+    y: f32,
+    buttons: u32,
+    changed_button: i16,
+) -> bool {
+    let Some(mobile) = (unsafe { handle.cast::<MobileRuntime>().as_ref() }) else {
+        return false;
+    };
+    let Some(event) = mobile_pointer_event(
+        timestamp_ms,
+        event,
+        pointer_id,
+        pointer_kind,
+        x,
+        y,
+        buttons,
+        changed_button,
+    ) else {
+        return false;
+    };
+    let modules = std::sync::Arc::clone(&mobile.modules);
+    with_mobile_module_host(&modules, || mobile.runtime.dispatch_input(&event))
+        .map(|value| value.consumed)
+        .unwrap_or_else(|error| {
+            eprintln!("Whisker mobile pointer input failed: {error}");
+            false
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn mobile_pointer_event(
+    timestamp_ms: f64,
+    event: u32,
+    pointer_id: u64,
+    pointer_kind: u32,
+    x: f32,
+    y: f32,
+    buttons: u32,
+    changed_button: i16,
+) -> Option<InputEvent> {
+    let kind = match event {
+        POINTER_DOWN => InputEventKind::PointerDown,
+        POINTER_MOVE => InputEventKind::PointerMove,
+        POINTER_UP => InputEventKind::PointerUp,
+        POINTER_CANCEL => InputEventKind::PointerCancel,
+        _ => return None,
+    };
+    let pointer_kind = match pointer_kind {
+        POINTER_MOUSE => PointerKind::Mouse,
+        POINTER_TOUCH => PointerKind::Touch,
+        POINTER_PEN => PointerKind::Pen,
+        POINTER_UNKNOWN => PointerKind::Unknown,
+        _ => return None,
+    };
+    let pointer_id = PointerId::new(pointer_id)?;
+    let event = InputEvent {
+        surface: SurfaceId::new(1).unwrap(),
+        timestamp_ms,
+        kind,
+        pointer: Some(PointerInput {
+            id: pointer_id,
+            kind: pointer_kind,
+            position: InputPoint { x, y },
+            buttons,
+            changed_button,
+        }),
+        target: None,
+        detail: WhiskerValue::Null,
+    };
+    event.validate().ok()?;
+    Some(event)
 }
 
 /// # Safety
@@ -1953,6 +2040,25 @@ mod tests {
         GradientStop, PaintCoordinate, PaintPosition, ProtocolVersion, TextContent,
         TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow,
     };
+
+    #[test]
+    fn mobile_pointer_input_decodes_without_host_specific_types() {
+        let event = mobile_pointer_event(42.5, 0, 7, 1, 24.0, 16.0, 1, -1).unwrap();
+        assert_eq!(event.kind, InputEventKind::PointerDown);
+        assert_eq!(event.target, None);
+        let pointer = event.pointer.unwrap();
+        assert_eq!(pointer.id.get(), 7);
+        assert_eq!(pointer.kind, PointerKind::Touch);
+        assert_eq!(pointer.position, InputPoint { x: 24.0, y: 16.0 });
+        assert_eq!(pointer.buttons, 1);
+        assert_eq!(pointer.changed_button, -1);
+
+        assert!(mobile_pointer_event(0.0, 4, 1, 0, 0.0, 0.0, 0, -1).is_none());
+        assert!(mobile_pointer_event(0.0, 0, 0, 0, 0.0, 0.0, 0, -1).is_none());
+        assert!(mobile_pointer_event(0.0, 0, 1, 4, 0.0, 0.0, 0, -1).is_none());
+        assert!(mobile_pointer_event(f64::NAN, 0, 1, 0, 0.0, 0.0, 0, -1).is_none());
+        assert!(mobile_pointer_event(0.0, 0, 1, 0, f32::NAN, 0.0, 0, -1).is_none());
+    }
 
     fn linear_background(name: &str) -> BackgroundLayer {
         BackgroundLayer {

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -7,8 +7,11 @@ import android.graphics.Color
 import android.os.Handler
 import android.os.Looper
 import android.view.Choreographer
+import android.view.MotionEvent
 import android.view.View
 import rs.whisker.runtime.WhiskerValue
+import rs.whisker.runtime.input.HostPointerInput
+import rs.whisker.runtime.input.normalizePointerInput
 import rs.whisker.runtime.measure.HostMeasurementProvider
 import rs.whisker.runtime.module.HostModuleDispatcher
 import rs.whisker.runtime.paint.HostRasterResourceStore
@@ -49,6 +52,7 @@ class WhiskerView(context: Context) :
     private val modules = HostModuleDispatcher(::nativeResolveModule)
     private var backdropCaptureTarget: HostNode? = null
     private var backdropCaptureReached = false
+    private var pointerInputObserver: ((HostPointerInput) -> Unit)? = null
 
     init {
         WhiskerApplication.initialize(context)
@@ -122,6 +126,63 @@ class WhiskerView(context: Context) :
         } else {
             frameScheduled = false
             choreographer.removeFrameCallback(this)
+        }
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        val childConsumed = super.dispatchTouchEvent(event)
+        val runtimeConsumed = dispatchPointerInput(event)
+        return childConsumed || runtimeConsumed
+    }
+
+    override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
+        val childConsumed = super.dispatchGenericMotionEvent(event)
+        val runtimeConsumed = dispatchPointerInput(event)
+        return childConsumed || runtimeConsumed
+    }
+
+    private fun dispatchPointerInput(event: MotionEvent): Boolean {
+        val density = resources.displayMetrics.density
+        var consumed = false
+        normalizePointerInput(event, density).forEach { pointer ->
+            pointerInputObserver?.invoke(pointer)
+            val handle = nativeHandle
+            if (handle != 0L) {
+                consumed = nativeDispatchPointer(
+                    handle,
+                    pointer.timestampMs,
+                    pointer.event,
+                    pointer.pointerId,
+                    pointer.kind,
+                    pointer.x,
+                    pointer.y,
+                    pointer.buttons,
+                    pointer.changedButton,
+                ) || consumed
+            }
+        }
+        return consumed
+    }
+
+    /** Test-only observer at the production MotionEvent-to-runtime dispatch seam. */
+    fun observePointerInputForTesting(observer: ((LongArray, DoubleArray) -> Unit)?) {
+        pointerInputObserver = observer?.let { callback ->
+            { pointer ->
+                callback(
+                    longArrayOf(
+                        pointer.event.toLong(),
+                        pointer.pointerId,
+                        pointer.kind.toLong(),
+                        pointer.buttons.toLong(),
+                        pointer.changedButton.toLong(),
+                    ),
+                    doubleArrayOf(
+                        pointer.timestampMs,
+                        pointer.x.toDouble(),
+                        pointer.y.toDouble(),
+                    ),
+                )
+            }
         }
     }
 
@@ -407,6 +468,17 @@ class WhiskerView(context: Context) :
         name: String,
         detail: WhiskerValue,
         timestampMs: Double,
+    ): Boolean
+    private external fun nativeDispatchPointer(
+        handle: Long,
+        timestampMs: Double,
+        event: Int,
+        pointerId: Long,
+        pointerKind: Int,
+        x: Float,
+        y: Float,
+        buttons: Int,
+        changedButton: Int,
     ): Boolean
     private external fun nativeResolveModule(
         callbackPtr: Long,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/input/PointerInput.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/input/PointerInput.kt
@@ -1,0 +1,87 @@
+package rs.whisker.runtime.input
+
+import android.view.MotionEvent
+
+/** One Android pointer sample normalized to Whisker's logical surface contract. */
+internal data class HostPointerInput(
+    val timestampMs: Double,
+    val event: Int,
+    val pointerId: Long,
+    val kind: Int,
+    val x: Float,
+    val y: Float,
+    val buttons: Int,
+    val changedButton: Int,
+)
+
+/** Projects one Android event into the per-pointer events consumed by the Rust runtime. */
+internal fun normalizePointerInput(event: MotionEvent, density: Float): List<HostPointerInput> {
+    if (!density.isFinite() || density <= 0f) return emptyList()
+    val eventKind = when (event.actionMasked) {
+        MotionEvent.ACTION_DOWN, MotionEvent.ACTION_POINTER_DOWN -> POINTER_DOWN
+        MotionEvent.ACTION_MOVE, MotionEvent.ACTION_HOVER_MOVE -> POINTER_MOVE
+        MotionEvent.ACTION_UP, MotionEvent.ACTION_POINTER_UP -> POINTER_UP
+        MotionEvent.ACTION_CANCEL -> POINTER_CANCEL
+        else -> return emptyList()
+    }
+    val indices = when (event.actionMasked) {
+        MotionEvent.ACTION_MOVE, MotionEvent.ACTION_HOVER_MOVE, MotionEvent.ACTION_CANCEL ->
+            0 until event.pointerCount
+        else -> event.actionIndex..event.actionIndex
+    }
+    return indices.map { index ->
+        val pointerKind = pointerKind(event.getToolType(index))
+        HostPointerInput(
+            timestampMs = event.eventTime.toDouble(),
+            event = eventKind,
+            pointerId = event.getPointerId(index).toLong() + POINTER_ID_OFFSET,
+            kind = pointerKind,
+            x = event.getX(index) / density,
+            y = event.getY(index) / density,
+            buttons = normalizedButtons(event, eventKind, pointerKind),
+            changedButton = changedButton(event, eventKind, pointerKind),
+        )
+    }
+}
+
+private fun pointerKind(toolType: Int): Int = when (toolType) {
+    MotionEvent.TOOL_TYPE_MOUSE -> POINTER_MOUSE
+    MotionEvent.TOOL_TYPE_FINGER -> POINTER_TOUCH
+    MotionEvent.TOOL_TYPE_STYLUS, MotionEvent.TOOL_TYPE_ERASER -> POINTER_PEN
+    else -> POINTER_UNKNOWN
+}
+
+private fun normalizedButtons(event: MotionEvent, eventKind: Int, pointerKind: Int): Int =
+    if (pointerKind == POINTER_TOUCH || pointerKind == POINTER_PEN) {
+        if (eventKind == POINTER_UP || eventKind == POINTER_CANCEL) 0 else PRIMARY_BUTTON_MASK
+    } else {
+        event.buttonState
+    }
+
+private fun changedButton(event: MotionEvent, eventKind: Int, pointerKind: Int): Int {
+    if (pointerKind == POINTER_TOUCH) return NO_CHANGED_BUTTON
+    if (eventKind != POINTER_DOWN && eventKind != POINTER_UP) return NO_CHANGED_BUTTON
+    val button = event.actionButton.takeIf { it != 0 }
+        ?: event.buttonState.takeIf { it != 0 }
+        ?: MotionEvent.BUTTON_PRIMARY
+    return when (button) {
+        MotionEvent.BUTTON_PRIMARY -> 0
+        MotionEvent.BUTTON_TERTIARY -> 1
+        MotionEvent.BUTTON_SECONDARY -> 2
+        MotionEvent.BUTTON_BACK -> 3
+        MotionEvent.BUTTON_FORWARD -> 4
+        else -> NO_CHANGED_BUTTON
+    }
+}
+
+private const val POINTER_ID_OFFSET = 1L
+private const val POINTER_DOWN = 0
+private const val POINTER_MOVE = 1
+private const val POINTER_UP = 2
+private const val POINTER_CANCEL = 3
+private const val POINTER_MOUSE = 0
+private const val POINTER_TOUCH = 1
+private const val POINTER_PEN = 2
+private const val POINTER_UNKNOWN = 3
+private const val PRIMARY_BUTTON_MASK = 1
+private const val NO_CHANGED_BUTTON = -1

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -13,8 +13,9 @@ use whisker_host_conformance::{
     CursorFixture, FillRuleFixture, Host, ImageRenderingFixture, ImageRepeatFixture,
     LinearGradientFixture, LoadedCase, OverflowClipFixture, PathCommandFixture,
     PixelRelationFixture, PixelRelationKind, PixelSampleFixture, PointerEventFixture,
-    PointerEventsFixture, RadialGradientFixture, ResourceSourceFixture, ResourceStateFixture,
-    Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture, load_required,
+    PointerEventsFixture, PointerKindFixture, RadialGradientFixture, ResourceSourceFixture,
+    ResourceStateFixture, Scenario, ScenarioSide, SceneNodeFixture, VisibilityFixture,
+    load_required,
 };
 use whisker_protocol::{
     AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
@@ -56,6 +57,15 @@ const fn pointer_event_protocol(value: PointerEventFixture) -> InputEventKind {
         PointerEventFixture::Move => InputEventKind::PointerMove,
         PointerEventFixture::Up => InputEventKind::PointerUp,
         PointerEventFixture::Cancel => InputEventKind::PointerCancel,
+    }
+}
+
+const fn pointer_kind_protocol(value: PointerKindFixture) -> PointerKind {
+    match value {
+        PointerKindFixture::Mouse => PointerKind::Mouse,
+        PointerKindFixture::Touch => PointerKind::Touch,
+        PointerKindFixture::Pen => PointerKind::Pen,
+        PointerKindFixture::Unknown => PointerKind::Unknown,
     }
 }
 
@@ -717,6 +727,7 @@ impl Driver {
                 ),
                 Command::EmitPointer {
                     event,
+                    pointer_kind,
                     pointer_id,
                     timestamp_ms,
                     x,
@@ -725,6 +736,7 @@ impl Driver {
                     changed_button,
                 } => self.emit_pointer(
                     *event,
+                    *pointer_kind,
                     *pointer_id,
                     *timestamp_ms,
                     [*x, *y],
@@ -733,10 +745,11 @@ impl Driver {
                 ),
                 Command::CheckpointInput {
                     event,
+                    pointer_kind,
                     pointer_id,
                     x,
                     y,
-                } => self.check_input(*event, *pointer_id, [*x, *y]),
+                } => self.check_input(*event, *pointer_kind, *pointer_id, [*x, *y]),
             }
         }
         checkpoints
@@ -1583,6 +1596,7 @@ impl Driver {
     fn emit_pointer(
         &mut self,
         kind: PointerEventFixture,
+        pointer_kind: PointerKindFixture,
         pointer_id: u64,
         timestamp_ms: f64,
         position: [f32; 2],
@@ -1596,7 +1610,7 @@ impl Driver {
             kind: pointer_event_protocol(kind),
             pointer: Some(PointerInput {
                 id: PointerId::new(pointer_id).expect("scenario pointer id is non-zero"),
-                kind: PointerKind::Mouse,
+                kind: pointer_kind_protocol(pointer_kind),
                 position: InputPoint {
                     x: position[0],
                     y: position[1],
@@ -1609,7 +1623,13 @@ impl Driver {
         });
     }
 
-    fn check_input(&self, kind: PointerEventFixture, pointer_id: u64, position: [f32; 2]) {
+    fn check_input(
+        &self,
+        kind: PointerEventFixture,
+        pointer_kind: PointerKindFixture,
+        pointer_id: u64,
+        position: [f32; 2],
+    ) {
         let event = self
             .input
             .events
@@ -1620,7 +1640,7 @@ impl Driver {
         assert_eq!(event.target, None);
         let pointer = event.pointer.expect("pointer checkpoint has pointer data");
         assert_eq!(pointer.id.get(), pointer_id);
-        assert_eq!(pointer.kind, PointerKind::Mouse);
+        assert_eq!(pointer.kind, pointer_kind_protocol(pointer_kind));
         assert_close(pointer.position.x, position[0], "pointer x");
         assert_close(pointer.position.y, position[1], "pointer y");
     }

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "whisker_bridge.h"
 
-enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 24 };
+enum { WHISKER_MOBILE_ABI_MAJOR = 2, WHISKER_MOBILE_ABI_MINOR = 25 };
 enum { WHISKER_APPLY_ACCEPTED = 0, WHISKER_APPLY_NEED_SNAPSHOT = 1, WHISKER_APPLY_REJECTED = 2 };
 enum { WHISKER_FRAME_SNAPSHOT = 0, WHISKER_FRAME_DELTA = 1 };
 enum {
@@ -212,6 +212,14 @@ typedef struct {
   uint32_t status, failure_code; uint64_t resource, generation;
   float width, height, scale; uint32_t dimensions_mask; WhiskerStringRef diagnostic;
 } WhiskerMobileResourceEvent;
+enum {
+  WHISKER_POINTER_DOWN = 0, WHISKER_POINTER_MOVE = 1,
+  WHISKER_POINTER_UP = 2, WHISKER_POINTER_CANCEL = 3
+};
+enum {
+  WHISKER_POINTER_MOUSE = 0, WHISKER_POINTER_TOUCH = 1,
+  WHISKER_POINTER_PEN = 2, WHISKER_POINTER_UNKNOWN = 3
+};
 _Static_assert(sizeof(WhiskerMobileMemberRegistration) == 24, "WhiskerMobileMemberRegistration ABI drift");
 _Static_assert(sizeof(WhiskerMobileElementRegistration) == 72, "WhiskerMobileElementRegistration ABI drift");
 _Static_assert(sizeof(WhiskerMobileBootstrap) == 24, "WhiskerMobileBootstrap ABI drift");

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -7,6 +7,14 @@ public final class WhiskerView: UIView {
     private var hostToken: UnsafeMutableRawPointer?
     private var runtimeHandle: UnsafeMutableRawPointer?
     private var isApplicationActive = true
+    private lazy var pointerInputRecognizer: WhiskerTouchObserverGestureRecognizer = {
+        let recognizer = WhiskerTouchObserverGestureRecognizer(target: nil, action: nil)
+        recognizer.touchHandler = { [weak self] touches, event in
+            self?.dispatchTouches(touches, event: event)
+        }
+        return recognizer
+    }()
+    private var touchIdentities = HostTouchIdentityMap()
     private let modules = HostModuleDispatcher()
     private let resources = HostResourceStore()
     private lazy var resourceService = HostResourceService(store: resources)
@@ -26,6 +34,8 @@ public final class WhiskerView: UIView {
         super.init(frame: frame)
         backgroundColor = .clear
         autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        isMultipleTouchEnabled = true
+        addGestureRecognizer(pointerInputRecognizer)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(applicationDidBecomeActive),
@@ -166,6 +176,73 @@ public final class WhiskerView: UIView {
         }
     }
 
+    private func dispatchTouches(_ touches: Set<UITouch>, event: HostPointerEvent) {
+        for touch in touches {
+            let key = ObjectIdentifier(touch)
+            let pointerID: UInt64
+            if event == .down {
+                pointerID = touchIdentities.begin(key)
+            } else if let existing = touchIdentities.existing(key) {
+                pointerID = existing
+            } else { continue }
+            let location = touch.location(in: self)
+            let viewport = logicalBounds
+            let logicalPosition = logicalPointerPosition(location, viewport: viewport)
+            dispatchTouchSample(
+                timestampMs: touch.timestamp * 1_000,
+                event: event,
+                pointerID: pointerID,
+                x: Float(logicalPosition.x),
+                y: Float(logicalPosition.y)
+            )
+            if event == .up || event == .cancel { touchIdentities.end(key) }
+        }
+    }
+
+    private func dispatchTouchSample(
+        timestampMs: Double,
+        event: HostPointerEvent,
+        pointerID: UInt64,
+        x: Float,
+        y: Float,
+        handle overrideHandle: UnsafeMutableRawPointer? = nil
+    ) {
+        guard timestampMs.isFinite, pointerID != 0, x.isFinite, y.isFinite,
+              let handle = overrideHandle ?? runtimeHandle else { return }
+        _ = dispatchWhiskerPointer(
+            handle: handle,
+            input: WhiskerPointerDispatch(
+                timestampMs: timestampMs,
+                event: event.rawValue,
+                pointerID: pointerID,
+                pointerKind: UInt32(WHISKER_POINTER_TOUCH),
+                x: x,
+                y: y,
+                buttons: event.buttons,
+                changedButton: -1
+            )
+        )
+    }
+
+#if WHISKER_HOST_CONFORMANCE
+    func dispatchConformanceTouchSample(
+        timestampMs: Double,
+        event: HostPointerEvent,
+        pointerID: UInt64,
+        x: Float,
+        y: Float
+    ) {
+        dispatchTouchSample(
+            timestampMs: timestampMs,
+            event: event,
+            pointerID: pointerID,
+            x: x,
+            y: y,
+            handle: UnsafeMutableRawPointer(bitPattern: 1)
+        )
+    }
+#endif
+
     private func unmount() {
         guard let handle = runtimeHandle else { return }
         runtimeHandle = nil
@@ -174,6 +251,7 @@ public final class WhiskerView: UIView {
         whiskerViewDestroy(handle)
         WhiskerModuleEventCenter.installEventSink(nil)
         scene.clear()
+        touchIdentities.clear()
         if let token = hostToken {
             Unmanaged<WhiskerView>.fromOpaque(token).release()
             hostToken = nil

--- a/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
@@ -63,6 +63,55 @@ func whiskerViewDispatchEvent(
     _ detail: UnsafePointer<WhiskerValueRaw>?
 ) -> Bool
 
+@_silgen_name("whisker_view_dispatch_pointer")
+func whiskerViewDispatchPointer(
+    _ handle: UnsafeMutableRawPointer?,
+    _ timestampMs: Double,
+    _ event: UInt32,
+    _ pointerID: UInt64,
+    _ pointerKind: UInt32,
+    _ x: Float,
+    _ y: Float,
+    _ buttons: UInt32,
+    _ changedButton: Int16
+) -> Bool
+
+struct WhiskerPointerDispatch: Equatable {
+    let timestampMs: Double
+    let event: UInt32
+    let pointerID: UInt64
+    let pointerKind: UInt32
+    let x: Float
+    let y: Float
+    let buttons: UInt32
+    let changedButton: Int16
+}
+
+#if WHISKER_HOST_CONFORMANCE
+var whiskerPointerDispatchObserver: ((WhiskerPointerDispatch) -> Void)?
+#endif
+
+@discardableResult
+func dispatchWhiskerPointer(
+    handle: UnsafeMutableRawPointer,
+    input: WhiskerPointerDispatch
+) -> Bool {
+#if WHISKER_HOST_CONFORMANCE
+    whiskerPointerDispatchObserver?(input)
+#endif
+    return whiskerViewDispatchPointer(
+        handle,
+        input.timestampMs,
+        input.event,
+        input.pointerID,
+        input.pointerKind,
+        input.x,
+        input.y,
+        input.buttons,
+        input.changedButton
+    )
+}
+
 @_silgen_name("whisker_view_dispatch_module_event")
 func whiskerViewDispatchModuleEvent(
     _ handle: UnsafeMutableRawPointer?,

--- a/platforms/ios/Sources/WhiskerRuntime/input/PointerInput.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/input/PointerInput.swift
@@ -1,0 +1,93 @@
+import UIKit
+
+func logicalPointerPosition(_ location: CGPoint, viewport: CGRect) -> CGPoint {
+    CGPoint(x: location.x - viewport.minX, y: location.y - viewport.minY)
+}
+
+enum HostPointerEvent: UInt32, Equatable {
+    case down = 0
+    case move = 1
+    case up = 2
+    case cancel = 3
+
+    var buttons: UInt32 {
+        switch self {
+        case .down, .move: 1
+        case .up, .cancel: 0
+        }
+    }
+}
+
+struct HostTouchIdentityMap {
+    private var pointerIDs = [ObjectIdentifier: UInt64]()
+    private var nextPointerID: UInt64 = 1
+
+    mutating func begin(_ touch: ObjectIdentifier) -> UInt64 {
+        if let existing = pointerIDs[touch] { return existing }
+        let result = max(nextPointerID, 1)
+        nextPointerID = result &+ 1
+        if nextPointerID == 0 { nextPointerID = 1 }
+        pointerIDs[touch] = result
+        return result
+    }
+
+    func existing(_ touch: ObjectIdentifier) -> UInt64? {
+        pointerIDs[touch]
+    }
+
+    mutating func end(_ touch: ObjectIdentifier) {
+        pointerIDs.removeValue(forKey: touch)
+    }
+
+    mutating func clear() {
+        pointerIDs.removeAll(keepingCapacity: true)
+    }
+}
+
+/// Passive ancestor observer: it never recognizes, so descendant controls and
+/// scroll recognizers continue to receive and arbitrate the original touches.
+final class WhiskerTouchObserverGestureRecognizer: UIGestureRecognizer {
+    var touchHandler: ((Set<UITouch>, HostPointerEvent) -> Void)?
+    private var activeTouches = Set<ObjectIdentifier>()
+
+    override init(target: Any?, action: Selector?) {
+        super.init(target: target, action: action)
+        cancelsTouchesInView = false
+        delaysTouchesBegan = false
+        delaysTouchesEnded = false
+    }
+
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool {
+        false
+    }
+
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool {
+        false
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        activeTouches.formUnion(touches.map(ObjectIdentifier.init))
+        touchHandler?(touches, .down)
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        touchHandler?(touches, .move)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        touchHandler?(touches, .up)
+        activeTouches.subtract(touches.map(ObjectIdentifier.init))
+        if activeTouches.isEmpty { state = .failed }
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        touchHandler?(touches, .cancel)
+        activeTouches.subtract(touches.map(ObjectIdentifier.init))
+        if activeTouches.isEmpty { state = .failed }
+    }
+
+    override func reset() {
+        super.reset()
+        activeTouches.removeAll(keepingCapacity: true)
+    }
+}

--- a/platforms/web/Cargo.toml
+++ b/platforms/web/Cargo.toml
@@ -39,6 +39,7 @@ web-sys = { version = "0.3", features = [
     "ImageData",
     "Node",
     "Performance",
+    "PointerEvent",
     "Url",
     "Window",
 ] }

--- a/platforms/web/src/application.rs
+++ b/platforms/web/src/application.rs
@@ -7,10 +7,13 @@ use whisker::runtime::RuntimeWakeHandle;
 use whisker::{Element, ElementRegistry, RuntimeInstance, SurfaceRuntime, WhiskerModule};
 use whisker_engine::LayoutOptions;
 use whisker_protocol::{
-    InputEvent, InputEventKind, ResourceCommand, ResourceEvent, ResourceId, SurfaceId,
+    InputEvent, InputEventKind, InputPoint, ResourceCommand, ResourceEvent, ResourceId, SurfaceId,
 };
 use whisker_style::StyleEnvironment;
 
+use crate::input::{
+    WebPointerEvent, WebPointerPhase, dispatch_pointer, pointer_kind, stable_pointer_id,
+};
 use crate::measure::text::DomMeasurementProvider;
 use crate::scene::frame_sink::DomFrameSink;
 use crate::scene::resource_service::WebResourceService;
@@ -47,6 +50,18 @@ pub fn run(config: WebAppConfig, application: fn() -> Element) -> Result<(), Web
             .map_err(|error| WebError(format!("mount Whisker application: {error}")))
     });
     if let Err(error) = mount {
+        APPLICATION.with(|slot| *slot.borrow_mut() = None);
+        return Err(error);
+    }
+
+    let pointer_listeners = APPLICATION.with(|slot| {
+        let slot = slot.borrow();
+        let application = slot
+            .as_ref()
+            .ok_or_else(|| WebError("Web application is not mounted".into()))?;
+        install_pointer_listeners(&application.root)
+    });
+    if let Err(error) = pointer_listeners {
         APPLICATION.with(|slot| *slot.borrow_mut() = None);
         return Err(error);
     }
@@ -97,6 +112,7 @@ pub async fn handle_resource_command(
 }
 
 struct WebApplication {
+    root: web_sys::Element,
     runtime: RuntimeInstance,
     measurements: DomMeasurementProvider,
     frames: DomFrameSink,
@@ -144,6 +160,7 @@ impl WebApplication {
         let resource_store = WebResourceStore::new();
         let resources = WebResourceService::new(resource_store.clone());
         Ok(Self {
+            root: root.clone(),
             runtime: RuntimeInstance::new(surface, wake),
             measurements: DomMeasurementProvider::new(document.clone()),
             frames: DomFrameSink::new_with_resources(
@@ -230,6 +247,56 @@ impl WebApplication {
             });
         }
     }
+}
+
+fn install_pointer_listeners(root: &web_sys::Element) -> Result<(), WebError> {
+    for (event_name, phase) in [
+        ("pointerdown", WebPointerPhase::Down),
+        ("pointermove", WebPointerPhase::Move),
+        ("pointerup", WebPointerPhase::Up),
+        ("pointercancel", WebPointerPhase::Cancel),
+    ] {
+        let event_root = root.clone();
+        let listener = Closure::<dyn FnMut(web_sys::PointerEvent)>::new(
+            move |event: web_sys::PointerEvent| {
+                let bounds = event_root.get_bounding_client_rect();
+                let input = WebPointerEvent {
+                    phase,
+                    timestamp_ms: event.time_stamp(),
+                    pointer_id: stable_pointer_id(event.pointer_id()),
+                    pointer_kind: pointer_kind(&event.pointer_type()),
+                    client_position: InputPoint {
+                        x: event.client_x() as f32,
+                        y: event.client_y() as f32,
+                    },
+                    buttons: u32::from(event.buttons()),
+                    changed_button: event.button(),
+                };
+                let result = APPLICATION.with(|slot| {
+                    let slot = slot.borrow();
+                    let application = slot
+                        .as_ref()
+                        .ok_or_else(|| WebError("Web application is not mounted".into()))?;
+                    dispatch_pointer(
+                        &application.runtime,
+                        InputPoint {
+                            x: bounds.left() as f32,
+                            y: bounds.top() as f32,
+                        },
+                        input,
+                    )
+                    .map(|_| ())
+                });
+                if let Err(error) = result {
+                    web_sys::console::error_1(&error.to_string().into());
+                }
+            },
+        );
+        root.add_event_listener_with_callback(event_name, listener.as_ref().unchecked_ref())
+            .map_err(|error| js_error("register pointer listener", error))?;
+        listener.forget();
+    }
+    Ok(())
 }
 
 pub(crate) fn request_frame() {

--- a/platforms/web/src/input.rs
+++ b/platforms/web/src/input.rs
@@ -1,0 +1,86 @@
+//! Browser pointer normalization and runtime dispatch.
+
+use whisker::RuntimeInstance;
+use whisker_protocol::{
+    InputEvent, InputEventKind, InputPoint, PointerId, PointerInput, PointerKind, WhiskerValue,
+};
+
+use crate::WebError;
+
+/// Browser pointer phase accepted by the retained input router.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WebPointerPhase {
+    Down,
+    Move,
+    Up,
+    Cancel,
+}
+
+/// Browser pointer fields captured before protocol normalization.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WebPointerEvent {
+    pub(crate) phase: WebPointerPhase,
+    pub(crate) timestamp_ms: f64,
+    pub(crate) pointer_id: u64,
+    pub(crate) pointer_kind: PointerKind,
+    pub(crate) client_position: InputPoint,
+    pub(crate) buttons: u32,
+    pub(crate) changed_button: i16,
+}
+
+/// Normalizes one root-relative browser pointer event and dispatches it through
+/// the same typed runtime boundary used by native Hosts.
+pub(crate) fn dispatch_pointer(
+    runtime: &RuntimeInstance,
+    root_origin: InputPoint,
+    input: WebPointerEvent,
+) -> Result<InputEvent, WebError> {
+    let pointer_id = PointerId::new(input.pointer_id)
+        .ok_or_else(|| WebError("browser pointer id must be non-zero".into()))?;
+    let event = InputEvent {
+        surface: runtime.surface().surface(),
+        timestamp_ms: input.timestamp_ms,
+        kind: match input.phase {
+            WebPointerPhase::Down => InputEventKind::PointerDown,
+            WebPointerPhase::Move => InputEventKind::PointerMove,
+            WebPointerPhase::Up => InputEventKind::PointerUp,
+            WebPointerPhase::Cancel => InputEventKind::PointerCancel,
+        },
+        pointer: Some(PointerInput {
+            id: pointer_id,
+            kind: input.pointer_kind,
+            position: InputPoint {
+                x: input.client_position.x - root_origin.x,
+                y: input.client_position.y - root_origin.y,
+            },
+            buttons: input.buttons,
+            changed_button: input.changed_button,
+        }),
+        target: None,
+        detail: WhiskerValue::Null,
+    };
+    runtime
+        .dispatch_input(&event)
+        .map_err(|error| WebError(format!("dispatch Web pointer input: {error}")))?;
+    Ok(event)
+}
+
+/// Converts the browser's signed pointer identifier into a stable, non-zero
+/// protocol identifier. Positive browser IDs retain their value; zero and
+/// defensive negative values occupy the otherwise unreachable high range.
+pub(crate) fn stable_pointer_id(pointer_id: i32) -> u64 {
+    if pointer_id > 0 {
+        pointer_id as u64
+    } else {
+        u64::MAX - u64::from(pointer_id.unsigned_abs())
+    }
+}
+
+pub(crate) fn pointer_kind(pointer_type: &str) -> PointerKind {
+    match pointer_type {
+        "mouse" => PointerKind::Mouse,
+        "touch" => PointerKind::Touch,
+        "pen" => PointerKind::Pen,
+        _ => PointerKind::Unknown,
+    }
+}

--- a/platforms/web/src/lib.rs
+++ b/platforms/web/src/lib.rs
@@ -18,6 +18,7 @@ pub use whisker_value::WhiskerValue;
 
 mod application;
 mod dom;
+mod input;
 mod measure;
 mod module_api;
 mod paint;

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -30,13 +30,15 @@ use whisker_protocol::{
     MeasureTextWordBreak, MeasureTextWrap, MeasurementKey, MeasurementMetrics, MeasurementPayload,
     MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
     PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
-    PaintLengthPercentage, PaintPosition, PathCommand, ProtocolVersion, RadialGradientExtent,
-    RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent, ResourceId,
-    ResourceKind, ResourceRequest, ResourceSource, SurfaceId, TextContent, TextMeasurePayload,
-    TextMeasureStyle, TextPaint, TextShadow, Transform, Visibility,
+    PaintLengthPercentage, PaintPosition, PathCommand, PointerKind, ProtocolVersion,
+    RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent,
+    ResourceId, ResourceKind, ResourceRequest, ResourceSource, SurfaceId, TextContent,
+    TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow, Transform, Visibility,
+    WhiskerValue,
 };
 use whisker_style::StyleEnvironment;
 
+use crate::input::{WebPointerEvent, WebPointerPhase, dispatch_pointer};
 use crate::measure::text::DomMeasurementProvider;
 use crate::module_api::built_in_element_factories;
 use crate::scene::frame_sink::DomFrameSink;
@@ -337,6 +339,9 @@ struct Driver {
     resource_lifecycle: bool,
     measurements: DomMeasurementProvider,
     measurement_results: HashMap<u64, MeasurementMetrics>,
+    attached_surface: Option<(f32, f32, f32)>,
+    input_runtime: Option<RuntimeInstance>,
+    last_input: Option<whisker_protocol::InputEvent>,
     expected_box: Option<ExpectedBox>,
     expected_scene: Option<Vec<SceneNodeFixture>>,
 }
@@ -379,6 +384,9 @@ impl Driver {
             resource_lifecycle: false,
             measurements,
             measurement_results: HashMap::new(),
+            attached_surface: None,
+            input_runtime: None,
+            last_input: None,
             expected_box: None,
             expected_scene: None,
         }
@@ -396,6 +404,7 @@ impl Driver {
                     set_style(&self.root, "position", "relative");
                     set_style(&self.root, "width", &format!("{width}px"));
                     set_style(&self.root, "height", &format!("{height}px"));
+                    self.attached_surface = Some((*width, *height, *scale));
                 }
                 Command::RegisterRasterResource {
                     id,
@@ -762,11 +771,99 @@ impl Driver {
                     [*min_height, *max_height],
                     *prepared_content,
                 ),
-                Command::EmitPointer { .. } | Command::CheckpointInput { .. } => {
-                    panic!("non-paint command reached the Web paint runner")
-                }
+                Command::EmitPointer {
+                    event,
+                    pointer_kind,
+                    pointer_id,
+                    timestamp_ms,
+                    x,
+                    y,
+                    buttons,
+                    changed_button,
+                } => self.emit_pointer(
+                    *event,
+                    *pointer_kind,
+                    *pointer_id,
+                    *timestamp_ms,
+                    [*x, *y],
+                    *buttons,
+                    *changed_button,
+                ),
+                Command::CheckpointInput {
+                    event,
+                    pointer_kind,
+                    pointer_id,
+                    x,
+                    y,
+                } => self.assert_input(*event, *pointer_kind, *pointer_id, [*x, *y]),
             }
         }
+    }
+
+    fn emit_pointer(
+        &mut self,
+        phase: whisker_host_conformance::PointerEventFixture,
+        pointer_kind: whisker_host_conformance::PointerKindFixture,
+        pointer_id: u64,
+        timestamp_ms: f64,
+        position: [f32; 2],
+        buttons: u32,
+        changed_button: i16,
+    ) {
+        if self.input_runtime.is_none() {
+            let (width, height, scale) = self
+                .attached_surface
+                .expect("attach_surface precedes emit_pointer");
+            let surface = SurfaceRuntime::new(
+                SurfaceId::new(1).unwrap(),
+                StyleEnvironment::new(width, height, scale, 16.0),
+            );
+            let mut runtime = RuntimeInstance::new(surface, RuntimeWakeHandle::new(|| {}));
+            runtime.mount(|| render! { view() }).unwrap();
+            assert!(runtime.surface().root().is_some());
+            self.input_runtime = Some(runtime);
+        }
+        let root_origin = whisker_protocol::InputPoint { x: 13.0, y: 7.0 };
+        let event = dispatch_pointer(
+            self.input_runtime.as_ref().unwrap(),
+            root_origin,
+            WebPointerEvent {
+                phase: fixture_pointer_phase(phase),
+                timestamp_ms,
+                pointer_id,
+                pointer_kind: fixture_pointer_kind_source(pointer_kind),
+                client_position: whisker_protocol::InputPoint {
+                    x: root_origin.x + position[0],
+                    y: root_origin.y + position[1],
+                },
+                buttons,
+                changed_button,
+            },
+        )
+        .expect("fixture pointer dispatch succeeds through the production Web path");
+        self.last_input = Some(event);
+    }
+
+    fn assert_input(
+        &self,
+        phase: whisker_host_conformance::PointerEventFixture,
+        pointer_kind: whisker_host_conformance::PointerKindFixture,
+        pointer_id: u64,
+        position: [f32; 2],
+    ) {
+        let event = self
+            .last_input
+            .as_ref()
+            .expect("input checkpoint follows emit_pointer");
+        assert_eq!(event.kind, fixture_pointer_kind(phase));
+        assert_eq!(event.surface, SurfaceId::new(1).unwrap());
+        assert_eq!(event.target, None);
+        assert_eq!(event.detail, WhiskerValue::Null);
+        let pointer = event.pointer.expect("pointer fixture has pointer payload");
+        assert_eq!(pointer.id.get(), pointer_id);
+        assert_eq!(pointer.kind, fixture_pointer_kind_source(pointer_kind));
+        assert_close(pointer.position.x, position[0], "pointer x");
+        assert_close(pointer.position.y, position[1], "pointer y");
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1555,6 +1652,7 @@ async fn every_shared_paint_fixture_reaches_the_production_dom_sink() {
                 Command::PresentBox { .. }
                     | Command::PresentScene { .. }
                     | Command::MeasureText { .. }
+                    | Command::EmitPointer { .. }
             )
         }) {
             continue;
@@ -2521,6 +2619,43 @@ fn fixture_measure_font_style(
     }
 }
 
+fn fixture_pointer_phase(value: whisker_host_conformance::PointerEventFixture) -> WebPointerPhase {
+    match value {
+        whisker_host_conformance::PointerEventFixture::Down => WebPointerPhase::Down,
+        whisker_host_conformance::PointerEventFixture::Move => WebPointerPhase::Move,
+        whisker_host_conformance::PointerEventFixture::Up => WebPointerPhase::Up,
+        whisker_host_conformance::PointerEventFixture::Cancel => WebPointerPhase::Cancel,
+    }
+}
+
+fn fixture_pointer_kind(
+    value: whisker_host_conformance::PointerEventFixture,
+) -> whisker_protocol::InputEventKind {
+    match value {
+        whisker_host_conformance::PointerEventFixture::Down => {
+            whisker_protocol::InputEventKind::PointerDown
+        }
+        whisker_host_conformance::PointerEventFixture::Move => {
+            whisker_protocol::InputEventKind::PointerMove
+        }
+        whisker_host_conformance::PointerEventFixture::Up => {
+            whisker_protocol::InputEventKind::PointerUp
+        }
+        whisker_host_conformance::PointerEventFixture::Cancel => {
+            whisker_protocol::InputEventKind::PointerCancel
+        }
+    }
+}
+
+fn fixture_pointer_kind_source(value: whisker_host_conformance::PointerKindFixture) -> PointerKind {
+    match value {
+        whisker_host_conformance::PointerKindFixture::Mouse => PointerKind::Mouse,
+        whisker_host_conformance::PointerKindFixture::Touch => PointerKind::Touch,
+        whisker_host_conformance::PointerKindFixture::Pen => PointerKind::Pen,
+        whisker_host_conformance::PointerKindFixture::Unknown => PointerKind::Unknown,
+    }
+}
+
 fn fixture_font_optical_sizing(
     value: whisker_host_conformance::FontOpticalSizingFixture,
 ) -> whisker_protocol::FontOpticalSizing {
@@ -2764,6 +2899,13 @@ fn assert_style(style: &web_sys::CssStyleDeclaration, property: &str, expected: 
     assert_eq!(
         actual, expected,
         "production DOM projection for {property} did not match the fixture"
+    );
+}
+
+fn assert_close(actual: f32, expected: f32, label: &str) {
+    assert!(
+        (actual - expected).abs() <= f32::EPSILON,
+        "{label} mismatch: expected {expected}, got {actual}",
     );
 }
 

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -170,7 +170,7 @@
       "id": "interaction.pointer",
       "basis": "lynx-4.0",
       "properties": ["cursor", "pointer-events"],
-      "supported_subset": ["pointer-events-auto-none", "keyword-only-cursors-web-desktop-android", "ios-hidden-text-vertical-text-crosshair-and-resize-shapes", "resolved-value-inheritance"],
+      "supported_subset": ["pointer-events-auto-none", "keyword-only-cursors-web-desktop-android", "ios-hidden-text-vertical-text-crosshair-and-resize-shapes", "resolved-value-inheritance", "host-normalized-pointer-down-move-up-cancel-all-hosts"],
       "pending_subset": ["ios-semantic-cursors-without-public-uikit-shapes"],
       "unsupported_browser_subset": ["resource-backed-cursors", "cursor-hotspots", "svg-pointer-events-values"],
       "compatibility_notes": ["Lynx pointer-events accepts auto and none; Whisker resolves the documented inheritance effect before emitting SetHitTest", "UIKit provides hidden, text beams, and custom geometric pointer shapes, which iOS uses for none, text, vertical-text, crosshair, and resize keywords", "UIKit has no public platform glyphs for link, context-menu, help, progress, wait, cell, alias, copy, move, no-drop, not-allowed, grab, grabbing, or zoom cursors; iOS preserves those keywords and deliberately retains the system pointer instead of conflating distinct semantics"],

--- a/tests/host-conformance/core/pointer-input-basic.json
+++ b/tests/host-conformance/core/pointer-input-basic.json
@@ -7,19 +7,78 @@
       {
         "type": "emit_pointer",
         "event": "down",
+        "pointer_kind": "touch",
         "pointer_id": 1,
         "timestamp_ms": 42.5,
         "x": 24.0,
         "y": 16.0,
         "buttons": 1,
-        "changed_button": 0
+        "changed_button": -1
       },
       {
         "type": "checkpoint_input",
         "event": "down",
+        "pointer_kind": "touch",
         "pointer_id": 1,
         "x": 24.0,
         "y": 16.0
+      },
+      {
+        "type": "emit_pointer",
+        "event": "move",
+        "pointer_kind": "touch",
+        "pointer_id": 1,
+        "timestamp_ms": 43.0,
+        "x": 30.0,
+        "y": 20.0,
+        "buttons": 1,
+        "changed_button": -1
+      },
+      {
+        "type": "checkpoint_input",
+        "event": "move",
+        "pointer_kind": "touch",
+        "pointer_id": 1,
+        "x": 30.0,
+        "y": 20.0
+      },
+      {
+        "type": "emit_pointer",
+        "event": "up",
+        "pointer_kind": "touch",
+        "pointer_id": 1,
+        "timestamp_ms": 44.0,
+        "x": 30.0,
+        "y": 20.0,
+        "buttons": 0,
+        "changed_button": -1
+      },
+      {
+        "type": "checkpoint_input",
+        "event": "up",
+        "pointer_kind": "touch",
+        "pointer_id": 1,
+        "x": 30.0,
+        "y": 20.0
+      },
+      {
+        "type": "emit_pointer",
+        "event": "cancel",
+        "pointer_kind": "touch",
+        "pointer_id": 2,
+        "timestamp_ms": 45.0,
+        "x": 40.0,
+        "y": 24.0,
+        "buttons": 0,
+        "changed_button": -1
+      },
+      {
+        "type": "checkpoint_input",
+        "event": "cancel",
+        "pointer_kind": "touch",
+        "pointer_id": 2,
+        "x": 40.0,
+        "y": 24.0
       }
     ]
   }

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -580,7 +580,7 @@
       "id": "host.input.pointer.basic",
       "feature": "pointer-input",
       "fixture": "core/pointer-input-basic.json",
-      "required_hosts": ["desktop"],
+      "required_hosts": ["desktop", "web", "android", "ios"],
       "checkpoints": ["input"]
     }
   ]

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -5,6 +5,8 @@ import android.os.Build
 import android.view.ViewGroup
 import android.widget.TextView
 import android.graphics.Canvas
+import android.view.InputDevice
+import android.view.MotionEvent
 import android.util.Base64
 import android.text.Spanned
 import android.text.style.LeadingMarginSpan
@@ -29,6 +31,17 @@ import rs.whisker.runtime.resource.HostResourceSnapshot
 import rs.whisker.runtime.resource.HostResourceState
 
 private const val BACKGROUND_PACKED_LAYERS = 256
+
+private data class CapturedPointerInput(
+    val event: Int,
+    val pointerId: Long,
+    val kind: Int,
+    val buttons: Int,
+    val changedButton: Int,
+    val timestampMs: Double,
+    val x: Float,
+    val y: Float,
+)
 
 @RunWith(AndroidJUnit4::class)
 class HostConformanceTest {
@@ -89,6 +102,27 @@ class HostConformanceTest {
                     count += 1
                 }
                 assertTrue("at least one shared measurement scenario", count > 0)
+            }
+    }
+
+    @Test
+    fun everySharedPointerScenarioUsesTheProductionAndroidNormalizer() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                val manifest = JSONObject(asset("manifest.json"))
+                var count = 0
+                manifest.getJSONArray("cases").objects().forEach { entry ->
+                    val scenario = JSONObject(asset(entry.getString("fixture")))
+                    val testSide = scenario.getJSONObject("test")
+                    if (testSide.getJSONArray("commands").objects().none {
+                            it.getString("type") == "emit_pointer"
+                        }) return@forEach
+                    Driver(context, scenario.getString("id")).executeInput(testSide)
+                    count += 1
+                }
+                assertTrue("at least one shared pointer scenario", count > 0)
             }
     }
 
@@ -247,6 +281,7 @@ private class Driver(
     private var logicalHeight = 0f
     private var checkpoint: Bitmap? = null
     private val measurements = HashMap<Long, FloatArray>()
+    private var pointerInput: CapturedPointerInput? = null
 
     init {
         view.beginBootstrapFromNative()
@@ -275,6 +310,18 @@ private class Driver(
             intArrayOf(), intArrayOf(), emptyArray(),
         )
         check(view.finishBootstrapFromNative())
+        view.observePointerInputForTesting { semantics, geometry ->
+            pointerInput = CapturedPointerInput(
+                event = semantics[0].toInt(),
+                pointerId = semantics[1],
+                kind = semantics[2].toInt(),
+                buttons = semantics[3].toInt(),
+                changedButton = semantics[4].toInt(),
+                timestampMs = geometry[0].toDouble(),
+                x = geometry[1].toFloat(),
+                y = geometry[2].toFloat(),
+            )
+        }
     }
 
     fun execute(side: JSONObject): Bitmap {
@@ -496,6 +543,98 @@ private class Driver(
                 else -> error("unsupported Android measurement command: ${command.getString("type")}")
             }
         }
+    }
+
+    fun executeInput(side: JSONObject) {
+        side.getJSONArray("commands").objects().forEach { command ->
+            when (command.getString("type")) {
+                "attach_surface" -> {
+                    logicalWidth = command.getDouble("width").toFloat()
+                    logicalHeight = command.getDouble("height").toFloat()
+                }
+                "emit_pointer" -> emitPointer(command)
+                "checkpoint_input" -> checkpointInput(command)
+                else -> error("unsupported Android pointer command: ${command.getString("type")}")
+            }
+        }
+    }
+
+    private fun emitPointer(command: JSONObject) {
+        val eventKind = when (command.getString("event")) {
+            "down" -> MotionEvent.ACTION_DOWN
+            "move" -> MotionEvent.ACTION_MOVE
+            "up" -> MotionEvent.ACTION_UP
+            "cancel" -> MotionEvent.ACTION_CANCEL
+            else -> error("unsupported pointer event: $command")
+        }
+        val pointerId = command.getLong("pointer_id")
+        check(pointerId in 1..Int.MAX_VALUE.toLong())
+        val density = context.resources.displayMetrics.density
+        val (toolType, source) = when (command.getString("pointer_kind")) {
+            "mouse" -> MotionEvent.TOOL_TYPE_MOUSE to InputDevice.SOURCE_MOUSE
+            "touch" -> MotionEvent.TOOL_TYPE_FINGER to InputDevice.SOURCE_TOUCHSCREEN
+            "pen" -> MotionEvent.TOOL_TYPE_STYLUS to InputDevice.SOURCE_STYLUS
+            "unknown" -> MotionEvent.TOOL_TYPE_UNKNOWN to InputDevice.SOURCE_UNKNOWN
+            else -> error("unsupported pointer kind: $command")
+        }
+        val properties = arrayOf(MotionEvent.PointerProperties().apply {
+            id = (pointerId - 1).toInt()
+            this.toolType = toolType
+        })
+        val coordinates = arrayOf(MotionEvent.PointerCoords().apply {
+            x = command.getDouble("x").toFloat() * density
+            y = command.getDouble("y").toFloat() * density
+            pressure = 1f
+            size = 1f
+        })
+        val timestampMs = command.getDouble("timestamp_ms").toLong()
+        val event = MotionEvent.obtain(
+            timestampMs,
+            timestampMs,
+            eventKind,
+            1,
+            properties,
+            coordinates,
+            0,
+            command.getInt("buttons"),
+            1f,
+            1f,
+            0,
+            0,
+            source,
+            0,
+        )
+        try {
+            view.dispatchTouchEvent(event)
+        } finally {
+            event.recycle()
+        }
+        val normalized = checkNotNull(pointerInput)
+        check(normalized.buttons == command.getInt("buttons"))
+        check(normalized.changedButton == command.getInt("changed_button"))
+    }
+
+    private fun checkpointInput(command: JSONObject) {
+        val normalized = checkNotNull(pointerInput)
+        val expectedEvent = when (command.getString("event")) {
+            "down" -> 0
+            "move" -> 1
+            "up" -> 2
+            "cancel" -> 3
+            else -> error("unsupported pointer checkpoint: $command")
+        }
+        check(normalized.event == expectedEvent)
+        check(normalized.pointerId == command.getLong("pointer_id"))
+        val expectedKind = when (command.getString("pointer_kind")) {
+            "mouse" -> 0
+            "touch" -> 1
+            "pen" -> 2
+            "unknown" -> 3
+            else -> error("unsupported pointer kind: $command")
+        }
+        check(normalized.kind == expectedKind)
+        check(abs(normalized.x - command.getDouble("x").toFloat()) < 0.001f)
+        check(abs(normalized.y - command.getDouble("y").toFloat()) < 0.001f)
     }
 
     private fun measureText(command: JSONObject) {

--- a/tests/host-conformance/runners/ios/Stubs/stubs.c
+++ b/tests/host-conformance/runners/ios/Stubs/stubs.c
@@ -7,5 +7,6 @@ void *whisker_view_create(void) { return NULL; }
 bool whisker_view_tick(void) { return true; }
 void whisker_view_destroy(void *handle) { (void)handle; }
 bool whisker_view_dispatch_event(void) { return false; }
+bool whisker_view_dispatch_pointer(void) { return false; }
 bool whisker_view_dispatch_module_event(void) { return false; }
 bool whisker_view_dispatch_resource_event(void) { return true; }

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -28,7 +28,8 @@ final class HostConformanceTests: XCTestCase {
             let testSide = try object(scenario, "test")
             guard try array(testSide, "commands").contains(where: {
                 let type = try string($0, "type")
-                return type == "present_box" || type == "present_scene" || type == "measure_text"
+                return type == "present_box" || type == "present_scene" || type == "measure_text" ||
+                    type == "emit_pointer"
             }) else { continue }
             let test = try Driver(id: id).execute(testSide)
             if let reference = scenario["reference"] as? [String: Any] {
@@ -72,6 +73,38 @@ final class HostConformanceTests: XCTestCase {
             .unsupportedSystemFallback, .unsupportedSystemFallback,
         ]
         XCTAssertEqual((0...34).map { hostCursorPresentation(keyword: Int32($0)) }, expected)
+    }
+
+    func testTouchObserverDoesNotArbitrateDescendantGestures() {
+        let observer = WhiskerTouchObserverGestureRecognizer(target: nil, action: nil)
+        let controlGesture = UITapGestureRecognizer()
+        XCTAssertFalse(observer.cancelsTouchesInView)
+        XCTAssertFalse(observer.delaysTouchesBegan)
+        XCTAssertFalse(observer.delaysTouchesEnded)
+        XCTAssertFalse(observer.canPrevent(controlGesture))
+        XCTAssertFalse(observer.canBePrevented(by: controlGesture))
+    }
+
+    func testTouchIdentityRemainsStableForTheStream() {
+        let firstTouch = NSObject()
+        let secondTouch = NSObject()
+        let firstKey = ObjectIdentifier(firstTouch)
+        let secondKey = ObjectIdentifier(secondTouch)
+        var identities = HostTouchIdentityMap()
+        let pointerID = identities.begin(firstKey)
+        XCTAssertNotEqual(pointerID, 0)
+        XCTAssertEqual(identities.existing(firstKey), pointerID)
+        XCTAssertEqual(identities.begin(firstKey), pointerID)
+        XCTAssertNotEqual(identities.begin(secondKey), pointerID)
+        identities.end(firstKey)
+        XCTAssertNil(identities.existing(firstKey))
+        XCTAssertEqual(
+            logicalPointerPosition(
+                CGPoint(x: 34, y: 27),
+                viewport: CGRect(x: 10, y: 11, width: 200, height: 100)
+            ),
+            CGPoint(x: 24, y: 16)
+        )
     }
 
     func testContentBoxRadiiUseTheCompleteInsetFromTheBorderBox() {
@@ -400,6 +433,7 @@ private final class Driver {
     private var surfaceScale: CGFloat = 1
     private var checkpoint: Pixels?
     private var measurements: [UInt64: WhiskerMobileMeasureResponse] = [:]
+    private var pointerInput: WhiskerPointerDispatch?
 
     init(id: String) throws {
         self.id = id
@@ -445,6 +479,10 @@ private final class Driver {
                 try measureText(command)
             case "checkpoint_measurement":
                 try checkpointMeasurement(command)
+            case "emit_pointer":
+                try emitPointer(command)
+            case "checkpoint_input":
+                try checkpointInput(command)
             case "checkpoint":
                 let name = try string(command, "name")
                 guard name == "paint.box" ||
@@ -837,6 +875,57 @@ private final class Driver {
         if id == "host.measure.text.basic" {
             XCTAssertGreaterThanOrEqual(response.height, 28)
         }
+        checkpoint = Pixels(width: 0, height: 0, bytes: [])
+    }
+
+    private func emitPointer(_ command: [String: Any]) throws {
+        let event: HostPointerEvent = switch try string(command, "event") {
+        case "down": .down
+        case "move": .move
+        case "up": .up
+        case "cancel": .cancel
+        default: throw Failure("unknown pointer event")
+        }
+        guard try string(command, "pointer_kind") == "touch" else {
+            throw Failure("iOS touch fixture requires pointer_kind=touch")
+        }
+        var observed: WhiskerPointerDispatch?
+        whiskerPointerDispatchObserver = { observed = $0 }
+        defer { whiskerPointerDispatchObserver = nil }
+        view.dispatchConformanceTouchSample(
+            timestampMs: try number(command, "timestamp_ms"),
+            event: event,
+            pointerID: UInt64(try number(command, "pointer_id")),
+            x: Float(try number(command, "x")),
+            y: Float(try number(command, "y"))
+        )
+        let input = try unwrap(observed, "production pointer ABI dispatch")
+        XCTAssertEqual(input.timestampMs, try number(command, "timestamp_ms"))
+        XCTAssertEqual(input.event, event.rawValue)
+        XCTAssertNotEqual(input.pointerID, 0)
+        XCTAssertEqual(input.pointerKind, UInt32(WHISKER_POINTER_TOUCH))
+        XCTAssertEqual(input.buttons, UInt32(try number(command, "buttons")))
+        XCTAssertEqual(input.changedButton, Int16(try number(command, "changed_button")))
+        pointerInput = input
+    }
+
+    private func checkpointInput(_ command: [String: Any]) throws {
+        let input = try unwrap(pointerInput, "pointer input checkpoint")
+        let event: HostPointerEvent = switch try string(command, "event") {
+        case "down": .down
+        case "move": .move
+        case "up": .up
+        case "cancel": .cancel
+        default: throw Failure("unknown checkpoint pointer event")
+        }
+        guard try string(command, "pointer_kind") == "touch" else {
+            throw Failure("iOS touch checkpoint requires pointer_kind=touch")
+        }
+        XCTAssertEqual(input.event, event.rawValue)
+        XCTAssertEqual(input.pointerID, UInt64(try number(command, "pointer_id")))
+        XCTAssertEqual(input.pointerKind, UInt32(WHISKER_POINTER_TOUCH))
+        XCTAssertEqual(input.x, Float(try number(command, "x")))
+        XCTAssertEqual(input.y, Float(try number(command, "y")))
         checkpoint = Pixels(width: 0, height: 0, bytes: [])
     }
 

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -430,6 +430,7 @@
       "required": [
         "type",
         "event",
+        "pointer_kind",
         "pointer_id",
         "timestamp_ms",
         "x",
@@ -440,7 +441,8 @@
       "properties": {
         "type": { "const": "emit_pointer" },
         "event": { "$ref": "#/$defs/pointerEvent" },
-        "pointer_id": { "type": "integer", "minimum": 0 },
+        "pointer_kind": { "$ref": "#/$defs/pointerKind" },
+        "pointer_id": { "type": "integer", "minimum": 1 },
         "timestamp_ms": { "type": "number", "minimum": 0 },
         "x": { "type": "number" },
         "y": { "type": "number" },
@@ -451,16 +453,18 @@
     "checkpointInput": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "event", "pointer_id", "x", "y"],
+      "required": ["type", "event", "pointer_kind", "pointer_id", "x", "y"],
       "properties": {
         "type": { "const": "checkpoint_input" },
         "event": { "$ref": "#/$defs/pointerEvent" },
-        "pointer_id": { "type": "integer", "minimum": 0 },
+        "pointer_kind": { "$ref": "#/$defs/pointerKind" },
+        "pointer_id": { "type": "integer", "minimum": 1 },
         "x": { "type": "number" },
         "y": { "type": "number" }
       }
     },
     "pointerEvent": { "enum": ["down", "move", "up", "cancel"] },
+    "pointerKind": { "enum": ["mouse", "touch", "pen", "unknown"] },
     "border": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- add the additive mobile ABI 2.25 `dispatch_pointer` entry point and export it from generated app binaries
- normalize native pointer/touch streams into typed protocol events with `target: None`, keeping hit testing and pointer capture in Rust
- implement passive production input observation for Android, iOS, and Web without disrupting descendant native controls
- expand the shared pointer fixture to down/move/up/cancel on all four Hosts with explicit touch-kind semantics

## Validation
- `cargo test -p whisker-host-conformance`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- Android androidTest Kotlin compilation and NDK C syntax check
- iOS Simulator XCTest (11 passed)
- `cargo check -p host-smoke --target aarch64-apple-ios-sim`
- targeted workspace and Web Wasm clippy with warnings denied
- `cargo fmt --all -- --check`
- `git diff --check`