### PR TITLE
test(host): expand z-index stacking conformance

### DIFF
--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1956,6 +1956,15 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/CSS2/zindex/z-index-003.json" => {
             include_str!("../../../../tests/host-conformance/wpt/css/CSS2/zindex/z-index-003.json")
         }
+        "wpt/css/CSS2/zindex/z-index-010.json" => {
+            include_str!("../../../../tests/host-conformance/wpt/css/CSS2/zindex/z-index-010.json")
+        }
+        "wpt/css/CSS2/zindex/z-index-stack-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/zindex/z-index-stack-001.json"
+        ),
+        "wpt/css/CSS2/zindex/z-index-stack-002.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/CSS2/zindex/z-index-stack-002.json"
+        ),
         "wpt/css/CSS2/borders/border-top-003.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/CSS2/borders/border-top-003.json"
         ),

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -143,7 +143,7 @@
       "id": "paint.compositing",
       "basis": "lynx-4.0",
       "properties": ["opacity", "visibility", "z-index"],
-      "supported_subset": ["element-group-opacity", "visibility-descendant-override"],
+      "supported_subset": ["element-group-opacity", "visibility-descendant-override", "signed-32-bit-z-order", "sibling-document-order-tiebreak"],
       "protocol": ["SetOpacity", "SetVisibility", "SetZOrder"],
       "rust": "implemented",
       "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -353,6 +353,27 @@
       "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css2.z-index-010",
+      "feature": "z-index-signed-32-bit-maximum",
+      "fixture": "wpt/css/CSS2/zindex/z-index-010.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css2.z-index-stack-001",
+      "feature": "z-index-sibling-stacking-levels",
+      "fixture": "wpt/css/CSS2/zindex/z-index-stack-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css2.z-index-stack-002",
+      "feature": "z-index-document-order-tiebreak",
+      "fixture": "wpt/css/CSS2/zindex/z-index-stack-002.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["rust-layout-protocol", "semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-backgrounds.border-radius-overflow-hidden",
       "feature": "border-radius-overflow-clip",
       "fixture": "wpt/css/css-backgrounds/border-radius-overflow-hidden.json",

--- a/tests/host-conformance/wpt/css/CSS2/zindex/z-index-010.json
+++ b/tests/host-conformance/wpt/css/CSS2/zindex/z-index-010.json
@@ -1,0 +1,52 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.z-index-010",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/zindex/z-index-010.xht",
+    "reference_path": "css/CSS2/reference/ref-filled-green-100px-square.xht",
+    "license": "BSD-3-Clause",
+    "assertion": "The maximum signed 32-bit z-index is handled without overflow and paints above a lower positive z-index.",
+    "adaptation": "The WPT's overlapping green and red boxes retain z-index values 2147483647 and 100 at half size."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 70.0, "height": 70.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "transparent" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [0.0, 0.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "green" },
+            "z_order": 2147483647
+          },
+          {
+            "id": 3,
+            "parent": 1,
+            "rect": [0.0, 0.0, 50.0, 50.0],
+            "background": { "kind": "named", "value": "red" },
+            "z_order": 100
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [35.0, 35.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/CSS2/zindex/z-index-stack-001.json
+++ b/tests/host-conformance/wpt/css/CSS2/zindex/z-index-stack-001.json
@@ -1,0 +1,61 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.z-index-stack-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/zindex/z-index-stack-001.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "Sibling boxes with greater stacking levels paint in front of boxes with lower stacking levels.",
+    "adaptation": "The WPT's three overlapping boxes are reduced to 60 logical pixels and use the fixture palette while preserving z-index values 2, 3, and 1. Pixel samples verify every exposed stacking band."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 110.0, "height": 110.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 90.0, 90.0],
+            "background": { "kind": "named", "value": "transparent" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [20.0, 20.0, 60.0, 60.0],
+            "background": { "kind": "named", "value": "red" },
+            "z_order": 2
+          },
+          {
+            "id": 3,
+            "parent": 1,
+            "rect": [40.0, 40.0, 60.0, 60.0],
+            "background": { "kind": "named", "value": "green" },
+            "z_order": 3
+          },
+          {
+            "id": 4,
+            "parent": 1,
+            "rect": [0.0, 0.0, 60.0, 60.0],
+            "background": { "kind": "named", "value": "blue" },
+            "z_order": 1
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [20.0, 20.0], "color": { "kind": "named", "value": "blue" }, "tolerance": 16 },
+          { "point": [40.0, 40.0], "color": { "kind": "named", "value": "red" }, "tolerance": 16 },
+          { "point": [60.0, 60.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/CSS2/zindex/z-index-stack-002.json
+++ b/tests/host-conformance/wpt/css/CSS2/zindex/z-index-stack-002.json
@@ -1,0 +1,61 @@
+{
+  "schema": 1,
+  "id": "wpt.css2.z-index-stack-002",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/CSS2/zindex/z-index-stack-002.xht",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "Sibling boxes at the same stacking level paint back-to-front in document tree order.",
+    "adaptation": "The WPT's three overlapping boxes are reduced to 60 logical pixels and use blue, red, and green while retaining an equal z-index of 1. Pixel samples verify the insertion-order tie break."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 110.0, "height": 110.0, "scale": 1.0 },
+      {
+        "type": "present_scene",
+        "revision": 1,
+        "nodes": [
+          {
+            "id": 1,
+            "parent": null,
+            "rect": [10.0, 10.0, 90.0, 90.0],
+            "background": { "kind": "named", "value": "transparent" }
+          },
+          {
+            "id": 2,
+            "parent": 1,
+            "rect": [0.0, 0.0, 60.0, 60.0],
+            "background": { "kind": "named", "value": "blue" },
+            "z_order": 1
+          },
+          {
+            "id": 3,
+            "parent": 1,
+            "rect": [20.0, 20.0, 60.0, 60.0],
+            "background": { "kind": "named", "value": "red" },
+            "z_order": 1
+          },
+          {
+            "id": 4,
+            "parent": 1,
+            "rect": [40.0, 40.0, 60.0, 60.0],
+            "background": { "kind": "named", "value": "green" },
+            "z_order": 1
+          }
+        ]
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [20.0, 20.0], "color": { "kind": "named", "value": "blue" }, "tolerance": 16 },
+          { "point": [40.0, 40.0], "color": { "kind": "named", "value": "red" }, "tolerance": 16 },
+          { "point": [60.0, 60.0], "color": { "kind": "named", "value": "green" }, "tolerance": 16 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}


### PR DESCRIPTION
## Summary
- adapt WPT z-index maximum signed 32-bit coverage
- add sibling stacking-level ordering coverage
- add equal-level document-order tie-break coverage
- require all four Hosts to execute the shared fixtures

## Validation
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo fmt --all --check`
- JSON fixture/manifest validation with `jq`

Stacked on #510.