### PR TITLE
refactor(css): require structured style values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6279,6 +6279,7 @@ dependencies = [
  "whisker-config",
  "whisker-plugin",
  "whisker-router-macros",
+ "whisker-style",
 ]
 
 [[package]]

--- a/crates/whisker-cli/src/new_app.rs
+++ b/crates/whisker-cli/src/new_app.rs
@@ -177,7 +177,10 @@ fn lib_rs(v: &Vars) -> String {
     format!(
         r##"//! {display} — a Whisker app.
 
-use whisker::css::{{AlignItems, Color, Display, FlexDirection, FontWeight, JustifyContent}};
+use whisker::css::{{
+    AlignItems, Color, ColorStop, Display, FlexDirection, FontWeight, Gradient,
+    JustifyContent, LinearDirection,
+}};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 
@@ -208,9 +211,7 @@ fn root() -> Element {{
 
     render! {{
         // Styles use the typed `css!` macro: field names map to CSS
-        // properties and values are checked at compile time. Reach for
-        // `.raw("prop", "value")` for anything the typed builder doesn't
-        // cover yet (here: `gap` and the gradient `background`).
+        // properties and values are checked at compile time.
         view(style: css!(
             flex_grow: 1.0,
             display: Display::Flex,
@@ -221,24 +222,30 @@ fn root() -> Element {{
             background_color: Color::hex(0x0b0b0f),
         )) {{
             // A card: column layout, padding, rounded corners, plus a
-            // `gap` and a linear-gradient background via `.raw(...)`.
+            // gap and a typed linear-gradient background.
             view(style: css!(
                 display: Display::Flex,
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
                 padding: px(32),
                 border_radius: px(20),
-            )
-            .raw("gap", "6px")
-            .raw("background", "linear-gradient(135deg, #7c5cff 0%, #4e9bff 100%)")) {{
+                gap: px(6),
+                background_image: Gradient::Linear {{
+                    direction: LinearDirection::Angle(135.deg().into()),
+                    stops: vec![
+                        ColorStop::at(Color::hex(0x7c5cff), percent(0)),
+                        ColorStop::at(Color::hex(0x4e9bff), percent(100)),
+                    ],
+                }},
+            )) {{
                 text(
                     value: "{display}",
                     style: css!(
                         color: Color::hex(0xffffff),
                         font_size: px(22),
                         font_weight: FontWeight::Bold,
-                    )
-                    .raw("letter-spacing", "0.5px"),
+                        letter_spacing: px(0.5),
+                    ),
                 )
                 text(
                     value: "Edit `Root` and save — hot reload in under a second",
@@ -258,8 +265,8 @@ fn root() -> Element {{
                     display: Display::Flex,
                     flex_direction: FlexDirection::Row,
                     margin_top: px(16),
-                )
-                .raw("gap", "12px")) {{
+                    gap: px(12),
+                )) {{
                     Button(label: "-1", delta: -1, count: count)
                     Button(label: "+1", delta: 1, count: count)
                 }}
@@ -278,8 +285,8 @@ fn button(label: &'static str, delta: i32, count: RwSignal<i32>) -> Element {{
             style: css!(
                 border_radius: px(12),
                 background_color: Color::rgba(255, 255, 255, 0.18),
-            )
-            .raw("padding", "12px 22px"),
+                padding: (px(12), px(22)),
+            ),
             on_tap: move |_| count.set(count.get() + delta),
         ) {{
             text(

--- a/crates/whisker-css/src/css.rs
+++ b/crates/whisker-css/src/css.rs
@@ -45,19 +45,13 @@ impl std::error::Error for UnmigratedStyleValue {}
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum PropertyKey {
     Known(StyleProperty),
-    Legacy(&'static str),
     Custom(CustomPropertyName),
 }
 
 impl PropertyKey {
-    fn from_name(name: &'static str) -> Self {
-        StyleProperty::from_css_name(name).map_or(Self::Legacy(name), Self::Known)
-    }
-
     fn name(&self) -> &str {
         match self {
             Self::Known(property) => property.css_name(),
-            Self::Legacy(name) => name,
             Self::Custom(name) => name.as_str(),
         }
     }
@@ -98,14 +92,6 @@ impl CssProp {
         }
     }
 
-    fn legacy(name: &'static str, value: String) -> Self {
-        Self {
-            property: PropertyKey::from_name(name),
-            style_value: None,
-            lynx_value: value,
-        }
-    }
-
     fn custom(name: CustomPropertyName, value: StyleValue, css_value: String) -> Self {
         Self {
             property: PropertyKey::Custom(name),
@@ -119,12 +105,11 @@ impl CssProp {
         self.property.name()
     }
 
-    /// The registered property identity, or `None` for an unknown name added
-    /// through the temporary [`Css::raw`] migration escape hatch.
+    /// The registered property identity, or `None` for a custom property.
     pub fn property(&self) -> Option<StyleProperty> {
         match &self.property {
             PropertyKey::Known(property) => Some(*property),
-            PropertyKey::Legacy(_) | PropertyKey::Custom(_) => None,
+            PropertyKey::Custom(_) => None,
         }
     }
 
@@ -218,20 +203,6 @@ impl Css {
     pub(crate) fn push_raw(mut self, property: StyleProperty, value: impl Into<String>) -> Self {
         self.props.push(CssProp::new(property, value.into()));
         self
-    }
-
-    /// Escape hatch — append a raw CSS declaration without
-    /// type-checking. Use this when Lynx supports a property Whisker
-    /// has not yet wrapped, or when copying a value verbatim from
-    /// hand-written CSS.
-    ///
-    /// `name` should be a `&'static str` because property names are
-    /// part of the CSS grammar, not runtime data. The value is taken
-    /// verbatim and not validated.
-    pub fn raw(self, name: &'static str, value: impl Into<String>) -> Self {
-        let mut this = self;
-        this.props.push(CssProp::legacy(name, value.into()));
-        this
     }
 
     /// Defines an inherited typed CSS custom property.
@@ -347,11 +318,6 @@ impl Css {
                 PropertyKey::Custom(name) => {
                     style = style.push_custom(name.clone(), value);
                 }
-                PropertyKey::Legacy(_) => {
-                    return Err(UnmigratedStyleValue {
-                        property: property.name().to_owned(),
-                    });
-                }
             }
         }
         Ok(style)
@@ -421,8 +387,8 @@ mod tests {
     }
 
     #[test]
-    fn raw_appends_a_declaration() {
-        let s = Css::new().raw("color", "red");
+    fn typed_builder_appends_a_declaration() {
+        let s = Css::new().color(Color::Named(NamedColor::Red));
         assert_eq!(s.to_css_string(), "color: red;");
         assert!(!s.is_empty());
         assert_eq!(s.len(), 1);
@@ -431,17 +397,17 @@ mod tests {
     #[test]
     fn multiple_distinct_properties_keep_order() {
         let s = Css::new()
-            .raw("color", "red")
-            .raw("background-color", "blue");
+            .color(Color::Named(NamedColor::Red))
+            .background_color(Color::Named(NamedColor::Blue));
         assert_eq!(s.to_css_string(), "color: red; background-color: blue;");
     }
 
     #[test]
     fn duplicate_property_uses_last_value() {
         let s = Css::new()
-            .raw("color", "red")
-            .raw("color", "blue")
-            .raw("color", "green");
+            .color(Color::Named(NamedColor::Red))
+            .color(Color::Named(NamedColor::Blue))
+            .color(Color::Named(NamedColor::Green));
         assert_eq!(s.to_css_string(), "color: green;");
         assert_eq!(s.len(), 3);
         assert_eq!(s.resolved().len(), 1);
@@ -452,31 +418,33 @@ mod tests {
         // The last write decides where the property lands in the
         // resolved order.
         let s = Css::new()
-            .raw("color", "red")
-            .raw("background-color", "white")
-            .raw("color", "blue");
+            .color(Color::Named(NamedColor::Red))
+            .background_color(Color::Named(NamedColor::White))
+            .color(Color::Named(NamedColor::Blue));
         assert_eq!(s.to_css_string(), "background-color: white; color: blue;");
     }
 
     #[test]
     fn entries_iterates_all_in_order() {
-        let s = Css::new().raw("color", "red").raw("color", "blue");
+        let s = Css::new()
+            .color(Color::Named(NamedColor::Red))
+            .color(Color::Named(NamedColor::Blue));
         let names: Vec<&str> = s.entries().map(|p| p.name()).collect();
         assert_eq!(names, ["color", "color"]);
     }
 
     #[test]
     fn merge_lets_other_win() {
-        let base = Css::new().raw("color", "red");
-        let overlay = Css::new().raw("color", "blue");
+        let base = Css::new().color(Color::Named(NamedColor::Red));
+        let overlay = Css::new().color(Color::Named(NamedColor::Blue));
         let merged = base.merge(overlay);
         assert_eq!(merged.to_css_string(), "color: blue;");
     }
 
     #[test]
     fn merge_preserves_distinct_props() {
-        let base = Css::new().raw("color", "red");
-        let overlay = Css::new().raw("background-color", "yellow");
+        let base = Css::new().color(Color::Named(NamedColor::Red));
+        let overlay = Css::new().background_color(Color::Named(NamedColor::Yellow));
         let merged = base.merge(overlay);
         assert_eq!(
             merged.to_css_string(),
@@ -486,50 +454,44 @@ mod tests {
 
     #[test]
     fn into_string_via_from_owned() {
-        let s = Css::new().raw("color", "red");
+        let s = Css::new().color(Color::Named(NamedColor::Red));
         let css: String = s.into();
         assert_eq!(css, "color: red;");
     }
 
     #[test]
     fn into_string_via_from_borrowed() {
-        let s = Css::new().raw("color", "red");
+        let s = Css::new().color(Color::Named(NamedColor::Red));
         let css: String = (&s).into();
         assert_eq!(css, "color: red;");
     }
 
     #[test]
     fn display_matches_to_css_string() {
-        let s = Css::new().raw("color", "red").raw("padding", "8px");
+        let s = Css::new()
+            .color(Color::Named(NamedColor::Red))
+            .padding_top(Length::Px(8.0));
         assert_eq!(format!("{s}"), s.to_css_string());
     }
 
     #[test]
     fn style_prop_accessors() {
-        let s = Css::new().raw("color", "red");
+        let s = Css::new().color(Color::Named(NamedColor::Red));
         let prop = s.entries().next().unwrap();
         assert_eq!(prop.name(), "color");
         assert_eq!(prop.property(), Some(StyleProperty::Color));
         assert_eq!(prop.property_id(), Some(StyleProperty::Color.id()));
-        assert_eq!(prop.style_value(), None);
+        assert!(prop.style_value().is_some());
         assert_eq!(prop.value(), "red");
         assert_eq!(prop.to_css_string(), "color: red;");
     }
 
     #[test]
-    fn unknown_raw_property_has_no_registered_identity() {
-        let s = Css::new().raw("future-property", "value");
-        let prop = s.entries().next().unwrap();
-        assert_eq!(prop.name(), "future-property");
-        assert_eq!(prop.property(), None);
-        assert_eq!(prop.property_id(), None);
-    }
-
-    #[test]
-    fn known_raw_and_typed_writes_share_the_same_slot() {
-        let s = Css::new()
-            .push(StyleProperty::Color, Token("red"))
-            .raw("color", "blue");
+    fn compatibility_and_typed_writes_share_the_same_slot() {
+        let s = Css {
+            props: vec![CssProp::new(StyleProperty::Color, "red".to_string())],
+        }
+        .color(Color::Named(NamedColor::Blue));
         assert_eq!(s.resolved().len(), 1);
         assert_eq!(s.to_css_string(), "color: blue;");
     }
@@ -558,14 +520,15 @@ mod tests {
 
     #[test]
     fn compatibility_fragment_reports_the_blocking_property() {
-        let error = Css::new()
-            .raw("future-property", "value")
-            .to_specified_style()
-            .unwrap_err();
-        assert_eq!(error.property(), "future-property");
+        let error = Css {
+            props: vec![CssProp::new(StyleProperty::Color, "red".to_string())],
+        }
+        .to_specified_style()
+        .unwrap_err();
+        assert_eq!(error.property(), "color");
         assert_eq!(
             error.to_string(),
-            "style property `future-property` still requires Lynx CSS compatibility"
+            "style property `color` still requires Lynx CSS compatibility"
         );
     }
 
@@ -873,13 +836,5 @@ mod tests {
         );
         assert_eq!(layout.gap.height.length(), 0.0);
         assert_eq!(layout.gap.height.fraction(), 0.1);
-    }
-
-    struct Token(&'static str);
-
-    impl ToCss for Token {
-        fn to_css(&self, dest: &mut dyn fmt::Write) -> fmt::Result {
-            dest.write_str(self.0)
-        }
     }
 }

--- a/crates/whisker-css/tests/compound_cases.rs
+++ b/crates/whisker-css/tests/compound_cases.rs
@@ -163,16 +163,6 @@ fn empty_style_is_empty_string() {
 }
 
 #[test]
-fn raw_escape_hatch_coexists_with_typed() {
-    let s = Css::new()
-        .padding(px(8))
-        .raw("-webkit-tap-highlight-color", "transparent");
-    let css = s.to_string();
-    assert!(css.contains("padding-top: 8px"));
-    assert!(css.contains("-webkit-tap-highlight-color: transparent"));
-}
-
-#[test]
 fn merge_overlays_other_onto_self() {
     let base = Css::new().padding(px(4)).color(Color::hex(0x000000));
     let overlay = Css::new().color(Color::hex(0xFFFFFF));

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -86,7 +86,7 @@ pub fn WhiskerModule(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// #[whisker::main]
 /// fn app() -> Element {
-///     render! { view(style: "flex-grow: 1;") { text(value: "Hello") } }
+///     render! { view(style: css!(flex_grow: 1.0)) { text(value: "Hello") } }
 /// }
 /// ```
 ///
@@ -371,7 +371,7 @@ pub(crate) fn fnv1a64(s: &str) -> u64 {
 ///
 /// let handle = render! {
 ///     view(
-///         style: "padding: 16px;",
+///         style: css!(padding: px(16)),
 ///         on_tap: move |_| println!("tapped"),
 ///     ) {
 ///         text(value: "Hello, world")
@@ -473,15 +473,15 @@ pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     name = "example.ui/Hello",
 ///     measurement = None,
 /// )]
-/// pub fn hello(style: Signal<String>) {}
+/// pub fn hello(style: whisker::Style) {}
 /// ```
 ///
 /// Generates the same Props + builder + PascalCase-alias surface as
 /// `#[component]`, but the function body is **auto-generated**: it
 /// calls `view::create_element_by_name(tag)` and then applies each
-/// declared prop as either an inline-style (for the `style` prop) or
+/// declared prop as either structured CSS (for the `style` prop) or
 /// a SetAttribute (everything else, kebab-cased). Static vs reactive
-/// dispatch goes through the same `apply_styles` / `apply_attr`
+/// dispatch goes through the same `apply_style` / `apply_attr`
 /// helpers built-in tags use, so a `Signal::Dynamic` prop transparently
 /// effect-wraps the attribute write.
 ///
@@ -505,7 +505,7 @@ pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// render! {
-///     Hello(style: "width: 100%; height: 8px;")
+///     Hello(style: css!(width: percent(100), height: px(8)))
 /// }
 /// ```
 ///

--- a/crates/whisker-macros/src/module_component.rs
+++ b/crates/whisker-macros/src/module_component.rs
@@ -5,7 +5,7 @@
 //! same `<Name>Props` struct, same hand-rolled builder, same
 //! PascalCase alias — but the function body is **auto-generated**
 //! rather than supplied by the user. Each declared parameter becomes
-//! either a component-specific attribute, an inline-style write, a
+//! either a component-specific attribute, a structured-style write, a
 //! component-specific event handler, or the children list on the
 //! underlying element, depending on its name + type. The generated
 //! builder also implements Whisker's common `ElementBuilder` API, so
@@ -22,7 +22,7 @@
 //! pub fn input(
 //!     value: Signal<String>,                // → SetAttribute("value", …) — Static / Dynamic dispatch
 //!     placeholder: Signal<String>,          // → SetAttribute("placeholder", …)
-//!     style: Signal<String>,                // → SetRawInlineStyles(…)
+//!     style: whisker::Style,                // → SetSpecifiedStyle(…)
 //!     checked: Signal<bool>,                // → SetAttribute("checked", "true" / "false") via ToString
 //!     on_focus: (),                         // → event::bind_unit("focus", Fn())
 //!     on_input: TouchEvent,                 // → event::bind_typed::<TouchEvent>("input", Fn(TouchEvent))
@@ -46,7 +46,7 @@
 //! | any          | `Children`           | Children block                     |
 //! | `on_*`       | `()`                 | Event handler, payload ignored     |
 //! | `on_*`       | `E: Deserialize`     | Event handler, body deserialized into `E` (`TouchEvent`, `WhiskerValue`, …) |
-//! | `style`      | `Signal<String>` etc.| Inline-styles (SetRawInlineStyles) |
+//! | `style`      | `whisker::Style`      | Structured style (SetSpecifiedStyle) |
 //! | other        | `Signal<T>`          | Attribute, dispatch on Static/Dynamic |
 //! | other        | `T`                  | Attribute, static set-once         |
 //!

--- a/crates/whisker-macros/src/render.rs
+++ b/crates/whisker-macros/src/render.rs
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn view_emission_uses_builder_chain() {
-        let input: TokenStream2 = quote::quote! { view(style: "x") };
+        let input: TokenStream2 = quote::quote! { view(style: typed_style) };
         let output = super::expand_test(input).to_string();
         assert!(
             output.contains("__view_ctor"),
@@ -545,7 +545,7 @@ mod tests {
 
     #[test]
     fn no_children_emits_bare_chain_expression() {
-        let input: TokenStream2 = quote::quote! { view(style: "x") };
+        let input: TokenStream2 = quote::quote! { view(style: typed_style) };
         let output = super::expand_test(input).to_string();
         assert!(
             !output.contains("let __h"),
@@ -658,7 +658,7 @@ mod tests {
     #[test]
     fn children_block_emits_child_method() {
         let input: TokenStream2 = quote::quote! {
-            view(style: "x") {
+            view(style: typed_style) {
                 view(class: "y")
             }
         };
@@ -672,7 +672,7 @@ mod tests {
     #[test]
     fn nested_children_use_inline_chain() {
         let input: TokenStream2 = quote::quote! {
-            view(style: "outer") {
+            view(style: outer_style) {
                 view(class: "inner")
             }
         };
@@ -687,7 +687,7 @@ mod tests {
     #[test]
     fn children_slot_lowers_to_mount_children() {
         let input: TokenStream2 = quote::quote! {
-            view(style: "x") {
+            view(style: typed_style) {
                 children()
             }
         };
@@ -709,7 +709,7 @@ mod tests {
         // The Rc is borrowed, never moved, so N projections all
         // succeed.
         let input: TokenStream2 = quote::quote! {
-            view(style: "x") {
+            view(style: typed_style) {
                 children()
                 view(class: "sep")
                 children()
@@ -727,7 +727,7 @@ mod tests {
     #[test]
     fn children_slot_sits_inside_child_method_call() {
         let input: TokenStream2 = quote::quote! {
-            view(style: "x") {
+            view(style: typed_style) {
                 children()
             }
         };

--- a/crates/whisker-runtime/src/reactive/prop.rs
+++ b/crates/whisker-runtime/src/reactive/prop.rs
@@ -100,8 +100,8 @@ use super::stored::StoredValue;
 // any `T: 'static` — `Signal<String>` included.
 pub enum Signal<T: 'static> {
     /// Plain value, held in an owner-bound [`StoredValue<T>`] arena
-    /// slot. The builder method that consumes this calls
-    /// `set_attribute` / `set_inline_styles` / etc. exactly once
+    /// slot. The builder method that consumes this applies the
+    /// corresponding renderer operation exactly once
     /// with the value. No reactive subscription is set up; reading
     /// the `StoredValue` does not tick the dependency graph.
     Stored(StoredValue<T>),
@@ -140,7 +140,7 @@ impl<T: 'static + Clone> Signal<T> {
     /// ```ignore
     /// #[component]
     /// fn dynamic_tile(color: Signal<String>) -> Element {
-    ///     let style = computed(move || format!("color: {};", color.get()));
+    ///     let style = computed(move || Css::new().color(Color::Named(color.get())));
     ///     //                                                  ^^^^^^^^^^^^
     ///     //                                                  registers sig
     ///     //                                                  with the
@@ -195,8 +195,8 @@ impl<T: 'static + Clone> From<RwSignal<T>> for Signal<T> {
 }
 
 // Without this impl a `&str` literal only reaches
-// `Into<Signal<&str>>` through the blanket `From<T>`, forcing callers
-// to write `.style("foo".to_string())`.
+// `Into<Signal<&str>>` through the blanket `From<T>`, forcing ordinary
+// string-valued props to allocate explicitly at call sites.
 impl From<&str> for Signal<String> {
     fn from(s: &str) -> Self {
         Signal::Stored(StoredValue::new(s.to_string()))

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -65,13 +65,6 @@ pub enum RuntimeBindingError {
         /// Child rejected before entering the retained scene.
         child: Element,
     },
-    /// A compatibility-only CSS string reached the typed renderer.
-    UnsupportedRawStyle {
-        /// Styled runtime handle.
-        element: Element,
-        /// Original CSS retained for diagnostics.
-        css: String,
-    },
     /// An attribute has not yet been mapped to a typed element property.
     UnsupportedAttribute {
         /// Target runtime handle.
@@ -3911,17 +3904,6 @@ impl DynRenderer for SurfaceRuntime {
         let mut state = self.state.borrow_mut();
         let result = state.set_property_value(handle, key, WhiskerValue::Float(value));
         state.record(result);
-    }
-
-    fn set_inline_styles(&self, handle: Element, css: &str) {
-        if css.trim().is_empty() {
-            return;
-        }
-        let mut state = self.state.borrow_mut();
-        state.record(Err(RuntimeBindingError::UnsupportedRawStyle {
-            element: handle,
-            css: css.to_owned(),
-        }));
     }
 
     fn set_specified_style(&self, handle: Element, style: &SpecifiedStyle) -> bool {

--- a/crates/whisker-runtime/src/view/apply.rs
+++ b/crates/whisker-runtime/src/view/apply.rs
@@ -11,29 +11,11 @@
 use crate::reactive::{Signal, effect};
 use crate::view::handle::Element;
 use crate::view::renderer::{
-    set_attribute, set_attribute_bool, set_attribute_double, set_attribute_int, set_inline_styles,
+    set_attribute, set_attribute_bool, set_attribute_double, set_attribute_int,
 };
 
-/// Apply an inline-styles value to `h`, picking a static vs reactive
-/// code path based on the [`Signal<T>`] variant. The `Dynamic` case
-/// wraps the read in an `effect` so the
-/// [`ReadSignal<T>::get`](crate::reactive::ReadSignal::get) call
-/// registers the source as a dependency.
-pub fn apply_styles<V, T>(h: Element, v: V)
-where
-    V: ::std::convert::Into<Signal<T>>,
-    T: ::std::string::ToString + ::std::clone::Clone + 'static,
-{
-    match v.into() {
-        Signal::Stored(sv) => sv.with(|t| set_inline_styles(h, &t.to_string())),
-        Signal::Dynamic(sig) => {
-            effect(move || set_inline_styles(h, &sig.get().to_string()));
-        }
-    }
-}
-
 /// Apply a named attribute value to `h`. Same Stored / Dynamic
-/// dispatch as [`apply_styles`].
+/// dispatch as other reactive property helpers.
 pub fn apply_attr<V, T>(h: Element, name: &'static str, v: V)
 where
     V: ::std::convert::Into<Signal<T>>,

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -29,7 +29,7 @@ mod tests;
 
 pub use apply::{
     apply_attr, apply_attr_bool, apply_attr_f64, apply_attr_int, apply_attr_int_mapped,
-    apply_attr_owned, apply_styles,
+    apply_attr_owned,
 };
 pub use handle::Element;
 pub use into_view::{
@@ -52,7 +52,7 @@ pub use renderer::{
     create_element_by_schema, create_phantom_element, dispatch_event, flush, insert_child_at,
     is_phantom, observe_layout, previous_sibling, release_element, remove_child, set_attribute,
     set_attribute_bool, set_attribute_double, set_attribute_int, set_attribute_object,
-    set_event_listener, set_inline_styles, set_root, set_specified_style,
+    set_event_listener, set_root, set_specified_style,
 };
 
 // Renderer-wiring internals. Public because Hosts and test renderers link

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -121,11 +121,9 @@ pub trait DynRenderer {
     fn set_attribute_double(&self, handle: Element, key: &str, value: f64) {
         self.set_attribute(handle, key, &value.to_string());
     }
-    fn set_inline_styles(&self, handle: Element, css: &str);
-
     /// Applies renderer-independent typed style and reports whether it was
-    /// accepted. Renderers that still consume Lynx CSS use the default `false`
-    /// result so the caller can fall back to [`Self::set_inline_styles`].
+    /// accepted. The default `false` is useful for lightweight test renderers;
+    /// application-facing style APIs do not fall back to raw CSS.
     fn set_specified_style(&self, _handle: Element, _style: &SpecifiedStyle) -> bool {
         false
     }
@@ -591,17 +589,7 @@ pub fn set_attribute_double(handle: Element, key: &str, value: f64) {
     with_renderer(|r| r.set_attribute_double(handle, key, value), ())
 }
 
-pub fn set_inline_styles(handle: Element, css: &str) {
-    if is_phantom(handle) {
-        return;
-    }
-    with_renderer(|r| r.set_inline_styles(handle, css), ())
-}
-
 /// Attempts to apply renderer-independent typed style.
-///
-/// A `false` result asks the umbrella authoring layer to preserve its legacy
-/// CSS-string fallback for renderers that have not migrated yet.
 pub fn set_specified_style(handle: Element, style: &SpecifiedStyle) -> bool {
     if is_phantom(handle) {
         return true;

--- a/crates/whisker-runtime/src/view/tests.rs
+++ b/crates/whisker-runtime/src/view/tests.rs
@@ -21,10 +21,6 @@ enum Op {
         key: String,
         value: String,
     },
-    SetStyles {
-        id: u32,
-        css: String,
-    },
     Append {
         parent: u32,
         child: u32,
@@ -104,12 +100,6 @@ impl DynRenderer for RecordingRenderer {
             id: h.id(),
             key: key.into(),
             value: value.into(),
-        });
-    }
-    fn set_inline_styles(&self, h: Element, css: &str) {
-        self.ops.borrow_mut().push(Op::SetStyles {
-            id: h.id(),
-            css: css.into(),
         });
     }
     fn append_child(&self, parent: Element, child: Element) {
@@ -546,7 +536,6 @@ mod reentrancy {
                 .borrow_mut()
                 .push(format!("set_attr {} {}={}", h.id(), key, value));
         }
-        fn set_inline_styles(&self, _h: Element, _css: &str) {}
         fn append_child(&self, parent: Element, child: Element) {
             // Scope the `parent_sign` borrow — never spanning anything
             // re-entrant (matches the renderer contract).

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -10,7 +10,7 @@
 //! #[whisker::main]
 //! fn app() -> Element {
 //!     render! {
-//!         view(style: "flex-grow: 1; background: white;") {
+//!         view(style: css!(flex_grow: 1.0, background_color: Color::hex(0xffffff))) {
 //!             text(value: "Hello, Whisker")
 //!         }
 //!     }
@@ -198,11 +198,11 @@ pub use whisker_runtime::view::{
 };
 
 /// Built-in tag builders. The `render!` macro lowers each built-in
-/// element invocation (`view(style: "x", on_tap: move |_| {})`) into a
+/// element invocation (`view(style: css!(flex_grow: 1.0), on_tap: move |_| {})`) into a
 /// builder method chain on one of these types
 /// (`__tags::view().style(|| "x").on_tap(|| {}).__h()`). Methods
 /// internally invoke the imperative runtime primitives
-/// (`create_element`, `set_inline_styles`, …).
+/// (`create_element`, `set_specified_style`, …).
 ///
 /// **Why a builder chain instead of struct-init or imperative
 /// codegen:** rust-analyzer's auto-completion picks up methods on
@@ -258,19 +258,19 @@ pub mod __tags {
 
         // ---- Styling ----------------------------------------------------
 
-        /// Inline CSS (`SetRawInlineStyles`).
+        /// Structured CSS declarations.
         ///
         /// Accepts any value that converts into [`crate::Style`] — a
-        /// [`whisker_css::Css`] builder, a `String` / `&str` raw CSS
-        /// literal, or a reactive [`ReadSignal`](crate::ReadSignal)
-        /// / [`RwSignal`](crate::RwSignal) of either form. Reactive variants re-apply the CSS via the
+        /// [`whisker_css::Css`] builder, or a reactive
+        /// [`ReadSignal`](crate::ReadSignal) / [`RwSignal`](crate::RwSignal)
+        /// carrying `Css`. Reactive variants re-apply the declarations via the
         /// element's internal `effect` whenever the underlying
         /// signal changes.
         ///
         /// ```ignore
-        /// view(style: "padding: 8px; background: red;")
-        /// view(style: Css::new().padding(8.px()).background(NamedColor::Red))
-        /// view(style: computed(move || format!("opacity: {}", alpha.get())))
+        /// view(style: css!(padding: px(8), background_color: Color::hex(0xff0000)))
+        /// view(style: Css::new().padding(px(8)).background_color(Color::hex(0xff0000)))
+        /// view(style: computed(move || Css::new().opacity(alpha.get())))
         /// ```
         fn style<V>(self, v: V) -> Self
         where
@@ -867,7 +867,7 @@ pub mod __tags {
     /// ```ignore
     /// render! {
     ///     view(
-    ///         style: "flex-direction: column; padding: 16px;",
+    ///         style: css!(flex_direction: FlexDirection::Column, padding: px(16)),
     ///         on_tap: move |_| println!("tapped"),
     ///     ) {
     ///         text(value: "Title")
@@ -904,7 +904,7 @@ pub mod __tags {
     /// let count = signal(0_i32);
     /// render! {
     ///     text {
-    ///         style: "font-size: 18px; color: black;",
+    ///         style: css!(font_size: px(18), color: Color::hex(0x000000)),
     ///         value: computed(move || format!("count: {}", count.get())),
     ///     }
     /// }
@@ -1068,7 +1068,7 @@ pub mod __tags {
     /// ```ignore
     /// render! {
     ///     scroll_view {
-    ///         style: "flex: 1;",
+    ///         style: css!(flex_grow: 1.0),
     ///         scroll_orientation: ScrollOrientation::Vertical,
     ///         on_scroll: |e| println!("y = {}", e.detail.scroll_top),
     ///         view { /* ... long content ... */ }

--- a/crates/whisker/src/style.rs
+++ b/crates/whisker/src/style.rs
@@ -2,16 +2,14 @@
 //! built-in element tag.
 //!
 //! The element builder's `style(...)` method accepts any value that
-//! converts into a [`Style`], which absorbs three source families:
+//! converts into a [`Style`], covering two structured source families:
 //!
 //! 1. A [`whisker_css::Css`] builder value (`Css::new().padding(8.px())`).
-//! 2. A raw CSS string (`String` or `&str` / `&String`).
-//! 3. A reactive [`ReadSignal<T>`] / [`RwSignal<T>`] of either form.
+//! 2. A reactive [`ReadSignal<Css>`] / [`RwSignal<Css>`].
 //!
-//! One wrapper lets the same `view(style: ...)` keyword accept every
-//! shape without callers calling `.to_css_string()` themselves.
-//! Reactive paths re-fire the attribute apply inside the element's
-//! `effect`, matching every other `Signal<T>`-driven prop.
+//! Raw CSS strings are deliberately rejected at compile time. Reactive paths
+//! re-fire the structured style apply inside the element's `effect`, matching
+//! every other `Signal<T>`-driven prop.
 //!
 //! `Style` is defined in the `whisker` umbrella crate (rather than
 //! in `whisker-css`) so the `Css` crate stays `whisker-runtime`-free
@@ -19,7 +17,7 @@
 
 use std::rc::Rc;
 
-use whisker_css::{Css, ToCss};
+use whisker_css::Css;
 use whisker_engine::whisker_style::{
     DisplayValue, FlexDirectionValue, GridAutoFlowValue, GridMaxTrackSizingValue,
     GridMinTrackSizingValue, GridRepetitionCountValue, GridTemplateComponentValue,
@@ -27,8 +25,8 @@ use whisker_engine::whisker_style::{
     SizeValue, SpecifiedStyle, StyleProperty, StyleValue,
 };
 use whisker_runtime::reactive::{ReadSignal, RwSignal, effect};
+use whisker_runtime::view::set_specified_style;
 use whisker_runtime::view::{Element, ScrollAxis, VirtualGridLayout, VirtualListLayout};
-use whisker_runtime::view::{set_inline_styles, set_specified_style};
 
 /// Value the `style:` builder method receives.
 ///
@@ -36,27 +34,50 @@ use whisker_runtime::view::{set_inline_styles, set_specified_style};
 /// shares the same closure rather than re-boxing it. This lets
 /// the `#[component]` / `#[module_component]` macros store a `Style`
 /// prop and re-clone it on every re-invoke (hot-reload remount path).
+///
+/// Raw CSS is intentionally not part of the authoring contract:
+///
+/// ```compile_fail
+/// use whisker::Style;
+///
+/// let _: Style = "padding: 8px".into();
+/// ```
+///
+/// ```compile_fail
+/// use whisker::Style;
+///
+/// let _: Style = String::from("padding: 8px").into();
+/// ```
+///
+/// ```compile_fail
+/// use whisker::{ReadSignal, Style};
+///
+/// fn apply(value: ReadSignal<String>) {
+///     let _: Style = value.into();
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use whisker::{RwSignal, Style};
+///
+/// fn apply(value: RwSignal<String>) {
+///     let _: Style = value.into();
+/// }
+/// ```
 #[derive(Clone)]
 pub enum Style {
     /// Typed declarations that can flow directly into the new scene engine.
     Typed(Css),
-    /// CSS source the builder applies once, at element-construction
-    /// time. Raw string inputs use this compatibility variant.
-    Static(String),
     /// Typed declarations produced by a reactive subscription.
     DynamicTyped(Rc<dyn Fn() -> Css + 'static>),
-    /// CSS source produced by a reactive subscription. The shared
-    /// closure is called inside an `effect` and re-fires whenever
-    /// any signal it reads changes.
-    Dynamic(Rc<dyn Fn() -> String + 'static>),
 }
 
 impl Default for Style {
-    /// An empty static style — what an element would see if no
+    /// An empty structured style — what an element would see if no
     /// `style:` prop were declared. Lets the macros emit
     /// `self.style.unwrap_or_default()` for an omitted style prop.
     fn default() -> Self {
-        Style::Static(String::new())
+        Style::Typed(Css::new())
     }
 }
 
@@ -74,39 +95,14 @@ impl From<&Css> for Style {
     }
 }
 
-impl From<String> for Style {
-    fn from(s: String) -> Self {
-        Style::Static(s)
-    }
-}
-
-impl From<&str> for Style {
-    fn from(s: &str) -> Self {
-        Style::Static(s.to_string())
-    }
-}
-
-impl From<&String> for Style {
-    fn from(s: &String) -> Self {
-        Style::Static(s.clone())
-    }
-}
-
 // ---- Reactive sources -------------------------------------------------------
 //
-// One impl per (`ReadSignal` × `RwSignal`) × (`Css` × `String`) pair.
-// Hand-written rather than blanket to keep coherence out of it and the
-// type-inference error on an unsupported `T` sharp.
+// One impl per signal family. Hand-written rather than blanket to keep
+// coherence out of it and the type-inference error on unsupported values sharp.
 
 impl From<ReadSignal<Css>> for Style {
     fn from(sig: ReadSignal<Css>) -> Self {
         Style::DynamicTyped(Rc::new(move || sig.get()))
-    }
-}
-
-impl From<ReadSignal<String>> for Style {
-    fn from(sig: ReadSignal<String>) -> Self {
-        Style::Dynamic(Rc::new(move || sig.get()))
     }
 }
 
@@ -116,25 +112,12 @@ impl From<RwSignal<Css>> for Style {
     }
 }
 
-impl From<RwSignal<String>> for Style {
-    fn from(sig: RwSignal<String>) -> Self {
-        Style::from(sig.read_only())
-    }
-}
-
-/// Apply a [`Style`] to a Lynx element. The `Static` branch sets the
-/// inline-styles attribute once; the `Dynamic` branch wraps the
-/// closure in an `effect` so it re-applies whenever any signal it
-/// reads fires.
+/// Apply a structured [`Style`] to an element.
 pub fn apply_style(h: Element, v: impl Into<Style>) {
     match v.into() {
-        Style::Typed(css) => apply_typed_or_legacy(h, &css),
-        Style::Static(css) => set_inline_styles(h, &css),
+        Style::Typed(css) => apply_structured_style(h, &css),
         Style::DynamicTyped(f) => {
-            effect(move || apply_typed_or_legacy(h, &f()));
-        }
-        Style::Dynamic(f) => {
-            effect(move || set_inline_styles(h, &f()));
+            effect(move || apply_structured_style(h, &f()));
         }
     }
 }
@@ -199,14 +182,6 @@ pub(crate) fn apply_list_content_style(
                 }
                 set_specified_style(element, &base.clone().merge(specified));
             });
-            VirtualListLayout::Linear
-        }
-        Some(Style::Static(css)) => {
-            set_inline_styles(element, &css);
-            VirtualListLayout::Linear
-        }
-        Some(Style::Dynamic(f)) => {
-            effect(move || set_inline_styles(element, &f()));
             VirtualListLayout::Linear
         }
     }
@@ -452,13 +427,14 @@ fn fixed_pixel_gap(value: &StyleValue) -> Option<f32> {
     value.is_finite().then_some(value.max(0.0))
 }
 
-fn apply_typed_or_legacy(h: Element, css: &Css) {
-    if let Ok(specified) = css.to_specified_style()
-        && whisker_runtime::view::set_specified_style(h, &specified)
-    {
-        return;
-    }
-    set_inline_styles(h, &css.to_css_string());
+fn apply_structured_style(h: Element, css: &Css) {
+    let specified = css
+        .to_specified_style()
+        .unwrap_or_else(|error| panic!("style must use structured CSS: {error}"));
+    // Renderer primitives intentionally remain no-ops when no renderer is
+    // installed so pure reactive/unit tests can mount trees without a Host.
+    // Real SurfaceRuntime-backed Hosts accept this typed path.
+    let _ = set_specified_style(h, &specified);
 }
 
 #[cfg(test)]
@@ -466,12 +442,10 @@ mod tests {
     use super::*;
     use whisker_css::ext::*;
 
-    fn css(d: Style) -> String {
+    fn css(d: Style) -> Css {
         match d {
-            Style::Typed(s) => s.to_css_string(),
-            Style::Static(s) => s,
-            Style::DynamicTyped(f) => f().to_css_string(),
-            Style::Dynamic(f) => f(),
+            Style::Typed(s) => s,
+            Style::DynamicTyped(f) => f(),
         }
     }
 
@@ -479,7 +453,7 @@ mod tests {
     fn from_css_serializes_via_to_css_string() {
         let s = Css::new().padding(px(8));
         let out = css(s.into());
-        assert!(out.contains("padding-top: 8px"));
+        assert_eq!(out.to_specified_style().unwrap().len(), 4);
     }
 
     #[test]
@@ -487,31 +461,7 @@ mod tests {
         let s = Css::new().padding(px(8));
         let style: Style = (&s).into();
         let out = css(style);
-        assert!(out.contains("padding-top: 8px"));
+        assert_eq!(out.to_specified_style().unwrap().len(), 4);
         assert!(!s.is_empty());
     }
-
-    #[test]
-    fn from_str_passes_through_verbatim() {
-        let out = css("color: red;".into());
-        assert_eq!(out, "color: red;");
-    }
-
-    #[test]
-    fn from_string_consumes_and_returns_same_text() {
-        let out = css(String::from("color: blue;").into());
-        assert_eq!(out, "color: blue;");
-    }
-
-    #[test]
-    fn from_string_ref_clones() {
-        let owner = String::from("color: green;");
-        let out = css((&owner).into());
-        assert_eq!(out, "color: green;");
-        assert_eq!(owner, "color: green;");
-    }
-
-    // The reactive `From` impls need the runtime arena, which this
-    // standalone test environment doesn't bootstrap; the static cases
-    // above cover the discriminant + serialization paths.
 }

--- a/crates/whisker/tests/children_slot.rs
+++ b/crates/whisker/tests/children_slot.rs
@@ -65,7 +65,6 @@ impl DynRenderer for Recorder {
             value: v.into(),
         });
     }
-    fn set_inline_styles(&self, _h: Element, _css: &str) {}
     fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),

--- a/crates/whisker/tests/component_invocation.rs
+++ b/crates/whisker/tests/component_invocation.rs
@@ -25,7 +25,6 @@ use whisker::runtime::view::{DynRenderer, Element, View, install_renderer, unins
 enum Op {
     Create { id: u32, tag: ElementTag },
     SetAttr { id: u32, key: String, value: String },
-    SetStyles { id: u32, css: String },
     Append { parent: u32, child: u32 },
 }
 
@@ -57,12 +56,6 @@ impl DynRenderer for Recorder {
             id: h.id(),
             key: k.into(),
             value: v.into(),
-        });
-    }
-    fn set_inline_styles(&self, h: Element, css: &str) {
-        self.log.borrow_mut().push(Op::SetStyles {
-            id: h.id(),
-            css: css.into(),
         });
     }
     fn append_child(&self, p: Element, c: Element) {

--- a/crates/whisker/tests/element_ref.rs
+++ b/crates/whisker/tests/element_ref.rs
@@ -53,7 +53,6 @@ impl DynRenderer for Recorder {
     }
     fn release_element(&self, _h: Element) {}
     fn set_attribute(&self, _h: Element, _k: &str, _v: &str) {}
-    fn set_inline_styles(&self, _h: Element, _css: &str) {}
     fn append_child(&self, _p: Element, _c: Element) {}
     fn remove_child(&self, _p: Element, _c: Element) {}
     fn set_event_listener(

--- a/crates/whisker/tests/module_component.rs
+++ b/crates/whisker/tests/module_component.rs
@@ -3,8 +3,7 @@
 //! Verifies the proc-macro lowers a tag-name + prop list into:
 //! - `XxxProps::builder().<prop>(v).build()` shape
 //! - a body that calls `view::create_element_by_name(tag)`
-//! - per-prop `apply_styles` / `apply_attr` (Static set-once,
-//!   Dynamic effect-wrapped) routing
+//! - structured `apply_style` plus per-prop `apply_attr` routing
 //!
 //! The in-memory `Recorder` captures every dispatched op into
 //! `Op::*` so assertions can verify the underlying tag-name + per-
@@ -20,12 +19,31 @@ use whisker::runtime::view::{DynRenderer, Element, install_renderer, uninstall_r
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
-    CreateByName { id: u32, tag_name: String },
-    Create { id: u32, tag: ElementTag },
-    SetAttr { id: u32, key: String, value: String },
-    SetStyles { id: u32, css: String },
-    Append { parent: u32, child: u32 },
-    Event { id: u32, name: String },
+    CreateByName {
+        id: u32,
+        tag_name: String,
+    },
+    Create {
+        id: u32,
+        tag: ElementTag,
+    },
+    SetAttr {
+        id: u32,
+        key: String,
+        value: String,
+    },
+    SetSpecifiedStyle {
+        id: u32,
+        style: whisker_engine::whisker_style::SpecifiedStyle,
+    },
+    Append {
+        parent: u32,
+        child: u32,
+    },
+    Event {
+        id: u32,
+        name: String,
+    },
 }
 
 #[derive(Default)]
@@ -66,11 +84,16 @@ impl DynRenderer for Recorder {
             value: v.into(),
         });
     }
-    fn set_inline_styles(&self, h: Element, css: &str) {
-        self.log.borrow_mut().push(Op::SetStyles {
+    fn set_specified_style(
+        &self,
+        h: Element,
+        style: &whisker_engine::whisker_style::SpecifiedStyle,
+    ) -> bool {
+        self.log.borrow_mut().push(Op::SetSpecifiedStyle {
             id: h.id(),
-            css: css.into(),
+            style: style.clone(),
         });
+        true
     }
     fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
@@ -112,7 +135,7 @@ fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
 pub fn x_zero_props() {}
 
 #[whisker::module_component("x-styled")]
-pub fn x_styled(style: Signal<String>) {}
+pub fn x_styled(style: whisker::Style) {}
 
 #[whisker::module_component("x-input")]
 pub fn x_input(value: Signal<String>, placeholder: Signal<String>) {}
@@ -130,7 +153,7 @@ pub fn x_input_payload(value: Signal<String>, on_input: ::whisker::WhiskerValue)
 pub fn x_typed_input(on_change: ::whisker::event::TouchEvent) {}
 
 #[whisker::module_component("x-container")]
-pub fn x_container(style: Signal<String>, children: ::whisker::Children) {}
+pub fn x_container(style: whisker::Style, children: ::whisker::Children) {}
 
 #[whisker::module_component(
     name = "whisker.test/GeneratedSchema",
@@ -248,7 +271,7 @@ fn module_component_builder_inherits_common_element_api() {
             GeneratedSchema(
                 enabled: true,
                 label: "generated",
-                style: "width: 10px;",
+                style: css!(width: px(10)),
                 id: "generated-id",
                 accessibility_label: "Generated element",
                 on_tap: |_event| {},
@@ -320,7 +343,7 @@ fn zero_props_component_inherits_style_and_common_element_api() {
     with_recorder_and_owner(|log| {
         let _handle = render! {
             XZeroProps(
-                style: "width: 12px;",
+                style: css!(width: px(12)),
                 id: "zero-props",
                 on_tap: |_event| {},
             )
@@ -328,7 +351,7 @@ fn zero_props_component_inherits_style_and_common_element_api() {
         let operations = log.borrow();
         assert!(operations.iter().any(|operation| matches!(
             operation,
-            Op::SetStyles { css, .. } if css == "width: 12px;"
+            Op::SetSpecifiedStyle { style, .. } if style.len() == 1
         )));
         assert!(operations.iter().any(|operation| matches!(
             operation,
@@ -342,51 +365,44 @@ fn zero_props_component_inherits_style_and_common_element_api() {
 }
 
 #[test]
-fn style_prop_routes_through_set_inline_styles() {
-    // The `style` prop must call set_inline_styles (Lynx's
-    // SetRawInlineStyles), not set_attribute — as built-in
-    // `view(style: …)` does.
+fn style_prop_routes_through_structured_style() {
     with_recorder_and_owner(|log| {
         let _h = render! {
-            XStyled(style: "background: red; height: 8px;")
+            XStyled(style: css!(background_color: Color::Named(NamedColor::Red), height: px(8)))
         };
         let styles: Vec<_> = log
             .borrow()
             .iter()
             .filter_map(|op| match op {
-                Op::SetStyles { css, .. } => Some(css.clone()),
+                Op::SetSpecifiedStyle { style, .. } => Some(style.clone()),
                 _ => None,
             })
             .collect();
-        assert_eq!(styles, vec!["background: red; height: 8px;".to_string()]);
+        assert_eq!(styles.len(), 1);
+        assert_eq!(styles[0].len(), 2);
     });
 }
 
 #[test]
 fn dynamic_style_re_runs_on_signal_change() {
     with_recorder_and_owner(|log| {
-        let (color, set_color) = signal("red".to_string()).split();
-        let css = computed(move || format!("background: {};", color.get()));
+        let (color, set_color) = signal(NamedColor::Red).split();
+        let css = computed(move || Css::new().background_color(Color::Named(color.get())));
         let _h = render! {
             XStyled(style: css)
         };
-        set_color.set("blue".into());
+        set_color.set(NamedColor::Blue);
         flush();
         let styles: Vec<_> = log
             .borrow()
             .iter()
             .filter_map(|op| match op {
-                Op::SetStyles { css, .. } => Some(css.clone()),
+                Op::SetSpecifiedStyle { style, .. } => Some(style.clone()),
                 _ => None,
             })
             .collect();
-        assert_eq!(
-            styles,
-            vec![
-                "background: red;".to_string(),
-                "background: blue;".to_string()
-            ]
-        );
+        assert_eq!(styles.len(), 2);
+        assert_ne!(styles[0], styles[1]);
     });
 }
 
@@ -530,7 +546,7 @@ fn children_prop_attaches_inner_view() {
     // `.children(Rc::new(move || { … }))` setter call.
     with_recorder_and_owner(|log| {
         let _h = render! {
-            XContainer(style: "padding: 10px;") {
+            XContainer(style: css!(padding: px(10))) {
                 text(value: "child 1")
                 text(value: "child 2")
             }

--- a/crates/whisker/tests/per_component_remount.rs
+++ b/crates/whisker/tests/per_component_remount.rs
@@ -29,7 +29,6 @@ use whisker::{ElementTag, flush};
 enum Op {
     Create { id: u32, tag: ElementTag },
     SetAttr { id: u32, key: String, value: String },
-    SetStyles { id: u32, css: String },
     Append { parent: u32, child: u32 },
     Remove { parent: u32, child: u32 },
     Event { id: u32, name: String },
@@ -74,12 +73,6 @@ impl DynRenderer for Recorder {
             id: h.id(),
             key: k.into(),
             value: v.into(),
-        });
-    }
-    fn set_inline_styles(&self, h: Element, css: &str) {
-        self.log.borrow_mut().push(Op::SetStyles {
-            id: h.id(),
-            css: css.into(),
         });
     }
     fn append_child(&self, p: Element, c: Element) {

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -27,9 +27,9 @@ enum Op {
         key: String,
         value: String,
     },
-    SetStyles {
+    SetSpecifiedStyle {
         id: u32,
-        css: String,
+        declarations: usize,
     },
     Append {
         parent: u32,
@@ -80,11 +80,16 @@ impl DynRenderer for Recorder {
             value: v.into(),
         });
     }
-    fn set_inline_styles(&self, h: Element, css: &str) {
-        self.log.borrow_mut().push(Op::SetStyles {
+    fn set_specified_style(
+        &self,
+        h: Element,
+        style: &whisker_engine::whisker_style::SpecifiedStyle,
+    ) -> bool {
+        self.log.borrow_mut().push(Op::SetSpecifiedStyle {
             id: h.id(),
-            css: css.into(),
+            declarations: style.len(),
         });
+        true
     }
     fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
@@ -207,10 +212,10 @@ fn nested_view_with_text_child() {
 }
 
 #[test]
-fn style_attribute_emits_set_inline_styles() {
+fn style_attribute_emits_structured_style() {
     with_recorder(|log| {
         let _ = render! {
-            view(style: "padding: 16px;")
+            view(style: css!(padding: px(16)))
         };
         let ops = log.borrow();
         assert_eq!(
@@ -220,9 +225,9 @@ fn style_attribute_emits_set_inline_styles() {
                 tag: ElementTag::View
             }
         );
-        assert!(ops.contains(&Op::SetStyles {
+        assert!(ops.contains(&Op::SetSpecifiedStyle {
             id: 0,
-            css: "padding: 16px;".into()
+            declarations: 4,
         }));
     });
 }
@@ -508,23 +513,23 @@ fn dynamic_value_updates_on_signal_write() {
 #[test]
 fn dynamic_style_re_runs_on_dep_change() {
     with_recorder_and_owner(|log| {
-        let (color, set_color) = signal("red".to_string()).split();
-        let css = computed(move || format!("color: {};", color.get()));
+        let (color, set_color) = signal(NamedColor::Red).split();
+        let css = computed(move || Css::new().color(Color::Named(color.get())));
         let _h = render! {
             view(style: css)
         };
-        set_color.set("blue".into());
+        set_color.set(NamedColor::Blue);
         flush();
 
         let styles: Vec<_> = log
             .borrow()
             .iter()
             .filter_map(|op| match op {
-                Op::SetStyles { css, .. } => Some(css.clone()),
+                Op::SetSpecifiedStyle { declarations, .. } => Some(*declarations),
                 _ => None,
             })
             .collect();
-        assert_eq!(styles, vec!["color: red;", "color: blue;"]);
+        assert_eq!(styles, vec![1, 1]);
     });
 }
 

--- a/crates/whisker/tests/show_skip.rs
+++ b/crates/whisker/tests/show_skip.rs
@@ -44,7 +44,6 @@ impl DynRenderer for Recorder {
     }
     fn release_element(&self, _h: Element) {}
     fn set_attribute(&self, _h: Element, _k: &str, _v: &str) {}
-    fn set_inline_styles(&self, _h: Element, _css: &str) {}
     fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
             parent: p.id(),

--- a/crates/whisker/tests/signal_props.rs
+++ b/crates/whisker/tests/signal_props.rs
@@ -24,15 +24,38 @@ use whisker::runtime::view::{DynRenderer, Element, install_renderer, uninstall_r
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Op {
-    Create { id: u32, tag: ElementTag },
-    SetAttr { id: u32, key: String, value: String },
-    SetStyles { id: u32, css: String },
-    Append { parent: u32, child: u32 },
-    Remove { parent: u32, child: u32 },
-    Event { id: u32, name: String },
-    SetRoot { id: u32 },
+    Create {
+        id: u32,
+        tag: ElementTag,
+    },
+    SetAttr {
+        id: u32,
+        key: String,
+        value: String,
+    },
+    SetSpecifiedStyle {
+        id: u32,
+        style: whisker_engine::whisker_style::SpecifiedStyle,
+    },
+    Append {
+        parent: u32,
+        child: u32,
+    },
+    Remove {
+        parent: u32,
+        child: u32,
+    },
+    Event {
+        id: u32,
+        name: String,
+    },
+    SetRoot {
+        id: u32,
+    },
     Flush,
-    Release { id: u32 },
+    Release {
+        id: u32,
+    },
 }
 
 #[derive(Default)]
@@ -75,11 +98,16 @@ impl DynRenderer for Recorder {
             value: v.into(),
         });
     }
-    fn set_inline_styles(&self, h: Element, css: &str) {
-        self.log.borrow_mut().push(Op::SetStyles {
+    fn set_specified_style(
+        &self,
+        h: Element,
+        style: &whisker_engine::whisker_style::SpecifiedStyle,
+    ) -> bool {
+        self.log.borrow_mut().push(Op::SetSpecifiedStyle {
             id: h.id(),
-            css: css.into(),
+            style: style.clone(),
         });
+        true
     }
     fn append_child(&self, p: Element, c: Element) {
         self.log.borrow_mut().push(Op::Append {
@@ -126,14 +154,17 @@ fn with_recorder_and_owner<R>(f: impl FnOnce(Rc<RefCell<Vec<Op>>>) -> R) -> R {
 
 // ----- The component under test ------------------------------------------
 
-/// Component with one `Signal<String>` prop. Body reads the prop
-/// inside a `computed` to drive a reactive `style` attribute.
+/// Component with one `Signal<String>` prop. Body reads the prop inside a
+/// `computed` to drive a reactive structured `style` attribute.
 #[component]
 fn colored_tile(color: Signal<String>) -> Element {
     // `Signal<T>` is `Copy`, so `color` moves into the `computed`
     // closure without a `.clone()` even though the `#[component]` body
     // is the `FnMut` the macro wraps for hot-patch dispatch.
-    let style = computed(move || format!("background: {};", color.get()));
+    let style = computed(move || {
+        let width = color.get().bytes().map(f32::from).sum::<f32>();
+        Css::new().width(px(width))
+    });
     render! {
         view(style: style)
     }
@@ -151,11 +182,12 @@ fn static_string_prop_sets_attribute_once() {
             .borrow()
             .iter()
             .filter_map(|op| match op {
-                Op::SetStyles { css, .. } => Some(css.clone()),
+                Op::SetSpecifiedStyle { style, .. } => Some(style.clone()),
                 _ => None,
             })
             .collect();
-        assert_eq!(styles, vec!["background: red;".to_string()]);
+        assert_eq!(styles.len(), 1);
+        assert_eq!(styles[0].len(), 1);
     });
 }
 
@@ -174,18 +206,13 @@ fn read_signal_prop_tracks_underlying_signal() {
             .borrow()
             .iter()
             .filter_map(|op| match op {
-                Op::SetStyles { css, .. } => Some(css.clone()),
+                Op::SetSpecifiedStyle { style, .. } => Some(style.clone()),
                 _ => None,
             })
             .collect();
-        assert_eq!(
-            styles,
-            vec![
-                "background: red;".to_string(),
-                "background: blue;".to_string(),
-                "background: green;".to_string(),
-            ]
-        );
+        assert_eq!(styles.len(), 3);
+        assert_ne!(styles[0], styles[1]);
+        assert_ne!(styles[1], styles[2]);
     });
 }
 
@@ -202,17 +229,12 @@ fn rw_signal_prop_tracks_underlying_signal() {
             .borrow()
             .iter()
             .filter_map(|op| match op {
-                Op::SetStyles { css, .. } => Some(css.clone()),
+                Op::SetSpecifiedStyle { style, .. } => Some(style.clone()),
                 _ => None,
             })
             .collect();
-        assert_eq!(
-            styles,
-            vec![
-                "background: orange;".to_string(),
-                "background: purple;".to_string(),
-            ]
-        );
+        assert_eq!(styles.len(), 2);
+        assert_ne!(styles[0], styles[1]);
     });
 }
 
@@ -237,14 +259,11 @@ fn show_flips_when_signal_holding_option_transitions() {
             .borrow()
             .iter()
             .filter_map(|op| match op {
-                Op::SetStyles { css, .. } => Some(css.clone()),
+                Op::SetSpecifiedStyle { style, .. } => Some(style.clone()),
                 _ => None,
             })
             .collect();
-        assert!(
-            initial_styles.iter().any(|s| s == "background: loading;"),
-            "initial render must mount the fallback branch (got styles {initial_styles:?})"
-        );
+        assert_eq!(initial_styles.len(), 1, "fallback branch must be styled");
 
         set_state.set(Some("done"));
         flush();
@@ -252,12 +271,13 @@ fn show_flips_when_signal_holding_option_transitions() {
             .borrow()
             .iter()
             .filter_map(|op| match op {
-                Op::SetStyles { css, .. } => Some(css.clone()),
+                Op::SetSpecifiedStyle { style, .. } => Some(style.clone()),
                 _ => None,
             })
             .collect();
         assert!(
-            after_styles.iter().any(|s| s == "background: loaded;"),
+            after_styles.len() > initial_styles.len()
+                && after_styles.last() != initial_styles.last(),
             "after set_state to Some, the children branch must be mounted \
              (this is the regression hn-reader hit: Loading banner never \
              swapped because Show's reactivity broke). styles seen: {after_styles:?}"
@@ -287,17 +307,12 @@ fn computed_prop_tracks_chain_of_signals() {
             .borrow()
             .iter()
             .filter_map(|op| match op {
-                Op::SetStyles { css, .. } => Some(css.clone()),
+                Op::SetSpecifiedStyle { style, .. } => Some(style.clone()),
                 _ => None,
             })
             .collect();
-        assert_eq!(
-            styles,
-            vec![
-                "background: even;".to_string(),
-                "background: odd;".to_string(),
-                "background: even;".to_string(),
-            ]
-        );
+        assert_eq!(styles.len(), 3);
+        assert_eq!(styles[0], styles[2]);
+        assert_ne!(styles[0], styles[1]);
     });
 }

--- a/docs/module-api-design.md
+++ b/docs/module-api-design.md
@@ -148,7 +148,7 @@ pub fn image(src: Signal<String>, mode: Signal<ImageMode>, style: whisker::Style
 ```rust
 // Usage
 render! {
-    Image(src: "https://…", mode: ImageMode::AspectFill, style: "width: 200px")
+    Image(src: "https://…", mode: ImageMode::AspectFill, style: css!(width: px(200)))
 }
 ```
 
@@ -202,7 +202,7 @@ impl VideoHandle {
 let video = VideoHandle::new();
 render! {
     view {
-        Video(ref: video.r(), src: "clip.mp4", style: "height: 200px")
+        Video(ref: video.r(), src: "clip.mp4", style: css!(height: px(200)))
         view(on_tap: move |_| video.play()) { text(value: "play") }
     }
 }

--- a/docs/reactivity-design.md
+++ b/docs/reactivity-design.md
@@ -305,7 +305,7 @@ fn counter(initial: i32, on_change: WriteSignal<i32>) -> Element {
     on_cleanup(|| log::info!("counter unmounted"));
 
     render! {
-        view(style: "flex-direction: column; padding: 16px;") {
+        view(style: css!(flex_direction: FlexDirection::Column, padding: px(16))) {
             text(value: computed(move || format!("Count: {}", count.get())))
             view(on_tap: move |_| set_count.update(|n| *n += 1)) {
                 text(value: "+")

--- a/examples/anim-smoke/src/lib.rs
+++ b/examples/anim-smoke/src/lib.rs
@@ -13,7 +13,7 @@
 //! per-frame transforms for *both* timing strategies (forward/reverse,
 //! idle when done).
 
-use whisker::css::{AlignItems, Color, Display, FlexDirection, JustifyContent};
+use whisker::css::{AlignItems, Color, Display, FlexDirection, JustifyContent, TransformFn};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker::{AnimConfig, animated};
@@ -60,8 +60,8 @@ fn root() -> Element {
                     margin_left: px(4),
                     border_radius: px(10),
                     background_color: Color::hex(0x7C5CFF),
-                )
-                .raw("transform", format!("translateX({}px)", curve_x.get()))))
+                    transform: TransformFn::TranslateX(px(curve_x.get()).into()),
+                )))
             }
 
             // Row 2 — spring box.
@@ -79,8 +79,8 @@ fn root() -> Element {
                     margin_left: px(4),
                     border_radius: px(10),
                     background_color: Color::hex(0x29D6C5),
-                )
-                .raw("transform", format!("translateX({}px)", spring_x.get()))))
+                    transform: TransformFn::TranslateX(px(spring_x.get()).into()),
+                )))
             }
 
             // Toggle button: flip direction and drive BOTH controllers.

--- a/examples/bluesky/src/lib.rs
+++ b/examples/bluesky/src/lib.rs
@@ -14,7 +14,7 @@
 
 use bsky_ui_kit::PostCard;
 use whisker::ListHandle;
-use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, JustifyContent};
+use whisker::css::{AlignItems, Display, FlexDirection, FontWeight, JustifyContent, PositionKind};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_icons::{Icon, lucide};
@@ -337,9 +337,15 @@ fn search_screen() -> Element {
                     on_submit: move |v: String| query.set(v),
                     placeholder_color: "#8B98A5",
                     caret_color: "#1083FE",
-                    style: "width: 100%; height: 40px; border-radius: 10px; \
-                            background-color: #16191F; color: #FFFFFF; font-size: 16px; \
-                            padding-left: 14px; padding-right: 14px;",
+                    style: Css::new()
+                        .width(percent(100))
+                        .height(px(40))
+                        .border_radius(px(10))
+                        .background_color(Color::hex(0x16191f))
+                        .color(Color::hex(0xffffff))
+                        .font_size(px(16))
+                        .padding_left(px(14))
+                        .padding_right(px(14)),
                 )
             }
             view(style: css!(
@@ -1651,9 +1657,15 @@ fn login_screen() -> Element {
                 spell_check: false,
                 placeholder_color: "#8B98A5",
                 caret_color: "#1083FE",
-                style: "height: 48px; border-radius: 10px; \
-                        background-color: #16191F; color: #FFFFFF; font-size: 16px; \
-                        padding-left: 14px; padding-right: 14px; margin-bottom: 12px;",
+                style: Css::new()
+                    .height(px(48))
+                    .border_radius(px(10))
+                    .background_color(Color::hex(0x16191f))
+                    .color(Color::hex(0xffffff))
+                    .font_size(px(16))
+                    .padding_left(px(14))
+                    .padding_right(px(14))
+                    .margin_bottom(px(12)),
             )
             Show(when: move || !error.get().is_empty(), fallback: || render! { fragment() }) {
                 text(
@@ -1770,7 +1782,7 @@ fn auth_screen() -> Element {
                 WebView(
                     url: auth_url,
                     on_navigation: on_nav.clone(),
-                    style: "flex-grow: 1;",
+                    style: css!(flex_grow: 1.0),
                 )
             }
         }
@@ -1870,8 +1882,8 @@ fn timeline_screen() -> Element {
             flex_direction: FlexDirection::Column,
             background_color: theme::BG,
             padding_top: px(insets.get().top as f32),
+            position: PositionKind::Relative,
         )
-        .raw("position", "relative")
     });
 
     render! {
@@ -1931,10 +1943,10 @@ fn compose_fab() -> Element {
                 display: Display::Flex,
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
-            )
-            .raw("position", "absolute")
-            .raw("right", "16px")
-            .raw("bottom", "16px"),
+                position: PositionKind::Absolute,
+                right: px(16),
+                bottom: px(16),
+            ),
             on_tap: move |_| {
                 let _ = nav.navigate("/compose");
             },
@@ -2287,7 +2299,11 @@ fn compose_screen() -> Element {
                 auto_focus: true,
                 placeholder_color: "#8B98A5",
                 caret_color: "#1083FE",
-                style: "flex-grow: 1; padding: 16px; color: #FFFFFF; font-size: 18px;",
+                style: Css::new()
+                    .flex_grow(1.0)
+                    .padding(px(16))
+                    .color(Color::hex(0xffffff))
+                    .font_size(px(18)),
             )
             Show(when: move || !error.get().is_empty(), fallback: || render! { fragment() }) {
                 text(

--- a/examples/podcast/crates/podcast-feature-detail/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-detail/src/lib.rs
@@ -161,7 +161,7 @@ fn detail_body(podcast: Podcast) -> Element {
                             height: px(220),
                             border_radius: theme::ARTWORK_RADIUS,
                             background_color: theme::SURFACE,
-                        ).raw("aspect-ratio", "1 / 1"),
+                        ).aspect_ratio(1.0, 1.0),
                         src: artwork_src,
                         mode: ImageMode::AspectFill,
                     )
@@ -173,7 +173,7 @@ fn detail_body(podcast: Podcast) -> Element {
                             margin_top: px(16),
                             text_align: TextAlign::Center,
                             text_overflow: TextOverflow::Ellipsis,
-                        ).raw("text-maxline", "3"),
+                        ),
                         value: title,
                     )
                     text(
@@ -491,7 +491,7 @@ fn episode_row(episode: Episode, show_title: String, show_artwork: String) -> El
                     color: theme::TEXT_PRIMARY,
                     font_weight: FontWeight::Numeric(600),
                     text_overflow: TextOverflow::Ellipsis,
-                ).raw("text-maxline", "2"),
+                ),
                 value: title.clone(),
             )
             text(

--- a/examples/podcast/crates/podcast-feature-search/src/lib.rs
+++ b/examples/podcast/crates/podcast-feature-search/src/lib.rs
@@ -222,10 +222,13 @@ fn search_input_bar(query: RwSignal<String>) -> Element {
                 text: query,
                 placeholder: "Podcasts, shows, episodes...",
                 return_key: ReturnKey::Search,
-                // Style as a raw string -- matches the whisker-input
-                // example pattern; sidesteps Css->Style->Option coercion.
-                style: "flex-grow: 1; flex-shrink: 1; margin-left: 8px; \
-                        font-size: 15px; color: #ffffff; min-height: 24px;",
+                style: Css::new()
+                    .flex_grow(1.0)
+                    .flex_shrink(1.0)
+                    .margin_left(px(8))
+                    .font_size(px(15))
+                    .color(Color::hex(0xffffff))
+                    .min_height(px(24)),
                 placeholder_color: "#8E8E93",
             )
         }
@@ -385,7 +388,7 @@ fn result_row(podcast: Podcast) -> Element {
                         color: theme::TEXT_PRIMARY,
                         font_weight: FontWeight::Numeric(600),
                         text_overflow: TextOverflow::Ellipsis,
-                    ).raw("text-maxline", "1"),
+                    ),
                     value: title,
                 )
                 text(
@@ -394,7 +397,7 @@ fn result_row(podcast: Podcast) -> Element {
                         color: theme::TEXT_SECONDARY,
                         margin_top: px(2),
                         text_overflow: TextOverflow::Ellipsis,
-                    ).raw("text-maxline", "1"),
+                    ),
                     value: artist,
                 )
             }

--- a/examples/podcast/crates/podcast-ui-kit/src/featured_card.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/featured_card.rs
@@ -34,11 +34,10 @@ pub fn featured_card(podcast: Podcast) -> Element {
                     font_size: theme::T_CATEGORY,
                     color: theme::TEXT_SECONDARY,
                     font_weight: FontWeight::Numeric(600),
-                ).raw("letter-spacing", "0.5px"),
+                    letter_spacing: px(0.5),
+                ),
                 value: category_label,
             )
-            // `text-maxline` is a Lynx-only extension not in the
-            // typed css! builder; `.raw(...)` appends it verbatim.
             text(
                 style: css!(
                     font_size: theme::T_FEATURED_TITLE,
@@ -46,7 +45,7 @@ pub fn featured_card(podcast: Podcast) -> Element {
                     font_weight: FontWeight::Numeric(600),
                     margin_top: px(6),
                     text_overflow: TextOverflow::Ellipsis,
-                ).raw("text-maxline", "2"),
+                ),
                 value: title_text,
             )
             Image(

--- a/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/mini_player.rs
@@ -129,7 +129,7 @@ pub fn mini_player() -> Element {
                         height: px(40),
                         border_radius: px(6),
                         background_color: Color::rgba(255, 255, 255, 0.15),
-                    ).raw("aspect-ratio", "1 / 1"),
+                    ).aspect_ratio(1.0, 1.0),
                     src: artwork_src,
                     mode: ImageMode::AspectFill,
                 )
@@ -150,7 +150,7 @@ pub fn mini_player() -> Element {
                             color: theme::TEXT_PRIMARY,
                             font_weight: FontWeight::Numeric(600),
                             text_overflow: TextOverflow::Ellipsis,
-                        ).raw("text-maxline", "1"),
+                        ),
                         value: title_text,
                     )
                     text(
@@ -159,7 +159,7 @@ pub fn mini_player() -> Element {
                             color: theme::TEXT_SECONDARY,
                             margin_top: px(2),
                             text_overflow: TextOverflow::Ellipsis,
-                        ).raw("text-maxline", "1"),
+                        ),
                         value: show_text,
                     )
                 }

--- a/examples/podcast/crates/podcast-ui-kit/src/ranked_card.rs
+++ b/examples/podcast/crates/podcast-ui-kit/src/ranked_card.rs
@@ -57,15 +57,13 @@ pub fn ranked_card(podcast: Podcast, rank: u32) -> Element {
                     flex_grow: 1.0,
                     flex_shrink: 1.0,
                 )) {
-                    // `text-maxline` is a Lynx-only extension not in
-                    // the typed css! builder; `.raw(...)` appends it.
                     text(
                         style: css!(
                             font_size: theme::T_CARD_TITLE,
                             color: theme::TEXT_PRIMARY,
                             font_weight: FontWeight::Numeric(500),
                             text_overflow: TextOverflow::Ellipsis,
-                        ).raw("text-maxline", "1"),
+                        ),
                         value: title_text,
                     )
                     text(
@@ -74,7 +72,7 @@ pub fn ranked_card(podcast: Podcast, rank: u32) -> Element {
                             color: theme::TEXT_SECONDARY,
                             margin_top: px(2),
                             text_overflow: TextOverflow::Ellipsis,
-                        ).raw("text-maxline", "2"),
+                        ),
                         value: subtitle_text,
                     )
                 }

--- a/packages/whisker-audio/src/lib.rs
+++ b/packages/whisker-audio/src/lib.rs
@@ -29,7 +29,7 @@
 //!     let status = player.status();
 //!
 //!     render! {
-//!         view(style: "flex-direction: column; padding: 16px;") {
+//!         view(style: css!(flex_direction: FlexDirection::Column, padding: px(16))) {
 //!             text(value: move || format!(
 //!                 "{:.1}s / {:.1}s",
 //!                 status.get().position,

--- a/packages/whisker-image/example/src/lib.rs
+++ b/packages/whisker-image/example/src/lib.rs
@@ -10,16 +10,17 @@
 //! * **prefetch** — three images warmed before any element points at
 //!   them; showing them afterwards should paint from cache.
 
+use whisker::css::{AlignItems, FlexDirection, FontWeight, JustifyContent};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_image::{Image, ImageEvent, ImageMode, prefetch};
 
-const BG: &str = "#101012";
-const CARD_BG: &str = "#1c1c1f";
-const FG: &str = "#f0f0f3";
-const MUTED: &str = "#9a9aa2";
-const OK: &str = "#5bd68a";
-const BAD: &str = "#ff5577";
+const BG: u32 = 0x101012;
+const CARD_BG: u32 = 0x1c1c1f;
+const FG: u32 = 0xf0f0f3;
+const MUTED: u32 = 0x9a9aa2;
+const OK: u32 = 0x5bd68a;
+const BAD: u32 = 0xff5577;
 
 /// Answers `200 image/png` with an `Accept` it likes and `406` without.
 const HEADER_PROBE: &str = "https://httpbin.org/image";
@@ -38,22 +39,42 @@ const WARM: [&str; 3] = [
 
 #[whisker::main]
 pub fn app() -> Element {
-    let page = format!(
-        "background-color: {BG}; flex-grow: 1; flex-direction: column; \
-         padding: 16px; padding-top: 64px;"
-    );
-    let card = format!(
-        "background-color: {CARD_BG}; border-radius: 12px; padding: 12px; \
-         margin-bottom: 16px; flex-direction: column;"
-    );
-    let heading = format!("color: {FG}; font-size: 16px; font-weight: bold;");
-    let note = format!("color: {MUTED}; font-size: 13px; margin-top: 4px;");
-    let thumb = "width: 100%; height: 140px; border-radius: 8px; margin-top: 8px;";
-    let button = format!(
-        "background-color: {BAD}; border-radius: 8px; padding: 10px; \
-         align-items: center; justify-content: center; margin-top: 8px;"
-    );
-    let button_text = format!("color: {FG}; font-size: 14px; font-weight: bold;");
+    let page = Css::new()
+        .background_color(Color::hex(BG))
+        .flex_grow(1.0)
+        .flex_direction(FlexDirection::Column)
+        .padding(px(16))
+        .padding_top(px(64));
+    let card = Css::new()
+        .background_color(Color::hex(CARD_BG))
+        .border_radius(px(12))
+        .padding(px(12))
+        .margin_bottom(px(16))
+        .flex_direction(FlexDirection::Column);
+    let heading = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(16))
+        .font_weight(FontWeight::Bold);
+    let note = Css::new()
+        .color(Color::hex(MUTED))
+        .font_size(px(13))
+        .margin_top(px(4));
+    let thumb = Css::new()
+        .width(percent(100))
+        .height(px(140))
+        .border_radius(px(8))
+        .margin_top(px(8));
+    let button = Css::new()
+        .background_color(Color::hex(BAD))
+        .border_radius(px(8))
+        .padding(px(10))
+        .align_items(AlignItems::Center)
+        .justify_content(JustifyContent::Center)
+        .margin_top(px(8));
+    let button_text = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(14))
+        .font_weight(FontWeight::Bold);
 
     // Card 1 — the header actually leaving the phone.
     // 0 none, 1 an Accept the host likes, 2 one it refuses. Platforms
@@ -63,12 +84,15 @@ pub fn app() -> Element {
     let accept = RwSignal::new(0u8);
     let probe_status = RwSignal::new("waiting".to_string());
     let probe_style = computed(move || {
-        let colour = if probe_status.get().starts_with("loaded") {
+        let color = if probe_status.get().starts_with("loaded") {
             OK
         } else {
             BAD
         };
-        format!("color: {colour}; font-size: 13px; margin-top: 4px;")
+        Css::new()
+            .color(Color::hex(color))
+            .font_size(px(13))
+            .margin_top(px(4))
     });
 
     // Card 2 / 3 — the two outcomes reported plainly.
@@ -105,7 +129,7 @@ pub fn app() -> Element {
                     on_error: move |event: ImageEvent| {
                         probe_status.set(format!("error: {}", event.error()));
                     },
-                    style: thumb,
+                    style: thumb.clone(),
                 )
                 view(
                     style: button.clone(),
@@ -140,7 +164,7 @@ pub fn app() -> Element {
                     on_error: move |event: ImageEvent| {
                         photo_status.set(format!("error: {}", event.error()));
                     },
-                    style: thumb,
+                    style: thumb.clone(),
                 )
             }
 
@@ -188,10 +212,10 @@ pub fn app() -> Element {
                     )
                 }
                 Show(when: move || warmed.get()) {
-                    view(style: "flex-direction: row; gap: 8px; margin-top: 8px;") {
-                        Image(src: WARM[0], style: "flex-grow: 1; height: 80px;")
-                        Image(src: WARM[1], style: "flex-grow: 1; height: 80px;")
-                        Image(src: WARM[2], style: "flex-grow: 1; height: 80px;")
+                    view(style: Css::new().flex_direction(FlexDirection::Row).gap(px(8)).margin_top(px(8))) {
+                        Image(src: WARM[0], style: css!(flex_grow: 1.0, height: px(80)))
+                        Image(src: WARM[1], style: css!(flex_grow: 1.0, height: px(80)))
+                        Image(src: WARM[2], style: css!(flex_grow: 1.0, height: px(80)))
                     }
                 }
             }

--- a/packages/whisker-image/src/lib.rs
+++ b/packages/whisker-image/src/lib.rs
@@ -35,7 +35,7 @@
 //!         Image(
 //!             src: "https://example.com/cover.jpg",
 //!             mode: ImageMode::AspectFill,
-//!             style: "width: 240px; height: 240px; border-radius: 8px;",
+//!             style: css!(width: px(240), height: px(240), border_radius: px(8)),
 //!         )
 //!     }
 //! }
@@ -50,7 +50,7 @@
 //! - `headers` — extra request headers for remote sources, as a JSON
 //!   object. Hot-link protection is what this is for: those hosts 403
 //!   without the `Referer` their own pages send.
-//! - `style` — standard Whisker style string. Width / height must be
+//! - `style` — structured Whisker CSS declarations. Width / height must be
 //!   set on the element (or via flex sizing) — Kingfisher / Coil
 //!   target-size the fetched bitmap against the rendered size, so an
 //!   element with `width: 0; height: 0;` would never paint.
@@ -220,7 +220,7 @@ pub fn image(
     /// that isn't a JSON object of strings is ignored.
     #[prop(default = String::new().into())]
     headers: Signal<String>,
-    /// Standard Whisker style string. Width / height must be set on the
+    /// Structured Whisker CSS declarations. Width / height must be set on the
     /// element (or via flex sizing) — the platform image loaders
     /// target-size the fetched bitmap against the rendered size.
     style: Option<whisker::Style>,

--- a/packages/whisker-input/example/src/lib.rs
+++ b/packages/whisker-input/example/src/lib.rs
@@ -11,25 +11,33 @@
 //! * **Multiline** — a `lines: 4` notes area.
 //! * **Secure** — a masked password field.
 
+use whisker::css::{FlexDirection, FontWeight};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_input::{Input, KeyboardType};
 
-const BG: &str = "#101012";
-const CARD_BG: &str = "#1c1c1f";
-const FG: &str = "#f0f0f3";
+const BG: u32 = 0x101012;
+const CARD_BG: u32 = 0x1c1c1f;
+const FG: u32 = 0xf0f0f3;
 const MUTED: &str = "#9a9aa2";
 const ACCENT: &str = "#ff5577";
 
 #[whisker::main]
 pub fn app() -> Element {
-    let page_style = format!(
-        "background-color: {BG}; flex-grow: 1; flex-shrink: 1; \
-         display: flex; flex-direction: column; \
-         padding-top: 56px; padding-left: 20px; padding-right: 20px;",
-    );
-    let header_style =
-        format!("color: {FG}; font-size: 22px; font-weight: 700; margin-bottom: 20px;",);
+    let page_style = Css::new()
+        .background_color(Color::hex(BG))
+        .flex_grow(1.0)
+        .flex_shrink(1.0)
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .padding_top(px(56))
+        .padding_left(px(20))
+        .padding_right(px(20));
+    let header_style = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(22))
+        .font_weight(FontWeight::Numeric(700))
+        .margin_bottom(px(20));
 
     render! {
         view(style: page_style) {
@@ -47,7 +55,10 @@ pub fn app() -> Element {
 #[component]
 fn two_way_demo() -> Element {
     let text = RwSignal::new(String::new());
-    let preview = format!("color: {MUTED}; font-size: 14px; margin-top: 6px;");
+    let preview = Css::new()
+        .color(Color::hex(0x9a9aa2))
+        .font_size(px(14))
+        .margin_top(px(6));
 
     render! {
         view(style: section_style()) {
@@ -92,11 +103,13 @@ fn controlled_demo() -> Element {
 #[component]
 fn multiline_demo() -> Element {
     let notes = RwSignal::new(String::new());
-    let area_style = format!(
-        "background-color: {CARD_BG}; color: {FG}; \
-         font-size: 16px; border-radius: 10px; \
-         padding: 12px; min-height: 96px;",
-    );
+    let area_style = Css::new()
+        .background_color(Color::hex(CARD_BG))
+        .color(Color::hex(FG))
+        .font_size(px(16))
+        .border_radius(px(10))
+        .padding(px(12))
+        .min_height(px(96));
 
     render! {
         view(style: section_style()) {
@@ -135,18 +148,28 @@ fn secure_demo() -> Element {
 
 // ---- Shared styling --------------------------------------------------------
 
-fn section_style() -> String {
-    "display: flex; flex-direction: column; margin-bottom: 24px;".to_string()
+fn section_style() -> Css {
+    Css::new()
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .margin_bottom(px(24))
 }
 
-fn label_style() -> String {
-    format!("color: {FG}; font-size: 13px; font-weight: 600; margin-bottom: 8px;")
+fn label_style() -> Css {
+    Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(13))
+        .font_weight(FontWeight::Numeric(600))
+        .margin_bottom(px(8))
 }
 
-fn field_style() -> String {
-    format!(
-        "background-color: {CARD_BG}; color: {FG}; \
-         font-size: 16px; height: 48px; border-radius: 10px; \
-         padding-left: 12px; padding-right: 12px;",
-    )
+fn field_style() -> Css {
+    Css::new()
+        .background_color(Color::hex(CARD_BG))
+        .color(Color::hex(FG))
+        .font_size(px(16))
+        .height(px(48))
+        .border_radius(px(10))
+        .padding_left(px(12))
+        .padding_right(px(12))
 }

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -22,11 +22,11 @@
 //! fn app() -> Element {
 //!     let text = RwSignal::new(String::new());
 //!     render! {
-//!         view(style: "flex-direction: column;") {
+//!         view(style: css!(flex_direction: FlexDirection::Column)) {
 //!             Input(
 //!                 text: text,
 //!                 placeholder: "Type something…",
-//!                 style: "height: 44px; font-size: 16px;",
+//!                 style: css!(height: px(44), font_size: px(16)),
 //!             )
 //!             // The bound signal updates on every keystroke.
 //!             text(value: move || format!("You typed: {}", text.get()))
@@ -55,7 +55,7 @@
 //! ```ignore
 //! Input(text: notes, multiline: true, lines: 4,
 //!       placeholder: "Notes…",
-//!       style: "min-height: 96px;")
+//!       style: css!(min_height: px(96)))
 //! ```
 //!
 //! ### Secure (password)
@@ -69,7 +69,7 @@
 //! ```ignore
 //! let field = InputRef::new();
 //! render! {
-//!     view(style: "flex-direction: row;") {
+//!     view(style: css!(flex_direction: FlexDirection::Row)) {
 //!         Input(text: text, input_ref: field.clone())
 //!         text(value: "Clear", on_tap: {
 //!             let field = field.clone();
@@ -105,7 +105,7 @@
 //! | `caret_color`      | `Signal<String>`                      | `""`          | Cursor color (CSS color string). |
 //! | `placeholder_color`| `Signal<String>`                      | `""`          | Placeholder text color. |
 //! | `selection_color`  | `Signal<String>`                      | `""`          | Selection-highlight color. |
-//! | `style`            | `Signal<String>`                      | `""`          | Standard Whisker CSS style string. |
+//! | `style`            | `Style`                              | empty          | Structured Whisker CSS declarations. |
 //! | `input_ref`        | [`InputRef`]                          | —             | Imperative handle (see [Methods](#methods)). |
 //!
 //! ## Styling

--- a/packages/whisker-paths/example/src/lib.rs
+++ b/packages/whisker-paths/example/src/lib.rs
@@ -5,11 +5,12 @@
 //! `whisker run` on a real device verifies the native module wiring and
 //! that `std::fs` works against the resolved paths.
 
+use whisker::css::{FlexDirection, FontWeight};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 
-const BG: &str = "#101012";
-const FG: &str = "#f0f0f3";
+const BG: u32 = 0x101012;
+const FG: u32 = 0xf0f0f3;
 
 #[whisker::main]
 pub fn app() -> Element {
@@ -60,12 +61,23 @@ pub fn app() -> Element {
         log.set(out);
     });
 
-    let page = format!(
-        "background-color: {BG}; flex-grow: 1; display: flex; flex-direction: column; \
-         padding-top: 72px; padding-left: 20px; padding-right: 20px;"
-    );
-    let title = format!("color: {FG}; font-size: 22px; font-weight: 700; margin-bottom: 20px;");
-    let body = format!("color: {FG}; font-size: 13px; line-height: 22px;");
+    let page = Css::new()
+        .background_color(Color::hex(BG))
+        .flex_grow(1.0)
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .padding_top(px(72))
+        .padding_left(px(20))
+        .padding_right(px(20));
+    let title = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(22))
+        .font_weight(FontWeight::Numeric(700))
+        .margin_bottom(px(20));
+    let body = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(13))
+        .line_height(px(22));
 
     render! {
         view(style: page) {

--- a/packages/whisker-router/Cargo.toml
+++ b/packages/whisker-router/Cargo.toml
@@ -67,6 +67,7 @@ whisker-router-macros = { workspace = true }
 # render-layer tests can advance a push/pop transition to completion and
 # assert the wrappers settle to their resting pose.
 whisker-animation = { workspace = true }
+whisker-style = { workspace = true }
 # Test-only: drive `RouterPlugin` through the real CNG engine + Android
 # renderer (`tests/plugin_e2e.rs`) and assert the generated manifest gets
 # `enableOnBackInvokedCallback`. No cycle: whisker-cng depends on

--- a/packages/whisker-router/src/render/components.rs
+++ b/packages/whisker-router/src/render/components.rs
@@ -11,7 +11,7 @@
 //! All stand on the recursive [`mount_node`](crate::render::node) engine;
 //! they differ only in *which* [`NodePath`] they hand it.
 
-use whisker::css::{Display, FlexDirection};
+use whisker::css::{Display, FlexDirection, PositionKind};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker::{Children, component, provide_context, render, use_context};
@@ -82,7 +82,8 @@ pub fn router(routes: RouteSet, children: Children) -> Element {
             flex_grow: 1.0,
             display: Display::Flex,
             flex_direction: FlexDirection::Column,
-        ).raw("position", "relative")) {}
+            position: PositionKind::Relative,
+        )) {}
     };
     provide_context(RouterRoot(root));
     // The tree is drawn by `children` (an Outlet / Tabs / Stack), NOT here —

--- a/packages/whisker-router/src/render/node.rs
+++ b/packages/whisker-router/src/render/node.rs
@@ -25,12 +25,15 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use whisker::css::ext::{percent, px};
+use whisker::css::{Color, Css, FlexDirection, Overflow, PointerEvents, Position, PositionKind};
 use whisker::runtime::reactive::{Owner, effect};
 use whisker::runtime::view::{
     Element, append_child, create_element, create_phantom_element, remove_child, set_attribute,
-    set_inline_styles,
 };
-use whisker::{AnimationController, ElementTag, computed, provide_context, use_context};
+use whisker::{
+    AnimationController, ElementTag, apply_style, computed, provide_context, use_context,
+};
 
 use crate::core::{NodePath, RouteState, RouteTree};
 use crate::render::components::OutletAnchor;
@@ -173,7 +176,7 @@ fn mount_switch(handle: &RouterHandle, path: NodePath) -> Element {
     // surrounding flex layout, e.g. above a tab bar) rather than against
     // some distant ancestor.
     let container = create_element(ElementTag::View);
-    set_inline_styles(container, &switch_container_style());
+    apply_style(container, switch_container_style());
     let handle = handle.clone();
 
     let branch_count = handle
@@ -185,13 +188,13 @@ fn mount_switch(handle: &RouterHandle, path: NodePath) -> Element {
     // Mount every branch once into its own wrapper; keep them all alive.
     // The wrapper MUST be a real `view` (not a phantom): it carries
     // `display` / `position: absolute` styles, and a phantom is a
-    // style-less transparent bundler whose `set_inline_styles` never
-    // reaches Lynx (so non-selected branches would not hide).
+    // style-less transparent bundler whose layout never reaches the retained
+    // surface (so non-selected branches would not hide).
     let mut wrappers: Vec<Element> = Vec::with_capacity(branch_count);
     for i in 0..branch_count {
         let wrapper = create_element(ElementTag::View);
         // Each branch fills the switch; visibility is toggled below.
-        set_inline_styles(wrapper, &branch_base_style(false));
+        apply_style(wrapper, branch_base_style(false));
         let child = mount_node(&handle, path.child(i));
         append_child(wrapper, child);
         append_child(container, wrapper);
@@ -203,7 +206,7 @@ fn mount_switch(handle: &RouterHandle, path: NodePath) -> Element {
     effect(move || {
         let sel = selected.get().unwrap_or(0);
         for (i, w) in wrappers.iter().enumerate() {
-            set_inline_styles(*w, &branch_base_style(i == sel));
+            apply_style(*w, branch_base_style(i == sel));
         }
     });
 
@@ -212,18 +215,29 @@ fn mount_switch(handle: &RouterHandle, path: NodePath) -> Element {
 
 /// The switch's positioned container: fills its flex slot and anchors the
 /// absolutely-positioned branch wrappers.
-fn switch_container_style() -> String {
-    "position: relative; flex-grow: 1; display: flex; flex-direction: column;".to_string()
+fn switch_container_style() -> Css {
+    Css::new()
+        .position(PositionKind::Relative)
+        .flex_grow(1.0)
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
 }
 
 /// A switch branch wrapper fills the container; only the selected one is
 /// displayed.
-fn branch_base_style(visible: bool) -> String {
-    let display = if visible { "flex" } else { "none" };
-    format!(
-        "display: {display}; flex-direction: column; position: absolute; \
-         left: 0; top: 0; right: 0; bottom: 0;"
-    )
+fn branch_base_style(visible: bool) -> Css {
+    let style = Css::new()
+        .flex_direction(FlexDirection::Column)
+        .position(PositionKind::Absolute)
+        .left(px(0))
+        .top(px(0))
+        .right(px(0))
+        .bottom(px(0));
+    if visible {
+        style.display_flex()
+    } else {
+        style.display_none()
+    }
 }
 
 /// One live history wrapper.
@@ -273,7 +287,7 @@ fn mount_stack(handle: &RouterHandle, path: NodePath) -> Element {
     // wrappers stack against IT (rather than a distant ancestor) and the
     // stack fills its flex slot.
     let slot = create_element(ElementTag::View);
-    set_inline_styles(slot, &stack_container_style());
+    apply_style(slot, stack_container_style());
     let handle = handle.clone();
 
     // Backdrop-dim layer: a black absolute fill that darkens the area
@@ -292,7 +306,7 @@ fn mount_stack(handle: &RouterHandle, path: NodePath) -> Element {
             Some(ctrl) => transition::predictive_dim(ctrl.value().get()),
             None => 0.0,
         });
-        effect(move || set_inline_styles(dim_eff, &dim_style(opacity.get())));
+        effect(move || apply_style(dim_eff, dim_style(opacity.get())));
     }
     append_child(slot, dim);
 
@@ -316,11 +330,16 @@ fn mount_stack(handle: &RouterHandle, path: NodePath) -> Element {
 /// Style for the stack's backdrop-dim layer at `opacity` (0 = invisible).
 /// Always behind the top card; `pointer-events: none` so it never eats
 /// touches.
-fn dim_style(opacity: f32) -> String {
-    format!(
-        "position: absolute; left: 0; top: 0; right: 0; bottom: 0; \
-         background-color: #000000; opacity: {opacity}; pointer-events: none;"
-    )
+fn dim_style(opacity: f32) -> Css {
+    Css::new()
+        .position(PositionKind::Absolute)
+        .left(px(0))
+        .top(px(0))
+        .right(px(0))
+        .bottom(px(0))
+        .background_color(Color::hex(0x000000))
+        .opacity(opacity)
+        .pointer_events(PointerEvents::None)
 }
 
 /// Reconcile the live wrappers against `stack`'s history.
@@ -723,8 +742,8 @@ fn mount_wrapper(
         // transform/opacity AND the clip view's animated corner radius.
         effect(move || {
             let pose = style.get();
-            set_inline_styles(wrapper, &wrapper_style(&pose));
-            set_inline_styles(clip, &clip_view_style(pose.radius_px));
+            apply_style(wrapper, wrapper_style(&pose));
+            apply_style(clip, clip_view_style(pose.radius_px));
         });
 
         let child = mount_node(handle, child_path);
@@ -765,8 +784,8 @@ fn dispose_wrapper(slot: Element, w: StackWrapper) {
 
 /// The stack's positioned container: fills its flex slot and anchors the
 /// absolutely-positioned entry wrappers.
-fn stack_container_style() -> String {
-    "position: relative; flex-grow: 1; display: flex; flex-direction: column;".to_string()
+fn stack_container_style() -> Css {
+    switch_container_style()
 }
 
 /// Base style for a stack wrapper: absolutely-filled, column flow, with
@@ -774,13 +793,18 @@ fn stack_container_style() -> String {
 /// the inner [`clip_view_style`], NOT here — see `mount_wrapper`. The
 /// transform origin is centred so the predictive-back scale shrinks the
 /// card around its middle.
-fn wrapper_style(pose: &Pose) -> String {
-    format!(
-        "position: absolute; left: 0; top: 0; right: 0; bottom: 0; \
-         display: flex; flex-direction: column; \
-         transform-origin: 50% 50%; transform: {}; opacity: {};",
-        pose.transform, pose.opacity,
-    )
+fn wrapper_style(pose: &Pose) -> Css {
+    Css::new()
+        .position(PositionKind::Absolute)
+        .left(px(0))
+        .top(px(0))
+        .right(px(0))
+        .bottom(px(0))
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .transform_origin(Position::Coords(percent(50).into(), percent(50).into()))
+        .transform(pose.transform.clone())
+        .opacity(pose.opacity)
 }
 
 /// Style for the per-screen **clip view** — the direct parent of the
@@ -790,10 +814,15 @@ fn wrapper_style(pose: &Pose) -> String {
 /// predictive-back gesture shrinks the card — Material style. The
 /// `clip-radius` Lynx attribute (set in `mount_wrapper`) is what makes the
 /// rounding actually clip the child.
-fn clip_view_style(radius_px: f32) -> String {
-    format!(
-        "position: absolute; left: 0; top: 0; width: 100%; height: 100%; \
-         display: flex; flex-direction: column; overflow: hidden; \
-         border-radius: {radius_px}px;"
-    )
+fn clip_view_style(radius_px: f32) -> Css {
+    Css::new()
+        .position(PositionKind::Absolute)
+        .left(px(0))
+        .top(px(0))
+        .width(percent(100))
+        .height(percent(100))
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .overflow(Overflow::Hidden)
+        .border_radius(px(radius_px))
 }

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -11,6 +11,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use whisker::css::ToCss;
 use whisker::runtime::reactive::Owner;
 
 use crate::core::{
@@ -585,7 +586,8 @@ fn pop_settles_survivor_to_active_pose() {
             crate::render::transition::Direction::Push,
         ));
         assert_eq!(
-            pose.transform, "translateX(0%)",
+            pose.transform.to_css_string(),
+            "translateX(0%)",
             "survivor settled to active 0% pose; role={role:?} progress={progress}"
         );
     });
@@ -1232,8 +1234,9 @@ fn predictive_pose_material_shape() {
 
     // At rest (value 1.0): identity, square.
     let rest = predictive_pose(Role::Top, 1.0, SwipeEdge::Left);
+    let rest_transform = rest.transform.to_css_string();
     assert!(
-        rest.transform.contains("scale(1)"),
+        rest_transform.contains("scale(1, 1)"),
         "scale 1 at rest: {rest:?}"
     );
     assert_eq!(rest.radius_px, 0.0, "square at rest");
@@ -1241,8 +1244,9 @@ fn predictive_pose_material_shape() {
     // Preview max (value 0.5): top shrunk to 0.9 (shared-element card),
     // rounded to the device radius, shifted toward the swipe edge.
     let preview = predictive_pose(Role::Top, 0.5, SwipeEdge::Left);
+    let preview_transform = preview.transform.to_css_string();
     assert!(
-        preview.transform.contains("scale(0.9)"),
+        preview_transform.contains("scale(0.9, 0.9)"),
         "shrinks to 0.9 at preview max: {preview:?}"
     );
     assert!(
@@ -1250,13 +1254,16 @@ fn predictive_pose_material_shape() {
         "rounds to the device radius at preview max: {preview:?}"
     );
     assert!(
-        preview.transform.contains("translateX(6%)"),
+        preview_transform.contains("translateX(6%)"),
         "left-edge swipe shifts the card right: {preview:?}"
     );
     // Right-edge swipe shifts the card the other way (negative translateX).
     let preview_right = predictive_pose(Role::Top, 0.5, SwipeEdge::Right);
     assert!(
-        preview_right.transform.contains("translateX(-6%)"),
+        preview_right
+            .transform
+            .to_css_string()
+            .contains("translateX(-6%)"),
         "right-edge swipe shifts the card left: {preview_right:?}"
     );
     // The shrink is DECELERATED (more apparent early): at value 0.75 the
@@ -1278,28 +1285,33 @@ fn predictive_pose_material_shape() {
     // peeks from the left during the drag, then slides in to fully present
     // and grows back to full size on commit.
     let under_preview = predictive_pose(Role::Under, 0.5, SwipeEdge::Left);
+    let under_preview_transform = under_preview.transform.to_css_string();
     assert!(
-        under_preview.transform.contains("scale(0.9)"),
+        under_preview_transform.contains("scale(0.9, 0.9)"),
         "under scales with the card to 0.9 at preview: {under_preview:?}"
     );
     assert!(
-        under_preview.transform.contains("translateX(-60%)"),
+        under_preview_transform.contains("translateX(-60%)"),
         "under peeks from the left: {under_preview:?}"
     );
     // Mid-drag (value 0.75) the under screen is held at the SAME -60% peek —
     // it only scales while the finger is down, it does not slide.
     let under_mid = predictive_pose(Role::Under, 0.75, SwipeEdge::Left);
     assert!(
-        under_mid.transform.contains("translateX(-60%)"),
+        under_mid
+            .transform
+            .to_css_string()
+            .contains("translateX(-60%)"),
         "under is fixed at the peek mid-drag (scale only, no slide): {under_mid:?}"
     );
     let under_committed = predictive_pose(Role::Under, 0.0, SwipeEdge::Left);
+    let under_committed_transform = under_committed.transform.to_css_string();
     assert!(
-        under_committed.transform.contains("translateX(0%)"),
+        under_committed_transform.contains("translateX(0%)"),
         "under slides to present on commit: {under_committed:?}"
     );
     assert!(
-        under_committed.transform.contains("scale(1)"),
+        under_committed_transform.contains("scale(1, 1)"),
         "under grows back to full size on commit: {under_committed:?}"
     );
     assert!(
@@ -1401,6 +1413,9 @@ fn one_transition_poses_all_four_directional_slots() {
         Direction, Pose, PoseContext, PoseMode, Role, RouteTransition, Transition, pose_for,
     };
 
+    use whisker::css::TransformFn;
+    use whisker::css::ext::percent;
+
     // A single asymmetric transition that tags each (role × direction) case —
     // the four Jetpack-Compose slots expressed by ONE `Transition`.
     struct Asym;
@@ -1410,12 +1425,12 @@ fn one_transition_poses_all_four_directional_slots() {
         }
         fn pose(&self, ctx: PoseContext) -> Pose {
             let slot = match (ctx.role, ctx.direction) {
-                (Role::Top, Direction::Push) => "enter",
-                (Role::Under, Direction::Push) => "exit",
-                (Role::Top, Direction::Pop) => "pop_exit",
-                (Role::Under, Direction::Pop) => "pop_enter",
+                (Role::Top, Direction::Push) => 1.0,
+                (Role::Under, Direction::Push) => 2.0,
+                (Role::Top, Direction::Pop) => 3.0,
+                (Role::Under, Direction::Pop) => 4.0,
             };
-            Pose::new(slot.to_string(), 1.0)
+            Pose::new(TransformFn::TranslateX(percent(slot).into()), 1.0)
         }
     }
 
@@ -1423,10 +1438,22 @@ fn one_transition_poses_all_four_directional_slots() {
     let push = PoseMode::Transition(t.clone(), Direction::Push);
     let pop = PoseMode::Transition(t, Direction::Pop);
 
-    assert_eq!(pose_for(&push, Role::Top, 0.5).transform, "enter");
-    assert_eq!(pose_for(&push, Role::Under, 0.5).transform, "exit");
-    assert_eq!(pose_for(&pop, Role::Top, 0.5).transform, "pop_exit");
-    assert_eq!(pose_for(&pop, Role::Under, 0.5).transform, "pop_enter");
+    assert_eq!(
+        pose_for(&push, Role::Top, 0.5).transform.to_css_string(),
+        "translateX(1%)"
+    );
+    assert_eq!(
+        pose_for(&push, Role::Under, 0.5).transform.to_css_string(),
+        "translateX(2%)"
+    );
+    assert_eq!(
+        pose_for(&pop, Role::Top, 0.5).transform.to_css_string(),
+        "translateX(3%)"
+    );
+    assert_eq!(
+        pose_for(&pop, Role::Under, 0.5).transform.to_css_string(),
+        "translateX(4%)"
+    );
 }
 
 // Renderer-level reproduction of the `replace` content-attach path.
@@ -1457,18 +1484,6 @@ mod replace_repro {
         /// A positioned insert whose reference wasn't a live child — the
         /// on-device silent drop. Non-empty = the bug is reproduced.
         violations: Vec<String>,
-    }
-
-    /// Pull the `display` value out of an inline-style string, if present.
-    fn parse_display(css: &str) -> Option<String> {
-        for decl in css.split(';') {
-            let mut it = decl.splitn(2, ':');
-            let k = it.next()?.trim();
-            if k == "display" {
-                return it.next().map(|v| v.trim().to_string());
-            }
-        }
-        None
     }
 
     #[derive(Clone, Default)]
@@ -1566,16 +1581,31 @@ mod replace_repro {
                 .or_default()
                 .insert(key.to_string(), value.to_string());
         }
-        fn set_inline_styles(&self, handle: Element, css: &str) {
-            // Record `display` transitions so tests can assert Switch
-            // branch visibility + mount ordering.
-            if let Some(d) = parse_display(css) {
+        fn set_specified_style(
+            &self,
+            handle: Element,
+            style: &whisker_style::SpecifiedStyle,
+        ) -> bool {
+            use whisker_style::{DisplayValue, StyleProperty, StyleValue};
+
+            let display = style.resolved().iter().find_map(|declaration| {
+                if declaration.property() != StyleProperty::Display {
+                    return None;
+                }
+                match declaration.value() {
+                    StyleValue::Display(DisplayValue::Flex) => Some("flex".to_string()),
+                    StyleValue::Display(DisplayValue::None) => Some("none".to_string()),
+                    _ => None,
+                }
+            });
+            if let Some(d) = display {
                 let mut inner = self.0.borrow_mut();
                 inner
                     .ops
                     .push(format!("style {} display={}", handle.id(), d));
                 inner.display.insert(handle, d);
             }
+            true
         }
         fn append_child(&self, parent: Element, child: Element) {
             let mut inner = self.0.borrow_mut();

--- a/packages/whisker-router/src/render/transition.rs
+++ b/packages/whisker-router/src/render/transition.rs
@@ -2,10 +2,9 @@
 //!
 //! A transition here is **not** a Lynx keyframe animation (see
 //! `docs/animation-design.md` for why the router uses the continuous
-//! engine instead). It is a pair of pure `progress → CSS` posers driven
+//! engine instead). It is a pair of pure `progress → Pose` functions driven
 //! by an [`AnimationController`]'s `0..1` value, composed into the screen
-//! wrapper's inline `transform` / `opacity` by a `computed` — exactly
-//! the proven `format!("translateX({}px)", x.get())` pattern.
+//! wrapper's typed `transform` / `opacity` by a `computed`.
 //!
 //! ## Progress convention
 //!
@@ -25,6 +24,8 @@
 use std::rc::Rc;
 
 use whisker::AnimConfig;
+use whisker::css::ext::percent;
+use whisker::css::{Number, Transform, TransformFn};
 
 /// A user-extensible screen transition: how a route enters and leaves when
 /// it becomes / stops being the top of its stack.
@@ -359,8 +360,8 @@ pub fn pose_for(mode: &PoseMode, role: Role, progress: f32) -> Pose {
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive] // a pose may grow fields (filter, scrim) — construct via the ctors
 pub struct Pose {
-    /// The `transform` CSS value.
-    pub transform: String,
+    /// The structured `transform` value.
+    pub transform: Transform,
     /// The `opacity` (0..1).
     pub opacity: f32,
     /// The `border-radius` in px the clip view rounds to (0 = square).
@@ -370,9 +371,9 @@ pub struct Pose {
 impl Pose {
     /// A pose with no corner rounding (`radius_px = 0`). The common
     /// constructor for custom [`Transition::pose`] implementations.
-    pub fn new(transform: String, opacity: f32) -> Self {
+    pub fn new(transform: impl Into<Transform>, opacity: f32) -> Self {
         Pose {
-            transform,
+            transform: transform.into(),
             opacity,
             radius_px: 0.0,
         }
@@ -380,13 +381,30 @@ impl Pose {
 
     /// A pose that also rounds the clip view to `radius_px` (used by the
     /// predictive-back card).
-    pub fn with_radius(transform: String, opacity: f32, radius_px: f32) -> Self {
+    pub fn with_radius(transform: impl Into<Transform>, opacity: f32, radius_px: f32) -> Self {
         Pose {
-            transform,
+            transform: transform.into(),
             opacity,
             radius_px,
         }
     }
+}
+
+fn translate_x(x_percent: f32) -> Transform {
+    Transform::new().push(TransformFn::TranslateX(percent(x_percent).into()))
+}
+
+fn translate_y(y_percent: f32) -> Transform {
+    Transform::new().push(TransformFn::TranslateY(percent(y_percent).into()))
+}
+
+fn translate_scale(x_percent: f32, scale: f32) -> Transform {
+    Transform::new()
+        .push(TransformFn::TranslateX(percent(x_percent).into()))
+        .push(TransformFn::Scale(
+            Number::new(scale).into(),
+            Number::new(scale).into(),
+        ))
 }
 
 /// The Material-style **predictive-back** pose for `role` at controller
@@ -433,7 +451,13 @@ pub fn predictive_pose(role: Role, value: f32, edge: SwipeEdge) -> Pose {
             let opacity = 1.0 - dismiss;
             let radius = max_radius * preview;
             Pose::with_radius(
-                format!("translateX({x}%) translateY({y}%) scale({scale})"),
+                Transform::new()
+                    .push(TransformFn::TranslateX(percent(x).into()))
+                    .push(TransformFn::TranslateY(percent(y).into()))
+                    .push(TransformFn::Scale(
+                        Number::new(scale).into(),
+                        Number::new(scale).into(),
+                    )),
                 opacity,
                 radius,
             )
@@ -450,7 +474,7 @@ pub fn predictive_pose(role: Role, value: f32, edge: SwipeEdge) -> Pose {
             // commit. No `preview` term ⇒ the drag scales without sliding.
             let x = -PB_UNDER_PEEK_PCT + dismiss * PB_UNDER_PEEK_PCT;
             let radius = max_radius * preview * (1.0 - dismiss);
-            Pose::with_radius(format!("translateX({x}%) scale({scale})"), 1.0, radius)
+            Pose::with_radius(translate_scale(x, scale), 1.0, radius)
         }
     }
 }
@@ -516,12 +540,12 @@ impl Transition for Slide {
             Role::Top => {
                 // p=0 → fully right (off), p=1 → centred.
                 let x = (1.0 - p) * 100.0;
-                Pose::new(format!("translateX({x}%)"), 1.0)
+                Pose::new(translate_x(x), 1.0)
             }
             Role::Under => {
                 // p=0 → at rest, p=1 → parallaxed left + dimmed.
                 let x = -(p * PARALLAX * 100.0);
-                Pose::new(format!("translateX({x}%)"), 1.0 - p * DIM)
+                Pose::new(translate_x(x), 1.0 - p * DIM)
             }
         }
     }
@@ -546,12 +570,12 @@ impl Transition for SmallSlideFade {
             Role::Top => {
                 // Small slide: ~8% of width from the right, plus a fade in.
                 let x = (1.0 - p) * ANDROID_TOP_SLIDE_PCT;
-                Pose::new(format!("translateX({x}%)"), p)
+                Pose::new(translate_x(x), p)
             }
             Role::Under => {
                 // A slight reverse slide + fade out so the swap reads.
                 let x = -(p * ANDROID_UNDER_SLIDE_PCT);
-                Pose::new(format!("translateX({x}%)"), 1.0 - p * ANDROID_UNDER_DIM)
+                Pose::new(translate_x(x), 1.0 - p * ANDROID_UNDER_DIM)
             }
         }
     }
@@ -574,9 +598,9 @@ impl Transition for Modal {
         match role {
             Role::Top => {
                 let y = (1.0 - p) * 100.0;
-                Pose::new(format!("translateY({y}%)"), 1.0)
+                Pose::new(translate_y(y), 1.0)
             }
-            Role::Under => Pose::new("translateX(0px)".to_string(), 1.0),
+            Role::Under => Pose::new(Transform::new(), 1.0),
         }
     }
 }
@@ -596,8 +620,8 @@ impl Transition for Fade {
         let PoseContext { role, progress, .. } = ctx;
         let p = progress.clamp(0.0, 1.0);
         match role {
-            Role::Top => Pose::new("translateX(0px)".to_string(), p),
-            Role::Under => Pose::new("translateX(0px)".to_string(), 1.0 - p * FADE_UNDER_DIM),
+            Role::Top => Pose::new(Transform::new(), p),
+            Role::Under => Pose::new(Transform::new(), 1.0 - p * FADE_UNDER_DIM),
         }
     }
 }
@@ -624,11 +648,8 @@ impl Transition for NoneTransition {
         match role {
             // Hide the top until it is at least half in so a swap doesn't
             // flash an off-screen frame.
-            Role::Top => Pose::new(
-                "translateX(0px)".to_string(),
-                if p > 0.0 { 1.0 } else { 0.0 },
-            ),
-            Role::Under => Pose::new("translateX(0px)".to_string(), 1.0),
+            Role::Top => Pose::new(Transform::new(), if p > 0.0 { 1.0 } else { 0.0 }),
+            Role::Under => Pose::new(Transform::new(), 1.0),
         }
     }
 }

--- a/packages/whisker-secure-store/example/src/lib.rs
+++ b/packages/whisker-secure-store/example/src/lib.rs
@@ -5,12 +5,13 @@
 //! and renders each step's result, so a `whisker run` on a real device
 //! verifies the native module wiring end-to-end.
 
+use whisker::css::{FlexDirection, FontWeight};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_secure_store::WhiskerSecureStore;
 
-const BG: &str = "#101012";
-const FG: &str = "#f0f0f3";
+const BG: u32 = 0x101012;
+const FG: u32 = 0xf0f0f3;
 
 #[whisker::main]
 pub fn app() -> Element {
@@ -44,12 +45,23 @@ pub fn app() -> Element {
         log.set(out);
     });
 
-    let page = format!(
-        "background-color: {BG}; flex-grow: 1; display: flex; flex-direction: column; \
-         padding-top: 72px; padding-left: 20px; padding-right: 20px;"
-    );
-    let title = format!("color: {FG}; font-size: 22px; font-weight: 700; margin-bottom: 20px;");
-    let body = format!("color: {FG}; font-size: 16px; line-height: 28px;");
+    let page = Css::new()
+        .background_color(Color::hex(BG))
+        .flex_grow(1.0)
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .padding_top(px(72))
+        .padding_left(px(20))
+        .padding_right(px(20));
+    let title = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(22))
+        .font_weight(FontWeight::Numeric(700))
+        .margin_bottom(px(20));
+    let body = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(16))
+        .line_height(px(28));
 
     render! {
         view(style: page) {

--- a/packages/whisker-svg/example/src/lib.rs
+++ b/packages/whisker-svg/example/src/lib.rs
@@ -15,14 +15,16 @@
 //! live inline so a `whisker run` round-trip is the only
 //! verification step.
 
+use whisker::css::{AlignItems, FlexDirection, FlexWrap, FontWeight, JustifyContent};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_svg::Svg;
 
-const BG: &str = "#101012";
-const CARD_BG: &str = "#1c1c1f";
-const FG: &str = "#f0f0f3";
-const ACCENT: &str = "#ff5577";
+const BG: u32 = 0x101012;
+const CARD_BG: u32 = 0x1c1c1f;
+const FG: u32 = 0xf0f0f3;
+const FG_TEXT: &str = "#f0f0f3";
+const ACCENT_TEXT: &str = "#ff5577";
 
 // ---- SVG payloads ----------------------------------------------------------
 //
@@ -70,29 +72,37 @@ const SVG_NESTED: &str = r##"<svg viewBox="0 0 24 24">
 
 #[whisker::main]
 pub fn app() -> Element {
-    let page_style = format!(
-        "background-color: {BG}; flex-grow: 1; flex-shrink: 1; \
-         display: flex; flex-direction: column; \
-         padding-top: 48px; padding-bottom: 24px;",
-    );
-    let header_style = format!(
-        "color: {FG}; font-size: 22px; font-weight: 700; \
-         margin-left: 20px; margin-bottom: 16px;",
-    );
-    let grid_style = "display: flex; flex-direction: row; flex-wrap: wrap; \
-                      padding-left: 12px; padding-right: 12px;"
-        .to_string();
+    let page_style = Css::new()
+        .background_color(Color::hex(BG))
+        .flex_grow(1.0)
+        .flex_shrink(1.0)
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .padding_top(px(48))
+        .padding_bottom(px(24));
+    let header_style = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(22))
+        .font_weight(FontWeight::Numeric(700))
+        .margin_left(px(20))
+        .margin_bottom(px(16));
+    let grid_style = Css::new()
+        .display_flex()
+        .flex_direction(FlexDirection::Row)
+        .flex_wrap(FlexWrap::Wrap)
+        .padding_left(px(12))
+        .padding_right(px(12));
 
     render! {
         view(style: page_style) {
             text(style: header_style, value: "whisker-svg gallery")
             view(style: grid_style) {
-                tile(label: "Rect (solid)",        svg: SVG_RECT,     color: FG)
-                tile(label: "Path (triangle)",     svg: SVG_TRIANGLE, color: FG)
-                tile(label: "Path (cubic curve)",  svg: SVG_CUBIC,    color: FG)
-                tile(label: "Stroke + width",      svg: SVG_STROKE,   color: FG)
-                tile(label: "currentColor tint",   svg: SVG_HEART,    color: ACCENT)
-                tile(label: "Nested <g> transform",svg: SVG_NESTED,   color: FG)
+                tile(label: "Rect (solid)",        svg: SVG_RECT,     color: FG_TEXT)
+                tile(label: "Path (triangle)",     svg: SVG_TRIANGLE, color: FG_TEXT)
+                tile(label: "Path (cubic curve)",  svg: SVG_CUBIC,    color: FG_TEXT)
+                tile(label: "Stroke + width",      svg: SVG_STROKE,   color: FG_TEXT)
+                tile(label: "currentColor tint",   svg: SVG_HEART,    color: ACCENT_TEXT)
+                tile(label: "Nested <g> transform",svg: SVG_NESTED,   color: FG_TEXT)
             }
         }
     }
@@ -103,18 +113,25 @@ pub fn app() -> Element {
 /// only variable in the visual is the SVG itself.
 #[component]
 fn tile(label: String, svg: String, color: String) -> Element {
-    let card_style = "width: 50%; \
-                      display: flex; flex-direction: column; align-items: center; \
-                      padding: 12px;"
-        .to_string();
-    let frame_style = format!(
-        "width: 96px; height: 96px; \
-         background-color: {CARD_BG}; \
-         border-radius: 12px; \
-         display: flex; align-items: center; justify-content: center;",
-    );
-    let svg_style = "width: 64px; height: 64px;".to_string();
-    let caption_style = format!("color: {FG}; font-size: 12px; margin-top: 8px;");
+    let card_style = Css::new()
+        .width(percent(50))
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .align_items(AlignItems::Center)
+        .padding(px(12));
+    let frame_style = Css::new()
+        .width(px(96))
+        .height(px(96))
+        .background_color(Color::hex(CARD_BG))
+        .border_radius(px(12))
+        .display_flex()
+        .align_items(AlignItems::Center)
+        .justify_content(JustifyContent::Center);
+    let svg_style = Css::new().width(px(64)).height(px(64));
+    let caption_style = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(12))
+        .margin_top(px(8));
 
     render! {
         view(style: card_style) {

--- a/packages/whisker-svg/src/lib.rs
+++ b/packages/whisker-svg/src/lib.rs
@@ -21,7 +21,7 @@
 //!                       stroke="currentColor" stroke-width="2" fill="none"/>
 //!             </svg>"#,
 //!             color: "#1d9bf0",
-//!             style: "width: 24px; height: 24px;",
+//!             style: css!(width: px(24), height: px(24)),
 //!         )
 //!     }
 //! }
@@ -95,7 +95,7 @@ use whisker::runtime::view::Element;
 /// - `color` — CSS-style colour applied to any `fill="currentColor"` /
 ///   `stroke="currentColor"` paint inside the SVG. Defaults to the
 ///   host's inherited foreground colour.
-/// - `style` — standard Whisker inline-style string for the host
+/// - `style` — structured Whisker CSS declarations for the host
 ///   `<view>`. Width / height MUST be set here (or via flex), the
 ///   replayer scales the SVG's viewBox to fill these bounds with
 ///   `preserveAspectRatio="xMidYMid meet"` semantics.

--- a/packages/whisker-video/src/lib.rs
+++ b/packages/whisker-video/src/lib.rs
@@ -17,12 +17,12 @@
 //! fn app() -> Element {
 //!     let video = VideoHandle::new();
 //!     render! {
-//!         view(style: "flex-direction: column;") {
+//!         view(style: css!(flex_direction: FlexDirection::Column)) {
 //!             Video(ref: video.r(), src: "https://example.com/clip.mp4",
-//!                   style: "width: 100%; height: 240px;")
+//!                   style: css!(width: percent(100), height: px(240)))
 //!             // `VideoHandle` is `Copy`, so each `move ||` closure
 //!             // captures its own copy — no `clone()` / pre-copy.
-//!             view(style: "flex-direction: row;") {
+//!             view(style: css!(flex_direction: FlexDirection::Row)) {
 //!                 text(value: "play",  on_tap: move |_| video.play())
 //!                 text(value: "pause", on_tap: move |_| video.pause())
 //!                 text(value: "+10s",  on_tap: move |_| video.seek(10.0))
@@ -59,7 +59,7 @@ use whisker::{ElementRef, Signal};
 /// `whisker-video:Video` element. The platform-side `@WhiskerModule`
 /// (`VideoModule`) registers a `VideoView` for this tag plus the
 /// `Prop("src")` setter + `play` / `pause` / `seek` commands. `src`
-/// is the media URL; `style` is the standard layout-styling string.
+/// is the media URL; `style` carries structured layout declarations.
 #[whisker::module_component(
     name = "whisker-video:Video",
     measurement = None,

--- a/packages/whisker-webview/example/src/lib.rs
+++ b/packages/whisker-webview/example/src/lib.rs
@@ -11,27 +11,35 @@
 //! * **Inline HTML** — a second [`WebView`] rendering `html:` with a
 //!   `<button>` that posts a message back to Rust.
 
+use whisker::css::{FlexDirection, FontWeight};
 use whisker::prelude::*;
 use whisker::runtime::view::Element;
 use whisker_webview::{WebView, WebViewRef};
 
-const BG: &str = "#101012";
-const CARD_BG: &str = "#1c1c1f";
-const FG: &str = "#f0f0f3";
-const MUTED: &str = "#9a9aa2";
-const ACCENT: &str = "#ff5577";
+const BG: u32 = 0x101012;
+const CARD_BG: u32 = 0x1c1c1f;
+const FG: u32 = 0xf0f0f3;
+const MUTED: u32 = 0x9a9aa2;
+const ACCENT: u32 = 0xff5577;
 
 const INLINE_HTML: &str = "<!doctype html><html><head><meta name='viewport' content='width=device-width, initial-scale=1'></head><body style='font-family: -apple-system, sans-serif; padding: 16px;'><h2>Inline HTML page</h2><button onclick=\"window.whisker.postMessage('hi from page')\">Post message to Rust</button></body></html>";
 
 #[whisker::main]
 pub fn app() -> Element {
-    let page_style = format!(
-        "background-color: {BG}; flex-grow: 1; flex-shrink: 1; \
-         display: flex; flex-direction: column; \
-         padding-top: 56px; padding-left: 20px; padding-right: 20px;",
-    );
-    let header_style =
-        format!("color: {FG}; font-size: 22px; font-weight: 700; margin-bottom: 20px;",);
+    let page_style = Css::new()
+        .background_color(Color::hex(BG))
+        .flex_grow(1.0)
+        .flex_shrink(1.0)
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .padding_top(px(56))
+        .padding_left(px(20))
+        .padding_right(px(20));
+    let header_style = Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(22))
+        .font_weight(FontWeight::Numeric(700))
+        .margin_bottom(px(20));
 
     render! {
         view(style: page_style) {
@@ -51,7 +59,10 @@ fn url_demo() -> Element {
     let last_message = RwSignal::new(String::from("(none)"));
     let webview = WebViewRef::new();
 
-    let msg_style = format!("color: {MUTED}; font-size: 14px; margin-top: 6px;");
+    let msg_style = Css::new()
+        .color(Color::hex(MUTED))
+        .font_size(px(14))
+        .margin_top(px(6));
 
     render! {
         view(style: section_style()) {
@@ -67,7 +78,7 @@ fn url_demo() -> Element {
                 style: webview_style(),
             )
 
-            view(style: "display: flex; flex-direction: row; margin-top: 10px;") {
+            view(style: Css::new().display_flex().flex_direction(FlexDirection::Row).margin_top(px(10))) {
                 text(style: button_style(), value: "Reload", on_tap: {
                     let w = webview.clone();
                     move |_| w.reload()
@@ -103,7 +114,10 @@ fn url_demo() -> Element {
 #[component]
 fn inline_html_demo() -> Element {
     let last_message = RwSignal::new(String::from("(none)"));
-    let msg_style = format!("color: {MUTED}; font-size: 14px; margin-top: 6px;");
+    let msg_style = Css::new()
+        .color(Color::hex(MUTED))
+        .font_size(px(14))
+        .margin_top(px(6));
 
     render! {
         view(style: section_style()) {
@@ -127,27 +141,38 @@ fn log_load(url: &str) {
 
 // ---- Shared styling --------------------------------------------------------
 
-fn section_style() -> String {
-    "display: flex; flex-direction: column; margin-bottom: 24px;".to_string()
+fn section_style() -> Css {
+    Css::new()
+        .display_flex()
+        .flex_direction(FlexDirection::Column)
+        .margin_bottom(px(24))
 }
 
-fn label_style() -> String {
-    format!("color: {FG}; font-size: 13px; font-weight: 600; margin-bottom: 8px;")
+fn label_style() -> Css {
+    Css::new()
+        .color(Color::hex(FG))
+        .font_size(px(13))
+        .font_weight(FontWeight::Numeric(600))
+        .margin_bottom(px(8))
 }
 
-fn webview_style() -> String {
-    format!(
-        "background-color: {CARD_BG}; height: 280px; \
-         border-radius: 10px;",
-    )
+fn webview_style() -> Css {
+    Css::new()
+        .background_color(Color::hex(CARD_BG))
+        .height(px(280))
+        .border_radius(px(10))
 }
 
-fn button_style() -> String {
-    format!(
-        "background-color: {ACCENT}; color: {FG}; \
-         font-size: 14px; font-weight: 600; \
-         padding-top: 8px; padding-bottom: 8px; \
-         padding-left: 14px; padding-right: 14px; \
-         margin-right: 8px; border-radius: 8px;",
-    )
+fn button_style() -> Css {
+    Css::new()
+        .background_color(Color::hex(ACCENT))
+        .color(Color::hex(FG))
+        .font_size(px(14))
+        .font_weight(FontWeight::Numeric(600))
+        .padding_top(px(8))
+        .padding_bottom(px(8))
+        .padding_left(px(14))
+        .padding_right(px(14))
+        .margin_right(px(8))
+        .border_radius(px(8))
 }

--- a/packages/whisker-webview/src/lib.rs
+++ b/packages/whisker-webview/src/lib.rs
@@ -23,8 +23,8 @@
 //! fn app() -> Element {
 //!     let url = RwSignal::new("https://example.com".to_string());
 //!     render! {
-//!         view(style: "flex-direction: column; flex-grow: 1;") {
-//!             WebView(url: url, style: "flex-grow: 1;")
+//!         view(style: css!(flex_direction: FlexDirection::Column, flex_grow: 1.0)) {
+//!             WebView(url: url, style: css!(flex_grow: 1.0))
 //!             // `url.set("https://other.com")` navigates the view.
 //!         }
 //!     }
@@ -40,7 +40,7 @@
 //!
 //! ```ignore
 //! let html = "<h1>Hi</h1>".to_string();
-//! render! { WebView(html: html, style: "flex-grow: 1;") }
+//! render! { WebView(html: html, style: css!(flex_grow: 1.0)) }
 //! ```
 //!
 //! ### JS bridge round-trip
@@ -65,9 +65,9 @@
 //! ```ignore
 //! let webview = WebViewRef::new();
 //! render! {
-//!     view(style: "flex-direction: column;") {
-//!         WebView(url: url, webview_ref: webview.clone(), style: "flex-grow: 1;")
-//!         view(style: "flex-direction: row;") {
+//!     view(style: css!(flex_direction: FlexDirection::Column)) {
+//!         WebView(url: url, webview_ref: webview.clone(), style: css!(flex_grow: 1.0))
+//!         view(style: css!(flex_direction: FlexDirection::Row)) {
 //!             text(value: "Reload", on_tap: {
 //!                 let w = webview.clone();
 //!                 move |_| w.reload()
@@ -93,7 +93,7 @@
 //! | `on_navigation`     | `Fn(String)`               | —                             | An internal navigation was requested; carries the URL. Fires for BOTH allowed and denied (off-whitelist / non-http(s), e.g. a custom-scheme OAuth redirect) attempts — filter by URL/scheme if you only care about one. |
 //! | `on_progress`       | `Fn(f32)`                  | —                             | Load progress `0.0..=1.0`. |
 //! | `on_error`          | `Fn(WebViewError)`         | —                             | Navigation failed (url / code / description). |
-//! | `style`             | `Signal<String>`           | `""`                          | Standard Whisker CSS style string. |
+//! | `style`             | `Style`                    | empty                         | Structured Whisker CSS declarations. |
 //! | `webview_ref`       | [`WebViewRef`]             | —                             | Imperative handle (see [Methods](#methods)). |
 //!
 //! ## JS bridge


### PR DESCRIPTION
## Summary

- remove raw CSS `String`/`&str` acceptance from `style`
- require `Css` or reactive signals of `Css` throughout the public API
- remove `Css::raw` and the raw-style runtime fallback
- migrate examples, packages, docs, and router transitions to structured CSS
- add compile-fail coverage for raw string styles

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Follow-up

The View/Text/ScrollView public API cleanup, structured accessibility contract, and `hit_slop` removal will be handled separately after the API specification discussion.