### PR TITLE
refactor(module): unify Host installation kernels

### DIFF
--- a/crates/whisker-build/src/ios/tests.rs
+++ b/crates/whisker-build/src/ios/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn generated_entrypoint_registers_the_built_in_element_module() {
     let source = render_register_all_swift(&[]);
-    assert!(source.contains("builtInModule.registerWithWhisker()"));
+    assert!(source.contains("WhiskerModuleKernel.install(builtInModule)"));
     assert!(source.contains("@_exported import WhiskerRuntime"));
     assert!(!source.contains("BuiltInElementBindings"));
 }

--- a/crates/whisker-cng/src/ios_modules.rs
+++ b/crates/whisker-cng/src/ios_modules.rs
@@ -279,7 +279,7 @@ pub fn render_register_all_swift(modules: &[&ResolvedModule]) -> String {
     out.push_str("        registered = true\n");
     out.push_str("        let builtInModule = BuiltInElementModule()\n");
     out.push_str("        builtInModule.qualifiedName = builtInModule.definitionLazy.name\n");
-    out.push_str("        builtInModule.registerWithWhisker()\n");
+    out.push_str("        WhiskerModuleKernel.install(builtInModule)\n");
     if modules.is_empty() {
         out.push_str("        // (no Whisker module dependencies)\n");
     }

--- a/crates/whisker-cng/src/lib.rs
+++ b/crates/whisker-cng/src/lib.rs
@@ -105,8 +105,7 @@ fn rust_element_module_config(modules: &[RustElementModuleInput]) -> String {
         .iter()
         .map(|module| {
             format!(
-                "\n            .with_element_module({}::__whisker_element_module_definition())\
-                 \n            .with_module_definition({}::__whisker_module_definition())",
+                "\n            .with_module(\n                {}::__whisker_element_module_definition(),\n                {}::__whisker_module_definition(),\n            )",
                 rust_crate_name(&module.package),
                 rust_crate_name(&module.host_package),
             )

--- a/crates/whisker-cng/src/macos.rs
+++ b/crates/whisker-cng/src/macos.rs
@@ -309,12 +309,8 @@ mod tests {
         let main = std::fs::read_to_string(out.join("src/main.rs")).unwrap();
         assert!(manifest.contains("whisker-toggle-desktop-host ="));
         assert!(!main.contains("#[path ="));
-        assert!(main.contains(
-            ".with_element_module(whisker_toggle::__whisker_element_module_definition())"
-        ));
-        assert!(main.contains(
-            ".with_module_definition(whisker_toggle_desktop_host::__whisker_module_definition())"
-        ));
+        assert!(main.contains(".with_module("));
+        assert!(main.contains("whisker_toggle_desktop_host::__whisker_module_definition()"));
         std::fs::remove_dir_all(root).ok();
     }
 }

--- a/crates/whisker-cng/src/web.rs
+++ b/crates/whisker-cng/src/web.rs
@@ -227,12 +227,8 @@ mod tests {
         let source = std::fs::read_to_string(out.join("src/lib.rs")).unwrap();
         assert!(manifest.contains("whisker-toggle-web-host ="));
         assert!(!source.contains("#[path ="));
-        assert!(source.contains(
-            ".with_element_module(whisker_toggle::__whisker_element_module_definition())"
-        ));
-        assert!(source.contains(
-            ".with_module_definition(whisker_toggle_web_host::__whisker_module_definition())"
-        ));
+        assert!(source.contains(".with_module("));
+        assert!(source.contains("whisker_toggle_web_host::__whisker_module_definition()"));
         std::fs::remove_dir_all(root).ok();
     }
 }

--- a/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerModuleBehaviorsTask.kt
+++ b/platforms/android/gradle-plugin/whisker-gradle-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerModuleBehaviorsTask.kt
@@ -42,7 +42,7 @@ abstract class WhiskerModuleBehaviorsTask : DefaultTask() {
             appendLine("package rs.whisker.runtime.generated")
             appendLine()
             appendLine("import rs.whisker.runtime.BuiltInElementModule")
-            appendLine("import rs.whisker.runtime.registerWithWhisker")
+            appendLine("import rs.whisker.runtime.WhiskerModuleKernel")
             appendLine("import java.util.concurrent.atomic.AtomicBoolean")
             appendLine()
             appendLine("public object WhiskerModuleBehaviors {")
@@ -51,7 +51,7 @@ abstract class WhiskerModuleBehaviorsTask : DefaultTask() {
             appendLine("    @JvmStatic")
             appendLine("    public fun registerAll() {")
             appendLine("        if (!registered.compareAndSet(false, true)) return")
-            appendLine("        BuiltInElementModule().registerWithWhisker()")
+            appendLine("        WhiskerModuleKernel.install(BuiltInElementModule())")
             val classes = behaviorsClasses.get()
             if (classes.isEmpty()) {
                 appendLine("        // (no Whisker module deps)")

--- a/platforms/android/ksp/ksp/src/main/kotlin/rs/whisker/ksp/WhiskerModuleProcessor.kt
+++ b/platforms/android/ksp/ksp/src/main/kotlin/rs/whisker/ksp/WhiskerModuleProcessor.kt
@@ -24,7 +24,7 @@ import com.google.devtools.ksp.symbol.Modifier
  * `rs.whisker.runtime.Module`.
  *
  * For each annotated module the generated code instantiates it, assigns its
- * fully-qualified name, and calls `.registerWithWhisker()`. The common
+ * fully-qualified name, and calls `WhiskerModuleKernel.install()`. The common
  * registrar handles both native Views and view-less function modules.
  *
  * The generated object's symbol matches what
@@ -151,7 +151,7 @@ public class WhiskerModuleProcessor(
             w.appendLine()
             w.appendLine("package rs.whisker.runtime.generated")
             w.appendLine()
-            w.appendLine("import rs.whisker.runtime.registerWithWhisker")
+            w.appendLine("import rs.whisker.runtime.WhiskerModuleKernel")
             w.appendLine("import java.util.concurrent.atomic.AtomicBoolean")
             w.appendLine()
             w.appendLine("public object $behaviorsObjectName {")
@@ -164,7 +164,7 @@ public class WhiskerModuleProcessor(
                 w.appendLine("        // (no @WhiskerModule declaration found)")
             }
 
-            // `registerWithWhisker()` handles both native-View and view-less
+            // `WhiskerModuleKernel.install()` handles native-View and view-less
             // module definitions, so code generation has one registration
             // path on every Host.
             for (cls in dslModules) {
@@ -193,7 +193,7 @@ public class WhiskerModuleProcessor(
                 w.appendLine("            val qualifiedName = if ('/' in $nameLocal) $nameLocal else \"$tagPrefix\" + $nameLocal")
                 w.appendLine("            $instanceLocal.qualifiedName = qualifiedName")
                 val crateArg = if (crateName != null) "\"$crateName\"" else "null"
-                w.appendLine("            $instanceLocal.registerWithWhisker($crateArg)")
+                w.appendLine("            WhiskerModuleKernel.install($instanceLocal, $crateArg)")
                 w.appendLine("        }")
             }
 

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -385,32 +385,39 @@ public object WhiskerElementRegistry {
         boundByType[elementType]?.registration
 }
 
-/** Register one independently compiled Host module declaration. */
-public fun Module.registerWithWhisker(crateName: String? = null) {
-    val def = definitionLazy
-    def.validateElementDeclaration()
-    val name = requireNotNull(def.name) { "ModuleDefinition requires Name" }
-    val qualifiedName = this.qualifiedName
-        ?: if (crateName.isNullOrEmpty() || '/' in name) name else "$crateName:$name"
-    this.qualifiedName = qualifiedName
-    WhiskerModuleEventCenter.register(this)
+/** Single bootstrap boundary for independently compiled Host modules. */
+public object WhiskerModuleKernel {
+    private val installedNames = ConcurrentHashMap.newKeySet<String>()
 
-    def.views.forEach { WhiskerElementRegistry.register(it, qualifiedName) }
+    /** Validates and installs one complete service + element declaration. */
+    @JvmStatic
+    public fun install(module: Module, crateName: String? = null) {
+        val def = module.definitionLazy
+        def.validateElementDeclaration()
+        val name = requireNotNull(def.name) { "ModuleDefinition requires Name" }
+        val qualifiedName = module.qualifiedName
+            ?: if (crateName.isNullOrEmpty() || '/' in name) name else "$crateName:$name"
+        require(installedNames.add(qualifiedName)) { "module already installed: $qualifiedName" }
+        module.qualifiedName = qualifiedName
+        WhiskerModuleEventCenter.register(module)
 
-    val functions = def.functions.associateBy { it.name }
-    if (functions.isNotEmpty()) {
-        WhiskerModuleRegistry.registerDispatch(qualifiedName) { method, args ->
-            val function = functions[method]
-                ?: return@registerDispatch WhiskerValue.Err("unknown method `$method` on module `$name`")
-            function.handler(args.asList())
+        def.views.forEach { WhiskerElementRegistry.register(it, qualifiedName) }
+
+        val functions = def.functions.associateBy { it.name }
+        if (functions.isNotEmpty()) {
+            WhiskerModuleRegistry.registerDispatch(qualifiedName) { method, args ->
+                val function = functions[method]
+                    ?: return@registerDispatch WhiskerValue.Err("unknown method `$method` on module `$name`")
+                function.handler(args.asList())
+            }
         }
-    }
-    val asyncFunctions = def.asyncFunctions.associateBy { it.name }
-    if (asyncFunctions.isNotEmpty()) {
-        WhiskerModuleRegistry.registerDispatchAsync(qualifiedName) { method, args, promise ->
-            val function = asyncFunctions[method] ?: return@registerDispatchAsync false
-            function.handler(args.asList(), promise)
-            true
+        val asyncFunctions = def.asyncFunctions.associateBy { it.name }
+        if (asyncFunctions.isNotEmpty()) {
+            WhiskerModuleRegistry.registerDispatchAsync(qualifiedName) { method, args, promise ->
+                val function = asyncFunctions[method] ?: return@registerDispatchAsync false
+                function.handler(args.asList(), promise)
+                true
+            }
         }
     }
 }

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -55,7 +55,7 @@ class HostConformanceTest {
         @JvmStatic
         @BeforeClass
         fun registerBuiltIns() {
-            BuiltInElementModule().registerWithWhisker()
+            WhiskerModuleKernel.install(BuiltInElementModule())
         }
     }
 

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -103,12 +103,16 @@ pub struct DesktopAppConfig {
     pub width: f64,
     /// Initial logical height in points.
     pub height: f64,
-    /// Element modules selected for this target.
-    pub module_definitions: Vec<DesktopModuleDefinition>,
-    /// Host-independent element schemas selected from Rust module crates.
-    pub element_modules: Vec<ElementModuleDefinition>,
+    /// Modules selected for this target, paired with their portable schema.
+    modules: Vec<DesktopModuleInstallation>,
     element_factories: Vec<DesktopElementFactory>,
     module_services: Vec<RustModuleDefinition>,
+}
+
+#[derive(Clone, Debug)]
+struct DesktopModuleInstallation {
+    elements: ElementModuleDefinition,
+    host: DesktopModuleDefinition,
 }
 
 impl DesktopAppConfig {
@@ -118,22 +122,23 @@ impl DesktopAppConfig {
             title: title.into(),
             width: 1024.0,
             height: 720.0,
-            module_definitions: Vec::new(),
-            element_modules: Vec::new(),
+            modules: Vec::new(),
             element_factories: Vec::new(),
             module_services: Vec::new(),
         }
     }
 
-    /// Adds one Rust element definition with its matching Desktop factory.
-    pub fn with_module_definition(mut self, definition: DesktopModuleDefinition) -> Self {
-        self.module_definitions.push(definition);
-        self
-    }
-
-    /// Adds one Host-independent Rust element module for bootstrap negotiation.
-    pub fn with_element_module(mut self, definition: ElementModuleDefinition) -> Self {
-        self.element_modules.push(definition);
+    /// Installs one module's portable element schema and Desktop implementation.
+    ///
+    /// Keeping the pair together makes it impossible for generated Hosts to
+    /// accidentally install only one side of a module.
+    pub fn with_module(
+        mut self,
+        elements: ElementModuleDefinition,
+        host: DesktopModuleDefinition,
+    ) -> Self {
+        self.modules
+            .push(DesktopModuleInstallation { elements, host });
         self
     }
 }
@@ -170,10 +175,11 @@ pub fn run_with_application_hash(
         .push(built_ins.service_definition().clone());
     let mut element_factories = built_ins.into_factories();
     let elements = ElementRegistry::standard_builder()
-        .register_modules(config.element_modules.drain(..))
+        .register_modules(config.modules.iter().map(|module| module.elements.clone()))
         .build()
         .map_err(|error| DesktopAppError(format!("build element registry: {error}")))?;
-    for definition in config.module_definitions.drain(..) {
+    for module in config.modules.drain(..) {
+        let definition = module.host;
         config
             .module_services
             .push(definition.service_definition().clone());
@@ -623,8 +629,7 @@ mod tests {
         assert_eq!(config.title, "Whisker");
         assert_eq!(config.width, 1024.0);
         assert_eq!(config.height, 720.0);
-        assert!(config.module_definitions.is_empty());
-        assert!(config.element_modules.is_empty());
+        assert!(config.modules.is_empty());
         assert!(config.element_factories.is_empty());
         assert!(config.module_services.is_empty());
     }

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
@@ -520,15 +520,25 @@ public enum WhiskerElementRegistry {
     }
 }
 
-public extension Module {
-    func registerWithWhisker() {
-        let definition = definitionLazy
+/// Single bootstrap boundary for independently compiled Host modules.
+public enum WhiskerModuleKernel {
+    private static let lock = NSLock()
+    private static var installedNames: Set<String> = []
+
+    /// Validates and installs one complete service + element declaration.
+    public static func install(_ module: Module) {
+        let definition = module.definitionLazy
         definition.validateElementDeclaration()
         guard let name = definition.name else {
             preconditionFailure("ModuleDefinition requires Name")
         }
-        if qualifiedName == nil { qualifiedName = name }
-        WhiskerModuleRegistry.register(self)
-        definition.views.forEach { WhiskerElementRegistry.register($0, fallbackName: qualifiedName!) }
+        if module.qualifiedName == nil { module.qualifiedName = name }
+        let qualifiedName = module.qualifiedName!
+        lock.lock()
+        let inserted = installedNames.insert(qualifiedName).inserted
+        lock.unlock()
+        precondition(inserted, "module already installed: \(qualifiedName)")
+        WhiskerModuleRegistry.register(module)
+        definition.views.forEach { WhiskerElementRegistry.register($0, fallbackName: qualifiedName) }
     }
 }

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -24,7 +24,7 @@ private final class EventLifecycleTestModule: Module {
 final class HostConformanceTests: XCTestCase {
     override class func setUp() {
         super.setUp()
-        BuiltInElementModule().registerWithWhisker()
+        WhiskerModuleKernel.install(BuiltInElementModule())
     }
 
     func testModuleEventsReachOnlyObservingSurfacesAndLifecycleIsAggregated() {

--- a/platforms/ios/macros/Sources/WhiskerModuleCodegen/main.swift
+++ b/platforms/ios/macros/Sources/WhiskerModuleCodegen/main.swift
@@ -72,7 +72,7 @@ func parseArgs(_ argv: [String]) -> Args? {
 
 /// One discovered `@WhiskerModule` declaration.
 /// The codegen emits a registration block that instantiates the class,
-/// assigns its fully-qualified name, and calls `registerWithWhisker()`.
+/// assigns its fully-qualified name, and calls `WhiskerModuleKernel.install()`.
 /// The shared registrar handles both native-View and view-less modules.
 struct DSLModuleHit {
     let className: String
@@ -169,7 +169,7 @@ func render(
                         // observer-hook routing can find it.
                         let qname = name.contains("/") ? name : "\(tagPrefix)" + name
                         module.qualifiedName = qname
-                    module.registerWithWhisker()
+                    WhiskerModuleKernel.install(module)
                 }
 
             """

--- a/platforms/web/src/application.rs
+++ b/platforms/web/src/application.rs
@@ -246,7 +246,7 @@ impl WebApplication {
     fn new(mut config: WebAppConfig) -> Result<Self, WebError> {
         let built_ins = BuiltInElementModule::definition();
         let mut module_definitions = vec![built_ins];
-        module_definitions.append(&mut config.module_definitions);
+        module_definitions.extend(config.modules.iter().map(|module| module.host.clone()));
         let module_services = module_definitions
             .iter()
             .map(|definition| definition.service_definition().clone());
@@ -257,7 +257,7 @@ impl WebApplication {
             .flat_map(WebModuleDefinition::into_factories)
             .collect::<Vec<_>>();
         let elements = ElementRegistry::standard_builder()
-            .register_modules(config.element_modules.drain(..))
+            .register_modules(config.modules.drain(..).map(|module| module.elements))
             .build()
             .map_err(|error| WebError(format!("build element registry: {error}")))?;
         let window = browser_window()?;

--- a/platforms/web/src/module_api.rs
+++ b/platforms/web/src/module_api.rs
@@ -22,10 +22,14 @@ pub struct WebAppConfig {
     pub title: String,
     /// DOM element id used as the surface root.
     pub root_id: String,
-    /// Element modules selected for this target.
-    pub module_definitions: Vec<WebModuleDefinition>,
-    /// Host-independent element schemas selected from Rust module crates.
-    pub element_modules: Vec<ElementModuleDefinition>,
+    /// Modules selected for this target, paired with their portable schema.
+    pub(crate) modules: Vec<WebModuleInstallation>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct WebModuleInstallation {
+    pub(crate) elements: ElementModuleDefinition,
+    pub(crate) host: WebModuleDefinition,
 }
 
 impl WebAppConfig {
@@ -34,20 +38,20 @@ impl WebAppConfig {
         Self {
             title: title.into(),
             root_id: "whisker-root".to_string(),
-            module_definitions: Vec::new(),
-            element_modules: Vec::new(),
+            modules: Vec::new(),
         }
     }
 
-    /// Adds one Rust element definition with its matching DOM factory.
-    pub fn with_module_definition(mut self, definition: WebModuleDefinition) -> Self {
-        self.module_definitions.push(definition);
-        self
-    }
-
-    /// Adds one Host-independent Rust element module for bootstrap negotiation.
-    pub fn with_element_module(mut self, definition: ElementModuleDefinition) -> Self {
-        self.element_modules.push(definition);
+    /// Installs one module's portable element schema and Web implementation.
+    ///
+    /// Keeping the pair together makes it impossible for generated Hosts to
+    /// accidentally install only one side of a module.
+    pub fn with_module(
+        mut self,
+        elements: ElementModuleDefinition,
+        host: WebModuleDefinition,
+    ) -> Self {
+        self.modules.push(WebModuleInstallation { elements, host });
         self
     }
 }


### PR DESCRIPTION
## Summary
- pair portable element schemas with their Web/Desktop Host implementations behind one `with_module` call
- add a single `WhiskerModuleKernel.install` bootstrap boundary to Kotlin and Swift
- route KSP, SwiftPM codegen, Gradle aggregation, SDK built-ins, and conformance setup through that kernel
- reject duplicate native module installation instead of silently replacing registry entries

## Validation
- `cargo test -p whisker-cng generated_host_wires_discovered`
- `cargo test -p whisker-build generated_entrypoint_registers_the_built_in_element_module`
- `cargo check -p whisker-desktop -p whisker-web`
- `cargo clippy -p whisker-cng -p whisker-build -p whisker-desktop -p whisker-web --all-targets -- -D warnings`
- Android `:module:compileDebugKotlin :runtime:compileDebugKotlin`
- iOS `xcodebuild -scheme WhiskerRuntime -destination generic/platform=iOS\ Simulator -skipPackagePluginValidation build`

## Stack
Depends on #542. Merge #542 first, then retarget this PR to `next-architecture`.