### PR TITLE
fix(webview): align the Android and iOS Host contract

### DIFF
--- a/crates/whisker-cng/src/modules.rs
+++ b/crates/whisker-cng/src/modules.rs
@@ -643,13 +643,13 @@ mod tests {
             .find(|module| module.package == "whisker-svg")
             .unwrap();
         let desktop = svg.rust_host(ModulePlatform::Desktop).unwrap();
-        assert_eq!(desktop.package, "whisker-svg-desktop-host");
+        assert_eq!(desktop.package, "whisker-svg-desktop");
         assert!(matches!(
             &desktop.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-svg/desktop")
         ));
         let web = svg.rust_host(ModulePlatform::Web).unwrap();
-        assert_eq!(web.package, "whisker-svg-web-host");
+        assert_eq!(web.package, "whisker-svg-web");
         assert!(matches!(
             &web.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-svg/web")

--- a/packages/whisker-webview/Cargo.toml
+++ b/packages/whisker-webview/Cargo.toml
@@ -22,17 +22,14 @@ include = [
     "src/lib.rs",
     "android/**/*.kt",
     "ios/**/*.swift",
-    "README.md",
 ]
 
 [lib]
 crate-type = ["rlib"]
 
-# Module-system opt-in marker. The bare table identifies this cargo
-# crate as a Whisker module; `whisker-build` walks the consuming app's
-# dep tree, picks out every dep carrying it, and wires the Android
-# Gradle subproject + iOS SwiftPM package into the host build.
-[package.metadata.whisker]
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
 
 [dependencies]
 whisker = { workspace = true }

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -8,18 +8,15 @@
 // `Module`-subclass registration lands in `<Target>+Generated.swift` at
 // build time.
 //
-// `whisker-build` injects the absolute location of Whisker's iOS runtime +
-// macros packages via env vars, so this module resolves them no matter where
-// the crate lives — in the monorepo, in a user's whisker project, or
-// unpacked from the cargo registry. No relative fallback: a Whisker module
-// is only ever built through `whisker run` / `whisker build`, never
-// standalone `swift build`.
+// The generated Xcode project links this package directly. Its checked-in
+// manifest and sources remain ordinary SwiftPM inputs; Whisker CNG only
+// assembles the app's package dependency graph.
 
 import PackageDescription
 
 let package = Package(
     name: "whisker-webview",
-    platforms: [.iOS(.v13), .macOS(.v13)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],

--- a/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WebViewModule.kt
+++ b/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WebViewModule.kt
@@ -27,35 +27,41 @@ class WebViewModule : Module() {
 
             // ---- content props -------------------------------------------
 
-            Prop("url") { view: WhiskerWebView, value ->
-                view.setUrl(value.asString() ?: "")
+            Prop("url", clear = { view: WhiskerWebView -> view.setUrl("") }) {
+                    view: WhiskerWebView, value -> view.setUrl(value.asString() ?: "")
             }
 
             // Inline HTML, used only when `url` is empty.
-            Prop("html") { view: WhiskerWebView, value ->
-                view.setHtml(value.asString() ?: "")
+            Prop("html", clear = { view: WhiskerWebView -> view.setHtml("") }) {
+                    view: WhiskerWebView, value -> view.setHtml(value.asString() ?: "")
             }
 
             // ---- behaviour props -----------------------------------------
 
             // Must be set before any load to take effect.
-            Prop("user-agent") { view: WhiskerWebView, value ->
-                view.setUserAgent(value.asString() ?: "")
+            Prop("user-agent", clear = { view: WhiskerWebView -> view.setUserAgent("") }) {
+                    view: WhiskerWebView, value -> view.setUserAgent(value.asString() ?: "")
             }
 
-            // Defaults to false on Android, unlike iOS.
-            Prop("javascript-enabled") { view: WhiskerWebView, value ->
-                view.setJavascriptEnabled(value.asString() ?: "false")
+            Prop(
+                "javascript-enabled",
+                clear = { view: WhiskerWebView -> view.setJavascriptEnabled(true) },
+            ) { view: WhiskerWebView, value ->
+                view.setJavascriptEnabled(value.asBool() ?: true)
             }
 
-            Prop("scroll-enabled") { view: WhiskerWebView, value ->
-                view.setScrollEnabled(value.asString() ?: "true")
+            Prop(
+                "scroll-enabled",
+                clear = { view: WhiskerWebView -> view.setScrollEnabled(true) },
+            ) { view: WhiskerWebView, value ->
+                view.setScrollEnabled(value.asBool() ?: true)
             }
 
             // JSON array string, e.g. `["https://*"]`.
-            Prop("origin-whitelist") { view: WhiskerWebView, value ->
-                view.setOriginWhitelist(value.asString() ?: "")
-            }
+            Prop(
+                "origin-whitelist",
+                clear = { view: WhiskerWebView -> view.setOriginWhitelist("") },
+            ) { view: WhiskerWebView, value -> view.setOriginWhitelist(value.asString() ?: "") }
 
             // `style` is handled by the WhiskerUI base.
 

--- a/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WhiskerWebView.kt
+++ b/packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WhiskerWebView.kt
@@ -27,7 +27,7 @@
 //
 // The ONE exception is `@JavascriptInterface`, which fires on JavaBridge,
 // a background thread. That path must hop to the UI thread via
-// `view?.post { … }` before touching any Android View / Host event emitter
+// `view().post { … }` before touching any Android View / Host event emitter
 // state — a genuine thread transition, not a reentrancy guard.
 //
 // ## Teardown
@@ -41,6 +41,8 @@ package rs.whisker.elements.webview
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
@@ -99,9 +101,9 @@ open class WhiskerWebView(context: WhiskerContext) :
     /** The current `html` prop value. Only rendered when `url` is empty. */
     private var pendingHtml: String = ""
 
-    private var jsEnabled: Boolean = false
-
     private var scrollEnabled: Boolean = true
+
+    private val cleanupHandler = Handler(Looper.getMainLooper())
 
     /** Glob patterns; an empty list means "allow all". */
     private var originWhitelist: List<String> = listOf("https://*", "http://*")
@@ -266,9 +268,16 @@ open class WhiskerWebView(context: WhiskerContext) :
 
                 override fun onViewDetachedFromWindow(v: android.view.View) {
                     val webView = v as? android.webkit.WebView ?: return
-                    webView.stopLoading()
-                    webView.removeJavascriptInterface("__whisker_android")
-                    webView.destroy()
+                    // A Host reparent can detach and attach synchronously in
+                    // one frame. Defer destruction so that path keeps the
+                    // live browsing context.
+                    cleanupHandler.post {
+                        if (!webView.isAttachedToWindow) {
+                            webView.stopLoading()
+                            webView.removeJavascriptInterface("__whisker_android")
+                            webView.destroy()
+                        }
+                    }
                 }
             }
         )
@@ -285,8 +294,14 @@ open class WhiskerWebView(context: WhiskerContext) :
      * re-render that touches an unrelated prop from re-loading the page.
      */
     fun setUrl(incoming: String) {
-        val wv = view ?: return
-        if (incoming.isEmpty()) return
+        val wv = view()
+        if (incoming.isEmpty()) {
+            if (lastLoadedUrl != null) {
+                lastLoadedUrl = null
+                loadInlineContent(wv)
+            }
+            return
+        }
         if (incoming == lastLoadedUrl) return
         lastLoadedUrl = incoming
         wv.loadUrl(incoming)
@@ -298,32 +313,30 @@ open class WhiskerWebView(context: WhiskerContext) :
      */
     fun setHtml(html: String) {
         pendingHtml = html
-        val wv = view ?: return
+        val wv = view()
         if (lastLoadedUrl != null && lastLoadedUrl!!.isNotEmpty()) return
-        if (html.isEmpty()) return
-        wv.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+        loadInlineContent(wv)
     }
 
     /** `user-agent` prop setter. Must be set before any load to take effect. */
     fun setUserAgent(ua: String) {
-        val wv = view ?: return
+        val wv = view()
         wv.settings.userAgentString = ua.ifEmpty { null }
     }
 
     @SuppressLint("SetJavaScriptEnabled")
-    fun setJavascriptEnabled(flag: String) {
-        jsEnabled = flag == "true"
-        val wv = view ?: return
-        wv.settings.javaScriptEnabled = jsEnabled
+    fun setJavascriptEnabled(enabled: Boolean) {
+        val wv = view()
+        wv.settings.javaScriptEnabled = enabled
     }
 
     /**
      * `scroll-enabled` prop setter. Disabling only blocks touch-driven
      * scrolling; programmatic `scrollTo()` still works.
      */
-    fun setScrollEnabled(flag: String) {
-        scrollEnabled = flag != "false"
-        val wv = view ?: return
+    fun setScrollEnabled(enabled: Boolean) {
+        scrollEnabled = enabled
+        val wv = view()
         wv.isVerticalScrollBarEnabled = scrollEnabled
         wv.isHorizontalScrollBarEnabled = scrollEnabled
         if (!scrollEnabled) {
@@ -365,49 +378,37 @@ open class WhiskerWebView(context: WhiskerContext) :
     // -------------------------------------------------------------------------
 
     fun reload() {
-        view?.reload()
+        view().reload()
     }
 
     fun goBack() {
-        val wv = view ?: return
+        val wv = view()
         if (wv.canGoBack()) wv.goBack()
     }
 
     fun goForward() {
-        val wv = view ?: return
+        val wv = view()
         if (wv.canGoForward()) wv.goForward()
     }
 
     fun stopLoading() {
-        view?.stopLoading()
+        view().stopLoading()
     }
 
     /**
      * Rust → page message delivery, via `window.whisker._receive(data)`.
      */
     fun postMessageToPage(data: String) {
-        val wv = view ?: return
+        val wv = view()
         // Encode as a JSON string literal so the page receives a JS string
         // rather than a bare token that would break the injected expression.
-        val encoded = buildString {
-            append('"')
-            for (c in data) {
-                when (c) {
-                    '\\' -> append("\\\\")
-                    '"' -> append("\\\"")
-                    '\n' -> append("\\n")
-                    '\r' -> append("\\r")
-                    else -> append(c)
-                }
-            }
-            append('"')
-        }
+        val encoded = org.json.JSONObject.quote(data)
         wv.evaluateJavascript("window.whisker._receive($encoded)", null)
     }
 
     /** Run [script] in the page for its side effects. */
     fun evaluateJs(script: String) {
-        view?.evaluateJavascript(script, null)
+        view().evaluateJavascript(script, null)
     }
 
     // -------------------------------------------------------------------------
@@ -418,13 +419,13 @@ open class WhiskerWebView(context: WhiskerContext) :
      * Receives `window.whisker.postMessage(data)` calls from the page.
      *
      * `@JavascriptInterface` methods run on the JavaBridge background
-     * thread, so the hop back to the UI thread via `view?.post { … }` must
+     * thread, so the hop back to the UI thread via `view().post { … }` must
      * happen before any View API or Host event emitter state is touched.
      */
     private inner class WhiskerBridge {
         @JavascriptInterface
         fun postMessage(data: String) {
-            view?.post {
+            view().post {
                 WhiskerCustomEvent.dispatch(
                     ui = this@WhiskerWebView,
                     name = "message",
@@ -437,6 +438,14 @@ open class WhiskerWebView(context: WhiskerContext) :
     // -------------------------------------------------------------------------
     // Internal helpers
     // -------------------------------------------------------------------------
+
+    private fun loadInlineContent(webView: android.webkit.WebView) {
+        if (pendingHtml.isEmpty()) {
+            webView.loadUrl("about:blank")
+        } else {
+            webView.loadDataWithBaseURL(null, pendingHtml, "text/html", "utf-8", null)
+        }
+    }
 
     /**
      * Match a URL against a glob pattern. Only `*` is meaningful; every

--- a/packages/whisker-webview/example/src/lib.rs
+++ b/packages/whisker-webview/example/src/lib.rs
@@ -70,7 +70,7 @@ fn url_demo() -> Element {
 
             WebView(
                 url: url,
-                webview_ref: webview.clone(),
+                webview_ref: webview,
                 on_message: {
                     move |msg: String| last_message.set(msg)
                 },
@@ -80,19 +80,19 @@ fn url_demo() -> Element {
 
             View(style: Css::new().display_flex().flex_direction(FlexDirection::Row).margin_top(px(10))) {
                 Text(style: button_style(), value: "Reload", on_tap: {
-                    let w = webview.clone();
+                    let w = webview;
                     move |_| w.reload()
                 })
                 Text(style: button_style(), value: "Back", on_tap: {
-                    let w = webview.clone();
+                    let w = webview;
                     move |_| w.go_back()
                 })
                 Text(style: button_style(), value: "Forward", on_tap: {
-                    let w = webview.clone();
+                    let w = webview;
                     move |_| w.go_forward()
                 })
                 Text(style: button_style(), value: "Ping JS", on_tap: {
-                    let w = webview.clone();
+                    let w = webview;
                     move |_| {
                         w.post_message("ping from rust");
                         w.evaluate_javascript(

--- a/packages/whisker-webview/ios/Sources/WhiskerWebview/WebViewModule.swift
+++ b/packages/whisker-webview/ios/Sources/WhiskerWebview/WebViewModule.swift
@@ -8,8 +8,8 @@
 //
 // ## Prop delivery
 //
-// Bool props and the JSON-array whitelist are pre-stringified by the Rust
-// layer, so every prop reads through `value.asString`.
+// Bool props remain typed Whisker values. The JSON-array whitelist is the
+// one string-encoded collection until element schemas support array props.
 
 import WhiskerModule
 
@@ -22,27 +22,32 @@ public final class WebViewModule: Module {
 
                 // ---- Content props ---------------------------------------
 
-                Prop("url") { (view: WhiskerWebViewView, value: WhiskerValue) in
+                Prop("url", clear: { (view: WhiskerWebViewView) in view.setUrl("") }) { (view: WhiskerWebViewView, value: WhiskerValue) in
                     view.setUrl(value.asString ?? "")
                 }
-                Prop("html") { (view: WhiskerWebViewView, value: WhiskerValue) in
+                Prop("html", clear: { (view: WhiskerWebViewView) in view.setHtml("") }) { (view: WhiskerWebViewView, value: WhiskerValue) in
                     view.setHtml(value.asString ?? "")
                 }
 
                 // ---- Browser behaviour props -----------------------------
 
-                Prop("user-agent") { (view: WhiskerWebViewView, value: WhiskerValue) in
+                Prop("user-agent", clear: { (view: WhiskerWebViewView) in view.setUserAgent("") }) { (view: WhiskerWebViewView, value: WhiskerValue) in
                     view.setUserAgent(value.asString ?? "")
                 }
-                // "true" / "false" string sent by the Rust bool_attr() helper.
-                Prop("javascript-enabled") { (view: WhiskerWebViewView, value: WhiskerValue) in
-                    view.setJavascriptEnabled(value.asString ?? "true")
+                Prop("javascript-enabled", clear: { (view: WhiskerWebViewView) in
+                    view.setJavascriptEnabled(true)
+                }) { (view: WhiskerWebViewView, value: WhiskerValue) in
+                    view.setJavascriptEnabled(value.asBool ?? true)
                 }
-                Prop("scroll-enabled") { (view: WhiskerWebViewView, value: WhiskerValue) in
-                    view.setScrollEnabled(value.asString ?? "true")
+                Prop("scroll-enabled", clear: { (view: WhiskerWebViewView) in
+                    view.setScrollEnabled(true)
+                }) { (view: WhiskerWebViewView, value: WhiskerValue) in
+                    view.setScrollEnabled(value.asBool ?? true)
                 }
                 // JSON array string, e.g. `["https://*","http://*"]`.
-                Prop("origin-whitelist") { (view: WhiskerWebViewView, value: WhiskerValue) in
+                Prop("origin-whitelist", clear: { (view: WhiskerWebViewView) in
+                    view.setOriginWhitelist("")
+                }) { (view: WhiskerWebViewView, value: WhiskerValue) in
                     view.setOriginWhitelist(value.asString ?? "")
                 }
 

--- a/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
+++ b/packages/whisker-webview/ios/Sources/WhiskerWebview/WhiskerWebView.swift
@@ -143,6 +143,8 @@ public final class WhiskerWebViewView: WhiskerUI<UIView> {
             self.emitProgress(progress)
         }
 
+        wv.frame = containerView.bounds
+        wv.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         containerView.addSubview(wv)
 
         // `setUrl` / `setHtml` optional-chain on `webView` and silently
@@ -158,11 +160,6 @@ public final class WhiskerWebViewView: WhiskerUI<UIView> {
         }
 
         return containerView
-    }
-
-    @objc public override func frameDidChange() {
-        super.frameDidChange()
-        webView?.frame = self.view().bounds
     }
 
     /// `WhiskerUI` / `WhiskerUI` exposes no teardown override, so cleanup has
@@ -187,7 +184,13 @@ public final class WhiskerWebViewView: WhiskerUI<UIView> {
     /// re-renders that don't touch the value from reloading the page.
     public func setUrl(_ urlString: String) {
         cachedUrl = urlString
-        guard !urlString.isEmpty else { return }
+        if urlString.isEmpty {
+            if !lastLoadedUrl.isEmpty {
+                lastLoadedUrl = ""
+                loadInlineContent()
+            }
+            return
+        }
         guard urlString != lastLoadedUrl else { return }
         lastLoadedUrl = urlString
         guard let url = URL(string: urlString) else { return }
@@ -199,7 +202,7 @@ public final class WhiskerWebViewView: WhiskerUI<UIView> {
     public func setHtml(_ html: String) {
         cachedHtml = html
         guard cachedUrl.isEmpty else { return }
-        webView?.loadHTMLString(html, baseURL: nil)
+        loadInlineContent()
     }
 
     // ---- Browser behaviour -----------------------------------------------
@@ -208,53 +211,36 @@ public final class WhiskerWebViewView: WhiskerUI<UIView> {
         webView?.customUserAgent = ua.isEmpty ? nil : ua
     }
 
-    public func setJavascriptEnabled(_ s: String) {
-        guard #available(iOS 14.0, *) else { return }
-        webView?.configuration.defaultWebpagePreferences.allowsContentJavaScript = (s != "false")
+    public func setJavascriptEnabled(_ enabled: Bool) {
+        if #available(iOS 14.0, *) {
+            webView?.configuration.defaultWebpagePreferences.allowsContentJavaScript = enabled
+        } else {
+            webView?.configuration.preferences.javaScriptEnabled = enabled
+        }
     }
 
-    public func setScrollEnabled(_ s: String) {
-        webView?.scrollView.isScrollEnabled = (s != "false")
+    public func setScrollEnabled(_ enabled: Bool) {
+        webView?.scrollView.isScrollEnabled = enabled
     }
 
     /// Parses a JSON-array string like `["https://*","http://*"]` into the
     /// local `originWhitelist` used by `decidePolicyFor`.
     public func setOriginWhitelist(_ json: String) {
-        guard !json.isEmpty else { return }
-        // Hand-rolled quoted-token scan rather than JSONSerialization: the
-        // only legal input is a JSON string array from the Rust
-        // `origin_whitelist_json` helper.
-        var patterns: [String] = []
-        var idx = json.startIndex
-        while idx < json.endIndex {
-            guard let open = json[idx...].firstIndex(of: "\"") else { break }
-            let afterOpen = json.index(after: open)
-            guard afterOpen < json.endIndex else { break }
-            // Scan to the closing quote, honouring `\"` escapes.
-            var end = afterOpen
-            while end < json.endIndex {
-                if json[end] == "\\" {
-                    let next = json.index(after: end)
-                    if next < json.endIndex { end = json.index(after: next) } else { end = next }
-                } else if json[end] == "\"" {
-                    break
-                } else {
-                    end = json.index(after: end)
-                }
-            }
-            let raw = String(json[afterOpen..<end])
-            let unescaped = raw
-                .replacingOccurrences(of: "\\\"", with: "\"")
-                .replacingOccurrences(of: "\\\\", with: "\\")
-            patterns.append(unescaped)
-            idx = end < json.endIndex ? json.index(after: end) : json.endIndex
+        guard !json.isEmpty else {
+            originWhitelist = ["https://*", "http://*"]
+            return
         }
-        if !patterns.isEmpty {
-            originWhitelist = patterns
-        }
+        guard let data = json.data(using: .utf8),
+              let patterns = try? JSONSerialization.jsonObject(with: data) as? [String]
+        else { return }
+        originWhitelist = patterns
     }
 
     // MARK: - Imperative method targets (called by WebViewModule's Function closures)
+
+    private func loadInlineContent() {
+        webView?.loadHTMLString(cachedHtml, baseURL: nil)
+    }
 
     public func reloadPage() {
         webView?.reload()

--- a/packages/whisker-webview/src/lib.rs
+++ b/packages/whisker-webview/src/lib.rs
@@ -50,7 +50,7 @@
 //! render! {
 //!     WebView(
 //!         url: url,
-//!         webview_ref: webview.clone(),
+//!         webview_ref: webview,
 //!         // JS → Rust: the page calls window.whisker.postMessage("…").
 //!         on_message: move |msg: String| log::info!("from page: {msg}"),
 //!     )
@@ -66,10 +66,10 @@
 //! let webview = WebViewRef::new();
 //! render! {
 //!     View(style: css!(flex_direction: FlexDirection::Column)) {
-//!         WebView(url: url, webview_ref: webview.clone(), style: css!(flex_grow: 1.0))
+//!         WebView(url: url, webview_ref: webview, style: css!(flex_grow: 1.0))
 //!         View(style: css!(flex_direction: FlexDirection::Row)) {
 //!             Text(value: "Reload", on_tap: {
-//!                 let w = webview.clone();
+//!                 let w = webview;
 //!                 move |_| w.reload()
 //!             })
 //!         }
@@ -81,7 +81,7 @@
 //!
 //! | Prop                | Type                       | Default                       | Description |
 //! |---------------------|----------------------------|-------------------------------|-------------|
-//! | `url`               | `RwSignal<String>`         | —                             | Controlled load address. `set()` navigates. One-way down. |
+//! | `url`               | `Signal<String>`           | —                             | Controlled load address. A reactive change navigates. One-way down. |
 //! | `html`              | `Signal<String>`           | —                             | Inline HTML to render (ignored when `url` is set). |
 //! | `user_agent`        | `Signal<String>`           | `""`                          | Custom User-Agent string. |
 //! | `javascript_enabled`| `bool`                     | `true`                        | Allow JavaScript execution. |
@@ -142,12 +142,10 @@
 //!
 //! Contributors: the matching platform module lives at
 //!
-//! - iOS: `packages/whisker-webview/ios/Sources/WhiskerWebView/WebViewModule.swift`
-//!   (view: `WebViewView.swift`)
+//! - iOS: `packages/whisker-webview/ios/Sources/WhiskerWebview/WebViewModule.swift`
+//!   (view: `WhiskerWebView.swift`)
 //! - Android: `packages/whisker-webview/android/src/main/kotlin/rs/whisker/elements/webview/WebViewModule.kt`
-//!   (view: `WhiskerWebViewView.kt`)
-
-use std::rc::Rc;
+//!   (view: `WhiskerWebView.kt`)
 
 use whisker::platform_module::WhiskerValue;
 use whisker::prelude::*;
@@ -284,29 +282,6 @@ pub struct WebViewError {
     pub description: String,
 }
 
-/// A cloneable user callback for a [`WebView`] event prop.
-///
-/// Wraps `Rc<dyn Fn(A)>` so it's `Clone` (required: `#[component]`
-/// re-clones every prop for the hot-reload remount path) and so a bare
-/// closure coerces into it via `Into` at the call site
-/// (`on_message: move |s| …`). `A` is `String` for the URL / message
-/// events, `f32` for `on_progress`, and [`WebViewError`] for `on_error`.
-#[derive(Clone)]
-pub struct Callback<A>(Rc<dyn Fn(A) + 'static>);
-
-impl<A> Callback<A> {
-    /// Invoke the wrapped callback.
-    pub fn call(&self, arg: A) {
-        (self.0)(arg)
-    }
-}
-
-impl<A, F: Fn(A) + 'static> From<F> for Callback<A> {
-    fn from(f: F) -> Self {
-        Callback(Rc::new(f))
-    }
-}
-
 /// The default navigation origin whitelist: `["https://*", "http://*"]`.
 ///
 /// Permits any HTTPS or HTTP origin. Tighten it per-app by passing an
@@ -323,9 +298,9 @@ pub fn default_origin_whitelist() -> Vec<String> {
 /// one-way operations; these convenience methods swallow "not mounted"
 /// / platform errors.
 ///
-/// `Clone` produces a shared handle (same backing arena slot), so the
-/// same handle can drive multiple event closures.
-#[derive(Clone)]
+/// `Copy` produces a shared handle (same backing arena slot), so the
+/// same handle can drive multiple event closures without allocation.
+#[derive(Copy, Clone)]
 pub struct WebViewRef {
     r: ElementRef,
 }
@@ -394,9 +369,9 @@ impl Default for WebViewRef {
     }
 }
 
-// Bool props reach the native side pre-stringified ("true" / "false") and the
-// origin whitelist as a JSON-array string, so it parses one stable form per
-// attr. Attr names are the kebab-cased field names (`user-agent`).
+// The origin whitelist crosses as a JSON-array string because the element
+// schema currently supports primitive property values. Bool props remain
+// typed `WhiskerValue::Bool` values throughout the module protocol.
 
 #[doc(hidden)]
 #[whisker::module_element(
@@ -412,12 +387,12 @@ impl Default for WebViewRef {
     ],
 )]
 pub fn native_webview(
+    user_agent: Signal<String>,
+    javascript_enabled: Signal<bool>,
+    scroll_enabled: Signal<bool>,
+    origin_whitelist: Signal<String>,
     url: Signal<String>,
     html: Signal<String>,
-    user_agent: Signal<String>,
-    javascript_enabled: Signal<String>,
-    scroll_enabled: Signal<String>,
-    origin_whitelist: Signal<String>,
     style: Style,
     on_message: MessageEvent,
     on_load_start: NavEvent,
@@ -438,7 +413,7 @@ pub fn native_webview(
 pub fn web_view(
     /// Controlled load address. Writing `url.set(...)` navigates the
     /// view. One-way down — internal navigations are not written back.
-    url: Option<RwSignal<String>>,
+    url: Option<Signal<String>>,
     /// Inline HTML to render (ignored when `url` is set).
     html: Option<Signal<String>>,
     /// Custom User-Agent string.
@@ -464,66 +439,54 @@ pub fn web_view(
     on_progress: Option<Callback<f32>>,
     /// Navigation failed (url / code / description).
     on_error: Option<Callback<WebViewError>>,
-    /// Standard Whisker style. Accepts a `Css` builder, a raw string,
-    /// or a reactive signal of either — same as a built-in element's
-    /// `style:`.
+    /// Standard structured Whisker style, identical to built-in elements.
     style: Option<Style>,
     /// Imperative handle ([`WebViewRef`]).
     webview_ref: Option<WebViewRef>,
 ) -> Element {
-    // `Signal::Dynamic` so an external `url.set(...)` re-applies natively.
-    // An unset `url` leaves the attr empty and the native side falls back
-    // to `html`.
-    let url_prop: Signal<String> = Signal::Dynamic(computed(move || match url {
-        Some(u) => u.get(),
-        None => String::new(),
-    }));
+    // An unset `url` leaves the property empty and the native side falls
+    // back to `html`; dynamic signals re-apply when their source changes.
+    let url_prop = url.unwrap_or_default();
 
     let on_message_cb = {
-        let on_message = on_message.clone();
         move |ev: MessageEvent| {
             if let Some(cb) = &on_message {
-                cb.call(ev.into_data());
+                cb.run(ev.into_data());
             }
         }
     };
     let on_load_start_cb = {
-        let on_load_start = on_load_start.clone();
         move |ev: NavEvent| {
             if let Some(cb) = &on_load_start {
-                cb.call(ev.into_url());
+                cb.run(ev.into_url());
             }
         }
     };
     let on_load_cb = {
-        let on_load = on_load.clone();
         move |ev: NavEvent| {
             if let Some(cb) = &on_load {
-                cb.call(ev.into_url());
+                cb.run(ev.into_url());
             }
         }
     };
     let on_navigation_cb = {
-        let on_navigation = on_navigation.clone();
         move |ev: NavEvent| {
             if let Some(cb) = &on_navigation {
-                cb.call(ev.into_url());
+                cb.run(ev.into_url());
             }
         }
     };
     let on_progress_cb = {
-        let on_progress = on_progress.clone();
         move |ev: ProgressEvent| {
             if let Some(cb) = &on_progress {
-                cb.call(ev.detail.progress as f32);
+                cb.run(ev.detail.progress as f32);
             }
         }
     };
     let on_error_cb = {
-        let on_error = on_error.clone();
         move |ev: ErrorEvent| {
             if let Some(cb) = &on_error {
-                cb.call(WebViewError {
+                cb.run(WebViewError {
                     url: ev.detail.url,
                     code: ev.detail.code,
                     description: ev.detail.description,
@@ -536,19 +499,17 @@ pub fn web_view(
     let user_agent_prop: Signal<String> = user_agent.unwrap_or_default();
     let style_prop: Style = style.clone().unwrap_or_default();
 
-    let javascript_enabled_attr = bool_attr(javascript_enabled);
-    let scroll_enabled_attr = bool_attr(scroll_enabled);
     let origin_whitelist_attr = origin_whitelist_json(&origin_whitelist);
 
     let element_ref = webview_ref.as_ref().map(|h| h.r());
 
     let mut builder = NativeWebview::builder()
+        .user_agent(user_agent_prop)
+        .javascript_enabled(javascript_enabled)
+        .scroll_enabled(scroll_enabled)
+        .origin_whitelist(origin_whitelist_attr)
         .url(url_prop)
         .html(html_prop)
-        .user_agent(user_agent_prop)
-        .javascript_enabled(javascript_enabled_attr)
-        .scroll_enabled(scroll_enabled_attr)
-        .origin_whitelist(origin_whitelist_attr)
         .style(style_prop)
         .on_message(on_message_cb)
         .on_load_start(on_load_start_cb)
@@ -562,11 +523,6 @@ pub fn web_view(
     }
 
     builder.build()
-}
-
-/// `true` / `false` wire string for a bool attr.
-fn bool_attr(b: bool) -> String {
-    if b { "true" } else { "false" }.to_string()
 }
 
 /// Serialize an origin whitelist to a JSON array string the native side
@@ -618,9 +574,41 @@ mod tests {
     }
 
     #[test]
-    fn bool_attr_strings() {
-        assert_eq!(bool_attr(true), "true");
-        assert_eq!(bool_attr(false), "false");
+    fn component_schema_preserves_boolean_property_types() {
+        let schema = native_webview_schema::schema();
+        let property = |name| {
+            schema
+                .properties
+                .iter()
+                .find(|property| property.name == name)
+                .expect("property is declared")
+                .value
+        };
+        assert_eq!(
+            property("javascript-enabled"),
+            whisker::ElementValueKind::Bool
+        );
+        assert_eq!(property("scroll-enabled"), whisker::ElementValueKind::Bool);
+    }
+
+    #[test]
+    fn browser_configuration_precedes_initial_content() {
+        let names = native_webview_schema::schema()
+            .properties
+            .into_iter()
+            .map(|property| property.name)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            [
+                "user-agent",
+                "javascript-enabled",
+                "scroll-enabled",
+                "origin-whitelist",
+                "url",
+                "html",
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- declare whisker-webview as an explicit Android/iOS-only module
- replace stringified booleans with typed WhiskerValue::Bool properties
- use the shared core Callback and a Copy WebViewRef in the public API
- apply browser settings before initial content and support URL-to-inline-HTML transitions
- restore property clear behavior, including an intentionally empty origin whitelist
- update stale Android WhiskerUI and iOS layout APIs so both native modules build again
- defer Android WebView destruction across same-frame Host reparenting

## Validation
- cargo test -p whisker-webview -p whisker-webview-example --all-targets
- cargo clippy -p whisker-webview -p whisker-webview-example --all-targets -- -D warnings
- cargo package -p whisker-webview --allow-dirty --no-verify --list
- whisker run android: KSP/Gradle assemble, install, and launch passed
- whisker run ios: Xcode/SwiftPM build, install, and launch passed