### PR TITLE
Unify run and build progress UI

### DIFF
--- a/crates/whisker-build/src/android.rs
+++ b/crates/whisker-build/src/android.rs
@@ -263,7 +263,10 @@ pub fn cargo_build_dylib(b: &CargoBuild<'_>) -> Result<PathBuf> {
     let so_mtime = |p: &std::path::Path| std::fs::metadata(p).and_then(|m| m.modified()).ok();
     let before = so_mtime(&so_path);
 
-    let cargo_step = crate::ui::step("compile", format!("{} ({triple})", b.package));
+    let cargo_step = crate::ui::step(
+        crate::ui::OperationKind::Compile,
+        format!("{} ({triple})", b.package),
+    );
     let status = cargo_step
         .pipe(&mut cmd)
         .with_context(|| format!("spawn cargo for {triple}"))?;
@@ -451,7 +454,7 @@ pub fn run_gradle_assemble(
         Profile::Release => ":app:assembleRelease",
         Profile::Debug => ":app:assembleDebug",
     };
-    let gradle_step = crate::ui::step("gradle", task.to_string());
+    let gradle_step = crate::ui::step(crate::ui::OperationKind::Gradle, task.to_string());
     let mut cmd = gradle_command(gen_android, task)?;
     if !features.is_empty() {
         cmd.env("WHISKER_FEATURES", features.join(" "));
@@ -533,9 +536,6 @@ fn gradle_command(gen_android: &Path, task: &str) -> Result<Command> {
             "WHISKER_CLI",
             std::env::current_exe().context("resolve current Whisker CLI executable")?,
         );
-    if crate::ui::is_tui() {
-        cmd.env("WHISKER_TUI", "1");
-    }
     if crate::ui::is_verbose() {
         cmd.env("WHISKER_VERBOSE", "1");
     }
@@ -577,7 +577,7 @@ pub fn run_gradle_release(
             &["app-release.apk", "app-release-unsigned.apk"],
         ),
     };
-    let gradle_step = crate::ui::step("gradle", task.to_string());
+    let gradle_step = crate::ui::step(crate::ui::OperationKind::Gradle, task.to_string());
     let mut cmd = gradle_command(gen_android, task)?;
     for (k, v) in signing_env {
         cmd.env(k, v);

--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -254,7 +254,10 @@ pub fn build_framework_for_xcode_run_script(
     let mut slice_paths: Vec<PathBuf> = Vec::with_capacity(inputs.archs.len());
     for arch in inputs.archs {
         let triple = map_arch_to_triple(inputs.platform, arch)?;
-        let s = crate::ui::step("compile", format!("{} ({triple})", inputs.package));
+        let s = crate::ui::step(
+            crate::ui::OperationKind::Compile,
+            format!("{} ({triple})", inputs.package),
+        );
         cargo_build_ios_dylib(
             inputs.workspace_root,
             inputs.package,
@@ -430,7 +433,10 @@ pub fn run_xcodebuild_app(args: &XcodebuildArgs<'_>) -> Result<PathBuf> {
         ));
     }
 
-    let _xc_step = crate::ui::step("xcodebuild", args.xcodeproj_name.to_string());
+    let xc_step = crate::ui::step(
+        crate::ui::OperationKind::Xcodebuild,
+        args.xcodeproj_name.to_string(),
+    );
     let destination = match args.sdk {
         "iphonesimulator" => "generic/platform=iOS Simulator".to_string(),
         "iphoneos" => "generic/platform=iOS".to_string(),
@@ -457,10 +463,12 @@ pub fn run_xcodebuild_app(args: &XcodebuildArgs<'_>) -> Result<PathBuf> {
     if let Some(p) = args.whisker_ios_macros_path {
         cmd.env("WHISKER_IOS_MACROS", p);
     }
-    let status = cmd.status().context("spawn xcodebuild")?;
+    let status = xc_step.pipe(&mut cmd).context("spawn xcodebuild")?;
     if !status.success() {
+        xc_step.fail(status.to_string());
         return Err(anyhow!("xcodebuild failed ({status})"));
     }
+    xc_step.done("");
 
     let product_subdir = match args.sdk {
         "iphonesimulator" => format!("{}-iphonesimulator", args.configuration),
@@ -568,7 +576,10 @@ pub fn archive_and_export(inputs: &IosReleaseInputs<'_>) -> Result<PathBuf> {
     let archive_path = out_root.join(format!("{scheme}.xcarchive"));
 
     // ---- archive ---------------------------------------------------
-    let archive_step = crate::ui::step("xcodebuild", format!("archive {scheme}"));
+    let archive_step = crate::ui::step(
+        crate::ui::OperationKind::Xcodebuild,
+        format!("archive {scheme}"),
+    );
     let mut cmd = Command::new("xcodebuild");
     cmd.arg("-project")
         .arg(&xcode_project)
@@ -611,7 +622,10 @@ pub fn archive_and_export(inputs: &IosReleaseInputs<'_>) -> Result<PathBuf> {
     .with_context(|| format!("write {}", options_path.display()))?;
     let export_dir = out_root.join("export");
 
-    let export_step = crate::ui::step("xcodebuild", format!("export {}", method.plist_value()));
+    let export_step = crate::ui::step(
+        crate::ui::OperationKind::Xcodebuild,
+        format!("export {}", method.plist_value()),
+    );
     let mut cmd = Command::new("xcodebuild");
     cmd.arg("-exportArchive")
         .arg("-archivePath")

--- a/crates/whisker-build/src/macos.rs
+++ b/crates/whisker-build/src/macos.rs
@@ -37,7 +37,7 @@ pub fn build_app(inputs: &MacosBuild<'_>) -> Result<PathBuf> {
         );
     }
     let step = ui::step(
-        "cargo",
+        ui::OperationKind::Compile,
         format!("{} ({:?})", inputs.binary_name, inputs.profile),
     );
     let mut command = std::process::Command::new("cargo");

--- a/crates/whisker-build/src/ui.rs
+++ b/crates/whisker-build/src/ui.rs
@@ -30,17 +30,177 @@
 //! pipeline so the env-var is the single source of truth across
 //! crate boundaries.
 //!
-//! ## Why free fns, not an `OutputSink` trait
+//! ## Presentation seam
 //!
-//! There is exactly one production sink (stderr), so threading a
-//! trait through every call site buys nothing a global mode knob
-//! doesn't already give.
+//! Call sites use the free functions in this module. A top-level
+//! workflow may install a scoped [`ProgressReporter`] to receive typed
+//! events; without one, the same calls render deterministic terminal
+//! output directly.
 
 use std::io::IsTerminal;
-use std::sync::{Mutex, OnceLock};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+// ---- Structured progress interface ---------------------------------
+
+/// Stable vocabulary shared by `whisker build`, `whisker run`, plain
+/// terminal output, and future editor integrations. Presentation code must
+/// not infer workflow state by parsing rendered strings.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OperationKind {
+    Setup,
+    Compile,
+    Gradle,
+    Xcodebuild,
+    Boot,
+    Install,
+    Launch,
+    HotReload,
+    Package,
+    Open,
+}
+
+impl OperationKind {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Setup => "setup",
+            Self::Compile => "compile",
+            Self::Gradle => "gradle",
+            Self::Xcodebuild => "xcodebuild",
+            Self::Boot => "boot",
+            Self::Install => "install",
+            Self::Launch => "launch",
+            Self::HotReload => "hot reload",
+            Self::Package => "package",
+            Self::Open => "open",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OperationOutcome {
+    Done,
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MessageLevel {
+    Info,
+    Warning,
+    Error,
+    Debug,
+    Log,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProgressEvent {
+    Section(String),
+    OperationStarted {
+        kind: OperationKind,
+        detail: String,
+    },
+    OperationProgress {
+        kind: OperationKind,
+        message: String,
+    },
+    OperationFinished {
+        kind: OperationKind,
+        detail: String,
+        outcome: OperationOutcome,
+        summary: String,
+        elapsed: Duration,
+    },
+    Message {
+        level: MessageLevel,
+        text: String,
+    },
+    Status(String),
+}
+
+/// Adapter interface at the presentation seam. Only a top-level user-facing
+/// workflow installs a reporter; nested Gradle/Xcode helper commands keep
+/// their deterministic plain stderr/stdout contracts.
+pub trait ProgressReporter: Send + Sync {
+    fn report(&self, event: ProgressEvent);
+}
+
+impl<F> ProgressReporter for F
+where
+    F: Fn(ProgressEvent) + Send + Sync,
+{
+    fn report(&self, event: ProgressEvent) {
+        self(event);
+    }
+}
+
+struct ReporterSlot {
+    id: u64,
+    reporter: Arc<dyn ProgressReporter>,
+}
+
+static REPORTER: Mutex<Option<ReporterSlot>> = Mutex::new(None);
+static NEXT_REPORTER_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Keeps the installed reporter scoped to one top-level workflow.
+pub struct ReporterGuard {
+    id: u64,
+}
+
+impl Drop for ReporterGuard {
+    fn drop(&mut self) {
+        if let Ok(mut slot) = REPORTER.lock() {
+            if slot.as_ref().map(|current| current.id) == Some(self.id) {
+                *slot = None;
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ReporterAlreadyInstalled;
+
+impl std::fmt::Display for ReporterAlreadyInstalled {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a Whisker progress reporter is already installed")
+    }
+}
+
+impl std::error::Error for ReporterAlreadyInstalled {}
+
+pub fn install_reporter(
+    reporter: impl ProgressReporter + 'static,
+) -> Result<ReporterGuard, ReporterAlreadyInstalled> {
+    let id = NEXT_REPORTER_ID.fetch_add(1, Ordering::Relaxed);
+    let mut slot = REPORTER.lock().map_err(|_| ReporterAlreadyInstalled)?;
+    if slot.is_some() {
+        return Err(ReporterAlreadyInstalled);
+    }
+    *slot = Some(ReporterSlot {
+        id,
+        reporter: Arc::new(reporter),
+    });
+    Ok(ReporterGuard { id })
+}
+
+fn report(event: ProgressEvent) -> bool {
+    let reporter = REPORTER
+        .lock()
+        .ok()
+        .and_then(|slot| slot.as_ref().map(|slot| Arc::clone(&slot.reporter)));
+    if let Some(reporter) = reporter {
+        reporter.report(event);
+        true
+    } else {
+        false
+    }
+}
+
+fn reporter_active() -> bool {
+    REPORTER.lock().map(|slot| slot.is_some()).unwrap_or(false)
+}
 
 // ---- Shared MultiProgress + status bar -------------------------------
 //
@@ -61,25 +221,13 @@ enum Mode {
     Curated,
     /// `WHISKER_VERBOSE=1` — plain `[whisker] …` lines, no spinners.
     Verbose,
-    /// `WHISKER_TUI=1` — whisker-cli is rendering a ratatui inline
-    /// viewport at the bottom of the terminal. Same curated
-    /// formatting as [`Mode::Curated`] (section headers, `✓`/`⏵` step
-    /// glyphs, color), but routed through plain `eprintln!` so the
-    /// lines scroll above the viewport as normal terminal content.
-    /// indicatif spinners are suppressed — they'd race with ratatui's
-    /// redraw and corrupt both surfaces.
-    Tui,
 }
 
 fn mode() -> Mode {
     static MODE: OnceLock<Mode> = OnceLock::new();
     *MODE.get_or_init(|| {
-        // Verbose outranks TUI so `WHISKER_VERBOSE=1` stays a
-        // universal "show me everything plain" override.
         if is_verbose() {
             Mode::Verbose
-        } else if is_tui() {
-            Mode::Tui
         } else {
             Mode::Curated
         }
@@ -92,18 +240,6 @@ fn mode() -> Mode {
 /// can opt out under verbose mode and let everything through.
 pub fn is_verbose() -> bool {
     std::env::var("WHISKER_VERBOSE")
-        .map(|v| !v.is_empty() && v != "0")
-        .unwrap_or(false)
-}
-
-/// `true` when `WHISKER_TUI=1` is set — `whisker-cli` sets this when
-/// it's rendering an inline TUI status bar. The flag exists so the
-/// `ui::*` surface can suppress indicatif animations (which would
-/// race with ratatui's own redraw) while still producing the curated
-/// `✓` / `⏵` formatting via plain `eprintln!`. Public so other
-/// crates can check the same state if needed.
-pub fn is_tui() -> bool {
-    std::env::var("WHISKER_TUI")
         .map(|v| !v.is_empty() && v != "0")
         .unwrap_or(false)
 }
@@ -133,8 +269,7 @@ static LAST_STATUS: Mutex<Option<String>> = Mutex::new(None);
 /// beyond that: `whisker-dev-server` calls it as the sentinel meaning
 /// "`set_status` is allowed from here on".
 pub fn ensure_status(_label: impl Into<String>) {
-    if matches!(mode(), Mode::Tui) {
-        // The cli's live region already shows this.
+    if reporter_active() {
         return;
     }
     if let Ok(mut guard) = LAST_STATUS.lock() {
@@ -147,14 +282,13 @@ pub fn ensure_status(_label: impl Into<String>) {
 /// print the same content. The line goes through `info()` so it
 /// shares the `· <msg>` visual style with other one-shot lines.
 ///
-/// In TUI mode this is a no-op: `whisker-cli`'s live region already
-/// renders the ws addr and client count from the dev-server's
-/// `Event::ClientConnected / Disconnected` stream.
+/// With a structured reporter this becomes a [`ProgressEvent::Status`].
 pub fn set_status(msg: impl Into<String>) {
-    if matches!(mode(), Mode::Tui) {
+    let msg = msg.into();
+    if report(ProgressEvent::Status(msg.clone())) {
         return;
     }
-    let m = msg.into();
+    let m = msg;
     let m_for_dedupe = m.clone();
     if let Ok(mut guard) = LAST_STATUS.lock() {
         if guard.as_ref() == Some(&m_for_dedupe) {
@@ -167,13 +301,13 @@ pub fn set_status(msg: impl Into<String>) {
 
 /// Emit a final dev-server status line on shutdown. Like `set_status`
 /// minus the dedupe, so the goodbye shows even when it repeats the
-/// previous status. No-ops in TUI mode — the live region disappearing
-/// is the goodbye.
+/// previous status.
 pub fn finish_status(final_msg: impl Into<String>) {
-    if matches!(mode(), Mode::Tui) {
+    let final_msg = final_msg.into();
+    if report(ProgressEvent::Status(final_msg.clone())) {
         return;
     }
-    info(format!("dev-server · {}", final_msg.into()));
+    info(format!("dev-server · {final_msg}"));
 }
 
 // ---- Section headers --------------------------------------------------
@@ -182,13 +316,14 @@ pub fn finish_status(final_msg: impl Into<String>) {
 /// `"Build"`, `"Patch"`, `"Watch"`, `"Install"`. Keep names short
 /// (one word) so the visual rhythm is regular.
 pub fn section(name: &str) {
+    if report(ProgressEvent::Section(name.to_string())) {
+        return;
+    }
     match mode() {
         Mode::Verbose => {
             eprintln!("[whisker] ─── {name} ───");
         }
-        Mode::Curated | Mode::Tui => {
-            // SGR color only, no cursor motion — safe to emit in TUI
-            // mode where the ratatui viewport owns the bottom region.
+        Mode::Curated => {
             let bar_chars = "─".repeat(40usize.saturating_sub(name.len()));
             let line = if is_tty() {
                 format!("\n\x1b[1;36m──── {name} {bar_chars}\x1b[0m")
@@ -200,10 +335,8 @@ pub fn section(name: &str) {
     }
 }
 
-/// `true` when indicatif's in-place redraw machinery is allowed to
-/// run. Off in TUI mode: ratatui owns the cursor and would race with
-/// indicatif's bar redraws if we let MultiProgress animate spinners
-/// or `suspend()` around eprintlns.
+/// `true` when indicatif's in-place redraw machinery is allowed to run.
+/// Structured reporters return before reaching this plain renderer.
 fn indicatif_active() -> bool {
     matches!(mode(), Mode::Curated) && is_tty()
 }
@@ -217,8 +350,7 @@ fn emit_above_bars(line: &str) {
     // runs the closure, and redraws, whereas println leaves the bar's
     // then-current spinner frame stuck in scrollback above each line.
     if !indicatif_active() {
-        // Nothing is animating, and in TUI mode `suspend` would flush
-        // stale indicatif state into the ratatui-owned region.
+        // Nothing is animating.
         eprintln!("{line}");
         return;
     }
@@ -244,8 +376,9 @@ pub struct Step {
     started_at: Instant,
     /// Carried separately from the bar's prefix because verbose-mode
     /// transitions need it for the final line emission too.
-    name: String,
+    kind: OperationKind,
     detail: String,
+    reported: bool,
 }
 
 impl Step {
@@ -280,16 +413,20 @@ impl Step {
         cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
         let mut child = cmd.spawn()?;
-        // Track the PID so `whisker run`'s hard-exit quit path can
-        // SIGTERM this build (cargo / gradle / xcodebuild) instead of
-        // orphaning it. The guard unregisters when `pipe` returns.
+        // Track the PID so build cancellation can SIGTERM cargo /
+        // gradle / xcodebuild instead of orphaning it. The guard
+        // unregisters when `pipe` returns.
         let _child_guard = crate::child_guard::track(child.id());
         let stdout = child.stdout.take();
         let stderr = child.stderr.take();
         let bar_stdout = self.bar.clone();
         let bar_stderr = self.bar.clone();
-        let t_out = std::thread::spawn(move || stream_through_bar(stdout, bar_stdout));
-        let t_err = std::thread::spawn(move || stream_through_bar(stderr, bar_stderr));
+        let reported = self.reported;
+        let kind = self.kind;
+        let t_out =
+            std::thread::spawn(move || stream_through_bar(stdout, bar_stdout, reported, kind));
+        let t_err =
+            std::thread::spawn(move || stream_through_bar(stderr, bar_stderr, reported, kind));
         let status = child.wait()?;
         let _ = t_out.join();
         let _ = t_err.join();
@@ -297,14 +434,28 @@ impl Step {
     }
 
     fn finish(self, kind: StepKind, summary: &str) {
-        let elapsed = format_elapsed(self.started_at.elapsed());
+        let duration = self.started_at.elapsed();
+        if self.reported {
+            report(ProgressEvent::OperationFinished {
+                kind: self.kind,
+                detail: self.detail,
+                outcome: match kind {
+                    StepKind::Done => OperationOutcome::Done,
+                    StepKind::Fail => OperationOutcome::Failed,
+                },
+                summary: summary.to_string(),
+                elapsed: duration,
+            });
+            return;
+        }
+        let elapsed = format_elapsed(duration);
         let summary = if summary.is_empty() {
             elapsed
         } else {
             format!("{summary}  {elapsed}")
         };
         let glyph = kind.glyph();
-        let line = render_step_line(glyph, &self.name, &self.detail, &summary, kind);
+        let line = render_step_line(glyph, self.kind.label(), &self.detail, &summary, kind);
         if let Some(bar) = self.bar {
             // Plain `{msg}` template so the final line is exactly the
             // text built above; the live template would re-render its
@@ -314,26 +465,10 @@ impl Step {
             );
             bar.finish_with_message(line);
         } else {
-            // The END marker pairs with the START one `step()` emits;
-            // it tells the cli to clear the live region's current step.
-            if matches!(mode(), Mode::Tui) {
-                eprintln!("{TUI_STEP_END_MARKER}");
-            }
             eprintln!("{line}");
         }
     }
 }
-
-/// Marker prefix the cli's capture thread looks for to learn that a
-/// step has *started*. Followed by `\x1e<name>\x1e<detail>` and a
-/// newline — i.e. one line per START. The `\x1e` (ASCII RS, "record
-/// separator") is deliberately non-printable so it can't collide
-/// with legitimate user output. See
-/// `whisker_cli::tui::capture_reader_loop`.
-pub const TUI_STEP_START_MARKER: &str = "\x1eWHISKER-TUI-STEP-START";
-/// Marker the cli's capture thread looks for to learn that the
-/// active step has *finished*. One token per line, no payload.
-pub const TUI_STEP_END_MARKER: &str = "\x1eWHISKER-TUI-STEP-END";
 
 /// Read `stream` line-by-line, classifying each line into one of
 /// three buckets:
@@ -352,14 +487,23 @@ pub const TUI_STEP_END_MARKER: &str = "\x1eWHISKER-TUI-STEP-END";
 fn stream_through_bar<R: std::io::Read + Send + 'static>(
     stream: Option<R>,
     bar: Option<ProgressBar>,
+    reported: bool,
+    kind: OperationKind,
 ) {
     use std::io::{BufRead, BufReader};
     let Some(s) = stream else { return };
     let reader = BufReader::new(s);
     for line in reader.lines().map_while(Result::ok) {
         if let Some(progress) = subprocess_progress_text(&line) {
+            if reported {
+                report(ProgressEvent::OperationProgress {
+                    kind,
+                    message: progress,
+                });
+                continue;
+            }
             if let Some(bar) = &bar {
-                bar.set_message(progress.to_string());
+                bar.set_message(progress);
                 // No steady tick (see `step`), so repaint by hand.
                 bar.tick();
             }
@@ -370,7 +514,14 @@ fn stream_through_bar<R: std::io::Read + Send + 'static>(
         } else if !line.is_empty() {
             // Verbose keeps everything, so a real diagnostic that gets
             // misclassified as noise is still reachable.
-            if matches!(mode(), Mode::Curated | Mode::Tui) && is_subprocess_noise(&line) {
+            if matches!(mode(), Mode::Curated) && is_subprocess_noise(&line) {
+                continue;
+            }
+            if reported {
+                report(ProgressEvent::Message {
+                    level: MessageLevel::Log,
+                    text: line,
+                });
                 continue;
             }
             // `multi.suspend`, not `bar.println` — see `emit_above_bars`.
@@ -538,10 +689,22 @@ impl StepKind {
 ///
 /// The split is purely typographical — keeping `name` to a small
 /// closed set lets readers visually align columns down the run log.
-pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
-    let name = name.into();
+pub fn step(kind: OperationKind, detail: impl Into<String>) -> Step {
     let detail = detail.into();
     let started_at = Instant::now();
+    if report(ProgressEvent::OperationStarted {
+        kind,
+        detail: detail.clone(),
+    }) {
+        return Step {
+            bar: None,
+            started_at,
+            kind,
+            detail,
+            reported: true,
+        };
+    }
+    let name = kind.label();
 
     match mode() {
         Mode::Verbose => {
@@ -549,22 +712,9 @@ pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
             Step {
                 bar: None,
                 started_at,
-                name,
+                kind,
                 detail,
-            }
-        }
-        Mode::Tui => {
-            // A committed scrollback line can't be overwritten, so a
-            // "⏵ started" line here would just stack above `finish()`'s
-            // "✓ done". The marker instead drives the cli's live-region
-            // spinner and never enters scrollback; see
-            // `whisker_cli::tui::capture_reader_loop`.
-            eprintln!("{TUI_STEP_START_MARKER}\x1e{name}\x1e{detail}");
-            Step {
-                bar: None,
-                started_at,
-                name,
-                detail,
+                reported: false,
             }
         }
         Mode::Curated if is_tty() => {
@@ -578,7 +728,7 @@ pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
                 ProgressStyle::with_template("  {spinner:.cyan} {prefix:<12} {msg:<24} …")
                     .expect("template literal is valid"),
             );
-            bar.set_prefix(name.clone());
+            bar.set_prefix(name);
             bar.set_message(detail.clone());
             let bar = multi().add(bar);
             // Show the bar now instead of at the first `set_message`.
@@ -586,8 +736,9 @@ pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
             Step {
                 bar: Some(bar),
                 started_at,
-                name,
+                kind,
                 detail,
+                reported: false,
             }
         }
         Mode::Curated => {
@@ -595,8 +746,9 @@ pub fn step(name: impl Into<String>, detail: impl Into<String>) -> Step {
             Step {
                 bar: None,
                 started_at,
-                name,
+                kind,
                 detail,
+                reported: false,
             }
         }
     }
@@ -639,9 +791,15 @@ fn format_elapsed(d: Duration) -> String {
 /// "watching examples/", "client connected", "patch sent").
 pub fn info(msg: impl AsRef<str>) {
     let m = msg.as_ref();
+    if report(ProgressEvent::Message {
+        level: MessageLevel::Info,
+        text: m.to_string(),
+    }) {
+        return;
+    }
     match mode() {
         Mode::Verbose => eprintln!("[whisker] {m}"),
-        Mode::Curated | Mode::Tui => {
+        Mode::Curated => {
             if is_tty() {
                 emit_above_bars(&format!("  \x1b[90m·\x1b[0m {m}"));
             } else {
@@ -657,9 +815,15 @@ pub fn info(msg: impl AsRef<str>) {
 /// rough edges that don't stop the pipeline.
 pub fn warn(msg: impl AsRef<str>) {
     let m = msg.as_ref();
+    if report(ProgressEvent::Message {
+        level: MessageLevel::Warning,
+        text: m.to_string(),
+    }) {
+        return;
+    }
     match mode() {
         Mode::Verbose => eprintln!("[whisker] warn: {m}"),
-        Mode::Curated | Mode::Tui => {
+        Mode::Curated => {
             if is_tty() {
                 emit_above_bars(&format!("  \x1b[33m⚠\x1b[0m {m}"));
             } else {
@@ -675,12 +839,21 @@ pub fn warn(msg: impl AsRef<str>) {
 /// (ASLR references, intermediate file paths, patcher symbol diffs)
 /// but distracting noise during normal `whisker run`.
 pub fn debug(msg: impl AsRef<str>) {
+    if reporter_active() {
+        if is_verbose() {
+            report(ProgressEvent::Message {
+                level: MessageLevel::Debug,
+                text: msg.as_ref().to_string(),
+            });
+        }
+        return;
+    }
     match mode() {
         Mode::Verbose => {
             let m = msg.as_ref();
             eprintln!("[whisker] debug: {m}");
         }
-        Mode::Curated | Mode::Tui => {}
+        Mode::Curated => {}
     }
 }
 
@@ -690,9 +863,15 @@ pub fn debug(msg: impl AsRef<str>) {
 /// + Err(anyhow!(...))?`).
 pub fn error(msg: impl AsRef<str>) {
     let m = msg.as_ref();
+    if report(ProgressEvent::Message {
+        level: MessageLevel::Error,
+        text: m.to_string(),
+    }) {
+        return;
+    }
     match mode() {
         Mode::Verbose => eprintln!("[whisker] error: {m}"),
-        Mode::Curated | Mode::Tui => {
+        Mode::Curated => {
             if is_tty() {
                 emit_above_bars(&format!("  \x1b[31m✗\x1b[0m {m}"));
             } else {
@@ -705,6 +884,43 @@ pub fn error(msg: impl AsRef<str>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scoped_reporter_receives_typed_progress_events() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        let guard = install_reporter(move |event| captured.lock().unwrap().push(event)).unwrap();
+
+        section("Build");
+        let operation = step(OperationKind::Compile, "host-smoke");
+        operation.done("ready");
+        info("artifact ready");
+
+        let events = events.lock().unwrap();
+        assert_eq!(
+            events.first(),
+            Some(&ProgressEvent::Section("Build".into()))
+        );
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ProgressEvent::OperationStarted {
+                kind: OperationKind::Compile,
+                detail,
+            } if detail == "host-smoke"
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ProgressEvent::OperationFinished {
+                kind: OperationKind::Compile,
+                outcome: OperationOutcome::Done,
+                summary,
+                ..
+            } if summary == "ready"
+        )));
+        drop(events);
+        drop(guard);
+        assert!(!reporter_active());
+    }
 
     #[test]
     fn format_elapsed_chooses_unit_by_magnitude() {

--- a/crates/whisker-build/src/web.rs
+++ b/crates/whisker-build/src/web.rs
@@ -101,10 +101,18 @@ pub fn compile(config: &WebBuild) -> Result<PathBuf> {
         })?;
         command.envs(crate::capture_env_vars_all_crates(capture));
     }
-    let status = command.status().context("spawn Cargo Web build")?;
+    let compile_step = crate::ui::step(
+        crate::ui::OperationKind::Compile,
+        format!("{} ({TARGET})", config.package),
+    );
+    let status = compile_step
+        .pipe(&mut command)
+        .context("spawn Cargo Web build")?;
     if !status.success() {
+        compile_step.fail(status.to_string());
         anyhow::bail!("Cargo Web build exited with {status}");
     }
+    compile_step.done("");
 
     let crate_stem = config.package.replace('-', "_");
     let raw_wasm = config
@@ -124,6 +132,20 @@ pub fn compile(config: &WebBuild) -> Result<PathBuf> {
 
 /// Run wasm-bindgen and stage the static document around `raw_wasm`.
 pub fn bindgen(config: &WebBuild, raw_wasm: &Path) -> Result<WebArtifacts> {
+    let package_step = crate::ui::step(crate::ui::OperationKind::Package, "wasm-bindgen");
+    match bindgen_inner(config, raw_wasm) {
+        Ok(artifacts) => {
+            package_step.done("");
+            Ok(artifacts)
+        }
+        Err(error) => {
+            package_step.fail("wasm-bindgen failed");
+            Err(error)
+        }
+    }
+}
+
+fn bindgen_inner(config: &WebBuild, raw_wasm: &Path) -> Result<WebArtifacts> {
     if config.dist_dir.exists() {
         std::fs::remove_dir_all(&config.dist_dir)
             .with_context(|| format!("clean {}", config.dist_dir.display()))?;

--- a/crates/whisker-cli/src/build/android.rs
+++ b/crates/whisker-cli/src/build/android.rs
@@ -20,7 +20,7 @@ pub struct Args {
     manifest_path: Option<PathBuf>,
 }
 
-pub fn run(artifact: ReleaseArtifact, args: Args) -> Result<()> {
+pub fn run(artifact: ReleaseArtifact, args: Args, no_tui: bool) -> Result<()> {
     let m = manifest::resolve(args.manifest_path.as_deref())?;
     let application_id = manifest::android_application_id(&m.config).ok_or_else(|| {
         anyhow!(
@@ -45,16 +45,17 @@ pub fn run(artifact: ReleaseArtifact, args: Args) -> Result<()> {
         ReleaseArtifact::AppBundle => "appbundle (.aab)",
         ReleaseArtifact::Apk => "apk",
     };
-    ui::section("Build");
-    ui::info(format!(
-        "building {application_id} {version} ({build_number}) — release {label}",
-    ));
-
     // Credential pre-step BEFORE any compilation: the decryption-key
     // prompt (if any) happens now, and key problems fail before, not
     // after, the long gradle+cargo build. `_staging` must stay alive
     // until gradle exits — the signing paths point into it.
     let (_staging, signing) = credential::require_android_signing(&m.crate_dir, &application_id)?;
+
+    let build_ui = super::BuildUi::start(no_tui, "Android", &application_id);
+    ui::section("Build");
+    ui::info(format!(
+        "building {application_id} {version} ({build_number}) — release {label}",
+    ));
 
     let sync = platforms::sync_for_target(
         Target::Android,
@@ -93,7 +94,7 @@ pub fn run(artifact: ReleaseArtifact, args: Args) -> Result<()> {
 
     let artifact_path =
         whisker_build::android::run_gradle_release(&sync.gen_dir, artifact, &signing_env)?;
-    ui::info(format!("✓ {}", artifact_path.display()));
+    build_ui.complete(&artifact_path);
     match artifact {
         ReleaseArtifact::AppBundle => {
             ui::info("upload to Play Console (first release: create the app there manually)");

--- a/crates/whisker-cli/src/build/ios.rs
+++ b/crates/whisker-cli/src/build/ios.rs
@@ -46,7 +46,7 @@ pub struct Args {
     manifest_path: Option<PathBuf>,
 }
 
-pub fn run(args: Args) -> Result<()> {
+pub fn run(args: Args, no_tui: bool) -> Result<()> {
     let m = manifest::resolve(args.manifest_path.as_deref())?;
     // Same resolution `whisker run ios` uses (run.rs::ios_params_from).
     let bundle_id = m
@@ -84,16 +84,17 @@ pub fn run(args: Args) -> Result<()> {
     let version = m.config.version.clone().unwrap_or_else(|| "0.1.0".into());
     let build_number = m.config.build_number.unwrap_or(1);
     let method: ExportMethod = args.method.into();
+    // Credential pre-step before any compilation (prompt up front,
+    // fail fast on key problems). `_staging` holds the decrypted .p8
+    // until xcodebuild finishes.
+    let (_staging, signing) = credential::require_ios_signing(&m.crate_dir, &bundle_id)?;
+
+    let build_ui = super::BuildUi::start(no_tui, "iOS", &bundle_id);
     ui::section("Build");
     ui::info(format!(
         "building {bundle_id} {version} ({build_number}) — release ipa [{}]",
         method.plist_value(),
     ));
-
-    // Credential pre-step before any compilation (prompt up front,
-    // fail fast on key problems). `_staging` holds the decrypted .p8
-    // until xcodebuild finishes.
-    let (_staging, signing) = credential::require_ios_signing(&m.crate_dir, &bundle_id)?;
 
     // `Target::IosSimulator` here only selects which gen tree to
     // render — gen/ios/ is one project for simulator and device;
@@ -123,7 +124,7 @@ pub fn run(args: Args) -> Result<()> {
             issuer_id: &signing.issuer_id,
         },
     })?;
-    ui::info(format!("✓ {}", ipa.display()));
+    build_ui.complete(&ipa);
     match method {
         ExportMethod::AppStoreConnect => {
             ui::info("upload via Transporter.app, or keep it for `whisker submit` (planned)");

--- a/crates/whisker-cli/src/build/macos.rs
+++ b/crates/whisker-cli/src/build/macos.rs
@@ -23,12 +23,12 @@ pub struct Args {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn run(_args: Args) -> Result<()> {
+pub fn run(_args: Args, _no_tui: bool) -> Result<()> {
     anyhow::bail!("`whisker build macos` must run on macOS")
 }
 
 #[cfg(target_os = "macos")]
-pub fn run(args: Args) -> Result<()> {
+pub fn run(args: Args, no_tui: bool) -> Result<()> {
     let manifest = manifest::resolve(args.manifest_path.as_deref())?;
     let workspace_root = crate::run::find_workspace_root(&manifest.crate_dir).ok_or_else(|| {
         anyhow!(
@@ -41,6 +41,7 @@ pub fn run(args: Args) -> Result<()> {
         .name
         .as_deref()
         .ok_or_else(|| anyhow!("whisker.rs: app.name(\"…\") is required for macOS"))?;
+    let build_ui = super::BuildUi::start(no_tui, "Desktop (macOS)", app_name);
     let sync = platforms::sync_for_target(
         Target::Macos,
         &manifest.config,
@@ -62,7 +63,7 @@ pub fn run(args: Args) -> Result<()> {
         features: &[],
         capture: None,
     })?;
-    whisker_build::ui::info(format!("✓ {}", bundle.display()));
+    build_ui.complete(&bundle);
     whisker_build::ui::info("bundle is unsigned; distribution signing/notarization is a follow-up");
     Ok(())
 }

--- a/crates/whisker-cli/src/build/mod.rs
+++ b/crates/whisker-cli/src/build/mod.rs
@@ -44,12 +44,42 @@ enum Cmd {
     Web(web::Args),
 }
 
-pub fn run(args: BuildArgs) -> Result<()> {
+pub fn run(args: BuildArgs, no_tui: bool) -> Result<()> {
     match args.cmd {
-        Cmd::Appbundle(a) => android::run(ReleaseArtifact::AppBundle, a),
-        Cmd::Apk(a) => android::run(ReleaseArtifact::Apk, a),
-        Cmd::Ipa(a) => ios::run(a),
-        Cmd::Macos(a) => macos::run(a),
-        Cmd::Web(a) => web::run(a),
+        Cmd::Appbundle(a) => android::run(ReleaseArtifact::AppBundle, a, no_tui),
+        Cmd::Apk(a) => android::run(ReleaseArtifact::Apk, a, no_tui),
+        Cmd::Ipa(a) => ios::run(a, no_tui),
+        Cmd::Macos(a) => macos::run(a, no_tui),
+        Cmd::Web(a) => web::run(a, no_tui),
+    }
+}
+
+pub(super) struct BuildUi {
+    session: Option<crate::tui::TuiSession>,
+}
+
+impl BuildUi {
+    pub fn start(no_tui: bool, target: &str, bundle: &str) -> Self {
+        let session = if crate::tui::should_start(no_tui) {
+            match crate::tui::TuiSession::start(crate::tui::WorkflowKind::Build, target, bundle) {
+                Ok(session) => Some(session),
+                Err(error) => {
+                    eprintln!("couldn't start TUI ({error:#}); falling back to plain output");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        Self { session }
+    }
+
+    pub fn complete(&self, artifact: &std::path::Path) {
+        if let Some(session) = self.session.as_ref() {
+            let handle = session.handle();
+            handle.set_artifact(artifact.display().to_string());
+            handle.set_phase(crate::tui::AppPhase::Completed);
+        }
+        whisker_build::ui::info(format!("artifact · {}", artifact.display()));
     }
 }

--- a/crates/whisker-cli/src/build/web.rs
+++ b/crates/whisker-cli/src/build/web.rs
@@ -16,7 +16,7 @@ pub struct Args {
     manifest_path: Option<PathBuf>,
 }
 
-pub fn run(args: Args) -> Result<()> {
+pub fn run(args: Args, no_tui: bool) -> Result<()> {
     let manifest = manifest::resolve(args.manifest_path.as_deref())?;
     let workspace_root = crate::run::find_workspace_root(&manifest.crate_dir).ok_or_else(|| {
         anyhow!(
@@ -24,6 +24,7 @@ pub fn run(args: Args) -> Result<()> {
             manifest.crate_dir.display()
         )
     })?;
+    let build_ui = super::BuildUi::start(no_tui, "Web", &manifest.package);
     let sync = platforms::sync_for_target(
         Target::Web,
         &manifest.config,
@@ -43,6 +44,6 @@ pub fn run(args: Args) -> Result<()> {
         capture: None,
         development: false,
     })?;
-    whisker_build::ui::info(format!("✓ {}", artifacts.index_html.display()));
+    build_ui.complete(&artifacts.index_html);
     Ok(())
 }

--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -63,6 +63,11 @@ struct Cli {
     #[arg(long, short = 'v', global = true)]
     verbose: bool,
 
+    /// Disable the inline progress UI for long-running build/run workflows.
+    /// Plain deterministic output is always used when piping or under CI.
+    #[arg(long, global = true)]
+    no_tui: bool,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -140,10 +145,10 @@ pub fn run(args: impl IntoIterator<Item = String>) -> Result<()> {
     }
     match cli.command {
         Command::Doctor(a) => doctor::run(a),
-        Command::Run(a) => run::run(a),
+        Command::Run(a) => run::run(a, cli.no_tui),
         Command::NewModule(a) => new_module::run(a),
         Command::New(a) => new_app::run(a),
-        Command::Build(a) => build::run(a),
+        Command::Build(a) => build::run(a, cli.no_tui),
         Command::Credential(a) => credential::run(a),
         Command::Fmt(a) => fmt::run(a),
         Command::BuildIos(a) => build_dispatch::run_ios(a),
@@ -216,6 +221,14 @@ mod tests {
     fn parses_build_web() {
         let cli = parse(["whisker", "build", "web"]).unwrap();
         assert!(matches!(cli.command, Command::Build(_)));
+    }
+
+    #[test]
+    fn parses_global_no_tui_for_run_and_build() {
+        let run = parse(["whisker", "run", "web", "--no-tui"]).unwrap();
+        assert!(run.no_tui);
+        let build = parse(["whisker", "--no-tui", "build", "web"]).unwrap();
+        assert!(build.no_tui);
     }
 
     #[test]

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -322,7 +322,10 @@ fn build_engine_with_discovered_plugins(
 /// redraw.
 fn build_discovered_plugins(workspace_root: &Path, discovered: &[DiscoveredPlugin]) -> Result<()> {
     for plugin in discovered {
-        let step = whisker_build::ui::step("compile", format!("plugin ({})", plugin.name));
+        let step = whisker_build::ui::step(
+            whisker_build::ui::OperationKind::Compile,
+            format!("plugin ({})", plugin.name),
+        );
         let mut cmd = Command::new("cargo");
         cmd.arg("build")
             .arg("--bin")

--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -51,14 +51,6 @@ pub struct Args {
     /// the resolved manifest's parent dir.
     #[arg(long)]
     pub workspace_root: Option<PathBuf>,
-
-    /// Disable the inline ratatui status bar at the bottom of the
-    /// terminal. On by default when stderr is a TTY; auto-off when
-    /// piping to a file or running under CI. Use this when running
-    /// against a tmux pane that doesn't like inline viewports, or
-    /// when you specifically want grep'able scrollback-only output.
-    #[arg(long)]
-    pub no_tui: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -80,16 +72,8 @@ impl From<CliTarget> for Target {
     }
 }
 
-pub fn run(args: Args) -> Result<()> {
-    // Set the cross-crate TUI signal before any `whisker_build::ui::*`
-    // call fires — `whisker_build::ui::mode()` caches its lookup in a
-    // `OnceLock` on the first call, so flipping this env later doesn't
-    // unstick a `Curated` cache.
-    let tui_enabled = !args.no_tui && std::io::IsTerminal::is_terminal(&std::io::stderr());
-    if tui_enabled {
-        // FIXME: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::set_var("WHISKER_TUI", "1") };
-    }
+pub fn run(args: Args, no_tui: bool) -> Result<()> {
+    let tui_enabled = crate::tui::should_start(no_tui);
 
     // Resolve the user-facing manifest before doing anything UI-y so
     // that the TUI header can display the bundle id from the moment
@@ -122,15 +106,16 @@ pub fn run(args: Args) -> Result<()> {
     // long setup steps (sync, plugin build, initial build, install)
     // render with a proper progress indicator instead of leaking
     // ahead of an inline status bar.
-    let tui_pieces = if tui_enabled {
-        match crate::tui::Tui::start(target_label.to_string(), bundle.clone()) {
-            Ok((tui, handle)) => {
+    let tui_session = if tui_enabled {
+        match crate::tui::TuiSession::start(
+            crate::tui::WorkflowKind::Run,
+            target_label.to_string(),
+            bundle.clone(),
+        ) {
+            Ok(session) => {
+                let handle = session.handle();
                 handle.set_phase(crate::tui::AppPhase::Setup);
-                let render_handle = std::thread::Builder::new()
-                    .name("whisker-tui-render".into())
-                    .spawn(move || run_tui_render_loop(tui))
-                    .ok();
-                Some((handle, render_handle))
+                Some(session)
             }
             Err(e) => {
                 eprintln!("couldn't start TUI ({e:#}); falling back to plain output");
@@ -140,7 +125,7 @@ pub fn run(args: Args) -> Result<()> {
     } else {
         None
     };
-    let tui_handle = tui_pieces.as_ref().map(|(h, _)| h.clone());
+    let tui_handle = tui_session.as_ref().map(crate::tui::TuiSession::handle);
 
     // Run the rest of the cli pipeline. Each phase pushes its progress
     // through `tui_handle`. If the TUI isn't running, every step is
@@ -150,36 +135,10 @@ pub fn run(args: Args) -> Result<()> {
 
     // Stop the render thread + restore the terminal. Use should_quit
     // as the signal so the render thread exits cleanly.
-    if let Some((handle, render_thread)) = tui_pieces {
-        handle.request_quit();
-        if let Some(t) = render_thread {
-            let _ = t.join();
-        }
+    if let Some(session) = tui_session {
+        session.finish();
     }
     result
-}
-
-fn run_tui_render_loop(mut tui: crate::tui::Tui) {
-    let _ = tui.render_until_quit();
-    let user_quit = tui.was_user_quit();
-    let _ = tui.shutdown();
-    if user_quit {
-        // The dev-server runs to completion (i.e. forever) inside
-        // `rt.block_on(server.run())` on the cli thread, so simply
-        // tearing the TUI down here would leave a headless `whisker
-        // run` process alive after `q`. Hard-exit with a normal
-        // status; tokio sockets / file watchers get reaped by the
-        // kernel. cli-initiated shutdowns (build failed, etc.) take
-        // the other branch and let `run()`'s normal return path
-        // surface the error.
-        //
-        // `exit` skips destructors, so an in-flight cargo / gradle /
-        // xcodebuild would be orphaned — SIGTERM the tracked build
-        // children first (the gradle daemon, in its own session, is
-        // spared).
-        whisker_build::child_guard::kill_all();
-        std::process::exit(0);
-    }
 }
 
 fn run_inner(
@@ -289,7 +248,7 @@ fn run_inner(
         .map(|p| p.display().to_string())
         .collect();
     if let Some(t) = tui {
-        t.set_dev_server(config.bind_addr.to_string(), watching_paths);
+        t.set_dev_server(target_destination(&config), watching_paths);
         t.set_phase(crate::tui::AppPhase::Initializing);
     }
 
@@ -355,7 +314,7 @@ fn run_macos(
     let watch_roots = explicit_watch_paths.to_vec();
     if let Some(tui) = tui {
         tui.set_dev_server(
-            bind_addr.to_string(),
+            format!("{app_name} · local application"),
             watch_roots
                 .iter()
                 .map(|path| path.display().to_string())
@@ -405,6 +364,33 @@ fn run_macos(
             }
         });
     runtime.block_on(server.run())
+}
+
+fn target_destination(config: &Config) -> String {
+    match config.target {
+        Target::Android => config
+            .android
+            .as_ref()
+            .map(|params| params.application_id.clone())
+            .unwrap_or_else(|| "Android application".into()),
+        Target::IosSimulator => config
+            .ios
+            .as_ref()
+            .map(|params| {
+                format!(
+                    "{} · {}",
+                    params.device_override.as_deref().unwrap_or("iOS Simulator"),
+                    params.bundle_id
+                )
+            })
+            .unwrap_or_else(|| "iOS Simulator".into()),
+        Target::Macos => config
+            .macos
+            .as_ref()
+            .map(|params| format!("{} · local application", params.app_name))
+            .unwrap_or_else(|| "Desktop application".into()),
+        Target::Web => format!("http://127.0.0.1:{}/", config.bind_addr.port()),
+    }
 }
 
 /// Generate a random hex token for the hot-reload session.

--- a/crates/whisker-cli/src/tui.rs
+++ b/crates/whisker-cli/src/tui.rs
@@ -1,4 +1,5 @@
-//! Inline-viewport TUI for `whisker run`.
+//! Inline-viewport TUI for the top-level `whisker run` and
+//! `whisker build` workflows.
 //!
 //! ## Design
 //!
@@ -26,17 +27,18 @@
 //!    whisker run · iOS Simulator · rs.example.bar · building · 4.1s
 //!    ⠋ xcodebuild …
 //!
-//!    r  hot reload   R  full reload   q  quit
+//!    r  hot reload   R  full reload   o  relaunch   q  quit
 //! ──────────────────────────────────────────────────────────────────
 //! ```
 //!
 //! ## Subprocess output → scrollback
 //!
-//! cargo / gradle / xcodebuild and every `whisker_build::ui::*` call
-//! write to stderr. We `dup2` `STDERR_FILENO` to a pipe whose read
-//! end a dedicated thread drains line-by-line, strips ANSI escapes
-//! from, and sends through an mpsc channel. The render thread drains
-//! that channel each frame and calls
+//! `whisker_build::ui::*` calls arrive as typed [`ProgressEvent`]s.
+//! Unstructured diagnostics from cargo / gradle / xcodebuild and
+//! other libraries may still write to stderr, so we `dup2`
+//! `STDERR_FILENO` to a pipe whose read end a dedicated thread drains
+//! line-by-line, strips ANSI escapes from, and sends through an mpsc
+//! channel. The render thread drains that channel each frame and calls
 //! [`Terminal::insert_before`] per line, so captured output lands
 //! above the live region — which the terminal's scrollback keeps for
 //! us. ratatui's backend is wired to the *saved* original stderr fd
@@ -52,9 +54,9 @@
 //! [`AppPhase`] tracks where the dev loop is. The cli calls
 //! [`TuiHandle::set_phase`] for phases it drives directly
 //! (`Setup`, `Initializing`); dev-server events drive the rest via
-//! [`TuiHandle::apply_event`]. Each transition emits a one-line
-//! "▶ <phase>" / "✓ <phase>  Xs" history entry plus updates the live
-//! header.
+//! [`TuiHandle::apply_event`]. Build operations and section history
+//! come from [`ProgressEvent`], so rendered terminal strings are never
+//! parsed to infer workflow state.
 
 use anyhow::{Context, Result};
 use crossterm::{
@@ -70,10 +72,14 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget, Wrap};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 use std::io::Write;
+use std::io::{IsTerminal, stderr, stdin};
 use std::os::raw::c_int;
 use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use whisker_build::ui::{
+    MessageLevel, OperationOutcome, ProgressEvent, ReporterGuard, install_reporter,
+};
 
 /// Height of the live region in rows. The header, current step,
 /// dev-server info and key hint together comfortably fit in 6 rows;
@@ -112,9 +118,28 @@ pub enum AppPhase {
     /// hot-reload patch in flight. Phase exit is signalled by
     /// `Event::PatchSent` or a full reload fallback's `Event::BuildingFull`.
     Patching { started_at: Instant },
+    /// A finite build workflow produced its artifact successfully.
+    Completed,
+    /// A user requested a graceful dev-server shutdown.
+    Stopping,
     /// Build failed. The live region surfaces the cause and the cli
     /// is about to exit non-zero.
     Failed { phase: String, reason: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowKind {
+    Run,
+    Build,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostStatus {
+    NotStarted,
+    Launching,
+    WaitingForConnection,
+    Connected,
+    Failed(String),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -123,8 +148,7 @@ pub enum BuildKind {
     Rebuild,
 }
 
-/// Outcome of a completed step. Pushed to scrollback by
-/// [`TuiHandle::finish_step`]; never rendered in the live region.
+/// Outcome of a completed step in terminal scrollback.
 #[derive(Debug, Clone, Copy)]
 pub enum StepStatus {
     Done,
@@ -139,27 +163,26 @@ pub enum StepStatus {
 /// thread that owns the ratatui terminal.
 #[derive(Debug, Clone)]
 pub struct LiveState {
+    pub workflow: WorkflowKind,
     pub target: String,
     pub bundle: String,
     pub phase: AppPhase,
     /// Label of the in-progress step (e.g. "xcodebuild …"). Cleared
     /// when the step finishes.
     pub current_step: Option<String>,
-    pub ws_addr: Option<String>,
+    pub target_destination: Option<String>,
+    pub host_status: HostStatus,
     pub watching: Vec<String>,
     pub client_count: usize,
     pub last_build: Option<String>,
     pub last_patch: Option<String>,
+    pub artifact: Option<String>,
     pub should_quit: bool,
-    /// `true` when the quit was triggered by a user keypress
-    /// (`q` / Esc / Ctrl-C), `false` when the cli called
-    /// `TuiHandle::request_quit` after its own work finished or
-    /// failed. The render thread uses this to decide whether to
-    /// force-exit the process after shutdown — the dev-server
-    /// `rt.block_on(server.run())` call in the main thread otherwise
-    /// blocks forever, so without a hard exit `q` would tear down the
-    /// TUI but leave the process running.
-    pub user_initiated_quit: bool,
+    /// `true` when the render loop must terminate the process because
+    /// no workflow command channel exists to perform an orderly stop.
+    /// Normal `run` shutdown leaves this `false`: the dev server owns
+    /// cleanup and the cli asks the TUI to finish after `run()` returns.
+    pub force_exit: bool,
     /// Persistent "press R to Full Reload" banner. Set by
     /// `Event::FullReloadRequired` (the dev loop hit a change it
     /// can't hot-reload), cleared when a Full Reload actually starts
@@ -172,19 +195,26 @@ pub struct LiveState {
 }
 
 impl LiveState {
-    pub fn new(target: impl Into<String>, bundle: impl Into<String>) -> Self {
+    pub fn new(
+        workflow: WorkflowKind,
+        target: impl Into<String>,
+        bundle: impl Into<String>,
+    ) -> Self {
         Self {
+            workflow,
             target: target.into(),
             bundle: bundle.into(),
             phase: AppPhase::Setup,
             current_step: None,
-            ws_addr: None,
+            target_destination: None,
+            host_status: HostStatus::NotStarted,
             watching: Vec::new(),
             client_count: 0,
             last_build: None,
             last_patch: None,
+            artifact: None,
             should_quit: false,
-            user_initiated_quit: false,
+            force_exit: false,
             full_reload_needed: None,
             command_tx: None,
         }
@@ -193,10 +223,9 @@ impl LiveState {
 
 /// One message the render thread receives from upstream producers
 /// (cli code, dev-server events, and the stderr capture thread).
-/// Most variants paint a row into the terminal's scrollback via
-/// [`Terminal::insert_before`]; the `SetCurrentStep` variant is the
-/// exception — it only mutates [`LiveState::current_step`] so the
-/// inline live region can show a spinner during the next frame.
+/// Variants paint a row into the terminal's scrollback via
+/// [`Terminal::insert_before`]. Live-only workflow state is updated
+/// directly through [`TuiHandle`].
 #[derive(Debug, Clone)]
 pub enum HistoryItem {
     /// Phase-transition heading: "▶ Initial build".
@@ -217,18 +246,16 @@ pub enum HistoryItem {
     /// escapes already stripped).
     CapturedStderr(String),
     /// Device log forwarded from the dev-server.
-    DeviceLog { stream: String, line: String },
+    DeviceLog {
+        stream: String,
+        line: String,
+    },
+    Message {
+        level: MessageLevel,
+        text: String,
+    },
     /// One-shot failure description for the scrollback.
     Failure(String),
-    /// Update the live region's `current_step` field. `Some(label)`
-    /// makes the spinner visible with the given label; `None`
-    /// hides it. Synthesised by the stderr capture thread when it
-    /// sees `whisker_build::ui::TUI_STEP_START_MARKER` /
-    /// `TUI_STEP_END_MARKER` — those markers let the dev-server's
-    /// `ui::step` calls drive the live spinner without committing
-    /// a "⏵ started" row that would later double-up with the
-    /// matching "✓ done" row in scrollback.
-    SetCurrentStep(Option<String>),
 }
 
 // ============================================================================
@@ -262,9 +289,9 @@ pub fn apply_event(
                 started_at: Instant::now(),
                 kind,
             };
-            // No history row: `whisker_build::ui::section` already puts
-            // "──── Initial build ────" in scrollback via the stderr
-            // capture, and a "▶ Initial build" line would duplicate it.
+            // No history row: `whisker_build::ui::section` already emits
+            // the structured section entry, and a second phase line would
+            // duplicate it.
             state.current_step = None;
         }
         Event::BuildSucceeded => {
@@ -302,11 +329,30 @@ pub fn apply_event(
             };
             state.current_step = None;
         }
+        Event::HostLaunching => {
+            state.host_status = HostStatus::Launching;
+        }
+        Event::HostLaunched => {
+            state.host_status = if state.client_count > 0 {
+                HostStatus::Connected
+            } else {
+                HostStatus::WaitingForConnection
+            };
+            state.phase = AppPhase::Idle;
+        }
+        Event::HostLaunchFailed(reason) => {
+            state.host_status = HostStatus::Failed(reason.clone());
+            history.push(HistoryItem::Failure(reason.clone()));
+        }
         Event::ClientConnected => {
             state.client_count = state.client_count.saturating_add(1);
+            state.host_status = HostStatus::Connected;
         }
         Event::ClientDisconnected => {
             state.client_count = state.client_count.saturating_sub(1);
+            if state.client_count == 0 {
+                state.host_status = HostStatus::WaitingForConnection;
+            }
         }
         Event::PatchBuilding => {
             // Exits are `Event::PatchSent` (→ Idle) or, when the loop
@@ -325,8 +371,8 @@ pub fn apply_event(
             state.current_step = None;
         }
         Event::FullReloadRequired { reason } => {
-            // Banner only — the dev-server's own `ui::warn` line is
-            // already in scrollback via captured stderr.
+            // Banner only — the dev-server's own `ui::warn` event is
+            // already in scrollback.
             state.full_reload_needed = Some(reason.clone());
             // An earlier `PatchBuilding` may have set Patching; reset
             // or the spinner runs forever.
@@ -369,37 +415,14 @@ impl TuiHandle {
 
     /// Enter `phase`. Updates the live region's phase label/spinner
     /// color and clears any in-progress step display. Does NOT push
-    /// a scrollback entry — `whisker_build::ui::section` already
-    /// prints labeled phase boundaries that flow into scrollback via
-    /// the stderr capture, so a duplicate "▶ <label>" line would just
-    /// be noise. Only a failed build emits a `HistoryItem::PhaseDone`
-    /// summary, from [`apply_event`].
+    /// a scrollback entry — `whisker_build::ui::section` already emits
+    /// labeled phase boundaries through the progress reporter, so a
+    /// duplicate "▶ <label>" line would just be noise. Only a failed
+    /// build emits a `HistoryItem::PhaseDone` summary, from [`apply_event`].
     pub fn set_phase(&self, phase: AppPhase) {
         self.with(|s| {
             s.phase = phase;
             s.current_step = None;
-        });
-    }
-
-    /// Begin a step. Updates `current_step` in the live region; on
-    /// `finish_step` the row gets committed to scrollback.
-    pub fn start_step(&self, label: impl Into<String>) {
-        let label = label.into();
-        self.with(|s| {
-            s.current_step = Some(label);
-        });
-    }
-
-    /// Finish the currently-displayed step. The row is pushed to
-    /// scrollback as "✓ <label>  <elapsed>"; the live region clears
-    /// `current_step`.
-    pub fn finish_step(&self, label: impl Into<String>, status: StepStatus, elapsed: Duration) {
-        let label = label.into();
-        self.with(|s| s.current_step = None);
-        self.send(HistoryItem::Step {
-            label,
-            status,
-            elapsed,
         });
     }
 
@@ -411,10 +434,79 @@ impl TuiHandle {
         }
     }
 
-    pub fn set_dev_server(&self, ws_addr: impl Into<String>, watching: Vec<String>) {
-        let ws_addr = ws_addr.into();
+    /// Apply one structured build/run progress event. This is the only place
+    /// the terminal model learns about build operations; rendered stderr is
+    /// retained for diagnostics but is never parsed to infer workflow state.
+    pub fn apply_progress_event(&self, event: ProgressEvent) {
+        match event {
+            ProgressEvent::Section(label) => self.send(HistoryItem::PhaseEnter(label)),
+            ProgressEvent::OperationStarted { kind, detail } => {
+                let label = format!("{} · {detail}", kind.label());
+                self.with(|state| {
+                    if state.workflow == WorkflowKind::Build
+                        && !matches!(state.phase, AppPhase::Building { .. })
+                    {
+                        state.phase = AppPhase::Building {
+                            started_at: Instant::now(),
+                            kind: BuildKind::Initial,
+                        };
+                    }
+                    state.current_step = Some(label);
+                });
+            }
+            ProgressEvent::OperationProgress { kind, message } => {
+                self.with(|state| {
+                    state.current_step = Some(format!("{} · {message}", kind.label()));
+                });
+            }
+            ProgressEvent::OperationFinished {
+                kind,
+                detail,
+                outcome,
+                summary,
+                elapsed,
+            } => {
+                self.with(|state| {
+                    state.current_step = None;
+                    if state.workflow == WorkflowKind::Build && outcome == OperationOutcome::Failed
+                    {
+                        state.phase = AppPhase::Failed {
+                            phase: kind.label().to_string(),
+                            reason: if summary.is_empty() {
+                                detail.clone()
+                            } else {
+                                summary.clone()
+                            },
+                        };
+                    }
+                });
+                self.send(HistoryItem::Step {
+                    label: format!("{} · {detail}", kind.label()),
+                    status: match outcome {
+                        OperationOutcome::Done => StepStatus::Done,
+                        OperationOutcome::Failed => StepStatus::Failed,
+                    },
+                    elapsed,
+                });
+            }
+            ProgressEvent::Message { level, text } => {
+                self.send(HistoryItem::Message { level, text });
+            }
+            // Run status is represented by target-aware dev-server events
+            // in the live region. The generic plain-output status string
+            // would duplicate that information in scrollback.
+            ProgressEvent::Status(_) => {}
+        }
+    }
+
+    pub fn set_artifact(&self, artifact: impl Into<String>) {
+        self.with(|state| state.artifact = Some(artifact.into()));
+    }
+
+    pub fn set_dev_server(&self, destination: impl Into<String>, watching: Vec<String>) {
+        let destination = destination.into();
         self.with(|s| {
-            s.ws_addr = Some(ws_addr);
+            s.target_destination = Some(destination);
             s.watching = watching;
         });
     }
@@ -474,6 +566,66 @@ pub struct Tui {
     rx: Receiver<HistoryItem>,
     saved_stderr_fd: c_int,
     spinner_idx: usize,
+    _reporter: ReporterGuard,
+}
+
+/// Owns the terminal render thread for one top-level CLI workflow.
+/// Nested build helpers never construct this type.
+pub struct TuiSession {
+    handle: TuiHandle,
+    render_thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl TuiSession {
+    pub fn start(
+        workflow: WorkflowKind,
+        target: impl Into<String>,
+        bundle: impl Into<String>,
+    ) -> Result<Self> {
+        let (tui, handle) = Tui::start(workflow, target.into(), bundle.into())?;
+        let render_thread = std::thread::Builder::new()
+            .name("whisker-tui-render".into())
+            .spawn(move || run_render_loop(tui))
+            .context("spawn TUI render thread")?;
+        Ok(Self {
+            handle,
+            render_thread: Some(render_thread),
+        })
+    }
+
+    pub fn handle(&self) -> TuiHandle {
+        self.handle.clone()
+    }
+
+    pub fn finish(mut self) {
+        self.handle.request_quit();
+        if let Some(thread) = self.render_thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for TuiSession {
+    fn drop(&mut self) {
+        self.handle.request_quit();
+        if let Some(thread) = self.render_thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+pub fn should_start(disabled: bool) -> bool {
+    !disabled && !whisker_build::ui::is_verbose() && stderr().is_terminal() && stdin().is_terminal()
+}
+
+fn run_render_loop(mut tui: Tui) {
+    let _ = tui.render_until_quit();
+    let force_exit = tui.requires_force_exit();
+    let _ = tui.shutdown();
+    if force_exit {
+        whisker_build::child_guard::kill_all();
+        std::process::exit(130);
+    }
 }
 
 impl Tui {
@@ -482,7 +634,11 @@ impl Tui {
     /// passes `Tui` to a dedicated OS thread that runs the render
     /// loop (ratatui's `Terminal` isn't `Send` once it has a backend
     /// holding raw fds — keep it pinned to one thread).
-    pub fn start(target: String, bundle: String) -> Result<(Self, TuiHandle)> {
+    pub fn start(
+        workflow: WorkflowKind,
+        target: String,
+        bundle: String,
+    ) -> Result<(Self, TuiHandle)> {
         let (saved_stderr_fd, capture_read_fd) =
             install_stderr_capture().context("install stderr capture")?;
         install_terminal_cleanup_once(saved_stderr_fd);
@@ -500,7 +656,7 @@ impl Tui {
         )
         .context("create ratatui terminal (inline viewport)")?;
 
-        let live = Arc::new(Mutex::new(LiveState::new(target, bundle)));
+        let live = Arc::new(Mutex::new(LiveState::new(workflow, target, bundle)));
         let (tx, rx) = channel::<HistoryItem>();
 
         {
@@ -518,6 +674,9 @@ impl Tui {
             live: Arc::clone(&live),
             tx,
         };
+        let progress_handle = handle.clone();
+        let reporter = install_reporter(move |event| progress_handle.apply_progress_event(event))
+            .context("install structured progress reporter")?;
 
         Ok((
             Self {
@@ -526,6 +685,7 @@ impl Tui {
                 rx,
                 saved_stderr_fd,
                 spinner_idx: 0,
+                _reporter: reporter,
             },
             handle,
         ))
@@ -570,6 +730,9 @@ impl Tui {
                             KeyCode::Char('R') => {
                                 self.send_command(whisker_dev_server::DevCommand::FullReload)
                             }
+                            KeyCode::Char('o') => {
+                                self.send_command(whisker_dev_server::DevCommand::Relaunch)
+                            }
                             _ => {}
                         }
                     }
@@ -588,13 +751,6 @@ impl Tui {
     fn drain_history_into_scrollback(&mut self) -> Result<()> {
         loop {
             match self.rx.try_recv() {
-                Ok(HistoryItem::SetCurrentStep(label)) => {
-                    // Live-region-only: no `insert_before`, so the
-                    // spinner label never enters scrollback.
-                    if let Ok(mut s) = self.live.lock() {
-                        s.current_step = label;
-                    }
-                }
                 Ok(item) => {
                     let lines = render_history_item(&item);
                     let height = lines.len().min(u16::MAX as usize) as u16;
@@ -626,28 +782,20 @@ impl Tui {
     }
 
     /// User-initiated quit (q / Esc / Ctrl-C from the TUI).
-    /// Distinguished from a cli-initiated quit (`TuiHandle::request_quit`)
-    /// so `run_until_quit`'s caller can decide to force-exit the
-    /// process — the dev-server's `rt.block_on` would otherwise keep
-    /// running after the TUI tears down.
+    /// Run workflows ask the dev server to shut down; finite build
+    /// workflows fall back to process cancellation after terminal cleanup.
     fn user_quit(&self) {
         if let Ok(mut s) = self.live.lock() {
-            s.should_quit = true;
-            s.user_initiated_quit = true;
+            request_user_quit(&mut s);
         }
     }
 
-    /// Whether the most recent quit signal came from a user keypress
-    /// rather than a `TuiHandle::request_quit` call. Callers use this
-    /// after `render_until_quit` returns to decide whether to
-    /// `process::exit` (user quit while the dev-server was running) or
-    /// to fall through and let the cli's own return path run (cli
-    /// finished its work).
-    pub fn was_user_quit(&self) -> bool {
-        self.live
-            .lock()
-            .map(|s| s.user_initiated_quit)
-            .unwrap_or(false)
+    /// Whether orderly workflow shutdown was unavailable and the
+    /// render thread must terminate the process after restoring the
+    /// terminal. This is primarily the finite build workflow, where
+    /// the main thread can be blocked in an external build command.
+    pub fn requires_force_exit(&self) -> bool {
+        self.live.lock().map(|s| s.force_exit).unwrap_or(false)
     }
 
     pub fn shutdown(mut self) -> Result<()> {
@@ -682,6 +830,19 @@ impl Tui {
         }
         Ok(())
     }
+}
+
+fn request_user_quit(state: &mut LiveState) {
+    if state.workflow == WorkflowKind::Run {
+        if let Some(tx) = &state.command_tx {
+            if tx.send(whisker_dev_server::DevCommand::Shutdown).is_ok() {
+                state.phase = AppPhase::Stopping;
+                return;
+            }
+        }
+    }
+    state.force_exit = true;
+    state.should_quit = true;
 }
 
 // ============================================================================
@@ -745,24 +906,6 @@ fn capture_reader_loop(read_fd: c_int, tx: Sender<HistoryItem>) {
                 Ok(s) => s,
                 Err(e) => String::from_utf8_lossy(&e.into_bytes()).into_owned(),
             };
-            // Marker detection must precede `strip_ansi`, which drops
-            // the framing `\x1e` (RS) along with the other C0 bytes.
-            // The literals mirror `whisker_build::ui::TUI_STEP_*_MARKER`
-            // rather than importing them, keeping this an internal
-            // protocol instead of a crate-level contract.
-            if let Some(rest) = text.strip_prefix("\x1eWHISKER-TUI-STEP-START\x1e") {
-                let label = rest.replace('\x1e', " ").trim().to_string();
-                if !label.is_empty() && tx.send(HistoryItem::SetCurrentStep(Some(label))).is_err() {
-                    return;
-                }
-                continue;
-            }
-            if text == "\x1eWHISKER-TUI-STEP-END" {
-                if tx.send(HistoryItem::SetCurrentStep(None)).is_err() {
-                    return;
-                }
-                continue;
-            }
             let text = strip_ansi(&text);
             if !text.is_empty() && tx.send(HistoryItem::CapturedStderr(text)).is_err() {
                 return;

--- a/crates/whisker-cli/src/tui/render.rs
+++ b/crates/whisker-cli/src/tui/render.rs
@@ -57,39 +57,57 @@ pub(super) fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Lin
         }
     }
 
-    if let Some(addr) = &state.ws_addr {
+    if state.workflow == WorkflowKind::Run {
+        if let Some(destination) = &state.target_destination {
+            lines.push(Line::from(vec![
+                Span::raw(" "),
+                Span::styled("target      ", Style::default().fg(Color::DarkGray)),
+                Span::raw(destination.clone()),
+            ]));
+            let host = match &state.host_status {
+                HostStatus::NotStarted => "not started".to_string(),
+                HostStatus::Launching => "launching".to_string(),
+                HostStatus::WaitingForConnection => "waiting for connection".to_string(),
+                HostStatus::Connected => format!("connected ({})", state.client_count),
+                HostStatus::Failed(reason) => format!("failed · {reason}"),
+            };
+            let mut watching = vec![
+                Span::raw(" "),
+                Span::styled("host        ", Style::default().fg(Color::DarkGray)),
+                Span::raw(host),
+            ];
+            if !state.watching.is_empty() {
+                watching.push(Span::styled(
+                    "   ·   ",
+                    Style::default().fg(Color::DarkGray),
+                ));
+                watching.push(Span::styled(
+                    format!("watching {} path(s)", state.watching.len()),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            lines.push(Line::from(watching));
+        } else {
+            // Reserve one row so the layout doesn't jiggle when the
+            // dev-server comes online mid-build.
+            lines.push(Line::from(""));
+        }
+    } else if let Some(artifact) = &state.artifact {
         lines.push(Line::from(vec![
             Span::raw(" "),
-            Span::styled("dev server  ", Style::default().fg(Color::DarkGray)),
-            Span::raw(format!("ws://{addr}")),
+            Span::styled("artifact    ", Style::default().fg(Color::DarkGray)),
+            Span::raw(artifact.clone()),
         ]));
-        let clients = format!("{} connected", state.client_count);
-        let mut watching = vec![
-            Span::raw(" "),
-            Span::styled("clients     ", Style::default().fg(Color::DarkGray)),
-            Span::raw(clients),
-        ];
-        if !state.watching.is_empty() {
-            watching.push(Span::styled(
-                "   ·   ",
-                Style::default().fg(Color::DarkGray),
-            ));
-            watching.push(Span::styled(
-                format!("watching {} path(s)", state.watching.len()),
-                Style::default().fg(Color::DarkGray),
-            ));
-        }
-        lines.push(Line::from(watching));
     } else {
         // Reserve one row so the layout doesn't jiggle when the
-        // dev-server comes online mid-build.
+        // artifact appears at the end of the build.
         lines.push(Line::from(""));
     }
 
     // Also the spacer row when no prompt is pending, so the layout
     // doesn't jiggle.
-    match &state.full_reload_needed {
-        Some(reason) => {
+    match (&state.workflow, &state.full_reload_needed) {
+        (WorkflowKind::Run, Some(reason)) => {
             lines.push(Line::from(vec![
                 Span::raw(" "),
                 Span::styled(
@@ -106,7 +124,7 @@ pub(super) fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Lin
                 Span::styled(" to Full Reload", Style::default().fg(Color::Yellow)),
             ]));
         }
-        None => lines.push(Line::from("")),
+        _ => lines.push(Line::from("")),
     }
 
     // Footer hint. The key chips use `White` (not `Black`) on the
@@ -125,15 +143,21 @@ pub(super) fn build_live_lines(state: &LiveState, spinner_idx: usize) -> Vec<Lin
     };
     let key_desc =
         |text: &str| Span::styled(text.to_string(), Style::default().fg(Color::DarkGray));
-    lines.push(Line::from(vec![
-        Span::raw(" "),
-        key_chip("r"),
-        key_desc("  hot reload   "),
-        key_chip("R"),
-        key_desc("  full reload   "),
-        key_chip("q"),
-        key_desc("  quit"),
-    ]));
+    let footer = match state.workflow {
+        WorkflowKind::Run => vec![
+            Span::raw(" "),
+            key_chip("r"),
+            key_desc("  hot reload   "),
+            key_chip("R"),
+            key_desc("  full reload   "),
+            key_chip("o"),
+            key_desc("  relaunch   "),
+            key_chip("q"),
+            key_desc("  quit"),
+        ],
+        WorkflowKind::Build => vec![Span::raw(" "), key_chip("q"), key_desc("  cancel")],
+    };
+    lines.push(Line::from(footer));
 
     // Truncate / pad to LIVE_HEIGHT so the viewport renders cleanly.
     lines.truncate(LIVE_HEIGHT as usize);
@@ -199,6 +223,23 @@ pub(super) fn render_history_item(item: &HistoryItem) -> Vec<Line<'static>> {
                 Span::raw(line.clone()),
             ])]
         }
+        HistoryItem::Message { level, text } => {
+            let (glyph, color) = match level {
+                MessageLevel::Info => ("·", Color::DarkGray),
+                MessageLevel::Warning => ("⚠", Color::Yellow),
+                MessageLevel::Error => ("✗", Color::Red),
+                MessageLevel::Debug => ("·", Color::DarkGray),
+                MessageLevel::Log => ("", Color::Reset),
+            };
+            if glyph.is_empty() {
+                vec![Line::from(Span::raw(text.clone()))]
+            } else {
+                vec![Line::from(vec![
+                    Span::styled(format!("{glyph} "), Style::default().fg(color)),
+                    Span::raw(text.clone()),
+                ])]
+            }
+        }
         HistoryItem::Failure(reason) => vec![Line::from(vec![
             Span::styled(
                 "✗ ",
@@ -206,11 +247,6 @@ pub(super) fn render_history_item(item: &HistoryItem) -> Vec<Line<'static>> {
             ),
             Span::styled(reason.clone(), Style::default().fg(Color::Red)),
         ])],
-        HistoryItem::SetCurrentStep(_) => {
-            // Live-region-only; consumed by
-            // `drain_history_into_scrollback` before reaching here.
-            Vec::new()
-        }
     }
 }
 
@@ -252,12 +288,27 @@ pub(super) fn status_chip(state: &LiveState) -> (&'static str, Color, Color) {
     if matches!(state.phase, AppPhase::Building { .. }) {
         return ("BUILDING", Color::Yellow, Color::Black);
     }
+    if matches!(state.phase, AppPhase::Completed) {
+        return ("BUILT", Color::Green, Color::Black);
+    }
+    if matches!(state.phase, AppPhase::Stopping) {
+        return ("STOPPING", Color::DarkGray, Color::White);
+    }
+    if state.current_step.is_some() {
+        return ("BUILDING", Color::Yellow, Color::Black);
+    }
     // Idle with a step in flight is still install / launch work.
     if matches!(state.phase, AppPhase::Idle) {
-        if state.current_step.is_some() {
-            return ("BUILDING", Color::Yellow, Color::Black);
-        }
-        return ("RUNNING", Color::Green, Color::Black);
+        return match (&state.workflow, &state.host_status) {
+            (WorkflowKind::Run, HostStatus::NotStarted | HostStatus::Launching) => {
+                ("LAUNCHING", Color::Yellow, Color::Black)
+            }
+            (WorkflowKind::Run, HostStatus::WaitingForConnection) => {
+                ("WAITING", Color::Yellow, Color::Black)
+            }
+            (WorkflowKind::Run, HostStatus::Failed(_)) => ("FAILED", Color::Red, Color::White),
+            _ => ("RUNNING", Color::Green, Color::Black),
+        };
     }
     // Setup / Initializing.
     ("STARTING", Color::DarkGray, Color::White)

--- a/crates/whisker-cli/src/tui/tests.rs
+++ b/crates/whisker-cli/src/tui/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use whisker_dev_server::Event;
 
 fn s() -> LiveState {
-    LiveState::new("iOS Simulator", "rs.whisker.podcast")
+    LiveState::new(WorkflowKind::Run, "iOS Simulator", "rs.whisker.podcast")
 }
 
 fn drain(state: &mut LiveState, e: &Event) -> Vec<HistoryItem> {
@@ -17,7 +17,7 @@ fn build_lifecycle_records_outcome() {
     let started = drain(&mut st, &Event::BuildingFull);
     assert!(matches!(st.phase, AppPhase::Building { .. }));
     // The section header comes from `whisker_build::ui::section`
-    // via captured stderr, so neither event emits a history row.
+    // through structured progress, so neither event duplicates it.
     assert!(started.is_empty());
     let done = drain(&mut st, &Event::BuildSucceeded);
     assert!(matches!(st.phase, AppPhase::Idle));
@@ -35,6 +35,41 @@ fn client_counter_saturates() {
     drain(&mut st, &Event::ClientDisconnected);
     drain(&mut st, &Event::ClientDisconnected);
     assert_eq!(st.client_count, 0);
+}
+
+#[test]
+fn host_lifecycle_tracks_launch_and_connection() {
+    let mut st = s();
+    drain(&mut st, &Event::HostLaunching);
+    assert_eq!(st.host_status, HostStatus::Launching);
+    drain(&mut st, &Event::HostLaunched);
+    assert_eq!(st.host_status, HostStatus::WaitingForConnection);
+    drain(&mut st, &Event::ClientConnected);
+    assert_eq!(st.host_status, HostStatus::Connected);
+    drain(&mut st, &Event::ClientDisconnected);
+    assert_eq!(st.host_status, HostStatus::WaitingForConnection);
+}
+
+#[test]
+fn run_quit_requests_graceful_dev_server_shutdown() {
+    let mut st = s();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    st.command_tx = Some(tx);
+
+    request_user_quit(&mut st);
+
+    assert_eq!(rx.try_recv(), Ok(whisker_dev_server::DevCommand::Shutdown));
+    assert!(matches!(st.phase, AppPhase::Stopping));
+    assert!(!st.should_quit);
+    assert!(!st.force_exit);
+}
+
+#[test]
+fn build_quit_uses_cancellation_path() {
+    let mut st = LiveState::new(WorkflowKind::Build, "Web", "host-smoke");
+    request_user_quit(&mut st);
+    assert!(st.should_quit);
+    assert!(st.force_exit);
 }
 
 #[test]
@@ -110,8 +145,8 @@ fn full_reload_required_sets_banner_and_returns_to_idle() {
         matches!(st.phase, AppPhase::Idle),
         "spinner must not keep running after a declined reload"
     );
-    // The dev-server's own ui::warn line reaches scrollback via
-    // captured stderr — no duplicate history row from the event.
+    // The dev-server's own ui::warn event reaches scrollback — no
+    // duplicate history row from the lifecycle event.
     assert!(h.is_empty());
 }
 
@@ -174,7 +209,79 @@ fn build_live_lines_footer_lists_reload_shortcuts() {
         .join("");
     assert!(rendered.contains("hot reload"));
     assert!(rendered.contains("full reload"));
+    assert!(rendered.contains("relaunch"));
     assert!(rendered.contains("quit"));
+}
+
+#[test]
+fn build_footer_only_offers_cancel() {
+    let st = LiveState::new(WorkflowKind::Build, "Web", "host-smoke");
+    let lines = build_live_lines(&st, 0);
+    let rendered = lines
+        .iter()
+        .flat_map(|line| line.spans.iter().map(|span| span.content.to_string()))
+        .collect::<Vec<_>>()
+        .join("");
+    assert!(rendered.contains("cancel"));
+    assert!(!rendered.contains("hot reload"));
+}
+
+#[test]
+fn structured_progress_drives_current_operation() {
+    let live = Arc::new(Mutex::new(s()));
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = TuiHandle {
+        live: Arc::clone(&live),
+        tx,
+    };
+
+    handle.apply_progress_event(ProgressEvent::OperationStarted {
+        kind: whisker_build::ui::OperationKind::Install,
+        detail: "app-debug.apk".into(),
+    });
+    assert_eq!(
+        handle.snapshot().current_step.as_deref(),
+        Some("install · app-debug.apk")
+    );
+
+    handle.apply_progress_event(ProgressEvent::OperationFinished {
+        kind: whisker_build::ui::OperationKind::Install,
+        detail: "app-debug.apk".into(),
+        outcome: whisker_build::ui::OperationOutcome::Done,
+        summary: String::new(),
+        elapsed: Duration::from_millis(12),
+    });
+    assert!(handle.snapshot().current_step.is_none());
+    assert!(matches!(rx.try_recv(), Ok(HistoryItem::Step { .. })));
+}
+
+#[test]
+fn finite_build_progress_keeps_the_workflow_in_building_phase_between_steps() {
+    let live = Arc::new(Mutex::new(LiveState::new(
+        WorkflowKind::Build,
+        "Web",
+        "host-smoke",
+    )));
+    let (tx, _rx) = std::sync::mpsc::channel();
+    let handle = TuiHandle {
+        live: Arc::clone(&live),
+        tx,
+    };
+
+    handle.apply_progress_event(ProgressEvent::OperationStarted {
+        kind: whisker_build::ui::OperationKind::Compile,
+        detail: "host-smoke".into(),
+    });
+    handle.apply_progress_event(ProgressEvent::OperationFinished {
+        kind: whisker_build::ui::OperationKind::Compile,
+        detail: "host-smoke".into(),
+        outcome: whisker_build::ui::OperationOutcome::Done,
+        summary: String::new(),
+        elapsed: Duration::from_millis(10),
+    });
+
+    assert!(matches!(handle.snapshot().phase, AppPhase::Building { .. }));
+    assert!(handle.snapshot().current_step.is_none());
 }
 
 #[test]
@@ -218,14 +325,15 @@ fn build_live_lines_shows_current_step() {
 #[test]
 fn build_live_lines_shows_dev_server_when_set() {
     let mut st = s();
-    st.ws_addr = Some("127.0.0.1:9090".into());
+    st.target_destination = Some("iPhone 17 Pro · rs.whisker.podcast".into());
     st.client_count = 1;
+    st.host_status = HostStatus::Connected;
     let lines = build_live_lines(&st, 0);
     let rendered = lines
         .iter()
         .flat_map(|l| l.spans.iter().map(|sp| sp.content.to_string()))
         .collect::<Vec<_>>()
         .join("");
-    assert!(rendered.contains("127.0.0.1:9090"));
-    assert!(rendered.contains("1 connected"));
+    assert!(rendered.contains("iPhone 17 Pro"));
+    assert!(rendered.contains("connected (1)"));
 }

--- a/crates/whisker-dev-server/src/hot_reload.rs
+++ b/crates/whisker-dev-server/src/hot_reload.rs
@@ -35,7 +35,10 @@ pub(super) async fn hot_reload_cycle(
 ) {
     // Opened before the build so the spinner spans the whole
     // "edit → app updated" duration.
-    let step = whisker_build::ui::step("hot reload", "subsecond patch");
+    let step = whisker_build::ui::step(
+        whisker_build::ui::OperationKind::HotReload,
+        "subsecond patch",
+    );
     // Emitted before the wall-clock-heavy patcher work; `PatchSent`
     // flips the cli back to Idle.
     emit(on_event, Event::PatchBuilding);
@@ -472,8 +475,12 @@ pub(super) async fn run_build_cycle(
     match builder.build().await {
         Ok(()) => {
             emit(on_event, Event::BuildSucceeded);
+            emit(on_event, Event::HostLaunching);
             if let Err(e) = installer.install_and_launch().await {
                 whisker_build::ui::error(format!("{label} install failed: {e}"));
+                emit(on_event, Event::HostLaunchFailed(format!("{e:#}")));
+            } else {
+                emit(on_event, Event::HostLaunched);
             }
             sender.reload_browser();
             whisker_build::ui::info(format!(

--- a/crates/whisker-dev-server/src/hotpatch/shim_paths.rs
+++ b/crates/whisker-dev-server/src/hotpatch/shim_paths.rs
@@ -122,7 +122,8 @@ fn build_shims(workspace_root: &Path) -> Result<()> {
     // skip this step. Stream the cargo output through a step so it
     // looks like the rest of the initial-build section rather than
     // dumping ~200 lines of `Compiling X v…` ahead of any UI chrome.
-    let step = whisker_build::ui::step("setup", "whisker-cli shims");
+    let step =
+        whisker_build::ui::step(whisker_build::ui::OperationKind::Setup, "whisker-cli shims");
     let mut cmd = std::process::Command::new("cargo");
     cmd.args([
         "build",

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -157,10 +157,32 @@ impl Installer {
             }
         }
     }
+
+    /// Start the artifact already present on the target. Unlike a Full Reload,
+    /// this does not compile or reinstall anything.
+    pub async fn relaunch(&self) -> Result<()> {
+        match self.target {
+            Target::Android => {
+                let params = self.android.as_ref().context(
+                    "target=Android but no AndroidParams — cli must populate Config.android",
+                )?;
+                android_launch(params).await
+            }
+            Target::IosSimulator => {
+                let params = self.ios.as_ref().context(
+                    "target=IosSimulator but no IosParams — cli must populate Config.ios",
+                )?;
+                ios_launch(params, self.dev_port, self.dev_token.as_deref()).await
+            }
+            Target::Macos => self.install_and_launch().await,
+            Target::Web => open_browser(self.dev_port).await,
+        }
+    }
 }
 
 async fn open_browser(port: u16) -> Result<()> {
     let url = format!("http://127.0.0.1:{port}/");
+    let open_step = whisker_build::ui::step(whisker_build::ui::OperationKind::Open, url.clone());
     let mut command = if cfg!(target_os = "macos") {
         let mut command = Command::new("open");
         command.arg(&url);
@@ -176,8 +198,10 @@ async fn open_browser(port: u16) -> Result<()> {
     };
     let status = command.status().await.context("open Web Host in browser")?;
     if !status.success() {
+        open_step.fail(status.to_string());
         anyhow::bail!("browser launcher exited with {status}");
     }
+    open_step.done("");
     Ok(())
 }
 
@@ -192,9 +216,9 @@ async fn run_filtered(mut cmd: Command, kind: SimctlNoise) -> Result<std::proces
     cmd.stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
     let mut child = cmd.spawn().context("spawn child")?;
-    // Track the PID so `whisker run`'s hard-exit quit path can SIGTERM
-    // an in-flight xcodebuild / simctl instead of orphaning it. The
-    // guard unregisters when this fn returns.
+    // Track the PID so workflow cancellation can SIGTERM an in-flight
+    // xcodebuild / simctl instead of orphaning it. The guard unregisters
+    // when this fn returns.
     let _child_guard = child.id().map(whisker_build::child_guard::track);
     let mut stdout = child.stdout.take();
     let mut stderr = child.stderr.take();
@@ -449,7 +473,7 @@ async fn android_install_and_launch(
     }
 
     let install_step = whisker_build::ui::step(
-        "install",
+        whisker_build::ui::OperationKind::Install,
         apk.file_name()
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| "app-debug.apk".into()),
@@ -465,13 +489,18 @@ async fn android_install_and_launch(
     }
     install_step.done("");
 
+    android_launch(p).await
+}
+
+async fn android_launch(p: &AndroidParams) -> Result<()> {
     // force-stop first, so the relaunch really re-bootstraps.
     let mut stop_cmd = Command::new("adb");
     stop_cmd.args(["shell", "am", "force-stop", &p.application_id]);
     let _ = run_filtered(stop_cmd, SimctlNoise::Other).await;
 
     let component = format!("{}/{}", p.application_id, p.launcher_activity);
-    let launch_step = whisker_build::ui::step("launch", component.clone());
+    let launch_step =
+        whisker_build::ui::step(whisker_build::ui::OperationKind::Launch, component.clone());
     let mut launch_cmd = Command::new("adb");
     launch_cmd.args(["shell", "am", "start", "-n", &component]);
     let launch = run_filtered(launch_cmd, SimctlNoise::AdbAmStart)
@@ -505,7 +534,10 @@ async fn ios_install_and_launch(
         .join("target/.whisker/ios-derived")
         .join(package);
 
-    let xc_step = whisker_build::ui::step("xcodebuild", p.scheme.clone());
+    let xc_step = whisker_build::ui::step(
+        whisker_build::ui::OperationKind::Xcodebuild,
+        p.scheme.clone(),
+    );
     let mut xc_cmd = Command::new("xcodebuild");
     use_current_whisker_cli(&mut xc_cmd)?;
     xc_cmd
@@ -576,13 +608,16 @@ async fn ios_install_and_launch(
         .clone()
         .or_else(pick_available_iphone)
         .unwrap_or_else(|| "iPhone 17 Pro".into());
-    let boot_step = whisker_build::ui::step("boot", device.clone());
+    let boot_step = whisker_build::ui::step(whisker_build::ui::OperationKind::Boot, device.clone());
     let mut boot_cmd = Command::new("xcrun");
     boot_cmd.args(["simctl", "boot", &device]);
     let _ = run_filtered(boot_cmd, SimctlNoise::Boot).await;
     boot_step.done("");
 
-    let install_step = whisker_build::ui::step("install", format!("{}.app", p.scheme));
+    let install_step = whisker_build::ui::step(
+        whisker_build::ui::OperationKind::Install,
+        format!("{}.app", p.scheme),
+    );
     let mut install_cmd = Command::new("xcrun");
     install_cmd
         .args(["simctl", "install", "booted"])
@@ -596,6 +631,10 @@ async fn ios_install_and_launch(
     }
     install_step.done("");
 
+    ios_launch(p, dev_port, dev_token).await
+}
+
+async fn ios_launch(p: &IosParams, dev_port: u16, dev_token: Option<&str>) -> Result<()> {
     // `SIMCTL_CHILD_<NAME>` shows up as `<NAME>` inside the launched
     // app's env — that's how the dev-runtime finds us.
     //
@@ -605,7 +644,10 @@ async fn ios_install_and_launch(
     // terminate` first would print `Simulator device failed to
     // terminate <bundle>.` on every cold start, where the app is
     // installed but not running; the flag handles that silently.
-    let launch_step = whisker_build::ui::step("launch", p.bundle_id.clone());
+    let launch_step = whisker_build::ui::step(
+        whisker_build::ui::OperationKind::Launch,
+        p.bundle_id.clone(),
+    );
     let mut launch_cmd = Command::new("xcrun");
     launch_cmd
         .args([

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -258,6 +258,9 @@ pub enum Event {
     BuildingFull,
     BuildSucceeded,
     BuildFailed(String),
+    HostLaunching,
+    HostLaunched,
+    HostLaunchFailed(String),
     ClientConnected,
     ClientDisconnected,
     /// A hot-reload patch build kicked off. Fires *before* the
@@ -298,7 +301,7 @@ pub enum Event {
 // ----- Server ---------------------------------------------------------------
 
 /// Explicit user command delivered into the dev loop (keyboard
-/// shortcuts in `whisker run`'s TUI: `r` / `R`). Reloads are
+/// shortcuts in `whisker run`'s TUI: `r`, `R`, `o`, and `q`). Reloads are
 /// user-triggered by design — the loop never full-reloads on its own,
 /// because an unexpected app restart mid-interaction loses more time
 /// than it saves.
@@ -311,6 +314,10 @@ pub enum DevCommand {
     /// Full reload: cargo rebuild + reinstall + relaunch. The only
     /// way dependency-graph changes (Cargo.toml) reach the device.
     FullReload,
+    /// Relaunch the current artifact without compiling it again.
+    Relaunch,
+    /// Gracefully stop the watcher and server loop.
+    Shutdown,
 }
 
 /// The dev loop. Construct with [`DevServer::new`], then drive with
@@ -365,15 +372,11 @@ impl DevServer {
     /// restarts the app automatically: changes a patch can't express
     /// prompt for an explicit Full Reload (`DevCommand::FullReload`).
     pub async fn run(mut self) -> Result<()> {
-        // The TUI's live-region header already carries package, target
-        // and phase, so the intro rows are for non-TUI runs only.
-        if !whisker_build::ui::is_tui() {
-            whisker_build::ui::section("whisker run");
-            whisker_build::ui::info(format!(
-                "{} · {:?}",
-                self.config.package, self.config.target,
-            ));
-        }
+        whisker_build::ui::section("whisker run");
+        whisker_build::ui::info(format!(
+            "{} · {:?}",
+            self.config.package, self.config.target,
+        ));
         whisker_build::ui::debug(format!("mode={:?}", self.config.hot_patch_mode));
 
         // Builder + Installer are wired before the socket so no
@@ -440,11 +443,7 @@ impl DevServer {
         // there is nothing to patch and nothing a later save could
         // recover.
         //
-        // The section header is non-TUI only — the live region's phase
-        // indicator already announces the build.
-        if !whisker_build::ui::is_tui() {
-            whisker_build::ui::section("Initial build");
-        }
+        whisker_build::ui::section("Initial build");
         emit(&self.on_event, Event::BuildingFull);
         if let Err(e) = builder.build().await {
             let msg = format!("{e:#}");
@@ -458,9 +457,9 @@ impl DevServer {
         emit(&self.on_event, Event::BuildSucceeded);
 
         // Bind the WS so `install_and_launch` (next) has somewhere for
-        // the device's `whisker-dev-runtime` to dial. The status calls
-        // are no-ops under the TUI, whose live region shows the ws addr
-        // and client count; they carry `--no-tui` and CI.
+        // the device's `whisker-dev-runtime` to dial. Status calls feed
+        // deterministic plain output; the TUI adapter uses target-aware
+        // lifecycle events for its live region and ignores these strings.
         whisker_build::ui::ensure_status("dev-server");
         let (sender, bound, _server_handle) = server::serve(
             self.config.bind_addr,
@@ -531,11 +530,14 @@ impl DevServer {
         // dev-loop against if the app never reached the device. The
         // in-loop rebuild path (`run_build_cycle`) shares this code but
         // does fall through, so the user can retry with another save.
+        emit(&self.on_event, Event::HostLaunching);
         if let Err(e) = installer.install_and_launch().await {
+            emit(&self.on_event, Event::HostLaunchFailed(format!("{e:#}")));
             // Bails rather than `ui::error`s — see the initial-build
             // arm above.
             anyhow::bail!("initial install failed: {e:#}");
         }
+        emit(&self.on_event, Event::HostLaunched);
         whisker_build::ui::info(format!(
             "initial done · {} client(s) connected",
             sender.client_count()
@@ -598,11 +600,7 @@ impl DevServer {
             };
             match input {
                 Input::Change(mut change) => {
-                    // Non-TUI only — the live region's phase flip
-                    // already announces a picked-up save.
-                    if !whisker_build::ui::is_tui() {
-                        whisker_build::ui::section("Change");
-                    }
+                    whisker_build::ui::section("Change");
                     whisker_build::ui::debug(format!(
                         "{:?} — {} path(s)",
                         change.kind,
@@ -659,9 +657,7 @@ impl DevServer {
                     }
                 }
                 Input::Command(DevCommand::HotReload) => {
-                    if !whisker_build::ui::is_tui() {
-                        whisker_build::ui::section("Hot Reload");
-                    }
+                    whisker_build::ui::section("Hot Reload");
                     ensure_patcher(&self.config, &hot_reload_init, &mut patcher);
                     match patcher.as_ref() {
                         Some(p) => hot_reload_cycle(p, &sender, &self.on_event, None).await,
@@ -672,12 +668,22 @@ impl DevServer {
                     }
                 }
                 Input::Command(DevCommand::FullReload) => {
-                    if !whisker_build::ui::is_tui() {
-                        whisker_build::ui::section("Full Reload");
-                    }
+                    whisker_build::ui::section("Full Reload");
                     run_build_cycle(&builder, &installer, &self.on_event, &sender, "full reload")
                         .await;
                 }
+                Input::Command(DevCommand::Relaunch) => {
+                    emit(&self.on_event, Event::HostLaunching);
+                    match installer.relaunch().await {
+                        Ok(()) => emit(&self.on_event, Event::HostLaunched),
+                        Err(error) => {
+                            let message = format!("{error:#}");
+                            whisker_build::ui::error(format!("relaunch failed: {message}"));
+                            emit(&self.on_event, Event::HostLaunchFailed(message));
+                        }
+                    }
+                }
+                Input::Command(DevCommand::Shutdown) => break,
             }
         }
 


### PR DESCRIPTION
## Summary
- add a scoped, structured progress reporter in `whisker-build` so build/dev-server code emits typed operations instead of terminal-specific markers
- share the inline TUI between `whisker run` and `whisker build`, with target-aware host state, artifact output, and a global `--no-tui` fallback
- add `relaunch` and graceful `shutdown` dev commands, plus host launch lifecycle events for Android, iOS, Web, and Desktop
- keep arbitrary subprocess diagnostics in normal terminal scrollback while using typed progress for workflow state

## Interaction
- `whisker run`: `r` hot reload, `R` full reload, `o` relaunch, `q` graceful shutdown
- `whisker build`: `q` cancels the active build
- non-TTY, CI, `--verbose`, and `--no-tui` continue to use deterministic plain output

## Verification
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `cargo test -p whisker-build -p whisker-cli -p whisker-dev-server --doc`
- `cargo run -p whisker-cli --bin whisker -- --no-tui build web --manifest-path examples/host-smoke/Cargo.toml`