### PR TITLE
fix(android): complete Aurora Wallet host integration

### DIFF
--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -743,7 +743,7 @@ pub fn inputs_from_with_engine(
         extra_gradle_plugins,
         extra_gradle_dependencies,
         extra_files,
-        template_version: 30,
+        template_version: 32,
     })
 }
 
@@ -787,13 +787,14 @@ mod tests {
             extra_gradle_plugins: Vec::new(),
             extra_gradle_dependencies: Vec::new(),
             extra_files: BTreeMap::new(),
-            template_version: 30,
+            template_version: 32,
         }
     }
 
     #[test]
     fn generated_activity_only_composes_the_sdk_view() {
         assert!(MAIN_ACTIVITY_KT.contains("import rs.whisker.runtime.WhiskerView"));
+        assert!(MAIN_ACTIVITY_KT.contains("WhiskerWindow.enableEdgeToEdge(this)"));
         assert!(MAIN_ACTIVITY_KT.contains("setContentView(WhiskerView(this))"));
     }
 

--- a/crates/whisker-cng/src/templates/android/app/src/main/kotlin/MainActivity.kt
+++ b/crates/whisker-cng/src/templates/android/app/src/main/kotlin/MainActivity.kt
@@ -3,6 +3,7 @@ package {{android_application_id}}
 import android.app.Activity
 import android.os.Bundle
 import rs.whisker.runtime.WhiskerView{{main_activity_imports}}
+import rs.whisker.runtime.WhiskerWindow
 import rs.whisker.runtime.generated.WhiskerModuleBehaviors
 
 /**
@@ -12,6 +13,7 @@ class MainActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
 {{main_activity_pre_super}}        super.onCreate(savedInstanceState)
 
+        WhiskerWindow.enableEdgeToEdge(this)
         System.loadLibrary("{{rust_lib_name}}")
         WhiskerModuleBehaviors.registerAll()
         setContentView(WhiskerView(this))

--- a/crates/whisker-cng/src/templates/android/build.gradle.kts
+++ b/crates/whisker-cng/src/templates/android/build.gradle.kts
@@ -5,3 +5,20 @@ plugins {
     id("com.android.library") version "8.6.1" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 }
+
+// Module packages are independently publishable, so their build scripts depend
+// on the published authoring API coordinate. Inside a Whisker checkout, replace
+// that coordinate for every included module subproject with the in-tree SDK.
+// This keeps module build.gradle.kts files identical in standalone and
+// workspace builds and prevents an older published SDK from reintroducing
+// legacy renderer dependencies into the generated app.
+subprojects {
+    configurations.configureEach {
+        resolutionStrategy.dependencySubstitution {
+            if (rootProject.findProject(":whisker-module") != null) {
+                substitute(module("rs.whisker:whisker-module-android"))
+                    .using(project(":whisker-module"))
+            }
+        }
+    }
+}

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -119,6 +119,11 @@ impl Builder {
                 &toolchain,
                 ABI,
             )?;
+            let modules =
+                whisker_build::modules::discover(&workspace_root.join("Cargo.toml"), &package)
+                    .context("discover Android Whisker modules")?;
+            whisker_build::android::stage_module_kotlin_sources(&gen_android, &modules)
+                .context("stage Android Whisker modules")?;
             whisker_build::android::run_gradle_assemble(
                 &gen_android,
                 whisker_build::Profile::Debug,

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -279,7 +279,11 @@ impl LayoutTree {
         if impact.is_empty() {
             return Ok(impact);
         }
-        let converted = convert_retained_style(&style, retained.measurable)?;
+        let converted = if self.surface_child == Some(node) {
+            convert_surface_child_style(&style, retained.measurable)?
+        } else {
+            convert_retained_style(&style, retained.measurable)?
+        };
         let backend_node = retained.backend;
         let parent = retained.parent;
         self.backend
@@ -302,8 +306,12 @@ impl LayoutTree {
             return Ok(false);
         }
         let backend = retained.backend;
-        let converted = convert_retained_style(&retained.style, measurable)
-            .expect("a retained style was validated when it entered layout");
+        let converted = if self.surface_child == Some(node) {
+            convert_surface_child_style(&retained.style, measurable)
+        } else {
+            convert_retained_style(&retained.style, measurable)
+        }
+        .expect("a retained style was validated when it entered layout");
         self.backend
             .set_style(backend, converted)
             .expect("retained backend node");
@@ -480,6 +488,20 @@ impl LayoutTree {
             self.surface_viewport = Some(viewport);
         }
         if self.surface_child != Some(root) {
+            if let Some(previous) = self.surface_child
+                && let Some(retained) = self.nodes.get(&previous)
+            {
+                let restored = convert_retained_style(&retained.style, retained.measurable)
+                    .expect("a retained style was validated when it entered layout");
+                self.backend
+                    .set_style(retained.backend, restored)
+                    .expect("previous surface child remains retained");
+            }
+            let constrained = convert_surface_child_style(&retained.style, retained.measurable)
+                .expect("a retained style was validated when it entered layout");
+            self.backend
+                .set_style(backend_root, constrained)
+                .expect("application root remains retained");
             self.backend
                 .set_children(self.surface_root, &[backend_root])
                 .expect("retained surface and application roots");
@@ -601,6 +623,23 @@ fn surface_root_style(viewport: LayoutSize) -> Style {
         },
         ..Style::default()
     }
+}
+
+fn convert_surface_child_style(
+    input: &ComputedLayoutStyle,
+    measurable: bool,
+) -> Result<Style, LayoutError> {
+    let mut style = convert_retained_style(input, measurable)?;
+    // The application root represents the Host viewport. CSS automatic
+    // minimums must not let descendant content enlarge that viewport; an
+    // explicit author min-size is still honored.
+    if style.min_size.width == Dimension::auto() {
+        style.min_size.width = Dimension::length(0.0);
+    }
+    if style.min_size.height == Dimension::auto() {
+        style.min_size.height = Dimension::length(0.0);
+    }
+    Ok(style)
 }
 
 fn from_taffy_available(value: TaffyAvailableSpace) -> AvailableSpace {
@@ -1627,6 +1666,42 @@ mod tests {
                 height: 300.0,
             }
         );
+    }
+
+    #[test]
+    fn application_root_auto_minimum_does_not_grow_past_viewport() {
+        let root = id(1);
+        let content = id(2);
+        let mut tree = LayoutTree::new();
+        tree.create_node(
+            root,
+            ComputedLayoutStyle {
+                flex_grow: StyleNumber::new(1.0),
+                flex_direction: FlexDirectionValue::Column,
+                ..ComputedLayoutStyle::default()
+            },
+        )
+        .unwrap();
+        tree.create_node(
+            content,
+            ComputedLayoutStyle {
+                size: Axes {
+                    width: ComputedSizeValue::Auto,
+                    height: ComputedSizeValue::Value(ComputedLengthPercentage::new(400.0, 0.0)),
+                },
+                flex_shrink: StyleNumber::new(0.0),
+                ..ComputedLayoutStyle::default()
+            },
+        )
+        .unwrap();
+        tree.set_children(root, &[content]).unwrap();
+
+        let snapshot = tree
+            .compute(root, LayoutSize::new(320.0, 240.0), &mut zero_measure)
+            .unwrap();
+        assert_eq!(snapshot.get(root).unwrap().border_box.width, 320.0);
+        assert_eq!(snapshot.get(root).unwrap().border_box.height, 240.0);
+        assert_eq!(snapshot.get(content).unwrap().border_box.height, 400.0);
     }
 
     #[test]

--- a/crates/whisker/src/element_registry.rs
+++ b/crates/whisker/src/element_registry.rs
@@ -8,6 +8,7 @@ use crate::ElementTag;
 use whisker_engine::whisker_protocol::{
     ElementRegistration, ElementRegistrationError, ElementSchema, ElementTypeId,
 };
+use whisker_engine::whisker_style::SpecifiedStyle;
 
 type SchemaKey = String;
 
@@ -32,6 +33,8 @@ pub struct ElementProviderMetadata {
     pub schema: ElementSchema,
     /// Authoring syntax that resolves to this contract.
     pub authoring: ElementAuthoringBinding,
+    /// Host-independent declarations applied before the caller's style.
+    pub base_style: SpecifiedStyle,
 }
 
 /// Generated Rust-side definition for one element-provider module.
@@ -66,6 +69,7 @@ impl ElementProviderMetadata {
         Self {
             schema,
             authoring: ElementAuthoringBinding::Builtin(tag),
+            base_style: SpecifiedStyle::new(),
         }
     }
 
@@ -77,7 +81,15 @@ impl ElementProviderMetadata {
         Self {
             schema,
             authoring: ElementAuthoringBinding::Named,
+            base_style: SpecifiedStyle::new(),
         }
+    }
+
+    /// Applies provider-owned defaults while preserving caller declarations as
+    /// the later, overriding style fragment.
+    pub fn with_base_style(mut self, style: SpecifiedStyle) -> Self {
+        self.base_style = style;
+        self
     }
 }
 
@@ -89,6 +101,7 @@ impl ElementProviderMetadata {
 #[derive(Clone, Debug)]
 pub struct ElementRegistry {
     registrations: Vec<ElementRegistration>,
+    base_styles: Vec<SpecifiedStyle>,
     builtins: HashMap<ElementTag, usize>,
     names: HashMap<String, usize>,
 }
@@ -117,6 +130,13 @@ impl ElementRegistry {
     /// Returns the normalized contracts in compact-ID order.
     pub fn registrations(&self) -> &[ElementRegistration] {
         &self.registrations
+    }
+
+    pub(crate) fn base_style(&self, registration: &ElementRegistration) -> &SpecifiedStyle {
+        let index = registration.element_type.get() as usize - 1;
+        self.base_styles
+            .get(index)
+            .expect("registrations and base styles share one compact-ID order")
     }
 
     /// Resolves one built-in authoring tag to its normalized contract.
@@ -163,6 +183,7 @@ impl ElementRegistry {
         let name = schema.name.clone();
         let index = self.registrations.len();
         self.registrations.push(schema.bind(raw_id));
+        self.base_styles.push(SpecifiedStyle::new());
         self.names.insert(name, index);
         Ok(&self.registrations[index])
     }
@@ -171,7 +192,7 @@ impl ElementRegistry {
 /// Mutable bootstrap description used to construct an [`ElementRegistry`].
 #[derive(Clone, Debug, Default)]
 pub struct ElementRegistryBuilder {
-    schemas: Vec<ElementSchema>,
+    schemas: Vec<(ElementSchema, SpecifiedStyle)>,
     builtin_bindings: Vec<(ElementTag, SchemaKey)>,
     name_bindings: Vec<(String, SchemaKey)>,
 }
@@ -196,7 +217,7 @@ impl ElementRegistryBuilder {
     /// Adds generated metadata for one UI-providing module.
     pub fn register_provider(mut self, provider: ElementProviderMetadata) -> Self {
         let name = provider.schema.name.clone();
-        self.schemas.push(provider.schema);
+        self.schemas.push((provider.schema, provider.base_style));
         match provider.authoring {
             ElementAuthoringBinding::Builtin(tag) => {
                 self.builtin_bindings.push((tag, name));
@@ -225,7 +246,7 @@ impl ElementRegistryBuilder {
     /// lower-level method supports schemas whose authoring binding is supplied
     /// separately or which are retained only for Host negotiation.
     pub fn register(mut self, schema: ElementSchema) -> Self {
-        self.schemas.push(schema);
+        self.schemas.push((schema, SpecifiedStyle::new()));
         self
     }
 
@@ -249,8 +270,9 @@ impl ElementRegistryBuilder {
     /// Validates schemas and bindings, then assigns compact IDs for the epoch.
     pub fn build(self) -> Result<ElementRegistry, ElementRegistryError> {
         let mut registrations = Vec::with_capacity(self.schemas.len());
+        let mut base_styles = Vec::with_capacity(self.schemas.len());
         let mut schemas = HashMap::with_capacity(self.schemas.len());
-        for (index, schema) in self.schemas.into_iter().enumerate() {
+        for (index, (schema, base_style)) in self.schemas.into_iter().enumerate() {
             schema
                 .validate()
                 .map_err(|error| ElementRegistryError::InvalidSchema {
@@ -268,6 +290,7 @@ impl ElementRegistryBuilder {
                 .ok_or(ElementRegistryError::ElementTypeIdExhausted)?;
             schemas.insert(key, registrations.len());
             registrations.push(schema.bind(raw_id));
+            base_styles.push(base_style);
         }
 
         let mut builtins = HashMap::with_capacity(self.builtin_bindings.len());
@@ -300,6 +323,7 @@ impl ElementRegistryBuilder {
 
         Ok(ElementRegistry {
             registrations,
+            base_styles,
             builtins,
             names,
         })

--- a/crates/whisker/src/mobile_runtime.rs
+++ b/crates/whisker/src/mobile_runtime.rs
@@ -26,6 +26,31 @@ use whisker_runtime::view::Element;
 
 use crate::{RuntimeInstance, SurfaceRuntime};
 
+#[cfg(target_os = "android")]
+fn mobile_error(message: impl std::fmt::Display) {
+    #[link(name = "log")]
+    unsafe extern "C" {
+        fn __android_log_write(
+            priority: std::os::raw::c_int,
+            tag: *const std::os::raw::c_char,
+            text: *const std::os::raw::c_char,
+        ) -> std::os::raw::c_int;
+    }
+    const ANDROID_LOG_ERROR: std::os::raw::c_int = 6;
+    let tag = c"WhiskerRust";
+    let Ok(text) = CString::new(message.to_string()) else {
+        return;
+    };
+    unsafe {
+        __android_log_write(ANDROID_LOG_ERROR, tag.as_ptr(), text.as_ptr());
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn mobile_error(message: impl std::fmt::Display) {
+    eprintln!("{message}");
+}
+
 pub type RequestFrameCallback = extern "C" fn(*mut c_void);
 
 struct MobileRuntime {
@@ -101,7 +126,7 @@ pub fn create(
     let mut runtime = RuntimeInstance::new(surface, wake);
     let modules = MobileModuleHost::new(module_data, invoke_module, observe_module);
     if let Err(error) = with_mobile_module_host(&modules, || runtime.mount(application)) {
-        eprintln!("Whisker mobile mount failed: {error}");
+        mobile_error(format_args!("Whisker mobile mount failed: {error}"));
         return std::ptr::null_mut();
     }
     let registrations = runtime.surface().element_registrations();
@@ -171,13 +196,13 @@ pub unsafe fn tick(
         )
     });
     if !mobile.drain_resource_commands() {
-        eprintln!("Whisker mobile Host rejected a resource command");
+        mobile_error("Whisker mobile Host rejected a resource command");
         return true;
     }
     match frame_result {
         Ok(drive) => !drive.needs_frame,
         Err(error) => {
-            eprintln!("Whisker mobile frame failed: {error}");
+            mobile_error(format_args!("Whisker mobile frame failed: {error}"));
             true
         }
     }

--- a/crates/whisker/src/runtime_instance.rs
+++ b/crates/whisker/src/runtime_instance.rs
@@ -1,7 +1,7 @@
 //! Host-driven lifecycle and frame execution for one application surface.
 
 use std::cell::RefCell;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
@@ -16,7 +16,10 @@ use crate::{
     RuntimeResourceError, SurfaceRuntime,
 };
 use whisker_engine::whisker_layout::LayoutSize;
-use whisker_engine::whisker_protocol::{ApplyResult, InputEvent, MeasurementReady, ResourceEvent};
+use whisker_engine::whisker_protocol::{
+    ApplyResult, InputEvent, InputEventKind, InputPoint, MeasurementReady, NodeId, PointerId,
+    PointerKind, ResourceEvent, WhiskerValue,
+};
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{DeferredMeasurementApply, FrameSink, LayoutOptions, MeasurementProvider};
 
@@ -123,8 +126,89 @@ pub struct RuntimeInstance {
     owner: Option<Owner>,
     lifecycle: RuntimeLifecycle,
     pending_input: RefCell<VecDeque<InputEvent>>,
+    activations: RefCell<ActivationRecognizer>,
     wake_enabled: Arc<AtomicBool>,
 }
+
+#[derive(Clone, Copy, Debug)]
+struct ActivationCandidate {
+    target: NodeId,
+    origin: InputPoint,
+    started_at_ms: f64,
+    pointer_kind: PointerKind,
+    cancelled: bool,
+}
+
+#[derive(Default)]
+struct ActivationRecognizer {
+    pointers: HashMap<PointerId, ActivationCandidate>,
+}
+
+impl ActivationRecognizer {
+    fn observe(&mut self, event: &InputEvent, hit_target: Option<NodeId>) -> Option<InputEvent> {
+        let pointer = event.pointer?;
+        match event.kind {
+            InputEventKind::PointerDown => {
+                if let Some(target) = hit_target {
+                    self.pointers.insert(
+                        pointer.id,
+                        ActivationCandidate {
+                            target,
+                            origin: pointer.position,
+                            started_at_ms: event.timestamp_ms,
+                            pointer_kind: pointer.kind,
+                            cancelled: false,
+                        },
+                    );
+                }
+                None
+            }
+            InputEventKind::PointerMove => {
+                let candidate = self.pointers.get_mut(&pointer.id)?;
+                let dx = pointer.position.x - candidate.origin.x;
+                let dy = pointer.position.y - candidate.origin.y;
+                if dx * dx + dy * dy > TAP_SLOP * TAP_SLOP {
+                    candidate.cancelled = true;
+                }
+                None
+            }
+            InputEventKind::PointerCancel => {
+                self.pointers.remove(&pointer.id);
+                None
+            }
+            InputEventKind::PointerUp => {
+                let candidate = self.pointers.remove(&pointer.id)?;
+                let elapsed = event.timestamp_ms - candidate.started_at_ms;
+                if candidate.cancelled
+                    || !(0.0..=TAP_TIMEOUT_MS).contains(&elapsed)
+                    || hit_target != Some(candidate.target)
+                {
+                    return None;
+                }
+                Some(InputEvent {
+                    surface: event.surface,
+                    timestamp_ms: event.timestamp_ms,
+                    kind: if candidate.pointer_kind == PointerKind::Mouse {
+                        InputEventKind::Click
+                    } else {
+                        InputEventKind::Tap
+                    },
+                    pointer: Some(pointer),
+                    target: Some(candidate.target),
+                    detail: WhiskerValue::Null,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.pointers.clear();
+    }
+}
+
+const TAP_SLOP: f32 = 10.0;
+const TAP_TIMEOUT_MS: f64 = 500.0;
 
 impl RuntimeInstance {
     /// Creates an unmounted runtime connected to one Host wake-up endpoint.
@@ -144,6 +228,7 @@ impl RuntimeInstance {
             owner: None,
             lifecycle: RuntimeLifecycle::Created,
             pending_input: RefCell::new(VecDeque::new()),
+            activations: RefCell::new(ActivationRecognizer::default()),
             wake_enabled,
         }
     }
@@ -187,6 +272,7 @@ impl RuntimeInstance {
     pub fn pause(&mut self) -> Result<(), RuntimeLifecycleError> {
         self.require(RuntimeLifecycle::Running, "pause")?;
         self.wake_enabled.store(false, Ordering::Release);
+        self.activations.borrow_mut().clear();
         let owner = self.owner.expect("a running runtime has a root owner");
         let surface = self.surface.clone();
         self.context.enter(|| {
@@ -231,6 +317,7 @@ impl RuntimeInstance {
             view::with_installed_renderer(surface.renderer(), || owner.dispose());
         });
         self.pending_input.borrow_mut().clear();
+        self.activations.borrow_mut().clear();
         self.context.shutdown();
         self.lifecycle = RuntimeLifecycle::Unmounted;
         Ok(())
@@ -409,7 +496,18 @@ impl RuntimeInstance {
         &self,
         event: &InputEvent,
     ) -> Result<InputDispatch, RuntimeInputError> {
-        let dispatch = self.surface.dispatch_input(event)?;
+        let mut dispatch = self.surface.dispatch_input(event)?;
+        let activation = self
+            .activations
+            .borrow_mut()
+            .observe(event, dispatch.target);
+        if let Some(activation) = activation {
+            let synthesized = self.surface.dispatch_input(&activation)?;
+            dispatch.target = synthesized.target.or(dispatch.target);
+            dispatch.consumed |= synthesized.consumed;
+            dispatch.listener_count += synthesized.listener_count;
+            dispatch.queued |= synthesized.queued;
+        }
         reactive::flush();
         reactive::flush_mounts();
         Ok(dispatch)

--- a/crates/whisker/src/standard_ui.rs
+++ b/crates/whisker/src/standard_ui.rs
@@ -1,6 +1,9 @@
 //! Rust-side definition of Whisker's built-in primitive element module.
 
 use crate::{ElementModuleDefinition, ElementProviderMetadata, ElementSchema, ElementTag};
+use whisker_engine::whisker_style::{
+    FlexDirectionValue, OverflowValue, SpecifiedStyle, StyleProperty, StyleValue,
+};
 
 #[whisker::builtin_component(
     name = "whisker.ui/View",
@@ -53,8 +56,28 @@ pub(crate) fn standard_element_providers() -> Vec<ElementProviderMetadata> {
     vec![
         ElementProviderMetadata::builtin(ElementTag::View, view_element_binding()),
         ElementProviderMetadata::builtin(ElementTag::Text, text_element_binding()),
-        ElementProviderMetadata::builtin(ElementTag::ScrollView, scroll_view_element_binding()),
+        ElementProviderMetadata::builtin(ElementTag::ScrollView, scroll_view_element_binding())
+            .with_base_style(scroll_view_base_style()),
     ]
+}
+
+fn scroll_view_base_style() -> SpecifiedStyle {
+    // A vertical ScrollView is a bounded viewport, not a row-shaped content
+    // container. Hidden layout overflow gives Taffy the CSS scroll-container
+    // automatic-minimum behavior; each native Host still owns scrolling.
+    SpecifiedStyle::new()
+        .push(
+            StyleProperty::FlexDirection,
+            StyleValue::FlexDirection(FlexDirectionValue::Column),
+        )
+        .push(
+            StyleProperty::OverflowX,
+            StyleValue::Overflow(OverflowValue::Hidden),
+        )
+        .push(
+            StyleProperty::OverflowY,
+            StyleValue::Overflow(OverflowValue::Hidden),
+        )
 }
 
 /// Returns the Rust-side module definition for `whisker.ui`.
@@ -93,6 +116,7 @@ mod tests {
         assert_eq!(definition.elements[0].schema, view_element_binding());
         assert_eq!(definition.elements[1].schema, text_element_binding());
         assert_eq!(definition.elements[2].schema, scroll_view_element_binding());
+        assert!(!definition.elements[2].base_style.is_empty());
         assert_eq!(
             definition.elements[0].authoring,
             crate::ElementAuthoringBinding::Builtin(ElementTag::View)

--- a/crates/whisker/src/surface_runtime.rs
+++ b/crates/whisker/src/surface_runtime.rs
@@ -659,6 +659,7 @@ struct BoundElement {
     node: Option<NodeId>,
     parent: Option<Element>,
     children: Vec<Element>,
+    base_specified: SpecifiedStyle,
     specified: SpecifiedStyle,
     resolved: Option<ResolvedNodeStyle>,
     text: Option<PlainTextInput>,
@@ -697,6 +698,12 @@ impl BoundElementKind {
             Self::RawText => None,
             Self::Registered { registration } => Some(registration),
         }
+    }
+}
+
+impl BoundElement {
+    fn effective_specified(&self) -> SpecifiedStyle {
+        self.base_specified.clone().merge(self.specified.clone())
     }
 }
 
@@ -894,7 +901,7 @@ impl BindingState {
         let Some(node) = entry.node else {
             return Ok(());
         };
-        let resolved = resolve_style(&entry.specified, parent, environment)?;
+        let resolved = resolve_style(&entry.effective_specified(), parent, environment)?;
         let children = entry.children.clone();
         updates.push(EnvironmentStyleUpdate {
             element,
@@ -947,8 +954,10 @@ impl BindingState {
         }
         let handle = Element::from_raw(self.next_element);
         self.next_element += 1;
-        let (kind, node, resolved, text) = if let Some(registration) = registration {
-            let resolved = resolve_style(&SpecifiedStyle::new(), None, self.environment)?;
+        let (kind, node, base_specified, resolved, text) = if let Some(registration) = registration
+        {
+            let base_specified = self.registry.base_style(&registration).clone();
+            let resolved = resolve_style(&base_specified, None, self.environment)?;
             let node = self.surface.create_node(
                 registration.element_type,
                 resolved.computed().layout().clone(),
@@ -960,11 +969,18 @@ impl BindingState {
             (
                 BoundElementKind::Registered { registration },
                 Some(node),
+                base_specified,
                 Some(resolved),
                 text,
             )
         } else {
-            (BoundElementKind::RawText, None, None, None)
+            (
+                BoundElementKind::RawText,
+                None,
+                SpecifiedStyle::new(),
+                None,
+                None,
+            )
         };
         self.elements.insert(
             handle,
@@ -973,6 +989,7 @@ impl BindingState {
                 node,
                 parent: None,
                 children: Vec::new(),
+                base_specified,
                 specified: SpecifiedStyle::new(),
                 resolved,
                 text,
@@ -1116,7 +1133,7 @@ impl BindingState {
         let Some(node) = entry.node else {
             return Ok(());
         };
-        let resolved = resolve_style(&entry.specified, parent_style, self.environment)?;
+        let resolved = resolve_style(&entry.effective_specified(), parent_style, self.environment)?;
         surface.update_computed_style(node, resolved.computed())?;
         let background = background_resources.reconcile_node(
             node,

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -1491,6 +1491,74 @@ fn pointer_hit_test_routes_capture_target_and_bubble_in_rust() {
 }
 
 #[test]
+fn raw_touch_stream_synthesizes_tap_but_drag_does_not() {
+    let surface = surface(36);
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    let taps = Rc::new(Cell::new(0));
+    let tap_count = Rc::clone(&taps);
+
+    runtime
+        .mount(move || {
+            render! {
+                view(
+                    style: css!(width: px(100), height: px(100)),
+                    on_tap: move |_| tap_count.set(tap_count.get() + 1),
+                )
+            }
+        })
+        .unwrap();
+
+    let mut measurements = NoMeasurement;
+    let mut sink = RecordingRenderer::new(surface.surface());
+    runtime
+        .drive_frame(
+            1.0,
+            StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+
+    let pointer = |timestamp_ms, kind, x, y, buttons| InputEvent {
+        surface: surface.surface(),
+        timestamp_ms,
+        kind,
+        pointer: Some(PointerInput {
+            id: PointerId::new(1).unwrap(),
+            kind: PointerKind::Touch,
+            position: InputPoint { x, y },
+            buttons,
+            changed_button: -1,
+        }),
+        target: None,
+        detail: WhiskerValue::Null,
+    };
+
+    runtime
+        .dispatch_input(&pointer(2.0, InputEventKind::PointerDown, 10.0, 10.0, 1))
+        .unwrap();
+    let up = runtime
+        .dispatch_input(&pointer(30.0, InputEventKind::PointerUp, 10.0, 10.0, 0))
+        .unwrap();
+    assert!(up.consumed);
+    assert_eq!(taps.get(), 1);
+
+    runtime
+        .dispatch_input(&pointer(40.0, InputEventKind::PointerDown, 10.0, 10.0, 1))
+        .unwrap();
+    runtime
+        .dispatch_input(&pointer(50.0, InputEventKind::PointerMove, 30.0, 10.0, 1))
+        .unwrap();
+    runtime
+        .dispatch_input(&pointer(60.0, InputEventKind::PointerUp, 30.0, 10.0, 0))
+        .unwrap();
+    assert_eq!(taps.get(), 1);
+}
+
+#[test]
 fn background_completion_parks_while_paused_and_resumes_on_host_drive() {
     let wakes = Arc::new(AtomicUsize::new(0));
     let wake_count = Arc::clone(&wakes);

--- a/examples/aurora-wallet/src/lib.rs
+++ b/examples/aurora-wallet/src/lib.rs
@@ -13,7 +13,10 @@
 //! state you'd built up (the selected segment, the hidden/shown balance,
 //! your scroll position) survives the patch.
 
-use whisker::css::{AlignItems, Color, Display, FlexDirection, FontWeight, JustifyContent, ToCss};
+use whisker::css::{
+    AlignItems, Color, ColorStop, Display, FlexDirection, FontWeight, Gradient, JustifyContent,
+    LinearDirection,
+};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_icons::{Icon, lucide};
@@ -28,7 +31,6 @@ const NEGATIVE: Color = Color::hex(0xFF6B6B); // expense
 const CURRENCY: &str = "$"; // try "€" / "£" / "¥"
 const USER: &str = "Alex"; // greeting name
 const CARD_RADIUS: i32 = 24; // balance-card corner radius
-const CARD_GRADIENT: &str = "linear-gradient(135deg, #7C5CFF 0%, #4E9BFF 100%)";
 // ─────────────────────────────────────────────────────────────────────
 
 fn muted() -> Color {
@@ -80,9 +82,6 @@ pub fn app() -> Element {
                 flex_grow: 1.0,
                 width: percent(100),
             ),
-            scroll_orientation: ScrollOrientation::Vertical,
-            scroll_bar_enable: false,
-            bounces: true,
         ) {
             view(style: css!(
                 display: Display::Flex,
@@ -129,7 +128,13 @@ pub fn app() -> Element {
                     border_radius: px(CARD_RADIUS),
                     padding: px(22),
                     margin_bottom: px(22),
-                ).raw("background", CARD_GRADIENT)) {
+                ).background_image(Gradient::Linear {
+                    direction: LinearDirection::ToBottomRight,
+                    stops: vec![
+                        ColorStop::new(ACCENT),
+                        ColorStop::new(Color::hex(0x4E9BFF)),
+                    ],
+                })) {
                     view(style: css!(
                         display: Display::Flex,
                         flex_direction: FlexDirection::Row,
@@ -229,7 +234,6 @@ fn segment(label: &'static str, index: usize, selected: RwSignal<usize>) -> Elem
             justify_content: JustifyContent::Center,
             background_color: if on { Color::hex(0xFF5CFF) } else { Color::rgba(0, 0, 0, 0.0) },
         )
-        .to_css_string()
     });
     let label_style = computed(move || {
         let on = selected.get() == index;
@@ -238,7 +242,6 @@ fn segment(label: &'static str, index: usize, selected: RwSignal<usize>) -> Elem
             font_weight: FontWeight::Numeric(600),
             color: if on { Color::hex(0xFFFFFF) } else { muted() },
         )
-        .to_css_string()
     });
 
     render! {

--- a/packages/whisker-icons/src/lib.rs
+++ b/packages/whisker-icons/src/lib.rs
@@ -49,6 +49,8 @@
 //! `packages/whisker-svg/{ios,android}/`. Icon bytes are vendored
 //! under `packages/whisker-icons/vendor/lucide/`.
 
+use whisker::css::ext::{em, percent, px, rem, vh, vw};
+use whisker::css::{Css, Size};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_svg::Svg;
@@ -72,15 +74,26 @@ pub fn icon(svg: Signal<String>, color: Signal<String>, size: Signal<String>) ->
     let style = computed(move || {
         let raw = size.get();
         let t = raw.trim();
-        // A bare number means `px`; anything with a unit passes through.
-        let has_unit = ["px", "em", "rem", "%", "vw", "vh"]
-            .iter()
-            .any(|u| t.ends_with(u));
-        if has_unit {
-            format!("width: {t}; height: {t};")
+        let value = |suffix: &str| {
+            t.strip_suffix(suffix)
+                .and_then(|value| value.trim().parse::<f32>().ok())
+        };
+        let size: Size = if let Some(value) = value("rem") {
+            rem(value).into()
+        } else if let Some(value) = value("px") {
+            px(value).into()
+        } else if let Some(value) = value("em") {
+            em(value).into()
+        } else if let Some(value) = value("vw") {
+            vw(value).into()
+        } else if let Some(value) = value("vh") {
+            vh(value).into()
+        } else if let Some(value) = value("%") {
+            percent(value).into()
         } else {
-            format!("width: {t}px; height: {t}px;")
-        }
+            px(t.parse::<f32>().unwrap_or_default()).into()
+        };
+        Css::new().width(size.clone()).height(size)
     });
 
     render! {

--- a/packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/WhiskerSvgView.kt
+++ b/packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/WhiskerSvgView.kt
@@ -25,7 +25,7 @@ open class WhiskerSvgView(context: WhiskerContext) : WhiskerUI<WhiskerSvgDrawing
      * (renders nothing).
      */
     fun setDisplayList(value: String) {
-        val v = view ?: return
+        val v = view()
         if (value.isEmpty()) {
             v.displayListBytes = null
             v.invalidate()
@@ -47,7 +47,7 @@ open class WhiskerSvgView(context: WhiskerContext) : WhiskerUI<WhiskerSvgDrawing
      * `stroke="currentColor"` — the `FILL_TINT` / `STROKE_TINT` opcodes.
      */
     fun setColor(value: String) {
-        val v = view ?: return
+        val v = view()
         v.tintArgb = parseCssColor(value)
         v.invalidate()
     }

--- a/packages/whisker-svg/src/lib.rs
+++ b/packages/whisker-svg/src/lib.rs
@@ -121,8 +121,20 @@ pub fn svg(content: Signal<String>, color: Signal<String>, style: Style) -> Elem
 /// signal "internal transport, not a user-facing API surface".
 /// (Whisker doesn't enforce visibility on Prop names yet — this
 /// is documentation-level.)
-#[whisker::module_component("Svg")]
+#[whisker::module_component(
+    name = "whisker-svg:Svg",
+    measurement = None,
+)]
 pub fn svg_renderer(display_list: Signal<String>, color: Signal<String>, style: Style) {}
+
+/// Element schemas exported by this package for surface bootstrap.
+#[doc(hidden)]
+pub fn __whisker_element_module_definition() -> whisker::ElementModuleDefinition {
+    whisker::ElementModuleDefinition::new(
+        env!("CARGO_PKG_NAME"),
+        [svg_renderer_schema::element_provider()],
+    )
+}
 
 /// Compile `svg_xml` to a base64-cased display list. Returns empty
 /// string on parse failure (the replayer treats that as

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -1,6 +1,7 @@
 package rs.whisker.runtime
 
 import android.content.Context
+import android.util.Log
 import android.view.View
 import java.util.concurrent.ConcurrentHashMap
 
@@ -147,6 +148,7 @@ private data class WhiskerBoundElement(
 
 /** Process-wide Host declaration registry and per-surface negotiated table. */
 public object WhiskerElementRegistry {
+    private const val LOG_TAG = "WhiskerElementRegistry"
     private val declarations = ConcurrentHashMap<String, WhiskerDeclaredElement>()
     @Volatile private var boundByType: Map<Int, WhiskerBoundElement> = emptyMap()
     @Volatile private var boundByName: Map<String, WhiskerBoundElement> = emptyMap()
@@ -195,22 +197,40 @@ public object WhiskerElementRegistry {
     /** Match Host strings to Rust registrations and compile compact dispatch tables. */
     @JvmStatic
     public fun bind(registrations: List<WhiskerElementRegistration>): Boolean {
+        fun reject(message: String): Boolean {
+            Log.e(LOG_TAG, "Host element bootstrap rejected: $message")
+            return false
+        }
+
         val byType = LinkedHashMap<Int, WhiskerBoundElement>()
         val byName = LinkedHashMap<String, WhiskerBoundElement>()
         for (registration in registrations) {
-            val declaration = declarations[registration.name] ?: return false
-            if ((registration.childPolicy == WhiskerChildPolicy.PlainText) != (declaration.factory.textUpdater != null)) return false
-            if (registration.measurement != WhiskerMeasurement.None && registration.measurement != WhiskerMeasurement.Text && declaration.factory.measurer == null) return false
+            val declaration = declarations[registration.name]
+                ?: return reject("no Host declaration for `${registration.name}`")
+            if ((registration.childPolicy == WhiskerChildPolicy.PlainText) != (declaration.factory.textUpdater != null)) {
+                return reject("child policy mismatch for `${registration.name}`: Rust=${registration.childPolicy}, Host text updater=${declaration.factory.textUpdater != null}")
+            }
+            if (registration.measurement != WhiskerMeasurement.None && registration.measurement != WhiskerMeasurement.Text && declaration.factory.measurer == null) {
+                return reject("missing Host measurer for `${registration.name}` (${registration.measurement})")
+            }
             val rustProps = registration.properties.associateBy { it.name }
-            if (rustProps.keys != declaration.properties.keys) return false
+            if (rustProps.keys != declaration.properties.keys) {
+                return reject("property mismatch for `${registration.name}`: Rust=${rustProps.keys.sorted()}, Host=${declaration.properties.keys.sorted()}")
+            }
             val rustEvents = registration.events.map { it.name }.toSet()
-            if (rustEvents != declaration.events) return false
+            if (rustEvents != declaration.events) {
+                return reject("event mismatch for `${registration.name}`: Rust=${rustEvents.sorted()}, Host=${declaration.events.sorted()}")
+            }
             val properties = registration.properties.associate { property ->
                 property.id to requireNotNull(declaration.properties[property.name])
             }
             val bound = WhiskerBoundElement(registration, declaration.factory, properties)
-            if (byType.put(registration.elementType, bound) != null) return false
-            if (byName.put(registration.name, bound) != null) return false
+            if (byType.put(registration.elementType, bound) != null) {
+                return reject("duplicate Rust element type ${registration.elementType}")
+            }
+            if (byName.put(registration.name, bound) != null) {
+                return reject("duplicate Rust element name `${registration.name}`")
+            }
         }
         boundByType = byType
         boundByName = byName

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -6,6 +6,7 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import android.view.Choreographer
 import android.view.MotionEvent
 import android.view.View
@@ -102,7 +103,11 @@ class WhiskerView(context: Context) :
             }
             val density = resources.displayMetrics.density
             nativeHandle = nativeCreate(width / density, height / density, density)
-            if (nativeHandle != 0L) requestFrameFromNative()
+            if (nativeHandle != 0L) {
+                requestFrameFromNative()
+            } else {
+                Log.e("WhiskerView", "Unable to create the Rust runtime; see bootstrap diagnostics above")
+            }
         }
     }
 
@@ -131,8 +136,8 @@ class WhiskerView(context: Context) :
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
         val childConsumed = super.dispatchTouchEvent(event)
-        val runtimeConsumed = dispatchPointerInput(event)
-        return childConsumed || runtimeConsumed
+        val runtimeReceived = dispatchPointerInput(event)
+        return childConsumed || runtimeReceived
     }
 
     override fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {
@@ -143,12 +148,12 @@ class WhiskerView(context: Context) :
 
     private fun dispatchPointerInput(event: MotionEvent): Boolean {
         val density = resources.displayMetrics.density
-        var consumed = false
-        normalizePointerInput(event, density).forEach { pointer ->
+        val pointers = normalizePointerInput(event, density)
+        pointers.forEach { pointer ->
             pointerInputObserver?.invoke(pointer)
             val handle = nativeHandle
             if (handle != 0L) {
-                consumed = nativeDispatchPointer(
+                nativeDispatchPointer(
                     handle,
                     pointer.timestampMs,
                     pointer.event,
@@ -158,10 +163,14 @@ class WhiskerView(context: Context) :
                     pointer.y,
                     pointer.buttons,
                     pointer.changedButton,
-                ) || consumed
+                )
             }
         }
-        return consumed
+        // Android requires the View that accepted ACTION_DOWN to retain the
+        // complete stream. Listener consumption is a Rust routing result, not
+        // an Android ownership decision, so receiving a normalized sample is
+        // enough to claim it while the runtime is mounted.
+        return nativeHandle != 0L && pointers.isNotEmpty()
     }
 
     /** Test-only observer at the production MotionEvent-to-runtime dispatch seam. */

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerWindow.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerWindow.kt
@@ -1,0 +1,40 @@
+package rs.whisker.runtime
+
+import android.app.Activity
+import android.graphics.Color
+import android.os.Build
+import android.view.WindowManager
+import androidx.core.view.WindowCompat
+
+/** Window-level defaults shared by generated and manually-authored Android Hosts. */
+public object WhiskerWindow {
+    /**
+     * Lets the Whisker surface own the complete window, including the areas
+     * behind the status/navigation bars and display cutout.
+     *
+     * Safe-area handling remains an application/module concern: this method
+     * changes the viewport and system-bar appearance but never injects padding.
+     */
+    @JvmStatic
+    @JvmOverloads
+    public fun enableEdgeToEdge(activity: Activity, darkSystemBarIcons: Boolean = false) {
+        val window = activity.window
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
+        WindowCompat.getInsetsController(window, window.decorView).apply {
+            isAppearanceLightStatusBars = darkSystemBarIcons
+            isAppearanceLightNavigationBars = darkSystemBarIcons
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            window.attributes = window.attributes.apply {
+                layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            }
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isStatusBarContrastEnforced = false
+            window.isNavigationBarContrastEnforced = false
+        }
+    }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
@@ -14,6 +14,7 @@ import android.text.TextUtils
 import android.text.style.LeadingMarginSpan
 import android.view.View
 import java.text.Bidi
+import kotlin.math.ceil
 import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerMeasureRequest
 import rs.whisker.runtime.resolveWhiskerTypeface
@@ -132,9 +133,9 @@ internal class HostMeasurementProvider(private val context: Context) {
             }
         }
         val maxWidthPx = if (availableWidthKind == DEFINITE && wrap != 0) {
-            (availableWidth * density).toInt().coerceAtLeast(1)
+            ceil(availableWidth * density).toInt().coerceAtLeast(1)
         } else {
-            (paint.measureText(text) + indentPixels).toInt().coerceAtLeast(1)
+            ceil(paint.measureText(text) + indentPixels).toInt().coerceAtLeast(1)
         }
         val builder = StaticLayout.Builder.obtain(
             layoutText, 0, layoutText.length, paint, maxWidthPx,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -106,7 +106,13 @@ internal class HostScene(
     }
 
     fun commit(): Boolean {
-        if (!validateStagedFrame()) return false
+        if (!validateStagedFrame()) {
+            Log.e(
+                "WhiskerView",
+                "Frame validation failed: snapshot=$stagedSnapshot, revision=$stagedTargetRevision, operations=${stagedOperations.size}",
+            )
+            return false
+        }
         return try {
             applyingFrame = true
             if (stagedSnapshot) clear()


### PR DESCRIPTION
## Summary

- make Android module discovery and local SDK linking work from generated applications
- enable edge-to-edge Android windows and keep the Whisker surface constrained to the Host viewport
- add module-owned ScrollView defaults so tall content remains scrollable
- synthesize tap and click activations from raw pointer streams and retain Android touch-stream ownership through pointer up
- fix Android text measurement rounding and migrate Aurora SVG, gradient, and dynamic styles to the typed module path
- add actionable Android runtime, module, frame, and resource diagnostics

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p whisker -p whisker-layout -p whisker-cng`
- `cargo test -p whisker-layout -p whisker --lib`
- `cargo test -p whisker --test runtime_instance`
- `cargo test -p whisker-cng generated_activity_only_composes_the_sdk_view`
- Android `:app:assembleDebug`
- Pixel emulator: verified edge-to-edge layout, full-width viewport, vertical scrolling, and Day/Week/Month tab interaction