### PR TITLE
fix(ios): complete Aurora Wallet host integration

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -487,6 +487,7 @@ pub struct XcodebuildArgs<'a> {
 pub fn stage_module_swift_sources(
     gen_ios: &Path,
     modules: &[crate::modules::ResolvedModule],
+    workspace_root: &Path,
 ) -> Result<()> {
     let root = gen_ios.join("whisker_modules");
     let sources_root = root.join("Sources/WhiskerModules");
@@ -506,9 +507,22 @@ pub fn stage_module_swift_sources(
         .filter(|m| m.manifest_dir.join("Package.swift").is_file())
         .collect();
 
+    // A Whisker source checkout contains the root Swift package that owns
+    // WhiskerModule, WhiskerRuntime, and the codegen plugin. Prefer it while
+    // developing the framework itself so the generated app tests the current
+    // Host sources instead of the last published SDK tag. Consumer workspaces
+    // do not have this layout and continue to resolve the released package.
+    let local_whisker_package = workspace_root
+        .join("platforms/ios/Sources/WhiskerRuntime")
+        .is_dir()
+        .then_some(workspace_root);
+
     let package_path = root.join("Package.swift");
-    std::fs::write(&package_path, render_modules_package_swift(&ios_modules))
-        .with_context(|| format!("write {}", package_path.display()))?;
+    std::fs::write(
+        &package_path,
+        render_modules_package_swift(local_whisker_package, &ios_modules),
+    )
+    .with_context(|| format!("write {}", package_path.display()))?;
 
     let register_all_path = sources_root.join("RegisterAll.swift");
     std::fs::write(&register_all_path, render_register_all_swift(&ios_modules))
@@ -580,9 +594,14 @@ fn ios_platform_major(modules: &[&crate::modules::ResolvedModule]) -> u32 {
 }
 
 /// Render `Package.swift` for the generated `WhiskerModules`
-/// aggregator. Depends on the released `WhiskerRuntime` package + each
-/// discovered module package via local-path SwiftPM dependency.
-fn render_modules_package_swift(modules: &[&crate::modules::ResolvedModule]) -> String {
+/// aggregator. Depends on the current checkout's `WhiskerRuntime` package
+/// while developing Whisker, or the released package from consumer
+/// workspaces, plus each discovered module package via local-path SwiftPM
+/// dependency.
+fn render_modules_package_swift(
+    local_whisker_package: Option<&Path>,
+    modules: &[&crate::modules::ResolvedModule],
+) -> String {
     let mut out = String::new();
     out.push_str(
         "// swift-tools-version:5.9\n\
@@ -612,11 +631,18 @@ fn render_modules_package_swift(modules: &[&crate::modules::ResolvedModule]) -> 
     out.push_str("        .library(name: \"WhiskerModules\", targets: [\"WhiskerModules\"]),\n");
     out.push_str("    ],\n");
     out.push_str("    dependencies: [\n");
-    out.push_str(&format!(
-        "        .package(url: {url:?}, exact: {version:?}),\n",
-        url = WHISKER_IOS_SPM_URL,
-        version = WHISKER_IOS_SPM_VERSION,
-    ));
+    if let Some(path) = local_whisker_package {
+        out.push_str(&format!(
+            "        .package(name: \"whisker\", path: {path:?}),\n",
+            path = path.display().to_string(),
+        ));
+    } else {
+        out.push_str(&format!(
+            "        .package(url: {url:?}, exact: {version:?}),\n",
+            url = WHISKER_IOS_SPM_URL,
+            version = WHISKER_IOS_SPM_VERSION,
+        ));
+    }
     for m in modules {
         // The module's SwiftPM package is rooted at the package
         // directory (Package.swift lives there, identity = the
@@ -974,13 +1000,21 @@ mod tests {
     }
 
     #[test]
-    fn generated_aggregator_links_the_source_host_runtime() {
-        let manifest = render_modules_package_swift(&[]);
+    fn generated_aggregator_links_the_released_host_runtime_for_consumers() {
+        let manifest = render_modules_package_swift(None, &[]);
         assert!(manifest.contains(&format!(
             ".package(url: {WHISKER_IOS_SPM_URL:?}, exact: {WHISKER_IOS_SPM_VERSION:?})"
         )));
         assert!(manifest.contains(".product(name: \"WhiskerRuntime\", package: \"whisker\")"));
         assert!(!manifest.contains(".package(name: \"whisker\", path:"));
+    }
+
+    #[test]
+    fn generated_aggregator_prefers_the_in_tree_host_runtime() {
+        let manifest = render_modules_package_swift(Some(Path::new("/workspace/whisker")), &[]);
+        assert!(manifest.contains(".package(name: \"whisker\", path: \"/workspace/whisker\")"));
+        assert!(!manifest.contains(WHISKER_IOS_SPM_URL));
+        assert!(manifest.contains(".product(name: \"WhiskerRuntime\", package: \"whisker\")"));
     }
 
     /// Every module package and the generated aggregator pin the runtime

--- a/crates/whisker-cli/src/build/ios.rs
+++ b/crates/whisker-cli/src/build/ios.rs
@@ -111,7 +111,7 @@ pub fn run(args: Args) -> Result<()> {
     // no-op package even with zero modules so `import WhiskerModules`
     // always resolves.
     let modules = whisker_build::modules::discover(&workspace_root.join("Cargo.toml"), &m.package)?;
-    whisker_build::ios::stage_module_swift_sources(&sync.gen_dir, &modules)?;
+    whisker_build::ios::stage_module_swift_sources(&sync.gen_dir, &modules, &workspace_root)?;
 
     let ipa = whisker_build::ios::archive_and_export(&IosReleaseInputs {
         gen_dir: &sync.gen_dir,

--- a/crates/whisker-dev-server/src/builder.rs
+++ b/crates/whisker-dev-server/src/builder.rs
@@ -138,6 +138,7 @@ impl Builder {
 
     async fn build_ios_simulator(&self) -> Result<()> {
         let workspace_root = self.workspace_root.clone();
+        let crate_dir = self.crate_dir.clone();
         let package = self.package.clone();
         let features = self.features.clone();
         tokio::task::spawn_blocking(move || -> Result<()> {
@@ -158,6 +159,21 @@ impl Builder {
                 },
                 &built_products,
             )?;
+            // The generated Xcode project imports the local
+            // `gen/ios/whisker_modules` Swift package. Unlike CNG-owned
+            // project files, this package reflects Cargo's current module
+            // dependency graph and must be staged on every cold build before
+            // Installer invokes xcodebuild. Keep this symmetric with the
+            // Android module staging above and with `whisker build ipa`.
+            let modules =
+                whisker_build::modules::discover(&workspace_root.join("Cargo.toml"), &package)
+                    .context("discover iOS Whisker modules")?;
+            whisker_build::ios::stage_module_swift_sources(
+                &crate_dir.join("gen/ios"),
+                &modules,
+                &workspace_root,
+            )
+            .context("stage iOS Whisker modules")?;
             Ok(())
         })
         .await

--- a/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
@@ -19,6 +19,12 @@ public final class WhiskerScrollContainerView: UIScrollView {
     public override init(frame: CGRect) {
         super.init(frame: frame)
         alwaysBounceVertical = false
+        // Whisker lays out against the complete edge-to-edge viewport and
+        // exposes safe-area insets separately through the SafeArea module.
+        // UIKit's automatic adjustment would add those insets a second time
+        // and make the Host disagree with Rust about every child coordinate.
+        contentInsetAdjustmentBehavior = .never
+        automaticallyAdjustsScrollIndicatorInsets = false
         addSubview(contentView)
     }
 

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -28,7 +28,9 @@ public final class WhiskerView: UIView {
         }
     )
 
-    private var logicalBounds: CGRect { bounds.inset(by: safeAreaInsets) }
+    private var logicalBounds: CGRect {
+        edgeToEdgeViewportBounds(bounds, safeAreaInsets: safeAreaInsets)
+    }
 
     public override init(frame: CGRect) {
         super.init(frame: frame)

--- a/platforms/ios/Sources/WhiskerRuntime/input/PointerInput.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/input/PointerInput.swift
@@ -1,5 +1,17 @@
 import UIKit
 
+/// The runtime viewport owns the complete Host view, including the regions
+/// behind the status bar and home indicator. Safe-area insets remain available
+/// independently through `WhiskerInsetsDispatcher`; they never shrink the
+/// surface itself.
+func edgeToEdgeViewportBounds(
+    _ bounds: CGRect,
+    safeAreaInsets: UIEdgeInsets
+) -> CGRect {
+    _ = safeAreaInsets
+    return bounds
+}
+
 func logicalPointerPosition(_ location: CGPoint, viewport: CGRect) -> CGPoint {
     CGPoint(x: location.x - viewport.minX, y: location.y - viewport.minY)
 }

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -332,8 +332,9 @@ final class WhiskerNodeView: UIView {
     }
 
     private func updateOverflowMask() {
+        let host = overflowClipHost()
         guard clipsOverflowHorizontally || clipsOverflowVertically else {
-            sceneChildrenHost().layer.mask = nil
+            host.layer.mask = nil
             return
         }
         let compositionBounds = hostCompositionBounds()
@@ -343,7 +344,6 @@ final class WhiskerNodeView: UIView {
             horizontal: clipsOverflowHorizontally,
             vertical: clipsOverflowVertically
         )
-        let host = sceneChildrenHost()
         let origin = host.convert(CGPoint.zero, from: self)
         let xUnit = host.convert(CGPoint(x: 1, y: 0), from: self)
         let yUnit = host.convert(CGPoint(x: 0, y: 1), from: self)
@@ -366,6 +366,21 @@ final class WhiskerNodeView: UIView {
         overflowMask.backgroundColor = UIColor.clear.cgColor
         overflowMask.fillColor = UIColor.white.cgColor
         host.layer.mask = overflowMask
+    }
+
+    /// Returns the stationary view that owns the element's clipping viewport.
+    ///
+    /// A children host is allowed to move inside its element root. In
+    /// particular, `UIScrollView` translates its content view as the user
+    /// scrolls. Attaching the overflow mask to that moving content view would
+    /// pin the mask to the initial content coordinates and permanently hide
+    /// every child that started outside the first viewport. The mounted root
+    /// remains stationary and is therefore the correct clip coordinate space.
+    private func overflowClipHost() -> UIView {
+        if let mountedElement, mountedElement.childrenHost() != nil {
+            return mountedElement.view
+        }
+        return defaultChildrenHost
     }
 
     private func updateClipPathMask() {

--- a/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
+++ b/tests/host-conformance/runners/ios/Tests/HostConformanceTests.swift
@@ -111,6 +111,58 @@ final class HostConformanceTests: XCTestCase {
         )
     }
 
+    func testViewportIncludesSystemBarRegions() {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 844)
+        XCTAssertEqual(
+            edgeToEdgeViewportBounds(
+                bounds,
+                safeAreaInsets: UIEdgeInsets(top: 47, left: 0, bottom: 34, right: 0)
+            ),
+            bounds
+        )
+    }
+
+    func testScrollViewDoesNotInjectSafeAreaInsets() {
+        let scrollView = WhiskerScrollContainerView(frame: .zero)
+        XCTAssertEqual(scrollView.contentInsetAdjustmentBehavior, .never)
+        XCTAssertFalse(scrollView.automaticallyAdjustsScrollIndicatorInsets)
+        XCTAssertEqual(scrollView.contentInset, .zero)
+    }
+
+    func testScrollOverflowClipUsesStationaryViewportInsteadOfMovingContent() throws {
+        let registration = WhiskerElementRegistration(
+            elementType: 3,
+            name: WhiskerBuiltInElements.scrollViewName,
+            childPolicy: .elements,
+            measurement: .none
+        )
+        XCTAssertTrue(WhiskerElementRegistry.bind([registration]))
+        let mounted = try XCTUnwrap(WhiskerElementRegistry.mount(3) { _, _ in })
+        let scrollView = try XCTUnwrap(mounted.view as? WhiskerScrollContainerView)
+        let node = WhiskerNodeView(element: registration.name)
+        node.mountedElement = mounted
+        node.addSubview(scrollView)
+        node.mountedContentDidInstall()
+        node.contentFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        node.setLayoutFrame(CGRect(x: 0, y: 0, width: 100, height: 100))
+        node.layoutIfNeeded()
+
+        let initiallyOffscreenChild = UIView(frame: CGRect(x: 0, y: 150, width: 100, height: 50))
+        scrollView.contentView.addSubview(initiallyOffscreenChild)
+        scrollView.setNeedsLayout()
+        scrollView.layoutIfNeeded()
+        node.setOverflowClip(horizontal: true, vertical: true)
+
+        XCTAssertTrue(scrollView.layer.mask != nil)
+        XCTAssertNil(scrollView.contentView.layer.mask)
+        XCTAssertGreaterThan(scrollView.contentSize.height, scrollView.bounds.height)
+
+        scrollView.contentOffset = CGPoint(x: 0, y: 100)
+        scrollView.layoutIfNeeded()
+        XCTAssertTrue(scrollView.layer.mask != nil)
+        XCTAssertNil(scrollView.contentView.layer.mask)
+    }
+
     func testUIKitTouchTypesMapToProtocolPointerKinds() {
         XCTAssertEqual(hostPointerKind(for: .direct), .touch)
         XCTAssertEqual(hostPointerKind(for: .pencil), .pen)


### PR DESCRIPTION
## Summary

- stage the generated iOS module aggregator during cold `whisker run ios` builds and use the checked-out Host SDK while developing Whisker
- expose the full edge-to-edge UIKit bounds as the Rust viewport while keeping safe-area insets available through the SafeArea module
- disable UIKit's automatic `UIScrollView` safe-area inset adjustment
- attach overflow clipping to the stationary element root so content outside the initial viewport remains visible after scrolling
- add focused iOS Host regression tests for viewport, scroll insets, and moving-content clipping

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p whisker-build generated_aggregator`
- `cargo test -p whisker-dev-server`
- `cargo check -p whisker-cli`
- `cargo xtask host-conformance ios`
