### PR TITLE
feat(host): normalize pointer kinds across hosts

### DIFF
--- a/platforms/desktop/src/input.rs
+++ b/platforms/desktop/src/input.rs
@@ -1,0 +1,248 @@
+use whisker_protocol::{
+    InputEvent, InputEventKind, InputPoint, PointerId, PointerInput, PointerKind, SurfaceId,
+};
+use whisker_value::WhiskerValue;
+
+/// Pointer phases emitted by a native Desktop window adapter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DesktopPointerPhase {
+    /// A pointer or mouse button became active.
+    Down,
+    /// An active pointer changed position.
+    Move,
+    /// A pointer or mouse button was released.
+    Up,
+    /// The operating system cancelled the active pointer stream.
+    Cancel,
+}
+
+impl DesktopPointerPhase {
+    const fn protocol(self) -> InputEventKind {
+        match self {
+            Self::Down => InputEventKind::PointerDown,
+            Self::Move => InputEventKind::PointerMove,
+            Self::Up => InputEventKind::PointerUp,
+            Self::Cancel => InputEventKind::PointerCancel,
+        }
+    }
+}
+
+/// Mouse buttons normalized from a native Desktop window event.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DesktopMouseButton {
+    /// Primary or left button.
+    Primary,
+    /// Auxiliary or middle button.
+    Auxiliary,
+    /// Secondary or right button.
+    Secondary,
+    /// Browser back button.
+    Back,
+    /// Browser forward button.
+    Forward,
+    /// A Host button without a portable CSS pointer mapping.
+    Other,
+}
+
+/// Host-projected pointer metadata before conversion to the shared protocol.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DesktopPointerEvent {
+    /// Monotonic Host timestamp in milliseconds.
+    pub timestamp_ms: f64,
+    /// Pointer lifecycle phase.
+    pub phase: DesktopPointerPhase,
+    /// Stable, non-zero identifier within this surface.
+    pub pointer_id: u64,
+    /// Host-classified pointer device kind.
+    pub pointer_kind: PointerKind,
+    /// Position in logical surface coordinates.
+    pub position: InputPoint,
+    /// CSS-compatible active-button bitset.
+    pub buttons: u32,
+    /// CSS-compatible changed button, or `-1` when not applicable.
+    pub changed_button: i16,
+}
+
+impl DesktopMouseButton {
+    const fn mask(self) -> u32 {
+        match self {
+            Self::Primary => 1,
+            Self::Secondary => 2,
+            Self::Auxiliary => 4,
+            Self::Back => 8,
+            Self::Forward => 16,
+            Self::Other => 0,
+        }
+    }
+
+    const fn changed(self) -> i16 {
+        match self {
+            Self::Primary => 0,
+            Self::Auxiliary => 1,
+            Self::Secondary => 2,
+            Self::Back => 3,
+            Self::Forward => 4,
+            Self::Other => -1,
+        }
+    }
+}
+
+/// Stateful Desktop pointer normalizer shared by the three OS shells.
+///
+/// It retains the last logical mouse position and active mouse-button bitset;
+/// touch identifiers are deterministically offset so they never collide with
+/// the reserved mouse pointer identifier.
+#[derive(Clone, Debug)]
+pub struct DesktopPointerAdapter {
+    surface: SurfaceId,
+    mouse_position: Option<InputPoint>,
+    mouse_buttons: u32,
+}
+
+impl DesktopPointerAdapter {
+    /// Creates an adapter for one retained runtime surface.
+    pub const fn new(surface: SurfaceId) -> Self {
+        Self {
+            surface,
+            mouse_position: None,
+            mouse_buttons: 0,
+        }
+    }
+
+    /// Normalizes a mouse cursor update at a logical window position.
+    pub fn cursor_moved(&mut self, timestamp_ms: f64, position: [f32; 2]) -> InputEvent {
+        let position = InputPoint {
+            x: position[0],
+            y: position[1],
+        };
+        self.mouse_position = Some(position);
+        self.pointer_event(DesktopPointerEvent {
+            timestamp_ms,
+            phase: DesktopPointerPhase::Move,
+            pointer_id: MOUSE_POINTER_ID,
+            pointer_kind: PointerKind::Mouse,
+            position,
+            buttons: self.mouse_buttons,
+            changed_button: -1,
+        })
+        .expect("the reserved mouse pointer identifier is valid")
+    }
+
+    /// Normalizes a native mouse-button transition at the last cursor position.
+    pub fn mouse_button(
+        &mut self,
+        timestamp_ms: f64,
+        button: DesktopMouseButton,
+        pressed: bool,
+    ) -> Option<InputEvent> {
+        let position = self.mouse_position?;
+        let mask = button.mask();
+        if pressed {
+            self.mouse_buttons |= mask;
+        } else {
+            self.mouse_buttons &= !mask;
+        }
+        self.pointer_event(DesktopPointerEvent {
+            timestamp_ms,
+            phase: if pressed {
+                DesktopPointerPhase::Down
+            } else {
+                DesktopPointerPhase::Up
+            },
+            pointer_id: MOUSE_POINTER_ID,
+            pointer_kind: PointerKind::Mouse,
+            position,
+            buttons: self.mouse_buttons,
+            changed_button: button.changed(),
+        })
+    }
+
+    /// Normalizes one winit-style touch update expressed in logical coordinates.
+    pub fn touch(
+        &self,
+        timestamp_ms: f64,
+        native_id: u64,
+        phase: DesktopPointerPhase,
+        position: [f32; 2],
+    ) -> Option<InputEvent> {
+        let pointer_id = native_id.checked_add(TOUCH_POINTER_ID_OFFSET)?;
+        self.pointer_event(DesktopPointerEvent {
+            timestamp_ms,
+            phase,
+            pointer_id,
+            pointer_kind: PointerKind::Touch,
+            position: InputPoint {
+                x: position[0],
+                y: position[1],
+            },
+            buttons: if matches!(phase, DesktopPointerPhase::Down | DesktopPointerPhase::Move) {
+                1
+            } else {
+                0
+            },
+            changed_button: -1,
+        })
+    }
+
+    /// Constructs the final protocol input used by production adapters and
+    /// conformance fixtures after Host-specific event projection.
+    pub fn pointer_event(&self, input: DesktopPointerEvent) -> Option<InputEvent> {
+        let pointer_id = PointerId::new(input.pointer_id)?;
+        let event = InputEvent {
+            surface: self.surface,
+            timestamp_ms: input.timestamp_ms,
+            kind: input.phase.protocol(),
+            pointer: Some(PointerInput {
+                id: pointer_id,
+                kind: input.pointer_kind,
+                position: input.position,
+                buttons: input.buttons,
+                changed_button: input.changed_button,
+            }),
+            target: None,
+            detail: WhiskerValue::Null,
+        };
+        event.validate().ok()?;
+        Some(event)
+    }
+}
+
+const MOUSE_POINTER_ID: u64 = 1;
+const TOUCH_POINTER_ID_OFFSET: u64 = 2;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mouse_state_tracks_logical_position_buttons_and_changed_button() {
+        let mut adapter = DesktopPointerAdapter::new(SurfaceId::new(1).unwrap());
+        let moved = adapter.cursor_moved(1.0, [24.0, 16.0]);
+        assert_eq!(moved.pointer.unwrap().buttons, 0);
+        let down = adapter
+            .mouse_button(2.0, DesktopMouseButton::Primary, true)
+            .unwrap();
+        let pointer = down.pointer.unwrap();
+        assert_eq!(down.kind, InputEventKind::PointerDown);
+        assert_eq!(pointer.position, InputPoint { x: 24.0, y: 16.0 });
+        assert_eq!(pointer.buttons, 1);
+        assert_eq!(pointer.changed_button, 0);
+        let up = adapter
+            .mouse_button(3.0, DesktopMouseButton::Primary, false)
+            .unwrap();
+        assert_eq!(up.pointer.unwrap().buttons, 0);
+    }
+
+    #[test]
+    fn touch_ids_do_not_collide_with_the_reserved_mouse_id() {
+        let adapter = DesktopPointerAdapter::new(SurfaceId::new(1).unwrap());
+        let down = adapter
+            .touch(1.0, 0, DesktopPointerPhase::Down, [3.0, 4.0])
+            .unwrap();
+        let pointer = down.pointer.unwrap();
+        assert_eq!(pointer.id.get(), 2);
+        assert_eq!(pointer.kind, PointerKind::Touch);
+        assert_eq!(pointer.buttons, 1);
+        assert_eq!(pointer.changed_button, -1);
+    }
+}

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -25,6 +25,7 @@ pub use whisker_value::WhiskerValue;
 
 mod element;
 mod gpu;
+mod input;
 mod paint;
 mod resource;
 mod scene;
@@ -39,6 +40,9 @@ use element::DesktopElementRegistry;
 pub use element::{
     BuiltInElementModule, DesktopElementFactory, DesktopModuleDefinition, DesktopNativeElement,
     DesktopNativeEvent, DesktopViewDefinition, DesktopViewImplementation,
+};
+pub use input::{
+    DesktopMouseButton, DesktopPointerAdapter, DesktopPointerEvent, DesktopPointerPhase,
 };
 /// Desktop Host module declaration, named consistently with native Hosts.
 pub type ModuleDefinition = DesktopModuleDefinition;

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -26,11 +26,10 @@ use whisker_protocol::{
     MeasureTextDirection, MeasureTextOverflow, MeasureTextWordBreak, MeasureTextWrap,
     MeasurementKey, MeasurementPayload, MeasurementRequest, MeasurementResponse, NodeId, Operation,
     OverflowClip, PaintBox, PaintColor, PaintCoordinate, PaintCornerRadius, PaintCorners,
-    PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition, PathCommand, PointerId,
-    PointerInput, PointerKind, ProtocolVersion, RadialGradientExtent, RadialGradientShape,
-    ResourceCommand, ResourceId, ResourceKind, ResourceRequest, ResourceSource, SurfaceId,
-    TextContent, TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow, Transform,
-    Visibility, WhiskerValue,
+    PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition, PathCommand, PointerKind,
+    ProtocolVersion, RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceId,
+    ResourceKind, ResourceRequest, ResourceSource, SurfaceId, TextContent, TextMeasurePayload,
+    TextMeasureStyle, TextPaint, TextShadow, Transform, Visibility,
 };
 use whisker_style::{PropertyOrigin, StyleEnvironment, StyleProperty};
 
@@ -41,6 +40,7 @@ use crate::gpu::{
     render_clipped_box_primitives_offscreen,
     render_clipped_box_primitives_with_backdrops_offscreen,
 };
+use crate::input::{DesktopPointerAdapter, DesktopPointerEvent, DesktopPointerPhase};
 use crate::paint::box_paint::{
     BoxPrimitiveKind, background_gradient_primitive, lower_box, resolve_box_geometry,
 };
@@ -493,6 +493,7 @@ struct Driver {
     scale: f32,
     text: NativeTextHost,
     measurement_responses: Vec<MeasurementResponse>,
+    pointer: Option<DesktopPointerAdapter>,
     input: RecordingInputSink,
     raster_resources: std::collections::HashMap<ResourceId, RasterResource>,
     resource_service: DesktopResourceService,
@@ -555,6 +556,7 @@ impl Driver {
                 .unwrap(),
             ),
             measurement_responses: Vec::new(),
+            pointer: None,
             input: RecordingInputSink::default(),
             raster_resources: std::collections::HashMap::new(),
             resource_service: DesktopResourceService::new(std::path::PathBuf::new(), || {}),
@@ -573,6 +575,7 @@ impl Driver {
                     assert!(*width > 0.0 && *height > 0.0 && *scale > 0.0);
                     let surface = SurfaceId::new(1).unwrap();
                     self.surface = Some(surface);
+                    self.pointer = Some(DesktopPointerAdapter::new(surface));
                     self.scene = Some(desktop_scene(surface));
                     self.logical_size = [*width, *height];
                     self.scale = *scale;
@@ -1603,24 +1606,31 @@ impl Driver {
         buttons: u32,
         changed_button: i16,
     ) {
-        let surface = self.surface.expect("attach_surface precedes emit_pointer");
-        self.input.dispatch(InputEvent {
-            surface,
-            timestamp_ms,
-            kind: pointer_event_protocol(kind),
-            pointer: Some(PointerInput {
-                id: PointerId::new(pointer_id).expect("scenario pointer id is non-zero"),
-                kind: pointer_kind_protocol(pointer_kind),
-                position: InputPoint {
-                    x: position[0],
-                    y: position[1],
-                },
-                buttons,
-                changed_button,
-            }),
-            target: None,
-            detail: WhiskerValue::Null,
-        });
+        let adapter = self
+            .pointer
+            .as_ref()
+            .expect("attach_surface precedes emit_pointer");
+        self.input.dispatch(
+            adapter
+                .pointer_event(DesktopPointerEvent {
+                    timestamp_ms,
+                    phase: match kind {
+                        PointerEventFixture::Down => DesktopPointerPhase::Down,
+                        PointerEventFixture::Move => DesktopPointerPhase::Move,
+                        PointerEventFixture::Up => DesktopPointerPhase::Up,
+                        PointerEventFixture::Cancel => DesktopPointerPhase::Cancel,
+                    },
+                    pointer_id,
+                    pointer_kind: pointer_kind_protocol(pointer_kind),
+                    position: InputPoint {
+                        x: position[0],
+                        y: position[1],
+                    },
+                    buttons,
+                    changed_button,
+                })
+                .expect("scenario pointer event passes the production Desktop adapter"),
+        );
     }
 
     fn check_input(

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -192,6 +192,7 @@ public final class WhiskerView: UIView {
                 timestampMs: touch.timestamp * 1_000,
                 event: event,
                 pointerID: pointerID,
+                pointerKind: hostPointerKind(for: touch.type),
                 x: Float(logicalPosition.x),
                 y: Float(logicalPosition.y)
             )
@@ -203,6 +204,7 @@ public final class WhiskerView: UIView {
         timestampMs: Double,
         event: HostPointerEvent,
         pointerID: UInt64,
+        pointerKind: HostPointerKind,
         x: Float,
         y: Float,
         handle overrideHandle: UnsafeMutableRawPointer? = nil
@@ -215,11 +217,11 @@ public final class WhiskerView: UIView {
                 timestampMs: timestampMs,
                 event: event.rawValue,
                 pointerID: pointerID,
-                pointerKind: UInt32(WHISKER_POINTER_TOUCH),
+                pointerKind: pointerKind.rawValue,
                 x: x,
                 y: y,
                 buttons: event.buttons,
-                changedButton: -1
+                changedButton: pointerKind.changedButton(for: event)
             )
         )
     }
@@ -229,6 +231,7 @@ public final class WhiskerView: UIView {
         timestampMs: Double,
         event: HostPointerEvent,
         pointerID: UInt64,
+        pointerKind: HostPointerKind,
         x: Float,
         y: Float
     ) {
@@ -236,6 +239,7 @@ public final class WhiskerView: UIView {
             timestampMs: timestampMs,
             event: event,
             pointerID: pointerID,
+            pointerKind: pointerKind,
             x: x,
             y: y,
             handle: UnsafeMutableRawPointer(bitPattern: 1)

--- a/platforms/ios/Sources/WhiskerRuntime/input/PointerInput.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/input/PointerInput.swift
@@ -18,6 +18,31 @@ enum HostPointerEvent: UInt32, Equatable {
     }
 }
 
+enum HostPointerKind: UInt32, Equatable {
+    case mouse = 0
+    case touch = 1
+    case pen = 2
+    case unknown = 3
+
+    func changedButton(for event: HostPointerEvent) -> Int16 {
+        guard self == .mouse || self == .pen else { return -1 }
+        switch event {
+        case .down, .up: return 0
+        case .move, .cancel: return -1
+        }
+    }
+}
+
+func hostPointerKind(for type: UITouch.TouchType) -> HostPointerKind {
+    if #available(iOS 13.4, *), type == .indirectPointer { return .mouse }
+    switch type {
+    case .direct: return .touch
+    case .pencil: return .pen
+    case .indirect: return .unknown
+    default: return .unknown
+    }
+}
+
 struct HostTouchIdentityMap {
     private var pointerIDs = [ObjectIdentifier: UInt64]()
     private var nextPointerID: UInt64 = 1

--- a/platforms/linux/src/app.rs
+++ b/platforms/linux/src/app.rs
@@ -7,13 +7,13 @@ use whisker::runtime::RuntimeWakeHandle;
 use whisker::{Element, ElementModuleDefinition, ElementRegistry, RuntimeInstance, SurfaceRuntime};
 use whisker_desktop::{
     BuiltInElementModule, DesktopElementFactory, DesktopFrameContext, DesktopModuleDefinition,
-    DesktopRuntime, WhiskerModule,
+    DesktopMouseButton, DesktopPointerAdapter, DesktopPointerPhase, DesktopRuntime, WhiskerModule,
 };
-use whisker_protocol::{CursorKeyword, SurfaceId};
+use whisker_protocol::{CursorKeyword, InputEvent, SurfaceId};
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
-use winit::event::WindowEvent;
+use winit::event::{ElementState, MouseButton, TouchPhase, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
 use winit::window::{CursorIcon, Window, WindowAttributes, WindowId};
 
@@ -52,6 +52,26 @@ fn cursor_icon(value: CursorKeyword) -> CursorIcon {
         CursorKeyword::NwseResize => CursorIcon::NwseResize,
         CursorKeyword::ZoomIn => CursorIcon::ZoomIn,
         CursorKeyword::ZoomOut => CursorIcon::ZoomOut,
+    }
+}
+
+fn mouse_button(value: MouseButton) -> DesktopMouseButton {
+    match value {
+        MouseButton::Left => DesktopMouseButton::Primary,
+        MouseButton::Middle => DesktopMouseButton::Auxiliary,
+        MouseButton::Right => DesktopMouseButton::Secondary,
+        MouseButton::Back => DesktopMouseButton::Back,
+        MouseButton::Forward => DesktopMouseButton::Forward,
+        MouseButton::Other(_) => DesktopMouseButton::Other,
+    }
+}
+
+fn touch_phase(value: TouchPhase) -> DesktopPointerPhase {
+    match value {
+        TouchPhase::Started => DesktopPointerPhase::Down,
+        TouchPhase::Moved => DesktopPointerPhase::Move,
+        TouchPhase::Ended => DesktopPointerPhase::Up,
+        TouchPhase::Cancelled => DesktopPointerPhase::Cancel,
     }
 }
 
@@ -151,6 +171,7 @@ struct LinuxApplication {
     environment_epoch: u64,
     started_at: Instant,
     frame_failed: bool,
+    pointer: DesktopPointerAdapter,
 }
 
 impl LinuxApplication {
@@ -173,6 +194,7 @@ impl LinuxApplication {
             environment_epoch: 1,
             started_at: Instant::now(),
             frame_failed: false,
+            pointer: DesktopPointerAdapter::new(SurfaceId::new(1).unwrap()),
         }
     }
 
@@ -274,6 +296,18 @@ impl LinuxApplication {
         self.frame_failed = false;
         self.request_frame();
     }
+
+    fn dispatch_input(&mut self, event: InputEvent) {
+        let Some(runtime) = &self.runtime else {
+            return;
+        };
+        if let Err(error) = runtime.dispatch_input(&event) {
+            self.frame_failed = true;
+            eprintln!("dispatch Linux input failed: {error}");
+        } else {
+            self.request_frame();
+        }
+    }
 }
 
 impl ApplicationHandler<HostEvent> for LinuxApplication {
@@ -314,14 +348,43 @@ impl ApplicationHandler<HostEvent> for LinuxApplication {
             }
             WindowEvent::RedrawRequested => self.drive_frame(),
             WindowEvent::CursorMoved { position, .. } => {
-                if let (Some(window), Some(host)) = (&self.window, &self.host) {
+                if let Some(window) = &self.window {
                     let logical = position.to_logical::<f32>(window.scale_factor());
-                    let cursor = host
-                        .cursor_at([logical.x, logical.y])
-                        .unwrap_or(CursorKeyword::Default);
-                    window.set_cursor_visible(cursor != CursorKeyword::None);
-                    if cursor != CursorKeyword::None {
-                        window.set_cursor(cursor_icon(cursor));
+                    let input = self.pointer.cursor_moved(
+                        self.started_at.elapsed().as_secs_f64() * 1000.0,
+                        [logical.x, logical.y],
+                    );
+                    self.dispatch_input(input);
+                    if let (Some(window), Some(host)) = (&self.window, &self.host) {
+                        let cursor = host
+                            .cursor_at([logical.x, logical.y])
+                            .unwrap_or(CursorKeyword::Default);
+                        window.set_cursor_visible(cursor != CursorKeyword::None);
+                        if cursor != CursorKeyword::None {
+                            window.set_cursor(cursor_icon(cursor));
+                        }
+                    }
+                }
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                if let Some(input) = self.pointer.mouse_button(
+                    self.started_at.elapsed().as_secs_f64() * 1000.0,
+                    mouse_button(button),
+                    state == ElementState::Pressed,
+                ) {
+                    self.dispatch_input(input);
+                }
+            }
+            WindowEvent::Touch(touch) => {
+                if let Some(window) = &self.window {
+                    let logical = touch.location.to_logical::<f32>(window.scale_factor());
+                    if let Some(input) = self.pointer.touch(
+                        self.started_at.elapsed().as_secs_f64() * 1000.0,
+                        touch.id,
+                        touch_phase(touch.phase),
+                        [logical.x, logical.y],
+                    ) {
+                        self.dispatch_input(input);
                     }
                 }
             }

--- a/platforms/macos/src/app.rs
+++ b/platforms/macos/src/app.rs
@@ -7,13 +7,13 @@ use whisker::runtime::RuntimeWakeHandle;
 use whisker::{Element, ElementModuleDefinition, ElementRegistry, RuntimeInstance, SurfaceRuntime};
 use whisker_desktop::{
     BuiltInElementModule, DesktopElementFactory, DesktopFrameContext, DesktopModuleDefinition,
-    DesktopRuntime, WhiskerModule,
+    DesktopMouseButton, DesktopPointerAdapter, DesktopPointerPhase, DesktopRuntime, WhiskerModule,
 };
-use whisker_protocol::{CursorKeyword, SurfaceId};
+use whisker_protocol::{CursorKeyword, InputEvent, SurfaceId};
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
-use winit::event::WindowEvent;
+use winit::event::{ElementState, MouseButton, TouchPhase, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
 use winit::window::{CursorIcon, Window, WindowAttributes, WindowId};
 
@@ -52,6 +52,26 @@ fn cursor_icon(value: CursorKeyword) -> CursorIcon {
         CursorKeyword::NwseResize => CursorIcon::NwseResize,
         CursorKeyword::ZoomIn => CursorIcon::ZoomIn,
         CursorKeyword::ZoomOut => CursorIcon::ZoomOut,
+    }
+}
+
+fn mouse_button(value: MouseButton) -> DesktopMouseButton {
+    match value {
+        MouseButton::Left => DesktopMouseButton::Primary,
+        MouseButton::Middle => DesktopMouseButton::Auxiliary,
+        MouseButton::Right => DesktopMouseButton::Secondary,
+        MouseButton::Back => DesktopMouseButton::Back,
+        MouseButton::Forward => DesktopMouseButton::Forward,
+        MouseButton::Other(_) => DesktopMouseButton::Other,
+    }
+}
+
+fn touch_phase(value: TouchPhase) -> DesktopPointerPhase {
+    match value {
+        TouchPhase::Started => DesktopPointerPhase::Down,
+        TouchPhase::Moved => DesktopPointerPhase::Move,
+        TouchPhase::Ended => DesktopPointerPhase::Up,
+        TouchPhase::Cancelled => DesktopPointerPhase::Cancel,
     }
 }
 
@@ -151,6 +171,7 @@ struct MacosApplication {
     environment_epoch: u64,
     started_at: Instant,
     frame_failed: bool,
+    pointer: DesktopPointerAdapter,
 }
 
 impl MacosApplication {
@@ -173,6 +194,7 @@ impl MacosApplication {
             environment_epoch: 1,
             started_at: Instant::now(),
             frame_failed: false,
+            pointer: DesktopPointerAdapter::new(SurfaceId::new(1).unwrap()),
         }
     }
 
@@ -274,6 +296,18 @@ impl MacosApplication {
         self.frame_failed = false;
         self.request_frame();
     }
+
+    fn dispatch_input(&mut self, event: InputEvent) {
+        let Some(runtime) = &self.runtime else {
+            return;
+        };
+        if let Err(error) = runtime.dispatch_input(&event) {
+            self.frame_failed = true;
+            eprintln!("dispatch macOS input failed: {error}");
+        } else {
+            self.request_frame();
+        }
+    }
 }
 
 impl ApplicationHandler<HostEvent> for MacosApplication {
@@ -314,14 +348,43 @@ impl ApplicationHandler<HostEvent> for MacosApplication {
             }
             WindowEvent::RedrawRequested => self.drive_frame(),
             WindowEvent::CursorMoved { position, .. } => {
-                if let (Some(window), Some(host)) = (&self.window, &self.host) {
+                if let Some(window) = &self.window {
                     let logical = position.to_logical::<f32>(window.scale_factor());
-                    let cursor = host
-                        .cursor_at([logical.x, logical.y])
-                        .unwrap_or(CursorKeyword::Default);
-                    window.set_cursor_visible(cursor != CursorKeyword::None);
-                    if cursor != CursorKeyword::None {
-                        window.set_cursor(cursor_icon(cursor));
+                    let input = self.pointer.cursor_moved(
+                        self.started_at.elapsed().as_secs_f64() * 1000.0,
+                        [logical.x, logical.y],
+                    );
+                    self.dispatch_input(input);
+                    if let (Some(window), Some(host)) = (&self.window, &self.host) {
+                        let cursor = host
+                            .cursor_at([logical.x, logical.y])
+                            .unwrap_or(CursorKeyword::Default);
+                        window.set_cursor_visible(cursor != CursorKeyword::None);
+                        if cursor != CursorKeyword::None {
+                            window.set_cursor(cursor_icon(cursor));
+                        }
+                    }
+                }
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                if let Some(input) = self.pointer.mouse_button(
+                    self.started_at.elapsed().as_secs_f64() * 1000.0,
+                    mouse_button(button),
+                    state == ElementState::Pressed,
+                ) {
+                    self.dispatch_input(input);
+                }
+            }
+            WindowEvent::Touch(touch) => {
+                if let Some(window) = &self.window {
+                    let logical = touch.location.to_logical::<f32>(window.scale_factor());
+                    if let Some(input) = self.pointer.touch(
+                        self.started_at.elapsed().as_secs_f64() * 1000.0,
+                        touch.id,
+                        touch_phase(touch.phase),
+                        [logical.x, logical.y],
+                    ) {
+                        self.dispatch_input(input);
                     }
                 }
             }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -38,7 +38,9 @@ use whisker_protocol::{
 };
 use whisker_style::StyleEnvironment;
 
-use crate::input::{WebPointerEvent, WebPointerPhase, dispatch_pointer};
+use crate::input::{
+    WebPointerEvent, WebPointerPhase, dispatch_pointer, pointer_kind, stable_pointer_id,
+};
 use crate::measure::text::DomMeasurementProvider;
 use crate::module_api::built_in_element_factories;
 use crate::scene::frame_sink::DomFrameSink;
@@ -48,6 +50,20 @@ const MANIFEST: &str = include_str!("../../../../tests/host-conformance/manifest
 const RASTER_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAF0lEQVR4nAXBAQEAAACCIKb33EBkQpUOQdYIeRyCeLsAAAAASUVORK5CYII=";
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn browser_pointer_metadata_maps_to_protocol_values() {
+    assert_eq!(pointer_kind("mouse"), PointerKind::Mouse);
+    assert_eq!(pointer_kind("touch"), PointerKind::Touch);
+    assert_eq!(pointer_kind("pen"), PointerKind::Pen);
+    assert_eq!(pointer_kind("future-pointer"), PointerKind::Unknown);
+
+    assert_eq!(stable_pointer_id(10), 10);
+    assert_ne!(stable_pointer_id(0), 0);
+    assert_ne!(stable_pointer_id(-1), 0);
+    assert_ne!(stable_pointer_id(0), stable_pointer_id(-1));
+    assert_eq!(stable_pointer_id(-1), stable_pointer_id(-1));
+}
 
 #[wasm_bindgen_test]
 fn padded_parent_preserves_child_border_box_coordinates() {
@@ -780,15 +796,15 @@ impl Driver {
                     y,
                     buttons,
                     changed_button,
-                } => self.emit_pointer(
-                    *event,
-                    *pointer_kind,
-                    *pointer_id,
-                    *timestamp_ms,
-                    [*x, *y],
-                    *buttons,
-                    *changed_button,
-                ),
+                } => self.emit_pointer(WebPointerEvent {
+                    phase: fixture_pointer_phase(*event),
+                    timestamp_ms: *timestamp_ms,
+                    pointer_id: *pointer_id,
+                    pointer_kind: fixture_pointer_kind_source(*pointer_kind),
+                    client_position: whisker_protocol::InputPoint { x: *x, y: *y },
+                    buttons: *buttons,
+                    changed_button: *changed_button,
+                }),
                 Command::CheckpointInput {
                     event,
                     pointer_kind,
@@ -800,16 +816,7 @@ impl Driver {
         }
     }
 
-    fn emit_pointer(
-        &mut self,
-        phase: whisker_host_conformance::PointerEventFixture,
-        pointer_kind: whisker_host_conformance::PointerKindFixture,
-        pointer_id: u64,
-        timestamp_ms: f64,
-        position: [f32; 2],
-        buttons: u32,
-        changed_button: i16,
-    ) {
+    fn emit_pointer(&mut self, mut input: WebPointerEvent) {
         if self.input_runtime.is_none() {
             let (width, height, scale) = self
                 .attached_surface
@@ -824,23 +831,16 @@ impl Driver {
             self.input_runtime = Some(runtime);
         }
         let root_origin = whisker_protocol::InputPoint { x: 13.0, y: 7.0 };
-        let event = dispatch_pointer(
-            self.input_runtime.as_ref().unwrap(),
-            root_origin,
-            WebPointerEvent {
-                phase: fixture_pointer_phase(phase),
-                timestamp_ms,
-                pointer_id,
-                pointer_kind: fixture_pointer_kind_source(pointer_kind),
-                client_position: whisker_protocol::InputPoint {
-                    x: root_origin.x + position[0],
-                    y: root_origin.y + position[1],
-                },
-                buttons,
-                changed_button,
-            },
-        )
-        .expect("fixture pointer dispatch succeeds through the production Web path");
+        let local_position = input.client_position;
+        input.client_position.x += root_origin.x;
+        input.client_position.y += root_origin.y;
+        let event = dispatch_pointer(self.input_runtime.as_ref().unwrap(), root_origin, input)
+            .expect("fixture pointer dispatch succeeds through the production Web path");
+        let pointer = event.pointer.expect("pointer fixture has pointer payload");
+        assert_eq!(event.timestamp_ms, input.timestamp_ms);
+        assert_eq!(pointer.position, local_position);
+        assert_eq!(pointer.buttons, input.buttons);
+        assert_eq!(pointer.changed_button, input.changed_button);
         self.last_input = Some(event);
     }
 
@@ -932,7 +932,6 @@ impl Driver {
                         })
                         .collect(),
                     optical_sizing: fixture_font_optical_sizing(font_optical_sizing),
-                    ..TextMeasureStyle::default()
                 },
                 locale: None,
                 direction: MeasureTextDirection::Auto,
@@ -1895,6 +1894,9 @@ fn fixture(path: &str) -> &'static str {
         "core/pointer-input-basic.json" => {
             include_str!("../../../../tests/host-conformance/core/pointer-input-basic.json")
         }
+        "core/pointer-input-kinds.json" => {
+            include_str!("../../../../tests/host-conformance/core/pointer-input-kinds.json")
+        }
         "core/pointer-style-lynx.json" => {
             include_str!("../../../../tests/host-conformance/core/pointer-style-lynx.json")
         }
@@ -2717,7 +2719,6 @@ fn fixture_text_content(text: &whisker_host_conformance::TextFixture) -> TextCon
                         whisker_protocol::FontOpticalSizing::None
                     }
                 },
-                ..TextMeasureStyle::default()
             },
             locale: None,
             direction: MeasureTextDirection::Auto,
@@ -2788,7 +2789,6 @@ fn fixture_text_content(text: &whisker_host_conformance::TextFixture) -> TextCon
                     color: color(&shadow.color),
                 })
                 .collect(),
-            ..TextPaint::default()
         },
         prepared_content: None,
     }

--- a/platforms/windows/src/app.rs
+++ b/platforms/windows/src/app.rs
@@ -7,13 +7,13 @@ use whisker::runtime::RuntimeWakeHandle;
 use whisker::{Element, ElementModuleDefinition, ElementRegistry, RuntimeInstance, SurfaceRuntime};
 use whisker_desktop::{
     BuiltInElementModule, DesktopElementFactory, DesktopFrameContext, DesktopModuleDefinition,
-    DesktopRuntime, WhiskerModule,
+    DesktopMouseButton, DesktopPointerAdapter, DesktopPointerPhase, DesktopRuntime, WhiskerModule,
 };
-use whisker_protocol::{CursorKeyword, SurfaceId};
+use whisker_protocol::{CursorKeyword, InputEvent, SurfaceId};
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
-use winit::event::WindowEvent;
+use winit::event::{ElementState, MouseButton, TouchPhase, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
 use winit::window::{CursorIcon, Window, WindowAttributes, WindowId};
 
@@ -52,6 +52,26 @@ fn cursor_icon(value: CursorKeyword) -> CursorIcon {
         CursorKeyword::NwseResize => CursorIcon::NwseResize,
         CursorKeyword::ZoomIn => CursorIcon::ZoomIn,
         CursorKeyword::ZoomOut => CursorIcon::ZoomOut,
+    }
+}
+
+fn mouse_button(value: MouseButton) -> DesktopMouseButton {
+    match value {
+        MouseButton::Left => DesktopMouseButton::Primary,
+        MouseButton::Middle => DesktopMouseButton::Auxiliary,
+        MouseButton::Right => DesktopMouseButton::Secondary,
+        MouseButton::Back => DesktopMouseButton::Back,
+        MouseButton::Forward => DesktopMouseButton::Forward,
+        MouseButton::Other(_) => DesktopMouseButton::Other,
+    }
+}
+
+fn touch_phase(value: TouchPhase) -> DesktopPointerPhase {
+    match value {
+        TouchPhase::Started => DesktopPointerPhase::Down,
+        TouchPhase::Moved => DesktopPointerPhase::Move,
+        TouchPhase::Ended => DesktopPointerPhase::Up,
+        TouchPhase::Cancelled => DesktopPointerPhase::Cancel,
     }
 }
 
@@ -151,6 +171,7 @@ struct WindowsApplication {
     environment_epoch: u64,
     started_at: Instant,
     frame_failed: bool,
+    pointer: DesktopPointerAdapter,
 }
 
 impl WindowsApplication {
@@ -173,6 +194,7 @@ impl WindowsApplication {
             environment_epoch: 1,
             started_at: Instant::now(),
             frame_failed: false,
+            pointer: DesktopPointerAdapter::new(SurfaceId::new(1).unwrap()),
         }
     }
 
@@ -274,6 +296,18 @@ impl WindowsApplication {
         self.frame_failed = false;
         self.request_frame();
     }
+
+    fn dispatch_input(&mut self, event: InputEvent) {
+        let Some(runtime) = &self.runtime else {
+            return;
+        };
+        if let Err(error) = runtime.dispatch_input(&event) {
+            self.frame_failed = true;
+            eprintln!("dispatch Windows input failed: {error}");
+        } else {
+            self.request_frame();
+        }
+    }
 }
 
 impl ApplicationHandler<HostEvent> for WindowsApplication {
@@ -314,14 +348,43 @@ impl ApplicationHandler<HostEvent> for WindowsApplication {
             }
             WindowEvent::RedrawRequested => self.drive_frame(),
             WindowEvent::CursorMoved { position, .. } => {
-                if let (Some(window), Some(host)) = (&self.window, &self.host) {
+                if let Some(window) = &self.window {
                     let logical = position.to_logical::<f32>(window.scale_factor());
-                    let cursor = host
-                        .cursor_at([logical.x, logical.y])
-                        .unwrap_or(CursorKeyword::Default);
-                    window.set_cursor_visible(cursor != CursorKeyword::None);
-                    if cursor != CursorKeyword::None {
-                        window.set_cursor(cursor_icon(cursor));
+                    let input = self.pointer.cursor_moved(
+                        self.started_at.elapsed().as_secs_f64() * 1000.0,
+                        [logical.x, logical.y],
+                    );
+                    self.dispatch_input(input);
+                    if let (Some(window), Some(host)) = (&self.window, &self.host) {
+                        let cursor = host
+                            .cursor_at([logical.x, logical.y])
+                            .unwrap_or(CursorKeyword::Default);
+                        window.set_cursor_visible(cursor != CursorKeyword::None);
+                        if cursor != CursorKeyword::None {
+                            window.set_cursor(cursor_icon(cursor));
+                        }
+                    }
+                }
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                if let Some(input) = self.pointer.mouse_button(
+                    self.started_at.elapsed().as_secs_f64() * 1000.0,
+                    mouse_button(button),
+                    state == ElementState::Pressed,
+                ) {
+                    self.dispatch_input(input);
+                }
+            }
+            WindowEvent::Touch(touch) => {
+                if let Some(window) = &self.window {
+                    let logical = touch.location.to_logical::<f32>(window.scale_factor());
+                    if let Some(input) = self.pointer.touch(
+                        self.started_at.elapsed().as_secs_f64() * 1000.0,
+                        touch.id,
+                        touch_phase(touch.phase),
+                        [logical.x, logical.y],
+                    ) {
+                        self.dispatch_input(input);
                     }
                 }
             }

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -170,13 +170,13 @@
       "id": "interaction.pointer",
       "basis": "lynx-4.0",
       "properties": ["cursor", "pointer-events"],
-      "supported_subset": ["pointer-events-auto-none", "keyword-only-cursors-web-desktop-android", "ios-hidden-text-vertical-text-crosshair-and-resize-shapes", "resolved-value-inheritance", "host-normalized-pointer-down-move-up-cancel-all-hosts"],
-      "pending_subset": ["ios-semantic-cursors-without-public-uikit-shapes"],
+      "supported_subset": ["pointer-events-auto-none", "keyword-only-cursors-web-desktop-android", "ios-hidden-text-vertical-text-crosshair-and-resize-shapes", "resolved-value-inheritance", "host-normalized-pointer-down-move-up-cancel-all-hosts", "mouse-touch-pen-kind-protocol-preservation-all-hosts", "native-mouse-and-touch-acquisition-desktop"],
+      "pending_subset": ["ios-semantic-cursors-without-public-uikit-shapes", "desktop-native-pen-classification"],
       "unsupported_browser_subset": ["resource-backed-cursors", "cursor-hotspots", "svg-pointer-events-values"],
-      "compatibility_notes": ["Lynx pointer-events accepts auto and none; Whisker resolves the documented inheritance effect before emitting SetHitTest", "UIKit provides hidden, text beams, and custom geometric pointer shapes, which iOS uses for none, text, vertical-text, crosshair, and resize keywords", "UIKit has no public platform glyphs for link, context-menu, help, progress, wait, cell, alias, copy, move, no-drop, not-allowed, grab, grabbing, or zoom cursors; iOS preserves those keywords and deliberately retains the system pointer instead of conflating distinct semantics"],
+      "compatibility_notes": ["Lynx pointer-events accepts auto and none; Whisker resolves the documented inheritance effect before emitting SetHitTest", "UIKit provides hidden, text beams, and custom geometric pointer shapes, which iOS uses for none, text, vertical-text, crosshair, and resize keywords", "UIKit has no public platform glyphs for link, context-menu, help, progress, wait, cell, alias, copy, move, no-drop, not-allowed, grab, grabbing, or zoom cursors; iOS preserves those keywords and deliberately retains the system pointer instead of conflating distinct semantics", "The shared Desktop adapter preserves every protocol pointer kind, while winit currently classifies native mouse and touch events but does not expose a portable stylus kind"],
       "protocol": ["SetCursor", "SetHitTest"],
       "rust": "implemented",
-      "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "partial"}
+      "hosts": {"desktop": "partial", "web": "implemented", "android": "implemented", "ios": "partial"}
     },
     {
       "id": "motion.rust",

--- a/tests/host-conformance/core/pointer-input-kinds.json
+++ b/tests/host-conformance/core/pointer-input-kinds.json
@@ -1,0 +1,85 @@
+{
+  "schema": 1,
+  "id": "host.input.pointer.kinds",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 200.0, "height": 100.0, "scale": 2.0 },
+      {
+        "type": "emit_pointer",
+        "event": "down",
+        "pointer_kind": "mouse",
+        "pointer_id": 10,
+        "timestamp_ms": 50.0,
+        "x": 32.0,
+        "y": 18.0,
+        "buttons": 1,
+        "changed_button": 0
+      },
+      {
+        "type": "checkpoint_input",
+        "event": "down",
+        "pointer_kind": "mouse",
+        "pointer_id": 10,
+        "x": 32.0,
+        "y": 18.0
+      },
+      {
+        "type": "emit_pointer",
+        "event": "up",
+        "pointer_kind": "mouse",
+        "pointer_id": 10,
+        "timestamp_ms": 51.0,
+        "x": 32.0,
+        "y": 18.0,
+        "buttons": 0,
+        "changed_button": 0
+      },
+      {
+        "type": "checkpoint_input",
+        "event": "up",
+        "pointer_kind": "mouse",
+        "pointer_id": 10,
+        "x": 32.0,
+        "y": 18.0
+      },
+      {
+        "type": "emit_pointer",
+        "event": "down",
+        "pointer_kind": "pen",
+        "pointer_id": 11,
+        "timestamp_ms": 52.0,
+        "x": 48.0,
+        "y": 28.0,
+        "buttons": 1,
+        "changed_button": 0
+      },
+      {
+        "type": "checkpoint_input",
+        "event": "down",
+        "pointer_kind": "pen",
+        "pointer_id": 11,
+        "x": 48.0,
+        "y": 28.0
+      },
+      {
+        "type": "emit_pointer",
+        "event": "cancel",
+        "pointer_kind": "pen",
+        "pointer_id": 11,
+        "timestamp_ms": 53.0,
+        "x": 49.0,
+        "y": 29.0,
+        "buttons": 0,
+        "changed_button": -1
+      },
+      {
+        "type": "checkpoint_input",
+        "event": "cancel",
+        "pointer_kind": "pen",
+        "pointer_id": 11,
+        "x": 49.0,
+        "y": 29.0
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -582,6 +582,13 @@
       "fixture": "core/pointer-input-basic.json",
       "required_hosts": ["desktop", "web", "android", "ios"],
       "checkpoints": ["input"]
+    },
+    {
+      "id": "host.input.pointer.kinds",
+      "feature": "pointer-input-kinds",
+      "fixture": "core/pointer-input-kinds.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["input"]
     }
   ]
 }

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -107,6 +107,20 @@ final class HostConformanceTests: XCTestCase {
         )
     }
 
+    func testUIKitTouchTypesMapToProtocolPointerKinds() {
+        XCTAssertEqual(hostPointerKind(for: .direct), .touch)
+        XCTAssertEqual(hostPointerKind(for: .pencil), .pen)
+        XCTAssertEqual(hostPointerKind(for: .indirect), .unknown)
+        if #available(iOS 13.4, *) {
+            XCTAssertEqual(hostPointerKind(for: .indirectPointer), .mouse)
+        }
+        XCTAssertEqual(HostPointerKind.touch.changedButton(for: .down), -1)
+        XCTAssertEqual(HostPointerKind.mouse.changedButton(for: .down), 0)
+        XCTAssertEqual(HostPointerKind.mouse.changedButton(for: .up), 0)
+        XCTAssertEqual(HostPointerKind.pen.changedButton(for: .down), 0)
+        XCTAssertEqual(HostPointerKind.pen.changedButton(for: .cancel), -1)
+    }
+
     func testContentBoxRadiiUseTheCompleteInsetFromTheBorderBox() {
         XCTAssertEqual(
             insetCornerRadii(
@@ -886,9 +900,7 @@ private final class Driver {
         case "cancel": .cancel
         default: throw Failure("unknown pointer event")
         }
-        guard try string(command, "pointer_kind") == "touch" else {
-            throw Failure("iOS touch fixture requires pointer_kind=touch")
-        }
+        let pointerKind = try fixturePointerKind(command)
         var observed: WhiskerPointerDispatch?
         whiskerPointerDispatchObserver = { observed = $0 }
         defer { whiskerPointerDispatchObserver = nil }
@@ -896,6 +908,7 @@ private final class Driver {
             timestampMs: try number(command, "timestamp_ms"),
             event: event,
             pointerID: UInt64(try number(command, "pointer_id")),
+            pointerKind: pointerKind,
             x: Float(try number(command, "x")),
             y: Float(try number(command, "y"))
         )
@@ -903,7 +916,7 @@ private final class Driver {
         XCTAssertEqual(input.timestampMs, try number(command, "timestamp_ms"))
         XCTAssertEqual(input.event, event.rawValue)
         XCTAssertNotEqual(input.pointerID, 0)
-        XCTAssertEqual(input.pointerKind, UInt32(WHISKER_POINTER_TOUCH))
+        XCTAssertEqual(input.pointerKind, pointerKind.rawValue)
         XCTAssertEqual(input.buttons, UInt32(try number(command, "buttons")))
         XCTAssertEqual(input.changedButton, Int16(try number(command, "changed_button")))
         pointerInput = input
@@ -918,15 +931,23 @@ private final class Driver {
         case "cancel": .cancel
         default: throw Failure("unknown checkpoint pointer event")
         }
-        guard try string(command, "pointer_kind") == "touch" else {
-            throw Failure("iOS touch checkpoint requires pointer_kind=touch")
-        }
+        let pointerKind = try fixturePointerKind(command)
         XCTAssertEqual(input.event, event.rawValue)
         XCTAssertEqual(input.pointerID, UInt64(try number(command, "pointer_id")))
-        XCTAssertEqual(input.pointerKind, UInt32(WHISKER_POINTER_TOUCH))
+        XCTAssertEqual(input.pointerKind, pointerKind.rawValue)
         XCTAssertEqual(input.x, Float(try number(command, "x")))
         XCTAssertEqual(input.y, Float(try number(command, "y")))
         checkpoint = Pixels(width: 0, height: 0, bytes: [])
+    }
+
+    private func fixturePointerKind(_ command: [String: Any]) throws -> HostPointerKind {
+        switch try string(command, "pointer_kind") {
+        case "mouse": .mouse
+        case "touch": .touch
+        case "pen": .pen
+        case "unknown": .unknown
+        default: throw Failure("unknown pointer kind")
+        }
     }
 
     private func registerRasterResource(_ command: [String: Any]) throws {


### PR DESCRIPTION
## Summary
- add a shared mouse/pen pointer-kind fixture required by all four Hosts
- map UIKit touch types and Web pointer metadata to protocol pointer kinds
- add a shared Desktop pointer adapter and connect macOS, Windows, and Linux winit events to runtime input
- preserve CSS-compatible button state and changed-button semantics

## Validation
- `cargo test -p whisker-host-conformance` (passed before the final Desktop adapter refactor)
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web` (6 passed)
- Android androidTest compile and fixture asset merge
- iOS Simulator XCTest (12 passed)
- `cargo check -p whisker-desktop -p whisker-macos` (passed before the final event-argument struct refactor)
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes
- Android already satisfied the new fixture through its production MotionEvent normalizer, so no Android source change was required.
- winit exposes portable mouse and touch acquisition but not a portable stylus classification; the capability remains explicitly partial for native Desktop pen acquisition.
- A final local Rust recheck was interrupted because the macOS dynamic loader stalled while loading a proc-macro dylib; CI is expected to provide the clean full validation.