### PR TITLE
chore(secure-store): declare native platform support

### DIFF
--- a/packages/whisker-secure-store/Cargo.toml
+++ b/packages/whisker-secure-store/Cargo.toml
@@ -30,11 +30,9 @@ include = [
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker. The bare table identifies this cargo
-# crate as a Whisker module; `whisker-build` walks the consuming app's
-# dep tree, picks out every dep carrying it, and wires the Android
-# Gradle subproject + iOS SwiftPM package into the host build.
-[package.metadata.whisker]
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
 
 [dependencies]
 whisker = { workspace = true }

--- a/packages/whisker-secure-store/src/lib.rs
+++ b/packages/whisker-secure-store/src/lib.rs
@@ -20,6 +20,12 @@
 //!     (Tink is Google's recommended replacement for the now-deprecated
 //!     `EncryptedSharedPreferences`.)
 //!
+//! Web and Desktop are not advertised as supported. Web storage cannot offer
+//! an OS-protected secret boundary against script running in the same origin.
+//! Desktop support requires explicit Keychain, Windows Credential Manager,
+//! and Linux Secret Service implementations; silently falling back to a JSON
+//! file would violate this crate's security contract.
+//!
 //! ## When to use this vs `whisker-local-store`
 //!
 //! Use **`whisker-secure-store`** for secrets: OAuth access / refresh


### PR DESCRIPTION
## Summary
- migrate `whisker-secure-store` to the explicit module platform manifest
- declare the existing Android Keystore/Tink and iOS Keychain implementations
- intentionally leave Web and Desktop unsupported instead of weakening the secure-storage contract with plaintext fallback
- document the security boundary required for future Desktop support

## Verification
- `cargo test -p whisker-secure-store --all-targets`
- `cargo clippy -p whisker-secure-store --all-targets -- -D warnings`
- `cargo package -p whisker-secure-store --allow-dirty --no-verify`

Depends on #550.