### PR TITLE
fix(host): preserve visible descendants of hidden nodes

### DIFF
--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -222,12 +222,13 @@ internal class HostNode(
         if (whiskerVisible) {
             drawOuterBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
             drawBackdropBlur(canvas)
+            super.draw(canvas)
+        } else {
+            // View.draw() paints this node's background before dispatching
+            // children. Dispatch only the child phase so a visible descendant
+            // can override this node's hidden computed visibility.
+            dispatchDraw(canvas)
         }
-        val ownBackground = background
-        val backgroundAlpha = ownBackground?.alpha
-        if (!whiskerVisible) ownBackground?.alpha = 0
-        super.draw(canvas)
-        if (backgroundAlpha != null) ownBackground.alpha = backgroundAlpha
         canvas.restoreToCount(save)
     }
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -71,6 +71,7 @@ internal class HostNode(
     private var paintClipPath: Path? = null
     private var resolvedBoxGeometry: ResolvedBoxGeometry? = null
     private var backdropRenderer: HostBackdropBlurRenderer? = null
+    private var whiskerVisible = true
 
     init {
         setWillNotDraw(false)
@@ -116,11 +117,34 @@ internal class HostNode(
         }
     }
 
-    override fun dispatchTouchEvent(event: MotionEvent): Boolean = when (hitTestBehavior) {
-        1 -> false
-        2 -> onTouchEvent(event)
-        else -> super.dispatchTouchEvent(event)
+    /**
+     * Sets this element's computed CSS visibility without hiding its View subtree.
+     *
+     * `View.INVISIBLE` would also suppress a descendant whose own computed
+     * visibility is `visible`, which is not CSS visibility semantics.
+     */
+    fun setWhiskerVisibility(visible: Boolean) {
+        if (whiskerVisible == visible) return
+        whiskerVisible = visible
+        mountedElement?.let { mounted ->
+            if (mounted.childrenHost() == null) {
+                mounted.view.visibility = if (visible) VISIBLE else INVISIBLE
+            }
+        }
+        invalidate()
     }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (!whiskerVisible && hitTestBehavior == 2) return false
+        return when (hitTestBehavior) {
+            1 -> false
+            2 -> onTouchEvent(event)
+            else -> super.dispatchTouchEvent(event)
+        }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean =
+        whiskerVisible && super.onTouchEvent(event)
 
     fun setOverflowClipGeometry(geometry: ResolvedBoxGeometry) {
         resolvedBoxGeometry = geometry
@@ -195,9 +219,15 @@ internal class HostNode(
     private fun drawClipped(canvas: Canvas) {
         val save = canvas.save()
         paintClipPath?.let(canvas::clipPath)
-        drawOuterBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
-        drawBackdropBlur(canvas)
+        if (whiskerVisible) {
+            drawOuterBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
+            drawBackdropBlur(canvas)
+        }
+        val ownBackground = background
+        val backgroundAlpha = ownBackground?.alpha
+        if (!whiskerVisible) ownBackground?.alpha = 0
         super.draw(canvas)
+        if (backgroundAlpha != null) ownBackground.alpha = backgroundAlpha
         canvas.restoreToCount(save)
     }
 
@@ -222,7 +252,9 @@ internal class HostNode(
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-        drawInsetBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
+        if (whiskerVisible) {
+            drawInsetBoxShadows(canvas, resolvedBoxGeometry, boxShadows)
+        }
     }
 
     override fun clipDescendants(

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -261,8 +261,7 @@ internal class HostScene(
                 root.resources.displayMetrics.density,
             )
             10 -> (nodes[id] ?: return).alpha = operation.scalar
-            11 -> (nodes[id] ?: return).visibility =
-                if (operation.integer != 0) View.VISIBLE else View.INVISIBLE
+            11 -> (nodes[id] ?: return).setWhiskerVisibility(operation.integer != 0)
             12 -> (nodes[id] ?: return).zOrder = operation.integer
             13 -> applyText(
                 nodes[id] ?: return,

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -366,11 +366,10 @@ impl DesktopScene {
     ) -> Option<whisker_protocol::CursorKeyword> {
         let state = self.nodes.get(&node)?;
         let presentation = &state.presentation;
-        if presentation.visibility == Visibility::Hidden
-            || presentation.hit_test == HitTestBehavior::None
-        {
+        if presentation.hit_test == HitTestBehavior::None {
             return None;
         }
+        let visible = presentation.visibility == Visibility::Visible;
         let rect = presentation.layout.border_box;
         let origin = [parent_origin[0] + rect.x, parent_origin[1] + rect.y];
         let contains_x = point[0] >= origin[0] && point[0] <= origin[0] + rect.width;
@@ -399,7 +398,10 @@ impl DesktopScene {
                 }
             }
         }
-        (contains_x && contains_y && presentation.hit_test != HitTestBehavior::DescendantsOnly)
+        (visible
+            && contains_x
+            && contains_y
+            && presentation.hit_test != HitTestBehavior::DescendantsOnly)
             .then_some(presentation.cursor.fallback)
     }
 
@@ -430,9 +432,7 @@ impl DesktopScene {
     ) {
         let node = self.nodes.get(&id).expect("retained child remains live");
         let presentation = &node.presentation;
-        if presentation.visibility == Visibility::Hidden {
-            return;
-        }
+        let visible = presentation.visibility == Visibility::Visible;
         let opacity_group = presentation.opacity < 1.0;
         if opacity_group {
             commands.push(PaintCommand::BeginOpacityGroup {
@@ -480,10 +480,11 @@ impl DesktopScene {
             });
             node_clip_bounds = transform_rect_aabb(clip_rect, transform);
         }
-        if let Some(radius) = presentation
-            .visual_effects
-            .backdrop_blur
-            .filter(|value| *value > 0.0)
+        if visible
+            && let Some(radius) = presentation
+                .visual_effects
+                .backdrop_blur
+                .filter(|value| *value > 0.0)
             && let Some(rect) = transform_rect_aabb(border, transform)
         {
             commands.push(PaintCommand::BackdropBlur {
@@ -492,9 +493,10 @@ impl DesktopScene {
                 clip: context.clip,
             });
         }
-        if presentation.paint.is_some()
-            || !presentation.background_layers.is_empty()
-            || !presentation.visual_effects.box_shadows.is_empty()
+        if visible
+            && (presentation.paint.is_some()
+                || !presentation.background_layers.is_empty()
+                || !presentation.visual_effects.box_shadows.is_empty())
         {
             commands.push(PaintCommand::Box {
                 rect: border,
@@ -551,7 +553,7 @@ impl DesktopScene {
                 );
             }
         }
-        if let Some(content) = node.content.text() {
+        if visible && let Some(content) = node.content.text() {
             let content_rect = LayoutRect {
                 x: border.x + presentation.layout.content_box.x,
                 y: border.y + presentation.layout.content_box.y,
@@ -1894,6 +1896,84 @@ mod tests {
             Some(whisker_protocol::CursorKeyword::Grab)
         );
         assert_eq!(scene.cursor_at([200.0, 20.0]), None);
+    }
+
+    #[test]
+    fn visible_descendant_paints_and_hit_tests_through_hidden_parent() {
+        let root = id(1);
+        let child = id(2);
+        let element_type = element_type(whisker::VIEW_ELEMENT_NAME);
+        let mut scene = scene(SurfaceId::new(1).unwrap());
+        scene
+            .present(&packet(
+                FrameMode::Snapshot,
+                0,
+                1,
+                vec![
+                    Operation::CreateNode {
+                        node: root,
+                        element_type,
+                    },
+                    Operation::CreateNode {
+                        node: child,
+                        element_type,
+                    },
+                    Operation::InsertChild {
+                        parent: root,
+                        child,
+                        index: 0,
+                    },
+                    Operation::SetLayout {
+                        node: root,
+                        geometry: geometry(10.0, 10.0, 80.0, 80.0),
+                    },
+                    Operation::SetLayout {
+                        node: child,
+                        geometry: geometry(10.0, 10.0, 30.0, 30.0),
+                    },
+                    Operation::SetBoxPaint {
+                        node: root,
+                        paint: paint(PaintColor::Named("red".into())),
+                    },
+                    Operation::SetBoxPaint {
+                        node: child,
+                        paint: paint(PaintColor::Named("green".into())),
+                    },
+                    Operation::SetVisibility {
+                        node: root,
+                        visibility: Visibility::Hidden,
+                    },
+                    Operation::SetVisibility {
+                        node: child,
+                        visibility: Visibility::Visible,
+                    },
+                    Operation::SetCursor {
+                        node: root,
+                        cursor: Cursor {
+                            resources: Vec::new(),
+                            fallback: whisker_protocol::CursorKeyword::Pointer,
+                        },
+                    },
+                    Operation::SetCursor {
+                        node: child,
+                        cursor: Cursor {
+                            resources: Vec::new(),
+                            fallback: whisker_protocol::CursorKeyword::Text,
+                        },
+                    },
+                ],
+            ))
+            .unwrap();
+
+        let commands = scene.paint_commands();
+        assert_eq!(commands.len(), 1);
+        assert!(matches!(&commands[0], PaintCommand::Box { rect, .. }
+            if *rect == LayoutRect { x: 20.0, y: 20.0, width: 30.0, height: 30.0 }));
+        assert_eq!(
+            scene.cursor_at([25.0, 25.0]),
+            Some(whisker_protocol::CursorKeyword::Text)
+        );
+        assert_eq!(scene.cursor_at([70.0, 70.0]), None);
     }
 
     #[test]

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -27,6 +27,7 @@ final class WhiskerNodeView: UIView {
     private(set) var cursorKeyword: Int32 = 0
     private var pointerDelegate: AnyObject?
     private var pointerInteraction: AnyObject?
+    private var whiskerVisible = true
 
     init(element: String) {
         self.element = element
@@ -154,6 +155,7 @@ final class WhiskerNodeView: UIView {
         // the first entry remains visually above later entries.
         for index in shadows.indices.reversed() {
             let shadowLayer = boxShadowLayers[index]
+            shadowLayer.isHidden = !whiskerVisible
             if shadows[index].inset {
                 paintView.layer.addSublayer(shadowLayer)
             } else {
@@ -175,6 +177,7 @@ final class WhiskerNodeView: UIView {
         } else {
             blurView = HostBackdropBlurView()
             blurView.layer.zPosition = -0.5
+            blurView.isHidden = !whiskerVisible
             insertSubview(blurView, at: 0)
             backdropBlurView = blurView
         }
@@ -201,11 +204,36 @@ final class WhiskerNodeView: UIView {
         }
     }
 
+    /// Applies computed CSS visibility to this element's own presentation.
+    /// Descendant node views stay mounted so an explicit `visibility: visible`
+    /// can override a hidden ancestor.
+    func setWhiskerVisibility(_ visible: Bool) {
+        guard whiskerVisible != visible else { return }
+        whiskerVisible = visible
+        paintView.isHidden = !visible
+        boxShadowLayers.forEach { $0.isHidden = !visible }
+        backdropBlurView?.isHidden = !visible
+        if let mountedElement, mountedElement.childrenHost() == nil {
+            mountedElement.view.isHidden = !visible
+        }
+    }
+
     var cursorPresentation: HostCursorPresentation {
         hostCursorPresentation(keyword: cursorKeyword)
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if !whiskerVisible {
+            guard hitTestBehavior != 1, hitTestBehavior != 2,
+                  let result = super.hitTest(point, with: event), result !== self
+            else { return nil }
+            var ancestor: UIView? = result
+            while let current = ancestor, current !== self {
+                if current is WhiskerNodeView { return result }
+                ancestor = current.superview
+            }
+            return nil
+        }
         switch hitTestBehavior {
         case 1:
             return nil

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -393,7 +393,7 @@ final class HostScene {
         case UInt32(WHISKER_OP_OPACITY):
             nodes[id]?.alpha = CGFloat(operation.scalar)
         case UInt32(WHISKER_OP_VISIBILITY):
-            nodes[id]?.isHidden = operation.integer == 0
+            nodes[id]?.setWhiskerVisibility(operation.integer != 0)
         case UInt32(WHISKER_OP_Z_ORDER):
             zOrders[id] = operation.integer
         case UInt32(WHISKER_OP_TEXT):

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1944,6 +1944,9 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/CSS2/visufx/visibility-004.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/visufx/visibility-004.json"
         ),
+        "wpt/css/CSS2/visufx/visibility-005.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/visufx/visibility-005.json"
+        ),
         "wpt/css/CSS2/zindex/z-index-003.json" => {
             include_str!("../../../../tests/host-conformance/wpt/css/CSS2/zindex/z-index-003.json")
         }

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -142,7 +142,7 @@
       "id": "paint.compositing",
       "basis": "lynx-4.0",
       "properties": ["opacity", "visibility", "z-index"],
-      "supported_subset": ["element-group-opacity"],
+      "supported_subset": ["element-group-opacity", "visibility-descendant-override"],
       "protocol": ["SetOpacity", "SetVisibility", "SetZOrder"],
       "rust": "implemented",
       "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -325,6 +325,13 @@
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css2.visibility-005",
+      "feature": "visibility-descendant-override",
+      "fixture": "wpt/css/CSS2/visufx/visibility-005.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css2.z-index-003",
       "feature": "z-index",
       "fixture": "wpt/css/CSS2/zindex/z-index-003.json",

--- a/tests/host-conformance/wpt/css/CSS2/visufx/visibility-004.json
+++ b/tests/host-conformance/wpt/css/CSS2/visufx/visibility-004.json
@@ -28,7 +28,8 @@
             "id": 2,
             "parent": 1,
             "rect": [5.0, 5.0, 30.0, 30.0],
-            "background": { "kind": "named", "value": "red" }
+            "background": { "kind": "named", "value": "red" },
+            "visibility": "hidden"
           }
         ]
       },

--- a/tests/host-conformance/wpt/css/CSS2/visufx/visibility-005.json
+++ b/tests/host-conformance/wpt/css/CSS2/visufx/visibility-005.json
@@ -1,0 +1,61 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.visibility-005",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/visufx/visibility-005.xht",
+    "reference_path": "css/CSS2/reference/ref-filled-green-100px-square.xht",
+    "license": "BSD-3-Clause",
+    "assertion": "A descendant of a visibility:hidden element is visible when its own computed visibility is visible.",
+    "adaptation": "A hidden red parent contains one explicitly visible green child and one child whose resolved visibility remains hidden. Pixel samples verify that the parent suppresses only its own paint and does not prevent the visible descendant from painting."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 80.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [0.0, 0.0, 80.0, 60.0],
+            "background": { "kind": "named", "value": "white" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [10.0, 10.0, 60.0, 40.0],
+            "background": { "kind": "named", "value": "red" },
+            "visibility": "hidden"
+          },
+          {
+            "id": 3,
+            "parent": 2,
+            "rect": [5.0, 5.0, 20.0, 20.0],
+            "background": { "kind": "named", "value": "green" },
+            "visibility": "visible"
+          },
+          {
+            "id": 4,
+            "parent": 2,
+            "rect": [35.0, 5.0, 20.0, 20.0],
+            "background": { "kind": "named", "value": "red" },
+            "visibility": "hidden"
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [20.0, 20.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [50.0, 20.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 },
+          { "point": [12.0, 42.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}


### PR DESCRIPTION
## Summary
- add an adapted WPT visibility-005 fixture shared by all four Hosts
- treat FramePacket visibility as computed per-node state instead of relying on native ancestor hiding
- suppress only a hidden node's own paint/content while preserving transform, clip, opacity, layout, and visible descendants
- preserve hit testing for explicitly visible descendants on Desktop, Android, and iOS

## Verification
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo test -p whisker-desktop --lib
- cargo clippy -p whisker-desktop --lib -- -D warnings
- cargo clippy -p whisker-web --lib -- -D warnings
- cargo test -p whisker-host-conformance
- Android runtime + runner Kotlin compilation
- xcodebuild WhiskerRuntime for generic iOS Simulator

Android/iOS bitmap capture is left to PR CI so no local emulator/simulator is kept running.