### PR TITLE
feat(audio): add Web Host support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6875,6 +6875,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-audio-web"
+version = "0.12.0"
+dependencies = [
+ "wasm-bindgen-futures",
+ "web-sys",
+ "whisker",
+ "whisker-web",
+]
+
+[[package]]
 name = "whisker-build"
 version = "0.12.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ members = [
     "packages/whisker-svg/example",
     "packages/whisker-video",
     "packages/whisker-audio",
+    "packages/whisker-audio/web",
     "packages/whisker-audio/example",
     "packages/whisker-webview",
     "packages/whisker-webview/example",

--- a/crates/whisker-cng/src/modules.rs
+++ b/crates/whisker-cng/src/modules.rs
@@ -643,13 +643,13 @@ mod tests {
             .find(|module| module.package == "whisker-svg")
             .unwrap();
         let desktop = svg.rust_host(ModulePlatform::Desktop).unwrap();
-        assert_eq!(desktop.package, "whisker-svg-desktop-host");
+        assert_eq!(desktop.package, "whisker-svg-desktop");
         assert!(matches!(
             &desktop.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-svg/desktop")
         ));
         let web = svg.rust_host(ModulePlatform::Web).unwrap();
-        assert_eq!(web.package, "whisker-svg-web-host");
+        assert_eq!(web.package, "whisker-svg-web");
         assert!(matches!(
             &web.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-svg/web")

--- a/packages/whisker-audio/Cargo.toml
+++ b/packages/whisker-audio/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Whisker platform module — audio playback backed by ExoPlayer (Android) / AVPlayer (iOS). Mirrors expo-audio's surface: a `<whisker-audio:Player>` element wired to a `Player` typed handle for imperative play/pause/seek, with reactive `position` / `duration` / `is_playing` signals fed by native playback events."
+description = "Whisker audio playback for Android, iOS, and Web, with imperative controls and reactive playback status."
 
 # Phase K — explicit `include` list so a `cargo publish` of this
 # crate ships the Kotlin + Swift platform sources alongside
@@ -24,17 +24,15 @@ include = [
     "bin/**/*.rs",
     "android/**/*.kt",
     "ios/**/*.swift",
-    "README.md",
 ]
 
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker. The bare table identifies this cargo
-# crate as a Whisker module; `whisker-build` walks the consuming
-# app's dep tree, picks out every dep carrying it, and wires the
-# Android Gradle subproject + iOS SwiftPM package into the host build.
-[package.metadata.whisker]
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
+web = { manifest = "web/Cargo.toml" }
 
 # Plugin registration — Whisker walks the consuming app's dep
 # tree, picks this entry up, builds the `whisker-audio-plugin`

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -13,7 +13,7 @@ import PackageDescription
 // so this module builds for an app created outside the whisker repo.
 let package = Package(
     name: "whisker-audio",
-    platforms: [.iOS(.v13), .macOS(.v13)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],

--- a/packages/whisker-audio/android/src/main/kotlin/rs/whisker/modules/audio/AudioModule.kt
+++ b/packages/whisker-audio/android/src/main/kotlin/rs/whisker/modules/audio/AudioModule.kt
@@ -5,8 +5,8 @@
 // `PlayerInner::drop` removes it.
 //
 // Playback state flows back through a single `statusChanged` event whose
-// payload carries `playerId`, so the Rust side's global dispatch table
-// can route it to the matching handle.
+// payload carries `playerId`, so the owning Rust runtime can route it
+// to the matching handle.
 
 package rs.whisker.modules.audio
 

--- a/packages/whisker-audio/src/lib.rs
+++ b/packages/whisker-audio/src/lib.rs
@@ -8,7 +8,8 @@
 //! reactive [`PlaybackStatus`] signal driven by native playback
 //! callbacks. The native player releases when the last clone drops.
 //!
-//! Backed by AVPlayer (iOS) and AndroidX Media3 ExoPlayer (Android).
+//! Backed by AVPlayer (iOS), AndroidX Media3 ExoPlayer (Android), and
+//! `HTMLAudioElement` (Web).
 //! The surface mirrors the imperative half of
 //! [Expo's `expo-audio`](https://docs.expo.dev/versions/latest/sdk/audio/):
 //! a player object you call `play` / `pause` / `seek_to` on, plus a
@@ -56,11 +57,10 @@
 //! - Methods (`play`, `pause`, `stop`, `seek_to`, `set_source`,
 //!   `set_volume`, `set_loop`) dispatch through
 //!   `whisker::module!("WhiskerAudio").invoke(method, args)`.
-//! - The native module emits a per-player `statusChanged` event
-//!   every time playback state changes (and at a ~200 ms cadence
-//!   while playing); [`Player::status`] lazily installs the
-//!   dispatch table on first call and routes events to the matching
-//!   handle's signal.
+//! - The Host module emits a per-player `statusChanged` event every
+//!   time playback state changes (and at a ~200 ms cadence while
+//!   playing). Each Whisker runtime owns its subscription and status
+//!   table, so multiple runtime instances remain isolated.
 //!
 //! ## Native source
 //!
@@ -68,6 +68,7 @@
 //!
 //! - iOS: `packages/whisker-audio/ios/Sources/WhiskerAudio/AudioModule.swift`
 //! - Android: `packages/whisker-audio/android/src/main/kotlin/rs/whisker/modules/audio/AudioModule.kt`
+//! - Web: `packages/whisker-audio/web/src/lib.rs`
 
 /// Whisker plugin — adds `Info.plist` / `AndroidManifest.xml`
 /// entries when the consuming app declares

--- a/packages/whisker-audio/src/runtime.rs
+++ b/packages/whisker-audio/src/runtime.rs
@@ -1,10 +1,10 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use whisker::platform_module::WhiskerValue;
+use whisker::runtime::module::ModuleSubscription;
 use whisker::{ArcReadSignal, ArcRwSignal, ReadSignal, module};
 
 /// Current playback state. Updated by the native side and read
@@ -64,6 +64,8 @@ pub struct Player {
 // native player without manual book-keeping.
 struct PlayerInner {
     id: u64,
+    status: ArcRwSignal<PlaybackStatus>,
+    runtime: Rc<RefCell<AudioRuntimeState>>,
 }
 
 impl PlayerInner {
@@ -80,7 +82,7 @@ impl Drop for PlayerInner {
         // Best-effort: a bridge teardown before us turns this into a
         // silent `WhiskerValue::Error`; the OS reclaims at exit.
         let _ = module!("WhiskerAudio").invoke("release", vec![WhiskerValue::Int(self.id as i64)]);
-        unregister_status(self.id);
+        self.runtime.borrow_mut().entries.remove(&self.id);
     }
 }
 
@@ -96,12 +98,20 @@ impl Player {
     pub fn new(source: impl Into<String>) -> Self {
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
         let source = source.into();
+        let runtime = whisker::runtime::runtime_local::state::<AudioRuntimeState>();
+        install_status_listener(&runtime);
+        let status = ArcRwSignal::new(PlaybackStatus::default());
+        runtime.borrow_mut().entries.insert(id, status.clone());
         module!("WhiskerAudio").invoke(
             "create",
             vec![WhiskerValue::Int(id as i64), WhiskerValue::String(source)],
         );
         Self {
-            inner: Rc::new(PlayerInner { id }),
+            inner: Rc::new(PlayerInner {
+                id,
+                status,
+                runtime,
+            }),
         }
     }
 
@@ -224,7 +234,8 @@ impl Player {
     /// `duration` — at that point `is_loaded` flips to `true`.
     /// All clones of the same `Player` see the identical signal.
     pub fn status(&self) -> ReadSignal<PlaybackStatus> {
-        register_status(self.inner.id)
+        let (read, _write): (ArcReadSignal<_>, _) = self.inner.status.clone().split();
+        read.into()
     }
 }
 
@@ -232,50 +243,23 @@ impl Player {
 // allocate; the dispatch path that consumes the id is main-thread-only.
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
-// Shared between the bridge-callback closure and `register_status`
-// inserts. Wrapped in `MainThreadOnly` so `OnceLock<T>`'s `T: Sync`
-// bound passes — see [`MainThreadOnly`] below.
-type StatusEntries = Rc<RefCell<HashMap<u64, ArcRwSignal<PlaybackStatus>>>>;
-
-struct StatusTable {
-    entries: MainThreadOnly<StatusEntries>,
-}
-
-static STATUS_TABLE: OnceLock<StatusTable> = OnceLock::new();
-
-/// Install the global `statusChanged` listener (once) and return
-/// the per-player signal handle. Re-entering for the same id
-/// returns the existing signal so two clones of the same `Player`
-/// see identical updates.
-fn register_status(id: u64) -> ReadSignal<PlaybackStatus> {
-    let table = STATUS_TABLE.get_or_init(install_status_listener);
-    let entries = &table.entries.inner;
-    let mut entries = entries.borrow_mut();
-    let signal = entries
-        .entry(id)
-        .or_insert_with(|| ArcRwSignal::new(PlaybackStatus::default()));
-    let (read, _write): (ArcReadSignal<_>, _) = signal.clone().split();
-    read.into()
-}
-
-/// Remove `id` from the dispatch table on player drop so a long-
-/// lived process doesn't accumulate dead per-player slots.
-fn unregister_status(id: u64) {
-    if let Some(table) = STATUS_TABLE.get() {
-        if let Ok(mut entries) = table.entries.inner.try_borrow_mut() {
-            entries.remove(&id);
-        }
-    }
+#[derive(Default)]
+struct AudioRuntimeState {
+    entries: HashMap<u64, ArcRwSignal<PlaybackStatus>>,
+    subscription: Option<ModuleSubscription>,
 }
 
 /// One-shot install of the `statusChanged` subscription. Stale
 /// events for ids that were already released drop silently.
-fn install_status_listener() -> StatusTable {
-    let entries: StatusEntries = Rc::new(RefCell::new(HashMap::new()));
-    let entries_for_listener = MainThreadOnly {
-        inner: entries.clone(),
-    };
+fn install_status_listener(runtime: &Rc<RefCell<AudioRuntimeState>>) {
+    if runtime.borrow().subscription.is_some() {
+        return;
+    }
+    let weak_runtime = Rc::downgrade(runtime);
     let sub = module!("WhiskerAudio").on_event("statusChanged", move |payload| {
+        let Some(runtime) = weak_runtime.upgrade() else {
+            return;
+        };
         let WhiskerValue::Map(fields) = payload else {
             return;
         };
@@ -290,20 +274,12 @@ fn install_status_listener() -> StatusTable {
             is_loaded: read_bool(&fields, "isLoaded"),
             is_playing: read_bool(&fields, "isPlaying"),
         };
-        // Bind the wrapper (not `.inner`) so Rust 2021 disjoint
-        // captures move the `Send + Sync` impl as a whole.
-        let table = &entries_for_listener;
-        let borrow = table.inner.borrow();
-        if let Some(rw) = borrow.get(&id) {
+        let runtime = runtime.borrow();
+        if let Some(rw) = runtime.entries.get(&id) {
             rw.set(status);
         }
     });
-    // Leak: listener lives for the process; dropping the
-    // subscription would also drop the closure the bridge holds.
-    std::mem::forget(sub);
-    StatusTable {
-        entries: MainThreadOnly { inner: entries },
-    }
+    runtime.borrow_mut().subscription = Some(sub);
 }
 
 fn read_f64(fields: &BTreeMap<String, WhiskerValue>, key: &str) -> f64 {
@@ -317,16 +293,3 @@ fn read_f64(fields: &BTreeMap<String, WhiskerValue>, key: &str) -> f64 {
 fn read_bool(fields: &BTreeMap<String, WhiskerValue>, key: &str) -> bool {
     matches!(fields.get(key), Some(WhiskerValue::Bool(true)))
 }
-
-/// Main-thread-only wrapper. Asserts the runtime-thread contract so
-/// `OnceLock<T>`'s `T: Sync` bound passes without making `Rc` actually
-/// `Sync`.
-#[derive(Clone)]
-struct MainThreadOnly<T> {
-    inner: T,
-}
-// SAFETY: every consumer runs on the reactive thread by contract — the
-// bridge dispatches status events on the main thread. Misuse would corrupt
-// the arena.
-unsafe impl<T> Send for MainThreadOnly<T> {}
-unsafe impl<T> Sync for MainThreadOnly<T> {}

--- a/packages/whisker-audio/web/Cargo.toml
+++ b/packages/whisker-audio/web/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "whisker-audio-web"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web Host implementation for whisker-audio."
+
+[dependencies]
+whisker = { workspace = true }
+whisker-web = { workspace = true }
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = [
+    "Event",
+    "EventTarget",
+    "HtmlAudioElement",
+    "HtmlMediaElement",
+] }

--- a/packages/whisker-audio/web/src/lib.rs
+++ b/packages/whisker-audio/web/src/lib.rs
@@ -1,0 +1,344 @@
+//! Web Host implementation for `whisker-audio` using `HTMLAudioElement`.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use wasm_bindgen_futures::{JsFuture, spawn_local};
+use whisker::runtime::module::ModuleEventEmitter;
+use whisker_web::wasm_bindgen::{JsCast, closure::Closure};
+use whisker_web::{ModuleDefinition, WhiskerModule, WhiskerValue, web_sys};
+
+const MODULE_NAME: &str = "whisker-audio:WhiskerAudio";
+
+type Players = Rc<RefCell<HashMap<i64, BrowserPlayer>>>;
+type MediaEventListener = (&'static str, Closure<dyn FnMut(web_sys::Event)>);
+
+struct BrowserPlayer {
+    audio: web_sys::HtmlAudioElement,
+    listeners: Vec<MediaEventListener>,
+}
+
+struct AudioModule;
+
+#[whisker_web::WhiskerModule]
+impl WhiskerModule for AudioModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        let players: Players = Rc::new(RefCell::new(HashMap::new()));
+
+        let create_players = Rc::clone(&players);
+        let source_players = Rc::clone(&players);
+        let play_players = Rc::clone(&players);
+        let pause_players = Rc::clone(&players);
+        let stop_players = Rc::clone(&players);
+        let seek_players = Rc::clone(&players);
+        let volume_players = Rc::clone(&players);
+        let loop_players = Rc::clone(&players);
+        let release_players = Rc::clone(&players);
+
+        ModuleDefinition::new()
+            .name(MODULE_NAME)
+            .function("create", move |args, emitter| {
+                let (id, source) = match id_and_string(args, "create", "source") {
+                    Ok(values) => values,
+                    Err(error) => return error,
+                };
+                match BrowserPlayer::new(id, source, emitter.clone()) {
+                    Ok(player) => {
+                        if let Some(previous) = create_players.borrow_mut().insert(id, player) {
+                            drop(previous);
+                        }
+                        WhiskerValue::Null
+                    }
+                    Err(error) => WhiskerValue::Error(error),
+                }
+            })
+            .function("setSource", move |args, emitter| {
+                let (id, source) = match id_and_string(args, "setSource", "source") {
+                    Ok(values) => values,
+                    Err(error) => return error,
+                };
+                with_player(&source_players, id, "setSource", |player| {
+                    player.audio.pause().ok();
+                    player.audio.set_src(source);
+                    player.audio.load();
+                    emit_status(id, &player.audio, emitter);
+                })
+            })
+            .function("play", move |args, emitter| {
+                let id = match id_argument(args, "play") {
+                    Ok(id) => id,
+                    Err(error) => return error,
+                };
+                with_player(&play_players, id, "play", |player| {
+                    if let Ok(promise) = player.audio.play() {
+                        // Autoplay policy may reject this promise. The public API is
+                        // fire-and-forget, so avoid an unhandled rejection and report
+                        // the actual paused state through the normal status event.
+                        spawn_local(async move {
+                            let _ = JsFuture::from(promise).await;
+                        });
+                    }
+                    emit_status(id, &player.audio, emitter);
+                })
+            })
+            .function("pause", move |args, emitter| {
+                let id = match id_argument(args, "pause") {
+                    Ok(id) => id,
+                    Err(error) => return error,
+                };
+                with_player(&pause_players, id, "pause", |player| {
+                    player.audio.pause().ok();
+                    emit_status(id, &player.audio, emitter);
+                })
+            })
+            .function("stop", move |args, emitter| {
+                let id = match id_argument(args, "stop") {
+                    Ok(id) => id,
+                    Err(error) => return error,
+                };
+                with_player(&stop_players, id, "stop", |player| {
+                    player.audio.pause().ok();
+                    player.audio.set_current_time(0.0);
+                    emit_status(id, &player.audio, emitter);
+                })
+            })
+            .function("seekTo", move |args, emitter| {
+                let (id, seconds) = match id_and_float(args, "seekTo", "position") {
+                    Ok(values) => values,
+                    Err(error) => return error,
+                };
+                with_player(&seek_players, id, "seekTo", |player| {
+                    let duration = player.audio.duration();
+                    let upper = if duration.is_finite() {
+                        duration.max(0.0)
+                    } else {
+                        f64::INFINITY
+                    };
+                    player.audio.set_current_time(seconds.clamp(0.0, upper));
+                    emit_status(id, &player.audio, emitter);
+                })
+            })
+            .function("setVolume", move |args, _| {
+                let (id, volume) = match id_and_float(args, "setVolume", "volume") {
+                    Ok(values) => values,
+                    Err(error) => return error,
+                };
+                with_player(&volume_players, id, "setVolume", |player| {
+                    player.audio.set_volume(volume.clamp(0.0, 1.0));
+                })
+            })
+            .function("setLoop", move |args, _| {
+                let (id, looping) = match id_and_bool(args, "setLoop", "loop") {
+                    Ok(values) => values,
+                    Err(error) => return error,
+                };
+                with_player(&loop_players, id, "setLoop", |player| {
+                    player.audio.set_loop(looping);
+                })
+            })
+            .function("release", move |args, _| {
+                let id = match id_argument(args, "release") {
+                    Ok(id) => id,
+                    Err(error) => return error,
+                };
+                if let Some(player) = release_players.borrow_mut().remove(&id) {
+                    drop(player);
+                }
+                WhiskerValue::Null
+            })
+            .event("statusChanged")
+    }
+}
+
+impl BrowserPlayer {
+    fn new(id: i64, source: &str, emitter: ModuleEventEmitter) -> Result<Self, String> {
+        let audio = web_sys::HtmlAudioElement::new_with_src(source)
+            .map_err(|error| format!("create HTMLAudioElement failed: {error:?}"))?;
+        audio.set_preload("auto");
+
+        let mut listeners = Vec::new();
+        for event in [
+            "loadedmetadata",
+            "durationchange",
+            "play",
+            "playing",
+            "pause",
+            "timeupdate",
+            "seeking",
+            "seeked",
+            "waiting",
+            "canplay",
+            "ended",
+            "error",
+            "emptied",
+        ] {
+            let event_audio = audio.clone();
+            let event_emitter = emitter.clone();
+            let listener = Closure::<dyn FnMut(web_sys::Event)>::new(move |_| {
+                emit_status(id, &event_audio, &event_emitter);
+            });
+            audio
+                .add_event_listener_with_callback(event, listener.as_ref().unchecked_ref())
+                .map_err(|error| {
+                    format!("register HTMLAudioElement {event} listener: {error:?}")
+                })?;
+            listeners.push((event, listener));
+        }
+
+        Ok(Self { audio, listeners })
+    }
+}
+
+impl Drop for BrowserPlayer {
+    fn drop(&mut self) {
+        for (event, listener) in &self.listeners {
+            let _ = self
+                .audio
+                .remove_event_listener_with_callback(event, listener.as_ref().unchecked_ref());
+        }
+        self.audio.pause().ok();
+        self.audio.set_src("");
+        self.audio.load();
+    }
+}
+
+fn with_player(
+    players: &Players,
+    id: i64,
+    operation: &str,
+    apply: impl FnOnce(&mut BrowserPlayer),
+) -> WhiskerValue {
+    let mut players = players.borrow_mut();
+    let Some(player) = players.get_mut(&id) else {
+        return WhiskerValue::Error(format!(
+            "WhiskerAudio.{operation} references unknown player {id}"
+        ));
+    };
+    apply(player);
+    WhiskerValue::Null
+}
+
+fn emit_status(id: i64, audio: &web_sys::HtmlAudioElement, emitter: &ModuleEventEmitter) {
+    let duration = audio.duration();
+    emitter.emit(
+        "statusChanged",
+        WhiskerValue::map([
+            ("playerId", WhiskerValue::Int(id)),
+            ("position", WhiskerValue::Float(audio.current_time())),
+            (
+                "duration",
+                WhiskerValue::Float(if duration.is_finite() { duration } else { 0.0 }),
+            ),
+            ("isLoaded", WhiskerValue::Bool(audio.ready_state() >= 1)),
+            (
+                "isPlaying",
+                WhiskerValue::Bool(!audio.paused() && !audio.ended()),
+            ),
+        ]),
+    );
+}
+
+fn id_argument(args: &[WhiskerValue], operation: &str) -> Result<i64, WhiskerValue> {
+    let [WhiskerValue::Int(id)] = args else {
+        return Err(argument_error(operation, "one player id"));
+    };
+    Ok(*id)
+}
+
+fn id_and_string<'a>(
+    args: &'a [WhiskerValue],
+    operation: &str,
+    value_name: &str,
+) -> Result<(i64, &'a str), WhiskerValue> {
+    let [WhiskerValue::Int(id), WhiskerValue::String(value)] = args else {
+        return Err(argument_error(
+            operation,
+            &format!("a player id and {value_name} string"),
+        ));
+    };
+    Ok((*id, value))
+}
+
+fn id_and_float(
+    args: &[WhiskerValue],
+    operation: &str,
+    value_name: &str,
+) -> Result<(i64, f64), WhiskerValue> {
+    let [WhiskerValue::Int(id), value] = args else {
+        return Err(argument_error(
+            operation,
+            &format!("a player id and {value_name} number"),
+        ));
+    };
+    let number = match value {
+        WhiskerValue::Float(value) => *value,
+        WhiskerValue::Int(value) => *value as f64,
+        _ => {
+            return Err(argument_error(
+                operation,
+                &format!("a player id and {value_name} number"),
+            ));
+        }
+    };
+    if !number.is_finite() {
+        return Err(WhiskerValue::Error(format!(
+            "WhiskerAudio.{operation} requires a finite {value_name}"
+        )));
+    }
+    Ok((*id, number))
+}
+
+fn id_and_bool(
+    args: &[WhiskerValue],
+    operation: &str,
+    value_name: &str,
+) -> Result<(i64, bool), WhiskerValue> {
+    let [WhiskerValue::Int(id), WhiskerValue::Bool(value)] = args else {
+        return Err(argument_error(
+            operation,
+            &format!("a player id and {value_name} boolean"),
+        ));
+    };
+    Ok((*id, *value))
+}
+
+fn argument_error(operation: &str, expected: &str) -> WhiskerValue {
+    WhiskerValue::Error(format!("WhiskerAudio.{operation} requires {expected}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declares_the_portable_audio_service() {
+        let definition = AudioModule::definition();
+        assert_eq!(
+            definition.service_definition().module_name(),
+            Some(MODULE_NAME)
+        );
+    }
+
+    #[test]
+    fn numeric_arguments_accept_ints_and_reject_non_finite_values() {
+        assert_eq!(
+            id_and_float(
+                &[WhiskerValue::Int(7), WhiskerValue::Int(3)],
+                "seekTo",
+                "position"
+            ),
+            Ok((7, 3.0))
+        );
+        assert!(matches!(
+            id_and_float(
+                &[WhiskerValue::Int(7), WhiskerValue::Float(f64::NAN)],
+                "seekTo",
+                "position"
+            ),
+            Err(WhiskerValue::Error(_))
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- declare explicit Android, iOS, and Web module platform manifests
- add an HTMLAudioElement-backed Web Host with playback controls and status events
- isolate reactive player status per RuntimeInstance instead of using an unsafe process-global table
- publish the Web Host as the conventional whisker-audio-web crate

## Validation
- cargo test -p whisker-audio --all-targets
- cargo test -p whisker-audio-web --all-targets
- cargo check -p whisker-audio-web --target wasm32-unknown-unknown --all-targets
- cargo clippy -p whisker-audio -p whisker-audio-web --all-targets -- -D warnings
- cargo test -p whisker-cng --lib
- cargo package -p whisker-audio --allow-dirty --no-verify --list
- cargo package -p whisker-audio-web --allow-dirty --no-verify --list