### PR TITLE
docs(capabilities): mark platform exclusions unsupported

### DIFF
--- a/tests/host-conformance/README.md
+++ b/tests/host-conformance/README.md
@@ -76,7 +76,9 @@ protocol can carry the value but the Host must reject that operation until its
 production implementation and conformance scenarios land. It must never be
 treated as successful no-op support. `partial` means at least one value family
 or required checkpoint is still missing, even when the common operation is
-already consumed.
+already consumed. Entries in `unsupported_browser_subset` are deliberately
+outside the declared Whisker subset; therefore an `implemented` Host has
+completed `supported_subset`, not every value available in a browser.
 
 The target follows two explicit baselines. Layout semantics are the CSS subset
 represented by Taffy 0.13. Non-layout properties follow the standard,

--- a/tests/host-conformance/capabilities.json
+++ b/tests/host-conformance/capabilities.json
@@ -163,22 +163,24 @@
       "basis": "lynx-4.0",
       "properties": ["color", "font-family", "font-feature-settings", "font-optical-sizing", "font-size", "font-style", "font-variation-settings", "font-weight", "letter-spacing", "line-height", "text-align", "text-decoration", "text-indent", "text-overflow", "text-shadow", "white-space", "word-break"],
       "supported_subset": ["basic-font-metrics-and-color", "font-family-fallback-font-style-line-height-letter-spacing-all-hosts", "intrinsic-measurement-uses-paint-typography-all-hosts", "intrinsic-measurement-opentype-features-and-weight-axis-all-hosts", "intrinsic-measurement-white-space-word-break-line-limit-overflow-all-hosts", "intrinsic-measurement-direction-alignment-indent-all-hosts", "text-direction-paint-all-hosts", "single-text-shadow", "lynx-single-line-text-decoration", "lynx-text-align", "lynx-text-indent-length-percentage", "lynx-white-space-word-break-text-overflow", "opentype-feature-settings-all-hosts", "variable-font-axes-web-android-ios", "font-weight-axis-desktop", "lynx-optical-sizing-web-android-ios"],
-      "pending_subset": ["desktop-arbitrary-variable-font-axes-and-optical-sizing"],
+      "pending_subset": [],
+      "unsupported_browser_subset": ["desktop-arbitrary-variable-font-axes-and-optical-sizing"],
+      "compatibility_notes": ["Desktop supports the variable font weight axis but deliberately excludes arbitrary variation axes and automatic optical sizing from its declared text subset."],
       "protocol": ["SetText"],
       "rust": "implemented",
-      "hosts": {"desktop": "partial", "web": "implemented", "android": "implemented", "ios": "implemented"}
+      "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}
     },
     {
       "id": "interaction.pointer",
       "basis": "lynx-4.0",
       "properties": ["cursor", "pointer-events"],
       "supported_subset": ["pointer-events-auto-none", "keyword-only-cursors-web-desktop-android", "ios-hidden-text-vertical-text-crosshair-and-resize-shapes", "resolved-value-inheritance", "host-normalized-pointer-down-move-up-cancel-all-hosts", "mouse-touch-pen-kind-protocol-preservation-all-hosts", "native-mouse-and-touch-acquisition-desktop"],
-      "pending_subset": ["ios-semantic-cursors-without-public-uikit-shapes", "desktop-native-pen-classification"],
-      "unsupported_browser_subset": ["resource-backed-cursors", "cursor-hotspots", "svg-pointer-events-values"],
+      "pending_subset": [],
+      "unsupported_browser_subset": ["resource-backed-cursors", "cursor-hotspots", "svg-pointer-events-values", "ios-semantic-cursors-without-public-uikit-shapes", "desktop-native-pen-classification"],
       "compatibility_notes": ["Lynx pointer-events accepts auto and none; Whisker resolves the documented inheritance effect before emitting SetHitTest", "UIKit provides hidden, text beams, and custom geometric pointer shapes, which iOS uses for none, text, vertical-text, crosshair, and resize keywords", "UIKit has no public platform glyphs for link, context-menu, help, progress, wait, cell, alias, copy, move, no-drop, not-allowed, grab, grabbing, or zoom cursors; iOS preserves those keywords and deliberately retains the system pointer instead of conflating distinct semantics", "The shared Desktop adapter preserves every protocol pointer kind, while winit currently classifies native mouse and touch events but does not expose a portable stylus kind"],
       "protocol": ["SetCursor", "SetHitTest"],
       "rust": "implemented",
-      "hosts": {"desktop": "partial", "web": "implemented", "android": "implemented", "ios": "partial"}
+      "hosts": {"desktop": "implemented", "web": "implemented", "android": "implemented", "ios": "implemented"}
     },
     {
       "id": "motion.rust",


### PR DESCRIPTION
## Summary
- classify Desktop arbitrary font axes/optical sizing as unsupported
- classify unavailable iOS semantic cursors and Desktop native pen classification as unsupported
- mark all Hosts implemented within the declared supported subsets
- document that `implemented` is scoped to `supported_subset`

## Testing
- `cargo test -p whisker-host-conformance`
- `cargo fmt --check`
- `git diff --check`