### PR TITLE
feat(modules): declare platform support explicitly

### DIFF
--- a/crates/whisker-cli/src/lib.rs
+++ b/crates/whisker-cli/src/lib.rs
@@ -81,7 +81,7 @@ enum Command {
     /// + subsecond hot patches over WebSocket.
     Run(run::Args),
     /// Scaffold a new Whisker module crate — Cargo.toml (with the
-    /// `[package.metadata.whisker]` marker), Package.swift,
+    /// `[package.metadata.whisker.module.platforms]` support map), Package.swift,
     /// build.gradle.kts, and skeleton Rust / Swift / Kotlin sources.
     /// See `docs/module-author-guide.md`.
     NewModule(new_module::NewModuleArgs),

--- a/crates/whisker-cli/src/new_module.rs
+++ b/crates/whisker-cli/src/new_module.rs
@@ -2,7 +2,7 @@
 //!
 //! Creates a directory matching the supplied crate name with a
 //! complete module skeleton: `Cargo.toml` (carrying the
-//! `[package.metadata.whisker]` discovery marker), `Package.swift`,
+//! `[package.metadata.whisker.module.platforms]` support map), `Package.swift`,
 //! `build.gradle.kts`, `src/lib.rs`, and the platform sources under
 //! `ios/`, `android/`, `desktop/`, and `web/` (Expo-style layout). The skeleton compiles
 //! standalone — the consumer just runs `cargo build` and adds the
@@ -223,16 +223,11 @@ fn whisker_dep_version() -> String {
 
 fn cargo_toml(v: &Vars, shape: &ModuleShape) -> String {
     let rust_hosts = if matches!(shape, ModuleShape::ViewBearing) {
-        format!(
-            r#"
-[package.metadata.whisker.desktop]
-package = "{name}-desktop-host"
-
-[package.metadata.whisker.web]
-package = "{name}-web-host"
-"#,
-            name = v.crate_name,
-        )
+        r#"
+desktop = { manifest = "desktop/Cargo.toml" }
+web = { manifest = "web/Cargo.toml" }
+"#
+        .to_string()
     } else {
         String::new()
     };
@@ -257,10 +252,11 @@ include = [
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker — the bare table identifies this cargo
-# crate as a Whisker module, so `whisker-build` wires its `android/`
-# Gradle subproject + `ios/` SwiftPM package into the host build.
-[package.metadata.whisker]
+# Module support is explicit. An omitted platform is unsupported;
+# `kind = "common"` means the parent Rust crate needs no Host adapter.
+[package.metadata.whisker.module.platforms]
+android = {{ manifest = "build.gradle.kts" }}
+ios = {{ manifest = "Package.swift" }}
 {rust_hosts}
 
 [dependencies]
@@ -470,7 +466,7 @@ pub fn __whisker_element_module_definition() -> whisker::ElementModuleDefinition
 fn desktop_cargo_toml(v: &Vars) -> String {
     format!(
         r#"[package]
-name = "{name}-desktop-host"
+name = "{name}-desktop"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -510,7 +506,7 @@ impl WhiskerModule for {tag}Module {{
 fn web_cargo_toml(v: &Vars) -> String {
     format!(
         r#"[package]
-name = "{name}-web-host"
+name = "{name}-web"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -916,8 +912,13 @@ mod tests {
         assert!(!common.contains("whisker_desktop"));
         assert!(!common.contains("whisker_web"));
         let manifest = std::fs::read_to_string(module.join("Cargo.toml")).unwrap();
-        assert!(manifest.contains("[package.metadata.whisker.desktop]"));
-        assert!(manifest.contains("package = \"whisker-switch-web-host\""));
+        assert!(manifest.contains("[package.metadata.whisker.module.platforms]"));
+        assert!(manifest.contains("web = { manifest = \"web/Cargo.toml\" }"));
+        assert!(manifest.contains("desktop = { manifest = \"desktop/Cargo.toml\" }"));
+        let desktop = std::fs::read_to_string(module.join("desktop/Cargo.toml")).unwrap();
+        assert!(desktop.contains("name = \"whisker-switch-desktop\""));
+        let web = std::fs::read_to_string(module.join("web/Cargo.toml")).unwrap();
+        assert!(web.contains("name = \"whisker-switch-web\""));
         std::fs::remove_dir_all(root).ok();
     }
 }

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -181,7 +181,9 @@ fn sync_macos(
         .iter()
         .cloned()
         .filter_map(|module| {
-            let contribution = module.desktop?;
+            let contribution = module
+                .rust_host(whisker_build::modules::ModulePlatform::Macos)?
+                .clone();
             let host_dependency = match contribution.source {
                 whisker_build::modules::ResolvedRustHostSource::Path(path) => {
                     whisker_cng::RustHostDependency::Path(path)
@@ -232,7 +234,9 @@ fn sync_web(
         .iter()
         .cloned()
         .filter_map(|module| {
-            let contribution = module.web?;
+            let contribution = module
+                .rust_host(whisker_build::modules::ModulePlatform::Web)?
+                .clone();
             let host_dependency = match contribution.source {
                 whisker_build::modules::ResolvedRustHostSource::Path(path) => {
                     whisker_cng::RustHostDependency::Path(path)

--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -83,7 +83,7 @@ pub struct AndroidInputs {
     /// Cargo crate name of the user app. Echoed into
     /// `whisker { userPackage = "..." }`. The Settings plugin
     /// walks the cargo dep graph rooted here for
-    /// `[package.metadata.whisker]`-tagged module deps.
+    /// `[package.metadata.whisker.module.platforms]` module deps.
     pub whisker_user_package: String,
     /// Version for `rs.whisker:whisker-runtime-android:<this>` and its
     /// sibling SDK coordinates.

--- a/crates/whisker-cng/src/ios_modules.rs
+++ b/crates/whisker-cng/src/ios_modules.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::modules::ResolvedModule;
+use crate::modules::{ModulePlatform, NativeManifestKind, ResolvedModule};
 
 /// Canonical remote Swift package containing Whisker's iOS Host SDK.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
@@ -68,11 +68,14 @@ pub fn stage_module_swift_sources(
     std::fs::create_dir_all(&sources_root)
         .with_context(|| format!("mkdir -p {}", sources_root.display()))?;
 
-    // A `Package.swift` next to the crate's `Cargo.toml` is the
-    // discovery signal, which skips Android-only modules for free.
+    // The module manifest is authoritative; unsupported and common-only iOS
+    // implementations do not enter SwiftPM's graph.
     let ios_modules: Vec<&ResolvedModule> = modules
         .iter()
-        .filter(|m| m.manifest_dir.join("Package.swift").is_file())
+        .filter(|m| {
+            m.native_manifest(ModulePlatform::Ios)
+                .is_some_and(|manifest| manifest.kind == NativeManifestKind::SwiftPm)
+        })
         .collect();
 
     // A Whisker source checkout contains the root Swift package that owns
@@ -149,7 +152,8 @@ pub fn parse_ios_platform_major(manifest: &str) -> Option<u32> {
 fn ios_platform_major(modules: &[&ResolvedModule]) -> u32 {
     modules
         .iter()
-        .filter_map(|m| std::fs::read_to_string(m.manifest_dir.join("Package.swift")).ok())
+        .filter_map(|m| m.native_manifest(ModulePlatform::Ios))
+        .filter_map(|manifest| std::fs::read_to_string(&manifest.path).ok())
         .filter_map(|manifest| parse_ios_platform_major(&manifest))
         .chain(std::iter::once(DEFAULT_IOS_PLATFORM_MAJOR))
         .max()
@@ -212,7 +216,12 @@ pub fn render_modules_package_swift(
         // directory (Package.swift lives there, identity = the
         // crate's dir name — unique). Its target sources live under
         // the package's `ios/` subdir (Expo-style layout).
-        let path = m.manifest_dir.display().to_string();
+        let path = m
+            .native_manifest(ModulePlatform::Ios)
+            .and_then(|manifest| manifest.path.parent())
+            .expect("iOS modules were filtered to SwiftPM manifests")
+            .display()
+            .to_string();
         out.push_str(&format!(
             "        .package(name: {pkg:?}, path: {path:?}),\n",
             pkg = m.package

--- a/crates/whisker-cng/src/lib.rs
+++ b/crates/whisker-cng/src/lib.rs
@@ -47,8 +47,9 @@ pub use discovery::{DiscoveredPlugin, discover_plugins};
 pub use ios::{IosInputs, sync as sync_ios};
 pub use macos::{MacosInputs, sync as sync_macos};
 pub use modules::{
-    ResolvedModule, ResolvedRustHostSource, ResolvedRustModuleContribution, build_modules_report,
-    discover as discover_modules, refresh_gradle_module_cache,
+    ModulePlatform, NativeManifestKind, ResolvedModule, ResolvedNativeManifest,
+    ResolvedPlatformImplementation, ResolvedRustHostSource, ResolvedRustModuleContribution,
+    build_modules_report, discover as discover_modules, refresh_gradle_module_cache,
 };
 pub use web::{WebInputs, sync as sync_web};
 pub use whisker_config::Config;

--- a/crates/whisker-cng/src/modules.rs
+++ b/crates/whisker-cng/src/modules.rs
@@ -1,13 +1,11 @@
 //! Whisker module-system — discovery + manifest parsing.
 //!
-//! When `whisker run` builds an app crate for
-//! iOS or Android, every cargo dependency may optionally contribute
-//! native code (Swift / Obj-C++ on iOS, Kotlin / JNI on Android) to
-//! the final host binary. A crate opts in by declaring a
-//! `[package.metadata.whisker]` table in its `Cargo.toml`. The
-//! Whisker CLI walks the consuming app's dep graph via `cargo
-//! metadata`, picks out every dependency carrying that table, and
-//! feeds each platform contribution through to its build system.
+//! A dependency becomes a Whisker module by declaring its supported
+//! platforms under `[package.metadata.whisker.module.platforms]`.
+//! Each platform is either implemented entirely by the common Rust
+//! crate (`kind = "common"`) or points at one explicit Host manifest.
+//! CNG resolves those declarations from Cargo's dependency graph and
+//! feeds each Host contribution to the corresponding build system.
 //!
 //! This module is platform-neutral — it just produces the
 //! `ResolvedModule` list. CNG renderers turn the list into complete
@@ -17,15 +15,11 @@
 //! ## Schema
 //!
 //! ```toml
-//! # packages/whisker-video/Cargo.toml
-//! [package.metadata.whisker]
-//! # The bare table is the marker — its presence identifies this
-//! # crate as a Whisker module. Platform code + build manifests live
-//! # at the package root in `android/` and `ios/` (Expo-style):
-//! #   android/build.gradle.kts   — AGP library
-//! #   ios/Package.swift          — SwiftPM library
-//! # CNG discovers those per-platform manifests directly,
-//! # so no source-file list is needed for DSL modules.
+//! [package.metadata.whisker.module.platforms]
+//! android = { manifest = "build.gradle.kts" }
+//! ios = { manifest = "Package.swift" }
+//! web = { manifest = "web/Cargo.toml" }
+//! desktop = { kind = "common" }
 //! ```
 //!
 //! All paths are resolved relative to the directory containing the
@@ -37,87 +31,16 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 use cargo_metadata::{Metadata, MetadataCommand};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-/// Top-level shape of the `[package.metadata.whisker]` table.
-///
-/// Every section is optional so a module can declare just the
-/// platform(s) it supports — the bare table (no sub-sections) is a
-/// valid marker for a pure-DSL module that ships only Swift /
-/// Kotlin via its `ios/` / `android/` dirs. Unknown sections /
-/// fields are rejected to catch typos early (we don't want a
-/// typoed `iOS` section to silently produce a no-op build).
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ManifestRaw {
-    #[serde(default)]
-    pub ios: Option<IosSectionRaw>,
-    #[serde(default)]
-    pub android: Option<AndroidSectionRaw>,
-    /// Rust Desktop Host crate published beside the common module crate.
-    #[serde(default)]
-    pub desktop: Option<RustHostSectionRaw>,
-    /// Rust Web Host crate published beside the common module crate.
-    #[serde(default)]
-    pub web: Option<RustHostSectionRaw>,
-    /// `[package.metadata.whisker.plugins.<name>]` entries —
-    /// consumed by `whisker_cng::discovery`, not by the module
-    /// system. Captured here as raw JSON so its presence doesn't
-    /// trip the `deny_unknown_fields` check on this struct.
-    /// Validation of the plugin entry's shape lives in
-    /// `whisker_cng::discovery::PluginEntryRaw`.
-    #[serde(default)]
-    pub plugins: Option<serde_json::Value>,
-}
+mod platforms;
 
-/// Published package identity for a Rust Host contribution.
-///
-/// A local checkout still discovers the nested manifest by convention. This
-/// declaration survives crates.io packaging, which deliberately excludes
-/// nested Cargo packages from the outer crate archive.
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct RustHostSectionRaw {
-    /// Cargo package name of the separately published Host library.
-    pub package: String,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct IosSectionRaw {
-    /// Paths to Swift source files that get staged into the
-    /// consuming app's gen tree under
-    /// `gen/ios/Sources/WhiskerModules/<crate-name>/` and compiled
-    /// into the host app target alongside its own Swift sources.
-    /// Mirror of `[android].kotlin_sources` for symmetry.
-    ///
-    /// Existence-checked but otherwise inert: iOS staging keys off a
-    /// module's `ios/Package.swift`, not this list.
-    #[serde(default)]
-    pub swift_sources: Vec<String>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct AndroidSectionRaw {
-    /// Paths to Kotlin / Java source files (`*.kt`, `*.java`) that
-    /// should be compiled into the host app's APK alongside the
-    /// runtime's own Kotlin sources. Paths are relative to the
-    /// manifest's directory.
-    ///
-    /// Most modules use these to declare a `WhiskerUI` subclass that
-    /// their generated Host registration points at.
-    #[serde(default)]
-    pub kotlin_sources: Vec<String>,
-    /// Paths to JNI C / C++ source files (`*.c`, `*.cc`, `*.cpp`)
-    /// — for modules that need to drop into native code on Android
-    /// (cross-language calls, raw NDK APIs, etc.). Less common than
-    /// kotlin_sources; most native_element modules can stay in
-    /// Kotlin.
-    #[serde(default)]
-    pub jni_sources: Vec<String>,
-}
+use platforms::{ManifestRaw, resolve_legacy_platforms, resolve_platforms};
+pub use platforms::{
+    ModulePlatform, NativeManifestKind, ResolvedModulePlatforms, ResolvedNativeManifest,
+    ResolvedPlatformImplementation, ResolvedRustHostSource, ResolvedRustModuleContribution,
+};
 
 /// A single discovered module after its metadata has been resolved
 /// against the cargo dep tree. `package` carries the cargo crate
@@ -138,34 +61,57 @@ pub struct ResolvedModule {
     /// for the Android build. Empty by default — most native_element
     /// modules use Kotlin, not JNI.
     pub android_jni_sources: Vec<PathBuf>,
-    /// Rust-native Desktop module contribution.
-    pub desktop: Option<ResolvedRustModuleContribution>,
-    /// Browser DOM module contribution.
-    pub web: Option<ResolvedRustModuleContribution>,
+    /// Explicit support and implementation selected for each Host.
+    pub platforms: ResolvedModulePlatforms,
 }
 
-/// One existence-checked Rust Host library shipped inside a module package.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct ResolvedRustModuleContribution {
-    /// Cargo package name declared by the Host library.
-    pub package: String,
-    /// How the generated Host should depend on this library.
-    pub source: ResolvedRustHostSource,
-}
+impl ResolvedModule {
+    pub fn rust_host(&self, platform: ModulePlatform) -> Option<&ResolvedRustModuleContribution> {
+        let implementation = match platform {
+            ModulePlatform::Macos => self
+                .platforms
+                .macos
+                .as_ref()
+                .or(self.platforms.desktop.as_ref()),
+            ModulePlatform::Windows => self
+                .platforms
+                .windows
+                .as_ref()
+                .or(self.platforms.desktop.as_ref()),
+            ModulePlatform::Linux => self
+                .platforms
+                .linux
+                .as_ref()
+                .or(self.platforms.desktop.as_ref()),
+            ModulePlatform::Android => self.platforms.android.as_ref(),
+            ModulePlatform::Ios => self.platforms.ios.as_ref(),
+            ModulePlatform::Web => self.platforms.web.as_ref(),
+            ModulePlatform::Desktop => self.platforms.desktop.as_ref(),
+        }?;
+        match implementation {
+            ResolvedPlatformImplementation::RustHost(host) => Some(host),
+            ResolvedPlatformImplementation::Common
+            | ResolvedPlatformImplementation::NativeManifest(_) => None,
+        }
+    }
 
-/// Location of one Rust Host library after module discovery.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub enum ResolvedRustHostSource {
-    /// A nested crate present in a path or git checkout.
-    Path(PathBuf),
-    /// A separately published crate used when Cargo unpacked the outer module
-    /// without its nested packages.
-    Registry { version: String },
+    pub fn native_manifest(&self, platform: ModulePlatform) -> Option<&ResolvedNativeManifest> {
+        let implementation = match platform {
+            ModulePlatform::Android => self.platforms.android.as_ref(),
+            ModulePlatform::Ios => self.platforms.ios.as_ref(),
+            _ => None,
+        }?;
+        match implementation {
+            ResolvedPlatformImplementation::NativeManifest(manifest) => Some(manifest),
+            ResolvedPlatformImplementation::Common
+            | ResolvedPlatformImplementation::RustHost(_) => None,
+        }
+    }
 }
 
 /// Walk the cargo dep graph of `app_package` (resolved at
 /// `manifest_path`) and return every dependency that declares a
-/// `[package.metadata.whisker]` table in its `Cargo.toml`.
+/// `[package.metadata.whisker.module.platforms]` table in its `Cargo.toml`.
 ///
 /// Ordering: `cargo metadata`'s topological order, deduplicated by
 /// package id (a diamond dep landed twice gets resolved once).
@@ -178,9 +124,8 @@ pub enum ResolvedRustHostSource {
 /// - Metadata parse failure (`[package.metadata.whisker]` exists
 ///   but has unknown sections / fields) propagates with the
 ///   offending crate name attached.
-/// - Native-source path referenced in the table but not present on disk, or
-///   an invalid conventional `desktop/Cargo.toml` / `web/Cargo.toml`, errors
-///   eagerly rather than silently dropping a Host implementation.
+/// - A declared manifest that is absent or has the wrong kind/package name
+///   errors eagerly rather than silently dropping a Host implementation.
 pub fn discover(manifest_path: &Path, app_package: &str) -> Result<Vec<ResolvedModule>> {
     let metadata = MetadataCommand::new()
         .manifest_path(manifest_path)
@@ -238,7 +183,7 @@ pub(crate) fn discover_from_metadata(
             }
         }
         // The root app declares native sources directly, never through
-        // a `[package.metadata.whisker]` table.
+        // module metadata.
         if pkg_id != &root_id {
             module_pkg_ids.push(pkg_id.clone());
         }
@@ -262,8 +207,9 @@ pub(crate) fn discover_from_metadata(
                     pkg.manifest_path,
                 )
             })?;
-        // A `[package.metadata.whisker]` table is the opt-in marker;
-        // deps without one are not modules.
+        // `module` is the current opt-in. During the package-by-package
+        // migration, an old platform field or a conventional native manifest
+        // also identifies a legacy module. `plugins` alone never does.
         let Some(whisker_meta) = pkg.metadata.get("whisker") else {
             continue;
         };
@@ -272,20 +218,35 @@ pub(crate) fn discover_from_metadata(
                 format!("parse [package.metadata.whisker] in {}", pkg.manifest_path,)
             })?;
         let package_version = pkg.version.to_string();
-        let desktop = resolve_rust_host_crate(
-            &pkg.name,
-            &package_version,
-            "desktop",
-            &manifest_dir,
-            manifest.desktop.as_ref(),
-        )?;
-        let web = resolve_rust_host_crate(
-            &pkg.name,
-            &package_version,
-            "web",
-            &manifest_dir,
-            manifest.web.as_ref(),
-        )?;
+        let has_legacy_fields = manifest.ios.is_some()
+            || manifest.android.is_some()
+            || manifest.desktop.is_some()
+            || manifest.web.is_some();
+        let has_conventional_native_manifest = manifest_dir.join("build.gradle.kts").is_file()
+            || manifest_dir.join("Package.swift").is_file();
+        if manifest.module.is_none() && !has_legacy_fields && !has_conventional_native_manifest {
+            continue;
+        }
+        if manifest.module.is_some() && has_legacy_fields {
+            return Err(anyhow!(
+                "module `{}` mixes [package.metadata.whisker.module.platforms] with legacy metadata.whisker platform tables",
+                pkg.name,
+            ));
+        }
+
+        let platforms = if let Some(module) = manifest.module.as_ref() {
+            resolve_platforms(
+                &pkg.name,
+                &package_version,
+                pkg.source
+                    .as_ref()
+                    .is_some_and(|source| source.repr.starts_with("registry+")),
+                &manifest_dir,
+                &module.platforms,
+            )?
+        } else {
+            resolve_legacy_platforms(&pkg.name, &package_version, &manifest_dir, &manifest)?
+        };
         let mut ios_swift: Vec<PathBuf> = Vec::new();
         if let Some(ios) = manifest.ios {
             for raw_path in ios.swift_sources {
@@ -335,8 +296,7 @@ pub(crate) fn discover_from_metadata(
             ios_swift_sources: ios_swift,
             android_kotlin_sources: android_kotlin,
             android_jni_sources: android_jni,
-            desktop,
-            web,
+            platforms,
         });
     }
 
@@ -344,63 +304,6 @@ pub(crate) fn discover_from_metadata(
     // gradle / cargo don't re-run downstream tasks on a permutation.
     resolved.sort_by(|a, b| a.package.cmp(&b.package));
     Ok(resolved)
-}
-
-fn resolve_rust_host_crate(
-    package: &str,
-    package_version: &str,
-    target: &str,
-    manifest_dir: &Path,
-    published: Option<&RustHostSectionRaw>,
-) -> Result<Option<ResolvedRustModuleContribution>> {
-    if let Some(published) = published
-        && published.package.trim().is_empty()
-    {
-        return Err(anyhow!(
-            "module `{package}` metadata.whisker.{target}.package must not be empty"
-        ));
-    }
-    let cargo_toml = manifest_dir.join(target).join("Cargo.toml");
-    if !cargo_toml.is_file() {
-        return Ok(published.map(|published| ResolvedRustModuleContribution {
-            package: published.package.clone(),
-            source: ResolvedRustHostSource::Registry {
-                version: package_version.to_string(),
-            },
-        }));
-    }
-    let source = std::fs::read_to_string(&cargo_toml)
-        .with_context(|| format!("read {} Host manifest {}", target, cargo_toml.display()))?;
-    let manifest: toml::Value = toml::from_str(&source)
-        .with_context(|| format!("parse {} Host manifest {}", target, cargo_toml.display()))?;
-    let host_package = manifest
-        .get("package")
-        .and_then(|value| value.get("name"))
-        .and_then(toml::Value::as_str)
-        .filter(|name| !name.trim().is_empty())
-        .ok_or_else(|| {
-            anyhow!(
-                "module `{package}` {target}/Cargo.toml must declare a non-empty [package].name"
-            )
-        })?;
-    if let Some(published) = published
-        && published.package != host_package
-    {
-        return Err(anyhow!(
-            "module `{package}` metadata.whisker.{target}.package is {:?}, but {target}/Cargo.toml declares package {:?}",
-            published.package,
-            host_package,
-        ));
-    }
-    let host_root = cargo_toml
-        .parent()
-        .expect("Cargo.toml has a parent")
-        .canonicalize()
-        .with_context(|| format!("canonicalize {} Host crate", cargo_toml.display()))?;
-    Ok(Some(ResolvedRustModuleContribution {
-        package: host_package.to_string(),
-        source: ResolvedRustHostSource::Path(host_root),
-    }))
 }
 
 /// Flatten every discovered module's Android Kotlin sources into a
@@ -448,11 +351,9 @@ pub struct ModulesReportModule {
     /// Absolute path to the directory containing the module's
     /// `Cargo.toml`.
     pub manifest_dir: PathBuf,
-    /// Android-side surface. `None` when the module has no `android/`
-    /// directory at the package root.
+    /// Android-side surface. `None` when Android is unsupported or common-only.
     pub android: Option<AndroidModuleReport>,
-    /// iOS-side surface. `None` when the module declares neither
-    /// `ios_swift_sources` nor an `ios/Package.swift`.
+    /// iOS-side surface. `None` when iOS is unsupported or common-only.
     pub ios: Option<IosModuleReport>,
 }
 
@@ -460,9 +361,7 @@ pub struct ModulesReportModule {
 pub struct AndroidModuleReport {
     /// Absolute path the Gradle Settings Plugin uses for
     /// `settings.project(":<crate>").projectDir = file(this)`.
-    /// This is the package root (manifest_dir) — the Expo-style
-    /// layout keeps `build.gradle.kts` at the root and points its
-    /// Kotlin source set at the `android/` subdirectory.
+    /// This is the directory containing the declared `build.gradle.kts`.
     pub subproject_dir: PathBuf,
     /// `<PascalCase(crate_name)>Behaviors` — the KSP-emitted object
     /// name. Lives in package `rs.whisker.runtime.generated`, same as
@@ -545,14 +444,9 @@ pub fn write_gradle_module_cache(
 /// [`discover`], `Cargo.lock` hashing, and per-platform availability
 /// classification.
 ///
-/// Detection rules — both follow the Expo-style "manifest at the
-/// package root, source under a per-platform subdir":
-///   * Android: `<manifest_dir>/build.gradle.kts` exists. The
-///     `subproject_dir` reported is `manifest_dir` (the AGP library
-///     module is rooted at the package root; its Kotlin source set
-///     points at `android/` internally).
-///   * iOS: `<manifest_dir>/Package.swift` exists, OR
-///     `ios_swift_sources` is non-empty.
+/// Platform availability comes from the resolved module declaration, never
+/// from directory guessing. Legacy source lists remain reportable during the
+/// package migration.
 pub fn build_modules_report(workspace_root: &Path, user_package: &str) -> Result<ModulesReport> {
     let manifest_path = workspace_root.join("Cargo.toml");
     let resolved = discover(&manifest_path, user_package)
@@ -574,19 +468,23 @@ fn build_modules_report_from_resolved(
         .iter()
         .cloned()
         .map(|m| {
-            let android = if m.manifest_dir.join("build.gradle.kts").is_file() {
-                Some(AndroidModuleReport {
-                    subproject_dir: m.manifest_dir.clone(),
+            let android = m
+                .native_manifest(ModulePlatform::Android)
+                .filter(|manifest| manifest.kind == NativeManifestKind::Gradle)
+                .map(|manifest| AndroidModuleReport {
+                    subproject_dir: manifest
+                        .path
+                        .parent()
+                        .expect("native manifest has a parent")
+                        .to_path_buf(),
                     behaviors_class: crate_to_behaviors_class(&m.package),
-                })
-            } else {
-                None
-            };
-            let swift_pkg = m.manifest_dir.join("Package.swift");
-            let has_ios = !m.ios_swift_sources.is_empty() || swift_pkg.is_file();
-            let ios = if has_ios {
+                });
+            let swift_manifest = m
+                .native_manifest(ModulePlatform::Ios)
+                .filter(|manifest| manifest.kind == NativeManifestKind::SwiftPm);
+            let ios = if swift_manifest.is_some() || !m.ios_swift_sources.is_empty() {
                 Some(IosModuleReport {
-                    swift_module: if swift_pkg.is_file() {
+                    swift_module: if swift_manifest.is_some() {
                         Some(crate_to_swift_module(&m.package))
                     } else {
                         None
@@ -665,6 +563,72 @@ fn hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn tempdir() -> PathBuf {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "whisker-module-discovery-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn plugin_only_dependency_is_not_a_module() {
+        let root = tempdir();
+        std::fs::create_dir_all(root.join("app/src")).unwrap();
+        std::fs::create_dir_all(root.join("plugin/src")).unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"app\", \"plugin\"]\nresolver = \"2\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("app/Cargo.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2024\"\n[dependencies]\nplugin = { path = \"../plugin\" }\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("app/src/lib.rs"), "pub fn app() {}\n").unwrap();
+        std::fs::write(
+            root.join("plugin/Cargo.toml"),
+            "[package]\nname = \"plugin\"\nversion = \"0.1.0\"\nedition = \"2024\"\n[package.metadata.whisker.plugins.example]\nbin = \"example-plugin\"\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("plugin/src/lib.rs"), "pub fn plugin() {}\n").unwrap();
+
+        let modules = discover(&root.join("Cargo.toml"), "app").unwrap();
+        assert!(modules.is_empty());
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn desktop_is_the_fallback_for_os_specific_hosts() {
+        let module = ResolvedModule {
+            package: "whisker-map".into(),
+            manifest_dir: PathBuf::from("/module"),
+            ios_swift_sources: Vec::new(),
+            android_kotlin_sources: Vec::new(),
+            android_jni_sources: Vec::new(),
+            platforms: ResolvedModulePlatforms {
+                desktop: Some(ResolvedPlatformImplementation::RustHost(
+                    ResolvedRustModuleContribution {
+                        package: "whisker-map-desktop".into(),
+                        source: ResolvedRustHostSource::Registry {
+                            version: "1.2.3".into(),
+                        },
+                    },
+                )),
+                ..Default::default()
+            },
+        };
+        assert_eq!(
+            module.rust_host(ModulePlatform::Macos).unwrap().package,
+            "whisker-map-desktop"
+        );
+    }
 
     #[test]
     fn discovers_rfc0004_rust_host_crates_by_convention() {
@@ -678,13 +642,13 @@ mod tests {
             .iter()
             .find(|module| module.package == "whisker-toggle")
             .unwrap();
-        let desktop = toggle.desktop.as_ref().unwrap();
+        let desktop = toggle.rust_host(ModulePlatform::Desktop).unwrap();
         assert_eq!(desktop.package, "whisker-toggle-desktop-host");
         assert!(matches!(
             &desktop.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-toggle/desktop")
         ));
-        let web = toggle.web.as_ref().unwrap();
+        let web = toggle.rust_host(ModulePlatform::Web).unwrap();
         assert_eq!(web.package, "whisker-toggle-web-host");
         assert!(matches!(
             &web.source,
@@ -704,33 +668,11 @@ mod tests {
             .iter()
             .find(|module| module.package == "whisker-router")
             .unwrap();
-        let web = router.web.as_ref().unwrap();
+        let web = router.rust_host(ModulePlatform::Web).unwrap();
         assert_eq!(web.package, "whisker-router-web-host");
         assert!(matches!(
             &web.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-router/web")
         ));
-    }
-
-    #[test]
-    fn published_rust_host_falls_back_to_the_outer_package_version() {
-        let contribution = resolve_rust_host_crate(
-            "whisker-toggle",
-            "1.2.3",
-            "desktop",
-            Path::new("/definitely/not/a/module/package"),
-            Some(&RustHostSectionRaw {
-                package: "whisker-toggle-desktop-host".into(),
-            }),
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(contribution.package, "whisker-toggle-desktop-host");
-        assert_eq!(
-            contribution.source,
-            ResolvedRustHostSource::Registry {
-                version: "1.2.3".into()
-            }
-        );
     }
 }

--- a/crates/whisker-cng/src/modules/platforms.rs
+++ b/crates/whisker-cng/src/modules/platforms.rs
@@ -1,0 +1,640 @@
+//! Module platform declarations and manifest resolution.
+//!
+//! This is the implementation behind module discovery's small interface:
+//! callers receive a resolved support map and never need to infer platform
+//! support from directory names.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+
+/// Top-level shape of `[package.metadata.whisker]`.
+///
+/// `module` is the module-system opt-in. `plugins` belongs to CNG and does not
+/// make a crate a module by itself. The legacy fields remain readable only so
+/// packages can migrate independently; new manifests must use `module`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ManifestRaw {
+    #[serde(default)]
+    pub module: Option<ModuleSectionRaw>,
+    // Legacy module metadata. Remove after all published packages have moved
+    // to `module.platforms`.
+    #[serde(default)]
+    pub ios: Option<IosSectionRaw>,
+    #[serde(default)]
+    pub android: Option<AndroidSectionRaw>,
+    #[serde(default)]
+    pub desktop: Option<RustHostSectionRaw>,
+    #[serde(default)]
+    pub web: Option<RustHostSectionRaw>,
+    /// Parsed separately by CNG plugin discovery.
+    #[serde(default, rename = "plugins")]
+    pub _plugins: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ModuleSectionRaw {
+    pub platforms: PlatformDeclarationsRaw,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PlatformDeclarationsRaw {
+    pub android: Option<PlatformDeclarationRaw>,
+    pub ios: Option<PlatformDeclarationRaw>,
+    pub web: Option<PlatformDeclarationRaw>,
+    pub desktop: Option<PlatformDeclarationRaw>,
+    pub macos: Option<PlatformDeclarationRaw>,
+    pub windows: Option<PlatformDeclarationRaw>,
+    pub linux: Option<PlatformDeclarationRaw>,
+}
+
+/// One platform declaration. Exactly one of `kind` and `manifest` is required.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PlatformDeclarationRaw {
+    pub kind: Option<String>,
+    pub manifest: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RustHostSectionRaw {
+    pub package: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct IosSectionRaw {
+    #[serde(default)]
+    pub swift_sources: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct AndroidSectionRaw {
+    #[serde(default)]
+    pub kotlin_sources: Vec<String>,
+    #[serde(default)]
+    pub jni_sources: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ResolvedModulePlatforms {
+    pub android: Option<ResolvedPlatformImplementation>,
+    pub ios: Option<ResolvedPlatformImplementation>,
+    pub web: Option<ResolvedPlatformImplementation>,
+    pub desktop: Option<ResolvedPlatformImplementation>,
+    pub macos: Option<ResolvedPlatformImplementation>,
+    pub windows: Option<ResolvedPlatformImplementation>,
+    pub linux: Option<ResolvedPlatformImplementation>,
+}
+
+/// The implementation behind one declared platform.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum ResolvedPlatformImplementation {
+    /// The parent Rust crate is the complete implementation.
+    Common,
+    /// A native build-system manifest (Gradle or SwiftPM).
+    NativeManifest(ResolvedNativeManifest),
+    /// A Rust Host adapter linked by Cargo.
+    RustHost(ResolvedRustModuleContribution),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedNativeManifest {
+    pub path: PathBuf,
+    pub kind: NativeManifestKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum NativeManifestKind {
+    Gradle,
+    SwiftPm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModulePlatform {
+    Android,
+    Ios,
+    Web,
+    Desktop,
+    Macos,
+    Windows,
+    Linux,
+}
+
+impl ModulePlatform {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Android => "android",
+            Self::Ios => "ios",
+            Self::Web => "web",
+            Self::Desktop => "desktop",
+            Self::Macos => "macos",
+            Self::Windows => "windows",
+            Self::Linux => "linux",
+        }
+    }
+}
+
+/// One existence-checked Rust Host library shipped beside a module package.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedRustModuleContribution {
+    pub package: String,
+    pub source: ResolvedRustHostSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum ResolvedRustHostSource {
+    Path(PathBuf),
+    Registry { version: String },
+}
+
+pub(super) fn resolve_platforms(
+    package: &str,
+    package_version: &str,
+    registry_source: bool,
+    manifest_dir: &Path,
+    raw: &PlatformDeclarationsRaw,
+) -> Result<ResolvedModulePlatforms> {
+    if raw.android.is_none()
+        && raw.ios.is_none()
+        && raw.web.is_none()
+        && raw.desktop.is_none()
+        && raw.macos.is_none()
+        && raw.windows.is_none()
+        && raw.linux.is_none()
+    {
+        return Err(anyhow!(
+            "module `{package}` must declare at least one platform under metadata.whisker.module.platforms"
+        ));
+    }
+
+    Ok(ResolvedModulePlatforms {
+        android: resolve_platform(
+            package,
+            package_version,
+            registry_source,
+            manifest_dir,
+            ModulePlatform::Android,
+            raw.android.as_ref(),
+        )?,
+        ios: resolve_platform(
+            package,
+            package_version,
+            registry_source,
+            manifest_dir,
+            ModulePlatform::Ios,
+            raw.ios.as_ref(),
+        )?,
+        web: resolve_platform(
+            package,
+            package_version,
+            registry_source,
+            manifest_dir,
+            ModulePlatform::Web,
+            raw.web.as_ref(),
+        )?,
+        desktop: resolve_platform(
+            package,
+            package_version,
+            registry_source,
+            manifest_dir,
+            ModulePlatform::Desktop,
+            raw.desktop.as_ref(),
+        )?,
+        macos: resolve_platform(
+            package,
+            package_version,
+            registry_source,
+            manifest_dir,
+            ModulePlatform::Macos,
+            raw.macos.as_ref(),
+        )?,
+        windows: resolve_platform(
+            package,
+            package_version,
+            registry_source,
+            manifest_dir,
+            ModulePlatform::Windows,
+            raw.windows.as_ref(),
+        )?,
+        linux: resolve_platform(
+            package,
+            package_version,
+            registry_source,
+            manifest_dir,
+            ModulePlatform::Linux,
+            raw.linux.as_ref(),
+        )?,
+    })
+}
+
+fn resolve_platform(
+    package: &str,
+    package_version: &str,
+    registry_source: bool,
+    manifest_dir: &Path,
+    platform: ModulePlatform,
+    raw: Option<&PlatformDeclarationRaw>,
+) -> Result<Option<ResolvedPlatformImplementation>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    match (raw.kind.as_deref(), raw.manifest.as_deref()) {
+        (Some("common"), None) => Ok(Some(ResolvedPlatformImplementation::Common)),
+        (Some(kind), None) => Err(anyhow!(
+            "module `{package}` metadata.whisker.module.platforms.{}.kind must be `common`, got {kind:?}",
+            platform.name(),
+        )),
+        (None, Some(path)) => resolve_platform_manifest(
+            package,
+            package_version,
+            registry_source,
+            manifest_dir,
+            platform,
+            path,
+        )
+        .map(Some),
+        (Some(_), Some(_)) => Err(anyhow!(
+            "module `{package}` metadata.whisker.module.platforms.{} must declare exactly one of `kind` and `manifest`",
+            platform.name(),
+        )),
+        (None, None) => Err(anyhow!(
+            "module `{package}` metadata.whisker.module.platforms.{} must declare `kind = \"common\"` or `manifest = \"...\"`",
+            platform.name(),
+        )),
+    }
+}
+
+fn resolve_platform_manifest(
+    package: &str,
+    package_version: &str,
+    registry_source: bool,
+    manifest_dir: &Path,
+    platform: ModulePlatform,
+    raw_path: &str,
+) -> Result<ResolvedPlatformImplementation> {
+    if raw_path.trim().is_empty() {
+        return Err(anyhow!(
+            "module `{package}` metadata.whisker.module.platforms.{}.manifest must not be empty",
+            platform.name(),
+        ));
+    }
+    let relative = Path::new(raw_path);
+    if relative.is_absolute() {
+        return Err(anyhow!(
+            "module `{package}` metadata.whisker.module.platforms.{}.manifest must be relative to Cargo.toml",
+            platform.name(),
+        ));
+    }
+    let path = manifest_dir.join(relative);
+    match platform {
+        ModulePlatform::Android => resolve_native_manifest(
+            package,
+            platform,
+            &path,
+            "build.gradle.kts",
+            NativeManifestKind::Gradle,
+        ),
+        ModulePlatform::Ios => resolve_native_manifest(
+            package,
+            platform,
+            &path,
+            "Package.swift",
+            NativeManifestKind::SwiftPm,
+        ),
+        ModulePlatform::Web
+        | ModulePlatform::Desktop
+        | ModulePlatform::Macos
+        | ModulePlatform::Windows
+        | ModulePlatform::Linux => {
+            resolve_rust_manifest(package, package_version, registry_source, platform, &path)
+        }
+    }
+}
+
+fn resolve_native_manifest(
+    package: &str,
+    platform: ModulePlatform,
+    path: &Path,
+    expected_file_name: &str,
+    kind: NativeManifestKind,
+) -> Result<ResolvedPlatformImplementation> {
+    if path.file_name().and_then(|name| name.to_str()) != Some(expected_file_name) {
+        return Err(anyhow!(
+            "module `{package}` {} manifest must point to `{expected_file_name}`, got {}",
+            platform.name(),
+            path.display(),
+        ));
+    }
+    let path = path.canonicalize().with_context(|| {
+        format!(
+            "module `{package}` declares {} manifest {}, but it does not exist",
+            platform.name(),
+            path.display(),
+        )
+    })?;
+    Ok(ResolvedPlatformImplementation::NativeManifest(
+        ResolvedNativeManifest { path, kind },
+    ))
+}
+
+fn resolve_rust_manifest(
+    package: &str,
+    package_version: &str,
+    registry_source: bool,
+    platform: ModulePlatform,
+    cargo_toml: &Path,
+) -> Result<ResolvedPlatformImplementation> {
+    if cargo_toml.file_name().and_then(|name| name.to_str()) != Some("Cargo.toml") {
+        return Err(anyhow!(
+            "module `{package}` {} manifest must point to a Cargo.toml, got {}",
+            platform.name(),
+            cargo_toml.display(),
+        ));
+    }
+    let expected_package = format!("{package}-{}", platform.name());
+    if !cargo_toml.is_file() {
+        if registry_source {
+            return Ok(ResolvedPlatformImplementation::RustHost(
+                ResolvedRustModuleContribution {
+                    package: expected_package,
+                    source: ResolvedRustHostSource::Registry {
+                        version: package_version.to_string(),
+                    },
+                },
+            ));
+        }
+        return Err(anyhow!(
+            "module `{package}` declares {} manifest {}, but it does not exist",
+            platform.name(),
+            cargo_toml.display(),
+        ));
+    }
+    let source = std::fs::read_to_string(cargo_toml).with_context(|| {
+        format!(
+            "read {} Host manifest {}",
+            platform.name(),
+            cargo_toml.display()
+        )
+    })?;
+    let manifest: toml::Value = toml::from_str(&source).with_context(|| {
+        format!(
+            "parse {} Host manifest {}",
+            platform.name(),
+            cargo_toml.display()
+        )
+    })?;
+    let actual_package = manifest
+        .get("package")
+        .and_then(|value| value.get("name"))
+        .and_then(toml::Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "{} must declare a non-empty [package].name",
+                cargo_toml.display()
+            )
+        })?;
+    if actual_package != expected_package {
+        return Err(anyhow!(
+            "module `{package}` {} Host package must be named `{expected_package}`, but {} declares `{actual_package}`",
+            platform.name(),
+            cargo_toml.display(),
+        ));
+    }
+    let root = cargo_toml
+        .parent()
+        .expect("Cargo.toml has a parent")
+        .canonicalize()
+        .with_context(|| format!("canonicalize {} Host crate", cargo_toml.display()))?;
+    Ok(ResolvedPlatformImplementation::RustHost(
+        ResolvedRustModuleContribution {
+            package: actual_package.to_string(),
+            source: ResolvedRustHostSource::Path(root),
+        },
+    ))
+}
+
+pub(super) fn resolve_legacy_platforms(
+    package: &str,
+    package_version: &str,
+    manifest_dir: &Path,
+    manifest: &ManifestRaw,
+) -> Result<ResolvedModulePlatforms> {
+    let android_path = manifest_dir.join("build.gradle.kts");
+    let ios_path = manifest_dir.join("Package.swift");
+    Ok(ResolvedModulePlatforms {
+        android: android_path
+            .is_file()
+            .then_some(ResolvedPlatformImplementation::NativeManifest(
+                ResolvedNativeManifest {
+                    path: android_path,
+                    kind: NativeManifestKind::Gradle,
+                },
+            )),
+        ios: ios_path
+            .is_file()
+            .then_some(ResolvedPlatformImplementation::NativeManifest(
+                ResolvedNativeManifest {
+                    path: ios_path,
+                    kind: NativeManifestKind::SwiftPm,
+                },
+            )),
+        desktop: resolve_legacy_rust_host(
+            package,
+            package_version,
+            "desktop",
+            manifest_dir,
+            manifest.desktop.as_ref(),
+        )?
+        .map(ResolvedPlatformImplementation::RustHost),
+        web: resolve_legacy_rust_host(
+            package,
+            package_version,
+            "web",
+            manifest_dir,
+            manifest.web.as_ref(),
+        )?
+        .map(ResolvedPlatformImplementation::RustHost),
+        macos: None,
+        windows: None,
+        linux: None,
+    })
+}
+
+fn resolve_legacy_rust_host(
+    package: &str,
+    package_version: &str,
+    target: &str,
+    manifest_dir: &Path,
+    published: Option<&RustHostSectionRaw>,
+) -> Result<Option<ResolvedRustModuleContribution>> {
+    if let Some(published) = published
+        && published.package.trim().is_empty()
+    {
+        return Err(anyhow!(
+            "module `{package}` metadata.whisker.{target}.package must not be empty"
+        ));
+    }
+    let cargo_toml = manifest_dir.join(target).join("Cargo.toml");
+    if !cargo_toml.is_file() {
+        return Ok(published.map(|published| ResolvedRustModuleContribution {
+            package: published.package.clone(),
+            source: ResolvedRustHostSource::Registry {
+                version: package_version.to_string(),
+            },
+        }));
+    }
+    let source = std::fs::read_to_string(&cargo_toml)
+        .with_context(|| format!("read {target} Host manifest {}", cargo_toml.display()))?;
+    let manifest: toml::Value = toml::from_str(&source)
+        .with_context(|| format!("parse {target} Host manifest {}", cargo_toml.display()))?;
+    let host_package = manifest
+        .get("package")
+        .and_then(|value| value.get("name"))
+        .and_then(toml::Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "module `{package}` {target}/Cargo.toml must declare a non-empty [package].name"
+            )
+        })?;
+    if let Some(published) = published
+        && published.package != host_package
+    {
+        return Err(anyhow!(
+            "module `{package}` metadata.whisker.{target}.package is {:?}, but {target}/Cargo.toml declares package {:?}",
+            published.package,
+            host_package,
+        ));
+    }
+    let host_root = cargo_toml
+        .parent()
+        .expect("Cargo.toml has a parent")
+        .canonicalize()
+        .with_context(|| format!("canonicalize {target} Host crate {}", cargo_toml.display()))?;
+    Ok(Some(ResolvedRustModuleContribution {
+        package: host_package.to_string(),
+        source: ResolvedRustHostSource::Path(host_root),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn tempdir() -> PathBuf {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "whisker-module-platforms-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn resolves_explicit_platform_contract_without_directory_guessing() {
+        let root = tempdir();
+        std::fs::create_dir_all(root.join("web")).unwrap();
+        std::fs::write(
+            root.join("web/Cargo.toml"),
+            "[package]\nname = \"whisker-map-web\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let raw: ManifestRaw = serde_json::from_value(serde_json::json!({
+            "module": { "platforms": {
+                "ios": { "kind": "common" },
+                "web": { "manifest": "web/Cargo.toml" }
+            }}
+        }))
+        .unwrap();
+        let platforms = resolve_platforms(
+            "whisker-map",
+            "1.2.3",
+            false,
+            &root,
+            &raw.module.unwrap().platforms,
+        )
+        .unwrap();
+        assert_eq!(platforms.ios, Some(ResolvedPlatformImplementation::Common));
+        let web = match platforms.web.unwrap() {
+            ResolvedPlatformImplementation::RustHost(host) => host,
+            other => panic!("expected Rust Host, got {other:?}"),
+        };
+        assert_eq!(web.package, "whisker-map-web");
+        assert!(matches!(web.source, ResolvedRustHostSource::Path(_)));
+        assert!(platforms.android.is_none());
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn rejects_ambiguous_platform_declarations() {
+        let raw = PlatformDeclarationRaw {
+            kind: Some("common".into()),
+            manifest: Some("web/Cargo.toml".into()),
+        };
+        let error = resolve_platform(
+            "whisker-map",
+            "1.2.3",
+            false,
+            Path::new("/module"),
+            ModulePlatform::Web,
+            Some(&raw),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("exactly one"));
+    }
+
+    #[test]
+    fn registry_rust_hosts_use_the_conventional_package_name() {
+        let resolved = resolve_platform_manifest(
+            "whisker-map",
+            "1.2.3",
+            true,
+            Path::new("/cargo/registry/whisker-map-1.2.3"),
+            ModulePlatform::Web,
+            "web/Cargo.toml",
+        )
+        .unwrap();
+        assert_eq!(
+            resolved,
+            ResolvedPlatformImplementation::RustHost(ResolvedRustModuleContribution {
+                package: "whisker-map-web".into(),
+                source: ResolvedRustHostSource::Registry {
+                    version: "1.2.3".into()
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn published_legacy_host_falls_back_to_the_outer_package_version() {
+        let contribution = resolve_legacy_rust_host(
+            "whisker-toggle",
+            "1.2.3",
+            "desktop",
+            Path::new("/definitely/not/a/module/package"),
+            Some(&RustHostSectionRaw {
+                package: "whisker-toggle-desktop-host".into(),
+            }),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(contribution.package, "whisker-toggle-desktop-host");
+        assert_eq!(
+            contribution.source,
+            ResolvedRustHostSource::Registry {
+                version: "1.2.3".into()
+            }
+        );
+    }
+}

--- a/docs/rfcs/0004-native-modules-and-host-elements.md
+++ b/docs/rfcs/0004-native-modules-and-host-elements.md
@@ -766,34 +766,51 @@ whisker-toggle/
   Cargo.toml              # platform-neutral module crate
   src/                    # schemas and authoring API only
   desktop/
-    Cargo.toml            # whisker-toggle-desktop-host
+    Cargo.toml            # whisker-toggle-desktop
     src/lib.rs
   web/
-    Cargo.toml            # whisker-toggle-web-host
+    Cargo.toml            # whisker-toggle-web
     src/lib.rs
   android/                # Gradle/Kotlin Host module
   ios/                    # SwiftPM/Swift Host module
 ```
 
-The `[package.metadata.whisker]` marker identifies the outer package. Local and
-git checkouts discover `desktop/Cargo.toml` and `web/Cargo.toml` by convention
-and verify the package names declared in the outer metadata:
+The outer package declares platform support explicitly. Directory presence is
+not a support signal, and the metadata never points back to the parent
+`Cargo.toml`:
 
 ```toml
-[package.metadata.whisker.desktop]
-package = "whisker-toggle-desktop-host"
-
-[package.metadata.whisker.web]
-package = "whisker-toggle-web-host"
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
+web = { manifest = "web/Cargo.toml" }
+desktop = { kind = "common" }
 ```
 
-This small amount of metadata is package identity, not a source-file list or a
-generated binding contract. It is necessary because Cargo intentionally omits
-nested packages from an outer crates.io archive even when its `include` list
-names them. The Desktop and Web Host libraries are therefore separately
-published packages at the same version as the common module crate. Discovery
-uses a nested path dependency when its manifest is present and an exact registry
-version otherwise.
+An omitted key means unsupported. `kind = "common"` means the parent Rust crate
+fully implements that platform and no Host adapter is linked. `manifest` means
+the platform has a separate Host build manifest; it is always explicit and
+relative to the parent `Cargo.toml`. The two forms are mutually exclusive, and
+`common` is the only accepted `kind`.
+
+Manifest type is implied by the platform: Android accepts
+`build.gradle.kts`, iOS accepts `Package.swift`, and Web/Desktop/macOS/Windows/
+Linux accept `Cargo.toml`. Android and iOS do not acquire a Cargo adapter merely
+because their Host implementation happens to contain Rust elsewhere. Desktop is
+the fallback declaration for macOS, Windows, and Linux; an exact OS declaration
+overrides it.
+
+For a local or git checkout, CNG reads each Rust Host manifest and verifies its
+package name. The package naming rule is `<module>-<platform>` — for example
+`whisker-toggle-web` and `whisker-toggle-desktop`; the old `-host` suffix is not
+used. Cargo intentionally omits nested packages from an outer crates.io archive,
+so each Rust Host library is separately published at the parent module's exact
+version. For a registry dependency CNG derives the package name from this rule
+and pins that version without requiring a duplicate `package = "..."` field.
+
+`[package.metadata.whisker.plugins]` is an independent CNG extension seam. A
+crate that declares only plugins is not a Whisker module and does not enter the
+Host module graph.
 
 CNG adds the common crate and the selected Host crate as ordinary dependencies
 of the generated Host Cargo project. The generated composition code calls the


### PR DESCRIPTION
## Summary
- replace directory/marker inference with `[package.metadata.whisker.module.platforms]`
- support explicit `kind = "common"` and platform-derived `manifest` declarations
- add desktop fallback with macOS/Windows/Linux overrides and conventional `-web`/`-desktop` Cargo package names
- keep a temporary legacy resolver so packages can migrate in independent PRs
- prevent plugin-only crates from entering the Host module graph
- update CNG mobile reports, Rust Host wiring, scaffolding, and RFC 0004

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p whisker-cng -p whisker-cli --all-targets -- -D warnings`
- `cargo test --workspace --all-targets --no-fail-fast`