### PR TITLE
feat(desktop): add shared native accessibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -285,7 +285,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1765,7 +1765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3549,7 +3549,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4340,6 +4340,16 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
@@ -4400,7 +4410,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4802,7 +4812,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4815,7 +4825,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5271,7 +5281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5453,10 +5463,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5924,7 +5934,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6473,7 +6483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.41.0",
  "quote",
 ]
 
@@ -7345,7 +7355,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7893,9 +7903,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.19.0"
+version = "5.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -7920,7 +7930,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.4",
+ "winnow 0.7.15",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -7952,14 +7962,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.19.0"
+version = "5.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -7967,34 +7977,25 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.4"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "winnow 1.0.4",
+ "winnow 0.7.15",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "5.2.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+checksum = "441a0064125265655bccc3a6af6bef56814d9277ac83fce48b1cd7e160b80eac"
 dependencies = [
+ "quick-xml 0.38.4",
  "serde",
- "winnow 1.0.4",
  "zbus_names",
  "zvariant",
-]
-
-[[package]]
-name = "zcheapstr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -8119,41 +8120,40 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zvariant"
-version = "5.15.0"
+version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.4",
- "zcheapstr",
+ "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.15.0"
+version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "4.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.3",
- "winnow 1.0.4",
+ "syn 2.0.119",
+ "winnow 0.7.15",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,114 @@
 version = 4
 
 [[package]]
+name = "accesskit"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "438a7081a65b95c668db56591a4fef9bc5dad275f448bd6223fc6949d823db38"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d47ad644916f6cb7e432a5ca0dbd7cc78281a9772881057bb72d4aadb93257"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "phf 0.14.0",
+ "serde",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc882fa0c9c24c53649e256311b51046cf36eca9a8f7e54ff4ef682160b0cb27"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "accesskit_ios"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e9b29c6ba5f4d2e0662e9c562484f061ffc58f658479c538ecca8299ada1e9"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.17.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f278988416e5fb600f24d0cfffe31a249ebbff980fb9c5a3b5fbed2c579f73"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.17.1",
+ "objc2 0.5.2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665c9079b7325a8168a6793437a172dda44b19a05af8ed52d7e32abaada996fe"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a59e8d7160cbac991c1345c99153783ab96423644ccb1f20617cf80c97596aa1"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.17.1",
+ "static_assertions",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb960a51582305f94b3884a7ff54b3462abe38f0de95a9e7e04dd7ab7b757da"
+dependencies = [
+ "accesskit",
+ "accesskit_ios",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +346,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +411,59 @@ dependencies = [
  "event-listener-strategy",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -358,6 +575,43 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "trait-variant",
+]
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
 ]
 
 [[package]]
@@ -554,6 +808,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -1187,7 +1454,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fda6aace1fbef3aa217b27f4c8d7d071ef2a70a5ca51050b1f17d40299d3f16"
 dependencies = [
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -1447,12 +1714,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1763,6 +2057,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,7 +2264,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -2049,6 +2356,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2061,6 +2371,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexf-parse"
@@ -2977,6 +3293,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metal"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3542,6 +3867,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,8 +3965,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros 0.14.0",
+ "phf_shared 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -3640,8 +3986,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.14.0",
 ]
 
 [[package]]
@@ -3650,8 +4006,21 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3662,6 +4031,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -3691,6 +4069,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"
@@ -4656,6 +5045,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5517,6 +5917,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5696,6 +6107,7 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -6242,7 +6654,7 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
+ "windows 0.58.0",
  "windows-core 0.58.0",
 ]
 
@@ -6416,6 +6828,8 @@ dependencies = [
 name = "whisker-desktop"
 version = "0.12.0"
 dependencies = [
+ "accesskit",
+ "accesskit_winit",
  "base64 0.22.1",
  "bytemuck",
  "csscolorparser",
@@ -6951,6 +7365,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6974,6 +7409,17 @@ dependencies = [
  "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7025,6 +7471,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -7130,6 +7586,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -7427,6 +7892,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zeno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7545,3 +8116,44 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.4",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,14 @@ yanked = "deny"
 #     TXT query (one name) against a trusted DoH endpoint, so the
 #     pathological input isn't reachable. The fix lands in hickory 0.25,
 #     which atrium 0.24 doesn't yet allow. Revisit on the atrium bump.
+#   RUSTSEC-2026-0194 / RUSTSEC-2026-0195  quick-xml 0.38.4 <-
+#     zbus-xml 5.1 <- zbus-lockstep <- AccessKit's Linux AT-SPI backend.
+#     This path parses only the upstream AT-SPI crate's checked-in interface
+#     XML from cfg(test) lockstep checks; Whisker's runtime does not feed it
+#     external XML. quick-xml 0.41 is available only through zbus releases
+#     requiring Rust 1.87, above the workspace's Rust 1.85 floor. Revisit when
+#     zbus ships a fixed release that preserves Rust 1.85 support, or when the
+#     workspace MSRV is raised.
 ignore = [
     "RUSTSEC-2024-0436",
     "RUSTSEC-2025-0119",
@@ -43,6 +51,8 @@ ignore = [
     "RUSTSEC-2026-0119",
     "RUSTSEC-2026-0206",
     "RUSTSEC-2026-0192",
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [bans]

--- a/platforms/desktop/Cargo.toml
+++ b/platforms/desktop/Cargo.toml
@@ -30,6 +30,7 @@ whisker-value = { workspace = true }
 whisker-dev-runtime = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
+accesskit = "0.25.0"
 base64 = { workspace = true }
 bytemuck = { version = "1", features = ["derive"] }
 csscolorparser = "0.7.2"
@@ -39,14 +40,17 @@ pollster = "0.4.0"
 ureq = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+accesskit_winit = { version = "0.34.0", default-features = false, features = ["rwh_06"] }
 wgpu = { version = "25.0.2", default-features = false, features = ["metal", "wgsl"] }
 winit = { version = "0.30", default-features = false, features = ["rwh_06"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+accesskit_winit = { version = "0.34.0", default-features = false, features = ["rwh_06"] }
 wgpu = { version = "25.0.2", default-features = false, features = ["dx12", "wgsl"] }
 winit = { version = "0.30", default-features = false, features = ["rwh_06"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+accesskit_winit = { version = "0.34.0", default-features = false, features = ["accesskit_unix", "async-io", "rwh_06"] }
 wgpu = { version = "25.0.2", default-features = false, features = ["vulkan", "gles", "wgsl"] }
 winit = { version = "0.30", default-features = false, features = ["rwh_06", "wayland", "wayland-dlopen", "x11"] }
 

--- a/platforms/desktop/src/accessibility.rs
+++ b/platforms/desktop/src/accessibility.rs
@@ -1,0 +1,404 @@
+//! AccessKit projection shared by the macOS, Windows, and Linux Hosts.
+
+use std::collections::HashMap;
+
+use accesskit::{
+    Action, ActionRequest, Affine, Node, NodeId as AccessNodeId, Rect, Role, Toggled, TreeId,
+    TreeInfo, TreeUpdate,
+};
+use whisker_protocol::{
+    Accessibility, AccessibilityChecked, AccessibilityRole, LayoutRect, NodeId as WhiskerNodeId,
+};
+
+const ROOT_ID: AccessNodeId = AccessNodeId(0);
+
+/// Host-neutral semantic node produced from the retained Desktop scene.
+#[derive(Clone, Debug)]
+pub(crate) struct DesktopAccessibilityNode {
+    pub(crate) id: WhiskerNodeId,
+    pub(crate) children: Vec<WhiskerNodeId>,
+    pub(crate) bounds: LayoutRect,
+    pub(crate) semantics: Accessibility,
+    pub(crate) text: Option<String>,
+    pub(crate) hidden: bool,
+}
+
+/// Complete semantic snapshot of one Desktop surface.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DesktopAccessibilitySnapshot {
+    pub(crate) roots: Vec<WhiskerNodeId>,
+    pub(crate) nodes: Vec<DesktopAccessibilityNode>,
+}
+
+/// Runtime result of an action requested by an assistive technology.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DesktopAccessibilityAction {
+    Click(WhiskerNodeId),
+    FocusChanged,
+    Ignored,
+}
+
+/// Converts scene snapshots into incremental AccessKit tree updates.
+pub(crate) struct DesktopAccessibilityBridge {
+    previous: HashMap<AccessNodeId, Node>,
+    focus: AccessNodeId,
+}
+
+impl Default for DesktopAccessibilityBridge {
+    fn default() -> Self {
+        Self {
+            previous: HashMap::new(),
+            focus: ROOT_ID,
+        }
+    }
+}
+
+impl DesktopAccessibilityBridge {
+    pub(crate) fn reset(&mut self) {
+        self.previous.clear();
+        self.focus = ROOT_ID;
+    }
+
+    pub(crate) fn update(
+        &mut self,
+        snapshot: DesktopAccessibilitySnapshot,
+        title: &str,
+        logical_size: [f32; 2],
+        scale: f32,
+        force_full: bool,
+    ) -> TreeUpdate {
+        let mut next = HashMap::with_capacity(snapshot.nodes.len() + 1);
+        let mut root = Node::new(Role::Window);
+        root.set_label(title);
+        root.set_bounds(Rect::new(
+            0.0,
+            0.0,
+            logical_size[0] as f64,
+            logical_size[1] as f64,
+        ));
+        root.set_transform(Affine::scale(scale as f64));
+        root.set_children(
+            snapshot
+                .roots
+                .into_iter()
+                .map(access_node_id)
+                .collect::<Vec<_>>(),
+        );
+        next.insert(ROOT_ID, root);
+
+        for semantic in snapshot.nodes {
+            next.insert(access_node_id(semantic.id), access_node(semantic));
+        }
+        if !next.contains_key(&self.focus) {
+            self.focus = ROOT_ID;
+        }
+
+        let full = force_full || self.previous.is_empty();
+        let mut nodes = next
+            .iter()
+            .filter(|(id, node)| full || self.previous.get(id) != Some(*node))
+            .map(|(id, node)| (*id, node.clone()))
+            .collect::<Vec<_>>();
+        nodes.sort_by_key(|(id, _)| id.0);
+        self.previous = next;
+
+        let tree = full.then(|| {
+            let mut tree = TreeInfo::new(ROOT_ID);
+            tree.toolkit_name = Some("Whisker".into());
+            tree.toolkit_version = Some(env!("CARGO_PKG_VERSION").into());
+            tree
+        });
+        TreeUpdate {
+            nodes,
+            tree,
+            tree_id: TreeId::ROOT,
+            focus: self.focus,
+        }
+    }
+
+    pub(crate) fn handle_action(&mut self, request: &ActionRequest) -> DesktopAccessibilityAction {
+        let Some(target) = self.previous.get(&request.target_node) else {
+            return DesktopAccessibilityAction::Ignored;
+        };
+        if request.target_tree != TreeId::ROOT || !target.supports_action(request.action) {
+            return DesktopAccessibilityAction::Ignored;
+        }
+        match request.action {
+            Action::Focus if request.target_node != ROOT_ID => {
+                self.focus = request.target_node;
+                DesktopAccessibilityAction::FocusChanged
+            }
+            Action::Blur if self.focus == request.target_node => {
+                self.focus = ROOT_ID;
+                DesktopAccessibilityAction::FocusChanged
+            }
+            Action::Click => {
+                let Some(node) = WhiskerNodeId::new(request.target_node.0) else {
+                    return DesktopAccessibilityAction::Ignored;
+                };
+                self.focus = request.target_node;
+                DesktopAccessibilityAction::Click(node)
+            }
+            _ => DesktopAccessibilityAction::Ignored,
+        }
+    }
+}
+
+fn access_node_id(id: WhiskerNodeId) -> AccessNodeId {
+    AccessNodeId(id.get())
+}
+
+fn access_node(semantic: DesktopAccessibilityNode) -> Node {
+    let role = semantic.semantics.role.map(access_role).unwrap_or_else(|| {
+        if semantic.text.is_some() {
+            Role::Label
+        } else {
+            Role::GenericContainer
+        }
+    });
+    let actionable = matches!(
+        role,
+        Role::Button
+            | Role::Link
+            | Role::CheckBox
+            | Role::RadioButton
+            | Role::Switch
+            | Role::Slider
+            | Role::SearchInput
+            | Role::Tab
+    );
+    let mut node = Node::new(role);
+    node.set_children(
+        semantic
+            .children
+            .into_iter()
+            .map(access_node_id)
+            .collect::<Vec<_>>(),
+    );
+    node.set_bounds(Rect::new(
+        semantic.bounds.x as f64,
+        semantic.bounds.y as f64,
+        (semantic.bounds.x + semantic.bounds.width) as f64,
+        (semantic.bounds.y + semantic.bounds.height) as f64,
+    ));
+    if let Some(label) = semantic.semantics.label {
+        node.set_label(label);
+    }
+    if let Some(text) = semantic.text {
+        node.set_value(text);
+    }
+    if let Some(hint) = semantic.semantics.hint {
+        node.set_description(hint);
+    }
+    if let Some(identifier) = semantic.semantics.identifier {
+        node.set_author_id(identifier);
+    }
+    if semantic.hidden || semantic.semantics.hidden {
+        node.set_hidden();
+    }
+    if semantic.semantics.modal {
+        node.set_modal();
+    }
+    if semantic.semantics.state.disabled == Some(true) {
+        node.set_disabled();
+    }
+    if let Some(selected) = semantic.semantics.state.selected {
+        node.set_selected(selected);
+    }
+    if let Some(expanded) = semantic.semantics.state.expanded {
+        node.set_expanded(expanded);
+    }
+    if let Some(checked) = semantic.semantics.state.checked {
+        node.set_toggled(match checked {
+            AccessibilityChecked::Unchecked => Toggled::False,
+            AccessibilityChecked::Checked => Toggled::True,
+            AccessibilityChecked::Mixed => Toggled::Mixed,
+            _ => Toggled::Mixed,
+        });
+    }
+    if actionable && semantic.semantics.state.disabled != Some(true) {
+        node.add_action(Action::Focus);
+        node.add_action(Action::Blur);
+        node.add_action(Action::Click);
+    }
+    node
+}
+
+fn access_role(role: AccessibilityRole) -> Role {
+    match role {
+        AccessibilityRole::Group => Role::Group,
+        AccessibilityRole::Text => Role::Label,
+        AccessibilityRole::Button => Role::Button,
+        AccessibilityRole::Link => Role::Link,
+        AccessibilityRole::Image => Role::Image,
+        AccessibilityRole::Header => Role::Heading,
+        AccessibilityRole::Checkbox => Role::CheckBox,
+        AccessibilityRole::Radio => Role::RadioButton,
+        AccessibilityRole::Switch => Role::Switch,
+        AccessibilityRole::Adjustable => Role::Slider,
+        AccessibilityRole::SearchBox => Role::SearchInput,
+        AccessibilityRole::Tab => Role::Tab,
+        _ => Role::GenericContainer,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_protocol::AccessibilityState;
+
+    fn id(value: u64) -> WhiskerNodeId {
+        WhiskerNodeId::new(value).unwrap()
+    }
+
+    fn snapshot(accessibility: Accessibility) -> DesktopAccessibilitySnapshot {
+        DesktopAccessibilitySnapshot {
+            roots: vec![id(1)],
+            nodes: vec![DesktopAccessibilityNode {
+                id: id(1),
+                children: Vec::new(),
+                bounds: LayoutRect {
+                    x: 10.0,
+                    y: 20.0,
+                    width: 30.0,
+                    height: 40.0,
+                },
+                semantics: accessibility,
+                text: None,
+                hidden: false,
+            }],
+        }
+    }
+
+    #[test]
+    fn full_tree_maps_semantics_state_geometry_and_actions() {
+        let semantics = Accessibility::new()
+            .label("Airplane mode")
+            .hint("Toggles wireless radios")
+            .identifier("airplane-mode")
+            .role(AccessibilityRole::Switch)
+            .state(
+                AccessibilityState::new()
+                    .checked(AccessibilityChecked::Checked)
+                    .selected(false)
+                    .expanded(false),
+            );
+        let mut bridge = DesktopAccessibilityBridge::default();
+
+        let update = bridge.update(snapshot(semantics), "Example", [100.0, 80.0], 2.0, true);
+
+        assert!(update.tree.is_some());
+        assert_eq!(update.focus, ROOT_ID);
+        let node = update
+            .nodes
+            .iter()
+            .find_map(|(node_id, node)| (*node_id == AccessNodeId(1)).then_some(node))
+            .unwrap();
+        assert_eq!(node.role(), Role::Switch);
+        assert_eq!(node.label(), Some("Airplane mode"));
+        assert_eq!(node.description(), Some("Toggles wireless radios"));
+        assert_eq!(node.author_id(), Some("airplane-mode"));
+        assert_eq!(node.toggled(), Some(Toggled::True));
+        assert_eq!(node.is_selected(), Some(false));
+        assert_eq!(node.is_expanded(), Some(false));
+        assert!(node.supports_action(Action::Click));
+        assert_eq!(node.bounds(), Some(Rect::new(10.0, 20.0, 40.0, 60.0)));
+    }
+
+    #[test]
+    fn unchanged_snapshots_emit_an_empty_incremental_update() {
+        let mut bridge = DesktopAccessibilityBridge::default();
+        let semantics = Accessibility::new().role(AccessibilityRole::Button);
+        bridge.update(
+            snapshot(semantics.clone()),
+            "Example",
+            [100.0, 80.0],
+            1.0,
+            true,
+        );
+
+        let update = bridge.update(snapshot(semantics), "Example", [100.0, 80.0], 1.0, false);
+
+        assert!(update.tree.is_none());
+        assert!(update.nodes.is_empty());
+    }
+
+    #[test]
+    fn accessibility_click_focuses_and_targets_the_whisker_node() {
+        let mut bridge = DesktopAccessibilityBridge::default();
+        bridge.update(
+            snapshot(Accessibility::new().role(AccessibilityRole::Button)),
+            "Example",
+            [100.0, 80.0],
+            1.0,
+            true,
+        );
+        let request = ActionRequest {
+            action: Action::Click,
+            target_tree: TreeId::ROOT,
+            target_node: AccessNodeId(1),
+            data: None,
+        };
+
+        assert_eq!(
+            bridge.handle_action(&request),
+            DesktopAccessibilityAction::Click(id(1))
+        );
+        let update = bridge.update(
+            snapshot(Accessibility::new().role(AccessibilityRole::Button)),
+            "Example",
+            [100.0, 80.0],
+            1.0,
+            false,
+        );
+        assert_eq!(update.focus, AccessNodeId(1));
+    }
+
+    #[test]
+    fn removing_a_subtree_updates_its_parent_and_restores_root_focus() {
+        let mut bridge = DesktopAccessibilityBridge::default();
+        bridge.update(
+            snapshot(Accessibility::new().role(AccessibilityRole::Button)),
+            "Example",
+            [100.0, 80.0],
+            1.0,
+            true,
+        );
+        bridge.handle_action(&ActionRequest {
+            action: Action::Focus,
+            target_tree: TreeId::ROOT,
+            target_node: AccessNodeId(1),
+            data: None,
+        });
+
+        let update = bridge.update(
+            DesktopAccessibilitySnapshot::default(),
+            "Example",
+            [100.0, 80.0],
+            1.0,
+            false,
+        );
+
+        assert_eq!(update.focus, ROOT_ID);
+        assert_eq!(update.nodes.len(), 1);
+        assert_eq!(update.nodes[0].0, ROOT_ID);
+        assert!(update.nodes[0].1.children().is_empty());
+    }
+
+    #[test]
+    fn plain_text_is_exposed_without_explicit_semantics() {
+        let mut semantic = snapshot(Accessibility::new());
+        semantic.nodes[0].text = Some("Balance: $42".into());
+        let mut bridge = DesktopAccessibilityBridge::default();
+
+        let update = bridge.update(semantic, "Example", [100.0, 80.0], 1.0, true);
+
+        let node = update
+            .nodes
+            .iter()
+            .find_map(|(node_id, node)| (*node_id == AccessNodeId(1)).then_some(node))
+            .unwrap();
+        assert_eq!(node.role(), Role::Label);
+        assert_eq!(node.value(), Some("Balance: $42"));
+    }
+}

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::accessibility::{DesktopAccessibilityAction, DesktopAccessibilityBridge};
 use crate::{
     BuiltInElementModule, DesktopElementFactory, DesktopFrameContext, DesktopModuleDefinition,
     DesktopMouseButton, DesktopPointerAdapter, DesktopPointerPhase, DesktopRuntime, WhiskerModule,
@@ -10,7 +11,7 @@ use crate::{
 use whisker::runtime::RuntimeWakeHandle;
 use whisker::runtime::module::RustModuleDefinition;
 use whisker::{Element, ElementModuleDefinition, ElementRegistry, RuntimeInstance, SurfaceRuntime};
-use whisker_protocol::{CursorKeyword, InputEvent, SurfaceId};
+use whisker_protocol::{CursorKeyword, InputEvent, InputEventKind, SurfaceId, WhiskerValue};
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
@@ -190,9 +191,16 @@ pub fn run_with_application_hash(
         .map_err(|error| DesktopAppError(format!("run {TARGET_NAME} event loop: {error}")))
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 enum HostEvent {
     RequestFrame,
+    Accessibility(accesskit_winit::Event),
+}
+
+impl From<accesskit_winit::Event> for HostEvent {
+    fn from(event: accesskit_winit::Event) -> Self {
+        Self::Accessibility(event)
+    }
 }
 
 struct DesktopApplication {
@@ -203,6 +211,8 @@ struct DesktopApplication {
     hot_reload: Option<DesktopHotReload>,
     proxy: EventLoopProxy<HostEvent>,
     window: Option<Arc<Window>>,
+    accessibility_adapter: Option<accesskit_winit::Adapter>,
+    accessibility_bridge: DesktopAccessibilityBridge,
     runtime: Option<RuntimeInstance>,
     host: Option<DesktopRuntime>,
     viewport: PhysicalSize<u32>,
@@ -230,6 +240,8 @@ impl DesktopApplication {
             hot_reload: None,
             proxy,
             window: None,
+            accessibility_adapter: None,
+            accessibility_bridge: DesktopAccessibilityBridge::default(),
             runtime: None,
             host: None,
             viewport: PhysicalSize::new(1, 1),
@@ -248,11 +260,17 @@ impl DesktopApplication {
         }
         let attributes = WindowAttributes::default()
             .with_title(self.config.title.clone())
-            .with_inner_size(LogicalSize::new(self.config.width, self.config.height));
+            .with_inner_size(LogicalSize::new(self.config.width, self.config.height))
+            .with_visible(false);
         let window =
             Arc::new(event_loop.create_window(attributes).map_err(|error| {
                 DesktopAppError(format!("create {TARGET_NAME} window: {error}"))
             })?);
+        let accessibility_adapter = accesskit_winit::Adapter::with_event_loop_proxy(
+            event_loop,
+            &window,
+            self.proxy.clone(),
+        );
         self.viewport = window.inner_size();
         let scale = window.scale_factor() as f32;
         let logical = self.viewport.to_logical::<f32>(window.scale_factor());
@@ -291,7 +309,12 @@ impl DesktopApplication {
         ));
         self.host = Some(host);
         self.runtime = Some(runtime);
+        self.accessibility_adapter = Some(accessibility_adapter);
         self.window = Some(window);
+        self.window
+            .as_ref()
+            .expect("mounted Desktop window")
+            .set_visible(true);
         self.request_frame();
         Ok(())
     }
@@ -320,7 +343,7 @@ impl DesktopApplication {
         }
         let scale = window.scale_factor();
         let logical = self.viewport.to_logical::<f32>(scale);
-        match host.drive_frame(
+        let frame_result = host.drive_frame(
             runtime,
             DesktopFrameContext {
                 timestamp_ms: self.started_at.elapsed().as_secs_f64() * 1000.0,
@@ -330,7 +353,8 @@ impl DesktopApplication {
                 environment_epoch: self.environment_epoch,
                 viewport_epoch: self.viewport_epoch,
             },
-        ) {
+        );
+        match frame_result {
             Ok(result) => {
                 if result.needs_frame {
                     window.request_redraw();
@@ -340,6 +364,9 @@ impl DesktopApplication {
                 self.frame_failed = true;
                 eprintln!("whisker {TARGET_NAME} frame failed: {error}");
             }
+        }
+        if !self.frame_failed {
+            self.update_accessibility(false);
         }
     }
 
@@ -371,6 +398,59 @@ impl DesktopApplication {
             eprintln!("dispatch {TARGET_NAME} input failed: {error}");
         } else {
             self.request_frame();
+        }
+    }
+
+    fn update_accessibility(&mut self, force_full: bool) {
+        let (Some(window), Some(host), Some(adapter)) = (
+            self.window.as_ref(),
+            self.host.as_ref(),
+            self.accessibility_adapter.as_mut(),
+        ) else {
+            return;
+        };
+        let scale = window.scale_factor();
+        let logical = self.viewport.to_logical::<f32>(scale);
+        let title = self.config.title.as_str();
+        let bridge = &mut self.accessibility_bridge;
+        adapter.update_if_active(|| {
+            bridge.update(
+                host.accessibility_snapshot(),
+                title,
+                [logical.width, logical.height],
+                scale as f32,
+                force_full,
+            )
+        });
+    }
+
+    fn handle_accessibility_event(&mut self, event: accesskit_winit::Event) {
+        if self.window.as_ref().map(|window| window.id()) != Some(event.window_id) {
+            return;
+        }
+        match event.window_event {
+            accesskit_winit::WindowEvent::InitialTreeRequested => {
+                self.update_accessibility(true);
+            }
+            accesskit_winit::WindowEvent::ActionRequested(request) => {
+                let action = self.accessibility_bridge.handle_action(&request);
+                if let DesktopAccessibilityAction::Click(target) = action {
+                    self.dispatch_input(InputEvent {
+                        surface: SurfaceId::new(1).expect("standalone surface id"),
+                        timestamp_ms: self.started_at.elapsed().as_secs_f64() * 1000.0,
+                        kind: InputEventKind::Click,
+                        pointer: None,
+                        target: Some(target),
+                        detail: WhiskerValue::Null,
+                    });
+                }
+                if action != DesktopAccessibilityAction::Ignored {
+                    self.update_accessibility(false);
+                }
+            }
+            accesskit_winit::WindowEvent::AccessibilityDeactivated => {
+                self.accessibility_bridge.reset();
+            }
         }
     }
 }
@@ -407,6 +487,7 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
     fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: HostEvent) {
         match event {
             HostEvent::RequestFrame => self.request_frame(),
+            HostEvent::Accessibility(event) => self.handle_accessibility_event(event),
         }
     }
 
@@ -418,6 +499,11 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
     ) {
         if self.window.as_ref().map(|window| window.id()) != Some(window_id) {
             return;
+        }
+        if let (Some(adapter), Some(window)) =
+            (&mut self.accessibility_adapter, self.window.as_ref())
+        {
+            adapter.process_event(window, &event);
         }
         match event {
             WindowEvent::CloseRequested => {

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -32,6 +32,7 @@ pub type WhiskerMeasuredSize = whisker_protocol::MeasuredSize;
 /// Resolved inherited text style delivered to Desktop module content.
 pub type WhiskerTextStyle = whisker_protocol::TextStyleSnapshot;
 
+mod accessibility;
 mod app;
 mod capabilities;
 mod element;
@@ -60,6 +61,7 @@ pub use input::{
 pub use whisker::runtime::module::{ModuleEventEmitter, ModulePromise};
 /// Desktop Host module declaration, named consistently with native Hosts.
 pub type ModuleDefinition = DesktopModuleDefinition;
+use accessibility::DesktopAccessibilitySnapshot;
 use gpu::RasterResource;
 use resource::{DesktopResourceService, DesktopResourceUpdate};
 use surface::DesktopSurface;
@@ -181,6 +183,10 @@ impl DesktopRuntime {
                 .surface
                 .hit_test([pointer.position.x, pointer.position.y]);
         }
+    }
+
+    pub(crate) fn accessibility_snapshot(&self) -> DesktopAccessibilitySnapshot {
+        self.surface.accessibility_snapshot()
     }
 
     /// Applies a logical wheel/trackpad delta to the nearest scroll container.

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -374,6 +374,7 @@ impl From<DesktopElementError> for DesktopPresentError {
 #[cfg(test)]
 mod tests;
 
+mod accessibility;
 mod transaction;
 pub(crate) use transaction::DesktopPresentError;
 

--- a/platforms/desktop/src/scene/accessibility.rs
+++ b/platforms/desktop/src/scene/accessibility.rs
@@ -1,0 +1,81 @@
+use super::*;
+use crate::accessibility::{DesktopAccessibilityNode, DesktopAccessibilitySnapshot};
+
+impl DesktopScene {
+    pub(crate) fn accessibility_snapshot(&self) -> DesktopAccessibilitySnapshot {
+        let mut roots = self
+            .nodes
+            .iter()
+            .filter_map(|(id, node)| {
+                node.presentation
+                    .parent
+                    .is_none()
+                    .then_some((*id, node.presentation.z_order))
+            })
+            .collect::<Vec<_>>();
+        roots.sort_by_key(|(id, z_order)| (*z_order, id.get()));
+        let root_ids = roots.iter().map(|(id, _)| *id).collect();
+        let mut nodes = Vec::with_capacity(self.nodes.len());
+        for (root, _) in roots {
+            self.collect_accessibility(root, PresentationContext::default(), false, &mut nodes);
+        }
+        DesktopAccessibilitySnapshot {
+            roots: root_ids,
+            nodes,
+        }
+    }
+
+    fn collect_accessibility(
+        &self,
+        id: NodeId,
+        context: PresentationContext,
+        ancestor_hidden: bool,
+        nodes: &mut Vec<DesktopAccessibilityNode>,
+    ) {
+        let node = self.nodes.get(&id).expect("retained child remains live");
+        let presentation = &node.presentation;
+        let border = LayoutRect {
+            x: context.origin[0] + presentation.layout.border_box.x,
+            y: context.origin[1] + presentation.layout.border_box.y,
+            width: presentation.layout.border_box.width,
+            height: presentation.layout.border_box.height,
+        };
+        let transform = multiply_transform(
+            context.transform,
+            transform_around(presentation.transform, border.x, border.y),
+        );
+        let bounds = transform_rect_aabb(border, transform).unwrap_or(border);
+        let hidden = ancestor_hidden
+            || presentation.visibility != Visibility::Visible
+            || presentation.accessibility.hidden;
+        nodes.push(DesktopAccessibilityNode {
+            id,
+            children: presentation.children.clone(),
+            bounds,
+            semantics: presentation.accessibility.clone(),
+            text: node.content.text().map(|text| text.payload.text.clone()),
+            hidden,
+        });
+
+        let child_origin = if node.content.is_scroll_container() {
+            [
+                border.x - node.scroll_offset[0],
+                border.y - node.scroll_offset[1],
+            ]
+        } else {
+            [border.x, border.y]
+        };
+        for child in &presentation.children {
+            self.collect_accessibility(
+                *child,
+                PresentationContext {
+                    origin: child_origin,
+                    transform,
+                    ..PresentationContext::default()
+                },
+                hidden,
+                nodes,
+            );
+        }
+    }
+}

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -251,11 +251,28 @@ fn accessibility_semantics_are_retained_with_the_common_presentation() {
                     node,
                     accessibility: accessibility.clone(),
                 },
+                Operation::SetLayout {
+                    node,
+                    geometry: geometry(12.0, 18.0, 90.0, 44.0),
+                },
             ],
         ))
         .unwrap();
 
     assert_eq!(scene.nodes[&node].presentation.accessibility, accessibility);
+    let snapshot = scene.accessibility_snapshot();
+    assert_eq!(snapshot.roots, vec![node]);
+    assert_eq!(snapshot.nodes.len(), 1);
+    assert_eq!(snapshot.nodes[0].id, node);
+    assert_eq!(
+        snapshot.nodes[0].bounds,
+        LayoutRect {
+            x: 12.0,
+            y: 18.0,
+            width: 90.0,
+            height: 44.0,
+        }
+    );
 }
 
 #[test]

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -2,6 +2,7 @@ use whisker::runtime::RuntimeWakeHandle;
 use whisker_engine::FrameSink;
 use whisker_protocol::{ApplyResult, FramePacket, RenderCapabilities, ResourceId, SurfaceId};
 
+use crate::accessibility::DesktopAccessibilitySnapshot;
 use crate::element::DesktopElementRegistry;
 use crate::gpu::{GpuError, GpuRenderer, RasterResource};
 use crate::scene::DesktopProviderEvent;
@@ -86,6 +87,10 @@ impl DesktopSurface {
 
     pub(crate) fn has_active_scroll_animations(&self) -> bool {
         self.scene.has_active_scroll_animations()
+    }
+
+    pub(crate) fn accessibility_snapshot(&self) -> DesktopAccessibilitySnapshot {
+        self.scene.accessibility_snapshot()
     }
 }
 


### PR DESCRIPTION
## Summary
- project retained Desktop semantics and transformed scene geometry into one common AccessKit tree
- connect the shared winit lifecycle to macOS, Windows, and Linux accessibility backends
- route accessibility activation through the existing Whisker click input path and retain focus locally
- emit incremental tree updates only while accessibility is active

## Validation
- cargo test -p whisker-desktop --lib
- cargo clippy -p whisker-desktop --all-targets -- -D warnings
- cargo check -p whisker-macos

Linux cross-check was attempted locally but the macOS environment does not have x86_64-linux-gnu-gcc; the native Linux CI build covers that target.