### PR TITLE
Batch Android frame and measurement JNI traffic

### DIFF
--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -15,8 +15,20 @@ typedef struct { jobject surface; void* runtime; } WhiskerAndroidView;
 static JavaVM* g_vm;
 static jclass g_view_class;
 static jmethodID g_request_frame, g_begin_bootstrap, g_register_element, g_finish_bootstrap;
-static jmethodID g_present_frame, g_current_revision, g_measure;
+static jmethodID g_present_frame, g_current_revision, g_measure_batch;
 static jmethodID g_resource_command, g_invoke_module, g_observe_module;
+static jclass g_measure_response_class;
+static jfieldID g_measure_response_longs, g_measure_response_ints, g_measure_response_floats;
+
+enum {
+    MEASURE_REQUEST_LONG_STRIDE = 3,
+    MEASURE_REQUEST_INT_STRIDE = 17,
+    MEASURE_REQUEST_FLOAT_STRIDE = 11,
+    MEASURE_REQUEST_STRING_STRIDE = 2,
+    MEASURE_RESPONSE_LONG_STRIDE = 4,
+    MEASURE_RESPONSE_INT_STRIDE = 3,
+    MEASURE_RESPONSE_FLOAT_STRIDE = 4,
+};
 
 enum { WHISKER_ANDROID_OPERATION_STRIDE = 10 };
 
@@ -685,57 +697,205 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
     (*env)->DeleteLocalRef(env, view); if (attached) (*g_vm)->DetachCurrentThread(g_vm); return ok;
 }
 
+static bool valid_measure_request(const WhiskerMobileMeasureRequest* r) {
+    return r->text.len <= INT32_MAX && (r->text.ptr == NULL) == (r->text.len == 0) &&
+        r->locale.len <= INT32_MAX && (r->locale.ptr == NULL) == (r->locale.len == 0) &&
+        r->payload.len <= INT32_MAX && (r->payload.ptr == NULL) == (r->payload.len == 0) &&
+        r->font_family_count <= 4096 &&
+        (r->font_families == NULL) == (r->font_family_count == 0) &&
+        (r->kind != WHISKER_MEASURE_TEXT || r->font_family_count != 0) &&
+        r->font_feature_count <= 4096 && r->font_variation_count <= 4096 &&
+        r->direction <= 2 && r->alignment <= 4 &&
+        r->font_family_count + r->font_feature_count + r->font_variation_count <= 4096 &&
+        valid_font_settings(r->font_features, r->font_feature_count,
+                            r->font_variations, r->font_variation_count);
+}
+
 static bool measure_host(void* data, const WhiskerMobileMeasureRequest* requests, size_t count,
                          WhiskerMobileMeasureResponse* responses) {
     if (count > 4096 || (requests == NULL) != (count == 0) ||
         (responses == NULL) != (count == 0)) return false;
-    bool attached; JNIEnv* env = whisker_env(&attached); jobject view = env != NULL ? local_view(env, data) : NULL;
-    if (view == NULL) { if (attached) (*g_vm)->DetachCurrentThread(g_vm); return false; }
-    bool ok = true;
-    for (size_t i=0;i<count && ok;++i) {
-        const WhiskerMobileMeasureRequest* r = &requests[i];
-        if (r->text.len > INT32_MAX || (r->text.ptr == NULL) != (r->text.len == 0) ||
-            r->locale.len > INT32_MAX || (r->locale.ptr == NULL) != (r->locale.len == 0) ||
-            r->payload.len > INT32_MAX || (r->payload.ptr == NULL) != (r->payload.len == 0) ||
-            r->font_family_count > 4096 ||
-            (r->font_families == NULL) != (r->font_family_count == 0) ||
-            (r->kind == WHISKER_MEASURE_TEXT && r->font_family_count == 0) ||
-            r->font_feature_count > 4096 ||
-            r->font_variation_count > 4096 ||
-            r->direction > 2 || r->alignment > 4 ||
-            r->font_family_count + r->font_feature_count + r->font_variation_count > 4096) {
-            ok = false;
-            break;
-        }
-        jstring text = new_string(env, r->text.ptr, r->text.len);
-        jobjectArray families = string_refs(env, r->font_families, r->font_family_count);
-        jbyteArray payload = (*env)->NewByteArray(env, (jsize)r->payload.len);
-        jobjectArray font_values = font_settings(env, r->font_features, r->font_feature_count,
-                                                  r->font_variations, r->font_variation_count);
-        if (text == NULL || families == NULL || payload == NULL || font_values == NULL) ok = false;
-        if (payload && r->payload.len) (*env)->SetByteArrayRegion(env, payload, 0, (jsize)r->payload.len, (const jbyte*)r->payload.ptr);
-        jfloatArray result = ok ? (*env)->CallObjectMethod(env, view, g_measure,
-            (jint)r->element_type,(jint)r->kind,r->known_width,r->known_height,(jint)r->known_mask,
-            r->available_width,r->available_height,(jint)r->available_width_kind,(jint)r->available_height_kind,
-            text,families,r->font_size,(jint)r->font_weight,(jint)r->font_style,(jint)r->wrap,
-            (jint)r->word_break,(jint)r->overflow,
-            r->letter_spacing,r->line_height,r->indent_logical_pixels,r->indent_percentage,
-            (jint)r->max_lines,font_values,(jint)r->font_feature_count,(jint)r->font_optical_sizing,
-            (jint)r->payload_version,payload,r->intrinsic_width,r->intrinsic_height,
-            (jint)r->intrinsic_mask,(jint)r->direction,(jint)r->alignment) : NULL;
-        if (clear_exception(env) || result == NULL || (*env)->GetArrayLength(env, result) < 7) ok = false;
-        if (ok) {
-            jfloat values[7]; (*env)->GetFloatArrayRegion(env, result, 0, 7, values);
-            responses[i].key=r->key; responses[i].environment_epoch=r->environment_epoch;
-            responses[i].status=(uint32_t)values[0]; responses[i].reason=(uint32_t)values[1];
-            responses[i].width=values[2]; responses[i].height=values[3]; responses[i].first_baseline=values[4];
-            responses[i].last_baseline=values[5]; responses[i].metrics_mask=(uint32_t)values[6];
-        }
-        if (result) (*env)->DeleteLocalRef(env, result); if (payload) (*env)->DeleteLocalRef(env, payload);
-        if (font_values) (*env)->DeleteLocalRef(env, font_values);
-        if (families) (*env)->DeleteLocalRef(env, families); if (text) (*env)->DeleteLocalRef(env, text);
+    for (size_t i = 0; i < count; ++i) {
+        if (!valid_measure_request(&requests[i])) return false;
     }
-    (*env)->DeleteLocalRef(env, view); if (attached) (*g_vm)->DetachCurrentThread(g_vm); return ok;
+
+    bool attached;
+    JNIEnv* env = whisker_env(&attached);
+    jobject view = env != NULL ? local_view(env, data) : NULL;
+    if (view == NULL) {
+        if (attached) (*g_vm)->DetachCurrentThread(g_vm);
+        return false;
+    }
+
+    jlongArray request_longs = (*env)->NewLongArray(env, (jsize)(count * MEASURE_REQUEST_LONG_STRIDE));
+    jintArray request_ints = (*env)->NewIntArray(env, (jsize)(count * MEASURE_REQUEST_INT_STRIDE));
+    jfloatArray request_floats = (*env)->NewFloatArray(env, (jsize)(count * MEASURE_REQUEST_FLOAT_STRIDE));
+    jclass string_class = (*env)->FindClass(env, "java/lang/String");
+    jclass string_array_class = (*env)->FindClass(env, "[Ljava/lang/String;");
+    jclass byte_array_class = (*env)->FindClass(env, "[B");
+    jobjectArray request_strings = string_class == NULL ? NULL : (*env)->NewObjectArray(
+        env, (jsize)(count * MEASURE_REQUEST_STRING_STRIDE), string_class, NULL);
+    jobjectArray family_batches = string_array_class == NULL ? NULL : (*env)->NewObjectArray(
+        env, (jsize)count, string_array_class, NULL);
+    jobjectArray setting_batches = string_array_class == NULL ? NULL : (*env)->NewObjectArray(
+        env, (jsize)count, string_array_class, NULL);
+    jobjectArray payload_batches = byte_array_class == NULL ? NULL : (*env)->NewObjectArray(
+        env, (jsize)count, byte_array_class, NULL);
+    jlong* longs = calloc(count * MEASURE_REQUEST_LONG_STRIDE + 1, sizeof(jlong));
+    jint* ints = calloc(count * MEASURE_REQUEST_INT_STRIDE + 1, sizeof(jint));
+    jfloat* values = calloc(count * MEASURE_REQUEST_FLOAT_STRIDE + 1, sizeof(jfloat));
+    bool ok = request_longs != NULL && request_ints != NULL && request_floats != NULL &&
+        request_strings != NULL && family_batches != NULL && setting_batches != NULL &&
+        payload_batches != NULL && longs != NULL && ints != NULL && values != NULL;
+
+    for (size_t i = 0; i < count && ok; ++i) {
+        const WhiskerMobileMeasureRequest* r = &requests[i];
+        size_t long_base = i * MEASURE_REQUEST_LONG_STRIDE;
+        longs[long_base] = (jlong)r->key;
+        longs[long_base + 1] = (jlong)r->node;
+        longs[long_base + 2] = (jlong)r->environment_epoch;
+
+        size_t int_base = i * MEASURE_REQUEST_INT_STRIDE;
+        ints[int_base] = (jint)r->element_type;
+        ints[int_base + 1] = (jint)r->kind;
+        ints[int_base + 2] = (jint)r->known_mask;
+        ints[int_base + 3] = (jint)r->available_width_kind;
+        ints[int_base + 4] = (jint)r->available_height_kind;
+        ints[int_base + 5] = (jint)r->font_weight;
+        ints[int_base + 6] = (jint)r->font_style;
+        ints[int_base + 7] = (jint)r->wrap;
+        ints[int_base + 8] = (jint)r->word_break;
+        ints[int_base + 9] = (jint)r->overflow;
+        ints[int_base + 10] = (jint)r->max_lines;
+        ints[int_base + 11] = (jint)r->font_feature_count;
+        ints[int_base + 12] = (jint)r->font_optical_sizing;
+        ints[int_base + 13] = (jint)r->payload_version;
+        ints[int_base + 14] = (jint)r->intrinsic_mask;
+        ints[int_base + 15] = (jint)r->direction;
+        ints[int_base + 16] = (jint)r->alignment;
+
+        size_t float_base = i * MEASURE_REQUEST_FLOAT_STRIDE;
+        values[float_base] = r->known_width;
+        values[float_base + 1] = r->known_height;
+        values[float_base + 2] = r->available_width;
+        values[float_base + 3] = r->available_height;
+        values[float_base + 4] = r->font_size;
+        values[float_base + 5] = r->line_height;
+        values[float_base + 6] = r->letter_spacing;
+        values[float_base + 7] = r->indent_logical_pixels;
+        values[float_base + 8] = r->indent_percentage;
+        values[float_base + 9] = r->intrinsic_width;
+        values[float_base + 10] = r->intrinsic_height;
+
+        jstring text = new_string(env, r->text.ptr, r->text.len);
+        jstring locale = new_string(env, r->locale.ptr, r->locale.len);
+        jobjectArray families = string_refs(env, r->font_families, r->font_family_count);
+        jobjectArray settings = font_settings(env, r->font_features, r->font_feature_count,
+                                               r->font_variations, r->font_variation_count);
+        jbyteArray payload = (*env)->NewByteArray(env, (jsize)r->payload.len);
+        ok = text != NULL && locale != NULL && families != NULL && settings != NULL && payload != NULL;
+        if (ok && r->payload.len > 0) {
+            (*env)->SetByteArrayRegion(env, payload, 0, (jsize)r->payload.len,
+                                      (const jbyte*)r->payload.ptr);
+        }
+        if (ok) {
+            (*env)->SetObjectArrayElement(env, request_strings,
+                (jsize)(i * MEASURE_REQUEST_STRING_STRIDE), text);
+            (*env)->SetObjectArrayElement(env, request_strings,
+                (jsize)(i * MEASURE_REQUEST_STRING_STRIDE + 1), locale);
+            (*env)->SetObjectArrayElement(env, family_batches, (jsize)i, families);
+            (*env)->SetObjectArrayElement(env, setting_batches, (jsize)i, settings);
+            (*env)->SetObjectArrayElement(env, payload_batches, (jsize)i, payload);
+            if (clear_exception(env)) ok = false;
+        }
+        if (payload) (*env)->DeleteLocalRef(env, payload);
+        if (settings) (*env)->DeleteLocalRef(env, settings);
+        if (families) (*env)->DeleteLocalRef(env, families);
+        if (locale) (*env)->DeleteLocalRef(env, locale);
+        if (text) (*env)->DeleteLocalRef(env, text);
+    }
+
+    if (ok && count > 0) {
+        (*env)->SetLongArrayRegion(env, request_longs, 0,
+            (jsize)(count * MEASURE_REQUEST_LONG_STRIDE), longs);
+        (*env)->SetIntArrayRegion(env, request_ints, 0,
+            (jsize)(count * MEASURE_REQUEST_INT_STRIDE), ints);
+        (*env)->SetFloatArrayRegion(env, request_floats, 0,
+            (jsize)(count * MEASURE_REQUEST_FLOAT_STRIDE), values);
+        if (clear_exception(env)) ok = false;
+    }
+    free(values);
+    free(ints);
+    free(longs);
+
+    jobject result = ok ? (*env)->CallObjectMethod(env, view, g_measure_batch,
+        request_longs, request_ints, request_floats, request_strings,
+        family_batches, setting_batches, payload_batches) : NULL;
+    if (clear_exception(env) || result == NULL) ok = false;
+
+    jlongArray response_longs = ok ? (jlongArray)(*env)->GetObjectField(
+        env, result, g_measure_response_longs) : NULL;
+    jintArray response_ints = ok ? (jintArray)(*env)->GetObjectField(
+        env, result, g_measure_response_ints) : NULL;
+    jfloatArray response_floats = ok ? (jfloatArray)(*env)->GetObjectField(
+        env, result, g_measure_response_floats) : NULL;
+    if (ok && (response_longs == NULL || response_ints == NULL || response_floats == NULL ||
+        (*env)->GetArrayLength(env, response_longs) != (jsize)(count * MEASURE_RESPONSE_LONG_STRIDE) ||
+        (*env)->GetArrayLength(env, response_ints) != (jsize)(count * MEASURE_RESPONSE_INT_STRIDE) ||
+        (*env)->GetArrayLength(env, response_floats) != (jsize)(count * MEASURE_RESPONSE_FLOAT_STRIDE))) {
+        ok = false;
+    }
+
+    jlong* returned_longs = calloc(count * MEASURE_RESPONSE_LONG_STRIDE + 1, sizeof(jlong));
+    jint* returned_ints = calloc(count * MEASURE_RESPONSE_INT_STRIDE + 1, sizeof(jint));
+    jfloat* returned_floats = calloc(count * MEASURE_RESPONSE_FLOAT_STRIDE + 1, sizeof(jfloat));
+    if (returned_longs == NULL || returned_ints == NULL || returned_floats == NULL) ok = false;
+    if (ok && count > 0) {
+        (*env)->GetLongArrayRegion(env, response_longs, 0,
+            (jsize)(count * MEASURE_RESPONSE_LONG_STRIDE), returned_longs);
+        (*env)->GetIntArrayRegion(env, response_ints, 0,
+            (jsize)(count * MEASURE_RESPONSE_INT_STRIDE), returned_ints);
+        (*env)->GetFloatArrayRegion(env, response_floats, 0,
+            (jsize)(count * MEASURE_RESPONSE_FLOAT_STRIDE), returned_floats);
+        if (clear_exception(env)) ok = false;
+    }
+    for (size_t i = 0; i < count && ok; ++i) {
+        size_t long_base = i * MEASURE_RESPONSE_LONG_STRIDE;
+        size_t int_base = i * MEASURE_RESPONSE_INT_STRIDE;
+        size_t float_base = i * MEASURE_RESPONSE_FLOAT_STRIDE;
+        responses[i].key = (uint64_t)returned_longs[long_base];
+        responses[i].environment_epoch = (uint64_t)returned_longs[long_base + 1];
+        responses[i].request_id = (uint64_t)returned_longs[long_base + 2];
+        responses[i].prepared_content = (uint64_t)returned_longs[long_base + 3];
+        responses[i].status = (uint32_t)returned_ints[int_base];
+        responses[i].reason = (uint32_t)returned_ints[int_base + 1];
+        responses[i].metrics_mask = (uint32_t)returned_ints[int_base + 2];
+        responses[i].width = returned_floats[float_base];
+        responses[i].height = returned_floats[float_base + 1];
+        responses[i].first_baseline = returned_floats[float_base + 2];
+        responses[i].last_baseline = returned_floats[float_base + 3];
+    }
+    free(returned_floats);
+    free(returned_ints);
+    free(returned_longs);
+
+    if (response_floats) (*env)->DeleteLocalRef(env, response_floats);
+    if (response_ints) (*env)->DeleteLocalRef(env, response_ints);
+    if (response_longs) (*env)->DeleteLocalRef(env, response_longs);
+    if (result) (*env)->DeleteLocalRef(env, result);
+    if (payload_batches) (*env)->DeleteLocalRef(env, payload_batches);
+    if (setting_batches) (*env)->DeleteLocalRef(env, setting_batches);
+    if (family_batches) (*env)->DeleteLocalRef(env, family_batches);
+    if (request_strings) (*env)->DeleteLocalRef(env, request_strings);
+    if (byte_array_class) (*env)->DeleteLocalRef(env, byte_array_class);
+    if (string_array_class) (*env)->DeleteLocalRef(env, string_array_class);
+    if (string_class) (*env)->DeleteLocalRef(env, string_class);
+    if (request_floats) (*env)->DeleteLocalRef(env, request_floats);
+    if (request_ints) (*env)->DeleteLocalRef(env, request_ints);
+    if (request_longs) (*env)->DeleteLocalRef(env, request_longs);
+    (*env)->DeleteLocalRef(env, view);
+    if (attached) (*g_vm)->DetachCurrentThread(g_vm);
+    return ok;
 }
 
 static char* copy_utf8(JNIEnv* env, jstring string, size_t* length) {
@@ -877,11 +1037,22 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
     METHOD(g_finish_bootstrap,"finishBootstrapFromNative","()Z")
     METHOD(g_present_frame,"presentFrameFromNative","(IIJJ[J[[F[Ljava/lang/String;[[Ljava/lang/String;[Lrs/whisker/runtime/WhiskerValue;[J)Z")
     METHOD(g_current_revision,"currentRevisionFromNative","()J")
-    METHOD(g_measure,"measureFromNative","(IIFFIFFIILjava/lang/String;[Ljava/lang/String;FIIIIIFFFFI[Ljava/lang/String;III[BFFIII)[F")
+    METHOD(g_measure_batch,"measureBatchFromNative","([J[I[F[Ljava/lang/String;[[Ljava/lang/String;[[Ljava/lang/String;[[B)Lrs/whisker/runtime/measure/HostMeasureBatchResponse;")
     METHOD(g_resource_command,"resourceCommandFromNative","(IIIJJLjava/lang/String;[B)Z")
     METHOD(g_invoke_module,"invokeModuleFromNative","(Ljava/lang/String;Ljava/lang/String;[Lrs/whisker/runtime/WhiskerValue;ZJJ)Z")
     METHOD(g_observe_module,"observeModuleFromNative","(Ljava/lang/String;Ljava/lang/String;Z)V")
 #undef METHOD
+    jclass measure_response_local = (*env)->FindClass(
+        env, "rs/whisker/runtime/measure/HostMeasureBatchResponse");
+    if (measure_response_local == NULL) return JNI_ERR;
+    g_measure_response_class = (*env)->NewGlobalRef(env, measure_response_local);
+    (*env)->DeleteLocalRef(env, measure_response_local);
+    if (g_measure_response_class == NULL) return JNI_ERR;
+    g_measure_response_longs = (*env)->GetFieldID(env, g_measure_response_class, "longs", "[J");
+    g_measure_response_ints = (*env)->GetFieldID(env, g_measure_response_class, "ints", "[I");
+    g_measure_response_floats = (*env)->GetFieldID(env, g_measure_response_class, "floats", "[F");
+    if (g_measure_response_longs == NULL || g_measure_response_ints == NULL ||
+        g_measure_response_floats == NULL) return JNI_ERR;
     return JNI_VERSION_1_6;
 }
 

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -15,8 +15,10 @@ typedef struct { jobject surface; void* runtime; } WhiskerAndroidView;
 static JavaVM* g_vm;
 static jclass g_view_class;
 static jmethodID g_request_frame, g_begin_bootstrap, g_register_element, g_finish_bootstrap;
-static jmethodID g_begin_frame, g_current_revision, g_stage_operation, g_commit_frame, g_measure;
+static jmethodID g_present_frame, g_current_revision, g_measure;
 static jmethodID g_resource_command, g_invoke_module, g_observe_module;
+
+enum { WHISKER_ANDROID_OPERATION_STRIDE = 10 };
 
 void whisker_mobile_bridge_anchor(void) {}
 
@@ -282,31 +284,33 @@ static jobjectArray font_settings(JNIEnv* env,
 }
 
 static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMobileApplyResponse* response) {
-    if (frame == NULL || response == NULL || frame->abi_major != WHISKER_MOBILE_ABI_MAJOR) return false;
+    if (frame == NULL || response == NULL || frame->abi_major != WHISKER_MOBILE_ABI_MAJOR ||
+        frame->operation_count > INT32_MAX / WHISKER_ANDROID_OPERATION_STRIDE ||
+        (frame->operations == NULL) != (frame->operation_count == 0)) return false;
     bool attached; JNIEnv* env = whisker_env(&attached); jobject view = env != NULL ? local_view(env, data) : NULL;
     if (view == NULL) return false;
-    jint begin = (*env)->CallIntMethod(env, view, g_begin_frame, (jint)frame->mode,
-        (jint)frame->scene_epoch, (jlong)frame->base_revision, (jlong)frame->target_revision);
-    if (clear_exception(env)) begin = WHISKER_APPLY_REJECTED;
-    if (begin == WHISKER_APPLY_NEED_SNAPSHOT) {
-        jlong revision = (*env)->CallLongMethod(env, view, g_current_revision);
-        if (clear_exception(env)) {
-            (*env)->DeleteLocalRef(env, view);
-            if (attached) (*g_vm)->DetachCurrentThread(g_vm);
-            return false;
-        }
-        response->status = WHISKER_APPLY_NEED_SNAPSHOT; response->revision = (uint64_t)revision;
-        (*env)->DeleteLocalRef(env, view); if (attached) (*g_vm)->DetachCurrentThread(g_vm); return true;
-    }
-    if (begin != WHISKER_APPLY_ACCEPTED) {
-        response->status = WHISKER_APPLY_REJECTED;
-        response->revision = (uint64_t)(*env)->CallLongMethod(env, view, g_current_revision);
-        bool failed = clear_exception(env);
-        (*env)->DeleteLocalRef(env, view);
-        if (attached) (*g_vm)->DetachCurrentThread(g_vm);
-        return !failed;
-    }
+
+    const jsize operation_count = (jsize)frame->operation_count;
+    const jsize metadata_count = operation_count * WHISKER_ANDROID_OPERATION_STRIDE;
+    jlongArray metadata = (*env)->NewLongArray(env, metadata_count);
+    jclass float_array_class = (*env)->FindClass(env, "[F");
+    jclass string_class = (*env)->FindClass(env, "java/lang/String");
+    jclass string_array_class = (*env)->FindClass(env, "[Ljava/lang/String;");
+    jclass value_class = (*env)->FindClass(env, "rs/whisker/runtime/WhiskerValue");
+    jobjectArray number_batches = float_array_class == NULL ? NULL
+        : (*env)->NewObjectArray(env, operation_count, float_array_class, NULL);
+    jobjectArray texts = string_class == NULL ? NULL
+        : (*env)->NewObjectArray(env, operation_count, string_class, NULL);
+    jobjectArray name_batches = string_array_class == NULL ? NULL
+        : (*env)->NewObjectArray(env, operation_count, string_array_class, NULL);
+    jobjectArray values = value_class == NULL ? NULL
+        : (*env)->NewObjectArray(env, operation_count, value_class, NULL);
+    jlongArray result = (*env)->NewLongArray(env, 2);
+    jlong* metadata_values = malloc(
+        (metadata_count > 0 ? (size_t)metadata_count : 1) * sizeof(jlong));
     bool ok = true;
+    if (metadata == NULL || number_batches == NULL || texts == NULL || name_batches == NULL ||
+        values == NULL || result == NULL || metadata_values == NULL || clear_exception(env)) ok = false;
     for (size_t i = 0; i < frame->operation_count && ok; ++i) {
         const WhiskerMobileOperation* op = &frame->operations[i];
         jfloatArray numbers = NULL; jstring text = NULL; jobjectArray names = NULL; jobject value = NULL;
@@ -618,27 +622,67 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
             case WHISKER_OP_PROPERTY: case WHISKER_OP_COMMAND: value = raw_to_value(env, op->payload); break;
         }
         if (!ok) break;
-        ok = (*env)->CallBooleanMethod(env, view, g_stage_operation,
-            (jint)op->tag,(jint)staged_flags,(jlong)op->node,(jlong)op->parent,(jlong)op->child,
-            (jint)op->index,(jint)op->member,(jint)op->integer,(jfloat)staged_scalar,(jlong)op->wide,
-            numbers,text,names,value) == JNI_TRUE && !clear_exception(env);
+        const size_t offset = i * WHISKER_ANDROID_OPERATION_STRIDE;
+        uint32_t scalar_bits;
+        memcpy(&scalar_bits, &staged_scalar, sizeof(scalar_bits));
+        metadata_values[offset] = (jlong)op->tag;
+        metadata_values[offset + 1] = (jlong)staged_flags;
+        metadata_values[offset + 2] = (jlong)op->node;
+        metadata_values[offset + 3] = (jlong)op->parent;
+        metadata_values[offset + 4] = (jlong)op->child;
+        metadata_values[offset + 5] = (jlong)op->index;
+        metadata_values[offset + 6] = (jlong)op->member;
+        metadata_values[offset + 7] = (jlong)op->integer;
+        metadata_values[offset + 8] = (jlong)scalar_bits;
+        metadata_values[offset + 9] = (jlong)op->wide;
+        (*env)->SetObjectArrayElement(env, number_batches, (jsize)i, numbers);
+        (*env)->SetObjectArrayElement(env, texts, (jsize)i, text);
+        (*env)->SetObjectArrayElement(env, name_batches, (jsize)i, names);
+        (*env)->SetObjectArrayElement(env, values, (jsize)i, value);
+        if (clear_exception(env)) ok = false;
         if (numbers) (*env)->DeleteLocalRef(env, numbers); if (text) (*env)->DeleteLocalRef(env, text);
         if (names) (*env)->DeleteLocalRef(env, names); if (value) (*env)->DeleteLocalRef(env, value);
     }
-    if (ok) ok = (*env)->CallBooleanMethod(env, view, g_commit_frame) == JNI_TRUE && !clear_exception(env);
+    if (ok && metadata_count > 0) {
+        (*env)->SetLongArrayRegion(env, metadata, 0, metadata_count, metadata_values);
+        if (clear_exception(env)) ok = false;
+    }
+    if (ok) ok = (*env)->CallBooleanMethod(env, view, g_present_frame,
+        (jint)frame->mode, (jint)frame->scene_epoch,
+        (jlong)frame->base_revision, (jlong)frame->target_revision,
+        metadata, number_batches, texts, name_batches, values, result) == JNI_TRUE &&
+        !clear_exception(env);
     if (ok) {
-        response->status = WHISKER_APPLY_ACCEPTED;
-        response->revision = frame->target_revision;
-    } else {
+        jlong result_values[2];
+        (*env)->GetLongArrayRegion(env, result, 0, 2, result_values);
+        ok = !clear_exception(env) && result_values[0] >= WHISKER_APPLY_ACCEPTED &&
+            result_values[0] <= WHISKER_APPLY_REJECTED;
+        if (ok) {
+            response->status = (uint8_t)result_values[0];
+            response->revision = (uint64_t)result_values[1];
+        }
+    }
+    if (!ok) {
         response->status = WHISKER_APPLY_REJECTED;
         response->revision = (uint64_t)(*env)->CallLongMethod(env, view, g_current_revision);
         if (clear_exception(env)) {
-            (*env)->DeleteLocalRef(env, view);
-            if (attached) (*g_vm)->DetachCurrentThread(g_vm);
-            return false;
+            ok = false;
+        } else {
+            ok = true;
         }
     }
-    (*env)->DeleteLocalRef(env, view); if (attached) (*g_vm)->DetachCurrentThread(g_vm); return true;
+    free(metadata_values);
+    if (result) (*env)->DeleteLocalRef(env, result);
+    if (values) (*env)->DeleteLocalRef(env, values);
+    if (name_batches) (*env)->DeleteLocalRef(env, name_batches);
+    if (texts) (*env)->DeleteLocalRef(env, texts);
+    if (number_batches) (*env)->DeleteLocalRef(env, number_batches);
+    if (value_class) (*env)->DeleteLocalRef(env, value_class);
+    if (string_array_class) (*env)->DeleteLocalRef(env, string_array_class);
+    if (string_class) (*env)->DeleteLocalRef(env, string_class);
+    if (float_array_class) (*env)->DeleteLocalRef(env, float_array_class);
+    if (metadata) (*env)->DeleteLocalRef(env, metadata);
+    (*env)->DeleteLocalRef(env, view); if (attached) (*g_vm)->DetachCurrentThread(g_vm); return ok;
 }
 
 static bool measure_host(void* data, const WhiskerMobileMeasureRequest* requests, size_t count,
@@ -831,10 +875,8 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
     METHOD(g_begin_bootstrap,"beginBootstrapFromNative","()V")
     METHOD(g_register_element,"registerElementFromNative","(ILjava/lang/String;III[I[I[Ljava/lang/String;[I[I[Ljava/lang/String;[I[I[Ljava/lang/String;)V")
     METHOD(g_finish_bootstrap,"finishBootstrapFromNative","()Z")
-    METHOD(g_begin_frame,"beginFrameFromNative","(IIJJ)I")
+    METHOD(g_present_frame,"presentFrameFromNative","(IIJJ[J[[F[Ljava/lang/String;[[Ljava/lang/String;[Lrs/whisker/runtime/WhiskerValue;[J)Z")
     METHOD(g_current_revision,"currentRevisionFromNative","()J")
-    METHOD(g_stage_operation,"stageOperationFromNative","(IIJJJIIIFJ[FLjava/lang/String;[Ljava/lang/String;Lrs/whisker/runtime/WhiskerValue;)Z")
-    METHOD(g_commit_frame,"commitFrameFromNative","()Z")
     METHOD(g_measure,"measureFromNative","(IIFFIFFIILjava/lang/String;[Ljava/lang/String;FIIIIIFFFFI[Ljava/lang/String;III[BFFIII)[F")
     METHOD(g_resource_command,"resourceCommandFromNative","(IIIJJLjava/lang/String;[B)Z")
     METHOD(g_invoke_module,"invokeModuleFromNative","(Ljava/lang/String;Ljava/lang/String;[Lrs/whisker/runtime/WhiskerValue;ZJJ)Z")

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -165,6 +165,89 @@ class HostConformanceTest {
     }
 
     @Test
+    fun acceptsHeterogeneousOperationsAsOneTransactionalFrameBatch() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                val view = WhiskerView(context)
+                val metadata = longArrayOf(
+                    // create node 1 as the built-in View element
+                    1, 0, 1, 0, 0, 0, 1, 0, 0, 0,
+                    // assign both border and content geometry
+                    6, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+                    // apply opacity after layout
+                    10, 0, 1, 0, 0, 0, 0, 0, 0.4f.toRawBits().toLong(), 0,
+                )
+                val response = LongArray(2)
+
+                assertTrue(
+                    view.presentFrameFromNative(
+                        mode = 0,
+                        epoch = 3,
+                        baseRevision = 0,
+                        targetRevision = 9,
+                        metadata = metadata,
+                        numbers = arrayOf(
+                            null,
+                            floatArrayOf(10f, 20f, 30f, 40f, 0f, 0f, 30f, 40f),
+                            null,
+                        ),
+                        texts = arrayOfNulls(3),
+                        names = arrayOfNulls(3),
+                        values = arrayOfNulls(3),
+                        response = response,
+                    ),
+                )
+                assertEquals(0L, response[0])
+                assertEquals(9L, response[1])
+                assertEquals(9L, view.currentRevisionFromNative())
+                assertEquals(0.4f, view.getChildAt(0).alpha, 0.001f)
+
+                val snapshotResponse = LongArray(2)
+                assertTrue(
+                    view.presentFrameFromNative(
+                        mode = 1,
+                        epoch = 3,
+                        baseRevision = 8,
+                        targetRevision = 10,
+                        metadata = LongArray(0),
+                        numbers = emptyArray(),
+                        texts = emptyArray(),
+                        names = emptyArray(),
+                        values = emptyArray(),
+                        response = snapshotResponse,
+                    ),
+                )
+                assertEquals(1L, snapshotResponse[0])
+                assertEquals(9L, snapshotResponse[1])
+                assertEquals(0.4f, view.getChildAt(0).alpha, 0.001f)
+
+                val rejectedResponse = LongArray(2)
+                assertTrue(
+                    view.presentFrameFromNative(
+                        mode = 1,
+                        epoch = 3,
+                        baseRevision = 9,
+                        targetRevision = 10,
+                        metadata = longArrayOf(
+                            10, 0, 1, 0, 0, 0, 0, 0,
+                            Float.NaN.toRawBits().toLong(), 0,
+                        ),
+                        numbers = arrayOf(null),
+                        texts = arrayOfNulls(1),
+                        names = arrayOfNulls(1),
+                        values = arrayOfNulls(1),
+                        response = rejectedResponse,
+                    ),
+                )
+                assertEquals(2L, rejectedResponse[0])
+                assertEquals(9L, rejectedResponse[1])
+                assertEquals(0.4f, view.getChildAt(0).alpha, 0.001f)
+            }
+    }
+
+    @Test
     fun rejectsAnUnregisteredBackgroundResourceTransactionally() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -29,6 +29,7 @@ import kotlin.math.roundToInt
 import rs.whisker.runtime.resource.HostResourceFailureCode
 import rs.whisker.runtime.resource.HostResourceSnapshot
 import rs.whisker.runtime.resource.HostResourceState
+import rs.whisker.runtime.measure.HostMeasureBatchAbi
 
 private const val BACKGROUND_PACKED_LAYERS = 256
 
@@ -796,44 +797,55 @@ private class Driver(
         val indent = command.optJSONObject("indent")
         val indentLogicalPixels = indent?.optDouble("logical_pixels", 0.0)?.toFloat() ?: 0f
         val indentPercentage = indent?.optDouble("percentage", 0.0)?.toFloat() ?: 0f
-        val result = view.measureFromNative(
-            elementType = 2,
-            kind = 1,
-            knownWidth = 0f,
-            knownHeight = 0f,
-            knownMask = 0,
-            availableWidth = command.getDouble("available_width").toFloat(),
-            availableHeight = Float.POSITIVE_INFINITY,
-            availableWidthKind = 0,
-            availableHeightKind = 2,
-            text = command.getString("text"),
-            fontFamilies = families,
-            fontSize = command.getDouble("font_size").toFloat(),
-            fontWeight = command.optInt("font_weight", 400),
-            fontStyle = when (command.optString("font_style", "normal")) {
+        val requestInts = IntArray(HostMeasureBatchAbi.REQUEST_INT_STRIDE).apply {
+            this[HostMeasureBatchAbi.ELEMENT_TYPE] = 2
+            this[HostMeasureBatchAbi.KIND] = 1
+            this[HostMeasureBatchAbi.AVAILABLE_WIDTH_KIND] = 0
+            this[HostMeasureBatchAbi.AVAILABLE_HEIGHT_KIND] = 2
+            this[HostMeasureBatchAbi.FONT_WEIGHT] = command.optInt("font_weight", 400)
+            this[HostMeasureBatchAbi.FONT_STYLE] = when (command.optString("font_style", "normal")) {
                 "italic" -> 1
                 "oblique" -> 2
                 "normal" -> 0
                 else -> error("unsupported font_style: $command")
-            },
-            wrap = wrap,
-            wordBreak = wordBreak,
-            overflow = overflow,
-            letterSpacing = command.optDouble("letter_spacing", 0.0).toFloat(),
-            lineHeight = command.getDouble("line_height").toFloat(),
-            indentLogicalPixels = indentLogicalPixels,
-            indentPercentage = indentPercentage,
-            maxLines = maxLines,
-            fontSettings = (featureSettings + variationSettings).toTypedArray(),
-            fontFeatureCount = featureSettings.size,
-            fontOpticalSizing = opticalSizing,
-            payloadVersion = 0,
-            payload = byteArrayOf(),
-            intrinsicWidth = 0f,
-            intrinsicHeight = 0f,
-            intrinsicMask = 0,
-            direction = direction,
-            alignment = alignment,
+            }
+            this[HostMeasureBatchAbi.WRAP] = wrap
+            this[HostMeasureBatchAbi.WORD_BREAK] = wordBreak
+            this[HostMeasureBatchAbi.OVERFLOW] = overflow
+            this[HostMeasureBatchAbi.MAX_LINES] = maxLines
+            this[HostMeasureBatchAbi.FONT_FEATURE_COUNT] = featureSettings.size
+            this[HostMeasureBatchAbi.FONT_OPTICAL_SIZING] = opticalSizing
+            this[HostMeasureBatchAbi.DIRECTION] = direction
+            this[HostMeasureBatchAbi.ALIGNMENT] = alignment
+        }
+        val requestFloats = FloatArray(HostMeasureBatchAbi.REQUEST_FLOAT_STRIDE).apply {
+            this[HostMeasureBatchAbi.AVAILABLE_WIDTH] =
+                command.getDouble("available_width").toFloat()
+            this[HostMeasureBatchAbi.AVAILABLE_HEIGHT] = Float.POSITIVE_INFINITY
+            this[HostMeasureBatchAbi.FONT_SIZE] = command.getDouble("font_size").toFloat()
+            this[HostMeasureBatchAbi.LINE_HEIGHT] = command.getDouble("line_height").toFloat()
+            this[HostMeasureBatchAbi.LETTER_SPACING] =
+                command.optDouble("letter_spacing", 0.0).toFloat()
+            this[HostMeasureBatchAbi.INDENT_LOGICAL_PIXELS] = indentLogicalPixels
+            this[HostMeasureBatchAbi.INDENT_PERCENTAGE] = indentPercentage
+        }
+        val batch = view.measureBatchFromNative(
+            longArrayOf(command.getLong("key"), 1L, 1L),
+            requestInts,
+            requestFloats,
+            arrayOf(command.getString("text"), command.optString("locale", "")),
+            arrayOf(families),
+            arrayOf((featureSettings + variationSettings).toTypedArray()),
+            arrayOf(byteArrayOf()),
+        )
+        val result = floatArrayOf(
+            batch.ints[0].toFloat(),
+            batch.ints[1].toFloat(),
+            batch.floats[0],
+            batch.floats[1],
+            batch.floats[2],
+            batch.floats[3],
+            batch.ints[2].toFloat(),
         )
         check(result.size >= 7 && result[0] == 1f) { "$id text measurement was not ready" }
         if (id == "host.measure.text.font-features") {

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/MeasurementBatchAbiTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/MeasurementBatchAbiTest.kt
@@ -1,0 +1,101 @@
+package rs.whisker.runtime
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import rs.whisker.runtime.measure.HostMeasureBatchAbi
+
+@RunWith(AndroidJUnit4::class)
+class MeasurementBatchAbiTest {
+    @Test
+    fun measurementBatchPreservesRequestOrderAndResponseFields() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val view = WhiskerView(
+                ApplicationProvider.getApplicationContext<android.content.Context>(),
+            )
+            val requestLongs = longArrayOf(
+                11L, 101L, 201L,
+                12L, 102L, 202L,
+            )
+            val requestInts = IntArray(2 * HostMeasureBatchAbi.REQUEST_INT_STRIDE).apply {
+                this[HostMeasureBatchAbi.ELEMENT_TYPE] = 41
+                this[HostMeasureBatchAbi.KIND] = 2
+                this[HostMeasureBatchAbi.AVAILABLE_WIDTH_KIND] = 2
+                this[HostMeasureBatchAbi.AVAILABLE_HEIGHT_KIND] = 1
+                this[HostMeasureBatchAbi.FONT_WEIGHT] = 400
+                this[HostMeasureBatchAbi.WRAP] = 1
+                this[HostMeasureBatchAbi.PAYLOAD_VERSION] = 7
+                this[HostMeasureBatchAbi.INTRINSIC_MASK] = 3
+                this[HostMeasureBatchAbi.DIRECTION] = 1
+                this[HostMeasureBatchAbi.ALIGNMENT] = 2
+
+                val second = HostMeasureBatchAbi.REQUEST_INT_STRIDE
+                this[second + HostMeasureBatchAbi.ELEMENT_TYPE] = 42
+                this[second + HostMeasureBatchAbi.KIND] = 2
+                this[second + HostMeasureBatchAbi.KNOWN_MASK] = 3
+                this[second + HostMeasureBatchAbi.AVAILABLE_WIDTH_KIND] = 1
+                this[second + HostMeasureBatchAbi.AVAILABLE_HEIGHT_KIND] = 2
+                this[second + HostMeasureBatchAbi.FONT_WEIGHT] = 700
+                this[second + HostMeasureBatchAbi.FONT_STYLE] = 1
+                this[second + HostMeasureBatchAbi.WORD_BREAK] = 2
+                this[second + HostMeasureBatchAbi.OVERFLOW] = 1
+                this[second + HostMeasureBatchAbi.MAX_LINES] = 3
+                this[second + HostMeasureBatchAbi.PAYLOAD_VERSION] = 9
+                this[second + HostMeasureBatchAbi.INTRINSIC_MASK] = 3
+                this[second + HostMeasureBatchAbi.DIRECTION] = 2
+                this[second + HostMeasureBatchAbi.ALIGNMENT] = 4
+            }
+            val requestFloats = FloatArray(2 * HostMeasureBatchAbi.REQUEST_FLOAT_STRIDE).apply {
+                this[HostMeasureBatchAbi.AVAILABLE_WIDTH] = 37f
+                this[HostMeasureBatchAbi.AVAILABLE_HEIGHT] = 41f
+                this[HostMeasureBatchAbi.FONT_SIZE] = 13f
+                this[HostMeasureBatchAbi.LINE_HEIGHT] = 17f
+                this[HostMeasureBatchAbi.LETTER_SPACING] = 2f
+                this[HostMeasureBatchAbi.INDENT_LOGICAL_PIXELS] = 3f
+                this[HostMeasureBatchAbi.INDENT_PERCENTAGE] = 4f
+                this[HostMeasureBatchAbi.INTRINSIC_WIDTH] = 43f
+                this[HostMeasureBatchAbi.INTRINSIC_HEIGHT] = 47f
+
+                val second = HostMeasureBatchAbi.REQUEST_FLOAT_STRIDE
+                this[second + HostMeasureBatchAbi.KNOWN_WIDTH] = 71f
+                this[second + HostMeasureBatchAbi.KNOWN_HEIGHT] = 73f
+                this[second + HostMeasureBatchAbi.AVAILABLE_WIDTH] = 79f
+                this[second + HostMeasureBatchAbi.AVAILABLE_HEIGHT] = 83f
+                this[second + HostMeasureBatchAbi.FONT_SIZE] = 19f
+                this[second + HostMeasureBatchAbi.LINE_HEIGHT] = 23f
+                this[second + HostMeasureBatchAbi.LETTER_SPACING] = 5f
+                this[second + HostMeasureBatchAbi.INDENT_LOGICAL_PIXELS] = 6f
+                this[second + HostMeasureBatchAbi.INDENT_PERCENTAGE] = 7f
+                this[second + HostMeasureBatchAbi.INTRINSIC_WIDTH] = 89f
+                this[second + HostMeasureBatchAbi.INTRINSIC_HEIGHT] = 97f
+            }
+
+            val response = view.measureBatchFromNative(
+                requestLongs,
+                requestInts,
+                requestFloats,
+                arrayOf("first", "ja-JP", "second", "en-US"),
+                arrayOf(arrayOf("sans-serif"), arrayOf("serif")),
+                arrayOf(arrayOf("kern=1"), arrayOf("wght=700")),
+                arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4, 5)),
+            )
+
+            assertArrayEquals(
+                longArrayOf(11L, 201L, 0L, 0L, 12L, 202L, 0L, 0L),
+                response.longs,
+            )
+            assertArrayEquals(
+                intArrayOf(1, 0, 0, 1, 0, 0),
+                response.ints,
+            )
+            assertArrayEquals(
+                floatArrayOf(43f, 47f, 0f, 0f, 71f, 73f, 0f, 0f),
+                response.floats,
+                0f,
+            )
+        }
+    }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -26,6 +26,10 @@ import rs.whisker.runtime.scene.HostNode
 import rs.whisker.runtime.scene.HostScene
 import rs.whisker.runtime.scene.HostSceneOperation
 
+private const val HOST_SCENE_OPERATION_STRIDE = 10
+private const val HOST_APPLY_ACCEPTED = 0
+private const val HOST_APPLY_REJECTED = 2
+
 /** The single Android View that owns a Whisker runtime and its native scene. */
 class WhiskerView(context: Context) :
     WhiskerContainerView(context),
@@ -276,6 +280,75 @@ class WhiskerView(context: Context) :
     ): Int = scene.beginFrame(mode, epoch, baseRevision, targetRevision)
 
     fun currentRevisionFromNative(): Long = scene.currentRevision()
+
+    /**
+     * Accepts one complete scene transaction through a single JNI method invocation.
+     *
+     * Each operation occupies ten longs in [metadata]: tag, flags, node, parent, child,
+     * index, member, integer, scalar bits, and wide. Variable-sized typed payloads remain
+     * in parallel arrays so JNI owns them for the duration of this call.
+     */
+    @Suppress("LongParameterList")
+    fun presentFrameFromNative(
+        mode: Int,
+        epoch: Int,
+        baseRevision: Long,
+        targetRevision: Long,
+        metadata: LongArray,
+        numbers: Array<FloatArray?>,
+        texts: Array<String?>,
+        names: Array<Array<String>?>,
+        values: Array<WhiskerValue?>,
+        response: LongArray,
+    ): Boolean {
+        if (response.size < 2) return false
+        val operationCount = metadata.size / HOST_SCENE_OPERATION_STRIDE
+        if (
+            metadata.size % HOST_SCENE_OPERATION_STRIDE != 0 ||
+            numbers.size != operationCount ||
+            texts.size != operationCount ||
+            names.size != operationCount ||
+            values.size != operationCount
+        ) {
+            response[0] = HOST_APPLY_REJECTED.toLong()
+            response[1] = scene.currentRevision()
+            return true
+        }
+
+        val beginStatus = scene.beginFrame(mode, epoch, baseRevision, targetRevision)
+        if (beginStatus != HOST_APPLY_ACCEPTED) {
+            response[0] = beginStatus.toLong()
+            response[1] = scene.currentRevision()
+            return true
+        }
+
+        repeat(operationCount) { index ->
+            val offset = index * HOST_SCENE_OPERATION_STRIDE
+            scene.stage(
+                HostSceneOperation(
+                    tag = metadata[offset].toInt(),
+                    flags = metadata[offset + 1].toInt(),
+                    node = metadata[offset + 2],
+                    parent = metadata[offset + 3],
+                    child = metadata[offset + 4],
+                    index = metadata[offset + 5].toInt(),
+                    member = metadata[offset + 6].toInt(),
+                    integer = metadata[offset + 7].toInt(),
+                    scalar = Float.fromBits(metadata[offset + 8].toInt()),
+                    wide = metadata[offset + 9],
+                    numbers = numbers[index],
+                    text = texts[index],
+                    names = names[index],
+                    value = values[index],
+                ),
+            )
+        }
+
+        val accepted = scene.commit()
+        response[0] = (if (accepted) HOST_APPLY_ACCEPTED else HOST_APPLY_REJECTED).toLong()
+        response[1] = if (accepted) targetRevision else scene.currentRevision()
+        return true
+    }
 
     /** Registers an already decoded raster. Acquisition and eviction are separate Host concerns. */
     fun registerRasterResourceFromNative(resourceId: Long, bitmap: Bitmap): Boolean =

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -14,6 +14,8 @@ import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.input.HostPointerInput
 import rs.whisker.runtime.input.normalizePointerInput
 import rs.whisker.runtime.measure.HostMeasurementProvider
+import rs.whisker.runtime.measure.HostMeasureBatchAbi
+import rs.whisker.runtime.measure.HostMeasureBatchResponse
 import rs.whisker.runtime.module.HostModuleDispatcher
 import rs.whisker.runtime.paint.HostRasterResourceStore
 import rs.whisker.runtime.resource.HostResourceAbiEvent
@@ -520,27 +522,24 @@ class WhiskerView(context: Context) :
         }
     }
 
-    @Suppress("LongParameterList")
-    fun measureFromNative(
-        elementType: Int, kind: Int,
-        knownWidth: Float, knownHeight: Float, knownMask: Int,
-        availableWidth: Float, availableHeight: Float, availableWidthKind: Int, availableHeightKind: Int,
-        text: String, fontFamilies: Array<String>, fontSize: Float, fontWeight: Int,
-        fontStyle: Int, wrap: Int, wordBreak: Int, overflow: Int, letterSpacing: Float,
-        lineHeight: Float, indentLogicalPixels: Float, indentPercentage: Float,
-        maxLines: Int, fontSettings: Array<String>, fontFeatureCount: Int,
-        fontOpticalSizing: Int, payloadVersion: Int, payload: ByteArray,
-        intrinsicWidth: Float, intrinsicHeight: Float, intrinsicMask: Int,
-        direction: Int, alignment: Int,
-    ): FloatArray = measurements.measure(
-        elementType, kind,
-        knownWidth, knownHeight, knownMask,
-        availableWidth, availableHeight, availableWidthKind, availableHeightKind,
-        text, fontFamilies, fontSize, fontWeight,
-        fontStyle, wrap, wordBreak, overflow, letterSpacing,
-        lineHeight, indentLogicalPixels, indentPercentage,
-        maxLines, fontSettings, fontFeatureCount, fontOpticalSizing, payloadVersion, payload,
-        intrinsicWidth, intrinsicHeight, intrinsicMask, direction, alignment,
+    /** Processes one native intrinsic-measurement batch in a single Host call. */
+    fun measureBatchFromNative(
+        requestLongs: LongArray,
+        requestInts: IntArray,
+        requestFloats: FloatArray,
+        requestStrings: Array<String>,
+        fontFamilies: Array<Array<String>>,
+        fontSettings: Array<Array<String>>,
+        payloads: Array<ByteArray>,
+    ): HostMeasureBatchResponse = HostMeasureBatchAbi.measure(
+        measurements,
+        requestLongs,
+        requestInts,
+        requestFloats,
+        requestStrings,
+        fontFamilies,
+        fontSettings,
+        payloads,
     )
 
     private external fun nativeCreate(width: Float, height: Float, scale: Float): Long

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/MeasurementBatch.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/MeasurementBatch.kt
@@ -1,0 +1,144 @@
+package rs.whisker.runtime.measure
+
+/** Result storage returned across the Android Host measurement JNI seam. */
+class HostMeasureBatchResponse(
+    @JvmField val longs: LongArray,
+    @JvmField val ints: IntArray,
+    @JvmField val floats: FloatArray,
+)
+
+/** Flat-array layout shared with the Android C bridge. */
+internal object HostMeasureBatchAbi {
+    const val REQUEST_LONG_STRIDE = 3
+    const val KEY = 0
+    const val NODE = 1
+    const val ENVIRONMENT_EPOCH = 2
+
+    const val REQUEST_INT_STRIDE = 17
+    const val ELEMENT_TYPE = 0
+    const val KIND = 1
+    const val KNOWN_MASK = 2
+    const val AVAILABLE_WIDTH_KIND = 3
+    const val AVAILABLE_HEIGHT_KIND = 4
+    const val FONT_WEIGHT = 5
+    const val FONT_STYLE = 6
+    const val WRAP = 7
+    const val WORD_BREAK = 8
+    const val OVERFLOW = 9
+    const val MAX_LINES = 10
+    const val FONT_FEATURE_COUNT = 11
+    const val FONT_OPTICAL_SIZING = 12
+    const val PAYLOAD_VERSION = 13
+    const val INTRINSIC_MASK = 14
+    const val DIRECTION = 15
+    const val ALIGNMENT = 16
+
+    const val REQUEST_FLOAT_STRIDE = 11
+    const val KNOWN_WIDTH = 0
+    const val KNOWN_HEIGHT = 1
+    const val AVAILABLE_WIDTH = 2
+    const val AVAILABLE_HEIGHT = 3
+    const val FONT_SIZE = 4
+    const val LINE_HEIGHT = 5
+    const val LETTER_SPACING = 6
+    const val INDENT_LOGICAL_PIXELS = 7
+    const val INDENT_PERCENTAGE = 8
+    const val INTRINSIC_WIDTH = 9
+    const val INTRINSIC_HEIGHT = 10
+
+    const val REQUEST_STRING_STRIDE = 2
+    const val TEXT = 0
+    const val LOCALE = 1
+
+    const val RESPONSE_LONG_STRIDE = 4
+    const val RESPONSE_INT_STRIDE = 3
+    const val RESPONSE_FLOAT_STRIDE = 4
+
+    @Suppress("LongParameterList")
+    fun measure(
+        provider: HostMeasurementProvider,
+        requestLongs: LongArray,
+        requestInts: IntArray,
+        requestFloats: FloatArray,
+        requestStrings: Array<String>,
+        fontFamilies: Array<Array<String>>,
+        fontSettings: Array<Array<String>>,
+        payloads: Array<ByteArray>,
+    ): HostMeasureBatchResponse {
+        require(requestLongs.size % REQUEST_LONG_STRIDE == 0)
+        val count = requestLongs.size / REQUEST_LONG_STRIDE
+        require(requestInts.size == count * REQUEST_INT_STRIDE)
+        require(requestFloats.size == count * REQUEST_FLOAT_STRIDE)
+        require(requestStrings.size == count * REQUEST_STRING_STRIDE)
+        require(fontFamilies.size == count)
+        require(fontSettings.size == count)
+        require(payloads.size == count)
+
+        val responseLongs = LongArray(count * RESPONSE_LONG_STRIDE)
+        val responseInts = IntArray(count * RESPONSE_INT_STRIDE)
+        val responseFloats = FloatArray(count * RESPONSE_FLOAT_STRIDE)
+        repeat(count) { index ->
+            val longBase = index * REQUEST_LONG_STRIDE
+            val intBase = index * REQUEST_INT_STRIDE
+            val floatBase = index * REQUEST_FLOAT_STRIDE
+            val stringBase = index * REQUEST_STRING_STRIDE
+            // Node remains in the batch contract for request identity even though
+            // the Android measurement provider does not currently consume it.
+            val measured = provider.measure(
+                requestInts[intBase + ELEMENT_TYPE],
+                requestInts[intBase + KIND],
+                requestFloats[floatBase + KNOWN_WIDTH],
+                requestFloats[floatBase + KNOWN_HEIGHT],
+                requestInts[intBase + KNOWN_MASK],
+                requestFloats[floatBase + AVAILABLE_WIDTH],
+                requestFloats[floatBase + AVAILABLE_HEIGHT],
+                requestInts[intBase + AVAILABLE_WIDTH_KIND],
+                requestInts[intBase + AVAILABLE_HEIGHT_KIND],
+                requestStrings[stringBase + TEXT],
+                requestStrings[stringBase + LOCALE],
+                fontFamilies[index],
+                requestFloats[floatBase + FONT_SIZE],
+                requestInts[intBase + FONT_WEIGHT],
+                requestInts[intBase + FONT_STYLE],
+                requestInts[intBase + WRAP],
+                requestInts[intBase + WORD_BREAK],
+                requestInts[intBase + OVERFLOW],
+                requestFloats[floatBase + LETTER_SPACING],
+                requestFloats[floatBase + LINE_HEIGHT],
+                requestFloats[floatBase + INDENT_LOGICAL_PIXELS],
+                requestFloats[floatBase + INDENT_PERCENTAGE],
+                requestInts[intBase + MAX_LINES],
+                fontSettings[index],
+                requestInts[intBase + FONT_FEATURE_COUNT],
+                requestInts[intBase + FONT_OPTICAL_SIZING],
+                requestInts[intBase + PAYLOAD_VERSION],
+                payloads[index],
+                requestFloats[floatBase + INTRINSIC_WIDTH],
+                requestFloats[floatBase + INTRINSIC_HEIGHT],
+                requestInts[intBase + INTRINSIC_MASK],
+                requestInts[intBase + DIRECTION],
+                requestInts[intBase + ALIGNMENT],
+            )
+            require(measured.size >= 7)
+
+            val responseLongBase = index * RESPONSE_LONG_STRIDE
+            responseLongs[responseLongBase] = requestLongs[longBase + KEY]
+            responseLongs[responseLongBase + 1] = requestLongs[longBase + ENVIRONMENT_EPOCH]
+            // Android measurement does not currently produce prepared-content handles.
+            responseLongs[responseLongBase + 2] = 0
+            responseLongs[responseLongBase + 3] = 0
+
+            val responseIntBase = index * RESPONSE_INT_STRIDE
+            responseInts[responseIntBase] = measured[0].toInt()
+            responseInts[responseIntBase + 1] = measured[1].toInt()
+            responseInts[responseIntBase + 2] = measured[6].toInt()
+
+            val responseFloatBase = index * RESPONSE_FLOAT_STRIDE
+            responseFloats[responseFloatBase] = measured[2]
+            responseFloats[responseFloatBase + 1] = measured[3]
+            responseFloats[responseFloatBase + 2] = measured[4]
+            responseFloats[responseFloatBase + 3] = measured[5]
+        }
+        return HostMeasureBatchResponse(responseLongs, responseInts, responseFloats)
+    }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
@@ -14,6 +14,7 @@ import android.text.TextUtils
 import android.text.style.LeadingMarginSpan
 import android.view.View
 import java.text.Bidi
+import java.util.Locale
 import kotlin.math.ceil
 import rs.whisker.runtime.WhiskerAvailableSpace
 import rs.whisker.runtime.WhiskerElementRegistry
@@ -31,7 +32,7 @@ internal class HostMeasurementProvider(private val context: Context) {
         knownWidth: Float, knownHeight: Float, knownMask: Int,
         availableWidth: Float, availableHeight: Float,
         availableWidthKind: Int, availableHeightKind: Int,
-        text: String, fontFamilies: Array<String>, fontSize: Float, fontWeight: Int,
+        text: String, locale: String, fontFamilies: Array<String>, fontSize: Float, fontWeight: Int,
         fontStyle: Int, wrap: Int, wordBreak: Int, overflow: Int, letterSpacing: Float,
         lineHeight: Float, indentLogicalPixels: Float, indentPercentage: Float,
         maxLines: Int, fontSettings: Array<String>, fontFeatureCount: Int,
@@ -43,7 +44,7 @@ internal class HostMeasurementProvider(private val context: Context) {
             return measureText(
                 knownWidth, knownHeight, knownMask,
                 availableWidth, availableWidthKind,
-                text, fontFamilies, fontSize, fontWeight, fontStyle, wrap, wordBreak, overflow,
+                text, locale, fontFamilies, fontSize, fontWeight, fontStyle, wrap, wordBreak, overflow,
                 letterSpacing, lineHeight, indentLogicalPixels, indentPercentage, maxLines,
                 fontSettings, fontFeatureCount, fontOpticalSizing, direction, alignment,
             )
@@ -79,7 +80,7 @@ internal class HostMeasurementProvider(private val context: Context) {
     private fun measureText(
         knownWidth: Float, knownHeight: Float, knownMask: Int,
         availableWidth: Float, availableWidthKind: Int,
-        text: String, fontFamilies: Array<String>, fontSize: Float, fontWeight: Int,
+        text: String, locale: String, fontFamilies: Array<String>, fontSize: Float, fontWeight: Int,
         fontStyle: Int, wrap: Int, wordBreak: Int, overflow: Int, letterSpacing: Float,
         lineHeight: Float, indentLogicalPixels: Float, indentPercentage: Float, maxLines: Int,
         fontSettings: Array<String>, fontFeatureCount: Int, fontOpticalSizing: Int,
@@ -88,6 +89,7 @@ internal class HostMeasurementProvider(private val context: Context) {
         val density = context.resources.displayMetrics.density
         val paint = TextPaint().apply {
             textSize = fontSize * density
+            if (locale.isNotEmpty()) textLocale = Locale.forLanguageTag(locale)
             val italic = fontStyle != FONT_STYLE_NORMAL
             val baseTypeface = resolveWhiskerTypeface(fontFamilies.asList())
             typeface = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {


### PR DESCRIPTION
## Summary
- present each Android FramePacket through one Kotlin method invocation instead of begin + one stage call per operation + commit
- submit each intrinsic-measurement batch through one Kotlin method invocation instead of one call per request
- preserve transactional frame validation, snapshot recovery, operation/request ordering, and complete response metadata
- pass locale through Android text measurement

## Validation
- `:runtime:compileDebugAndroidTestKotlin`
- `:runtime:assembleDebugAndroidTest`
- `:runtime:assembleRelease`
- `cargo check -p whisker-driver-sys --target aarch64-linux-android`
- Android bridge C syntax check with `-Wall -Wextra -Werror`
- `cargo test -p whisker-driver-sys`
- `cargo fmt --all --check`

## Dependency
This is stacked on #524 so the Android ABI changes are reviewed after the module-platform parity foundation.