### PR TITLE
test(host): cover rounded asymmetric border edges

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -560,9 +560,16 @@ func roundedPath(in rect: CGRect, radii: [CGSize]) -> UIBezierPath {
     return path
 }
 
-private func normalizedRadii(_ radii: [CGSize], in rect: CGRect) -> [CGSize] {
+func normalizedRadii(_ radii: [CGSize], in rect: CGRect) -> [CGSize] {
     var normalized = Array((radii + [.zero, .zero, .zero, .zero]).prefix(4)).map {
-        CGSize(width: max($0.width, 0), height: max($0.height, 0))
+        let width = max($0.width, 0)
+        let height = max($0.height, 0)
+        // CSS Backgrounds requires the entire corner radius to become zero when
+        // either axis is zero. Keeping a degenerate ellipse here makes
+        // CoreGraphics draw a diagonal curve instead of a square corner.
+        return width == 0 || height == 0
+            ? .zero
+            : CGSize(width: width, height: height)
     }
     let horizontalTop = normalized[0].width + normalized[1].width
     let horizontalBottom = normalized[3].width + normalized[2].width

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BoxPaint.swift
@@ -277,6 +277,34 @@ final class HostBoxPainter {
         let right = min(widths[1], bounds.width)
         let bottom = min(widths[2], bounds.height)
         let left = min(widths[3], bounds.width)
+        if widths.allSatisfy({ $0 > 0 }) &&
+            styles.allSatisfy({ $0 == borderStyleSolid }) &&
+            colors.dropFirst().allSatisfy({ $0.isEqual(colors[0]) }) {
+            let innerRect = CGRect(
+                x: bounds.minX + left,
+                y: bounds.minY + top,
+                width: max(0, bounds.width - left - right),
+                height: max(0, bounds.height - top - bottom)
+            )
+            let innerRadii = insetCornerRadii(
+                normalizedRadii(cornerRadii, in: bounds),
+                top: top,
+                right: right,
+                bottom: bottom,
+                left: left
+            )
+            let ring = CGMutablePath()
+            ring.addPath(outerPath.cgPath)
+            if !innerRect.isEmpty {
+                ring.addPath(roundedPath(in: innerRect, radii: innerRadii).cgPath)
+            }
+            context.saveGState()
+            colors[0].setFill()
+            context.addPath(ring)
+            context.drawPath(using: .eoFill)
+            context.restoreGState()
+            return
+        }
         let innerTopLeft = CGPoint(x: bounds.minX + left, y: bounds.minY + top)
         let innerTopRight = CGPoint(x: bounds.maxX - right, y: bounds.minY + top)
         let innerBottomRight = CGPoint(x: bounds.maxX - right, y: bounds.maxY - bottom)

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1890,6 +1890,12 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-backgrounds/border-radius-004.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-004.json"
         ),
+        "wpt/css/css-backgrounds/border-radius-different-width-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-different-width-001.json"
+        ),
+        "wpt/css/css-backgrounds/border-radius-horizontal-value-is-zero.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-horizontal-value-is-zero.json"
+        ),
         "wpt/css/css-backgrounds/border-radius-overflow-hidden.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-overflow-hidden.json"
         ),

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -91,6 +91,7 @@
       "id": "paint.box",
       "basis": "lynx-4.0",
       "properties": ["background-color", "border", "border-bottom", "border-bottom-color", "border-bottom-left-radius", "border-bottom-right-radius", "border-bottom-style", "border-bottom-width", "border-color", "border-end-end-radius", "border-end-start-radius", "border-inline-end-color", "border-inline-end-style", "border-inline-end-width", "border-inline-start-color", "border-inline-start-style", "border-inline-start-width", "border-left", "border-left-color", "border-left-style", "border-left-width", "border-radius", "border-right", "border-right-color", "border-right-style", "border-right-width", "border-start-end-radius", "border-start-start-radius", "border-style", "border-top", "border-top-color", "border-top-left-radius", "border-top-right-radius", "border-top-style", "border-top-width", "border-width"],
+      "supported_subset": ["asymmetric-rounded-border-joins", "zero-radius-axis-squares-corner"],
       "protocol": ["SetBoxPaint"],
       "rust": "implemented",
       "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -213,6 +213,20 @@
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.border-radius-different-width-001",
+      "feature": "border-radius-asymmetric-widths",
+      "fixture": "wpt/css/css-backgrounds/border-radius-different-width-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-backgrounds.border-radius-horizontal-value-is-zero",
+      "feature": "border-radius-zero-axis",
+      "fixture": "wpt/css/css-backgrounds/border-radius-horizontal-value-is-zero.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-overflow.clip-002.horizontal",
       "feature": "overflow-x",
       "fixture": "wpt/css/css-overflow/clip-002.json",

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -140,6 +140,26 @@ final class HostConformanceTests: XCTestCase {
         )
     }
 
+    func testAZeroRadiusAxisMakesTheWholeCornerSquare() {
+        XCTAssertEqual(
+            normalizedRadii(
+                [
+                    CGSize(width: 0, height: 20),
+                    CGSize(width: 20, height: 0),
+                    CGSize(width: 20, height: 10),
+                    CGSize(width: -1, height: 20),
+                ],
+                in: CGRect(x: 0, y: 0, width: 100, height: 100)
+            ),
+            [
+                .zero,
+                .zero,
+                CGSize(width: 20, height: 10),
+                .zero,
+            ]
+        )
+    }
+
     func testBackgroundLayerArrayRejectsAnUnregisteredResourceTransactionally() throws {
         var pixel: [UInt8] = [0, 0, 255, 255]
         let context = try XCTUnwrap(CGContext(

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-different-width-001.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-different-width-001.json
@@ -1,0 +1,51 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-different-width-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-different-width-001.htm",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "Adjoining rounded borders with different thicknesses form a smooth transition between the thicker and thinner sides.",
+    "adaptation": "The first WPT box is reduced to a 100 by 60 logical-pixel box with top/right/bottom/left widths of 5/10/15/20 and a 20px radius. Samples cover the transparent outer corners, each physical border side, the white inner box, and the asymmetric top-left join."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 120.0, "height": 80.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [10.0, 10.0, 100.0, 60.0],
+        "background": { "kind": "named", "value": "white" },
+        "border": {
+          "widths": [5.0, 10.0, 15.0, 20.0],
+          "colors": [
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" }
+          ],
+          "styles": ["solid", "solid", "solid", "solid"],
+          "radii": [20.0, 20.0, 20.0, 20.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [12.0, 12.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [108.0, 68.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 16 },
+          { "point": [60.0, 12.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [105.0, 40.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [60.0, 62.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [15.0, 40.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [20.0, 20.0], "color": { "kind": "named", "value": "black" }, "tolerance": 16 },
+          { "point": [35.0, 20.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 },
+          { "point": [60.0, 40.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-horizontal-value-is-zero.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-horizontal-value-is-zero.json
@@ -1,0 +1,47 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-horizontal-value-is-zero",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-horizontal-value-is-zero.html",
+    "reference_path": "css/css-backgrounds/reference/border-radius-horizontal-value-is-zero-ref.html",
+    "license": "BSD-3-Clause",
+    "assertion": "If either radius of a corner is zero, that corner is square rather than rounded.",
+    "adaptation": "The WPT's `border-radius: 0 / 5em` box is represented by four [0, 20] elliptical radii. Green samples at every outer corner distinguish the required square corners from an incorrect vertically rounded projection."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 80.0, "height": 60.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [10.0, 10.0, 60.0, 40.0],
+        "background": { "kind": "named", "value": "white" },
+        "border": {
+          "widths": [5.0, 5.0, 5.0, 5.0],
+          "colors": [
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "green" }
+          ],
+          "styles": ["solid", "solid", "solid", "solid"],
+          "radii": [[0.0, 20.0], [0.0, 20.0], [0.0, 20.0], [0.0, 20.0]]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [11.0, 11.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [69.0, 11.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [69.0, 49.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [11.0, 49.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 },
+          { "point": [20.0, 20.0], "color": { "kind": "named", "value": "white" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}


### PR DESCRIPTION
## Summary
- adapt WPT border-radius-different-width-001 for asymmetric rounded border joins
- adapt the zero-horizontal-radius WPT to verify that either zero radius axis produces a square corner
- run both pixel fixtures through Desktop, Web, Android, and iOS Host conformance
- record the covered paint.box subsets in capabilities.json

## Local verification
- cargo xtask host-conformance desktop
- cargo xtask host-conformance web
- cargo test -p whisker-host-conformance

Android/iOS pixel capture runs in PR CI.