### PR TITLE
feat(haptics): add web vibration support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6992,6 +6992,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-haptics-web"
+version = "0.12.0"
+dependencies = [
+ "js-sys",
+ "web-sys",
+ "whisker-web",
+]
+
+[[package]]
 name = "whisker-host-conformance"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "examples/carousel",
     "tests/mobile-link-test",
     "packages/whisker-haptics",
+    "packages/whisker-haptics/web",
     "packages/whisker-icons",
     "packages/whisker-icons/example",
     "packages/whisker-image",

--- a/packages/whisker-haptics/Cargo.toml
+++ b/packages/whisker-haptics/Cargo.toml
@@ -30,10 +30,11 @@ include = [
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker: identifies this cargo crate as a Whisker
-# module so `whisker-build` wires the Android Gradle subproject + iOS
-# SwiftPM package into the host build.
-[package.metadata.whisker]
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
+web = { manifest = "web/Cargo.toml" }
+desktop = { kind = "common" }
 
 # Plugin registration — Whisker builds the `whisker-haptics-plugin`
 # binary below and runs it during every gen-tree sync. It appends the

--- a/packages/whisker-haptics/src/lib.rs
+++ b/packages/whisker-haptics/src/lib.rs
@@ -14,6 +14,9 @@
 //!
 //! Mirrors [`expo-haptics`](https://docs.expo.dev/versions/latest/sdk/haptics/)'s
 //! three functions exactly.
+//! Web maps these calls to the Vibration API when the browser permits it.
+//! Desktop currently exposes the same API as a successful no-op because
+//! desktop machines do not have a generally available haptic device.
 //!
 //! Deliberately **not async**: the native module DSL only supports
 //! synchronous `Function`s today (no `AsyncFunction` yet). Firing a

--- a/packages/whisker-haptics/src/runtime.rs
+++ b/packages/whisker-haptics/src/runtime.rs
@@ -6,7 +6,9 @@
 //! prepends this crate's name (→ `whisker-haptics:WhiskerHaptics`) so
 //! module names never collide across crates.
 
-use whisker::platform_module::{WhiskerModuleError, WhiskerValue};
+use whisker::platform_module::WhiskerModuleError;
+#[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))]
+use whisker::platform_module::WhiskerValue;
 
 use crate::plugin::WhiskerHaptics;
 
@@ -21,6 +23,7 @@ pub enum ImpactStyle {
     Heavy,
 }
 
+#[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))]
 impl ImpactStyle {
     fn as_str(self) -> &'static str {
         match self {
@@ -40,6 +43,7 @@ pub enum NotificationType {
     Error,
 }
 
+#[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))]
 impl NotificationType {
     fn as_str(self) -> &'static str {
         match self {
@@ -59,35 +63,68 @@ impl WhiskerHaptics {
     /// touchstart, since a touch that turns into a scroll/drag and
     /// never becomes a real tap shouldn't buzz.
     pub fn impact(style: ImpactStyle) -> Result<(), WhiskerModuleError> {
-        let result = whisker::module!("WhiskerHaptics").invoke(
-            "impact",
-            vec![WhiskerValue::String(style.as_str().to_string())],
-        );
-        match result {
-            WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
-            _ => Ok(()),
+        #[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))]
+        {
+            return invoke(
+                "impact",
+                vec![WhiskerValue::String(style.as_str().to_string())],
+            );
+        }
+        #[cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))]
+        {
+            let _ = style;
+            Ok(())
         }
     }
 
     /// Fire a light tick — for discrete value changes, e.g. a drag
     /// gesture starting.
     pub fn selection() -> Result<(), WhiskerModuleError> {
-        let result = whisker::module!("WhiskerHaptics").invoke("selection", vec![]);
-        match result {
-            WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
-            _ => Ok(()),
+        #[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))]
+        {
+            return invoke("selection", vec![]);
         }
+        #[cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))]
+        Ok(())
     }
 
     /// Fire a longer pattern communicating success/warning/error.
     pub fn notification(kind: NotificationType) -> Result<(), WhiskerModuleError> {
-        let result = whisker::module!("WhiskerHaptics").invoke(
-            "notification",
-            vec![WhiskerValue::String(kind.as_str().to_string())],
-        );
-        match result {
-            WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
-            _ => Ok(()),
+        #[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))]
+        {
+            return invoke(
+                "notification",
+                vec![WhiskerValue::String(kind.as_str().to_string())],
+            );
         }
+        #[cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))]
+        {
+            let _ = kind;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))]
+fn invoke(function: &str, arguments: Vec<WhiskerValue>) -> Result<(), WhiskerModuleError> {
+    let result = whisker::module!("WhiskerHaptics").invoke(function, arguments);
+    match result {
+        WhiskerValue::Error(msg) => Err(WhiskerModuleError(msg)),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(all(
+    test,
+    not(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))
+))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desktop_fallback_is_a_successful_no_op() {
+        assert!(WhiskerHaptics::impact(ImpactStyle::Heavy).is_ok());
+        assert!(WhiskerHaptics::selection().is_ok());
+        assert!(WhiskerHaptics::notification(NotificationType::Success).is_ok());
     }
 }

--- a/packages/whisker-haptics/web/Cargo.toml
+++ b/packages/whisker-haptics/web/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "whisker-haptics-web"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web Host implementation for whisker-haptics."
+
+[dependencies]
+js-sys = "0.3"
+whisker-web = { workspace = true }
+web-sys = { version = "0.3", features = ["Navigator", "Window"] }

--- a/packages/whisker-haptics/web/src/lib.rs
+++ b/packages/whisker-haptics/web/src/lib.rs
@@ -1,0 +1,81 @@
+//! Web Host implementation for `whisker-haptics` using the Vibration API.
+
+use whisker_web::{ModuleDefinition, WhiskerModule, WhiskerValue};
+
+const MODULE_NAME: &str = "whisker-haptics:WhiskerHaptics";
+
+struct HapticsModule;
+
+#[whisker_web::WhiskerModule]
+impl WhiskerModule for HapticsModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new()
+            .name(MODULE_NAME)
+            .function("impact", |args, _| {
+                let style = match string_argument(args, "impact") {
+                    Ok(style) => style,
+                    Err(error) => return error,
+                };
+                let duration = match style {
+                    "light" => 10,
+                    "medium" => 20,
+                    "heavy" => 35,
+                    _ => return invalid_value("impact", style),
+                };
+                vibrate(&[duration])
+            })
+            .function("selection", |args, _| {
+                if !args.is_empty() {
+                    return WhiskerValue::Error(
+                        "WhiskerHaptics.selection does not accept arguments".into(),
+                    );
+                }
+                vibrate(&[8])
+            })
+            .function("notification", |args, _| {
+                let kind = match string_argument(args, "notification") {
+                    Ok(kind) => kind,
+                    Err(error) => return error,
+                };
+                let pattern: &[u32] = match kind {
+                    "success" => &[20, 30, 20],
+                    "warning" => &[30, 35, 30],
+                    "error" => &[45, 30, 45],
+                    _ => return invalid_value("notification", kind),
+                };
+                vibrate(pattern)
+            })
+    }
+}
+
+fn string_argument<'a>(args: &'a [WhiskerValue], operation: &str) -> Result<&'a str, WhiskerValue> {
+    let [WhiskerValue::String(value)] = args else {
+        return Err(WhiskerValue::Error(format!(
+            "WhiskerHaptics.{operation} requires one string argument"
+        )));
+    };
+    Ok(value)
+}
+
+fn invalid_value(operation: &str, value: &str) -> WhiskerValue {
+    WhiskerValue::Error(format!(
+        "WhiskerHaptics.{operation} received unsupported value {value:?}"
+    ))
+}
+
+fn vibrate(pattern: &[u32]) -> WhiskerValue {
+    let Some(window) = web_sys::window() else {
+        return WhiskerValue::Error("browser Window is unavailable".into());
+    };
+    let values = js_sys::Array::new();
+    for duration in pattern {
+        values.push(&(*duration).into());
+    }
+    // Unsupported browsers return false. That is a capability fallback, not
+    // an application error, so callers retain the cross-platform fire-and-
+    // forget semantics.
+    let _ = window.navigator().vibrate_with_pattern(&values.into());
+    WhiskerValue::Null
+}


### PR DESCRIPTION
## Summary
- migrate `whisker-haptics` to the explicit module platform manifest
- keep Android and iOS native haptic implementations
- add `whisker-haptics-web` backed by the browser Vibration API
- declare Desktop as a successful common no-op fallback
- avoid missing-module errors when desktop applications call the shared API

## Verification
- `cargo test -p whisker-haptics --all-targets`
- `cargo clippy -p whisker-haptics -p whisker-haptics-web --all-targets -- -D warnings`
- `cargo check -p whisker-haptics-web --target wasm32-unknown-unknown`
- `cargo check -p whisker-haptics --no-default-features`
- `cargo package -p whisker-haptics --allow-dirty --no-verify`

Depends on #550.