### PR TITLE
chore(asset): declare native platform support

### DIFF
--- a/packages/whisker-asset/Cargo.toml
+++ b/packages/whisker-asset/Cargo.toml
@@ -28,15 +28,10 @@ include = [
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker. The bare table identifies this cargo
-# crate as a Whisker module (in addition to the plugin registration
-# below); `whisker-build` walks the consuming app's dep tree, picks
-# out every dep carrying it, and wires the Android Gradle subproject +
-# iOS SwiftPM package into the host build. whisker-asset's native half
-# is startup-only: it installs the runtime resolver base (the iOS
-# `whisker_assets` bundle dir / the Android packaged-assets prefix) so
-# `asset!(…)` resolves to a loadable path/URL.
-[package.metadata.whisker]
+# The native half is startup-only: it installs the runtime resolver base.
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
 
 # Plugin registration — Whisker walks the consuming app's dep tree,
 # picks this entry up, builds the `whisker-asset-plugin` binary below,

--- a/packages/whisker-asset/src/lib.rs
+++ b/packages/whisker-asset/src/lib.rs
@@ -23,6 +23,12 @@
 //! | `AndroidAssets`            | `file:///android_asset/whisker/images/logo.png`       |
 //! | *(unset)*                  | the relative path, unchanged (see "Fallback")         |
 //!
+//! Web and Desktop are not declared as supported package targets yet. Their
+//! development servers may resolve the relative fallback, but production
+//! support also requires the CNG plugin IR to copy assets into those generated
+//! outputs. Advertising support before that build-time half exists would make
+//! release builds depend on their launch working directory.
+//!
 //! # Fallback
 //!
 //! If no base has been installed yet (unit tests, or any render that runs


### PR DESCRIPTION
## Summary
- migrate `whisker-asset` to the explicit module platform manifest
- declare its existing Android and iOS startup resolvers
- document why Web/Desktop are not yet advertised: the plugin IR currently copies assets only into mobile generated projects, so relative-path success in development is not production support
- retain existing macros, resolver fallback, and plugin behaviour

## Verification
- `cargo test -p whisker-asset --all-targets`
- `cargo clippy -p whisker-asset --all-targets -- -D warnings`
- `cargo package -p whisker-asset --allow-dirty --no-verify`

Depends on #550.