### PR TITLE
fix(android): clean local build diagnostics

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,13 +11,12 @@ coverage-text = "llvm-cov --workspace"
 coverage-lcov = "llvm-cov --workspace --lcov --output-path lcov.info"
 
 [target.aarch64-linux-android]
-# `-outline-atomics` keeps us clear of the compiler-rt outline-atomics
-# dispatcher — both its `init_have_lse_atomics` ELF initializer (which
-# crashes inside a local `getauxval` stub when the bionic build
-# differs) and the `__aarch64_cas*` helpers (which end up unresolved
-# at .so load time when we strip compiler-rt out). With the dispatcher
-# off and no `+lse`, LLVM emits classic Armv8.0 `ldaxr`/`stlxr` loops,
-# which every `arm64-v8a` device can execute.
+# Keep the target at its default Armv8.0 baseline. Current Rust emits
+# classic `ldxr`/`stxr` loops for atomics on `aarch64-linux-android`,
+# which every `arm64-v8a` device can execute. Do not explicitly disable
+# the internal `outline-atomics` target feature: it is not part of
+# Rust's stable target-feature surface and produces a warning on every
+# crate with current toolchains.
 #
 # Do NOT add `+lse` here (nor `-march=armv8.1-a` on the C++ side): it
 # inlines Armv8.1 `ldadd`/`cas`, and `arm64-v8a` is an Armv8.0
@@ -32,6 +31,5 @@ coverage-lcov = "llvm-cov --workspace --lcov --output-path lcov.info"
 # becomes redundant — remove this line once we drop NDK r26
 # support.
 rustflags = [
-    "-C", "target-feature=-outline-atomics",
     "-C", "link-arg=-Wl,-z,max-page-size=16384",
 ]

--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -698,7 +698,16 @@ fn gradle_command(gen_android: &Path, task: &str) -> Result<Command> {
         .arg("--no-daemon")
         .arg("--console=plain")
         .current_dir(gen_android)
-        .env("JAVA_HOME", &java_home);
+        .env("JAVA_HOME", &java_home)
+        // Keep Gradle's nested `modules` / `build-android` calls on the
+        // exact CLI that launched this build. This is essential for local
+        // `cargo run`: PATH may still contain an older installed Whisker.
+        // Android Studio builds do not pass this env and the plugins retain
+        // their normal PATH fallback.
+        .env(
+            "WHISKER_CLI",
+            std::env::current_exe().context("resolve current Whisker CLI executable")?,
+        );
     if crate::ui::is_tui() {
         cmd.env("WHISKER_TUI", "1");
     }
@@ -867,6 +876,28 @@ mod tests {
                 "profile.dev.package.\"list-benchmark\".opt-level=0",
             ],
         );
+    }
+
+    #[test]
+    fn gradle_uses_the_current_whisker_cli_for_nested_builds() {
+        let tmp = std::env::temp_dir().join(format!(
+            "whisker-build-gradle-cli-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(tmp.join("gradlew"), "#!/bin/sh\n").unwrap();
+
+        let command = gradle_command(&tmp, ":app:assembleDebug").unwrap();
+        let configured = command
+            .get_envs()
+            .find_map(|(key, value)| (key == "WHISKER_CLI").then_some(value))
+            .flatten();
+        assert_eq!(
+            configured,
+            Some(std::env::current_exe().unwrap().as_os_str())
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/crates/whisker-subsecond/src/lib.rs
+++ b/crates/whisker-subsecond/src/lib.rs
@@ -858,8 +858,8 @@ pub fn aslr_reference() -> usize {
 /// - https://developer.android.com/ndk/reference/structandroid/dlextinfo
 #[cfg(target_os = "android")]
 unsafe fn android_memmap_dlopen(file: &std::path::Path) -> Result<libloading::Library, PatchError> {
-    use std::ffi::{CStr, CString, c_void};
-    use std::os::fd::{AsRawFd, BorrowedFd};
+    use std::ffi::c_void;
+    use std::os::fd::AsRawFd;
     use std::ptr;
 
     #[repr(C)]
@@ -881,24 +881,25 @@ unsafe fn android_memmap_dlopen(file: &std::path::Path) -> Result<libloading::Li
         ) -> *const c_void;
     }
 
-    use memmap2::MmapAsRawDesc;
-    use std::os::unix::prelude::{FromRawFd, IntoRawFd};
-
     let contents = std::fs::read(file)
         .map_err(|e| PatchError::AndroidMemfd(format!("Failed to read file: {}", e)))?;
-    let mut mfd = memfd::MemfdOptions::default()
+    let mfd = memfd::MemfdOptions::default()
         .create("subsecond-patch")
         .map_err(|e| PatchError::AndroidMemfd(format!("Failed to create memfd: {}", e)))?;
     mfd.as_file()
         .set_len(contents.len() as u64)
         .map_err(|e| PatchError::AndroidMemfd(format!("Failed to set memfd length: {}", e)))?;
 
-    let raw_fd = mfd.into_raw_fd();
+    let raw_fd = mfd.as_file().as_raw_fd();
 
-    let mut map = memmap2::MmapMut::map_mut(raw_fd)
+    // SAFETY: `mfd` owns `raw_fd` and remains alive through both this mapping and
+    // `android_dlopen_ext` below. The mapping cannot outlive the descriptor here.
+    let mut map = unsafe { memmap2::MmapMut::map_mut(mfd.as_file()) }
         .map_err(|e| PatchError::AndroidMemfd(format!("Failed to map memfd: {}", e)))?;
     map.copy_from_slice(&contents);
-    let map = map
+    // Keep the executable mapping alive until the dynamic linker has consumed
+    // the descriptor. Both it and the owning memfd are released on return.
+    let _executable_map = map
         .make_exec()
         .map_err(|e| PatchError::AndroidMemfd(format!("Failed to make memfd executable: {}", e)))?;
 
@@ -918,7 +919,9 @@ unsafe fn android_memmap_dlopen(file: &std::path::Path) -> Result<libloading::Li
 
     let handle = libloading::os::unix::with_dlerror(
         || {
-            let ptr = android_dlopen_ext(filename.as_ptr() as _, flags, &info);
+            // SAFETY: `filename` is NUL-terminated, `info` points to a valid
+            // `ExtInfo`, and its `library_fd` remains open for this call.
+            let ptr = unsafe { android_dlopen_ext(filename.as_ptr() as _, flags, &info) };
             if ptr.is_null() {
                 return None;
             } else {

--- a/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerBuildTask.kt
+++ b/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerBuildTask.kt
@@ -69,15 +69,16 @@ abstract class WhiskerBuildTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        // Fail fast with a clear message if `whisker` isn't on
-        // PATH. Without this, Gradle reports the raw POSIX error
-        // (`Cannot run program 'whisker': error=2, No such file
-        // or directory`) which leaves the user guessing what to
-        // install. Mirrors the `command -v` check the iOS Run Script
-        // does up-front for the same reason.
-        if (!isOnPath("whisker")) {
+        val whiskerCli = System.getenv("WHISKER_CLI")
+            ?.takeIf { it.isNotBlank() }
+            ?: "whisker"
+        // Fail fast with a clear message when the selected CLI cannot
+        // execute. `whisker run/build` supplies its own absolute path;
+        // Android Studio builds fall back to resolving `whisker` on PATH.
+        // Without this check Gradle only reports a raw POSIX spawn error.
+        if (!isExecutable(whiskerCli)) {
             error(
-                "rs.whisker.gradle: 'whisker' is not on PATH. " +
+                "rs.whisker.gradle: Whisker CLI '$whiskerCli' is not executable. " +
                     "Install with: cargo install whisker-cli " +
                     "(re-open Android Studio after install so it picks up the new PATH).",
             )
@@ -106,7 +107,7 @@ abstract class WhiskerBuildTask : DefaultTask() {
         execOperations.exec {
             commandLine(
                 listOf(
-                    "whisker",
+                    whiskerCli,
                     "build-android",
                     "--workspace=$ws",
                     "--package=${packageName.get()}",
@@ -128,7 +129,11 @@ abstract class WhiskerBuildTask : DefaultTask() {
         }
     }
 
-    private fun isOnPath(tool: String): Boolean {
+    private fun isExecutable(tool: String): Boolean {
+        val direct = java.io.File(tool)
+        if (direct.isAbsolute || tool.contains(java.io.File.separatorChar)) {
+            return direct.isFile && direct.canExecute()
+        }
         val pathEnv = System.getenv("PATH") ?: return false
         val sep = System.getProperty("path.separator") ?: ":"
         return pathEnv.split(sep).any { dir ->

--- a/platforms/android/gradle-plugin/whisker-settings-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerPlugin.kt
+++ b/platforms/android/gradle-plugin/whisker-settings-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerPlugin.kt
@@ -128,8 +128,11 @@ class WhiskerPlugin : Plugin<Settings> {
     }
 
     private fun runWhiskerBuildModules(workspace: File, userPackage: String): String {
+        val whiskerCli = System.getenv("WHISKER_CLI")
+            ?.takeIf { it.isNotBlank() }
+            ?: "whisker"
         val proc = ProcessBuilder(
-            "whisker",
+            whiskerCli,
             "modules",
             "--workspace=${workspace.absolutePath}",
             "--package=$userPackage",
@@ -141,6 +144,7 @@ class WhiskerPlugin : Plugin<Settings> {
             error(
                 "whisker modules failed (exit $rc).\n" +
                     "stderr:\n$err\n" +
+                    "Whisker CLI: $whiskerCli\n" +
                     "Hint: install with `cargo install whisker-cli` " +
                     "and make sure it's on the JVM's PATH.",
             )


### PR DESCRIPTION
## Summary
- keep Gradle-triggered Rust builds on the currently running local Whisker CLI
- remove the now-redundant unstable `outline-atomics` rustflag that emitted one warning per crate
- make the Android subsecond memfd loader Rust 2024-clean and close each patch fd after loading

## Verification
- `cargo check -p whisker-subsecond --target aarch64-linux-android`
- `cargo test -p whisker-subsecond`
- `cargo run -p whisker-cli --bin whisker -- run android --manifest-path examples/host-smoke/Cargo.toml --no-tui`
- initial Rust build, Gradle rebuild, app launch, module event, and two subsecond patches completed with zero warnings