### PR TITLE
chore(paths): declare native platform support

### DIFF
--- a/packages/whisker-paths/Cargo.toml
+++ b/packages/whisker-paths/Cargo.toml
@@ -29,10 +29,9 @@ include = [
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker. Identifies this crate as a Whisker
-# module so `whisker-build` wires its Android Gradle subproject + iOS
-# SwiftPM package into any consuming app's build.
-[package.metadata.whisker]
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
 
 [dependencies]
 whisker = { workspace = true }

--- a/packages/whisker-paths/src/lib.rs
+++ b/packages/whisker-paths/src/lib.rs
@@ -25,6 +25,12 @@
 //! | [`support_dir`]  | persistent, non-user, backed up   | `NSApplicationSupportDirectory` | `filesDir/support` |
 //! | [`temp_dir`]     | cleared aggressively by the OS    | `NSTemporaryDirectory()` | `cacheDir/tmp` |
 //!
+//! Web and Desktop are intentionally not declared as supported yet. Web has
+//! no `std::fs` filesystem matching this API, while a correct Desktop result
+//! needs the generated application's identity rather than a package-global
+//! directory. The existing temporary-directory fallback remains available for
+//! defensive compatibility, but it is not advertised as persistent storage.
+//!
 //! Pick [`cache_dir`] for regenerable data (downloaded thumbnails,
 //! HTTP response caches), [`document_dir`] for data the user would be
 //! upset to lose, [`support_dir`] for app-managed persistent state that


### PR DESCRIPTION
## Summary
- migrate `whisker-paths` to the explicit module platform manifest
- declare only its existing Android and iOS Host implementations
- document why Web and Desktop are not advertised yet: Web lacks matching `std::fs` semantics, while Desktop needs the generated app identity for correct per-app directories
- retain the existing temporary fallback for defensive compatibility

## Verification
- `cargo test -p whisker-paths --all-targets`
- `cargo clippy -p whisker-paths --all-targets -- -D warnings`
- `cargo package -p whisker-paths --allow-dirty --no-verify`

Depends on #550.