### PR TITLE
feat(web-browser): support web and desktop hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,6 +2910,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3852,6 +3871,16 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "open"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
+dependencies = [
+ "is-wsl",
+ "libc",
+]
 
 [[package]]
 name = "orbclient"
@@ -7349,6 +7378,23 @@ version = "0.12.0"
 dependencies = [
  "futures-channel",
  "whisker",
+]
+
+[[package]]
+name = "whisker-web-browser-desktop"
+version = "0.12.0"
+dependencies = [
+ "open",
+ "whisker-desktop",
+]
+
+[[package]]
+name = "whisker-web-browser-web"
+version = "0.12.0"
+dependencies = [
+ "web-sys",
+ "whisker",
+ "whisker-web",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ members = [
     "packages/whisker-splash-screen",
     "packages/whisker-status-bar",
     "packages/whisker-web-browser",
+    "packages/whisker-web-browser/desktop",
+    "packages/whisker-web-browser/web",
     "packages/whisker-svg",
     "packages/whisker-svg/desktop",
     "packages/whisker-svg/web",

--- a/packages/whisker-web-browser/Cargo.toml
+++ b/packages/whisker-web-browser/Cargo.toml
@@ -24,7 +24,11 @@ include = [
 [lib]
 crate-type = ["rlib"]
 
-[package.metadata.whisker]
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
+web = { manifest = "web/Cargo.toml" }
+desktop = { manifest = "desktop/Cargo.toml" }
 
 [dependencies]
 whisker = { workspace = true }

--- a/packages/whisker-web-browser/desktop/Cargo.toml
+++ b/packages/whisker-web-browser/desktop/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "whisker-web-browser-desktop"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Desktop Host implementation for whisker-web-browser."
+
+[dependencies]
+open = "5"
+whisker-desktop = { workspace = true }

--- a/packages/whisker-web-browser/desktop/src/lib.rs
+++ b/packages/whisker-web-browser/desktop/src/lib.rs
@@ -1,0 +1,63 @@
+//! Desktop system-browser Host for `whisker-web-browser`.
+
+use whisker_desktop::{ModuleDefinition, WhiskerModule, WhiskerValue};
+
+const MODULE_NAME: &str = "whisker-web-browser:WebBrowser";
+
+struct WebBrowserModule;
+
+#[whisker_desktop::WhiskerModule]
+impl WhiskerModule for WebBrowserModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new()
+            .name(MODULE_NAME)
+            .function("openAuthSession", |_args, emitter| {
+                emitter.emit(
+                    "authSessionCompleted",
+                    WhiskerValue::map([
+                        ("type", WhiskerValue::String("error".into())),
+                        (
+                            "message",
+                            WhiskerValue::String(
+                                "Desktop auth redirect interception is not supported".into(),
+                            ),
+                        ),
+                    ]),
+                );
+                WhiskerValue::Null
+            })
+            .function("dismissAuthSession", |_args, _| WhiskerValue::Null)
+            .function("openBrowser", |args, emitter| {
+                let [WhiskerValue::String(url)] = args else {
+                    return WhiskerValue::Error(
+                        "WebBrowser.openBrowser requires one URL string".into(),
+                    );
+                };
+                if let Err(error) = open::that_detached(url) {
+                    return WhiskerValue::Error(error.to_string());
+                }
+                // The system browser is a separate process, so its close state is
+                // not observable. Resolve once the handoff succeeds.
+                emitter.emit(
+                    "browserClosed",
+                    WhiskerValue::map([("type", WhiskerValue::String("dismiss".into()))]),
+                );
+                WhiskerValue::Null
+            })
+            .function("dismissBrowser", |_args, _| WhiskerValue::Null)
+            .event("authSessionCompleted")
+            .event("browserClosed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_is_service_only() {
+        assert!(__whisker_module_definition().factories().is_empty());
+    }
+}

--- a/packages/whisker-web-browser/src/lib.rs
+++ b/packages/whisker-web-browser/src/lib.rs
@@ -2,6 +2,10 @@
 //! `open_auth_session_async` (`ASWebAuthenticationSession` /
 //! Chrome Custom Tabs) for in-app OAuth, plus a plain
 //! `open_browser_async` (`SFSafariViewController` / Custom Tabs).
+//! Web uses a popup and observes its same-origin redirect/close state.
+//! Desktop hands plain browser URLs to the system browser; auth-session
+//! redirect interception is reported as unsupported until a loopback/deep-link
+//! receiver is part of the Desktop Host.
 //!
 //! ## OAuth redirect
 //!

--- a/packages/whisker-web-browser/web/Cargo.toml
+++ b/packages/whisker-web-browser/web/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "whisker-web-browser-web"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web Host implementation for whisker-web-browser."
+
+[dependencies]
+whisker = { workspace = true }
+whisker-web = { workspace = true }
+web-sys = { version = "0.3", features = ["Location", "Window"] }

--- a/packages/whisker-web-browser/web/src/lib.rs
+++ b/packages/whisker-web-browser/web/src/lib.rs
@@ -1,0 +1,176 @@
+//! Web popup Host for `whisker-web-browser`.
+
+use std::cell::RefCell;
+
+use whisker::runtime::module::ModuleEventEmitter;
+use whisker_web::wasm_bindgen::closure::Closure;
+use whisker_web::{ModuleDefinition, WhiskerModule, WhiskerValue, web_sys};
+
+const MODULE_NAME: &str = "whisker-web-browser:WebBrowser";
+
+thread_local! {
+    static SESSION: RefCell<Option<PopupSession>> = const { RefCell::new(None) };
+}
+
+enum SessionKind {
+    Auth { redirect_url: String },
+    Browser,
+}
+
+struct PopupSession {
+    popup: web_sys::Window,
+    interval: i32,
+    _poll: Closure<dyn FnMut()>,
+}
+
+struct WebBrowserModule;
+
+#[whisker_web::WhiskerModule]
+impl WhiskerModule for WebBrowserModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new()
+            .name(MODULE_NAME)
+            .function("openAuthSession", |args, emitter| {
+                let [
+                    WhiskerValue::String(url),
+                    WhiskerValue::String(redirect_url),
+                    WhiskerValue::Bool(_),
+                ] = args
+                else {
+                    return WhiskerValue::Error(
+                        "WebBrowser.openAuthSession requires URL, redirect URL, and ephemeral flag"
+                            .into(),
+                    );
+                };
+                open_popup(
+                    url,
+                    SessionKind::Auth {
+                        redirect_url: redirect_url.clone(),
+                    },
+                    emitter,
+                )
+            })
+            .function("dismissAuthSession", |args, emitter| {
+                if !args.is_empty() {
+                    return WhiskerValue::Error(
+                        "WebBrowser.dismissAuthSession does not accept arguments".into(),
+                    );
+                }
+                finish("authSessionCompleted", "dismiss", None, emitter);
+                WhiskerValue::Null
+            })
+            .function("openBrowser", |args, emitter| {
+                let [WhiskerValue::String(url)] = args else {
+                    return WhiskerValue::Error(
+                        "WebBrowser.openBrowser requires one URL string".into(),
+                    );
+                };
+                open_popup(url, SessionKind::Browser, emitter)
+            })
+            .function("dismissBrowser", |args, emitter| {
+                if !args.is_empty() {
+                    return WhiskerValue::Error(
+                        "WebBrowser.dismissBrowser does not accept arguments".into(),
+                    );
+                }
+                finish("browserClosed", "dismiss", None, emitter);
+                WhiskerValue::Null
+            })
+            .event("authSessionCompleted")
+            .event("browserClosed")
+    }
+}
+
+fn open_popup(url: &str, kind: SessionKind, emitter: &ModuleEventEmitter) -> WhiskerValue {
+    close_current();
+    let Some(window) = web_sys::window() else {
+        return WhiskerValue::Error("browser Window is unavailable".into());
+    };
+    let popup = match window.open_with_url_and_target(url, "_blank") {
+        Ok(Some(popup)) => popup,
+        Ok(None) => return WhiskerValue::Error("browser blocked the popup".into()),
+        Err(error) => return WhiskerValue::Error(format!("open popup failed: {error:?}")),
+    };
+    let polled_popup = popup.clone();
+    let event_emitter = emitter.clone();
+    let poll = Closure::<dyn FnMut()>::new(move || {
+        if polled_popup.closed().unwrap_or(true) {
+            match &kind {
+                SessionKind::Auth { .. } => {
+                    emit_result(&event_emitter, "authSessionCompleted", "cancel", None)
+                }
+                SessionKind::Browser => {
+                    emit_result(&event_emitter, "browserClosed", "dismiss", None)
+                }
+            }
+            clear_later();
+            return;
+        }
+        if let SessionKind::Auth { redirect_url } = &kind
+            && let Ok(location) = polled_popup.location().href()
+            && location.starts_with(redirect_url)
+        {
+            emit_result(
+                &event_emitter,
+                "authSessionCompleted",
+                "success",
+                Some(location),
+            );
+            let _ = polled_popup.close();
+            clear_later();
+        }
+    });
+    let interval = match window
+        .set_interval_with_callback_and_timeout_and_arguments_0(poll.as_ref().unchecked_ref(), 100)
+    {
+        Ok(interval) => interval,
+        Err(error) => return WhiskerValue::Error(format!("start popup observer: {error:?}")),
+    };
+    SESSION.with(|slot| {
+        *slot.borrow_mut() = Some(PopupSession {
+            popup,
+            interval,
+            _poll: poll,
+        });
+    });
+    WhiskerValue::Null
+}
+
+fn finish(event: &str, kind: &str, url: Option<String>, emitter: &ModuleEventEmitter) {
+    close_current();
+    emit_result(emitter, event, kind, url);
+}
+
+fn close_current() {
+    SESSION.with(|slot| {
+        if let Some(session) = slot.borrow_mut().take() {
+            if let Some(window) = web_sys::window() {
+                window.clear_interval_with_handle(session.interval);
+            }
+            let _ = session.popup.close();
+        }
+    });
+}
+
+fn clear_later() {
+    let callback = Closure::once(close_current);
+    if let Some(window) = web_sys::window() {
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            callback.as_ref().unchecked_ref(),
+            0,
+        );
+        callback.forget();
+    }
+}
+
+fn emit_result(emitter: &ModuleEventEmitter, event: &str, kind: &str, url: Option<String>) {
+    let mut fields = vec![("type", WhiskerValue::String(kind.to_owned()))];
+    if let Some(url) = url {
+        fields.push(("url", WhiskerValue::String(url)));
+    }
+    emitter.emit(event, WhiskerValue::map(fields));
+}
+
+use whisker_web::wasm_bindgen::JsCast;


### PR DESCRIPTION
## Summary
- migrate `whisker-web-browser` to the explicit four-platform module manifest
- add a Web popup Host that detects close/cancel and same-origin OAuth redirects
- support explicit popup dismissal without dropping an executing callback
- add a Desktop system-browser handoff for plain browser URLs
- make Desktop auth sessions fail promptly until a loopback/deep-link receiver exists
- retain Android Custom Tabs and iOS Safari/AuthSession implementations

## Verification
- `cargo test -p whisker-web-browser -p whisker-web-browser-desktop --all-targets`
- `cargo clippy -p whisker-web-browser -p whisker-web-browser-desktop -p whisker-web-browser-web --all-targets -- -D warnings`
- `cargo check -p whisker-web-browser-web --target wasm32-unknown-unknown`

Depends on #550.