### PR TITLE
feat(svg): support web and desktop hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4676,6 +4682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4864,6 +4876,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -6333,11 +6370,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-svg-desktop-host"
+version = "0.12.0"
+dependencies = [
+ "base64 0.22.1",
+ "csscolorparser",
+ "tiny-skia",
+ "whisker-desktop",
+ "whisker-svg",
+]
+
+[[package]]
 name = "whisker-svg-example"
 version = "0.1.0"
 dependencies = [
  "whisker",
  "whisker-svg",
+]
+
+[[package]]
+name = "whisker-svg-web-host"
+version = "0.12.0"
+dependencies = [
+ "base64 0.22.1",
+ "whisker-svg",
+ "whisker-web",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ members = [
     "packages/whisker-status-bar",
     "packages/whisker-web-browser",
     "packages/whisker-svg",
+    "packages/whisker-svg/desktop",
+    "packages/whisker-svg/web",
     "packages/whisker-svg/example",
     "packages/whisker-video",
     "packages/whisker-audio",
@@ -134,6 +136,7 @@ whisker-web = { path = "platforms/web", version = "0.12.0" }
 whisker-router = { path = "packages/whisker-router", version = "0.12.0" }
 whisker-router-macros = { path = "packages/whisker-router-macros", version = "0.12.0" }
 whisker-toggle = { path = "packages/whisker-toggle", version = "0.12.0" }
+whisker-svg = { path = "packages/whisker-svg", version = "0.12.0" }
 
 anyhow = "1"
 thiserror = "2"

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -733,21 +733,22 @@ impl SurfaceRuntime {
             }
             event.validate().map_err(RuntimeInputError::InvalidInput)?;
             let root = state.root.ok_or(RuntimeInputError::MissingRoot)?;
-            let target = if let Some(target) = event.target {
+            let captured = event
+                .pointer
+                .and_then(|pointer| state.surface.pointer_capture_target(pointer.id));
+            let target = if let Some(captured) = captured {
+                Some(captured)
+            } else if let Some(target) = event.target {
                 if state.surface.node(target).is_none() {
                     return Err(RuntimeInputError::UnknownTarget { node: target });
                 }
                 Some(target)
             } else if let Some(pointer) = event.pointer {
-                if let Some(captured) = state.surface.pointer_capture_target(pointer.id) {
-                    Some(captured)
-                } else {
-                    state
-                        .surface
-                        .hit_test(root, pointer.position)
-                        .map_err(RuntimeBindingError::from)
-                        .map_err(RuntimeInputError::Binding)?
-                }
+                state
+                    .surface
+                    .hit_test(root, pointer.position)
+                    .map_err(RuntimeBindingError::from)
+                    .map_err(RuntimeInputError::Binding)?
             } else {
                 None
             };

--- a/examples/aurora-wallet/src/lib.rs
+++ b/examples/aurora-wallet/src/lib.rs
@@ -31,6 +31,11 @@ const NEGATIVE: Color = Color::hex(0xFF6B6B); // expense
 const CURRENCY: &str = "$"; // try "€" / "£" / "¥"
 const USER: &str = "Alex"; // greeting name
 const CARD_RADIUS: i32 = 24; // balance-card corner radius
+const TOP_PADDING: i32 = if cfg!(any(target_os = "android", target_os = "ios")) {
+    64
+} else {
+    20
+};
 // ─────────────────────────────────────────────────────────────────────
 
 fn muted() -> Color {
@@ -87,7 +92,7 @@ pub fn app() -> Element {
                 display: Display::Flex,
                 flex_direction: FlexDirection::Column,
                 padding: px(20),
-                padding_top: px(64),
+                padding_top: px(TOP_PADDING),
                 padding_bottom: px(40),
             )) {
                 // ── Header ───────────────────────────────────────────

--- a/examples/aurora-wallet/src/lib.rs
+++ b/examples/aurora-wallet/src/lib.rs
@@ -150,7 +150,10 @@ pub fn app() -> Element {
                             style: css!(color: Color::rgba(255, 255, 255, 0.85), font_size: px(14)),
                             value: "Total balance",
                         )
-                        view(on_tap: move |_| hidden.set(!hidden.get())) {
+                        view(
+                            on_tap: move |_| hidden.set(!hidden.get()),
+                            on_click: move |_| hidden.set(!hidden.get()),
+                        ) {
                             Icon(svg: eye_icon, color: "#FFFFFF", size: "18")
                         }
                     }
@@ -250,7 +253,11 @@ fn segment(label: &'static str, index: usize, selected: RwSignal<usize>) -> Elem
     });
 
     render! {
-        view(style: pill_style, on_tap: move |_| selected.set(index)) {
+        view(
+            style: pill_style,
+            on_tap: move |_| selected.set(index),
+            on_click: move |_| selected.set(index),
+        ) {
             text(style: label_style, value: label)
         }
     }

--- a/packages/whisker-svg/CHANGELOG.md
+++ b/packages/whisker-svg/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Web SVG-DOM and Desktop raster Host implementations.
+
 ## [0.11.1](https://github.com/whiskerrs/whisker/compare/whisker-svg-v0.11.0...whisker-svg-v0.11.1) - 2026-08-12
 
 ### Other

--- a/packages/whisker-svg/Cargo.toml
+++ b/packages/whisker-svg/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Whisker SVG widget — `Svg(content: …, color: …, style: …)`. Compiles inline SVG XML to the v1 display-list byte stream defined in `SPEC.md` and hands it to the iOS / Android replayer modules over `WhiskerValue::Bytes` (base64-cased through the existing string Prop pipeline to avoid C ABI churn)."
+description = "Whisker SVG widget with native Android, iOS, Web, and Desktop host renderers."
 
 # Explicit include — mirrors whisker-image / whisker-safe-area:
 # `cargo publish` ships the Kotlin + Swift platform sources next to
@@ -30,7 +30,11 @@ include = [
 crate-type = ["rlib"]
 
 # Module-system opt-in marker — same as whisker-image / whisker-video.
-[package.metadata.whisker]
+[package.metadata.whisker.desktop]
+package = "whisker-svg-desktop-host"
+
+[package.metadata.whisker.web]
+package = "whisker-svg-web-host"
 
 [dependencies]
 whisker = { workspace = true }

--- a/packages/whisker-svg/SPEC.md
+++ b/packages/whisker-svg/SPEC.md
@@ -1,11 +1,11 @@
 # whisker-svg display-list binary format — SPEC v1
 
 This document is the **single source of truth** for the byte format
-transported through `WhiskerValue::Bytes` between
+transported as the base64-encoded `display-list` module Prop between
 `packages/whisker-svg` (Rust producer) and the per-platform
-replayers in `packages/whisker-svg/{ios,android}/`. All three
-implementations MUST validate against this document. Changes here
-require updating every implementation in lockstep.
+replayers in `packages/whisker-svg/{android,ios,web,desktop}/`.
+All host implementations MUST validate against this document.
+Changes here require updating every implementation in lockstep.
 
 ## Design goals
 

--- a/packages/whisker-svg/desktop/Cargo.toml
+++ b/packages/whisker-svg/desktop/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "whisker-svg-desktop-host"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Desktop Host implementation for whisker-svg."
+
+[dependencies]
+base64 = { workspace = true }
+csscolorparser = "0.7.2"
+tiny-skia = { version = "0.11", default-features = false, features = ["std", "simd"] }
+whisker-desktop = { workspace = true }
+whisker-svg = { workspace = true }

--- a/packages/whisker-svg/desktop/src/lib.rs
+++ b/packages/whisker-svg/desktop/src/lib.rs
@@ -1,0 +1,406 @@
+//! Desktop Host implementation for `whisker-svg`.
+
+use std::sync::Mutex;
+
+use base64::Engine;
+use tiny_skia::{FillRule, Paint, Path, PathBuilder, Pixmap, Stroke};
+use whisker_desktop::{
+    DesktopRaster, DesktopViewDefinition, ModuleDefinition, WhiskerModule, WhiskerValue,
+};
+use whisker_svg::{Color, Transform, Visitor, replay};
+
+#[derive(Debug)]
+struct SvgDesktopView {
+    display_list: Vec<u8>,
+    tint: Color,
+    generation: u64,
+    cache: Mutex<Option<CachedRaster>>,
+}
+
+#[derive(Debug)]
+struct CachedRaster {
+    generation: u64,
+    width: u32,
+    height: u32,
+    raster: DesktopRaster,
+}
+
+impl Default for SvgDesktopView {
+    fn default() -> Self {
+        Self {
+            display_list: Vec::new(),
+            tint: Color::BLACK,
+            generation: 0,
+            cache: Mutex::new(None),
+        }
+    }
+}
+
+impl SvgDesktopView {
+    fn set_display_list(&mut self, encoded: &str) {
+        self.display_list = if encoded.is_empty() {
+            Vec::new()
+        } else {
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .unwrap_or_default()
+        };
+        self.invalidate();
+    }
+
+    fn set_color(&mut self, value: &str) {
+        self.tint = parse_color(value);
+        self.invalidate();
+    }
+
+    fn invalidate(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        *self
+            .cache
+            .get_mut()
+            .expect("SVG raster cache lock poisoned") = None;
+    }
+
+    fn rasterize(&self, width: u32, height: u32) -> Option<DesktopRaster> {
+        if self.display_list.is_empty() || width == 0 || height == 0 {
+            return None;
+        }
+        let mut cache = self.cache.lock().expect("SVG raster cache lock poisoned");
+        if let Some(cached) = cache.as_ref()
+            && cached.generation == self.generation
+            && cached.width == width
+            && cached.height == height
+        {
+            return Some(cached.raster.clone());
+        }
+        let raster = render_raster(
+            &self.display_list,
+            self.tint,
+            self.generation,
+            width,
+            height,
+        )?;
+        *cache = Some(CachedRaster {
+            generation: self.generation,
+            width,
+            height,
+            raster: raster.clone(),
+        });
+        Some(raster)
+    }
+}
+
+struct SvgModule;
+
+#[WhiskerModule]
+impl WhiskerModule for SvgModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new().view(
+            DesktopViewDefinition::new("whisker-svg:Svg", SvgDesktopView::default)
+                .prop(
+                    "display-list",
+                    |view, value| {
+                        let WhiskerValue::String(value) = value else {
+                            unreachable!("Desktop Host validates SVG property shapes")
+                        };
+                        view.set_display_list(value);
+                    },
+                    |view| view.set_display_list(""),
+                )
+                .prop(
+                    "color",
+                    |view, value| {
+                        let WhiskerValue::String(value) = value else {
+                            unreachable!("Desktop Host validates SVG property shapes")
+                        };
+                        view.set_color(value);
+                    },
+                    |view| view.set_color(""),
+                )
+                .raster(SvgDesktopView::rasterize),
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PaintSource {
+    Literal(Color),
+    Tint,
+}
+
+#[derive(Clone, Copy)]
+struct State {
+    transform: tiny_skia::Transform,
+    fill: Option<PaintSource>,
+    stroke: Option<PaintSource>,
+    stroke_width: f32,
+    opacity: f32,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            transform: tiny_skia::Transform::identity(),
+            fill: Some(PaintSource::Literal(Color::BLACK)),
+            stroke: None,
+            stroke_width: 1.0,
+            opacity: 1.0,
+        }
+    }
+}
+
+struct RasterVisitor {
+    pixmap: Pixmap,
+    size: [f32; 2],
+    tint: Color,
+    state: State,
+    stack: Vec<State>,
+    builder: Option<PathBuilder>,
+    path: Option<Path>,
+}
+
+impl RasterVisitor {
+    fn new(width: u32, height: u32, tint: Color) -> Option<Self> {
+        Some(Self {
+            pixmap: Pixmap::new(width, height)?,
+            size: [width as f32, height as f32],
+            tint,
+            state: State::default(),
+            stack: Vec::new(),
+            builder: None,
+            path: None,
+        })
+    }
+
+    fn builder(&mut self) -> &mut PathBuilder {
+        self.path = None;
+        self.builder.get_or_insert_with(PathBuilder::new)
+    }
+
+    fn finish_path(&mut self) -> Option<&Path> {
+        if self.path.is_none() {
+            self.path = self.builder.take().and_then(PathBuilder::finish);
+        }
+        self.path.as_ref()
+    }
+
+    fn paint(&self, source: PaintSource) -> Paint<'static> {
+        let color = match source {
+            PaintSource::Literal(color) => color,
+            PaintSource::Tint => self.tint,
+        };
+        let alpha =
+            ((color.a as f32 * self.state.opacity.clamp(0.0, 1.0)).round()).clamp(0.0, 255.0) as u8;
+        let mut paint = Paint::default();
+        paint.set_color_rgba8(color.r, color.g, color.b, alpha);
+        paint
+    }
+
+    fn draw_fill(&mut self) {
+        let Some(source) = self.state.fill else {
+            return;
+        };
+        let paint = self.paint(source);
+        let transform = self.state.transform;
+        let Some(path) = self.finish_path().cloned() else {
+            return;
+        };
+        self.pixmap
+            .fill_path(&path, &paint, FillRule::Winding, transform, None);
+    }
+
+    fn draw_stroke(&mut self) {
+        let Some(source) = self.state.stroke else {
+            return;
+        };
+        let paint = self.paint(source);
+        let transform = self.state.transform;
+        let stroke = Stroke {
+            width: self.state.stroke_width.max(0.0),
+            ..Stroke::default()
+        };
+        let Some(path) = self.finish_path().cloned() else {
+            return;
+        };
+        self.pixmap
+            .stroke_path(&path, &paint, &stroke, transform, None);
+    }
+
+    fn into_straight_rgba(mut self) -> Vec<u8> {
+        for pixel in self.pixmap.data_mut().chunks_exact_mut(4) {
+            let alpha = pixel[3];
+            if alpha == 0 {
+                pixel[..3].fill(0);
+            } else if alpha < 255 {
+                for channel in &mut pixel[..3] {
+                    *channel =
+                        ((*channel as u32 * 255 + alpha as u32 / 2) / alpha as u32).min(255) as u8;
+                }
+            }
+        }
+        self.pixmap.take()
+    }
+}
+
+impl Visitor for RasterVisitor {
+    fn save(&mut self) {
+        self.stack.push(self.state);
+    }
+
+    fn restore(&mut self) {
+        if let Some(state) = self.stack.pop() {
+            self.state = state;
+        }
+    }
+
+    fn concat(&mut self, transform: &Transform) {
+        self.state.transform = self.state.transform.pre_concat(to_skia(*transform));
+    }
+
+    fn viewport(&mut self, min_x: f32, min_y: f32, width: f32, height: f32) {
+        if width <= 0.0 || height <= 0.0 {
+            return;
+        }
+        let scale = (self.size[0] / width).min(self.size[1] / height);
+        let tx = (self.size[0] - width * scale) * 0.5 - min_x * scale;
+        let ty = (self.size[1] - height * scale) * 0.5 - min_y * scale;
+        self.state.transform = self
+            .state
+            .transform
+            .pre_concat(tiny_skia::Transform::from_row(
+                scale, 0.0, 0.0, scale, tx, ty,
+            ));
+    }
+
+    fn fill_color(&mut self, color: Color) {
+        self.state.fill = Some(PaintSource::Literal(color));
+    }
+
+    fn stroke_color(&mut self, color: Color) {
+        self.state.stroke = Some(PaintSource::Literal(color));
+    }
+
+    fn stroke_width(&mut self, width: f32) {
+        self.state.stroke_width = width;
+    }
+
+    fn opacity(&mut self, alpha: f32) {
+        self.state.opacity = alpha.clamp(0.0, 1.0);
+    }
+
+    fn fill_tint(&mut self) {
+        self.state.fill = Some(PaintSource::Tint);
+    }
+
+    fn stroke_tint(&mut self) {
+        self.state.stroke = Some(PaintSource::Tint);
+    }
+
+    fn path_begin(&mut self) {
+        self.builder = Some(PathBuilder::new());
+        self.path = None;
+    }
+
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.builder().move_to(x, y);
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.builder().line_to(x, y);
+    }
+
+    fn quad_to(&mut self, cx: f32, cy: f32, x: f32, y: f32) {
+        self.builder().quad_to(cx, cy, x, y);
+    }
+
+    fn cubic_to(&mut self, c1x: f32, c1y: f32, c2x: f32, c2y: f32, x: f32, y: f32) {
+        self.builder().cubic_to(c1x, c1y, c2x, c2y, x, y);
+    }
+
+    fn close(&mut self) {
+        self.builder().close();
+    }
+
+    fn fill(&mut self) {
+        self.draw_fill();
+    }
+
+    fn stroke(&mut self) {
+        self.draw_stroke();
+    }
+
+    fn fill_and_stroke(&mut self) {
+        self.draw_fill();
+        self.draw_stroke();
+    }
+}
+
+fn render_raster(
+    bytes: &[u8],
+    tint: Color,
+    generation: u64,
+    width: u32,
+    height: u32,
+) -> Option<DesktopRaster> {
+    let mut visitor = RasterVisitor::new(width, height, tint)?;
+    replay(bytes, &mut visitor).ok()?;
+    DesktopRaster::new(generation, width, height, visitor.into_straight_rgba()).ok()
+}
+
+fn to_skia(transform: Transform) -> tiny_skia::Transform {
+    tiny_skia::Transform::from_row(
+        transform.a,
+        transform.b,
+        transform.c,
+        transform.d,
+        transform.tx,
+        transform.ty,
+    )
+}
+
+fn parse_color(value: &str) -> Color {
+    value
+        .parse::<csscolorparser::Color>()
+        .map(|color| {
+            let [r, g, b, a] = color.to_rgba8();
+            Color::rgba(r, g, b, a)
+        })
+        .unwrap_or(Color::BLACK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_color_rasterizes_with_transparent_background() {
+        let compiled = whisker_svg::compile(
+            r#"<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="currentColor"/></svg>"#,
+        )
+        .unwrap();
+        let raster =
+            render_raster(&compiled.bytes, Color::rgba(12, 34, 56, 255), 7, 20, 10).unwrap();
+        assert_eq!(raster.generation(), 7);
+        assert_eq!([raster.width(), raster.height()], [20, 10]);
+        assert_eq!(&raster.pixels()[0..4], &[0, 0, 0, 0]);
+        let center = ((5 * 20 + 10) * 4) as usize;
+        assert_eq!(&raster.pixels()[center..center + 4], &[12, 34, 56, 255]);
+    }
+
+    #[test]
+    fn raster_cache_reuses_generation_and_size() {
+        let compiled =
+            whisker_svg::compile(r#"<svg viewBox="0 0 1 1"><rect width="1" height="1"/></svg>"#)
+                .unwrap();
+        let view = SvgDesktopView {
+            display_list: compiled.bytes,
+            ..SvgDesktopView::default()
+        };
+        let first = view.rasterize(8, 8).unwrap();
+        let second = view.rasterize(8, 8).unwrap();
+        assert_eq!(first.generation(), second.generation());
+        assert_eq!(first.pixels(), second.pixels());
+    }
+}

--- a/packages/whisker-svg/example/Cargo.toml
+++ b/packages/whisker-svg/example/Cargo.toml
@@ -3,7 +3,7 @@ name = "whisker-svg-example"
 version = "0.1.0"
 edition = "2024"
 publish = false
-description = "Example app for `whisker-svg`. Renders a small gallery of SVGs (solid fills, strokes, currentColor tinting) so visual + on-device verification of the display-list replayer happens in one place. The iOS / Android test targets defined in the parent `whisker-svg` package's `Package.swift` / `build.gradle.kts` are reachable through this example's gen/ project — `cd gen/android && ./gradlew :whisker-svg:testDebugUnitTest`, `cd gen/ios && xcodebuild -scheme WhiskerSvg test`."
+description = "Example app for visual and on-device verification of whisker-svg on Android, iOS, Web, and Desktop."
 
 [lib]
 crate-type = ["rlib"]

--- a/packages/whisker-svg/src/compile.rs
+++ b/packages/whisker-svg/src/compile.rs
@@ -53,8 +53,7 @@ pub struct Compiled {
     /// emitted unconditionally, and at minimum every successful
     /// compile contains that opcode plus the trailing end marker.
     ///
-    /// Pass straight through `WhiskerValue::Bytes` (or, in the
-    /// current transport, the base64-encoded `display_list:` prop)
+    /// Pass through the current base64-encoded `display_list:` Prop
     /// to the platform replayer. The bytes carry no input-side
     /// references — they're freely copyable across the FFI
     /// boundary and don't depend on `svg_xml` staying alive.

--- a/packages/whisker-svg/src/lib.rs
+++ b/packages/whisker-svg/src/lib.rs
@@ -33,11 +33,10 @@
 //! the v1 display-list byte stream defined in
 //! `packages/whisker-svg/SPEC.md`. The bytes are base64-encoded
 //! and sent through the standard Whisker `apply_attr` stringified-
-//! value path — Whisker's existing C ABI doesn't expose a "binary
-//! Prop" channel, and the iOS / Android replayer modules accept
-//! the base64 directly. A future PR can swap the transport without
-//! touching the platform replayer logic (the base64 layer is paint
-//! around the `display_list` Prop only).
+//! value path — Whisker's existing module contract doesn't expose
+//! a binary Prop channel, and each host replayer accepts the base64
+//! directly. A future transport can change this without touching
+//! the platform replay logic.
 //!
 //! ## Tinting
 //!
@@ -55,6 +54,8 @@
 //!   (view: `WhiskerSvgView.swift`, decoder: `DisplayListReplayer.swift`)
 //! - Android: `packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/SvgModule.kt`
 //!   (view: `WhiskerSvgView.kt`, decoder: `DisplayListReplayer.kt`)
+//! - Web: `packages/whisker-svg/web/src/lib.rs`
+//! - Desktop: `packages/whisker-svg/desktop/src/lib.rs`
 
 // Modules below are `#[doc(hidden)]` — `pub` for the `tests/` crate
 // integration tests, but not part of the SemVer surface. The

--- a/packages/whisker-svg/src/replay.rs
+++ b/packages/whisker-svg/src/replay.rs
@@ -4,12 +4,10 @@
 //!
 //! The same `replay` function powers Rust-side unit tests
 //! (`TraceVisitor` records every call and assertions compare the
-//! trace to a golden file) and will, in the future, power any
-//! Rust-side rasteriser. The per-platform replayers in
-//! `packages/whisker-svg/{ios,android}/` are independent
-//! reimplementations of this logic against the same SPEC; the
-//! cross-platform tests in `tests/` verify that all three agree
-//! by feeding them identical fixture bytes.
+//! trace to a golden file), the Web SVG-DOM renderer, and the
+//! Desktop rasterizer. The Swift and Kotlin replayers are independent
+//! implementations of this logic against the same SPEC. All hosts
+//! consume the same fixture-generated display-list bytes.
 
 use crate::builder::{Color, Transform};
 use crate::format::*;

--- a/packages/whisker-svg/tests/fixtures_test.rs
+++ b/packages/whisker-svg/tests/fixtures_test.rs
@@ -5,8 +5,7 @@
 //! [`TraceVisitor`], and asserts the trace matches the matching
 //! `*.trace.txt`. Also asserts the produced bytes match
 //! `*.bin` — those byte files are the canonical cross-platform
-//! fixtures consumed by the iOS / Android replayer tests in
-//! `packages/whisker-svg/`.
+//! fixtures consumed by each Host replayer.
 //!
 //! ## Updating goldens
 //!

--- a/packages/whisker-svg/web/Cargo.toml
+++ b/packages/whisker-svg/web/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "whisker-svg-web-host"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web Host implementation for whisker-svg."
+
+[dependencies]
+base64 = { workspace = true }
+whisker-svg = { workspace = true }
+whisker-web = { workspace = true }

--- a/packages/whisker-svg/web/src/lib.rs
+++ b/packages/whisker-svg/web/src/lib.rs
@@ -1,0 +1,344 @@
+//! Web Host implementation for `whisker-svg`.
+
+use base64::Engine;
+use whisker_svg::{Color, Transform, Visitor, replay};
+use whisker_web::{
+    ModuleDefinition, WebViewDefinition, WhiskerModule, WhiskerValue, wasm_bindgen, web_sys,
+};
+
+const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
+
+#[derive(Debug)]
+struct SvgWebView {
+    element: web_sys::Element,
+}
+
+impl SvgWebView {
+    fn set_display_list(&mut self, encoded: &str) -> Result<(), wasm_bindgen::JsValue> {
+        if encoded.is_empty() {
+            self.element.set_inner_html("");
+            self.element.remove_attribute("viewBox")?;
+            return Ok(());
+        }
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|error| {
+                wasm_bindgen::JsValue::from_str(&format!(
+                    "whisker-svg display-list is not valid base64: {error}"
+                ))
+            })?;
+        let rendered = render_display_list(&bytes).map_err(|error| {
+            wasm_bindgen::JsValue::from_str(&format!(
+                "whisker-svg display-list replay failed: {error:?}"
+            ))
+        })?;
+        if let Some(view_box) = rendered.view_box {
+            self.element.set_attribute("viewBox", &view_box)?;
+        } else {
+            self.element.remove_attribute("viewBox")?;
+        }
+        self.element.set_inner_html(&rendered.body);
+        Ok(())
+    }
+
+    fn set_color(&mut self, color: &str) -> Result<(), wasm_bindgen::JsValue> {
+        if color.trim().is_empty() {
+            self.element.remove_attribute("color")
+        } else {
+            self.element.set_attribute("color", color)
+        }
+    }
+}
+
+struct SvgModule;
+
+#[WhiskerModule]
+impl WhiskerModule for SvgModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new().view(
+            WebViewDefinition::new(
+                "whisker-svg:Svg",
+                |document, _emitter| {
+                    let element = document.create_element_ns(Some(SVG_NAMESPACE), "svg")?;
+                    element.set_attribute("preserveAspectRatio", "xMidYMid meet")?;
+                    element.set_attribute("aria-hidden", "true")?;
+                    element.set_attribute("focusable", "false")?;
+                    Ok(SvgWebView { element })
+                },
+                |view| view.element.clone(),
+            )
+            .prop(
+                "display-list",
+                |view, value| {
+                    let WhiskerValue::String(value) = value else {
+                        return Err(wasm_bindgen::JsValue::from_str(
+                            "Svg display-list property must be a string",
+                        ));
+                    };
+                    view.set_display_list(value)
+                },
+                |view| view.set_display_list(""),
+            )
+            .prop(
+                "color",
+                |view, value| {
+                    let WhiskerValue::String(value) = value else {
+                        return Err(wasm_bindgen::JsValue::from_str(
+                            "Svg color property must be a string",
+                        ));
+                    };
+                    view.set_color(value)
+                },
+                |view| view.set_color(""),
+            ),
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Paint {
+    Literal(Color),
+    Tint,
+}
+
+#[derive(Clone, Copy)]
+struct State {
+    transform: Transform,
+    fill: Option<Paint>,
+    stroke: Option<Paint>,
+    stroke_width: f32,
+    opacity: f32,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            transform: Transform::IDENTITY,
+            fill: Some(Paint::Literal(Color::BLACK)),
+            stroke: None,
+            stroke_width: 1.0,
+            opacity: 1.0,
+        }
+    }
+}
+
+#[derive(Default)]
+struct SvgMarkupVisitor {
+    state: State,
+    stack: Vec<State>,
+    path: String,
+    body: String,
+    view_box: Option<String>,
+}
+
+struct RenderedSvg {
+    view_box: Option<String>,
+    body: String,
+}
+
+fn render_display_list(bytes: &[u8]) -> Result<RenderedSvg, whisker_svg::ReplayError> {
+    let mut visitor = SvgMarkupVisitor::default();
+    replay(bytes, &mut visitor)?;
+    Ok(RenderedSvg {
+        view_box: visitor.view_box,
+        body: visitor.body,
+    })
+}
+
+impl SvgMarkupVisitor {
+    fn push_number(target: &mut String, value: f32) {
+        use std::fmt::Write;
+        let _ = write!(target, "{value}");
+    }
+
+    fn append_path(&mut self, fill: bool, stroke: bool) {
+        use std::fmt::Write;
+        if self.path.is_empty() {
+            return;
+        }
+        self.body.push_str("<path d=\"");
+        self.body.push_str(&self.path);
+        self.body.push('"');
+        if fill {
+            write_paint(&mut self.body, "fill", self.state.fill);
+        } else {
+            self.body.push_str(" fill=\"none\"");
+        }
+        if stroke {
+            write_paint(&mut self.body, "stroke", self.state.stroke);
+            let _ = write!(
+                self.body,
+                " stroke-width=\"{}\" stroke-linecap=\"butt\" stroke-linejoin=\"miter\"",
+                self.state.stroke_width
+            );
+        } else {
+            self.body.push_str(" stroke=\"none\"");
+        }
+        let transform = self.state.transform;
+        if transform != Transform::IDENTITY {
+            let _ = write!(
+                self.body,
+                " transform=\"matrix({} {} {} {} {} {})\"",
+                transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty,
+            );
+        }
+        if self.state.opacity < 1.0 {
+            let _ = write!(self.body, " opacity=\"{}\"", self.state.opacity);
+        }
+        self.body.push_str("/>");
+    }
+}
+
+impl Visitor for SvgMarkupVisitor {
+    fn save(&mut self) {
+        self.stack.push(self.state);
+    }
+
+    fn restore(&mut self) {
+        if let Some(state) = self.stack.pop() {
+            self.state = state;
+        }
+    }
+
+    fn concat(&mut self, transform: &Transform) {
+        self.state.transform = multiply(self.state.transform, *transform);
+    }
+
+    fn viewport(&mut self, min_x: f32, min_y: f32, width: f32, height: f32) {
+        self.view_box = Some(format!("{min_x} {min_y} {width} {height}"));
+    }
+
+    fn fill_color(&mut self, color: Color) {
+        self.state.fill = Some(Paint::Literal(color));
+    }
+
+    fn stroke_color(&mut self, color: Color) {
+        self.state.stroke = Some(Paint::Literal(color));
+    }
+
+    fn stroke_width(&mut self, width: f32) {
+        self.state.stroke_width = width;
+    }
+
+    fn opacity(&mut self, alpha: f32) {
+        self.state.opacity = alpha.clamp(0.0, 1.0);
+    }
+
+    fn fill_tint(&mut self) {
+        self.state.fill = Some(Paint::Tint);
+    }
+
+    fn stroke_tint(&mut self) {
+        self.state.stroke = Some(Paint::Tint);
+    }
+
+    fn path_begin(&mut self) {
+        self.path.clear();
+    }
+
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.path.push('M');
+        Self::push_number(&mut self.path, x);
+        self.path.push(' ');
+        Self::push_number(&mut self.path, y);
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.path.push('L');
+        Self::push_number(&mut self.path, x);
+        self.path.push(' ');
+        Self::push_number(&mut self.path, y);
+    }
+
+    fn quad_to(&mut self, cx: f32, cy: f32, x: f32, y: f32) {
+        self.path.push('Q');
+        for value in [cx, cy, x, y] {
+            Self::push_number(&mut self.path, value);
+            self.path.push(' ');
+        }
+    }
+
+    fn cubic_to(&mut self, c1x: f32, c1y: f32, c2x: f32, c2y: f32, x: f32, y: f32) {
+        self.path.push('C');
+        for value in [c1x, c1y, c2x, c2y, x, y] {
+            Self::push_number(&mut self.path, value);
+            self.path.push(' ');
+        }
+    }
+
+    fn close(&mut self) {
+        self.path.push('Z');
+    }
+
+    fn fill(&mut self) {
+        self.append_path(true, false);
+    }
+
+    fn stroke(&mut self) {
+        self.append_path(false, true);
+    }
+
+    fn fill_and_stroke(&mut self) {
+        self.append_path(true, true);
+    }
+}
+
+fn write_paint(target: &mut String, name: &str, paint: Option<Paint>) {
+    use std::fmt::Write;
+    match paint {
+        Some(Paint::Literal(color)) => {
+            let _ = write!(
+                target,
+                " {name}=\"#{:02x}{:02x}{:02x}{:02x}\"",
+                color.r, color.g, color.b, color.a,
+            );
+        }
+        Some(Paint::Tint) => {
+            let _ = write!(target, " {name}=\"currentColor\"");
+        }
+        None => {
+            let _ = write!(target, " {name}=\"none\"");
+        }
+    }
+}
+
+fn multiply(left: Transform, right: Transform) -> Transform {
+    Transform {
+        a: left.a * right.a + left.c * right.b,
+        b: left.b * right.a + left.d * right.b,
+        c: left.a * right.c + left.c * right.d,
+        d: left.b * right.c + left.d * right.d,
+        tx: left.a * right.tx + left.c * right.ty + left.tx,
+        ty: left.b * right.tx + left.d * right.ty + left.ty,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_list_becomes_scalable_svg_markup() {
+        let compiled = whisker_svg::compile(
+            r#"<svg viewBox="0 0 24 24"><path d="M2 3 L20 3 L20 21 Z" fill="currentColor"/></svg>"#,
+        )
+        .unwrap();
+        let rendered = render_display_list(&compiled.bytes).unwrap();
+        assert_eq!(rendered.view_box.as_deref(), Some("0 0 24 24"));
+        assert!(rendered.body.contains("fill=\"currentColor\""));
+        assert!(rendered.body.contains("M2 3L20 3L20 21Z"));
+    }
+
+    #[test]
+    fn literal_color_and_transform_are_preserved() {
+        let compiled = whisker_svg::compile(
+            r##"<svg viewBox="0 0 10 10"><g transform="translate(2 3)"><rect width="4" height="5" fill="#ff000080"/></g></svg>"##,
+        )
+        .unwrap();
+        let rendered = render_display_list(&compiled.bytes).unwrap();
+        assert!(rendered.body.contains("fill=\"#ff000080\""));
+        assert!(rendered.body.contains("transform=\"matrix(1 0 0 1 2 3)\""));
+    }
+}

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -60,6 +60,7 @@ type DesktopPropSetter<T> = Arc<dyn Fn(&mut T, &WhiskerValue) + Send + Sync>;
 type DesktopPropClearer<T> = Arc<dyn Fn(&mut T) + Send + Sync>;
 type DesktopCommandHandler<T> =
     Arc<dyn Fn(&mut T, &WhiskerValue) -> Option<DesktopNativeEvent> + Send + Sync>;
+type DesktopRasterizer<T> = Arc<dyn Fn(&T, u32, u32) -> Option<DesktopRaster> + Send + Sync>;
 
 struct DesktopPropBinding<T> {
     set: DesktopPropSetter<T>,
@@ -82,6 +83,7 @@ pub struct DesktopViewDefinition<T> {
     properties: HashMap<String, DesktopPropBinding<T>>,
     events: HashSet<String>,
     commands: HashMap<String, DesktopCommandHandler<T>>,
+    rasterizer: Option<DesktopRasterizer<T>>,
     plain_text: bool,
 }
 
@@ -97,6 +99,7 @@ where
             properties: HashMap::new(),
             events: HashSet::new(),
             commands: HashMap::new(),
+            rasterizer: None,
             plain_text: false,
         }
     }
@@ -163,6 +166,20 @@ where
         self
     }
 
+    /// Declares module-owned raster content painted inside the element's
+    /// computed content box.
+    pub fn raster(
+        mut self,
+        rasterize: impl Fn(&T, u32, u32) -> Option<DesktopRaster> + Send + Sync + 'static,
+    ) -> Self {
+        assert!(
+            self.rasterizer.replace(Arc::new(rasterize)).is_none(),
+            "duplicate Desktop raster binding for {}",
+            self.name,
+        );
+        self
+    }
+
     fn bind(&self, registration: &ElementRegistration) -> Result<NativeConstructor, String> {
         if registration.child_policy.accepts_plain_text() != self.plain_text {
             return Err(format!(
@@ -217,6 +234,7 @@ where
             create: Arc::clone(&self.create),
             properties,
             commands,
+            rasterizer: self.rasterizer.clone(),
         });
         Ok(Arc::new(move || {
             Box::new(DeclaredDesktopElement {
@@ -242,6 +260,7 @@ struct BoundDesktopViewDefinition<T> {
     create: Arc<dyn Fn() -> T + Send + Sync>,
     properties: HashMap<PropertyId, DesktopPropBinding<T>>,
     commands: HashMap<CommandId, DesktopCommandHandler<T>>,
+    rasterizer: Option<DesktopRasterizer<T>>,
 }
 
 struct DeclaredDesktopElement<T> {
@@ -288,6 +307,17 @@ where
             .get(&command)
             .expect("Desktop Host validates command IDs");
         handler(&mut self.state, arguments)
+    }
+
+    fn rasterize(&self, width: u32, height: u32) -> Option<DesktopRaster> {
+        self.definition
+            .rasterizer
+            .as_ref()
+            .and_then(|rasterize| rasterize(&self.state, width, height))
+    }
+
+    fn has_raster_content(&self) -> bool {
+        self.definition.rasterizer.is_some()
     }
 }
 
@@ -453,6 +483,103 @@ pub struct DesktopNativeEvent {
     pub detail: WhiskerValue,
 }
 
+/// RGBA8 content produced by a module-owned Desktop element.
+///
+/// The module keeps vector decoding or native drawing dependencies on its own
+/// side of the Host boundary. The shared Desktop renderer only uploads this
+/// platform-neutral pixel buffer and composites it with common Whisker layout,
+/// clipping, transforms, and opacity.
+#[derive(Clone, Debug)]
+pub struct DesktopRaster {
+    generation: u64,
+    width: u32,
+    height: u32,
+    pixels: Arc<[u8]>,
+}
+
+impl DesktopRaster {
+    /// Creates a validated straight-alpha RGBA8 raster.
+    pub fn new(
+        generation: u64,
+        width: u32,
+        height: u32,
+        pixels: impl Into<Arc<[u8]>>,
+    ) -> Result<Self, DesktopRasterError> {
+        let pixels = pixels.into();
+        let expected = width
+            .checked_mul(height)
+            .and_then(|count| count.checked_mul(4))
+            .map(|count| count as usize)
+            .ok_or(DesktopRasterError::DimensionsOverflow)?;
+        if width == 0 || height == 0 {
+            return Err(DesktopRasterError::EmptyDimensions);
+        }
+        if pixels.len() != expected {
+            return Err(DesktopRasterError::ByteLength {
+                actual: pixels.len(),
+                expected,
+            });
+        }
+        Ok(Self {
+            generation,
+            width,
+            height,
+            pixels,
+        })
+    }
+
+    /// Module-defined generation used by the GPU upload cache.
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Physical pixel width.
+    pub const fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Physical pixel height.
+    pub const fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Straight-alpha RGBA8 bytes in row-major order.
+    pub fn pixels(&self) -> &[u8] {
+        &self.pixels
+    }
+}
+
+/// Invalid module-owned Desktop raster data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DesktopRasterError {
+    /// Width or height was zero.
+    EmptyDimensions,
+    /// Computing `width * height * 4` overflowed.
+    DimensionsOverflow,
+    /// The RGBA8 payload did not match its dimensions.
+    ByteLength {
+        /// Received byte count.
+        actual: usize,
+        /// Required byte count.
+        expected: usize,
+    },
+}
+
+impl fmt::Display for DesktopRasterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyDimensions => formatter.write_str("Desktop raster dimensions are empty"),
+            Self::DimensionsOverflow => formatter.write_str("Desktop raster dimensions overflow"),
+            Self::ByteLength { actual, expected } => write!(
+                formatter,
+                "Desktop raster has {actual} bytes, expected {expected}",
+            ),
+        }
+    }
+}
+
+impl Error for DesktopRasterError {}
+
 /// Target definition implemented beside an external element's Rust schema.
 ///
 /// The schema remains the source of truth for valid IDs and value shapes; the
@@ -470,6 +597,20 @@ pub trait DesktopNativeElement: fmt::Debug + 'static {
         command: CommandId,
         arguments: &WhiskerValue,
     ) -> Option<DesktopNativeEvent>;
+
+    /// Produces element-owned pixels for the requested physical bounds.
+    ///
+    /// Implementations should cache by `(generation, width, height)` and may
+    /// return `None` for empty or temporarily unavailable content. The default
+    /// keeps state-only custom elements allocation-free.
+    fn rasterize(&self, _width: u32, _height: u32) -> Option<DesktopRaster> {
+        None
+    }
+
+    /// Whether this element contributes raster content at all.
+    fn has_raster_content(&self) -> bool {
+        false
+    }
 }
 
 /// Built-in element implementations contributed by the Desktop platform.
@@ -511,6 +652,16 @@ impl DesktopElementContent {
             Self::Text(content) => content.as_ref(),
             Self::Native { text, .. } => text.as_ref(),
             Self::Empty | Self::ScrollContainer => None,
+        }
+    }
+
+    pub(crate) fn rasterizer(&self) -> Option<&dyn DesktopNativeElement> {
+        match self {
+            Self::Native { implementation, .. } if implementation.has_raster_content() => {
+                Some(implementation.as_ref())
+            }
+            Self::Native { .. } => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
         }
     }
 
@@ -849,6 +1000,25 @@ mod tests {
     use whisker_style::StyleEnvironment;
 
     use super::*;
+
+    #[test]
+    fn desktop_raster_validates_dimensions_and_rgba_length() {
+        assert_eq!(
+            DesktopRaster::new(1, 0, 1, Vec::<u8>::new()).unwrap_err(),
+            DesktopRasterError::EmptyDimensions,
+        );
+        assert_eq!(
+            DesktopRaster::new(1, 2, 2, vec![0; 15]).unwrap_err(),
+            DesktopRasterError::ByteLength {
+                actual: 15,
+                expected: 16,
+            },
+        );
+        let raster = DesktopRaster::new(7, 2, 2, vec![255; 16]).unwrap();
+        assert_eq!(raster.generation(), 7);
+        assert_eq!((raster.width(), raster.height()), (2, 2));
+        assert_eq!(raster.pixels(), &[255; 16]);
+    }
 
     #[test]
     fn built_in_module_binds_view_text_and_scroll_through_one_registry() {

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -85,6 +85,7 @@ pub struct DesktopViewDefinition<T> {
     commands: HashMap<String, DesktopCommandHandler<T>>,
     rasterizer: Option<DesktopRasterizer<T>>,
     plain_text: bool,
+    scroll_content: bool,
 }
 
 impl<T> DesktopViewDefinition<T>
@@ -101,6 +102,7 @@ where
             commands: HashMap::new(),
             rasterizer: None,
             plain_text: false,
+            scroll_content: false,
         }
     }
 
@@ -108,6 +110,12 @@ where
     /// content through the common Desktop text renderer.
     pub fn plain_text(mut self) -> Self {
         self.plain_text = true;
+        self
+    }
+
+    /// Declares that the Host object owns transient vertical scroll state.
+    pub fn scroll_container(mut self) -> Self {
+        self.scroll_content = true;
         self
     }
 
@@ -235,6 +243,7 @@ where
             properties,
             commands,
             rasterizer: self.rasterizer.clone(),
+            scroll_content: self.scroll_content,
         });
         Ok(Arc::new(move || {
             Box::new(DeclaredDesktopElement {
@@ -261,6 +270,7 @@ struct BoundDesktopViewDefinition<T> {
     properties: HashMap<PropertyId, DesktopPropBinding<T>>,
     commands: HashMap<CommandId, DesktopCommandHandler<T>>,
     rasterizer: Option<DesktopRasterizer<T>>,
+    scroll_content: bool,
 }
 
 struct DeclaredDesktopElement<T> {
@@ -318,6 +328,10 @@ where
 
     fn has_raster_content(&self) -> bool {
         self.definition.rasterizer.is_some()
+    }
+
+    fn is_scroll_container(&self) -> bool {
+        self.definition.scroll_content
     }
 }
 
@@ -611,6 +625,11 @@ pub trait DesktopNativeElement: fmt::Debug + 'static {
     fn has_raster_content(&self) -> bool {
         false
     }
+
+    /// Whether this element owns transient vertical scroll state.
+    fn is_scroll_container(&self) -> bool {
+        false
+    }
 }
 
 /// Built-in element implementations contributed by the Desktop platform.
@@ -624,7 +643,7 @@ impl WhiskerModule for BuiltInElementModule {
         DesktopModuleDefinition::new()
             .view(DesktopViewDefinition::new("whisker.ui/View", || ()))
             .view(DesktopViewDefinition::new("whisker.ui/Text", || ()).plain_text())
-            .view(DesktopViewDefinition::new("whisker.ui/ScrollView", || ()))
+            .view(DesktopViewDefinition::new("whisker.ui/ScrollView", || ()).scroll_container())
     }
 }
 
@@ -647,6 +666,14 @@ pub(crate) enum DesktopElementContent {
 }
 
 impl DesktopElementContent {
+    pub(crate) fn is_scroll_container(&self) -> bool {
+        match self {
+            Self::ScrollContainer => true,
+            Self::Native { implementation, .. } => implementation.is_scroll_container(),
+            Self::Empty | Self::Text(_) => false,
+        }
+    }
+
     pub(crate) fn text(&self) -> Option<&TextContent> {
         match self {
             Self::Text(content) => content.as_ref(),
@@ -1029,6 +1056,10 @@ mod tests {
         let registry = DesktopElementRegistry::bind(&registrations, &factories).unwrap();
         for registration in &registrations {
             let content = registry.create(registration.element_type).unwrap();
+            assert_eq!(
+                content.is_scroll_container(),
+                registration.name == whisker::SCROLL_VIEW_ELEMENT_NAME,
+            );
             assert_eq!(
                 matches!(
                     content,

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -1499,6 +1499,7 @@ enum DrawCommand {
         shape_clips: ShapeClipStack,
         gradient: Option<LinearGradientDraw>,
         resource: Option<ResourceId>,
+        native: Option<NodeId>,
         pixelated: bool,
     },
     Text {
@@ -1919,8 +1920,61 @@ fn push_quad_draw(
         shape_clips: shape_clips.clone(),
         gradient,
         resource,
+        native: None,
         pixelated,
     });
+}
+
+struct NativeRasterDraw<'a> {
+    node: NodeId,
+    rect: LayoutRect,
+    transform: Transform,
+    clip: LogicalClip,
+    shape_clips: &'a ShapeClipStack,
+    opacity: f32,
+}
+
+fn push_native_raster_draw(
+    vertices: &mut Vec<BoxVertex>,
+    draws: &mut Vec<DrawCommand>,
+    draw: NativeRasterDraw<'_>,
+) {
+    let NativeRasterDraw {
+        node,
+        rect,
+        transform,
+        clip,
+        shape_clips,
+        opacity,
+    } = draw;
+    let paint = whisker_protocol::BoxPaint::default();
+    let primitive = background_gradient_primitive(rect, rect, &paint, PaintBox::Border);
+    let start = vertices.len() as u32;
+    push_transformed_quad(vertices, primitive, transform);
+    draws.push(DrawCommand::Quads {
+        vertices: start..vertices.len() as u32,
+        clip,
+        shape_clips: shape_clips.clone(),
+        gradient: Some(LinearGradientDraw {
+            start_end: [opacity, 0.0, 0.0, 0.0],
+            tile_rect: [rect.x, rect.y, rect.width, rect.height],
+            tile_stride: [rect.width, rect.height, 0.0, 0.0],
+            tile_domain: [rect.x, rect.y, rect.width, rect.height],
+            stops: Vec::new(),
+            kind: 4,
+            geometry_flags: 3,
+        }),
+        resource: None,
+        native: Some(node),
+        pixelated: false,
+    });
+}
+
+struct NativeRasterCache {
+    generation: u64,
+    width: u32,
+    height: u32,
+    image: GpuImageResource,
 }
 
 pub(crate) struct GpuRenderer {
@@ -1934,6 +1988,7 @@ pub(crate) struct GpuRenderer {
     text_atlas: TextAtlas,
     text_renderers: HashMap<NodeId, TextRenderer>,
     image_resources: HashMap<ResourceId, GpuImageResource>,
+    native_rasters: HashMap<NodeId, NativeRasterCache>,
 }
 
 impl GpuRenderer {
@@ -2002,6 +2057,7 @@ impl GpuRenderer {
             text_atlas,
             text_renderers: HashMap::new(),
             image_resources: HashMap::new(),
+            native_rasters: HashMap::new(),
         })
     }
 
@@ -2261,8 +2317,71 @@ impl GpuRenderer {
                     }
                     draws.push(DrawCommand::Text { index, node: *node })
                 }
+                PaintCommand::Raster {
+                    node,
+                    rect,
+                    rasterizer,
+                    clip,
+                    shape_clips,
+                    transform,
+                    opacity,
+                } => {
+                    let width = (rect.width * scale).ceil().max(1.0) as u32;
+                    let height = (rect.height * scale).ceil().max(1.0) as u32;
+                    let Some(raster) = rasterizer.rasterize(width, height) else {
+                        self.native_rasters.remove(node);
+                        continue;
+                    };
+                    let stale = self.native_rasters.get(node).is_none_or(|cached| {
+                        cached.generation != raster.generation()
+                            || cached.width != raster.width()
+                            || cached.height != raster.height()
+                    });
+                    if stale {
+                        let upload = RasterResource::new(
+                            raster.width(),
+                            raster.height(),
+                            raster.pixels().to_vec(),
+                        )?;
+                        let image = self
+                            .box_gpu
+                            .upload_image(&self.device, &self.queue, &upload);
+                        self.native_rasters.insert(
+                            *node,
+                            NativeRasterCache {
+                                generation: raster.generation(),
+                                width: raster.width(),
+                                height: raster.height(),
+                                image,
+                            },
+                        );
+                    }
+                    push_native_raster_draw(
+                        &mut vertices,
+                        &mut draws,
+                        NativeRasterDraw {
+                            node: *node,
+                            rect: *rect,
+                            transform: *transform,
+                            clip: *clip,
+                            shape_clips,
+                            opacity: *opacity,
+                        },
+                    );
+                }
             }
         }
+        let live_native_nodes = draws
+            .iter()
+            .filter_map(|draw| match draw {
+                DrawCommand::Quads {
+                    native: Some(node), ..
+                } => Some(*node),
+                _ => None,
+            })
+            .collect::<HashSet<_>>();
+        self.native_rasters
+            .retain(|node, _| live_native_nodes.contains(node));
         let live_text_nodes = draws
             .iter()
             .filter_map(|draw| match draw {
@@ -2614,6 +2733,7 @@ impl GpuRenderer {
                     vertices,
                     clip,
                     resource,
+                    native,
                     pixelated,
                     ..
                 } => {
@@ -2642,8 +2762,11 @@ impl GpuRenderer {
                     pass.set_pipeline(&self.box_gpu.pipeline);
                     pass.set_bind_group(0, &self.box_gpu.viewport_bind_group, &[]);
                     pass.set_bind_group(1, &shape_clip_bind_group, &[]);
-                    let image = resource
-                        .and_then(|resource| self.image_resources.get(&resource))
+                    let image = native
+                        .and_then(|node| self.native_rasters.get(&node).map(|entry| &entry.image))
+                        .or_else(|| {
+                            resource.and_then(|resource| self.image_resources.get(&resource))
+                        })
                         .unwrap_or(&self.box_gpu.fallback_image);
                     pass.set_bind_group(
                         2,
@@ -2739,7 +2862,11 @@ impl GpuRenderer {
         let bottom = (clip.bottom.unwrap_or(self.config.height as f32 / scale) * scale)
             .ceil()
             .clamp(0.0, self.config.height as f32) as u32;
-        (right > left && bottom > top).then_some((left, top, right - left, bottom - top))
+        if right > left && bottom > top {
+            Some((left, top, right - left, bottom - top))
+        } else {
+            None
+        }
     }
 }
 
@@ -2961,6 +3088,7 @@ pub(crate) async fn render_clipped_box_primitives_with_backdrops_offscreen(
             shape_clips: shape_clips.clone(),
             gradient: gradient.clone(),
             resource: *resource,
+            native: None,
             pixelated: *pixelated,
         });
     }

--- a/platforms/desktop/src/input.rs
+++ b/platforms/desktop/src/input.rs
@@ -109,6 +109,11 @@ impl DesktopPointerAdapter {
         }
     }
 
+    /// Last logical cursor position observed by this surface.
+    pub const fn mouse_position(&self) -> Option<InputPoint> {
+        self.mouse_position
+    }
+
     /// Normalizes a mouse cursor update at a logical window position.
     pub fn cursor_moved(&mut self, timestamp_ms: f64, position: [f32; 2]) -> InputEvent {
         let position = InputPoint {

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -140,6 +140,22 @@ impl DesktopRuntime {
         self.surface.cursor_at(logical_position)
     }
 
+    /// Resolves the Host-visible target after applying transient scroll state.
+    pub fn target_input(&self, event: &mut InputEvent) {
+        if event.target.is_none()
+            && let Some(pointer) = event.pointer
+        {
+            event.target = self
+                .surface
+                .hit_test([pointer.position.x, pointer.position.y]);
+        }
+    }
+
+    /// Applies a logical wheel/trackpad delta to the nearest scroll container.
+    pub fn scroll_at(&mut self, logical_position: [f32; 2], delta: [f32; 2]) -> bool {
+        self.surface.scroll_at(logical_position, delta)
+    }
+
     /// Registers one already-decoded RGBA8 raster for later `ResourceId`
     /// background-image references. Acquisition and decoding remain Host work
     /// and do not run in the per-frame protocol path.

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -39,7 +39,8 @@ mod host_conformance_tests;
 use element::DesktopElementRegistry;
 pub use element::{
     BuiltInElementModule, DesktopElementFactory, DesktopModuleDefinition, DesktopNativeElement,
-    DesktopNativeEvent, DesktopViewDefinition, DesktopViewImplementation,
+    DesktopNativeEvent, DesktopRaster, DesktopRasterError, DesktopViewDefinition,
+    DesktopViewImplementation,
 };
 pub use input::{
     DesktopMouseButton, DesktopPointerAdapter, DesktopPointerEvent, DesktopPointerPhase,

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -305,6 +305,15 @@ pub(crate) enum PaintCommand<'a> {
         transform: Transform,
         opacity: f32,
     },
+    Raster {
+        node: NodeId,
+        rect: LayoutRect,
+        rasterizer: &'a dyn crate::DesktopNativeElement,
+        clip: LogicalClip,
+        shape_clips: ShapeClipStack,
+        transform: Transform,
+        opacity: f32,
+    },
 }
 
 #[derive(Debug)]
@@ -565,6 +574,17 @@ impl DesktopScene {
                 rect: content_rect,
                 content,
                 clip: descendant_clip.intersect(content_rect, true, true),
+                shape_clips: descendant_shape_clips.clone(),
+                transform,
+                opacity,
+            });
+        }
+        if visible && let Some(rasterizer) = node.content.rasterizer() {
+            commands.push(PaintCommand::Raster {
+                node: id,
+                rect: content,
+                rasterizer,
+                clip: descendant_clip.intersect(content, true, true),
                 shape_clips: descendant_shape_clips.clone(),
                 transform,
                 opacity,

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -62,6 +62,7 @@ struct RenderNode {
     presentation: CommonPresentation,
     content: DesktopElementContent,
     event_mask: u64,
+    scroll_offset: [f32; 2],
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -349,6 +350,18 @@ impl DesktopScene {
     }
 
     pub(crate) fn cursor_at(&self, point: [f32; 2]) -> Option<whisker_protocol::CursorKeyword> {
+        let node = self.hit_test(point)?;
+        Some(
+            self.nodes
+                .get(&node)
+                .expect("hit-tested Desktop node remains live")
+                .presentation
+                .cursor
+                .fallback,
+        )
+    }
+
+    pub(crate) fn hit_test(&self, point: [f32; 2]) -> Option<NodeId> {
         let mut roots = self
             .nodes
             .iter()
@@ -364,15 +377,15 @@ impl DesktopScene {
         roots
             .into_iter()
             .rev()
-            .find_map(|(node, _)| self.cursor_at_node(node, point, [0.0, 0.0]))
+            .find_map(|(node, _)| self.hit_test_node(node, point, [0.0, 0.0]))
     }
 
-    fn cursor_at_node(
+    fn hit_test_node(
         &self,
         node: NodeId,
         point: [f32; 2],
         parent_origin: [f32; 2],
-    ) -> Option<whisker_protocol::CursorKeyword> {
+    ) -> Option<NodeId> {
         let state = self.nodes.get(&node)?;
         let presentation = &state.presentation;
         if presentation.hit_test == HitTestBehavior::None {
@@ -386,6 +399,14 @@ impl DesktopScene {
         let clipped = (presentation.clip.horizontal == OverflowClip::Hidden && !contains_x)
             || (presentation.clip.vertical == OverflowClip::Hidden && !contains_y);
         if presentation.hit_test != HitTestBehavior::BoxOnly && !clipped {
+            let child_origin = if state.content.is_scroll_container() {
+                [
+                    origin[0] - state.scroll_offset[0],
+                    origin[1] - state.scroll_offset[1],
+                ]
+            } else {
+                origin
+            };
             let mut children = presentation
                 .children
                 .iter()
@@ -402,8 +423,8 @@ impl DesktopScene {
                 .collect::<Vec<_>>();
             children.sort_by_key(|(_, z_order, index)| (*z_order, *index));
             for (child, _, _) in children.into_iter().rev() {
-                if let Some(cursor) = self.cursor_at_node(child, point, origin) {
-                    return Some(cursor);
+                if let Some(target) = self.hit_test_node(child, point, child_origin) {
+                    return Some(target);
                 }
             }
         }
@@ -411,7 +432,62 @@ impl DesktopScene {
             && contains_x
             && contains_y
             && presentation.hit_test != HitTestBehavior::DescendantsOnly)
-            .then_some(presentation.cursor.fallback)
+            .then_some(node)
+    }
+
+    pub(crate) fn scroll_at(&mut self, point: [f32; 2], delta: [f32; 2]) -> bool {
+        let Some(hit) = self.hit_test(point) else {
+            return false;
+        };
+        let mut current = Some(hit);
+        while let Some(node) = current {
+            let is_scroll = self
+                .nodes
+                .get(&node)
+                .is_some_and(|state| state.content.is_scroll_container());
+            if is_scroll {
+                let max = self.max_scroll_offset(node);
+                let state = self.nodes.get_mut(&node).expect("scroll hit remains live");
+                let next = [0.0, (state.scroll_offset[1] + delta[1]).clamp(0.0, max[1])];
+                let changed = next != state.scroll_offset;
+                state.scroll_offset = next;
+                return changed;
+            }
+            current = self
+                .nodes
+                .get(&node)
+                .and_then(|state| state.presentation.parent);
+        }
+        false
+    }
+
+    fn max_scroll_offset(&self, node: NodeId) -> [f32; 2] {
+        let state = self.nodes.get(&node).expect("scroll node remains live");
+        let viewport = state.presentation.layout.content_box;
+        let content_height = state
+            .presentation
+            .children
+            .iter()
+            .filter_map(|child| self.nodes.get(child))
+            .fold(viewport.height, |extent, child| {
+                let rect = child.presentation.layout.border_box;
+                extent.max(rect.y + rect.height)
+            });
+        [0.0, (content_height - viewport.height).max(0.0)]
+    }
+
+    fn clamp_scroll_offsets(&mut self) {
+        let scroll_nodes = self
+            .nodes
+            .iter()
+            .filter_map(|(node, state)| state.content.is_scroll_container().then_some(*node))
+            .collect::<Vec<_>>();
+        for node in scroll_nodes {
+            let max = self.max_scroll_offset(node);
+            let state = self.nodes.get_mut(&node).expect("scroll node remains live");
+            state.scroll_offset[0] = state.scroll_offset[0].clamp(0.0, max[0]);
+            state.scroll_offset[1] = state.scroll_offset[1].clamp(0.0, max[1]);
+        }
     }
 
     pub(crate) fn paint_commands(&self) -> Vec<PaintCommand<'_>> {
@@ -608,10 +684,18 @@ impl DesktopScene {
             .collect::<Vec<_>>();
         children.sort_by_key(|(_, z, index)| (*z, *index));
         for (child, _, _) in children {
+            let child_origin = if node.content.is_scroll_container() {
+                [
+                    border.x - node.scroll_offset[0],
+                    border.y - node.scroll_offset[1],
+                ]
+            } else {
+                [border.x, border.y]
+            };
             self.collect_commands(
                 child,
                 PresentationContext {
-                    origin: [border.x, border.y],
+                    origin: child_origin,
                     transform,
                     clip: descendant_clip,
                     shape_clips: descendant_shape_clips.clone(),
@@ -759,6 +843,7 @@ impl DesktopScene {
                             presentation: CommonPresentation::default(),
                             content,
                             event_mask: 0,
+                            scroll_offset: [0.0; 2],
                         },
                     );
                 }
@@ -954,6 +1039,7 @@ impl DesktopScene {
                 }
             }
         }
+        self.clamp_scroll_offsets();
     }
 
     fn delete_subtree(&mut self, node: NodeId) {
@@ -1731,6 +1817,85 @@ mod tests {
             scene.nodes[&node].presentation.background_layers,
             vec![layer]
         );
+    }
+
+    #[test]
+    fn scroll_container_offsets_paint_and_hit_testing_inside_its_viewport() {
+        let scroll = id(1);
+        let content = id(2);
+        let target = id(3);
+        let mut scene = scene(SurfaceId::new(1).unwrap());
+        scene
+            .present(&packet(
+                FrameMode::Snapshot,
+                0,
+                1,
+                vec![
+                    Operation::CreateNode {
+                        node: scroll,
+                        element_type: element_type(whisker::SCROLL_VIEW_ELEMENT_NAME),
+                    },
+                    Operation::CreateNode {
+                        node: content,
+                        element_type: element_type(whisker::VIEW_ELEMENT_NAME),
+                    },
+                    Operation::CreateNode {
+                        node: target,
+                        element_type: element_type(whisker::VIEW_ELEMENT_NAME),
+                    },
+                    Operation::InsertChild {
+                        parent: scroll,
+                        child: content,
+                        index: 0,
+                    },
+                    Operation::InsertChild {
+                        parent: content,
+                        child: target,
+                        index: 0,
+                    },
+                    Operation::SetLayout {
+                        node: scroll,
+                        geometry: geometry(0.0, 0.0, 100.0, 100.0),
+                    },
+                    Operation::SetLayout {
+                        node: content,
+                        geometry: geometry(0.0, 0.0, 100.0, 300.0),
+                    },
+                    Operation::SetLayout {
+                        node: target,
+                        geometry: geometry(0.0, 150.0, 100.0, 40.0),
+                    },
+                    Operation::SetClip {
+                        node: scroll,
+                        clip: BoxClip {
+                            horizontal: OverflowClip::Hidden,
+                            vertical: OverflowClip::Hidden,
+                        },
+                    },
+                    Operation::SetBoxPaint {
+                        node: target,
+                        paint: paint(PaintColor::Srgba {
+                            red: 255,
+                            green: 0,
+                            blue: 0,
+                            alpha: 1.0,
+                        }),
+                    },
+                ],
+            ))
+            .unwrap();
+
+        assert_eq!(scene.hit_test([10.0, 60.0]), Some(content));
+        assert!(scene.scroll_at([10.0, 60.0], [0.0, 120.0]));
+        assert_eq!(scene.nodes[&scroll].scroll_offset, [0.0, 120.0]);
+        assert_eq!(scene.hit_test([10.0, 60.0]), Some(target));
+        assert!(scene.paint_commands().iter().any(|command| {
+            matches!(
+                command,
+                PaintCommand::Box { rect, .. }
+                    if rect.x == 0.0 && rect.y == 30.0 && rect.width == 100.0
+            )
+        }));
     }
 
     #[test]

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -65,6 +65,14 @@ impl DesktopSurface {
     ) -> Option<whisker_protocol::CursorKeyword> {
         self.scene.cursor_at(logical_position)
     }
+
+    pub(crate) fn hit_test(&self, logical_position: [f32; 2]) -> Option<whisker_protocol::NodeId> {
+        self.scene.hit_test(logical_position)
+    }
+
+    pub(crate) fn scroll_at(&mut self, logical_position: [f32; 2], delta: [f32; 2]) -> bool {
+        self.scene.scroll_at(logical_position, delta)
+    }
 }
 
 impl FrameSink for DesktopSurface {

--- a/platforms/linux/src/app.rs
+++ b/platforms/linux/src/app.rs
@@ -13,7 +13,7 @@ use whisker_protocol::{CursorKeyword, InputEvent, SurfaceId};
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
-use winit::event::{ElementState, MouseButton, TouchPhase, WindowEvent};
+use winit::event::{ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
 use winit::window::{CursorIcon, Window, WindowAttributes, WindowId};
 
@@ -72,6 +72,16 @@ fn touch_phase(value: TouchPhase) -> DesktopPointerPhase {
         TouchPhase::Moved => DesktopPointerPhase::Move,
         TouchPhase::Ended => DesktopPointerPhase::Up,
         TouchPhase::Cancelled => DesktopPointerPhase::Cancel,
+    }
+}
+
+fn scroll_delta(value: MouseScrollDelta, scale: f64) -> [f32; 2] {
+    match value {
+        MouseScrollDelta::LineDelta(x, y) => [-x * 40.0, -y * 40.0],
+        MouseScrollDelta::PixelDelta(position) => {
+            let logical = position.to_logical::<f32>(scale);
+            [-logical.x, -logical.y]
+        }
     }
 }
 
@@ -297,7 +307,10 @@ impl LinuxApplication {
         self.request_frame();
     }
 
-    fn dispatch_input(&mut self, event: InputEvent) {
+    fn dispatch_input(&mut self, mut event: InputEvent) {
+        if let Some(host) = &self.host {
+            host.target_input(&mut event);
+        }
         let Some(runtime) = &self.runtime else {
             return;
         };
@@ -373,6 +386,17 @@ impl ApplicationHandler<HostEvent> for LinuxApplication {
                     state == ElementState::Pressed,
                 ) {
                     self.dispatch_input(input);
+                }
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                if let (Some(window), Some(position), Some(host)) =
+                    (&self.window, self.pointer.mouse_position(), &mut self.host)
+                    && host.scroll_at(
+                        [position.x, position.y],
+                        scroll_delta(delta, window.scale_factor()),
+                    )
+                {
+                    self.request_frame();
                 }
             }
             WindowEvent::Touch(touch) => {

--- a/platforms/macos/src/app.rs
+++ b/platforms/macos/src/app.rs
@@ -13,7 +13,7 @@ use whisker_protocol::{CursorKeyword, InputEvent, SurfaceId};
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
-use winit::event::{ElementState, MouseButton, TouchPhase, WindowEvent};
+use winit::event::{ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
 use winit::window::{CursorIcon, Window, WindowAttributes, WindowId};
 
@@ -72,6 +72,16 @@ fn touch_phase(value: TouchPhase) -> DesktopPointerPhase {
         TouchPhase::Moved => DesktopPointerPhase::Move,
         TouchPhase::Ended => DesktopPointerPhase::Up,
         TouchPhase::Cancelled => DesktopPointerPhase::Cancel,
+    }
+}
+
+fn scroll_delta(value: MouseScrollDelta, scale: f64) -> [f32; 2] {
+    match value {
+        MouseScrollDelta::LineDelta(x, y) => [-x * 40.0, -y * 40.0],
+        MouseScrollDelta::PixelDelta(position) => {
+            let logical = position.to_logical::<f32>(scale);
+            [-logical.x, -logical.y]
+        }
     }
 }
 
@@ -297,7 +307,10 @@ impl MacosApplication {
         self.request_frame();
     }
 
-    fn dispatch_input(&mut self, event: InputEvent) {
+    fn dispatch_input(&mut self, mut event: InputEvent) {
+        if let Some(host) = &self.host {
+            host.target_input(&mut event);
+        }
         let Some(runtime) = &self.runtime else {
             return;
         };
@@ -373,6 +386,17 @@ impl ApplicationHandler<HostEvent> for MacosApplication {
                     state == ElementState::Pressed,
                 ) {
                     self.dispatch_input(input);
+                }
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                if let (Some(window), Some(position), Some(host)) =
+                    (&self.window, self.pointer.mouse_position(), &mut self.host)
+                    && host.scroll_at(
+                        [position.x, position.y],
+                        scroll_delta(delta, window.scale_factor()),
+                    )
+                {
+                    self.request_frame();
                 }
             }
             WindowEvent::Touch(touch) => {

--- a/platforms/web/Cargo.toml
+++ b/platforms/web/Cargo.toml
@@ -40,6 +40,7 @@ web-sys = { version = "0.3", features = [
     "Node",
     "Performance",
     "PointerEvent",
+    "SvgElement",
     "Url",
     "Window",
 ] }

--- a/platforms/web/src/dom.rs
+++ b/platforms/web/src/dom.rs
@@ -20,10 +20,16 @@ pub(crate) fn set_style(
     property: &str,
     value: &str,
 ) -> Result<(), WebError> {
-    let html = element
-        .dyn_ref::<web_sys::HtmlElement>()
-        .ok_or_else(|| WebError("Whisker DOM node is not an HtmlElement".into()))?;
-    html.style()
+    let style = if let Some(html) = element.dyn_ref::<web_sys::HtmlElement>() {
+        html.style()
+    } else if let Some(svg) = element.dyn_ref::<web_sys::SvgElement>() {
+        svg.style()
+    } else {
+        return Err(WebError(
+            "Whisker DOM node exposes no CSS style declaration".into(),
+        ));
+    };
+    style
         .set_property(property, value)
         .map_err(|error| js_error(&format!("set CSS property {property}"), error))
 }

--- a/platforms/web/src/paint/clip.rs
+++ b/platforms/web/src/paint/clip.rs
@@ -7,23 +7,47 @@ pub(crate) fn apply(
     clip: BoxClip,
     scroll_content: bool,
 ) -> Result<(), WebError> {
-    set_style(
-        element,
-        "overflow-x",
-        overflow(clip.horizontal, scroll_content),
-    )?;
-    set_style(
-        element,
-        "overflow-y",
-        overflow(clip.vertical, scroll_content),
-    )
+    let [horizontal, vertical] = overflow(clip, scroll_content);
+    set_style(element, "overflow-x", horizontal)?;
+    set_style(element, "overflow-y", vertical)
 }
 
-fn overflow(value: OverflowClip, scroll_content: bool) -> &'static str {
-    match (value, scroll_content) {
-        (OverflowClip::Hidden, true) => "hidden",
-        (OverflowClip::Visible, true) => "auto",
-        (OverflowClip::Hidden, false) => "clip",
-        (OverflowClip::Visible, false) => "visible",
+fn overflow(clip: BoxClip, scroll_content: bool) -> [&'static str; 2] {
+    if scroll_content {
+        // A built-in ScrollView is a vertical native scroll container. Its
+        // base style clips overflowing content, but that clip must not replace
+        // the Host's scrolling mechanism with CSS `overflow: hidden`.
+        return ["hidden", "auto"];
+    }
+    [overflow_axis(clip.horizontal), overflow_axis(clip.vertical)]
+}
+
+fn overflow_axis(value: OverflowClip) -> &'static str {
+    match value {
+        OverflowClip::Hidden => "clip",
+        OverflowClip::Visible => "visible",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scroll_container_keeps_vertical_native_scrolling_enabled() {
+        let hidden = BoxClip {
+            horizontal: OverflowClip::Hidden,
+            vertical: OverflowClip::Hidden,
+        };
+        assert_eq!(overflow(hidden, true), ["hidden", "auto"]);
+    }
+
+    #[test]
+    fn ordinary_elements_follow_the_protocol_clip() {
+        let mixed = BoxClip {
+            horizontal: OverflowClip::Hidden,
+            vertical: OverflowClip::Visible,
+        };
+        assert_eq!(overflow(mixed, false), ["clip", "visible"]);
     }
 }

--- a/platforms/windows/src/app.rs
+++ b/platforms/windows/src/app.rs
@@ -13,7 +13,7 @@ use whisker_protocol::{CursorKeyword, InputEvent, SurfaceId};
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
-use winit::event::{ElementState, MouseButton, TouchPhase, WindowEvent};
+use winit::event::{ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
 use winit::window::{CursorIcon, Window, WindowAttributes, WindowId};
 
@@ -72,6 +72,16 @@ fn touch_phase(value: TouchPhase) -> DesktopPointerPhase {
         TouchPhase::Moved => DesktopPointerPhase::Move,
         TouchPhase::Ended => DesktopPointerPhase::Up,
         TouchPhase::Cancelled => DesktopPointerPhase::Cancel,
+    }
+}
+
+fn scroll_delta(value: MouseScrollDelta, scale: f64) -> [f32; 2] {
+    match value {
+        MouseScrollDelta::LineDelta(x, y) => [-x * 40.0, -y * 40.0],
+        MouseScrollDelta::PixelDelta(position) => {
+            let logical = position.to_logical::<f32>(scale);
+            [-logical.x, -logical.y]
+        }
     }
 }
 
@@ -297,7 +307,10 @@ impl WindowsApplication {
         self.request_frame();
     }
 
-    fn dispatch_input(&mut self, event: InputEvent) {
+    fn dispatch_input(&mut self, mut event: InputEvent) {
+        if let Some(host) = &self.host {
+            host.target_input(&mut event);
+        }
         let Some(runtime) = &self.runtime else {
             return;
         };
@@ -373,6 +386,17 @@ impl ApplicationHandler<HostEvent> for WindowsApplication {
                     state == ElementState::Pressed,
                 ) {
                     self.dispatch_input(input);
+                }
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                if let (Some(window), Some(position), Some(host)) =
+                    (&self.window, self.pointer.mouse_position(), &mut self.host)
+                    && host.scroll_at(
+                        [position.x, position.y],
+                        scroll_delta(delta, window.scale_factor()),
+                    )
+                {
+                    self.request_frame();
                 }
             }
             WindowEvent::Touch(touch) => {


### PR DESCRIPTION
## Summary

- add a Web Host that replays Whisker SVG display lists into native SVG DOM nodes
- add a Desktop Host that rasterizes display lists with tiny-skia and composites cached RGBA content through WGPU
- add the reusable DesktopRaster custom-element contract and wire SVG Host crates through module discovery/CNG
- preserve the existing Android/iOS module path and update SVG protocol documentation for all four hosts

## Verification

- `cargo test -p whisker-svg`
- `cargo test -p whisker-svg-web-host`
- `cargo test -p whisker-svg-desktop-host`
- `cargo test -p whisker-desktop`
- `cargo test -p whisker-build`
- `cargo test -p whisker-cng`
- `cargo check -p whisker-svg-web-host --target wasm32-unknown-unknown`
- `cargo clippy -p whisker-desktop -p whisker-svg-desktop-host -p whisker-svg-web-host --all-targets -- -D warnings`
- launched Aurora Wallet on Web and Desktop and visually verified SVG icons and `currentColor` rendering
