### PR TITLE
feat(local-store): support web and desktop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7079,6 +7079,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-local-store-desktop"
+version = "0.12.0"
+dependencies = [
+ "serde_json",
+ "whisker-desktop",
+]
+
+[[package]]
+name = "whisker-local-store-web"
+version = "0.12.0"
+dependencies = [
+ "web-sys",
+ "whisker-web",
+]
+
+[[package]]
 name = "whisker-macos"
 version = "0.12.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ members = [
     "packages/whisker-toggle/desktop",
     "packages/whisker-toggle/web",
     "packages/whisker-local-store",
+    "packages/whisker-local-store/desktop",
+    "packages/whisker-local-store/web",
     "packages/whisker-paths",
     "packages/whisker-paths/example",
     "packages/whisker-router",

--- a/packages/whisker-local-store/Cargo.toml
+++ b/packages/whisker-local-store/Cargo.toml
@@ -28,9 +28,11 @@ include = [
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker. See `whisker-video/Cargo.toml` for the
-# rationale; the bare table identifies this crate as a Whisker module.
-[package.metadata.whisker]
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
+web = { manifest = "web/Cargo.toml" }
+desktop = { manifest = "desktop/Cargo.toml" }
 
 [dependencies]
 # The umbrella `whisker` crate — same dep app crates use. The proc

--- a/packages/whisker-local-store/desktop/Cargo.toml
+++ b/packages/whisker-local-store/desktop/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "whisker-local-store-desktop"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Desktop Host implementation for whisker-local-store."
+
+[dependencies]
+serde_json = { workspace = true }
+whisker-desktop = { workspace = true }

--- a/packages/whisker-local-store/desktop/src/lib.rs
+++ b/packages/whisker-local-store/desktop/src/lib.rs
@@ -1,0 +1,190 @@
+//! Desktop Host implementation for `whisker-local-store`.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use whisker_desktop::{ModuleDefinition, WhiskerModule, WhiskerValue};
+
+const MODULE_NAME: &str = "whisker-local-store:WhiskerLocalStore";
+
+struct LocalStoreModule;
+
+#[whisker_desktop::WhiskerModule]
+impl WhiskerModule for LocalStoreModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new()
+            .name(MODULE_NAME)
+            .function("save", |args, _| {
+                let [WhiskerValue::String(key), WhiskerValue::String(value)] = args else {
+                    return argument_error("save", "key and value strings");
+                };
+                mutate_store(|values| {
+                    values.insert(key.clone(), value.clone());
+                    WhiskerValue::Bool(true)
+                })
+            })
+            .function("load", |args, _| {
+                let [WhiskerValue::String(key)] = args else {
+                    return argument_error("load", "one key string");
+                };
+                read_store(|values| {
+                    values
+                        .get(key)
+                        .cloned()
+                        .map_or(WhiskerValue::Null, WhiskerValue::String)
+                })
+            })
+            .function("remove", |args, _| {
+                let [WhiskerValue::String(key)] = args else {
+                    return argument_error("remove", "one key string");
+                };
+                mutate_store(|values| {
+                    values.remove(key);
+                    WhiskerValue::Null
+                })
+            })
+    }
+}
+
+struct FileStore {
+    path: PathBuf,
+    values: BTreeMap<String, String>,
+}
+
+impl FileStore {
+    fn open(path: PathBuf) -> Result<Self, String> {
+        let values = match std::fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .map_err(|error| format!("decode {}: {error}", path.display()))?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => BTreeMap::new(),
+            Err(error) => return Err(format!("read {}: {error}", path.display())),
+        };
+        Ok(Self { path, values })
+    }
+
+    fn persist(&self) -> Result<(), String> {
+        let parent = self
+            .path
+            .parent()
+            .ok_or_else(|| format!("store path has no parent: {}", self.path.display()))?;
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("create {}: {error}", parent.display()))?;
+        let bytes = serde_json::to_vec(&self.values)
+            .map_err(|error| format!("encode local store: {error}"))?;
+        std::fs::write(&self.path, bytes)
+            .map_err(|error| format!("write {}: {error}", self.path.display()))
+    }
+}
+
+static STORE: OnceLock<Result<Mutex<FileStore>, String>> = OnceLock::new();
+
+fn store() -> Result<&'static Mutex<FileStore>, String> {
+    STORE
+        .get_or_init(|| FileStore::open(default_store_path()).map(Mutex::new))
+        .as_ref()
+        .map_err(Clone::clone)
+}
+
+fn read_store(operation: impl FnOnce(&BTreeMap<String, String>) -> WhiskerValue) -> WhiskerValue {
+    let result = store().and_then(|store| {
+        store
+            .lock()
+            .map_err(|_| "local store lock is poisoned".to_owned())
+    });
+    match result {
+        Ok(store) => operation(&store.values),
+        Err(error) => WhiskerValue::Error(error),
+    }
+}
+
+fn mutate_store(
+    operation: impl FnOnce(&mut BTreeMap<String, String>) -> WhiskerValue,
+) -> WhiskerValue {
+    let result = store().and_then(|store| {
+        store
+            .lock()
+            .map_err(|_| "local store lock is poisoned".to_owned())
+    });
+    let mut store = match result {
+        Ok(store) => store,
+        Err(error) => return WhiskerValue::Error(error),
+    };
+    let previous = store.values.clone();
+    let value = operation(&mut store.values);
+    if let Err(error) = store.persist() {
+        store.values = previous;
+        return WhiskerValue::Error(error);
+    }
+    value
+}
+
+fn default_store_path() -> PathBuf {
+    let application = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.file_stem().map(|name| name.to_owned()))
+        .and_then(|name| name.to_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| "application".to_owned());
+    user_data_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("whisker")
+        .join(application)
+        .join("local-store.json")
+}
+
+#[cfg(target_os = "macos")]
+fn user_data_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join("Library/Application Support"))
+}
+
+#[cfg(target_os = "windows")]
+fn user_data_dir() -> Option<PathBuf> {
+    std::env::var_os("LOCALAPPDATA").map(PathBuf::from)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn user_data_dir() -> Option<PathBuf> {
+    std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .map(|home| home.join(".local/share"))
+        })
+}
+
+fn argument_error(operation: &str, expected: &str) -> WhiskerValue {
+    WhiskerValue::Error(format!("WhiskerLocalStore.{operation} requires {expected}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_store_persists_string_values() {
+        let root =
+            std::env::temp_dir().join(format!("whisker-local-store-test-{}", std::process::id()));
+        std::fs::remove_dir_all(&root).ok();
+        let path = root.join("store.json");
+        let mut store = FileStore::open(path.clone()).unwrap();
+        store.values.insert("theme".into(), "dark".into());
+        store.persist().unwrap();
+
+        let reopened = FileStore::open(path).unwrap();
+        assert_eq!(
+            reopened.values.get("theme").map(String::as_str),
+            Some("dark")
+        );
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn host_definition_contains_no_views() {
+        assert!(__whisker_module_definition().factories().is_empty());
+    }
+}

--- a/packages/whisker-local-store/src/lib.rs
+++ b/packages/whisker-local-store/src/lib.rs
@@ -10,8 +10,11 @@
 //! Backed by:
 //!   - **iOS**: `UserDefaults.standard`
 //!   - **Android**: `SharedPreferences` (named `"WhiskerLocalStore"`)
+//!   - **Web**: origin-scoped `localStorage`
+//!   - **Desktop**: a small JSON file in the OS user-data directory,
+//!     scoped by the executable name
 //!
-//! Both platforms persist across app launches but don't sync across
+//! All platforms persist across app launches but don't sync across
 //! devices. For app-level preferences, small state, and similar
 //! data — not for large blobs (use a real file API or database for
 //! anything > ~1 MB per entry).

--- a/packages/whisker-local-store/web/Cargo.toml
+++ b/packages/whisker-local-store/web/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "whisker-local-store-web"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web Host implementation for whisker-local-store."
+
+[dependencies]
+whisker-web = { workspace = true }
+web-sys = { version = "0.3", features = ["Storage", "Window"] }

--- a/packages/whisker-local-store/web/src/lib.rs
+++ b/packages/whisker-local-store/web/src/lib.rs
@@ -1,0 +1,74 @@
+//! Web Host implementation for `whisker-local-store`.
+
+use whisker_web::{ModuleDefinition, WhiskerModule, WhiskerValue, wasm_bindgen};
+
+const MODULE_NAME: &str = "whisker-local-store:WhiskerLocalStore";
+const KEY_PREFIX: &str = "whisker-local-store:";
+
+struct LocalStoreModule;
+
+#[whisker_web::WhiskerModule]
+impl WhiskerModule for LocalStoreModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new()
+            .name(MODULE_NAME)
+            .function("save", |args, _| {
+                let [WhiskerValue::String(key), WhiskerValue::String(value)] = args else {
+                    return argument_error("save", "key and value strings");
+                };
+                with_storage(|storage| {
+                    storage
+                        .set_item(&storage_key(key), value)
+                        .map(|()| WhiskerValue::Bool(true))
+                })
+            })
+            .function("load", |args, _| {
+                let [WhiskerValue::String(key)] = args else {
+                    return argument_error("load", "one key string");
+                };
+                with_storage(|storage| {
+                    storage
+                        .get_item(&storage_key(key))
+                        .map(|value| value.map_or(WhiskerValue::Null, WhiskerValue::String))
+                })
+            })
+            .function("remove", |args, _| {
+                let [WhiskerValue::String(key)] = args else {
+                    return argument_error("remove", "one key string");
+                };
+                with_storage(|storage| {
+                    storage
+                        .remove_item(&storage_key(key))
+                        .map(|()| WhiskerValue::Null)
+                })
+            })
+    }
+}
+
+fn storage_key(key: &str) -> String {
+    format!("{KEY_PREFIX}{key}")
+}
+
+fn with_storage(
+    operation: impl FnOnce(web_sys::Storage) -> Result<WhiskerValue, wasm_bindgen::JsValue>,
+) -> WhiskerValue {
+    let result = web_sys::window()
+        .ok_or_else(|| wasm_bindgen::JsValue::from_str("browser Window is unavailable"))
+        .and_then(|window| {
+            window.local_storage().and_then(|storage| {
+                storage.ok_or_else(|| {
+                    wasm_bindgen::JsValue::from_str("browser localStorage is unavailable")
+                })
+            })
+        })
+        .and_then(operation);
+    result.unwrap_or_else(|error| {
+        WhiskerValue::Error(format!("localStorage operation failed: {error:?}"))
+    })
+}
+
+fn argument_error(operation: &str, expected: &str) -> WhiskerValue {
+    WhiskerValue::Error(format!("WhiskerLocalStore.{operation} requires {expected}"))
+}


### PR DESCRIPTION
## Summary
- migrate `whisker-local-store` to the explicit four-platform module manifest
- add a Web Host adapter backed by origin-scoped `localStorage`
- add a Desktop Host adapter backed by a per-executable JSON file in the OS user-data directory
- preserve the existing typed Rust API and Android/iOS implementations
- test Desktop persistence and Host registration; compile-check Web for wasm

## Verification
- `cargo test -p whisker-local-store -p whisker-local-store-desktop --all-targets`
- `cargo clippy -p whisker-local-store -p whisker-local-store-desktop -p whisker-local-store-web --all-targets -- -D warnings`
- `cargo check -p whisker-local-store-web --target wasm32-unknown-unknown`
- `cargo package -p whisker-local-store --allow-dirty --no-verify`

Depends on #550.