### PR TITLE
Isolate runtime state and module events per surface

### DIFF
--- a/crates/whisker-animation/src/controller.rs
+++ b/crates/whisker-animation/src/controller.rs
@@ -1,4 +1,4 @@
-//! [`AnimationController`] + the per-thread [`AnimationScheduler`].
+//! [`AnimationController`] + the per-runtime [`AnimationScheduler`].
 //!
 //! The controller is a state machine driving a `0..1` **progress**
 //! signal. It is *idle when not driving*: `forward` / `reverse` /
@@ -296,22 +296,17 @@ impl ControllerState {
     }
 }
 
-thread_local! {
-    static SCHEDULER: RefCell<AnimationScheduler> =
-        RefCell::new(AnimationScheduler::new());
-}
-
-/// One per runtime thread: holds the set of active controllers and
+/// One per runtime instance: holds the set of active controllers and
 /// advances them each frame. Registered with the runtime's
 /// [`anim_hook`] the first time any controller is created on this
-/// thread, so the driver's `tick_frame` drives it.
+/// instance, so the driver's `tick_frame` drives it.
 struct AnimationScheduler {
     active: Vec<Rc<RefCell<ControllerState>>>,
     /// Most recent timestamp seen from `step` — used as the start time
     /// for a `forward`/`reverse` issued between frames.
     last_ms: f64,
     /// Whether the per-frame callback has been registered with the
-    /// runtime's `anim_hook` for this thread.
+    /// runtime's `anim_hook` for this instance.
     hook_installed: bool,
 }
 
@@ -325,33 +320,50 @@ impl AnimationScheduler {
     }
 }
 
+impl Default for AnimationScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+type Scheduler = Rc<RefCell<AnimationScheduler>>;
+
+fn scheduler() -> Scheduler {
+    whisker_runtime::runtime_local::state::<AnimationScheduler>()
+}
+
 /// Ensure the scheduler's per-frame step callback is registered with
-/// the runtime, so `tick_frame` advances animations on this thread.
-fn ensure_hook_installed() {
-    let already = SCHEDULER.with(|s| {
+/// the runtime, so `tick_frame` advances animations for this instance.
+fn ensure_hook_installed() -> Scheduler {
+    let scheduler = scheduler();
+    let already = {
+        let s = &scheduler;
         let mut s = s.borrow_mut();
         let was = s.hook_installed;
         s.hook_installed = true;
         was
-    });
+    };
     if !already {
-        anim_hook::set_step_callback(Box::new(step));
+        let owned = Rc::clone(&scheduler);
+        anim_hook::set_step_callback(Box::new(move |now_ms| step(&owned, now_ms)));
     }
+    scheduler
 }
 
 /// Advance every active controller by one frame at `now_ms`. Returns
 /// `true` if any controller is still animating afterward. This is the
 /// callback the runtime's `anim_hook` invokes each `tick_frame`.
-fn step(now_ms: f64) -> bool {
+fn step(scheduler: &Scheduler, now_ms: f64) -> bool {
     // Snapshot outside the scheduler borrow: `advance` writes a value
     // signal, scheduling reactive subscribers. None re-enter the
     // scheduler, but the tight borrow window matches the runtime's
     // discipline.
-    let snapshot: Vec<Rc<RefCell<ControllerState>>> = SCHEDULER.with(|s| {
+    let snapshot: Vec<Rc<RefCell<ControllerState>>> = {
+        let s = scheduler;
         let mut s = s.borrow_mut();
         s.last_ms = now_ms;
         s.active.clone()
-    });
+    };
 
     let mut finished: Vec<*const RefCell<ControllerState>> = Vec::new();
     for st in &snapshot {
@@ -361,7 +373,8 @@ fn step(now_ms: f64) -> bool {
         }
     }
 
-    SCHEDULER.with(|s| {
+    {
+        let s = scheduler;
         let mut s = s.borrow_mut();
         if !finished.is_empty() {
             s.active.retain(|st| !finished.contains(&Rc::as_ptr(st)));
@@ -369,7 +382,7 @@ fn step(now_ms: f64) -> bool {
         let any = !s.active.is_empty();
         anim_hook::mark_animating(any);
         any
-    })
+    }
 }
 
 /// Register `state` as active (idempotent) and wake the host so a frame
@@ -381,18 +394,19 @@ fn step(now_ms: f64) -> bool {
 /// clock. We deliberately **do not** touch `velocity` here: the run's
 /// initial velocity is decided by the caller before registering (see the
 /// hand-off note on `AnimationController::start_run`).
-fn register(state: &Rc<RefCell<ControllerState>>) {
-    let already = SCHEDULER.with(|s| {
+fn register(scheduler: &Scheduler, state: &Rc<RefCell<ControllerState>>) {
+    let already = {
+        let s = scheduler;
         let s = s.borrow();
         s.active.iter().any(|a| Rc::ptr_eq(a, state))
-    });
+    };
     {
         let mut st = state.borrow_mut();
         st.start_ms = None;
         st.last_frame_ms = None;
     }
     if !already {
-        SCHEDULER.with(|s| s.borrow_mut().active.push(state.clone()));
+        scheduler.borrow_mut().active.push(state.clone());
     }
     // Report busy before the next `step`, and nudge the host for a frame.
     anim_hook::mark_animating(true);
@@ -400,20 +414,21 @@ fn register(state: &Rc<RefCell<ControllerState>>) {
 }
 
 /// Deregister `state` from the active list (no-op if absent).
-fn deregister(state: &Rc<RefCell<ControllerState>>) {
-    SCHEDULER.with(|s| {
+fn deregister(scheduler: &Scheduler, state: &Rc<RefCell<ControllerState>>) {
+    {
+        let s = scheduler;
         let mut s = s.borrow_mut();
         s.active.retain(|a| !Rc::ptr_eq(a, state));
         if s.active.is_empty() {
             anim_hook::mark_animating(false);
         }
-    });
+    }
 }
 
-/// (Test only) number of currently-active controllers on this thread.
+/// (Test only) number of currently-active controllers in the active runtime.
 #[doc(hidden)]
 pub fn __active_count() -> usize {
-    SCHEDULER.with(|s| s.borrow().active.len())
+    scheduler().borrow().active.len()
 }
 
 /// (Test only) drive one animation frame at monotonic time `now_ms`
@@ -424,16 +439,16 @@ pub fn __active_count() -> usize {
 /// Returns `true` if any controller is still animating.
 #[doc(hidden)]
 pub fn __step_for_tests(now_ms: f64) -> bool {
-    let still = step(now_ms);
+    let still = step(&scheduler(), now_ms);
     whisker_runtime::reactive::flush();
     still
 }
 
-/// (Test only) reset the scheduler thread-local. Pairs with the
+/// (Test only) reset the active runtime's scheduler. Pairs with the
 /// runtime's `__reset_for_tests`.
 #[doc(hidden)]
 pub fn __reset_for_tests() {
-    SCHEDULER.with(|s| *s.borrow_mut() = AnimationScheduler::new());
+    *scheduler().borrow_mut() = AnimationScheduler::new();
     anim_hook::__reset_for_tests();
 }
 
@@ -456,12 +471,13 @@ pub fn __reset_for_tests() {
 #[derive(Clone)]
 pub struct AnimationController {
     state: Rc<RefCell<ControllerState>>,
+    scheduler: Scheduler,
 }
 
 impl AnimationController {
     /// Create a controller for `cfg`, sitting idle at progress `0.0`.
     pub fn new(cfg: AnimConfig) -> Self {
-        ensure_hook_installed();
+        let scheduler = ensure_hook_installed();
         let value = signal(0.0_f32);
         let state = Rc::new(RefCell::new(ControllerState {
             cfg,
@@ -480,13 +496,14 @@ impl AnimationController {
         // Deregister on owner dispose, or a controller created inside a
         // component leaves a dangling frame request behind.
         let weak = Rc::downgrade(&state);
+        let weak_scheduler = Rc::downgrade(&scheduler);
         on_cleanup(move || {
-            if let Some(st) = weak.upgrade() {
-                deregister(&st);
+            if let (Some(st), Some(scheduler)) = (weak.upgrade(), weak_scheduler.upgrade()) {
+                deregister(&scheduler, &st);
             }
         });
 
-        Self { state }
+        Self { state, scheduler }
     }
 
     /// The live progress as a read-only signal (`0.0..=1.0`).
@@ -615,7 +632,7 @@ impl AnimationController {
             st.fire_on_finish(true);
             return;
         }
-        register(&self.state);
+        register(&self.scheduler, &self.state);
     }
 
     /// Halt at the current value. Deregisters from the scheduler; the
@@ -631,7 +648,7 @@ impl AnimationController {
         if was_active {
             self.state.borrow_mut().fire_on_finish(false);
         }
-        deregister(&self.state);
+        deregister(&self.scheduler, &self.state);
     }
 
     /// Set the progress to `v` (clamped `0.0..=1.0`) **once**, without
@@ -646,7 +663,7 @@ impl AnimationController {
             st.velocity = 0.0;
             st.value.set(v);
         }
-        deregister(&self.state);
+        deregister(&self.scheduler, &self.state);
     }
 
     /// Register a callback fired each time a non-repeating run finishes.
@@ -672,7 +689,7 @@ impl AnimationController {
             st.target = 1.0;
             st.active = true;
         }
-        register(&self.state);
+        register(&self.scheduler, &self.state);
     }
 
     /// Ping-pong forever: forward to `1.0`, reverse to `0.0`, repeat.
@@ -687,7 +704,7 @@ impl AnimationController {
             st.target = 1.0;
             st.active = true;
         }
-        register(&self.state);
+        register(&self.scheduler, &self.state);
     }
 
     /// Whether this controller is currently self-driving.

--- a/crates/whisker-animation/src/tests.rs
+++ b/crates/whisker-animation/src/tests.rs
@@ -9,6 +9,7 @@
 use super::*;
 use whisker_css::data_type::Color;
 use whisker_runtime::reactive::{Owner, ReadSignal, flush};
+use whisker_runtime::{RuntimeContext, RuntimeWakeHandle};
 
 /// Reset thread-local runtime + animation scheduler.
 fn fresh() {
@@ -19,6 +20,44 @@ fn fresh() {
 /// Approximate float equality for progress/value assertions.
 fn approx(a: f32, b: f32) -> bool {
     (a - b).abs() < 1e-3
+}
+
+#[test]
+fn animation_schedulers_are_isolated_between_runtime_contexts_on_one_thread() {
+    fresh();
+    let first = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+    let second = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+
+    let first_controller = first.enter(|| AnimationController::new(AnimConfig::linear(100)));
+    let second_controller = second.enter(|| AnimationController::new(AnimConfig::linear(100)));
+    first.enter(|| first_controller.forward());
+    second.enter(|| second_controller.forward());
+
+    first.enter(|| {
+        whisker_runtime::anim_hook::step(0.0);
+        whisker_runtime::anim_hook::step(50.0);
+        flush();
+    });
+
+    assert!(approx(
+        first.enter(|| first_controller.value().get_untracked()),
+        0.5
+    ));
+    assert!(approx(
+        second.enter(|| second_controller.value().get_untracked()),
+        0.0
+    ));
+
+    first.shutdown();
+    second.enter(|| {
+        whisker_runtime::anim_hook::step(0.0);
+        whisker_runtime::anim_hook::step(50.0);
+        flush();
+    });
+    assert!(approx(
+        second.enter(|| second_controller.value().get_untracked()),
+        0.5
+    ));
 }
 
 #[test]

--- a/crates/whisker-driver/src/ffi_runtime.rs
+++ b/crates/whisker-driver/src/ffi_runtime.rs
@@ -381,8 +381,13 @@ pub unsafe fn dispatch_module_event(
         return false;
     };
     let payload = unsafe { decode_value(payload) };
-    let modules = std::rc::Rc::clone(&mobile.modules);
-    with_module_host(&modules, || modules.dispatch_event(module, event, payload))
+    mobile
+        .runtime
+        .dispatch_module_event(&mobile.modules, module, event, payload)
+        .unwrap_or_else(|error| {
+            mobile_error(format_args!("Whisker mobile module event failed: {error}"));
+            false
+        })
 }
 
 /// # Safety

--- a/crates/whisker-runtime/src/lib.rs
+++ b/crates/whisker-runtime/src/lib.rs
@@ -24,6 +24,8 @@ pub mod module;
 pub mod reactive;
 mod runtime_context;
 mod runtime_instance;
+#[doc(hidden)]
+pub mod runtime_local;
 pub mod runtime_wake;
 mod standard_ui;
 mod surface_runtime;

--- a/crates/whisker-runtime/src/module.rs
+++ b/crates/whisker-runtime/src/module.rs
@@ -582,16 +582,24 @@ impl RustModuleRuntime {
         with_module_host(&self.host, work)
     }
 
-    /// Delivers queued Host events to Rust subscribers without re-entering
-    /// application code from the originating Host callback.
-    pub fn dispatch_pending_events(&self) -> usize {
+    /// Delivers queued Host events through the owning runtime's ordinary event
+    /// transaction rather than re-entering application code from the
+    /// originating Host callback.
+    pub fn dispatch_pending_events(
+        &self,
+        runtime: &crate::RuntimeInstance,
+    ) -> Result<usize, crate::RuntimeEventError> {
         let pending = std::mem::take(&mut *self.inner.pending.borrow_mut());
         let count = pending.len();
         for event in pending {
-            self.host
-                .dispatch_event(&event.module, &event.event, event.payload);
+            runtime.dispatch_module_event(
+                &self.host,
+                &event.module,
+                &event.event,
+                event.payload,
+            )?;
         }
-        count
+        Ok(count)
     }
 }
 
@@ -683,18 +691,36 @@ mod tests {
         });
 
         let payload = Rc::new(RefCell::new(None));
-        let subscription = runtime.with_host(|| {
-            let payload = Rc::clone(&payload);
-            PlatformModule::named("demo:Echo").on_event("ready", move |value| {
-                *payload.borrow_mut() = Some(value);
-            })
+        let subscription = Rc::new(RefCell::new(None));
+        let surface = crate::SurfaceRuntime::new(
+            whisker_protocol::SurfaceId::new(1).unwrap(),
+            whisker_style::StyleEnvironment::new(100.0, 100.0, 1.0, 14.0),
+        );
+        let mut instance =
+            crate::RuntimeInstance::new(surface, crate::RuntimeWakeHandle::new(|| {}));
+        runtime.with_host(|| {
+            instance
+                .mount({
+                    let payload = Rc::clone(&payload);
+                    let subscription = Rc::clone(&subscription);
+                    move || {
+                        *subscription.borrow_mut() = Some(
+                            PlatformModule::named("demo:Echo").on_event("ready", move |value| {
+                                *payload.borrow_mut() = Some(value);
+                            }),
+                        );
+                        crate::view::create_element(crate::ElementTag::View)
+                    }
+                })
+                .unwrap();
         });
         assert_eq!(starts.get(), 1);
         assert_eq!(wakes.get(), 1);
-        runtime.with_host(|| assert_eq!(runtime.dispatch_pending_events(), 1));
+        assert_eq!(runtime.dispatch_pending_events(&instance).unwrap(), 1);
         assert_eq!(*payload.borrow(), Some(WhiskerValue::String("now".into())));
-        drop(subscription);
+        drop(subscription.borrow_mut().take());
         assert_eq!(stops.get(), 1);
+        runtime.with_host(|| instance.unmount().unwrap());
     }
 
     #[test]

--- a/crates/whisker-runtime/src/runtime_context.rs
+++ b/crates/whisker-runtime/src/runtime_context.rs
@@ -5,6 +5,7 @@ use std::cell::{Cell, RefCell};
 use crate::anim_hook::AnimationState;
 use crate::dispatch::RuntimeDispatcher;
 use crate::reactive::runtime::ReactiveRuntime;
+use crate::runtime_local::RuntimeLocalState;
 use crate::runtime_wake::RuntimeWakeHandle;
 use crate::tasks::TaskState;
 use crate::view::renderer::ViewRuntimeState;
@@ -18,6 +19,7 @@ struct ContextState {
     pending_mount: Option<(crate::reactive::MountId, crate::view::Element)>,
     wake: Option<RuntimeWakeHandle>,
     dispatcher: Option<RuntimeDispatcher>,
+    runtime_local: RuntimeLocalState,
 }
 
 impl ContextState {
@@ -31,6 +33,7 @@ impl ContextState {
             pending_mount: None,
             wake: Some(wake),
             dispatcher: Some(dispatcher),
+            runtime_local: RuntimeLocalState::new(),
         }
     }
 
@@ -42,15 +45,17 @@ impl ContextState {
         anim_hook::swap_state(&mut self.animation);
         runtime_wake::swap_active_wake(&mut self.wake);
         dispatch::swap_active(&mut self.dispatcher);
+        crate::runtime_local::swap_state(&mut self.runtime_local);
     }
 }
 
 /// Isolated single-threaded state for one mounted Whisker runtime.
 ///
-/// A context owns reactive nodes, view bookkeeping, local async tasks, and
-/// animation state while the Host is not executing it. [`Self::enter`] moves
-/// that state into the current UI thread for one short event or frame and
-/// restores the previous context even if application code panics.
+/// A context owns reactive nodes, view bookkeeping, local async tasks,
+/// animation state, and typed subsystem-local state while the Host is not
+/// executing it. [`Self::enter`] moves that state into the current UI thread
+/// for one short event or frame and restores the previous context even if
+/// application code panics.
 pub struct RuntimeContext {
     state: RefCell<ContextState>,
     entered: Cell<bool>,
@@ -116,6 +121,7 @@ impl RuntimeContext {
         state.view = ViewRuntimeState::new();
         state.tasks = TaskState::new();
         state.animation = AnimationState::new();
+        state.runtime_local = RuntimeLocalState::new();
         state.pending_mount = None;
     }
 }
@@ -242,5 +248,29 @@ mod tests {
         context.shutdown();
 
         assert!(!dispatcher.post(|| panic!("closed callback must be dropped")));
+    }
+
+    #[test]
+    fn typed_subsystem_state_is_isolated_and_restored_after_panic() {
+        #[derive(Default)]
+        struct Counter(usize);
+
+        let first = context();
+        let second = context();
+        first.enter(|| crate::runtime_local::state::<Counter>().borrow_mut().0 = 1);
+        second.enter(|| crate::runtime_local::state::<Counter>().borrow_mut().0 = 2);
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            first.enter(|| panic!("restore runtime-local state"));
+        }));
+        assert!(panic.is_err());
+        assert_eq!(
+            first.enter(|| crate::runtime_local::state::<Counter>().borrow().0),
+            1
+        );
+        assert_eq!(
+            second.enter(|| crate::runtime_local::state::<Counter>().borrow().0),
+            2
+        );
     }
 }

--- a/crates/whisker-runtime/src/runtime_instance.rs
+++ b/crates/whisker-runtime/src/runtime_instance.rs
@@ -4,10 +4,12 @@ use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::error::Error;
 use std::fmt;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::RuntimeContext;
+use crate::module::{ModuleHost, with_module_host};
 use crate::reactive::{self, Owner};
 use crate::runtime_wake::RuntimeWakeHandle;
 use crate::view::{self, Element};
@@ -38,9 +40,13 @@ pub enum RuntimeLifecycle {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
     use super::*;
     use crate::element::ElementTag;
-    use crate::reactive::__reset_for_tests;
+    use crate::module::{ModuleHost, ModuleSubscription, PlatformModule, with_module_host};
+    use crate::reactive::{__reset_for_tests, RwSignal, effect};
     use crate::view::{
         BindType, append_child, create_element, set_attribute, set_event_listener,
         set_specified_style,
@@ -99,6 +105,91 @@ mod tests {
             .unwrap();
 
         assert_eq!(surface.surface_snapshot_count(), 1);
+    }
+
+    #[test]
+    fn module_events_run_inside_the_owning_runtime_context() {
+        __reset_for_tests();
+        let first_surface = SurfaceRuntime::new(
+            SurfaceId::new(77).unwrap(),
+            StyleEnvironment::new(320.0, 100.0, 1.0, 14.0),
+        );
+        let second_surface = SurfaceRuntime::new(
+            SurfaceId::new(78).unwrap(),
+            StyleEnvironment::new(320.0, 100.0, 1.0, 14.0),
+        );
+        let mut first = RuntimeInstance::new(first_surface, RuntimeWakeHandle::new(|| {}));
+        let mut second = RuntimeInstance::new(second_surface, RuntimeWakeHandle::new(|| {}));
+        let first_host = ModuleHost::new(|_, _, _, _, _| false, |_, _, _| {});
+        let second_host = ModuleHost::new(|_, _, _, _, _| false, |_, _, _| {});
+        let first_observed = Rc::new(Cell::new(0));
+        let second_observed = Rc::new(Cell::new(0));
+        let first_subscription = Rc::new(RefCell::new(None::<ModuleSubscription>));
+        let second_subscription = Rc::new(RefCell::new(None::<ModuleSubscription>));
+
+        with_module_host(&first_host, || {
+            first
+                .mount({
+                    let observed = Rc::clone(&first_observed);
+                    let subscription = Rc::clone(&first_subscription);
+                    move || {
+                        let signal = RwSignal::new(0_i64);
+                        effect(move || observed.set(signal.get()));
+                        *subscription.borrow_mut() = Some(PlatformModule::named("demo").on_event(
+                            "tick",
+                            move |payload| match payload {
+                                WhiskerValue::Int(value) => signal.set(value),
+                                _ => panic!("expected integer module payload"),
+                            },
+                        ));
+                        create_element(ElementTag::View)
+                    }
+                })
+                .unwrap();
+        });
+        with_module_host(&second_host, || {
+            second
+                .mount({
+                    let observed = Rc::clone(&second_observed);
+                    let subscription = Rc::clone(&second_subscription);
+                    move || {
+                        let signal = RwSignal::new(0_i64);
+                        effect(move || observed.set(signal.get()));
+                        *subscription.borrow_mut() = Some(PlatformModule::named("demo").on_event(
+                            "tick",
+                            move |payload| match payload {
+                                WhiskerValue::Int(value) => signal.set(value),
+                                _ => panic!("expected integer module payload"),
+                            },
+                        ));
+                        create_element(ElementTag::View)
+                    }
+                })
+                .unwrap();
+        });
+
+        assert!(
+            first
+                .dispatch_module_event(&first_host, "demo", "tick", WhiskerValue::Int(11))
+                .unwrap()
+        );
+        assert_eq!(first_observed.get(), 11);
+        assert_eq!(second_observed.get(), 0);
+
+        assert!(
+            second
+                .dispatch_module_event(&second_host, "demo", "tick", WhiskerValue::Int(22))
+                .unwrap()
+        );
+        assert_eq!(first_observed.get(), 11);
+        assert_eq!(second_observed.get(), 22);
+
+        first
+            .context
+            .enter(|| first_subscription.borrow_mut().take());
+        second
+            .context
+            .enter(|| second_subscription.borrow_mut().take());
     }
 }
 
@@ -431,6 +522,49 @@ impl RuntimeInstance {
                 self.drain_pending_input()
                     .map_err(RuntimeEventError::Input)?;
                 Ok(dispatch)
+            })
+        })
+    }
+
+    /// Delivers one native-module event inside this instance's renderer and
+    /// reactive transaction.
+    ///
+    /// Module objects may be process-wide on the Host, but subscriptions and
+    /// application callbacks belong to exactly one runtime instance. Paused
+    /// instances may retain state changes; their owner resumes effects later.
+    pub fn dispatch_module_event(
+        &self,
+        modules: &Rc<ModuleHost>,
+        module: &str,
+        event: &str,
+        payload: WhiskerValue,
+    ) -> Result<bool, RuntimeEventError> {
+        if !matches!(
+            self.lifecycle,
+            RuntimeLifecycle::Running | RuntimeLifecycle::Paused
+        ) {
+            return Err(RuntimeEventError::Lifecycle(RuntimeLifecycleError {
+                state: self.lifecycle,
+                operation: "dispatch a module event",
+            }));
+        }
+        let surface = self.surface.clone();
+        self.context.enter(|| {
+            view::with_installed_renderer(surface.renderer(), || {
+                with_module_host(modules, || {
+                    if self.lifecycle == RuntimeLifecycle::Running {
+                        crate::drain_runtime_dispatches();
+                    }
+                    surface.begin_mutation_batch();
+                    let dispatched = modules.dispatch_event(module, event, payload);
+                    reactive::flush();
+                    reactive::flush_mounts();
+                    surface
+                        .finish_mutation_batch()
+                        .map_err(RuntimeInputError::Binding)
+                        .map_err(RuntimeEventError::Input)?;
+                    Ok(dispatched)
+                })
             })
         })
     }

--- a/crates/whisker-runtime/src/runtime_local.rs
+++ b/crates/whisker-runtime/src/runtime_local.rs
@@ -1,0 +1,43 @@
+//! Type-indexed state owned by the currently entered runtime instance.
+
+use std::any::{Any, TypeId};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+pub(crate) struct RuntimeLocalState {
+    values: HashMap<TypeId, Box<dyn Any>>,
+}
+
+impl RuntimeLocalState {
+    pub(crate) fn new() -> Self {
+        Self {
+            values: HashMap::new(),
+        }
+    }
+}
+
+thread_local! {
+    static ACTIVE: RefCell<RuntimeLocalState> = RefCell::new(RuntimeLocalState::new());
+}
+
+/// Returns one typed state cell owned by the currently entered runtime.
+///
+/// The lookup happens when a subsystem first captures its state. Hot paths can
+/// retain the returned `Rc` and do not need to repeat the type-map lookup.
+#[doc(hidden)]
+pub fn state<T: Default + 'static>() -> Rc<RefCell<T>> {
+    ACTIVE.with_borrow_mut(|active| {
+        active
+            .values
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Box::new(Rc::new(RefCell::new(T::default()))))
+            .downcast_ref::<Rc<RefCell<T>>>()
+            .expect("runtime-local TypeId entry has a consistent type")
+            .clone()
+    })
+}
+
+pub(crate) fn swap_state(state: &mut RuntimeLocalState) {
+    ACTIVE.with_borrow_mut(|active| std::mem::swap(active, state));
+}

--- a/crates/whisker/src/back.rs
+++ b/crates/whisker/src/back.rs
@@ -1,4 +1,4 @@
-//! Process-global back-interception registry — Whisker's analogue of
+//! Runtime-local back-interception registry — Whisker's analogue of
 //! React Native's `BackHandler`.
 //!
 //! [`on_back`] registers a handler for the platform back action
@@ -22,8 +22,8 @@
 //! mounted the registry is inert and the platform default applies.
 //! Main-thread only, like [`crate::focus`].
 
-use std::cell::{Cell, RefCell};
-use std::rc::Rc;
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
 
 use whisker_runtime::reactive::{Owner, RwSignal};
 
@@ -39,28 +39,33 @@ impl Entry {
     }
 }
 
-thread_local! {
-    static HANDLERS: RefCell<Vec<Entry>> = const { RefCell::new(Vec::new()) };
-    static NEXT_ID: Cell<u64> = const { Cell::new(0) };
-    static EXIT_IMPL: RefCell<Option<Rc<dyn Fn()>>> = const { RefCell::new(None) };
-    static REVISION: Cell<Option<RwSignal<u64>>> = const { Cell::new(None) };
+#[derive(Default)]
+struct BackState {
+    handlers: Vec<Entry>,
+    next_id: u64,
+    exit_impl: Option<Rc<dyn Fn()>>,
+    revision: Option<RwSignal<u64>>,
+}
+
+type SharedBackState = Rc<RefCell<BackState>>;
+
+fn state() -> SharedBackState {
+    whisker_runtime::runtime_local::state::<BackState>()
 }
 
 /// Registry-change signal, minted lazily under a detached root so its
-/// lifetime is the process, not whichever scope touches it first.
-fn revision_signal() -> RwSignal<u64> {
-    REVISION.with(|slot| {
-        if let Some(sig) = slot.get() {
-            return sig;
-        }
-        let sig = Owner::detached_root().with(|| RwSignal::new(0_u64));
-        slot.set(Some(sig));
-        sig
-    })
+/// lifetime is the runtime instance, not whichever scope touches it first.
+fn revision_signal(state: &SharedBackState) -> RwSignal<u64> {
+    if let Some(signal) = state.borrow().revision {
+        return signal;
+    }
+    let signal = Owner::detached_root().with(|| RwSignal::new(0_u64));
+    state.borrow_mut().revision = Some(signal);
+    signal
 }
 
-fn bump_revision() {
-    let sig = revision_signal();
+fn bump_revision(state: &SharedBackState) {
+    let sig = revision_signal(state);
     sig.set(sig.get_untracked() + 1);
 }
 
@@ -70,12 +75,19 @@ fn bump_revision() {
 #[must_use = "the handler is unregistered when the guard drops"]
 pub struct BackGuard {
     id: u64,
+    state: Weak<RefCell<BackState>>,
 }
 
 impl Drop for BackGuard {
     fn drop(&mut self) {
-        HANDLERS.with(|h| h.borrow_mut().retain(|e| e.id != self.id));
-        bump_revision();
+        let Some(state) = self.state.upgrade() else {
+            return;
+        };
+        state
+            .borrow_mut()
+            .handlers
+            .retain(|entry| entry.id != self.id);
+        bump_revision(&state);
     }
 }
 
@@ -95,20 +107,23 @@ impl Drop for BackGuard {
 /// // The dialog's "exit" button then calls `back::exit_app()`.
 /// ```
 pub fn on_back(handler: impl Fn() + 'static) -> BackGuard {
-    let id = NEXT_ID.with(|n| {
-        let id = n.get();
-        n.set(id + 1);
+    let state = state();
+    let id = {
+        let mut state = state.borrow_mut();
+        let id = state.next_id;
+        state.next_id = id.saturating_add(1);
         id
+    };
+    state.borrow_mut().handlers.push(Entry {
+        id,
+        owner: Owner::current(),
+        handler: Rc::new(handler),
     });
-    HANDLERS.with(|h| {
-        h.borrow_mut().push(Entry {
-            id,
-            owner: Owner::current(),
-            handler: Rc::new(handler),
-        })
-    });
-    bump_revision();
-    BackGuard { id }
+    bump_revision(&state);
+    BackGuard {
+        id,
+        state: Rc::downgrade(&state),
+    }
 }
 
 /// Trigger the platform's default back-out-of-the-app behavior
@@ -117,7 +132,7 @@ pub fn on_back(handler: impl Fn() + 'static) -> BackGuard {
 /// handler once the user confirms leaving. No-op where no platform
 /// exit is wired (iOS, or no router mounted).
 pub fn exit_app() {
-    let f = EXIT_IMPL.with(|e| e.borrow().clone());
+    let f = state().borrow().exit_impl.clone();
     if let Some(f) = f {
         f();
     }
@@ -126,7 +141,7 @@ pub fn exit_app() {
 /// Framework wiring: install the platform exit implementation
 /// [`exit_app`] calls. Registered by the platform gesture component.
 pub fn set_exit_impl(f: impl Fn() + 'static) {
-    EXIT_IMPL.with(|e| *e.borrow_mut() = Some(Rc::new(f)));
+    state().borrow_mut().exit_impl = Some(Rc::new(f));
 }
 
 /// Framework wiring: whether an active (non-paused) handler exists
@@ -134,8 +149,9 @@ pub fn set_exit_impl(f: impl Fn() + 'static) {
 /// the registry's revision signal, so calling inside an `effect`
 /// re-runs it on register / unregister.
 pub fn has_active_handler() -> bool {
-    let _ = revision_signal().get();
-    HANDLERS.with(|h| h.borrow().iter().any(Entry::is_active))
+    let state = state();
+    let _ = revision_signal(&state).get();
+    state.borrow().handlers.iter().any(Entry::is_active)
 }
 
 /// Framework wiring: whether ANY registration exists, paused or not —
@@ -147,21 +163,23 @@ pub fn has_active_handler() -> bool {
 /// the platform callback enabled; [`dispatch`]'s pause filter still
 /// routes the action to the pop instead of the buried handler.
 pub fn has_any_handler() -> bool {
-    let _ = revision_signal().get();
-    HANDLERS.with(|h| !h.borrow().is_empty())
+    let state = state();
+    let _ = revision_signal(&state).get();
+    !state.borrow().handlers.is_empty()
 }
 
 /// Framework wiring: deliver one back action to the most recent
 /// active handler. Returns `false` when no handler consumed it and
 /// the caller should fall back to its own behavior (pop / default).
 pub fn dispatch() -> bool {
-    let handler = HANDLERS.with(|h| {
-        h.borrow()
-            .iter()
-            .rev()
-            .find(|e| e.is_active())
-            .map(|e| e.handler.clone())
-    });
+    let state = state();
+    let handler = state
+        .borrow()
+        .handlers
+        .iter()
+        .rev()
+        .find(|e| e.is_active())
+        .map(|e| e.handler.clone());
     match handler {
         Some(f) => {
             f();
@@ -173,11 +191,15 @@ pub fn dispatch() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use super::*;
 
     fn reset() {
-        HANDLERS.with(|h| h.borrow_mut().clear());
-        EXIT_IMPL.with(|e| *e.borrow_mut() = None);
+        let state = state();
+        let mut state = state.borrow_mut();
+        state.handlers.clear();
+        state.exit_impl = None;
     }
 
     #[test]
@@ -252,5 +274,57 @@ mod tests {
         set_exit_impl(move || h.set(h.get() + 1));
         exit_app();
         assert_eq!(hits.get(), 1);
+    }
+
+    #[test]
+    fn handlers_and_exit_callbacks_are_isolated_between_runtime_contexts() {
+        use whisker_runtime::{RuntimeContext, RuntimeWakeHandle};
+
+        reset();
+        let first = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        let second = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        let hits = Rc::new(RefCell::new(Vec::new()));
+        let first_hits = Rc::clone(&hits);
+        let second_hits = Rc::clone(&hits);
+        let first_guard = first.enter(|| {
+            set_exit_impl({
+                let hits = Rc::clone(&hits);
+                move || hits.borrow_mut().push("first-exit")
+            });
+            on_back(move || first_hits.borrow_mut().push("first"))
+        });
+        let second_guard = second.enter(|| {
+            set_exit_impl({
+                let hits = Rc::clone(&hits);
+                move || hits.borrow_mut().push("second-exit")
+            });
+            on_back(move || second_hits.borrow_mut().push("second"))
+        });
+
+        first.enter(|| {
+            assert!(dispatch());
+            exit_app();
+        });
+        second.enter(|| {
+            assert!(dispatch());
+            exit_app();
+        });
+        assert_eq!(
+            *hits.borrow(),
+            vec!["first", "first-exit", "second", "second-exit"]
+        );
+
+        first.enter(|| drop(first_guard));
+        second.enter(|| drop(second_guard));
+    }
+
+    #[test]
+    fn guard_can_outlive_runtime_shutdown() {
+        use whisker_runtime::{RuntimeContext, RuntimeWakeHandle};
+
+        let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        let guard = runtime.enter(|| on_back(|| {}));
+        runtime.shutdown();
+        drop(guard);
     }
 }

--- a/crates/whisker/src/focus.rs
+++ b/crates/whisker/src/focus.rs
@@ -1,4 +1,4 @@
-//! Process-global "currently focused element" registry — Whisker's
+//! Runtime-local "currently focused element" registry — Whisker's
 //! analogue of React Native's `TextInput.State.currentlyFocusedInput()`.
 //!
 //! A focusable native element (an `<input>`) records itself here when it
@@ -12,7 +12,7 @@
 //! exactly why React Navigation captures the concrete input and blurs
 //! *that* ref rather than calling `Keyboard.dismiss()` on forward pushes.
 //!
-//! Main-thread only: the reactive/UI world is thread-local, and the cell
+//! Main-thread only: the reactive/UI world is runtime-local, and the state
 //! is only ever touched from focus/blur event handlers and navigation
 //! verbs, all of which run on the runtime thread.
 
@@ -20,28 +20,54 @@ use std::cell::Cell;
 
 use crate::element_ref::ElementRef;
 
-thread_local! {
-    static FOCUSED: Cell<Option<ElementRef>> = const { Cell::new(None) };
+#[derive(Default)]
+struct FocusState {
+    focused: Cell<Option<ElementRef>>,
+}
+
+fn state() -> std::rc::Rc<std::cell::RefCell<FocusState>> {
+    whisker_runtime::runtime_local::state::<FocusState>()
 }
 
 /// Record `el` as the element that currently holds focus. Call from an
 /// input's focus handler.
 pub fn note_focused(el: ElementRef) {
-    FOCUSED.with(|f| f.set(Some(el)));
+    state().borrow().focused.set(Some(el));
 }
 
 /// Clear the focused element **iff** it is still `el`, so a stale blur
 /// (fired after another field already took focus) can't wipe the newer
 /// registration. Call from an input's blur handler.
 pub fn note_blurred(el: ElementRef) {
-    FOCUSED.with(|f| {
-        if f.get() == Some(el) {
-            f.set(None);
-        }
-    });
+    let state = state();
+    let state = state.borrow();
+    if state.focused.get() == Some(el) {
+        state.focused.set(None);
+    }
 }
 
 /// The element that currently holds focus, if any.
 pub fn focused_element() -> Option<ElementRef> {
-    FOCUSED.with(Cell::get)
+    state().borrow().focused.get()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_runtime::{RuntimeContext, RuntimeWakeHandle};
+
+    #[test]
+    fn focused_element_is_isolated_between_runtime_contexts() {
+        let first = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        let second = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        let first_ref = first.enter(ElementRef::new);
+        let second_ref = second.enter(ElementRef::new);
+
+        first.enter(|| note_focused(first_ref));
+        second.enter(|| note_focused(second_ref));
+        first.enter(|| note_blurred(first_ref));
+
+        assert_eq!(first.enter(focused_element), None);
+        assert_eq!(second.enter(focused_element), Some(second_ref));
+    }
 }

--- a/platforms/android/module/build.gradle.kts
+++ b/platforms/android/module/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     // modules see `WindowInsetsCompat` on their compile classpath when
     // they write an inset callback.
     api("androidx.core:core-ktx:1.13.1")
+    testImplementation("junit:junit:4.13.2")
 
     // No annotation re-export needed (Phase M / Issue #59): a
     // module's `build.gradle.kts` depends on this AAR alone for

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleEventCenter.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleEventCenter.kt
@@ -4,9 +4,17 @@
 package rs.whisker.runtime
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.IdentityHashMap
 
-/** Process-wide module registry and Host-injected event sink. */
+/** Process-wide module registry and surface-scoped Host event subscriptions. */
 public object WhiskerModuleEventCenter {
+
+    private data class EventKey(val module: String, val event: String)
+
+    private class SurfaceSink(
+        var dispatch: (String, String, WhiskerValue) -> Unit,
+        val observed: MutableSet<EventKey> = mutableSetOf(),
+    )
 
     /**
      * `qualifiedName → Module` lookup the JNI trampolines consult
@@ -14,8 +22,8 @@ public object WhiskerModuleEventCenter {
      * `(module, event)` event.
      */
     private val modulesByName = ConcurrentHashMap<String, Module>()
-    @Volatile
-    private var eventSink: ((String, String, WhiskerValue) -> Unit)? = null
+    private val eventSinkLock = Any()
+    private val eventSinks = IdentityHashMap<Any, SurfaceSink>()
 
     /**
      * Register [module] after its qualified name has been assigned.
@@ -27,19 +35,68 @@ public object WhiskerModuleEventCenter {
         modulesByName[qname] = module
     }
 
-    /** Install the event consumer owned by the active Whisker Host. */
+    /** Install or remove the event consumer owned by one Host surface. */
     @JvmStatic
-    public fun installEventSink(sink: ((String, String, WhiskerValue) -> Unit)?) {
-        eventSink = sink
+    public fun installEventSink(
+        owner: Any,
+        sink: ((String, String, WhiskerValue) -> Unit)?,
+    ) {
+        val stopped = synchronized(eventSinkLock) {
+            if (sink == null) {
+                val removed = eventSinks.remove(owner) ?: return@synchronized emptyList()
+                removed.observed.filterTo(mutableListOf()) { key ->
+                    eventSinks.values.none { key in it.observed }
+                }
+            } else {
+                val existing = eventSinks[owner]
+                if (existing == null) {
+                    eventSinks[owner] = SurfaceSink(sink)
+                } else {
+                    existing.dispatch = sink
+                }
+                emptyList()
+            }
+        }
+        stopped.forEach { key -> fireStop(key.module, key.event) }
     }
 
-    /** Forward a module event to the active Host, if one is installed. */
+    /** Update one surface's first/last Rust-side subscription. */
+    @JvmStatic
+    public fun setObserving(
+        owner: Any,
+        moduleName: String,
+        eventName: String,
+        observing: Boolean,
+    ) {
+        val key = EventKey(moduleName, eventName)
+        val transition = synchronized(eventSinkLock) {
+            val surface = eventSinks[owner] ?: return
+            if (observing) {
+                if (!surface.observed.add(key)) return
+                eventSinks.values.count { key in it.observed } == 1
+            } else {
+                if (!surface.observed.remove(key)) return
+                eventSinks.values.none { key in it.observed }
+            }
+        }
+        if (transition) {
+            if (observing) fireStart(moduleName, eventName) else fireStop(moduleName, eventName)
+        }
+    }
+
+    /** Forward an event only to surfaces currently observing its channel. */
     internal fun dispatchSend(
         moduleName: String,
         eventName: String,
         payload: WhiskerValue,
     ) {
-        eventSink?.invoke(moduleName, eventName, payload)
+        val key = EventKey(moduleName, eventName)
+        val sinks = synchronized(eventSinkLock) {
+            eventSinks.values.filter { key in it.observed }.map { it.dispatch }
+        }
+        if (sinks.isEmpty()) return
+        val snapshot = payload.snapshotForDispatch()
+        sinks.forEach { sink -> sink(moduleName, eventName, snapshot) }
     }
 
     /**
@@ -47,14 +104,29 @@ public object WhiskerModuleEventCenter {
      * Hosts call this when wiring Rust-side subscriptions.
      */
     @JvmStatic
-    public fun fireStart(moduleName: String, eventName: String) {
+    internal fun fireStart(moduleName: String, eventName: String) {
         modulesByName[moduleName]?.fireOnStartObserving(eventName)
     }
 
     /** Counterpart to [fireStart] — fires on 1 → 0 transitions. */
     @JvmStatic
-    public fun fireStop(moduleName: String, eventName: String) {
+    internal fun fireStop(moduleName: String, eventName: String) {
         modulesByName[moduleName]?.fireOnStopObserving(eventName)
     }
 
+}
+
+/** Own mutable byte/container storage before crossing an asynchronous Host turn. */
+private fun WhiskerValue.snapshotForDispatch(): WhiskerValue = when (this) {
+    WhiskerValue.Null -> this
+    is WhiskerValue.Bool -> this
+    is WhiskerValue.Int -> this
+    is WhiskerValue.Float -> this
+    is WhiskerValue.Str -> this
+    is WhiskerValue.Bytes -> WhiskerValue.Bytes(value.copyOf())
+    is WhiskerValue.Array -> WhiskerValue.Array(value.map { it.snapshotForDispatch() })
+    is WhiskerValue.Map -> WhiskerValue.Map(
+        value.entries.associate { (key, item) -> key to item.snapshotForDispatch() },
+    )
+    is WhiskerValue.Err -> this
 }

--- a/platforms/android/module/src/test/kotlin/rs/whisker/runtime/WhiskerModuleEventCenterTest.kt
+++ b/platforms/android/module/src/test/kotlin/rs/whisker/runtime/WhiskerModuleEventCenterTest.kt
@@ -1,0 +1,64 @@
+package rs.whisker.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WhiskerModuleEventCenterTest {
+    @Test
+    fun moduleEventsReachOnlyObservingSurfacesAndLifecycleIsAggregated() {
+        val starts = mutableListOf<String>()
+        val stops = mutableListOf<String>()
+        val module = object : Module() {
+            override fun definition(): ModuleDefinition = ModuleDefinition {
+                Name("Clock")
+                Events("tick")
+                OnStartObserving("tick") { starts += "start" }
+                OnStopObserving("tick") { stops += "stop" }
+            }
+        }.also {
+            it.qualifiedName = "event-test:Clock"
+            WhiskerModuleEventCenter.register(it)
+        }
+        val moduleName = requireNotNull(module.qualifiedName)
+        val firstOwner = Any()
+        val secondOwner = Any()
+        val received = mutableListOf<String>()
+        var firstPayload: WhiskerValue? = null
+        WhiskerModuleEventCenter.installEventSink(firstOwner) { _, _, payload ->
+            received += "first"
+            firstPayload = payload
+        }
+        WhiskerModuleEventCenter.installEventSink(secondOwner) { _, _, _ -> received += "second" }
+
+        try {
+            WhiskerModuleEventCenter.setObserving(firstOwner, moduleName, "tick", true)
+            assertEquals(listOf("start"), starts)
+            val mutableBytes = byteArrayOf(1, 2, 3)
+            WhiskerModuleEventCenter.dispatchSend(
+                moduleName,
+                "tick",
+                WhiskerValue.Bytes(mutableBytes),
+            )
+            mutableBytes[0] = 9
+            assertEquals(listOf("first"), received)
+            assertEquals(WhiskerValue.Bytes(byteArrayOf(1, 2, 3)), firstPayload)
+
+            received.clear()
+            WhiskerModuleEventCenter.setObserving(secondOwner, moduleName, "tick", true)
+            assertEquals(listOf("start"), starts)
+            WhiskerModuleEventCenter.dispatchSend(moduleName, "tick", WhiskerValue.Int(2))
+            assertEquals(setOf("first", "second"), received.toSet())
+
+            WhiskerModuleEventCenter.installEventSink(firstOwner, null)
+            assertEquals(emptyList<String>(), stops)
+            received.clear()
+            WhiskerModuleEventCenter.dispatchSend(moduleName, "tick", WhiskerValue.Int(3))
+            assertEquals(listOf("second"), received)
+            WhiskerModuleEventCenter.installEventSink(secondOwner, null)
+            assertEquals(listOf("stop"), stops)
+        } finally {
+            WhiskerModuleEventCenter.installEventSink(firstOwner, null)
+            WhiskerModuleEventCenter.installEventSink(secondOwner, null)
+        }
+    }
+}

--- a/platforms/android/runtime/build.gradle.kts
+++ b/platforms/android/runtime/build.gradle.kts
@@ -52,6 +52,7 @@ tasks.configureEach {
 dependencies {
     val moduleProject = if (rootProject.findProject(":module") != null) ":module" else ":whisker-module"
     api(project(moduleProject))
+    testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test:core-ktx:1.6.1")
     androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")
     androidTestImplementation("androidx.test:runner:1.6.2")

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -18,6 +18,8 @@ import rs.whisker.runtime.measure.HostMeasurementProvider
 import rs.whisker.runtime.measure.HostMeasureBatchAbi
 import rs.whisker.runtime.measure.HostMeasureBatchResponse
 import rs.whisker.runtime.module.HostModuleDispatcher
+import rs.whisker.runtime.module.PendingModuleEvent
+import rs.whisker.runtime.module.PendingModuleEvents
 import rs.whisker.runtime.paint.HostRasterResourceStore
 import rs.whisker.runtime.resource.HostResourceAbiEvent
 import rs.whisker.runtime.resource.HostResourceChannel
@@ -61,6 +63,26 @@ class WhiskerView(context: Context) :
     private var backdropCaptureReached = false
     private val pendingContinuousEvents = PendingContinuousEvents()
     private var continuousEventFlushPending = false
+    private val pendingModuleEvents = PendingModuleEvents()
+    private val moduleEventFlush = Runnable {
+        val pending = pendingModuleEvents.drain(moduleEventSinkEpoch)
+        if (pending.isEmpty()) return@Runnable
+        scene.dispatchOrDefer {
+            val handle = nativeHandle
+            if (handle == 0L) return@dispatchOrDefer
+            var dispatched = false
+            pending.forEach { moduleEvent ->
+                dispatched = nativeDispatchModuleEvent(
+                    handle,
+                    moduleEvent.module,
+                    moduleEvent.event,
+                    moduleEvent.payload,
+                ) || dispatched
+            }
+            if (dispatched) requestFrameFromNative()
+        }
+    }
+    private var moduleEventSinkEpoch = 0L
     private val continuousEventFlush = Runnable {
         val pending = pendingContinuousEvents.drain()
         if (nativeHandle == 0L || pending.isEmpty()) return@Runnable
@@ -119,29 +141,41 @@ class WhiskerView(context: Context) :
 
     private fun mountWhenSized() {
         if (nativeHandle == 0L && isAttachedToWindow && width > 0 && height > 0) {
-            WhiskerModuleEventCenter.installEventSink { module, event, payload ->
-                dispatchModuleEvent(module, event, payload)
+            moduleEventSinkEpoch += 1
+            val sinkEpoch = moduleEventSinkEpoch
+            WhiskerModuleEventCenter.installEventSink(this) { module, event, payload ->
+                val shouldPost = pendingModuleEvents.offer(
+                    PendingModuleEvent(sinkEpoch, module, event, payload),
+                )
+                if (shouldPost) {
+                    mainHandler.post(moduleEventFlush)
+                }
             }
             val density = resources.displayMetrics.density
             nativeHandle = nativeCreate(width / density, height / density, density)
             if (nativeHandle != 0L) {
                 requestFrameFromNative()
             } else {
+                moduleEventSinkEpoch += 1
+                WhiskerModuleEventCenter.installEventSink(this, null)
                 Log.e("WhiskerView", "Unable to create the Rust runtime; see bootstrap diagnostics above")
             }
         }
     }
 
     override fun onDetachedFromWindow() {
+        moduleEventSinkEpoch += 1
+        WhiskerModuleEventCenter.installEventSink(this, null)
         if (nativeHandle != 0L) nativeDestroy(nativeHandle)
         nativeHandle = 0L
         frameScheduled = false
         continuousEventFlushPending = false
         choreographer.removeFrameCallback(this)
         mainHandler.removeCallbacks(continuousEventFlush)
-        WhiskerModuleEventCenter.installEventSink(null)
+        mainHandler.removeCallbacks(moduleEventFlush)
         scene.clear()
         pendingContinuousEvents.clear()
+        pendingModuleEvents.clear()
         WhiskerAppContext.popRuntimeOwner(this)
         super.onDetachedFromWindow()
     }
@@ -514,26 +548,7 @@ class WhiskerView(context: Context) :
 
     /** Called by Rust on the first and last listener transition. */
     fun observeModuleFromNative(module: String, event: String, observing: Boolean) {
-        modules.observe(module, event, observing)
-    }
-
-    private fun dispatchModuleEvent(module: String, event: String, payload: WhiskerValue) {
-        scene.dispatchOrDefer {
-            val handle = nativeHandle
-            if (handle == 0L) {
-                // OnStartObserving can synchronously emit while nativeCreate is
-                // still returning its handle. Retry once on the next main-loop
-                // turn instead of dropping that initial value.
-                post {
-                    val mountedHandle = nativeHandle
-                    if (mountedHandle != 0L) {
-                        nativeDispatchModuleEvent(mountedHandle, module, event, payload)
-                    }
-                }
-            } else {
-                nativeDispatchModuleEvent(handle, module, event, payload)
-            }
-        }
+        modules.observe(this, module, event, observing)
     }
 
     /** Processes one native intrinsic-measurement batch in a single Host call. */

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/module/HostModuleDispatcher.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/module/HostModuleDispatcher.kt
@@ -36,11 +36,7 @@ internal class HostModuleDispatcher(
         true
     }
 
-    fun observe(module: String, event: String, observing: Boolean) {
-        if (observing) {
-            WhiskerModuleEventCenter.fireStart(module, event)
-        } else {
-            WhiskerModuleEventCenter.fireStop(module, event)
-        }
+    fun observe(owner: Any, module: String, event: String, observing: Boolean) {
+        WhiskerModuleEventCenter.setObserving(owner, module, event, observing)
     }
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/module/PendingModuleEvents.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/module/PendingModuleEvents.kt
@@ -1,0 +1,42 @@
+package rs.whisker.runtime.module
+
+import rs.whisker.runtime.WhiskerValue
+
+internal data class PendingModuleEvent(
+    val epoch: Long,
+    val module: String,
+    val event: String,
+    val payload: WhiskerValue,
+)
+
+/** Any-thread ingress queue drained once per main-loop turn. */
+internal class PendingModuleEvents {
+    private val lock = Any()
+    private val queue = ArrayDeque<PendingModuleEvent>()
+    private var flushScheduled = false
+
+    /** Returns true only when the caller must schedule the shared flush. */
+    fun offer(event: PendingModuleEvent): Boolean = synchronized(lock) {
+        queue.addLast(event)
+        if (flushScheduled) {
+            false
+        } else {
+            flushScheduled = true
+            true
+        }
+    }
+
+    fun drain(epoch: Long): List<PendingModuleEvent> = synchronized(lock) {
+        flushScheduled = false
+        buildList {
+            while (queue.isNotEmpty()) {
+                queue.removeFirst().takeIf { it.epoch == epoch }?.let(::add)
+            }
+        }
+    }
+
+    fun clear() = synchronized(lock) {
+        queue.clear()
+        flushScheduled = false
+    }
+}

--- a/platforms/android/runtime/src/test/kotlin/rs/whisker/runtime/module/PendingModuleEventsTest.kt
+++ b/platforms/android/runtime/src/test/kotlin/rs/whisker/runtime/module/PendingModuleEventsTest.kt
@@ -1,0 +1,20 @@
+package rs.whisker.runtime.module
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import rs.whisker.runtime.WhiskerValue
+
+class PendingModuleEventsTest {
+    @Test
+    fun coalescesWakeupsAndRejectsEventsFromAnEarlierMountEpoch() {
+        val pending = PendingModuleEvents()
+        assertTrue(pending.offer(PendingModuleEvent(1, "demo", "tick", WhiskerValue.Int(1))))
+        assertFalse(pending.offer(PendingModuleEvent(1, "demo", "tick", WhiskerValue.Int(2))))
+        assertEquals(listOf(WhiskerValue.Int(1), WhiskerValue.Int(2)), pending.drain(1).map { it.payload })
+
+        assertTrue(pending.offer(PendingModuleEvent(1, "demo", "tick", WhiskerValue.Int(3))))
+        assertTrue(pending.drain(2).isEmpty())
+    }
+}

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -242,9 +242,9 @@ impl DesktopRuntime {
             .min(100.0) as f32;
         self.last_frame_timestamp_ms = Some(context.timestamp_ms);
         self.surface.advance_scroll_animations(delta_ms);
-        self.modules.with_host(|| {
-            self.modules.dispatch_pending_events();
-        });
+        self.modules
+            .dispatch_pending_events(runtime)
+            .map_err(|error| DesktopError(format!("dispatch Desktop module event: {error}")))?;
         self.drain_runtime_resource_commands(runtime)?;
         let dispatched_resource_event = self.dispatch_pending_resource_events(runtime)?;
         let events = self.surface.take_events();
@@ -264,9 +264,9 @@ impl DesktopRuntime {
                     DesktopError(format!("dispatch Desktop provider event: {error}"))
                 })?;
         }
-        self.modules.with_host(|| {
-            self.modules.dispatch_pending_events();
-        });
+        self.modules
+            .dispatch_pending_events(runtime)
+            .map_err(|error| DesktopError(format!("dispatch Desktop module event: {error}")))?;
         let environment = StyleEnvironment::new(
             context.logical_width,
             context.logical_height,
@@ -286,9 +286,9 @@ impl DesktopRuntime {
         });
         self.drain_runtime_resource_commands(runtime)?;
         let drive = drive.map_err(|error| DesktopError(format!("drive Desktop frame: {error}")))?;
-        self.modules.with_host(|| {
-            self.modules.dispatch_pending_events();
-        });
+        self.modules
+            .dispatch_pending_events(runtime)
+            .map_err(|error| DesktopError(format!("dispatch Desktop module event: {error}")))?;
         self.surface
             .paint(
                 &mut self.measurements,

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleEventCenter.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleEventCenter.swift
@@ -9,6 +9,20 @@ import Foundation
 /// points.
 public enum WhiskerModuleEventCenter {
 
+    private struct EventKey: Hashable {
+        let module: String
+        let event: String
+    }
+
+    private final class SurfaceSink {
+        var dispatch: (String, String, WhiskerValue) -> Void
+        var observed: Set<EventKey> = []
+
+        init(dispatch: @escaping (String, String, WhiskerValue) -> Void) {
+            self.dispatch = dispatch
+        }
+    }
+
     // MARK: - Registry
 
     /// Locked map of `qualifiedName → Module` instance the shared
@@ -16,7 +30,7 @@ public enum WhiskerModuleEventCenter {
     /// OnStop closure for an incoming `(module, event)` event.
     private static let lock = NSLock()
     private static var modulesByName: [String: Module] = [:]
-    private static var eventSink: ((String, String, WhiskerValue) -> Void)?
+    private static var eventSinks: [ObjectIdentifier: SurfaceSink] = [:]
 
     // MARK: - Module registration
 
@@ -40,15 +54,63 @@ public enum WhiskerModuleEventCenter {
 
     }
 
-    /// Install the process-wide event sink owned by the active Whisker
-    /// runtime. Keeping this as a Swift closure avoids a second, legacy C
-    /// registration ABI beside WhiskerView's runtime ABI.
+    /// Install or remove the event sink owned by one Host surface.
+    /// Keeping these as Swift closures avoids a second, legacy C registration
+    /// ABI beside WhiskerView's runtime ABI.
     public static func installEventSink(
+        owner: AnyObject,
         _ sink: ((String, String, WhiskerValue) -> Void)?
     ) {
         lock.lock()
-        eventSink = sink
+        let key = ObjectIdentifier(owner)
+        var stopped: [EventKey] = []
+        if let sink {
+            if let existing = eventSinks[key] {
+                existing.dispatch = sink
+            } else {
+                eventSinks[key] = SurfaceSink(dispatch: sink)
+            }
+        } else {
+            let removed = eventSinks.removeValue(forKey: key)
+            stopped = removed?.observed.filter { event in
+                !eventSinks.values.contains { $0.observed.contains(event) }
+            } ?? []
+        }
         lock.unlock()
+        for event in stopped {
+            fireStop(module: event.module, event: event.event)
+        }
+    }
+
+    /// Update one surface's first/last Rust-side subscription.
+    public static func setObserving(
+        owner: AnyObject,
+        module: String,
+        event: String,
+        observing: Bool
+    ) {
+        let key = EventKey(module: module, event: event)
+        lock.lock()
+        guard let surface = eventSinks[ObjectIdentifier(owner)] else {
+            lock.unlock()
+            return
+        }
+        let changed: Bool
+        let transition: Bool
+        if observing {
+            changed = surface.observed.insert(key).inserted
+            transition = changed && eventSinks.values.filter { $0.observed.contains(key) }.count == 1
+        } else {
+            changed = surface.observed.remove(key) != nil
+            transition = changed && !eventSinks.values.contains { $0.observed.contains(key) }
+        }
+        lock.unlock()
+        guard transition else { return }
+        if observing {
+            fireStart(module: module, event: event)
+        } else {
+            fireStop(module: module, event: event)
+        }
     }
 
     // MARK: - sendEvent
@@ -60,10 +122,15 @@ public enum WhiskerModuleEventCenter {
         event: String,
         payload: WhiskerValue
     ) {
+        let key = EventKey(module: module, event: event)
         lock.lock()
-        let sink = eventSink
+        let sinks = eventSinks.values
+            .filter { $0.observed.contains(key) }
+            .map(\.dispatch)
         lock.unlock()
-        sink?(module, event, payload)
+        for sink in sinks {
+            sink(module, event, payload)
+        }
     }
 
     // MARK: - Observer hook routing
@@ -71,7 +138,7 @@ public enum WhiskerModuleEventCenter {
     /// Look up the Module + event-name pair and fire any matching
     /// `OnStartObserving` closures. Called by the shared C
     /// trampoline below.
-    public static func fireStart(module: String, event: String) {
+    private static func fireStart(module: String, event: String) {
         lock.lock()
         let m = modulesByName[module]
         lock.unlock()
@@ -82,7 +149,7 @@ public enum WhiskerModuleEventCenter {
     }
 
     /// Counterpart to `fireStart`.
-    public static func fireStop(module: String, event: String) {
+    private static func fireStop(module: String, event: String) {
         lock.lock()
         let m = modulesByName[module]
         lock.unlock()

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -7,6 +7,8 @@ public final class WhiskerView: UIView {
     private var hostToken: UnsafeMutableRawPointer?
     private var runtimeHandle: UnsafeMutableRawPointer?
     private var isApplicationActive = true
+    private var moduleEventSinkEpoch: UInt64 = 0
+    private let pendingModuleEvents = PendingModuleEvents()
     private lazy var pointerInputRecognizer: WhiskerTouchObserverGestureRecognizer = {
         let recognizer = WhiskerTouchObserverGestureRecognizer(target: nil, action: nil)
         recognizer.touchHandler = { [weak self] touches, event in
@@ -127,8 +129,19 @@ public final class WhiskerView: UIView {
         guard runtimeHandle == nil, window != nil, viewport.width > 0, viewport.height > 0 else { return }
         let token = Unmanaged.passRetained(self).toOpaque()
         hostToken = token
-        WhiskerModuleEventCenter.installEventSink { [weak self] module, event, payload in
-            self?.dispatchModuleEvent(module: module, event: event, payload: payload)
+        moduleEventSinkEpoch &+= 1
+        let sinkEpoch = moduleEventSinkEpoch
+        WhiskerModuleEventCenter.installEventSink(owner: self) { [weak self] module, event, payload in
+            guard let self else { return }
+            let shouldSchedule = self.pendingModuleEvents.offer(PendingModuleEvent(
+                epoch: sinkEpoch,
+                module: module,
+                event: event,
+                payload: payload
+            ))
+            if shouldSchedule {
+                DispatchQueue.main.async { [weak self] in self?.flushModuleEventsOnMain() }
+            }
         }
         runtimeHandle = whiskerViewCreate(
             Float(viewport.width), Float(viewport.height), Float(window?.screen.scale ?? 1),
@@ -143,6 +156,8 @@ public final class WhiskerView: UIView {
             driveRuntimeFrame(timestampMs: ProcessInfo.processInfo.systemUptime * 1_000)
             requestFrame()
         } else {
+            moduleEventSinkEpoch &+= 1
+            WhiskerModuleEventCenter.installEventSink(owner: self, nil)
             Unmanaged<WhiskerView>.fromOpaque(token).release()
             hostToken = nil
         }
@@ -226,13 +241,19 @@ public final class WhiskerView: UIView {
     }
 
     private func unmount() {
-        guard let handle = runtimeHandle else { return }
+        moduleEventSinkEpoch &+= 1
+        WhiskerModuleEventCenter.installEventSink(owner: self, nil)
+        let handle = runtimeHandle
+        let ownedRuntime = handle != nil || hostToken != nil
         runtimeHandle = nil
         displayLink?.invalidate()
         displayLink = nil
-        whiskerViewDestroy(handle)
-        WhiskerModuleEventCenter.installEventSink(nil)
-        scene.clear()
+        if let handle { whiskerViewDestroy(handle) }
+        // Avoid initializing the lazy scene from `deinit` for a View that was
+        // never mounted. Its initializer captures `weak self`, which UIKit
+        // correctly rejects once object deallocation has begun.
+        if ownedRuntime { scene.clear() }
+        pendingModuleEvents.clear()
         touchIdentities.clear()
         if let token = hostToken {
             Unmanaged<WhiskerView>.fromOpaque(token).release()
@@ -326,35 +347,35 @@ public final class WhiskerView: UIView {
     }
 
     func observeModule(module: String, event: String, observing: Bool) {
-        modules.observe(module: module, event: event, observing: observing)
+        modules.observe(owner: self, module: module, event: event, observing: observing)
     }
 
-    private func dispatchModuleEvent(module: String, event: String, payload: WhiskerValue) {
+    private func flushModuleEventsOnMain() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let pending = pendingModuleEvents.drain(epoch: moduleEventSinkEpoch)
+        guard !pending.isEmpty else { return }
         scene.dispatchOrDefer { [weak self] in
-            guard let self else { return }
-            guard let handle = runtimeHandle else {
-                DispatchQueue.main.async { [weak self] in
-                    guard self?.runtimeHandle != nil else { return }
-                    self?.dispatchModuleEvent(module: module, event: event, payload: payload)
-                }
-                return
-            }
-            var raw = payload.toRaw()
-            defer { WhiskerValue.releaseRaw(&raw) }
-            let moduleBytes = Array(module.utf8)
-            let eventBytes = Array(event.utf8)
-            moduleBytes.withUnsafeBytes { moduleBuffer in
-                eventBytes.withUnsafeBytes { eventBuffer in
-                    _ = whiskerViewDispatchModuleEvent(
-                        handle,
-                        moduleBuffer.bindMemory(to: UInt8.self).baseAddress,
-                        moduleBytes.count,
-                        eventBuffer.bindMemory(to: UInt8.self).baseAddress,
-                        eventBytes.count,
-                        &raw
-                    )
+            guard let self, let handle = runtimeHandle else { return }
+            var dispatched = false
+            for moduleEvent in pending {
+                var raw = moduleEvent.payload.toRaw()
+                defer { WhiskerValue.releaseRaw(&raw) }
+                let moduleBytes = Array(moduleEvent.module.utf8)
+                let eventBytes = Array(moduleEvent.event.utf8)
+                moduleBytes.withUnsafeBytes { moduleBuffer in
+                    eventBytes.withUnsafeBytes { eventBuffer in
+                        dispatched = whiskerViewDispatchModuleEvent(
+                            handle,
+                            moduleBuffer.bindMemory(to: UInt8.self).baseAddress,
+                            moduleBytes.count,
+                            eventBuffer.bindMemory(to: UInt8.self).baseAddress,
+                            eventBytes.count,
+                            &raw
+                        ) || dispatched
+                    }
                 }
             }
+            if dispatched { requestFrame() }
         }
     }
 }

--- a/platforms/ios/Sources/WhiskerRuntime/module/HostModuleDispatcher.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/module/HostModuleDispatcher.swift
@@ -27,12 +27,13 @@ final class HostModuleDispatcher {
         return true
     }
 
-    func observe(module: String, event: String, observing: Bool) {
-        if observing {
-            WhiskerModuleEventCenter.fireStart(module: module, event: event)
-        } else {
-            WhiskerModuleEventCenter.fireStop(module: module, event: event)
-        }
+    func observe(owner: AnyObject, module: String, event: String, observing: Bool) {
+        WhiskerModuleEventCenter.setObserving(
+            owner: owner,
+            module: module,
+            event: event,
+            observing: observing
+        )
     }
 
     private func deliver(

--- a/platforms/ios/Sources/WhiskerRuntime/module/PendingModuleEvents.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/module/PendingModuleEvents.swift
@@ -1,0 +1,42 @@
+import Foundation
+import WhiskerModule
+
+struct PendingModuleEvent: Equatable {
+    let epoch: UInt64
+    let module: String
+    let event: String
+    let payload: WhiskerValue
+}
+
+/// Any-queue ingress buffer drained once per main-loop turn.
+final class PendingModuleEvents {
+    private let lock = NSLock()
+    private var queue: [PendingModuleEvent] = []
+    private var flushScheduled = false
+
+    /// Returns true only when the caller must schedule the shared flush.
+    func offer(_ event: PendingModuleEvent) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        queue.append(event)
+        guard !flushScheduled else { return false }
+        flushScheduled = true
+        return true
+    }
+
+    func drain(epoch: UInt64) -> [PendingModuleEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        flushScheduled = false
+        let current = queue.filter { $0.epoch == epoch }
+        queue.removeAll(keepingCapacity: true)
+        return current
+    }
+
+    func clear() {
+        lock.lock()
+        queue.removeAll(keepingCapacity: false)
+        flushScheduled = false
+        lock.unlock()
+    }
+}

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -6,11 +6,102 @@ import WhiskerCBridge
 @testable import WhiskerModule
 import XCTest
 
+private final class EventLifecycleTestModule: Module {
+    var starts = 0
+    var stops = 0
+
+    override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("Clock")
+            Events("tick")
+            OnStartObserving("tick") { [weak self] in self?.starts += 1 }
+            OnStopObserving("tick") { [weak self] in self?.stops += 1 }
+        }
+    }
+}
+
 @MainActor
 final class HostConformanceTests: XCTestCase {
     override class func setUp() {
         super.setUp()
         BuiltInElementModule().registerWithWhisker()
+    }
+
+    func testModuleEventsReachOnlyObservingSurfacesAndLifecycleIsAggregated() {
+        let module = EventLifecycleTestModule()
+        module.qualifiedName = "event-test:Clock"
+        WhiskerModuleEventCenter.register(module)
+        let moduleName = try! XCTUnwrap(module.qualifiedName)
+        let firstOwner = NSObject()
+        let secondOwner = NSObject()
+        var received: [String] = []
+        WhiskerModuleEventCenter.installEventSink(owner: firstOwner) { _, _, _ in
+            received.append("first")
+        }
+        WhiskerModuleEventCenter.installEventSink(owner: secondOwner) { _, _, _ in
+            received.append("second")
+        }
+        defer {
+            WhiskerModuleEventCenter.installEventSink(owner: firstOwner, nil)
+            WhiskerModuleEventCenter.installEventSink(owner: secondOwner, nil)
+        }
+
+        WhiskerModuleEventCenter.setObserving(
+            owner: firstOwner,
+            module: moduleName,
+            event: "tick",
+            observing: true
+        )
+        XCTAssertEqual(module.starts, 1)
+        WhiskerModuleEventCenter.dispatchSend(
+            module: moduleName,
+            event: "tick",
+            payload: .int(1)
+        )
+        XCTAssertEqual(received, ["first"])
+
+        received.removeAll()
+        WhiskerModuleEventCenter.setObserving(
+            owner: secondOwner,
+            module: moduleName,
+            event: "tick",
+            observing: true
+        )
+        XCTAssertEqual(module.starts, 1)
+        WhiskerModuleEventCenter.dispatchSend(
+            module: moduleName,
+            event: "tick",
+            payload: .int(2)
+        )
+        XCTAssertEqual(Set(received), Set(["first", "second"]))
+
+        WhiskerModuleEventCenter.installEventSink(owner: firstOwner, nil)
+        XCTAssertEqual(module.stops, 0)
+        received.removeAll()
+        WhiskerModuleEventCenter.dispatchSend(
+            module: moduleName,
+            event: "tick",
+            payload: .int(3)
+        )
+        XCTAssertEqual(received, ["second"])
+        WhiskerModuleEventCenter.installEventSink(owner: secondOwner, nil)
+        XCTAssertEqual(module.stops, 1)
+    }
+
+    func testPendingModuleEventsCoalesceWakeupsAndRejectEarlierMountEpoch() {
+        let pending = PendingModuleEvents()
+        XCTAssertTrue(pending.offer(PendingModuleEvent(
+            epoch: 1, module: "demo", event: "tick", payload: .int(1)
+        )))
+        XCTAssertFalse(pending.offer(PendingModuleEvent(
+            epoch: 1, module: "demo", event: "tick", payload: .int(2)
+        )))
+        XCTAssertEqual(pending.drain(epoch: 1).map(\.payload), [.int(1), .int(2)])
+
+        XCTAssertTrue(pending.offer(PendingModuleEvent(
+            epoch: 1, module: "demo", event: "tick", payload: .int(3)
+        )))
+        XCTAssertTrue(pending.drain(epoch: 2).isEmpty)
     }
 
     func testCommonAccessibilityMapsToUIKitNodeSemantics() {

--- a/platforms/web/src/application.rs
+++ b/platforms/web/src/application.rs
@@ -193,9 +193,9 @@ impl WebApplication {
 
     fn drive_frame(&mut self, timestamp_ms: f64) -> Result<(), WebError> {
         self.start_resource_commands();
-        self.modules.with_host(|| {
-            self.modules.dispatch_pending_events();
-        });
+        self.modules
+            .dispatch_pending_events(&self.runtime)
+            .map_err(|error| WebError(format!("dispatch Web module event: {error}")))?;
         for event in self.frames.take_events() {
             self.modules
                 .with_host(|| {
@@ -230,9 +230,9 @@ impl WebApplication {
                 )
             })
             .map_err(|error| WebError(format!("drive Web frame: {error}")))?;
-        self.modules.with_host(|| {
-            self.modules.dispatch_pending_events();
-        });
+        self.modules
+            .dispatch_pending_events(&self.runtime)
+            .map_err(|error| WebError(format!("dispatch Web module event: {error}")))?;
         self.start_resource_commands();
         if drive.needs_frame {
             request_frame();


### PR DESCRIPTION
## Summary

- move animation schedulers, focus, and back interception into `RuntimeContext`-owned runtime-local state
- route native and direct-Rust module events through `RuntimeInstance`, with the owning renderer and reactive transaction installed
- route Android/iOS module events only to observing surfaces and aggregate `OnStartObserving` / `OnStopObserving` across mounted surfaces
- queue any-thread mobile events onto one UI-loop flush, deep-copy mutable Android payloads, and reject stale mount epochs
- keep the public application APIs and existing C ABI unchanged

This PR is independent of #535 and targets `next-architecture` directly.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p whisker-runtime -p whisker-animation -p whisker -p whisker-driver --all-targets -- -D warnings`
- `cargo test -p whisker-runtime -p whisker-animation -p whisker -p whisker-driver --no-fail-fast`
- `cargo xtask host-conformance desktop`
- `cargo xtask host-conformance web`
- `cargo xtask host-conformance ios` (21 simulator tests)
- Android module/runtime JVM tests and runtime AAR assembly
- `cargo xtask mobile-link-test android`
- `cargo xtask mobile-link-test ios`

Android instrumentation APK compilation succeeds locally; execution is left to CI because no emulator/device was connected.