### PR TITLE
test(host): cover rounded border styles

### DIFF
--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1899,6 +1899,21 @@ fn fixture(path: &str) -> &'static str {
         "wpt/css/css-backgrounds/border-radius-horizontal-value-is-zero.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-horizontal-value-is-zero.json"
         ),
+        "wpt/css/css-backgrounds/border-radius-style-001.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-001.json"
+        ),
+        "wpt/css/css-backgrounds/border-radius-style-002.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-002.json"
+        ),
+        "wpt/css/css-backgrounds/border-radius-style-003.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-003.json"
+        ),
+        "wpt/css/css-backgrounds/border-radius-style-004.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-004.json"
+        ),
+        "wpt/css/css-backgrounds/border-radius-style-005.json" => include_str!(
+            "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-005.json"
+        ),
         "wpt/css/css-backgrounds/border-radius-overflow-hidden.json" => include_str!(
             "../../../../tests/host-conformance/wpt/css/css-backgrounds/border-radius-overflow-hidden.json"
         ),

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -91,7 +91,7 @@
       "id": "paint.box",
       "basis": "lynx-4.0",
       "properties": ["background-color", "border", "border-bottom", "border-bottom-color", "border-bottom-left-radius", "border-bottom-right-radius", "border-bottom-style", "border-bottom-width", "border-color", "border-end-end-radius", "border-end-start-radius", "border-inline-end-color", "border-inline-end-style", "border-inline-end-width", "border-inline-start-color", "border-inline-start-style", "border-inline-start-width", "border-left", "border-left-color", "border-left-style", "border-left-width", "border-radius", "border-right", "border-right-color", "border-right-style", "border-right-width", "border-start-end-radius", "border-start-start-radius", "border-style", "border-top", "border-top-color", "border-top-left-radius", "border-top-right-radius", "border-top-style", "border-top-width", "border-width"],
-      "supported_subset": ["asymmetric-rounded-border-joins", "zero-radius-axis-squares-corner", "proportional-overlapping-radius-normalization"],
+      "supported_subset": ["asymmetric-rounded-border-joins", "rounded-border-styles", "zero-radius-axis-squares-corner", "proportional-overlapping-radius-normalization"],
       "protocol": ["SetBoxPaint"],
       "rust": "implemented",
       "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -234,6 +234,41 @@
       "checkpoints": ["semantic-projection", "pixel-samples"]
     },
     {
+      "id": "wpt.css-backgrounds.border-radius-style-001",
+      "feature": "border-radius-dotted-style",
+      "fixture": "wpt/css/css-backgrounds/border-radius-style-001.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-backgrounds.border-radius-style-002",
+      "feature": "border-radius-dashed-style",
+      "fixture": "wpt/css/css-backgrounds/border-radius-style-002.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-backgrounds.border-radius-style-003",
+      "feature": "border-radius-double-style",
+      "fixture": "wpt/css/css-backgrounds/border-radius-style-003.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-backgrounds.border-radius-style-004",
+      "feature": "border-radius-solid-style",
+      "fixture": "wpt/css/css-backgrounds/border-radius-style-004.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
+      "id": "wpt.css-backgrounds.border-radius-style-005",
+      "feature": "border-radius-none-style",
+      "fixture": "wpt/css/css-backgrounds/border-radius-style-005.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["semantic-projection", "pixel-samples"]
+    },
+    {
       "id": "wpt.css-overflow.clip-002.horizontal",
       "feature": "overflow-x",
       "fixture": "wpt/css/css-overflow/clip-002.json",

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -31,16 +31,20 @@ final class HostConformanceTests: XCTestCase {
                 return type == "present_box" || type == "present_scene" || type == "measure_text" ||
                     type == "emit_pointer"
             }) else { continue }
-            let test = try Driver(id: id).execute(testSide)
-            if let reference = scenario["reference"] as? [String: Any] {
-                let expected = try Driver(id: id).execute(reference)
-                XCTAssertEqual(test.width, expected.width)
-                XCTAssertEqual(test.height, expected.height)
-                XCTAssertLessThanOrEqual(
-                    largestDifference(test.bytes, expected.bytes),
-                    1,
-                    id
-                )
+            do {
+                let test = try Driver(id: id).execute(testSide)
+                if let reference = scenario["reference"] as? [String: Any] {
+                    let expected = try Driver(id: id).execute(reference)
+                    XCTAssertEqual(test.width, expected.width)
+                    XCTAssertEqual(test.height, expected.height)
+                    XCTAssertLessThanOrEqual(
+                        largestDifference(test.bytes, expected.bytes),
+                        1,
+                        id
+                    )
+                }
+            } catch {
+                throw Failure("\(id): \(error)")
             }
             count += 1
         }

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-001.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-001.json
@@ -21,7 +21,7 @@
         "border": {
           "widths": [12.0, 12.0, 12.0, 12.0],
           "colors": [
-            { "kind": "named", "value": "purple" },
+            { "kind": "srgba", "red": 128, "green": 0, "blue": 128, "alpha": 1.0 },
             { "kind": "named", "value": "green" },
             { "kind": "named", "value": "blue" },
             { "kind": "named", "value": "gray" }
@@ -34,7 +34,7 @@
         "type": "checkpoint",
         "name": "paint.box",
         "samples": [
-          { "point": [70.0, 16.0], "color": { "kind": "named", "value": "purple" }, "tolerance": 24 },
+          { "point": [70.0, 16.0], "color": { "kind": "srgba", "red": 128, "green": 0, "blue": 128, "alpha": 1.0 }, "tolerance": 24 },
           { "point": [124.0, 70.0], "color": { "kind": "named", "value": "green" }, "tolerance": 24 },
           { "point": [70.0, 124.0], "color": { "kind": "named", "value": "blue" }, "tolerance": 24 },
           { "point": [16.0, 70.0], "color": { "kind": "named", "value": "gray" }, "tolerance": 24 },

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-001.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-001.json
@@ -1,0 +1,49 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-style-001",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-style-001.htm",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A dotted border follows the rounded border curve and preserves the color of each physical side.",
+    "adaptation": "The WPT box is reduced to a 120 logical-pixel square with a 12px dotted border and 40px radii. Semantic projection checks all four side colors; samples cover dots on each straight run, a gap, the transparent outer corner, and the unpainted interior. Exact corner dot distribution remains Host-defined as allowed by CSS."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 140.0, "height": 140.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [10.0, 10.0, 120.0, 120.0],
+        "background": { "kind": "named", "value": "transparent" },
+        "border": {
+          "widths": [12.0, 12.0, 12.0, 12.0],
+          "colors": [
+            { "kind": "named", "value": "purple" },
+            { "kind": "named", "value": "green" },
+            { "kind": "named", "value": "blue" },
+            { "kind": "named", "value": "gray" }
+          ],
+          "styles": ["dotted", "dotted", "dotted", "dotted"],
+          "radii": [40.0, 40.0, 40.0, 40.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [70.0, 16.0], "color": { "kind": "named", "value": "purple" }, "tolerance": 24 },
+          { "point": [124.0, 70.0], "color": { "kind": "named", "value": "green" }, "tolerance": 24 },
+          { "point": [70.0, 124.0], "color": { "kind": "named", "value": "blue" }, "tolerance": 24 },
+          { "point": [16.0, 70.0], "color": { "kind": "named", "value": "gray" }, "tolerance": 24 },
+          { "point": [52.0, 16.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 },
+          { "point": [11.0, 11.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 },
+          { "point": [70.0, 70.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-002.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-002.json
@@ -1,0 +1,46 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-style-002",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-style-002.htm",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A dashed border follows the rounded border curve.",
+    "adaptation": "The WPT box is reduced to a 120 logical-pixel square with a 12px dashed border and 40px radii. Samples distinguish a dash from the following gap, preserve the rounded transparent corner, and verify that the interior remains unpainted. Exact dash distribution around corners remains Host-defined as allowed by CSS."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 140.0, "height": 140.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [10.0, 10.0, 120.0, 120.0],
+        "background": { "kind": "named", "value": "transparent" },
+        "border": {
+          "widths": [12.0, 12.0, 12.0, 12.0],
+          "colors": [
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" }
+          ],
+          "styles": ["dashed", "dashed", "dashed", "dashed"],
+          "radii": [40.0, 40.0, 40.0, 40.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [70.0, 16.0], "color": { "kind": "named", "value": "black" }, "tolerance": 24 },
+          { "point": [100.0, 16.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 },
+          { "point": [11.0, 11.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 },
+          { "point": [70.0, 70.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-003.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-003.json
@@ -1,0 +1,47 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-style-003",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-style-003.htm",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A double border follows the rounded border curve and retains two visible bands.",
+    "adaptation": "The WPT box is reduced to a 120 by 80 logical-pixel box with an 18px double border and 36px radii. Samples distinguish the outer band, transparent middle gap, inner band, rounded outer corner, and unpainted content."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 140.0, "height": 100.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [10.0, 10.0, 120.0, 80.0],
+        "background": { "kind": "named", "value": "transparent" },
+        "border": {
+          "widths": [18.0, 18.0, 18.0, 18.0],
+          "colors": [
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" }
+          ],
+          "styles": ["double", "double", "double", "double"],
+          "radii": [36.0, 36.0, 36.0, 36.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [70.0, 13.0], "color": { "kind": "named", "value": "black" }, "tolerance": 24 },
+          { "point": [70.0, 19.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 },
+          { "point": [70.0, 25.0], "color": { "kind": "named", "value": "black" }, "tolerance": 24 },
+          { "point": [11.0, 11.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 },
+          { "point": [70.0, 50.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-004.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-004.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-style-004",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-style-004.htm",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A solid border follows the rounded border curve.",
+    "adaptation": "The WPT box is reduced to a 120 logical-pixel square with a 12px solid border and 40px radii. Samples cover the solid edge, rounded transparent corner, and unpainted content."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 140.0, "height": 140.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [10.0, 10.0, 120.0, 120.0],
+        "background": { "kind": "named", "value": "transparent" },
+        "border": {
+          "widths": [12.0, 12.0, 12.0, 12.0],
+          "colors": [
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" },
+            { "kind": "named", "value": "black" }
+          ],
+          "styles": ["solid", "solid", "solid", "solid"],
+          "radii": [40.0, 40.0, 40.0, 40.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [70.0, 16.0], "color": { "kind": "named", "value": "black" }, "tolerance": 24 },
+          { "point": [11.0, 11.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 },
+          { "point": [70.0, 70.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}

--- a/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-005.json
+++ b/tests/host-conformance/wpt/css/css-backgrounds/border-radius-style-005.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "id": "wpt.css-backgrounds.border-radius-style-005",
+  "upstream": {
+    "repository": "https://github.com/web-platform-tests/wpt",
+    "revision": "db80bd24a77f1b5f8ba40a5b320dec3720a37c8d",
+    "path": "css/css-backgrounds/border-radius-style-005.htm",
+    "reference_path": null,
+    "license": "BSD-3-Clause",
+    "assertion": "A none border paints no border while the element background remains clipped by border-radius.",
+    "adaptation": "The WPT box is reduced to a 120 logical-pixel square with the none border's computed zero widths, a black background, and 40px radii. Samples verify the rounded background, transparent outer corner, black center, and absence of border paint."
+  },
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 140.0, "height": 140.0, "scale": 1.0 },
+      {
+        "type": "present_box",
+        "revision": 1,
+        "rect": [10.0, 10.0, 120.0, 120.0],
+        "background": { "kind": "named", "value": "black" },
+        "border": {
+          "widths": [0.0, 0.0, 0.0, 0.0],
+          "colors": [
+            { "kind": "named", "value": "red" },
+            { "kind": "named", "value": "red" },
+            { "kind": "named", "value": "red" },
+            { "kind": "named", "value": "red" }
+          ],
+          "styles": ["none", "none", "none", "none"],
+          "radii": [40.0, 40.0, 40.0, 40.0]
+        }
+      },
+      {
+        "type": "checkpoint",
+        "name": "paint.box",
+        "samples": [
+          { "point": [70.0, 16.0], "color": { "kind": "named", "value": "black" }, "tolerance": 24 },
+          { "point": [11.0, 11.0], "color": { "kind": "named", "value": "transparent" }, "tolerance": 24 },
+          { "point": [70.0, 70.0], "color": { "kind": "named", "value": "black" }, "tolerance": 24 }
+        ]
+      }
+    ]
+  },
+  "reference": null
+}


### PR DESCRIPTION
## Summary
- adapt WPT rounded border style cases for dotted, dashed, double, solid, and none
- require semantic projection and native pixel samples across all four Hosts
- record rounded border styles in the paint.box capability subset

## Validation
- `cargo fmt --all --check`
- `cargo test -p whisker-host-conformance`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- Android build and fixture asset staging passed; local pixel execution requires a connected emulator and is left to CI
- iOS simulator execution is left to CI to avoid restarting local simulators