### PR TITLE
test: isolate Host conformance support from SDKs

### DIFF
--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -9,6 +9,7 @@ import android.view.InputDevice
 import android.view.MotionEvent
 import android.util.Base64
 import android.text.Spanned
+import android.text.TextDirectionHeuristics
 import android.text.style.LeadingMarginSpan
 import android.view.View
 import android.view.Gravity
@@ -29,7 +30,9 @@ import kotlin.math.roundToInt
 import rs.whisker.runtime.resource.HostResourceFailureCode
 import rs.whisker.runtime.resource.HostResourceSnapshot
 import rs.whisker.runtime.resource.HostResourceState
+import rs.whisker.runtime.input.normalizePointerInput
 import rs.whisker.runtime.measure.HostMeasureBatchAbi
+import rs.whisker.runtime.measure.resolveTextLayoutSemantics
 import rs.whisker.runtime.scene.HostAccessibility
 import rs.whisker.runtime.scene.HostNode
 
@@ -44,14 +47,6 @@ private data class CapturedPointerInput(
     val timestampMs: Double,
     val x: Float,
     val y: Float,
-)
-
-private data class CapturedTextMeasurement(
-    val direction: Int,
-    val alignment: Int,
-    val paragraphDirection: Int,
-    val layoutAlignment: Int,
-    val indent: Float,
 )
 
 @RunWith(AndroidJUnit4::class)
@@ -457,7 +452,6 @@ private class Driver(
     private var checkpoint: Bitmap? = null
     private val measurements = HashMap<Long, FloatArray>()
     private var pointerInput: CapturedPointerInput? = null
-    private var textMeasurement: CapturedTextMeasurement? = null
 
     init {
         view.beginBootstrapFromNative()
@@ -488,27 +482,6 @@ private class Driver(
             intArrayOf(), intArrayOf(), emptyArray(),
         )
         check(view.finishBootstrapFromNative())
-        view.observePointerInputForTesting { semantics, geometry ->
-            pointerInput = CapturedPointerInput(
-                event = semantics[0].toInt(),
-                pointerId = semantics[1],
-                kind = semantics[2].toInt(),
-                buttons = semantics[3].toInt(),
-                changedButton = semantics[4].toInt(),
-                timestampMs = geometry[0].toDouble(),
-                x = geometry[1].toFloat(),
-                y = geometry[2].toFloat(),
-            )
-        }
-        view.observeTextMeasurementForTesting { semantics, geometry ->
-            textMeasurement = CapturedTextMeasurement(
-                direction = semantics[0],
-                alignment = semantics[1],
-                paragraphDirection = semantics[2],
-                layoutAlignment = semantics[3],
-                indent = geometry[0],
-            )
-        }
     }
 
     fun execute(side: JSONObject): Bitmap {
@@ -799,6 +772,17 @@ private class Driver(
             0,
         )
         try {
+            val normalized = normalizePointerInput(event, density).single()
+            pointerInput = CapturedPointerInput(
+                event = normalized.event,
+                pointerId = normalized.pointerId,
+                kind = normalized.kind,
+                buttons = normalized.buttons,
+                changedButton = normalized.changedButton,
+                timestampMs = normalized.timestampMs,
+                x = normalized.x,
+                y = normalized.y,
+            )
             view.dispatchTouchEvent(event)
         } finally {
             event.recycle()
@@ -937,19 +921,28 @@ private class Driver(
             check(opticalSizing == 1)
         }
         if (id == "host.measure.text.direction") {
-            val applied = checkNotNull(textMeasurement)
-            check(applied.direction == direction)
-            check(applied.alignment == alignment)
-            check(abs(applied.indent - (indentLogicalPixels +
+            val density = context.resources.displayMetrics.density
+            val semantics = resolveTextLayoutSemantics(
+                text = command.getString("text"),
+                direction = direction,
+                alignment = alignment,
+                localeRtl = context.resources.configuration.layoutDirection ==
+                    View.LAYOUT_DIRECTION_RTL,
+                widthBasis = command.getDouble("available_width").toFloat(),
+                density = density,
+                indentLogicalPixels = indentLogicalPixels,
+                indentPercentage = indentPercentage,
+            )
+            check(abs(semantics.indentPixels / density - (indentLogicalPixels +
                 command.getDouble("available_width").toFloat() * indentPercentage / 100f)) < 0.01f)
             when (command.getLong("key")) {
                 20L -> {
-                    check(applied.paragraphDirection == -1)
-                    check(applied.layoutAlignment == android.text.Layout.Alignment.ALIGN_OPPOSITE.ordinal)
+                    check(semantics.directionHeuristic === TextDirectionHeuristics.RTL)
+                    check(semantics.alignment == android.text.Layout.Alignment.ALIGN_OPPOSITE)
                 }
                 21L -> {
-                    check(applied.paragraphDirection == 1)
-                    check(applied.layoutAlignment == android.text.Layout.Alignment.ALIGN_CENTER.ordinal)
+                    check(semantics.directionHeuristic === TextDirectionHeuristics.LTR)
+                    check(semantics.alignment == android.text.Layout.Alignment.ALIGN_CENTER)
                 }
             }
         }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -13,7 +13,6 @@ import android.view.View
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.bridge.AndroidFrameBatch
 import rs.whisker.runtime.bridge.MobileAbi
-import rs.whisker.runtime.input.HostPointerInput
 import rs.whisker.runtime.input.normalizePointerInput
 import rs.whisker.runtime.measure.HostMeasurementProvider
 import rs.whisker.runtime.measure.HostMeasureBatchAbi
@@ -60,7 +59,6 @@ class WhiskerView(context: Context) :
     private val modules = HostModuleDispatcher(::nativeResolveModule)
     private var backdropCaptureTarget: HostNode? = null
     private var backdropCaptureReached = false
-    private var pointerInputObserver: ((HostPointerInput) -> Unit)? = null
     private val pendingContinuousEvents = PendingContinuousEvents()
     private var continuousEventFlushPending = false
     private val continuousEventFlush = Runnable {
@@ -179,7 +177,6 @@ class WhiskerView(context: Context) :
         val density = resources.displayMetrics.density
         val pointers = normalizePointerInput(event, density)
         pointers.forEach { pointer ->
-            pointerInputObserver?.invoke(pointer)
             val handle = nativeHandle
             if (handle != 0L) {
                 nativeDispatchPointer(
@@ -200,33 +197,6 @@ class WhiskerView(context: Context) :
         // an Android ownership decision, so receiving a normalized sample is
         // enough to claim it while the runtime is mounted.
         return nativeHandle != 0L && pointers.isNotEmpty()
-    }
-
-    /** Test-only observer at the production MotionEvent-to-runtime dispatch seam. */
-    fun observePointerInputForTesting(observer: ((LongArray, DoubleArray) -> Unit)?) {
-        pointerInputObserver = observer?.let { callback ->
-            { pointer ->
-                callback(
-                    longArrayOf(
-                        pointer.event.toLong(),
-                        pointer.pointerId,
-                        pointer.kind.toLong(),
-                        pointer.buttons.toLong(),
-                        pointer.changedButton.toLong(),
-                    ),
-                    doubleArrayOf(
-                        pointer.timestampMs,
-                        pointer.x.toDouble(),
-                        pointer.y.toDouble(),
-                    ),
-                )
-            }
-        }
-    }
-
-    /** Test-only observer at the production text shaping configuration seam. */
-    fun observeTextMeasurementForTesting(observer: ((IntArray, FloatArray) -> Unit)?) {
-        measurements.textInspectionObserver = observer
     }
 
     /** Called from Rust through JNI. Safe even when the wake originates off-main. */

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
@@ -24,8 +24,6 @@ import rs.whisker.runtime.resolveWhiskerTypeface
 
 /** Intrinsic measurement implementation shared by all Android Host frames. */
 internal class HostMeasurementProvider(private val context: Context) {
-    var textInspectionObserver: ((IntArray, FloatArray) -> Unit)? = null
-
     @Suppress("LongParameterList")
     fun measure(
         elementType: Int, kind: Int,
@@ -121,17 +119,24 @@ internal class HostMeasurementProvider(private val context: Context) {
             availableWidthKind == DEFINITE -> availableWidth
             else -> 0f
         }
-        val indentPixels = indentLogicalPixels * density +
-            widthBasis * density * indentPercentage / 100f
         val displayText = if (wordBreak == WORD_BREAK_KEEP_ALL) protectCjkBreaks(text) else text
         val localeRtl = context.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL
-        val resolvedRtl = resolvesRightToLeft(displayText, direction, localeRtl)
-        val layoutText: CharSequence = if (displayText.isEmpty() || indentPixels == 0f) {
+        val semantics = resolveTextLayoutSemantics(
+            displayText,
+            direction,
+            alignment,
+            localeRtl,
+            widthBasis,
+            density,
+            indentLogicalPixels,
+            indentPercentage,
+        )
+        val layoutText: CharSequence = if (displayText.isEmpty() || semantics.indentPixels == 0f) {
             displayText
         } else {
             SpannableString(displayText).apply {
                 setSpan(
-                    LeadingMarginSpan.Standard(indentPixels.toInt(), 0),
+                    LeadingMarginSpan.Standard(semantics.indentPixels.toInt(), 0),
                     0,
                     length,
                     Spanned.SPAN_INCLUSIVE_EXCLUSIVE,
@@ -141,13 +146,13 @@ internal class HostMeasurementProvider(private val context: Context) {
         val maxWidthPx = if (availableWidthKind == DEFINITE && wrap != 0) {
             ceil(availableWidth * density).toInt().coerceAtLeast(1)
         } else {
-            ceil(paint.measureText(text) + indentPixels).toInt().coerceAtLeast(1)
+            ceil(paint.measureText(text) + semantics.indentPixels).toInt().coerceAtLeast(1)
         }
         val builder = StaticLayout.Builder.obtain(
             layoutText, 0, layoutText.length, paint, maxWidthPx,
         )
-            .setAlignment(resolveAlignment(alignment, resolvedRtl))
-            .setTextDirection(resolveDirectionHeuristic(direction, localeRtl))
+            .setAlignment(semantics.alignment)
+            .setTextDirection(semantics.directionHeuristic)
             .setIncludePad(false)
             .setMaxLines(if (maxLines == 0) Int.MAX_VALUE else maxLines)
             .setBreakStrategy(
@@ -162,15 +167,6 @@ internal class HostMeasurementProvider(private val context: Context) {
             builder.setLineSpacing((lineHeight * density - fontHeight).coerceAtLeast(0f), 1f)
         }
         val layout = builder.build()
-        textInspectionObserver?.invoke(
-            intArrayOf(
-                direction,
-                alignment,
-                if (layout.lineCount > 0) layout.getParagraphDirection(0) else if (resolvedRtl) -1 else 1,
-                layout.alignment.ordinal,
-            ),
-            floatArrayOf(indentPixels / density),
-        )
         val width = when {
             knownMask and WIDTH != 0 -> knownWidth
             availableWidthKind == DEFINITE && wrap != 0 ->
@@ -189,6 +185,32 @@ internal class HostMeasurementProvider(private val context: Context) {
 
     private fun ready(width: Float, height: Float): FloatArray =
         floatArrayOf(READY, 0f, width, height, 0f, 0f, 0f)
+}
+
+internal data class TextLayoutSemantics(
+    val alignment: Layout.Alignment,
+    val directionHeuristic: TextDirectionHeuristic,
+    val indentPixels: Float,
+)
+
+@Suppress("LongParameterList")
+internal fun resolveTextLayoutSemantics(
+    text: String,
+    direction: Int,
+    alignment: Int,
+    localeRtl: Boolean,
+    widthBasis: Float,
+    density: Float,
+    indentLogicalPixels: Float,
+    indentPercentage: Float,
+): TextLayoutSemantics {
+    val rightToLeft = resolvesRightToLeft(text, direction, localeRtl)
+    return TextLayoutSemantics(
+        alignment = resolveAlignment(alignment, rightToLeft),
+        directionHeuristic = resolveDirectionHeuristic(direction, localeRtl),
+        indentPixels = indentLogicalPixels * density +
+            widthBasis * density * indentPercentage / 100f,
+    )
 }
 
 private fun resolveDirectionHeuristic(

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -38,8 +38,7 @@ let package = Package(
         .target(
             name: "WhiskerRuntime",
             dependencies: ["WhiskerModule"],
-            path: "Sources/WhiskerRuntime",
-            swiftSettings: [.define("WHISKER_HOST_CONFORMANCE")]
+            path: "Sources/WhiskerRuntime"
         ),
         .target(
             name: "WhiskerHostConformanceStubs",

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -208,46 +208,22 @@ public final class WhiskerView: UIView {
         pointerID: UInt64,
         pointerKind: HostPointerKind,
         x: Float,
-        y: Float,
-        handle overrideHandle: UnsafeMutableRawPointer? = nil
-    ) {
-        guard timestampMs.isFinite, pointerID != 0, x.isFinite, y.isFinite,
-              let handle = overrideHandle ?? runtimeHandle else { return }
-        _ = dispatchWhiskerPointer(
-            handle: handle,
-            input: WhiskerPointerDispatch(
-                timestampMs: timestampMs,
-                event: event.rawValue,
-                pointerID: pointerID,
-                pointerKind: pointerKind.rawValue,
-                x: x,
-                y: y,
-                buttons: event.buttons,
-                changedButton: pointerKind.changedButton(for: event)
-            )
-        )
-    }
-
-#if WHISKER_HOST_CONFORMANCE
-    func dispatchConformanceTouchSample(
-        timestampMs: Double,
-        event: HostPointerEvent,
-        pointerID: UInt64,
-        pointerKind: HostPointerKind,
-        x: Float,
         y: Float
     ) {
-        dispatchTouchSample(
-            timestampMs: timestampMs,
-            event: event,
-            pointerID: pointerID,
-            pointerKind: pointerKind,
-            x: x,
-            y: y,
-            handle: UnsafeMutableRawPointer(bitPattern: 1)
+        guard let handle = runtimeHandle,
+              let input = makeWhiskerPointerDispatch(
+                  timestampMs: timestampMs,
+                  event: event,
+                  pointerID: pointerID,
+                  pointerKind: pointerKind,
+                  x: x,
+                  y: y
+              ) else { return }
+        _ = dispatchWhiskerPointer(
+            handle: handle,
+            input: input
         )
     }
-#endif
 
     private func unmount() {
         guard let handle = runtimeHandle else { return }
@@ -310,15 +286,6 @@ public final class WhiskerView: UIView {
     ) -> Bool {
         scene.applyFrame(frame, response: &response)
     }
-
-#if WHISKER_HOST_CONFORMANCE
-    func applyConformanceFrame(
-        _ frame: WhiskerMobileFrame,
-        response: inout WhiskerMobileApplyResponse
-    ) -> Bool {
-        scene.applyFrame(frame, response: &response)
-    }
-#endif
     private func dispatchElementEvent(node: UInt64, name: String, detail: WhiskerValue) {
         scene.dispatchOrDefer { [weak self] in
             guard let self, let handle = runtimeHandle else { return }

--- a/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
@@ -78,18 +78,32 @@ struct WhiskerPointerDispatch: Equatable {
     let changedButton: Int16
 }
 
-#if WHISKER_HOST_CONFORMANCE
-var whiskerPointerDispatchObserver: ((WhiskerPointerDispatch) -> Void)?
-#endif
+func makeWhiskerPointerDispatch(
+    timestampMs: Double,
+    event: HostPointerEvent,
+    pointerID: UInt64,
+    pointerKind: HostPointerKind,
+    x: Float,
+    y: Float
+) -> WhiskerPointerDispatch? {
+    guard timestampMs.isFinite, pointerID != 0, x.isFinite, y.isFinite else { return nil }
+    return WhiskerPointerDispatch(
+        timestampMs: timestampMs,
+        event: event.rawValue,
+        pointerID: pointerID,
+        pointerKind: pointerKind.rawValue,
+        x: x,
+        y: y,
+        buttons: event.buttons,
+        changedButton: pointerKind.changedButton(for: event)
+    )
+}
 
 @discardableResult
 func dispatchWhiskerPointer(
     handle: UnsafeMutableRawPointer,
     input: WhiskerPointerDispatch
 ) -> Bool {
-#if WHISKER_HOST_CONFORMANCE
-    whiskerPointerDispatchObserver?(input)
-#endif
     return whiskerViewDispatchPointer(
         handle,
         input.timestampMs,

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -385,12 +385,12 @@ final class HostConformanceTests: XCTestCase {
                         frame.operations = UnsafePointer(operationBuffer.baseAddress!)
                         frame.operation_count = operationBuffer.count
                         var response = WhiskerMobileApplyResponse()
-                        XCTAssertTrue(view.applyConformanceFrame(frame, response: &response))
+                        XCTAssertTrue(view.applyFrame(frame, response: &response))
                         XCTAssertEqual(response.status, UInt8(WHISKER_APPLY_REJECTED))
                         XCTAssertTrue(
                             view.registerRasterResource(id: resourceID, image: raster)
                         )
-                        XCTAssertTrue(view.applyConformanceFrame(frame, response: &response))
+                        XCTAssertTrue(view.applyFrame(frame, response: &response))
                         XCTAssertEqual(response.status, UInt8(WHISKER_APPLY_ACCEPTED))
                     }
                 }
@@ -1154,18 +1154,14 @@ private final class Driver {
         default: throw Failure("unknown pointer event")
         }
         let pointerKind = try fixturePointerKind(command)
-        var observed: WhiskerPointerDispatch?
-        whiskerPointerDispatchObserver = { observed = $0 }
-        defer { whiskerPointerDispatchObserver = nil }
-        view.dispatchConformanceTouchSample(
+        let input = try unwrap(makeWhiskerPointerDispatch(
             timestampMs: try number(command, "timestamp_ms"),
             event: event,
             pointerID: UInt64(try number(command, "pointer_id")),
             pointerKind: pointerKind,
             x: Float(try number(command, "x")),
             y: Float(try number(command, "y"))
-        )
-        let input = try unwrap(observed, "production pointer ABI dispatch")
+        ), "production pointer ABI dispatch")
         XCTAssertEqual(input.timestampMs, try number(command, "timestamp_ms"))
         XCTAssertEqual(input.event, event.rawValue)
         XCTAssertNotEqual(input.pointerID, 0)
@@ -1355,7 +1351,7 @@ private final class Driver {
                     }
                     frame.operation_count = buffer.count
                     var response = WhiskerMobileApplyResponse()
-                    guard view.applyConformanceFrame(frame, response: &response),
+                    guard view.applyFrame(frame, response: &response),
                           response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
                         throw Failure("UIKit Host rejected fixture frame")
                     }
@@ -1892,7 +1888,7 @@ private final class Driver {
                                 frame.operations = UnsafePointer(buffer.baseAddress!)
                                 frame.operation_count = buffer.count
                                 var response = WhiskerMobileApplyResponse()
-                                guard view.applyConformanceFrame(frame, response: &response),
+                                guard view.applyFrame(frame, response: &response),
                                       response.status == UInt8(WHISKER_APPLY_ACCEPTED) else {
                                     throw Failure("UIKit Host rejected scene fixture frame")
                                 }

--- a/xtask/src/host_sdk_surface.rs
+++ b/xtask/src/host_sdk_surface.rs
@@ -1,0 +1,110 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const FORBIDDEN_PRODUCTION_MARKERS: &[&str] = &[
+    "WHISKER_HOST_CONFORMANCE",
+    "ForTesting",
+    "ConformanceFrame",
+    "ConformanceTouch",
+    "pointerInputObserver",
+    "textInspectionObserver",
+];
+
+fn production_host_sources(root: &Path, relative_paths: &[&str]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for relative_path in relative_paths {
+        let path = root.join(relative_path);
+        if path.is_dir() {
+            collect_sources(&path, &mut files);
+        } else {
+            files.push(path);
+        }
+    }
+    files
+}
+
+fn collect_sources(directory: &Path, files: &mut Vec<PathBuf>) {
+    let mut entries = fs::read_dir(directory)
+        .unwrap_or_else(|error| panic!("read {}: {error}", directory.display()))
+        .map(|entry| entry.expect("read production Host source entry").path())
+        .collect::<Vec<_>>();
+    entries.sort();
+    for path in entries {
+        if path.is_dir() {
+            collect_sources(&path, files);
+        } else if matches!(
+            path.extension().and_then(|extension| extension.to_str()),
+            Some("kt" | "swift")
+        ) {
+            files.push(path);
+        }
+    }
+}
+
+#[test]
+fn ios_production_host_sources_exclude_test_support() {
+    let root = super::workspace_root().expect("resolve workspace root");
+    for package in ["Package.swift", "platforms/ios/Package.swift"] {
+        assert_swift_runtime_target_has_no_conformance_define(&root.join(package));
+    }
+    assert_no_test_support(&root, &["platforms/ios/Sources/WhiskerRuntime"]);
+}
+
+#[test]
+fn android_production_host_sources_exclude_test_support() {
+    let root = super::workspace_root().expect("resolve workspace root");
+    assert_no_test_support(
+        &root,
+        &[
+            "platforms/android/module/src/main",
+            "platforms/android/runtime/src/main",
+        ],
+    );
+}
+
+fn assert_no_test_support(root: &Path, relative_paths: &[&str]) {
+    let leaks = production_host_sources(root, relative_paths)
+        .into_iter()
+        .flat_map(|path| {
+            let source = fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+            FORBIDDEN_PRODUCTION_MARKERS
+                .iter()
+                .filter(|marker| source.contains(**marker))
+                .map(|marker| {
+                    format!(
+                        "{} contains forbidden production marker {marker}",
+                        path.strip_prefix(root).unwrap_or(&path).display()
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        leaks.is_empty(),
+        "Host conformance support leaked into the production SDK:\n{}",
+        leaks.join("\n")
+    );
+}
+
+fn assert_swift_runtime_target_has_no_conformance_define(package: &Path) {
+    let source = fs::read_to_string(package)
+        .unwrap_or_else(|error| panic!("read {}: {error}", package.display()));
+    let target_start = source
+        .find(".target(\n            name: \"WhiskerRuntime\"")
+        .unwrap_or_else(|| panic!("{} has no WhiskerRuntime target", package.display()));
+    let target = &source[target_start..];
+    let target_end = target.find("\n        ),").unwrap_or_else(|| {
+        panic!(
+            "{} has an unterminated WhiskerRuntime target",
+            package.display()
+        )
+    });
+    let target = &target[..target_end];
+    assert!(
+        !target.contains("WHISKER_HOST_CONFORMANCE"),
+        "{} compiles the production WhiskerRuntime target with Host conformance support",
+        package.display()
+    );
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,9 @@ use anyhow::{Context, Result, bail};
 mod mobile_abi;
 mod mobile_link_test;
 
+#[cfg(test)]
+mod host_sdk_surface;
+
 fn main() -> Result<()> {
     let mut arguments = std::env::args().skip(1);
     match (arguments.next().as_deref(), arguments.next().as_deref()) {


### PR DESCRIPTION
## Summary
- remove the always-on iOS Host conformance compile flag and test-only WhiskerView/RuntimeABI branches
- remove Android pointer and text measurement observers from the production AAR surface
- run conformance fixtures through shared production pointer normalization, text layout semantics, and frame application interfaces
- add a Rust regression check preventing test-support markers from returning to production Host sources or the Swift runtime target

## Verification
- cargo xtask host-conformance ios
- cargo xtask mobile-link-test ios
- cargo xtask mobile-link-test android
- platforms/android/gradle-plugin/gradlew --project-dir platforms/android :runtime:assembleDebugAndroidTest :runtime:assembleRelease --no-daemon
- cargo test -p xtask
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt --all --check