### PR TITLE
feat(video): add Web Host support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7437,6 +7437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-video-web"
+version = "0.12.0"
+dependencies = [
+ "wasm-bindgen-futures",
+ "web-sys",
+ "whisker-web",
+]
+
+[[package]]
 name = "whisker-web"
 version = "0.12.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "packages/whisker-svg/web",
     "packages/whisker-svg/example",
     "packages/whisker-video",
+    "packages/whisker-video/web",
     "packages/whisker-audio",
     "packages/whisker-audio/example",
     "packages/whisker-webview",

--- a/crates/whisker-cng/src/modules.rs
+++ b/crates/whisker-cng/src/modules.rs
@@ -643,13 +643,13 @@ mod tests {
             .find(|module| module.package == "whisker-svg")
             .unwrap();
         let desktop = svg.rust_host(ModulePlatform::Desktop).unwrap();
-        assert_eq!(desktop.package, "whisker-svg-desktop-host");
+        assert_eq!(desktop.package, "whisker-svg-desktop");
         assert!(matches!(
             &desktop.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-svg/desktop")
         ));
         let web = svg.rust_host(ModulePlatform::Web).unwrap();
-        assert_eq!(web.package, "whisker-svg-web-host");
+        assert_eq!(web.package, "whisker-svg-web");
         assert!(matches!(
             &web.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-svg/web")

--- a/packages/whisker-video/Cargo.toml
+++ b/packages/whisker-video/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Whisker platform component module — `whisker-video:Video` element backed by AVPlayer on iOS / Media3 ExoPlayer on Android. Demonstrates `@WhiskerUIMethod` (`play()`, `pause()`, `seek(position)`) and `ElementRef<T>` for imperative Rust-side control of a mounted element."
+description = "Whisker video element for Android, iOS, and Web, with imperative playback controls."
 
 # Phase K — explicit `include` list so a `cargo publish` of this crate
 # ships the Kotlin + Swift platform sources alongside `src/lib.rs`.
@@ -23,20 +23,15 @@ include = [
     "src/lib.rs",
     "android/**/*.kt",
     "ios/**/*.swift",
-    "README.md",
 ]
 
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker. The bare table identifies this cargo
-# crate as a Whisker module; `whisker-build` walks the consuming
-# app's dep tree, picks out every dep carrying it, and wires the
-# Android Gradle subproject (`android/build.gradle.kts`) + iOS
-# SwiftPM package (`ios/Package.swift`) into the host build. No
-# source list needed — the per-platform manifests are the source of
-# truth.
-[package.metadata.whisker]
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
+web = { manifest = "web/Cargo.toml" }
 
 [dependencies]
 # The umbrella `whisker` crate. Module crates and app crates depend

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -23,7 +23,7 @@ import PackageDescription
 // so this module builds for an app created outside the whisker repo.
 let package = Package(
     name: "whisker-video",
-    platforms: [.iOS(.v13), .macOS(.v13)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(name: "WhiskerVideo", targets: ["WhiskerVideo"]),
     ],

--- a/packages/whisker-video/android/src/main/kotlin/rs/whisker/elements/video/VideoModule.kt
+++ b/packages/whisker-video/android/src/main/kotlin/rs/whisker/elements/video/VideoModule.kt
@@ -22,9 +22,10 @@ class VideoModule : Module() {
     override fun definition() = ModuleDefinition {
         Name("Video")
         View("whisker-video:Video", VideoView::class.java) {
-            Prop("src") { view: VideoView, value ->
-                view.setSrc(value.asString() ?: "")
-            }
+            Prop(
+                "src",
+                clear = { view: VideoView -> view.setSrc("") },
+            ) { view: VideoView, value -> view.setSrc(value.asString() ?: "") }
             Command("play") { view: VideoView, _ -> view.play() }
             Command("pause") { view: VideoView, _ -> view.pause() }
             Command("seek") { view: VideoView, parameters ->

--- a/packages/whisker-video/android/src/main/kotlin/rs/whisker/elements/video/VideoView.kt
+++ b/packages/whisker-video/android/src/main/kotlin/rs/whisker/elements/video/VideoView.kt
@@ -5,6 +5,8 @@
 package rs.whisker.elements.video
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.view.View
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
@@ -16,6 +18,7 @@ open class VideoView(context: WhiskerContext) : WhiskerUI<View>(context) {
 
     private var player: ExoPlayer? = null
     private var playerView: PlayerView? = null
+    private val cleanupHandler = Handler(Looper.getMainLooper())
 
     override fun createView(context: Context): View {
         val view = PlayerView(context)
@@ -31,6 +34,9 @@ open class VideoView(context: WhiskerContext) : WhiskerUI<View>(context) {
         // Media3 requires `release()` before the last reference is
         // dropped, or the audio session leaks.
         player?.release()
+        player = null
+        playerView?.player = null
+        if (value.isEmpty()) return
 
         val ctx = view?.context ?: return
         val p = ExoPlayer.Builder(ctx).build()
@@ -46,6 +52,15 @@ open class VideoView(context: WhiskerContext) : WhiskerUI<View>(context) {
     fun play() { player?.play() }
     fun pause() { player?.pause() }
     fun seek(seconds: Double) {
-        player?.seekTo((seconds * 1000.0).toLong())
+        player?.seekTo((seconds.coerceAtLeast(0.0) * 1000.0).toLong())
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        // Reparenting can detach and attach synchronously in one Host batch.
+        // Defer cleanup one main-loop turn so that path keeps its player.
+        cleanupHandler.post {
+            if (!isAttachedToWindow) setSrc("")
+        }
     }
 }

--- a/packages/whisker-video/android/src/main/kotlin/rs/whisker/elements/video/VideoView.kt
+++ b/packages/whisker-video/android/src/main/kotlin/rs/whisker/elements/video/VideoView.kt
@@ -38,7 +38,7 @@ open class VideoView(context: WhiskerContext) : WhiskerUI<View>(context) {
         playerView?.player = null
         if (value.isEmpty()) return
 
-        val ctx = view?.context ?: return
+        val ctx = view().context
         val p = ExoPlayer.Builder(ctx).build()
         playerView?.player = p
         p.setMediaItem(MediaItem.fromUri(value))

--- a/packages/whisker-video/ios/Sources/WhiskerVideo/VideoModule.swift
+++ b/packages/whisker-video/ios/Sources/WhiskerVideo/VideoModule.swift
@@ -17,7 +17,7 @@ public final class VideoModule: Module {
         ModuleDefinition {
             Name("Video")
             View("whisker-video:Video", VideoView.self) {
-                Prop("src") { (view: VideoView, value: WhiskerValue) in
+                Prop("src", clear: { (view: VideoView) in view.setSrc("") }) { (view: VideoView, value: WhiskerValue) in
                     view.setSrc(value.asString ?? "")
                 }
                 Command("play")  { (view: VideoView, _: WhiskerValue) in view.play() }

--- a/packages/whisker-video/ios/Sources/WhiskerVideo/VideoView.swift
+++ b/packages/whisker-video/ios/Sources/WhiskerVideo/VideoView.swift
@@ -22,10 +22,8 @@ public final class VideoView: WhiskerUI<UIView> {
     }
 
     /// Keep the AVPlayerLayer sized to the host UIView's bounds.
-    /// The Host fires this after applying the element's computed frame —
-    /// `self.view().bounds` is authoritative here.
-    @objc public override func frameDidChange() {
-        super.frameDidChange()
+    public override func layoutSubviews() {
+        super.layoutSubviews()
         playerLayer?.frame = self.view().bounds
     }
 
@@ -48,7 +46,7 @@ public final class VideoView: WhiskerUI<UIView> {
         // setSrc can fire before the Host assigns the view its computed
         // frame — the first dispatch happens during initial-mount prop
         // application — so the layer needs a placeholder rect until
-        // `frameDidChange` resizes it.
+        // `layoutSubviews` resizes it.
         layer.frame = hostView.bounds.isEmpty
             ? CGRect(x: 0, y: 0, width: 400, height: 200)
             : hostView.bounds

--- a/packages/whisker-video/ios/Sources/WhiskerVideo/VideoView.swift
+++ b/packages/whisker-video/ios/Sources/WhiskerVideo/VideoView.swift
@@ -31,10 +31,13 @@ public final class VideoView: WhiskerUI<UIView> {
 
     /// Backing of the `src` prop.
     public func setSrc(_ value: String) {
-        guard let url = URL(string: value) else { return }
         // Tear down any prior player + layer so a `src=` change
         // rebuilds cleanly.
+        player?.pause()
         playerLayer?.removeFromSuperlayer()
+        playerLayer = nil
+        player = nil
+        guard !value.isEmpty, let url = URL(string: value) else { return }
 
         let p = AVPlayer(url: url)
         let layer = AVPlayerLayer(player: p)
@@ -61,7 +64,12 @@ public final class VideoView: WhiskerUI<UIView> {
     public func play()  { player?.play()  }
     public func pause() { player?.pause() }
     public func seek(_ seconds: Double) {
-        let time = CMTime(seconds: seconds, preferredTimescale: 600)
+        let time = CMTime(seconds: max(0, seconds), preferredTimescale: 600)
         player?.seek(to: time)
+    }
+
+    deinit {
+        player?.pause()
+        playerLayer?.removeFromSuperlayer()
     }
 }

--- a/packages/whisker-video/src/lib.rs
+++ b/packages/whisker-video/src/lib.rs
@@ -4,8 +4,8 @@
 //! [`docs/module-api-design.md`](https://github.com/whiskerrs/whisker/blob/main/docs/module-api-design.md)
 //! §"Shape 2". A native UI element ([`Video`]) plus a typed handle
 //! ([`VideoHandle`]) bound on mount via `element_ref:`; methods dispatch
-//! through the element handle. Backed by AVPlayer (iOS) and Media3
-//! ExoPlayer (Android).
+//! through the element handle. Backed by AVPlayer (iOS), Media3
+//! ExoPlayer (Android), and `HTMLVideoElement` (Web).
 //!
 //! ## Usage
 //!
@@ -52,6 +52,7 @@
 //!   (view: `VideoView.swift`)
 //! - Android: `packages/whisker-video/android/src/main/kotlin/rs/whisker/elements/video/VideoModule.kt`
 //!   (view: `VideoView.kt`)
+//! - Web: `packages/whisker-video/web/src/lib.rs`
 
 use whisker::platform_module::WhiskerValue;
 use whisker::{ElementRef, Signal};

--- a/packages/whisker-video/web/Cargo.toml
+++ b/packages/whisker-video/web/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "whisker-video-web"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web Host implementation for whisker-video."
+
+[dependencies]
+wasm-bindgen-futures = "0.4"
+whisker-web = { workspace = true }
+web-sys = { version = "0.3", features = [
+    "CssStyleDeclaration",
+    "Element",
+    "HtmlElement",
+    "HtmlMediaElement",
+    "HtmlVideoElement",
+] }

--- a/packages/whisker-video/web/src/lib.rs
+++ b/packages/whisker-video/web/src/lib.rs
@@ -1,0 +1,147 @@
+//! Web Host implementation for `whisker-video` using `HTMLVideoElement`.
+
+use wasm_bindgen_futures::{JsFuture, spawn_local};
+use whisker_web::wasm_bindgen::JsCast;
+use whisker_web::{
+    ModuleDefinition, WebViewDefinition, WhiskerModule, WhiskerValue, wasm_bindgen, web_sys,
+};
+
+const MODULE_NAME: &str = "whisker-video:Video";
+
+struct VideoWebView {
+    video: web_sys::HtmlVideoElement,
+}
+
+impl VideoWebView {
+    fn set_source(&self, source: &str) {
+        self.video.set_src(source);
+        self.video.load();
+        if !source.is_empty() {
+            play(&self.video);
+        }
+    }
+}
+
+impl Drop for VideoWebView {
+    fn drop(&mut self) {
+        self.video.pause().ok();
+        self.video.set_src("");
+        self.video.load();
+    }
+}
+
+struct VideoModule;
+
+#[whisker_web::WhiskerModule]
+impl WhiskerModule for VideoModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new().name(MODULE_NAME).view(
+            WebViewDefinition::new(
+                MODULE_NAME,
+                |document, _| {
+                    let video = document
+                        .create_element("video")?
+                        .dyn_into::<web_sys::HtmlVideoElement>()?;
+                    video.set_autoplay(true);
+                    video.set_controls(false);
+                    video.set_attribute("playsinline", "")?;
+                    video.style().set_property("width", "100%")?;
+                    video.style().set_property("height", "100%")?;
+                    video.style().set_property("object-fit", "cover")?;
+                    Ok(VideoWebView { video })
+                },
+                |view| view.video.clone().unchecked_into(),
+            )
+            .prop(
+                "src",
+                |view, value| {
+                    let WhiskerValue::String(source) = value else {
+                        return Err(js_error("Video src property must be a string"));
+                    };
+                    view.set_source(source);
+                    Ok(())
+                },
+                |view| {
+                    view.set_source("");
+                    Ok(())
+                },
+            )
+            .command("play", |view, parameters| {
+                require_null("play", parameters).map_err(|error| js_error(&error))?;
+                play(&view.video);
+                Ok(())
+            })
+            .command("pause", |view, parameters| {
+                require_null("pause", parameters).map_err(|error| js_error(&error))?;
+                view.video.pause()?;
+                Ok(())
+            })
+            .command("seek", |view, parameters| {
+                let seconds = match parameters {
+                    WhiskerValue::Float(value) => *value,
+                    WhiskerValue::Int(value) => *value as f64,
+                    _ => return Err(js_error("Video seek command requires a number")),
+                };
+                if !seconds.is_finite() {
+                    return Err(js_error("Video seek command requires a finite number"));
+                }
+                let duration = view.video.duration();
+                let upper = if duration.is_finite() {
+                    duration.max(0.0)
+                } else {
+                    f64::INFINITY
+                };
+                view.video.set_current_time(seconds.clamp(0.0, upper));
+                Ok(())
+            }),
+        )
+    }
+}
+
+fn play(video: &web_sys::HtmlVideoElement) {
+    if let Ok(promise) = video.play() {
+        // Browser autoplay policy can reject this promise. Playback remains
+        // controllable from a user gesture, and the rejected autoplay attempt
+        // must not become an unhandled JavaScript rejection.
+        spawn_local(async move {
+            let _ = JsFuture::from(promise).await;
+        });
+    }
+}
+
+fn require_null(command: &str, parameters: &WhiskerValue) -> Result<(), String> {
+    if matches!(parameters, WhiskerValue::Null) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Video {command} command does not accept parameters"
+        ))
+    }
+}
+
+fn js_error(message: &str) -> wasm_bindgen::JsValue {
+    wasm_bindgen::JsValue::from_str(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declares_one_video_view() {
+        let definition = VideoModule::definition();
+        assert_eq!(
+            definition.service_definition().module_name(),
+            Some(MODULE_NAME)
+        );
+        assert_eq!(definition.factories().len(), 1);
+    }
+
+    #[test]
+    fn parameterless_commands_reject_payloads() {
+        assert!(require_null("play", &WhiskerValue::Null).is_ok());
+        assert!(require_null("play", &WhiskerValue::Int(1)).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- declare explicit Android, iOS, and Web module platform manifests
- add an HTMLVideoElement-backed Web Host for src, play, pause, and seek
- clear native media state consistently and release Android ExoPlayer instances when elements leave the Host tree
- clamp negative seek positions across Hosts

## Validation
- cargo test -p whisker-video -p whisker-video-web --all-targets
- cargo check -p whisker-video-web --target wasm32-unknown-unknown --all-targets
- cargo clippy -p whisker-video -p whisker-video-web --all-targets -- -D warnings
- swiftc -frontend -parse packages/whisker-video/ios/Sources/WhiskerVideo/VideoModule.swift packages/whisker-video/ios/Sources/WhiskerVideo/VideoView.swift
- cargo package -p whisker-video --allow-dirty --no-verify --list
- cargo package -p whisker-video-web --allow-dirty --no-verify --list