### PR TITLE
chore(router): adopt explicit platform manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7161,7 +7161,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "whisker-router-web-host"
+name = "whisker-router-web"
 version = "0.12.0"
 dependencies = [
  "wasm-bindgen",

--- a/crates/whisker-cng/src/modules.rs
+++ b/crates/whisker-cng/src/modules.rs
@@ -669,7 +669,7 @@ mod tests {
             .find(|module| module.package == "whisker-router")
             .unwrap();
         let web = router.rust_host(ModulePlatform::Web).unwrap();
-        assert_eq!(web.package, "whisker-router-web-host");
+        assert_eq!(web.package, "whisker-router-web");
         assert!(matches!(
             &web.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-router/web")

--- a/packages/whisker-router/Cargo.toml
+++ b/packages/whisker-router/Cargo.toml
@@ -30,13 +30,11 @@ include = [
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker. The Whisker build pipeline scans dep
-# trees for this table to discover module crates and stage their
-# `ios/` + `android/` directories into the platform builds.
-[package.metadata.whisker]
-
-[package.metadata.whisker.web]
-package = "whisker-router-web-host"
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { kind = "common" }
+web = { manifest = "web/Cargo.toml" }
+desktop = { kind = "common" }
 
 # Plugin registration — Whisker walks the consuming app's dep tree, picks
 # this up, builds the `whisker-router-plugin` binary below, and runs it on

--- a/packages/whisker-router/src/render/history.rs
+++ b/packages/whisker-router/src/render/history.rs
@@ -1,7 +1,7 @@
 //! Private Router ↔ Host history seam.
 //!
 //! The Router core stays independent of browser bindings. On Web this module
-//! talks to the checked-in `whisker-router-web-host` implementation through the
+//! talks to the checked-in `whisker-router-web` implementation through the
 //! same `WhiskerValue` service-module path used by native modules. Other Hosts
 //! compile the no-op adapter and keep navigation entirely in Rust.
 

--- a/packages/whisker-router/web/Cargo.toml
+++ b/packages/whisker-router/web/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "whisker-router-web-host"
+name = "whisker-router-web"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary
- migrate `whisker-router` to the explicit module platform manifest
- keep Android predictive-back as a Gradle Host module
- declare iOS and Desktop as common Rust implementations
- link Web through its explicit Cargo manifest
- rename the Web adapter package from `whisker-router-web-host` to `whisker-router-web`
- update module discovery coverage for the new package name

## Verification
- `cargo test -p whisker-router --all-targets`
- `cargo clippy -p whisker-router -p whisker-router-web --all-targets -- -D warnings`
- `cargo check -p whisker-router-web --target wasm32-unknown-unknown`
- `cargo test -p whisker-cng modules::tests::discovers_router_history_as_a_service_only_web_host`

`cargo package` is currently blocked by unpublished workspace crate `whisker-style` 0.12.0; compilation and tests pass. Depends on #550.