### PR TITLE
fix(desktop): composite opacity over element groups

### DIFF
--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -628,7 +628,7 @@ const BACKDROP_SHADER: &str = r#"
 struct BlurUniform {
     direction: vec2<f32>,
     radius: f32,
-    _padding: f32,
+    opacity: f32,
 };
 
 @group(0) @binding(0) var source_texture: texture_2d<f32>;
@@ -656,7 +656,7 @@ fn vs_main(@builtin(vertex_index) index: u32) -> VertexOutput {
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     if blur.radius <= 0.0 {
-        return textureSample(source_texture, source_sampler, input.uv);
+        return textureSample(source_texture, source_sampler, input.uv) * blur.opacity;
     }
     let dimensions = vec2<f32>(textureDimensions(source_texture));
     let step = blur.direction * max(blur.radius / 8.0, 0.5) / dimensions;
@@ -668,7 +668,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         color += textureSample(source_texture, source_sampler, input.uv + step * f32(offset)) * weight;
         weight_sum += weight;
     }
-    return color / weight_sum;
+    return color / weight_sum * blur.opacity;
 }
 "#;
 
@@ -677,11 +677,12 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
 struct BackdropUniform {
     direction: [f32; 2],
     radius: f32,
-    _padding: f32,
+    opacity: f32,
 }
 
 struct BackdropGpuPipeline {
     pipeline: RenderPipeline,
+    composite_pipeline: RenderPipeline,
     layout: wgpu::BindGroupLayout,
     sampler: wgpu::Sampler,
 }
@@ -728,31 +729,38 @@ impl BackdropGpuPipeline {
             bind_group_layouts: &[&layout],
             push_constant_ranges: &[],
         });
-        let pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
-            label: Some("whisker Desktop backdrop pipeline"),
-            layout: Some(&pipeline_layout),
-            vertex: VertexState {
-                module: &shader,
-                entry_point: Some("vs_main"),
-                compilation_options: PipelineCompilationOptions::default(),
-                buffers: &[],
-            },
-            fragment: Some(FragmentState {
-                module: &shader,
-                entry_point: Some("fs_main"),
-                compilation_options: PipelineCompilationOptions::default(),
-                targets: &[Some(ColorTargetState {
-                    format,
-                    blend: None,
-                    write_mask: ColorWrites::ALL,
-                })],
-            }),
-            primitive: PrimitiveState::default(),
-            depth_stencil: None,
-            multisample: MultisampleState::default(),
-            multiview: None,
-            cache: None,
-        });
+        let create_pipeline = |label, blend| {
+            device.create_render_pipeline(&RenderPipelineDescriptor {
+                label: Some(label),
+                layout: Some(&pipeline_layout),
+                vertex: VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    compilation_options: PipelineCompilationOptions::default(),
+                    buffers: &[],
+                },
+                fragment: Some(FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    compilation_options: PipelineCompilationOptions::default(),
+                    targets: &[Some(ColorTargetState {
+                        format,
+                        blend,
+                        write_mask: ColorWrites::ALL,
+                    })],
+                }),
+                primitive: PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            })
+        };
+        let pipeline = create_pipeline("whisker Desktop backdrop pipeline", None);
+        let composite_pipeline = create_pipeline(
+            "whisker Desktop opacity group compositor",
+            Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+        );
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("whisker Desktop backdrop sampler"),
             address_mode_u: wgpu::AddressMode::ClampToEdge,
@@ -764,6 +772,7 @@ impl BackdropGpuPipeline {
         });
         Self {
             pipeline,
+            composite_pipeline,
             layout,
             sampler,
         }
@@ -997,6 +1006,7 @@ pub(crate) type ClippedBoxPrimitive = (
     Option<LinearGradientDraw>,
     Option<ResourceId>,
     bool,
+    Vec<(NodeId, f32)>,
 );
 
 #[cfg(all(test, feature = "host-conformance"))]
@@ -1471,6 +1481,13 @@ impl BoxGpuPipeline {
 }
 
 enum DrawCommand {
+    BeginOpacityGroup {
+        node: NodeId,
+        opacity: f32,
+    },
+    EndOpacityGroup {
+        node: NodeId,
+    },
     BackdropBlur {
         rect: LayoutRect,
         radius: f32,
@@ -1494,7 +1511,10 @@ impl DrawCommand {
     fn gradient(&self) -> Option<&LinearGradientDraw> {
         match self {
             Self::Quads { gradient, .. } => gradient.as_ref(),
-            Self::Text { .. } | Self::BackdropBlur { .. } => None,
+            Self::BeginOpacityGroup { .. }
+            | Self::EndOpacityGroup { .. }
+            | Self::Text { .. }
+            | Self::BackdropBlur { .. } => None,
         }
     }
 }
@@ -2034,6 +2054,15 @@ impl GpuRenderer {
         let mut draws = Vec::new();
         for (index, command) in commands.iter().enumerate() {
             match command {
+                PaintCommand::BeginOpacityGroup { node, opacity } => {
+                    draws.push(DrawCommand::BeginOpacityGroup {
+                        node: *node,
+                        opacity: *opacity,
+                    });
+                }
+                PaintCommand::EndOpacityGroup { node } => {
+                    draws.push(DrawCommand::EndOpacityGroup { node: *node });
+                }
                 PaintCommand::BackdropBlur { rect, radius, clip } => {
                     draws.push(DrawCommand::BackdropBlur {
                         rect: *rect,
@@ -2238,7 +2267,10 @@ impl GpuRenderer {
             .iter()
             .filter_map(|draw| match draw {
                 DrawCommand::Text { node, .. } => Some(*node),
-                DrawCommand::Quads { .. } | DrawCommand::BackdropBlur { .. } => None,
+                DrawCommand::BeginOpacityGroup { .. }
+                | DrawCommand::EndOpacityGroup { .. }
+                | DrawCommand::Quads { .. }
+                | DrawCommand::BackdropBlur { .. } => None,
             })
             .collect::<HashSet<_>>();
         self.text_renderers
@@ -2395,6 +2427,45 @@ impl GpuRenderer {
         });
         let scene_view = scene_texture.create_view(&TextureViewDescriptor::default());
         let scratch_view = scratch_texture.create_view(&TextureViewDescriptor::default());
+        let mut opacity_depth = 0usize;
+        let mut maximum_opacity_depth = 0usize;
+        for draw in &draws {
+            match draw {
+                DrawCommand::BeginOpacityGroup { .. } => {
+                    opacity_depth += 1;
+                    maximum_opacity_depth = maximum_opacity_depth.max(opacity_depth);
+                }
+                DrawCommand::EndOpacityGroup { .. } => {
+                    opacity_depth = opacity_depth
+                        .checked_sub(1)
+                        .expect("scene emits balanced opacity groups");
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(opacity_depth, 0, "scene emits balanced opacity groups");
+        let opacity_textures = (0..maximum_opacity_depth)
+            .map(|_| {
+                self.device.create_texture(&wgpu::TextureDescriptor {
+                    label: Some("whisker Desktop opacity group"),
+                    size: wgpu::Extent3d {
+                        width: self.config.width,
+                        height: self.config.height,
+                        depth_or_array_layers: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: self.config.format,
+                    usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+                    view_formats: &[],
+                })
+            })
+            .collect::<Vec<_>>();
+        let opacity_views = opacity_textures
+            .iter()
+            .map(|texture| texture.create_view(&TextureViewDescriptor::default()))
+            .collect::<Vec<_>>();
         let mut encoder = self
             .device
             .create_command_encoder(&CommandEncoderDescriptor {
@@ -2417,17 +2488,77 @@ impl GpuRenderer {
             });
         }
 
+        let mut active_opacity_groups = Vec::new();
         for (draw_index, draw) in draws.into_iter().enumerate() {
             match draw {
+                DrawCommand::BeginOpacityGroup { node, opacity } => {
+                    let view = &opacity_views[active_opacity_groups.len()];
+                    let _clear = encoder.begin_render_pass(&RenderPassDescriptor {
+                        label: Some("whisker Desktop clear opacity group"),
+                        color_attachments: &[Some(RenderPassColorAttachment {
+                            view,
+                            resolve_target: None,
+                            ops: Operations {
+                                load: LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                                store: StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+                    active_opacity_groups.push((node, opacity));
+                }
+                DrawCommand::EndOpacityGroup { node } => {
+                    let (open_node, opacity) = active_opacity_groups
+                        .pop()
+                        .expect("scene emits balanced opacity groups");
+                    assert_eq!(open_node, node, "scene opacity groups remain nested");
+                    let source = &opacity_views[active_opacity_groups.len()];
+                    let target = active_opacity_groups
+                        .len()
+                        .checked_sub(1)
+                        .map_or(&scene_view, |depth| &opacity_views[depth]);
+                    let (_buffer, bind_group) = self.backdrop_gpu.bind_group(
+                        &self.device,
+                        source,
+                        BackdropUniform {
+                            direction: [0.0, 0.0],
+                            radius: 0.0,
+                            opacity,
+                        },
+                    );
+                    let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+                        label: Some("whisker Desktop composite opacity group"),
+                        color_attachments: &[Some(RenderPassColorAttachment {
+                            view: target,
+                            resolve_target: None,
+                            ops: Operations {
+                                load: LoadOp::Load,
+                                store: StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+                    pass.set_pipeline(&self.backdrop_gpu.composite_pipeline);
+                    pass.set_bind_group(0, &bind_group, &[]);
+                    pass.draw(0..3, 0..1);
+                }
                 DrawCommand::BackdropBlur { rect, radius, clip } => {
+                    let target = active_opacity_groups
+                        .len()
+                        .checked_sub(1)
+                        .map_or(&scene_view, |depth| &opacity_views[depth]);
                     let horizontal = BackdropUniform {
                         direction: [1.0, 0.0],
                         radius: radius * scale,
-                        _padding: 0.0,
+                        opacity: 1.0,
                     };
                     let (_horizontal_buffer, horizontal_group) =
                         self.backdrop_gpu
-                            .bind_group(&self.device, &scene_view, horizontal);
+                            .bind_group(&self.device, target, horizontal);
                     {
                         let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
                             label: Some("whisker Desktop backdrop horizontal blur"),
@@ -2450,7 +2581,7 @@ impl GpuRenderer {
                     let vertical = BackdropUniform {
                         direction: [0.0, 1.0],
                         radius: radius * scale,
-                        _padding: 0.0,
+                        opacity: 1.0,
                     };
                     let (_vertical_buffer, vertical_group) =
                         self.backdrop_gpu
@@ -2463,7 +2594,7 @@ impl GpuRenderer {
                     let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
                         label: Some("whisker Desktop backdrop vertical blur"),
                         color_attachments: &[Some(RenderPassColorAttachment {
-                            view: &scene_view,
+                            view: target,
                             resolve_target: None,
                             ops: Operations {
                                 load: LoadOp::Load,
@@ -2486,13 +2617,17 @@ impl GpuRenderer {
                     pixelated,
                     ..
                 } => {
+                    let target = active_opacity_groups
+                        .len()
+                        .checked_sub(1)
+                        .map_or(&scene_view, |depth| &opacity_views[depth]);
                     let Some((x, y, width, height)) = self.scissor(clip, scale) else {
                         continue;
                     };
                     let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
                         label: Some("whisker Desktop boxes"),
                         color_attachments: &[Some(RenderPassColorAttachment {
-                            view: &scene_view,
+                            view: target,
                             resolve_target: None,
                             ops: Operations {
                                 load: LoadOp::Load,
@@ -2532,10 +2667,14 @@ impl GpuRenderer {
                     if !prepared_text_nodes.contains(&node) {
                         continue;
                     }
+                    let target = active_opacity_groups
+                        .len()
+                        .checked_sub(1)
+                        .map_or(&scene_view, |depth| &opacity_views[depth]);
                     let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
                         label: Some("whisker Desktop text"),
                         color_attachments: &[Some(RenderPassColorAttachment {
-                            view: &scene_view,
+                            view: target,
                             resolve_target: None,
                             ops: Operations {
                                 load: LoadOp::Load,
@@ -2554,10 +2693,14 @@ impl GpuRenderer {
                 }
             }
         }
+        assert!(
+            active_opacity_groups.is_empty(),
+            "scene emits balanced opacity groups"
+        );
         let present_uniform = BackdropUniform {
             direction: [0.0, 0.0],
             radius: 0.0,
-            _padding: 0.0,
+            opacity: 1.0,
         };
         let (_present_buffer, present_group) =
             self.backdrop_gpu
@@ -2740,6 +2883,7 @@ pub(crate) async fn render_box_primitives_offscreen(
                 None,
                 None,
                 false,
+                Vec::new(),
             )
         })
         .collect::<Vec<_>>();
@@ -2790,7 +2934,25 @@ pub(crate) async fn render_clipped_box_primitives_with_backdrops_offscreen(
 
     let mut vertices = Vec::new();
     let mut draws = Vec::new();
-    for (primitive, clip, transform, shape_clips, gradient, resource, pixelated) in primitives {
+    let mut active_opacity_groups = Vec::<(NodeId, f32)>::new();
+    for (primitive, clip, transform, shape_clips, gradient, resource, pixelated, groups) in
+        primitives
+    {
+        let shared = active_opacity_groups
+            .iter()
+            .zip(groups)
+            .take_while(|(left, right)| left.0 == right.0)
+            .count();
+        for (node, _) in active_opacity_groups.drain(shared..).rev() {
+            draws.push(DrawCommand::EndOpacityGroup { node });
+        }
+        for (node, opacity) in &groups[shared..] {
+            draws.push(DrawCommand::BeginOpacityGroup {
+                node: *node,
+                opacity: *opacity,
+            });
+        }
+        active_opacity_groups.extend_from_slice(&groups[shared..]);
         let start = vertices.len() as u32;
         push_transformed_quad(&mut vertices, *primitive, *transform);
         draws.push(DrawCommand::Quads {
@@ -2801,6 +2963,9 @@ pub(crate) async fn render_clipped_box_primitives_with_backdrops_offscreen(
             resource: *resource,
             pixelated: *pixelated,
         });
+    }
+    for (node, _) in active_opacity_groups.into_iter().rev() {
+        draws.push(DrawCommand::EndOpacityGroup { node });
     }
     let image_resources = resources
         .iter()
@@ -2845,6 +3010,48 @@ pub(crate) async fn render_clipped_box_primitives_with_backdrops_offscreen(
         view_formats: &[],
     });
     let scratch_view = scratch.create_view(&TextureViewDescriptor::default());
+    let mut opacity_depth = 0usize;
+    let mut maximum_opacity_depth = 0usize;
+    for draw in &draws {
+        match draw {
+            DrawCommand::BeginOpacityGroup { .. } => {
+                opacity_depth += 1;
+                maximum_opacity_depth = maximum_opacity_depth.max(opacity_depth);
+            }
+            DrawCommand::EndOpacityGroup { .. } => {
+                opacity_depth = opacity_depth
+                    .checked_sub(1)
+                    .expect("conformance draw emits balanced opacity groups");
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(
+        opacity_depth, 0,
+        "conformance draw emits balanced opacity groups"
+    );
+    let opacity_textures = (0..maximum_opacity_depth)
+        .map(|_| {
+            device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("whisker Desktop conformance opacity group"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            })
+        })
+        .collect::<Vec<_>>();
+    let opacity_views = opacity_textures
+        .iter()
+        .map(|texture| texture.create_view(&TextureViewDescriptor::default()))
+        .collect::<Vec<_>>();
     let unpadded_bytes_per_row = width * 4;
     let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
         * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
@@ -2876,54 +3083,120 @@ pub(crate) async fn render_clipped_box_primitives_with_backdrops_offscreen(
         });
     }
     if let Some(vertex_buffer) = &vertex_buffer {
+        let mut active_opacity_groups = Vec::new();
         for (draw_index, draw) in draws.into_iter().enumerate() {
-            let DrawCommand::Quads {
-                vertices: range,
-                clip,
-                resource,
-                pixelated,
-                ..
-            } = draw
-            else {
-                unreachable!();
-            };
-            let Some((x, y, clip_width, clip_height)) = offscreen_scissor(clip, width, height)
-            else {
-                continue;
-            };
-            let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
-                label: Some("whisker Desktop conformance boxes"),
-                color_attachments: &[Some(RenderPassColorAttachment {
-                    view: &view,
-                    resolve_target: None,
-                    ops: Operations {
-                        load: LoadOp::Load,
-                        store: StoreOp::Store,
-                    },
-                })],
-                depth_stencil_attachment: None,
-                timestamp_writes: None,
-                occlusion_query_set: None,
-            });
-            pass.set_scissor_rect(x, y, clip_width, clip_height);
-            pass.set_pipeline(&box_gpu.pipeline);
-            pass.set_bind_group(0, &box_gpu.viewport_bind_group, &[]);
-            pass.set_bind_group(1, &shape_clip_bind_group, &[]);
-            let image = resource
-                .and_then(|resource| image_resources.get(&resource))
-                .unwrap_or(&box_gpu.fallback_image);
-            pass.set_bind_group(
-                2,
-                if pixelated {
-                    &image.nearest_bind_group
-                } else {
-                    &image.linear_bind_group
-                },
-                &[],
-            );
-            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-            pass.draw(range, draw_index as u32..draw_index as u32 + 1);
+            match draw {
+                DrawCommand::BeginOpacityGroup { node, opacity } => {
+                    let target = &opacity_views[active_opacity_groups.len()];
+                    let _clear = encoder.begin_render_pass(&RenderPassDescriptor {
+                        label: Some("whisker Desktop conformance clear opacity group"),
+                        color_attachments: &[Some(RenderPassColorAttachment {
+                            view: target,
+                            resolve_target: None,
+                            ops: Operations {
+                                load: LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                                store: StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+                    active_opacity_groups.push((node, opacity));
+                }
+                DrawCommand::EndOpacityGroup { node } => {
+                    let (open_node, opacity) = active_opacity_groups
+                        .pop()
+                        .expect("conformance draw emits balanced opacity groups");
+                    assert_eq!(open_node, node, "opacity groups remain nested");
+                    let source = &opacity_views[active_opacity_groups.len()];
+                    let target = active_opacity_groups
+                        .len()
+                        .checked_sub(1)
+                        .map_or(&view, |depth| &opacity_views[depth]);
+                    let (_buffer, bind_group) = backdrop_gpu.bind_group(
+                        &device,
+                        source,
+                        BackdropUniform {
+                            direction: [0.0, 0.0],
+                            radius: 0.0,
+                            opacity,
+                        },
+                    );
+                    let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+                        label: Some("whisker Desktop conformance composite opacity group"),
+                        color_attachments: &[Some(RenderPassColorAttachment {
+                            view: target,
+                            resolve_target: None,
+                            ops: Operations {
+                                load: LoadOp::Load,
+                                store: StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+                    pass.set_pipeline(&backdrop_gpu.composite_pipeline);
+                    pass.set_bind_group(0, &bind_group, &[]);
+                    pass.draw(0..3, 0..1);
+                }
+                DrawCommand::Quads {
+                    vertices: range,
+                    clip,
+                    resource,
+                    pixelated,
+                    ..
+                } => {
+                    let Some((x, y, clip_width, clip_height)) =
+                        offscreen_scissor(clip, width, height)
+                    else {
+                        continue;
+                    };
+                    let target = active_opacity_groups
+                        .len()
+                        .checked_sub(1)
+                        .map_or(&view, |depth| &opacity_views[depth]);
+                    let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+                        label: Some("whisker Desktop conformance boxes"),
+                        color_attachments: &[Some(RenderPassColorAttachment {
+                            view: target,
+                            resolve_target: None,
+                            ops: Operations {
+                                load: LoadOp::Load,
+                                store: StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+                    pass.set_scissor_rect(x, y, clip_width, clip_height);
+                    pass.set_pipeline(&box_gpu.pipeline);
+                    pass.set_bind_group(0, &box_gpu.viewport_bind_group, &[]);
+                    pass.set_bind_group(1, &shape_clip_bind_group, &[]);
+                    let image = resource
+                        .and_then(|resource| image_resources.get(&resource))
+                        .unwrap_or(&box_gpu.fallback_image);
+                    pass.set_bind_group(
+                        2,
+                        if pixelated {
+                            &image.nearest_bind_group
+                        } else {
+                            &image.linear_bind_group
+                        },
+                        &[],
+                    );
+                    pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+                    pass.draw(range, draw_index as u32..draw_index as u32 + 1);
+                }
+                DrawCommand::Text { .. } | DrawCommand::BackdropBlur { .. } => unreachable!(),
+            }
         }
+        assert!(
+            active_opacity_groups.is_empty(),
+            "conformance draw emits balanced opacity groups"
+        );
     }
     for (rect, radius, clip) in backdrops {
         let (_horizontal_buffer, horizontal_group) = backdrop_gpu.bind_group(
@@ -2932,7 +3205,7 @@ pub(crate) async fn render_clipped_box_primitives_with_backdrops_offscreen(
             BackdropUniform {
                 direction: [1.0, 0.0],
                 radius: *radius,
-                _padding: 0.0,
+                opacity: 1.0,
             },
         );
         {
@@ -2960,7 +3233,7 @@ pub(crate) async fn render_clipped_box_primitives_with_backdrops_offscreen(
             BackdropUniform {
                 direction: [0.0, 1.0],
                 radius: *radius,
-                _padding: 0.0,
+                opacity: 1.0,
             },
         );
         let Some((x, y, clip_width, clip_height)) =

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -151,7 +151,6 @@ struct PresentationContext {
     transform: Transform,
     clip: LogicalClip,
     shape_clips: ShapeClipStack,
-    opacity: f32,
 }
 
 impl Default for PresentationContext {
@@ -161,7 +160,6 @@ impl Default for PresentationContext {
             transform: Transform::IDENTITY,
             clip: LogicalClip::default(),
             shape_clips: ShapeClipStack::default(),
-            opacity: 1.0,
         }
     }
 }
@@ -275,6 +273,13 @@ fn preserves_screen_axes(transform: Transform) -> bool {
 
 #[derive(Clone, Debug)]
 pub(crate) enum PaintCommand<'a> {
+    BeginOpacityGroup {
+        node: NodeId,
+        opacity: f32,
+    },
+    EndOpacityGroup {
+        node: NodeId,
+    },
     BackdropBlur {
         rect: LayoutRect,
         radius: f32,
@@ -428,13 +433,20 @@ impl DesktopScene {
         if presentation.visibility == Visibility::Hidden {
             return;
         }
+        let opacity_group = presentation.opacity < 1.0;
+        if opacity_group {
+            commands.push(PaintCommand::BeginOpacityGroup {
+                node: id,
+                opacity: presentation.opacity,
+            });
+        }
         let border = LayoutRect {
             x: context.origin[0] + presentation.layout.border_box.x,
             y: context.origin[1] + presentation.layout.border_box.y,
             width: presentation.layout.border_box.width,
             height: presentation.layout.border_box.height,
         };
-        let opacity = context.opacity * presentation.opacity;
+        let opacity = 1.0;
         let content = LayoutRect {
             x: border.x + presentation.layout.content_box.x,
             y: border.y + presentation.layout.content_box.y,
@@ -581,10 +593,12 @@ impl DesktopScene {
                     transform,
                     clip: descendant_clip,
                     shape_clips: descendant_shape_clips.clone(),
-                    opacity,
                 },
                 commands,
             );
+        }
+        if opacity_group {
+            commands.push(PaintCommand::EndOpacityGroup { node: id });
         }
     }
 
@@ -1760,19 +1774,38 @@ mod tests {
             Ok(ApplyResult::Accepted { revision: 1 })
         );
         let commands = scene.paint_commands();
+        assert_eq!(commands.len(), 6);
         assert!(matches!(
             &commands[0],
-            PaintCommand::Box { rect, opacity, .. }
-                if *rect == LayoutRect { x: 4.0, y: 5.0, width: 100.0, height: 80.0 }
-                    && *opacity == 0.5
+            PaintCommand::BeginOpacityGroup { node, opacity }
+                if *node == root && *opacity == 0.5
         ));
         assert!(matches!(
             &commands[1],
+            PaintCommand::Box { rect, opacity, .. }
+                if *rect == LayoutRect { x: 4.0, y: 5.0, width: 100.0, height: 80.0 }
+                    && *opacity == 1.0
+        ));
+        assert!(matches!(
+            &commands[2],
+            PaintCommand::BeginOpacityGroup { node, opacity }
+                if *node == child && *opacity == 0.5
+        ));
+        assert!(matches!(
+            &commands[3],
             PaintCommand::Text { rect, clip, opacity, .. }
                 if *rect == LayoutRect { x: 7.0, y: 10.0, width: 18.0, height: 6.0 }
                     && clip.left == Some(7.0)
                     && clip.right == Some(25.0)
-                    && *opacity == 0.25
+                    && *opacity == 1.0
+        ));
+        assert!(matches!(
+            &commands[4],
+            PaintCommand::EndOpacityGroup { node } if *node == child
+        ));
+        assert!(matches!(
+            &commands[5],
+            PaintCommand::EndOpacityGroup { node } if *node == root
         ));
     }
 

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -1265,7 +1265,20 @@ impl Driver {
     fn clipped_box_primitives(&self) -> Vec<ClippedBoxPrimitive> {
         let scene = self.scene.as_ref().expect("checkpoint follows attach");
         let mut primitives = Vec::new();
+        let mut opacity_groups = Vec::new();
         for command in scene.paint_commands() {
+            match &command {
+                PaintCommand::BeginOpacityGroup { node, opacity } => {
+                    opacity_groups.push((*node, *opacity));
+                }
+                PaintCommand::EndOpacityGroup { node } => {
+                    let (open_node, _) = opacity_groups
+                        .pop()
+                        .expect("scene emits balanced opacity groups");
+                    assert_eq!(open_node, *node, "scene opacity groups remain nested");
+                }
+                _ => {}
+            }
             if let PaintCommand::Box {
                 rect,
                 content_rect,
@@ -1300,6 +1313,7 @@ impl Driver {
                                     None,
                                     None,
                                     false,
+                                    opacity_groups.clone(),
                                 )
                             })
                         }),
@@ -1320,6 +1334,7 @@ impl Driver {
                                 None,
                                 None,
                                 false,
+                                opacity_groups.clone(),
                             )
                         }),
                 );
@@ -1367,6 +1382,7 @@ impl Driver {
                                 visual_effects.image_rendering,
                                 ImageRendering::Pixelated | ImageRendering::CrispEdges
                             ),
+                        opacity_groups.clone(),
                     ));
                 }
                 primitives.extend(
@@ -1388,6 +1404,7 @@ impl Driver {
                                     None,
                                     None,
                                     false,
+                                    opacity_groups.clone(),
                                 )
                             })
                         }),
@@ -1405,11 +1422,16 @@ impl Driver {
                                 None,
                                 None,
                                 false,
+                                opacity_groups.clone(),
                             )
                         }),
                 );
             }
         }
+        assert!(
+            opacity_groups.is_empty(),
+            "scene emits balanced opacity groups"
+        );
         primitives
     }
 

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1923,6 +1923,12 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-color/t32-opacity-basic-0.6-a.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-color/t32-opacity-basic-0.6-a.json"
         ),
+        "wpt/css/css-color/t32-opacity-offscreen-multiple-boxes-2-c.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-color/t32-opacity-offscreen-multiple-boxes-2-c.json"
+        ),
+        "wpt/css/css-color/t32-opacity-offscreen-with-alpha-c.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-color/t32-opacity-offscreen-with-alpha-c.json"
+        ),
         "wpt/css/CSS2/visufx/visibility-004.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/visufx/visibility-004.json"
         ),

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1666,7 +1666,19 @@ impl Driver {
                                 )
                             })
                         })
-                        .or_else(|| expected.iter().rev().find(|node| node.opacity.is_some()))
+                        .or_else(|| {
+                            let painted = opaque_hit.and_then(|id| {
+                                expected.iter().find(|node| node.id.to_string() == *id)
+                            })?;
+                            hit_nodes
+                                .iter()
+                                .any(|id| {
+                                    expected.iter().any(|node| {
+                                        node.id.to_string() == *id && node.opacity.is_some()
+                                    })
+                                })
+                                .then_some(painted)
+                        })
                         .or_else(|| {
                             expected.iter().find(|node| {
                                 !node.background_layers.is_empty()

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -142,6 +142,7 @@
       "id": "paint.compositing",
       "basis": "lynx-4.0",
       "properties": ["opacity", "visibility", "z-index"],
+      "supported_subset": ["element-group-opacity"],
       "protocol": ["SetOpacity", "SetVisibility", "SetZOrder"],
       "rust": "implemented",
       "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -304,6 +304,20 @@
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-color.opacity-offscreen-multiple-boxes-2",
+      "feature": "opacity-group-compositing",
+      "fixture": "wpt/css/css-color/t32-opacity-offscreen-multiple-boxes-2-c.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-color.opacity-offscreen-with-alpha",
+      "feature": "opacity-group-alpha-compositing",
+      "fixture": "wpt/css/css-color/t32-opacity-offscreen-with-alpha-c.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.visibility-004",
       "feature": "visibility",
       "fixture": "wpt/css/CSS2/visufx/visibility-004.json",

--- a/tests/host-conformance/wpt/css/css-color/t32-opacity-offscreen-multiple-boxes-2-c.json
+++ b/tests/host-conformance/wpt/css/css-color/t32-opacity-offscreen-multiple-boxes-2-c.json
@@ -1,0 +1,66 @@
+{
+  "schema": 1,
+  "id": "wpt.css-color.opacity-offscreen-multiple-boxes-2",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-color/t32-opacity-offscreen-multiple-boxes-2-c.xht",
+    "reference_path": "css/css-color/t32-opacity-offscreen-multiple-boxes-2-c-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "Opacity is group opacity over elements rather than independent opacity over each painted child box.",
+    "adaptation": "Two opaque blue children overlap inside a parent with opacity 0.4 over white. Both the single-child and overlapping regions must remain rgb(153, 153, 255); applying 0.4 independently to each child would make the overlap darker."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 70.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 70.0, 60.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": null,
+            "rect": [10.0, 10.0, 50.0, 40.0],
+            "background": { "kind": "named", "value": "transparent" },
+            "opacity": 0.4
+          },
+          {
+            "id": 3,
+            "parent": 2,
+            "rect": [0.0, 0.0, 30.0, 30.0],
+            "background": { "kind": "named", "value": "blue" }
+          },
+          {
+            "id": 4,
+            "parent": 2,
+            "rect": [10.0, 10.0, 30.0, 30.0],
+            "background": { "kind": "named", "value": "blue" }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          {
+            "point": [15.0, 15.0],
+            "color": { "kind": "srgba", "red": 153, "green": 153, "blue": 255, "alpha": 1.0 },
+            "tolerance": 18
+          },
+          {
+            "point": [25.0, 25.0],
+            "color": { "kind": "srgba", "red": 153, "green": 153, "blue": 255, "alpha": 1.0 },
+            "tolerance": 18
+          }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-color/t32-opacity-offscreen-with-alpha-c.json
+++ b/tests/host-conformance/wpt/css/css-color/t32-opacity-offscreen-with-alpha-c.json
@@ -1,0 +1,74 @@
+{
+  "schema": 1,
+  "id": "wpt.css-color.opacity-offscreen-with-alpha",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-color/t32-opacity-offscreen-with-alpha-c.xht",
+    "reference_path": "css/css-color/t32-opacity-offscreen-with-alpha-c-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "Alpha within an offscreen opacity group is composited correctly.",
+    "adaptation": "Three blue boxes over white reach the same effective alpha 0.2 through direct opacity, nested parent/child opacity, and a translucent child inside an opaque group. Equal samples distinguish premultiplied group compositing from repeated straight-alpha blending."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 80.0, "height": 80.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 80.0, 80.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": null,
+            "rect": [10.0, 10.0, 50.0, 14.0],
+            "background": { "kind": "named", "value": "blue" },
+            "opacity": 0.2
+          },
+          {
+            "id": 3,
+            "parent": null,
+            "rect": [10.0, 30.0, 50.0, 14.0],
+            "background": { "kind": "named", "value": "transparent" },
+            "opacity": 0.5
+          },
+          {
+            "id": 4,
+            "parent": 3,
+            "rect": [0.0, 0.0, 50.0, 14.0],
+            "background": { "kind": "named", "value": "blue" },
+            "opacity": 0.4
+          },
+          {
+            "id": 5,
+            "parent": null,
+            "rect": [10.0, 50.0, 50.0, 14.0],
+            "background": { "kind": "named", "value": "transparent" },
+            "opacity": 0.4
+          },
+          {
+            "id": 6,
+            "parent": 5,
+            "rect": [0.0, 0.0, 50.0, 14.0],
+            "background": { "kind": "srgba", "red": 0, "green": 0, "blue": 255, "alpha": 0.5 }
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [30.0, 17.0], "color": { "kind": "srgba", "red": 204, "green": 204, "blue": 255, "alpha": 1.0 }, "tolerance": 18 },
+          { "point": [30.0, 37.0], "color": { "kind": "srgba", "red": 204, "green": 204, "blue": 255, "alpha": 1.0 }, "tolerance": 18 },
+          { "point": [30.0, 57.0], "color": { "kind": "srgba", "red": 204, "green": 204, "blue": 255, "alpha": 1.0 }, "tolerance": 18 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}


### PR DESCRIPTION
## Summary
- adapt two pinned WPT opacity-group cases into the shared four-Host fixture suite
- emit explicit nested opacity-group boundaries from the retained Desktop scene
- render each active group into a transparent wgpu target and composite it once with premultiplied alpha
- reuse one target per nesting depth, with no extra target or pass when a frame has no non-opaque element
- teach the Web semantic checkpoint to distinguish the painted child from an opacity-bearing ancestor

## Tests
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo test -p whisker-desktop --lib`
- `cargo test -p whisker-host-conformance`
- `cargo clippy -p whisker-desktop --lib -- -D warnings`
- `cargo clippy -p whisker-web --lib -- -D warnings`

Local Android fixture compilation passed; bitmap execution requires a connected emulator and is covered by the independent PR check together with iOS Simulator conformance.