### PR TITLE
chore(svg): adopt explicit platform manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7258,7 +7258,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "whisker-svg-desktop-host"
+name = "whisker-svg-desktop"
 version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
@@ -7277,7 +7277,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "whisker-svg-web-host"
+name = "whisker-svg-web"
 version = "0.12.0"
 dependencies = [
  "base64 0.22.1",

--- a/packages/whisker-svg/Cargo.toml
+++ b/packages/whisker-svg/Cargo.toml
@@ -29,12 +29,11 @@ include = [
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker — same as whisker-image / whisker-video.
-[package.metadata.whisker.desktop]
-package = "whisker-svg-desktop-host"
-
-[package.metadata.whisker.web]
-package = "whisker-svg-web-host"
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
+web = { manifest = "web/Cargo.toml" }
+desktop = { manifest = "desktop/Cargo.toml" }
 
 [dependencies]
 whisker = { workspace = true }

--- a/packages/whisker-svg/desktop/Cargo.toml
+++ b/packages/whisker-svg/desktop/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "whisker-svg-desktop-host"
+name = "whisker-svg-desktop"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/packages/whisker-svg/web/Cargo.toml
+++ b/packages/whisker-svg/web/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "whisker-svg-web-host"
+name = "whisker-svg-web"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary
- migrate `whisker-svg` to the explicit four-platform module manifest
- point Android/iOS at their native manifests and Web/Desktop at their Cargo adapters
- rename Rust Host packages to `whisker-svg-web` and `whisker-svg-desktop`
- retain the existing platform renderers unchanged

## Verification
- `cargo test -p whisker-svg -p whisker-svg-desktop --all-targets`
- `cargo clippy -p whisker-svg -p whisker-svg-desktop -p whisker-svg-web --all-targets -- -D warnings`
- `cargo check -p whisker-svg-web --target wasm32-unknown-unknown`
- `cargo package -p whisker-svg --allow-dirty --no-verify`

Depends on #550.