### PR TITLE
test(host): cover text measurement flow

### DIFF
--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -243,6 +243,18 @@ pub enum Command {
         /// Lynx optical-sizing behavior.
         #[serde(default)]
         font_optical_sizing: FontOpticalSizingFixture,
+        /// Lynx `white-space` value projected to the Host wrapping policy.
+        #[serde(default)]
+        white_space: WhiteSpaceFixture,
+        /// Lynx `word-break` value used when wrapping is enabled.
+        #[serde(default)]
+        word_break: WordBreakFixture,
+        /// Maximum visible line count; zero means unlimited.
+        #[serde(default)]
+        max_lines: u32,
+        /// Lynx `text-overflow` value applied at the line limit.
+        #[serde(default)]
+        overflow: TextOverflowFixture,
         /// Definite available width.
         available_width: f32,
     },

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -700,6 +700,10 @@ impl Driver {
                     font_features,
                     font_variations,
                     font_optical_sizing,
+                    white_space,
+                    word_break,
+                    max_lines,
+                    overflow,
                     available_width,
                 } => self.measure_text(
                     *key,
@@ -713,6 +717,10 @@ impl Driver {
                     font_features,
                     font_variations,
                     *font_optical_sizing,
+                    *white_space,
+                    *word_break,
+                    *max_lines,
+                    *overflow,
                     *available_width,
                 ),
                 Command::CheckpointMeasurement {
@@ -1441,6 +1449,10 @@ impl Driver {
         font_features: &[whisker_host_conformance::FontFeatureFixture],
         font_variations: &[whisker_host_conformance::FontVariationFixture],
         font_optical_sizing: whisker_host_conformance::FontOpticalSizingFixture,
+        white_space: whisker_host_conformance::WhiteSpaceFixture,
+        word_break: whisker_host_conformance::WordBreakFixture,
+        max_lines: u32,
+        overflow: whisker_host_conformance::TextOverflowFixture,
         available_width: f32,
     ) {
         let surface = self.surface.expect("attach_surface precedes measure_text");
@@ -1512,10 +1524,30 @@ impl Driver {
                 direction: MeasureTextDirection::Auto,
                 alignment: whisker_protocol::MeasureTextAlignment::Start,
                 indent: Default::default(),
-                wrap: MeasureTextWrap::Wrap,
-                word_break: Default::default(),
-                max_lines: None,
-                overflow: MeasureTextOverflow::Clip,
+                wrap: match white_space {
+                    whisker_host_conformance::WhiteSpaceFixture::Normal => MeasureTextWrap::Wrap,
+                    whisker_host_conformance::WhiteSpaceFixture::NoWrap => MeasureTextWrap::NoWrap,
+                },
+                word_break: match word_break {
+                    whisker_host_conformance::WordBreakFixture::Normal => {
+                        MeasureTextWordBreak::Normal
+                    }
+                    whisker_host_conformance::WordBreakFixture::BreakAll => {
+                        MeasureTextWordBreak::BreakAll
+                    }
+                    whisker_host_conformance::WordBreakFixture::KeepAll => {
+                        MeasureTextWordBreak::KeepAll
+                    }
+                },
+                max_lines: (max_lines > 0).then_some(max_lines),
+                overflow: match overflow {
+                    whisker_host_conformance::TextOverflowFixture::Clip => {
+                        MeasureTextOverflow::Clip
+                    }
+                    whisker_host_conformance::TextOverflowFixture::Ellipsis => {
+                        MeasureTextOverflow::Ellipsis
+                    }
+                },
             }),
         };
         self.text

--- a/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
@@ -9,6 +9,9 @@ let whiskerIOSMeasure: WhiskerMeasureHost = { data, requests, count, responses i
         let request = requests.advanced(by: index).pointee
         guard request.kind == UInt32(WHISKER_MEASURE_TEXT) else { continue }
         guard request.font_style <= 2,
+              request.wrap <= 1,
+              request.word_break <= 2,
+              request.overflow <= 1,
               request.font_size.isFinite,
               request.font_size > 0,
               request.line_height.isFinite,

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -369,6 +369,16 @@ struct ExpectedBox {
     border: Option<BorderFixture>,
 }
 
+struct ExpectedMeasurementStyle<'a> {
+    font_features: &'a [whisker_host_conformance::FontFeatureFixture],
+    font_variations: &'a [whisker_host_conformance::FontVariationFixture],
+    font_optical_sizing: whisker_host_conformance::FontOpticalSizingFixture,
+    white_space: whisker_host_conformance::WhiteSpaceFixture,
+    word_break: whisker_host_conformance::WordBreakFixture,
+    max_lines: u32,
+    overflow: whisker_host_conformance::TextOverflowFixture,
+}
+
 impl Driver {
     fn new() -> Self {
         let document = web_sys::window().unwrap().document().unwrap();
@@ -759,6 +769,10 @@ impl Driver {
                     font_features,
                     font_variations,
                     font_optical_sizing,
+                    white_space,
+                    word_break,
+                    max_lines,
+                    overflow,
                     available_width,
                 } => self.measure_text(
                     *key,
@@ -772,6 +786,10 @@ impl Driver {
                     font_features,
                     font_variations,
                     *font_optical_sizing,
+                    *white_space,
+                    *word_break,
+                    *max_lines,
+                    *overflow,
                     *available_width,
                 ),
                 Command::CheckpointMeasurement {
@@ -880,6 +898,10 @@ impl Driver {
         font_features: &[whisker_host_conformance::FontFeatureFixture],
         font_variations: &[whisker_host_conformance::FontVariationFixture],
         font_optical_sizing: whisker_host_conformance::FontOpticalSizingFixture,
+        white_space: whisker_host_conformance::WhiteSpaceFixture,
+        word_break: whisker_host_conformance::WordBreakFixture,
+        max_lines: u32,
+        overflow: whisker_host_conformance::TextOverflowFixture,
         available_width: f32,
     ) {
         let key_id = MeasurementKey::new(key).expect("fixture measurement key is non-zero");
@@ -937,17 +959,23 @@ impl Driver {
                 direction: MeasureTextDirection::Auto,
                 alignment: whisker_protocol::MeasureTextAlignment::Start,
                 indent: Default::default(),
-                wrap: MeasureTextWrap::Wrap,
-                word_break: MeasureTextWordBreak::Normal,
-                max_lines: None,
-                overflow: MeasureTextOverflow::Clip,
+                wrap: fixture_measure_wrap(white_space),
+                word_break: fixture_measure_word_break(word_break),
+                max_lines: (max_lines > 0).then_some(max_lines),
+                overflow: fixture_measure_overflow(overflow),
             }),
         };
         self.assert_measurement_style(
             &request,
-            font_features,
-            font_variations,
-            font_optical_sizing,
+            ExpectedMeasurementStyle {
+                font_features,
+                font_variations,
+                font_optical_sizing,
+                white_space,
+                word_break,
+                max_lines,
+                overflow,
+            },
         );
         let mut responses = Vec::new();
         self.measurements
@@ -974,9 +1002,7 @@ impl Driver {
     fn assert_measurement_style(
         &self,
         request: &MeasurementRequest,
-        font_features: &[whisker_host_conformance::FontFeatureFixture],
-        font_variations: &[whisker_host_conformance::FontVariationFixture],
-        font_optical_sizing: whisker_host_conformance::FontOpticalSizingFixture,
+        expected: ExpectedMeasurementStyle<'_>,
     ) {
         let MeasurementPayload::Text(text) = &request.payload else {
             panic!("Web text measurement fixture produced a non-text request")
@@ -994,21 +1020,52 @@ impl Driver {
         assert_style(
             &style,
             "font-feature-settings",
-            &fixture_font_settings(font_features, |value| value.value.to_string()),
+            &fixture_font_settings(expected.font_features, |value| value.value.to_string()),
         );
         assert_style(
             &style,
             "font-variation-settings",
-            &fixture_font_settings(font_variations, |value| value.value.to_string()),
+            &fixture_font_settings(expected.font_variations, |value| value.value.to_string()),
         );
         assert_style(
             &style,
             "font-optical-sizing",
-            match font_optical_sizing {
+            match expected.font_optical_sizing {
                 whisker_host_conformance::FontOpticalSizingFixture::Auto => "auto",
                 whisker_host_conformance::FontOpticalSizingFixture::None => "none",
             },
         );
+        assert_style(
+            &style,
+            "white-space",
+            match expected.white_space {
+                whisker_host_conformance::WhiteSpaceFixture::Normal => "normal",
+                whisker_host_conformance::WhiteSpaceFixture::NoWrap => "nowrap",
+            },
+        );
+        assert_style(
+            &style,
+            "word-break",
+            match expected.word_break {
+                whisker_host_conformance::WordBreakFixture::Normal => "normal",
+                whisker_host_conformance::WordBreakFixture::BreakAll => "break-all",
+                whisker_host_conformance::WordBreakFixture::KeepAll => "keep-all",
+            },
+        );
+        assert_style(
+            &style,
+            "text-overflow",
+            match expected.overflow {
+                whisker_host_conformance::TextOverflowFixture::Clip => "clip",
+                whisker_host_conformance::TextOverflowFixture::Ellipsis => "ellipsis",
+            },
+        );
+        let line_clamp = if expected.max_lines == 0 {
+            "initial".to_owned()
+        } else {
+            expected.max_lines.to_string()
+        };
+        assert_style(&style, "-webkit-line-clamp", &line_clamp);
     }
 
     fn assert_measurement(
@@ -1891,6 +1948,9 @@ fn fixture(path: &str) -> &'static str {
         "core/text-measure-font-features.json" => {
             include_str!("../../../../tests/host-conformance/core/text-measure-font-features.json")
         }
+        "core/text-measure-flow.json" => {
+            include_str!("../../../../tests/host-conformance/core/text-measure-flow.json")
+        }
         "core/pointer-input-basic.json" => {
             include_str!("../../../../tests/host-conformance/core/pointer-input-basic.json")
         }
@@ -2618,6 +2678,32 @@ fn fixture_measure_font_style(
         whisker_host_conformance::FontStyleFixture::Normal => MeasureFontStyle::Normal,
         whisker_host_conformance::FontStyleFixture::Italic => MeasureFontStyle::Italic,
         whisker_host_conformance::FontStyleFixture::Oblique => MeasureFontStyle::Oblique,
+    }
+}
+
+fn fixture_measure_wrap(value: whisker_host_conformance::WhiteSpaceFixture) -> MeasureTextWrap {
+    match value {
+        whisker_host_conformance::WhiteSpaceFixture::Normal => MeasureTextWrap::Wrap,
+        whisker_host_conformance::WhiteSpaceFixture::NoWrap => MeasureTextWrap::NoWrap,
+    }
+}
+
+fn fixture_measure_word_break(
+    value: whisker_host_conformance::WordBreakFixture,
+) -> MeasureTextWordBreak {
+    match value {
+        whisker_host_conformance::WordBreakFixture::Normal => MeasureTextWordBreak::Normal,
+        whisker_host_conformance::WordBreakFixture::BreakAll => MeasureTextWordBreak::BreakAll,
+        whisker_host_conformance::WordBreakFixture::KeepAll => MeasureTextWordBreak::KeepAll,
+    }
+}
+
+fn fixture_measure_overflow(
+    value: whisker_host_conformance::TextOverflowFixture,
+) -> MeasureTextOverflow {
+    match value {
+        whisker_host_conformance::TextOverflowFixture::Clip => MeasureTextOverflow::Clip,
+        whisker_host_conformance::TextOverflowFixture::Ellipsis => MeasureTextOverflow::Ellipsis,
     }
 }
 

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -160,7 +160,7 @@
       "id": "paint.text",
       "basis": "lynx-4.0",
       "properties": ["color", "font-family", "font-feature-settings", "font-optical-sizing", "font-size", "font-style", "font-variation-settings", "font-weight", "letter-spacing", "line-height", "text-align", "text-decoration", "text-indent", "text-overflow", "text-shadow", "white-space", "word-break"],
-      "supported_subset": ["basic-font-metrics-and-color", "font-family-fallback-font-style-line-height-letter-spacing-all-hosts", "intrinsic-measurement-uses-paint-typography-all-hosts", "intrinsic-measurement-opentype-features-and-weight-axis-all-hosts", "single-text-shadow", "lynx-single-line-text-decoration", "lynx-text-align", "lynx-text-indent-length-percentage", "lynx-white-space-word-break-text-overflow", "opentype-feature-settings-all-hosts", "variable-font-axes-web-android-ios", "font-weight-axis-desktop", "lynx-optical-sizing-web-android-ios"],
+      "supported_subset": ["basic-font-metrics-and-color", "font-family-fallback-font-style-line-height-letter-spacing-all-hosts", "intrinsic-measurement-uses-paint-typography-all-hosts", "intrinsic-measurement-opentype-features-and-weight-axis-all-hosts", "intrinsic-measurement-white-space-word-break-line-limit-overflow-all-hosts", "single-text-shadow", "lynx-single-line-text-decoration", "lynx-text-align", "lynx-text-indent-length-percentage", "lynx-white-space-word-break-text-overflow", "opentype-feature-settings-all-hosts", "variable-font-axes-web-android-ios", "font-weight-axis-desktop", "lynx-optical-sizing-web-android-ios"],
       "pending_subset": ["desktop-arbitrary-variable-font-axes-and-optical-sizing"],
       "protocol": ["SetText"],
       "rust": "implemented",

--- a/tests/host-conformance/core/text-measure-flow.json
+++ b/tests/host-conformance/core/text-measure-flow.json
@@ -1,0 +1,87 @@
+{
+  "schema": 1,
+  "id": "host.measure.text.flow",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 320.0, "height": 240.0, "scale": 1.0 },
+      {
+        "type": "measure_text",
+        "key": 10,
+        "text": "one two three four five six seven eight",
+        "font_families": ["system"],
+        "font_size": 18.0,
+        "line_height": 24.0,
+        "white_space": "normal",
+        "word_break": "normal",
+        "available_width": 96.0
+      },
+      {
+        "type": "checkpoint_measurement",
+        "key": 10,
+        "min_width": 40.0,
+        "max_width": 96.0,
+        "min_height": 48.0,
+        "max_height": 192.0
+      },
+      {
+        "type": "measure_text",
+        "key": 11,
+        "text": "one two three four five six seven eight",
+        "font_families": ["system"],
+        "font_size": 18.0,
+        "line_height": 24.0,
+        "white_space": "no_wrap",
+        "word_break": "normal",
+        "available_width": 96.0
+      },
+      {
+        "type": "checkpoint_measurement",
+        "key": 11,
+        "min_width": 96.0,
+        "max_width": 400.0,
+        "min_height": 18.0,
+        "max_height": 30.0
+      },
+      {
+        "type": "measure_text",
+        "key": 12,
+        "text": "abcdefghijklmnopqrstuvwx",
+        "font_families": ["system"],
+        "font_size": 18.0,
+        "line_height": 24.0,
+        "white_space": "normal",
+        "word_break": "break_all",
+        "available_width": 72.0
+      },
+      {
+        "type": "checkpoint_measurement",
+        "key": 12,
+        "min_width": 40.0,
+        "max_width": 72.0,
+        "min_height": 48.0,
+        "max_height": 120.0
+      },
+      {
+        "type": "measure_text",
+        "key": 13,
+        "text": "this line is deliberately too long",
+        "font_families": ["system"],
+        "font_size": 18.0,
+        "line_height": 24.0,
+        "white_space": "normal",
+        "word_break": "normal",
+        "max_lines": 1,
+        "overflow": "ellipsis",
+        "available_width": 110.0
+      },
+      {
+        "type": "checkpoint_measurement",
+        "key": 13,
+        "min_width": 60.0,
+        "max_width": 110.0,
+        "min_height": 18.0,
+        "max_height": 30.0
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -563,6 +563,13 @@
       "checkpoints": ["measurement", "semantic-projection"]
     },
     {
+      "id": "host.measure.text.flow",
+      "feature": "text-measurement-flow",
+      "fixture": "core/text-measure-flow.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["measurement", "semantic-projection"]
+    },
+    {
       "id": "core.pointer-style-lynx",
       "feature": "cursor-pointer-events",
       "fixture": "core/pointer-style-lynx.json",

--- a/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/tests/host-conformance/runners/android/app/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -638,7 +638,7 @@ private class Driver(
     }
 
     private fun measureText(command: JSONObject) {
-        val families = command.getJSONArray("font_families").strings()
+        val families = command.optJSONArray("font_families")?.strings() ?: arrayOf("system")
         check(families.isNotEmpty())
         val featureSettings = command.optJSONArray("font_features")?.objects()?.map { setting ->
             "${setting.getString("tag")}=${setting.getLong("value")}"
@@ -648,8 +648,27 @@ private class Driver(
         }?.toList().orEmpty()
         val opticalSizing = when (command.optString("font_optical_sizing", "none")) {
             "auto" -> 0
-            else -> 1
+            "none" -> 1
+            else -> error("unsupported font_optical_sizing: $command")
         }
+        val wrap = when (command.optString("white_space", "normal")) {
+            "normal" -> 1
+            "no_wrap" -> 0
+            else -> error("unsupported white_space: $command")
+        }
+        val wordBreak = when (command.optString("word_break", "normal")) {
+            "normal" -> 0
+            "break_all" -> 1
+            "keep_all" -> 2
+            else -> error("unsupported word_break: $command")
+        }
+        val overflow = when (command.optString("overflow", "clip")) {
+            "clip" -> 0
+            "ellipsis" -> 1
+            else -> error("unsupported overflow: $command")
+        }
+        val maxLines = command.optInt("max_lines", 0)
+        check(maxLines >= 0)
         val result = view.measureFromNative(
             elementType = 2,
             kind = 1,
@@ -663,20 +682,21 @@ private class Driver(
             text = command.getString("text"),
             fontFamilies = families,
             fontSize = command.getDouble("font_size").toFloat(),
-            fontWeight = command.getInt("font_weight"),
-            fontStyle = when (command.getString("font_style")) {
+            fontWeight = command.optInt("font_weight", 400),
+            fontStyle = when (command.optString("font_style", "normal")) {
                 "italic" -> 1
                 "oblique" -> 2
-                else -> 0
+                "normal" -> 0
+                else -> error("unsupported font_style: $command")
             },
-            wrap = 1,
-            wordBreak = 0,
-            overflow = 0,
-            letterSpacing = command.getDouble("letter_spacing").toFloat(),
+            wrap = wrap,
+            wordBreak = wordBreak,
+            overflow = overflow,
+            letterSpacing = command.optDouble("letter_spacing", 0.0).toFloat(),
             lineHeight = command.getDouble("line_height").toFloat(),
             indentLogicalPixels = 0f,
             indentPercentage = 0f,
-            maxLines = 0,
+            maxLines = maxLines,
             fontSettings = (featureSettings + variationSettings).toTypedArray(),
             fontFeatureCount = featureSettings.size,
             fontOpticalSizing = opticalSizing,

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -738,6 +738,26 @@ private final class Driver {
         case "none": fontOpticalSizing = 1
         default: throw Failure("unknown measurement optical sizing")
         }
+        let wrap: UInt8
+        switch command["white_space"] as? String ?? "normal" {
+        case "normal": wrap = 1
+        case "no_wrap": wrap = 0
+        default: throw Failure("unknown measurement white-space")
+        }
+        let wordBreak: UInt8
+        switch command["word_break"] as? String ?? "normal" {
+        case "normal": wordBreak = 0
+        case "break_all": wordBreak = 1
+        case "keep_all": wordBreak = 2
+        default: throw Failure("unknown measurement word-break")
+        }
+        let maxLines = UInt32((command["max_lines"] as? NSNumber)?.uintValue ?? 0)
+        let overflow: UInt8
+        switch command["overflow"] as? String ?? "clip" {
+        case "clip": overflow = 0
+        case "ellipsis": overflow = 1
+        default: throw Failure("unknown measurement overflow")
+        }
 
         let textBytes = Array(value.utf8CString)
         let textStorage = UnsafeMutablePointer<CChar>.allocate(capacity: textBytes.count)
@@ -802,7 +822,10 @@ private final class Driver {
         request.available_width_kind = 0
         request.available_height_kind = 2
         request.font_style = fontStyle
-        request.wrap = 1
+        request.wrap = wrap
+        request.word_break = wordBreak
+        request.max_lines = maxLines
+        request.overflow = overflow
         request.text = WhiskerStringRef(
             ptr: UnsafePointer(textStorage),
             len: textBytes.count - 1
@@ -818,6 +841,11 @@ private final class Driver {
         request.font_variations = variationStorage.map { UnsafePointer($0) }
         request.font_variation_count = fontVariations.count
         request.font_optical_sizing = fontOpticalSizing
+
+        XCTAssertEqual(request.wrap, wrap)
+        XCTAssertEqual(request.word_break, wordBreak)
+        XCTAssertEqual(request.max_lines, maxLines)
+        XCTAssertEqual(request.overflow, overflow)
 
         if !fontFeatures.isEmpty || !fontVariations.isEmpty {
             XCTAssertEqual(request.font_feature_count, 2)

--- a/tests/host-conformance/schema/scenario.schema.json
+++ b/tests/host-conformance/schema/scenario.schema.json
@@ -400,6 +400,10 @@
         "font_features": { "type": "array", "items": { "$ref": "#/$defs/fontFeature" } },
         "font_variations": { "type": "array", "items": { "$ref": "#/$defs/fontVariation" } },
         "font_optical_sizing": { "enum": ["auto", "none"], "default": "none" },
+        "white_space": { "enum": ["normal", "no_wrap"], "default": "normal" },
+        "word_break": { "enum": ["normal", "break_all", "keep_all"], "default": "normal" },
+        "max_lines": { "type": "integer", "minimum": 0, "default": 0 },
+        "overflow": { "enum": ["clip", "ellipsis"], "default": "clip" },
         "available_width": { "type": "number", "minimum": 0 }
       }
     },


### PR DESCRIPTION
## Summary
- extend shared text-measure fixtures with white-space, word-break, line limits, and overflow
- add a common flow fixture required by Desktop, Web, Android, and iOS
- project the fixture through each Host production measurement path
- validate iOS MobileMeasure enum discriminants and Web DOM CSS projection

## Validation
- `cargo test -p whisker-host-conformance`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web` (6 passed)
- Android androidTest compile and fixture asset merge
- iOS Simulator XCTest (12 passed)
- Web all-target clippy with `-D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes
- Android had no connected device locally, so its instrumented execution is left to CI.
- The four production measurers already implemented the flow behavior; this change removes fixed runner defaults and makes that behavior part of the shared conformance contract.